### PR TITLE
fix: better error string for CEL

### DIFF
--- a/internal/cel/cel.go
+++ b/internal/cel/cel.go
@@ -111,5 +111,11 @@ func (p *CELParser) ParseAndEvalWorkflowString(workflowExp string, in WorkflowSt
 		return "", err
 	}
 
-	return out.Value().(string), nil
+	// Switch on the type of the output.
+	switch out.Type() {
+	case types.StringType:
+		return out.Value().(string), nil
+	default:
+		return "", fmt.Errorf("output must evaluate to a string: got %s", out.Type().TypeName())
+	}
 }


### PR DESCRIPTION
# Description

In the case of a CEL expression that converts to an object, not a string, we panic instead of sending a good user-facing error. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)