### PR TITLE
feat: google sso

### DIFF
--- a/api-contracts/openapi/components/schemas/_index.yaml
+++ b/api-contracts/openapi/components/schemas/_index.yaml
@@ -1,3 +1,7 @@
+APIMeta:
+  $ref: "./metadata.yaml#/APIMeta"
+APIMetaAuth:
+  $ref: "./metadata.yaml#/APIMetaAuth"
 APIErrors:
   $ref: "./metadata.yaml#/APIErrors"
 APIError:

--- a/api-contracts/openapi/components/schemas/metadata.yaml
+++ b/api-contracts/openapi/components/schemas/metadata.yaml
@@ -1,3 +1,19 @@
+APIMeta:
+  type: object
+  properties:
+    auth:
+      $ref: "#/APIMetaAuth"
+APIMetaAuth:
+  type: object
+  properties:
+    schemes:
+      items:
+        type: string
+      type: array
+      description: the supported types of authentication
+      example:
+        - basic
+        - google
 APIError:
   type: object
   properties:

--- a/api-contracts/openapi/openapi.yaml
+++ b/api-contracts/openapi/openapi.yaml
@@ -20,8 +20,14 @@ components:
   schemas:
     $ref: "./components/schemas/_index.yaml"
 paths:
+  /api/v1/meta:
+    $ref: "./paths/metadata/metadata.yaml#/metadata"
   /api/v1/users/login:
     $ref: "./paths/user/user.yaml#/login"
+  /api/v1/users/google/start:
+    $ref: "./paths/user/user.yaml#/oauth-start-google"
+  /api/v1/users/google/callback:
+    $ref: "./paths/user/user.yaml#/oauth-callback-google"
   /api/v1/users/current:
     $ref: "./paths/user/user.yaml#/current"
   /api/v1/users/register:

--- a/api-contracts/openapi/paths/metadata/metadata.yaml
+++ b/api-contracts/openapi/paths/metadata/metadata.yaml
@@ -1,0 +1,21 @@
+metadata:
+  get:
+    description: Gets metadata for the Hatchet instance
+    operationId: metadata:get
+    responses:
+      "200":
+        content:
+          application/json:
+            schema:
+              $ref: "../../components/schemas/_index.yaml#/APIMeta"
+        description: Successfully retrieved the metadata
+      "400":
+        content:
+          application/json:
+            schema:
+              $ref: "../../components/schemas/_index.yaml#/APIErrors"
+        description: A malformed or bad request
+    security: []
+    summary: Get metadata
+    tags:
+      - Metadata

--- a/api-contracts/openapi/paths/user/user.yaml
+++ b/api-contracts/openapi/paths/user/user.yaml
@@ -108,6 +108,36 @@ register:
     summary: Register user
     tags:
       - User
+oauth-start-google:
+  get:
+    description: Starts the OAuth flow
+    operationId: user:update:oauth-start
+    responses:
+      "302":
+        description: Successfully started the OAuth flow
+        headers:
+          location:
+            schema:
+              type: string
+    security: []
+    summary: Start OAuth flow
+    tags:
+      - User
+oauth-callback-google:
+  get:
+    description: Completes the OAuth flow
+    operationId: user:update:oauth-callback
+    responses:
+      "302":
+        description: Successfully completed the OAuth flow
+        headers:
+          location:
+            schema:
+              type: string
+    security: []
+    summary: Complete OAuth flow
+    tags:
+      - User
 logout:
   post:
     description: Logs out a user.

--- a/api/v1/server/authn/middleware.go
+++ b/api/v1/server/authn/middleware.go
@@ -3,10 +3,11 @@ package authn
 import (
 	"net/http"
 
-	"github.com/hatchet-dev/hatchet/api/v1/server/middleware"
-	"github.com/hatchet-dev/hatchet/internal/config/server"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog"
+
+	"github.com/hatchet-dev/hatchet/api/v1/server/middleware"
+	"github.com/hatchet-dev/hatchet/internal/config/server"
 )
 
 type AuthN struct {
@@ -64,8 +65,6 @@ func (a *AuthN) authenticate(c echo.Context, r *middleware.RouteInfo) error {
 }
 
 func (a *AuthN) handleNoAuth(c echo.Context) error {
-	forbidden := echo.NewHTTPError(http.StatusForbidden, "Please provide valid credentials")
-
 	store := a.config.SessionStore
 
 	session, err := store.Get(c.Request(), store.GetName())
@@ -73,13 +72,13 @@ func (a *AuthN) handleNoAuth(c echo.Context) error {
 	if err != nil {
 		a.l.Debug().Err(err).Msg("error getting session")
 
-		return forbidden
+		return GetRedirectWithError(c, a.l, err, "Could not log in. Please try again and make sure cookies are enabled.")
 	}
 
 	if auth, ok := session.Values["authenticated"].(bool); ok && auth {
 		a.l.Debug().Msgf("user was authenticated when no security schemes permit auth")
 
-		return forbidden
+		return GetRedirectNoError(c, a.config.Runtime.ServerURL)
 	}
 
 	// set unauthenticated session in context

--- a/api/v1/server/authn/redirect.go
+++ b/api/v1/server/authn/redirect.go
@@ -1,0 +1,15 @@
+package authn
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog"
+)
+
+func GetRedirectWithError(ctx echo.Context, l *zerolog.Logger, internalErr error, userErr string) error {
+	l.Err(internalErr).Msgf("redirecting with error")
+	return ctx.Redirect(302, "/auth/login?error="+userErr)
+}
+
+func GetRedirectNoError(ctx echo.Context, serverURL string) error {
+	return ctx.Redirect(302, serverURL)
+}

--- a/api/v1/server/authn/session_helpers.go
+++ b/api/v1/server/authn/session_helpers.go
@@ -56,7 +56,7 @@ func (s *SessionHelpers) SaveUnauthenticated(c echo.Context) error {
 func (s *SessionHelpers) SaveOAuthState(
 	c echo.Context,
 ) (string, error) {
-	stateBytes, err := encryption.GenerateRandomBytes(16)
+	state, err := encryption.GenerateRandomBytes(16)
 
 	if err != nil {
 		return "", err
@@ -69,7 +69,7 @@ func (s *SessionHelpers) SaveOAuthState(
 	}
 
 	// need state parameter to validate when redirected
-	session.Values["state"] = string(stateBytes)
+	session.Values["state"] = state
 
 	// need a parameter to indicate that this was triggered through the oauth flow
 	session.Values["oauth_triggered"] = true
@@ -78,7 +78,7 @@ func (s *SessionHelpers) SaveOAuthState(
 		return "", err
 	}
 
-	return string(stateBytes), nil
+	return state, nil
 }
 
 func (s *SessionHelpers) ValidateOAuthState(

--- a/api/v1/server/authn/session_helpers.go
+++ b/api/v1/server/authn/session_helpers.go
@@ -1,10 +1,14 @@
 package authn
 
 import (
+	"fmt"
+
 	"github.com/gorilla/sessions"
-	"github.com/hatchet-dev/hatchet/internal/config/server"
-	"github.com/hatchet-dev/hatchet/internal/repository/prisma/db"
 	"github.com/labstack/echo/v4"
+
+	"github.com/hatchet-dev/hatchet/internal/config/server"
+	"github.com/hatchet-dev/hatchet/internal/encryption"
+	"github.com/hatchet-dev/hatchet/internal/repository/prisma/db"
 )
 
 type SessionHelpers struct {
@@ -47,6 +51,70 @@ func (s *SessionHelpers) SaveUnauthenticated(c echo.Context) error {
 	session.Options.MaxAge = -1
 
 	return session.Save(c.Request(), c.Response())
+}
+
+func (s *SessionHelpers) SaveOAuthState(
+	c echo.Context,
+) (string, error) {
+	stateBytes, err := encryption.GenerateRandomBytes(16)
+
+	if err != nil {
+		return "", err
+	}
+
+	session, err := s.config.SessionStore.Get(c.Request(), s.config.SessionStore.GetName())
+
+	if err != nil {
+		return "", err
+	}
+
+	// need state parameter to validate when redirected
+	session.Values["state"] = string(stateBytes)
+
+	// need a parameter to indicate that this was triggered through the oauth flow
+	session.Values["oauth_triggered"] = true
+
+	if err := session.Save(c.Request(), c.Response()); err != nil {
+		return "", err
+	}
+
+	return string(stateBytes), nil
+}
+
+func (s *SessionHelpers) ValidateOAuthState(
+	c echo.Context,
+) (isValidated bool, isOAuthTriggered bool, err error) {
+	session, err := s.config.SessionStore.Get(c.Request(), s.config.SessionStore.GetName())
+
+	if err != nil {
+		return false, false, err
+	}
+
+	if _, ok := session.Values["state"]; !ok {
+		return false, false, fmt.Errorf("state parameter not found in session")
+	}
+
+	if c.Request().URL.Query().Get("state") != session.Values["state"] {
+		return false, false, fmt.Errorf("state parameters do not match")
+	}
+
+	if isOAuthTriggeredVal, exists := session.Values["oauth_triggered"]; exists {
+		var ok bool
+
+		isOAuthTriggered, ok = isOAuthTriggeredVal.(bool)
+
+		isOAuthTriggered = ok && isOAuthTriggered
+	}
+
+	// need state parameter to validate when redirected
+	session.Values["state"] = ""
+	session.Values["oauth_triggered"] = false
+
+	if err := session.Save(c.Request(), c.Response()); err != nil {
+		return false, false, fmt.Errorf("could not clear session")
+	}
+
+	return true, isOAuthTriggered, nil
 }
 
 func saveNewSession(c echo.Context, session *sessions.Session) error {

--- a/api/v1/server/handlers/metadata/get.go
+++ b/api/v1/server/handlers/metadata/get.go
@@ -1,0 +1,27 @@
+package metadata
+
+import (
+	"github.com/labstack/echo/v4"
+
+	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
+)
+
+func (u *MetadataService) MetadataGet(ctx echo.Context, request gen.MetadataGetRequestObject) (gen.MetadataGetResponseObject, error) {
+	authTypes := []string{}
+
+	if u.config.Auth.ConfigFile.BasicAuthEnabled {
+		authTypes = append(authTypes, "basic")
+	}
+
+	if u.config.Auth.ConfigFile.Google.Enabled {
+		authTypes = append(authTypes, "google")
+	}
+
+	meta := gen.APIMeta{
+		Auth: &gen.APIMetaAuth{
+			Schemes: &authTypes,
+		},
+	}
+
+	return gen.MetadataGet200JSONResponse(meta), nil
+}

--- a/api/v1/server/handlers/metadata/service.go
+++ b/api/v1/server/handlers/metadata/service.go
@@ -1,0 +1,15 @@
+package metadata
+
+import (
+	"github.com/hatchet-dev/hatchet/internal/config/server"
+)
+
+type MetadataService struct {
+	config *server.ServerConfig
+}
+
+func NewMetadataService(config *server.ServerConfig) *MetadataService {
+	return &MetadataService{
+		config: config,
+	}
+}

--- a/api/v1/server/handlers/users/google_oauth_callback.go
+++ b/api/v1/server/handlers/users/google_oauth_callback.go
@@ -1,0 +1,150 @@
+package users
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"golang.org/x/oauth2"
+
+	"github.com/hatchet-dev/hatchet/api/v1/server/authn"
+	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
+	"github.com/hatchet-dev/hatchet/internal/config/server"
+	"github.com/hatchet-dev/hatchet/internal/repository"
+	"github.com/hatchet-dev/hatchet/internal/repository/prisma/db"
+)
+
+// Note: we want all errors to redirect, otherwise the user will be greeted with raw JSON in the middle of the login flow.
+func (u *UserService) UserUpdateOauthCallback(ctx echo.Context, _ gen.UserUpdateOauthCallbackRequestObject) (gen.UserUpdateOauthCallbackResponseObject, error) {
+	isValid, _, err := authn.NewSessionHelpers(u.config).ValidateOAuthState(ctx)
+
+	if err != nil || !isValid {
+		return nil, authn.GetRedirectWithError(ctx, u.config.Logger, err, "Could not log in. Please try again and make sure cookies are enabled.")
+	}
+
+	token, err := u.config.Auth.GoogleOAuthConfig.Exchange(oauth2.NoContext, ctx.Request().URL.Query().Get("code"))
+
+	if err != nil {
+		return nil, authn.GetRedirectWithError(ctx, u.config.Logger, err, "Forbidden")
+	}
+
+	if !token.Valid() {
+		return nil, authn.GetRedirectWithError(ctx, u.config.Logger, fmt.Errorf("invalid token"), "Forbidden")
+	}
+
+	user, err := u.upsertGoogleUserFromToken(u.config, token)
+
+	if err != nil {
+		return nil, authn.GetRedirectWithError(ctx, u.config.Logger, err, "Internal error.")
+	}
+
+	err = authn.NewSessionHelpers(u.config).SaveAuthenticated(ctx, user)
+
+	if err != nil {
+		return nil, authn.GetRedirectWithError(ctx, u.config.Logger, err, "Internal error.")
+	}
+
+	return gen.UserUpdateOauthCallback302Response{
+		Headers: gen.UserUpdateOauthCallback302ResponseHeaders{
+			Location: u.config.Runtime.ServerURL,
+		},
+	}, nil
+}
+
+func (u *UserService) upsertGoogleUserFromToken(config *server.ServerConfig, tok *oauth2.Token) (*db.UserModel, error) {
+	gInfo, err := getGoogleUserInfoFromToken(tok)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := u.checkUserRestrictions(config, gInfo.HD); err != nil {
+		return nil, err
+	}
+
+	expiresAt := tok.Expiry
+
+	oauthOpts := &repository.OAuthOpts{
+		Provider:       "google",
+		ProviderUserId: gInfo.Sub,
+		AccessToken:    tok.AccessToken,
+		RefreshToken:   repository.StringPtr(tok.RefreshToken),
+		ExpiresAt:      &expiresAt,
+	}
+
+	user, err := u.config.Repository.User().GetUserByEmail(gInfo.Email)
+
+	switch err {
+	case nil:
+		user, err = u.config.Repository.User().UpdateUser(user.ID, &repository.UpdateUserOpts{
+			EmailVerified: repository.BoolPtr(gInfo.EmailVerified),
+			Name:          repository.StringPtr(gInfo.Name),
+			OAuth:         oauthOpts,
+		})
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to update user: %s", err.Error())
+		}
+	case db.ErrNotFound:
+		user, err = u.config.Repository.User().CreateUser(&repository.CreateUserOpts{
+			Email:         gInfo.Email,
+			EmailVerified: repository.BoolPtr(gInfo.EmailVerified),
+			Name:          repository.StringPtr(gInfo.Name),
+			OAuth:         oauthOpts,
+		})
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to create user: %s", err.Error())
+		}
+	default:
+		return nil, fmt.Errorf("failed to get user: %s", err.Error())
+	}
+
+	return user, nil
+}
+
+type googleUserInfo struct {
+	Email         string `json:"email"`
+	EmailVerified bool   `json:"email_verified"`
+	HD            string `json:"hd"`
+	Sub           string `json:"sub"`
+	Name          string `json:"name"`
+}
+
+func getGoogleUserInfoFromToken(tok *oauth2.Token) (*googleUserInfo, error) {
+	// use userinfo endpoint for Google OIDC to get claims
+	url := "https://openidconnect.googleapis.com/v1/userinfo"
+
+	req, err := http.NewRequest("GET", url, nil)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed creating request: %s", err.Error())
+	}
+
+	req.Header.Add("Authorization", "Bearer "+tok.AccessToken)
+
+	client := &http.Client{}
+
+	response, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed getting user info: %s", err.Error())
+	}
+
+	defer response.Body.Close()
+
+	contents, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed reading response body: %s", err.Error())
+	}
+
+	// parse contents into Google userinfo claims
+	gInfo := &googleUserInfo{}
+	err = json.Unmarshal(contents, &gInfo)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed parsing response body: %s", err.Error())
+	}
+
+	return gInfo, nil
+}

--- a/api/v1/server/handlers/users/google_oauth_callback.go
+++ b/api/v1/server/handlers/users/google_oauth_callback.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -24,7 +25,7 @@ func (u *UserService) UserUpdateOauthCallback(ctx echo.Context, _ gen.UserUpdate
 		return nil, authn.GetRedirectWithError(ctx, u.config.Logger, err, "Could not log in. Please try again and make sure cookies are enabled.")
 	}
 
-	token, err := u.config.Auth.GoogleOAuthConfig.Exchange(oauth2.NoContext, ctx.Request().URL.Query().Get("code"))
+	token, err := u.config.Auth.GoogleOAuthConfig.Exchange(context.Background(), ctx.Request().URL.Query().Get("code"))
 
 	if err != nil {
 		return nil, authn.GetRedirectWithError(ctx, u.config.Logger, err, "Forbidden")

--- a/api/v1/server/handlers/users/google_oauth_start.go
+++ b/api/v1/server/handlers/users/google_oauth_start.go
@@ -1,0 +1,25 @@
+package users
+
+import (
+	"github.com/labstack/echo/v4"
+
+	"github.com/hatchet-dev/hatchet/api/v1/server/authn"
+	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
+)
+
+// Note: we want all errors to redirect, otherwise the user will be greeted with raw JSON in the middle of the login flow.
+func (u *UserService) UserUpdateOauthStart(ctx echo.Context, _ gen.UserUpdateOauthStartRequestObject) (gen.UserUpdateOauthStartResponseObject, error) {
+	state, err := authn.NewSessionHelpers(u.config).SaveOAuthState(ctx)
+
+	if err != nil {
+		return nil, authn.GetRedirectWithError(ctx, u.config.Logger, err, "Could not get cookie. Please make sure cookies are enabled.")
+	}
+
+	url := u.config.Auth.GoogleOAuthConfig.AuthCodeURL(state)
+
+	return gen.UserUpdateOauthStart302Response{
+		Headers: gen.UserUpdateOauthStart302ResponseHeaders{
+			Location: url,
+		},
+	}, nil
+}

--- a/api/v1/server/handlers/users/service.go
+++ b/api/v1/server/handlers/users/service.go
@@ -1,6 +1,8 @@
 package users
 
 import (
+	"fmt"
+
 	"github.com/hatchet-dev/hatchet/internal/config/server"
 )
 
@@ -12,4 +14,18 @@ func NewUserService(config *server.ServerConfig) *UserService {
 	return &UserService{
 		config: config,
 	}
+}
+
+func (u *UserService) checkUserRestrictions(conf *server.ServerConfig, emailDomain string) error {
+	if len(conf.Auth.ConfigFile.RestrictedEmailDomains) == 0 {
+		return nil
+	}
+
+	for _, domain := range conf.Auth.ConfigFile.RestrictedEmailDomains {
+		if domain == emailDomain {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("email is not in the restricted domain group")
 }

--- a/api/v1/server/handlers/users/update_login.go
+++ b/api/v1/server/handlers/users/update_login.go
@@ -4,19 +4,20 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/labstack/echo/v4"
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/hatchet-dev/hatchet/api/v1/server/authn"
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/apierrors"
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/transformers"
 	"github.com/hatchet-dev/hatchet/internal/repository"
 	"github.com/hatchet-dev/hatchet/internal/repository/prisma/db"
-	"github.com/labstack/echo/v4"
-	"golang.org/x/crypto/bcrypt"
 )
 
 func (u *UserService) UserUpdateLogin(ctx echo.Context, request gen.UserUpdateLoginRequestObject) (gen.UserUpdateLoginResponseObject, error) {
 	// check that the server supports local registration
-	if !u.config.Auth.BasicAuthEnabled {
+	if !u.config.Auth.ConfigFile.BasicAuthEnabled {
 		return gen.UserUpdateLogin405JSONResponse(
 			apierrors.NewAPIErrors("local registration is not enabled"),
 		), nil

--- a/api/v1/server/run/run.go
+++ b/api/v1/server/run/run.go
@@ -4,9 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+
 	"github.com/hatchet-dev/hatchet/api/v1/server/authn"
 	"github.com/hatchet-dev/hatchet/api/v1/server/authz"
 	"github.com/hatchet-dev/hatchet/api/v1/server/handlers/events"
+	"github.com/hatchet-dev/hatchet/api/v1/server/handlers/metadata"
 	"github.com/hatchet-dev/hatchet/api/v1/server/handlers/tenants"
 	"github.com/hatchet-dev/hatchet/api/v1/server/handlers/users"
 	"github.com/hatchet-dev/hatchet/api/v1/server/handlers/workers"
@@ -14,8 +18,6 @@ import (
 	"github.com/hatchet-dev/hatchet/api/v1/server/middleware/populator"
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
 	"github.com/hatchet-dev/hatchet/internal/config/server"
-	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo/v4/middleware"
 
 	hatchetmiddleware "github.com/hatchet-dev/hatchet/api/v1/server/middleware"
 )
@@ -26,6 +28,7 @@ type apiService struct {
 	*events.EventService
 	*workflows.WorkflowService
 	*workers.WorkerService
+	*metadata.MetadataService
 }
 
 func newAPIService(config *server.ServerConfig) *apiService {
@@ -35,6 +38,7 @@ func newAPIService(config *server.ServerConfig) *apiService {
 		EventService:    events.NewEventService(config),
 		WorkflowService: workflows.NewWorkflowService(config),
 		WorkerService:   workers.NewWorkerService(config),
+		MetadataService: metadata.NewMetadataService(config),
 	}
 }
 

--- a/cmd/hatchet-admin/cli/seed.go
+++ b/cmd/hatchet-admin/cli/seed.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/hatchet-dev/hatchet/internal/config/loader"
 	"github.com/hatchet-dev/hatchet/internal/repository"
 	"github.com/hatchet-dev/hatchet/internal/repository/prisma/db"
-	"github.com/spf13/cobra"
 )
 
 // seedCmd seeds the database with initial data
@@ -59,7 +60,7 @@ func runSeed(cf *loader.ConfigLoader) error {
 					Email:         dc.Seed.AdminEmail,
 					Name:          repository.StringPtr(dc.Seed.AdminName),
 					EmailVerified: repository.BoolPtr(true),
-					Password:      *hashedPw,
+					Password:      hashedPw,
 				})
 
 				if err != nil {

--- a/frontend/app/src/components/molecules/nav-bar/nav-bar.tsx
+++ b/frontend/app/src/components/molecules/nav-bar/nav-bar.tsx
@@ -1,0 +1,72 @@
+import { Button } from '@/components/ui/button';
+import { UserCircleIcon } from '@heroicons/react/24/outline';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+import { useNavigate } from 'react-router-dom';
+import api, { User } from '@/lib/api';
+import { useApiError } from '@/lib/hooks';
+import { useMutation } from '@tanstack/react-query';
+
+interface MainNavProps {
+  user: User;
+}
+
+export default function MainNav({ user }: MainNavProps) {
+  const navigate = useNavigate();
+  const { handleApiError } = useApiError({});
+
+  const logoutMutation = useMutation({
+    mutationKey: ['user:update:logout'],
+    mutationFn: async () => {
+      await api.userUpdateLogout();
+    },
+    onSuccess: () => {
+      navigate('/auth/login');
+    },
+    onError: handleApiError,
+  });
+
+  return (
+    <div className="fixed top-0 w-screen h-16">
+      <div className="flex h-16 items-center pr-4 pl-7">
+        <div className="ml-auto flex items-center space-x-4">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                className="relative h-10 w-10 rounded-full p-1"
+              >
+                <UserCircleIcon className="h-6 w-6 text-foreground cursor-pointer" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="w-56" align="end" forceMount>
+              <DropdownMenuLabel className="font-normal">
+                <div className="flex flex-col space-y-1">
+                  <p className="text-sm font-medium leading-none">
+                    {user.name || user.email}
+                  </p>
+                  <p className="text-xs leading-none text-muted-foreground">
+                    {user.email}
+                  </p>
+                </div>
+              </DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => logoutMutation.mutate()}>
+                Log out
+                <DropdownMenuShortcut>⇧⌘Q</DropdownMenuShortcut>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/src/lib/api/generated/Api.ts
+++ b/frontend/app/src/lib/api/generated/Api.ts
@@ -12,6 +12,7 @@
 import {
   APIError,
   APIErrors,
+  APIMeta,
   CreateTenantRequest,
   EventData,
   EventKey,
@@ -39,6 +40,21 @@ import { ContentType, HttpClient, RequestParams } from "./http-client";
 
 export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
   /**
+   * @description Gets metadata for the Hatchet instance
+   *
+   * @tags Metadata
+   * @name MetadataGet
+   * @summary Get metadata
+   * @request GET:/api/v1/meta
+   */
+  metadataGet = (params: RequestParams = {}) =>
+    this.request<APIMeta, APIErrors>({
+      path: `/api/v1/meta`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
    * @description Logs in a user.
    *
    * @tags User
@@ -53,6 +69,34 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
       body: data,
       type: ContentType.Json,
       format: "json",
+      ...params,
+    });
+  /**
+   * @description Starts the OAuth flow
+   *
+   * @tags User
+   * @name UserUpdateOauthStart
+   * @summary Start OAuth flow
+   * @request GET:/api/v1/users/google/start
+   */
+  userUpdateOauthStart = (params: RequestParams = {}) =>
+    this.request<any, void>({
+      path: `/api/v1/users/google/start`,
+      method: "GET",
+      ...params,
+    });
+  /**
+   * @description Completes the OAuth flow
+   *
+   * @tags User
+   * @name UserUpdateOauthCallback
+   * @summary Complete OAuth flow
+   * @request GET:/api/v1/users/google/callback
+   */
+  userUpdateOauthCallback = (params: RequestParams = {}) =>
+    this.request<any, void>({
+      path: `/api/v1/users/google/callback`,
+      method: "GET",
       ...params,
     });
   /**

--- a/frontend/app/src/lib/api/generated/data-contracts.ts
+++ b/frontend/app/src/lib/api/generated/data-contracts.ts
@@ -9,6 +9,18 @@
  * ---------------------------------------------------------------
  */
 
+export interface APIMeta {
+  auth?: APIMetaAuth;
+}
+
+export interface APIMetaAuth {
+  /**
+   * the supported types of authentication
+   * @example ["basic","google"]
+   */
+  schemes?: string[];
+}
+
 export interface APIErrors {
   errors: APIError[];
 }

--- a/frontend/app/src/pages/auth/hooks/use-api-meta.ts
+++ b/frontend/app/src/pages/auth/hooks/use-api-meta.ts
@@ -1,0 +1,22 @@
+import api from '@/lib/api';
+import { useApiError } from '@/lib/hooks';
+import { useQuery } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+export default function useApiMeta() {
+  const { handleApiError } = useApiError({});
+
+  const metaQuery = useQuery({
+    queryKey: ['metadata:get'],
+    queryFn: async () => {
+      const meta = await api.metadataGet();
+      return meta;
+    },
+  });
+
+  if (metaQuery.isError) {
+    handleApiError(metaQuery.error as AxiosError);
+  }
+
+  return metaQuery;
+}

--- a/frontend/app/src/pages/auth/hooks/use-error-param.ts
+++ b/frontend/app/src/pages/auth/hooks/use-error-param.ts
@@ -1,0 +1,25 @@
+import { useToast } from '@/components/ui/use-toast';
+import { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+export default function useErrorParam() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { toast } = useToast();
+
+  useEffect(() => {
+    console.log('useErrorParam', searchParams.get('error'));
+
+    if (searchParams.get('error') && searchParams.get('error') !== '') {
+      toast({
+        title: 'Error',
+        description: searchParams.get('error') || '',
+        duration: 5000,
+      });
+
+      // remove from search params
+      const newSearchParams = new URLSearchParams(searchParams);
+      newSearchParams.delete('error');
+      setSearchParams(newSearchParams);
+    }
+  }, [toast, searchParams, setSearchParams]);
+}

--- a/frontend/app/src/pages/auth/login/index.tsx
+++ b/frontend/app/src/pages/auth/login/index.tsx
@@ -20,6 +20,20 @@ export default function Login() {
   }
 
   const schemes = meta.data?.data?.auth?.schemes || [];
+  const basicEnabled = schemes.includes('basic');
+  const googleEnabled = schemes.includes('google');
+
+  let prompt = 'Enter your email and password below.';
+
+  if (basicEnabled && googleEnabled) {
+    prompt = 'Enter your email and password below, or continue with Google.';
+  } else if (googleEnabled) {
+    prompt = 'Continue with Google.';
+  } else if (basicEnabled) {
+    prompt = 'Enter your email and password below.';
+  } else {
+    prompt = 'No login methods are enabled.';
+  }
 
   return (
     <div className="flex flex-row flex-1 w-full h-full">
@@ -39,12 +53,10 @@ export default function Login() {
               <h1 className="text-2xl font-semibold tracking-tight">
                 Log in to Hatchet
               </h1>
-              <p className="text-sm text-muted-foreground">
-                Enter your email and password below.
-              </p>
+              <p className="text-sm text-muted-foreground">{prompt}</p>
             </div>
-            {schemes.includes('basic') && <BasicLogin />}
-            {schemes.includes('basic') && schemes.length > 1 && (
+            {basicEnabled && <BasicLogin />}
+            {basicEnabled && schemes.length > 1 && (
               <div className="relative">
                 <div className="absolute inset-0 flex items-center">
                   <span className="w-full border-t" />
@@ -56,7 +68,7 @@ export default function Login() {
                 </div>
               </div>
             )}
-            {schemes.includes('google') && <GoogleLogin />}
+            {googleEnabled && <GoogleLogin />}
             <p className="text-left text-sm text-muted-foreground w-full">
               By clicking continue, you agree to our{' '}
               <Link

--- a/frontend/app/src/pages/auth/register/index.tsx
+++ b/frontend/app/src/pages/auth/register/index.tsx
@@ -20,6 +20,21 @@ export default function Register() {
   }
 
   const schemes = meta.data?.data?.auth?.schemes || [];
+  const basicEnabled = schemes.includes('basic');
+  const googleEnabled = schemes.includes('google');
+
+  let prompt = 'Create an account to get started.';
+
+  if (basicEnabled && googleEnabled) {
+    prompt =
+      'Enter your email and password to create an account, or continue with Google.';
+  } else if (googleEnabled) {
+    prompt = 'Continue with Google.';
+  } else if (basicEnabled) {
+    prompt = 'Create an account to get started.';
+  } else {
+    prompt = 'No login methods are enabled.';
+  }
 
   return (
     <div className="flex flex-row flex-1 w-full h-full">
@@ -39,12 +54,10 @@ export default function Register() {
               <h1 className="text-2xl font-semibold tracking-tight">
                 Create an account
               </h1>
-              <p className="text-sm text-muted-foreground">
-                Create an account to get started.
-              </p>
+              <p className="text-sm text-muted-foreground">{prompt}</p>
             </div>
-            {schemes.includes('basic') && <BasicRegister />}
-            {schemes.includes('basic') && schemes.length > 1 && (
+            {basicEnabled && <BasicRegister />}
+            {basicEnabled && schemes.length > 1 && (
               <div className="relative">
                 <div className="absolute inset-0 flex items-center">
                   <span className="w-full border-t" />
@@ -56,7 +69,7 @@ export default function Register() {
                 </div>
               </div>
             )}
-            {schemes.includes('google') && <GoogleLogin />}
+            {googleEnabled && <GoogleLogin />}
             <p className="text-left text-sm text-muted-foreground w-full">
               By clicking continue, you agree to our{' '}
               <Link

--- a/frontend/app/src/pages/authenticated.tsx
+++ b/frontend/app/src/pages/authenticated.tsx
@@ -87,17 +87,3 @@ export default function Authenticated() {
     </div>
   );
 }
-
-// function Authenticated() {
-//   const ctx = useOutletContext<UserContextType>();
-//   const { user } = ctx;
-
-//   return (
-//     <>
-//       <MainNav user={user} />
-//       <Outlet />
-//     </>
-//   );
-// }
-
-// export default Authenticated;

--- a/frontend/app/src/pages/authenticated.tsx
+++ b/frontend/app/src/pages/authenticated.tsx
@@ -1,3 +1,4 @@
+import MainNav from '@/components/molecules/nav-bar/nav-bar';
 import {
   LoaderFunctionArgs,
   Outlet,
@@ -59,7 +60,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   };
 }
 
-export default function Auth() {
+export default function Authenticated() {
   const listMembershipsQuery = useQuery({
     ...queries.user.listTenantMemberships,
   });
@@ -77,5 +78,26 @@ export default function Auth() {
     return <Loading />;
   }
 
-  return <Outlet context={ctx} />;
+  return (
+    <div className="flex flex-row flex-1 w-full h-full">
+      <MainNav user={user} />
+      <div className="pt-12 flex-grow overflow-y-auto overflow-x-hidden">
+        <Outlet context={ctx} />
+      </div>
+    </div>
+  );
 }
+
+// function Authenticated() {
+//   const ctx = useOutletContext<UserContextType>();
+//   const { user } = ctx;
+
+//   return (
+//     <>
+//       <MainNav user={user} />
+//       <Outlet />
+//     </>
+//   );
+// }
+
+// export default Authenticated;

--- a/frontend/app/src/pages/main/index.tsx
+++ b/frontend/app/src/pages/main/index.tsx
@@ -68,9 +68,9 @@ function Main() {
 
   return (
     <div className="flex flex-row flex-1 w-full h-full">
-      <MainNav user={user} />
+      {/* <MainNav user={user} /> */}
       <Sidebar memberships={memberships} currTenant={currTenant} />
-      <div className="pt-12 flex-grow overflow-y-auto overflow-x-hidden">
+      <div className="pt-12 pl-80 flex-grow overflow-y-auto overflow-x-hidden">
         <Outlet context={childCtx} />
       </div>
     </div>
@@ -86,7 +86,7 @@ interface SidebarProps extends React.HTMLAttributes<HTMLDivElement> {
 
 function Sidebar({ className, memberships, currTenant }: SidebarProps) {
   return (
-    <div className={cn('h-full border-r max-w-xs', className)}>
+    <div className={cn('h-full border-r w-80 absolute top-0', className)}>
       <div className="flex flex-col justify-between items-start space-y-4 px-4 py-4 h-full">
         <div className="grow">
           <div className="py-2">

--- a/frontend/app/src/pages/main/index.tsx
+++ b/frontend/app/src/pages/main/index.tsx
@@ -8,17 +8,7 @@ import {
   QueueListIcon,
   ServerStackIcon,
   Squares2X2Icon,
-  UserCircleIcon,
 } from '@heroicons/react/24/outline';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuShortcut,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import hatchet from '@/assets/hatchet_logo.png';
 import invariant from 'tiny-invariant';
 
@@ -30,10 +20,8 @@ import {
   CommandSeparator,
 } from '@/components/ui/command';
 
-import { Link, Outlet, useNavigate, useOutletContext } from 'react-router-dom';
-import api, { Tenant, TenantMember, User } from '@/lib/api';
-import { useApiError } from '@/lib/hooks';
-import { useMutation } from '@tanstack/react-query';
+import { Link, Outlet, useOutletContext } from 'react-router-dom';
+import { Tenant, TenantMember } from '@/lib/api';
 import { CaretSortIcon, PlusCircledIcon } from '@radix-ui/react-icons';
 import {
   PopoverTrigger,
@@ -68,7 +56,6 @@ function Main() {
 
   return (
     <div className="flex flex-row flex-1 w-full h-full">
-      {/* <MainNav user={user} /> */}
       <Sidebar memberships={memberships} currTenant={currTenant} />
       <div className="pt-12 pl-80 flex-grow overflow-y-auto overflow-x-hidden">
         <Outlet context={childCtx} />
@@ -134,62 +121,6 @@ function Sidebar({ className, memberships, currTenant }: SidebarProps) {
           </div>
         </div>
         <TenantSwitcher memberships={memberships} currTenant={currTenant} />
-      </div>
-    </div>
-  );
-}
-
-interface MainNavProps {
-  user: User;
-}
-
-function MainNav({ user }: MainNavProps) {
-  const navigate = useNavigate();
-  const { handleApiError } = useApiError({});
-
-  const logoutMutation = useMutation({
-    mutationKey: ['user:update:logout'],
-    mutationFn: async () => {
-      await api.userUpdateLogout();
-    },
-    onSuccess: () => {
-      navigate('/auth/login');
-    },
-    onError: handleApiError,
-  });
-
-  return (
-    <div className="absolute top-0 w-screen h-12">
-      <div className="flex h-16 items-center pr-4 pl-7">
-        <div className="ml-auto flex items-center space-x-4">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                className="relative h-10 w-10 rounded-full p-1"
-              >
-                <UserCircleIcon className="h-6 w-6 text-foreground cursor-pointer" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent className="w-56" align="end" forceMount>
-              <DropdownMenuLabel className="font-normal">
-                <div className="flex flex-col space-y-1">
-                  <p className="text-sm font-medium leading-none">
-                    {user.name || user.email}
-                  </p>
-                  <p className="text-xs leading-none text-muted-foreground">
-                    {user.email}
-                  </p>
-                </div>
-              </DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => logoutMutation.mutate()}>
-                Log out
-                <DropdownMenuShortcut>⇧⌘Q</DropdownMenuShortcut>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
       </div>
     </div>
   );

--- a/frontend/app/src/pages/root.tsx
+++ b/frontend/app/src/pages/root.tsx
@@ -6,8 +6,8 @@ function Root() {
   return (
     <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
       <div className="fixed h-full w-full">
-        <Outlet />
         <Toaster />
+        <Outlet />
       </div>
     </ThemeProvider>
   );

--- a/frontend/app/src/router.tsx
+++ b/frontend/app/src/router.tsx
@@ -47,7 +47,7 @@ const routes = [
       {
         path: '/',
         lazy: async () =>
-          import('./pages/main/auth').then((res) => {
+          import('./pages/authenticated').then((res) => {
             return {
               loader: res.loader,
               Component: res.default,

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.16.0
-	github.com/steebchen/prisma-client-go v0.31.4-0.20231228102837-d2b2373128a2
+	github.com/steebchen/prisma-client-go v0.32.1
 	go.opentelemetry.io/otel v1.21.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.21.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.21.0
@@ -61,6 +61,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	golang.org/x/exp v0.0.0-20231219180239-dc181d75b848 // indirect
 	golang.org/x/time v0.3.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20231120223509-83a465c0220f // indirect
 )
 
@@ -92,10 +93,11 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.8.4
 	github.com/subosito/gotenv v1.6.0 // indirect
-	golang.org/x/crypto v0.17.0
-	golang.org/x/net v0.18.0 // indirect
+	golang.org/x/crypto v0.18.0
+	golang.org/x/net v0.20.0 // indirect
+	golang.org/x/oauth2 v0.16.0
 	golang.org/x/sync v0.4.0
-	golang.org/x/sys v0.15.0 // indirect
+	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f // indirect
 	google.golang.org/grpc v1.59.0

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,8 @@ github.com/spf13/viper v1.16.0/go.mod h1:yg78JgCJcbrQOvV9YLXgkLaZqUidkY9K+Dd1Fof
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/steebchen/prisma-client-go v0.31.4-0.20231228102837-d2b2373128a2 h1:8vofR6qaIWoTi2AGymk1MlipkUWLjBNjKjYA8DYaHps=
 github.com/steebchen/prisma-client-go v0.31.4-0.20231228102837-d2b2373128a2/go.mod h1:ksKELgUZSn56rbAv1jlF8D7o8V6lis0Tc2LEgv2qNbs=
+github.com/steebchen/prisma-client-go v0.32.1 h1:7jUke4XVSzUkV2TN4VhYSwjU7qizM9w475gpudkLCNI=
+github.com/steebchen/prisma-client-go v0.32.1/go.mod h1:shY2GTQyv15WYTE4p2zffr01ratTzX0zXtBWnDHiLpo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -362,6 +364,8 @@ golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
 golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
+golang.org/x/crypto v0.18.0 h1:PGVlW0xEltQnzFZ55hkuX5+KLyrMYhHld1YHO4AKcdc=
+golang.org/x/crypto v0.18.0/go.mod h1:R0j02AL6hcrfOiy9T4ZYp/rcWeMxM3L6QYxlOuEG1mg=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -431,6 +435,8 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.18.0 h1:mIYleuAkSbHh0tCv7RvjL3F6ZVbLjq4+R7zbOn3Kokg=
 golang.org/x/net v0.18.0/go.mod h1:/czyP5RqHAH4odGYxBJ1qz0+CE5WZ+2j1YgoEo8F2jQ=
+golang.org/x/net v0.20.0 h1:aCL9BSgETF1k+blQaYUBx9hJ9LOGP3gAVemcZlf1Kpo=
+golang.org/x/net v0.20.0/go.mod h1:z8BVo6PvndSri0LbOE3hAn0apkU+1YvI6E70E9jsnvY=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -440,6 +446,8 @@ golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.16.0 h1:aDkGMBSYxElaoP81NpoUoz2oo2R2wHdZpGToUxfyQrQ=
+golang.org/x/oauth2 v0.16.0/go.mod h1:hqZ+0LWXsiVoZpeld6jVt06P3adbS2Uu911W1SsJv2o=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -496,6 +504,8 @@ golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
+golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -588,6 +598,7 @@ google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/internal/auth/oauth/configs.go
+++ b/internal/auth/oauth/configs.go
@@ -13,7 +13,7 @@ type Config struct {
 
 const (
 	GoogleAuthURL  string = "https://accounts.google.com/o/oauth2/v2/auth"
-	GoogleTokenURL string = "https://oauth2.googleapis.com/token"
+	GoogleTokenURL string = "https://oauth2.googleapis.com/token" // #nosec G101
 )
 
 func NewGoogleClient(cfg *Config) *oauth2.Config {

--- a/internal/auth/oauth/configs.go
+++ b/internal/auth/oauth/configs.go
@@ -1,0 +1,30 @@
+package oauth
+
+import (
+	"golang.org/x/oauth2"
+)
+
+type Config struct {
+	ClientID     string
+	ClientSecret string
+	Scopes       []string
+	BaseURL      string
+}
+
+const (
+	GoogleAuthURL  string = "https://accounts.google.com/o/oauth2/v2/auth"
+	GoogleTokenURL string = "https://oauth2.googleapis.com/token"
+)
+
+func NewGoogleClient(cfg *Config) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     cfg.ClientID,
+		ClientSecret: cfg.ClientSecret,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  GoogleAuthURL,
+			TokenURL: GoogleTokenURL,
+		},
+		RedirectURL: cfg.BaseURL + "/api/v1/users/google/callback",
+		Scopes:      cfg.Scopes,
+	}
+}

--- a/internal/config/client/client.go
+++ b/internal/config/client/client.go
@@ -27,14 +27,14 @@ type ClientConfig struct {
 }
 
 func BindAllEnv(v *viper.Viper) {
-	v.BindEnv("tenantId", "HATCHET_CLIENT_TENANT_ID")
+	_ = v.BindEnv("tenantId", "HATCHET_CLIENT_TENANT_ID")
 
 	// tls options
-	v.BindEnv("tls.base.tlsCertFile", "HATCHET_CLIENT_TLS_CERT_FILE")
-	v.BindEnv("tls.base.tlsKeyFile", "HATCHET_CLIENT_TLS_KEY_FILE")
-	v.BindEnv("tls.base.tlsRootCAFile", "HATCHET_CLIENT_TLS_ROOT_CA_FILE")
-	v.BindEnv("tls.base.tlsCert", "HATCHET_CLIENT_TLS_CERT")
-	v.BindEnv("tls.base.tlsKey", "HATCHET_CLIENT_TLS_KEY")
-	v.BindEnv("tls.base.tlsRootCA", "HATCHET_CLIENT_TLS_ROOT_CA")
-	v.BindEnv("tls.tlsServerName", "HATCHET_CLIENT_TLS_SERVER_NAME")
+	_ = v.BindEnv("tls.base.tlsCertFile", "HATCHET_CLIENT_TLS_CERT_FILE")
+	_ = v.BindEnv("tls.base.tlsKeyFile", "HATCHET_CLIENT_TLS_KEY_FILE")
+	_ = v.BindEnv("tls.base.tlsRootCAFile", "HATCHET_CLIENT_TLS_ROOT_CA_FILE")
+	_ = v.BindEnv("tls.base.tlsCert", "HATCHET_CLIENT_TLS_CERT")
+	_ = v.BindEnv("tls.base.tlsKey", "HATCHET_CLIENT_TLS_KEY")
+	_ = v.BindEnv("tls.base.tlsRootCA", "HATCHET_CLIENT_TLS_ROOT_CA")
+	_ = v.BindEnv("tls.tlsServerName", "HATCHET_CLIENT_TLS_SERVER_NAME")
 }

--- a/internal/config/database/config.go
+++ b/internal/config/database/config.go
@@ -1,9 +1,10 @@
 package database
 
 import (
+	"github.com/spf13/viper"
+
 	"github.com/hatchet-dev/hatchet/internal/config/shared"
 	"github.com/hatchet-dev/hatchet/internal/repository"
-	"github.com/spf13/viper"
 )
 
 type ConfigFile struct {
@@ -40,20 +41,20 @@ type Config struct {
 }
 
 func BindAllEnv(v *viper.Viper) {
-	v.BindEnv("host", "DATABASE_POSTGRES_HOST")
-	v.BindEnv("port", "DATABASE_POSTGRES_PORT")
-	v.BindEnv("username", "DATABASE_POSTGRES_USERNAME")
-	v.BindEnv("password", "DATABASE_POSTGRES_PASSWORD")
-	v.BindEnv("dbName", "DATABASE_POSTGRES_DB_NAME")
-	v.BindEnv("sslMode", "DATABASE_POSTGRES_SSL_MODE")
+	_ = v.BindEnv("host", "DATABASE_POSTGRES_HOST")
+	_ = v.BindEnv("port", "DATABASE_POSTGRES_PORT")
+	_ = v.BindEnv("username", "DATABASE_POSTGRES_USERNAME")
+	_ = v.BindEnv("password", "DATABASE_POSTGRES_PASSWORD")
+	_ = v.BindEnv("dbName", "DATABASE_POSTGRES_DB_NAME")
+	_ = v.BindEnv("sslMode", "DATABASE_POSTGRES_SSL_MODE")
 
-	v.BindEnv("seed.adminEmail", "ADMIN_EMAIL")
-	v.BindEnv("seed.adminPassword", "ADMIN_PASSWORD")
-	v.BindEnv("seed.adminName", "ADMIN_NAME")
-	v.BindEnv("seed.defaultTenantName", "DEFAULT_TENANT_NAME")
-	v.BindEnv("seed.defaultTenantSlug", "DEFAULT_TENANT_SLUG")
-	v.BindEnv("seed.isDevelopment", "SEED_DEVELOPMENT")
+	_ = v.BindEnv("seed.adminEmail", "ADMIN_EMAIL")
+	_ = v.BindEnv("seed.adminPassword", "ADMIN_PASSWORD")
+	_ = v.BindEnv("seed.adminName", "ADMIN_NAME")
+	_ = v.BindEnv("seed.defaultTenantName", "DEFAULT_TENANT_NAME")
+	_ = v.BindEnv("seed.defaultTenantSlug", "DEFAULT_TENANT_SLUG")
+	_ = v.BindEnv("seed.isDevelopment", "SEED_DEVELOPMENT")
 
-	v.BindEnv("logger.level", "DATABASE_LOGGER_LEVEL")
-	v.BindEnv("logger.format", "DATABASE_LOGGER_FORMAT")
+	_ = v.BindEnv("logger.level", "DATABASE_LOGGER_LEVEL")
+	_ = v.BindEnv("logger.format", "DATABASE_LOGGER_FORMAT")
 }

--- a/internal/config/loader/loader.go
+++ b/internal/config/loader/loader.go
@@ -8,7 +8,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/jackc/pgx/v5/pgxpool"
+
 	"github.com/hatchet-dev/hatchet/internal/auth/cookie"
+	"github.com/hatchet-dev/hatchet/internal/auth/oauth"
 	"github.com/hatchet-dev/hatchet/internal/config/database"
 	"github.com/hatchet-dev/hatchet/internal/config/loader/loaderutils"
 	"github.com/hatchet-dev/hatchet/internal/config/server"
@@ -18,7 +21,6 @@ import (
 	"github.com/hatchet-dev/hatchet/internal/services/ingestor"
 	"github.com/hatchet-dev/hatchet/internal/taskqueue/rabbitmq"
 	"github.com/hatchet-dev/hatchet/internal/validator"
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // LoadDatabaseConfigFile loads the database config file via viper
@@ -171,9 +173,32 @@ func GetServerConfigFromConfigfile(dc *database.Config, cf *server.ServerConfigF
 		return nil, fmt.Errorf("could not create ingestor: %w", err)
 	}
 
+	auth := server.AuthConfig{
+		ConfigFile: cf.Auth,
+	}
+
+	if cf.Auth.Google.Enabled {
+		if cf.Auth.Google.ClientID == "" {
+			return nil, fmt.Errorf("google client id is required")
+		}
+
+		if cf.Auth.Google.ClientSecret == "" {
+			return nil, fmt.Errorf("google client secret is required")
+		}
+
+		gClient := oauth.NewGoogleClient(&oauth.Config{
+			ClientID:     cf.Auth.Google.ClientID,
+			ClientSecret: cf.Auth.Google.ClientSecret,
+			BaseURL:      cf.Runtime.ServerURL,
+			Scopes:       cf.Auth.Google.Scopes,
+		})
+
+		auth.GoogleOAuthConfig = gClient
+	}
+
 	return &server.ServerConfig{
 		Runtime:       cf.Runtime,
-		Auth:          cf.Auth,
+		Auth:          auth,
 		Config:        dc,
 		TaskQueue:     tq,
 		Services:      cf.Services,

--- a/internal/config/server/server.go
+++ b/internal/config/server/server.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/spf13/viper"
+	"golang.org/x/oauth2"
 
 	"github.com/hatchet-dev/hatchet/internal/auth/cookie"
 	"github.com/hatchet-dev/hatchet/internal/config/database"
@@ -61,6 +62,16 @@ type ConfigFileAuth struct {
 
 	// Configuration options for the cookie
 	Cookie ConfigFileAuthCookie `mapstructure:"cookie" json:"cookie,omitempty"`
+
+	Google ConfigFileAuthGoogle `mapstructure:"google" json:"google,omitempty"`
+}
+
+type ConfigFileAuthGoogle struct {
+	Enabled bool `mapstructure:"enabled" json:"enabled,omitempty" default:"false"`
+
+	ClientID     string   `mapstructure:"clientID" json:"clientID,omitempty"`
+	ClientSecret string   `mapstructure:"clientSecret" json:"clientSecret,omitempty"`
+	Scopes       []string `mapstructure:"scopes" json:"scopes,omitempty" default:"[\"openid\", \"profile\", \"email\"]"`
 }
 
 type ConfigFileAuthCookie struct {
@@ -80,10 +91,16 @@ type RabbitMQConfigFile struct {
 	URL string `mapstructure:"url" json:"url,omitempty" validate:"required" default:"amqp://user:password@localhost:5672/"`
 }
 
+type AuthConfig struct {
+	ConfigFile ConfigFileAuth
+
+	GoogleOAuthConfig *oauth2.Config
+}
+
 type ServerConfig struct {
 	*database.Config
 
-	Auth ConfigFileAuth
+	Auth AuthConfig
 
 	Runtime ConfigFileRuntime
 
@@ -133,6 +150,10 @@ func BindAllEnv(v *viper.Viper) {
 	v.BindEnv("auth.cookie.domain", "SERVER_AUTH_COOKIE_DOMAIN")
 	v.BindEnv("auth.cookie.secrets", "SERVER_AUTH_COOKIE_SECRETS")
 	v.BindEnv("auth.cookie.insecure", "SERVER_AUTH_COOKIE_INSECURE")
+	v.BindEnv("auth.google.enabled", "SERVER_AUTH_GOOGLE_ENABLED")
+	v.BindEnv("auth.google.clientID", "SERVER_AUTH_GOOGLE_CLIENT_ID")
+	v.BindEnv("auth.google.clientSecret", "SERVER_AUTH_GOOGLE_CLIENT_SECRET")
+	v.BindEnv("auth.google.scopes", "SERVER_AUTH_GOOGLE_SCOPES")
 
 	// task queue options
 	v.BindEnv("taskQueue.kind", "SERVER_TASKQUEUE_KIND")

--- a/internal/config/server/server.go
+++ b/internal/config/server/server.go
@@ -135,44 +135,44 @@ func (c *ServerConfig) HasService(name string) bool {
 
 func BindAllEnv(v *viper.Viper) {
 	// runtime options
-	v.BindEnv("runtime.port", "SERVER_PORT")
-	v.BindEnv("runtime.url", "SERVER_URL")
-	v.BindEnv("runtime.grpcPort", "SERVER_GRPC_PORT")
-	v.BindEnv("runtime.grpcBindAddress", "SERVER_GRPC_BIND_ADDRESS")
-	v.BindEnv("runtime.grpcInsecure", "SERVER_GRPC_INSECURE")
-	v.BindEnv("services", "SERVER_SERVICES")
+	_ = v.BindEnv("runtime.port", "SERVER_PORT")
+	_ = v.BindEnv("runtime.url", "SERVER_URL")
+	_ = v.BindEnv("runtime.grpcPort", "SERVER_GRPC_PORT")
+	_ = v.BindEnv("runtime.grpcBindAddress", "SERVER_GRPC_BIND_ADDRESS")
+	_ = v.BindEnv("runtime.grpcInsecure", "SERVER_GRPC_INSECURE")
+	_ = v.BindEnv("services", "SERVER_SERVICES")
 
 	// auth options
-	v.BindEnv("auth.restrictedEmailDomains", "SERVER_AUTH_RESTRICTED_EMAIL_DOMAINS")
-	v.BindEnv("auth.basicAuthEnabled", "SERVER_AUTH_BASIC_AUTH_ENABLED")
-	v.BindEnv("auth.setEmailVerified", "SERVER_AUTH_SET_EMAIL_VERIFIED")
-	v.BindEnv("auth.cookie.name", "SERVER_AUTH_COOKIE_NAME")
-	v.BindEnv("auth.cookie.domain", "SERVER_AUTH_COOKIE_DOMAIN")
-	v.BindEnv("auth.cookie.secrets", "SERVER_AUTH_COOKIE_SECRETS")
-	v.BindEnv("auth.cookie.insecure", "SERVER_AUTH_COOKIE_INSECURE")
-	v.BindEnv("auth.google.enabled", "SERVER_AUTH_GOOGLE_ENABLED")
-	v.BindEnv("auth.google.clientID", "SERVER_AUTH_GOOGLE_CLIENT_ID")
-	v.BindEnv("auth.google.clientSecret", "SERVER_AUTH_GOOGLE_CLIENT_SECRET")
-	v.BindEnv("auth.google.scopes", "SERVER_AUTH_GOOGLE_SCOPES")
+	_ = v.BindEnv("auth.restrictedEmailDomains", "SERVER_AUTH_RESTRICTED_EMAIL_DOMAINS")
+	_ = v.BindEnv("auth.basicAuthEnabled", "SERVER_AUTH_BASIC_AUTH_ENABLED")
+	_ = v.BindEnv("auth.setEmailVerified", "SERVER_AUTH_SET_EMAIL_VERIFIED")
+	_ = v.BindEnv("auth.cookie.name", "SERVER_AUTH_COOKIE_NAME")
+	_ = v.BindEnv("auth.cookie.domain", "SERVER_AUTH_COOKIE_DOMAIN")
+	_ = v.BindEnv("auth.cookie.secrets", "SERVER_AUTH_COOKIE_SECRETS")
+	_ = v.BindEnv("auth.cookie.insecure", "SERVER_AUTH_COOKIE_INSECURE")
+	_ = v.BindEnv("auth.google.enabled", "SERVER_AUTH_GOOGLE_ENABLED")
+	_ = v.BindEnv("auth.google.clientID", "SERVER_AUTH_GOOGLE_CLIENT_ID")
+	_ = v.BindEnv("auth.google.clientSecret", "SERVER_AUTH_GOOGLE_CLIENT_SECRET")
+	_ = v.BindEnv("auth.google.scopes", "SERVER_AUTH_GOOGLE_SCOPES")
 
 	// task queue options
-	v.BindEnv("taskQueue.kind", "SERVER_TASKQUEUE_KIND")
-	v.BindEnv("taskQueue.rabbitmq.url", "SERVER_TASKQUEUE_RABBITMQ_URL")
+	_ = v.BindEnv("taskQueue.kind", "SERVER_TASKQUEUE_KIND")
+	_ = v.BindEnv("taskQueue.rabbitmq.url", "SERVER_TASKQUEUE_RABBITMQ_URL")
 
 	// tls options
-	v.BindEnv("tls.tlsCert", "SERVER_TLS_CERT")
-	v.BindEnv("tls.tlsCertFile", "SERVER_TLS_CERT_FILE")
-	v.BindEnv("tls.tlsKey", "SERVER_TLS_KEY")
-	v.BindEnv("tls.tlsKeyFile", "SERVER_TLS_KEY_FILE")
-	v.BindEnv("tls.tlsRootCA", "SERVER_TLS_ROOT_CA")
-	v.BindEnv("tls.tlsRootCAFile", "SERVER_TLS_ROOT_CA_FILE")
-	v.BindEnv("tls.tlsServerName", "SERVER_TLS_SERVER_NAME")
+	_ = v.BindEnv("tls.tlsCert", "SERVER_TLS_CERT")
+	_ = v.BindEnv("tls.tlsCertFile", "SERVER_TLS_CERT_FILE")
+	_ = v.BindEnv("tls.tlsKey", "SERVER_TLS_KEY")
+	_ = v.BindEnv("tls.tlsKeyFile", "SERVER_TLS_KEY_FILE")
+	_ = v.BindEnv("tls.tlsRootCA", "SERVER_TLS_ROOT_CA")
+	_ = v.BindEnv("tls.tlsRootCAFile", "SERVER_TLS_ROOT_CA_FILE")
+	_ = v.BindEnv("tls.tlsServerName", "SERVER_TLS_SERVER_NAME")
 
 	// logger options
-	v.BindEnv("logger.level", "SERVER_LOGGER_LEVEL")
-	v.BindEnv("logger.format", "SERVER_LOGGER_FORMAT")
+	_ = v.BindEnv("logger.level", "SERVER_LOGGER_LEVEL")
+	_ = v.BindEnv("logger.format", "SERVER_LOGGER_FORMAT")
 
 	// otel options
-	v.BindEnv("otel.serviceName", "SERVER_OTEL_SERVICE_NAME")
-	v.BindEnv("otel.collectorURL", "SERVER_OTEL_COLLECTOR_URL")
+	_ = v.BindEnv("otel.serviceName", "SERVER_OTEL_SERVICE_NAME")
+	_ = v.BindEnv("otel.collectorURL", "SERVER_OTEL_COLLECTOR_URL")
 }

--- a/internal/repository/prisma/dbsqlc/models.go
+++ b/internal/repository/prisma/dbsqlc/models.go
@@ -402,6 +402,18 @@ type User struct {
 	Name          pgtype.Text      `json:"name"`
 }
 
+type UserOAuth struct {
+	ID             pgtype.UUID      `json:"id"`
+	CreatedAt      pgtype.Timestamp `json:"createdAt"`
+	UpdatedAt      pgtype.Timestamp `json:"updatedAt"`
+	UserId         pgtype.UUID      `json:"userId"`
+	Provider       string           `json:"provider"`
+	ProviderUserId string           `json:"providerUserId"`
+	AccessToken    string           `json:"accessToken"`
+	RefreshToken   pgtype.Text      `json:"refreshToken"`
+	ExpiresAt      pgtype.Timestamp `json:"expiresAt"`
+}
+
 type UserPassword struct {
 	Hash   string      `json:"hash"`
 	UserId pgtype.UUID `json:"userId"`

--- a/internal/repository/prisma/dbsqlc/schema.sql
+++ b/internal/repository/prisma/dbsqlc/schema.sql
@@ -203,6 +203,21 @@ CREATE TABLE "User" (
 );
 
 -- CreateTable
+CREATE TABLE "UserOAuth" (
+    "id" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" UUID NOT NULL,
+    "provider" TEXT NOT NULL,
+    "providerUserId" TEXT NOT NULL,
+    "accessToken" TEXT NOT NULL,
+    "refreshToken" TEXT,
+    "expiresAt" TIMESTAMP(3),
+
+    CONSTRAINT "UserOAuth_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
 CREATE TABLE "UserPassword" (
     "hash" TEXT NOT NULL,
     "userId" UUID NOT NULL
@@ -435,6 +450,15 @@ CREATE UNIQUE INDEX "User_email_key" ON "User"("email" ASC);
 CREATE UNIQUE INDEX "User_id_key" ON "User"("id" ASC);
 
 -- CreateIndex
+CREATE UNIQUE INDEX "UserOAuth_id_key" ON "UserOAuth"("id" ASC);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserOAuth_userId_key" ON "UserOAuth"("userId" ASC);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserOAuth_userId_provider_key" ON "UserOAuth"("userId" ASC, "provider" ASC);
+
+-- CreateIndex
 CREATE UNIQUE INDEX "UserPassword_userId_key" ON "UserPassword"("userId" ASC);
 
 -- CreateIndex
@@ -586,6 +610,9 @@ ALTER TABLE "TenantMember" ADD CONSTRAINT "TenantMember_tenantId_fkey" FOREIGN K
 
 -- AddForeignKey
 ALTER TABLE "TenantMember" ADD CONSTRAINT "TenantMember_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserOAuth" ADD CONSTRAINT "UserOAuth_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "UserPassword" ADD CONSTRAINT "UserPassword_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/internal/repository/prisma/user.go
+++ b/internal/repository/prisma/user.go
@@ -5,10 +5,11 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/steebchen/prisma-client-go/runtime/transaction"
+
 	"github.com/hatchet-dev/hatchet/internal/repository"
 	"github.com/hatchet-dev/hatchet/internal/repository/prisma/db"
 	"github.com/hatchet-dev/hatchet/internal/validator"
-	"github.com/steebchen/prisma-client-go/runtime/transaction"
 )
 
 type userRepository struct {
@@ -71,10 +72,24 @@ func (r *userRepository) CreateUser(opts *repository.CreateUserOpts) (*db.UserMo
 
 	txs := []transaction.Param{
 		createTx,
-		r.client.UserPassword.CreateOne(
-			db.UserPassword.Hash.Set(opts.Password),
+	}
+
+	if opts.Password != nil {
+		txs = append(txs, r.client.UserPassword.CreateOne(
+			db.UserPassword.Hash.Set(*opts.Password),
 			db.UserPassword.User.Link(db.User.ID.Equals(userId)),
-		).Tx(),
+		).Tx())
+	}
+
+	if opts.OAuth != nil {
+		txs = append(txs, r.client.UserOAuth.CreateOne(
+			db.UserOAuth.User.Link(db.User.ID.Equals(userId)),
+			db.UserOAuth.Provider.Set(opts.OAuth.Provider),
+			db.UserOAuth.ProviderUserID.Set(opts.OAuth.ProviderUserId),
+			db.UserOAuth.AccessToken.Set(opts.OAuth.AccessToken),
+			db.UserOAuth.RefreshToken.SetIfPresent(opts.OAuth.RefreshToken),
+			db.UserOAuth.ExpiresAt.SetIfPresent(opts.OAuth.ExpiresAt),
+		).Tx())
 	}
 
 	if err := r.client.Prisma.Transaction(txs...).Exec(context.Background()); err != nil {
@@ -99,11 +114,41 @@ func (r *userRepository) UpdateUser(id string, opts *repository.UpdateUserOpts) 
 		params = append(params, db.User.Name.Set(*opts.Name))
 	}
 
-	return r.client.User.FindUnique(
+	updateTx := r.client.User.FindUnique(
 		db.User.ID.Equals(id),
 	).Update(
 		params...,
-	).Exec(context.Background())
+	).Tx()
+
+	txs := []transaction.Param{
+		updateTx,
+	}
+
+	if opts.OAuth != nil {
+		txs = append(txs, r.client.UserOAuth.UpsertOne(
+			db.UserOAuth.UserIDProvider(
+				db.UserOAuth.UserID.Equals(id),
+				db.UserOAuth.Provider.Equals(opts.OAuth.Provider),
+			),
+		).Create(
+			db.UserOAuth.User.Link(db.User.ID.Equals(id)),
+			db.UserOAuth.Provider.Set(opts.OAuth.Provider),
+			db.UserOAuth.ProviderUserID.Set(opts.OAuth.ProviderUserId),
+			db.UserOAuth.AccessToken.Set(opts.OAuth.AccessToken),
+			db.UserOAuth.RefreshToken.SetIfPresent(opts.OAuth.RefreshToken),
+			db.UserOAuth.ExpiresAt.SetIfPresent(opts.OAuth.ExpiresAt),
+		).Update(
+			db.UserOAuth.AccessToken.Set(opts.OAuth.AccessToken),
+			db.UserOAuth.RefreshToken.SetIfPresent(opts.OAuth.RefreshToken),
+			db.UserOAuth.ExpiresAt.SetIfPresent(opts.OAuth.ExpiresAt),
+		).Tx())
+	}
+
+	if err := r.client.Prisma.Transaction(txs...).Exec(context.Background()); err != nil {
+		return nil, err
+	}
+
+	return updateTx.Result(), nil
 }
 
 func (r *userRepository) ListTenantMemberships(userId string) ([]db.TenantMemberModel, error) {

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -2,21 +2,36 @@ package repository
 
 import (
 	"fmt"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
 
 	"github.com/hatchet-dev/hatchet/internal/repository/prisma/db"
-	"golang.org/x/crypto/bcrypt"
 )
 
 type CreateUserOpts struct {
 	Email         string `validate:"required,email"`
 	EmailVerified *bool
 	Name          *string
-	Password      string `validate:"required"`
+
+	// auth options
+	Password *string    `validate:"omitempty,required_without=OAuth,excluded_with=OAuth"`
+	OAuth    *OAuthOpts `validate:"omitempty,required_without=Password,excluded_with=Password"`
+}
+
+type OAuthOpts struct {
+	Provider       string     `validate:"required,oneof=google"`
+	ProviderUserId string     `validate:"required,min=1"`
+	AccessToken    string     `validate:"required,min=1"`
+	RefreshToken   *string    // optional
+	ExpiresAt      *time.Time // optional
 }
 
 type UpdateUserOpts struct {
 	EmailVerified *bool
 	Name          *string
+
+	OAuth *OAuthOpts `validate:"omitempty"`
 }
 
 type UserRepository interface {

--- a/prisma/migrations/20240121020228_v0_6_0/migration.sql
+++ b/prisma/migrations/20240121020228_v0_6_0/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "UserOAuth" (
+    "id" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" UUID NOT NULL,
+    "provider" TEXT NOT NULL,
+    "providerUserId" TEXT NOT NULL,
+    "accessToken" TEXT NOT NULL,
+    "refreshToken" TEXT,
+    "expiresAt" TIMESTAMP(3),
+
+    CONSTRAINT "UserOAuth_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserOAuth_id_key" ON "UserOAuth"("id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserOAuth_userId_key" ON "UserOAuth"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserOAuth_userId_provider_key" ON "UserOAuth"("userId", "provider");
+
+-- AddForeignKey
+ALTER TABLE "UserOAuth" ADD CONSTRAINT "UserOAuth_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,9 @@ model User {
   // whether the user's email address has been verified
   emailVerified Boolean @default(false)
 
+  // the user's oauth providers
+  oauthProviders UserOAuth[]
+
   // The hashed user's password. This is placed in a separate table so that it isn't returned by default. 
   password UserPassword?
 
@@ -31,6 +34,35 @@ model User {
   sessions UserSession[]
 
   memberships TenantMember[]
+}
+
+model UserOAuth {
+  // base fields
+  id        String   @id @unique @default(uuid()) @db.Uuid
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  // the linked user
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  userId String @unique @db.Uuid
+
+  // the oauth provider
+  provider String
+
+  // the oauth provider's user id
+  providerUserId String
+
+  // the oauth provider's access token
+  accessToken String
+
+  // the oauth provider's refresh token
+  refreshToken String?
+
+  // the oauth provider's expiry time
+  expiresAt DateTime?
+
+  // oauth should be unique per user id + provider
+  @@unique([userId, provider])
 }
 
 model UserPassword {


### PR DESCRIPTION
- Many file changes so it becomes much easier to add a new SSO provider in the future (assuming oauth). This includes a server `/api/v1/metadata` endpoint to query for the permitted auth schemes on the Hatchet instance. 
- Frontend is dynamic so it will change the login screen based on the registered providers. This can be changed with the `SERVER_AUTH_GOOGLE_ENABLED` and `SERVER_AUTH_BASIC_AUTH_ENABLED` flags at the moment. Here are the variants:

**Basic + Google Login:**

<img width="1728" alt="image" src="https://github.com/hatchet-dev/hatchet/assets/25448214/b021a363-fbe3-4bd9-bddc-7b87596fdda6">

**Just basic:**

<img width="1728" alt="image" src="https://github.com/hatchet-dev/hatchet/assets/25448214/a48d387d-79c9-46b5-9209-738541b0e806">

**Just Google:**

<img width="1728" alt="image" src="https://github.com/hatchet-dev/hatchet/assets/25448214/f214b9fc-573c-4fb1-a49e-3fba70018bbc">

