### PR TITLE
fix: race condition on playground inputs

### DIFF
--- a/frontend/app/src/pages/main/workflow-runs/$run/components/step-run-playground.tsx
+++ b/frontend/app/src/pages/main/workflow-runs/$run/components/step-run-playground.tsx
@@ -116,6 +116,8 @@ export function StepRunPlayground({
       ) {
         return 1000;
       }
+
+      return 5000;
     },
   });
 

--- a/internal/datautils/job_data.go
+++ b/internal/datautils/job_data.go
@@ -1,11 +1,5 @@
 package datautils
 
-import (
-	"fmt"
-
-	"github.com/steebchen/prisma-client-go/runtime/types"
-)
-
 type TriggeredBy string
 
 const (
@@ -34,75 +28,3 @@ type StepRunData struct {
 }
 
 type StepData map[string]interface{}
-
-func NewJobRunLookupDataFromInputBytes(input []byte, triggeredBy TriggeredBy) (JobRunLookupData, error) {
-	inputMap, err := jsonBytesToMap(input)
-
-	if err != nil {
-		return JobRunLookupData{}, fmt.Errorf("failed to convert input to map: %w", err)
-	}
-
-	return NewJobRunLookupData(inputMap, triggeredBy), nil
-}
-
-func NewJobRunLookupData(input map[string]interface{}, triggeredBy TriggeredBy) JobRunLookupData {
-	return JobRunLookupData{
-		Input:       input,
-		TriggeredBy: triggeredBy,
-		Steps:       map[string]StepData{},
-	}
-}
-
-func GetJobRunLookupData(data *types.JSON) (JobRunLookupData, error) {
-	if data == nil {
-		return JobRunLookupData{}, nil
-	}
-
-	currData := JobRunLookupData{}
-	err := FromJSONType(data, &currData)
-
-	if err != nil {
-		return JobRunLookupData{}, fmt.Errorf("failed to convert data to map: %w", err)
-	}
-
-	return currData, nil
-}
-
-// func AddStepOutput(data *types.JSON, stepReadableId string, stepOutput []byte) ([]byte, error) {
-// 	if data == nil {
-// 		data = &types.JSON{}
-// 	}
-
-// 	unquoted, err := strconv.Unquote(string(stepOutput))
-
-// 	if err == nil {
-// 		stepOutput = []byte(unquoted)
-// 	}
-
-// 	outputMap, err := jsonBytesToMap(stepOutput)
-
-// 	if err != nil {
-// 		return nil, fmt.Errorf("failed to convert step output to map: %w", err)
-// 	}
-
-// 	currData := JobRunLookupData{}
-// 	err = FromJSONType(data, &currData)
-
-// 	if err != nil {
-// 		return nil, fmt.Errorf("failed to convert data to map: %w", err)
-// 	}
-
-// 	if currData.Steps == nil {
-// 		currData.Steps = map[string]StepData{}
-// 	}
-
-// 	currData.Steps[stepReadableId] = outputMap
-
-// 	jsonBytes, err := json.Marshal(currData)
-
-// 	if err != nil {
-// 		return nil, fmt.Errorf("failed to marshal data: %w", err)
-// 	}
-
-// 	return jsonBytes, nil
-// }

--- a/internal/datautils/map.go
+++ b/internal/datautils/map.go
@@ -23,10 +23,10 @@ func ToJSONMap(data interface{}) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	return jsonBytesToMap(jsonBytes)
+	return JSONBytesToMap(jsonBytes)
 }
 
-func jsonBytesToMap(jsonBytes []byte) (map[string]interface{}, error) {
+func JSONBytesToMap(jsonBytes []byte) (map[string]interface{}, error) {
 	dataMap := map[string]interface{}{}
 
 	err := json.Unmarshal(jsonBytes, &dataMap)

--- a/typescript-sdk/examples/dag-worker.ts
+++ b/typescript-sdk/examples/dag-worker.ts
@@ -45,9 +45,15 @@ const workflow: Workflow = {
     {
       name: 'dag-step4',
       parents: ['dag-step1', 'dag-step3'],
-      run: (ctx) => {
-        const value = ctx.playground('test', 'test');
-        console.log('executed step4!', value);
+      run: async (ctx) => {
+        await sleep(5000);
+
+        // simulate a really slow network call
+        setTimeout(async () => {
+          await sleep(1000);
+          ctx.playground('slow', 'call');
+        }, 5000);
+
         return { step4: 'step4' };
       },
     },

--- a/typescript-sdk/examples/dag-worker.ts
+++ b/typescript-sdk/examples/dag-worker.ts
@@ -46,7 +46,8 @@ const workflow: Workflow = {
       name: 'dag-step4',
       parents: ['dag-step1', 'dag-step3'],
       run: (ctx) => {
-        console.log('executed step4!');
+        const value = ctx.playground('test', 'test');
+        console.log('executed step4!', value);
         return { step4: 'step4' };
       },
     },


### PR DESCRIPTION
# Description

Playground view has a race condition where a step's input schema may be loaded in before the overrides have synced. This prevents the step run from overwriting the input schema if this has occurred. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)