### PR TITLE
fix: rabbitmq concurrent processing

### DIFF
--- a/examples/loadtest/emitter/main.go
+++ b/examples/loadtest/emitter/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/pkg/client"
+	"github.com/hatchet-dev/hatchet/pkg/cmdutils"
+	"github.com/joho/godotenv"
+)
+
+type Event struct {
+	ID        uint64    `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type stepOneOutput struct {
+	Message string `json:"message"`
+}
+
+func StepOne(ctx context.Context, input *Event) (result *stepOneOutput, err error) {
+	fmt.Println(input.ID, "delay", time.Since(input.CreatedAt))
+
+	return &stepOneOutput{
+		Message: "This ran at: " + time.Now().Format(time.RubyDate),
+	}, nil
+}
+
+func main() {
+	err := godotenv.Load()
+
+	if err != nil {
+		panic(err)
+	}
+
+	client, err := client.New()
+
+	if err != nil {
+		panic(err)
+	}
+
+	interruptCtx, cancel := cmdutils.InterruptContextFromChan(cmdutils.InterruptChan())
+	defer cancel()
+
+	var id uint64
+	go func() {
+		for {
+			select {
+			case <-time.After(5 * time.Second):
+				for i := 0; i < 100; i++ {
+					id++
+
+					ev := Event{CreatedAt: time.Now(), ID: id}
+					fmt.Println("pushed event", ev.ID)
+					err = client.Event().Push(interruptCtx, "test:event", ev)
+					if err != nil {
+						panic(err)
+					}
+				}
+			case <-interruptCtx.Done():
+				return
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-interruptCtx.Done():
+			return
+		default:
+			time.Sleep(time.Second)
+		}
+	}
+}

--- a/internal/repository/prisma/dbsqlc/job_runs.sql
+++ b/internal/repository/prisma/dbsqlc/job_runs.sql
@@ -39,8 +39,8 @@ END, "finishedAt" = CASE
 END, "startedAt" = CASE 
     -- Started at is final, cannot be changed
     WHEN "startedAt" IS NOT NULL THEN "startedAt"
-    -- If a step is running, then the job has started
-    WHEN s.runningRuns > 0 THEN NOW()
+    -- If steps are running (or have finished), then set the started at time
+    WHEN s.runningRuns > 0 OR s.succeededRuns > 0 OR s.failedRuns > 0 AND s.cancelledRuns > 0 THEN NOW()
     ELSE "startedAt"
 END
 FROM stepRuns s

--- a/internal/repository/prisma/dbsqlc/job_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/job_runs.sql.go
@@ -52,8 +52,8 @@ END, "finishedAt" = CASE
 END, "startedAt" = CASE 
     -- Started at is final, cannot be changed
     WHEN "startedAt" IS NOT NULL THEN "startedAt"
-    -- If a step is running, then the job has started
-    WHEN s.runningRuns > 0 THEN NOW()
+    -- If steps are running (or have finished), then set the started at time
+    WHEN s.runningRuns > 0 OR s.succeededRuns > 0 OR s.failedRuns > 0 AND s.cancelledRuns > 0 THEN NOW()
     ELSE "startedAt"
 END
 FROM stepRuns s

--- a/internal/repository/prisma/dbsqlc/workflow_runs.sql
+++ b/internal/repository/prisma/dbsqlc/workflow_runs.sql
@@ -96,8 +96,8 @@ END, "finishedAt" = CASE
 END, "startedAt" = CASE 
     -- Started at is final, cannot be changed
     WHEN "startedAt" IS NOT NULL THEN "startedAt"
-    -- If a job is running, then the workflow has started
-    WHEN j.runningRuns > 0 THEN NOW()
+    -- If a job is running or in a final state, then the workflow has started
+    WHEN j.runningRuns > 0 OR j.succeededRuns > 0 OR j.failedRuns > 0 OR j.cancelledRuns > 0 THEN NOW()
     ELSE "startedAt"
 END
 FROM

--- a/internal/repository/prisma/dbsqlc/workflow_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/workflow_runs.sql.go
@@ -211,8 +211,8 @@ END, "finishedAt" = CASE
 END, "startedAt" = CASE 
     -- Started at is final, cannot be changed
     WHEN "startedAt" IS NOT NULL THEN "startedAt"
-    -- If a job is running, then the workflow has started
-    WHEN j.runningRuns > 0 THEN NOW()
+    -- If a job is running or in a final state, then the workflow has started
+    WHEN j.runningRuns > 0 OR j.succeededRuns > 0 OR j.failedRuns > 0 OR j.cancelledRuns > 0 THEN NOW()
     ELSE "startedAt"
 END
 FROM

--- a/internal/services/admin/server.go
+++ b/internal/services/admin/server.go
@@ -275,7 +275,7 @@ func (a *AdminServiceImpl) PutWorkflow(ctx context.Context, req *contracts.PutWo
 						// remove cron
 						_, err = a.repo.Ticker().RemoveScheduledWorkflow(
 							ticker.ID,
-							&scheduleTrigger,
+							&scheduleTriggerCp,
 						)
 
 						if err != nil {

--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -168,11 +168,13 @@ func (d *DispatcherImpl) Start(ctx context.Context) error {
 
 			return err
 		case task := <-taskChan:
-			err = d.handleTask(ctx, task)
+			go func(task *taskqueue.Task) {
+				err = d.handleTask(ctx, task)
 
-			if err != nil {
-				d.l.Error().Err(err).Msgf("could not handle event task %s", task.ID)
-			}
+				if err != nil {
+					d.l.Error().Err(err).Msgf("could not handle event task %s", task.ID)
+				}
+			}(task)
 		}
 	}
 }

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -265,7 +265,7 @@ func (s *DispatcherImpl) handleStepRunStarted(ctx context.Context, request *cont
 }
 
 func (s *DispatcherImpl) handleStepRunCompleted(ctx context.Context, request *contracts.ActionEvent) (*contracts.ActionEventResponse, error) {
-	s.l.Debug().Msgf("Received step started event for step run %s", request.StepRunId)
+	s.l.Debug().Msgf("Received step completed event for step run %s", request.StepRunId)
 
 	finishedAt := request.EventTimestamp.AsTime()
 

--- a/internal/services/jobscontroller/controller.go
+++ b/internal/services/jobscontroller/controller.go
@@ -101,16 +101,18 @@ func (jc *JobsControllerImpl) Start(ctx context.Context) error {
 		return err
 	}
 
-	for {
-		select {
-		case task := <-taskChan:
+	// TODO: close when ctx is done
+	for task := range taskChan {
+		go func(task *taskqueue.Task) {
 			err = jc.handleTask(ctx, task)
 
 			if err != nil {
 				jc.l.Error().Err(err).Msg("could not handle job task")
 			}
-		}
+		}(task)
 	}
+
+	return nil
 }
 
 func (ec *JobsControllerImpl) handleTask(ctx context.Context, task *taskqueue.Task) error {

--- a/internal/services/ticker/step_run_timeout.go
+++ b/internal/services/ticker/step_run_timeout.go
@@ -73,7 +73,7 @@ func (t *TickerImpl) handleCancelStepRunTimeout(ctx context.Context, task *taskq
 	childTimeoutCtxVal, ok := t.stepRuns.Load(payload.StepRunId)
 
 	if !ok {
-		return fmt.Errorf("could not find step run %s", payload.StepRunId)
+		return nil
 	}
 
 	// cancel the timeout

--- a/internal/services/ticker/ticker.go
+++ b/internal/services/ticker/ticker.go
@@ -178,11 +178,13 @@ func (t *TickerImpl) Start(ctx context.Context) error {
 			// return err
 			return nil
 		case task := <-taskChan:
-			err = t.handleTask(ctx, task)
+			go func(task *taskqueue.Task) {
+				err = t.handleTask(ctx, task)
 
-			if err != nil {
-				t.l.Error().Err(err).Msgf("could not handle event task %s", task.ID)
-			}
+				if err != nil {
+					t.l.Error().Err(err).Msgf("could not handle event task %s", task.ID)
+				}
+			}(task)
 		}
 	}
 }


### PR DESCRIPTION
There were several issues with the previous implementation of the task queue - messages were sent and processed synchronously from RabbitMQ and the sent `msg` was using implicit memory aliasing which was causing some duplicate messages/dropped messages