### PR TITLE
docs(self-hosting): remove invalid k8s link

### DIFF
--- a/frontend/docs/pages/self-hosting/index.mdx
+++ b/frontend/docs/pages/self-hosting/index.mdx
@@ -4,6 +4,6 @@ There are currently three supported ways to self-host Hatchet:
 
 1. [Hatchet Lite](./self-hosting/hatchet-lite)
 2. [Docker Compose](./self-hosting/docker-compose)
-3. [Kubernetes](./self-hosting/kubernetes):
+3. Kubernetes:
    - [Quickstart with Helm](./self-hosting/kubernetes-quickstart)
    - [Glasskube](./self-hosting/kubernetes-glasskube)


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Removes pointing to an invalid link, and the quickstart is already linked to.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Documentation change (pure documentation change)

## What's Changed
