### PR TITLE
chore(eslint): turn off react-refresh/only-export-components

### DIFF
--- a/frontend/app/.eslintrc.json
+++ b/frontend/app/.eslintrc.json
@@ -35,12 +35,7 @@
     "@typescript-eslint/no-use-before-define": "off",
     "import/extensions": "off",
     "react/react-in-jsx-scope": "off",
-    "react-refresh/only-export-components": [
-      "warn",
-      {
-        "allowConstantExport": true
-      }
-    ],
+    "react-refresh/only-export-components": "off",
     "unused-imports/no-unused-imports": "error",
     "no-unused-vars": "off",
     "prettier/prettier": "error",


### PR DESCRIPTION
seems to be a really minor issue and would need some internal refactors, I don't think it's worth to do

https://github.com/remix-run/react-router/discussions/10856

https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react#consistent-components-exports