### PR TITLE
fix: don't update or cancel completed steps

### DIFF
--- a/internal/repository/prisma/dbsqlc/step_runs.sql
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql
@@ -174,12 +174,16 @@ WITH currStepRun AS (
 UPDATE
     "StepRun" as sr
 SET "status" = CASE
+    -- When the step is in a final state, it cannot be updated
+    WHEN sr."status" IN ('SUCCEEDED', 'FAILED', 'CANCELLED') THEN sr."status"
     -- When the given step run has failed or been cancelled, then all later step runs are cancelled
     WHEN (cs."status" = 'FAILED' OR cs."status" = 'CANCELLED') THEN 'CANCELLED'
     ELSE sr."status"
     END,
     -- When the previous step run timed out, the cancelled reason is set
     "cancelledReason" = CASE
+    -- When the step is in a final state, it cannot be updated
+    WHEN sr."status" IN ('SUCCEEDED', 'FAILED', 'CANCELLED') THEN sr."cancelledReason"
     WHEN (cs."status" = 'CANCELLED' AND cs."cancelledReason" = 'TIMED_OUT'::text) THEN 'PREVIOUS_STEP_TIMED_OUT'
     WHEN (cs."status" = 'CANCELLED') THEN 'PREVIOUS_STEP_CANCELLED'
     ELSE NULL

--- a/internal/repository/prisma/dbsqlc/step_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql.go
@@ -788,12 +788,16 @@ WITH currStepRun AS (
 UPDATE
     "StepRun" as sr
 SET "status" = CASE
+    -- When the step is in a final state, it cannot be updated
+    WHEN sr."status" IN ('SUCCEEDED', 'FAILED', 'CANCELLED') THEN sr."status"
     -- When the given step run has failed or been cancelled, then all later step runs are cancelled
     WHEN (cs."status" = 'FAILED' OR cs."status" = 'CANCELLED') THEN 'CANCELLED'
     ELSE sr."status"
     END,
     -- When the previous step run timed out, the cancelled reason is set
     "cancelledReason" = CASE
+    -- When the step is in a final state, it cannot be updated
+    WHEN sr."status" IN ('SUCCEEDED', 'FAILED', 'CANCELLED') THEN sr."cancelledReason"
     WHEN (cs."status" = 'CANCELLED' AND cs."cancelledReason" = 'TIMED_OUT'::text) THEN 'PREVIOUS_STEP_TIMED_OUT'
     WHEN (cs."status" = 'CANCELLED') THEN 'PREVIOUS_STEP_CANCELLED'
     ELSE NULL


### PR DESCRIPTION
# Description

Step runs on different branches are being cancelled due to usage of `order`. This is a quick fix to not update any steps which have already entered a final state in the step run's state machine.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
