### PR TITLE
fix: use single queue limit

### DIFF
--- a/pkg/repository/prisma/step_run.go
+++ b/pkg/repository/prisma/step_run.go
@@ -865,7 +865,7 @@ func (s *stepRunEngineRepository) QueueStepRuns(ctx context.Context, tenantId st
 
 	limit := 100
 
-	if limit > s.cf.SingleQueueLimit {
+	if s.cf.SingleQueueLimit != 0 {
 		limit = s.cf.SingleQueueLimit
 	}
 


### PR DESCRIPTION
# Description

We previously weren't using the single queue limit correctly when set to `>100`. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)