### PR TITLE
docs: use RegisterWorkflow instead of On

### DIFF
--- a/frontend/docs/pages/home/features/on-failure-step.mdx
+++ b/frontend/docs/pages/home/features/on-failure-step.mdx
@@ -10,6 +10,7 @@ You can define an On Failure Step on your Workflow using the Hatchet client libr
 
 <Tabs items={['Python', 'Typescript', 'Go']}>
 <Tabs.Tab>
+
 ```python
 @hatchet.workflow(on_events=["user:create"])
 class OnFailureWorkflow:
@@ -22,78 +23,78 @@ class OnFailureWorkflow:
         print("executed on_failure")
         print(context)
 
-````
+```
+
 </Tabs.Tab>
 
 <Tabs.Tab>
+
 ```typescript
 const workflow: Workflow = {
-  id: 'on-failure-example',
-  description: 'test',
+  id: "on-failure-example",
+  description: "test",
   on: {
-    event: 'user:create',
+    event: "user:create",
   },
   steps: [
     {
-      name: 'step1',
+      name: "step1",
       run: async (ctx) => {
-        console.log('Starting Step 1!');
+        console.log("Starting Step 1!");
         await sleep(1000);
-        throw new Error('Step 1 failed');
+        throw new Error("Step 1 failed");
       },
     },
   ],
   onFailure: {
-    name: 'on-failure-step',
+    name: "on-failure-step",
     run: async (ctx) => {
-      console.log('Starting On Failure Step!');
-      return { onFailure: 'step' };
+      console.log("Starting On Failure Step!");
+      return { onFailure: "step" };
     },
   },
 };
-````
+```
 
 </Tabs.Tab>
 <Tabs.Tab>
+
 ```go
 
-func StepOne(ctx worker.HatchetContext) (result \*stepOneOutput, err error) {
-return nil, fmt.Errorf("test on failure")
+func StepOne(ctx worker.HatchetContext) (result *stepOneOutput, err error) {
+	return nil, fmt.Errorf("test on failure")
 }
 
-func OnFailure(ctx worker.HatchetContext) (result \*stepOneOutput, err error) {
-return &stepOneOutput{
-Message: "Failure!",
-}, nil
+func OnFailure(ctx worker.HatchetContext) (result *stepOneOutput, err error) {
+	return &stepOneOutput{
+		Message: "Failure!",
+	}, nil
 }
 
-err = w.On(
-worker.NoTrigger(),
-&worker.WorkflowJob{
-Name: "on-failure-workflow",
-Description: "This runs at a scheduled time.",
-Steps: []*worker.WorkflowStep{
-worker.Fn(StepOne).SetName("step-one"),
-},
-OnFailure: &worker.WorkflowJob{
-Name: "scheduled-workflow-failure",
-Description: "This runs when the scheduled workflow fails.",
-Steps: []*worker.WorkflowStep{
-worker.Fn(OnFailure).SetName("on-failure"),
-},
-},
-},
+err = w.RegisterWorkflow(
+	&worker.WorkflowJob{
+		Name:        "on-failure-workflow",
+		On:          worker.NoTrigger(),
+		Description: "This runs at a scheduled time.",
+		Steps: []*worker.WorkflowStep{
+			worker.Fn(StepOne).SetName("step-one"),
+		},
+		OnFailure: &worker.WorkflowJob{
+			Name:        "scheduled-workflow-failure",
+			Description: "This runs when the scheduled workflow fails.",
+			Steps: []*worker.WorkflowStep{
+				worker.Fn(OnFailure).SetName("on-failure"),
+			},
+		},
+	},
 )
 
-````
+```
+
 </Tabs.Tab>
 </Tabs>
 
 In the above examples, the `on_failure` step is defined separately from the main workflow steps. It will be executed only if any of the main workflow steps fail.
-
-{/* <Callout type="info">
-The On Failure Step has access to the workflow context, which contains information about the failed step and the error that occurred.
-</Callout> */}
 
 ## Use Cases
 
@@ -114,7 +115,7 @@ def on_failure(self, context):
     slack_client.send_message(
         f"Workflow {context.workflow_run_id()} failed"
     )
-````
+```
 
 In this example, the On Failure Step sends a Slack notification with details about the failed workflow, including the workflow run ID which can be used to find the run in the Hatchet Dashboard.
 

--- a/frontend/docs/pages/home/features/rate-limits.mdx
+++ b/frontend/docs/pages/home/features/rate-limits.mdx
@@ -74,11 +74,11 @@ const workflow: Workflow = {
   </Tabs.Tab>
   <Tabs.Tab>
 ```go
-err = w.On(
-    worker.NoTrigger(),
+err = w.RegisterWorkflow(
     &worker.WorkflowJob{
         Name:        "rate-limit-workflow",
         Description: "This illustrates rate limiting.",
+        On:          worker.NoTrigger(),
         Steps: []*worker.WorkflowStep{
             worker.Fn(StepOne).SetName("step-one").SetRateLimit(
                 worker.RateLimit{

--- a/frontend/docs/pages/home/hatchet-cloud-quickstart.mdx
+++ b/frontend/docs/pages/home/hatchet-cloud-quickstart.mdx
@@ -16,7 +16,7 @@ If you haven't already signed up for Hatchet Cloud, please register [here](https
 
 In Hatchet Cloud, you'll be shown a screen to create your first tenant. A tenant is a logical separation of your environments (e.g. `dev`, `staging`, `production`). Each tenant has its own set of users who can access it.
 
-After creating your tenant, navigate to your Hatchet dashboard and navigate to your settings tab. You should see a section called "API Keys". Click "Create API Key", input a name for the key and copy the key. Then set the following environment variables:
+After creating your tenant, navigate to your Hatchet dashboard and navigate to your settings tab. You should see a section called "API Keys". Click "Create API Key", input a name for the key and copy the key. Place the following in a `.env` file:
 
 ```sh
 HATCHET_CLIENT_TOKEN="<your-api-key>"
@@ -134,7 +134,13 @@ npm run worker
 
   </Tabs.Tab>
   <Tabs.Tab>
-  In a new Go project, copy the following code into a `main.go` file:
+Run the following to initialize a new Go project:
+
+```sh
+go mod init my-hatchet-project
+```
+
+Then copy the following code into a `main.go` file:
 
 ```go filename="main.go" copy
 package main
@@ -173,13 +179,11 @@ func main() {
 		panic(fmt.Sprintf("error creating worker: %v", err))
 	}
 
-	testSvc := w.NewService("test")
-
-	err = testSvc.On(
-		worker.Events("simple"),
+	err = w.RegisterWorkflow(
 		&worker.WorkflowJob{
 			Name:        "simple-workflow",
 			Description: "Simple one-step workflow.",
+			On:          worker.Events("simple"),
 			Steps: []*worker.WorkflowStep{
 				worker.Fn(func(ctx worker.HatchetContext) (result *stepOutput, err error) {
 					fmt.Println("executed step 1")
@@ -209,7 +213,7 @@ func main() {
 }
 ```
 
-Next, run the following command to start the worker:
+Next, run `go mod tidy` to install the dependencies, and finally run the following to start the worker:
 
 ```sh
 go run main.go

--- a/frontend/docs/pages/launches/rate-limits.mdx
+++ b/frontend/docs/pages/launches/rate-limits.mdx
@@ -70,11 +70,11 @@ err = c.Admin().PutRateLimit("example-limit", &types.RateLimitOpts{
 2. Then, specify the consumption of limits in step definitions:
 
 ```go
-err = w.On(
-    worker.NoTrigger(),
+err = w.RegisterWorkflow(
     &worker.WorkflowJob{
         Name:        "rate-limit-workflow",
         Description: "This illustrates rate limiting.",
+        On:          worker.NoTrigger(),
         Steps: []*worker.WorkflowStep{
             worker.Fn(StepOne).SetName("step-one").SetRateLimit(
                 worker.RateLimit{

--- a/frontend/docs/pages/sdks/go-sdk/creating-a-workflow.mdx
+++ b/frontend/docs/pages/sdks/go-sdk/creating-a-workflow.mdx
@@ -1,14 +1,13 @@
 # Creating a Workflow
 
-The simplest way to define a workflow is by using the `worker.On` method. This method accepts two arguments: a workflow trigger and the workflow definition. For example, to trigger a workflow on the `user:created` event, you can do the following:
+The simplest way to define a workflow is by using the `worker.RegisterWorkflow` method. This method is passed the workflow definition, which includes triggers for the workflow and the steps that the workflow should execute. For example, to trigger a workflow on the `user:created` event, you can do the following:
 
 ```go
-w.On(
-    worker.Event("user:created"),
+w.RegisterWorkflow(
     &worker.WorkflowJob{
-        Name:        "post-user-sign-up",
-        Description: "Workflow that executes after a user signs up.",
-        Timeout:     "60s",
+        Name:        "simple-workflow",
+        Description: "Simple one-step workflow.",
+        On:          worker.Event("user:created"),
         Steps: []*worker.WorkflowStep{
             worker.Fn(func(ctx worker.HatchetContext) error {
                 return nil
@@ -33,11 +32,10 @@ w.On(
 
 ## Single-Step Workflows
 
-If your workflow is a single method, you can use `worker.Fn` to define your workflow:
+If your workflow is a single method that is only triggered via API, you can use `worker.Fn` to define your workflow:
 
 ```go
-w.On(
-    worker.Event("user:created"),
+w.RegisterWorkflow(
     worker.Fn(func(ctx worker.HatchetContext) error {
         return nil
     }),
@@ -47,8 +45,7 @@ w.On(
 Anonymous functions will be given an auto-generated name based on the package and parent function name. To avoid ugly auto-generated names, you can use `SetName` on the `worker.Fn` struct:
 
 ```go
-w.On(
-    worker.Event("user:created"),
+w.RegisterWorkflow(
     worker.Fn(func(ctx worker.HatchetContext) error {
         return nil
     }).SetName("post-user-create"), // this workflow will be named "post-user-create"
@@ -64,11 +61,12 @@ type stepOneOutput struct {
     Message string `json:"message"`
 }
 
-err = w.On(
-	worker.Events("user:create"),
+err = w.RegisterWorkflow(
+
 	&worker.WorkflowJob{
 		Name:        "two-step-workflow",
 		Description: "This is an example two-step workflow.",
+        On:          worker.Events("user:create"),
 		Steps: []*worker.WorkflowStep{
 			worker.Fn(func(ctx worker.HatchetContext) (result *stepOneOutput, err error) {
 				input := &userCreateEvent{}
@@ -135,10 +133,10 @@ Services are a way to logically group workflows into different categories. For e
 ```go
 userService := w.NewService("user")
 
-userService.On(
-    worker.Event("user:created"),
+userService.RegisterWorkflow(
     &worker.WorkflowJob{
         Name:        "post-user-sign-up",
+        On:          worker.Event("user:created"),
         Description: "Workflow that executes after a user signs up.",
         Timeout:     "60s",
         Steps: []*worker.WorkflowStep{
@@ -166,10 +164,10 @@ func getConcurrencyKey(ctx worker.HatchetContext) (string, error) {
 	return "my-key", nil
 }
 
-err = testSvc.On(
-    worker.Events("concurrency-test-event"),
+err = w.RegisterWorkflow(
     &worker.WorkflowJob{
         Name:        "concurrency-limit",
+        On:          worker.Events("concurrency-test-event"),
         Description: "This limits concurrency to 1 run at a time.",
         Concurrency: worker.Concurrency(getConcurrencyKey).MaxRuns(1),
         Steps: []*worker.WorkflowStep{
@@ -199,10 +197,10 @@ func getConcurrencyKey(ctx worker.HatchetContext) (string, error) {
     return event.UserId, nil
 }
 
-err = testSvc.On(
-    worker.Events("concurrency-test-event"),
+err = w.RegisterWorkflow(
     &worker.WorkflowJob{
         Name:        "concurrency-limit-per-user",
+        On:          worker.Events("concurrency-test-event"),
         Description: "This limits concurrency to 1 run at a time per user.",
         Concurrency: worker.Concurrency(getConcurrencyKey).MaxRuns(1),
         Steps: []*worker.WorkflowStep{
@@ -214,13 +212,13 @@ err = testSvc.On(
 
 ## Cron Schedules
 
-You can declare a cron schedule by passing `worker.Cron` to the `worker.On` method. For example, to trigger a workflow every 5 minutes, you can do the following:
+You can declare a cron schedule by passing `worker.Cron` to the `worker.RegisterWorkflow` method. For example, to trigger a workflow every 5 minutes, you can do the following:
 
 ```go
-w.On(
-    worker.Cron("*/5 * * * *"),
+w.RegisterWorkflow(
     &worker.WorkflowJob{
         Name:        "my-cron-job",
+        On:          worker.Cron("*/5 * * * *"),
         Description: "Cron workflow example.",
         Timeout:     "60s",
         Steps: []*worker.WorkflowStep{
@@ -283,8 +281,7 @@ if err != nil {
 	panic(err)
 }
 
-err = testSvc.On(
-	worker.Events("user:create", "user:update"),
+err = testSvc.RegisterWorkflow(
 	testSvc.Call("step-one"),
 )
 ```

--- a/frontend/docs/pages/sdks/go-sdk/index.mdx
+++ b/frontend/docs/pages/sdks/go-sdk/index.mdx
@@ -72,11 +72,11 @@ func main() {
 		panic(fmt.Sprintf("error creating worker: %v", err))
 	}
 
-	err = w.On(
-		worker.Events("simple"),
+	err = w.RegisterWorkflow(
 		&worker.WorkflowJob{
 			Name:        "simple-workflow",
 			Description: "Simple one-step workflow.",
+			On:          worker.Events("simple"),
 			Steps: []*worker.WorkflowStep{
 				worker.Fn(func(ctx worker.HatchetContext) (result *stepOutput, err error) {
 					fmt.Println("executed step 1")

--- a/frontend/docs/pages/self-hosting/docker-compose.mdx
+++ b/frontend/docs/pages/self-hosting/docker-compose.mdx
@@ -342,13 +342,11 @@ func main() {
 		panic(fmt.Sprintf("error creating worker: %v", err))
 	}
 
-	testSvc := w.NewService("test")
-
-	err = testSvc.On(
-		worker.Events("simple"),
+	err = w.RegisterWorkflow(
 		&worker.WorkflowJob{
 			Name:        "simple-workflow",
 			Description: "Simple one-step workflow.",
+      On:          worker.Events("simple"),
 			Steps: []*worker.WorkflowStep{
 				worker.Fn(func(ctx worker.HatchetContext) (result *stepOutput, err error) {
 					fmt.Println("executed step 1")
@@ -359,6 +357,7 @@ func main() {
 			},
 		},
 	)
+
 	if err != nil {
 		panic(fmt.Sprintf("error registering workflow: %v", err))
 	}

--- a/frontend/docs/pages/self-hosting/hatchet-lite.mdx
+++ b/frontend/docs/pages/self-hosting/hatchet-lite.mdx
@@ -301,13 +301,11 @@ func main() {
 		panic(fmt.Sprintf("error creating worker: %v", err))
 	}
 
-	testSvc := w.NewService("test")
-
-	err = testSvc.On(
-		worker.Events("simple"),
+	err = w.RegisterWorkflow(
 		&worker.WorkflowJob{
 			Name:        "simple-workflow",
 			Description: "Simple one-step workflow.",
+      On:          worker.Events("simple"),
 			Steps: []*worker.WorkflowStep{
 				worker.Fn(func(ctx worker.HatchetContext) (result *stepOutput, err error) {
 					fmt.Println("executed step 1")

--- a/frontend/docs/pages/self-hosting/kubernetes-glasskube.mdx
+++ b/frontend/docs/pages/self-hosting/kubernetes-glasskube.mdx
@@ -303,11 +303,11 @@ func main() {
 		panic(fmt.Sprintf("error creating worker: %v", err))
 	}
 
-	err = w.On(
-		worker.Events("simple"),
+	err = w.RegisterWorkflow(
 		&worker.WorkflowJob{
 			Name:        "simple-workflow",
 			Description: "Simple one-step workflow.",
+      On:          worker.Events("simple"),
 			Steps: []*worker.WorkflowStep{
 				worker.Fn(func(ctx worker.HatchetContext) (result *stepOutput, err error) {
 					fmt.Println("executed step 1")

--- a/frontend/docs/pages/self-hosting/kubernetes-quickstart.mdx
+++ b/frontend/docs/pages/self-hosting/kubernetes-quickstart.mdx
@@ -279,11 +279,11 @@ func main() {
 		panic(fmt.Sprintf("error creating worker: %v", err))
 	}
 
-	err = w.On(
-		worker.Events("simple"),
+	err = w.RegisterWorkflow(
 		&worker.WorkflowJob{
 			Name:        "simple-workflow",
 			Description: "Simple one-step workflow.",
+      On:          worker.Events("simple"),
 			Steps: []*worker.WorkflowStep{
 				worker.Fn(func(ctx worker.HatchetContext) (result *stepOutput, err error) {
 					fmt.Println("executed step 1")


### PR DESCRIPTION
# Description

Switch to using `RegisterWorkflow` in all Go examples instead of `On`. 

## Type of change

- [X] Documentation change (pure documentation change)