### PR TITLE
fix: alerting should query for recently finished runs instead of recently created runs

### DIFF
--- a/internal/integrations/alerting/alerter.go
+++ b/internal/integrations/alerting/alerter.go
@@ -96,7 +96,7 @@ func (t *TenantAlertManager) sendAlert(ctx context.Context, tenantAlerting *repo
 			Limit:          &limit,
 			OrderBy:        repository.StringPtr("createdAt"),
 			OrderDirection: repository.StringPtr("DESC"),
-			CreatedAfter:   &prevLastAlertedAt,
+			FinishedAfter:  &prevLastAlertedAt,
 		},
 	)
 

--- a/internal/repository/prisma/dbsqlc/tickers.sql
+++ b/internal/repository/prisma/dbsqlc/tickers.sql
@@ -243,7 +243,7 @@ failed_run_count_by_tenant AS (
         "status" = 'FAILED'
         AND (
             "lastAlertedAt" IS NULL OR
-            workflowRun."createdAt" >= "lastAlertedAt"
+            workflowRun."finishedAt" >= "lastAlertedAt"
         )
     GROUP BY workflowRun."tenantId"
 )

--- a/internal/repository/prisma/dbsqlc/tickers.sql.go
+++ b/internal/repository/prisma/dbsqlc/tickers.sql.go
@@ -534,7 +534,7 @@ failed_run_count_by_tenant AS (
         "status" = 'FAILED'
         AND (
             "lastAlertedAt" IS NULL OR
-            workflowRun."createdAt" >= "lastAlertedAt"
+            workflowRun."finishedAt" >= "lastAlertedAt"
         )
     GROUP BY workflowRun."tenantId"
 )

--- a/internal/repository/prisma/dbsqlc/workflow_runs.sql
+++ b/internal/repository/prisma/dbsqlc/workflow_runs.sql
@@ -52,6 +52,10 @@ WHERE
     (
         sqlc.narg('createdAfter')::timestamp IS NULL OR
         runs."createdAt" > sqlc.narg('createdAfter')::timestamp
+    ) AND
+    (
+        sqlc.narg('finishedAfter')::timestamp IS NULL OR
+        runs."finishedAt" > sqlc.narg('finishedAfter')::timestamp
     );
 
 -- name: WorkflowRunsMetricsCount :one
@@ -153,6 +157,10 @@ WHERE
     (
         sqlc.narg('createdAfter')::timestamp IS NULL OR
         runs."createdAt" > sqlc.narg('createdAfter')::timestamp
+    ) AND
+    (
+        sqlc.narg('finishedAfter')::timestamp IS NULL OR
+        runs."finishedAt" > sqlc.narg('finishedAfter')::timestamp
     )
 ORDER BY
     case when @orderBy = 'createdAt ASC' THEN runs."createdAt" END ASC ,

--- a/internal/repository/prisma/dbsqlc/workflow_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/workflow_runs.sql.go
@@ -65,6 +65,10 @@ WHERE
     (
         $11::timestamp IS NULL OR
         runs."createdAt" > $11::timestamp
+    ) AND
+    (
+        $12::timestamp IS NULL OR
+        runs."finishedAt" > $12::timestamp
     )
 `
 
@@ -80,6 +84,7 @@ type CountWorkflowRunsParams struct {
 	GroupKey           pgtype.Text      `json:"groupKey"`
 	Statuses           []string         `json:"statuses"`
 	CreatedAfter       pgtype.Timestamp `json:"createdAfter"`
+	FinishedAfter      pgtype.Timestamp `json:"finishedAfter"`
 }
 
 func (q *Queries) CountWorkflowRuns(ctx context.Context, db DBTX, arg CountWorkflowRunsParams) (int64, error) {
@@ -95,6 +100,7 @@ func (q *Queries) CountWorkflowRuns(ctx context.Context, db DBTX, arg CountWorkf
 		arg.GroupKey,
 		arg.Statuses,
 		arg.CreatedAfter,
+		arg.FinishedAfter,
 	)
 	var total int64
 	err := row.Scan(&total)
@@ -765,14 +771,18 @@ WHERE
     (
         $11::timestamp IS NULL OR
         runs."createdAt" > $11::timestamp
+    ) AND
+    (
+        $12::timestamp IS NULL OR
+        runs."finishedAt" > $12::timestamp
     )
 ORDER BY
-    case when $12 = 'createdAt ASC' THEN runs."createdAt" END ASC ,
-    case when $12 = 'createdAt DESC' then runs."createdAt" END DESC
+    case when $13 = 'createdAt ASC' THEN runs."createdAt" END ASC ,
+    case when $13 = 'createdAt DESC' then runs."createdAt" END DESC
 OFFSET
-    COALESCE($13, 0)
+    COALESCE($14, 0)
 LIMIT
-    COALESCE($14, 50)
+    COALESCE($15, 50)
 `
 
 type ListWorkflowRunsParams struct {
@@ -787,6 +797,7 @@ type ListWorkflowRunsParams struct {
 	GroupKey           pgtype.Text      `json:"groupKey"`
 	Statuses           []string         `json:"statuses"`
 	CreatedAfter       pgtype.Timestamp `json:"createdAfter"`
+	FinishedAfter      pgtype.Timestamp `json:"finishedAfter"`
 	Orderby            interface{}      `json:"orderby"`
 	Offset             interface{}      `json:"offset"`
 	Limit              interface{}      `json:"limit"`
@@ -816,6 +827,7 @@ func (q *Queries) ListWorkflowRuns(ctx context.Context, db DBTX, arg ListWorkflo
 		arg.GroupKey,
 		arg.Statuses,
 		arg.CreatedAfter,
+		arg.FinishedAfter,
 		arg.Orderby,
 		arg.Offset,
 		arg.Limit,

--- a/internal/repository/prisma/workflow_run.go
+++ b/internal/repository/prisma/workflow_run.go
@@ -326,6 +326,11 @@ func listWorkflowRuns(ctx context.Context, pool *pgxpool.Pool, queries *dbsqlc.Q
 		queryParams.CreatedAfter = sqlchelpers.TimestampFromTime(*opts.CreatedAfter)
 	}
 
+	if opts.FinishedAfter != nil {
+		countParams.FinishedAfter = sqlchelpers.TimestampFromTime(*opts.FinishedAfter)
+		queryParams.FinishedAfter = sqlchelpers.TimestampFromTime(*opts.FinishedAfter)
+	}
+
 	orderByField := "createdAt"
 
 	if opts.OrderBy != nil {

--- a/internal/repository/workflow_run.go
+++ b/internal/repository/workflow_run.go
@@ -258,6 +258,9 @@ type ListWorkflowRunsOpts struct {
 	// (optional) a time after which the run was created
 	CreatedAfter *time.Time
 
+	// (optional) a time before which the run was finished
+	FinishedAfter *time.Time
+
 	// (optional) exact metadata to filter by
 	AdditionalMetadata map[string]interface{} `validate:"omitempty"`
 }


### PR DESCRIPTION
# Description

If runs were created before the last alerted time, but finished after the last alerted time, we weren't alerting on them. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
