### PR TITLE
fix: soft delete workflows causes collision on new workflow inserts

### DIFF
--- a/pkg/repository/prisma/dbsqlc/workflows.sql
+++ b/pkg/repository/prisma/dbsqlc/workflows.sql
@@ -493,6 +493,9 @@ WITH versions AS (
     WHERE "workflowId" = @id::uuid
 )
 UPDATE "Workflow"
-SET "deletedAt" = CURRENT_TIMESTAMP
+SET
+    -- set name to the current name plus a random suffix to avoid conflicts
+    "name" = "name" || '-' || gen_random_uuid(),
+    "deletedAt" = CURRENT_TIMESTAMP
 WHERE "id" = @id::uuid
 RETURNING *;

--- a/pkg/repository/prisma/dbsqlc/workflows.sql.go
+++ b/pkg/repository/prisma/dbsqlc/workflows.sql.go
@@ -1100,7 +1100,10 @@ WITH versions AS (
     WHERE "workflowId" = $1::uuid
 )
 UPDATE "Workflow"
-SET "deletedAt" = CURRENT_TIMESTAMP
+SET
+    -- set name to the current name plus a random suffix to avoid conflicts
+    "name" = "name" || '-' || gen_random_uuid(),
+    "deletedAt" = CURRENT_TIMESTAMP
 WHERE "id" = $1::uuid
 RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", name, description
 `


### PR DESCRIPTION
# Description

Fixes collision when creating a new workflow with the same name as a deleted workflow. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)