### PR TITLE
fix: semaphores increasing on manual replays

### DIFF
--- a/internal/repository/prisma/dbsqlc/step_runs.sql
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql
@@ -620,34 +620,3 @@ WHERE
     srl."tenantId" = lrl."tenantId" AND
     srl."key" = lrl."key"
 RETURNING srl.*;
-
-
-
-SELECT t.id as tenant_id, t.name, COUNT(w.id) AS run_count
-FROM "Tenant" t
-JOIN "WorkflowRun" w ON t.id = w."tenantId"
-JOIN "TenantMember" tm ON t.id = tm."tenantId"
-JOIN "User" u ON tm."userId" = u.id
-GROUP BY t.id, t.name;
-
-SELECT t.id as tenant_id, t.name, COUNT(DISTINCT w.id) AS run_count, COUNT(DISTINCT u.id) AS user_count
-FROM "Tenant" t
-JOIN "WorkflowRun" w ON t.id = w."tenantId"
-JOIN "TenantMember" tm ON t.id = tm."tenantId"
-JOIN "User" u ON tm."userId" = u.id
-GROUP BY t.id, t.name;
-
-
-SELECT t.id as tenant_id, t.name, COUNT(DISTINCT w.id) AS run_count, STRING_AGG(DISTINCT u.email, ', ') AS user_emails
-FROM "Tenant" t
-JOIN "WorkflowRun" w ON t.id = w."tenantId"
-JOIN "TenantMember" tm ON t.id = tm."tenantId"
-JOIN "User" u ON tm."userId" = u.id
-GROUP BY t.id, t.name;
-
-SELECT COUNT(DISTINCT sr.id) AS step_run_count
-FROM "StepRun" sr
-WHERE
--- LAST 30 DAYS
-sr."createdAt" > NOW() - INTERVAL '30 days'
-AND "status" = 'SUCCEEDED';

--- a/internal/repository/prisma/step_run.go
+++ b/internal/repository/prisma/step_run.go
@@ -541,6 +541,19 @@ func (s *stepRunEngineRepository) UpdateStepRun(ctx context.Context, tenantId, s
 	return stepRun, updateInfo, nil
 }
 
+func (s *stepRunEngineRepository) UnlinkStepRunFromWorker(ctx context.Context, tenantId, stepRunId string) error {
+	_, err := s.queries.UnlinkStepRunFromWorker(ctx, s.pool, dbsqlc.UnlinkStepRunFromWorkerParams{
+		Steprunid: sqlchelpers.UUIDFromStr(stepRunId),
+		Tenantid:  sqlchelpers.UUIDFromStr(tenantId),
+	})
+
+	if err != nil {
+		return fmt.Errorf("could not unlink step run from worker: %w", err)
+	}
+
+	return nil
+}
+
 func (s *stepRunEngineRepository) UpdateStepRunOverridesData(ctx context.Context, tenantId, stepRunId string, opts *repository.UpdateStepRunOverridesDataOpts) ([]byte, error) {
 	if err := s.v.Validate(opts); err != nil {
 		return nil, err

--- a/internal/repository/step_run.go
+++ b/internal/repository/step_run.go
@@ -82,6 +82,8 @@ type StepRunEngineRepository interface {
 
 	UpdateStepRun(ctx context.Context, tenantId, stepRunId string, opts *UpdateStepRunOpts) (*dbsqlc.GetStepRunForEngineRow, *StepRunUpdateInfo, error)
 
+	UnlinkStepRunFromWorker(ctx context.Context, tenantId, stepRunId string) error
+
 	// UpdateStepRunOverridesData updates the overrides data field in the input for a step run. This returns the input
 	// bytes.
 	UpdateStepRunOverridesData(ctx context.Context, tenantId, stepRunId string, opts *UpdateStepRunOverridesDataOpts) ([]byte, error)


### PR DESCRIPTION
# Description

When step runs are manually replayed, semaphores are increased on workers when they shouldn't be.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)