### PR TITLE
fix: add max msg size as env var

### DIFF
--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -367,6 +367,7 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("runtime.grpcBindAddress", "SERVER_GRPC_BIND_ADDRESS")
 	_ = v.BindEnv("runtime.grpcBroadcastAddress", "SERVER_GRPC_BROADCAST_ADDRESS")
 	_ = v.BindEnv("runtime.grpcInsecure", "SERVER_GRPC_INSECURE")
+	_ = v.BindEnv("runtime.grpcMaxMsgSize", "SERVER_GRPC_MAX_MSG_SIZE")
 	_ = v.BindEnv("runtime.shutdownWait", "SERVER_SHUTDOWN_WAIT")
 	_ = v.BindEnv("services", "SERVER_SERVICES")
 	_ = v.BindEnv("runtime.enforceLimits", "SERVER_ENFORCE_LIMITS")


### PR DESCRIPTION
# Description

Adds max msg size as env var `SERVER_GRPC_MAX_MSG_SIZE` so it's easier to set. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)