### PR TITLE
fix: reset on replay

### DIFF
--- a/pkg/repository/prisma/dbsqlc/step_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql
@@ -883,10 +883,33 @@ SET
     "updatedAt" = CURRENT_TIMESTAMP,
     "startedAt" = NULL,
     "finishedAt" = NULL,
-    "duration" = NULL
+    "duration" = NULL,
+    "concurrencyGroupId" = NULL,
+    "error" = NULL
 WHERE
     "id" =  @workflowRunId::uuid
 RETURNING *;
+
+
+-- name: ReplayWorkflowRunResetGetGroupKeyRun :one
+UPDATE
+    "GetGroupKeyRun"
+SET
+    "status" = 'PENDING',
+    "scheduleTimeoutAt" = NULL,
+    "finishedAt" = NULL,
+    "startedAt" = NULL,
+    "timeoutAt" = NULL,
+    "output" = NULL,
+    "error" = NULL,
+    "cancelledAt" = NULL,
+    "cancelledReason" = NULL,
+    "cancelledError" = NULL,
+    "input" = NULL
+WHERE
+    "workflowRunId" = @workflowRunId::uuid
+RETURNING *;
+
 
 -- name: ReplayStepRunResetJobRun :one
 UPDATE

--- a/pkg/repository/prisma/workflow_run.go
+++ b/pkg/repository/prisma/workflow_run.go
@@ -338,6 +338,13 @@ func (s *workflowRunEngineRepository) ReplayWorkflowRun(ctx context.Context, ten
 			}
 		}
 
+		// reset concurrency key
+		_, err = s.queries.ReplayWorkflowRunResetGetGroupKeyRun(ctx, tx, pgWorkflowRunId)
+
+		if err != nil {
+			return fmt.Errorf("error resetting get group key run: %w", err)
+		}
+
 		// get all step runs for the workflow
 		stepRuns, err := s.queries.ListStepRuns(ctx, tx, dbsqlc.ListStepRunsParams{
 			TenantId: sqlchelpers.UUIDFromStr(tenantId),


### PR DESCRIPTION
# Description

Concurrency (GetGroupKeyIdRun) was not reset on replay so it was never replayed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
