### PR TITLE
fix: reassignment should reset scheduling timeout

### DIFF
--- a/pkg/repository/prisma/dbsqlc/step_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql
@@ -408,7 +408,6 @@ step_runs_to_reassign AS (
     WHERE
         "workerId" = ANY(SELECT "id" FROM inactive_workers)
         AND "stepRunId" IS NOT NULL
-    FOR UPDATE SKIP LOCKED
 ),
 update_semaphore_steps AS (
     UPDATE "WorkerSemaphoreSlot" wss
@@ -423,13 +422,15 @@ step_runs_with_data AS (
         sr."scheduleTimeoutAt",
         s."actionId",
         s."id" AS "stepId",
-        s."timeout" AS "stepTimeout"
+        s."timeout" AS "stepTimeout",
+        s."scheduleTimeout" AS "scheduleTimeout"
     FROM
         "StepRun" sr
     JOIN
         "Step" s ON sr."stepId" = s."id"
     WHERE
         sr."id" = ANY(SELECT "stepRunId" FROM step_runs_to_reassign)
+    FOR UPDATE SKIP LOCKED
 ),
 inserted_queue_items AS (
     INSERT INTO "QueueItem" (
@@ -447,9 +448,7 @@ inserted_queue_items AS (
         srs."id",
         srs."stepId",
         srs."actionId",
-        -- FIXME: this should be configurable. It doesn't make sense to use the existing scheduleTimeoutAt
-        -- as we might be well past that time.
-        NOW() + INTERVAL '5 minutes',
+        CURRENT_TIMESTAMP + COALESCE(convert_duration_to_interval(srs."scheduleTimeout"), INTERVAL '5 minutes'),
         srs."stepTimeout",
         -- Queue with priority 4 so that reassignment gets highest priority
         4,
@@ -458,6 +457,16 @@ inserted_queue_items AS (
         srs."actionId"
     FROM
         step_runs_with_data srs
+),
+updated_step_runs AS (
+    UPDATE "StepRun" sr
+    SET
+        "status" = 'PENDING_ASSIGNMENT',
+        "scheduleTimeoutAt" = CURRENT_TIMESTAMP + COALESCE(convert_duration_to_interval(srs."scheduleTimeout"), INTERVAL '5 minutes'),
+        "updatedAt" = CURRENT_TIMESTAMP
+    FROM step_runs_with_data srs
+    WHERE sr."id" = srs."id"
+    RETURNING sr."id"
 )
 SELECT
     srs."id"


### PR DESCRIPTION
# Description

Fixes an issue where reassignments which occur after the original scheduling timeout cause the step to end up in a permanently assigned state.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)