### PR TITLE
fix: health check improvements

### DIFF
--- a/api/v1/server/handlers/metadata/health.go
+++ b/api/v1/server/handlers/metadata/health.go
@@ -9,12 +9,28 @@ import (
 )
 
 func (u *MetadataService) LivenessGet(ctx echo.Context, request gen.LivenessGetRequestObject) (gen.LivenessGetResponseObject, error) {
+	if !u.config.APIRepository.Health().IsHealthy() {
+		return nil, fmt.Errorf("api repository is not healthy")
+	}
+
+	if !u.config.EngineRepository.Health().IsHealthy() {
+		return nil, fmt.Errorf("engine repository is not healthy")
+	}
+
+	if !u.config.MessageQueue.IsReady() {
+		return nil, fmt.Errorf("task queue is not healthy")
+	}
+
 	return gen.LivenessGet200Response{}, nil
 }
 
 func (u *MetadataService) ReadinessGet(ctx echo.Context, request gen.ReadinessGetRequestObject) (gen.ReadinessGetResponseObject, error) {
 	if !u.config.APIRepository.Health().IsHealthy() {
-		return nil, fmt.Errorf("repository is not healthy")
+		return nil, fmt.Errorf("api repository is not healthy")
+	}
+
+	if !u.config.EngineRepository.Health().IsHealthy() {
+		return nil, fmt.Errorf("engine repository is not healthy")
 	}
 
 	if !u.config.MessageQueue.IsReady() {

--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -379,6 +379,10 @@ func (d *DispatcherImpl) handleStepRunCancelled(ctx context.Context, task *msgqu
 
 	if err != nil && !errors.Is(err, ErrWorkerNotFound) {
 		return fmt.Errorf("could not get worker: %w", err)
+	} else if errors.Is(err, ErrWorkerNotFound) {
+		// if the worker is not found, we can ignore this task
+		d.l.Debug().Msgf("worker %s not found, ignoring task", payload.WorkerId)
+		return nil
 	}
 
 	// load the step run from the database

--- a/internal/services/health/health.go
+++ b/internal/services/health/health.go
@@ -34,11 +34,16 @@ func (h *Health) Start() (func() error, error) {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/live", func(w http.ResponseWriter, r *http.Request) {
+		if !h.ready || !h.queue.IsReady() || !h.repository.Health().IsHealthy() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+
 		w.WriteHeader(http.StatusOK)
 	})
 
 	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
-		if !h.ready || !h.queue.IsReady() || !h.repository.Health().IsHealthy() || !h.repository.Health().IsHealthy() {
+		if !h.ready || !h.queue.IsReady() || !h.repository.Health().IsHealthy() {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			return
 		}


### PR DESCRIPTION
# Description

Health checks weren't checking the engine repository connection on the API layer (it's occasionally called), and liveness probes now match readiness probes, since we want container restarts when we can't connect to the database. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
