### PR TITLE
fix: more casing in atlas-apply script

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -59,7 +59,7 @@ tasks:
     cmds:
       - task: generate-sqlc
       - sh ./hack/dev/atlas-migrate.sh {{.CLI_ARGS}}
-      - DATABASE_URL='postgresql://hatchet:hatchet@127.0.0.1:5431/hatchet?sslmode=disable' sh ./hack/db/atlas-apply.sh
+      - DATABASE_URL='postgresql://hatchet:hatchet@127.0.0.1:5431/hatchet' sh ./hack/db/atlas-apply.sh
   prisma-push:
     cmds:
       - sh ./hack/dev/run-go-with-env.sh run github.com/steebchen/prisma-client-go db push


### PR DESCRIPTION
# Description

Strips the suffix from the prisma migration version when running atlas-apply, and also makes the `sslmode` query param optional to match the behavior of prisma. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)