### PR TITLE
fix: ensure auth redirects throw an error

### DIFF
--- a/api/v1/server/authn/middleware.go
+++ b/api/v1/server/authn/middleware.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/hatchet-dev/hatchet/api/v1/server/middleware"
+	"github.com/hatchet-dev/hatchet/api/v1/server/middleware/redirect"
 	"github.com/hatchet-dev/hatchet/internal/config/server"
 	"github.com/hatchet-dev/hatchet/internal/repository/prisma/db"
 )
@@ -82,13 +83,13 @@ func (a *AuthN) handleNoAuth(c echo.Context) error {
 	if err != nil {
 		a.l.Debug().Err(err).Msg("error getting session")
 
-		return GetRedirectWithError(c, a.l, err, "Could not log in. Please try again and make sure cookies are enabled.")
+		return redirect.GetRedirectWithError(c, a.l, err, "Could not log in. Please try again and make sure cookies are enabled.")
 	}
 
 	if auth, ok := session.Values["authenticated"].(bool); ok && auth {
 		a.l.Debug().Msgf("user was authenticated when no security schemes permit auth")
 
-		return GetRedirectNoError(c, a.config.Runtime.ServerURL)
+		return redirect.GetRedirectNoError(c, a.config.Runtime.ServerURL)
 	}
 
 	// set unauthenticated session in context

--- a/api/v1/server/handlers/github-app/oauth_start.go
+++ b/api/v1/server/handlers/github-app/oauth_start.go
@@ -5,6 +5,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/hatchet-dev/hatchet/api/v1/server/authn"
+	"github.com/hatchet-dev/hatchet/api/v1/server/middleware/redirect"
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
 )
 
@@ -13,13 +14,13 @@ func (g *GithubAppService) UserUpdateGithubAppOauthStart(ctx echo.Context, _ gen
 	ghApp, err := GetGithubAppConfig(g.config)
 
 	if err != nil {
-		return nil, authn.GetRedirectWithError(ctx, g.config.Logger, err, "Github app is misconfigured on this Hatchet instance.")
+		return nil, redirect.GetRedirectWithError(ctx, g.config.Logger, err, "Github app is misconfigured on this Hatchet instance.")
 	}
 
 	state, err := authn.NewSessionHelpers(g.config).SaveOAuthState(ctx, "github")
 
 	if err != nil {
-		return nil, authn.GetRedirectWithError(ctx, g.config.Logger, err, "Could not get cookie. Please make sure cookies are enabled.")
+		return nil, redirect.GetRedirectWithError(ctx, g.config.Logger, err, "Could not get cookie. Please make sure cookies are enabled.")
 	}
 
 	url := ghApp.AuthCodeURL(state, oauth2.AccessTypeOffline)

--- a/api/v1/server/handlers/slack-app/oauth_start.go
+++ b/api/v1/server/handlers/slack-app/oauth_start.go
@@ -5,6 +5,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/hatchet-dev/hatchet/api/v1/server/authn"
+	"github.com/hatchet-dev/hatchet/api/v1/server/middleware/redirect"
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
 	"github.com/hatchet-dev/hatchet/internal/repository/prisma/db"
 )
@@ -16,19 +17,19 @@ func (g *SlackAppService) UserUpdateSlackOauthStart(ctx echo.Context, _ gen.User
 	oauth, ok := g.config.AdditionalOAuthConfigs["slack"]
 
 	if !ok {
-		return nil, authn.GetRedirectWithError(ctx, g.config.Logger, nil, "Slack OAuth is not configured on this Hatchet instance.")
+		return nil, redirect.GetRedirectWithError(ctx, g.config.Logger, nil, "Slack OAuth is not configured on this Hatchet instance.")
 	}
 
 	sh := authn.NewSessionHelpers(g.config)
 
 	if err := sh.SaveKV(ctx, "tenant", tenant.ID); err != nil {
-		return nil, authn.GetRedirectWithError(ctx, g.config.Logger, err, "Could not get cookie. Please make sure cookies are enabled.")
+		return nil, redirect.GetRedirectWithError(ctx, g.config.Logger, err, "Could not get cookie. Please make sure cookies are enabled.")
 	}
 
 	state, err := sh.SaveOAuthState(ctx, "slack")
 
 	if err != nil {
-		return nil, authn.GetRedirectWithError(ctx, g.config.Logger, err, "Could not get cookie. Please make sure cookies are enabled.")
+		return nil, redirect.GetRedirectWithError(ctx, g.config.Logger, err, "Could not get cookie. Please make sure cookies are enabled.")
 	}
 
 	url := oauth.AuthCodeURL(state, oauth2.AccessTypeOffline)

--- a/api/v1/server/handlers/users/github_oauth_callback.go
+++ b/api/v1/server/handlers/users/github_oauth_callback.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/hatchet-dev/hatchet/api/v1/server/authn"
+	"github.com/hatchet-dev/hatchet/api/v1/server/middleware/redirect"
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
 	"github.com/hatchet-dev/hatchet/internal/config/server"
 	"github.com/hatchet-dev/hatchet/internal/repository"
@@ -21,37 +22,37 @@ func (u *UserService) UserUpdateGithubOauthCallback(ctx echo.Context, _ gen.User
 	isValid, _, err := authn.NewSessionHelpers(u.config).ValidateOAuthState(ctx, "github")
 
 	if err != nil || !isValid {
-		return nil, authn.GetRedirectWithError(ctx, u.config.Logger, err, "Could not log in. Please try again and make sure cookies are enabled.")
+		return nil, redirect.GetRedirectWithError(ctx, u.config.Logger, err, "Could not log in. Please try again and make sure cookies are enabled.")
 	}
 
 	token, err := u.config.Auth.GithubOAuthConfig.Exchange(context.Background(), ctx.Request().URL.Query().Get("code"))
 
 	if err != nil {
-		return nil, authn.GetRedirectWithError(ctx, u.config.Logger, err, "Forbidden")
+		return nil, redirect.GetRedirectWithError(ctx, u.config.Logger, err, "Forbidden")
 	}
 
 	if !token.Valid() {
-		return nil, authn.GetRedirectWithError(ctx, u.config.Logger, fmt.Errorf("invalid token"), "Forbidden")
+		return nil, redirect.GetRedirectWithError(ctx, u.config.Logger, fmt.Errorf("invalid token"), "Forbidden")
 	}
 
 	user, err := u.upsertGithubUserFromToken(u.config, token)
 
 	if err != nil {
 		if errors.Is(err, ErrGithubNotVerified) {
-			return nil, authn.GetRedirectWithError(ctx, u.config.Logger, err, "Please verify your email on Github.")
+			return nil, redirect.GetRedirectWithError(ctx, u.config.Logger, err, "Please verify your email on Github.")
 		}
 
 		if errors.Is(err, ErrGithubNoEmail) {
-			return nil, authn.GetRedirectWithError(ctx, u.config.Logger, err, "Github user must have an email.")
+			return nil, redirect.GetRedirectWithError(ctx, u.config.Logger, err, "Github user must have an email.")
 		}
 
-		return nil, authn.GetRedirectWithError(ctx, u.config.Logger, err, "Internal error.")
+		return nil, redirect.GetRedirectWithError(ctx, u.config.Logger, err, "Internal error.")
 	}
 
 	err = authn.NewSessionHelpers(u.config).SaveAuthenticated(ctx, user)
 
 	if err != nil {
-		return nil, authn.GetRedirectWithError(ctx, u.config.Logger, err, "Internal error.")
+		return nil, redirect.GetRedirectWithError(ctx, u.config.Logger, err, "Internal error.")
 	}
 
 	return gen.UserUpdateGithubOauthCallback302Response{

--- a/api/v1/server/handlers/users/github_oauth_start.go
+++ b/api/v1/server/handlers/users/github_oauth_start.go
@@ -4,6 +4,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"github.com/hatchet-dev/hatchet/api/v1/server/authn"
+	"github.com/hatchet-dev/hatchet/api/v1/server/middleware/redirect"
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
 )
 
@@ -12,7 +13,7 @@ func (u *UserService) UserUpdateGithubOauthStart(ctx echo.Context, _ gen.UserUpd
 	state, err := authn.NewSessionHelpers(u.config).SaveOAuthState(ctx, "github")
 
 	if err != nil {
-		return nil, authn.GetRedirectWithError(ctx, u.config.Logger, err, "Could not get cookie. Please make sure cookies are enabled.")
+		return nil, redirect.GetRedirectWithError(ctx, u.config.Logger, err, "Could not get cookie. Please make sure cookies are enabled.")
 	}
 
 	url := u.config.Auth.GithubOAuthConfig.AuthCodeURL(state)

--- a/api/v1/server/handlers/users/google_oauth_start.go
+++ b/api/v1/server/handlers/users/google_oauth_start.go
@@ -4,6 +4,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"github.com/hatchet-dev/hatchet/api/v1/server/authn"
+	"github.com/hatchet-dev/hatchet/api/v1/server/middleware/redirect"
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
 )
 
@@ -12,7 +13,7 @@ func (u *UserService) UserUpdateGoogleOauthStart(ctx echo.Context, _ gen.UserUpd
 	state, err := authn.NewSessionHelpers(u.config).SaveOAuthState(ctx, "google")
 
 	if err != nil {
-		return nil, authn.GetRedirectWithError(ctx, u.config.Logger, err, "Could not get cookie. Please make sure cookies are enabled.")
+		return nil, redirect.GetRedirectWithError(ctx, u.config.Logger, err, "Could not get cookie. Please make sure cookies are enabled.")
 	}
 
 	url := u.config.Auth.GoogleOAuthConfig.AuthCodeURL(state)

--- a/api/v1/server/middleware/middleware.go
+++ b/api/v1/server/middleware/middleware.go
@@ -10,6 +10,8 @@ import (
 	"github.com/getkin/kin-openapi/routers/gorillamux"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/labstack/echo/v4"
+
+	"github.com/hatchet-dev/hatchet/api/v1/server/middleware/redirect"
 )
 
 type SecurityRequirement interface {

--- a/api/v1/server/middleware/redirect/redirect.go
+++ b/api/v1/server/middleware/redirect/redirect.go
@@ -1,15 +1,31 @@
-package authn
+package redirect
 
 import (
+	"errors"
+
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog"
 )
 
+var ErrRedirect = errors.New("redirecting")
+
 func GetRedirectWithError(ctx echo.Context, l *zerolog.Logger, internalErr error, userErr string) error {
 	l.Err(internalErr).Msgf("redirecting with error")
-	return ctx.Redirect(302, "/auth/login?error="+userErr)
+	err := ctx.Redirect(302, "/auth/login?error="+userErr)
+
+	if err != nil {
+		return err
+	}
+
+	return ErrRedirect
 }
 
 func GetRedirectNoError(ctx echo.Context, serverURL string) error {
-	return ctx.Redirect(302, serverURL)
+	err := ctx.Redirect(302, serverURL)
+
+	if err != nil {
+		return err
+	}
+
+	return ErrRedirect
 }


### PR DESCRIPTION
# Description

Auth redirects aren't currently throwing an error, which means there are situations where security should be disabled `security: []` causing an authenticated user to be able to call a handler. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)