### PR TITLE
fix: reject heartbeats when dispatcher disconnects, step runs

### DIFF
--- a/internal/repository/prisma/dbsqlc/step_runs.sql
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql
@@ -123,7 +123,11 @@ UPDATE
     "StepRun"
 SET
     "requeueAfter" = COALESCE(sqlc.narg('requeueAfter')::timestamp, "requeueAfter"),
-    "scheduleTimeoutAt" = COALESCE(sqlc.narg('scheduleTimeoutAt')::timestamp, "scheduleTimeoutAt"),
+    "scheduleTimeoutAt" = CASE
+        -- if this is a rerun, we clear the scheduleTimeoutAt
+        WHEN sqlc.narg('rerun')::boolean THEN NULL
+        ELSE COALESCE(sqlc.narg('scheduleTimeoutAt')::timestamp, "scheduleTimeoutAt")
+    END,
     "startedAt" = COALESCE(sqlc.narg('startedAt')::timestamp, "startedAt"),
     "finishedAt" = CASE
         -- if this is a rerun, we clear the finishedAt

--- a/internal/repository/prisma/dbsqlc/workers.sql
+++ b/internal/repository/prisma/dbsqlc/workers.sql
@@ -42,10 +42,13 @@ SELECT
     w."id" AS "id",
     w."tenantId" AS "tenantId",
     w."dispatcherId" AS "dispatcherId",
+    d."lastHeartbeatAt" AS "dispatcherLastHeartbeatAt",
     w."isActive" AS "isActive",
     w."lastListenerEstablished" AS "lastListenerEstablished"
 FROM
     "Worker" w
+LEFT JOIN
+    "Dispatcher" d ON w."dispatcherId" = d."id"
 WHERE
     w."tenantId" = @tenantId
     AND w."id" = @id;

--- a/internal/repository/prisma/dbsqlc/workers.sql.go
+++ b/internal/repository/prisma/dbsqlc/workers.sql.go
@@ -116,10 +116,13 @@ SELECT
     w."id" AS "id",
     w."tenantId" AS "tenantId",
     w."dispatcherId" AS "dispatcherId",
+    d."lastHeartbeatAt" AS "dispatcherLastHeartbeatAt",
     w."isActive" AS "isActive",
     w."lastListenerEstablished" AS "lastListenerEstablished"
 FROM
     "Worker" w
+LEFT JOIN
+    "Dispatcher" d ON w."dispatcherId" = d."id"
 WHERE
     w."tenantId" = $1
     AND w."id" = $2
@@ -131,11 +134,12 @@ type GetWorkerForEngineParams struct {
 }
 
 type GetWorkerForEngineRow struct {
-	ID                      pgtype.UUID      `json:"id"`
-	TenantId                pgtype.UUID      `json:"tenantId"`
-	DispatcherId            pgtype.UUID      `json:"dispatcherId"`
-	IsActive                bool             `json:"isActive"`
-	LastListenerEstablished pgtype.Timestamp `json:"lastListenerEstablished"`
+	ID                        pgtype.UUID      `json:"id"`
+	TenantId                  pgtype.UUID      `json:"tenantId"`
+	DispatcherId              pgtype.UUID      `json:"dispatcherId"`
+	DispatcherLastHeartbeatAt pgtype.Timestamp `json:"dispatcherLastHeartbeatAt"`
+	IsActive                  bool             `json:"isActive"`
+	LastListenerEstablished   pgtype.Timestamp `json:"lastListenerEstablished"`
 }
 
 func (q *Queries) GetWorkerForEngine(ctx context.Context, db DBTX, arg GetWorkerForEngineParams) (*GetWorkerForEngineRow, error) {
@@ -145,6 +149,7 @@ func (q *Queries) GetWorkerForEngine(ctx context.Context, db DBTX, arg GetWorker
 		&i.ID,
 		&i.TenantId,
 		&i.DispatcherId,
+		&i.DispatcherLastHeartbeatAt,
 		&i.IsActive,
 		&i.LastListenerEstablished,
 	)


### PR DESCRIPTION
# Description

Rejects heartbeats when the dispatcher that the worker is connected to is no longer active. Also fixes scheduling timeouts causing issues on replay. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)