### PR TITLE
fix: don't requeue step runs immediately

### DIFF
--- a/internal/repository/prisma/step_run.go
+++ b/internal/repository/prisma/step_run.go
@@ -527,7 +527,7 @@ func (s *stepRunEngineRepository) assignStepRunToWorkerAttempt(ctx context.Conte
 
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, repository.ErrNoWorkerAvailable
+			s.l.Warn().Err(err).Msg("no rows returned from worker assign")
 		}
 
 		return nil, fmt.Errorf("query to assign worker failed: %w", err)

--- a/internal/services/controllers/jobs/controller.go
+++ b/internal/services/controllers/jobs/controller.go
@@ -746,7 +746,11 @@ func (ec *JobsControllerImpl) queueStepRun(ctx context.Context, tenantId, stepId
 
 	servertel.WithStepRunModel(span, stepRun)
 
-	updateStepOpts := &repository.UpdateStepRunOpts{}
+	requeueAfterTime := time.Now().Add(4 * time.Second).UTC()
+
+	updateStepOpts := &repository.UpdateStepRunOpts{
+		RequeueAfter: &requeueAfterTime,
+	}
 
 	// set scheduling timeout
 	if scheduleTimeoutAt := stepRun.StepRun.ScheduleTimeoutAt.Time; scheduleTimeoutAt.IsZero() {


### PR DESCRIPTION
# Description

When workflow runs sit in the queue for a long time, any step runs which are started are immediately requeued, because we only set `requeueAfter` in when the step run is first created. This is causing collisions in the `AssignStepRunToWorker` method. 

This fix simply updates the `requeueAfter` time in the `queueStepRun` query, which occurs when the step run is placed into the `PENDING_ASSIGNMENT` state for the first time. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)