### PR TITLE
fix: retry deadlocks on semaphore updates

### DIFF
--- a/api-contracts/openapi/paths/workflow/workflow.yaml
+++ b/api-contracts/openapi/paths/workflow/workflow.yaml
@@ -274,7 +274,7 @@ triggerWorkflow:
     tags:
       - Workflow Run
 
-cancelWorkflowRuns: 
+cancelWorkflowRuns:
   post:
     x-resources: ["tenant"]
     description: Cancel a batch of workflow runs


### PR DESCRIPTION
# Description

Deadlocks are currently not retried for worker semaphore leading to a high requeue count. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)