### PR TITLE
fix(webhooks): set deleted to false on upsert

### DIFF
--- a/api/v1/server/handlers/webhook-worker/create.go
+++ b/api/v1/server/handlers/webhook-worker/create.go
@@ -34,6 +34,7 @@ func (i *WebhookWorkersService) WebhookCreate(ctx echo.Context, request gen.Webh
 		Name:     request.Body.Name,
 		URL:      request.Body.Url,
 		Secret:   encSecret,
+		Deleted:  repository.BoolPtr(false),
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/repository/prisma/dbsqlc/webhook_workers.sql
+++ b/pkg/repository/prisma/dbsqlc/webhook_workers.sql
@@ -19,7 +19,8 @@ INSERT INTO "WebhookWorker" (
     "url",
     "tenantId",
     "tokenId",
-    "tokenValue"
+    "tokenValue",
+    "deleted"
 )
 VALUES (
     gen_random_uuid(),
@@ -30,7 +31,8 @@ VALUES (
     @url::text,
     @tenantId::uuid,
     sqlc.narg('tokenId')::uuid,
-    sqlc.narg('tokenValue')::text
+    sqlc.narg('tokenValue')::text,
+    coalesce(sqlc.narg('deleted')::boolean, false)
 )
 ON CONFLICT ("url") DO
 UPDATE
@@ -39,7 +41,8 @@ SET
     "tokenValue" = coalesce(sqlc.narg('tokenValue')::text, excluded."tokenValue"),
     "name" = coalesce(sqlc.narg('name')::text, excluded."name"),
     "secret" = coalesce(sqlc.narg('secret')::text, excluded."secret"),
-    "url" = coalesce(sqlc.narg('url')::text, excluded."url")
+    "url" = coalesce(sqlc.narg('url')::text, excluded."url"),
+    "deleted" = coalesce(sqlc.narg('deleted')::boolean, excluded."deleted")
 RETURNING *;
 
 -- name: DeleteWebhookWorker :exec

--- a/pkg/repository/prisma/sqlchelpers/bool.go
+++ b/pkg/repository/prisma/sqlchelpers/bool.go
@@ -1,0 +1,13 @@
+package sqlchelpers
+
+import "github.com/jackc/pgx/v5/pgtype"
+
+func BoolFromBoolean(v bool) pgtype.Bool {
+	var bgBool pgtype.Bool
+
+	if err := bgBool.Scan(v); err != nil {
+		panic(err)
+	}
+
+	return bgBool
+}

--- a/pkg/repository/prisma/webhook_worker.go
+++ b/pkg/repository/prisma/webhook_worker.go
@@ -50,6 +50,10 @@ func (r *webhookWorkerEngineRepository) UpsertWebhookWorker(ctx context.Context,
 		Url:      sqlchelpers.TextFromStr(opts.URL),
 	}
 
+	if opts.Deleted != nil {
+		params.Deleted = sqlchelpers.BoolFromBoolean(*opts.Deleted)
+	}
+
 	if opts.TokenID != nil {
 		params.TokenId = sqlchelpers.UUIDFromStr(*opts.TokenID)
 	}

--- a/pkg/repository/webhook_worker.go
+++ b/pkg/repository/webhook_worker.go
@@ -11,6 +11,7 @@ type UpsertWebhookWorkerOpts struct {
 	URL        string `validate:"required,url"`
 	Secret     string
 	TenantId   string `validate:"uuid"`
+	Deleted    *bool
 	TokenValue *string
 	TokenID    *string
 }


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Sets deleted to false so that previously deleted webhook workers are un-deleted if a webhook worker is created with the same unique URL.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed
