### PR TITLE
feat: make max msg size configurable

### DIFF
--- a/internal/services/grpc/server.go
+++ b/internal/services/grpc/server.go
@@ -259,6 +259,12 @@ func (s *Server) startGRPC() (func() error, error) {
 
 	serverOpts = append(serverOpts, grpc.KeepaliveParams(kasp))
 
+	serverOpts = append(serverOpts, grpc.MaxRecvMsgSize(
+		s.config.Runtime.GRPCMaxMsgSize,
+	), grpc.MaxSendMsgSize(
+		s.config.Runtime.GRPCMaxMsgSize,
+	))
+
 	grpcServer := grpc.NewServer(serverOpts...)
 
 	if s.ingestor != nil {

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -72,6 +72,9 @@ type ConfigFileRuntime struct {
 	// GRPCInsecure controls whether the grpc server is insecure or uses certs
 	GRPCInsecure bool `mapstructure:"grpcInsecure" json:"grpcInsecure,omitempty" default:"false"`
 
+	// GRPCMaxMsgSize is the maximum message size that the grpc server will accept
+	GRPCMaxMsgSize int `mapstructure:"grpcMaxMsgSize" json:"grpcMaxMsgSize,omitempty" default:"4194304"`
+
 	// ShutdownWait is the time between the readiness probe being offline when a shutdown is triggered and the actual start of cleaning up resources.
 	ShutdownWait time.Duration `mapstructure:"shutdownWait" json:"shutdownWait,omitempty" default:"20s"`
 


### PR DESCRIPTION
# Description

Makes GRPC max message size configurable. Defaults to 4 MB. 

## Type of change

- [X] New feature (non-breaking change which adds functionality)