### PR TITLE
feat: propagate additional metadata on spawn

### DIFF
--- a/pkg/repository/workflow_run.go
+++ b/pkg/repository/workflow_run.go
@@ -70,12 +70,25 @@ func WithParent(
 	parentId, parentStepRunId string,
 	childIndex int,
 	childKey *string,
+	additionalMetadata map[string]interface{},
+	parentAdditionalMetadata map[string]interface{},
 ) CreateWorkflowRunOpt {
 	return func(opts *CreateWorkflowRunOpts) {
 		opts.ParentId = &parentId
 		opts.ParentStepRunId = &parentStepRunId
 		opts.ChildIndex = &childIndex
 		opts.ChildKey = childKey
+
+		opts.AdditionalMetadata = parentAdditionalMetadata
+
+		if opts.AdditionalMetadata == nil {
+			opts.AdditionalMetadata = make(map[string]interface{})
+		}
+
+		for k, v := range additionalMetadata {
+			opts.AdditionalMetadata[k] = v
+		}
+
 	}
 }
 
@@ -113,6 +126,7 @@ func GetCreateWorkflowRunOptsFromParent(
 	childIndex int,
 	childKey *string,
 	additionalMetadata map[string]interface{},
+	parentAdditionalMetadata map[string]interface{},
 ) (*CreateWorkflowRunOpts, error) {
 	if input == nil {
 		input = []byte("{}")
@@ -124,10 +138,9 @@ func GetCreateWorkflowRunOptsFromParent(
 		ManualTriggerInput: StringPtr(string(input)),
 		TriggeredBy:        string(datautils.TriggeredByParent),
 		InputData:          input,
-		AdditionalMetadata: additionalMetadata,
 	}
 
-	WithParent(parentId, parentStepRunId, childIndex, childKey)(opts)
+	WithParent(parentId, parentStepRunId, childIndex, childKey, additionalMetadata, parentAdditionalMetadata)(opts)
 
 	if workflowVersion.ConcurrencyLimitStrategy.Valid {
 		opts.GetGroupKeyRun = &CreateGroupKeyRunOpts{


### PR DESCRIPTION
# Description

Propagates Additional Meta params from parent workflow runs to children. This matches the expected behavior from event -> workflow run.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## What's Changed

- [x] If a parent has additional meta set it will now propagate to a child spawned via the context object. If additional metadata is set via spawn, these keys will be added to or override parent additional meta (the data will be merged).
