### PR TITLE
fix(ticker): clean up job run timeout goroutine

### DIFF
--- a/internal/services/ticker/job_run_timeout.go
+++ b/internal/services/ticker/job_run_timeout.go
@@ -34,13 +34,14 @@ func (t *TickerImpl) handleScheduleJobRunTimeout(ctx context.Context, task *task
 		return fmt.Errorf("could not parse timeout at: %w", err)
 	}
 
-	// schedule the timeout
-	// TODO: ??? make sure this doesn't have any side effects
 	childCtx, cancel := context.WithDeadline(context.Background(), timeoutAt)
 
 	go func() {
-		<-childCtx.Done()
-		t.runJobRunTimeout(metadata.TenantId, payload.JobRunId)
+		select {
+		case <-childCtx.Done():
+			t.runJobRunTimeout(metadata.TenantId, payload.JobRunId)
+		case <-ctx.Done():
+		}
 	}()
 
 	// store the schedule in the step run map


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Follow up of #216

Cleans up the job run timeout goroutines to prevent any leaking goroutines.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed
