### PR TITLE
fix: empty message

### DIFF
--- a/internal/repository/prisma/stream_event.go
+++ b/internal/repository/prisma/stream_event.go
@@ -38,9 +38,15 @@ func (r *streamEventEngineRepository) PutStreamEvent(ctx context.Context, tenant
 		return nil, err
 	}
 
+	message := opts.Message
+
+	if message == nil {
+		message = []byte("")
+	}
+
 	createParams := dbsqlc.CreateStreamEventParams{
 		Tenantid:  sqlchelpers.UUIDFromStr(tenantId),
-		Message:   opts.Message,
+		Message:   message,
 		Steprunid: sqlchelpers.UUIDFromStr(opts.StepRunId),
 	}
 

--- a/internal/repository/stream_event.go
+++ b/internal/repository/stream_event.go
@@ -15,7 +15,7 @@ type CreateStreamEventOpts struct {
 	CreatedAt *time.Time
 
 	// (required) The message of the Stream Event.
-	Message []byte `validate:"required,min=1"`
+	Message []byte
 
 	// (optional) The metadata of the Stream Event.
 	Metadata []byte

--- a/internal/services/ingestor/server.go
+++ b/internal/services/ingestor/server.go
@@ -91,12 +91,18 @@ func (i *IngestorImpl) PutStreamEvent(ctx context.Context, req *contracts.PutStr
 		metadata = []byte(req.Metadata)
 	}
 
-	streamEvent, err := i.streamEventRepository.PutStreamEvent(ctx, tenantId, &repository.CreateStreamEventOpts{
+	opts := repository.CreateStreamEventOpts{
 		StepRunId: req.StepRunId,
 		CreatedAt: createdAt,
 		Message:   req.Message,
 		Metadata:  metadata,
-	})
+	}
+
+	if err := i.v.Validate(opts); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Invalid request: %s", err)
+	}
+
+	streamEvent, err := i.streamEventRepository.PutStreamEvent(ctx, tenantId, &opts)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

Putting an empty string would silently fail validation

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## What's Changed

- [x] Allow empty byte message input, patch with empty string if nil