### PR TITLE
fix: throw correct error from assign step runs

### DIFF
--- a/internal/repository/prisma/step_run.go
+++ b/internal/repository/prisma/step_run.go
@@ -451,6 +451,12 @@ func (s *stepRunEngineRepository) AssignStepRunToWorker(ctx context.Context, ste
 	})
 
 	if err != nil {
+		var target *errNoWorkerWithSlots
+
+		if errors.As(err, &target) {
+			return "", "", repository.ErrNoWorkerAvailable
+		}
+
 		return "", "", err
 	}
 


### PR DESCRIPTION
# Description

One of the internal repository errors is getting through to the jobs controller, this returns a predictable error. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)