### PR TITLE
fix: use separate database pool for queueing, statement timeouts on tx

### DIFF
--- a/internal/services/controllers/jobs/queue.go
+++ b/internal/services/controllers/jobs/queue.go
@@ -69,7 +69,6 @@ type operation struct {
 	isRunning      bool
 	tenantId       string
 	lastRun        time.Time
-	lastSchedule   time.Time
 }
 
 func (o *operation) run(l *zerolog.Logger, ql *zerolog.Logger, scheduler func(context.Context, string) (bool, error)) {
@@ -85,9 +84,6 @@ func (o *operation) run(l *zerolog.Logger, ql *zerolog.Logger, scheduler func(co
 		}()
 
 		f := func() {
-			ql.Info().Str("tenant_id", o.tenantId).TimeDiff("last_schedule", time.Now(), o.lastSchedule).Msg("running scheduling")
-			o.lastSchedule = time.Now()
-
 			o.setContinue(false)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -269,9 +265,8 @@ func (q *queue) runTenantQueues(ctx context.Context) func() {
 
 			if !ok {
 				op = &operation{
-					tenantId:     tenantId,
-					lastRun:      time.Now(),
-					lastSchedule: time.Now(),
+					tenantId: tenantId,
+					lastRun:  time.Now(),
 				}
 
 				q.tenantOperations.Store(tenantId, op)

--- a/internal/services/controllers/jobs/queue.go
+++ b/internal/services/controllers/jobs/queue.go
@@ -77,12 +77,11 @@ func (o *operation) run(l *zerolog.Logger, ql *zerolog.Logger, scheduler func(co
 		return
 	}
 
-	ql.Info().Str("tenant_id", o.tenantId).TimeDiff("last_run", time.Now(), o.lastRun).Msg("running tenant queue")
-	o.setRunning(true)
+	o.setRunning(true, ql)
 
 	go func() {
 		defer func() {
-			o.setRunning(false)
+			o.setRunning(false, ql)
 		}()
 
 		f := func() {
@@ -116,11 +115,13 @@ func (o *operation) run(l *zerolog.Logger, ql *zerolog.Logger, scheduler func(co
 	}()
 }
 
-func (o *operation) setRunning(isRunning bool) {
+func (o *operation) setRunning(isRunning bool, ql *zerolog.Logger) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
 	if isRunning {
+		ql.Info().Str("tenant_id", o.tenantId).TimeDiff("last_run", time.Now(), o.lastRun).Msg("running tenant queue")
+
 		o.lastRun = time.Now()
 	}
 

--- a/pkg/config/database/config.go
+++ b/pkg/config/database/config.go
@@ -21,6 +21,9 @@ type ConfigFile struct {
 	MaxConns int `mapstructure:"maxConns" json:"maxConns,omitempty" default:"20"`
 	MinConns int `mapstructure:"minConns" json:"minConns,omitempty" default:"10"`
 
+	MaxQueueConns int `mapstructure:"maxQueueConns" json:"maxQueueConns,omitempty" default:"50"`
+	MinQueueConns int `mapstructure:"minQueueConns" json:"minQueueConns,omitempty" default:"10"`
+
 	Seed SeedConfigFile `mapstructure:"seed" json:"seed,omitempty"`
 
 	Logger shared.LoggerConfigFile `mapstructure:"logger" json:"logger,omitempty"`
@@ -47,6 +50,8 @@ type Config struct {
 
 	Pool *pgxpool.Pool
 
+	QueuePool *pgxpool.Pool
+
 	APIRepository repository.APIRepository
 
 	EngineRepository repository.EngineRepository
@@ -66,6 +71,8 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("logQueries", "DATABASE_LOG_QUERIES")
 	_ = v.BindEnv("maxConns", "DATABASE_MAX_CONNS")
 	_ = v.BindEnv("minConns", "DATABASE_MIN_CONNS")
+	_ = v.BindEnv("maxQueueConns", "DATABASE_MAX_QUEUE_CONNS")
+	_ = v.BindEnv("minQueueConns", "DATABASE_MIN_QUEUE_CONNS")
 
 	_ = v.BindEnv("cacheDuration", "CACHE_DURATION")
 

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -151,14 +151,26 @@ func GetDatabaseConfigFromConfigFile(cf *database.ConfigFile, runtime *server.Co
 		return nil, err
 	}
 
+	queueConfig, err := pgxpool.ParseConfig(databaseUrl)
+
+	if err != nil {
+		return nil, err
+	}
+
 	if cf.LogQueries {
 		config.ConnConfig.Tracer = &tracelog.TraceLog{
+			Logger:   pgxzero.NewLogger(l),
+			LogLevel: tracelog.LogLevelDebug,
+		}
+
+		queueConfig.ConnConfig.Tracer = &tracelog.TraceLog{
 			Logger:   pgxzero.NewLogger(l),
 			LogLevel: tracelog.LogLevelDebug,
 		}
 	}
 
 	config.ConnConfig.Tracer = otelpgx.NewTracer()
+	queueConfig.ConnConfig.Tracer = otelpgx.NewTracer()
 
 	if cf.MaxConns != 0 {
 		config.MaxConns = int32(cf.MaxConns)
@@ -168,7 +180,22 @@ func GetDatabaseConfigFromConfigFile(cf *database.ConfigFile, runtime *server.Co
 		config.MinConns = int32(cf.MinConns)
 	}
 
+	if cf.MaxQueueConns != 0 {
+		queueConfig.MaxConns = int32(cf.MaxQueueConns)
+	}
+
+	if cf.MinQueueConns != 0 {
+		queueConfig.MinConns = int32(cf.MinQueueConns)
+	}
+
 	pool, err := pgxpool.NewWithConfig(context.Background(), config)
+
+	if err != nil {
+		return nil, fmt.Errorf("could not connect to database: %w", err)
+	}
+
+	queuePool, err := pgxpool.NewWithConfig(context.Background(), queueConfig)
+
 	if err != nil {
 		return nil, fmt.Errorf("could not connect to database: %w", err)
 	}
@@ -186,8 +213,9 @@ func GetDatabaseConfigFromConfigFile(cf *database.ConfigFile, runtime *server.Co
 			return c.Prisma.Disconnect()
 		},
 		Pool:                  pool,
+		QueuePool:             queuePool,
 		APIRepository:         prisma.NewAPIRepository(c, pool, prisma.WithLogger(&l), prisma.WithCache(ch), prisma.WithMetered(meter)),
-		EngineRepository:      prisma.NewEngineRepository(pool, runtime, prisma.WithLogger(&l), prisma.WithCache(ch), prisma.WithMetered(meter)),
+		EngineRepository:      prisma.NewEngineRepository(pool, queuePool, runtime, prisma.WithLogger(&l), prisma.WithCache(ch), prisma.WithMetered(meter)),
 		EntitlementRepository: entitlementRepo,
 		Seed:                  cf.Seed,
 	}, nil

--- a/pkg/repository/prisma/repository.go
+++ b/pkg/repository/prisma/repository.go
@@ -276,7 +276,7 @@ func (r *engineRepository) WebhookWorker() repository.WebhookWorkerEngineReposit
 	return r.webhookWorker
 }
 
-func NewEngineRepository(pool *pgxpool.Pool, cf *server.ConfigFileRuntime, fs ...PrismaRepositoryOpt) repository.EngineRepository {
+func NewEngineRepository(pool *pgxpool.Pool, queuePool *pgxpool.Pool, cf *server.ConfigFileRuntime, fs ...PrismaRepositoryOpt) repository.EngineRepository {
 	opts := defaultPrismaRepositoryOpts()
 
 	for _, f := range fs {
@@ -297,7 +297,7 @@ func NewEngineRepository(pool *pgxpool.Pool, cf *server.ConfigFileRuntime, fs ..
 		event:          NewEventEngineRepository(pool, opts.v, opts.l, opts.metered),
 		getGroupKeyRun: NewGetGroupKeyRunRepository(pool, opts.v, opts.l),
 		jobRun:         NewJobRunEngineRepository(pool, opts.v, opts.l),
-		stepRun:        NewStepRunEngineRepository(pool, opts.v, opts.l, cf),
+		stepRun:        NewStepRunEngineRepository(queuePool, opts.v, opts.l, cf),
 		tenant:         NewTenantEngineRepository(pool, opts.v, opts.l, opts.cache),
 		tenantAlerting: NewTenantAlertingEngineRepository(pool, opts.v, opts.l, opts.cache),
 		ticker:         NewTickerRepository(pool, opts.v, opts.l),

--- a/pkg/repository/prisma/step_run.go
+++ b/pkg/repository/prisma/step_run.go
@@ -468,13 +468,13 @@ var genericRetry = func(l *zerolog.Event, maxRetries int, f func() error, msg st
 
 func (s *stepRunEngineRepository) ReleaseStepRunSemaphore(ctx context.Context, tenantId, stepRunId string) error {
 	return deadlockRetry(s.l, func() error {
-		tx, err := s.pool.Begin(ctx)
+		tx, rollback, err := s.prepareTx(ctx, 5000)
 
 		if err != nil {
 			return err
 		}
 
-		defer deferRollback(ctx, s.l, tx.Rollback)
+		defer rollback()
 
 		stepRun, err := s.getStepRunForEngineTx(context.Background(), tx, tenantId, stepRunId)
 
@@ -2176,15 +2176,25 @@ func removeDuplicates(qis []*scheduling.QueueItemWithOrder) ([]*scheduling.Queue
 	return result, duplicates
 }
 
-type debugInfo struct {
-	NumQueues             int    `json:"num_queues"`
-	TotalStepRuns         int    `json:"total_step_runs"`
-	TotalStepRunsAssigned int    `json:"total_step_runs_assigned"`
-	TotalSlots            int    `json:"total_slots"`
-	NumDuplicates         int    `json:"num_duplicates"`
-	NumCancelled          int    `json:"num_cancelled"`
-	TotalDuration         string `json:"total_duration"`
-	TenantId              string `json:"tenant_id"`
+func (r *stepRunEngineRepository) prepareTx(ctx context.Context, timeoutMs int) (pgx.Tx, func(), error) {
+	tx, err := r.pool.Begin(ctx)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	defer deferRollback(ctx, r.l, tx.Rollback)
+
+	// set tx timeout to 5 seconds to avoid deadlocks
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET statement_timeout=%d", timeoutMs))
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return tx, func() {
+		deferRollback(ctx, r.l, tx.Rollback)
+	}, nil
 }
 
 func printQueueDebugInfo(
@@ -2200,29 +2210,29 @@ func printQueueDebugInfo(
 ) {
 	duration := time.Since(startedAt)
 
-	// pretty-print json with 2 spaces
-	debugInfo := debugInfo{
-		TenantId:              tenantId,
-		NumQueues:             len(queues),
-		TotalStepRuns:         len(queueItems),
-		TotalStepRunsAssigned: len(plan.StepRunIds),
-		TotalSlots:            len(slots),
-		NumDuplicates:         len(duplicates),
-		NumCancelled:          len(cancelled),
-		TotalDuration:         duration.String(),
-	}
+	e := l.Debug()
+	msg := "queue debug information"
 
-	debugInfoBytes, err := json.MarshalIndent(debugInfo, "", "  ")
-
-	if err != nil {
-		l.Warn().Err(err).Msg("could not marshal debug info")
-		return
-	}
-
-	// if the duration is greater than 100 milliseconds, log the debug info
 	if duration > 100*time.Millisecond {
-		l.Warn().Msgf("queue duration was greater than 100ms: %s", string(debugInfoBytes))
-	} else {
-		l.Debug().Msgf("queue debug information: %s", string(debugInfoBytes))
+		e = l.Warn()
+		msg = "queue duration was greater than 100ms"
 	}
+
+	e.Str(
+		"tenant_id", tenantId,
+	).Int(
+		"num_queues", len(queues),
+	).Int(
+		"total_step_runs", len(queueItems),
+	).Int(
+		"total_step_runs_assigned", len(plan.StepRunIds),
+	).Int(
+		"total_slots", len(slots),
+	).Int(
+		"num_duplicates", len(duplicates),
+	).Int(
+		"num_cancelled", len(cancelled),
+	).Dur(
+		"total_duration", duration,
+	).Msg(msg)
 }

--- a/pkg/repository/prisma/step_run.go
+++ b/pkg/repository/prisma/step_run.go
@@ -2183,8 +2183,6 @@ func (r *stepRunEngineRepository) prepareTx(ctx context.Context, timeoutMs int) 
 		return nil, nil, err
 	}
 
-	defer deferRollback(ctx, r.l, tx.Rollback)
-
 	// set tx timeout to 5 seconds to avoid deadlocks
 	_, err = tx.Exec(ctx, fmt.Sprintf("SET statement_timeout=%d", timeoutMs))
 


### PR DESCRIPTION
# Description

Adds support for a separate database pool for queueing + updating step runs along with setting statement timeouts on step runs to avoid connection saturation from tx blocking.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)