### PR TITLE
fix: reset step run inputs on replay

### DIFF
--- a/internal/repository/prisma/dbsqlc/job_runs.sql
+++ b/internal/repository/prisma/dbsqlc/job_runs.sql
@@ -92,12 +92,22 @@ WITH readable_id AS (
 )
 UPDATE "JobRunLookupData"
 SET
-    "data" = jsonb_set(
-        "JobRunLookupData"."data",
-        ARRAY['steps', (SELECT "readableId" FROM readable_id)],
-        @jsonData::jsonb,
-        true
-    ),
+    "data" = CASE
+        WHEN @jsonData::jsonb IS NULL THEN
+            jsonb_set(
+                "data",
+                '{steps}',
+                ("data"->'steps') - (SELECT "readableId" FROM readable_id),
+                true
+            )
+        ELSE
+            jsonb_set(
+                "data",
+                ARRAY['steps', (SELECT "readableId" FROM readable_id)],
+                @jsonData::jsonb,
+                true
+            )
+    END,
     "updatedAt" = CURRENT_TIMESTAMP
 WHERE
     "jobRunId" = (

--- a/internal/repository/prisma/dbsqlc/job_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/job_runs.sql.go
@@ -174,12 +174,22 @@ WITH readable_id AS (
 )
 UPDATE "JobRunLookupData"
 SET
-    "data" = jsonb_set(
-        "JobRunLookupData"."data",
-        ARRAY['steps', (SELECT "readableId" FROM readable_id)],
-        $1::jsonb,
-        true
-    ),
+    "data" = CASE
+        WHEN $1::jsonb IS NULL THEN
+            jsonb_set(
+                "data",
+                '{steps}',
+                ("data"->'steps') - (SELECT "readableId" FROM readable_id),
+                true
+            )
+        ELSE
+            jsonb_set(
+                "data",
+                ARRAY['steps', (SELECT "readableId" FROM readable_id)],
+                $1::jsonb,
+                true
+            )
+    END,
     "updatedAt" = CURRENT_TIMESTAMP
 WHERE
     "jobRunId" = (

--- a/internal/repository/prisma/dbsqlc/step_runs.sql
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql
@@ -755,7 +755,8 @@ SET
     "output" = NULL,
     "error" = NULL,
     "cancelledAt" = NULL,
-    "cancelledReason" = NULL
+    "cancelledReason" = NULL,
+    "input" = NULL
 FROM
     childStepRuns csr
 WHERE

--- a/internal/repository/prisma/dbsqlc/step_runs.sql.go
+++ b/internal/repository/prisma/dbsqlc/step_runs.sql.go
@@ -1170,7 +1170,8 @@ SET
     "output" = NULL,
     "error" = NULL,
     "cancelledAt" = NULL,
-    "cancelledReason" = NULL
+    "cancelledReason" = NULL,
+    "input" = NULL
 FROM
     childStepRuns csr
 WHERE

--- a/internal/repository/prisma/step_run.go
+++ b/internal/repository/prisma/step_run.go
@@ -820,6 +820,20 @@ func (s *stepRunEngineRepository) ReplayStepRun(ctx context.Context, tenantId, s
 				return err
 			}
 
+			// remove the previous step run result from the job lookup data
+			err = s.queries.UpdateJobRunLookupDataWithStepRun(
+				ctx,
+				tx,
+				dbsqlc.UpdateJobRunLookupDataWithStepRunParams{
+					Steprunid: sqlchelpers.UUIDFromStr(laterStepRunId),
+					Tenantid:  sqlchelpers.UUIDFromStr(tenantId),
+				},
+			)
+
+			if err != nil {
+				return err
+			}
+
 			// create a deferred event for each of these step runs
 			defer s.deferredStepRunEvent(
 				laterStepRunCp.ID,


### PR DESCRIPTION
# Description

Fixes a bug with the replaying a parent step run when children have already been triggered. To reproduce this bug: 

1. Child step fails due to parent step output
2. Parent step is replayed such that it produces a different (correct) output
3. Child step is correctly reset and replayed, but still fails due to the old parent step result being passed to it

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)