### PR TITLE
fix: close create event dialog on success

### DIFF
--- a/frontend/app/src/pages/main/events/index.tsx
+++ b/frontend/app/src/pages/main/events/index.tsx
@@ -261,6 +261,10 @@ function EventsTable() {
       return res.data;
     },
     onError: handleCreateEventApiError,
+    onSuccess: () => {
+      refetch();
+      setShowCreateEvent(false);
+    },
   });
 
   const {


### PR DESCRIPTION
# Description

Create event dialog should close when event is successfully created. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)