### PR TITLE
fix: keep alive enforcement policy

### DIFF
--- a/internal/services/grpc/server.go
+++ b/internal/services/grpc/server.go
@@ -245,6 +245,13 @@ func (s *Server) startGRPC() (func() error, error) {
 		recovery.UnaryServerInterceptor(recovery.WithRecoveryHandler(grpcPanicRecoveryHandler)),
 	))
 
+	var enforcement = keepalive.EnforcementPolicy{
+		MinTime:             10 * time.Second,
+		PermitWithoutStream: true,
+	}
+
+	serverOpts = append(serverOpts, grpc.KeepaliveEnforcementPolicy(enforcement))
+
 	var kasp = keepalive.ServerParameters{
 		// ping the client every 30 seconds if idle to ensure the connection is still active
 		Time: 30 * time.Second,

--- a/internal/services/grpc/server.go
+++ b/internal/services/grpc/server.go
@@ -246,7 +246,7 @@ func (s *Server) startGRPC() (func() error, error) {
 	))
 
 	var enforcement = keepalive.EnforcementPolicy{
-		MinTime:             10 * time.Second,
+		MinTime:             5 * time.Second,
 		PermitWithoutStream: true,
 	}
 


### PR DESCRIPTION
# Description

Fixes inconsistent GRPC Config x-sdks and server instance

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] MinTime is the minimum amount of time a client should wait before sending a keepalive ping. Set to 10s on Server.

