### PR TITLE
Update `hatchet-admin quickstart` and remove encryption footguns

### DIFF
--- a/internal/config/database/database.go
+++ b/internal/config/database/database.go
@@ -9,7 +9,7 @@ import (
 type ConfigFile struct {
 	Kind string `mapstructure:"kind" json:"kind,omitempty" default:"sqlite"`
 
-	EncryptionKey string `mapstructure:"encryptionKey" json:"encryptionKey,omitempty" default:"__random_strong_encryption_key__"`
+	EncryptionKey string `mapstructure:"encryptionKey" json:"encryptionKey,omitempty"`
 
 	AutoMigrate bool `mapstructure:"autoMigrate" json:"autoMigrate,omitempty" default:"true"`
 

--- a/internal/config/shared/shared.go
+++ b/internal/config/shared/shared.go
@@ -62,7 +62,7 @@ type FileStorageConfigFile struct {
 
 type FileStorageConfigFileLocal struct {
 	FileDirectory     string `mapstructure:"directory" json:"directory,omitempty" default:"./tmp/files"`
-	FileEncryptionKey string `mapstructure:"encryptionKey" json:"encryptionKey,omitempty" default:"__random_strong_encryption_key__"`
+	FileEncryptionKey string `mapstructure:"encryptionKey" json:"encryptionKey,omitempty"`
 }
 
 type FileStorageConfigFileS3 struct {
@@ -70,7 +70,7 @@ type FileStorageConfigFileS3 struct {
 	S3StateAWSSecretKey   string `mapstructure:"secretKey" json:"secretKey,omitempty"`
 	S3StateAWSRegion      string `mapstructure:"region" json:"region,omitempty"`
 	S3StateBucketName     string `mapstructure:"bucketName" json:"bucketName,omitempty"`
-	S3StateEncryptionKey  string `mapstructure:"encryptionKey" json:"encryptionKey,omitempty" default:"__random_strong_encryption_key__"`
+	S3StateEncryptionKey  string `mapstructure:"encryptionKey" json:"encryptionKey,omitempty"`
 }
 
 type ConfigFileAuth struct {
@@ -91,7 +91,7 @@ type ConfigFileAuth struct {
 type ConfigFileAuthCookie struct {
 	Name     string   `mapstructure:"name" json:"name,omitempty" default:"hatchet"`
 	Domain   string   `mapstructure:"domain" json:"domain,omitempty"`
-	Secrets  []string `mapstructure:"secrets" json:"secrets,omitempty" default:"[\"random_hash_key_\",\"random_block_key\"]"`
+	Secrets  []string `mapstructure:"secrets" json:"secrets,omitempty"`
 	Insecure bool     `mapstructure:"insecure" json:"insecure,omitempty" default:"false"`
 }
 

--- a/internal/config/temporal/temporal.go
+++ b/internal/config/temporal/temporal.go
@@ -18,7 +18,7 @@ type TemporalConfigFile struct {
 	TemporalSQLLitePath        string   `mapstructure:"sqlLitePath" json:"sqlLitePath,omitempty" default:"/hatchet/temporal.db"`
 	TemporalNamespaces         []string `mapstructure:"namespaces" json:"namespaces,omitempty" default:"[\"default\"]"`
 	TemporalInternalNamespace  string   `mapstructure:"internalNamespace" json:"internalNamespace,omitempty" default:"hatchet-internal"`
-	TemporalInternalSigningKey string   `mapstructure:"internalSigningKey" json:"internalSigningKey,omitempty" default:"__random_strong_encryption_key__"`
+	TemporalInternalSigningKey string   `mapstructure:"internalSigningKey" json:"internalSigningKey,omitempty"`
 
 	Token shared.ConfigFileAuthToken `mapstructure:"token" json:"token,omitempty"`
 


### PR DESCRIPTION
- [X] Updates `hatchet-admin quickstart` to prevent accidental overwrites of generated config. The command will now merge the existing generated config first, and if `--overwrite=false` it won't write config that's already been written. One caveat here is that the certificate generation script is all-or-nothing (generates 7 cert files at once), so only the root CA path is checked before deciding to write cert config. 
- [X] Gets rid of default encryption keys, such as `_random_strong_encryption_key_`. Not only are these footguns since many users will keep them as default and run insecure instances, but these defaults also make it difficult to detect whether config has already been written. 