### PR TITLE
fix: don't populate step runs in ticker

### DIFF
--- a/internal/repository/prisma/ticker.go
+++ b/internal/repository/prisma/ticker.go
@@ -174,8 +174,6 @@ func (t *tickerRepository) GetTickerById(tickerId string) (*db.TickerModel, erro
 				db.WorkflowVersion.Workflow.Fetch(),
 			),
 		),
-		db.Ticker.JobRuns.Fetch(),
-		db.Ticker.StepRuns.Fetch(),
 	).Exec(context.Background())
 }
 


### PR DESCRIPTION
# Description

Don't populate all step and job runs in ticker response. 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)