### PR TITLE
fix: only print routes in debug mode

### DIFF
--- a/api/v1/server/run/run.go
+++ b/api/v1/server/run/run.go
@@ -86,7 +86,7 @@ func (t *APIServer) RunWithServer(e *echo.Echo) (func() error, error) {
 	routes := e.Routes()
 
 	for _, route := range routes {
-		fmt.Println(route.Method, route.Path)
+		t.config.Logger.Debug().Msgf("registered route: %s %s", route.Method, route.Path)
 	}
 
 	go func() {


### PR DESCRIPTION
# Description

Don't call `fmt.Println` on server startup unless we're debugging. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
