### PR TITLE
fix: add back deprecated service names and fix webhook worker query

### DIFF
--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -176,7 +176,9 @@ func RunWithConfig(ctx context.Context, sc *server.ServerConfig) ([]Teardown, er
 		})
 	}
 
-	if sc.HasService("queue") {
+	// FIXME: jobscontroller and workflowscontroller are deprecated service names, but there's not a clear upgrade
+	// path for old config files.
+	if sc.HasService("queue") || sc.HasService("jobscontroller") || sc.HasService("workflowscontroller") {
 		partitionTeardown, partitionId, err := p.withControllers(ctx)
 
 		if err != nil {

--- a/pkg/repository/prisma/dbsqlc/webhook_workers.sql
+++ b/pkg/repository/prisma/dbsqlc/webhook_workers.sql
@@ -5,7 +5,8 @@ WITH tenants AS (
     FROM
         "Tenant"
     WHERE
-        "workerPartitionId" = sqlc.arg('workerPartitionId')::text
+        "workerPartitionId" = sqlc.arg('workerPartitionId')::text OR
+        "workerPartitionId" IS NULL
 ), update_partition AS (
     UPDATE
         "TenantWorkerPartition"

--- a/pkg/repository/prisma/dbsqlc/webhook_workers.sql.go
+++ b/pkg/repository/prisma/dbsqlc/webhook_workers.sql.go
@@ -73,7 +73,8 @@ WITH tenants AS (
     FROM
         "Tenant"
     WHERE
-        "workerPartitionId" = $1::text
+        "workerPartitionId" = $1::text OR
+        "workerPartitionId" IS NULL
 ), update_partition AS (
     UPDATE
         "TenantWorkerPartition"


### PR DESCRIPTION
# Description

Adds back old service names `workflowscontroller` and `jobscontroller`. 

Queries for webhook workers which don't have a partition.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)