### PR TITLE
fix: run rabbitmq-server with docker entrypoint

### DIFF
--- a/hack/lite/start.sh
+++ b/hack/lite/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Start RabbitMQ
-rabbitmq-server &
+docker-entrypoint.sh rabbitmq-server &
 
 # Wait for RabbitMQ to be ready
 until rabbitmqctl status; do


### PR DESCRIPTION
# Description

Make sure starting rabbitmq-server is in line with the start command from the Dockerfile: https://github.com/docker-library/rabbitmq/blob/83604b7ec3bda015495dda883fe3b471f206d562/3.13/alpine/Dockerfile