### PR TITLE
revert: scheduleToStart retries

### DIFF
--- a/internal/repository/prisma/dbsqlc/step_runs.sql
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql
@@ -346,10 +346,7 @@ step_runs AS (
         ) OR (
             sr."status" = 'ASSIGNED'
             -- reassign if the run is stuck in assigned
-            AND (
-                sr."updatedAt" < NOW() - INTERVAL '30 seconds'
-                OR w."lastHeartbeatAt" < NOW() - INTERVAL '30 seconds'
-            )
+            AND w."lastHeartbeatAt" < NOW() - INTERVAL '30 seconds'
         ))
         AND jr."status" = 'RUNNING'
         AND sr."input" IS NOT NULL

--- a/internal/repository/prisma/dbsqlc/step_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql.go
@@ -944,10 +944,7 @@ step_runs AS (
         ) OR (
             sr."status" = 'ASSIGNED'
             -- reassign if the run is stuck in assigned
-            AND (
-                sr."updatedAt" < NOW() - INTERVAL '30 seconds'
-                OR w."lastHeartbeatAt" < NOW() - INTERVAL '30 seconds'
-            )
+            AND w."lastHeartbeatAt" < NOW() - INTERVAL '30 seconds'
         ))
         AND jr."status" = 'RUNNING'
         AND sr."input" IS NOT NULL


### PR DESCRIPTION
# Description

Removes the 30-second retries of a step run which takes a long time to start. This is causing aggressive retries on worker SDKs which don't have de-duplication of steps in place, causing a larger step volume. 