### PR TITLE
fix: list initial step runs query + better serialized queue operations

### DIFF
--- a/pkg/repository/prisma/dbsqlc/step_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql
@@ -112,16 +112,11 @@ SELECT
     child_run."id" AS "id"
 FROM
     "StepRun" AS child_run
-JOIN
-    "JobRun" AS job_run ON child_run."jobRunId" = job_run."id"
 LEFT JOIN
     "_StepRunOrder" AS step_run_order ON step_run_order."B" = child_run."id"
 WHERE
     child_run."jobRunId" = @jobRunId::uuid
-    AND child_run."deletedAt" IS NULL
-    AND job_run."deletedAt" IS NULL
     AND child_run."status" = 'PENDING'
-    AND job_run."status" = 'RUNNING'
     AND step_run_order."A" IS NULL;
 
 -- name: ListStartableStepRuns :many

--- a/pkg/repository/prisma/dbsqlc/step_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql.go
@@ -1143,16 +1143,11 @@ SELECT
     child_run."id" AS "id"
 FROM
     "StepRun" AS child_run
-JOIN
-    "JobRun" AS job_run ON child_run."jobRunId" = job_run."id"
 LEFT JOIN
     "_StepRunOrder" AS step_run_order ON step_run_order."B" = child_run."id"
 WHERE
     child_run."jobRunId" = $1::uuid
-    AND child_run."deletedAt" IS NULL
-    AND job_run."deletedAt" IS NULL
     AND child_run."status" = 'PENDING'
-    AND job_run."status" = 'RUNNING'
     AND step_run_order."A" IS NULL
 `
 


### PR DESCRIPTION
# Description

There's a risk of concurrency within the queueing logic not being respected in rare cases, and improves performance of `ListInitialStepRuns`. 
  
- [X] Bug fix (non-breaking change which fixes an issue)