### PR TITLE
use consistent logger name 

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -106,7 +106,7 @@ func defaultClientOpts(cf *client.ClientConfigFile) *ClientOpts {
 
 func WithLogLevel(lvl string) ClientOpt {
 	return func(opts *ClientOpts) {
-		logger := logger.NewDefaultLogger("worker")
+		logger := logger.NewDefaultLogger("client")
 		lvl, err := zerolog.ParseLevel(lvl)
 
 		if err == nil {


### PR DESCRIPTION
# Description

One line.  Use consistent logger name at client.go file.

Fixes # (issue)

## improve unambiguity

<!-- Please delete options that are not relevant. -->

- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] Chore (changes which are not directly related to any business logic)

## What's Changed

- [ ] Make sure previous name was **not** used intentionally 
