### PR TITLE
fix: reconnecting workers should get new dispatcher id

### DIFF
--- a/internal/repository/prisma/dbsqlc/tickers.sql
+++ b/internal/repository/prisma/dbsqlc/tickers.sql
@@ -1,12 +1,12 @@
--- name: ListStaleTickers :many
+-- name: ListNewlyStaleTickers :many
 SELECT
     sqlc.embed(tickers)
 FROM "Ticker" as tickers
 WHERE
     -- last heartbeat older than 15 seconds
     "lastHeartbeatAt" < NOW () - INTERVAL '15 seconds'
-    -- not active
-    AND "isActive" = false;
+    -- active
+    AND "isActive" = true;
 
 -- name: ListActiveTickers :many
 SELECT

--- a/internal/repository/prisma/dbsqlc/tickers.sql.go
+++ b/internal/repository/prisma/dbsqlc/tickers.sql.go
@@ -52,30 +52,30 @@ func (q *Queries) ListActiveTickers(ctx context.Context, db DBTX) ([]*ListActive
 	return items, nil
 }
 
-const listStaleTickers = `-- name: ListStaleTickers :many
+const listNewlyStaleTickers = `-- name: ListNewlyStaleTickers :many
 SELECT
     tickers.id, tickers."createdAt", tickers."updatedAt", tickers."lastHeartbeatAt", tickers."isActive"
 FROM "Ticker" as tickers
 WHERE
     -- last heartbeat older than 15 seconds
     "lastHeartbeatAt" < NOW () - INTERVAL '15 seconds'
-    -- not active
-    AND "isActive" = false
+    -- active
+    AND "isActive" = true
 `
 
-type ListStaleTickersRow struct {
+type ListNewlyStaleTickersRow struct {
 	Ticker Ticker `json:"ticker"`
 }
 
-func (q *Queries) ListStaleTickers(ctx context.Context, db DBTX) ([]*ListStaleTickersRow, error) {
-	rows, err := db.Query(ctx, listStaleTickers)
+func (q *Queries) ListNewlyStaleTickers(ctx context.Context, db DBTX) ([]*ListNewlyStaleTickersRow, error) {
+	rows, err := db.Query(ctx, listNewlyStaleTickers)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*ListStaleTickersRow
+	var items []*ListNewlyStaleTickersRow
 	for rows.Next() {
-		var i ListStaleTickersRow
+		var i ListNewlyStaleTickersRow
 		if err := rows.Scan(
 			&i.Ticker.ID,
 			&i.Ticker.CreatedAt,

--- a/internal/repository/prisma/ticker.go
+++ b/internal/repository/prisma/ticker.go
@@ -174,7 +174,7 @@ func (t *tickerRepository) UpdateStaleTickers(onStale func(tickerId string, getV
 
 	defer tx.Rollback(context.Background())
 
-	staleTickers, err := t.queries.ListStaleTickers(context.Background(), tx)
+	staleTickers, err := t.queries.ListNewlyStaleTickers(context.Background(), tx)
 
 	if err != nil {
 		return err

--- a/internal/repository/prisma/worker.go
+++ b/internal/repository/prisma/worker.go
@@ -255,6 +255,12 @@ func (w *workerRepository) UpdateWorker(tenantId, workerId string, opts *reposit
 		optionals = append(optionals, db.Worker.LastHeartbeatAt.Set(*opts.LastHeartbeatAt))
 	}
 
+	if opts.DispatcherId != nil {
+		optionals = append(optionals, db.Worker.Dispatcher.Link(
+			db.Dispatcher.ID.Equals(*opts.DispatcherId),
+		))
+	}
+
 	if len(opts.Actions) > 0 {
 		for _, action := range opts.Actions {
 			txs = append(txs, w.client.Action.UpsertOne(

--- a/internal/repository/worker.go
+++ b/internal/repository/worker.go
@@ -21,6 +21,9 @@ type CreateWorkerOpts struct {
 }
 
 type UpdateWorkerOpts struct {
+	// The id of the dispatcher
+	DispatcherId *string `validate:"omitempty,uuid"`
+
 	// The status of the worker
 	Status *db.WorkerStatus
 


### PR DESCRIPTION
- Assigns workers a new `dispatcherId` when they reconnect
- Also fixes a bug where tickers never get marked as inactive