### PR TITLE
fix(cli): log errors via stderr and always exit

### DIFF
--- a/cmd/hatchet-admin/cli/keyset.go
+++ b/cmd/hatchet-admin/cli/keyset.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -27,7 +28,7 @@ var keysetCreateLocalKeysetsCmd = &cobra.Command{
 		err := runCreateLocalKeysets()
 
 		if err != nil {
-			fmt.Printf("Fatal: could not run [keyset create-local-keys] command: %v\n", err)
+			log.Printf("Fatal: could not run [keyset create-local-keys] command: %v", err)
 			os.Exit(1)
 		}
 	},
@@ -40,7 +41,7 @@ var keysetCreateCloudKMSJWTCmd = &cobra.Command{
 		err := runCreateCloudKMSJWTKeyset()
 
 		if err != nil {
-			fmt.Printf("Fatal: could not run [keyset create-cloudkms-jwt] command: %v\n", err)
+			log.Printf("Fatal: could not run [keyset create-cloudkms-jwt] command: %v", err)
 			os.Exit(1)
 		}
 	},

--- a/cmd/hatchet-admin/cli/root.go
+++ b/cmd/hatchet-admin/cli/root.go
@@ -30,7 +30,7 @@ var rootCmd = &cobra.Command{
 		// sc, err = configLoader.LoadServerConfig()
 
 		// if err != nil {
-		// 	fmt.Printf("Fatal: could not load server config: %v\n", err)
+		// 	log.Printf("Fatal: could not load server config: %v\n", err)
 		// 	os.Exit(1)
 		// }
 	},

--- a/cmd/hatchet-admin/cli/seed.go
+++ b/cmd/hatchet-admin/cli/seed.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -23,7 +24,7 @@ var seedCmd = &cobra.Command{
 		err = runSeed(configLoader)
 
 		if err != nil {
-			fmt.Printf("Fatal: could not run seed command: %v\n", err)
+			log.Printf("Fatal: could not run seed command: %v", err)
 			os.Exit(1)
 		}
 	},

--- a/cmd/hatchet-admin/cli/token.go
+++ b/cmd/hatchet-admin/cli/token.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"fmt"
+	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -25,7 +27,8 @@ var tokenCreateAPICmd = &cobra.Command{
 		err := runCreateAPIToken()
 
 		if err != nil {
-			fmt.Printf("Fatal: could not run [token create] command: %v\n", err)
+			log.Printf("Fatal: could not run [token create] command: %v", err)
+			os.Exit(1)
 		}
 	},
 }


### PR DESCRIPTION
# Description

In the CLI package, fmt.Printf somehow does not actually log anything, so it was changed to log.Printf. Also, there was one os.Exit(1) missing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# What's Changed

