### PR TITLE
fix: docker-compose set to pg 15

### DIFF
--- a/frontend/docs/pages/self-hosting/docker-compose.mdx
+++ b/frontend/docs/pages/self-hosting/docker-compose.mdx
@@ -26,7 +26,7 @@ import { FileTree } from 'nextra/components'
 version: "3.8"
 services:
   postgres:
-    image: postgres:latest
+    image: postgres:15.6
     command: postgres -c 'max_connections=200'
     restart: always
     hostname: "postgres"


### PR DESCRIPTION
# Description

Sets postgres docker image to pg15. 
