### PR TITLE
fix broken link to child-workflows

### DIFF
--- a/frontend/docs/pages/launches/child-workflows.mdx
+++ b/frontend/docs/pages/launches/child-workflows.mdx
@@ -122,6 +122,6 @@ Child workflows can be used to support more complex use-cases, like:
 
 ## Feedback
 
-The example repository illustrating child workflows can be found [here](https://github.com/hatchet-dev/hatchet-typescript-quickstart/tree/main/child-workfows).
+The example repository illustrating child workflows can be found [here](https://github.com/hatchet-dev/hatchet-typescript-quickstart/tree/main/child-workflows).
 
 Child workflows are available in engine version `v0.18.0` and above, and on all the latest SDK versions. We'd love to hear your feedback in our [Discord](https://discord.gg/ZMeUafwH89)!


### PR DESCRIPTION
Small fix to correct a typo that resulted in a broken link