### PR TITLE
fix(typescript-sdk): multi-workflow bugs and action collision fix

### DIFF
--- a/typescript-sdk/examples/multi-workflow.ts
+++ b/typescript-sdk/examples/multi-workflow.ts
@@ -1,0 +1,45 @@
+import Hatchet from '../src/sdk';
+
+const hatchet: Hatchet = Hatchet.init();
+
+async function main() {
+  const worker = await hatchet.worker('test-worker2', 5);
+
+  await worker.registerWorkflow({
+    id: 'test1',
+    description: 'desc',
+    on: {
+      event: 'test1',
+    },
+    steps: [
+      {
+        name: 'test1-step1',
+        run: (ctx) => {
+          console.log('executed step1 of test1!');
+          return { step1: 'step1' };
+        },
+      },
+    ],
+  });
+
+  await worker.registerWorkflow({
+    id: 'test2',
+    description: 'desc',
+    on: {
+      event: 'test2',
+    },
+    steps: [
+      {
+        name: 'test2-step1',
+        run: (ctx) => {
+          console.log('executed step1 of test2!');
+          return { step1: 'step1' };
+        },
+      },
+    ],
+  });
+
+  await worker.start();
+}
+
+main();

--- a/typescript-sdk/package.json
+++ b/typescript-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Background task orchestration & visibility for developers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -36,6 +36,7 @@
     "worker:concurrency:rr": "npm run exec -- ./examples/concurrency/group-round-robin/concurrency-worker.ts",
     "event:concurrency:rr": "npm run exec -- ./examples/concurrency/group-round-robin/concurrency-event.ts",
     "worker:retries": "npm run exec -- ./examples/retries-worker.ts",
+    "worker:multi-workflow": "npm run exec -- ./examples/multi-workflow.ts",
     "api": "npm run exec -- ./examples/api.ts",
     "prepublish": "cp package.json dist/package.json;",
     "publish:ci": "rm -rf ./dist && npm run tsc:build && npm run prepublish && cd dist && npm publish --access public --no-git-checks",

--- a/typescript-sdk/src/clients/worker/worker.test.ts
+++ b/typescript-sdk/src/clients/worker/worker.test.ts
@@ -76,7 +76,7 @@ describe('Worker', () => {
       expect(putWorkflowSpy).toHaveBeenCalledTimes(1);
 
       expect(worker.action_registry).toEqual({
-        [`default:step1`]: workflow.steps[0].run,
+        [`workflow1:step1`]: workflow.steps[0].run,
       });
     });
   });


### PR DESCRIPTION
# Description

Fixes two bugs in the typescript sdk:
- Steps named the same thing in different workflows (for example, `step1`) will collide and only 1 will register
- Registering multiple workflows overrides the actions available on the worker
 
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)