### PR TITLE
fix:  branch cancelation strategy

### DIFF
--- a/frontend/app/src/pages/main/workflow-runs/$run/index.tsx
+++ b/frontend/app/src/pages/main/workflow-runs/$run/index.tsx
@@ -27,11 +27,10 @@ export default function ExpandedWorkflowRun() {
     ...queries.workflowRuns.get(tenant.metadata.id, params.run),
     refetchInterval: (query) => {
       const data = query.state.data;
-
       if (
-        data?.status != 'SUCCEEDED' &&
-        data?.status != 'FAILED' &&
-        data?.status != 'CANCELLED'
+        data &&
+        data.jobRuns &&
+        data.jobRuns.some((x) => x.status === 'RUNNING')
       ) {
         return 1000;
       }

--- a/internal/repository/prisma/dbsqlc/job_runs.sql
+++ b/internal/repository/prisma/dbsqlc/job_runs.sql
@@ -24,10 +24,11 @@ UPDATE "JobRun"
 SET "status" = CASE 
     -- Final states are final, cannot be updated
     WHEN "status" IN ('SUCCEEDED', 'FAILED', 'CANCELLED') THEN "status"
+    -- NOTE: Order of the following conditions is important
+    -- When one step run is running, then the job is running
+    WHEN (s.runningRuns > 0 OR s.pendingRuns > 0) THEN 'RUNNING'
     -- When one step run has failed, then the job is failed
     WHEN s.failedRuns > 0 THEN 'FAILED'
-    -- When one step run is running, then the job is running
-    WHEN s.runningRuns > 0 THEN 'RUNNING'
     -- When one step run has been cancelled, then the job is cancelled
     WHEN s.cancelledRuns > 0 THEN 'CANCELLED'
     -- When no step runs exist that are not succeeded, then the job is succeeded

--- a/internal/repository/prisma/dbsqlc/job_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/job_runs.sql.go
@@ -98,10 +98,10 @@ UPDATE "JobRun"
 SET "status" = CASE 
     -- Final states are final, cannot be updated
     WHEN "status" IN ('SUCCEEDED', 'FAILED', 'CANCELLED') THEN "status"
+    -- When one step run is running, then the job is running
+    WHEN (s.runningRuns > 0 OR s.pendingRuns > 0) THEN 'RUNNING'
     -- When one step run has failed, then the job is failed
     WHEN s.failedRuns > 0 THEN 'FAILED'
-    -- When one step run is running, then the job is running
-    WHEN s.runningRuns > 0 THEN 'RUNNING'
     -- When one step run has been cancelled, then the job is cancelled
     WHEN s.cancelledRuns > 0 THEN 'CANCELLED'
     -- When no step runs exist that are not succeeded, then the job is succeeded

--- a/internal/repository/prisma/dbsqlc/job_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/job_runs.sql.go
@@ -98,6 +98,7 @@ UPDATE "JobRun"
 SET "status" = CASE 
     -- Final states are final, cannot be updated
     WHEN "status" IN ('SUCCEEDED', 'FAILED', 'CANCELLED') THEN "status"
+    -- NOTE: Order of the following conditions is important
     -- When one step run is running, then the job is running
     WHEN (s.runningRuns > 0 OR s.pendingRuns > 0) THEN 'RUNNING'
     -- When one step run has failed, then the job is failed

--- a/internal/repository/prisma/dbsqlc/step_runs.sql
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql
@@ -208,6 +208,7 @@ SET  "status" = CASE
     -- When the step is in a final state, it cannot be updated
     WHEN sr."status" IN ('SUCCEEDED', 'FAILED', 'CANCELLED') THEN sr."cancelledReason"
     WHEN (SELECT "status" FROM currStepRun) = 'CANCELLED' AND (SELECT "cancelledReason" FROM currStepRun) = 'TIMED_OUT'::text THEN 'PREVIOUS_STEP_TIMED_OUT'
+    WHEN (SELECT "status" FROM currStepRun) = 'FAILED' THEN 'PREVIOUS_STEP_FAILED'
     WHEN (SELECT "status" FROM currStepRun) = 'CANCELLED' THEN 'PREVIOUS_STEP_CANCELLED'
     ELSE NULL
     END

--- a/internal/repository/prisma/dbsqlc/step_runs.sql
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql
@@ -175,43 +175,46 @@ WHERE
 RETURNING *;
 
 -- name: ResolveLaterStepRuns :many
-WITH currStepRun AS (
+WITH RECURSIVE currStepRun AS (
   SELECT *
   FROM "StepRun"
   WHERE
     "id" = @stepRunId::uuid AND
     "tenantId" = @tenantId::uuid
+), childStepRuns AS (
+  SELECT sr."id", sr."status"
+  FROM "StepRun" sr
+  JOIN "_StepRunOrder" sro ON sr."id" = sro."B"
+  WHERE sro."A" = (SELECT "id" FROM currStepRun)
+  
+  UNION ALL
+  
+  SELECT sr."id", sr."status"
+  FROM "StepRun" sr
+  JOIN "_StepRunOrder" sro ON sr."id" = sro."B"
+  JOIN childStepRuns csr ON sro."A" = csr."id"
 )
 UPDATE
     "StepRun" as sr
-SET "status" = CASE
+SET  "status" = CASE
     -- When the step is in a final state, it cannot be updated
     WHEN sr."status" IN ('SUCCEEDED', 'FAILED', 'CANCELLED') THEN sr."status"
-    -- When the given step run has failed or been cancelled, then all later step runs are cancelled
-    WHEN (cs."status" = 'FAILED' OR cs."status" = 'CANCELLED') THEN 'CANCELLED'
+    -- When the given step run has failed or been cancelled, then all child step runs are cancelled
+    WHEN (SELECT "status" FROM currStepRun) IN ('FAILED', 'CANCELLED') THEN 'CANCELLED'
     ELSE sr."status"
     END,
     -- When the previous step run timed out, the cancelled reason is set
     "cancelledReason" = CASE
     -- When the step is in a final state, it cannot be updated
     WHEN sr."status" IN ('SUCCEEDED', 'FAILED', 'CANCELLED') THEN sr."cancelledReason"
-    WHEN (cs."status" = 'CANCELLED' AND cs."cancelledReason" = 'TIMED_OUT'::text) THEN 'PREVIOUS_STEP_TIMED_OUT'
-    WHEN (cs."status" = 'CANCELLED') THEN 'PREVIOUS_STEP_CANCELLED'
+    WHEN (SELECT "status" FROM currStepRun) = 'CANCELLED' AND (SELECT "cancelledReason" FROM currStepRun) = 'TIMED_OUT'::text THEN 'PREVIOUS_STEP_TIMED_OUT'
+    WHEN (SELECT "status" FROM currStepRun) = 'CANCELLED' THEN 'PREVIOUS_STEP_CANCELLED'
     ELSE NULL
     END
 FROM
-    currStepRun cs
+    childStepRuns csr
 WHERE
-    sr."jobRunId" = (
-        SELECT "jobRunId"
-        FROM "StepRun"
-        WHERE "id" = @stepRunId::uuid
-    ) AND
-    sr."order" > (
-        SELECT "order"
-        FROM "StepRun"
-        WHERE "id" = @stepRunId::uuid
-    ) AND
+    sr."id" = csr."id" AND
     sr."tenantId" = @tenantId::uuid
 RETURNING sr.*;
 

--- a/internal/repository/prisma/dbsqlc/step_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql.go
@@ -781,54 +781,57 @@ func (q *Queries) ListStepRunsToRequeue(ctx context.Context, db DBTX, tenantid p
 }
 
 const resolveLaterStepRuns = `-- name: ResolveLaterStepRuns :many
-WITH currStepRun AS (
+WITH RECURSIVE currStepRun AS (
   SELECT id, "createdAt", "updatedAt", "deletedAt", "tenantId", "jobRunId", "stepId", "order", "workerId", "tickerId", status, input, output, "requeueAfter", "scheduleTimeoutAt", error, "startedAt", "finishedAt", "timeoutAt", "cancelledAt", "cancelledReason", "cancelledError", "inputSchema", "callerFiles", "gitRepoBranch", "retryCount"
   FROM "StepRun"
   WHERE
-    "id" = $1::uuid AND
-    "tenantId" = $2::uuid
+    "id" = $2::uuid AND
+    "tenantId" = $1::uuid
+), childStepRuns AS (
+  SELECT sr."id", sr."status"
+  FROM "StepRun" sr
+  JOIN "_StepRunOrder" sro ON sr."id" = sro."B"
+  WHERE sro."A" = (SELECT "id" FROM currStepRun)
+  
+  UNION ALL
+  
+  SELECT sr."id", sr."status"
+  FROM "StepRun" sr
+  JOIN "_StepRunOrder" sro ON sr."id" = sro."B"
+  JOIN childStepRuns csr ON sro."A" = csr."id"
 )
 UPDATE
     "StepRun" as sr
-SET "status" = CASE
+SET  "status" = CASE
     -- When the step is in a final state, it cannot be updated
     WHEN sr."status" IN ('SUCCEEDED', 'FAILED', 'CANCELLED') THEN sr."status"
-    -- When the given step run has failed or been cancelled, then all later step runs are cancelled
-    WHEN (cs."status" = 'FAILED' OR cs."status" = 'CANCELLED') THEN 'CANCELLED'
+    -- When the given step run has failed or been cancelled, then all child step runs are cancelled
+    WHEN (SELECT "status" FROM currStepRun) IN ('FAILED', 'CANCELLED') THEN 'CANCELLED'
     ELSE sr."status"
     END,
     -- When the previous step run timed out, the cancelled reason is set
     "cancelledReason" = CASE
     -- When the step is in a final state, it cannot be updated
     WHEN sr."status" IN ('SUCCEEDED', 'FAILED', 'CANCELLED') THEN sr."cancelledReason"
-    WHEN (cs."status" = 'CANCELLED' AND cs."cancelledReason" = 'TIMED_OUT'::text) THEN 'PREVIOUS_STEP_TIMED_OUT'
-    WHEN (cs."status" = 'CANCELLED') THEN 'PREVIOUS_STEP_CANCELLED'
+    WHEN (SELECT "status" FROM currStepRun) = 'CANCELLED' AND (SELECT "cancelledReason" FROM currStepRun) = 'TIMED_OUT'::text THEN 'PREVIOUS_STEP_TIMED_OUT'
+    WHEN (SELECT "status" FROM currStepRun) = 'CANCELLED' THEN 'PREVIOUS_STEP_CANCELLED'
     ELSE NULL
     END
 FROM
-    currStepRun cs
+    childStepRuns csr
 WHERE
-    sr."jobRunId" = (
-        SELECT "jobRunId"
-        FROM "StepRun"
-        WHERE "id" = $1::uuid
-    ) AND
-    sr."order" > (
-        SELECT "order"
-        FROM "StepRun"
-        WHERE "id" = $1::uuid
-    ) AND
-    sr."tenantId" = $2::uuid
+    sr."id" = csr."id" AND
+    sr."tenantId" = $1::uuid
 RETURNING sr.id, sr."createdAt", sr."updatedAt", sr."deletedAt", sr."tenantId", sr."jobRunId", sr."stepId", sr."order", sr."workerId", sr."tickerId", sr.status, sr.input, sr.output, sr."requeueAfter", sr."scheduleTimeoutAt", sr.error, sr."startedAt", sr."finishedAt", sr."timeoutAt", sr."cancelledAt", sr."cancelledReason", sr."cancelledError", sr."inputSchema", sr."callerFiles", sr."gitRepoBranch", sr."retryCount"
 `
 
 type ResolveLaterStepRunsParams struct {
-	Steprunid pgtype.UUID `json:"steprunid"`
 	Tenantid  pgtype.UUID `json:"tenantid"`
+	Steprunid pgtype.UUID `json:"steprunid"`
 }
 
 func (q *Queries) ResolveLaterStepRuns(ctx context.Context, db DBTX, arg ResolveLaterStepRunsParams) ([]*StepRun, error) {
-	rows, err := db.Query(ctx, resolveLaterStepRuns, arg.Steprunid, arg.Tenantid)
+	rows, err := db.Query(ctx, resolveLaterStepRuns, arg.Tenantid, arg.Steprunid)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repository/prisma/dbsqlc/step_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql.go
@@ -814,6 +814,7 @@ SET  "status" = CASE
     -- When the step is in a final state, it cannot be updated
     WHEN sr."status" IN ('SUCCEEDED', 'FAILED', 'CANCELLED') THEN sr."cancelledReason"
     WHEN (SELECT "status" FROM currStepRun) = 'CANCELLED' AND (SELECT "cancelledReason" FROM currStepRun) = 'TIMED_OUT'::text THEN 'PREVIOUS_STEP_TIMED_OUT'
+    WHEN (SELECT "status" FROM currStepRun) = 'FAILED' THEN 'PREVIOUS_STEP_FAILED'
     WHEN (SELECT "status" FROM currStepRun) = 'CANCELLED' THEN 'PREVIOUS_STEP_CANCELLED'
     ELSE NULL
     END


### PR DESCRIPTION
# Description

In the event of a single step failure, it is expected and desirable for only dependent steps to be canceled down stream. In other words, independent branches can continue execution.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## What's Changed
- [x] revise ResolveLaterStepRuns to only update children of the current step
- [x] revise resolve job run query to continue in running if any running or pending step runs exist
- [x] fix polling for step run details based on job run statuses
