### PR TITLE
fix: stale queries in update semaphore

### DIFF
--- a/examples/rate-limit/main.go
+++ b/examples/rate-limit/main.go
@@ -88,12 +88,6 @@ func main() {
 		panic(err)
 	}
 
-	_, err = w.Start()
-
-	if err != nil {
-		panic(fmt.Errorf("error cleaning up: %w", err))
-	}
-
 	for i := 0; i < 12; i++ {
 		_, err = c.Admin().RunWorkflow("rate-limit-workflow", &rateLimitInput{
 			Index: i,

--- a/internal/repository/prisma/dbsqlc/step_runs.sql
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql
@@ -513,9 +513,9 @@ semaphore AS (
 UPDATE
     "WorkerSemaphore" ws
 SET
-    "slots" = (semaphore."slots" + @inc::int)
+    "slots" = (ws."slots" + @inc::int)
 FROM
-    semaphore, worker_id
+    worker_id
 WHERE
     ws."workerId" = worker_id."workerId"
 RETURNING ws.*;

--- a/internal/repository/prisma/dbsqlc/step_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql.go
@@ -1040,9 +1040,9 @@ semaphore AS (
 UPDATE
     "WorkerSemaphore" ws
 SET
-    "slots" = (semaphore."slots" + $1::int)
+    "slots" = (ws."slots" + $1::int)
 FROM
-    semaphore, worker_id
+    worker_id
 WHERE
     ws."workerId" = worker_id."workerId"
 RETURNING ws."workerId", ws.slots


### PR DESCRIPTION
# Description

Updates for semaphores and step runs now uses `FOR UPDATE` to lock the rows before selecting them again in the update statement. There were some edge cases around stale counter updates causing invalid semaphore updates. We are still in read committed isolation level, when used with `for update` we shouldn't need a stricter isolation level. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)