### PR TITLE
fix: remove input from index

### DIFF
--- a/internal/repository/prisma/dbsqlc/schema.sql
+++ b/internal/repository/prisma/dbsqlc/schema.sql
@@ -877,7 +877,7 @@ CREATE INDEX "StepRun_jobRunId_tenantId_order_idx" ON "StepRun"("jobRunId" ASC, 
 CREATE INDEX "StepRun_stepId_idx" ON "StepRun"("stepId" ASC);
 
 -- CreateIndex
-CREATE INDEX "StepRun_tenantId_status_input_requeueAfter_createdAt_idx" ON "StepRun"("tenantId" ASC, "status" ASC, "input" ASC, "requeueAfter" ASC, "createdAt" ASC);
+CREATE INDEX "StepRun_tenantId_status_requeueAfter_createdAt_idx" ON "StepRun"("tenantId" ASC, "status" ASC, "requeueAfter" ASC, "createdAt" ASC);
 
 -- CreateIndex
 CREATE UNIQUE INDEX "StepRunEvent_id_key" ON "StepRunEvent"("id" ASC);

--- a/prisma/migrations/20240509213608_v0_26_0/migration.sql
+++ b/prisma/migrations/20240509213608_v0_26_0/migration.sql
@@ -2,13 +2,7 @@
 CREATE INDEX "JobRun_workflowRunId_tenantId_idx" ON "JobRun" ("workflowRunId", "tenantId");
 
 -- CreateIndex
-CREATE INDEX "StepRun_tenantId_status_input_requeueAfter_createdAt_idx" ON "StepRun" (
-    "tenantId",
-    "status",
-    "input",
-    "requeueAfter",
-    "createdAt"
-);
+CREATE INDEX "StepRun_tenantId_status_requeueAfter_createdAt_idx" ON "StepRun" ("tenantId", "status", "requeueAfter", "createdAt");
 
 -- CreateIndex
 CREATE INDEX "StepRun_stepId_idx" ON "StepRun" ("stepId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1016,7 +1016,7 @@ model StepRun {
   events StepRunEvent[]
 
   // index for ListStepRunsToRequeue and ListStepRunsToReassign
-  @@index([tenantId, status, input, requeueAfter, createdAt])
+  @@index([tenantId, status, requeueAfter, createdAt])
   // index for LinkStepRunParents
   @@index([stepId])
   // index for ListStartableStepRuns


### PR DESCRIPTION
# Description

Having `input` in the index can exceed the index row byte limit, which isn't easy to fix - this removes input from indexing for now. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)