### PR TITLE
fix: keep semaphore table

### DIFF
--- a/internal/repository/prisma/dbsqlc/models.go
+++ b/internal/repository/prisma/dbsqlc/models.go
@@ -969,6 +969,11 @@ type Worker struct {
 	LastListenerEstablished pgtype.Timestamp `json:"lastListenerEstablished"`
 }
 
+type WorkerSemaphore struct {
+	WorkerId pgtype.UUID `json:"workerId"`
+	Slots    int32       `json:"slots"`
+}
+
 type WorkerSemaphoreSlot struct {
 	ID        pgtype.UUID `json:"id"`
 	WorkerId  pgtype.UUID `json:"workerId"`

--- a/internal/repository/prisma/dbsqlc/schema.sql
+++ b/internal/repository/prisma/dbsqlc/schema.sql
@@ -564,6 +564,12 @@ CREATE TABLE "Worker" (
 );
 
 -- CreateTable
+CREATE TABLE "WorkerSemaphore" (
+    "workerId" UUID NOT NULL,
+    "slots" INTEGER NOT NULL
+);
+
+-- CreateTable
 CREATE TABLE "WorkerSemaphoreSlot" (
     "id" UUID NOT NULL,
     "workerId" UUID NOT NULL,
@@ -956,6 +962,9 @@ CREATE UNIQUE INDEX "UserSession_id_key" ON "UserSession"("id" ASC);
 CREATE UNIQUE INDEX "Worker_id_key" ON "Worker"("id" ASC);
 
 -- CreateIndex
+CREATE UNIQUE INDEX "WorkerSemaphore_workerId_key" ON "WorkerSemaphore"("workerId" ASC);
+
+-- CreateIndex
 CREATE UNIQUE INDEX "WorkerSemaphoreSlot_id_key" ON "WorkerSemaphoreSlot"("id" ASC);
 
 -- CreateIndex
@@ -1242,6 +1251,9 @@ ALTER TABLE "Worker" ADD CONSTRAINT "Worker_dispatcherId_fkey" FOREIGN KEY ("dis
 
 -- AddForeignKey
 ALTER TABLE "Worker" ADD CONSTRAINT "Worker_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WorkerSemaphore" ADD CONSTRAINT "WorkerSemaphore_workerId_fkey" FOREIGN KEY ("workerId") REFERENCES "Worker"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "WorkerSemaphoreSlot" ADD CONSTRAINT "WorkerSemaphoreSlot_stepRunId_fkey" FOREIGN KEY ("stepRunId") REFERENCES "StepRun"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20240531200418_v0_30_1/migration.sql
+++ b/prisma/migrations/20240531200418_v0_30_1/migration.sql
@@ -3,8 +3,6 @@
 - Made the column `maxRuns` on table `Worker` required. This step will fail if there are existing NULL values in that column.
 */
 
--- DropForeignKey
-ALTER TABLE "WorkerSemaphore" DROP CONSTRAINT IF EXISTS "WorkerSemaphore_workerId_fkey";
 
 -- Update existing workers with NULL maxRuns to have a default value
 UPDATE "Worker" SET "maxRuns" = 100 WHERE "maxRuns" IS NULL;
@@ -12,9 +10,6 @@ UPDATE "Worker" SET "maxRuns" = 100 WHERE "maxRuns" IS NULL;
 -- AlterTable
 ALTER TABLE "Worker" ALTER COLUMN "maxRuns" SET NOT NULL,
                      ALTER COLUMN "maxRuns" SET DEFAULT 100;
-
--- DropTable
-DROP TABLE IF EXISTS "WorkerSemaphore";
 
 -- CreateTable
 CREATE TABLE IF NOT EXISTS "WorkerSemaphoreSlot" (

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1206,6 +1206,19 @@ model Worker {
   groupKeyRuns GetGroupKeyRun[]
 
   slots WorkerSemaphoreSlot[]
+
+  // DEPRECATED in v_0_30_1, replaced with slots and will be removed in a future release
+  semaphore WorkerSemaphore? // FIXME remove this in a few releases from v_0_30_1
+}
+
+// DEPRECATED in v_0_30_1, replaced with slots and will be removed in a future release
+// FIXME remove in a future release
+model WorkerSemaphore {
+  // the parent worker
+  worker   Worker @relation(fields: [workerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  workerId String @unique @db.Uuid
+  // keeps track of maxRuns - runningRuns on the worker
+  slots Int
 }
 
 model WorkerSemaphoreSlot {


### PR DESCRIPTION
# Description

Dropping the WorkerSemaphore table in #540 results in dropped step run event writing.

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Remove drop table from migration and prisma schema

