### PR TITLE
fix: queue properly on internal retry

### DIFF
--- a/pkg/repository/prisma/step_run.go
+++ b/pkg/repository/prisma/step_run.go
@@ -2295,7 +2295,7 @@ func (s *stepRunEngineRepository) QueueStepRun(ctx context.Context, tenantId, st
 	}
 
 	// if this is not a retry, and the step run is already in a pending assignment state, this is a no-op
-	if !opts.IsRetry && innerStepRun.SRStatus == dbsqlc.StepRunStatusPENDINGASSIGNMENT {
+	if !opts.IsRetry && !opts.IsInternalRetry && innerStepRun.SRStatus == dbsqlc.StepRunStatusPENDINGASSIGNMENT {
 		return nil, repository.ErrAlreadyQueued
 	}
 


### PR DESCRIPTION
# Description

Internal retries should requeue a step run as long as it's not in a running or final state. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)