### PR TITLE
docs: Docker compose update

### DIFF
--- a/frontend/docs/pages/self-hosting/docker-compose.mdx
+++ b/frontend/docs/pages/self-hosting/docker-compose.mdx
@@ -77,11 +77,11 @@ services:
       DATABASE_POSTGRES_PORT: "5432"
       DATABASE_POSTGRES_HOST: "postgres"
       SERVER_TASKQUEUE_RABBITMQ_URL: amqp://user:password@rabbitmq:5672/
-      SERVER_AUTH_COOKIE_DOMAIN: localhost:8080
+      SERVER_AUTH_COOKIE_DOMAIN: 127.0.0.1:8080
       SERVER_AUTH_COOKIE_INSECURE: "t"
-      SERVER_GRPC_BIND_ADDRESS: "0.0.0.0"
       SERVER_GRPC_INSECURE: "t"
-      SERVER_GRPC_BROADCAST_ADDRESS: localhost:7077
+      SERVER_GRPC_BIND_ADDRESS: "0.0.0.0"
+      SERVER_GRPC_BROADCAST_ADDRESS: "host.docker.internal:7077"
     volumes:
       - hatchet_certs:/hatchet/certs
       - hatchet_config:/hatchet/config


### PR DESCRIPTION
# Description

If you run Hatchet and your app locally in docker-compose, you get an error:
```
"UNKNOWN:Error received from peer  {created_time:"2024-05-13T08:39:34.861686763+00:00", grpc_status:14, grpc_message:"failed to connect to all addresses; last error: UNKNOWN: ipv4:127.0.0.1:7077: Failed to connect to remote host: Connection refused"}"
```

Fixes # (issue)
SERVER_GRPC_BROADCAST_ADDRESS is embedded into HATCHET_CLIENT_TOKEN
```
echo $HATCHET_CLIENT_TOKEN | cut -d "." -f 2 | base64 -d 2>/dev/null || echo $HATCHET_CLIENT_TOKEN | cut -d "." -f 2 | base64 -d -i 2>/dev/null


{"aud":"http://localhost:8080", "exp":1723365005, "grpc_broadcast_address":"localhost:7077", "iat":1715589005, "iss":"http://localhost:8080", "server_url":"http://localhost:8080", "sub":"707d0855-80ab-4e1f-a156-f1c4546cbf52", "token_id":"318a2447-a053-4f86-86d9-8770608a5df2"}%  
```

You have to set `SERVER_GRPC_BROADCAST_ADDRESS: "host.docker.internal:7077"` under setup-config in the docker compose file and generate a new Hatchet client token


## Type of change

- [ ] Documentation change (pure documentation change)


## What's Changed

- [ ] Updated self-hosted page documentation
