### PR TITLE
fix: timeout set to 0 when not explicitly set

### DIFF
--- a/internal/repository/prisma/dbsqlc/workflows.sql
+++ b/internal/repository/prisma/dbsqlc/workflows.sql
@@ -232,7 +232,7 @@ INSERT INTO "Step" (
     @tenantId::uuid,
     @jobId::uuid,
     @actionId::text,
-    @timeout::text,
+    sqlc.narg('timeout')::text,
     coalesce(sqlc.narg('customUserData')::jsonb, '{}'),
     coalesce(sqlc.narg('retries')::integer, 0),
     coalesce(sqlc.narg('scheduleTimeout')::text, '5m')

--- a/internal/repository/prisma/dbsqlc/workflows.sql.go
+++ b/internal/repository/prisma/dbsqlc/workflows.sql.go
@@ -244,7 +244,7 @@ type CreateStepParams struct {
 	Tenantid        pgtype.UUID      `json:"tenantid"`
 	Jobid           pgtype.UUID      `json:"jobid"`
 	Actionid        string           `json:"actionid"`
-	Timeout         string           `json:"timeout"`
+	Timeout         pgtype.Text      `json:"timeout"`
 	CustomUserData  []byte           `json:"customUserData"`
 	Retries         pgtype.Int4      `json:"retries"`
 	ScheduleTimeout pgtype.Text      `json:"scheduleTimeout"`

--- a/internal/repository/prisma/workflow.go
+++ b/internal/repository/prisma/workflow.go
@@ -656,13 +656,13 @@ func (r *workflowEngineRepository) createWorkflowVersionTxs(ctx context.Context,
 			stepId := uuid.New().String()
 
 			var (
-				timeout        string
+				timeout        pgtype.Text
 				customUserData []byte
 				retries        pgtype.Int4
 			)
 
 			if stepOpts.Timeout != nil {
-				timeout = *stepOpts.Timeout
+				timeout = sqlchelpers.TextFromStr(*stepOpts.Timeout)
 			}
 
 			if stepOpts.UserData != nil {

--- a/prisma/migrations/20240321215205_v0_17_1/migration.sql
+++ b/prisma/migrations/20240321215205_v0_17_1/migration.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE FUNCTION convert_duration_to_interval(duration text) RETURNS interval AS $$
+DECLARE
+    num_value INT;
+BEGIN
+    num_value := substring(duration from '^\d+');
+
+    RETURN CASE
+        WHEN duration LIKE '%ms' THEN make_interval(secs => num_value::float / 1000)
+        WHEN duration LIKE '%s' THEN make_interval(secs => num_value)
+        WHEN duration LIKE '%m' THEN make_interval(mins => num_value)
+        WHEN duration LIKE '%h' THEN make_interval(hours => num_value)
+        WHEN duration LIKE '%d' THEN make_interval(days => num_value)
+        WHEN duration LIKE '%w' THEN make_interval(days => num_value * 7)
+        WHEN duration LIKE '%y' THEN make_interval(months => num_value * 12)
+        ELSE '5 minutes'::interval
+    END;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
# Description

Bug introduced in release `v0.17.0` where timeout values are set to 0 when not passed in, which results in immediate step cancellation. 
 
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
