### PR TITLE
fix: cron schedules cancelled early by context

### DIFF
--- a/internal/services/ticker/cron.go
+++ b/internal/services/ticker/cron.go
@@ -83,7 +83,7 @@ func (t *TickerImpl) handleScheduleCron(ctx context.Context, cron *dbsqlc.PollCr
 	_, err = t.s.NewJob(
 		gocron.CronJob(cron.Cron, false),
 		gocron.NewTask(
-			t.runCronWorkflow(ctx, tenantId, workflowVersionId, cron.Cron, cronParentId, cron.Input),
+			t.runCronWorkflow(tenantId, workflowVersionId, cron.Cron, cronParentId, cron.Input),
 		),
 	)
 
@@ -99,9 +99,9 @@ func (t *TickerImpl) handleScheduleCron(ctx context.Context, cron *dbsqlc.PollCr
 	return nil
 }
 
-func (t *TickerImpl) runCronWorkflow(ctx context.Context, tenantId, workflowVersionId, cron, cronParentId string, input []byte) func() {
+func (t *TickerImpl) runCronWorkflow(tenantId, workflowVersionId, cron, cronParentId string, input []byte) func() {
 	return func() {
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
 		t.l.Debug().Msgf("ticker: running workflow %s", workflowVersionId)

--- a/internal/services/ticker/schedule_workflow.go
+++ b/internal/services/ticker/schedule_workflow.go
@@ -86,7 +86,7 @@ func (t *TickerImpl) handleScheduleWorkflow(ctx context.Context, scheduledWorkfl
 	if triggerAt.Before(time.Now()) {
 		t.l.Debug().Msg("ticker: trigger time is in the past, running now")
 
-		t.runScheduledWorkflow(ctx, tenantId, workflowVersionId, scheduledWorkflowId, scheduledWorkflow)()
+		t.runScheduledWorkflow(tenantId, workflowVersionId, scheduledWorkflowId, scheduledWorkflow)()
 		return nil
 	}
 
@@ -96,7 +96,7 @@ func (t *TickerImpl) handleScheduleWorkflow(ctx context.Context, scheduledWorkfl
 			gocron.OneTimeJobStartDateTime(triggerAt),
 		),
 		gocron.NewTask(
-			t.runScheduledWorkflow(ctx, tenantId, workflowVersionId, scheduledWorkflowId, scheduledWorkflow),
+			t.runScheduledWorkflow(tenantId, workflowVersionId, scheduledWorkflowId, scheduledWorkflow),
 		),
 	)
 
@@ -112,9 +112,9 @@ func (t *TickerImpl) handleScheduleWorkflow(ctx context.Context, scheduledWorkfl
 	return nil
 }
 
-func (t *TickerImpl) runScheduledWorkflow(ctx context.Context, tenantId, workflowVersionId, scheduledWorkflowId string, scheduled *dbsqlc.PollScheduledWorkflowsRow) func() {
+func (t *TickerImpl) runScheduledWorkflow(tenantId, workflowVersionId, scheduledWorkflowId string, scheduled *dbsqlc.PollScheduledWorkflowsRow) func() {
 	return func() {
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
 		t.l.Debug().Msgf("ticker: running workflow %s", workflowVersionId)


### PR DESCRIPTION
# Description

Cron schedules have a cancelled context due to an errant `context.WithTimeout` in a poller, which is causing them not to run.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)