### PR TITLE
fix(engine): retry setting empty data

### DIFF
--- a/internal/services/controllers/jobs/controller.go
+++ b/internal/services/controllers/jobs/controller.go
@@ -400,7 +400,7 @@ func (ec *JobsControllerImpl) handleStepRunRetry(ctx context.Context, task *task
 	var inputBytes []byte
 	var retryCount = stepRun.RetryCount + 1
 
-	if len(payload.InputData) > 0 {
+	if payload.InputData != "" {
 		// update the input schema for the step run based on the new input
 		jsonSchemaBytes, err := schema.SchemaBytesFromBytes([]byte(payload.InputData))
 


### PR DESCRIPTION
# Description

Retries were clearing out step data when workflows failed and `retries > 0` which were causing all sorts of problems on the SDKs. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)