### PR TITLE
fix: worker locking on requeues

### DIFF
--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -165,6 +165,7 @@ func Run(ctx context.Context, cf *loader.ConfigLoader) error {
 	if sc.HasService("grpc") {
 		// create the dispatcher
 		d, err := dispatcher.New(
+			dispatcher.WithAlerter(sc.Alerter),
 			dispatcher.WithMessageQueue(sc.MessageQueue),
 			dispatcher.WithRepository(sc.Repository),
 			dispatcher.WithLogger(sc.Logger),

--- a/internal/repository/prisma/dbsqlc/get_group_key_runs.sql
+++ b/internal/repository/prisma/dbsqlc/get_group_key_runs.sql
@@ -96,7 +96,7 @@ WITH get_group_key_run AS (
     WHERE
         ggr."id" = @getGroupKeyRunId::uuid AND
         ggr."tenantId" = @tenantId::uuid
-    FOR UPDATE
+    FOR UPDATE SKIP LOCKED
 ), valid_workers AS (
     SELECT
         w."id", w."dispatcherId"
@@ -112,11 +112,11 @@ WITH get_group_key_run AS (
             WHERE "Action"."tenantId" = @tenantId AND "Action"."id" = get_group_key_run."actionId"
         )
     ORDER BY random()
-    FOR UPDATE SKIP LOCKED
 ), selected_worker AS (
     SELECT "id", "dispatcherId"
     FROM valid_workers
     LIMIT 1
+    FOR UPDATE SKIP LOCKED
 )
 UPDATE
     "GetGroupKeyRun"

--- a/internal/repository/prisma/dbsqlc/get_group_key_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/get_group_key_runs.sql.go
@@ -72,7 +72,7 @@ WITH get_group_key_run AS (
     WHERE
         ggr."id" = $1::uuid AND
         ggr."tenantId" = $2::uuid
-    FOR UPDATE
+    FOR UPDATE SKIP LOCKED
 ), valid_workers AS (
     SELECT
         w."id", w."dispatcherId"
@@ -88,11 +88,11 @@ WITH get_group_key_run AS (
             WHERE "Action"."tenantId" = $2 AND "Action"."id" = get_group_key_run."actionId"
         )
     ORDER BY random()
-    FOR UPDATE SKIP LOCKED
 ), selected_worker AS (
     SELECT "id", "dispatcherId"
     FROM valid_workers
     LIMIT 1
+    FOR UPDATE SKIP LOCKED
 )
 UPDATE
     "GetGroupKeyRun"

--- a/internal/repository/prisma/dbsqlc/step_runs.sql
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql
@@ -278,7 +278,7 @@ WITH step_run AS (
     WHERE
         sr."id" = @stepRunId::uuid AND
         sr."tenantId" = @tenantId::uuid
-    FOR UPDATE
+    FOR UPDATE SKIP LOCKED
 ),
 valid_workers AS (
     SELECT
@@ -303,12 +303,12 @@ valid_workers AS (
             )
         )
     ORDER BY random()
-    FOR UPDATE SKIP LOCKED
 ),
 selected_worker AS (
     SELECT "id", "dispatcherId"
     FROM valid_workers
     LIMIT 1
+    FOR UPDATE SKIP LOCKED
 )
 UPDATE
     "StepRun"

--- a/internal/repository/prisma/dbsqlc/step_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql.go
@@ -152,7 +152,7 @@ WITH step_run AS (
     WHERE
         sr."id" = $1::uuid AND
         sr."tenantId" = $2::uuid
-    FOR UPDATE
+    FOR UPDATE SKIP LOCKED
 ),
 valid_workers AS (
     SELECT
@@ -177,12 +177,12 @@ valid_workers AS (
             )
         )
     ORDER BY random()
-    FOR UPDATE SKIP LOCKED
 ),
 selected_worker AS (
     SELECT "id", "dispatcherId"
     FROM valid_workers
     LIMIT 1
+    FOR UPDATE SKIP LOCKED
 )
 UPDATE
     "StepRun"

--- a/python-sdk/examples/dag/event_test.py
+++ b/python-sdk/examples/dag/event_test.py
@@ -5,9 +5,11 @@ load_dotenv()
 
 client = new_client()
 
-client.event.push(
-    "user:create",
-    {
-        "test": "test"
-    }
-)
+for i in range(10):
+    client.event.push(
+        "user:create",
+        {
+            "test": "test"
+        }
+    )
+


### PR DESCRIPTION
# Description

Using `for update` on the list of workers instead of the selected worker results in requeues only getting 1 step run (usually)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)