### PR TITLE
Fix: python sdk docs hatchet.admin references

### DIFF
--- a/frontend/docs/pages/sdks/python-sdk/get-workflow-results.mdx
+++ b/frontend/docs/pages/sdks/python-sdk/get-workflow-results.mdx
@@ -2,14 +2,14 @@ import { Callout } from "nextra/components";
 
 # Getting Workflow Run Results
 
-It is possible to wait for or stream the results of a workflow run by getting a `WorkflowRunRef`. This is the return value of the `run_workflow` and `get_workflow_run` methods on the `hatchet.admin` client, or the `spawn_workflow` method on a `Context` object. For example:
+It is possible to wait for or stream the results of a workflow run by getting a `WorkflowRunRef`. This is the return value of the `run_workflow` and `get_workflow_run` methods on the `hatchet.client.admin` client, or the `spawn_workflow` method on a `Context` object. For example:
 
 ```py filename="get_workflow_run.py" copy
 from hatchet_sdk import Hatchet, ClientConfig
 
 hatchet = Hatchet()
 
-workflow_run_ref = hatchet.admin.get_workflow_run(
+workflow_run_ref = hatchet.client.admin.get_workflow_run(
     "5a3a617d-1200-4ee2-92e6-be4bd27ca26f",
 )
 
@@ -24,7 +24,7 @@ This method takes the `workflow_run_id` as a parameter and returns a reference t
 If you need to get the workflow run id from a different method than where it was invoked, you can store the value of the `workflow_run_id` attribute of the return value of [`run_workflow`](./run-workflow-api) or [`spawn_workflow`](./run-workflow-child). For example:
 
 ```py
-workflow_run = hatchet.admin.run_workflow(
+workflow_run = hatchet.client.admin.run_workflow(
     "ManualTriggerWorkflow",
     {"test": "test"},
 )
@@ -54,7 +54,7 @@ It is also possible to stream the results of a workflow run as each step is exec
 ```py filename="stream_workflow_run.py" copy
 from hatchet_sdk import Hatchet, ClientConfig
 
-workflow_run_ref = hatchet.admin.get_workflow_run(
+workflow_run_ref = hatchet.client.admin.get_workflow_run(
     "5a3a617d-1200-4ee2-92e6-be4bd27ca26f",
 )
 

--- a/frontend/docs/pages/sdks/python-sdk/run-workflow-api.mdx
+++ b/frontend/docs/pages/sdks/python-sdk/run-workflow-api.mdx
@@ -1,13 +1,13 @@
 # Running Workflows via API
 
-Workflows can be triggered from the API by calling `run_workflow`. This method is available on the `hatchet.admin` client:
+Workflows can be triggered from the API by calling `run_workflow`. This method is available on the `hatchet.client.admin` client:
 
 ```python filename="run_workflow.py" copy
 from hatchet_sdk import Hatchet, ClientConfig
 
 hatchet = Hatchet()
 
-workflowRun = hatchet.admin.run_workflow(
+workflowRun = hatchet.client.admin.run_workflow(
     "ManualTriggerWorkflow",
     {"test": "test"},
     options={"additional_metadata": {"hello": "moon"}},

--- a/frontend/docs/pages/sdks/python-sdk/run-workflow-schedule.mdx
+++ b/frontend/docs/pages/sdks/python-sdk/run-workflow-schedule.mdx
@@ -1,6 +1,6 @@
 # Running Scheduled Workflows
 
-Workflows can be scheduled from the API to run at some future time by calling `schedule_workflow`. This method is available on the `hatchet.admin` client:
+Workflows can be scheduled from the API to run at some future time by calling `schedule_workflow`. This method is available on the `hatchet.client.admin` client:
 
 ```py filename="scheduled_workflow.py" copy
 from hatchet_sdk import Hatchet, ClientConfig
@@ -10,7 +10,7 @@ hatchet = Hatchet()
 now = datetime.now()
 future_time = now + timedelta(seconds=15)
 
-workflowRun = hatchet.admin.schedule_workflow(
+workflowRun = hatchet.client.admin.schedule_workflow(
     "ManualTriggerWorkflow",
     [future_time],
     {"test": "test"},


### PR DESCRIPTION
Fix references to hatchet admin module in python-sdk docs

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...
