### PR TITLE
feat: queued metrics, along with bug fixes for round robin queueing

### DIFF
--- a/api-contracts/openapi/components/schemas/_index.yaml
+++ b/api-contracts/openapi/components/schemas/_index.yaml
@@ -178,3 +178,5 @@ ListSNSIntegrations:
   $ref: "./sns.yaml#/ListSNSIntegrations"
 CreateSNSIntegrationRequest:
   $ref: "./sns.yaml#/CreateSNSIntegrationRequest"
+WorkflowMetrics:
+  $ref: "./workflow.yaml#/WorkflowMetrics"

--- a/api-contracts/openapi/components/schemas/event.yaml
+++ b/api-contracts/openapi/components/schemas/event.yaml
@@ -50,6 +50,10 @@ EventWorkflowRunSummary:
       type: integer
       format: int64
       description: The number of running runs.
+    queued:
+      type: integer
+      format: int64
+      description: The number of queued runs.
     succeeded:
       type: integer
       format: int64

--- a/api-contracts/openapi/components/schemas/workflow.yaml
+++ b/api-contracts/openapi/components/schemas/workflow.yaml
@@ -283,3 +283,13 @@ LinkGithubRepositoryRequest:
     - gitRepoName
     - gitRepoOwner
     - gitRepoBranch
+
+WorkflowMetrics:
+  type: object
+  properties:
+    groupKeyRunsCount:
+      type: integer
+      description: The number of runs for a specific group key (passed via filter)
+    groupKeyCount:
+      type: integer
+      description: The total number of concurrency group keys.

--- a/api-contracts/openapi/components/schemas/workflow_run.yaml
+++ b/api-contracts/openapi/components/schemas/workflow_run.yaml
@@ -87,6 +87,7 @@ WorkflowRunStatus:
     - SUCCEEDED
     - FAILED
     - CANCELLED
+    - QUEUED
 
 WorkflowRunStatusList:
   type: array

--- a/api-contracts/openapi/openapi.yaml
+++ b/api-contracts/openapi/openapi.yaml
@@ -96,6 +96,8 @@ paths:
     $ref: "./paths/workflow/workflow.yaml#/workflowVersionDefinition"
   /api/v1/workflows/{workflow}/link-github:
     $ref: "./paths/workflow/workflow.yaml#/linkGithub"
+  /api/v1/workflows/{workflow}/metrics:
+    $ref: "./paths/workflow/workflow.yaml#/getMetrics"
   /api/v1/step-runs/{step-run}/create-pr:
     $ref: "./paths/workflow/workflow.yaml#/createPullRequest"
   /api/v1/step-runs/{step-run}/logs:

--- a/api-contracts/openapi/paths/workflow/workflow.yaml
+++ b/api-contracts/openapi/paths/workflow/workflow.yaml
@@ -601,3 +601,58 @@ getDiff:
     summary: Get diff
     tags:
       - Workflow
+getMetrics:
+  get:
+    x-resources: ["tenant", "workflow"]
+    description: Get the metrics for a workflow version
+    operationId: workflow:get:metrics
+    parameters:
+      - description: The workflow id
+        in: path
+        name: workflow
+        required: true
+        schema:
+          type: string
+          format: uuid
+          minLength: 36
+          maxLength: 36
+      - description: A status of workflow runs to filter by
+        in: query
+        name: status
+        required: false
+        schema:
+          $ref: "../../components/schemas/_index.yaml#/WorkflowRunStatus"
+      - description: A group key to filter metrics by
+        in: query
+        name: groupKey
+        required: false
+        schema:
+          type: string
+    responses:
+      "200":
+        content:
+          application/json:
+            schema:
+              $ref: "../../components/schemas/_index.yaml#/WorkflowMetrics"
+        description: Successfully retrieved the workflow version metrics
+      "400":
+        content:
+          application/json:
+            schema:
+              $ref: "../../components/schemas/_index.yaml#/APIErrors"
+        description: A malformed or bad request
+      "403":
+        content:
+          application/json:
+            schema:
+              $ref: "../../components/schemas/_index.yaml#/APIErrors"
+        description: Forbidden
+      "404":
+        content:
+          application/json:
+            schema:
+              $ref: "../../components/schemas/_index.yaml#/APIErrors"
+        description: Not found
+    summary: Get workflow metrics
+    tags:
+      - Workflow

--- a/api/v1/server/handlers/workflows/get_metrics.go
+++ b/api/v1/server/handlers/workflows/get_metrics.go
@@ -1,0 +1,44 @@
+package workflows
+
+import (
+	"errors"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/hatchet-dev/hatchet/api/v1/server/oas/apierrors"
+	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
+	"github.com/hatchet-dev/hatchet/internal/repository"
+	"github.com/hatchet-dev/hatchet/internal/repository/prisma/db"
+)
+
+func (t *WorkflowService) WorkflowGetMetrics(ctx echo.Context, request gen.WorkflowGetMetricsRequestObject) (gen.WorkflowGetMetricsResponseObject, error) {
+	tenant := ctx.Get("tenant").(*db.TenantModel)
+	workflow := ctx.Get("workflow").(*db.WorkflowModel)
+
+	opts := &repository.GetWorkflowMetricsOpts{}
+
+	if request.Params.Status != nil {
+		opts.Status = (*string)(request.Params.Status)
+	}
+
+	if request.Params.GroupKey != nil {
+		opts.GroupKey = request.Params.GroupKey
+	}
+
+	metrics, err := t.config.APIRepository.Workflow().GetWorkflowMetrics(tenant.ID, workflow.ID, opts)
+
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return gen.WorkflowGetMetrics404JSONResponse(
+				apierrors.NewAPIErrors("workflow not found"),
+			), nil
+		}
+
+		return nil, err
+	}
+
+	return gen.WorkflowGetMetrics200JSONResponse(gen.WorkflowMetrics{
+		GroupKeyCount:     &metrics.GroupKeyCount,
+		GroupKeyRunsCount: &metrics.GroupKeyRunsCount,
+	}), nil
+}

--- a/api/v1/server/oas/transformers/event.go
+++ b/api/v1/server/oas/transformers/event.go
@@ -34,6 +34,7 @@ func ToEventFromSQLC(eventRow *dbsqlc.ListEventsRow) *gen.Event {
 		Running:   &eventRow.Runningruns,
 		Succeeded: &eventRow.Succeededruns,
 		Pending:   &eventRow.Pendingruns,
+		Queued:    &eventRow.Queuedruns,
 	}
 
 	return res

--- a/frontend/app/src/lib/api/generated/Api.ts
+++ b/frontend/app/src/lib/api/generated/Api.ts
@@ -63,8 +63,10 @@ import {
   Workflow,
   WorkflowID,
   WorkflowList,
+  WorkflowMetrics,
   WorkflowRun,
   WorkflowRunList,
+  WorkflowRunStatus,
   WorkflowRunStatusList,
   WorkflowVersion,
   WorkflowVersionDefinition,
@@ -863,6 +865,33 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
       body: data,
       secure: true,
       type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get the metrics for a workflow version
+   *
+   * @tags Workflow
+   * @name WorkflowGetMetrics
+   * @summary Get workflow metrics
+   * @request GET:/api/v1/workflows/{workflow}/metrics
+   * @secure
+   */
+  workflowGetMetrics = (
+    workflow: string,
+    query?: {
+      /** A status of workflow runs to filter by */
+      status?: WorkflowRunStatus;
+      /** A group key to filter metrics by */
+      groupKey?: string;
+    },
+    params: RequestParams = {},
+  ) =>
+    this.request<WorkflowMetrics, APIErrors>({
+      path: `/api/v1/workflows/${workflow}/metrics`,
+      method: "GET",
+      query: query,
+      secure: true,
       format: "json",
       ...params,
     });

--- a/frontend/app/src/lib/api/generated/data-contracts.ts
+++ b/frontend/app/src/lib/api/generated/data-contracts.ts
@@ -287,6 +287,11 @@ export interface EventWorkflowRunSummary {
    */
   running?: number;
   /**
+   * The number of queued runs.
+   * @format int64
+   */
+  queued?: number;
+  /**
    * The number of succeeded runs.
    * @format int64
    */
@@ -499,6 +504,7 @@ export enum WorkflowRunStatus {
   SUCCEEDED = "SUCCEEDED",
   FAILED = "FAILED",
   CANCELLED = "CANCELLED",
+  QUEUED = "QUEUED",
 }
 
 export type WorkflowRunStatusList = WorkflowRunStatus[];
@@ -781,4 +787,11 @@ export interface ListSNSIntegrations {
 export interface CreateSNSIntegrationRequest {
   /** The Amazon Resource Name (ARN) of the SNS topic. */
   topicArn: string;
+}
+
+export interface WorkflowMetrics {
+  /** The number of runs for a specific group key (passed via filter) */
+  groupKeyRunsCount?: number;
+  /** The total number of concurrency group keys. */
+  groupKeyCount?: number;
 }

--- a/frontend/app/src/lib/api/queries.ts
+++ b/frontend/app/src/lib/api/queries.ts
@@ -56,6 +56,10 @@ export const queries = createQueryKeyStore({
       queryKey: ['workflow:get', workflow],
       queryFn: async () => (await api.workflowGet(workflow)).data,
     }),
+    getMetrics: (workflow: string) => ({
+      queryKey: ['workflow:get:metrics', workflow],
+      queryFn: async () => (await api.workflowGetMetrics(workflow)).data,
+    }),
     getVersion: (workflow: string, version?: string) => ({
       queryKey: ['workflow-version:get', workflow, version],
       queryFn: async () =>

--- a/frontend/app/src/pages/main/events/components/event-columns.tsx
+++ b/frontend/app/src/pages/main/events/components/event-columns.tsx
@@ -119,14 +119,14 @@ function WorkflowRunSummary({ event }: { event: Event }) {
   invariant(tenant);
 
   const [hoverCardOpen, setPopoverOpen] = useState<
-    'failed' | 'succeeded' | 'running'
+    'failed' | 'succeeded' | 'running' | 'queued' | 'pending'
   >();
 
   const numFailed = event.workflowRunSummary?.failed || 0;
   const numSucceeded = event.workflowRunSummary?.succeeded || 0;
-  const numRunning =
-    (event.workflowRunSummary?.pending || 0) +
-    (event.workflowRunSummary?.running || 0);
+  const numRunning = event.workflowRunSummary?.running || 0;
+  const numPending = event.workflowRunSummary?.pending || 0;
+  const numQueued = event.workflowRunSummary?.queued || 0;
 
   const listWorkflowRunsQuery = useQuery({
     ...queries.workflowRuns.list(tenant.metadata.id, {
@@ -148,7 +148,13 @@ function WorkflowRunSummary({ event }: { event: Event }) {
             return run.status == 'SUCCEEDED';
           }
           if (hoverCardOpen == 'running') {
-            return run.status == 'RUNNING' || run.status == 'PENDING';
+            return run.status == 'RUNNING';
+          }
+          if (hoverCardOpen == 'pending') {
+            return run.status == 'PENDING';
+          }
+          if (hoverCardOpen == 'queued') {
+            return run.status == 'QUEUED';
           }
         }
 
@@ -245,6 +251,58 @@ function WorkflowRunSummary({ event }: { event: Event }) {
               onClick={() => setPopoverOpen('running')}
             >
               {numRunning} Running
+            </Badge>
+          </PopoverTrigger>
+          <PopoverContent
+            className="min-w-fit p-0 bg-background border-none z-40"
+            align="end"
+          >
+            {hoverCardContent}
+          </PopoverContent>
+        </Popover>
+      )}
+      {numPending > 0 && (
+        <Popover
+          open={hoverCardOpen == 'pending'}
+          onOpenChange={(open) => {
+            if (!open) {
+              setPopoverOpen(undefined);
+            }
+          }}
+        >
+          <PopoverTrigger>
+            <Badge
+              variant="inProgress"
+              className="cursor-pointer"
+              onClick={() => setPopoverOpen('pending')}
+            >
+              {numPending} Pending
+            </Badge>
+          </PopoverTrigger>
+          <PopoverContent
+            className="min-w-fit p-0 bg-background border-none z-40"
+            align="end"
+          >
+            {hoverCardContent}
+          </PopoverContent>
+        </Popover>
+      )}
+      {numQueued > 0 && (
+        <Popover
+          open={hoverCardOpen == 'queued'}
+          onOpenChange={(open) => {
+            if (!open) {
+              setPopoverOpen(undefined);
+            }
+          }}
+        >
+          <PopoverTrigger>
+            <Badge
+              variant="inProgress"
+              className="cursor-pointer"
+              onClick={() => setPopoverOpen('queued')}
+            >
+              {numQueued} Queued
             </Badge>
           </PopoverTrigger>
           <PopoverContent

--- a/frontend/app/src/pages/main/events/index.tsx
+++ b/frontend/app/src/pages/main/events/index.tsx
@@ -231,6 +231,10 @@ function EventsTable() {
         label: 'Running',
       },
       {
+        value: WorkflowRunStatus.QUEUED,
+        label: 'Queued',
+      },
+      {
         value: WorkflowRunStatus.PENDING,
         label: 'Pending',
       },

--- a/internal/repository/prisma/dbsqlc/events.sql
+++ b/internal/repository/prisma/dbsqlc/events.sql
@@ -62,7 +62,8 @@ INSERT INTO "Event" (
 -- name: ListEvents :many
 SELECT
     sqlc.embed(events),
-    sum(case when runs."status" = 'PENDING' OR runs."status" = 'QUEUED' then 1 else 0 end) AS pendingRuns,
+    sum(case when runs."status" = 'PENDING' then 1 else 0 end) AS pendingRuns,
+    sum(case when runs."status" = 'QUEUED' then 1 else 0 end) AS queuedRuns,
     sum(case when runs."status" = 'RUNNING' then 1 else 0 end) AS runningRuns,
     sum(case when runs."status" = 'SUCCEEDED' then 1 else 0 end) AS succeededRuns,
     sum(case when runs."status" = 'FAILED' then 1 else 0 end) AS failedRuns

--- a/internal/repository/prisma/dbsqlc/events.sql.go
+++ b/internal/repository/prisma/dbsqlc/events.sql.go
@@ -190,7 +190,8 @@ func (q *Queries) GetEventsForRange(ctx context.Context, db DBTX) ([]*GetEventsF
 const listEvents = `-- name: ListEvents :many
 SELECT
     events.id, events."createdAt", events."updatedAt", events."deletedAt", events.key, events."tenantId", events."replayedFromId", events.data,
-    sum(case when runs."status" = 'PENDING' OR runs."status" = 'QUEUED' then 1 else 0 end) AS pendingRuns,
+    sum(case when runs."status" = 'PENDING' then 1 else 0 end) AS pendingRuns,
+    sum(case when runs."status" = 'QUEUED' then 1 else 0 end) AS queuedRuns,
     sum(case when runs."status" = 'RUNNING' then 1 else 0 end) AS runningRuns,
     sum(case when runs."status" = 'SUCCEEDED' then 1 else 0 end) AS succeededRuns,
     sum(case when runs."status" = 'FAILED' then 1 else 0 end) AS failedRuns
@@ -248,6 +249,7 @@ type ListEventsParams struct {
 type ListEventsRow struct {
 	Event         Event `json:"event"`
 	Pendingruns   int64 `json:"pendingruns"`
+	Queuedruns    int64 `json:"queuedruns"`
 	Runningruns   int64 `json:"runningruns"`
 	Succeededruns int64 `json:"succeededruns"`
 	Failedruns    int64 `json:"failedruns"`
@@ -281,6 +283,7 @@ func (q *Queries) ListEvents(ctx context.Context, db DBTX, arg ListEventsParams)
 			&i.Event.ReplayedFromId,
 			&i.Event.Data,
 			&i.Pendingruns,
+			&i.Queuedruns,
 			&i.Runningruns,
 			&i.Succeededruns,
 			&i.Failedruns,

--- a/internal/repository/prisma/dbsqlc/workflow_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/workflow_runs.sql.go
@@ -844,20 +844,10 @@ func (q *Queries) ListWorkflowRuns(ctx context.Context, db DBTX, arg ListWorkflo
 }
 
 const popWorkflowRunsRoundRobin = `-- name: PopWorkflowRunsRoundRobin :many
-WITH running_count AS (
-    SELECT
-        COUNT(*) AS "count"
-    FROM
-        "WorkflowRun" r1
-    JOIN
-        "WorkflowVersion" workflowVersion ON r1."workflowVersionId" = workflowVersion."id"
-    WHERE
-        r1."tenantId" = $1 AND
-        r1."status" = 'RUNNING' AND
-        workflowVersion."id" = $2
-), queued_row_numbers AS (
+WITH workflow_runs AS (
     SELECT
         r2.id,
+        r2."status",
         row_number() OVER (PARTITION BY r2."concurrencyGroupId" ORDER BY r2."createdAt") AS rn,
         row_number() over (order by r2."createdAt" ASC) as seqnum
     FROM
@@ -865,32 +855,42 @@ WITH running_count AS (
     LEFT JOIN
         "WorkflowVersion" workflowVersion ON r2."workflowVersionId" = workflowVersion."id"
     WHERE
-        r2."tenantId" = $1 AND
-        r2."status" = 'QUEUED' AND
-        workflowVersion."id" = $2
+        r2."tenantId" = $1::uuid AND
+        (r2."status" = 'QUEUED' OR r2."status" = 'RUNNING') AND
+        workflowVersion."workflowId" = $2::uuid
     ORDER BY
         rn, seqnum ASC
 ), min_rn AS (
     SELECT
         MIN(rn) as min_rn
     FROM
-        queued_row_numbers
-), first_partition_count AS (
+        workflow_runs
+), total_group_count AS ( -- counts the number of groups
     SELECT
         COUNT(*) as count
     FROM
-        queued_row_numbers
+        workflow_runs
     WHERE
         rn = (SELECT min_rn FROM min_rn)
 ), eligible_runs AS (
     SELECT
         id
     FROM
-        queued_row_numbers
+        "WorkflowRun" wr
     WHERE
-        -- We can run up to maxRuns per group, so we multiple max runs by the number of groups, then subtract the 
-        -- total number of running workflows.
-        queued_row_numbers."seqnum" <= ($3::int) * (SELECT count FROM first_partition_count) - (SELECT "count" FROM running_count)
+        wr."id" IN (
+            SELECT
+                id
+            FROM
+                workflow_runs
+            ORDER BY
+                rn, seqnum ASC
+            LIMIT
+                -- We can run up to maxRuns per group, so we multiple max runs by the number of groups, then subtract the 
+                -- total number of running workflows.
+                ($3::int) * (SELECT count FROM total_group_count)
+        ) AND
+        wr."status" = 'QUEUED'
     FOR UPDATE SKIP LOCKED
 )
 UPDATE "WorkflowRun"
@@ -899,19 +899,20 @@ SET
 FROM
     eligible_runs
 WHERE
-    "WorkflowRun".id = eligible_runs.id
+    "WorkflowRun".id = eligible_runs.id AND
+    "WorkflowRun"."status" = 'QUEUED'
 RETURNING
     "WorkflowRun"."createdAt", "WorkflowRun"."updatedAt", "WorkflowRun"."deletedAt", "WorkflowRun"."tenantId", "WorkflowRun"."workflowVersionId", "WorkflowRun".status, "WorkflowRun".error, "WorkflowRun"."startedAt", "WorkflowRun"."finishedAt", "WorkflowRun"."concurrencyGroupId", "WorkflowRun"."displayName", "WorkflowRun".id, "WorkflowRun"."gitRepoBranch", "WorkflowRun"."childIndex", "WorkflowRun"."childKey", "WorkflowRun"."parentId", "WorkflowRun"."parentStepRunId"
 `
 
 type PopWorkflowRunsRoundRobinParams struct {
-	TenantId pgtype.UUID `json:"tenantId"`
-	ID       pgtype.UUID `json:"id"`
-	Maxruns  int32       `json:"maxruns"`
+	Tenantid   pgtype.UUID `json:"tenantid"`
+	Workflowid pgtype.UUID `json:"workflowid"`
+	Maxruns    int32       `json:"maxruns"`
 }
 
 func (q *Queries) PopWorkflowRunsRoundRobin(ctx context.Context, db DBTX, arg PopWorkflowRunsRoundRobinParams) ([]*WorkflowRun, error) {
-	rows, err := db.Query(ctx, popWorkflowRunsRoundRobin, arg.TenantId, arg.ID, arg.Maxruns)
+	rows, err := db.Query(ctx, popWorkflowRunsRoundRobin, arg.Tenantid, arg.Workflowid, arg.Maxruns)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repository/prisma/workflow_run.go
+++ b/internal/repository/prisma/workflow_run.go
@@ -199,38 +199,12 @@ func (w *workflowRunEngineRepository) GetScheduledChildWorkflowRun(parentId, par
 	return w.queries.GetScheduledChildWorkflowRun(context.Background(), w.pool, params)
 }
 
-func (w *workflowRunEngineRepository) PopWorkflowRunsRoundRobin(tenantId, workflowVersionId string, maxRuns int) ([]*dbsqlc.WorkflowRun, error) {
-	pgTenantId := &pgtype.UUID{}
-
-	if err := pgTenantId.Scan(tenantId); err != nil {
-		return nil, err
-	}
-
-	tx, err := w.pool.Begin(context.Background())
-
-	if err != nil {
-		return nil, err
-	}
-
-	defer deferRollback(context.Background(), w.l, tx.Rollback)
-
-	res, err := w.queries.PopWorkflowRunsRoundRobin(context.Background(), tx, dbsqlc.PopWorkflowRunsRoundRobinParams{
-		Maxruns:  int32(maxRuns),
-		TenantId: *pgTenantId,
-		ID:       sqlchelpers.UUIDFromStr(workflowVersionId),
+func (w *workflowRunEngineRepository) PopWorkflowRunsRoundRobin(tenantId, workflowId string, maxRuns int) ([]*dbsqlc.WorkflowRun, error) {
+	return w.queries.PopWorkflowRunsRoundRobin(context.Background(), w.pool, dbsqlc.PopWorkflowRunsRoundRobinParams{
+		Maxruns:    int32(maxRuns),
+		Tenantid:   sqlchelpers.UUIDFromStr(tenantId),
+		Workflowid: sqlchelpers.UUIDFromStr(workflowId),
 	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	err = tx.Commit(context.Background())
-
-	if err != nil {
-		return nil, err
-	}
-
-	return res, nil
 }
 
 func (w *workflowRunEngineRepository) CreateNewWorkflowRun(ctx context.Context, tenantId string, opts *repository.CreateWorkflowRunOpts) (string, error) {

--- a/internal/repository/workflow.go
+++ b/internal/repository/workflow.go
@@ -176,6 +176,22 @@ type UpsertWorkflowDeploymentConfigOpts struct {
 	GitRepoBranch string `validate:"required"`
 }
 
+type WorkflowMetrics struct {
+	// the number of runs for a specific group key
+	GroupKeyRunsCount int `json:"groupKeyRunsCount,omitempty"`
+
+	// the total number of concurrency group keys
+	GroupKeyCount int `json:"groupKeyCount,omitempty"`
+}
+
+type GetWorkflowMetricsOpts struct {
+	// (optional) the group key to filter by
+	GroupKey *string
+
+	// (optional) the workflow run status to filter by
+	Status *string `validate:"omitnil,oneof=PENDING QUEUED RUNNING SUCCEEDED FAILED"`
+}
+
 type WorkflowAPIRepository interface {
 	// ListWorkflows returns all workflows for a given tenant.
 	ListWorkflows(tenantId string, opts *ListWorkflowsOpts) (*ListWorkflowsResult, error)
@@ -192,6 +208,9 @@ type WorkflowAPIRepository interface {
 
 	// DeleteWorkflow deletes a workflow for a given tenant.
 	DeleteWorkflow(tenantId, workflowId string) (*db.WorkflowModel, error)
+
+	// GetWorkflowVersionMetrics returns the metrics for a given workflow version.
+	GetWorkflowMetrics(tenantId, workflowId string, opts *GetWorkflowMetricsOpts) (*WorkflowMetrics, error)
 
 	UpsertWorkflowDeploymentConfig(workflowId string, opts *UpsertWorkflowDeploymentConfigOpts) (*db.WorkflowDeploymentConfigModel, error)
 }

--- a/internal/repository/workflow_run.go
+++ b/internal/repository/workflow_run.go
@@ -290,7 +290,7 @@ type WorkflowRunEngineRepository interface {
 
 	GetScheduledChildWorkflowRun(parentId, parentStepRunId string, childIndex int, childkey *string) (*dbsqlc.WorkflowTriggerScheduledRef, error)
 
-	PopWorkflowRunsRoundRobin(tenantId, workflowVersionId string, maxRuns int) ([]*dbsqlc.WorkflowRun, error)
+	PopWorkflowRunsRoundRobin(tenantId, workflowId string, maxRuns int) ([]*dbsqlc.WorkflowRun, error)
 
 	// CreateNewWorkflowRun creates a new workflow run for a workflow version.
 	CreateNewWorkflowRun(ctx context.Context, tenantId string, opts *CreateWorkflowRunOpts) (string, error)

--- a/internal/services/controllers/workflows/queue.go
+++ b/internal/services/controllers/workflows/queue.go
@@ -503,12 +503,13 @@ func (wc *WorkflowsControllerImpl) queueByGroupRoundRobin(ctx context.Context, t
 	defer span.End()
 
 	workflowVersionId := sqlchelpers.UUIDToStr(workflowVersion.WorkflowVersion.ID)
+	workflowId := sqlchelpers.UUIDToStr(workflowVersion.WorkflowVersion.WorkflowId)
 	maxRuns := int(workflowVersion.ConcurrencyMaxRuns.Int32)
 
 	wc.l.Info().Msgf("handling queue with strategy GROUP_ROUND_ROBIN for workflow version %s", workflowVersionId)
 
 	// get workflow runs which are queued for this group key
-	poppedWorkflowRuns, err := wc.repo.WorkflowRun().PopWorkflowRunsRoundRobin(tenantId, workflowVersionId, maxRuns)
+	poppedWorkflowRuns, err := wc.repo.WorkflowRun().PopWorkflowRunsRoundRobin(tenantId, workflowId, maxRuns)
 
 	if err != nil {
 		return fmt.Errorf("could not list queued workflow runs: %w", err)

--- a/python-sdk/hatchet_sdk/clients/rest/__init__.py
+++ b/python-sdk/hatchet_sdk/clients/rest/__init__.py
@@ -114,6 +114,7 @@ from hatchet_sdk.clients.rest.models.workflow import Workflow
 from hatchet_sdk.clients.rest.models.workflow_concurrency import WorkflowConcurrency
 from hatchet_sdk.clients.rest.models.workflow_deployment_config import WorkflowDeploymentConfig
 from hatchet_sdk.clients.rest.models.workflow_list import WorkflowList
+from hatchet_sdk.clients.rest.models.workflow_metrics import WorkflowMetrics
 from hatchet_sdk.clients.rest.models.workflow_run import WorkflowRun
 from hatchet_sdk.clients.rest.models.workflow_run_list import WorkflowRunList
 from hatchet_sdk.clients.rest.models.workflow_run_status import WorkflowRunStatus

--- a/python-sdk/hatchet_sdk/clients/rest/api/workflow_api.py
+++ b/python-sdk/hatchet_sdk/clients/rest/api/workflow_api.py
@@ -16,7 +16,7 @@ from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictInt
+from pydantic import Field, StrictInt, StrictStr
 from typing import Optional
 from typing_extensions import Annotated
 from hatchet_sdk.clients.rest.models.create_pull_request_from_step_run import CreatePullRequestFromStepRun
@@ -26,8 +26,10 @@ from hatchet_sdk.clients.rest.models.list_pull_requests_response import ListPull
 from hatchet_sdk.clients.rest.models.pull_request_state import PullRequestState
 from hatchet_sdk.clients.rest.models.workflow import Workflow
 from hatchet_sdk.clients.rest.models.workflow_list import WorkflowList
+from hatchet_sdk.clients.rest.models.workflow_metrics import WorkflowMetrics
 from hatchet_sdk.clients.rest.models.workflow_run import WorkflowRun
 from hatchet_sdk.clients.rest.models.workflow_run_list import WorkflowRunList
+from hatchet_sdk.clients.rest.models.workflow_run_status import WorkflowRunStatus
 from hatchet_sdk.clients.rest.models.workflow_version import WorkflowVersion
 from hatchet_sdk.clients.rest.models.workflow_version_definition import WorkflowVersionDefinition
 
@@ -1131,6 +1133,308 @@ class WorkflowApi:
         return self.api_client.param_serialize(
             method='GET',
             resource_path='/api/v1/workflows/{workflow}',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+
+    @validate_call
+    def workflow_get_metrics(
+        self,
+        workflow: Annotated[str, Field(min_length=36, strict=True, max_length=36, description="The workflow id")],
+        status: Annotated[Optional[WorkflowRunStatus], Field(description="A status of workflow runs to filter by")] = None,
+        group_key: Annotated[Optional[StrictStr], Field(description="A group key to filter metrics by")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> WorkflowMetrics:
+        """Get workflow metrics
+
+        Get the metrics for a workflow version
+
+        :param workflow: The workflow id (required)
+        :type workflow: str
+        :param status: A status of workflow runs to filter by
+        :type status: WorkflowRunStatus
+        :param group_key: A group key to filter metrics by
+        :type group_key: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._workflow_get_metrics_serialize(
+            workflow=workflow,
+            status=status,
+            group_key=group_key,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "WorkflowMetrics",
+            '400': "APIErrors",
+            '403': "APIErrors",
+            '404': "APIErrors",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def workflow_get_metrics_with_http_info(
+        self,
+        workflow: Annotated[str, Field(min_length=36, strict=True, max_length=36, description="The workflow id")],
+        status: Annotated[Optional[WorkflowRunStatus], Field(description="A status of workflow runs to filter by")] = None,
+        group_key: Annotated[Optional[StrictStr], Field(description="A group key to filter metrics by")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[WorkflowMetrics]:
+        """Get workflow metrics
+
+        Get the metrics for a workflow version
+
+        :param workflow: The workflow id (required)
+        :type workflow: str
+        :param status: A status of workflow runs to filter by
+        :type status: WorkflowRunStatus
+        :param group_key: A group key to filter metrics by
+        :type group_key: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._workflow_get_metrics_serialize(
+            workflow=workflow,
+            status=status,
+            group_key=group_key,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "WorkflowMetrics",
+            '400': "APIErrors",
+            '403': "APIErrors",
+            '404': "APIErrors",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def workflow_get_metrics_without_preload_content(
+        self,
+        workflow: Annotated[str, Field(min_length=36, strict=True, max_length=36, description="The workflow id")],
+        status: Annotated[Optional[WorkflowRunStatus], Field(description="A status of workflow runs to filter by")] = None,
+        group_key: Annotated[Optional[StrictStr], Field(description="A group key to filter metrics by")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Get workflow metrics
+
+        Get the metrics for a workflow version
+
+        :param workflow: The workflow id (required)
+        :type workflow: str
+        :param status: A status of workflow runs to filter by
+        :type status: WorkflowRunStatus
+        :param group_key: A group key to filter metrics by
+        :type group_key: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._workflow_get_metrics_serialize(
+            workflow=workflow,
+            status=status,
+            group_key=group_key,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "WorkflowMetrics",
+            '400': "APIErrors",
+            '403': "APIErrors",
+            '404': "APIErrors",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _workflow_get_metrics_serialize(
+        self,
+        workflow,
+        status,
+        group_key,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[str, str] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        if workflow is not None:
+            _path_params['workflow'] = workflow
+        # process the query parameters
+        if status is not None:
+            
+            _query_params.append(('status', status.value))
+            
+        if group_key is not None:
+            
+            _query_params.append(('groupKey', group_key))
+            
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+
+
+        # set the HTTP header `Accept`
+        _header_params['Accept'] = self.api_client.select_header_accept(
+            [
+                'application/json'
+            ]
+        )
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+            'cookieAuth', 
+            'bearerAuth'
+        ]
+
+        return self.api_client.param_serialize(
+            method='GET',
+            resource_path='/api/v1/workflows/{workflow}/metrics',
             path_params=_path_params,
             query_params=_query_params,
             header_params=_header_params,

--- a/python-sdk/hatchet_sdk/clients/rest/models/__init__.py
+++ b/python-sdk/hatchet_sdk/clients/rest/models/__init__.py
@@ -84,6 +84,7 @@ from hatchet_sdk.clients.rest.models.workflow import Workflow
 from hatchet_sdk.clients.rest.models.workflow_concurrency import WorkflowConcurrency
 from hatchet_sdk.clients.rest.models.workflow_deployment_config import WorkflowDeploymentConfig
 from hatchet_sdk.clients.rest.models.workflow_list import WorkflowList
+from hatchet_sdk.clients.rest.models.workflow_metrics import WorkflowMetrics
 from hatchet_sdk.clients.rest.models.workflow_run import WorkflowRun
 from hatchet_sdk.clients.rest.models.workflow_run_list import WorkflowRunList
 from hatchet_sdk.clients.rest.models.workflow_run_status import WorkflowRunStatus

--- a/python-sdk/hatchet_sdk/clients/rest/models/workflow_metrics.py
+++ b/python-sdk/hatchet_sdk/clients/rest/models/workflow_metrics.py
@@ -22,16 +22,13 @@ from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
 
-class EventWorkflowRunSummary(BaseModel):
+class WorkflowMetrics(BaseModel):
     """
-    EventWorkflowRunSummary
+    WorkflowMetrics
     """ # noqa: E501
-    pending: Optional[StrictInt] = Field(default=None, description="The number of pending runs.")
-    running: Optional[StrictInt] = Field(default=None, description="The number of running runs.")
-    queued: Optional[StrictInt] = Field(default=None, description="The number of queued runs.")
-    succeeded: Optional[StrictInt] = Field(default=None, description="The number of succeeded runs.")
-    failed: Optional[StrictInt] = Field(default=None, description="The number of failed runs.")
-    __properties: ClassVar[List[str]] = ["pending", "running", "queued", "succeeded", "failed"]
+    group_key_runs_count: Optional[StrictInt] = Field(default=None, description="The number of runs for a specific group key (passed via filter)", alias="groupKeyRunsCount")
+    group_key_count: Optional[StrictInt] = Field(default=None, description="The total number of concurrency group keys.", alias="groupKeyCount")
+    __properties: ClassVar[List[str]] = ["groupKeyRunsCount", "groupKeyCount"]
 
     model_config = {
         "populate_by_name": True,
@@ -51,7 +48,7 @@ class EventWorkflowRunSummary(BaseModel):
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:
-        """Create an instance of EventWorkflowRunSummary from a JSON string"""
+        """Create an instance of WorkflowMetrics from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
     def to_dict(self) -> Dict[str, Any]:
@@ -76,7 +73,7 @@ class EventWorkflowRunSummary(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
-        """Create an instance of EventWorkflowRunSummary from a dict"""
+        """Create an instance of WorkflowMetrics from a dict"""
         if obj is None:
             return None
 
@@ -84,11 +81,8 @@ class EventWorkflowRunSummary(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "pending": obj.get("pending"),
-            "running": obj.get("running"),
-            "queued": obj.get("queued"),
-            "succeeded": obj.get("succeeded"),
-            "failed": obj.get("failed")
+            "groupKeyRunsCount": obj.get("groupKeyRunsCount"),
+            "groupKeyCount": obj.get("groupKeyCount")
         })
         return _obj
 

--- a/python-sdk/hatchet_sdk/clients/rest/models/workflow_run_status.py
+++ b/python-sdk/hatchet_sdk/clients/rest/models/workflow_run_status.py
@@ -31,6 +31,7 @@ class WorkflowRunStatus(str, Enum):
     SUCCEEDED = 'SUCCEEDED'
     FAILED = 'FAILED'
     CANCELLED = 'CANCELLED'
+    QUEUED = 'QUEUED'
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:


### PR DESCRIPTION
# Description

Adds an endpoint for getting queued metrics for concurrency groups. 

Also fixes an ordering issue in the round robin queueing strategy where the queue was returned with an incorrect ordering (see comments in PR review). 

Also adds better visualization for queued runs in the events view.  

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
