### PR TITLE
refactor: cleanup functions in api + worker

### DIFF
--- a/cmd/hatchet-api/api/run.go
+++ b/cmd/hatchet-api/api/run.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/hatchet-dev/hatchet/api/v1/server/run"
+	"github.com/hatchet-dev/hatchet/internal/config/loader"
+	"github.com/hatchet-dev/hatchet/internal/services/worker"
+)
+
+func Start(cf *loader.ConfigLoader, interruptCh <-chan interface{}) error {
+	// init the repository
+	cleanup, sc, err := cf.LoadServerConfig()
+	defer func() {
+		if err := cleanup(); err != nil {
+			panic(fmt.Errorf("could not cleanup server config: %v", err))
+		}
+	}()
+
+	if err != nil {
+		return fmt.Errorf("error loading server config: %w", err)
+	}
+
+	var teardown []func() error
+
+	if sc.InternalClient != nil {
+		w, err := worker.NewWorker(
+			worker.WithRepository(sc.Repository),
+			worker.WithClient(sc.InternalClient),
+			worker.WithVCSProviders(sc.VCSProviders),
+		)
+
+		if err != nil {
+			return fmt.Errorf("error creating worker: %w", err)
+		}
+
+		cleanup, err := w.Start()
+		if err != nil {
+			return fmt.Errorf("error starting worker: %w", err)
+		}
+
+		teardown = append(teardown, cleanup)
+	}
+
+	runner := run.NewAPIServer(sc)
+
+	cleanup, err = runner.Run()
+	if err != nil {
+		return fmt.Errorf("error starting API server: %w", err)
+	}
+
+	teardown = append(teardown, cleanup)
+
+	sc.Logger.Debug().Msgf("api started successfully")
+
+	<-interruptCh
+
+	sc.Logger.Debug().Msgf("api is shutting down...")
+
+	for _, teardown := range teardown {
+		if err := teardown(); err != nil {
+			return err
+		}
+	}
+
+	sc.Logger.Debug().Msgf("api successfully shut down")
+
+	return nil
+}

--- a/cmd/hatchet-api/main.go
+++ b/cmd/hatchet-api/main.go
@@ -7,9 +7,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/hatchet-dev/hatchet/api/v1/server/run"
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-api/api"
 	"github.com/hatchet-dev/hatchet/internal/config/loader"
-	"github.com/hatchet-dev/hatchet/internal/services/worker"
 	"github.com/hatchet-dev/hatchet/pkg/cmdutils"
 )
 
@@ -29,7 +28,7 @@ var rootCmd = &cobra.Command{
 		cf := loader.NewConfigLoader(configDirectory)
 		interruptChan := cmdutils.InterruptChan()
 
-		if err := startAPI(cf, interruptChan); err != nil {
+		if err := api.Start(cf, interruptChan); err != nil {
 			log.Println("error starting API:", err)
 			os.Exit(1)
 		}
@@ -58,64 +57,4 @@ func main() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-}
-
-func startAPI(cf *loader.ConfigLoader, interruptCh <-chan interface{}) error {
-	// init the repository
-	cleanup, sc, err := cf.LoadServerConfig()
-	defer func() {
-		if err := cleanup(); err != nil {
-			panic(fmt.Errorf("could not cleanup server config: %v", err))
-		}
-	}()
-
-	if err != nil {
-		return fmt.Errorf("error loading server config: %w", err)
-	}
-
-	var teardowns []func() error
-
-	if sc.InternalClient != nil {
-		w, err := worker.NewWorker(
-			worker.WithRepository(sc.Repository),
-			worker.WithClient(sc.InternalClient),
-			worker.WithVCSProviders(sc.VCSProviders),
-		)
-
-		if err != nil {
-			return fmt.Errorf("error creating worker: %w", err)
-		}
-
-		cleanup, err := w.Start()
-		if err != nil {
-			return fmt.Errorf("error starting worker: %w", err)
-		}
-
-		teardowns = append(teardowns, cleanup)
-	}
-
-	runner := run.NewAPIServer(sc)
-
-	cleanup, err = runner.Run()
-	if err != nil {
-		return fmt.Errorf("error starting API server: %w", err)
-	}
-
-	teardowns = append(teardowns, cleanup)
-
-	sc.Logger.Debug().Msgf("api started successfully")
-
-	<-interruptCh
-
-	sc.Logger.Debug().Msgf("api is shutting down...")
-
-	for _, teardown := range teardowns {
-		if err := teardown(); err != nil {
-			return err
-		}
-	}
-
-	sc.Logger.Debug().Msgf("api successfully shut down")
-
-	return nil
 }

--- a/examples/cron/main.go
+++ b/examples/cron/main.go
@@ -51,12 +51,16 @@ func main() {
 		panic(err)
 	}
 
-	interruptCtx, cancel := cmdutils.InterruptContextFromChan(cmdutils.InterruptChan())
-	defer cancel()
+	interrupt := cmdutils.InterruptChan()
 
-	err = w.Start(interruptCtx)
-
+	cleanup, err := w.Start()
 	if err != nil {
 		panic(err)
+	}
+
+	<-interrupt
+
+	if err := cleanup(); err != nil {
+		panic(fmt.Errorf("error cleaning up: %w", err))
 	}
 }

--- a/examples/dag/main.go
+++ b/examples/dag/main.go
@@ -130,15 +130,10 @@ func run(ch <-chan interface{}, events chan<- string) error {
 	interruptCtx, cancel := cmdutils.InterruptContextFromChan(ch)
 	defer cancel()
 
-	go func() {
-		err = w.Start(interruptCtx)
-
-		if err != nil {
-			panic(err)
-		}
-
-		cancel()
-	}()
+	cleanup, err := w.Start()
+	if err != nil {
+		return fmt.Errorf("error starting worker: %w", err)
+	}
 
 	testEvent := userCreateEvent{
 		Username: "echo-test",
@@ -164,7 +159,7 @@ func run(ch <-chan interface{}, events chan<- string) error {
 	for {
 		select {
 		case <-interruptCtx.Done():
-			return nil
+			return cleanup()
 		default:
 			time.Sleep(time.Second)
 		}

--- a/examples/deprecated/requeue/main.go
+++ b/examples/deprecated/requeue/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/joho/godotenv"
@@ -64,20 +65,19 @@ func main() {
 		panic(err)
 	}
 
-	go func() {
-		// wait to register the worker for 10 seconds, to let the requeuer kick in
-		time.Sleep(10 * time.Second)
-
-		err = worker.Start(interruptCtx)
-
-		if err != nil {
-			panic(err)
-		}
-	}()
+	// wait to register the worker for 10 seconds, to let the requeuer kick in
+	time.Sleep(10 * time.Second)
+	cleanup, err := worker.Start()
+	if err != nil {
+		panic(err)
+	}
 
 	for {
 		select {
 		case <-interruptCtx.Done():
+			if err := cleanup(); err != nil {
+				panic(fmt.Errorf("error cleaning up: %w", err))
+			}
 			return
 		default:
 			time.Sleep(time.Second)

--- a/examples/deprecated/slack/main.go
+++ b/examples/deprecated/slack/main.go
@@ -1,11 +1,10 @@
 package main
 
 import (
+	"context"
 	_ "embed"
 	"os"
 	"strings"
-
-	"context"
 	"time"
 
 	"github.com/joho/godotenv"
@@ -92,7 +91,7 @@ func main() {
 	interruptCtx, cancel := cmdutils.InterruptContextFromChan(cmdutils.InterruptChan())
 	defer cancel()
 
-	go worker.Start(interruptCtx)
+	go worker.Start()
 
 	testEvent := teamCreateEvent{
 		Name: "test-team-2",

--- a/examples/deprecated/timeout/main.go
+++ b/examples/deprecated/timeout/main.go
@@ -57,13 +57,10 @@ func main() {
 	interruptCtx, cancel := cmdutils.InterruptContextFromChan(cmdutils.InterruptChan())
 	defer cancel()
 
-	go func() {
-		err = worker.Start(interruptCtx)
-
-		if err != nil {
-			panic(err)
-		}
-	}()
+	cleanup, err := worker.Start()
+	if err != nil {
+		panic(fmt.Errorf("error starting worker: %w", err))
+	}
 
 	event := sampleEvent{}
 
@@ -81,6 +78,9 @@ func main() {
 	for {
 		select {
 		case <-interruptCtx.Done():
+			if err := cleanup(); err != nil {
+				panic(fmt.Errorf("error cleaning up: %w", err))
+			}
 			return
 		default:
 			time.Sleep(time.Second)

--- a/examples/manual-trigger/worker/main.go
+++ b/examples/manual-trigger/worker/main.go
@@ -121,13 +121,13 @@ func run(ch <-chan interface{}, events chan<- string) error {
 		return fmt.Errorf("error registering workflow: %w", err)
 	}
 
-	interruptCtx, cancel := cmdutils.InterruptContextFromChan(ch)
-	defer cancel()
-
-	err = w.Start(interruptCtx)
-
+	cleanup, err := w.Start()
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("error starting worker: %w", err)
+	}
+
+	if err := cleanup(); err != nil {
+		return fmt.Errorf("error cleaning up: %w", err)
 	}
 
 	return nil

--- a/examples/middleware/main.go
+++ b/examples/middleware/main.go
@@ -1,16 +1,11 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"log"
-	"time"
 
 	"github.com/joho/godotenv"
 
-	"github.com/hatchet-dev/hatchet/pkg/client"
 	"github.com/hatchet-dev/hatchet/pkg/cmdutils"
-	"github.com/hatchet-dev/hatchet/pkg/worker"
 )
 
 type userCreateEvent struct {
@@ -30,140 +25,15 @@ func main() {
 	}
 
 	events := make(chan string, 50)
-	ctx, _ := cmdutils.NewInterruptContext()
-	if err := run(ctx, events); err != nil {
+	ch := cmdutils.InterruptChan()
+	cleanup, err := run(events)
+	if err != nil {
 		panic(err)
 	}
-}
 
-func run(interruptCtx context.Context, events chan<- string) error {
-	c, err := client.New()
-	if err != nil {
-		return fmt.Errorf("error creating client: %w", err)
-	}
+	<-ch
 
-	w, err := worker.NewWorker(
-		worker.WithClient(
-			c,
-		),
-	)
-	if err != nil {
-		return fmt.Errorf("error creating worker: %w", err)
-	}
-
-	w.Use(func(ctx worker.HatchetContext, next func(worker.HatchetContext) error) error {
-		log.Printf("1st-middleware")
-		events <- "1st-middleware"
-		ctx.SetContext(context.WithValue(ctx.GetContext(), "testkey", "testvalue"))
-		return next(ctx)
-	})
-
-	w.Use(func(ctx worker.HatchetContext, next func(worker.HatchetContext) error) error {
-		log.Printf("2nd-middleware")
-		events <- "2nd-middleware"
-
-		// time the function duration
-		start := time.Now()
-		err := next(ctx)
-		duration := time.Since(start)
-		fmt.Printf("step function took %s\n", duration)
-		return err
-	})
-
-	testSvc := w.NewService("test")
-
-	testSvc.Use(func(ctx worker.HatchetContext, next func(worker.HatchetContext) error) error {
-		events <- "svc-middleware"
-		ctx.SetContext(context.WithValue(ctx.GetContext(), "svckey", "svcvalue"))
-		return next(ctx)
-	})
-
-	err = testSvc.On(
-		worker.Events("user:create:middleware"),
-		&worker.WorkflowJob{
-			Name:        "middleware",
-			Description: "This runs after an update to the user model.",
-			Steps: []*worker.WorkflowStep{
-				worker.Fn(func(ctx worker.HatchetContext) (result *stepOneOutput, err error) {
-					input := &userCreateEvent{}
-
-					err = ctx.WorkflowInput(input)
-
-					if err != nil {
-						return nil, err
-					}
-
-					log.Printf("step-one")
-					events <- "step-one"
-
-					testVal := ctx.Value("testkey").(string)
-					events <- testVal
-					svcVal := ctx.Value("svckey").(string)
-					events <- svcVal
-
-					return &stepOneOutput{
-						Message: "Username is: " + input.Username,
-					}, nil
-				},
-				).SetName("step-one"),
-				worker.Fn(func(ctx worker.HatchetContext) (result *stepOneOutput, err error) {
-					input := &stepOneOutput{}
-					err = ctx.StepOutput("step-one", input)
-
-					if err != nil {
-						return nil, err
-					}
-
-					log.Printf("step-two")
-					events <- "step-two"
-
-					return &stepOneOutput{
-						Message: "Above message is: " + input.Message,
-					}, nil
-				}).SetName("step-two").AddParents("step-one"),
-			},
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("error registering workflow: %w", err)
-	}
-
-	go func() {
-		log.Printf("pushing event user:create:middleware")
-
-		testEvent := userCreateEvent{
-			Username: "echo-test",
-			UserID:   "1234",
-			Data: map[string]string{
-				"test": "test",
-			},
-		}
-
-		// push an event
-		err = c.Event().Push(
-			context.Background(),
-			"user:create:middleware",
-			testEvent,
-		)
-		if err != nil {
-			panic(fmt.Errorf("error pushing event: %w", err))
-		}
-	}()
-
-	cleanup, err := w.Start()
-	if err != nil {
-		return fmt.Errorf("error starting worker: %w", err)
-	}
-
-	for {
-		select {
-		case <-interruptCtx.Done():
-			if err := cleanup(); err != nil {
-				return fmt.Errorf("error cleaning up: %w", err)
-			}
-			return nil
-		default:
-			time.Sleep(time.Second)
-		}
+	if err := cleanup(); err != nil {
+		panic(fmt.Errorf("cleanup() error = %v", err))
 	}
 }

--- a/examples/middleware/main.go
+++ b/examples/middleware/main.go
@@ -150,15 +150,17 @@ func run(interruptCtx context.Context, events chan<- string) error {
 		}
 	}()
 
-	err = w.Start(interruptCtx)
-
+	cleanup, err := w.Start()
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("error starting worker: %w", err)
 	}
 
 	for {
 		select {
 		case <-interruptCtx.Done():
+			if err := cleanup(); err != nil {
+				return fmt.Errorf("error cleaning up: %w", err)
+			}
 			return nil
 		default:
 			time.Sleep(time.Second)

--- a/examples/middleware/main_e2e_test.go
+++ b/examples/middleware/main_e2e_test.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -21,11 +20,10 @@ func TestMiddleware(t *testing.T) {
 
 	events := make(chan string, 50)
 
-	go func() {
-		if err := run(ctx, events); err != nil {
-			panic(fmt.Errorf("run() error = %v", err))
-		}
-	}()
+	cleanup, err := run(events)
+	if err != nil {
+		t.Fatalf("run() error = %s", err)
+	}
 
 	var items []string
 
@@ -51,4 +49,8 @@ outer:
 		"svc-middleware",
 		"step-two",
 	}, items)
+
+	if err := cleanup(); err != nil {
+		t.Fatalf("cleanup() error = %s", err)
+	}
 }

--- a/examples/middleware/run.go
+++ b/examples/middleware/run.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/pkg/client"
+	"github.com/hatchet-dev/hatchet/pkg/worker"
+)
+
+func run(events chan<- string) (func() error, error) {
+	c, err := client.New()
+	if err != nil {
+		return nil, fmt.Errorf("error creating client: %w", err)
+	}
+
+	w, err := worker.NewWorker(
+		worker.WithClient(
+			c,
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error creating worker: %w", err)
+	}
+
+	w.Use(func(ctx worker.HatchetContext, next func(worker.HatchetContext) error) error {
+		log.Printf("1st-middleware")
+		events <- "1st-middleware"
+		ctx.SetContext(context.WithValue(ctx.GetContext(), "testkey", "testvalue"))
+		return next(ctx)
+	})
+
+	w.Use(func(ctx worker.HatchetContext, next func(worker.HatchetContext) error) error {
+		log.Printf("2nd-middleware")
+		events <- "2nd-middleware"
+
+		// time the function duration
+		start := time.Now()
+		err := next(ctx)
+		duration := time.Since(start)
+		fmt.Printf("step function took %s\n", duration)
+		return err
+	})
+
+	testSvc := w.NewService("test")
+
+	testSvc.Use(func(ctx worker.HatchetContext, next func(worker.HatchetContext) error) error {
+		events <- "svc-middleware"
+		ctx.SetContext(context.WithValue(ctx.GetContext(), "svckey", "svcvalue"))
+		return next(ctx)
+	})
+
+	err = testSvc.On(
+		worker.Events("user:create:middleware"),
+		&worker.WorkflowJob{
+			Name:        "middleware",
+			Description: "This runs after an update to the user model.",
+			Steps: []*worker.WorkflowStep{
+				worker.Fn(func(ctx worker.HatchetContext) (result *stepOneOutput, err error) {
+					input := &userCreateEvent{}
+
+					err = ctx.WorkflowInput(input)
+
+					if err != nil {
+						return nil, err
+					}
+
+					log.Printf("step-one")
+					events <- "step-one"
+
+					testVal := ctx.Value("testkey").(string)
+					events <- testVal
+					svcVal := ctx.Value("svckey").(string)
+					events <- svcVal
+
+					return &stepOneOutput{
+						Message: "Username is: " + input.Username,
+					}, nil
+				},
+				).SetName("step-one"),
+				worker.Fn(func(ctx worker.HatchetContext) (result *stepOneOutput, err error) {
+					input := &stepOneOutput{}
+					err = ctx.StepOutput("step-one", input)
+
+					if err != nil {
+						return nil, err
+					}
+
+					log.Printf("step-two")
+					events <- "step-two"
+
+					return &stepOneOutput{
+						Message: "Above message is: " + input.Message,
+					}, nil
+				}).SetName("step-two").AddParents("step-one"),
+			},
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error registering workflow: %w", err)
+	}
+
+	go func() {
+		log.Printf("pushing event user:create:middleware")
+
+		testEvent := userCreateEvent{
+			Username: "echo-test",
+			UserID:   "1234",
+			Data: map[string]string{
+				"test": "test",
+			},
+		}
+
+		// push an event
+		err = c.Event().Push(
+			context.Background(),
+			"user:create:middleware",
+			testEvent,
+		)
+		if err != nil {
+			panic(fmt.Errorf("error pushing event: %w", err))
+		}
+	}()
+
+	cleanup, err := w.Start()
+	if err != nil {
+		return nil, fmt.Errorf("error starting worker: %w", err)
+	}
+
+	return cleanup, nil
+}

--- a/examples/scheduled/main.go
+++ b/examples/scheduled/main.go
@@ -78,15 +78,10 @@ func main() {
 	interruptCtx, cancel := cmdutils.InterruptContextFromChan(cmdutils.InterruptChan())
 	defer cancel()
 
-	go func() {
-		err = w.Start(interruptCtx)
-
-		if err != nil {
-			panic(err)
-		}
-
-		cancel()
-	}()
+	cleanup, err := w.Start()
+	if err != nil {
+		panic(fmt.Errorf("error cleaning up: %w", err))
+	}
 
 	go func() {
 		time.Sleep(5 * time.Second)
@@ -110,6 +105,9 @@ func main() {
 	for {
 		select {
 		case <-interruptCtx.Done():
+			if err := cleanup(); err != nil {
+				panic(fmt.Errorf("error cleaning up: %w", err))
+			}
 			return
 		default:
 			time.Sleep(time.Second)

--- a/examples/simple/main_e2e_test.go
+++ b/examples/simple/main_e2e_test.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -21,11 +20,10 @@ func TestSimple(t *testing.T) {
 
 	events := make(chan string, 50)
 
-	go func() {
-		if err := run(ctx, events); err != nil {
-			panic(fmt.Errorf("run() error = %v", err))
-		}
-	}()
+	cleanup, err := run(events)
+	if err != nil {
+		t.Fatalf("/run() error = %v", err)
+	}
 
 	var items []string
 
@@ -43,4 +41,8 @@ outer:
 		"step-one",
 		"step-two",
 	}, items)
+
+	if err := cleanup(); err != nil {
+		t.Fatalf("cleanup() error = %v", err)
+	}
 }

--- a/pkg/client/dispatcher.go
+++ b/pkg/client/dispatcher.go
@@ -90,7 +90,7 @@ type Action struct {
 }
 
 type WorkerActionListener interface {
-	Actions(ctx context.Context, errCh chan<- error) (<-chan *Action, error)
+	Actions(ctx context.Context) (<-chan *Action, error)
 
 	Unregister() error
 }
@@ -209,7 +209,7 @@ func (d *dispatcherClientImpl) newActionListener(ctx context.Context, req *GetAc
 	}, nil
 }
 
-func (a *actionListenerImpl) Actions(ctx context.Context, errCh chan<- error) (<-chan *Action, error) {
+func (a *actionListenerImpl) Actions(ctx context.Context) (<-chan *Action, error) {
 	ch := make(chan *Action)
 
 	a.l.Debug().Msgf("Starting to listen for actions")
@@ -228,7 +228,7 @@ func (a *actionListenerImpl) Actions(ctx context.Context, errCh chan<- error) (<
 
 					if err != nil {
 						a.l.Error().Msgf("Failed to close send: %v", err)
-						errCh <- fmt.Errorf("failed to close send: %w", err)
+						panic(fmt.Errorf("failed to close send: %w", err))
 					}
 
 					return
@@ -243,15 +243,14 @@ func (a *actionListenerImpl) Actions(ctx context.Context, errCh chan<- error) (<
 
 					if err != nil {
 						a.l.Error().Msgf("Failed to subscribe: %v", err)
-						errCh <- fmt.Errorf("failed to subscribe: %w", err)
-						return
+						panic(fmt.Errorf("failed to subscribe: %w", err))
 					}
 
 					continue
 				}
 
 				a.l.Error().Msgf("Failed to receive message: %v", err)
-				errCh <- fmt.Errorf("failed to receive message: %w", err)
+				panic(fmt.Errorf("failed to receive message: %w", err))
 				return
 			}
 

--- a/pkg/client/dispatcher.go
+++ b/pkg/client/dispatcher.go
@@ -251,7 +251,6 @@ func (a *actionListenerImpl) Actions(ctx context.Context) (<-chan *Action, error
 
 				a.l.Error().Msgf("Failed to receive message: %v", err)
 				panic(fmt.Errorf("failed to receive message: %w", err))
-				return
 			}
 
 			var actionType ActionType


### PR DESCRIPTION
# Description

Adds cleanup functions to the API and the worker instance instead of cancelling via context

## Type of change

- [x] Refactor

# What's Changed

- [x] cleanup functions in worker
- [x] proper cleanup in api
- [x] refactor api
