### PR TITLE
Remove `pkg` dir from Dockerfile 

### DIFF
--- a/build/package/server.Dockerfile
+++ b/build/package/server.Dockerfile
@@ -11,7 +11,6 @@ COPY /cmd ./cmd
 COPY /ee ./ee
 COPY /internal ./internal
 COPY /hack ./hack
-COPY /pkg ./pkg
 
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1


### PR DESCRIPTION
Removes `pkg` directory from the `server.Dockerfile`. 