### PR TITLE
fix: large step run payloads

### DIFF
--- a/internal/services/controllers/jobs/controller.go
+++ b/internal/services/controllers/jobs/controller.go
@@ -928,7 +928,7 @@ func (ec *JobsControllerImpl) queueStepRun(ctx context.Context, tenantId, stepId
 	return ec.a.WrapErr(ec.scheduleStepRun(ctx, tenantId, stepRun), errData)
 }
 
-func (ec *JobsControllerImpl) scheduleStepRun(ctx context.Context, tenantId string, stepRun *dbsqlc.GetStepRunForEngineRow) error {
+func (ec *JobsControllerImpl) scheduleStepRun(ctx context.Context, tenantId string, stepRun *repository.GetStepRunForEngineRow) error {
 	ctx, span := telemetry.NewSpan(ctx, "schedule-step-run")
 	defer span.End()
 
@@ -1318,7 +1318,7 @@ func (ec *JobsControllerImpl) cancelStepRun(ctx context.Context, tenantId, stepR
 	return nil
 }
 
-func (ec *JobsControllerImpl) handleStepRunUpdateInfo(stepRun *dbsqlc.GetStepRunForEngineRow, updateInfo *repository.StepRunUpdateInfo) {
+func (ec *JobsControllerImpl) handleStepRunUpdateInfo(stepRun *repository.GetStepRunForEngineRow, updateInfo *repository.StepRunUpdateInfo) {
 	defer func() {
 		if r := recover(); r != nil {
 			recoveryutils.RecoverWithAlert(ec.l, ec.a, r) // nolint:errcheck
@@ -1381,7 +1381,7 @@ func stepRunCancelledTask(tenantId, stepRunId, workerId, dispatcherId, cancelled
 	}
 }
 
-func getScheduleTimeout(stepRun *dbsqlc.GetStepRunForEngineRow) time.Time {
+func getScheduleTimeout(stepRun *repository.GetStepRunForEngineRow) time.Time {
 	var timeoutDuration time.Duration
 
 	// get the schedule timeout from the step

--- a/internal/services/controllers/workflows/queue.go
+++ b/internal/services/controllers/workflows/queue.go
@@ -780,7 +780,7 @@ func (wc *WorkflowsControllerImpl) cancelWorkflowRun(ctx context.Context, tenant
 
 	for i := range stepRuns {
 		stepRunCp := stepRuns[i]
-		stepRunId := sqlchelpers.UUIDToStr(stepRunCp.StepRun.ID)
+		stepRunId := sqlchelpers.UUIDToStr(stepRunCp.SRID)
 
 		errGroup.Go(func() error {
 			return wc.mq.AddMessage(

--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -449,13 +449,19 @@ func (d *DispatcherImpl) handleStepRunAssignedTask(ctx context.Context, task *ms
 		return fmt.Errorf("could not get step run: %w", err)
 	}
 
+	data, err := d.repo.StepRun().GetStepRunDataForEngine(ctx, metadata.TenantId, payload.StepRunId)
+
+	if err != nil {
+		return fmt.Errorf("could not get step run data: %w", err)
+	}
+
 	servertel.WithStepRunModel(span, stepRun)
 
 	var multiErr error
 	var success bool
 
 	for _, w := range workers {
-		err = w.StartStepRun(ctx, metadata.TenantId, stepRun)
+		err = w.StartStepRun(ctx, metadata.TenantId, stepRun, data)
 
 		if err != nil {
 			multiErr = multierror.Append(multiErr, fmt.Errorf("could not send step action to worker: %w", err))

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -38,7 +38,7 @@ type subscribedWorker struct {
 func (worker *subscribedWorker) StartStepRun(
 	ctx context.Context,
 	tenantId string,
-	stepRun *dbsqlc.GetStepRunForEngineRow,
+	stepRun *repository.GetStepRunForEngineRow,
 ) error {
 	ctx, span := telemetry.NewSpan(ctx, "start-step-run") // nolint:ineffassign
 	defer span.End()
@@ -92,7 +92,7 @@ func (worker *subscribedWorker) StartGroupKeyAction(
 func (worker *subscribedWorker) CancelStepRun(
 	ctx context.Context,
 	tenantId string,
-	stepRun *dbsqlc.GetStepRunForEngineRow,
+	stepRun *repository.GetStepRunForEngineRow,
 ) error {
 	ctx, span := telemetry.NewSpan(ctx, "cancel-step-run") // nolint:ineffassign
 	defer span.End()

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -38,15 +38,16 @@ type subscribedWorker struct {
 func (worker *subscribedWorker) StartStepRun(
 	ctx context.Context,
 	tenantId string,
-	stepRun *repository.GetStepRunForEngineRow,
+	stepRun *dbsqlc.GetStepRunForEngineRow,
+	stepRunData *dbsqlc.GetStepRunDataForEngineRow,
 ) error {
 	ctx, span := telemetry.NewSpan(ctx, "start-step-run") // nolint:ineffassign
 	defer span.End()
 
 	inputBytes := []byte{}
 
-	if stepRun.StepRun.Input != nil {
-		inputBytes = stepRun.StepRun.Input
+	if stepRunData.Input != nil {
+		inputBytes = stepRunData.Input
 	}
 
 	stepName := stepRun.StepReadableId.String
@@ -57,13 +58,13 @@ func (worker *subscribedWorker) StartStepRun(
 		JobName:       stepRun.JobName,
 		JobRunId:      sqlchelpers.UUIDToStr(stepRun.JobRunId),
 		StepId:        sqlchelpers.UUIDToStr(stepRun.StepId),
-		StepRunId:     sqlchelpers.UUIDToStr(stepRun.StepRun.ID),
+		StepRunId:     sqlchelpers.UUIDToStr(stepRun.SRID),
 		ActionType:    contracts.ActionType_START_STEP_RUN,
 		ActionId:      stepRun.ActionId,
 		ActionPayload: string(inputBytes),
 		StepName:      stepName,
 		WorkflowRunId: sqlchelpers.UUIDToStr(stepRun.WorkflowRunId),
-		RetryCount:    stepRun.StepRun.RetryCount,
+		RetryCount:    stepRun.SRRetryCount,
 	})
 }
 
@@ -92,7 +93,7 @@ func (worker *subscribedWorker) StartGroupKeyAction(
 func (worker *subscribedWorker) CancelStepRun(
 	ctx context.Context,
 	tenantId string,
-	stepRun *repository.GetStepRunForEngineRow,
+	stepRun *dbsqlc.GetStepRunForEngineRow,
 ) error {
 	ctx, span := telemetry.NewSpan(ctx, "cancel-step-run") // nolint:ineffassign
 	defer span.End()
@@ -103,11 +104,11 @@ func (worker *subscribedWorker) CancelStepRun(
 		JobName:       stepRun.JobName,
 		JobRunId:      sqlchelpers.UUIDToStr(stepRun.JobRunId),
 		StepId:        sqlchelpers.UUIDToStr(stepRun.StepId),
-		StepRunId:     sqlchelpers.UUIDToStr(stepRun.StepRun.ID),
+		StepRunId:     sqlchelpers.UUIDToStr(stepRun.SRID),
 		ActionType:    contracts.ActionType_CANCEL_STEP_RUN,
 		StepName:      stepRun.StepReadableId.String,
 		WorkflowRunId: sqlchelpers.UUIDToStr(stepRun.WorkflowRunId),
-		RetryCount:    stepRun.StepRun.RetryCount,
+		RetryCount:    stepRun.SRRetryCount,
 	})
 }
 
@@ -1115,7 +1116,7 @@ func (s *DispatcherImpl) tenantTaskToWorkflowEvent(task *msgqueue.Message, tenan
 		}
 
 		workflowEvent.StepRetries = &stepRun.StepRetries
-		workflowEvent.RetryCount = &stepRun.StepRun.RetryCount
+		workflowEvent.RetryCount = &stepRun.SRRetryCount
 
 		if workflowEvent.EventType == contracts.ResourceEventType_RESOURCE_EVENT_TYPE_STREAM {
 			streamEventId, err := strconv.ParseInt(task.Metadata["stream_event_id"].(string), 10, 64)
@@ -1203,23 +1204,30 @@ func (s *DispatcherImpl) getStepResultsForWorkflowRun(tenantId string, workflowR
 	res := make(map[string][]*contracts.StepRunResult)
 
 	for _, stepRun := range stepRuns {
+
+		data, err := s.repo.StepRun().GetStepRunDataForEngine(context.Background(), tenantId, sqlchelpers.UUIDToStr(stepRun.SRID))
+
+		if err != nil {
+			return nil, fmt.Errorf("could not get step run data for %s, %e", sqlchelpers.UUIDToStr(stepRun.SRID), err)
+		}
+
 		resStepRun := &contracts.StepRunResult{
-			StepRunId:      sqlchelpers.UUIDToStr(stepRun.StepRun.ID),
+			StepRunId:      sqlchelpers.UUIDToStr(stepRun.SRID),
 			StepReadableId: stepRun.StepReadableId.String,
 			JobRunId:       sqlchelpers.UUIDToStr(stepRun.JobRunId),
 		}
 
-		if stepRun.StepRun.Error.Valid {
-			resStepRun.Error = &stepRun.StepRun.Error.String
+		if data.Error.Valid {
+			resStepRun.Error = &data.Error.String
 		}
 
-		if stepRun.StepRun.CancelledReason.Valid {
-			errString := fmt.Sprintf("this step run was cancelled due to %s", stepRun.StepRun.CancelledReason.String)
+		if stepRun.SRCancelledReason.Valid {
+			errString := fmt.Sprintf("this step run was cancelled due to %s", stepRun.SRCancelledReason.String)
 			resStepRun.Error = &errString
 		}
 
-		if stepRun.StepRun.Output != nil {
-			resStepRun.Output = repository.StringPtr(string(stepRun.StepRun.Output))
+		if data.Output != nil {
+			resStepRun.Output = repository.StringPtr(string(data.Output))
 		}
 
 		workflowRunId := sqlchelpers.UUIDToStr(stepRun.WorkflowRunId)

--- a/internal/services/shared/tasktypes/step.go
+++ b/internal/services/shared/tasktypes/step.go
@@ -3,8 +3,8 @@ package tasktypes
 import (
 	"github.com/hatchet-dev/hatchet/internal/datautils"
 	"github.com/hatchet-dev/hatchet/internal/msgqueue"
-	"github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/db"
+	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/dbsqlc"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/sqlchelpers"
 )
 
@@ -150,10 +150,10 @@ func TenantToStepRunRequeueTask(tenant db.TenantModel) *msgqueue.Message {
 	}
 }
 
-func StepRunRetryToTask(stepRun *repository.GetStepRunForEngineRow, inputData []byte) *msgqueue.Message {
+func StepRunRetryToTask(stepRun *dbsqlc.GetStepRunForEngineRow, inputData []byte) *msgqueue.Message {
 	jobRunId := sqlchelpers.UUIDToStr(stepRun.JobRunId)
-	stepRunId := sqlchelpers.UUIDToStr(stepRun.StepRun.ID)
-	tenantId := sqlchelpers.UUIDToStr(stepRun.StepRun.TenantId)
+	stepRunId := sqlchelpers.UUIDToStr(stepRun.SRID)
+	tenantId := sqlchelpers.UUIDToStr(stepRun.SRTenantId)
 
 	payload, _ := datautils.ToJSONMap(StepRunRetryTaskPayload{
 		JobRunId:  jobRunId,
@@ -173,10 +173,10 @@ func StepRunRetryToTask(stepRun *repository.GetStepRunForEngineRow, inputData []
 	}
 }
 
-func StepRunReplayToTask(stepRun *repository.GetStepRunForEngineRow, inputData []byte) *msgqueue.Message {
+func StepRunReplayToTask(stepRun *dbsqlc.GetStepRunForEngineRow, inputData []byte) *msgqueue.Message {
 	jobRunId := sqlchelpers.UUIDToStr(stepRun.JobRunId)
-	stepRunId := sqlchelpers.UUIDToStr(stepRun.StepRun.ID)
-	tenantId := sqlchelpers.UUIDToStr(stepRun.StepRun.TenantId)
+	stepRunId := sqlchelpers.UUIDToStr(stepRun.SRID)
+	tenantId := sqlchelpers.UUIDToStr(stepRun.SRTenantId)
 
 	payload, _ := datautils.ToJSONMap(StepRunReplayTaskPayload{
 		JobRunId:  jobRunId,
@@ -196,9 +196,9 @@ func StepRunReplayToTask(stepRun *repository.GetStepRunForEngineRow, inputData [
 	}
 }
 
-func StepRunCancelToTask(stepRun *repository.GetStepRunForEngineRow, reason string) *msgqueue.Message {
-	stepRunId := sqlchelpers.UUIDToStr(stepRun.StepRun.ID)
-	tenantId := sqlchelpers.UUIDToStr(stepRun.StepRun.TenantId)
+func StepRunCancelToTask(stepRun *dbsqlc.GetStepRunForEngineRow, reason string) *msgqueue.Message {
+	stepRunId := sqlchelpers.UUIDToStr(stepRun.SRID)
+	tenantId := sqlchelpers.UUIDToStr(stepRun.SRTenantId)
 
 	payload, _ := datautils.ToJSONMap(StepRunNotifyCancelTaskPayload{
 		StepRunId:       stepRunId,
@@ -217,10 +217,10 @@ func StepRunCancelToTask(stepRun *repository.GetStepRunForEngineRow, reason stri
 	}
 }
 
-func StepRunQueuedToTask(stepRun *repository.GetStepRunForEngineRow) *msgqueue.Message {
+func StepRunQueuedToTask(stepRun *dbsqlc.GetStepRunForEngineRow) *msgqueue.Message {
 	payload, _ := datautils.ToJSONMap(StepRunTaskPayload{
 		JobRunId:  sqlchelpers.UUIDToStr(stepRun.JobRunId),
-		StepRunId: sqlchelpers.UUIDToStr(stepRun.StepRun.ID),
+		StepRunId: sqlchelpers.UUIDToStr(stepRun.SRID),
 	})
 
 	metadata, _ := datautils.ToJSONMap(StepRunTaskMetadata{
@@ -229,7 +229,7 @@ func StepRunQueuedToTask(stepRun *repository.GetStepRunForEngineRow) *msgqueue.M
 		JobName:           stepRun.JobName,
 		JobId:             sqlchelpers.UUIDToStr(stepRun.JobId),
 		WorkflowVersionId: sqlchelpers.UUIDToStr(stepRun.WorkflowVersionId),
-		TenantId:          sqlchelpers.UUIDToStr(stepRun.StepRun.TenantId),
+		TenantId:          sqlchelpers.UUIDToStr(stepRun.SRTenantId),
 	})
 
 	return &msgqueue.Message{

--- a/internal/services/shared/tasktypes/step.go
+++ b/internal/services/shared/tasktypes/step.go
@@ -3,8 +3,8 @@ package tasktypes
 import (
 	"github.com/hatchet-dev/hatchet/internal/datautils"
 	"github.com/hatchet-dev/hatchet/internal/msgqueue"
+	"github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/db"
-	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/dbsqlc"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/sqlchelpers"
 )
 
@@ -150,7 +150,7 @@ func TenantToStepRunRequeueTask(tenant db.TenantModel) *msgqueue.Message {
 	}
 }
 
-func StepRunRetryToTask(stepRun *dbsqlc.GetStepRunForEngineRow, inputData []byte) *msgqueue.Message {
+func StepRunRetryToTask(stepRun *repository.GetStepRunForEngineRow, inputData []byte) *msgqueue.Message {
 	jobRunId := sqlchelpers.UUIDToStr(stepRun.JobRunId)
 	stepRunId := sqlchelpers.UUIDToStr(stepRun.StepRun.ID)
 	tenantId := sqlchelpers.UUIDToStr(stepRun.StepRun.TenantId)
@@ -173,7 +173,7 @@ func StepRunRetryToTask(stepRun *dbsqlc.GetStepRunForEngineRow, inputData []byte
 	}
 }
 
-func StepRunReplayToTask(stepRun *dbsqlc.GetStepRunForEngineRow, inputData []byte) *msgqueue.Message {
+func StepRunReplayToTask(stepRun *repository.GetStepRunForEngineRow, inputData []byte) *msgqueue.Message {
 	jobRunId := sqlchelpers.UUIDToStr(stepRun.JobRunId)
 	stepRunId := sqlchelpers.UUIDToStr(stepRun.StepRun.ID)
 	tenantId := sqlchelpers.UUIDToStr(stepRun.StepRun.TenantId)
@@ -196,7 +196,7 @@ func StepRunReplayToTask(stepRun *dbsqlc.GetStepRunForEngineRow, inputData []byt
 	}
 }
 
-func StepRunCancelToTask(stepRun *dbsqlc.GetStepRunForEngineRow, reason string) *msgqueue.Message {
+func StepRunCancelToTask(stepRun *repository.GetStepRunForEngineRow, reason string) *msgqueue.Message {
 	stepRunId := sqlchelpers.UUIDToStr(stepRun.StepRun.ID)
 	tenantId := sqlchelpers.UUIDToStr(stepRun.StepRun.TenantId)
 
@@ -217,7 +217,7 @@ func StepRunCancelToTask(stepRun *dbsqlc.GetStepRunForEngineRow, reason string) 
 	}
 }
 
-func StepRunQueuedToTask(stepRun *dbsqlc.GetStepRunForEngineRow) *msgqueue.Message {
+func StepRunQueuedToTask(stepRun *repository.GetStepRunForEngineRow) *msgqueue.Message {
 	payload, _ := datautils.ToJSONMap(StepRunTaskPayload{
 		JobRunId:  sqlchelpers.UUIDToStr(stepRun.JobRunId),
 		StepRunId: sqlchelpers.UUIDToStr(stepRun.StepRun.ID),

--- a/internal/telemetry/servertel/attributes.go
+++ b/internal/telemetry/servertel/attributes.go
@@ -4,13 +4,14 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/hatchet-dev/hatchet/internal/telemetry"
+	"github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/dbsqlc"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/sqlchelpers"
 
 	"go.opentelemetry.io/otel/trace"
 )
 
-func WithStepRunModel(span trace.Span, stepRun *dbsqlc.GetStepRunForEngineRow) {
+func WithStepRunModel(span trace.Span, stepRun *repository.GetStepRunForEngineRow) {
 	telemetry.WithAttributes(
 		span,
 		TenantId(stepRun.StepRun.TenantId),

--- a/internal/telemetry/servertel/attributes.go
+++ b/internal/telemetry/servertel/attributes.go
@@ -4,18 +4,17 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/hatchet-dev/hatchet/internal/telemetry"
-	"github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/dbsqlc"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/sqlchelpers"
 
 	"go.opentelemetry.io/otel/trace"
 )
 
-func WithStepRunModel(span trace.Span, stepRun *repository.GetStepRunForEngineRow) {
+func WithStepRunModel(span trace.Span, stepRun *dbsqlc.GetStepRunForEngineRow) {
 	telemetry.WithAttributes(
 		span,
-		TenantId(stepRun.StepRun.TenantId),
-		StepRunId(stepRun.StepRun.ID),
+		TenantId(stepRun.SRTenantId),
+		StepRunId(stepRun.SRID),
 		Step(stepRun.StepId),
 		JobRunId(stepRun.JobRunId),
 	)

--- a/pkg/repository/prisma/dbsqlc/step_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql
@@ -7,72 +7,42 @@ WHERE
     "id" = @id::uuid AND
     "tenantId" = @tenantId::uuid;
 
+-- name: GetStepRunDataForEngine :one
+SELECT
+    "input",
+    "output",
+    "error"
+FROM
+    "StepRun"
+WHERE
+    "id" = @id::uuid AND
+    "tenantId" = @tenantId::uuid;
+
 -- name: GetStepRunForEngine :many
 SELECT
     DISTINCT ON (sr."id")
-    sqlc.embed(sr),
+    sr."id" AS "SR_id",
+    sr."createdAt" AS "SR_createdAt",
+    sr."updatedAt" AS "SR_updatedAt",
+    sr."deletedAt" AS "SR_deletedAt",
+    sr."tenantId" AS "SR_tenantId",
+    sr."order" AS "SR_order",
+    sr."workerId" AS "SR_workerId",
+    sr."tickerId" AS "SR_tickerId",
+    sr."status" AS "SR_status",
+    sr."requeueAfter" AS "SR_requeueAfter",
+    sr."scheduleTimeoutAt" AS "SR_scheduleTimeoutAt",
+    sr."startedAt" AS "SR_startedAt",
+    sr."finishedAt" AS "SR_finishedAt",
+    sr."timeoutAt" AS "SR_timeoutAt",
+    sr."cancelledAt" AS "SR_cancelledAt",
+    sr."cancelledReason" AS "SR_cancelledReason",
+    sr."cancelledError" AS "SR_cancelledError",
+    sr."callerFiles" AS "SR_callerFiles",
+    sr."gitRepoBranch" AS "SR_gitRepoBranch",
+    sr."retryCount" AS "SR_retryCount",
+    sr."semaphoreReleased" AS "SR_semaphoreReleased",
     jrld."data" AS "jobRunLookupData",
-    -- TODO: everything below this line is cacheable and should be moved to a separate query
-    jr."id" AS "jobRunId",
-    s."id" AS "stepId",
-    s."retries" AS "stepRetries",
-    s."timeout" AS "stepTimeout",
-    s."scheduleTimeout" AS "stepScheduleTimeout",
-    s."readableId" AS "stepReadableId",
-    s."customUserData" AS "stepCustomUserData",
-    j."name" AS "jobName",
-    j."id" AS "jobId",
-    j."kind" AS "jobKind",
-    j."workflowVersionId" AS "workflowVersionId",
-    jr."workflowRunId" AS "workflowRunId",
-    a."actionId" AS "actionId"
-FROM
-    "StepRun" sr
-JOIN
-    "Step" s ON sr."stepId" = s."id"
-JOIN
-    "Action" a ON s."actionId" = a."actionId" AND s."tenantId" = a."tenantId"
-JOIN
-    "JobRun" jr ON sr."jobRunId" = jr."id"
-JOIN
-    "JobRunLookupData" jrld ON jr."id" = jrld."jobRunId"
-JOIN
-    "Job" j ON jr."jobId" = j."id"
-WHERE
-    sr."id" = ANY(@ids::uuid[]) AND
-    (
-        sqlc.narg('tenantId')::uuid IS NULL OR
-        sr."tenantId" = sqlc.narg('tenantId')::uuid
-    );
-
--- name: GetStepRunForEngineLite :many
-SELECT
-    DISTINCT ON (sr."id")
-    json_build_object(
-        'id', sr."id",
-        'createdAt', sr."createdAt",
-        'updatedAt', sr."updatedAt",
-        'deletedAt', sr."deletedAt",
-        'tenantId', sr."tenantId",
-        'jobRunId', sr."jobRunId",
-        'stepId', sr."stepId",
-        'order', sr."order",
-        'workerId', sr."workerId",
-        'tickerId', sr."tickerId",
-        'status', sr."status",
-        'requeueAfter', sr."requeueAfter",
-        'scheduleTimeoutAt', sr."scheduleTimeoutAt",
-        'startedAt', sr."startedAt",
-        'finishedAt', sr."finishedAt",
-        'timeoutAt', sr."timeoutAt",
-        'cancelledAt', sr."cancelledAt",
-        'cancelledReason', sr."cancelledReason",
-        'cancelledError', sr."cancelledError",
-        'callerFiles', sr."callerFiles",
-        'gitRepoBranch', sr."gitRepoBranch",
-        'retryCount', sr."retryCount",
-        'semaphoreReleased', sr."semaphoreReleased"
-    ) AS "StepRun",
     -- TODO: everything below this line is cacheable and should be moved to a separate query
     jr."id" AS "jobRunId",
     s."id" AS "stepId",

--- a/pkg/repository/prisma/dbsqlc/step_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql.go
@@ -544,10 +544,60 @@ func (q *Queries) GetStepRun(ctx context.Context, db DBTX, arg GetStepRunParams)
 	return &i, err
 }
 
+const getStepRunDataForEngine = `-- name: GetStepRunDataForEngine :one
+SELECT
+    "input",
+    "output",
+    "error"
+FROM
+    "StepRun"
+WHERE
+    "id" = $1::uuid AND
+    "tenantId" = $2::uuid
+`
+
+type GetStepRunDataForEngineParams struct {
+	ID       pgtype.UUID `json:"id"`
+	Tenantid pgtype.UUID `json:"tenantid"`
+}
+
+type GetStepRunDataForEngineRow struct {
+	Input  []byte      `json:"input"`
+	Output []byte      `json:"output"`
+	Error  pgtype.Text `json:"error"`
+}
+
+func (q *Queries) GetStepRunDataForEngine(ctx context.Context, db DBTX, arg GetStepRunDataForEngineParams) (*GetStepRunDataForEngineRow, error) {
+	row := db.QueryRow(ctx, getStepRunDataForEngine, arg.ID, arg.Tenantid)
+	var i GetStepRunDataForEngineRow
+	err := row.Scan(&i.Input, &i.Output, &i.Error)
+	return &i, err
+}
+
 const getStepRunForEngine = `-- name: GetStepRunForEngine :many
 SELECT
     DISTINCT ON (sr."id")
-    sr.id, sr."createdAt", sr."updatedAt", sr."deletedAt", sr."tenantId", sr."jobRunId", sr."stepId", sr."order", sr."workerId", sr."tickerId", sr.status, sr.input, sr.output, sr."requeueAfter", sr."scheduleTimeoutAt", sr.error, sr."startedAt", sr."finishedAt", sr."timeoutAt", sr."cancelledAt", sr."cancelledReason", sr."cancelledError", sr."inputSchema", sr."callerFiles", sr."gitRepoBranch", sr."retryCount", sr."semaphoreReleased",
+    sr."id" AS "SR_id",
+    sr."createdAt" AS "SR_createdAt",
+    sr."updatedAt" AS "SR_updatedAt",
+    sr."deletedAt" AS "SR_deletedAt",
+    sr."tenantId" AS "SR_tenantId",
+    sr."order" AS "SR_order",
+    sr."workerId" AS "SR_workerId",
+    sr."tickerId" AS "SR_tickerId",
+    sr."status" AS "SR_status",
+    sr."requeueAfter" AS "SR_requeueAfter",
+    sr."scheduleTimeoutAt" AS "SR_scheduleTimeoutAt",
+    sr."startedAt" AS "SR_startedAt",
+    sr."finishedAt" AS "SR_finishedAt",
+    sr."timeoutAt" AS "SR_timeoutAt",
+    sr."cancelledAt" AS "SR_cancelledAt",
+    sr."cancelledReason" AS "SR_cancelledReason",
+    sr."cancelledError" AS "SR_cancelledError",
+    sr."callerFiles" AS "SR_callerFiles",
+    sr."gitRepoBranch" AS "SR_gitRepoBranch",
+    sr."retryCount" AS "SR_retryCount",
+    sr."semaphoreReleased" AS "SR_semaphoreReleased",
     jrld."data" AS "jobRunLookupData",
     -- TODO: everything below this line is cacheable and should be moved to a separate query
     jr."id" AS "jobRunId",
@@ -589,21 +639,41 @@ type GetStepRunForEngineParams struct {
 }
 
 type GetStepRunForEngineRow struct {
-	StepRun             StepRun     `json:"step_run"`
-	JobRunLookupData    []byte      `json:"jobRunLookupData"`
-	JobRunId            pgtype.UUID `json:"jobRunId"`
-	StepId              pgtype.UUID `json:"stepId"`
-	StepRetries         int32       `json:"stepRetries"`
-	StepTimeout         pgtype.Text `json:"stepTimeout"`
-	StepScheduleTimeout string      `json:"stepScheduleTimeout"`
-	StepReadableId      pgtype.Text `json:"stepReadableId"`
-	StepCustomUserData  []byte      `json:"stepCustomUserData"`
-	JobName             string      `json:"jobName"`
-	JobId               pgtype.UUID `json:"jobId"`
-	JobKind             JobKind     `json:"jobKind"`
-	WorkflowVersionId   pgtype.UUID `json:"workflowVersionId"`
-	WorkflowRunId       pgtype.UUID `json:"workflowRunId"`
-	ActionId            string      `json:"actionId"`
+	SRID                pgtype.UUID      `json:"SR_id"`
+	SRCreatedAt         pgtype.Timestamp `json:"SR_createdAt"`
+	SRUpdatedAt         pgtype.Timestamp `json:"SR_updatedAt"`
+	SRDeletedAt         pgtype.Timestamp `json:"SR_deletedAt"`
+	SRTenantId          pgtype.UUID      `json:"SR_tenantId"`
+	SROrder             int64            `json:"SR_order"`
+	SRWorkerId          pgtype.UUID      `json:"SR_workerId"`
+	SRTickerId          pgtype.UUID      `json:"SR_tickerId"`
+	SRStatus            StepRunStatus    `json:"SR_status"`
+	SRRequeueAfter      pgtype.Timestamp `json:"SR_requeueAfter"`
+	SRScheduleTimeoutAt pgtype.Timestamp `json:"SR_scheduleTimeoutAt"`
+	SRStartedAt         pgtype.Timestamp `json:"SR_startedAt"`
+	SRFinishedAt        pgtype.Timestamp `json:"SR_finishedAt"`
+	SRTimeoutAt         pgtype.Timestamp `json:"SR_timeoutAt"`
+	SRCancelledAt       pgtype.Timestamp `json:"SR_cancelledAt"`
+	SRCancelledReason   pgtype.Text      `json:"SR_cancelledReason"`
+	SRCancelledError    pgtype.Text      `json:"SR_cancelledError"`
+	SRCallerFiles       []byte           `json:"SR_callerFiles"`
+	SRGitRepoBranch     pgtype.Text      `json:"SR_gitRepoBranch"`
+	SRRetryCount        int32            `json:"SR_retryCount"`
+	SRSemaphoreReleased bool             `json:"SR_semaphoreReleased"`
+	JobRunLookupData    []byte           `json:"jobRunLookupData"`
+	JobRunId            pgtype.UUID      `json:"jobRunId"`
+	StepId              pgtype.UUID      `json:"stepId"`
+	StepRetries         int32            `json:"stepRetries"`
+	StepTimeout         pgtype.Text      `json:"stepTimeout"`
+	StepScheduleTimeout string           `json:"stepScheduleTimeout"`
+	StepReadableId      pgtype.Text      `json:"stepReadableId"`
+	StepCustomUserData  []byte           `json:"stepCustomUserData"`
+	JobName             string           `json:"jobName"`
+	JobId               pgtype.UUID      `json:"jobId"`
+	JobKind             JobKind          `json:"jobKind"`
+	WorkflowVersionId   pgtype.UUID      `json:"workflowVersionId"`
+	WorkflowRunId       pgtype.UUID      `json:"workflowRunId"`
+	ActionId            string           `json:"actionId"`
 }
 
 func (q *Queries) GetStepRunForEngine(ctx context.Context, db DBTX, arg GetStepRunForEngineParams) ([]*GetStepRunForEngineRow, error) {
@@ -616,153 +686,28 @@ func (q *Queries) GetStepRunForEngine(ctx context.Context, db DBTX, arg GetStepR
 	for rows.Next() {
 		var i GetStepRunForEngineRow
 		if err := rows.Scan(
-			&i.StepRun.ID,
-			&i.StepRun.CreatedAt,
-			&i.StepRun.UpdatedAt,
-			&i.StepRun.DeletedAt,
-			&i.StepRun.TenantId,
-			&i.StepRun.JobRunId,
-			&i.StepRun.StepId,
-			&i.StepRun.Order,
-			&i.StepRun.WorkerId,
-			&i.StepRun.TickerId,
-			&i.StepRun.Status,
-			&i.StepRun.Input,
-			&i.StepRun.Output,
-			&i.StepRun.RequeueAfter,
-			&i.StepRun.ScheduleTimeoutAt,
-			&i.StepRun.Error,
-			&i.StepRun.StartedAt,
-			&i.StepRun.FinishedAt,
-			&i.StepRun.TimeoutAt,
-			&i.StepRun.CancelledAt,
-			&i.StepRun.CancelledReason,
-			&i.StepRun.CancelledError,
-			&i.StepRun.InputSchema,
-			&i.StepRun.CallerFiles,
-			&i.StepRun.GitRepoBranch,
-			&i.StepRun.RetryCount,
-			&i.StepRun.SemaphoreReleased,
+			&i.SRID,
+			&i.SRCreatedAt,
+			&i.SRUpdatedAt,
+			&i.SRDeletedAt,
+			&i.SRTenantId,
+			&i.SROrder,
+			&i.SRWorkerId,
+			&i.SRTickerId,
+			&i.SRStatus,
+			&i.SRRequeueAfter,
+			&i.SRScheduleTimeoutAt,
+			&i.SRStartedAt,
+			&i.SRFinishedAt,
+			&i.SRTimeoutAt,
+			&i.SRCancelledAt,
+			&i.SRCancelledReason,
+			&i.SRCancelledError,
+			&i.SRCallerFiles,
+			&i.SRGitRepoBranch,
+			&i.SRRetryCount,
+			&i.SRSemaphoreReleased,
 			&i.JobRunLookupData,
-			&i.JobRunId,
-			&i.StepId,
-			&i.StepRetries,
-			&i.StepTimeout,
-			&i.StepScheduleTimeout,
-			&i.StepReadableId,
-			&i.StepCustomUserData,
-			&i.JobName,
-			&i.JobId,
-			&i.JobKind,
-			&i.WorkflowVersionId,
-			&i.WorkflowRunId,
-			&i.ActionId,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const getStepRunForEngineLite = `-- name: GetStepRunForEngineLite :many
-SELECT
-    DISTINCT ON (sr."id")
-    json_build_object(
-        'id', sr."id",
-        'createdAt', sr."createdAt",
-        'updatedAt', sr."updatedAt",
-        'deletedAt', sr."deletedAt",
-        'tenantId', sr."tenantId",
-        'jobRunId', sr."jobRunId",
-        'stepId', sr."stepId",
-        'order', sr."order",
-        'workerId', sr."workerId",
-        'tickerId', sr."tickerId",
-        'status', sr."status",
-        'requeueAfter', sr."requeueAfter",
-        'scheduleTimeoutAt', sr."scheduleTimeoutAt",
-        'startedAt', sr."startedAt",
-        'finishedAt', sr."finishedAt",
-        'timeoutAt', sr."timeoutAt",
-        'cancelledAt', sr."cancelledAt",
-        'cancelledReason', sr."cancelledReason",
-        'cancelledError', sr."cancelledError",
-        'callerFiles', sr."callerFiles",
-        'gitRepoBranch', sr."gitRepoBranch",
-        'retryCount', sr."retryCount",
-        'semaphoreReleased', sr."semaphoreReleased"
-    ) AS "StepRun",
-    -- TODO: everything below this line is cacheable and should be moved to a separate query
-    jr."id" AS "jobRunId",
-    s."id" AS "stepId",
-    s."retries" AS "stepRetries",
-    s."timeout" AS "stepTimeout",
-    s."scheduleTimeout" AS "stepScheduleTimeout",
-    s."readableId" AS "stepReadableId",
-    s."customUserData" AS "stepCustomUserData",
-    j."name" AS "jobName",
-    j."id" AS "jobId",
-    j."kind" AS "jobKind",
-    j."workflowVersionId" AS "workflowVersionId",
-    jr."workflowRunId" AS "workflowRunId",
-    a."actionId" AS "actionId"
-FROM
-    "StepRun" sr
-JOIN
-    "Step" s ON sr."stepId" = s."id"
-JOIN
-    "Action" a ON s."actionId" = a."actionId" AND s."tenantId" = a."tenantId"
-JOIN
-    "JobRun" jr ON sr."jobRunId" = jr."id"
-JOIN
-    "JobRunLookupData" jrld ON jr."id" = jrld."jobRunId"
-JOIN
-    "Job" j ON jr."jobId" = j."id"
-WHERE
-    sr."id" = ANY($1::uuid[]) AND
-    (
-        $2::uuid IS NULL OR
-        sr."tenantId" = $2::uuid
-    )
-`
-
-type GetStepRunForEngineLiteParams struct {
-	Ids      []pgtype.UUID `json:"ids"`
-	TenantId pgtype.UUID   `json:"tenantId"`
-}
-
-type GetStepRunForEngineLiteRow struct {
-	StepRun             []byte      `json:"StepRun"`
-	JobRunId            pgtype.UUID `json:"jobRunId"`
-	StepId              pgtype.UUID `json:"stepId"`
-	StepRetries         int32       `json:"stepRetries"`
-	StepTimeout         pgtype.Text `json:"stepTimeout"`
-	StepScheduleTimeout string      `json:"stepScheduleTimeout"`
-	StepReadableId      pgtype.Text `json:"stepReadableId"`
-	StepCustomUserData  []byte      `json:"stepCustomUserData"`
-	JobName             string      `json:"jobName"`
-	JobId               pgtype.UUID `json:"jobId"`
-	JobKind             JobKind     `json:"jobKind"`
-	WorkflowVersionId   pgtype.UUID `json:"workflowVersionId"`
-	WorkflowRunId       pgtype.UUID `json:"workflowRunId"`
-	ActionId            string      `json:"actionId"`
-}
-
-func (q *Queries) GetStepRunForEngineLite(ctx context.Context, db DBTX, arg GetStepRunForEngineLiteParams) ([]*GetStepRunForEngineLiteRow, error) {
-	rows, err := db.Query(ctx, getStepRunForEngineLite, arg.Ids, arg.TenantId)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*GetStepRunForEngineLiteRow
-	for rows.Next() {
-		var i GetStepRunForEngineLiteRow
-		if err := rows.Scan(
-			&i.StepRun,
 			&i.JobRunId,
 			&i.StepId,
 			&i.StepRetries,

--- a/pkg/repository/step_run.go
+++ b/pkg/repository/step_run.go
@@ -133,6 +133,54 @@ type RefreshTimeoutBy struct {
 	IncrementTimeoutBy string `validate:"required,duration"`
 }
 
+type StepRun struct {
+	ID                pgtype.UUID          `json:"id"`
+	CreatedAt         pgtype.Timestamp     `json:"createdAt"`
+	UpdatedAt         pgtype.Timestamp     `json:"updatedAt"`
+	DeletedAt         pgtype.Timestamp     `json:"deletedAt"`
+	TenantId          pgtype.UUID          `json:"tenantId"`
+	JobRunId          pgtype.UUID          `json:"jobRunId"`
+	StepId            pgtype.UUID          `json:"stepId"`
+	Order             int64                `json:"order"`
+	WorkerId          pgtype.UUID          `json:"workerId"`
+	TickerId          pgtype.UUID          `json:"tickerId"`
+	Status            dbsqlc.StepRunStatus `json:"status"`
+	Input             []byte               `json:"input"`
+	Output            []byte               `json:"output"`
+	RequeueAfter      pgtype.Timestamp     `json:"requeueAfter"`
+	ScheduleTimeoutAt pgtype.Timestamp     `json:"scheduleTimeoutAt"`
+	Error             pgtype.Text          `json:"error"`
+	StartedAt         pgtype.Timestamp     `json:"startedAt"`
+	FinishedAt        pgtype.Timestamp     `json:"finishedAt"`
+	TimeoutAt         pgtype.Timestamp     `json:"timeoutAt"`
+	CancelledAt       pgtype.Timestamp     `json:"cancelledAt"`
+	CancelledReason   pgtype.Text          `json:"cancelledReason"`
+	CancelledError    pgtype.Text          `json:"cancelledError"`
+	InputSchema       []byte               `json:"inputSchema"`
+	CallerFiles       []byte               `json:"callerFiles"`
+	GitRepoBranch     pgtype.Text          `json:"gitRepoBranch"`
+	RetryCount        int32                `json:"retryCount"`
+	SemaphoreReleased bool                 `json:"semaphoreReleased"`
+}
+
+type GetStepRunForEngineRow struct {
+	StepRun             StepRun        `json:"step_run"`
+	JobRunLookupData    []byte         `json:"jobRunLookupData"`
+	JobRunId            pgtype.UUID    `json:"jobRunId"`
+	StepId              pgtype.UUID    `json:"stepId"`
+	StepRetries         int32          `json:"stepRetries"`
+	StepTimeout         pgtype.Text    `json:"stepTimeout"`
+	StepScheduleTimeout string         `json:"stepScheduleTimeout"`
+	StepReadableId      pgtype.Text    `json:"stepReadableId"`
+	StepCustomUserData  []byte         `json:"stepCustomUserData"`
+	JobName             string         `json:"jobName"`
+	JobId               pgtype.UUID    `json:"jobId"`
+	JobKind             dbsqlc.JobKind `json:"jobKind"`
+	WorkflowVersionId   pgtype.UUID    `json:"workflowVersionId"`
+	WorkflowRunId       pgtype.UUID    `json:"workflowRunId"`
+	ActionId            string         `json:"actionId"`
+}
+
 var ErrPreflightReplayStepRunNotInFinalState = fmt.Errorf("step run is not in a final state")
 var ErrPreflightReplayChildStepRunNotInFinalState = fmt.Errorf("child step run is not in a final state")
 
@@ -148,19 +196,19 @@ type StepRunAPIRepository interface {
 
 type StepRunEngineRepository interface {
 	// ListStepRunsForWorkflowRun returns a list of step runs for a workflow run.
-	ListStepRuns(ctx context.Context, tenantId string, opts *ListStepRunsOpts) ([]*dbsqlc.GetStepRunForEngineRow, error)
+	ListStepRuns(ctx context.Context, tenantId string, opts *ListStepRunsOpts) ([]*GetStepRunForEngineRow, error)
 
 	// ListStepRunsToRequeue returns a list of step runs which are in a requeueable state.
-	ListStepRunsToRequeue(ctx context.Context, tenantId string) ([]*dbsqlc.GetStepRunForEngineRow, error)
+	ListStepRunsToRequeue(ctx context.Context, tenantId string) ([]*GetStepRunForEngineRow, error)
 
 	// ListStepRunsToReassign returns a list of step runs which are in a reassignable state.
-	ListStepRunsToReassign(ctx context.Context, tenantId string) ([]*dbsqlc.GetStepRunForEngineRow, error)
+	ListStepRunsToReassign(ctx context.Context, tenantId string) ([]*GetStepRunForEngineRow, error)
 
-	ListStepRunsToTimeout(ctx context.Context, tenantId string) ([]*dbsqlc.GetStepRunForEngineRow, error)
+	ListStepRunsToTimeout(ctx context.Context, tenantId string) ([]*GetStepRunForEngineRow, error)
 
-	UpdateStepRun(ctx context.Context, tenantId, stepRunId string, opts *UpdateStepRunOpts) (*dbsqlc.GetStepRunForEngineRow, *StepRunUpdateInfo, error)
+	UpdateStepRun(ctx context.Context, tenantId, stepRunId string, opts *UpdateStepRunOpts) (*GetStepRunForEngineRow, *StepRunUpdateInfo, error)
 
-	ReplayStepRun(ctx context.Context, tenantId, stepRunId string, opts *UpdateStepRunOpts) (*dbsqlc.GetStepRunForEngineRow, error)
+	ReplayStepRun(ctx context.Context, tenantId, stepRunId string, opts *UpdateStepRunOpts) (*GetStepRunForEngineRow, error)
 
 	// PreflightCheckReplayStepRun checks if a step run can be replayed. If it can, it will return nil.
 	PreflightCheckReplayStepRun(ctx context.Context, tenantId, stepRunId string) error
@@ -177,15 +225,15 @@ type StepRunEngineRepository interface {
 
 	UpdateStepRunInputSchema(ctx context.Context, tenantId, stepRunId string, schema []byte) ([]byte, error)
 
-	AssignStepRunToWorker(ctx context.Context, stepRun *dbsqlc.GetStepRunForEngineRow) (workerId string, dispatcherId string, err error)
+	AssignStepRunToWorker(ctx context.Context, stepRun *GetStepRunForEngineRow) (workerId string, dispatcherId string, err error)
 
-	GetStepRunForEngine(ctx context.Context, tenantId, stepRunId string) (*dbsqlc.GetStepRunForEngineRow, error)
+	GetStepRunForEngine(ctx context.Context, tenantId, stepRunId string) (*GetStepRunForEngineRow, error)
 
 	// QueueStepRun is like UpdateStepRun, except that it will only update the step run if it is in
 	// a pending state.
-	QueueStepRun(ctx context.Context, tenantId, stepRunId string, opts *UpdateStepRunOpts) (*dbsqlc.GetStepRunForEngineRow, error)
+	QueueStepRun(ctx context.Context, tenantId, stepRunId string, opts *UpdateStepRunOpts) (*GetStepRunForEngineRow, error)
 
-	ListStartableStepRuns(ctx context.Context, tenantId, jobRunId string, parentStepRunId *string) ([]*dbsqlc.GetStepRunForEngineRow, error)
+	ListStartableStepRuns(ctx context.Context, tenantId, jobRunId string, parentStepRunId *string) ([]*GetStepRunForEngineRow, error)
 
 	ArchiveStepRunResult(ctx context.Context, tenantId, stepRunId string) error
 


### PR DESCRIPTION
# Description

Large step run payloads can add significant latency to polling requeue query and unneeded memory.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

