### PR TITLE
fix: delete queue items when no longer used

### DIFF
--- a/internal/services/controllers/retention/controller.go
+++ b/internal/services/controllers/retention/controller.go
@@ -146,7 +146,7 @@ func (rc *RetentionControllerImpl) Start() (func() error, error) {
 
 	if err != nil {
 		cancel()
-		return nil, fmt.Errorf("could not delete expired workflow runs: %w", err)
+		return nil, fmt.Errorf("could not set up runDeleteExpiredWorkflowRuns: %w", err)
 	}
 
 	_, err = rc.s.NewJob(
@@ -158,7 +158,7 @@ func (rc *RetentionControllerImpl) Start() (func() error, error) {
 
 	if err != nil {
 		cancel()
-		return nil, fmt.Errorf("could not delete expired events: %w", err)
+		return nil, fmt.Errorf("could not set up runDeleteExpiredEvents: %w", err)
 	}
 
 	_, err = rc.s.NewJob(
@@ -170,7 +170,19 @@ func (rc *RetentionControllerImpl) Start() (func() error, error) {
 
 	if err != nil {
 		cancel()
-		return nil, fmt.Errorf("could not delete expired step runs: %w", err)
+		return nil, fmt.Errorf("could not set up runDeleteExpiredStepRuns: %w", err)
+	}
+
+	_, err = rc.s.NewJob(
+		gocron.DurationJob(interval),
+		gocron.NewTask(
+			rc.runDeleteQueueItems(ctx),
+		),
+	)
+
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("could not set up runDeleteQueueItems: %w", err)
 	}
 
 	_, err = rc.s.NewJob(
@@ -182,7 +194,7 @@ func (rc *RetentionControllerImpl) Start() (func() error, error) {
 
 	if err != nil {
 		cancel()
-		return nil, fmt.Errorf("could not delete expired job runs: %w", err)
+		return nil, fmt.Errorf("could not set up runDeleteExpiredJobRuns: %w", err)
 	}
 	rc.s.Start()
 

--- a/internal/services/controllers/retention/queue.go
+++ b/internal/services/controllers/retention/queue.go
@@ -1,0 +1,33 @@
+package retention
+
+import (
+	"context"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/internal/telemetry"
+	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/dbsqlc"
+	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/sqlchelpers"
+)
+
+func (rc *RetentionControllerImpl) runDeleteQueueItems(ctx context.Context) func() {
+	return func() {
+		ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		defer cancel()
+
+		rc.l.Debug().Msgf("retention controller: deleting queue items")
+
+		err := rc.ForTenants(ctx, rc.runDeleteQueueItemsTenant)
+
+		if err != nil {
+			rc.l.Err(err).Msg("could not run delete expired job runs")
+		}
+	}
+}
+
+func (rc *RetentionControllerImpl) runDeleteQueueItemsTenant(ctx context.Context, tenant dbsqlc.Tenant) error {
+	ctx, span := telemetry.NewSpan(ctx, "delete-queue-items-tenant")
+	defer span.End()
+
+	tenantId := sqlchelpers.UUIDToStr(tenant.ID)
+	return rc.repo.StepRun().CleanupQueueItems(ctx, tenantId)
+}

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -410,6 +410,7 @@ func GetServerConfigFromConfigfile(dc *database.Config, cf *server.ServerConfigF
 		Email:                  emailSvc,
 		TenantAlerter:          alerting.New(dc.EngineRepository, encryptionSvc, cf.Runtime.ServerURL, emailSvc),
 		AdditionalOAuthConfigs: additionalOAuthConfigs,
+		EnableDataRetention:    cf.EnableDataRetention,
 	}, nil
 }
 

--- a/pkg/repository/prisma/dbsqlc/queue.sql
+++ b/pkg/repository/prisma/dbsqlc/queue.sql
@@ -49,6 +49,24 @@ VALUES
         sqlc.narg('desiredWorkerId')::uuid
     );
 
+-- name: GetMinMaxProcessedQueueItems :one
+SELECT
+    COALESCE(MIN("id"), 0)::bigint AS "minId",
+    COALESCE(MAX("id"), 0)::bigint AS "maxId"
+FROM
+    "QueueItem"
+WHERE
+    "isQueued" = 'f'
+    AND "tenantId" = @tenantId::uuid;
+
+-- name: CleanupQueueItems :exec
+DELETE FROM "QueueItem"
+WHERE "isQueued" = 'f'
+AND
+    "id" >= @minId::bigint
+    AND "id" <= @maxId::bigint
+    AND "tenantId" = @tenantId::uuid;
+
 -- name: ListQueueItems :batchmany
 SELECT
     *

--- a/pkg/repository/step_run.go
+++ b/pkg/repository/step_run.go
@@ -202,6 +202,8 @@ type StepRunEngineRepository interface {
 
 	QueueStepRuns(ctx context.Context, tenantId string) (QueueStepRunsResult, error)
 
+	CleanupQueueItems(ctx context.Context, tenantId string) error
+
 	ListStartableStepRuns(ctx context.Context, tenantId, jobRunId string, parentStepRunId *string) ([]*dbsqlc.GetStepRunForEngineRow, error)
 
 	ArchiveStepRunResult(ctx context.Context, tenantId, stepRunId string) error


### PR DESCRIPTION
# Description

Deletes queue items from the database when `isQueued = 'f'`. This avoids index bloat on the QueueItem table with high throughput. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)