### PR TITLE
fix: increase duration of ticker contexts to 30 seconds

### DIFF
--- a/internal/services/ticker/cron.go
+++ b/internal/services/ticker/cron.go
@@ -101,7 +101,7 @@ func (t *TickerImpl) handleScheduleCron(ctx context.Context, cron *dbsqlc.PollCr
 
 func (t *TickerImpl) runCronWorkflow(tenantId, workflowVersionId, cron, cronParentId string, input []byte) func() {
 	return func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
 		t.l.Debug().Msgf("ticker: running workflow %s", workflowVersionId)

--- a/internal/services/ticker/schedule_workflow.go
+++ b/internal/services/ticker/schedule_workflow.go
@@ -114,7 +114,7 @@ func (t *TickerImpl) handleScheduleWorkflow(ctx context.Context, scheduledWorkfl
 
 func (t *TickerImpl) runScheduledWorkflow(tenantId, workflowVersionId, scheduledWorkflowId string, scheduled *dbsqlc.PollScheduledWorkflowsRow) func() {
 	return func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
 		t.l.Debug().Msgf("ticker: running workflow %s", workflowVersionId)

--- a/internal/services/ticker/step_run_timeout.go
+++ b/internal/services/ticker/step_run_timeout.go
@@ -12,7 +12,7 @@ import (
 
 func (t *TickerImpl) runPollStepRuns(ctx context.Context) func() {
 	return func() {
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 
 		t.l.Debug().Msgf("ticker: polling step runs")


### PR DESCRIPTION
# Description

Under high load, 5 second duration on ticker context is too short. This increases to 30 seconds, which is 1/2 of the cron scheduling interval.  

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)