### PR TITLE
fix: multi-arch builds for latest on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,31 +19,61 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Pull and push hatchet-api
         run: |
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}
-          docker tag ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}} ghcr.io/hatchet-dev/hatchet/hatchet-api:latest
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-api:latest
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-arm64
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-amd64
+
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-api:latest \
+            ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-arm64
+
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-admin:latest
       - name: Pull and push hatchet-engine
         run: |
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}
-          docker tag ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}} ghcr.io/hatchet-dev/hatchet/hatchet-engine:latest
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-engine:latest
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-arm64
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-amd64
+
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-engine:latest \
+            ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-arm64
+
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-engine:latest
       - name: Pull and push hatchet-admin
         run: |
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}
-          docker tag ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}} ghcr.io/hatchet-dev/hatchet/hatchet-admin:latest
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-admin:latest
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-arm64
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-amd64
+
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-admin:latest \
+            ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-arm64
+
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-admin:latest
       - name: Pull and push hatchet-frontend
         run: |
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}
-          docker tag ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}} ghcr.io/hatchet-dev/hatchet/hatchet-frontend:latest
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-frontend:latest
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-arm64
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-amd64
+
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-frontend:latest \
+            ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-arm64
+
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-frontend:latest
       - name: Pull and push hatchet-migrate
         run: |
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}
-          docker tag ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}} ghcr.io/hatchet-dev/hatchet/hatchet-migrate:latest
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-migrate:latest
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-arm64
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-amd64
+
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-migrate:latest \
+            ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-arm64
+
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-migrate:latest
       - name: Pull and push hatchet-lite
         run: |
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}
-          docker tag ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}} ghcr.io/hatchet-dev/hatchet/hatchet-lite:latest
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-lite:latest
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-arm64
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-amd64
+
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-lite:latest \
+            ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-arm64
+
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-lite:latest


### PR DESCRIPTION
# Description

`latest` should be a multi-arch image, right now it's pushing/pulling `amd64` only. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)