### PR TITLE
fix: list methods should select distinct step run ids

### DIFF
--- a/internal/repository/prisma/dbsqlc/get_group_key_runs.sql
+++ b/internal/repository/prisma/dbsqlc/get_group_key_runs.sql
@@ -23,6 +23,7 @@ RETURNING "GetGroupKeyRun".*;
 
 -- name: GetGroupKeyRunForEngine :many
 SELECT
+    DISTINCT ON (ggr."id")
     sqlc.embed(ggr),
     -- TODO: everything below this line is cacheable and should be moved to a separate query
     wr."id" AS "workflowRunId",
@@ -38,13 +39,14 @@ JOIN
 JOIN
     "WorkflowConcurrency" wc ON wv."id" = wc."workflowVersionId"
 JOIN
-    "Action" a ON wc."getConcurrencyGroupId" = a."id"
+    "Action" a ON wc."getConcurrencyGroupId" = a."id" AND a."tenantId" = ggr."tenantId"
 WHERE
     ggr."id" = ANY(@ids::uuid[]) AND
     ggr."tenantId" = @tenantId::uuid;
 
 -- name: ListGetGroupKeyRunsToRequeue :many
 SELECT
+    DISTINCT ON (ggr."id")
     ggr.*
 FROM
     "GetGroupKeyRun" ggr
@@ -60,6 +62,7 @@ ORDER BY
 
 -- name: ListGetGroupKeyRunsToReassign :many
 SELECT
+    DISTINCT ON (ggr."id")
     ggr.*
 FROM
     "GetGroupKeyRun" ggr

--- a/internal/repository/prisma/dbsqlc/get_group_key_runs.sql
+++ b/internal/repository/prisma/dbsqlc/get_group_key_runs.sql
@@ -46,7 +46,6 @@ WHERE
 
 -- name: ListGetGroupKeyRunsToRequeue :many
 SELECT
-    DISTINCT ON (ggr."id")
     ggr.*
 FROM
     "GetGroupKeyRun" ggr
@@ -62,7 +61,6 @@ ORDER BY
 
 -- name: ListGetGroupKeyRunsToReassign :many
 SELECT
-    DISTINCT ON (ggr."id")
     ggr.*
 FROM
     "GetGroupKeyRun" ggr

--- a/internal/repository/prisma/dbsqlc/get_group_key_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/get_group_key_runs.sql.go
@@ -212,7 +212,6 @@ func (q *Queries) GetGroupKeyRunForEngine(ctx context.Context, db DBTX, arg GetG
 
 const listGetGroupKeyRunsToReassign = `-- name: ListGetGroupKeyRunsToReassign :many
 SELECT
-    DISTINCT ON (ggr."id")
     ggr.id, ggr."createdAt", ggr."updatedAt", ggr."deletedAt", ggr."tenantId", ggr."workerId", ggr."tickerId", ggr.status, ggr.input, ggr.output, ggr."requeueAfter", ggr.error, ggr."startedAt", ggr."finishedAt", ggr."timeoutAt", ggr."cancelledAt", ggr."cancelledReason", ggr."cancelledError", ggr."workflowRunId", ggr."scheduleTimeoutAt"
 FROM
     "GetGroupKeyRun" ggr
@@ -274,7 +273,6 @@ func (q *Queries) ListGetGroupKeyRunsToReassign(ctx context.Context, db DBTX, te
 
 const listGetGroupKeyRunsToRequeue = `-- name: ListGetGroupKeyRunsToRequeue :many
 SELECT
-    DISTINCT ON (ggr."id")
     ggr.id, ggr."createdAt", ggr."updatedAt", ggr."deletedAt", ggr."tenantId", ggr."workerId", ggr."tickerId", ggr.status, ggr.input, ggr.output, ggr."requeueAfter", ggr.error, ggr."startedAt", ggr."finishedAt", ggr."timeoutAt", ggr."cancelledAt", ggr."cancelledReason", ggr."cancelledError", ggr."workflowRunId", ggr."scheduleTimeoutAt"
 FROM
     "GetGroupKeyRun" ggr

--- a/internal/repository/prisma/dbsqlc/get_group_key_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/get_group_key_runs.sql.go
@@ -130,6 +130,7 @@ func (q *Queries) AssignGetGroupKeyRunToWorker(ctx context.Context, db DBTX, arg
 
 const getGroupKeyRunForEngine = `-- name: GetGroupKeyRunForEngine :many
 SELECT
+    DISTINCT ON (ggr."id")
     ggr.id, ggr."createdAt", ggr."updatedAt", ggr."deletedAt", ggr."tenantId", ggr."workerId", ggr."tickerId", ggr.status, ggr.input, ggr.output, ggr."requeueAfter", ggr.error, ggr."startedAt", ggr."finishedAt", ggr."timeoutAt", ggr."cancelledAt", ggr."cancelledReason", ggr."cancelledError", ggr."workflowRunId", ggr."scheduleTimeoutAt",
     -- TODO: everything below this line is cacheable and should be moved to a separate query
     wr."id" AS "workflowRunId",
@@ -145,7 +146,7 @@ JOIN
 JOIN
     "WorkflowConcurrency" wc ON wv."id" = wc."workflowVersionId"
 JOIN
-    "Action" a ON wc."getConcurrencyGroupId" = a."id"
+    "Action" a ON wc."getConcurrencyGroupId" = a."id" AND a."tenantId" = ggr."tenantId"
 WHERE
     ggr."id" = ANY($1::uuid[]) AND
     ggr."tenantId" = $2::uuid
@@ -211,6 +212,7 @@ func (q *Queries) GetGroupKeyRunForEngine(ctx context.Context, db DBTX, arg GetG
 
 const listGetGroupKeyRunsToReassign = `-- name: ListGetGroupKeyRunsToReassign :many
 SELECT
+    DISTINCT ON (ggr."id")
     ggr.id, ggr."createdAt", ggr."updatedAt", ggr."deletedAt", ggr."tenantId", ggr."workerId", ggr."tickerId", ggr.status, ggr.input, ggr.output, ggr."requeueAfter", ggr.error, ggr."startedAt", ggr."finishedAt", ggr."timeoutAt", ggr."cancelledAt", ggr."cancelledReason", ggr."cancelledError", ggr."workflowRunId", ggr."scheduleTimeoutAt"
 FROM
     "GetGroupKeyRun" ggr
@@ -272,6 +274,7 @@ func (q *Queries) ListGetGroupKeyRunsToReassign(ctx context.Context, db DBTX, te
 
 const listGetGroupKeyRunsToRequeue = `-- name: ListGetGroupKeyRunsToRequeue :many
 SELECT
+    DISTINCT ON (ggr."id")
     ggr.id, ggr."createdAt", ggr."updatedAt", ggr."deletedAt", ggr."tenantId", ggr."workerId", ggr."tickerId", ggr.status, ggr.input, ggr.output, ggr."requeueAfter", ggr.error, ggr."startedAt", ggr."finishedAt", ggr."timeoutAt", ggr."cancelledAt", ggr."cancelledReason", ggr."cancelledError", ggr."workflowRunId", ggr."scheduleTimeoutAt"
 FROM
     "GetGroupKeyRun" ggr

--- a/internal/repository/prisma/dbsqlc/step_runs.sql
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql
@@ -9,6 +9,7 @@ WHERE
 
 -- name: GetStepRunForEngine :many
 SELECT
+    DISTINCT ON (sr."id")
     sqlc.embed(sr),
     jrld."data" AS "jobRunLookupData",
     -- TODO: everything below this line is cacheable and should be moved to a separate query
@@ -30,7 +31,7 @@ FROM
 JOIN
     "Step" s ON sr."stepId" = s."id"
 JOIN
-    "Action" a ON s."actionId" = a."actionId"
+    "Action" a ON s."actionId" = a."actionId" AND s."tenantId" = a."tenantId"
 JOIN
     "JobRun" jr ON sr."jobRunId" = jr."id"
 JOIN
@@ -57,6 +58,7 @@ WITH job_run AS (
     WHERE "id" = @jobRunId::uuid
 )
 SELECT 
+    DISTINCT ON (child_run."id")
     child_run."id" AS "id"
 FROM 
     "StepRun" AS child_run
@@ -86,6 +88,7 @@ WHERE
 
 -- name: ListStepRuns :many
 SELECT
+    DISTINCT ON ("StepRun"."id")
     "StepRun"."id"
 FROM
     "StepRun"
@@ -272,6 +275,7 @@ RETURNING *;
 
 -- name: ListStepRunsToReassign :many
 SELECT
+    DISTINCT ON (sr."id")
     sr.*
 FROM
     "StepRun" sr
@@ -303,6 +307,7 @@ ORDER BY
 
 -- name: ListStepRunsToRequeue :many
 SELECT
+    DISTINCT ON (sr."id")
     sr.*
 FROM
     "StepRun" sr

--- a/internal/repository/prisma/dbsqlc/step_runs.sql
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql
@@ -275,7 +275,6 @@ RETURNING *;
 
 -- name: ListStepRunsToReassign :many
 SELECT
-    DISTINCT ON (sr."id")
     sr.*
 FROM
     "StepRun" sr
@@ -307,7 +306,6 @@ ORDER BY
 
 -- name: ListStepRunsToRequeue :many
 SELECT
-    DISTINCT ON (sr."id")
     sr.*
 FROM
     "StepRun" sr

--- a/internal/repository/prisma/dbsqlc/step_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql.go
@@ -232,6 +232,7 @@ func (q *Queries) GetStepRun(ctx context.Context, db DBTX, arg GetStepRunParams)
 
 const getStepRunForEngine = `-- name: GetStepRunForEngine :many
 SELECT
+    DISTINCT ON (sr."id")
     sr.id, sr."createdAt", sr."updatedAt", sr."deletedAt", sr."tenantId", sr."jobRunId", sr."stepId", sr."order", sr."workerId", sr."tickerId", sr.status, sr.input, sr.output, sr."requeueAfter", sr."scheduleTimeoutAt", sr.error, sr."startedAt", sr."finishedAt", sr."timeoutAt", sr."cancelledAt", sr."cancelledReason", sr."cancelledError", sr."inputSchema", sr."callerFiles", sr."gitRepoBranch", sr."retryCount",
     jrld."data" AS "jobRunLookupData",
     -- TODO: everything below this line is cacheable and should be moved to a separate query
@@ -253,7 +254,7 @@ FROM
 JOIN
     "Step" s ON sr."stepId" = s."id"
 JOIN
-    "Action" a ON s."actionId" = a."actionId"
+    "Action" a ON s."actionId" = a."actionId" AND s."tenantId" = a."tenantId"
 JOIN
     "JobRun" jr ON sr."jobRunId" = jr."id"
 JOIN
@@ -365,6 +366,7 @@ WITH job_run AS (
     WHERE "id" = $1::uuid
 )
 SELECT 
+    DISTINCT ON (child_run."id")
     child_run."id" AS "id"
 FROM 
     "StepRun" AS child_run
@@ -420,6 +422,7 @@ func (q *Queries) ListStartableStepRuns(ctx context.Context, db DBTX, arg ListSt
 
 const listStepRuns = `-- name: ListStepRuns :many
 SELECT
+    DISTINCT ON ("StepRun"."id")
     "StepRun"."id"
 FROM
     "StepRun"
@@ -481,6 +484,7 @@ func (q *Queries) ListStepRuns(ctx context.Context, db DBTX, arg ListStepRunsPar
 
 const listStepRunsToReassign = `-- name: ListStepRunsToReassign :many
 SELECT
+    DISTINCT ON (sr."id")
     sr.id, sr."createdAt", sr."updatedAt", sr."deletedAt", sr."tenantId", sr."jobRunId", sr."stepId", sr."order", sr."workerId", sr."tickerId", sr.status, sr.input, sr.output, sr."requeueAfter", sr."scheduleTimeoutAt", sr.error, sr."startedAt", sr."finishedAt", sr."timeoutAt", sr."cancelledAt", sr."cancelledReason", sr."cancelledError", sr."inputSchema", sr."callerFiles", sr."gitRepoBranch", sr."retryCount"
 FROM
     "StepRun" sr
@@ -560,6 +564,7 @@ func (q *Queries) ListStepRunsToReassign(ctx context.Context, db DBTX, tenantid 
 
 const listStepRunsToRequeue = `-- name: ListStepRunsToRequeue :many
 SELECT
+    DISTINCT ON (sr."id")
     sr.id, sr."createdAt", sr."updatedAt", sr."deletedAt", sr."tenantId", sr."jobRunId", sr."stepId", sr."order", sr."workerId", sr."tickerId", sr.status, sr.input, sr.output, sr."requeueAfter", sr."scheduleTimeoutAt", sr.error, sr."startedAt", sr."finishedAt", sr."timeoutAt", sr."cancelledAt", sr."cancelledReason", sr."cancelledError", sr."inputSchema", sr."callerFiles", sr."gitRepoBranch", sr."retryCount"
 FROM
     "StepRun" sr

--- a/internal/repository/prisma/dbsqlc/step_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql.go
@@ -484,7 +484,6 @@ func (q *Queries) ListStepRuns(ctx context.Context, db DBTX, arg ListStepRunsPar
 
 const listStepRunsToReassign = `-- name: ListStepRunsToReassign :many
 SELECT
-    DISTINCT ON (sr."id")
     sr.id, sr."createdAt", sr."updatedAt", sr."deletedAt", sr."tenantId", sr."jobRunId", sr."stepId", sr."order", sr."workerId", sr."tickerId", sr.status, sr.input, sr.output, sr."requeueAfter", sr."scheduleTimeoutAt", sr.error, sr."startedAt", sr."finishedAt", sr."timeoutAt", sr."cancelledAt", sr."cancelledReason", sr."cancelledError", sr."inputSchema", sr."callerFiles", sr."gitRepoBranch", sr."retryCount"
 FROM
     "StepRun" sr
@@ -564,7 +563,6 @@ func (q *Queries) ListStepRunsToReassign(ctx context.Context, db DBTX, tenantid 
 
 const listStepRunsToRequeue = `-- name: ListStepRunsToRequeue :many
 SELECT
-    DISTINCT ON (sr."id")
     sr.id, sr."createdAt", sr."updatedAt", sr."deletedAt", sr."tenantId", sr."jobRunId", sr."stepId", sr."order", sr."workerId", sr."tickerId", sr.status, sr.input, sr.output, sr."requeueAfter", sr."scheduleTimeoutAt", sr.error, sr."startedAt", sr."finishedAt", sr."timeoutAt", sr."cancelledAt", sr."cancelledReason", sr."cancelledError", sr."inputSchema", sr."callerFiles", sr."gitRepoBranch", sr."retryCount"
 FROM
     "StepRun" sr


### PR DESCRIPTION
# Description

Hotfix for when multiple `actionIds` across different tenants where resulting in duplicate step runs due to usage of `JOIN`. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
