### PR TITLE
feat(go-sdk): capture panics and send to alerter

### DIFF
--- a/pkg/worker/middleware_test.go
+++ b/pkg/worker/middleware_test.go
@@ -56,6 +56,10 @@ func (c *testHatchetContext) StreamEvent(message []byte) {
 	panic("not implemented")
 }
 
+func (c *testHatchetContext) action() *client.Action {
+	panic("not implemented")
+}
+
 func (c *testHatchetContext) index() int {
 	panic("not implemented")
 }


### PR DESCRIPTION
# Description

Panics weren't captured by the Go SDK. Now they're captured, sent to any integrated alerters, and displayed in the dashboard. 

## Type of change

- [X] New feature (non-breaking change which adds functionality)