### PR TITLE
fix: replay without group keys and status updates

### DIFF
--- a/internal/services/controllers/jobs/queue.go
+++ b/internal/services/controllers/jobs/queue.go
@@ -417,6 +417,7 @@ func (q *queue) processStepRunUpdates(ctx context.Context, tenantId string) (boo
 
 			if err != nil {
 				q.l.Error().Err(err).Msg("could not list startable step runs")
+				continue
 			}
 
 			for _, nextStepRun := range nextStepRuns {

--- a/pkg/repository/prisma/dbsqlc/step_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql
@@ -838,8 +838,8 @@ WHERE NOT EXISTS (
 -- name: BulkCreateStepRunEvent :exec
 WITH input_values AS (
     SELECT
-        CURRENT_TIMESTAMP AS "timeFirstSeen",
-        CURRENT_TIMESTAMP AS "timeLastSeen",
+        unnest(@timeSeen::timestamp[]) AS "timeFirstSeen",
+        unnest(@timeSeen::timestamp[]) AS "timeLastSeen",
         unnest(@stepRunIds::uuid[]) AS "stepRunId",
         unnest(cast(@reasons::text[] as"StepRunEventReason"[])) AS "reason",
         unnest(cast(@severities::text[] as "StepRunEventSeverity"[])) AS "severity",
@@ -850,7 +850,7 @@ WITH input_values AS (
 updated AS (
     UPDATE "StepRunEvent"
     SET
-        "timeLastSeen" = CURRENT_TIMESTAMP,
+        "timeLastSeen" = input_values."timeLastSeen",
         "message" = input_values."message",
         "count" = "StepRunEvent"."count" + 1,
         "data" = input_values."data"

--- a/pkg/repository/prisma/workflow_run.go
+++ b/pkg/repository/prisma/workflow_run.go
@@ -400,7 +400,7 @@ func (s *workflowRunEngineRepository) ReplayWorkflowRun(ctx context.Context, ten
 		// reset concurrency key
 		_, err = s.queries.ReplayWorkflowRunResetGetGroupKeyRun(ctx, tx, pgWorkflowRunId)
 
-		if err != nil {
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return fmt.Errorf("error resetting get group key run: %w", err)
 		}
 

--- a/pkg/repository/step_run.go
+++ b/pkg/repository/step_run.go
@@ -44,6 +44,8 @@ type CreateStepRunEventOpts struct {
 
 	EventSeverity *dbsqlc.StepRunEventSeverity
 
+	Timestamp *time.Time
+
 	EventData map[string]interface{}
 }
 


### PR DESCRIPTION
# Description

Fixes an issue where replaying a workflow run without a group key run breaks the replay, and sets proper timestamps on events.  

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)