### PR TITLE
Feat  expiring token email and slack alerts

### DIFF
--- a/internal/integrations/alerting/alerttypes/expiring_token.go
+++ b/internal/integrations/alerting/alerttypes/expiring_token.go
@@ -1,0 +1,8 @@
+package alerttypes
+
+type ExpiringTokenItem struct {
+	Link                  string `json:"link"`
+	TokenName             string `json:"token_name"`
+	ExpiresAtRelativeDate string `json:"expires_at_relative_date"`
+	ExpiresAtAbsoluteDate string `json:"expires_at_absolute_date"`
+}

--- a/internal/integrations/alerting/email.go
+++ b/internal/integrations/alerting/email.go
@@ -42,7 +42,7 @@ func (t *TenantAlertManager) sendEmailExpiringTokenAlert(tenant *dbsqlc.Tenant, 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	subject := fmt.Sprintf("Hatchet token expiring in %s", payload.ExpiresAtRelativeDate)
+	subject := fmt.Sprintf("Hatchet token expiring %s", payload.ExpiresAtRelativeDate)
 
 	emails := strings.Split(emailGroup.Emails, ",")
 	tenantId := sqlchelpers.UUIDToStr(tenant.ID)

--- a/internal/integrations/alerting/email.go
+++ b/internal/integrations/alerting/email.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hatchet-dev/hatchet/internal/repository/prisma/sqlchelpers"
 )
 
-func (t *TenantAlertManager) sendEmailAlert(tenant *dbsqlc.Tenant, emailGroup *dbsqlc.TenantAlertEmailGroup, numFailed int, failedRuns []alerttypes.WorkflowRunFailedItem) error {
+func (t *TenantAlertManager) sendEmailWorkflowRunAlert(tenant *dbsqlc.Tenant, emailGroup *dbsqlc.TenantAlertEmailGroup, numFailed int, failedRuns []alerttypes.WorkflowRunFailedItem) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -34,6 +34,30 @@ func (t *TenantAlertManager) sendEmailAlert(tenant *dbsqlc.Tenant, emailGroup *d
 			Subject:      subject,
 			Summary:      subject,
 			SettingsLink: fmt.Sprintf("%s/tenant-settings/alerting?tenant=%s", t.serverURL, tenantId),
+		},
+	)
+}
+
+func (t *TenantAlertManager) sendEmailExpiringTokenAlert(tenant *dbsqlc.Tenant, emailGroup *dbsqlc.TenantAlertEmailGroup, payload *alerttypes.ExpiringTokenItem) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	subject := fmt.Sprintf("Hatchet token expiring in %s", payload.ExpiresAtRelativeDate)
+
+	emails := strings.Split(emailGroup.Emails, ",")
+	tenantId := sqlchelpers.UUIDToStr(tenant.ID)
+
+	return t.email.SendExpiringTokenEmail(
+		ctx,
+		emails,
+		email.ExpiringTokenEmailData{
+			TenantName:            tenant.Name,
+			TokenName:             payload.TokenName,
+			ExpiresAtAbsoluteDate: payload.ExpiresAtAbsoluteDate,
+			ExpiresAtRelativeDate: payload.ExpiresAtRelativeDate,
+			Subject:               subject,
+			TokenSettings:         payload.Link,
+			SettingsLink:          fmt.Sprintf("%s/tenant-settings/alerting?tenant=%s", t.serverURL, tenantId),
 		},
 	)
 }

--- a/internal/integrations/alerting/slack.go
+++ b/internal/integrations/alerting/slack.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hatchet-dev/hatchet/internal/repository/prisma/dbsqlc"
 )
 
-func (t *TenantAlertManager) sendSlackAlert(slackWebhook *dbsqlc.SlackAppWebhook, numFailed int, failedRuns []alerttypes.WorkflowRunFailedItem) error {
-	headerText, blocks := t.getSlackTextAndBlocks(numFailed, failedRuns)
+func (t *TenantAlertManager) sendSlackWorkflowRunAlert(slackWebhook *dbsqlc.SlackAppWebhook, numFailed int, failedRuns []alerttypes.WorkflowRunFailedItem) error {
+	headerText, blocks := t.getSlackWorkflowRunTextAndBlocks(numFailed, failedRuns)
 
 	// decrypt the webhook url
 	whDecrypted, err := t.enc.Decrypt(slackWebhook.WebhookURL, "incoming_webhook_url")
@@ -31,7 +31,7 @@ func (t *TenantAlertManager) sendSlackAlert(slackWebhook *dbsqlc.SlackAppWebhook
 	return nil
 }
 
-func (t *TenantAlertManager) getSlackTextAndBlocks(numFailed int, failedRuns []alerttypes.WorkflowRunFailedItem) (string, *slack.Blocks) {
+func (t *TenantAlertManager) getSlackWorkflowRunTextAndBlocks(numFailed int, failedRuns []alerttypes.WorkflowRunFailedItem) (string, *slack.Blocks) {
 	res := make([]slack.Block, 0)
 
 	headerText := fmt.Sprintf("%d Hatchet workflows failed:", numFailed)
@@ -74,6 +74,66 @@ func (t *TenantAlertManager) getSlackTextAndBlocks(numFailed int, failedRuns []a
 			buttonAccessory,
 		))
 	}
+
+	return headerText, &slack.Blocks{
+		BlockSet: res,
+	}
+}
+
+func (t *TenantAlertManager) sendSlackExpiringTokenAlert(slackWebhook *dbsqlc.SlackAppWebhook, payload *alerttypes.ExpiringTokenItem) error {
+	headerText, blocks := t.getSlackExpiringTokenTextAndBlocks(payload)
+
+	// decrypt the webhook url
+	whDecrypted, err := t.enc.Decrypt(slackWebhook.WebhookURL, "incoming_webhook_url")
+
+	if err != nil {
+		return err
+	}
+
+	err = slack.PostWebhook(string(whDecrypted), &slack.WebhookMessage{
+		Text:   headerText,
+		Blocks: blocks,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *TenantAlertManager) getSlackExpiringTokenTextAndBlocks(payload *alerttypes.ExpiringTokenItem) (string, *slack.Blocks) {
+	res := make([]slack.Block, 0)
+
+	headerText := fmt.Sprintf(":lock: Heads up! Your `%s` hatchet token will expire in %s", payload.TokenName, payload.ExpiresAtRelativeDate)
+
+	res = append(res, slack.NewSectionBlock(
+		slack.NewTextBlockObject(slack.MarkdownType, headerText, false, false),
+		nil,
+		nil,
+	))
+
+	buttonAccessory := slack.NewAccessory(
+		slack.NewButtonBlockElement(
+			"Manage Tokens",
+			payload.TokenName,
+			slack.NewTextBlockObject(slack.PlainTextType, "View", true, false),
+		),
+	)
+
+	buttonAccessory.ButtonElement.URL = payload.Link
+	buttonAccessory.ButtonElement.ActionID = "button-action"
+
+	res = append(res, slack.NewSectionBlock(
+		slack.NewTextBlockObject(
+			slack.MarkdownType,
+			"Once expired, any workers or clients using this token will no longer be able to connect to Hatchet.",
+			false,
+			false,
+		),
+		nil,
+		buttonAccessory,
+	))
 
 	return headerText, &slack.Blocks{
 		BlockSet: res,

--- a/internal/integrations/alerting/slack.go
+++ b/internal/integrations/alerting/slack.go
@@ -105,7 +105,7 @@ func (t *TenantAlertManager) sendSlackExpiringTokenAlert(slackWebhook *dbsqlc.Sl
 func (t *TenantAlertManager) getSlackExpiringTokenTextAndBlocks(payload *alerttypes.ExpiringTokenItem) (string, *slack.Blocks) {
 	res := make([]slack.Block, 0)
 
-	headerText := fmt.Sprintf(":lock: Heads up! Your `%s` hatchet token will expire %s", payload.TokenName, payload.ExpiresAtRelativeDate)
+	headerText := fmt.Sprintf(":lock: Heads up! Your `%s` hatchet token will expire `%s`", payload.TokenName, payload.ExpiresAtRelativeDate)
 
 	res = append(res, slack.NewSectionBlock(
 		slack.NewTextBlockObject(slack.MarkdownType, headerText, false, false),
@@ -117,7 +117,7 @@ func (t *TenantAlertManager) getSlackExpiringTokenTextAndBlocks(payload *alertty
 		slack.NewButtonBlockElement(
 			"Manage Tokens",
 			payload.TokenName,
-			slack.NewTextBlockObject(slack.PlainTextType, "View", true, false),
+			slack.NewTextBlockObject(slack.PlainTextType, "Manage Tokens", true, false),
 		),
 	)
 

--- a/internal/integrations/alerting/slack.go
+++ b/internal/integrations/alerting/slack.go
@@ -105,7 +105,7 @@ func (t *TenantAlertManager) sendSlackExpiringTokenAlert(slackWebhook *dbsqlc.Sl
 func (t *TenantAlertManager) getSlackExpiringTokenTextAndBlocks(payload *alerttypes.ExpiringTokenItem) (string, *slack.Blocks) {
 	res := make([]slack.Block, 0)
 
-	headerText := fmt.Sprintf(":lock: Heads up! Your `%s` hatchet token will expire in %s", payload.TokenName, payload.ExpiresAtRelativeDate)
+	headerText := fmt.Sprintf(":lock: Heads up! Your `%s` hatchet token will expire %s", payload.TokenName, payload.ExpiresAtRelativeDate)
 
 	res = append(res, slack.NewSectionBlock(
 		slack.NewTextBlockObject(slack.MarkdownType, headerText, false, false),

--- a/internal/integrations/email/email.go
+++ b/internal/integrations/email/email.go
@@ -20,12 +20,23 @@ type WorkflowRunsFailedEmailData struct {
 	SettingsLink string                             `json:"settings_link"`
 }
 
+type ExpiringTokenEmailData struct {
+	ExpiresAtAbsoluteDate string `json:"expires_at_absolute_date"`
+	ExpiresAtRelativeDate string `json:"expires_at_relative_date"`
+	TokenName             string `json:"token_name"`
+	Subject               string `json:"subject"`
+	TenantName            string `json:"tenant_name"`
+	TokenSettings         string `json:"token_settings"`
+	SettingsLink          string `json:"settings_link"`
+}
+
 type EmailService interface {
 	// for clients to show email settings
 	IsValid() bool
 
 	SendTenantInviteEmail(ctx context.Context, email string, data TenantInviteEmailData) error
 	SendWorkflowRunFailedAlerts(ctx context.Context, emails []string, data WorkflowRunsFailedEmailData) error
+	SendExpiringTokenEmail(ctx context.Context, emails []string, data ExpiringTokenEmailData) error
 }
 
 type NoOpService struct{}
@@ -39,5 +50,9 @@ func (s *NoOpService) SendTenantInviteEmail(ctx context.Context, email string, d
 }
 
 func (s *NoOpService) SendWorkflowRunFailedAlerts(ctx context.Context, emails []string, data WorkflowRunsFailedEmailData) error {
+	return nil
+}
+
+func (s *NoOpService) SendExpiringTokenEmail(ctx context.Context, emails []string, data ExpiringTokenEmailData) error {
 	return nil
 }

--- a/internal/integrations/email/postmark/postmark.go
+++ b/internal/integrations/email/postmark/postmark.go
@@ -35,6 +35,7 @@ const (
 	postmarkAPIURL             = "https://api.postmarkapp.com"
 	userInviteTemplate         = "user-invitation"
 	workflowRunsFailedTemplate = "workflow-runs-failed"
+	tokenAlertExpiringTemplate = "token-expiring" // nolint: gosec
 )
 
 type sendEmailFromTemplateRequest struct {
@@ -59,6 +60,10 @@ func (c *PostmarkClient) SendTenantInviteEmail(ctx context.Context, to string, d
 
 func (c *PostmarkClient) SendWorkflowRunFailedAlerts(ctx context.Context, emails []string, data email.WorkflowRunsFailedEmailData) error {
 	return c.sendTemplateEmailBCC(ctx, strings.Join(emails, ","), workflowRunsFailedTemplate, data)
+}
+
+func (c *PostmarkClient) SendExpiringTokenEmail(ctx context.Context, emails []string, data email.ExpiringTokenEmailData) error {
+	return c.sendTemplateEmail(ctx, strings.Join(emails, ","), tokenAlertExpiringTemplate, data)
 }
 
 func (c *PostmarkClient) sendTemplateEmail(ctx context.Context, to, templateAlias string, templateModelData interface{}) error {

--- a/internal/repository/prisma/dbsqlc/api_tokens.sql.go
+++ b/internal/repository/prisma/dbsqlc/api_tokens.sql.go
@@ -26,7 +26,7 @@ INSERT INTO "APIToken" (
     $2::uuid,
     $3::text,
     $4::timestamp
-) RETURNING id, "createdAt", "updatedAt", "expiresAt", revoked, name, "tenantId"
+) RETURNING id, "createdAt", "updatedAt", "expiresAt", revoked, name, "tenantId", "nextAlertAt"
 `
 
 type CreateAPITokenParams struct {
@@ -52,13 +52,14 @@ func (q *Queries) CreateAPIToken(ctx context.Context, db DBTX, arg CreateAPIToke
 		&i.Revoked,
 		&i.Name,
 		&i.TenantId,
+		&i.NextAlertAt,
 	)
 	return &i, err
 }
 
 const getAPITokenById = `-- name: GetAPITokenById :one
 SELECT
-    id, "createdAt", "updatedAt", "expiresAt", revoked, name, "tenantId"
+    id, "createdAt", "updatedAt", "expiresAt", revoked, name, "tenantId", "nextAlertAt"
 FROM
     "APIToken"
 WHERE
@@ -76,6 +77,7 @@ func (q *Queries) GetAPITokenById(ctx context.Context, db DBTX, id pgtype.UUID) 
 		&i.Revoked,
 		&i.Name,
 		&i.TenantId,
+		&i.NextAlertAt,
 	)
 	return &i, err
 }

--- a/internal/repository/prisma/dbsqlc/models.go
+++ b/internal/repository/prisma/dbsqlc/models.go
@@ -503,13 +503,14 @@ func (ns NullWorkflowRunStatus) Value() (driver.Value, error) {
 }
 
 type APIToken struct {
-	ID        pgtype.UUID      `json:"id"`
-	CreatedAt pgtype.Timestamp `json:"createdAt"`
-	UpdatedAt pgtype.Timestamp `json:"updatedAt"`
-	ExpiresAt pgtype.Timestamp `json:"expiresAt"`
-	Revoked   bool             `json:"revoked"`
-	Name      pgtype.Text      `json:"name"`
-	TenantId  pgtype.UUID      `json:"tenantId"`
+	ID          pgtype.UUID      `json:"id"`
+	CreatedAt   pgtype.Timestamp `json:"createdAt"`
+	UpdatedAt   pgtype.Timestamp `json:"updatedAt"`
+	ExpiresAt   pgtype.Timestamp `json:"expiresAt"`
+	Revoked     bool             `json:"revoked"`
+	Name        pgtype.Text      `json:"name"`
+	TenantId    pgtype.UUID      `json:"tenantId"`
+	NextAlertAt pgtype.Timestamp `json:"nextAlertAt"`
 }
 
 type Action struct {

--- a/internal/repository/prisma/dbsqlc/schema.sql
+++ b/internal/repository/prisma/dbsqlc/schema.sql
@@ -40,6 +40,7 @@ CREATE TABLE "APIToken" (
     "revoked" BOOLEAN NOT NULL DEFAULT false,
     "name" TEXT,
     "tenantId" UUID,
+    "nextAlertAt" TIMESTAMP(3),
 
     CONSTRAINT "APIToken_pkey" PRIMARY KEY ("id")
 );

--- a/internal/repository/prisma/dbsqlc/tickers.sql
+++ b/internal/repository/prisma/dbsqlc/tickers.sql
@@ -258,3 +258,34 @@ WHERE
     alerts."id" = active_tenant_alerts."id" AND
     alerts."tenantId" IN (SELECT "tenantId" FROM failed_run_count_by_tenant WHERE "failedWorkflowRunCount" > 0)
 RETURNING alerts.*, active_tenant_alerts."lastAlertedAt" AS "prevLastAlertedAt";
+
+
+-- name: PollExpiringTokens :many
+WITH expiring_tokens AS (
+    SELECT
+        t0."id", t0."name", t0."expiresAt"
+    FROM
+        "APIToken" as t0
+    WHERE
+        t0."revoked" = false
+        AND t0."expiresAt" <= NOW() + INTERVAL '1 year'
+        AND (
+            t0."nextAlertAt" IS NULL OR
+            t0."nextAlertAt" <= NOW()
+        )
+    FOR UPDATE SKIP LOCKED
+    LIMIT 100
+)
+UPDATE
+    "APIToken" as t1
+SET
+    "nextAlertAt" = NOW() + INTERVAL '1 day'
+FROM
+    expiring_tokens
+WHERE
+    t1."id" = expiring_tokens."id"
+RETURNING
+    t1."id",
+    t1."name",
+    t1."tenantId",
+    t1."expiresAt";

--- a/internal/repository/prisma/dbsqlc/tickers.sql
+++ b/internal/repository/prisma/dbsqlc/tickers.sql
@@ -269,6 +269,7 @@ WITH expiring_tokens AS (
     WHERE
         t0."revoked" = false
         AND t0."expiresAt" <= NOW() + INTERVAL '7 days'
+        AND t0."expiresAt" >= NOW()
         AND (
             t0."nextAlertAt" IS NULL OR
             t0."nextAlertAt" <= NOW()

--- a/internal/repository/prisma/dbsqlc/tickers.sql
+++ b/internal/repository/prisma/dbsqlc/tickers.sql
@@ -268,7 +268,7 @@ WITH expiring_tokens AS (
         "APIToken" as t0
     WHERE
         t0."revoked" = false
-        AND t0."expiresAt" <= NOW() + INTERVAL '1 year'
+        AND t0."expiresAt" <= NOW() + INTERVAL '7 days'
         AND (
             t0."nextAlertAt" IS NULL OR
             t0."nextAlertAt" <= NOW()

--- a/internal/repository/prisma/dbsqlc/tickers.sql.go
+++ b/internal/repository/prisma/dbsqlc/tickers.sql.go
@@ -263,6 +263,69 @@ func (q *Queries) PollCronSchedules(ctx context.Context, db DBTX, tickerid pgtyp
 	return items, nil
 }
 
+const pollExpiringTokens = `-- name: PollExpiringTokens :many
+WITH expiring_tokens AS (
+    SELECT
+        t0."id", t0."name", t0."expiresAt"
+    FROM
+        "APIToken" as t0
+    WHERE
+        t0."revoked" = false
+        AND t0."expiresAt" <= NOW() + INTERVAL '1 year'
+        AND (
+            t0."nextAlertAt" IS NULL OR
+            t0."nextAlertAt" <= NOW()
+        )
+    FOR UPDATE SKIP LOCKED
+    LIMIT 100
+)
+UPDATE
+    "APIToken" as t1
+SET
+    "nextAlertAt" = NOW() + INTERVAL '1 day'
+FROM
+    expiring_tokens
+WHERE
+    t1."id" = expiring_tokens."id"
+RETURNING
+    t1."id",
+    t1."name",
+    t1."tenantId",
+    t1."expiresAt"
+`
+
+type PollExpiringTokensRow struct {
+	ID        pgtype.UUID      `json:"id"`
+	Name      pgtype.Text      `json:"name"`
+	TenantId  pgtype.UUID      `json:"tenantId"`
+	ExpiresAt pgtype.Timestamp `json:"expiresAt"`
+}
+
+func (q *Queries) PollExpiringTokens(ctx context.Context, db DBTX) ([]*PollExpiringTokensRow, error) {
+	rows, err := db.Query(ctx, pollExpiringTokens)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*PollExpiringTokensRow
+	for rows.Next() {
+		var i PollExpiringTokensRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.TenantId,
+			&i.ExpiresAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const pollGetGroupKeyRuns = `-- name: PollGetGroupKeyRuns :many
 WITH getGroupKeyRunsToTimeout AS (
     SELECT

--- a/internal/repository/prisma/dbsqlc/tickers.sql.go
+++ b/internal/repository/prisma/dbsqlc/tickers.sql.go
@@ -272,6 +272,7 @@ WITH expiring_tokens AS (
     WHERE
         t0."revoked" = false
         AND t0."expiresAt" <= NOW() + INTERVAL '7 days'
+        AND t0."expiresAt" >= NOW()
         AND (
             t0."nextAlertAt" IS NULL OR
             t0."nextAlertAt" <= NOW()

--- a/internal/repository/prisma/dbsqlc/tickers.sql.go
+++ b/internal/repository/prisma/dbsqlc/tickers.sql.go
@@ -271,7 +271,7 @@ WITH expiring_tokens AS (
         "APIToken" as t0
     WHERE
         t0."revoked" = false
-        AND t0."expiresAt" <= NOW() + INTERVAL '1 year'
+        AND t0."expiresAt" <= NOW() + INTERVAL '7 days'
         AND (
             t0."nextAlertAt" IS NULL OR
             t0."nextAlertAt" <= NOW()

--- a/internal/repository/prisma/ticker.go
+++ b/internal/repository/prisma/ticker.go
@@ -104,3 +104,7 @@ func (t *tickerRepository) PollScheduledWorkflows(ctx context.Context, tickerId 
 func (t *tickerRepository) PollTenantAlerts(ctx context.Context, tickerId string) ([]*dbsqlc.PollTenantAlertsRow, error) {
 	return t.queries.PollTenantAlerts(ctx, t.pool, sqlchelpers.UUIDFromStr(tickerId))
 }
+
+func (t *tickerRepository) PollExpiringTokens(ctx context.Context) ([]*dbsqlc.PollExpiringTokensRow, error) {
+	return t.queries.PollExpiringTokens(ctx, t.pool)
+}

--- a/internal/repository/ticker.go
+++ b/internal/repository/ticker.go
@@ -48,6 +48,7 @@ type TickerEngineRepository interface {
 
 	PollTenantAlerts(ctx context.Context, tickerId string) ([]*dbsqlc.PollTenantAlertsRow, error)
 
+	PollExpiringTokens(ctx context.Context) ([]*dbsqlc.PollExpiringTokensRow, error)
 	// // AddJobRun assigns a job run to a ticker.
 	// AddJobRun(tickerId string, jobRun *db.JobRunModel) (*db.TickerModel, error)
 

--- a/internal/services/ticker/tenant_alerting.go
+++ b/internal/services/ticker/tenant_alerting.go
@@ -28,7 +28,7 @@ func (t *TickerImpl) runPollTenantAlerts(ctx context.Context) func() {
 
 			t.l.Debug().Msgf("ticker: handling alert for tenant %s", tenantId)
 
-			innerErr := t.ta.SendAlert(tenantId, alert.PrevLastAlertedAt.Time)
+			innerErr := t.ta.SendWorkflowRunAlert(tenantId, alert.PrevLastAlertedAt.Time)
 
 			if innerErr != nil {
 				err = multierror.Append(err, innerErr)
@@ -37,6 +37,40 @@ func (t *TickerImpl) runPollTenantAlerts(ctx context.Context) func() {
 
 		if err != nil {
 			t.l.Err(err).Msg("could not handle tenant alerts")
+		}
+	}
+}
+
+func (t *TickerImpl) runExpiringTokenAlerts(ctx context.Context) func() {
+	return func() {
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		t.l.Debug().Msg("ticker: polling expiring tokens")
+
+		expiring_tokens, err := t.repo.Ticker().PollExpiringTokens(ctx)
+
+		if err != nil {
+			t.l.Err(err).Msg("could not poll expiring tokens")
+			return
+		}
+
+		t.l.Debug().Msgf("ticker: alerting %d expiring tokens", len(expiring_tokens))
+
+		for _, expiring_token := range expiring_tokens {
+			tenantId := sqlchelpers.UUIDToStr(expiring_token.TenantId)
+
+			t.l.Debug().Msgf("ticker: handling expiring token for tenant %s", tenantId)
+
+			innerErr := t.ta.SendExpiringTokenAlert(tenantId, expiring_token)
+
+			if innerErr != nil {
+				err = multierror.Append(err, innerErr)
+			}
+		}
+
+		if err != nil {
+			t.l.Err(err).Msg("could not handle expiring tokens")
 		}
 	}
 }

--- a/internal/services/ticker/ticker.go
+++ b/internal/services/ticker/ticker.go
@@ -222,6 +222,19 @@ func (t *TickerImpl) Start() (func() error, error) {
 		return nil, fmt.Errorf("could not schedule tenant alert polling: %w", err)
 	}
 
+	// poll for expiring tokens every 1 minutes
+	_, err = t.s.NewJob(
+		gocron.DurationJob(time.Minute*1),
+		gocron.NewTask(
+			t.runExpiringTokenAlerts(ctx),
+		),
+	)
+
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("could not schedule tenant alert polling: %w", err)
+	}
+
 	// poll to resolve worker semaphore slots every 1 minute
 	_, err = t.s.NewJob(
 		gocron.DurationJob(time.Minute*1),

--- a/internal/services/ticker/ticker.go
+++ b/internal/services/ticker/ticker.go
@@ -222,9 +222,9 @@ func (t *TickerImpl) Start() (func() error, error) {
 		return nil, fmt.Errorf("could not schedule tenant alert polling: %w", err)
 	}
 
-	// poll for expiring tokens every 1 minutes
+	// poll for expiring tokens every 15 minutes
 	_, err = t.s.NewJob(
-		gocron.DurationJob(time.Minute*1),
+		gocron.DurationJob(time.Minute*15),
 		gocron.NewTask(
 			t.runExpiringTokenAlerts(ctx),
 		),

--- a/prisma/migrations/20240531142907_v0_29_0/migration.sql
+++ b/prisma/migrations/20240531142907_v0_29_0/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "APIToken" ADD COLUMN     "nextAlertAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -221,6 +221,9 @@ model APIToken {
   // whether the token has been revoked
   revoked Boolean @default(false)
 
+  // when to next alert about expiration
+  nextAlertAt DateTime?
+
   // an optional name for the token
   name String?
 


### PR DESCRIPTION
# Description

Tokens expire after 90 days with no warning, adds daily slack and email alerts for tokens expiring within 1 week.

Fixes #255 HAT-260

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## What's Changed

- [x] Add `nextAlertAt` column to APIToken to track when to send the next notification
- [x] Add ticker for polling expiring tokens
- [x] Add Slack template
- [x] Add Email template
