### PR TITLE
fix(go-sdk): support tls strategy of none, with docs

### DIFF
--- a/examples/no-tls/main.go
+++ b/examples/no-tls/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/joho/godotenv"
 

--- a/examples/no-tls/main.go
+++ b/examples/no-tls/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/joho/godotenv"
+
+	"github.com/hatchet-dev/hatchet/pkg/client"
+	"github.com/hatchet-dev/hatchet/pkg/cmdutils"
+	"github.com/hatchet-dev/hatchet/pkg/worker"
+)
+
+type stepOutput struct{}
+
+func main() {
+	err := godotenv.Load()
+	if err != nil {
+		panic(err)
+	}
+
+	c, err := client.New()
+
+	if err != nil {
+		panic(fmt.Errorf("error creating client: %w", err))
+	}
+
+	w, err := worker.NewWorker(
+		worker.WithClient(
+			c,
+		),
+		worker.WithMaxRuns(1),
+	)
+	if err != nil {
+		panic(fmt.Errorf("error creating worker: %w", err))
+	}
+
+	testSvc := w.NewService("test")
+
+	err = testSvc.On(
+		worker.Events("simple"),
+		&worker.WorkflowJob{
+			Name:        "simple-workflow",
+			Description: "Simple one-step workflow.",
+			Steps: []*worker.WorkflowStep{
+				worker.Fn(func(ctx worker.HatchetContext) (result *stepOutput, err error) {
+					fmt.Println("executed step 1")
+
+					return &stepOutput{}, nil
+				},
+				).SetName("step-one"),
+			},
+		},
+	)
+	if err != nil {
+		panic(fmt.Errorf("error registering workflow: %w", err))
+	}
+
+	interruptCtx, cancel := cmdutils.InterruptContextFromChan(cmdutils.InterruptChan())
+	defer cancel()
+
+	cleanup, err := w.Start()
+	if err != nil {
+		panic(fmt.Errorf("error starting worker: %w", err))
+	}
+
+	for {
+		select {
+		case <-interruptCtx.Done():
+			cleanup() // nolint: errcheck
+		default:
+			time.Sleep(time.Second)
+		}
+	}
+}

--- a/examples/no-tls/main.go
+++ b/examples/no-tls/main.go
@@ -64,12 +64,8 @@ func main() {
 		panic(fmt.Sprintf("error starting worker: %v", err))
 	}
 
-	for {
-		select {
-		case <-interruptCtx.Done():
-			cleanup() // nolint: errcheck
-		default:
-			time.Sleep(time.Second)
-		}
+	<-interruptCtx.Done()
+	if err := cleanup(); err != nil {
+		panic(err)
 	}
 }

--- a/examples/no-tls/main.go
+++ b/examples/no-tls/main.go
@@ -22,7 +22,7 @@ func main() {
 	c, err := client.New()
 
 	if err != nil {
-		panic(fmt.Errorf("error creating client: %w", err))
+		panic(fmt.Sprintf("error creating client: %v", err))
 	}
 
 	w, err := worker.NewWorker(
@@ -32,7 +32,7 @@ func main() {
 		worker.WithMaxRuns(1),
 	)
 	if err != nil {
-		panic(fmt.Errorf("error creating worker: %w", err))
+		panic(fmt.Sprintf("error creating worker: %v", err))
 	}
 
 	testSvc := w.NewService("test")
@@ -53,7 +53,7 @@ func main() {
 		},
 	)
 	if err != nil {
-		panic(fmt.Errorf("error registering workflow: %w", err))
+		panic(fmt.Sprintf("error registering workflow: %v", err))
 	}
 
 	interruptCtx, cancel := cmdutils.InterruptContextFromChan(cmdutils.InterruptChan())
@@ -61,7 +61,7 @@ func main() {
 
 	cleanup, err := w.Start()
 	if err != nil {
-		panic(fmt.Errorf("error starting worker: %w", err))
+		panic(fmt.Sprintf("error starting worker: %v", err))
 	}
 
 	for {

--- a/frontend/docs/pages/self-hosting/docker-compose.mdx
+++ b/frontend/docs/pages/self-hosting/docker-compose.mdx
@@ -317,7 +317,7 @@ func main() {
 	c, err := client.New()
 
 	if err != nil {
-		panic(fmt.Errorf("error creating client: %w", err))
+		panic(fmt.Sprintf("error creating client: %v", err))
 	}
 
 	w, err := worker.NewWorker(
@@ -327,7 +327,7 @@ func main() {
 		worker.WithMaxRuns(1),
 	)
 	if err != nil {
-		panic(fmt.Errorf("error creating worker: %w", err))
+		panic(fmt.Sprintf("error creating worker: %v", err))
 	}
 
 	testSvc := w.NewService("test")
@@ -348,7 +348,7 @@ func main() {
 		},
 	)
 	if err != nil {
-		panic(fmt.Errorf("error registering workflow: %w", err))
+		panic(fmt.Sprintf("error registering workflow: %v", err))
 	}
 
 	interruptCtx, cancel := cmdutils.InterruptContextFromChan(cmdutils.InterruptChan())
@@ -356,7 +356,7 @@ func main() {
 
 	cleanup, err := w.Start()
 	if err != nil {
-		panic(fmt.Errorf("error starting worker: %w", err))
+		panic(fmt.Sprintf("error starting worker: %v", err))
 	}
 
 	for {

--- a/frontend/docs/pages/self-hosting/docker-compose.mdx
+++ b/frontend/docs/pages/self-hosting/docker-compose.mdx
@@ -359,13 +359,9 @@ func main() {
 		panic(fmt.Sprintf("error starting worker: %v", err))
 	}
 
-	for {
-		select {
-		case <-interruptCtx.Done():
-			cleanup() // nolint: errcheck
-		default:
-			time.Sleep(time.Second)
-		}
+	<-interruptCtx.Done()
+	if err := cleanup(); err != nil {
+		panic(err)
 	}
 }
 ```

--- a/frontend/docs/pages/self-hosting/docker-compose.mdx
+++ b/frontend/docs/pages/self-hosting/docker-compose.mdx
@@ -184,7 +184,7 @@ You will need this in the following example.
 
 ### Run your first worker
 
-<Tabs items={['Python', 'Typescript']}>
+<Tabs items={['Python', 'Typescript', 'Go']}>
   <Tabs.Tab>
 Make sure you have the following dependencies installed:
 
@@ -289,6 +289,93 @@ Now to start the worker, in a new terminal run:
 npm run worker
 ```
   </Tabs.Tab>
+  <Tabs.Tab>
+  In a new Go project, copy the following code into a `main.go` file:
+
+```go filename="main.go" copy
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/joho/godotenv"
+
+	"github.com/hatchet-dev/hatchet/pkg/client"
+	"github.com/hatchet-dev/hatchet/pkg/cmdutils"
+	"github.com/hatchet-dev/hatchet/pkg/worker"
+)
+
+type stepOutput struct{}
+
+func main() {
+	err := godotenv.Load()
+	if err != nil {
+		panic(err)
+	}
+
+	c, err := client.New()
+
+	if err != nil {
+		panic(fmt.Errorf("error creating client: %w", err))
+	}
+
+	w, err := worker.NewWorker(
+		worker.WithClient(
+			c,
+		),
+		worker.WithMaxRuns(1),
+	)
+	if err != nil {
+		panic(fmt.Errorf("error creating worker: %w", err))
+	}
+
+	testSvc := w.NewService("test")
+
+	err = testSvc.On(
+		worker.Events("simple"),
+		&worker.WorkflowJob{
+			Name:        "simple-workflow",
+			Description: "Simple one-step workflow.",
+			Steps: []*worker.WorkflowStep{
+				worker.Fn(func(ctx worker.HatchetContext) (result *stepOutput, err error) {
+					fmt.Println("executed step 1")
+
+					return &stepOutput{}, nil
+				},
+				).SetName("step-one"),
+			},
+		},
+	)
+	if err != nil {
+		panic(fmt.Errorf("error registering workflow: %w", err))
+	}
+
+	interruptCtx, cancel := cmdutils.InterruptContextFromChan(cmdutils.InterruptChan())
+	defer cancel()
+
+	cleanup, err := w.Start()
+	if err != nil {
+		panic(fmt.Errorf("error starting worker: %w", err))
+	}
+
+	for {
+		select {
+		case <-interruptCtx.Done():
+			cleanup() // nolint: errcheck
+		default:
+			time.Sleep(time.Second)
+		}
+	}
+}
+```
+
+Next, run the following command to start the worker:
+
+```sh
+go run main.go
+```
+</Tabs.Tab>
 </Tabs>
 
 ### Run your first workflow

--- a/frontend/docs/pages/self-hosting/docker-compose.mdx
+++ b/frontend/docs/pages/self-hosting/docker-compose.mdx
@@ -297,7 +297,6 @@ package main
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/joho/godotenv"
 

--- a/internal/config/client/client.go
+++ b/internal/config/client/client.go
@@ -31,6 +31,7 @@ type ClientConfig struct {
 	ServerURL            string
 	GRPCBroadcastAddress string
 
+	// TLSConfig will be nil if the strategy is "none"
 	TLSConfig *tls.Config
 }
 

--- a/internal/config/loader/loaderutils/tls.go
+++ b/internal/config/loader/loaderutils/tls.go
@@ -27,6 +27,8 @@ func LoadClientTLSConfig(tlsConfig *client.ClientTLSConfigFile, serverName strin
 	case "mtls":
 		res.ServerName = tlsConfig.TLSServerName
 		res.RootCAs = ca
+	case "none":
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("invalid TLS strategy: %s", tlsConfig.Base.TLSStrategy)
 	}

--- a/internal/config/shared/shared.go
+++ b/internal/config/shared/shared.go
@@ -1,7 +1,7 @@
 package shared
 
 type TLSConfigFile struct {
-	// TLSStrategy can be "tls" or "mtls"
+	// TLSStrategy can be "tls", "mtls", or "none"
 	TLSStrategy string `mapstructure:"tlsStrategy" json:"tlsStrategy,omitempty" default:"tls"`
 
 	TLSCert       string `mapstructure:"tlsCert" json:"tlsCert,omitempty"`


### PR DESCRIPTION
# Description

Adds option to the Go SDK to support `HATCHET_CLIENT_TLS_STRATEGY=none`. Also updates the docker-compose quickstart to include the Go SDK.

Fixes #257

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation change (pure documentation change)