### PR TITLE
Add centralized deployment option to `runner-worker`

### DIFF
--- a/cmd/hatchet-runner-worker/main.go
+++ b/cmd/hatchet-runner-worker/main.go
@@ -3,9 +3,15 @@ package main
 import (
 	"fmt"
 	"os"
+	"sync"
+	"time"
 
 	"github.com/hatchet-dev/hatchet/cmd/cmdutils"
+	"github.com/hatchet-dev/hatchet/internal/config/database"
 	"github.com/hatchet-dev/hatchet/internal/config/loader"
+	workerconfig "github.com/hatchet-dev/hatchet/internal/config/worker"
+	"github.com/hatchet-dev/hatchet/internal/models"
+	"github.com/hatchet-dev/hatchet/internal/temporal"
 	"github.com/hatchet-dev/hatchet/internal/temporal/worker"
 	"github.com/spf13/cobra"
 )
@@ -27,7 +33,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		configLoader := loader.NewConfigLoader(Version, configDirectory)
-		interruptChan := cmdutils.InterruptChan()
+
 		rwc, err := configLoader.LoadRunnerWorkerConfig()
 
 		if err != nil {
@@ -35,11 +41,18 @@ var rootCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		err = worker.StartRunnerWorker(rwc, true, interruptChan)
+		// if this is a centralized mechanism, load a database connection
+		if rwc.ProvisionerMechanism == "centralized" {
+			dc, err := configLoader.LoadDatabaseConfig()
 
-		if err != nil {
-			fmt.Printf("Fatal: could not start worker: %v\n", err)
-			os.Exit(1)
+			if err != nil {
+				fmt.Printf("Fatal: could not load database config: %v\n", err)
+				os.Exit(1)
+			}
+
+			startWorkerCentralized(rwc, dc)
+		} else {
+			startWorkerDecentralized(rwc)
 		}
 	},
 }
@@ -61,6 +74,82 @@ func main() {
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+type teams struct {
+	teams map[string]string
+
+	mu sync.Mutex
+}
+
+func startWorkerCentralized(rwc *workerconfig.RunnerConfig, dc *database.Config) {
+	interruptChan := cmdutils.InterruptChan()
+
+	ts := &teams{
+		teams: map[string]string{},
+	}
+
+	// spawn a go process that lists teams in the database periodically
+	ticker := time.NewTicker(15 * time.Second)
+
+	for {
+		select {
+		case <-interruptChan:
+			return
+		case <-ticker.C:
+			var teams []*models.Team
+
+			if err := dc.GormDB.Find(&teams).Error; err != nil {
+				fmt.Printf("Fatal: could not list teams: %v\n", err)
+				os.Exit(1)
+			}
+
+			for _, team := range teams {
+				if _, exists := ts.teams[team.ID]; !exists {
+					ts.mu.Lock()
+					ts.teams[team.ID] = team.ID
+					ts.mu.Unlock()
+
+					fmt.Printf("adding new runner worker for team %s\n", team.ID)
+
+					_rwc := *rwc
+					var err error
+
+					newOpts := rwc.TemporalClient.GetOpts()
+
+					newOpts.Namespace = team.ID
+
+					_rwc.TemporalClient, err = temporal.NewTemporalClient(newOpts)
+
+					if err != nil {
+						fmt.Printf("Fatal: could not create new temporal client: %v\n", err)
+						os.Exit(1)
+					}
+
+					// create a new runner worker
+					err = worker.StartRunnerWorker(&_rwc, false, interruptChan)
+
+					if err != nil {
+						fmt.Printf("Fatal: could not start runner worker: %v\n", err)
+						os.Exit(1)
+					}
+
+					fmt.Printf("successfully added new runner worker for team %s\n", team.ID)
+				}
+			}
+		}
+	}
+}
+
+func startWorkerDecentralized(rwc *workerconfig.RunnerConfig) {
+	interruptChan := cmdutils.InterruptChan()
+
+	err := worker.StartRunnerWorker(rwc, true, interruptChan)
+
+	if err != nil {
+		fmt.Printf("Fatal: could not start worker: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/internal/config/loader/loader.go
+++ b/internal/config/loader/loader.go
@@ -788,11 +788,14 @@ func GetRunnerWorkerConfigFromConfigFile(
 	var provisioner provisioner.Provisioner
 
 	if wc.Provisioner.Kind == "local" {
-		provisioner = local.NewLocalProvisioner()
+		provisioner = local.NewLocalProvisioner(&local.LocalProvisionerOpts{
+			BinaryPath: wc.Provisioner.Local.BinaryPath,
+		})
 	}
 
 	return &worker.RunnerConfig{
-		Config:             *sharedConfig,
-		DefaultProvisioner: provisioner,
+		ProvisionerMechanism: wc.ProvisionerMechanism,
+		Config:               *sharedConfig,
+		DefaultProvisioner:   provisioner,
 	}, nil
 }

--- a/internal/config/worker/worker.go
+++ b/internal/config/worker/worker.go
@@ -95,6 +95,8 @@ func BindAllBackgroundEnv(v *viper.Viper) {
 }
 
 type RunnerConfigFile struct {
+	ProvisionerMechanism string `mapstructure:"provisioner_mechanism" json:"provisioner_mechanism,omitempty" default:"centralized" validator:"oneof=centralized decentralized"`
+
 	Provisioner RunnerConfigFileProvisioner `mapstructure:"provisioner" json:"provisioner,omitempty"`
 
 	RunnerGRPCServerAddress string `mapstructure:"grpcServerAddress" json:"grpcServerAddress,omitempty" default:"http://localhost:8080"`
@@ -102,15 +104,25 @@ type RunnerConfigFile struct {
 
 type RunnerConfigFileProvisioner struct {
 	Kind string `mapstructure:"kind" json:"kind,omitempty" default:"local"`
+
+	Local LocalProvisionerConfig `mapstructure:"local" json:"local,omitempty"`
+}
+
+type LocalProvisionerConfig struct {
+	BinaryPath string `mapstructure:"binaryPath" json:"binaryPath,omitempty"`
 }
 
 type RunnerConfig struct {
 	shared.Config
+
+	ProvisionerMechanism string
 
 	DefaultProvisioner provisioner.Provisioner
 }
 
 func BindAllRunnerEnv(v *viper.Viper) {
 	v.BindEnv("provisioner.kind", "RUNNER_WORKER_PROVISIONER_KIND")
+	v.BindEnv("provisioner.local.binaryPath", "RUNNER_WORKER_PROVISIONER_LOCAL_BINARY_PATH")
+
 	v.BindEnv("grpcServerAddress", "RUNNER_WORKER_GRPC_SERVER_ADDRESS")
 }

--- a/internal/provisioner/local/provisioner.go
+++ b/internal/provisioner/local/provisioner.go
@@ -9,10 +9,15 @@ import (
 )
 
 type LocalProvisioner struct {
+	binaryPath string
 }
 
-func NewLocalProvisioner() *LocalProvisioner {
-	return &LocalProvisioner{}
+type LocalProvisionerOpts struct {
+	BinaryPath string
+}
+
+func NewLocalProvisioner(opts *LocalProvisionerOpts) *LocalProvisioner {
+	return &LocalProvisioner{opts.BinaryPath}
 }
 
 func (l *LocalProvisioner) RunPlan(opts *provisioner.ProvisionOpts) error {
@@ -125,7 +130,7 @@ func (l *LocalProvisioner) RunAfterApplyMonitor(opts *provisioner.ProvisionOpts,
 
 func (l *LocalProvisioner) getRunFunc(opts *provisioner.ProvisionOpts, arg string) func() error {
 	return func() error {
-		cmdProv := exec.Command("./bin/hatchet-runner", arg)
+		cmdProv := exec.Command(l.binaryPath, arg)
 		cmdProv.Stdout = os.Stdout
 		cmdProv.Stderr = os.Stderr
 
@@ -148,7 +153,7 @@ func (l *LocalProvisioner) getRunFunc(opts *provisioner.ProvisionOpts, arg strin
 
 func (l *LocalProvisioner) getMonitorFunc(opts *provisioner.ProvisionOpts, monitorID string, policy []byte, arg string) func() error {
 	return func() error {
-		cmdProv := exec.Command("./bin/hatchet-runner", "monitor", arg)
+		cmdProv := exec.Command(l.binaryPath, "monitor", arg)
 		cmdProv.Stdout = os.Stdout
 		cmdProv.Stderr = os.Stderr
 		env := opts.Env

--- a/internal/temporal/client.go
+++ b/internal/temporal/client.go
@@ -148,6 +148,10 @@ func (c *Client) GetClient(queueName string) (client.Client, error) {
 	return tc, nil
 }
 
+func (c *Client) GetOpts() *ClientOpts {
+	return c.opts
+}
+
 func (c *Client) GetBroadcastAddress() string {
 	return c.opts.BroadcastAddress
 }


### PR DESCRIPTION
- [X] Adds a centralized deployment option that can deploy across all Hatchet teams
- [X] Adds binary path to `runner-worker` local provisioner