### PR TITLE
fix: handle last alerted null case + some logging/cleanup improvements

### DIFF
--- a/api/v1/server/handlers/workflows/get_step_run_diff.go
+++ b/api/v1/server/handlers/workflows/get_step_run_diff.go
@@ -1,10 +1,12 @@
 package workflows
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/labstack/echo/v4"
 
+	"github.com/hatchet-dev/hatchet/api/v1/server/oas/apierrors"
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
 	"github.com/hatchet-dev/hatchet/internal/integrations/vcs/vcsutils"
 	"github.com/hatchet-dev/hatchet/internal/repository/prisma/db"
@@ -16,6 +18,12 @@ func (t *WorkflowService) StepRunGetDiff(ctx echo.Context, request gen.StepRunGe
 	diffs, originalValues, err := vcsutils.GetStepRunOverrideDiffs(t.config.APIRepository.StepRun(), stepRun)
 
 	if err != nil {
+		if errors.Is(err, vcsutils.ErrNoInput) {
+			return gen.StepRunGetDiff404JSONResponse(
+				apierrors.NewAPIErrors("step run does not have an input"),
+			), nil
+		}
+
 		return nil, fmt.Errorf("could not get diffs: %s", err)
 	}
 

--- a/frontend/app/src/pages/main/workflow-runs/$run/components/step-run-playground.tsx
+++ b/frontend/app/src/pages/main/workflow-runs/$run/components/step-run-playground.tsx
@@ -137,7 +137,7 @@ export function StepRunPlayground({
 
   const stepRunDiffQuery = useQuery({
     ...queries.stepRuns.getDiff(stepRun?.metadata.id || ''),
-    enabled: !!stepRun,
+    enabled: !!stepRun && !!stepRun.input,
     refetchInterval: () => {
       if (stepRun?.status === StepRunStatus.RUNNING) {
         return 1000;

--- a/internal/integrations/alerting/alerter.go
+++ b/internal/integrations/alerting/alerter.go
@@ -46,9 +46,16 @@ func (t *TenantAlertManager) HandleAlert(tenantId string) error {
 		return err
 	}
 
-	if lastAlertedAt.IsZero() || time.Since(lastAlertedAt) > maxFrequency {
+	isZero := lastAlertedAt.IsZero()
+
+	if isZero || time.Since(lastAlertedAt) > maxFrequency {
 		// update the lastAlertedAt
 		now := time.Now().UTC()
+
+		// if we're in the zero state, we don't want to alert since the very beginning of the interval
+		if isZero {
+			lastAlertedAt = now.Add(-1 * maxFrequency)
+		}
 
 		err = t.repo.TenantAlertingSettings().UpdateTenantAlertingSettings(ctx, tenantId, &repository.UpdateTenantAlertingSettingsOpts{
 			LastAlertedAt: &now,

--- a/internal/repository/prisma/dbsqlc/tickers.sql.go
+++ b/internal/repository/prisma/dbsqlc/tickers.sql.go
@@ -514,9 +514,6 @@ WITH active_tenant_alerts AS (
         alerts.id, alerts."createdAt", alerts."updatedAt", alerts."deletedAt", alerts."tenantId", alerts."maxFrequency", alerts."lastAlertedAt", alerts."tickerId"
     FROM
         "TenantAlertingSettings" as alerts
-    -- only return alerts which have a slack webhook enabled
-    JOIN
-        "SlackAppWebhook" as webhooks ON webhooks."tenantId" = alerts."tenantId"
     WHERE
         "lastAlertedAt" IS NULL OR
         "lastAlertedAt" <= NOW() - convert_duration_to_interval(alerts."maxFrequency")
@@ -533,7 +530,10 @@ failed_run_count_by_tenant AS (
     WHERE
         "status" = 'FAILED'
         AND (
-            "lastAlertedAt" IS NULL OR
+            (
+                "lastAlertedAt" IS NULL AND
+                workflowRun."finishedAt" >= NOW() - convert_duration_to_interval(active_tenant_alerts."maxFrequency")
+            ) OR
             workflowRun."finishedAt" >= "lastAlertedAt"
         )
     GROUP BY workflowRun."tenantId"


### PR DESCRIPTION
# Description

We previously were alerting on all failed workflows that had ever been run when `lastAlertedAt = null` - this refactors to only look at failed workflows within the max frequency duration time. 

Also improves logging for the API. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)