### PR TITLE
fix: clarify that empty strings are not valid returns

### DIFF
--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -862,6 +862,11 @@ func (s *DispatcherImpl) handleStepRunCompleted(ctx context.Context, request *co
 				return nil, status.Errorf(codes.InvalidArgument, "Return value is an array, which is not supported")
 			}
 
+			// if the payload starts with a \", then it is a string which we don't currently support
+			if request.EventPayload[0] == '"' {
+				return nil, status.Errorf(codes.InvalidArgument, "Return value is a string, which is not supported")
+			}
+
 			return nil, status.Errorf(codes.InvalidArgument, "Return value is not a valid JSON object")
 		}
 	}


### PR DESCRIPTION
# Description

Add a case for parsing completed step run events to ensure that clients do not send strings as a payload. 

## Type of change

- [X] Chore (changes which are not directly related to any business logic)
