### PR TITLE
chore(generate): use go:generate for prisma generation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
         run: go mod download
 
       - name: Generate
-        run: go run github.com/steebchen/prisma-client-go generate
+        run: go generate ./...
 
       - name: Test
         run: go test ./... -v -failfast

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -31,7 +31,7 @@ tasks:
   generate:
     cmds:
       - task: generate-api
-      - task: generate-prisma
+      - task: generate-go
       - task: generate-proto
       - task: generate-sqlc
   generate-api:
@@ -49,9 +49,9 @@ tasks:
     cmds:
       - sh ./hack/oas/generate-client.sh
     silent: true
-  generate-prisma:
+  generate-go:
     cmds:
-      - go run github.com/steebchen/prisma-client-go generate
+      - go generate ./...
   generate-proto:
     cmds:
       - sh ./hack/proto/proto.sh

--- a/build/package/servers.dockerfile
+++ b/build/package/servers.dockerfile
@@ -24,8 +24,7 @@ COPY /hack ./hack
 COPY /prisma ./prisma
 COPY /cmd ./cmd
 
-# generate the Prisma Client Go client
-RUN go run github.com/steebchen/prisma-client-go generate --generator go
+RUN go generate ./...
 
 # OpenAPI bundle environment
 # -------------------------

--- a/prisma/tools.go
+++ b/prisma/tools.go
@@ -1,0 +1,3 @@
+//go:generate go run github.com/steebchen/prisma-client-go generate
+
+package prisma


### PR DESCRIPTION
Simplifies the use of anything which needs to generated to `go generate ./...`. I just went with `tools.go` in the Prisma folder as I wasn't sure where else to put the `go:generate` annotation.