### PR TITLE
fix: revert failed assigned grpc stream and write event

### DIFF
--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -492,6 +492,14 @@ func (d *DispatcherImpl) handleStepRunAssignedTask(ctx context.Context, task *ms
 
 	if err != nil {
 		multiErr = multierror.Append(multiErr, fmt.Errorf("💥 could not revert step run: %w", err))
+
+		defer d.repo.StepRun().DeferredStepRunEvent(
+			stepRun.SRID,
+			dbsqlc.StepRunEventReasonREASSIGNED,
+			dbsqlc.StepRunEventSeverityCRITICAL,
+			"Could not revert step run to pending assignment",
+			nil,
+		)
 	}
 
 	return multiErr

--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -488,14 +488,6 @@ func (d *DispatcherImpl) handleStepRunAssignedTask(ctx context.Context, task *ms
 
 	if err != nil {
 		multiErr = multierror.Append(multiErr, fmt.Errorf("💥 could not revert step run: %w", err))
-
-		defer d.repo.StepRun().DeferredStepRunEvent(
-			stepRun.SRID,
-			dbsqlc.StepRunEventReasonREASSIGNED,
-			dbsqlc.StepRunEventSeverityCRITICAL,
-			"Could not revert step run to pending assignment",
-			nil,
-		)
 	}
 
 	return multiErr

--- a/pkg/repository/prisma/step_run.go
+++ b/pkg/repository/prisma/step_run.go
@@ -650,7 +650,7 @@ func (s *stepRunEngineRepository) assignStepRunToWorkerAttempt(ctx context.Conte
 	return assigned, nil
 }
 
-func (s *stepRunEngineRepository) deferredStepRunEvent(
+func (s *stepRunEngineRepository) DeferredStepRunEvent(
 	stepRunId pgtype.UUID,
 	reason dbsqlc.StepRunEventReason,
 	severity dbsqlc.StepRunEventSeverity,
@@ -713,7 +713,7 @@ func (s *stepRunEngineRepository) AssignStepRunToWorker(ctx context.Context, ste
 		var target *errNoWorkerWithSlots
 
 		if errors.As(err, &target) {
-			defer s.deferredStepRunEvent(
+			defer s.DeferredStepRunEvent(
 				stepRun.SRID,
 				dbsqlc.StepRunEventReasonREQUEUEDNOWORKER,
 				dbsqlc.StepRunEventSeverityWARNING,
@@ -725,7 +725,7 @@ func (s *stepRunEngineRepository) AssignStepRunToWorker(ctx context.Context, ste
 		}
 
 		if errors.Is(err, repository.ErrNoWorkerAvailable) {
-			defer s.deferredStepRunEvent(
+			defer s.DeferredStepRunEvent(
 				stepRun.SRID,
 				dbsqlc.StepRunEventReasonREQUEUEDNOWORKER,
 				dbsqlc.StepRunEventSeverityWARNING,
@@ -735,7 +735,7 @@ func (s *stepRunEngineRepository) AssignStepRunToWorker(ctx context.Context, ste
 		}
 
 		if errors.Is(err, repository.ErrRateLimitExceeded) {
-			defer s.deferredStepRunEvent(
+			defer s.DeferredStepRunEvent(
 				stepRun.SRID,
 				dbsqlc.StepRunEventReasonREQUEUEDRATELIMIT,
 				dbsqlc.StepRunEventSeverityWARNING,
@@ -747,7 +747,7 @@ func (s *stepRunEngineRepository) AssignStepRunToWorker(ctx context.Context, ste
 		return "", "", err
 	}
 
-	defer s.deferredStepRunEvent(
+	defer s.DeferredStepRunEvent(
 		stepRun.SRID,
 		dbsqlc.StepRunEventReasonASSIGNED,
 		dbsqlc.StepRunEventSeverityINFO,
@@ -911,7 +911,7 @@ func (s *stepRunEngineRepository) ReplayStepRun(ctx context.Context, tenantId, s
 			}
 
 			// create a deferred event for each of these step runs
-			defer s.deferredStepRunEvent(
+			defer s.DeferredStepRunEvent(
 				laterStepRunCp.ID,
 				dbsqlc.StepRunEventReasonRETRIEDBYUSER,
 				dbsqlc.StepRunEventSeverityINFO,
@@ -1554,7 +1554,7 @@ func (s *stepRunEngineRepository) RefreshTimeoutBy(ctx context.Context, tenantId
 		return nil, err
 	}
 
-	defer s.deferredStepRunEvent(
+	defer s.DeferredStepRunEvent(
 		stepRunUUID,
 		dbsqlc.StepRunEventReasonTIMEOUTREFRESHED,
 		dbsqlc.StepRunEventSeverityINFO,

--- a/pkg/repository/step_run.go
+++ b/pkg/repository/step_run.go
@@ -179,6 +179,8 @@ type StepRunEngineRepository interface {
 
 	AssignStepRunToWorker(ctx context.Context, stepRun *dbsqlc.GetStepRunForEngineRow) (workerId string, dispatcherId string, err error)
 
+	UnassignStepRunFromWorker(ctx context.Context, tenantId, stepRunId string) error
+
 	GetStepRunForEngine(ctx context.Context, tenantId, stepRunId string) (*dbsqlc.GetStepRunForEngineRow, error)
 
 	GetStepRunDataForEngine(ctx context.Context, tenantId, stepRunId string) (*dbsqlc.GetStepRunDataForEngineRow, error)

--- a/pkg/repository/step_run.go
+++ b/pkg/repository/step_run.go
@@ -194,4 +194,12 @@ type StepRunEngineRepository interface {
 	RefreshTimeoutBy(ctx context.Context, tenantId, stepRunId string, opts RefreshTimeoutBy) (*dbsqlc.StepRun, error)
 
 	ResolveRelatedStatuses(ctx context.Context, tenantId pgtype.UUID, stepRunId pgtype.UUID) (*StepRunUpdateInfo, error)
+
+	DeferredStepRunEvent(
+		stepRunId pgtype.UUID,
+		reason dbsqlc.StepRunEventReason,
+		severity dbsqlc.StepRunEventSeverity,
+		message string,
+		data map[string]interface{},
+	)
 }


### PR DESCRIPTION
# Description

It is possible for a step run to be assigned to a worker, but the start event is not successfully pushed to the worker grpc stream. This can lead to blocked workers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Revert step run to pending assignment if it fails to send
- [x] Improve visibility by writing step run events for step run state