### PR TITLE
fix: cron and scheduled workflow leaks

### DIFF
--- a/internal/services/ticker/cron.go
+++ b/internal/services/ticker/cron.go
@@ -80,7 +80,7 @@ func (t *TickerImpl) handleScheduleCron(ctx context.Context, cron *dbsqlc.PollCr
 	cronParentId := sqlchelpers.UUIDToStr(cron.ParentId)
 
 	// schedule the cron
-	_, err = t.s.NewJob(
+	_, err = s.NewJob(
 		gocron.CronJob(cron.Cron, false),
 		gocron.NewTask(
 			t.runCronWorkflow(tenantId, workflowVersionId, cron.Cron, cronParentId, cron.Input),
@@ -164,7 +164,11 @@ func (t *TickerImpl) handleCancelCron(ctx context.Context, key string) error {
 
 	defer t.crons.Delete(key)
 
-	scheduler := schedulerVal.(gocron.Scheduler)
+	scheduler, ok := schedulerVal.(gocron.Scheduler)
+
+	if !ok {
+		return fmt.Errorf("could not cast scheduler")
+	}
 
 	// cancel the cron
 	if err := scheduler.Shutdown(); err != nil {

--- a/internal/services/ticker/schedule_workflow.go
+++ b/internal/services/ticker/schedule_workflow.go
@@ -91,7 +91,7 @@ func (t *TickerImpl) handleScheduleWorkflow(ctx context.Context, scheduledWorkfl
 	}
 
 	// schedule the workflow
-	_, err = t.s.NewJob(
+	_, err = s.NewJob(
 		gocron.OneTimeJob(
 			gocron.OneTimeJobStartDateTime(triggerAt),
 		),
@@ -219,7 +219,11 @@ func (t *TickerImpl) handleCancelWorkflow(ctx context.Context, key string) error
 
 	defer t.scheduledWorkflows.Delete(key)
 
-	scheduler := schedulerVal.(gocron.Scheduler)
+	scheduler, ok := schedulerVal.(gocron.Scheduler)
+
+	if !ok {
+		return fmt.Errorf("could not cast scheduler")
+	}
 
 	// cancel the schedule
 	return scheduler.Shutdown()


### PR DESCRIPTION
# Description

Cron and scheduled workflows were being placed on the scheduler belonging to the ticker, instead of the newly instantiated scheduler. 

Fixes #410 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
