### PR TITLE
feat: add scheduling timeout (non-configurable)

### DIFF
--- a/cmd/hatchet-admin/cli/seed.go
+++ b/cmd/hatchet-admin/cli/seed.go
@@ -23,7 +23,7 @@ var seedCmd = &cobra.Command{
 		err = runSeed(configLoader)
 
 		if err != nil {
-			fmt.Printf("Fatal: could not load server config: %v\n", err)
+			fmt.Printf("Fatal: could not run seed command: %v\n", err)
 			os.Exit(1)
 		}
 	},
@@ -134,8 +134,7 @@ func seedDev(repo repository.Repository, tenantId string) error {
 
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
-
-			_, err := repo.Workflow().CreateNewWorkflow(tenantId, &repository.CreateWorkflowVersionOpts{
+			workflowVersion, err := repo.Workflow().CreateNewWorkflow(tenantId, &repository.CreateWorkflowVersionOpts{
 				Name:        "test-workflow",
 				Description: repository.StringPtr("This is a test workflow."),
 				Version:     "v0.1.0",
@@ -175,10 +174,12 @@ func seedDev(repo repository.Repository, tenantId string) error {
 				return err
 			}
 
-			fmt.Println("created workflow", workflow.ID, workflow.Name)
-		}
+			workflow = workflowVersion.Workflow()
 
-		return err
+			fmt.Println("created workflow", workflow.ID, workflow.Name)
+		} else {
+			return err
+		}
 	}
 
 	return nil

--- a/examples/schedule-timeout/.hatchet/schedule-timeout-workflow.yaml
+++ b/examples/schedule-timeout/.hatchet/schedule-timeout-workflow.yaml
@@ -1,0 +1,10 @@
+name: "test-schedule-timeout"
+version: v0.1.0
+triggers:
+  events:
+    - user:create
+jobs:
+  timeout-job:
+    steps:
+      - id: timeout
+        action: timeout:timeout

--- a/examples/schedule-timeout/main.go
+++ b/examples/schedule-timeout/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/pkg/client"
+)
+
+type sampleEvent struct{}
+
+type timeoutInput struct{}
+
+func main() {
+	client, err := client.New(
+		client.InitWorkflows(),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	event := sampleEvent{}
+
+	// push an event
+	err = client.Event().Push(
+		context.Background(),
+		"user:create",
+		event,
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	time.Sleep(35 * time.Second)
+
+	fmt.Println("step should have timed out")
+}

--- a/examples/timeout/main.go
+++ b/examples/timeout/main.go
@@ -37,7 +37,7 @@ func main() {
 
 	err = worker.RegisterAction("timeout:timeout", func(ctx context.Context, input *timeoutInput) (result any, err error) {
 		// wait for context done signal
-		timeStart := time.Now()
+		timeStart := time.Now().UTC()
 		<-ctx.Done()
 		fmt.Println("context cancelled in ", time.Since(timeStart).Seconds(), " seconds")
 

--- a/frontend/app/src/pages/main/workflow-runs/$run/index.tsx
+++ b/frontend/app/src/pages/main/workflow-runs/$run/index.tsx
@@ -261,6 +261,9 @@ function StepStatusSection({ stepRun }: { stepRun: StepRun }) {
             stepRun.step?.timeout || '60s'
           }`;
           break;
+        case 'SCHEDULING_TIMED_OUT':
+          statusText = `This step was cancelled because no workers were available to run ${stepRun.step?.action}`;
+          break;
         case 'PREVIOUS_STEP_TIMED_OUT':
           statusText = `This step was cancelled because the previous step timed out`;
           break;

--- a/frontend/app/src/pages/main/workflow-runs/components/run-statuses.tsx
+++ b/frontend/app/src/pages/main/workflow-runs/components/run-statuses.tsx
@@ -28,6 +28,9 @@ export function RunStatus({
         case 'TIMED_OUT':
           text = 'Timed out';
           break;
+        case 'SCHEDULING_TIMED_OUT':
+          text = 'No workers available';
+          break;
         default:
           break;
       }

--- a/internal/auth/cookie/sessionstore.go
+++ b/internal/auth/cookie/sessionstore.go
@@ -223,11 +223,11 @@ func (store *UserSessionStore) save(session *sessions.Session) error {
 	var expiresOn time.Time
 
 	if exOn == nil {
-		expiresOn = time.Now().Add(time.Second * time.Duration(session.Options.MaxAge))
+		expiresOn = time.Now().UTC().Add(time.Second * time.Duration(session.Options.MaxAge))
 	} else {
 		expiresOn = exOn.(time.Time)
-		if expiresOn.Sub(time.Now().Add(time.Second*time.Duration(session.Options.MaxAge))) < 0 {
-			expiresOn = time.Now().Add(time.Second * time.Duration(session.Options.MaxAge))
+		if expiresOn.Sub(time.Now().UTC().Add(time.Second*time.Duration(session.Options.MaxAge))) < 0 {
+			expiresOn = time.Now().UTC().Add(time.Second * time.Duration(session.Options.MaxAge))
 		}
 	}
 

--- a/internal/repository/prisma/dbsqlc/models.go
+++ b/internal/repository/prisma/dbsqlc/models.go
@@ -65,7 +65,7 @@ const (
 	StepRunStatusRUNNING           StepRunStatus = "RUNNING"
 	StepRunStatusSUCCEEDED         StepRunStatus = "SUCCEEDED"
 	StepRunStatusFAILED            StepRunStatus = "FAILED"
-	StepRunStatusCancelled         StepRunStatus = "CANCELLED"
+	StepRunStatusCANCELLED         StepRunStatus = "CANCELLED"
 )
 
 func (e *StepRunStatus) Scan(src interface{}) error {
@@ -318,28 +318,29 @@ type Step struct {
 }
 
 type StepRun struct {
-	ID              pgtype.UUID      `json:"id"`
-	CreatedAt       pgtype.Timestamp `json:"createdAt"`
-	UpdatedAt       pgtype.Timestamp `json:"updatedAt"`
-	DeletedAt       pgtype.Timestamp `json:"deletedAt"`
-	TenantId        pgtype.UUID      `json:"tenantId"`
-	JobRunId        pgtype.UUID      `json:"jobRunId"`
-	StepId          pgtype.UUID      `json:"stepId"`
-	NextId          pgtype.UUID      `json:"nextId"`
-	Order           int16            `json:"order"`
-	WorkerId        pgtype.UUID      `json:"workerId"`
-	TickerId        pgtype.UUID      `json:"tickerId"`
-	Status          StepRunStatus    `json:"status"`
-	Input           []byte           `json:"input"`
-	Output          []byte           `json:"output"`
-	RequeueAfter    pgtype.Timestamp `json:"requeueAfter"`
-	Error           pgtype.Text      `json:"error"`
-	StartedAt       pgtype.Timestamp `json:"startedAt"`
-	FinishedAt      pgtype.Timestamp `json:"finishedAt"`
-	TimeoutAt       pgtype.Timestamp `json:"timeoutAt"`
-	CancelledAt     pgtype.Timestamp `json:"cancelledAt"`
-	CancelledReason pgtype.Text      `json:"cancelledReason"`
-	CancelledError  pgtype.Text      `json:"cancelledError"`
+	ID                pgtype.UUID      `json:"id"`
+	CreatedAt         pgtype.Timestamp `json:"createdAt"`
+	UpdatedAt         pgtype.Timestamp `json:"updatedAt"`
+	DeletedAt         pgtype.Timestamp `json:"deletedAt"`
+	TenantId          pgtype.UUID      `json:"tenantId"`
+	JobRunId          pgtype.UUID      `json:"jobRunId"`
+	StepId            pgtype.UUID      `json:"stepId"`
+	NextId            pgtype.UUID      `json:"nextId"`
+	Order             int16            `json:"order"`
+	WorkerId          pgtype.UUID      `json:"workerId"`
+	TickerId          pgtype.UUID      `json:"tickerId"`
+	Status            StepRunStatus    `json:"status"`
+	Input             []byte           `json:"input"`
+	Output            []byte           `json:"output"`
+	RequeueAfter      pgtype.Timestamp `json:"requeueAfter"`
+	ScheduleTimeoutAt pgtype.Timestamp `json:"scheduleTimeoutAt"`
+	Error             pgtype.Text      `json:"error"`
+	StartedAt         pgtype.Timestamp `json:"startedAt"`
+	FinishedAt        pgtype.Timestamp `json:"finishedAt"`
+	TimeoutAt         pgtype.Timestamp `json:"timeoutAt"`
+	CancelledAt       pgtype.Timestamp `json:"cancelledAt"`
+	CancelledReason   pgtype.Text      `json:"cancelledReason"`
+	CancelledError    pgtype.Text      `json:"cancelledError"`
 }
 
 type Tenant struct {

--- a/internal/repository/prisma/dbsqlc/schema.sql
+++ b/internal/repository/prisma/dbsqlc/schema.sql
@@ -131,6 +131,7 @@ CREATE TABLE "StepRun" (
     "input" JSONB,
     "output" JSONB,
     "requeueAfter" TIMESTAMP(3),
+    "scheduleTimeoutAt" TIMESTAMP(3),
     "error" TEXT,
     "startedAt" TIMESTAMP(3),
     "finishedAt" TIMESTAMP(3),

--- a/internal/repository/prisma/dbsqlc/step_runs.sql
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql
@@ -3,9 +3,14 @@ UPDATE
     "StepRun"
 SET
     "requeueAfter" = COALESCE(sqlc.narg('requeueAfter')::timestamp, "requeueAfter"),
+    "scheduleTimeoutAt" = COALESCE(sqlc.narg('scheduleTimeoutAt')::timestamp, "scheduleTimeoutAt"),
     "startedAt" = COALESCE(sqlc.narg('startedAt')::timestamp, "startedAt"),
     "finishedAt" = COALESCE(sqlc.narg('finishedAt')::timestamp, "finishedAt"),
-    "status" = COALESCE(sqlc.narg('status'), "status"),
+    "status" = CASE 
+        -- Final states are final, cannot be updated
+        WHEN "status" IN ('SUCCEEDED', 'FAILED', 'CANCELLED') THEN "status"
+        ELSE COALESCE(sqlc.narg('status'), "status")
+    END,
     "input" = COALESCE(sqlc.narg('input')::jsonb, "input"),
     "output" = COALESCE(sqlc.narg('output')::jsonb, "output"),
     "error" = COALESCE(sqlc.narg('error')::text, "error"),

--- a/internal/repository/prisma/step_run.go
+++ b/internal/repository/prisma/step_run.go
@@ -77,7 +77,7 @@ func (j *stepRunRepository) ListStepRuns(tenantId string, opts *repository.ListS
 		// and their previous step is completed
 		params = append(
 			params,
-			db.StepRun.RequeueAfter.Before(time.Now()),
+			db.StepRun.RequeueAfter.Before(time.Now().UTC()),
 			db.StepRun.WorkerID.IsNull(),
 			db.StepRun.Status.Equals(db.StepRunStatusPendingAssignment),
 			// db.StepRun.Or(
@@ -139,6 +139,10 @@ func (j *stepRunRepository) UpdateStepRun(tenantId, stepRunId string, opts *repo
 
 	if opts.RequeueAfter != nil {
 		updateParams.RequeueAfter = sqlchelpers.TimestampFromTime(opts.RequeueAfter)
+	}
+
+	if opts.ScheduleTimeoutAt != nil {
+		updateParams.ScheduleTimeoutAt = sqlchelpers.TimestampFromTime(opts.ScheduleTimeoutAt)
 	}
 
 	if opts.StartedAt != nil {
@@ -301,7 +305,7 @@ func (j *stepRunRepository) CancelPendingStepRuns(tenantId, jobRunId, reason str
 		db.StepRun.Status.Equals(db.StepRunStatusPending),
 	).Update(
 		db.StepRun.Status.Set(db.StepRunStatusCancelled),
-		db.StepRun.CancelledAt.Set(time.Now()),
+		db.StepRun.CancelledAt.Set(time.Now().UTC()),
 		db.StepRun.CancelledReason.Set(reason),
 	).Exec(context.Background())
 

--- a/internal/repository/prisma/ticker.go
+++ b/internal/repository/prisma/ticker.go
@@ -24,7 +24,7 @@ func NewTickerRepository(client *db.PrismaClient, v validator.Validator) reposit
 func (t *tickerRepository) CreateNewTicker(opts *repository.CreateTickerOpts) (*db.TickerModel, error) {
 	return t.client.Ticker.CreateOne(
 		db.Ticker.ID.Set(opts.ID),
-		db.Ticker.LastHeartbeatAt.Set(time.Now()),
+		db.Ticker.LastHeartbeatAt.Set(time.Now().UTC()),
 	).Exec(context.Background())
 }
 

--- a/internal/repository/prisma/workflow_run.go
+++ b/internal/repository/prisma/workflow_run.go
@@ -168,7 +168,7 @@ func (w *workflowRunRepository) CreateNewWorkflowRun(tenantId string, opts *repo
 	for _, jobOpts := range opts.JobRuns {
 		jobRunId := uuid.New().String()
 
-		requeueAfter := time.Now().Add(5 * time.Second)
+		requeueAfter := time.Now().UTC().Add(5 * time.Second)
 
 		if jobOpts.RequeueAfter != nil {
 			requeueAfter = *jobOpts.RequeueAfter

--- a/internal/repository/step_run.go
+++ b/internal/repository/step_run.go
@@ -26,6 +26,8 @@ type ListStepRunsOpts struct {
 type UpdateStepRunOpts struct {
 	RequeueAfter *time.Time
 
+	ScheduleTimeoutAt *time.Time
+
 	Status *db.StepRunStatus
 
 	StartedAt *time.Time

--- a/internal/services/admin/server.go
+++ b/internal/services/admin/server.go
@@ -97,7 +97,7 @@ func (a *AdminServiceImpl) PutWorkflow(ctx context.Context, req *contracts.PutWo
 	}
 
 	if crons := triggers.Crons(); len(crons) > 0 {
-		within := time.Now().Add(-6 * time.Second)
+		within := time.Now().UTC().Add(-6 * time.Second)
 
 		tickers, err := a.repo.Ticker().ListTickers(&repository.ListTickerOpts{
 			LatestHeartbeatAt: &within,

--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -261,7 +261,7 @@ func (d *DispatcherImpl) runUpdateHeartbeat(ctx context.Context) func() {
 	return func() {
 		d.l.Debug().Msgf("dispatcher: updating heartbeat")
 
-		now := time.Now()
+		now := time.Now().UTC()
 
 		// update the heartbeat
 		_, err := d.repo.Dispatcher().UpdateDispatcher(d.dispatcherId, &repository.UpdateDispatcherOpts{

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -147,7 +147,7 @@ func (s *DispatcherImpl) Listen(request *contracts.WorkerListenRequest, stream c
 	// update the worker with a last heartbeat time every 5 seconds as long as the worker is connected
 	go func() {
 		timer := time.NewTicker(100 * time.Millisecond)
-		lastHeartbeat := time.Now()
+		lastHeartbeat := time.Now().UTC()
 		defer timer.Stop()
 
 		for {
@@ -156,7 +156,7 @@ func (s *DispatcherImpl) Listen(request *contracts.WorkerListenRequest, stream c
 				s.l.Debug().Msgf("worker id %s has disconnected", request.WorkerId)
 				return
 			case <-timer.C:
-				if now := time.Now(); lastHeartbeat.Add(5 * time.Second).Before(now) {
+				if now := time.Now().UTC(); lastHeartbeat.Add(5 * time.Second).Before(now) {
 					s.l.Debug().Msgf("updating worker %s heartbeat", request.WorkerId)
 
 					_, err := s.repo.Worker().UpdateWorker(request.TenantId, request.WorkerId, &repository.UpdateWorkerOpts{
@@ -168,7 +168,7 @@ func (s *DispatcherImpl) Listen(request *contracts.WorkerListenRequest, stream c
 						return
 					}
 
-					lastHeartbeat = time.Now()
+					lastHeartbeat = time.Now().UTC()
 				}
 			}
 		}

--- a/internal/services/ticker/ticker.go
+++ b/internal/services/ticker/ticker.go
@@ -231,7 +231,7 @@ func (t *TickerImpl) runUpdateHeartbeat(ctx context.Context) func() {
 	return func() {
 		t.l.Debug().Msgf("ticker: updating heartbeat")
 
-		now := time.Now()
+		now := time.Now().UTC()
 
 		// update the heartbeat
 		_, err := t.repo.Ticker().UpdateTicker(t.tickerId, &repository.UpdateTickerOpts{

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -335,7 +335,7 @@ func (w *Worker) cancelStepRun(ctx context.Context, assignedAction *client.Actio
 }
 
 func (w *Worker) getActionEvent(action *client.Action, eventType client.ActionEventType) *client.ActionEvent {
-	timestamp := time.Now()
+	timestamp := time.Now().UTC()
 
 	return &client.ActionEvent{
 		Action:         action,

--- a/prisma/migrations/20231222174753_init/migration.sql
+++ b/prisma/migrations/20231222174753_init/migration.sql
@@ -270,6 +270,7 @@ CREATE TABLE "StepRun" (
     "input" JSONB,
     "output" JSONB,
     "requeueAfter" TIMESTAMP(3),
+    "scheduleTimeoutAt" TIMESTAMP(3),
     "error" TEXT,
     "startedAt" TIMESTAMP(3),
     "finishedAt" TIMESTAMP(3),

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -576,6 +576,9 @@ model StepRun {
     // when the step should be requeued
     requeueAfter DateTime?
 
+    // when the step run times out due to a scheduling timeout (no workers available)
+    scheduleTimeoutAt DateTime?
+
     // the run error
     error String?
 


### PR DESCRIPTION
Addresses #10 and #11

Adds a non-configurable scheduling timeout of 30 seconds. This can be made configurable in the step declaration eventually. 

A quick note on active versus passive scheduling: 
- Active scheduling runs a timer which schedules time outs precisely using a context deadline or the cron library (this is active because it is "always on"). It is performed by the `ticker` service. This service currently handles job run timeouts and step run timeouts, but does not handle requeueing or scheduling timeouts. 
- Passive scheduling queries values in the database at some configurable interval, and runs an idempotent query against the database to update the state of a job run or step run if it detects that the job or step runs are past a certain timeout. 

The proper way to do this is to schedule _all_ timeouts with the ticker for active listening, and passively query _all_ timeouts as a fallback if a ticker goes down. The passive interval sets the error boundaries on the timing - for example, +5 seconds for requeueing timeouts. This means that if a ticker unexpectedly fails or goes down, the passive scheduler can still cancel jobs and step runs within the error boundary. Smaller error boundaries mean more database load. 

A future PR will make all timeouts both passive and active, but at the moment requeueing and scheduling timeouts are passive while job run and step run timeouts are active. 