### PR TITLE
fix(client): make WithToken work

### DIFF
--- a/pkg/client/loader/loader.go
+++ b/pkg/client/loader/loader.go
@@ -15,7 +15,7 @@ type ConfigLoader struct {
 }
 
 // LoadClientConfig loads the client configuration
-func (c *ConfigLoader) LoadClientConfig() (res *client.ClientConfig, err error) {
+func (c *ConfigLoader) LoadClientConfig(token *string) (res *client.ClientConfig, err error) {
 	sharedFilePath := filepath.Join(c.directory, "client.yaml")
 	configFileBytes, err := loaderutils.GetConfigBytes(sharedFilePath)
 
@@ -27,6 +27,10 @@ func (c *ConfigLoader) LoadClientConfig() (res *client.ClientConfig, err error) 
 
 	if err != nil {
 		return nil, err
+	}
+
+	if token != nil {
+		cf.Token = *token
 	}
 
 	return GetClientConfigFromConfigFile(cf)


### PR DESCRIPTION
# Description

The token is expected before the WithToken option is applied which results in an error that the token is missing, even though it is set with WithToken().

This currently does not work and this PR makes it work:

```
c, err := client.New(
	client.WithToken(opts.Token),
)
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed
