### PR TITLE
fix(docs): "Edit this page" link was broken

### DIFF
--- a/frontend/docs/theme.config.tsx
+++ b/frontend/docs/theme.config.tsx
@@ -15,7 +15,7 @@ const config: DocsThemeConfig = {
   chat: {
     link: "https://discord.gg/ZMeUafwH89",
   },
-  docsRepositoryBase: "https://github.com/hatchet-dev/hatchet/frontend/docs",
+  docsRepositoryBase: "https://github.com/hatchet-dev/hatchet/blob/main/frontend/docs",
   feedback: {
     labels: "Feedback",
     useLink: (...args: unknown[]) =>


### PR DESCRIPTION
# Description

The "Edit this page" is currently pointing to a 404 page.

Fixes # 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation change (pure documentation change)


## What's Changed

- The Edit this page button for https://docs.hatchet.run/
