### PR TITLE
fix: workflow run sort order

### DIFF
--- a/api/v1/server/handlers/workflows/list_runs.go
+++ b/api/v1/server/handlers/workflows/list_runs.go
@@ -19,10 +19,14 @@ func (t *WorkflowService) WorkflowRunList(ctx echo.Context, request gen.Workflow
 
 	limit := 50
 	offset := 0
+	orderDirection := "DESC"
+	orderBy := "createdAt"
 
 	listOpts := &repository.ListWorkflowRunsOpts{
-		Limit:  &limit,
-		Offset: &offset,
+		Limit:          &limit,
+		Offset:         &offset,
+		OrderBy:        &orderBy,
+		OrderDirection: &orderDirection,
 	}
 
 	if request.Params.Limit != nil {

--- a/frontend/app/src/pages/main/workflow-runs/components/workflow-runs-columns.tsx
+++ b/frontend/app/src/pages/main/workflow-runs/components/workflow-runs-columns.tsx
@@ -92,6 +92,29 @@ export const columns: ColumnDef<WorkflowRun>[] = [
     enableHiding: true,
   },
   {
+    accessorKey: 'Created at',
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        column={column}
+        title="Created at"
+        className="whitespace-nowrap"
+      />
+    ),
+    cell: ({ row }) => {
+      return (
+        <div className="whitespace-nowrap">
+          {row.original.metadata.createdAt ? (
+            <RelativeDate date={row.original.metadata.createdAt} />
+          ) : (
+            'N/A'
+          )}
+        </div>
+      );
+    },
+    enableSorting: false,
+    enableHiding: true,
+  },
+  {
     accessorKey: 'Started at',
     header: ({ column }) => (
       <DataTableColumnHeader


### PR DESCRIPTION
# Description

No default sort order on workflow run list can cause jitter on poll

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

