### PR TITLE
Add centralized/decentralized options for main server

### DIFF
--- a/cmd/hatchet-runner-worker/main.go
+++ b/cmd/hatchet-runner-worker/main.go
@@ -3,15 +3,9 @@ package main
 import (
 	"fmt"
 	"os"
-	"sync"
-	"time"
 
 	"github.com/hatchet-dev/hatchet/cmd/cmdutils"
-	"github.com/hatchet-dev/hatchet/internal/config/database"
 	"github.com/hatchet-dev/hatchet/internal/config/loader"
-	workerconfig "github.com/hatchet-dev/hatchet/internal/config/worker"
-	"github.com/hatchet-dev/hatchet/internal/models"
-	"github.com/hatchet-dev/hatchet/internal/temporal"
 	"github.com/hatchet-dev/hatchet/internal/temporal/worker"
 	"github.com/spf13/cobra"
 )
@@ -41,6 +35,8 @@ var rootCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		interruptChan := cmdutils.InterruptChan()
+
 		// if this is a centralized mechanism, load a database connection
 		if rwc.ProvisionerMechanism == "centralized" {
 			dc, err := configLoader.LoadDatabaseConfig()
@@ -50,9 +46,14 @@ var rootCmd = &cobra.Command{
 				os.Exit(1)
 			}
 
-			startWorkerCentralized(rwc, dc)
+			err = worker.StartRunnerWorkerCentralized(rwc, dc, interruptChan, true)
 		} else {
-			startWorkerDecentralized(rwc)
+			err = worker.StartRunnerWorkerDecentralized(rwc, interruptChan, true)
+		}
+
+		if err != nil {
+			fmt.Printf("Fatal: error running worker: %v\n", err)
+			os.Exit(1)
 		}
 	},
 }
@@ -74,82 +75,6 @@ func main() {
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
-		os.Exit(1)
-	}
-}
-
-type teams struct {
-	teams map[string]string
-
-	mu sync.Mutex
-}
-
-func startWorkerCentralized(rwc *workerconfig.RunnerConfig, dc *database.Config) {
-	interruptChan := cmdutils.InterruptChan()
-
-	ts := &teams{
-		teams: map[string]string{},
-	}
-
-	// spawn a go process that lists teams in the database periodically
-	ticker := time.NewTicker(15 * time.Second)
-
-	for {
-		select {
-		case <-interruptChan:
-			return
-		case <-ticker.C:
-			var teams []*models.Team
-
-			if err := dc.GormDB.Find(&teams).Error; err != nil {
-				fmt.Printf("Fatal: could not list teams: %v\n", err)
-				os.Exit(1)
-			}
-
-			for _, team := range teams {
-				if _, exists := ts.teams[team.ID]; !exists {
-					ts.mu.Lock()
-					ts.teams[team.ID] = team.ID
-					ts.mu.Unlock()
-
-					fmt.Printf("adding new runner worker for team %s\n", team.ID)
-
-					_rwc := *rwc
-					var err error
-
-					newOpts := rwc.TemporalClient.GetOpts()
-
-					newOpts.Namespace = team.ID
-
-					_rwc.TemporalClient, err = temporal.NewTemporalClient(newOpts)
-
-					if err != nil {
-						fmt.Printf("Fatal: could not create new temporal client: %v\n", err)
-						os.Exit(1)
-					}
-
-					// create a new runner worker
-					err = worker.StartRunnerWorker(&_rwc, false, interruptChan)
-
-					if err != nil {
-						fmt.Printf("Fatal: could not start runner worker: %v\n", err)
-						os.Exit(1)
-					}
-
-					fmt.Printf("successfully added new runner worker for team %s\n", team.ID)
-				}
-			}
-		}
-	}
-}
-
-func startWorkerDecentralized(rwc *workerconfig.RunnerConfig) {
-	interruptChan := cmdutils.InterruptChan()
-
-	err := worker.StartRunnerWorker(rwc, true, interruptChan)
-
-	if err != nil {
-		fmt.Printf("Fatal: could not start worker: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/hatchet-server/main.go
+++ b/cmd/hatchet-server/main.go
@@ -176,7 +176,18 @@ func startRunnerWorkerOrDie(configLoader *loader.ConfigLoader, interruptCh <-cha
 		os.Exit(1)
 	}
 
-	err = worker.StartRunnerWorker(rwc, false, interruptCh)
+	if rwc.ProvisionerMechanism == "centralized" {
+		dc, err := configLoader.LoadDatabaseConfig()
+
+		if err != nil {
+			fmt.Printf("Fatal: could not load database config: %v\n", err)
+			os.Exit(1)
+		}
+
+		err = worker.StartRunnerWorkerCentralized(rwc, dc, interruptCh, false)
+	} else {
+		err = worker.StartRunnerWorkerDecentralized(rwc, interruptCh, false)
+	}
 
 	if err != nil {
 		fmt.Fprintf(os.Stdout, "Fatal: could not start worker: %v\n", err)

--- a/internal/temporal/worker/worker.go
+++ b/internal/temporal/worker/worker.go
@@ -2,7 +2,6 @@ package worker
 
 import (
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
@@ -105,16 +104,14 @@ func StartRunnerWorkerCentralized(rwc *workerconfig.RunnerConfig, dc *database.C
 						_rwc.TemporalClient, err = temporal.NewTemporalClient(newOpts)
 
 						if err != nil {
-							fmt.Printf("Fatal: could not create new temporal client: %v\n", err)
-							os.Exit(1)
+							return fmt.Errorf("Fatal: could not create new temporal client: %v\n", err)
 						}
 
 						// create a new runner worker
 						err = startRunnerWorker(&_rwc, false, interruptChan)
 
 						if err != nil {
-							fmt.Printf("Fatal: could not start runner worker: %v\n", err)
-							os.Exit(1)
+							return fmt.Errorf("Fatal: could not start runner worker: %v\n", err)
 						}
 
 						fmt.Printf("successfully added new runner worker for team %s\n", team.ID)

--- a/internal/temporal/worker/worker.go
+++ b/internal/temporal/worker/worker.go
@@ -1,6 +1,13 @@
 package worker
 
 import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/internal/models"
+	"github.com/hatchet-dev/hatchet/internal/temporal"
 	"github.com/hatchet-dev/hatchet/internal/temporal/enums"
 	"github.com/hatchet-dev/hatchet/internal/temporal/workflows/logflusher"
 	"github.com/hatchet-dev/hatchet/internal/temporal/workflows/modulequeuechecker"
@@ -10,7 +17,9 @@ import (
 	"github.com/hatchet-dev/hatchet/internal/temporal/workflows/queuechecker"
 	"go.temporal.io/sdk/worker"
 
+	"github.com/hatchet-dev/hatchet/internal/config/database"
 	hatchetworker "github.com/hatchet-dev/hatchet/internal/config/worker"
+	workerconfig "github.com/hatchet-dev/hatchet/internal/config/worker"
 )
 
 func StartBackgroundWorker(config *hatchetworker.BackgroundConfig, interruptCh <-chan interface{}) error {
@@ -51,7 +60,103 @@ func StartBackgroundWorker(config *hatchetworker.BackgroundConfig, interruptCh <
 	return backgroundWorker.Start()
 }
 
-func StartRunnerWorker(config *hatchetworker.RunnerConfig, blocking bool, interruptCh <-chan interface{}) error {
+type teams struct {
+	teams map[string]string
+
+	mu sync.Mutex
+}
+
+func StartRunnerWorkerCentralized(rwc *workerconfig.RunnerConfig, dc *database.Config, interruptChan <-chan interface{}, blocking bool) error {
+	ts := &teams{
+		teams: map[string]string{},
+	}
+
+	// spawn a go process that lists teams in the database periodically
+	ticker := time.NewTicker(15 * time.Second)
+
+	runFunc := func() error {
+		for {
+			select {
+			case <-interruptChan:
+				return nil
+			case <-ticker.C:
+				var teams []*models.Team
+
+				if err := dc.GormDB.Find(&teams).Error; err != nil {
+					fmt.Printf("Fatal: could not list teams: %v\n", err)
+					return err
+				}
+
+				for _, team := range teams {
+					if _, exists := ts.teams[team.ID]; !exists {
+						ts.mu.Lock()
+						ts.teams[team.ID] = team.ID
+						ts.mu.Unlock()
+
+						fmt.Printf("adding new runner worker for team %s\n", team.ID)
+
+						_rwc := *rwc
+						var err error
+
+						newOpts := rwc.TemporalClient.GetOpts()
+
+						newOpts.Namespace = team.ID
+
+						_rwc.TemporalClient, err = temporal.NewTemporalClient(newOpts)
+
+						if err != nil {
+							fmt.Printf("Fatal: could not create new temporal client: %v\n", err)
+							os.Exit(1)
+						}
+
+						// create a new runner worker
+						err = startRunnerWorker(&_rwc, false, interruptChan)
+
+						if err != nil {
+							fmt.Printf("Fatal: could not start runner worker: %v\n", err)
+							os.Exit(1)
+						}
+
+						fmt.Printf("successfully added new runner worker for team %s\n", team.ID)
+					}
+				}
+			}
+		}
+
+	}
+
+	if blocking {
+		return runFunc()
+	} else {
+		go runFunc()
+	}
+
+	return nil
+
+}
+
+func StartRunnerWorkerDecentralized(rwc *workerconfig.RunnerConfig, interruptChan <-chan interface{}, blocking bool) error {
+	runFunc := func() error {
+		err := startRunnerWorker(rwc, true, interruptChan)
+
+		if err != nil {
+			fmt.Printf("Fatal: could not start worker: %v\n", err)
+			return err
+		}
+
+		return nil
+	}
+
+	if blocking {
+		return runFunc()
+	} else {
+		go runFunc()
+	}
+
+	return nil
+}
+
+func startRunnerWorker(config *hatchetworker.RunnerConfig, blocking bool, interruptChan <-chan interface{}) error {
 	tc, err := config.TemporalClient.GetClient(enums.ModuleRunQueueName)
 
 	if err != nil {
@@ -70,11 +175,11 @@ func StartRunnerWorker(config *hatchetworker.RunnerConfig, blocking bool, interr
 	runnerWorker.RegisterActivity(mr.Monitor)
 
 	if blocking {
-		return runnerWorker.Run(interruptCh)
+		return runnerWorker.Run(interruptChan)
 	}
 
 	go func() {
-		<-interruptCh
+		<-interruptChan
 		runnerWorker.Stop()
 	}()
 


### PR DESCRIPTION
- Adds the `centralized` vs `decentralized` runtime options for the primary Hatchet instance

## Details

When the `runner-worker` process runs in `centralized` mode, it continuously lists teams on the Hatchet server and spawns a new process to handle provisioning for that team. Otherwise, each `runner-worker` process listens to events for a single team. 

Previously only the `runner-worker` process supports both options, while the main Hatchet server supported only the decentralized approach when running in single-binary mode. This PR adds both options to the main server as well. 