### PR TITLE
fix: old Listen endpoint not setting worker to active

### DIFF
--- a/api/v1/server/oas/transformers/worker.go
+++ b/api/v1/server/oas/transformers/worker.go
@@ -73,7 +73,7 @@ func ToWorkerSqlc(worker *dbsqlc.Worker, stepCount *int64, slots *int) *gen.Work
 
 	status := gen.ACTIVE
 
-	if worker.LastHeartbeatAt.Time.Add(4 * time.Second).Before(time.Now()) {
+	if worker.LastHeartbeatAt.Time.Add(5 * time.Second).Before(time.Now()) {
 		status = gen.INACTIVE
 	}
 

--- a/internal/repository/prisma/dbsqlc/step_runs.sql
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql
@@ -310,6 +310,8 @@ WITH valid_workers AS (
     WHERE
         w."tenantId" = @tenantId::uuid
         AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+        -- necessary becauseisActive is set to false immediately when the stream closes
+        AND w."isActive" = true
     GROUP BY
         w."id"
 ),
@@ -395,6 +397,8 @@ WITH valid_workers AS (
     WHERE
         w."tenantId" = @tenantId::uuid
         AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+        -- necessary becauseisActive is set to false immediately when the stream closes
+        AND w."isActive" = true
     GROUP BY
         w."id"
 ),
@@ -466,6 +470,8 @@ WITH valid_workers AS (
         w."tenantId" = @tenantId::uuid
         AND w."dispatcherId" IS NOT NULL
         AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+        -- necessary becauseisActive is set to false immediately when the stream closes
+        AND w."isActive" = true
         AND w."id" IN (
             SELECT "_ActionToWorker"."B"
             FROM "_ActionToWorker"
@@ -500,6 +506,8 @@ WITH valid_workers AS (
         w."tenantId" = @tenantId::uuid
         AND w."dispatcherId" IS NOT NULL
         AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+        -- necessary becauseisActive is set to false immediately when the stream closes
+        AND w."isActive" = true
         AND w."id" IN (
             SELECT "_ActionToWorker"."B"
             FROM "_ActionToWorker"

--- a/internal/repository/prisma/dbsqlc/step_runs.sql
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql
@@ -310,7 +310,6 @@ WITH valid_workers AS (
     WHERE
         w."tenantId" = @tenantId::uuid
         AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
-        AND w."isActive" = true
     GROUP BY
         w."id"
 ),
@@ -396,7 +395,6 @@ WITH valid_workers AS (
     WHERE
         w."tenantId" = @tenantId::uuid
         AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
-        AND w."isActive" = true
     GROUP BY
         w."id"
 ),
@@ -468,7 +466,6 @@ WITH valid_workers AS (
         w."tenantId" = @tenantId::uuid
         AND w."dispatcherId" IS NOT NULL
         AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
-        AND w."isActive" = true
         AND w."id" IN (
             SELECT "_ActionToWorker"."B"
             FROM "_ActionToWorker"
@@ -503,7 +500,6 @@ WITH valid_workers AS (
         w."tenantId" = @tenantId::uuid
         AND w."dispatcherId" IS NOT NULL
         AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
-        AND w."isActive" = true
         AND w."id" IN (
             SELECT "_ActionToWorker"."B"
             FROM "_ActionToWorker"

--- a/internal/repository/prisma/dbsqlc/step_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql.go
@@ -107,7 +107,6 @@ WITH valid_workers AS (
         w."tenantId" = $1::uuid
         AND w."dispatcherId" IS NOT NULL
         AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
-        AND w."isActive" = true
         AND w."id" IN (
             SELECT "_ActionToWorker"."B"
             FROM "_ActionToWorker"
@@ -579,7 +578,6 @@ WITH valid_workers AS (
         w."tenantId" = $1::uuid
         AND w."dispatcherId" IS NOT NULL
         AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
-        AND w."isActive" = true
         AND w."id" IN (
             SELECT "_ActionToWorker"."B"
             FROM "_ActionToWorker"
@@ -909,7 +907,6 @@ WITH valid_workers AS (
     WHERE
         w."tenantId" = $1::uuid
         AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
-        AND w."isActive" = true
     GROUP BY
         w."id"
 ),
@@ -1016,7 +1013,6 @@ WITH valid_workers AS (
     WHERE
         w."tenantId" = $1::uuid
         AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
-        AND w."isActive" = true
     GROUP BY
         w."id"
 ),

--- a/internal/repository/prisma/dbsqlc/step_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql.go
@@ -107,6 +107,8 @@ WITH valid_workers AS (
         w."tenantId" = $1::uuid
         AND w."dispatcherId" IS NOT NULL
         AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+        -- necessary becauseisActive is set to false immediately when the stream closes
+        AND w."isActive" = true
         AND w."id" IN (
             SELECT "_ActionToWorker"."B"
             FROM "_ActionToWorker"
@@ -578,6 +580,8 @@ WITH valid_workers AS (
         w."tenantId" = $1::uuid
         AND w."dispatcherId" IS NOT NULL
         AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+        -- necessary becauseisActive is set to false immediately when the stream closes
+        AND w."isActive" = true
         AND w."id" IN (
             SELECT "_ActionToWorker"."B"
             FROM "_ActionToWorker"
@@ -907,6 +911,8 @@ WITH valid_workers AS (
     WHERE
         w."tenantId" = $1::uuid
         AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+        -- necessary becauseisActive is set to false immediately when the stream closes
+        AND w."isActive" = true
     GROUP BY
         w."id"
 ),
@@ -1013,6 +1019,8 @@ WITH valid_workers AS (
     WHERE
         w."tenantId" = $1::uuid
         AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+        -- necessary becauseisActive is set to false immediately when the stream closes
+        AND w."isActive" = true
     GROUP BY
         w."id"
 ),

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -225,6 +225,7 @@ func (s *DispatcherImpl) Listen(request *contracts.WorkerListenRequest, stream c
 
 					_, err := s.repo.Worker().UpdateWorker(ctx, tenantId, request.WorkerId, &repository.UpdateWorkerOpts{
 						LastHeartbeatAt: &now,
+						IsActive:        repository.BoolPtr(true),
 					})
 
 					if err != nil {
@@ -361,7 +362,7 @@ func (s *DispatcherImpl) Heartbeat(ctx context.Context, req *contracts.Heartbeat
 	}
 
 	if worker.LastListenerEstablished.Valid && !worker.IsActive {
-		return nil, fmt.Errorf("Heartbeat rejected, worker stream is not active")
+		return nil, fmt.Errorf("Heartbeat rejected, worker stream for %s is not active", req.WorkerId)
 	}
 
 	_, err = s.repo.Worker().UpdateWorker(ctx, tenantId, req.WorkerId, &repository.UpdateWorkerOpts{


### PR DESCRIPTION
# Description

The additional active checks within the `Assign`, `Requeue` and `Reassign` queries are causing issues with clients that are using the old listener (`Listen` instead of `ListenV2`). The reason for this is that the workers are never updated with `isActive = true`. 

I've removed the `isActive` checks to fix this issue but also because they're redundant - we already reject the heartbeats if the worker isn't active, and our API is casing on whether a worker is inactive or active based on the heartbeat, so it makes sense to have the heartbeat be the only source of truth for scheduling. 

I've also added a fix to set workers to active on the old `Listen` endpoint to ensure this is fixed, should we choose to rely on `isActive` in the future.  

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
