### PR TITLE
fix: only join latest workflow version

### DIFF
--- a/internal/repository/prisma/dbsqlc/workflows.sql
+++ b/internal/repository/prisma/dbsqlc/workflows.sql
@@ -364,10 +364,16 @@ INSERT INTO "WorkflowTriggerScheduledRef" (
 ) RETURNING *;
 
 -- name: ListWorkflowsForEvent :many
+WITH LatestWorkflowVersions AS (
+    SELECT DISTINCT ON ("workflowId") "id", "workflowId"
+    FROM "WorkflowVersion"
+    ORDER BY "workflowId", "order" DESC
+)
 SELECT DISTINCT ON ("WorkflowVersion"."workflowId") "WorkflowVersion".id
 FROM "WorkflowVersion"
 LEFT JOIN "Workflow" AS j1 ON j1.id = "WorkflowVersion"."workflowId"
 LEFT JOIN "WorkflowTriggers" AS j2 ON j2."workflowVersionId" = "WorkflowVersion"."id"
+JOIN LatestWorkflowVersions AS l ON l."id" = "WorkflowVersion"."id"
 WHERE
     (j1."tenantId"::uuid = @tenantId AND j1.id IS NOT NULL)
     AND

--- a/internal/repository/prisma/dbsqlc/workflows.sql.go
+++ b/internal/repository/prisma/dbsqlc/workflows.sql.go
@@ -938,10 +938,16 @@ func (q *Queries) ListWorkflows(ctx context.Context, db DBTX, arg ListWorkflowsP
 }
 
 const listWorkflowsForEvent = `-- name: ListWorkflowsForEvent :many
+WITH LatestWorkflowVersions AS (
+    SELECT DISTINCT ON ("workflowId") "id", "workflowId"
+    FROM "WorkflowVersion"
+    ORDER BY "workflowId", "order" DESC
+)
 SELECT DISTINCT ON ("WorkflowVersion"."workflowId") "WorkflowVersion".id
 FROM "WorkflowVersion"
 LEFT JOIN "Workflow" AS j1 ON j1.id = "WorkflowVersion"."workflowId"
 LEFT JOIN "WorkflowTriggers" AS j2 ON j2."workflowVersionId" = "WorkflowVersion"."id"
+JOIN LatestWorkflowVersions AS l ON l."id" = "WorkflowVersion"."id"
 WHERE
     (j1."tenantId"::uuid = $1 AND j1.id IS NOT NULL)
     AND

--- a/internal/repository/prisma/dbsqlc/workflows.sql.go
+++ b/internal/repository/prisma/dbsqlc/workflows.sql.go
@@ -938,16 +938,10 @@ func (q *Queries) ListWorkflows(ctx context.Context, db DBTX, arg ListWorkflowsP
 }
 
 const listWorkflowsForEvent = `-- name: ListWorkflowsForEvent :many
-WITH LatestWorkflowVersions AS (
-    SELECT DISTINCT ON ("workflowId") "id", "workflowId"
-    FROM "WorkflowVersion"
-    ORDER BY "workflowId", "order" DESC
-)
 SELECT DISTINCT ON ("WorkflowVersion"."workflowId") "WorkflowVersion".id
 FROM "WorkflowVersion"
 LEFT JOIN "Workflow" AS j1 ON j1.id = "WorkflowVersion"."workflowId"
 LEFT JOIN "WorkflowTriggers" AS j2 ON j2."workflowVersionId" = "WorkflowVersion"."id"
-JOIN LatestWorkflowVersions AS l ON l."id" = "WorkflowVersion"."id"
 WHERE
     (j1."tenantId"::uuid = $1 AND j1.id IS NOT NULL)
     AND
@@ -956,6 +950,14 @@ WHERE
         FROM "WorkflowTriggerEventRef" AS t3
         WHERE t3."eventKey" = $2 AND t3."parentId" IS NOT NULL
     ) AND j2.id IS NOT NULL)
+    AND "WorkflowVersion".id = (
+        -- confirm that the workflow version is the latest
+        SELECT wv2.id
+        FROM "WorkflowVersion" wv2
+        WHERE wv2."workflowId" = "WorkflowVersion"."workflowId"
+        ORDER BY wv2."order" DESC
+        LIMIT 1
+    )
 ORDER BY "WorkflowVersion"."workflowId", "WorkflowVersion"."order" DESC
 `
 


### PR DESCRIPTION
# Description

Old workflow version event triggers would trigger new workflow runs.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- Only filter Workflows to Run from the latest versions of workflows

