### PR TITLE
fix: unicode values in input JSON break typescript SDK

### DIFF
--- a/internal/datautils/map.go
+++ b/internal/datautils/map.go
@@ -3,7 +3,6 @@ package datautils
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/rs/zerolog"
@@ -47,19 +46,9 @@ func FromJSONType(data *types.JSON, target interface{}) error {
 		return nil
 	}
 
-	dataBytes, err := data.MarshalJSON()
+	dataBytes := []byte(*data)
 
-	if err != nil {
-		return fmt.Errorf("failed to marshal json: %w", err)
-	}
-
-	unquoted, err := strconv.Unquote(string(dataBytes))
-
-	if err != nil {
-		return fmt.Errorf("failed to unquote json: %w", err)
-	}
-
-	if err := json.Unmarshal([]byte(unquoted), &target); err != nil {
+	if err := json.Unmarshal(dataBytes, &target); err != nil {
 		return fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 

--- a/internal/repository/prisma/event.go
+++ b/internal/repository/prisma/event.go
@@ -187,12 +187,6 @@ func (r *eventRepository) CreateEvent(ctx context.Context, opts *repository.Crea
 		return nil, err
 	}
 
-	// dataBytes, err := opts.Data.MarshalJSON()
-
-	// if err != nil {
-	// 	return nil, err
-	// }
-
 	createParams := dbsqlc.CreateEventParams{
 		ID:       sqlchelpers.UUIDFromStr(uuid.New().String()),
 		Key:      opts.Key,

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -51,15 +51,25 @@ func (worker *subscribedWorker) StartStepRun(
 	defer span.End()
 
 	inputBytes := []byte{}
+
 	inputType, ok := stepRun.Input()
 
-	if ok {
-		var err error
-		inputBytes, err = inputType.MarshalJSON()
+	// if ok {
+	// 	stepRunInputBytes := []byte(inputType)
 
-		if err != nil {
-			return err
-		}
+	// 	var err error
+	// 	var inputBytesStr string
+	// 	inputBytesStr, err = strconv.Unquote(string(stepRunInputBytes))
+
+	// 	if err != nil {
+	// 		inputBytes = stepRunInputBytes
+	// 	} else {
+	// 		inputBytes = []byte(inputBytesStr)
+	// 	}
+	// }
+
+	if ok {
+		inputBytes = []byte(inputType)
 	}
 
 	stepName, _ := stepRun.Step().ReadableID()
@@ -128,11 +138,7 @@ func (worker *subscribedWorker) StartGroupKeyAction(
 		}
 	}
 
-	inputBytes, err := inputData.MarshalJSON()
-
-	if err != nil {
-		return err
-	}
+	inputBytes = []byte(inputData)
 
 	getGroupKeyRun, ok := workflowRun.GetGroupKeyRun()
 

--- a/internal/services/ingestor/server.go
+++ b/internal/services/ingestor/server.go
@@ -158,12 +158,7 @@ func toEvent(e db.EventModel) (*contracts.Event, error) {
 	var payload string
 
 	if data, ok := e.Data(); ok {
-		payloadBytes, err := data.MarshalJSON()
-
-		if err != nil {
-			return nil, err
-		}
-
+		payloadBytes := []byte(data)
 		payload = string(payloadBytes)
 	}
 

--- a/typescript-sdk/src/step.ts
+++ b/typescript-sdk/src/step.ts
@@ -5,6 +5,7 @@ import { Action } from './clients/dispatcher/action-listener';
 import { DispatcherClient } from './clients/dispatcher/dispatcher-client';
 import { EventClient, LogLevel } from './clients/event/event-client';
 import { Logger } from './util/logger';
+import { parseJSON } from './util/parse';
 
 export const CreateStepSchema = z.object({
   name: z.string(),
@@ -36,7 +37,7 @@ export class Context<T, K> {
 
   constructor(action: Action, client: DispatcherClient, eventClient: EventClient) {
     try {
-      const data = JSON.parse(JSON.parse(action.actionPayload));
+      const data = parseJSON(action.actionPayload);
       this.data = data;
       this.action = action;
       this.client = client;

--- a/typescript-sdk/src/util/parse.ts
+++ b/typescript-sdk/src/util/parse.ts
@@ -1,0 +1,15 @@
+export function parseJSON(json: string): any {
+  try {
+    const firstParse = JSON.parse(json);
+
+    // Hatchet engine versions <=0.14.0 return JSON as a quoted string which needs to be parsed again.
+    // This is a workaround for that issue, but will not be needed in future versions.
+    try {
+      return JSON.parse(firstParse);
+    } catch (e: any) {
+      return firstParse;
+    }
+  } catch (e: any) {
+    throw new Error(`Could not parse JSON: ${e.message}`);
+  }
+}


### PR DESCRIPTION
# Description

Unicode values like `󱜧󱜧󱜧󱜧󱜧󱜧` are breaking the typescript SDK.

## Details

It turns out this is due to a missing `strconv.Unquote` method in the dispatcher. But more broadly, values that are read directly from the Prisma client with `MarshalJSON` are [using the `"%q"` formatting directive](https://github.com/steebchen/prisma-client-go/blob/89a6c1514fc0f58b1ddec89580739bdb809bcd96/runtime/types/types.go#L64) and thus have escape sequences like `\U...`. However, `JSON.parse` does not handle this type of escape sequence, so we have previously been using `.Unquote` liberally to remove this additional encoding.

Instead of adding another `.Unquote` I removed all usage of `MarshalJSON` in favor of casting to `[]byte` instead. This should have probably been done from the beginning and is why we were seeing double-escaped inputs to step runs. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [X] Backwards-compat `parseJSON` in Typescript SDK
- [X] Updates to the engine to avoid usage of `MarshalJSON`