### PR TITLE
fix: long token expiry for k8s quickstart

### DIFF
--- a/cmd/hatchet-admin/cli/k8s.go
+++ b/cmd/hatchet-admin/cli/k8s.go
@@ -97,7 +97,7 @@ func init() {
 	k8sQuickstartCmd.PersistentFlags().BoolVar(
 		&k8sQuickstartOverwrite,
 		"overwrite",
-		true,
+		false,
 		"whether existing configmap should be overwritten, if it exists",
 	)
 
@@ -168,6 +168,14 @@ func runK8sQuickstart() error {
 		encryptionJwtPrivateKeyset: c.get("SERVER_ENCRYPTION_JWT_PRIVATE_KEYSET"),
 		encryptionJwtPublicKeyset:  c.get("SERVER_ENCRYPTION_JWT_PUBLIC_KEYSET"),
 	}
+
+	fmt.Printf(
+		"overwrite: %t, exists: %t, hasAuthCookieSecrets: %t, hasEncryptionKeys: %t\n",
+		k8sQuickstartOverwrite,
+		exists,
+		res.authCookieSecrets != "",
+		res.encryptionMasterKeyset != "" && res.encryptionJwtPrivateKeyset != "" && res.encryptionJwtPublicKeyset != "",
+	)
 
 	if k8sQuickstartOverwrite || res.authCookieSecrets == "" {
 		// generate the random strings for SERVER_AUTH_COOKIE_SECRETS

--- a/cmd/hatchet-admin/cli/k8s.go
+++ b/cmd/hatchet-admin/cli/k8s.go
@@ -169,14 +169,6 @@ func runK8sQuickstart() error {
 		encryptionJwtPublicKeyset:  c.get("SERVER_ENCRYPTION_JWT_PUBLIC_KEYSET"),
 	}
 
-	fmt.Printf(
-		"overwrite: %t, exists: %t, hasAuthCookieSecrets: %t, hasEncryptionKeys: %t\n",
-		k8sQuickstartOverwrite,
-		exists,
-		res.authCookieSecrets != "",
-		res.encryptionMasterKeyset != "" && res.encryptionJwtPrivateKeyset != "" && res.encryptionJwtPublicKeyset != "",
-	)
-
 	if k8sQuickstartOverwrite || res.authCookieSecrets == "" {
 		// generate the random strings for SERVER_AUTH_COOKIE_SECRETS
 		authCookieSecret1, err := random.Generate(16)
@@ -258,7 +250,7 @@ func runCreateWorkerToken() error {
 
 	defer serverConf.Disconnect() // nolint:errcheck
 
-	expiresAt := time.Now().UTC().Add(expiresIn)
+	expiresAt := time.Now().UTC().Add(100 * 365 * 24 * time.Hour)
 
 	tenantId := tokenTenantId
 


### PR DESCRIPTION
# Description

Increase token expiration to 100 years when setting up with quickstart. 

## Type of change

- [X] Chore (changes which are not directly related to any business logic)