### PR TITLE
docs: The tab order for python/typescript/go was wrong

### DIFF
--- a/frontend/docs/pages/home/features/child-workflows.mdx
+++ b/frontend/docs/pages/home/features/child-workflows.mdx
@@ -222,6 +222,29 @@ For example, to spawn a recovery workflow if a child workflow fails:
 <Tabs items={['Python', 'Typescript', 'Go']}>
   <Tabs.Tab>
 
+```python
+@hatchet.workflow("fanout:create")
+class Parent:
+    @hatchet.step()
+    async def spawn(self, context: Context):
+        try:
+            (
+                await context.aio.spawn_workflow(
+                  "Child", {"a": str(i)}, key=f"child{i}"
+                )
+            ).result()
+        except Exception as e:
+          # Spawn a recovery workflow
+          context.spawn_workflow("recovery-workflow", { "error": str(e) });
+
+        return {}
+
+```
+
+  </Tabs.Tab>
+
+  <Tabs.Tab>
+
 ```typescript
 const parentWorkflow: Workflow = {
   id: "parent-workflow",
@@ -252,28 +275,7 @@ const parentWorkflow: Workflow = {
 ```
 
   </Tabs.Tab>
-  <Tabs.Tab>
 
-```python
-@hatchet.workflow("fanout:create")
-class Parent:
-    @hatchet.step()
-    async def spawn(self, context: Context):
-        try:
-            (
-                await context.aio.spawn_workflow(
-                  "Child", {"a": str(i)}, key=f"child{i}"
-                )
-            ).result()
-        except Exception as e:
-          # Spawn a recovery workflow
-          context.spawn_workflow("recovery-workflow", { "error": str(e) });
-
-        return {}
-
-```
-
-  </Tabs.Tab>
   <Tabs.Tab>
 
 ```go


### PR DESCRIPTION
# Description

On of the docs had python/typescript/go mixed up. I simply put them in the right order

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Documentation change (pure documentation change)
- [x] Chore (changes which are not directly related to any business logic)
- [x] This change requires a documentation update

## What's Changed

- [x] order of code samples
