### PR TITLE
fix: assigned step runs not timing out or reassigned

### DIFF
--- a/internal/repository/prisma/dbsqlc/step_runs.sql
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql
@@ -362,7 +362,7 @@ valid_workers AS (
             w."maxRuns" > (
                 SELECT COUNT(*)
                 FROM "StepRun" srs
-                WHERE srs."workerId" = w."id" AND srs."status" = 'RUNNING'
+                WHERE srs."workerId" = w."id" AND (srs."status" = 'RUNNING' OR srs."status" = 'ASSIGNED')
             )
         )
     ORDER BY random()

--- a/internal/repository/prisma/dbsqlc/step_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql.go
@@ -131,7 +131,7 @@ valid_workers AS (
             w."maxRuns" > (
                 SELECT COUNT(*)
                 FROM "StepRun" srs
-                WHERE srs."workerId" = w."id" AND srs."status" = 'RUNNING'
+                WHERE srs."workerId" = w."id" AND (srs."status" = 'RUNNING' OR srs."status" = 'ASSIGNED')
             )
         )
     ORDER BY random()

--- a/internal/repository/prisma/dbsqlc/tickers.sql
+++ b/internal/repository/prisma/dbsqlc/tickers.sql
@@ -74,7 +74,7 @@ WITH stepRunsToTimeout AS (
     FROM
         "StepRun" as stepRun
     WHERE
-        "status" = 'RUNNING'
+        ("status" = 'RUNNING' OR "status" = 'ASSIGNED')
         AND "timeoutAt" < NOW()
         AND (
             NOT EXISTS (
@@ -101,7 +101,7 @@ WITH getGroupKeyRunsToTimeout AS (
     FROM
         "GetGroupKeyRun" as getGroupKeyRun
     WHERE
-        "status" = 'RUNNING'
+        ("status" = 'RUNNING' OR "status" = 'ASSIGNED')
         AND "timeoutAt" < NOW()
         AND (
             NOT EXISTS (

--- a/internal/repository/prisma/dbsqlc/tickers.sql.go
+++ b/internal/repository/prisma/dbsqlc/tickers.sql.go
@@ -429,7 +429,7 @@ WITH stepRunsToTimeout AS (
     FROM
         "StepRun" as stepRun
     WHERE
-        "status" = 'RUNNING'
+        ("status" = 'RUNNING' OR "status" = 'ASSIGNED')
         AND "timeoutAt" < NOW()
         AND (
             NOT EXISTS (

--- a/internal/repository/prisma/dbsqlc/tickers.sql.go
+++ b/internal/repository/prisma/dbsqlc/tickers.sql.go
@@ -267,7 +267,7 @@ WITH getGroupKeyRunsToTimeout AS (
     FROM
         "GetGroupKeyRun" as getGroupKeyRun
     WHERE
-        "status" = 'RUNNING'
+        ("status" = 'RUNNING' OR "status" = 'ASSIGNED')
         AND "timeoutAt" < NOW()
         AND (
             NOT EXISTS (


### PR DESCRIPTION
# Description

Step runs which are stuck in an `ASSIGNED` state are not getting timed out or reassigned. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)