### PR TITLE
Golang Example Delimeters

### DIFF
--- a/examples/assignment-affinity/run.go
+++ b/examples/assignment-affinity/run.go
@@ -1,3 +1,4 @@
+//Golang
 package main
 
 import (
@@ -16,7 +17,7 @@ func run() (func() error, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error creating client: %w", err)
 	}
-
+	//START specifying-worker-labels
 	w, err := worker.NewWorker(
 		worker.WithClient(
 			c,
@@ -26,10 +27,11 @@ func run() (func() error, error) {
 			"memory": 512,
 		}),
 	)
+	//END specifying-worker-labels
 	if err != nil {
 		return nil, fmt.Errorf("error creating worker: %w", err)
 	}
-
+	//START specifying-step-desired-labels
 	err = w.RegisterWorkflow(
 		&worker.WorkflowJob{
 			On:          worker.Events("user:create:affinity"),
@@ -69,6 +71,7 @@ func run() (func() error, error) {
 			},
 		},
 	)
+	//END specifying-step-desired-labels
 	if err != nil {
 		return nil, fmt.Errorf("error registering workflow: %w", err)
 	}

--- a/examples/assignment-sticky/run.go
+++ b/examples/assignment-sticky/run.go
@@ -1,3 +1,4 @@
+//Golang
 package main
 
 import (
@@ -25,7 +26,7 @@ func run() (func() error, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error creating worker: %w", err)
 	}
-
+	//START setting-sticky-assignment
 	err = w.RegisterWorkflow(
 		&worker.WorkflowJob{
 			On:             worker.Events("user:create:sticky"),
@@ -62,6 +63,7 @@ func run() (func() error, error) {
 			},
 		},
 	)
+	//END setting-sticky-assignment
 	if err != nil {
 		return nil, fmt.Errorf("error registering workflow: %w", err)
 	}

--- a/examples/cancellation/run.go
+++ b/examples/cancellation/run.go
@@ -1,3 +1,4 @@
+//Golang
 package main
 
 import (
@@ -28,7 +29,7 @@ func run(events chan<- string) (func() error, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error creating worker: %w", err)
 	}
-
+	//START cancellation-mechanisms
 	err = w.RegisterWorkflow(
 		&worker.WorkflowJob{
 			On:          worker.Events("user:create:cancellation"),
@@ -54,6 +55,7 @@ func run(events chan<- string) (func() error, error) {
 			},
 		},
 	)
+	//END cancellation-mechanisms
 	if err != nil {
 		return nil, fmt.Errorf("error registering workflow: %w", err)
 	}

--- a/examples/limit-concurrency/cancel-in-progress/main.go
+++ b/examples/limit-concurrency/cancel-in-progress/main.go
@@ -1,5 +1,7 @@
+//Golang
 package main
 
+//START concurrency_cancel_in_progress
 import (
 	"context"
 	"fmt"
@@ -139,3 +141,4 @@ func run(ch <-chan interface{}, events chan<- string) error {
 		}
 	}
 }
+//END concurrency_cancel_in_progress

--- a/examples/limit-concurrency/group-round-robin/main.go
+++ b/examples/limit-concurrency/group-round-robin/main.go
@@ -1,3 +1,4 @@
+//Golang
 package main
 
 import (
@@ -50,12 +51,13 @@ func run(ch <-chan interface{}, events chan<- string) error {
 	if err != nil {
 		return fmt.Errorf("error creating client: %w", err)
 	}
-
+	//START setting-concurrency-on-workers
 	w, err := worker.NewWorker(
 		worker.WithClient(
 			c,
 		),
 	)
+	//END setting-concurrency-on-workers
 	if err != nil {
 		return fmt.Errorf("error creating worker: %w", err)
 	}

--- a/examples/limit-concurrency/group-round-robin/main.go
+++ b/examples/limit-concurrency/group-round-robin/main.go
@@ -63,7 +63,7 @@ func run(ch <-chan interface{}, events chan<- string) error {
 	}
 
 	testSvc := w.NewService("test")
-
+	//START concurrency_group_red_robin
 	err = testSvc.On(
 		worker.Events("concurrency-test-event-rr"),
 		&worker.WorkflowJob{
@@ -92,6 +92,7 @@ func run(ch <-chan interface{}, events chan<- string) error {
 			},
 		},
 	)
+	//END concurrency_group_red_robin
 	if err != nil {
 		return fmt.Errorf("error registering workflow: %w", err)
 	}

--- a/examples/on-failure/main.go
+++ b/examples/on-failure/main.go
@@ -1,3 +1,4 @@
+//Golang
 package main
 
 import (
@@ -10,7 +11,7 @@ import (
 	"github.com/hatchet-dev/hatchet/pkg/cmdutils"
 	"github.com/hatchet-dev/hatchet/pkg/worker"
 )
-
+//START defining-an-on-failure-step
 type stepOneOutput struct {
 	Message string `json:"message"`
 }
@@ -90,3 +91,4 @@ func main() {
 		}
 	}
 }
+//END defining-an-on-failure-step

--- a/examples/rate-limit/main.go
+++ b/examples/rate-limit/main.go
@@ -1,3 +1,4 @@
+//Golang
 package main
 
 import (
@@ -48,11 +49,12 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-
+	//START declaring-global-limits
 	err = c.Admin().PutRateLimit("api1", &types.RateLimitOpts{
 		Max:      3,
 		Duration: "day",
 	})
+	//END declaring-global-limits
 
 	if err != nil {
 		panic(err)
@@ -67,7 +69,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-
+	//START consuming-rate-limits
 	err = w.On(
 		worker.NoTrigger(),
 		&worker.WorkflowJob{
@@ -83,7 +85,7 @@ func main() {
 			},
 		},
 	)
-
+	//END consuming-rate-limits
 	if err != nil {
 		panic(err)
 	}

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -1,3 +1,4 @@
+//Golang
 package main
 
 import (
@@ -48,6 +49,7 @@ func getConcurrencyKey(ctx worker.HatchetContext) (string, error) {
 }
 
 func run(events chan<- string) (func() error, error) {
+	//START registering_workflows_starting_workers
 	c, err := client.New()
 
 	if err != nil {
@@ -141,4 +143,5 @@ func run(events chan<- string) (func() error, error) {
 	}
 
 	return cleanup, nil
+	//END registering_workflows_starting_workers
 }

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -24,6 +24,7 @@ type stepOneOutput struct {
 }
 
 func main() {
+	//START how-to-use-step-level-retries
 	err := godotenv.Load()
 	if err != nil {
 		panic(err)
@@ -42,6 +43,7 @@ func main() {
 	if err := cleanup(); err != nil {
 		panic(fmt.Errorf("error cleaning up: %w", err))
 	}
+	//END how-to-use-step-level-retries
 }
 
 func getConcurrencyKey(ctx worker.HatchetContext) (string, error) {

--- a/examples/stream-event-by-meta/main.go
+++ b/examples/stream-event-by-meta/main.go
@@ -1,3 +1,4 @@
+//Golang
 package main
 
 import (
@@ -82,7 +83,7 @@ func main() {
 	if err != nil {
 		panic(fmt.Errorf("error cleaning up: %w", err))
 	}
-
+	//START streaming-by-additional-metadata
 	// Generate a random number between 1 and 100
 	streamKey := "streamKey"
 	streamValue := fmt.Sprintf("stream-event-%d", rand.Intn(100)+1)
@@ -107,4 +108,5 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	//END streaming-by-additional-metadata
 }

--- a/examples/timeout/main.go
+++ b/examples/timeout/main.go
@@ -1,3 +1,4 @@
+//Golang
 package main
 
 import (
@@ -24,7 +25,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-
+	//START scheduling-timeouts
 	events := make(chan string, 50)
 	cleanup, err := run(events, worker.WorkflowJob{
 		Name:        "timeout",
@@ -36,6 +37,7 @@ func main() {
 			}).SetName("step-one").SetTimeout("10s"),
 		},
 	})
+	//END scheduling-timeouts
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Adding delimiters to the Golang examples. We used our best judgement to set these delimeters. In some cases, these code blocks are not 1:1 to the examples in the docs (and in others, they can not be found at all in the examples folder).

Delimeters include:
- `//Golang` at the front of the file.
- `//START (codeblock name)` at the start of the code block.
- `//END (codeblock name)` at the end of the code block.

Codeblock names should be unique within a language.