### PR TITLE
fix: hangup subscriber when workflow run is finished

### DIFF
--- a/internal/repository/prisma/workflow_run.go
+++ b/internal/repository/prisma/workflow_run.go
@@ -160,7 +160,7 @@ func (w *workflowRunEngineRepository) GetWorkflowRunById(ctx context.Context, te
 	}
 
 	if len(runs) != 1 {
-		return nil, errors.New("workflow run not found")
+		return nil, repository.ErrWorkflowRunNotFound
 	}
 
 	return runs[0], nil

--- a/internal/repository/workflow_run.go
+++ b/internal/repository/workflow_run.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/hatchet-dev/hatchet/internal/datautils"
@@ -357,6 +358,8 @@ type WorkflowRunAPIRepository interface {
 
 	ListPullRequestsForWorkflowRun(tenantId, workflowRunId string, opts *ListPullRequestsForWorkflowRunOpts) ([]db.GithubPullRequestModel, error)
 }
+
+var ErrWorkflowRunNotFound = fmt.Errorf("workflow run not found")
 
 type WorkflowRunEngineRepository interface {
 	// ListWorkflowRuns returns workflow runs for a given workflow version id.

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -50,6 +50,9 @@ func (worker *subscribedWorker) StartStepRun(
 
 	stepName := stepRun.StepReadableId.String
 
+	// add artificial latency of 80ms to simulate slow network
+	time.Sleep(80 * time.Millisecond)
+
 	return worker.stream.Send(&contracts.AssignedAction{
 		TenantId:      tenantId,
 		JobId:         sqlchelpers.UUIDToStr(stepRun.JobId),
@@ -362,7 +365,7 @@ func (s *DispatcherImpl) Heartbeat(ctx context.Context, req *contracts.Heartbeat
 	}
 
 	if worker.LastListenerEstablished.Valid && !worker.IsActive {
-		return nil, fmt.Errorf("Heartbeat rejected, worker stream for %s is not active", req.WorkerId)
+		return nil, status.Errorf(codes.FailedPrecondition, "Heartbeat rejected, worker stream for %s is not active", req.WorkerId)
 	}
 
 	_, err = s.repo.Worker().UpdateWorker(ctx, tenantId, req.WorkerId, &repository.UpdateWorkerOpts{
@@ -409,6 +412,21 @@ func (s *DispatcherImpl) SubscribeToWorkflowEvents(request *contracts.SubscribeT
 
 	ctx, cancel := context.WithCancel(stream.Context())
 	defer cancel()
+
+	// if the workflow run is in a final state, hang up the connection
+	workflowRun, err := s.repo.WorkflowRun().GetWorkflowRunById(ctx, tenantId, request.WorkflowRunId)
+
+	if err != nil {
+		if errors.Is(err, repository.ErrWorkflowRunNotFound) {
+			return status.Errorf(codes.NotFound, "workflow run %s not found", request.WorkflowRunId)
+		}
+
+		return err
+	}
+
+	if repository.IsFinalWorkflowRunStatus(workflowRun.WorkflowRun.Status) {
+		return nil
+	}
 
 	wg := sync.WaitGroup{}
 

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -50,9 +50,6 @@ func (worker *subscribedWorker) StartStepRun(
 
 	stepName := stepRun.StepReadableId.String
 
-	// add artificial latency of 80ms to simulate slow network
-	time.Sleep(80 * time.Millisecond)
-
 	return worker.stream.Send(&contracts.AssignedAction{
 		TenantId:      tenantId,
 		JobId:         sqlchelpers.UUIDToStr(stepRun.JobId),


### PR DESCRIPTION
# Description

Workflow run events listener doesn't hang up if workflow run is already finished. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
