### PR TITLE
Implement fixes for onboarding issues based on user feedback

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -37,6 +37,7 @@ import UserAccountsView from "views/useraccounts/UserAccountsView";
 import CreateMonitorView from "views/createmonitor/CreateMonitorView";
 import ExpandedMonitorView from "views/expandedmonitor/ExpandedMonitorView";
 import Notifications from "views/notifications/Notifications";
+import HatchetErrorBoundary from "shared/errors/ErrorBoundary";
 
 const App: React.FunctionComponent = () => {
   const queryClient = new QueryClient();
@@ -47,7 +48,9 @@ const App: React.FunctionComponent = () => {
         <GlobalStyle />
         <BrowserRouter>
           <QueryClientProvider client={queryClient}>
-            <AppContents />
+            <HatchetErrorBoundary>
+              <AppContents />
+            </HatchetErrorBoundary>
           </QueryClientProvider>
         </BrowserRouter>
       </AppWrapper>
@@ -398,7 +401,9 @@ const WrappedTeamContents: React.FunctionComponent<WrapperContentsProps> = ({
           links={DashboardSidebarLinks}
           team_links={DashboardTeamSidebarLinks}
         />
-        <ViewWrapper>{children}</ViewWrapper>
+        <HatchetErrorBoundary>
+          <ViewWrapper>{children}</ViewWrapper>
+        </HatchetErrorBoundary>
       </Populator>
     </>
   );

--- a/dashboard/src/components/team/teammanager/index.tsx
+++ b/dashboard/src/components/team/teammanager/index.tsx
@@ -9,7 +9,7 @@ import React, { useState } from "react";
 import { useHistory } from "react-router-dom";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import api from "shared/api";
-import { CreateTeamRequest } from "shared/api/generated/data-contracts";
+import { CreateTeamRequest, Team } from "shared/api/generated/data-contracts";
 import { currOrgAtom } from "shared/atoms/atoms";
 import { useAtom } from "jotai";
 import CreateTeamForm from "../createteamform";
@@ -19,6 +19,7 @@ const defaultAddTeamHelper =
   "Add organization members by entering their email and assigning them a role.";
 
 type Props = {
+  create_team?: (team: Team) => void;
   can_remove?: boolean;
   header_level?: "H2" | "H3";
   add_team_helper?: string;
@@ -28,6 +29,7 @@ const TeamManager: React.FunctionComponent<Props> = ({
   can_remove = false,
   header_level = "H2",
   add_team_helper = defaultAddTeamHelper,
+  create_team,
 }) => {
   const [currOrg] = useAtom(currOrgAtom);
   const [err, setErr] = useState("");
@@ -51,6 +53,7 @@ const TeamManager: React.FunctionComponent<Props> = ({
     onSuccess: (data) => {
       setErr("");
       refetch();
+      create_team && create_team(data?.data);
     },
     onError: (err: any) => {
       if (!err?.error?.errors || err.error.errors.length == 0) {

--- a/dashboard/src/shared/errors/ErrorBoundary.tsx
+++ b/dashboard/src/shared/errors/ErrorBoundary.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import {
+  FlexColCenter,
+  Placeholder,
+  SmallSpan,
+} from "@hatchet-dev/hatchet-components";
+import styled from "styled-components";
+
+type Props = {
+  children?: React.ReactNode;
+};
+
+const HatchetErrorBoundary: React.FC<Props> = ({ children }) => {
+  const handleError = (err: Error) => {
+    console.log(err);
+  };
+
+  return (
+    <ErrorBoundary onError={handleError} FallbackComponent={ErrorPage}>
+      {children}
+    </ErrorBoundary>
+  );
+};
+
+export default HatchetErrorBoundary;
+
+const ErrorPage = ({ error }: any) => (
+  <Placeholder>
+    <FlexColVerticalCenter height="100%" width="100%">
+      <SmallSpan>
+        An unexpected error occurred. Please refresh the page and try again.
+      </SmallSpan>
+    </FlexColVerticalCenter>
+  </Placeholder>
+);
+
+const FlexColVerticalCenter = styled(FlexColCenter)`
+  justify-content: center;
+  align-items: center;
+`;

--- a/dashboard/src/shared/populator/Populator.tsx
+++ b/dashboard/src/shared/populator/Populator.tsx
@@ -101,6 +101,8 @@ const Populator: React.FunctionComponent<Props> = ({
       }
     }
   }, [
+    currOrg,
+    data,
     currTeam,
     currTeamsQuery.data,
     currTeamsQuery.isFetching,

--- a/dashboard/src/views/createorganization/components/CreateTeams.tsx
+++ b/dashboard/src/views/createorganization/components/CreateTeams.tsx
@@ -20,6 +20,7 @@ const teamHelper =
 const CreateTeams: React.FunctionComponent = () => {
   const [currOrg] = useAtom(currOrgAtom);
   const [err, setErr] = useState("");
+  const [createdTeam, setCreatedTeam] = useState(false);
   const history = useHistory();
 
   const mutation = useMutation({
@@ -48,7 +49,12 @@ const CreateTeams: React.FunctionComponent = () => {
   return (
     <FlexCol>
       <SectionArea width="600px">
-        <TeamManager add_team_helper={teamHelper} />
+        <TeamManager
+          add_team_helper={teamHelper}
+          create_team={(t) => {
+            setCreatedTeam(true);
+          }}
+        />
       </SectionArea>
       <HorizontalSpacer spacepixels={24} />
       <FlexRowRight>
@@ -61,6 +67,7 @@ const CreateTeams: React.FunctionComponent = () => {
           }}
           margin={"0"}
           is_loading={mutation.isLoading}
+          disabled={!createdTeam}
         />
       </FlexRowRight>
     </FlexCol>

--- a/dashboard/src/views/expandedmodule/components/modulesettings/index.tsx
+++ b/dashboard/src/views/expandedmodule/components/modulesettings/index.tsx
@@ -235,13 +235,17 @@ const ModuleSettings: React.FC<Props> = ({ team_id, module }) => {
         <HorizontalSpacer spacepixels={20} />
         <UpdateModuleName module={module} setModuleName={setName} />
         <HorizontalSpacer spacepixels={24} />
-        <ExpandableSettings text="Github settings">
-          <SelectGitSource
-            set_request={setGithubParams}
-            current_params={currentGithubParams}
-          />
-        </ExpandableSettings>
-        <HorizontalSpacer spacepixels={8} />
+        {module?.deployment_mechanism == "github" && (
+          <ExpandableSettings text="Github settings">
+            <SelectGitSource
+              set_request={setGithubParams}
+              current_params={currentGithubParams}
+            />
+          </ExpandableSettings>
+        )}
+        {module?.deployment_mechanism == "github" && (
+          <HorizontalSpacer spacepixels={8} />
+        )}
         <ExpandableSettings text="Values configuration">
           <SetModuleValues
             set_github_values={setGithubValueParams}

--- a/dashboard/src/views/notifications/components/notificationslist/NotificationsList.tsx
+++ b/dashboard/src/views/notifications/components/notificationslist/NotificationsList.tsx
@@ -44,7 +44,7 @@ const NotificationsList: React.FC<Props> = ({ notifications }) => {
 
   return (
     <NotificationListContainer width="460px">
-      {notifications.map((notif) => {
+      {notifications?.map((notif) => {
         return (
           <NotificationMetaContainer
             key={notif.id}


### PR DESCRIPTION
Implements the following improvements based on onboarding difficulties:
- [x]  Team creation should be mandatory, can’t be skipped
- [x]  Subsequent `hatchet init` commands from the same directory should re-init Terraform, not throw an error
- [x]  `hatchet config set-api-token` needs to set organization/team automatically if current organization is not in the list of orgs
- [x] Github settings should be removed from the module settings tab if it’s a local deployment
- [x]  If you click on notifications with no teams set up, it breaks
- [x]  Add global error boundary