### PR TITLE
chore(contributing): adapt deps, hardcode generator versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,6 @@
 - [`Taskfile`](https://taskfile.dev/installation/)
 - The following additional devtools:
   - `protoc`: `brew install protobuf`
-  - `sqlc`: `brew install sqlc`
   - `caddy` and `nss`: `brew install caddy nss`
 
 ### Setup

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -59,7 +59,7 @@ tasks:
   generate-sqlc:
     cmds:
       - npx --yes prisma migrate diff --from-empty --to-schema-datasource prisma/schema.prisma --script > internal/repository/prisma/dbsqlc/schema.sql
-      - sqlc generate --file internal/repository/prisma/dbsqlc/sqlc.yaml
+      - go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.24.0 generate --file internal/repository/prisma/dbsqlc/sqlc.yaml
   kill-query-engines:
     cmds:
       - ps -A | grep 'prisma-query-engine-darwin-arm64' | grep -v grep | awk '{print $1}' | xargs kill -9 $1

--- a/hack/oas/generate-server.sh
+++ b/hack/oas/generate-server.sh
@@ -3,4 +3,4 @@
 set -eux
 
 npx --yes swagger-cli bundle ./api-contracts/openapi/openapi.yaml --outfile bin/oas/openapi.yaml --type yaml
-go run github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen@latest -config ./api/v1/server/oas/gen/codegen.yaml ./bin/oas/openapi.yaml
+go run github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen@v2.0.0 -config ./api/v1/server/oas/gen/codegen.yaml ./bin/oas/openapi.yaml


### PR DESCRIPTION
- remove sqlc brew dependency and use go install instead
- use hardcoded oapi-codegen version