### PR TITLE
feat: improve versioning to use checksums

### DIFF
--- a/api/v1/server/oas/transformers/workflow.go
+++ b/api/v1/server/oas/transformers/workflow.go
@@ -64,9 +64,12 @@ func ToWorkflow(workflow *db.WorkflowModel, lastRun *db.WorkflowRunModel) (*gen.
 func ToWorkflowVersionMeta(version *db.WorkflowVersionModel) *gen.WorkflowVersionMeta {
 	res := &gen.WorkflowVersionMeta{
 		Metadata:   *toAPIMetadata(version.ID, version.CreatedAt, version.UpdatedAt),
-		Version:    version.Version,
 		WorkflowId: version.WorkflowID,
 		Order:      int32(version.Order),
+	}
+
+	if setVersion, ok := version.Version(); ok {
+		res.Version = setVersion
 	}
 
 	return res
@@ -75,9 +78,12 @@ func ToWorkflowVersionMeta(version *db.WorkflowVersionModel) *gen.WorkflowVersio
 func ToWorkflowVersion(workflow *db.WorkflowModel, version *db.WorkflowVersionModel) (*gen.WorkflowVersion, error) {
 	res := &gen.WorkflowVersion{
 		Metadata:   *toAPIMetadata(version.ID, version.CreatedAt, version.UpdatedAt),
-		Version:    version.Version,
 		WorkflowId: version.WorkflowID,
 		Order:      int32(version.Order),
+	}
+
+	if setVersion, ok := version.Version(); ok {
+		res.Version = setVersion
 	}
 
 	if version.RelationsWorkflowVersion.Jobs != nil {
@@ -116,8 +122,11 @@ func ToWorkflowVersion(workflow *db.WorkflowModel, version *db.WorkflowVersionMo
 
 func ToWorkflowYAMLBytes(workflow *db.WorkflowModel, version *db.WorkflowVersionModel) ([]byte, error) {
 	res := &types.Workflow{
-		Name:    workflow.Name,
-		Version: version.Version,
+		Name: workflow.Name,
+	}
+
+	if setVersion, ok := version.Version(); ok {
+		res.Version = setVersion
 	}
 
 	if description, ok := workflow.Description(); ok {
@@ -276,7 +285,7 @@ func ToWorkflowFromSQLC(row *dbsqlc.Workflow) *gen.Workflow {
 func ToWorkflowVersionMetaFromSQLC(row *dbsqlc.WorkflowVersion, workflow *gen.Workflow) *gen.WorkflowVersionMeta {
 	res := &gen.WorkflowVersionMeta{
 		Metadata:   *toAPIMetadata(pgUUIDToStr(row.ID), row.CreatedAt.Time, row.UpdatedAt.Time),
-		Version:    row.Version,
+		Version:    row.Version.String,
 		WorkflowId: pgUUIDToStr(row.WorkflowId),
 		Order:      int32(row.Order),
 		Workflow:   workflow,
@@ -288,7 +297,7 @@ func ToWorkflowVersionMetaFromSQLC(row *dbsqlc.WorkflowVersion, workflow *gen.Wo
 func ToWorkflowVersionFromSQLC(row *dbsqlc.WorkflowVersion, workflow *gen.Workflow) *gen.WorkflowVersion {
 	res := &gen.WorkflowVersion{
 		Metadata:   *toAPIMetadata(pgUUIDToStr(row.ID), row.CreatedAt.Time, row.UpdatedAt.Time),
-		Version:    row.Version,
+		Version:    row.Version.String,
 		WorkflowId: pgUUIDToStr(row.WorkflowId),
 		Order:      int32(row.Order),
 		Workflow:   workflow,

--- a/cmd/hatchet-admin/cli/seed.go
+++ b/cmd/hatchet-admin/cli/seed.go
@@ -130,7 +130,7 @@ func seedDev(repo repository.Repository, tenantId string) error {
 		wf, err := repo.Workflow().CreateNewWorkflow(tenantId, &repository.CreateWorkflowVersionOpts{
 			Name:        "test-workflow",
 			Description: repository.StringPtr("This is a test workflow."),
-			Version:     "v0.1.0",
+			Version:     repository.StringPtr("v0.1.0"),
 			EventTriggers: []string{
 				"user:create",
 			},

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo/v4 v4.11.3
 	github.com/oapi-codegen/runtime v1.1.0
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/shopspring/decimal v1.3.1
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -278,6 +278,8 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/oapi-codegen/runtime v1.1.0 h1:rJpoNUawn5XTvekgfkvSZr0RqEnoYpFkyvrzfWeFKWM=
 github.com/oapi-codegen/runtime v1.1.0/go.mod h1:BeSfBkWWWnAnGdyS+S/GnlbmHKzf8/hwkvelJZDeKA8=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=

--- a/internal/digest/compute.go
+++ b/internal/digest/compute.go
@@ -1,0 +1,24 @@
+package digest
+
+import (
+	"encoding/json"
+
+	"github.com/opencontainers/go-digest"
+)
+
+// DigestValues calculates the digest of the values using SHA-512.
+func DigestValues(values map[string]interface{}) (digest.Digest, error) {
+	valueBytes, err := json.Marshal(values)
+
+	if err != nil {
+		return "", err
+	}
+
+	digester := digest.SHA512.Digester()
+
+	if _, err := digester.Hash().Write(valueBytes); err != nil {
+		return "", err
+	}
+
+	return digester.Digest(), nil
+}

--- a/internal/digest/compute_test.go
+++ b/internal/digest/compute_test.go
@@ -1,0 +1,70 @@
+package digest_test
+
+import (
+	"testing"
+
+	"github.com/hatchet-dev/hatchet/internal/digest"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDigestValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		values map[string]interface{}
+	}{
+		{
+			name:   "Empty map",
+			values: map[string]interface{}{},
+		},
+		{
+			name: "Single key-value pair",
+			values: map[string]interface{}{
+				"key": "value",
+			},
+		},
+		{
+			name: "Multiple key-value pairs",
+			values: map[string]interface{}{
+				"a": 1,
+				"b": 2,
+				"c": 3,
+			},
+		},
+		{
+			name: "Nested map",
+			values: map[string]interface{}{
+				"parent": map[string]interface{}{
+					"child1": 1,
+					"child2": 2,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			digest1, err1 := digest.DigestValues(tc.values)
+			assert.NoError(t, err1)
+
+			// Shuffle the map order and calculate the digest again
+			shuffledValues := shuffleMap(tc.values)
+			digest2, err2 := digest.DigestValues(shuffledValues)
+			assert.NoError(t, err2)
+
+			// The digests should be the same regardless of key order
+			assert.Equal(t, digest1, digest2)
+		})
+	}
+}
+
+// shuffleMap rearranges the map entries to simulate different iteration orders.
+// this doesn't really do anything since Go map values are random anyway.
+func shuffleMap(values map[string]interface{}) map[string]interface{} {
+	shuffled := make(map[string]interface{})
+	for k, v := range values {
+		shuffled[k] = v
+	}
+
+	return shuffled
+}

--- a/internal/repository/prisma/dbsqlc/models.go
+++ b/internal/repository/prisma/dbsqlc/models.go
@@ -589,7 +589,8 @@ type WorkflowVersion struct {
 	CreatedAt  pgtype.Timestamp `json:"createdAt"`
 	UpdatedAt  pgtype.Timestamp `json:"updatedAt"`
 	DeletedAt  pgtype.Timestamp `json:"deletedAt"`
-	Version    string           `json:"version"`
+	Checksum   string           `json:"checksum"`
+	Version    pgtype.Text      `json:"version"`
 	Order      int16            `json:"order"`
 	WorkflowId pgtype.UUID      `json:"workflowId"`
 }

--- a/internal/repository/prisma/dbsqlc/schema.sql
+++ b/internal/repository/prisma/dbsqlc/schema.sql
@@ -381,7 +381,8 @@ CREATE TABLE "WorkflowVersion" (
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "deletedAt" TIMESTAMP(3),
-    "version" TEXT NOT NULL,
+    "checksum" TEXT NOT NULL,
+    "version" TEXT,
     "order" SMALLSERIAL NOT NULL,
     "workflowId" UUID NOT NULL,
 
@@ -552,9 +553,6 @@ CREATE UNIQUE INDEX "WorkflowTriggers_workflowVersionId_key" ON "WorkflowTrigger
 
 -- CreateIndex
 CREATE UNIQUE INDEX "WorkflowVersion_id_key" ON "WorkflowVersion"("id" ASC);
-
--- CreateIndex
-CREATE UNIQUE INDEX "WorkflowVersion_workflowId_version_key" ON "WorkflowVersion"("workflowId" ASC, "version" ASC);
 
 -- CreateIndex
 CREATE UNIQUE INDEX "_ActionToWorker_AB_unique" ON "_ActionToWorker"("A" ASC, "B" ASC);

--- a/internal/repository/prisma/dbsqlc/workflow_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/workflow_runs.sql.go
@@ -474,7 +474,7 @@ SELECT
     runs.id, runs."createdAt", runs."updatedAt", runs."deletedAt", runs."tenantId", runs."workflowVersionId", runs.status, runs.error, runs."startedAt", runs."finishedAt", 
     workflow.id, workflow."createdAt", workflow."updatedAt", workflow."deletedAt", workflow."tenantId", workflow.name, workflow.description, 
     runtriggers.id, runtriggers."createdAt", runtriggers."updatedAt", runtriggers."deletedAt", runtriggers."tenantId", runtriggers."parentId", runtriggers."eventId", runtriggers."cronParentId", runtriggers."cronSchedule", runtriggers."scheduledId", 
-    workflowversion.id, workflowversion."createdAt", workflowversion."updatedAt", workflowversion."deletedAt", workflowversion.version, workflowversion."order", workflowversion."workflowId", 
+    workflowversion.id, workflowversion."createdAt", workflowversion."updatedAt", workflowversion."deletedAt", workflowversion.checksum, workflowversion.version, workflowversion."order", workflowversion."workflowId", 
     -- waiting on https://github.com/sqlc-dev/sqlc/pull/2858 for nullable events field
     events.id, events.key, events."createdAt", events."updatedAt"
 FROM
@@ -574,6 +574,7 @@ func (q *Queries) ListWorkflowRuns(ctx context.Context, db DBTX, arg ListWorkflo
 			&i.WorkflowVersion.CreatedAt,
 			&i.WorkflowVersion.UpdatedAt,
 			&i.WorkflowVersion.DeletedAt,
+			&i.WorkflowVersion.Checksum,
 			&i.WorkflowVersion.Version,
 			&i.WorkflowVersion.Order,
 			&i.WorkflowVersion.WorkflowId,

--- a/internal/repository/prisma/dbsqlc/workflows.sql
+++ b/internal/repository/prisma/dbsqlc/workflows.sql
@@ -152,6 +152,7 @@ INSERT INTO "WorkflowVersion" (
     "createdAt",
     "updatedAt",
     "deletedAt",
+    "checksum",
     "version",
     "workflowId"
 ) VALUES (
@@ -159,7 +160,8 @@ INSERT INTO "WorkflowVersion" (
     coalesce(sqlc.narg('createdAt')::timestamp, CURRENT_TIMESTAMP),
     coalesce(sqlc.narg('updatedAt')::timestamp, CURRENT_TIMESTAMP),
     @deletedAt::timestamp,
-    @version::text,
+    @checksum::text,
+    sqlc.narg('version')::text,
     @workflowId::uuid
 ) RETURNING *;
 

--- a/internal/repository/prisma/dbsqlc/workflows.sql.go
+++ b/internal/repository/prisma/dbsqlc/workflows.sql.go
@@ -397,6 +397,7 @@ INSERT INTO "WorkflowVersion" (
     "createdAt",
     "updatedAt",
     "deletedAt",
+    "checksum",
     "version",
     "workflowId"
 ) VALUES (
@@ -405,8 +406,9 @@ INSERT INTO "WorkflowVersion" (
     coalesce($3::timestamp, CURRENT_TIMESTAMP),
     $4::timestamp,
     $5::text,
-    $6::uuid
-) RETURNING id, "createdAt", "updatedAt", "deletedAt", version, "order", "workflowId"
+    $6::text,
+    $7::uuid
+) RETURNING id, "createdAt", "updatedAt", "deletedAt", checksum, version, "order", "workflowId"
 `
 
 type CreateWorkflowVersionParams struct {
@@ -414,7 +416,8 @@ type CreateWorkflowVersionParams struct {
 	CreatedAt  pgtype.Timestamp `json:"createdAt"`
 	UpdatedAt  pgtype.Timestamp `json:"updatedAt"`
 	Deletedat  pgtype.Timestamp `json:"deletedat"`
-	Version    string           `json:"version"`
+	Checksum   string           `json:"checksum"`
+	Version    pgtype.Text      `json:"version"`
 	Workflowid pgtype.UUID      `json:"workflowid"`
 }
 
@@ -424,6 +427,7 @@ func (q *Queries) CreateWorkflowVersion(ctx context.Context, db DBTX, arg Create
 		arg.CreatedAt,
 		arg.UpdatedAt,
 		arg.Deletedat,
+		arg.Checksum,
 		arg.Version,
 		arg.Workflowid,
 	)
@@ -433,6 +437,7 @@ func (q *Queries) CreateWorkflowVersion(ctx context.Context, db DBTX, arg Create
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
+		&i.Checksum,
 		&i.Version,
 		&i.Order,
 		&i.WorkflowId,
@@ -450,7 +455,7 @@ FROM (
         "Workflow" as workflows 
     LEFT JOIN
         (
-            SELECT id, "createdAt", "updatedAt", "deletedAt", version, "order", "workflowId" FROM "WorkflowVersion" as workflowVersion ORDER BY workflowVersion."order" DESC LIMIT 1
+            SELECT id, "createdAt", "updatedAt", "deletedAt", checksum, version, "order", "workflowId" FROM "WorkflowVersion" as workflowVersion ORDER BY workflowVersion."order" DESC LIMIT 1
         ) as workflowVersion ON workflows."id" = workflowVersion."workflowId"
     LEFT JOIN
         "WorkflowTriggers" as workflowTrigger ON workflowVersion."id" = workflowTrigger."workflowVersionId"

--- a/internal/repository/prisma/workflow.go
+++ b/internal/repository/prisma/workflow.go
@@ -447,12 +447,25 @@ func (r *workflowRepository) ListWorkflowsForEvent(ctx context.Context, tenantId
 func (r *workflowRepository) createWorkflowVersionTxs(ctx context.Context, tx pgx.Tx, tenantId, workflowId pgtype.UUID, opts *repository.CreateWorkflowVersionOpts) (string, error) {
 	workflowVersionId := uuid.New().String()
 
+	var version pgtype.Text
+
+	if opts.Version != nil {
+		version = sqlchelpers.TextFromStr(*opts.Version)
+	}
+
+	cs, err := opts.Checksum()
+
+	if err != nil {
+		return "", err
+	}
+
 	sqlcWorkflowVersion, err := r.queries.CreateWorkflowVersion(
 		context.Background(),
 		tx,
 		dbsqlc.CreateWorkflowVersionParams{
 			ID:         sqlchelpers.UUIDFromStr(workflowVersionId),
-			Version:    opts.Version,
+			Checksum:   cs,
+			Version:    version,
 			Workflowid: workflowId,
 		},
 	)

--- a/internal/repository/workflow.go
+++ b/internal/repository/workflow.go
@@ -29,7 +29,7 @@ type CreateWorkflowVersionOpts struct {
 	CronTriggers []string `validate:"dive,cron"`
 
 	// (optional) scheduled triggers for the workflow
-	ScheduledTriggers []time.Time `json:"-"` // we marshal this for computing checksums, and this isn't part of the core definition
+	ScheduledTriggers []time.Time
 
 	// (required) the workflow jobs
 	Jobs []CreateWorkflowJobOpts `validate:"required,min=1,dive"`

--- a/internal/repository/workflow.go
+++ b/internal/repository/workflow.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hatchet-dev/hatchet/internal/datautils"
+	"github.com/hatchet-dev/hatchet/internal/digest"
 	"github.com/hatchet-dev/hatchet/internal/repository/prisma/db"
 )
 
@@ -15,10 +17,10 @@ type CreateWorkflowVersionOpts struct {
 	Tags []CreateWorkflowTagOpts `validate:"dive"`
 
 	// (optional) the workflow description
-	Description *string
+	Description *string `json:"description,omitempty"`
 
-	// (required) the workflow version
-	Version string `validate:"required,semver"`
+	// (optional) the workflow version
+	Version *string `json:"version,omitempty"`
 
 	// (optional) event triggers for the workflow
 	EventTriggers []string
@@ -27,10 +29,27 @@ type CreateWorkflowVersionOpts struct {
 	CronTriggers []string `validate:"dive,cron"`
 
 	// (optional) scheduled triggers for the workflow
-	ScheduledTriggers []time.Time
+	ScheduledTriggers []time.Time `json:"-"` // we marshal this for computing checksums, and this isn't part of the core definition
 
 	// (required) the workflow jobs
 	Jobs []CreateWorkflowJobOpts `validate:"required,min=1,dive"`
+}
+
+func (o *CreateWorkflowVersionOpts) Checksum() (string, error) {
+	// compute a checksum for the workflow
+	declaredValues, err := datautils.ToJSONMap(o)
+
+	if err != nil {
+		return "", err
+	}
+
+	workflowChecksum, err := digest.DigestValues(declaredValues)
+
+	if err != nil {
+		return "", err
+	}
+
+	return workflowChecksum.String(), nil
 }
 
 type CreateWorkflowSchedulesOpts struct {

--- a/pkg/worker/service.go
+++ b/pkg/worker/service.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"fmt"
 
-	"github.com/hatchet-dev/hatchet/pkg/client"
 	"github.com/hatchet-dev/hatchet/pkg/client/types"
 )
 
@@ -29,7 +28,7 @@ func (s *Service) On(t triggerConverter, workflow workflowConverter) error {
 	apiWorkflow.Triggers = *wt
 
 	// create the workflow via the API
-	err := s.worker.client.Admin().PutWorkflow(&apiWorkflow, client.WithAutoVersion())
+	err := s.worker.client.Admin().PutWorkflow(&apiWorkflow)
 
 	if err != nil {
 		return err

--- a/prisma/migrations/20240126235456_v0_7_0/migration.sql
+++ b/prisma/migrations/20240126235456_v0_7_0/migration.sql
@@ -38,8 +38,17 @@ DROP COLUMN "refreshToken",
 ADD COLUMN     "refreshToken" BYTEA;
 
 -- AlterTable
-ALTER TABLE "WorkflowVersion" ADD COLUMN     "checksum" TEXT NOT NULL,
-ALTER COLUMN "version" DROP NOT NULL;
+ALTER TABLE "WorkflowVersion" ADD COLUMN "checksum" TEXT;
+
+-- Add a default random string value to existing rows
+UPDATE "WorkflowVersion"
+SET "checksum" = md5(random()::text || clock_timestamp()::text);
+
+-- Make the checksum column NOT NULL
+ALTER TABLE "WorkflowVersion" ALTER COLUMN "checksum" SET NOT NULL;
+
+-- Update the version column to allow NULL
+ALTER TABLE "WorkflowVersion" ALTER COLUMN "version" DROP NOT NULL;
 
 -- AlterTable
 ALTER TABLE "_ActionToWorker" DROP COLUMN "A",

--- a/prisma/migrations/20240126235456_v0_7_0/migration.sql
+++ b/prisma/migrations/20240126235456_v0_7_0/migration.sql
@@ -8,6 +8,7 @@
   - Added the required column `actionId` to the `Action` table without a default value. This is not possible if the table is not empty.
   - Changed the type of `id` on the `Action` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
   - Changed the type of `accessToken` on the `UserOAuth` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Added the required column `checksum` to the `WorkflowVersion` table without a default value. This is not possible if the table is not empty.
   - Changed the type of `A` on the `_ActionToWorker` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
 
 */
@@ -19,6 +20,9 @@ ALTER TABLE "_ActionToWorker" DROP CONSTRAINT "_ActionToWorker_A_fkey";
 
 -- DropIndex
 DROP INDEX "Action_tenantId_id_key";
+
+-- DropIndex
+DROP INDEX "WorkflowVersion_workflowId_version_key";
 
 -- AlterTable
 ALTER TABLE "Action" DROP CONSTRAINT "Action_pkey",
@@ -32,6 +36,10 @@ ALTER TABLE "UserOAuth" DROP COLUMN "accessToken",
 ADD COLUMN     "accessToken" BYTEA NOT NULL,
 DROP COLUMN "refreshToken",
 ADD COLUMN     "refreshToken" BYTEA;
+
+-- AlterTable
+ALTER TABLE "WorkflowVersion" ADD COLUMN     "checksum" TEXT NOT NULL,
+ALTER COLUMN "version" DROP NOT NULL;
 
 -- AlterTable
 ALTER TABLE "_ActionToWorker" DROP COLUMN "A",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -275,8 +275,11 @@ model WorkflowVersion {
   updatedAt DateTime  @default(now()) @updatedAt
   deletedAt DateTime?
 
-  version String
-  order   Int    @default(autoincrement()) @db.SmallInt
+  // note that checksums don't need to be unique, as they're computed from the workflow
+  // declaration, which can be the same for multiple versions (e.g. on revert)
+  checksum String
+  version  String?
+  order    Int     @default(autoincrement()) @db.SmallInt
 
   // the parent workflow
   workflow   Workflow @relation(fields: [workflowId], references: [id], onDelete: Cascade, onUpdate: Cascade)
@@ -293,9 +296,6 @@ model WorkflowVersion {
 
   // the scheduled runs for the workflow
   scheduled WorkflowTriggerScheduledRef[]
-
-  // versions are unique per workflow
-  @@unique([workflowId, version])
 }
 
 model WorkflowTriggers {

--- a/python-client/examples/dag/event_test.py
+++ b/python-client/examples/dag/event_test.py
@@ -1,4 +1,7 @@
 from hatchet_sdk import new_client
+from dotenv import load_dotenv
+
+load_dotenv()
 
 client = new_client()
 

--- a/python-client/examples/dag/worker.py
+++ b/python-client/examples/dag/worker.py
@@ -1,4 +1,7 @@
 from hatchet_sdk import Hatchet, Context
+from dotenv import load_dotenv
+
+load_dotenv()
 
 hatchet = Hatchet()
 

--- a/python-client/hatchet_sdk/hatchet.py
+++ b/python-client/hatchet_sdk/hatchet.py
@@ -12,12 +12,13 @@ class Hatchet:
         if not debug:
             logger.disable("hatchet_sdk")
 
-    def workflow(self, name : str='', on_events : list=[], on_crons : list=[]):
+    def workflow(self, name : str='', on_events : list=[], on_crons : list=[], version : str=''):
         def inner(cls):
                 cls.on_events = on_events
                 cls.on_crons = on_crons
                 cls.name = name or str(cls.__name__)
                 cls.client = self.client
+                cls.version = version
 
                 # Define a new class with the same name and bases as the original, but with WorkflowMeta as its metaclass
                 return WorkflowMeta(cls.__name__, cls.__bases__, dict(cls.__dict__))

--- a/python-client/hatchet_sdk/workflow.py
+++ b/python-client/hatchet_sdk/workflow.py
@@ -35,6 +35,7 @@ class WorkflowMeta(type):
         name = attrs['name']
         event_triggers = attrs['on_events']
         cron_triggers = attrs['on_crons']
+        version = attrs['version']
 
         createStepOpts: List[CreateWorkflowStepOpts] = [
             CreateWorkflowStepOpts(
@@ -49,7 +50,7 @@ class WorkflowMeta(type):
 
         client.admin.put_workflow(CreateWorkflowVersionOpts(
             name=name,
-            version="v0.62.0",
+            version=version,
             event_triggers=event_triggers,
             cron_triggers=cron_triggers,
             jobs=[
@@ -59,6 +60,6 @@ class WorkflowMeta(type):
                     steps=createStepOpts,
                 )
             ]
-        ), auto_version=True)
+        ))
 
         return super(WorkflowMeta, cls).__new__(cls, name, bases, attrs)


### PR DESCRIPTION
This uses `sha512` to compute checksums for the declared workflow, instead of offloading versioning logic to clients. 