### PR TITLE
fix: make rabbitmq connection optional and disable for token generation

### DIFF
--- a/cmd/hatchet-admin/cli/token.go
+++ b/cmd/hatchet-admin/cli/token.go
@@ -63,7 +63,7 @@ func runCreateAPIToken() error {
 
 	cleanup, serverConf, err := configLoader.LoadServerConfig(func(scf *server.ServerConfigFile) {
 		// disable rabbitmq since it's not needed to create the api token
-		scf.MessageQueue.RabbitMQ.Enabled = false
+		scf.MessageQueue.Enabled = false
 	})
 
 	if err != nil {

--- a/cmd/hatchet-admin/cli/token.go
+++ b/cmd/hatchet-admin/cli/token.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/hatchet-dev/hatchet/pkg/config/loader"
+	"github.com/hatchet-dev/hatchet/pkg/config/server"
 )
 
 var (
@@ -60,7 +61,11 @@ func runCreateAPIToken() error {
 	// read in the local config
 	configLoader := loader.NewConfigLoader(configDirectory)
 
-	cleanup, serverConf, err := configLoader.LoadServerConfig()
+	cleanup, serverConf, err := configLoader.LoadServerConfig(func(scf *server.ServerConfigFile) {
+		// disable rabbitmq since it's not needed to create the api token
+		scf.MessageQueue.RabbitMQ.Enabled = false
+	})
+
 	if err != nil {
 		return err
 	}

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -218,23 +218,25 @@ func GetServerConfigFromConfigfile(dc *database.Config, cf *server.ServerConfigF
 		return nil
 	}
 
-	if cf.MessageQueue.RabbitMQ.Enabled {
+	var ing ingestor.Ingestor
+
+	if cf.MessageQueue.Enabled {
 		cleanup1, mq = rabbitmq.New(
 			rabbitmq.WithURL(cf.MessageQueue.RabbitMQ.URL),
 			rabbitmq.WithLogger(&l),
 		)
-	}
 
-	ingestor, err := ingestor.NewIngestor(
-		ingestor.WithEventRepository(dc.EngineRepository.Event()),
-		ingestor.WithStreamEventsRepository(dc.EngineRepository.StreamEvent()),
-		ingestor.WithLogRepository(dc.EngineRepository.Log()),
-		ingestor.WithMessageQueue(mq),
-		ingestor.WithEntitlementsRepository(dc.EntitlementRepository),
-	)
+		ing, err = ingestor.NewIngestor(
+			ingestor.WithEventRepository(dc.EngineRepository.Event()),
+			ingestor.WithStreamEventsRepository(dc.EngineRepository.StreamEvent()),
+			ingestor.WithLogRepository(dc.EngineRepository.Log()),
+			ingestor.WithMessageQueue(mq),
+			ingestor.WithEntitlementsRepository(dc.EntitlementRepository),
+		)
 
-	if err != nil {
-		return nil, nil, fmt.Errorf("could not create ingestor: %w", err)
+		if err != nil {
+			return nil, nil, fmt.Errorf("could not create ingestor: %w", err)
+		}
 	}
 
 	var alerter errors.Alerter
@@ -453,7 +455,7 @@ func GetServerConfigFromConfigfile(dc *database.Config, cf *server.ServerConfigF
 		TLSConfig:              tls,
 		SessionStore:           ss,
 		Validator:              validator.NewDefaultValidator(),
-		Ingestor:               ingestor,
+		Ingestor:               ing,
 		OpenTelemetry:          cf.OpenTelemetry,
 		VCSProviders:           vcsProviders,
 		InternalClient:         internalClient,

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -255,14 +255,14 @@ type ConfigFileAuthCookie struct {
 }
 
 type MessageQueueConfigFile struct {
+	Enabled bool `mapstructure:"enabled" json:"enabled,omitempty" default:"true"`
+
 	Kind string `mapstructure:"kind" json:"kind,omitempty" validate:"required"`
 
 	RabbitMQ RabbitMQConfigFile `mapstructure:"rabbitmq" json:"rabbitmq,omitempty" validate:"required"`
 }
 
 type RabbitMQConfigFile struct {
-	Enabled bool `mapstructure:"enabled" json:"enabled,omitempty" default:"true"`
-
 	URL string `mapstructure:"url" json:"url,omitempty" validate:"required" default:"amqp://user:password@localhost:5672/"`
 }
 

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -261,6 +261,8 @@ type MessageQueueConfigFile struct {
 }
 
 type RabbitMQConfigFile struct {
+	Enabled bool `mapstructure:"enabled" json:"enabled,omitempty" default:"true"`
+
 	URL string `mapstructure:"url" json:"url,omitempty" validate:"required" default:"amqp://user:password@localhost:5672/"`
 }
 


### PR DESCRIPTION
# Description

RabbitMQ connection is not needed for API token generation, but connection is still attempted. This PR adds the option to override config values in the config loader, and disables the rabbitmq connection from the `api-token` command.  

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)