### PR TITLE
fix: smallserial -> bigserial

### DIFF
--- a/internal/repository/prisma/dbsqlc/get_group_key_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/get_group_key_runs.sql.go
@@ -31,7 +31,7 @@ SET
 WHERE 
   "id" = $10::uuid AND
   "tenantId" = $11::uuid
-RETURNING "GetGroupKeyRun".id, "GetGroupKeyRun"."createdAt", "GetGroupKeyRun"."updatedAt", "GetGroupKeyRun"."deletedAt", "GetGroupKeyRun"."tenantId", "GetGroupKeyRun"."workflowRunId", "GetGroupKeyRun"."workerId", "GetGroupKeyRun"."tickerId", "GetGroupKeyRun".status, "GetGroupKeyRun".input, "GetGroupKeyRun".output, "GetGroupKeyRun"."requeueAfter", "GetGroupKeyRun".error, "GetGroupKeyRun"."startedAt", "GetGroupKeyRun"."finishedAt", "GetGroupKeyRun"."timeoutAt", "GetGroupKeyRun"."cancelledAt", "GetGroupKeyRun"."cancelledReason", "GetGroupKeyRun"."cancelledError"
+RETURNING "GetGroupKeyRun".id, "GetGroupKeyRun"."createdAt", "GetGroupKeyRun"."updatedAt", "GetGroupKeyRun"."deletedAt", "GetGroupKeyRun"."tenantId", "GetGroupKeyRun"."workerId", "GetGroupKeyRun"."tickerId", "GetGroupKeyRun".status, "GetGroupKeyRun".input, "GetGroupKeyRun".output, "GetGroupKeyRun"."requeueAfter", "GetGroupKeyRun".error, "GetGroupKeyRun"."startedAt", "GetGroupKeyRun"."finishedAt", "GetGroupKeyRun"."timeoutAt", "GetGroupKeyRun"."cancelledAt", "GetGroupKeyRun"."cancelledReason", "GetGroupKeyRun"."cancelledError", "GetGroupKeyRun"."workflowRunId"
 `
 
 type UpdateGetGroupKeyRunParams struct {
@@ -69,7 +69,6 @@ func (q *Queries) UpdateGetGroupKeyRun(ctx context.Context, db DBTX, arg UpdateG
 		&i.UpdatedAt,
 		&i.DeletedAt,
 		&i.TenantId,
-		&i.WorkflowRunId,
 		&i.WorkerId,
 		&i.TickerId,
 		&i.Status,
@@ -83,6 +82,7 @@ func (q *Queries) UpdateGetGroupKeyRun(ctx context.Context, db DBTX, arg UpdateG
 		&i.CancelledAt,
 		&i.CancelledReason,
 		&i.CancelledError,
+		&i.WorkflowRunId,
 	)
 	return &i, err
 }

--- a/internal/repository/prisma/dbsqlc/job_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/job_runs.sql.go
@@ -62,7 +62,7 @@ WHERE "id" = (
     FROM "StepRun"
     WHERE "id" = $1::uuid
 ) AND "tenantId" = $2::uuid
-RETURNING "JobRun".id, "JobRun"."createdAt", "JobRun"."updatedAt", "JobRun"."deletedAt", "JobRun"."tenantId", "JobRun"."workflowRunId", "JobRun"."jobId", "JobRun"."tickerId", "JobRun".status, "JobRun".result, "JobRun"."startedAt", "JobRun"."finishedAt", "JobRun"."timeoutAt", "JobRun"."cancelledAt", "JobRun"."cancelledReason", "JobRun"."cancelledError"
+RETURNING "JobRun".id, "JobRun"."createdAt", "JobRun"."updatedAt", "JobRun"."deletedAt", "JobRun"."tenantId", "JobRun"."jobId", "JobRun"."tickerId", "JobRun".status, "JobRun".result, "JobRun"."startedAt", "JobRun"."finishedAt", "JobRun"."timeoutAt", "JobRun"."cancelledAt", "JobRun"."cancelledReason", "JobRun"."cancelledError", "JobRun"."workflowRunId"
 `
 
 type ResolveJobRunStatusParams struct {
@@ -79,7 +79,6 @@ func (q *Queries) ResolveJobRunStatus(ctx context.Context, db DBTX, arg ResolveJ
 		&i.UpdatedAt,
 		&i.DeletedAt,
 		&i.TenantId,
-		&i.WorkflowRunId,
 		&i.JobId,
 		&i.TickerId,
 		&i.Status,
@@ -90,6 +89,7 @@ func (q *Queries) ResolveJobRunStatus(ctx context.Context, db DBTX, arg ResolveJ
 		&i.CancelledAt,
 		&i.CancelledReason,
 		&i.CancelledError,
+		&i.WorkflowRunId,
 	)
 	return &i, err
 }
@@ -105,7 +105,7 @@ END
 WHERE
     "id" = $2::uuid AND
     "tenantId" = $3::uuid
-RETURNING "JobRun".id, "JobRun"."createdAt", "JobRun"."updatedAt", "JobRun"."deletedAt", "JobRun"."tenantId", "JobRun"."workflowRunId", "JobRun"."jobId", "JobRun"."tickerId", "JobRun".status, "JobRun".result, "JobRun"."startedAt", "JobRun"."finishedAt", "JobRun"."timeoutAt", "JobRun"."cancelledAt", "JobRun"."cancelledReason", "JobRun"."cancelledError"
+RETURNING "JobRun".id, "JobRun"."createdAt", "JobRun"."updatedAt", "JobRun"."deletedAt", "JobRun"."tenantId", "JobRun"."jobId", "JobRun"."tickerId", "JobRun".status, "JobRun".result, "JobRun"."startedAt", "JobRun"."finishedAt", "JobRun"."timeoutAt", "JobRun"."cancelledAt", "JobRun"."cancelledReason", "JobRun"."cancelledError", "JobRun"."workflowRunId"
 `
 
 type UpdateJobRunParams struct {
@@ -123,7 +123,6 @@ func (q *Queries) UpdateJobRun(ctx context.Context, db DBTX, arg UpdateJobRunPar
 		&i.UpdatedAt,
 		&i.DeletedAt,
 		&i.TenantId,
-		&i.WorkflowRunId,
 		&i.JobId,
 		&i.TickerId,
 		&i.Status,
@@ -134,6 +133,7 @@ func (q *Queries) UpdateJobRun(ctx context.Context, db DBTX, arg UpdateJobRunPar
 		&i.CancelledAt,
 		&i.CancelledReason,
 		&i.CancelledError,
+		&i.WorkflowRunId,
 	)
 	return &i, err
 }

--- a/internal/repository/prisma/dbsqlc/models.go
+++ b/internal/repository/prisma/dbsqlc/models.go
@@ -278,10 +278,10 @@ type WorkflowRunStatus string
 
 const (
 	WorkflowRunStatusPENDING   WorkflowRunStatus = "PENDING"
-	WorkflowRunStatusQUEUED    WorkflowRunStatus = "QUEUED"
 	WorkflowRunStatusRUNNING   WorkflowRunStatus = "RUNNING"
 	WorkflowRunStatusSUCCEEDED WorkflowRunStatus = "SUCCEEDED"
 	WorkflowRunStatusFAILED    WorkflowRunStatus = "FAILED"
+	WorkflowRunStatusQUEUED    WorkflowRunStatus = "QUEUED"
 )
 
 func (e *WorkflowRunStatus) Scan(src interface{}) error {
@@ -330,15 +330,15 @@ type APIToken struct {
 }
 
 type Action struct {
-	ID          pgtype.UUID `json:"id"`
-	ActionId    string      `json:"actionId"`
 	Description pgtype.Text `json:"description"`
 	TenantId    pgtype.UUID `json:"tenantId"`
+	ActionId    string      `json:"actionId"`
+	ID          pgtype.UUID `json:"id"`
 }
 
 type ActionToWorker struct {
-	A pgtype.UUID `json:"A"`
 	B pgtype.UUID `json:"B"`
+	A pgtype.UUID `json:"A"`
 }
 
 type Dispatcher struct {
@@ -367,7 +367,6 @@ type GetGroupKeyRun struct {
 	UpdatedAt       pgtype.Timestamp `json:"updatedAt"`
 	DeletedAt       pgtype.Timestamp `json:"deletedAt"`
 	TenantId        pgtype.UUID      `json:"tenantId"`
-	WorkflowRunId   pgtype.UUID      `json:"workflowRunId"`
 	WorkerId        pgtype.UUID      `json:"workerId"`
 	TickerId        pgtype.UUID      `json:"tickerId"`
 	Status          StepRunStatus    `json:"status"`
@@ -381,6 +380,7 @@ type GetGroupKeyRun struct {
 	CancelledAt     pgtype.Timestamp `json:"cancelledAt"`
 	CancelledReason pgtype.Text      `json:"cancelledReason"`
 	CancelledError  pgtype.Text      `json:"cancelledError"`
+	WorkflowRunId   pgtype.UUID      `json:"workflowRunId"`
 }
 
 type Job struct {
@@ -401,7 +401,6 @@ type JobRun struct {
 	UpdatedAt       pgtype.Timestamp `json:"updatedAt"`
 	DeletedAt       pgtype.Timestamp `json:"deletedAt"`
 	TenantId        pgtype.UUID      `json:"tenantId"`
-	WorkflowRunId   pgtype.UUID      `json:"workflowRunId"`
 	JobId           pgtype.UUID      `json:"jobId"`
 	TickerId        pgtype.UUID      `json:"tickerId"`
 	Status          JobRunStatus     `json:"status"`
@@ -412,6 +411,7 @@ type JobRun struct {
 	CancelledAt     pgtype.Timestamp `json:"cancelledAt"`
 	CancelledReason pgtype.Text      `json:"cancelledReason"`
 	CancelledError  pgtype.Text      `json:"cancelledError"`
+	WorkflowRunId   pgtype.UUID      `json:"workflowRunId"`
 }
 
 type JobRunLookupData struct {
@@ -465,7 +465,7 @@ type StepRun struct {
 	TenantId          pgtype.UUID      `json:"tenantId"`
 	JobRunId          pgtype.UUID      `json:"jobRunId"`
 	StepId            pgtype.UUID      `json:"stepId"`
-	Order             int16            `json:"order"`
+	Order             int64            `json:"order"`
 	WorkerId          pgtype.UUID      `json:"workerId"`
 	TickerId          pgtype.UUID      `json:"tickerId"`
 	Status            StepRunStatus    `json:"status"`
@@ -542,9 +542,9 @@ type UserOAuth struct {
 	UserId         pgtype.UUID      `json:"userId"`
 	Provider       string           `json:"provider"`
 	ProviderUserId string           `json:"providerUserId"`
+	ExpiresAt      pgtype.Timestamp `json:"expiresAt"`
 	AccessToken    []byte           `json:"accessToken"`
 	RefreshToken   []byte           `json:"refreshToken"`
-	ExpiresAt      pgtype.Timestamp `json:"expiresAt"`
 }
 
 type UserPassword struct {
@@ -594,18 +594,18 @@ type WorkflowConcurrency struct {
 }
 
 type WorkflowRun struct {
-	ID                 pgtype.UUID       `json:"id"`
 	CreatedAt          pgtype.Timestamp  `json:"createdAt"`
 	UpdatedAt          pgtype.Timestamp  `json:"updatedAt"`
 	DeletedAt          pgtype.Timestamp  `json:"deletedAt"`
-	DisplayName        pgtype.Text       `json:"displayName"`
 	TenantId           pgtype.UUID       `json:"tenantId"`
 	WorkflowVersionId  pgtype.UUID       `json:"workflowVersionId"`
-	ConcurrencyGroupId pgtype.Text       `json:"concurrencyGroupId"`
 	Status             WorkflowRunStatus `json:"status"`
 	Error              pgtype.Text       `json:"error"`
 	StartedAt          pgtype.Timestamp  `json:"startedAt"`
 	FinishedAt         pgtype.Timestamp  `json:"finishedAt"`
+	ConcurrencyGroupId pgtype.Text       `json:"concurrencyGroupId"`
+	DisplayName        pgtype.Text       `json:"displayName"`
+	ID                 pgtype.UUID       `json:"id"`
 }
 
 type WorkflowRunTriggeredBy struct {
@@ -614,12 +614,12 @@ type WorkflowRunTriggeredBy struct {
 	UpdatedAt    pgtype.Timestamp `json:"updatedAt"`
 	DeletedAt    pgtype.Timestamp `json:"deletedAt"`
 	TenantId     pgtype.UUID      `json:"tenantId"`
-	ParentId     pgtype.UUID      `json:"parentId"`
-	Input        []byte           `json:"input"`
 	EventId      pgtype.UUID      `json:"eventId"`
 	CronParentId pgtype.UUID      `json:"cronParentId"`
 	CronSchedule pgtype.Text      `json:"cronSchedule"`
 	ScheduledId  pgtype.UUID      `json:"scheduledId"`
+	Input        []byte           `json:"input"`
+	ParentId     pgtype.UUID      `json:"parentId"`
 }
 
 type WorkflowTag struct {
@@ -670,8 +670,8 @@ type WorkflowVersion struct {
 	CreatedAt  pgtype.Timestamp `json:"createdAt"`
 	UpdatedAt  pgtype.Timestamp `json:"updatedAt"`
 	DeletedAt  pgtype.Timestamp `json:"deletedAt"`
-	Checksum   string           `json:"checksum"`
 	Version    pgtype.Text      `json:"version"`
-	Order      int16            `json:"order"`
+	Order      int64            `json:"order"`
 	WorkflowId pgtype.UUID      `json:"workflowId"`
+	Checksum   string           `json:"checksum"`
 }

--- a/internal/repository/prisma/dbsqlc/schema.sql
+++ b/internal/repository/prisma/dbsqlc/schema.sql
@@ -17,7 +17,7 @@ CREATE TYPE "TenantMemberRole" AS ENUM ('OWNER', 'ADMIN', 'MEMBER');
 CREATE TYPE "WorkerStatus" AS ENUM ('ACTIVE', 'INACTIVE');
 
 -- CreateEnum
-CREATE TYPE "WorkflowRunStatus" AS ENUM ('PENDING', 'QUEUED', 'RUNNING', 'SUCCEEDED', 'FAILED');
+CREATE TYPE "WorkflowRunStatus" AS ENUM ('PENDING', 'RUNNING', 'SUCCEEDED', 'FAILED', 'QUEUED');
 
 -- CreateTable
 CREATE TABLE "APIToken" (
@@ -34,10 +34,10 @@ CREATE TABLE "APIToken" (
 
 -- CreateTable
 CREATE TABLE "Action" (
-    "id" UUID NOT NULL,
-    "actionId" TEXT NOT NULL,
     "description" TEXT,
     "tenantId" UUID NOT NULL,
+    "actionId" TEXT NOT NULL,
+    "id" UUID NOT NULL,
 
     CONSTRAINT "Action_pkey" PRIMARY KEY ("id")
 );
@@ -75,7 +75,6 @@ CREATE TABLE "GetGroupKeyRun" (
     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "deletedAt" TIMESTAMP(3),
     "tenantId" UUID NOT NULL,
-    "workflowRunId" UUID NOT NULL,
     "workerId" UUID,
     "tickerId" UUID,
     "status" "StepRunStatus" NOT NULL DEFAULT 'PENDING',
@@ -89,6 +88,7 @@ CREATE TABLE "GetGroupKeyRun" (
     "cancelledAt" TIMESTAMP(3),
     "cancelledReason" TEXT,
     "cancelledError" TEXT,
+    "workflowRunId" UUID NOT NULL,
 
     CONSTRAINT "GetGroupKeyRun_pkey" PRIMARY KEY ("id")
 );
@@ -115,7 +115,6 @@ CREATE TABLE "JobRun" (
     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "deletedAt" TIMESTAMP(3),
     "tenantId" UUID NOT NULL,
-    "workflowRunId" UUID NOT NULL,
     "jobId" UUID NOT NULL,
     "tickerId" UUID,
     "status" "JobRunStatus" NOT NULL DEFAULT 'PENDING',
@@ -126,6 +125,7 @@ CREATE TABLE "JobRun" (
     "cancelledAt" TIMESTAMP(3),
     "cancelledReason" TEXT,
     "cancelledError" TEXT,
+    "workflowRunId" UUID NOT NULL,
 
     CONSTRAINT "JobRun_pkey" PRIMARY KEY ("id")
 );
@@ -181,7 +181,7 @@ CREATE TABLE "StepRun" (
     "tenantId" UUID NOT NULL,
     "jobRunId" UUID NOT NULL,
     "stepId" UUID NOT NULL,
-    "order" SMALLSERIAL NOT NULL,
+    "order" BIGSERIAL NOT NULL,
     "workerId" UUID,
     "tickerId" UUID,
     "status" "StepRunStatus" NOT NULL DEFAULT 'PENDING',
@@ -271,9 +271,9 @@ CREATE TABLE "UserOAuth" (
     "userId" UUID NOT NULL,
     "provider" TEXT NOT NULL,
     "providerUserId" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3),
     "accessToken" BYTEA NOT NULL,
     "refreshToken" BYTEA,
-    "expiresAt" TIMESTAMP(3),
 
     CONSTRAINT "UserOAuth_pkey" PRIMARY KEY ("id")
 );
@@ -339,18 +339,18 @@ CREATE TABLE "WorkflowConcurrency" (
 
 -- CreateTable
 CREATE TABLE "WorkflowRun" (
-    "id" UUID NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "deletedAt" TIMESTAMP(3),
-    "displayName" TEXT,
     "tenantId" UUID NOT NULL,
     "workflowVersionId" UUID NOT NULL,
-    "concurrencyGroupId" TEXT,
     "status" "WorkflowRunStatus" NOT NULL DEFAULT 'PENDING',
     "error" TEXT,
     "startedAt" TIMESTAMP(3),
     "finishedAt" TIMESTAMP(3),
+    "concurrencyGroupId" TEXT,
+    "displayName" TEXT,
+    "id" UUID NOT NULL,
 
     CONSTRAINT "WorkflowRun_pkey" PRIMARY KEY ("id")
 );
@@ -362,12 +362,12 @@ CREATE TABLE "WorkflowRunTriggeredBy" (
     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "deletedAt" TIMESTAMP(3),
     "tenantId" UUID NOT NULL,
-    "parentId" UUID NOT NULL,
-    "input" JSONB,
     "eventId" UUID,
     "cronParentId" UUID,
     "cronSchedule" TEXT,
     "scheduledId" UUID,
+    "input" JSONB,
+    "parentId" UUID NOT NULL,
 
     CONSTRAINT "WorkflowRunTriggeredBy_pkey" PRIMARY KEY ("id")
 );
@@ -427,18 +427,18 @@ CREATE TABLE "WorkflowVersion" (
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "deletedAt" TIMESTAMP(3),
-    "checksum" TEXT NOT NULL,
     "version" TEXT,
-    "order" SMALLSERIAL NOT NULL,
+    "order" BIGSERIAL NOT NULL,
     "workflowId" UUID NOT NULL,
+    "checksum" TEXT NOT NULL,
 
     CONSTRAINT "WorkflowVersion_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateTable
 CREATE TABLE "_ActionToWorker" (
-    "A" UUID NOT NULL,
-    "B" UUID NOT NULL
+    "B" UUID NOT NULL,
+    "A" UUID NOT NULL
 );
 
 -- CreateTable

--- a/internal/repository/prisma/dbsqlc/workflow_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/workflow_runs.sql.go
@@ -112,7 +112,7 @@ INSERT INTO "GetGroupKeyRun" (
     NULL,
     NULL,
     NULL
-) RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "workflowRunId", "workerId", "tickerId", status, input, output, "requeueAfter", error, "startedAt", "finishedAt", "timeoutAt", "cancelledAt", "cancelledReason", "cancelledError"
+) RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "workerId", "tickerId", status, input, output, "requeueAfter", error, "startedAt", "finishedAt", "timeoutAt", "cancelledAt", "cancelledReason", "cancelledError", "workflowRunId"
 `
 
 type CreateGetGroupKeyRunParams struct {
@@ -138,7 +138,6 @@ func (q *Queries) CreateGetGroupKeyRun(ctx context.Context, db DBTX, arg CreateG
 		&i.UpdatedAt,
 		&i.DeletedAt,
 		&i.TenantId,
-		&i.WorkflowRunId,
 		&i.WorkerId,
 		&i.TickerId,
 		&i.Status,
@@ -152,6 +151,7 @@ func (q *Queries) CreateGetGroupKeyRun(ctx context.Context, db DBTX, arg CreateG
 		&i.CancelledAt,
 		&i.CancelledReason,
 		&i.CancelledError,
+		&i.WorkflowRunId,
 	)
 	return &i, err
 }
@@ -191,7 +191,7 @@ INSERT INTO "JobRun" (
     NULL,
     NULL,
     NULL
-) RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "workflowRunId", "jobId", "tickerId", status, result, "startedAt", "finishedAt", "timeoutAt", "cancelledAt", "cancelledReason", "cancelledError"
+) RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "jobId", "tickerId", status, result, "startedAt", "finishedAt", "timeoutAt", "cancelledAt", "cancelledReason", "cancelledError", "workflowRunId"
 `
 
 type CreateJobRunParams struct {
@@ -215,7 +215,6 @@ func (q *Queries) CreateJobRun(ctx context.Context, db DBTX, arg CreateJobRunPar
 		&i.UpdatedAt,
 		&i.DeletedAt,
 		&i.TenantId,
-		&i.WorkflowRunId,
 		&i.JobId,
 		&i.TickerId,
 		&i.Status,
@@ -226,6 +225,7 @@ func (q *Queries) CreateJobRun(ctx context.Context, db DBTX, arg CreateJobRunPar
 		&i.CancelledAt,
 		&i.CancelledReason,
 		&i.CancelledError,
+		&i.WorkflowRunId,
 	)
 	return &i, err
 }
@@ -402,7 +402,7 @@ INSERT INTO "WorkflowRun" (
     NULL, -- assuming error is not set on creation
     NULL, -- assuming startedAt is not set on creation
     NULL  -- assuming finishedAt is not set on creation
-) RETURNING id, "createdAt", "updatedAt", "deletedAt", "displayName", "tenantId", "workflowVersionId", "concurrencyGroupId", status, error, "startedAt", "finishedAt"
+) RETURNING "createdAt", "updatedAt", "deletedAt", "tenantId", "workflowVersionId", status, error, "startedAt", "finishedAt", "concurrencyGroupId", "displayName", id
 `
 
 type CreateWorkflowRunParams struct {
@@ -421,18 +421,18 @@ func (q *Queries) CreateWorkflowRun(ctx context.Context, db DBTX, arg CreateWork
 	)
 	var i WorkflowRun
 	err := row.Scan(
-		&i.ID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
-		&i.DisplayName,
 		&i.TenantId,
 		&i.WorkflowVersionId,
-		&i.ConcurrencyGroupId,
 		&i.Status,
 		&i.Error,
 		&i.StartedAt,
 		&i.FinishedAt,
+		&i.ConcurrencyGroupId,
+		&i.DisplayName,
+		&i.ID,
 	)
 	return &i, err
 }
@@ -460,7 +460,7 @@ INSERT INTO "WorkflowRunTriggeredBy" (
     $4::uuid, -- NULL if not provided
     $5::text, -- NULL if not provided
     $6::uuid -- NULL if not provided
-) RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "parentId", input, "eventId", "cronParentId", "cronSchedule", "scheduledId"
+) RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "eventId", "cronParentId", "cronSchedule", "scheduledId", input, "parentId"
 `
 
 type CreateWorkflowRunTriggeredByParams struct {
@@ -488,12 +488,12 @@ func (q *Queries) CreateWorkflowRunTriggeredBy(ctx context.Context, db DBTX, arg
 		&i.UpdatedAt,
 		&i.DeletedAt,
 		&i.TenantId,
-		&i.ParentId,
-		&i.Input,
 		&i.EventId,
 		&i.CronParentId,
 		&i.CronSchedule,
 		&i.ScheduledId,
+		&i.Input,
+		&i.ParentId,
 	)
 	return &i, err
 }
@@ -589,10 +589,10 @@ func (q *Queries) ListStartableStepRuns(ctx context.Context, db DBTX, arg ListSt
 
 const listWorkflowRuns = `-- name: ListWorkflowRuns :many
 SELECT
-    runs.id, runs."createdAt", runs."updatedAt", runs."deletedAt", runs."displayName", runs."tenantId", runs."workflowVersionId", runs."concurrencyGroupId", runs.status, runs.error, runs."startedAt", runs."finishedAt", 
+    runs."createdAt", runs."updatedAt", runs."deletedAt", runs."tenantId", runs."workflowVersionId", runs.status, runs.error, runs."startedAt", runs."finishedAt", runs."concurrencyGroupId", runs."displayName", runs.id, 
     workflow.id, workflow."createdAt", workflow."updatedAt", workflow."deletedAt", workflow."tenantId", workflow.name, workflow.description, 
-    runtriggers.id, runtriggers."createdAt", runtriggers."updatedAt", runtriggers."deletedAt", runtriggers."tenantId", runtriggers."parentId", runtriggers.input, runtriggers."eventId", runtriggers."cronParentId", runtriggers."cronSchedule", runtriggers."scheduledId", 
-    workflowversion.id, workflowversion."createdAt", workflowversion."updatedAt", workflowversion."deletedAt", workflowversion.checksum, workflowversion.version, workflowversion."order", workflowversion."workflowId", 
+    runtriggers.id, runtriggers."createdAt", runtriggers."updatedAt", runtriggers."deletedAt", runtriggers."tenantId", runtriggers."eventId", runtriggers."cronParentId", runtriggers."cronSchedule", runtriggers."scheduledId", runtriggers.input, runtriggers."parentId", 
+    workflowversion.id, workflowversion."createdAt", workflowversion."updatedAt", workflowversion."deletedAt", workflowversion.version, workflowversion."order", workflowversion."workflowId", workflowversion.checksum, 
     -- waiting on https://github.com/sqlc-dev/sqlc/pull/2858 for nullable events field
     events.id, events.key, events."createdAt", events."updatedAt"
 FROM
@@ -679,18 +679,18 @@ func (q *Queries) ListWorkflowRuns(ctx context.Context, db DBTX, arg ListWorkflo
 	for rows.Next() {
 		var i ListWorkflowRunsRow
 		if err := rows.Scan(
-			&i.WorkflowRun.ID,
 			&i.WorkflowRun.CreatedAt,
 			&i.WorkflowRun.UpdatedAt,
 			&i.WorkflowRun.DeletedAt,
-			&i.WorkflowRun.DisplayName,
 			&i.WorkflowRun.TenantId,
 			&i.WorkflowRun.WorkflowVersionId,
-			&i.WorkflowRun.ConcurrencyGroupId,
 			&i.WorkflowRun.Status,
 			&i.WorkflowRun.Error,
 			&i.WorkflowRun.StartedAt,
 			&i.WorkflowRun.FinishedAt,
+			&i.WorkflowRun.ConcurrencyGroupId,
+			&i.WorkflowRun.DisplayName,
+			&i.WorkflowRun.ID,
 			&i.Workflow.ID,
 			&i.Workflow.CreatedAt,
 			&i.Workflow.UpdatedAt,
@@ -703,20 +703,20 @@ func (q *Queries) ListWorkflowRuns(ctx context.Context, db DBTX, arg ListWorkflo
 			&i.WorkflowRunTriggeredBy.UpdatedAt,
 			&i.WorkflowRunTriggeredBy.DeletedAt,
 			&i.WorkflowRunTriggeredBy.TenantId,
-			&i.WorkflowRunTriggeredBy.ParentId,
-			&i.WorkflowRunTriggeredBy.Input,
 			&i.WorkflowRunTriggeredBy.EventId,
 			&i.WorkflowRunTriggeredBy.CronParentId,
 			&i.WorkflowRunTriggeredBy.CronSchedule,
 			&i.WorkflowRunTriggeredBy.ScheduledId,
+			&i.WorkflowRunTriggeredBy.Input,
+			&i.WorkflowRunTriggeredBy.ParentId,
 			&i.WorkflowVersion.ID,
 			&i.WorkflowVersion.CreatedAt,
 			&i.WorkflowVersion.UpdatedAt,
 			&i.WorkflowVersion.DeletedAt,
-			&i.WorkflowVersion.Checksum,
 			&i.WorkflowVersion.Version,
 			&i.WorkflowVersion.Order,
 			&i.WorkflowVersion.WorkflowId,
+			&i.WorkflowVersion.Checksum,
 			&i.ID,
 			&i.Key,
 			&i.CreatedAt,
@@ -781,7 +781,7 @@ WHERE "id" = (
     FROM "JobRun"
     WHERE "id" = $1::uuid
 ) AND "tenantId" = $2::uuid
-RETURNING "WorkflowRun".id, "WorkflowRun"."createdAt", "WorkflowRun"."updatedAt", "WorkflowRun"."deletedAt", "WorkflowRun"."displayName", "WorkflowRun"."tenantId", "WorkflowRun"."workflowVersionId", "WorkflowRun"."concurrencyGroupId", "WorkflowRun".status, "WorkflowRun".error, "WorkflowRun"."startedAt", "WorkflowRun"."finishedAt"
+RETURNING "WorkflowRun"."createdAt", "WorkflowRun"."updatedAt", "WorkflowRun"."deletedAt", "WorkflowRun"."tenantId", "WorkflowRun"."workflowVersionId", "WorkflowRun".status, "WorkflowRun".error, "WorkflowRun"."startedAt", "WorkflowRun"."finishedAt", "WorkflowRun"."concurrencyGroupId", "WorkflowRun"."displayName", "WorkflowRun".id
 `
 
 type ResolveWorkflowRunStatusParams struct {
@@ -793,18 +793,18 @@ func (q *Queries) ResolveWorkflowRunStatus(ctx context.Context, db DBTX, arg Res
 	row := db.QueryRow(ctx, resolveWorkflowRunStatus, arg.Jobrunid, arg.Tenantid)
 	var i WorkflowRun
 	err := row.Scan(
-		&i.ID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
-		&i.DisplayName,
 		&i.TenantId,
 		&i.WorkflowVersionId,
-		&i.ConcurrencyGroupId,
 		&i.Status,
 		&i.Error,
 		&i.StartedAt,
 		&i.FinishedAt,
+		&i.ConcurrencyGroupId,
+		&i.DisplayName,
+		&i.ID,
 	)
 	return &i, err
 }
@@ -838,7 +838,7 @@ FROM
 WHERE 
 workflowRun."id" = groupKeyRun."workflowRunId" AND
 workflowRun."tenantId" = $1::uuid
-RETURNING workflowrun.id, workflowrun."createdAt", workflowrun."updatedAt", workflowrun."deletedAt", workflowrun."displayName", workflowrun."tenantId", workflowrun."workflowVersionId", workflowrun."concurrencyGroupId", workflowrun.status, workflowrun.error, workflowrun."startedAt", workflowrun."finishedAt"
+RETURNING workflowrun."createdAt", workflowrun."updatedAt", workflowrun."deletedAt", workflowrun."tenantId", workflowrun."workflowVersionId", workflowrun.status, workflowrun.error, workflowrun."startedAt", workflowrun."finishedAt", workflowrun."concurrencyGroupId", workflowrun."displayName", workflowrun.id
 `
 
 type UpdateWorkflowRunGroupKeyParams struct {
@@ -850,18 +850,18 @@ func (q *Queries) UpdateWorkflowRunGroupKey(ctx context.Context, db DBTX, arg Up
 	row := db.QueryRow(ctx, updateWorkflowRunGroupKey, arg.Tenantid, arg.Groupkeyrunid)
 	var i WorkflowRun
 	err := row.Scan(
-		&i.ID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
-		&i.DisplayName,
 		&i.TenantId,
 		&i.WorkflowVersionId,
-		&i.ConcurrencyGroupId,
 		&i.Status,
 		&i.Error,
 		&i.StartedAt,
 		&i.FinishedAt,
+		&i.ConcurrencyGroupId,
+		&i.DisplayName,
+		&i.ID,
 	)
 	return &i, err
 }

--- a/internal/repository/prisma/dbsqlc/workflows.sql.go
+++ b/internal/repository/prisma/dbsqlc/workflows.sql.go
@@ -471,7 +471,7 @@ INSERT INTO "WorkflowVersion" (
     $5::text,
     $6::text,
     $7::uuid
-) RETURNING id, "createdAt", "updatedAt", "deletedAt", checksum, version, "order", "workflowId"
+) RETURNING id, "createdAt", "updatedAt", "deletedAt", version, "order", "workflowId", checksum
 `
 
 type CreateWorkflowVersionParams struct {
@@ -500,10 +500,10 @@ func (q *Queries) CreateWorkflowVersion(ctx context.Context, db DBTX, arg Create
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
-		&i.Checksum,
 		&i.Version,
 		&i.Order,
 		&i.WorkflowId,
+		&i.Checksum,
 	)
 	return &i, err
 }
@@ -518,7 +518,7 @@ FROM (
         "Workflow" as workflows 
     LEFT JOIN
         (
-            SELECT id, "createdAt", "updatedAt", "deletedAt", checksum, version, "order", "workflowId" FROM "WorkflowVersion" as workflowVersion ORDER BY workflowVersion."order" DESC LIMIT 1
+            SELECT id, "createdAt", "updatedAt", "deletedAt", version, "order", "workflowId", checksum FROM "WorkflowVersion" as workflowVersion ORDER BY workflowVersion."order" DESC LIMIT 1
         ) as workflowVersion ON workflows."id" = workflowVersion."workflowId"
     LEFT JOIN
         "WorkflowTriggers" as workflowTrigger ON workflowVersion."id" = workflowTrigger."workflowVersionId"
@@ -612,7 +612,7 @@ func (q *Queries) ListWorkflows(ctx context.Context, db DBTX, arg ListWorkflowsP
 
 const listWorkflowsLatestRuns = `-- name: ListWorkflowsLatestRuns :many
 SELECT
-    DISTINCT ON (workflow."id") runs.id, runs."createdAt", runs."updatedAt", runs."deletedAt", runs."displayName", runs."tenantId", runs."workflowVersionId", runs."concurrencyGroupId", runs.status, runs.error, runs."startedAt", runs."finishedAt", workflow."id" as "workflowId"
+    DISTINCT ON (workflow."id") runs."createdAt", runs."updatedAt", runs."deletedAt", runs."tenantId", runs."workflowVersionId", runs.status, runs.error, runs."startedAt", runs."finishedAt", runs."concurrencyGroupId", runs."displayName", runs.id, workflow."id" as "workflowId"
 FROM
     "WorkflowRun" as runs
 LEFT JOIN
@@ -671,18 +671,18 @@ func (q *Queries) ListWorkflowsLatestRuns(ctx context.Context, db DBTX, arg List
 	for rows.Next() {
 		var i ListWorkflowsLatestRunsRow
 		if err := rows.Scan(
-			&i.WorkflowRun.ID,
 			&i.WorkflowRun.CreatedAt,
 			&i.WorkflowRun.UpdatedAt,
 			&i.WorkflowRun.DeletedAt,
-			&i.WorkflowRun.DisplayName,
 			&i.WorkflowRun.TenantId,
 			&i.WorkflowRun.WorkflowVersionId,
-			&i.WorkflowRun.ConcurrencyGroupId,
 			&i.WorkflowRun.Status,
 			&i.WorkflowRun.Error,
 			&i.WorkflowRun.StartedAt,
 			&i.WorkflowRun.FinishedAt,
+			&i.WorkflowRun.ConcurrencyGroupId,
+			&i.WorkflowRun.DisplayName,
+			&i.WorkflowRun.ID,
 			&i.WorkflowId,
 		); err != nil {
 			return nil, err
@@ -711,7 +711,7 @@ SET
     "tenantId" = EXCLUDED."tenantId"
 WHERE
     "Action"."tenantId" = $2 AND "Action"."actionId" = LOWER($1::text)
-RETURNING id, "actionId", description, "tenantId"
+RETURNING description, "tenantId", "actionId", id
 `
 
 type UpsertActionParams struct {
@@ -723,10 +723,10 @@ func (q *Queries) UpsertAction(ctx context.Context, db DBTX, arg UpsertActionPar
 	row := db.QueryRow(ctx, upsertAction, arg.Action, arg.Tenantid)
 	var i Action
 	err := row.Scan(
-		&i.ID,
-		&i.ActionId,
 		&i.Description,
 		&i.TenantId,
+		&i.ActionId,
+		&i.ID,
 	)
 	return &i, err
 }

--- a/prisma/migrations/20240215162148_v0_10_2/migration.sql
+++ b/prisma/migrations/20240215162148_v0_10_2/migration.sql
@@ -1,0 +1,12 @@
+-- Create sequence and alter the table for StepRun
+CREATE SEQUENCE step_run_order_seq;
+ALTER TABLE "StepRun" ALTER COLUMN "order" TYPE BIGINT;
+ALTER SEQUENCE step_run_order_seq OWNED BY "StepRun"."order";
+ALTER TABLE "StepRun" ALTER COLUMN "order" SET DEFAULT nextval('step_run_order_seq'::regclass);
+
+-- Create sequence and alter the table for WorkflowVersion
+CREATE SEQUENCE workflow_version_order_seq;
+ALTER TABLE "WorkflowVersion" ALTER COLUMN "order" TYPE BIGINT;
+ALTER SEQUENCE workflow_version_order_seq OWNED BY "WorkflowVersion"."order";
+ALTER TABLE "WorkflowVersion" ALTER COLUMN "order" SET DEFAULT nextval('workflow_version_order_seq'::regclass);
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -280,7 +280,7 @@ model WorkflowVersion {
   // declaration, which can be the same for multiple versions (e.g. on revert)
   checksum String
   version  String?
-  order    Int     @default(autoincrement()) @db.SmallInt
+  order    BigInt  @default(autoincrement()) @db.BigInt
 
   // the parent workflow
   workflow   Workflow @relation(fields: [workflowId], references: [id], onDelete: Cascade, onUpdate: Cascade)
@@ -761,7 +761,7 @@ model StepRun {
   // a list of dependencies for this step
   parents StepRun[] @relation("StepRunOrder")
 
-  order Int @default(autoincrement()) @db.SmallInt
+  order BigInt @default(autoincrement()) @db.BigInt
 
   // the worker assigned to this job
   worker   Worker? @relation(fields: [workerId], references: [id])


### PR DESCRIPTION
# Description

Hard limit of 32k workflow runs due to usage of `SMALLSERIAL` for autoincrementing IDs. This sets the sequence to `BIGSERIAL`. 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# What's Changed

- [X] Database schema fixes