### PR TITLE
fix: nested and non string return type

### DIFF
--- a/typescript-sdk/package.json
+++ b/typescript-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Background task orchestration & visibility for developers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/typescript-sdk/src/step.ts
+++ b/typescript-sdk/src/step.ts
@@ -10,7 +10,9 @@ export const CreateStepSchema = z.object({
   retries: z.number().optional(),
 });
 
-export type NextStep = { [key: string]: string };
+type JSONPrimitive = string | number | boolean | null;
+
+export type NextStep = { [key: string]: NextStep | JSONPrimitive };
 
 interface ContextData<T, K> {
   input: T;


### PR DESCRIPTION
# Description

The return type of a step function was too restrictive

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## What's Changed

- [x] functions can now return props string | number | boolean | null or nested json object with the same type
