### PR TITLE
fix: report slot count from semaphore

### DIFF
--- a/api/v1/server/handlers/workers/list.go
+++ b/api/v1/server/handlers/workers/list.go
@@ -28,8 +28,9 @@ func (t *WorkerService) WorkerList(ctx echo.Context, request gen.WorkerListReque
 
 	for i, worker := range workers {
 		workerCp := worker
+		slots := int(worker.Slots)
 
-		rows[i] = *transformers.ToWorkerSqlc(&workerCp.Worker, &worker.RunningStepRuns)
+		rows[i] = *transformers.ToWorkerSqlc(&workerCp.Worker, &worker.RunningStepRuns, &slots)
 	}
 
 	return gen.WorkerList200JSONResponse(

--- a/api/v1/server/oas/transformers/worker.go
+++ b/api/v1/server/oas/transformers/worker.go
@@ -61,12 +61,11 @@ func ToWorker(worker *db.WorkerModel) *gen.Worker {
 	return res
 }
 
-func ToWorkerSqlc(worker *dbsqlc.Worker, stepCount *int64) *gen.Worker {
+func ToWorkerSqlc(worker *dbsqlc.Worker, stepCount *int64, slots *int) *gen.Worker {
 
 	dispatcherId := uuid.MustParse(pgUUIDToStr(worker.DispatcherId))
 
 	maxRuns := int(worker.MaxRuns.Int32)
-	availableRuns := maxRuns - int(*stepCount)
 
 	status := gen.ACTIVE
 
@@ -80,7 +79,7 @@ func ToWorkerSqlc(worker *dbsqlc.Worker, stepCount *int64) *gen.Worker {
 		Status:        &status,
 		DispatcherId:  &dispatcherId,
 		MaxRuns:       &maxRuns,
-		AvailableRuns: &availableRuns,
+		AvailableRuns: slots,
 	}
 
 	if !worker.LastHeartbeatAt.Time.IsZero() {

--- a/internal/repository/prisma/dbsqlc/workers.sql
+++ b/internal/repository/prisma/dbsqlc/workers.sql
@@ -1,11 +1,14 @@
 -- name: ListWorkersWithStepCount :many
 SELECT
     sqlc.embed(workers),
-    COUNT(runs."id") FILTER (WHERE runs."status" = 'RUNNING') AS "runningStepRuns"
+    COUNT(runs."id") FILTER (WHERE runs."status" = 'RUNNING') AS "runningStepRuns",
+    ws."slots" AS "slots"
 FROM
     "Worker" workers
 LEFT JOIN
     "StepRun" AS runs ON runs."workerId" = workers."id" AND runs."status" = 'RUNNING'
+JOIN
+    "WorkerSemaphore" AS ws ON ws."workerId" = workers."id"
 WHERE
     workers."tenantId" = @tenantId
     AND (
@@ -31,6 +34,7 @@ WHERE
         ))
     )
 GROUP BY
+    ws."slots",
     workers."id";
 
 -- name: GetWorkerForEngine :one


### PR DESCRIPTION
# Description

Worker slot count was incorrectly reporting based on number of runs instead of semaphore slot value.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Update SQLC to join semaphore value and propagate value downstream in the list
