### PR TITLE
fix: cleanup worker assign events + limit semaphore query

### DIFF
--- a/api/v1/server/handlers/workers/get.go
+++ b/api/v1/server/handlers/workers/get.go
@@ -43,7 +43,7 @@ func (t *WorkerService) WorkerGet(ctx echo.Context, request gen.WorkerGetRequest
 		respStepRuns[i] = *genStepRun
 	}
 
-	slots := int(worker.FilledSlots)
+	slots := int(worker.RemainingSlots)
 
 	workerResp := *transformers.ToWorkerSqlc(&worker.Worker, &slots, &worker.WebhookUrl.String, actions)
 

--- a/internal/services/controllers/retention/workers.go
+++ b/internal/services/controllers/retention/workers.go
@@ -17,12 +17,35 @@ func (rc *RetentionControllerImpl) runDeleteOldWorkers(ctx context.Context) func
 
 		rc.l.Debug().Msgf("retention controller: deleting old workers")
 
-		err := rc.ForTenants(ctx, rc.runDeleteOldWorkersTenant)
+		err := rc.ForTenants(ctx, rc.runDeleteOldWorkerDataTenant)
 
 		if err != nil {
 			rc.l.Err(err).Msg("could not run delete old workers")
 		}
 	}
+}
+
+func (wc *RetentionControllerImpl) runDeleteOldWorkerDataTenant(ctx context.Context, tenant dbsqlc.Tenant) error {
+	// simultenously delete old workers and worker assign events
+	errCh := make(chan error, 2)
+
+	go func() {
+		errCh <- wc.runDeleteOldWorkersTenant(ctx, tenant)
+	}()
+
+	go func() {
+		errCh <- wc.runDeleteOldWorkerAssignEventsTenant(ctx, tenant)
+	}()
+
+	for i := 0; i < 2; i++ {
+		err := <-errCh
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (wc *RetentionControllerImpl) runDeleteOldWorkersTenant(ctx context.Context, tenant dbsqlc.Tenant) error {
@@ -53,4 +76,22 @@ func (wc *RetentionControllerImpl) runDeleteOldWorkersTenant(ctx context.Context
 			return nil
 		}
 	}
+}
+
+func (wc *RetentionControllerImpl) runDeleteOldWorkerAssignEventsTenant(ctx context.Context, tenant dbsqlc.Tenant) error {
+	ctx, span := telemetry.NewSpan(ctx, "delete-old-workers-tenant")
+	defer span.End()
+
+	tenantId := sqlchelpers.UUIDToStr(tenant.ID)
+
+	// hard-coded to last heartbeat after 24 hours
+	lastHeartbeatAfter := time.Now().UTC().Add(-24 * time.Hour)
+
+	err := wc.repo.Worker().DeleteOldWorkerEvents(ctx, tenantId, lastHeartbeatAfter)
+
+	if err != nil {
+		return fmt.Errorf("could not delete expired events: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/repository/worker.go
+++ b/pkg/repository/worker.go
@@ -113,4 +113,6 @@ type WorkerEngineRepository interface {
 	UpsertWorkerLabels(ctx context.Context, workerId pgtype.UUID, opts []UpsertWorkerLabelOpts) ([]*dbsqlc.WorkerLabel, error)
 
 	DeleteOldWorkers(ctx context.Context, tenantId string, lastHeartbeatBefore time.Time) (bool, error)
+
+	DeleteOldWorkerEvents(ctx context.Context, tenantId string, lastHeartbeatAfter time.Time) error
 }


### PR DESCRIPTION
# Description

Cleans up worker assign events, and adds a limit + filter to the query which lists semaphore slots in the workers view. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)