### PR TITLE
fix: use read-only message queue

### DIFF
--- a/internal/msgqueue/msgqueue.go
+++ b/internal/msgqueue/msgqueue.go
@@ -162,6 +162,9 @@ type MessageQueue interface {
 	// Clone copies the message queue with a new instance.
 	Clone() (func() error, MessageQueue)
 
+	// SetQOS sets the quality of service for the message queue.
+	SetQOS(prefetchCount int)
+
 	// AddMessage adds a task to the queue
 	AddMessage(ctx context.Context, queue Queue, task *Message) error
 

--- a/internal/msgqueue/msgqueue.go
+++ b/internal/msgqueue/msgqueue.go
@@ -159,6 +159,9 @@ func (t *Message) TenantID() string {
 type AckHook func(task *Message) error
 
 type MessageQueue interface {
+	// Clone copies the message queue with a new instance.
+	Clone() (func() error, MessageQueue)
+
 	// AddMessage adds a task to the queue
 	AddMessage(ctx context.Context, queue Queue, task *Message) error
 

--- a/internal/msgqueue/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/rabbitmq/rabbitmq.go
@@ -41,6 +41,7 @@ type MessageQueueImpl struct {
 	sessions chan chan session
 	msgs     chan *msgWithQueue
 	identity string
+	configFs []MessageQueueImplOpt
 
 	qos int
 
@@ -108,6 +109,7 @@ func New(fs ...MessageQueueImplOpt) (func() error, *MessageQueueImpl) {
 		identity: identity(),
 		l:        opts.l,
 		qos:      opts.qos,
+		configFs: fs,
 	}
 
 	constructor := func(context.Context) (*amqp.Connection, error) {
@@ -182,6 +184,10 @@ func New(fs ...MessageQueueImplOpt) (func() error, *MessageQueueImpl) {
 	}
 
 	return cleanup, t
+}
+
+func (t *MessageQueueImpl) Clone() (func() error, msgqueue.MessageQueue) {
+	return New(t.configFs...)
 }
 
 // AddMessage adds a msg to the queue.

--- a/internal/msgqueue/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/rabbitmq/rabbitmq.go
@@ -190,6 +190,10 @@ func (t *MessageQueueImpl) Clone() (func() error, msgqueue.MessageQueue) {
 	return New(t.configFs...)
 }
 
+func (t *MessageQueueImpl) SetQOS(prefetchCount int) {
+	t.qos = prefetchCount
+}
+
 // AddMessage adds a msg to the queue.
 func (t *MessageQueueImpl) AddMessage(ctx context.Context, q msgqueue.Queue, msg *msgqueue.Message) error {
 	// inject otel carrier into the message

--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -241,6 +241,7 @@ func New(fs ...DispatcherOpt) (*DispatcherImpl, error) {
 func (d *DispatcherImpl) Start() (func() error, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	mqCleanup, heavyReadMQ := d.mq.Clone()
+	heavyReadMQ.SetQOS(1000)
 
 	d.heavyReadMQ = heavyReadMQ
 

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -602,7 +602,7 @@ func (s *DispatcherImpl) subscribeToWorkflowEventsByAdditionalMeta(key string, v
 	}
 
 	// subscribe to the task queue for the tenant
-	cleanupQueue, err := s.mq.Subscribe(q, msgqueue.NoOpHook, f)
+	cleanupQueue, err := s.heavyReadMQ.Subscribe(q, msgqueue.NoOpHook, f)
 
 	if err != nil {
 		return err
@@ -685,7 +685,7 @@ func (s *DispatcherImpl) subscribeToWorkflowEventsByWorkflowRunId(workflowRunId 
 	}
 
 	// subscribe to the task queue for the tenant
-	cleanupQueue, err := s.mq.Subscribe(q, msgqueue.NoOpHook, f)
+	cleanupQueue, err := s.heavyReadMQ.Subscribe(q, msgqueue.NoOpHook, f)
 
 	if err != nil {
 		return err
@@ -879,7 +879,7 @@ func (s *DispatcherImpl) SubscribeToWorkflowRuns(server contracts.Dispatcher_Sub
 	}
 
 	// subscribe to the task queue for the tenant
-	cleanupQueue, err := s.mq.Subscribe(q, msgqueue.NoOpHook, f)
+	cleanupQueue, err := s.heavyReadMQ.Subscribe(q, msgqueue.NoOpHook, f)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description

WIP of a read-only message queue for heavy reads on tenant fanout queues. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)