### PR TITLE
fix: rendering null additional metadata causes page crash

### DIFF
--- a/frontend/app/src/pages/main/events/components/additional-metadata.tsx
+++ b/frontend/app/src/pages/main/events/components/additional-metadata.tsx
@@ -27,7 +27,7 @@ export function AdditionalMetadata({ metadata }: { metadata: object }) {
                 className="mr-2 truncate cursor-default font-normal"
                 variant="secondary"
               >
-                {`${key}: ${JSON.stringify(value).substring(0, 10)}${value.length > 10 ? '...' : ''}`}
+                {`${key}: ${getValueString(value)}`}
               </Badge>
             </TooltipTrigger>
             <TooltipContent>
@@ -65,3 +65,13 @@ export function AdditionalMetadata({ metadata }: { metadata: object }) {
     </div>
   );
 }
+
+const getValueString = (value: any) => {
+  const res = JSON.stringify(value).substring(0, 10);
+
+  if (value && value?.length > 10) {
+    return `${res}...`;
+  }
+
+  return res;
+};


### PR DESCRIPTION
# Description

Rendering additional metadata values which are null causes the frontend to crash. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)