### PR TITLE
fix: hard sticky assignment to workers when no desired worker id

### DIFF
--- a/pkg/scheduling/fixtures/sticky_hard_no_desired.json
+++ b/pkg/scheduling/fixtures/sticky_hard_no_desired.json
@@ -1,0 +1,53 @@
+{
+  "Slots": [
+    {
+      "id": "8cf68f09-b914-4f31-9777-8082b751a2d4",
+      "workerId": "aaaaaaaa-43db-4b5f-876a-c6c71f4d52aa",
+      "dispatcherId": "9994a9eb-430d-46da-934d-d9dd953cfd21",
+      "actionId": "child:process2"
+    },
+    {
+      "id": "aed946be-43db-4b5f-876a-c6c71f4d52aa",
+      "workerId": "aaaaaaaa-43db-4b5f-876a-c6c71f4d52aa",
+      "dispatcherId": "9994a9eb-430d-46da-934d-d9dd953cfd21",
+      "actionId": "child:process2"
+    }
+  ],
+  "UniqueActions": ["child:process2"],
+  "QueueItems": [
+    {
+      "id": 137295,
+      "stepRunId": "16fa711e-c03e-435c-88d9-62adf1591d98",
+      "stepId": "29fae13a-6672-48cb-9aed-3b0bf481f570",
+      "actionId": "child:process2",
+      "scheduleTimeoutAt": "2024-08-07T19:43:30.692Z",
+      "stepTimeout": "60s",
+      "isQueued": true,
+      "tenantId": "707d0855-80ab-4e1f-a156-f1c4546cbf52",
+      "queue": "child:process2",
+      "Order": 0,
+      "sticky": {
+        "StickyStrategy": "HARD",
+        "Valid": true
+      }
+    },
+    {
+      "id": 152259,
+      "stepRunId": "064e787a-6cfd-4f82-8b6d-d8031459fdee",
+      "stepId": "e2c744b8-bebb-4b05-8292-d2ce36f27928",
+      "actionId": "child:process2",
+      "scheduleTimeoutAt": "2024-08-07T21:12:49.56Z",
+      "stepTimeout": "60s",
+      "isQueued": true,
+      "tenantId": "707d0855-80ab-4e1f-a156-f1c4546cbf52",
+      "queue": "child:process2",
+      "Order": 1,
+      "sticky": {
+        "StickyStrategy": "HARD",
+        "Valid": true
+      }
+    }
+  ],
+  "WorkerLabels": {},
+  "StepDesiredLabels": {}
+}

--- a/pkg/scheduling/fixtures/sticky_hard_no_desired_output.json
+++ b/pkg/scheduling/fixtures/sticky_hard_no_desired_output.json
@@ -1,0 +1,35 @@
+{
+  "StepRunIds": [
+    "16fa711e-c03e-435c-88d9-62adf1591d98",
+    "064e787a-6cfd-4f82-8b6d-d8031459fdee"
+  ],
+  "StepRunTimeouts": ["60s", "60s"],
+  "SlotIds": [
+    "8cf68f09-b914-4f31-9777-8082b751a2d4",
+    "aed946be-43db-4b5f-876a-c6c71f4d52aa"
+  ],
+  "WorkerIds": [
+    "aaaaaaaa-43db-4b5f-876a-c6c71f4d52aa",
+    "aaaaaaaa-43db-4b5f-876a-c6c71f4d52aa"
+  ],
+  "UnassignedStepRunIds": [],
+  "QueuedStepRuns": [
+    {
+      "StepRunId": "16fa711e-c03e-435c-88d9-62adf1591d98",
+      "WorkerId": "aaaaaaaa-43db-4b5f-876a-c6c71f4d52aa",
+      "DispatcherId": "9994a9eb-430d-46da-934d-d9dd953cfd21"
+    },
+    {
+      "StepRunId": "064e787a-6cfd-4f82-8b6d-d8031459fdee",
+      "WorkerId": "aaaaaaaa-43db-4b5f-876a-c6c71f4d52aa",
+      "DispatcherId": "9994a9eb-430d-46da-934d-d9dd953cfd21"
+    }
+  ],
+  "TimedOutStepRuns": [],
+  "RateLimitedStepRuns": [],
+  "RateLimitedQueues": {},
+  "QueuedItems": [137295, 152259],
+  "ShouldContinue": false,
+  "MinQueuedIds": {},
+  "RateLimitUnitsConsumed": {}
+}

--- a/pkg/scheduling/scheduling_test.go
+++ b/pkg/scheduling/scheduling_test.go
@@ -229,6 +229,25 @@ func TestGeneratePlan(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "GeneratePlan_Sticky_Hard_No_Desired",
+			args: args{
+				fixtureArgs:   "./fixtures/sticky_hard_no_desired.json",
+				fixtureResult: "./fixtures/sticky_hard_no_desired_output.json",
+				noTimeout:     true,
+			},
+			want: func(s SchedulePlan, fixtureResult string) bool {
+				// DumpResults(s, "sticky_hard_output.json")
+
+				assert, err := assertResult(s, fixtureResult)
+				if err != nil {
+					fmt.Println(err)
+				}
+
+				return assert
+			},
+			wantErr: assert.NoError,
+		},
+		{
 			name: "GeneratePlan_TimedOut",
 			args: args{
 				fixtureArgs:   "./fixtures/simple_plan.json",

--- a/pkg/scheduling/worker_state_manager.go
+++ b/pkg/scheduling/worker_state_manager.go
@@ -87,7 +87,7 @@ func (wm *WorkerStateManager) AttemptAssignSlot(qi *QueueItemWithOrder) *dbsqlc.
 			return nil
 		}
 
-		if qi.Sticky.StickyStrategy == dbsqlc.StickyStrategyHARD {
+		if qi.DesiredWorkerId.Valid && qi.Sticky.StickyStrategy == dbsqlc.StickyStrategyHARD {
 			// if we have a HARD sticky worker and we can't find it then return nil
 			// to indicate that we can't assign the slot
 			return nil


### PR DESCRIPTION
# Description

Fixes an issue where `sticky` is `true` with a hard requirement, but the run does not have a `desiredWorkerId`. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)