### PR TITLE
fix: job cancellations with shared ctx

### DIFF
--- a/internal/services/ticker/job_run_timeout.go
+++ b/internal/services/ticker/job_run_timeout.go
@@ -38,21 +38,16 @@ func (t *TickerImpl) handleScheduleJobRunTimeout(ctx context.Context, task *task
 	// TODO: ??? make sure this doesn't have any side effects
 	childCtx, cancel := context.WithDeadline(context.Background(), timeoutAt)
 
+	go func() {
+		<-childCtx.Done()
+		t.runJobRunTimeout(metadata.TenantId, payload.JobRunId)
+	}()
+
 	// store the schedule in the step run map
 	t.jobRuns.Store(payload.JobRunId, &timeoutCtx{
 		ctx:    childCtx,
 		cancel: cancel,
 	})
-
-	go func() {
-		<-childCtx.Done()
-		t.runJobRunTimeout(metadata.TenantId, payload.JobRunId)
-		t.jobRuns.Range(func(key, value interface{}) bool {
-			v, _ := value.(*timeoutCtx)
-			v.cancel()
-			return true
-		})
-	}()
 
 	return nil
 }

--- a/internal/services/ticker/job_run_timeout.go
+++ b/internal/services/ticker/job_run_timeout.go
@@ -36,7 +36,7 @@ func (t *TickerImpl) handleScheduleJobRunTimeout(ctx context.Context, task *task
 
 	// schedule the timeout
 	// TODO: ??? make sure this doesn't have any side effects
-	childCtx, cancel := context.WithDeadline(ctx, timeoutAt)
+	childCtx, cancel := context.WithDeadline(context.Background(), timeoutAt)
 
 	// store the schedule in the step run map
 	t.jobRuns.Store(payload.JobRunId, &timeoutCtx{


### PR DESCRIPTION
# Description

Job cancellation methods are sharing a ctx parameter which is causing all jobs to get cancellations when some unknown upstream context is calling cancel on the ticker. Root cause still needs investigating. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)