### PR TITLE
fix: parse schema in API, not engine

### DIFF
--- a/api-contracts/openapi/components/schemas/workflow_run.yaml
+++ b/api-contracts/openapi/components/schemas/workflow_run.yaml
@@ -210,8 +210,6 @@ StepRun:
       type: string
     cancelledError:
       type: string
-    inputSchema:
-      type: string
   required:
     - metadata
     - tenantId

--- a/api-contracts/openapi/openapi.yaml
+++ b/api-contracts/openapi/openapi.yaml
@@ -106,6 +106,8 @@ paths:
     $ref: "./paths/step-run/step-run.yaml#/stepRunScoped"
   /api/v1/tenants/{tenant}/step-runs/{step-run}/rerun:
     $ref: "./paths/step-run/step-run.yaml#/rerunStepRun"
+  /api/v1/tenants/{tenant}/step-runs/{step-run}/schema:
+    $ref: "./paths/step-run/step-run.yaml#/getSchema"
   /api/v1/tenants/{tenant}/worker:
     $ref: "./paths/worker/worker.yaml#/withTenant"
   /api/v1/workers/{worker}:

--- a/api-contracts/openapi/paths/step-run/step-run.yaml
+++ b/api-contracts/openapi/paths/step-run/step-run.yaml
@@ -104,3 +104,55 @@ rerunStepRun:
     summary: Rerun step run
     tags:
       - Step Run
+getSchema:
+  get:
+    x-resources: ["tenant", "step-run"]
+    description: Get the schema for a step run
+    operationId: step-run:get:schema
+    parameters:
+      - description: The tenant id
+        in: path
+        name: tenant
+        required: true
+        schema:
+          type: string
+          format: uuid
+          minLength: 36
+          maxLength: 36
+      - description: The step run id
+        in: path
+        name: step-run
+        required: true
+        schema:
+          type: string
+          format: uuid
+          minLength: 36
+          maxLength: 36
+    responses:
+      "200":
+        content:
+          application/json:
+            schema:
+              type: object
+        description: Successfully retrieved the step run schema
+      "400":
+        content:
+          application/json:
+            schema:
+              $ref: "../../components/schemas/_index.yaml#/APIErrors"
+        description: A malformed or bad request
+      "403":
+        content:
+          application/json:
+            schema:
+              $ref: "../../components/schemas/_index.yaml#/APIErrors"
+        description: Forbidden
+      "404":
+        content:
+          application/json:
+            schema:
+              $ref: "../../components/schemas/_index.yaml#/APIErrors"
+        description: The step run was not found
+    summary: Get step run schema
+    tags:
+      - Step Run

--- a/api-contracts/openapi/paths/workflow/workflow.yaml
+++ b/api-contracts/openapi/paths/workflow/workflow.yaml
@@ -72,6 +72,44 @@ withWorkflow:
     summary: Get workflow
     tags:
       - Workflow
+  delete:
+    x-resources: ["tenant", "workflow"]
+    description: Delete a workflow for a tenant
+    operationId: workflow:delete
+    parameters:
+      - description: The workflow id
+        in: path
+        name: workflow
+        required: true
+        schema:
+          type: string
+          format: uuid
+          minLength: 36
+          maxLength: 36
+    responses:
+      "204":
+        description: Successfully deleted the workflow
+      "400":
+        content:
+          application/json:
+            schema:
+              $ref: "../../components/schemas/_index.yaml#/APIErrors"
+        description: A malformed or bad request
+      "403":
+        content:
+          application/json:
+            schema:
+              $ref: "../../components/schemas/_index.yaml#/APIErrors"
+        description: Forbidden
+      "404":
+        content:
+          application/json:
+            schema:
+              $ref: "../../components/schemas/_index.yaml#/APIErrors"
+        description: Not found
+    summary: Delete workflow
+    tags:
+      - Workflow
 workflowVersion:
   get:
     x-resources: ["tenant", "workflow"]

--- a/api/v1/server/handlers/step-runs/get_schema.go
+++ b/api/v1/server/handlers/step-runs/get_schema.go
@@ -1,0 +1,36 @@
+package stepruns
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
+	"github.com/hatchet-dev/hatchet/internal/repository/prisma/db"
+	"github.com/hatchet-dev/hatchet/internal/schema"
+)
+
+func (t *StepRunService) StepRunGetSchema(ctx echo.Context, request gen.StepRunGetSchemaRequestObject) (gen.StepRunGetSchemaResponseObject, error) {
+	stepRun := ctx.Get("step-run").(*db.StepRunModel)
+
+	var res map[string]interface{}
+
+	input, ok := stepRun.Input()
+
+	if ok {
+		schemaBytes, err := schema.SchemaBytesFromBytes(input)
+
+		if err != nil {
+			return nil, fmt.Errorf("could not get schema bytes: %w", err)
+		}
+
+		err = json.Unmarshal(schemaBytes, &res)
+
+		if err != nil {
+			return nil, fmt.Errorf("could not unmarshal schema: %w", err)
+		}
+	}
+
+	return gen.StepRunGetSchema200JSONResponse(res), nil
+}

--- a/api/v1/server/handlers/workflows/delete.go
+++ b/api/v1/server/handlers/workflows/delete.go
@@ -1,0 +1,21 @@
+package workflows
+
+import (
+	"github.com/labstack/echo/v4"
+
+	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
+	"github.com/hatchet-dev/hatchet/internal/repository/prisma/db"
+)
+
+func (t *WorkflowService) WorkflowDelete(ctx echo.Context, request gen.WorkflowDeleteRequestObject) (gen.WorkflowDeleteResponseObject, error) {
+	tenant := ctx.Get("tenant").(*db.TenantModel)
+	workflow := ctx.Get("workflow").(*db.WorkflowModel)
+
+	workflow, err := t.config.Repository.Workflow().DeleteWorkflow(tenant.ID, workflow.ID)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return gen.WorkflowDelete204Response{}, nil
+}

--- a/api/v1/server/oas/transformers/workflow_run.go
+++ b/api/v1/server/oas/transformers/workflow_run.go
@@ -212,10 +212,6 @@ func ToStepRun(stepRun *db.StepRunModel) (*gen.StepRun, error) {
 		res.Output = repository.StringPtr(string(json.RawMessage(outputData)))
 	}
 
-	if inputSchema, ok := stepRun.InputSchema(); ok {
-		res.InputSchema = repository.StringPtr(string(json.RawMessage(inputSchema)))
-	}
-
 	if jobRun := stepRun.RelationsStepRun.JobRun; jobRun != nil {
 		var err error
 

--- a/frontend/app/src/components/ui/json-form.tsx
+++ b/frontend/app/src/components/ui/json-form.tsx
@@ -15,7 +15,9 @@ import { DynamicSizeInputTemplate } from './form-inputs/dynamic-size-input-templ
 import { createContext, useRef } from 'react';
 
 type JSONPrimitive = string | number | boolean | null | Array<JSONPrimitive>;
-type JSONType = { [key: string]: JSONType | JSONPrimitive | Array<JSONType> };
+export type JSONType = {
+  [key: string]: JSONType | JSONPrimitive | Array<JSONType>;
+};
 
 export const DEFAULT_COLLAPSED = ['advanced', 'user data'];
 

--- a/frontend/app/src/lib/api/generated/Api.ts
+++ b/frontend/app/src/lib/api/generated/Api.ts
@@ -979,6 +979,23 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
       ...params,
     });
   /**
+   * @description Get the schema for a step run
+   *
+   * @tags Step Run
+   * @name StepRunGetSchema
+   * @summary Get step run schema
+   * @request GET:/api/v1/tenants/{tenant}/step-runs/{step-run}/schema
+   * @secure
+   */
+  stepRunGetSchema = (tenant: string, stepRun: string, params: RequestParams = {}) =>
+    this.request<object, APIErrors>({
+      path: `/api/v1/tenants/${tenant}/step-runs/${stepRun}/schema`,
+      method: "GET",
+      secure: true,
+      format: "json",
+      ...params,
+    });
+  /**
    * @description Get all workers for a tenant
    *
    * @tags Worker

--- a/frontend/app/src/lib/api/generated/Api.ts
+++ b/frontend/app/src/lib/api/generated/Api.ts
@@ -664,6 +664,22 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
       ...params,
     });
   /**
+   * @description Delete a workflow for a tenant
+   *
+   * @tags Workflow
+   * @name WorkflowDelete
+   * @summary Delete workflow
+   * @request DELETE:/api/v1/workflows/{workflow}
+   * @secure
+   */
+  workflowDelete = (workflow: string, params: RequestParams = {}) =>
+    this.request<void, APIErrors>({
+      path: `/api/v1/workflows/${workflow}`,
+      method: "DELETE",
+      secure: true,
+      ...params,
+    });
+  /**
    * @description Get a workflow version for a tenant
    *
    * @tags Workflow

--- a/frontend/app/src/lib/api/generated/data-contracts.ts
+++ b/frontend/app/src/lib/api/generated/data-contracts.ts
@@ -548,7 +548,6 @@ export interface StepRun {
   cancelledAtEpoch?: number;
   cancelledReason?: string;
   cancelledError?: string;
-  inputSchema?: string;
 }
 
 export interface WorkerList {

--- a/frontend/app/src/lib/api/queries.ts
+++ b/frontend/app/src/lib/api/queries.ts
@@ -109,6 +109,10 @@ export const queries = createQueryKeyStore({
       queryKey: ['log-lines:list', stepRun],
       queryFn: async () => (await api.logLineList(stepRun, query)).data,
     }),
+    getSchema: (tenant: string, stepRun: string) => ({
+      queryKey: ['step-run:get:schema', stepRun],
+      queryFn: async () => (await api.stepRunGetSchema(tenant, stepRun)).data,
+    }),
   },
   events: {
     list: (tenant: string, query: ListEventQuery) => ({

--- a/frontend/app/src/pages/main/workflow-runs/$run/components/step-run-inputs.tsx
+++ b/frontend/app/src/pages/main/workflow-runs/$run/components/step-run-inputs.tsx
@@ -1,9 +1,9 @@
 import { CodeEditor } from '@/components/ui/code-editor';
-import { JsonForm } from '@/components/ui/json-form';
+import { JSONType, JsonForm } from '@/components/ui/json-form';
 
 export interface StepRunOutputProps {
   input: string;
-  schema: string;
+  schema: object;
   setInput: React.Dispatch<React.SetStateAction<string>>;
   disabled: boolean;
   handleOnPlay: () => void;
@@ -22,11 +22,11 @@ export const StepRunInputs: React.FC<StepRunOutputProps> = ({
     <>
       {mode === 'form' && (
         <div>
-          {schema === '' ? (
+          {!schema ? (
             <>No Schema</>
           ) : (
             <JsonForm
-              inputSchema={JSON.parse(schema)}
+              inputSchema={schema as JSONType}
               setInput={setInput}
               inputData={JSON.parse(input)}
               onSubmit={handleOnPlay}

--- a/frontend/app/src/pages/main/workflow-runs/$run/components/step-run-playground.tsx
+++ b/frontend/app/src/pages/main/workflow-runs/$run/components/step-run-playground.tsx
@@ -123,6 +123,21 @@ export function StepRunPlayground({
 
   const queryClient = useQueryClient();
 
+  const stepRunSchemaQuery = useQuery({
+    ...queries.stepRuns.getSchema(
+      stepRun?.tenantId || '',
+      stepRun?.metadata.id || '',
+    ),
+    enabled: !!stepRun,
+    refetchInterval: () => {
+      if (stepRun?.status === StepRunStatus.RUNNING) {
+        return 1000;
+      }
+
+      return 5000;
+    },
+  });
+
   const stepRunDiffQuery = useQuery({
     ...queries.stepRuns.getDiff(stepRun?.metadata.id || ''),
     enabled: !!stepRun,
@@ -347,7 +362,7 @@ export function StepRunPlayground({
               </div>
               {stepInput && (
                 <StepRunInputs
-                  schema={stepRun.inputSchema || ''}
+                  schema={stepRunSchemaQuery.data || {}}
                   input={stepInput}
                   setInput={setStepInput}
                   disabled={disabled}

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"regexp"
-	"strings"
 
 	"github.com/invopop/jsonschema"
 )
@@ -57,6 +55,8 @@ func parse(data interface{}) reflect.Type {
 // parseObject handles JSON objects by creating a struct type with appropriately typed fields.
 func parseObject(obj map[string]interface{}) reflect.Type {
 	var fields []reflect.StructField
+	count := 0
+
 	for key, val := range obj {
 		fieldType := parse(val)
 		defaultValue := formatDefaultValue(val)
@@ -68,11 +68,12 @@ func parseObject(obj map[string]interface{}) reflect.Type {
 		}
 
 		field := reflect.StructField{
-			Name: toExportedName(key),
+			Name: fmt.Sprintf("Field%d", count),
 			Type: fieldType,
 			Tag:  reflect.StructTag(tag),
 		}
 		fields = append(fields, field)
+		count++
 	}
 	return reflect.StructOf(fields)
 }
@@ -97,21 +98,4 @@ func parseArray(arr []interface{}) reflect.Type {
 	}
 	elemType := parse(arr[0])
 	return reflect.SliceOf(elemType)
-}
-
-var nameRegex = regexp.MustCompile(`(\b|-|_|\.)[a-z]`)
-
-var invalidCharRegex = regexp.MustCompile(`[^a-zA-Z0-9_]`)
-
-// toExportedName converts a JSON key into an exported Go field name.
-func toExportedName(key string) string {
-	res := nameRegex.ReplaceAllStringFunc(key, func(t string) string {
-		if len(t) == 1 {
-			return strings.ToUpper(t)
-		}
-
-		return strings.ToUpper(string(t[1]))
-	})
-
-	return invalidCharRegex.ReplaceAllString(res, "")
 }

--- a/internal/services/controllers/jobs/controller.go
+++ b/internal/services/controllers/jobs/controller.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hatchet-dev/hatchet/internal/repository"
 	"github.com/hatchet-dev/hatchet/internal/repository/prisma/db"
 	"github.com/hatchet-dev/hatchet/internal/repository/prisma/sqlchelpers"
-	"github.com/hatchet-dev/hatchet/internal/schema"
 	"github.com/hatchet-dev/hatchet/internal/services/shared/defaults"
 	"github.com/hatchet-dev/hatchet/internal/services/shared/tasktypes"
 	"github.com/hatchet-dev/hatchet/internal/taskqueue"
@@ -474,17 +473,17 @@ func (ec *JobsControllerImpl) handleStepRunRetry(ctx context.Context, task *task
 			inputBytes = mergedInputBytes
 		}
 
-		jsonSchemaBytes, err := schema.SchemaBytesFromBytes(inputBytes)
+		// jsonSchemaBytes, err := schema.SchemaBytesFromBytes(inputBytes)
 
-		if err != nil {
-			return err
-		}
+		// if err != nil {
+		// 	return err
+		// }
 
-		_, err = ec.repo.StepRun().UpdateStepRunInputSchema(metadata.TenantId, stepRun.ID, jsonSchemaBytes)
+		// _, err = ec.repo.StepRun().UpdateStepRunInputSchema(metadata.TenantId, stepRun.ID, jsonSchemaBytes)
 
-		if err != nil {
-			return err
-		}
+		// if err != nil {
+		// 	return err
+		// }
 
 		// if the input data has been manually set, we reset the retry count as this is a user-triggered retry
 		retryCount = 0
@@ -817,21 +816,21 @@ func (ec *JobsControllerImpl) queueStepRun(ctx context.Context, tenantId, stepId
 			}
 
 			// defer the update of the input schema to the step run
-			defer func() {
-				jsonSchemaBytes, err := schema.SchemaBytesFromBytes(inputDataBytes)
+			// defer func() {
+			// 	jsonSchemaBytes, err := schema.SchemaBytesFromBytes(inputDataBytes)
 
-				if err != nil {
-					ec.l.Err(err).Msgf("could not get schema bytes from bytes: %s", err.Error())
-					return
-				}
+			// 	if err != nil {
+			// 		ec.l.Err(err).Msgf("could not get schema bytes from bytes: %s", err.Error())
+			// 		return
+			// 	}
 
-				_, err = ec.repo.StepRun().UpdateStepRunInputSchema(stepRun.TenantID, stepRun.ID, jsonSchemaBytes)
+			// 	_, err = ec.repo.StepRun().UpdateStepRunInputSchema(stepRun.TenantID, stepRun.ID, jsonSchemaBytes)
 
-				if err != nil {
-					ec.l.Err(err).Msgf("could not update step run input schema: %s", err.Error())
-					return
-				}
-			}()
+			// 	if err != nil {
+			// 		ec.l.Err(err).Msgf("could not update step run input schema: %s", err.Error())
+			// 		return
+			// 	}
+			// }()
 
 			updateStepOpts.Input = inputDataBytes
 		}

--- a/internal/services/controllers/jobs/controller.go
+++ b/internal/services/controllers/jobs/controller.go
@@ -462,15 +462,22 @@ func (ec *JobsControllerImpl) handleStepRunRetry(ctx context.Context, task *task
 				return fmt.Errorf("could not convert current input to map: %w", err)
 			}
 
-			mergedInput := datautils.MergeMaps(currentInputMap, inputMap)
+			currentInputOverridesMap, ok1 := currentInputMap["overrides"].(map[string]interface{})
+			inputOverridesMap, ok2 := inputMap["overrides"].(map[string]interface{})
 
-			mergedInputBytes, err := json.Marshal(mergedInput)
+			if ok1 && ok2 {
+				mergedInputOverrides := datautils.MergeMaps(currentInputOverridesMap, inputOverridesMap)
 
-			if err != nil {
-				return fmt.Errorf("could not marshal merged input: %w", err)
+				inputMap["overrides"] = mergedInputOverrides
+
+				mergedInputBytes, err := json.Marshal(inputMap)
+
+				if err != nil {
+					return fmt.Errorf("could not marshal merged input: %w", err)
+				}
+
+				inputBytes = mergedInputBytes
 			}
-
-			inputBytes = mergedInputBytes
 		}
 
 		// jsonSchemaBytes, err := schema.SchemaBytesFromBytes(inputBytes)

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -422,7 +422,7 @@ func (s *DispatcherImpl) PutOverridesData(ctx context.Context, request *contract
 		opts.CallerFile = &request.CallerFilename
 	}
 
-	input, err := s.repo.StepRun().UpdateStepRunOverridesData(tenant.ID, request.StepRunId, opts)
+	_, err := s.repo.StepRun().UpdateStepRunOverridesData(tenant.ID, request.StepRunId, opts)
 
 	if err != nil {
 		return nil, err

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hatchet-dev/hatchet/internal/datautils"
 	"github.com/hatchet-dev/hatchet/internal/repository"
 	"github.com/hatchet-dev/hatchet/internal/repository/prisma/db"
-	"github.com/hatchet-dev/hatchet/internal/schema"
 	"github.com/hatchet-dev/hatchet/internal/services/dispatcher/contracts"
 	"github.com/hatchet-dev/hatchet/internal/services/shared/tasktypes"
 	"github.com/hatchet-dev/hatchet/internal/taskqueue"
@@ -429,17 +428,17 @@ func (s *DispatcherImpl) PutOverridesData(ctx context.Context, request *contract
 		return nil, err
 	}
 
-	jsonSchemaBytes, err := schema.SchemaBytesFromBytes(input)
+	// jsonSchemaBytes, err := schema.SchemaBytesFromBytes(input)
 
-	if err != nil {
-		return nil, err
-	}
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	_, err = s.repo.StepRun().UpdateStepRunInputSchema(tenant.ID, request.StepRunId, jsonSchemaBytes)
+	// _, err = s.repo.StepRun().UpdateStepRunInputSchema(tenant.ID, request.StepRunId, jsonSchemaBytes)
 
-	if err != nil {
-		return nil, err
-	}
+	// if err != nil {
+	// 	return nil, err
+	// }
 
 	return &contracts.OverridesDataResponse{}, nil
 }

--- a/python-sdk/hatchet_sdk/clients/rest/api/step_run_api.py
+++ b/python-sdk/hatchet_sdk/clients/rest/api/step_run_api.py
@@ -323,6 +323,289 @@ class StepRunApi:
 
 
     @validate_call
+    def step_run_get_schema(
+        self,
+        tenant: Annotated[str, Field(min_length=36, strict=True, max_length=36, description="The tenant id")],
+        step_run: Annotated[str, Field(min_length=36, strict=True, max_length=36, description="The step run id")],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> object:
+        """Get step run schema
+
+        Get the schema for a step run
+
+        :param tenant: The tenant id (required)
+        :type tenant: str
+        :param step_run: The step run id (required)
+        :type step_run: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._step_run_get_schema_serialize(
+            tenant=tenant,
+            step_run=step_run,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "object",
+            '400': "APIErrors",
+            '403': "APIErrors",
+            '404': "APIErrors",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def step_run_get_schema_with_http_info(
+        self,
+        tenant: Annotated[str, Field(min_length=36, strict=True, max_length=36, description="The tenant id")],
+        step_run: Annotated[str, Field(min_length=36, strict=True, max_length=36, description="The step run id")],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[object]:
+        """Get step run schema
+
+        Get the schema for a step run
+
+        :param tenant: The tenant id (required)
+        :type tenant: str
+        :param step_run: The step run id (required)
+        :type step_run: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._step_run_get_schema_serialize(
+            tenant=tenant,
+            step_run=step_run,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "object",
+            '400': "APIErrors",
+            '403': "APIErrors",
+            '404': "APIErrors",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def step_run_get_schema_without_preload_content(
+        self,
+        tenant: Annotated[str, Field(min_length=36, strict=True, max_length=36, description="The tenant id")],
+        step_run: Annotated[str, Field(min_length=36, strict=True, max_length=36, description="The step run id")],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Get step run schema
+
+        Get the schema for a step run
+
+        :param tenant: The tenant id (required)
+        :type tenant: str
+        :param step_run: The step run id (required)
+        :type step_run: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._step_run_get_schema_serialize(
+            tenant=tenant,
+            step_run=step_run,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "object",
+            '400': "APIErrors",
+            '403': "APIErrors",
+            '404': "APIErrors",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _step_run_get_schema_serialize(
+        self,
+        tenant,
+        step_run,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[str, str] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        if tenant is not None:
+            _path_params['tenant'] = tenant
+        if step_run is not None:
+            _path_params['step-run'] = step_run
+        # process the query parameters
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+
+
+        # set the HTTP header `Accept`
+        _header_params['Accept'] = self.api_client.select_header_accept(
+            [
+                'application/json'
+            ]
+        )
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+            'cookieAuth', 
+            'bearerAuth'
+        ]
+
+        return self.api_client.param_serialize(
+            method='GET',
+            resource_path='/api/v1/tenants/{tenant}/step-runs/{step-run}/schema',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+
+    @validate_call
     def step_run_update_rerun(
         self,
         tenant: Annotated[str, Field(min_length=36, strict=True, max_length=36, description="The tenant id")],

--- a/python-sdk/hatchet_sdk/clients/rest/api/workflow_api.py
+++ b/python-sdk/hatchet_sdk/clients/rest/api/workflow_api.py
@@ -614,6 +614,274 @@ class WorkflowApi:
 
 
     @validate_call
+    def workflow_delete(
+        self,
+        workflow: Annotated[str, Field(min_length=36, strict=True, max_length=36, description="The workflow id")],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> None:
+        """Delete workflow
+
+        Delete a workflow for a tenant
+
+        :param workflow: The workflow id (required)
+        :type workflow: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._workflow_delete_serialize(
+            workflow=workflow,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '204': None,
+            '400': "APIErrors",
+            '403': "APIErrors",
+            '404': "APIErrors",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def workflow_delete_with_http_info(
+        self,
+        workflow: Annotated[str, Field(min_length=36, strict=True, max_length=36, description="The workflow id")],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[None]:
+        """Delete workflow
+
+        Delete a workflow for a tenant
+
+        :param workflow: The workflow id (required)
+        :type workflow: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._workflow_delete_serialize(
+            workflow=workflow,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '204': None,
+            '400': "APIErrors",
+            '403': "APIErrors",
+            '404': "APIErrors",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def workflow_delete_without_preload_content(
+        self,
+        workflow: Annotated[str, Field(min_length=36, strict=True, max_length=36, description="The workflow id")],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Delete workflow
+
+        Delete a workflow for a tenant
+
+        :param workflow: The workflow id (required)
+        :type workflow: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._workflow_delete_serialize(
+            workflow=workflow,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '204': None,
+            '400': "APIErrors",
+            '403': "APIErrors",
+            '404': "APIErrors",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _workflow_delete_serialize(
+        self,
+        workflow,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[str, str] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        if workflow is not None:
+            _path_params['workflow'] = workflow
+        # process the query parameters
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+
+
+        # set the HTTP header `Accept`
+        _header_params['Accept'] = self.api_client.select_header_accept(
+            [
+                'application/json'
+            ]
+        )
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+            'cookieAuth', 
+            'bearerAuth'
+        ]
+
+        return self.api_client.param_serialize(
+            method='DELETE',
+            resource_path='/api/v1/workflows/{workflow}',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+
+    @validate_call
     def workflow_get(
         self,
         workflow: Annotated[str, Field(min_length=36, strict=True, max_length=36, description="The workflow id")],

--- a/python-sdk/hatchet_sdk/clients/rest/models/step_run.py
+++ b/python-sdk/hatchet_sdk/clients/rest/models/step_run.py
@@ -55,8 +55,7 @@ class StepRun(BaseModel):
     cancelled_at_epoch: Optional[StrictInt] = Field(default=None, alias="cancelledAtEpoch")
     cancelled_reason: Optional[StrictStr] = Field(default=None, alias="cancelledReason")
     cancelled_error: Optional[StrictStr] = Field(default=None, alias="cancelledError")
-    input_schema: Optional[StrictStr] = Field(default=None, alias="inputSchema")
-    __properties: ClassVar[List[str]] = ["metadata", "tenantId", "jobRunId", "jobRun", "stepId", "step", "children", "parents", "workerId", "input", "output", "status", "requeueAfter", "result", "error", "startedAt", "startedAtEpoch", "finishedAt", "finishedAtEpoch", "timeoutAt", "timeoutAtEpoch", "cancelledAt", "cancelledAtEpoch", "cancelledReason", "cancelledError", "inputSchema"]
+    __properties: ClassVar[List[str]] = ["metadata", "tenantId", "jobRunId", "jobRun", "stepId", "step", "children", "parents", "workerId", "input", "output", "status", "requeueAfter", "result", "error", "startedAt", "startedAtEpoch", "finishedAt", "finishedAtEpoch", "timeoutAt", "timeoutAtEpoch", "cancelledAt", "cancelledAtEpoch", "cancelledReason", "cancelledError"]
 
     model_config = {
         "populate_by_name": True,
@@ -142,8 +141,7 @@ class StepRun(BaseModel):
             "cancelledAt": obj.get("cancelledAt"),
             "cancelledAtEpoch": obj.get("cancelledAtEpoch"),
             "cancelledReason": obj.get("cancelledReason"),
-            "cancelledError": obj.get("cancelledError"),
-            "inputSchema": obj.get("inputSchema")
+            "cancelledError": obj.get("cancelledError")
         })
         return _obj
 

--- a/typescript-sdk/src/clients/rest/generated/Api.ts
+++ b/typescript-sdk/src/clients/rest/generated/Api.ts
@@ -996,6 +996,23 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
       ...params,
     });
   /**
+   * @description Get the schema for a step run
+   *
+   * @tags Step Run
+   * @name StepRunGetSchema
+   * @summary Get step run schema
+   * @request GET:/api/v1/tenants/{tenant}/step-runs/{step-run}/schema
+   * @secure
+   */
+  stepRunGetSchema = (tenant: string, stepRun: string, params: RequestParams = {}) =>
+    this.request<object, APIErrors>({
+      path: `/api/v1/tenants/${tenant}/step-runs/${stepRun}/schema`,
+      method: 'GET',
+      secure: true,
+      format: 'json',
+      ...params,
+    });
+  /**
    * @description Get all workers for a tenant
    *
    * @tags Worker

--- a/typescript-sdk/src/clients/rest/generated/Api.ts
+++ b/typescript-sdk/src/clients/rest/generated/Api.ts
@@ -668,6 +668,22 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
       ...params,
     });
   /**
+   * @description Delete a workflow for a tenant
+   *
+   * @tags Workflow
+   * @name WorkflowDelete
+   * @summary Delete workflow
+   * @request DELETE:/api/v1/workflows/{workflow}
+   * @secure
+   */
+  workflowDelete = (workflow: string, params: RequestParams = {}) =>
+    this.request<void, APIErrors>({
+      path: `/api/v1/workflows/${workflow}`,
+      method: 'DELETE',
+      secure: true,
+      ...params,
+    });
+  /**
    * @description Get a workflow version for a tenant
    *
    * @tags Workflow

--- a/typescript-sdk/src/clients/rest/generated/data-contracts.ts
+++ b/typescript-sdk/src/clients/rest/generated/data-contracts.ts
@@ -548,7 +548,6 @@ export interface StepRun {
   cancelledAtEpoch?: number;
   cancelledReason?: string;
   cancelledError?: string;
-  inputSchema?: string;
 }
 
 export interface WorkerList {


### PR DESCRIPTION
# Description

We spend some cycles parsing the schema in the engine and usage of `defer` can crash the engine since it's not caught by `panic...recover`. We move this logic to the API because we're guaranteed panic...recover in the handler and parsing the schema is not core to the engine.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
