### PR TITLE
fix: pass external error on PutWorkflow

### DIFF
--- a/internal/repository/workflow.go
+++ b/internal/repository/workflow.go
@@ -106,7 +106,7 @@ type CreateWorkflowStepOpts struct {
 	Action string `validate:"required,actionId"`
 
 	// (optional) the step timeout
-	Timeout *string
+	Timeout *string `validate:"omitempty,duration"`
 
 	// (optional) the parents that this step depends on
 	Parents []string `validate:"dive,hatchetName"`

--- a/internal/services/admin/admin.go
+++ b/internal/services/admin/admin.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hatchet-dev/hatchet/internal/msgqueue"
 	"github.com/hatchet-dev/hatchet/internal/repository"
 	"github.com/hatchet-dev/hatchet/internal/services/admin/contracts"
+	"github.com/hatchet-dev/hatchet/internal/validator"
 )
 
 type AdminService interface {
@@ -17,6 +18,7 @@ type AdminServiceImpl struct {
 
 	repo repository.EngineRepository
 	mq   msgqueue.MessageQueue
+	v    validator.Validator
 }
 
 type AdminServiceOpt func(*AdminServiceOpts)
@@ -24,10 +26,15 @@ type AdminServiceOpt func(*AdminServiceOpts)
 type AdminServiceOpts struct {
 	repo repository.EngineRepository
 	mq   msgqueue.MessageQueue
+	v    validator.Validator
 }
 
 func defaultAdminServiceOpts() *AdminServiceOpts {
-	return &AdminServiceOpts{}
+	v := validator.NewDefaultValidator()
+
+	return &AdminServiceOpts{
+		v: v,
+	}
 }
 
 func WithRepository(r repository.EngineRepository) AdminServiceOpt {
@@ -39,6 +46,12 @@ func WithRepository(r repository.EngineRepository) AdminServiceOpt {
 func WithMessageQueue(mq msgqueue.MessageQueue) AdminServiceOpt {
 	return func(opts *AdminServiceOpts) {
 		opts.mq = mq
+	}
+}
+
+func WithValidator(v validator.Validator) AdminServiceOpt {
+	return func(opts *AdminServiceOpts) {
+		opts.v = v
 	}
 }
 
@@ -60,5 +73,6 @@ func NewAdminService(fs ...AdminServiceOpt) (AdminService, error) {
 	return &AdminServiceImpl{
 		repo: opts.repo,
 		mq:   opts.mq,
+		v:    opts.v,
 	}, nil
 }

--- a/internal/services/admin/server.go
+++ b/internal/services/admin/server.go
@@ -142,6 +142,16 @@ func (a *AdminServiceImpl) PutWorkflow(ctx context.Context, req *contracts.PutWo
 		return nil, err
 	}
 
+	// validate createOpts
+	if apiErrors, err := a.v.ValidateAPI(createOpts); err != nil {
+		return nil, err
+	} else if apiErrors != nil {
+		return nil, status.Error(
+			codes.InvalidArgument,
+			apiErrors.String(),
+		)
+	}
+
 	// determine if workflow already exists
 	var workflowVersion *dbsqlc.GetWorkflowVersionForEngineRow
 	var oldWorkflowVersion *dbsqlc.GetWorkflowVersionForEngineRow

--- a/internal/services/admin/server.go
+++ b/internal/services/admin/server.go
@@ -365,9 +365,12 @@ func getCreateWorkflowOpts(req *contracts.PutWorkflowRequest) (*repository.Creat
 			steps[j] = repository.CreateWorkflowStepOpts{
 				ReadableId: stepCp.ReadableId,
 				Action:     parsedAction.String(),
-				Timeout:    &stepCp.Timeout,
 				Parents:    stepCp.Parents,
 				Retries:    &retries,
+			}
+
+			if stepCp.Timeout != "" {
+				steps[j].Timeout = &stepCp.Timeout
 			}
 
 			for _, rateLimit := range stepCp.RateLimits {

--- a/pkg/client/admin.go
+++ b/pkg/client/admin.go
@@ -78,7 +78,7 @@ func (a *adminClientImpl) PutWorkflow(workflow *types.Workflow, fs ...PutOptFunc
 	_, err = a.client.PutWorkflow(a.ctx.newContext(context.Background()), req)
 
 	if err != nil {
-		return fmt.Errorf("could not create workflow: %w", err)
+		return fmt.Errorf("could not create workflow %s: %w", workflow.Name, err)
 	}
 
 	return nil


### PR DESCRIPTION
# Description

Errors on `PutWorkflow` which are user-facing are currently captured by the internal error handler.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)