### PR TITLE
fix: have refresh timeout use timeout queue item

### DIFF
--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -1017,15 +1017,15 @@ func (d *DispatcherImpl) RefreshTimeout(ctx context.Context, request *contracts.
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid request: %s", apiErrors.String())
 	}
 
-	stepRun, err := d.repo.StepRun().RefreshTimeoutBy(ctx, tenantId, request.StepRunId, opts)
+	pgTimeoutAt, err := d.repo.StepRun().RefreshTimeoutBy(ctx, tenantId, request.StepRunId, opts)
 
 	if err != nil {
 		return nil, err
 	}
 
 	timeoutAt := &timestamppb.Timestamp{
-		Seconds: stepRun.TimeoutAt.Time.Unix(),
-		Nanos:   int32(stepRun.TimeoutAt.Time.Nanosecond()),
+		Seconds: pgTimeoutAt.Time.Unix(),
+		Nanos:   int32(pgTimeoutAt.Time.Nanosecond()), // nolint:gosec
 	}
 
 	return &contracts.RefreshTimeoutResponse{

--- a/pkg/repository/prisma/dbsqlc/step_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql.go
@@ -1901,20 +1901,37 @@ func (q *Queries) QueueStepRun(ctx context.Context, db DBTX, arg QueueStepRunPar
 }
 
 const refreshTimeoutBy = `-- name: RefreshTimeoutBy :one
-UPDATE
-    "StepRun" sr
+WITH step_run AS (
+    SELECT
+        "id",
+        "retryCount",
+        "tenantId"
+    FROM
+        "StepRun"
+    WHERE
+        "id" = $2::uuid AND
+        "tenantId" = $3::uuid
+)
+INSERT INTO
+    "TimeoutQueueItem" (
+        "stepRunId",
+        "retryCount",
+        "timeoutAt",
+        "tenantId",
+        "isQueued"
+    )
+SELECT
+    sr."id",
+    sr."retryCount",
+    NOW() + convert_duration_to_interval($1::text),
+    sr."tenantId",
+    true
+FROM
+    step_run sr
+ON CONFLICT ("stepRunId", "retryCount") DO UPDATE
 SET
-    "timeoutAt" = CASE
-        -- Only update timeoutAt if the step run is currently in RUNNING status
-        WHEN sr."status" = 'RUNNING' THEN
-            COALESCE(sr."timeoutAt", CURRENT_TIMESTAMP) + convert_duration_to_interval($1::text)
-            ELSE sr."timeoutAt"
-        END,
-    "updatedAt" = CURRENT_TIMESTAMP
-WHERE
-    "id" = $2::uuid AND
-    "tenantId" = $3::uuid
-RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "jobRunId", "stepId", "order", "workerId", "tickerId", status, input, output, "requeueAfter", "scheduleTimeoutAt", error, "startedAt", "finishedAt", "timeoutAt", "cancelledAt", "cancelledReason", "cancelledError", "inputSchema", "callerFiles", "gitRepoBranch", "retryCount", "semaphoreReleased", queue, priority
+    "timeoutAt" = "TimeoutQueueItem"."timeoutAt" + convert_duration_to_interval($1::text)
+RETURNING "TimeoutQueueItem"."timeoutAt"
 `
 
 type RefreshTimeoutByParams struct {
@@ -1923,41 +1940,11 @@ type RefreshTimeoutByParams struct {
 	Tenantid           pgtype.UUID `json:"tenantid"`
 }
 
-func (q *Queries) RefreshTimeoutBy(ctx context.Context, db DBTX, arg RefreshTimeoutByParams) (*StepRun, error) {
+func (q *Queries) RefreshTimeoutBy(ctx context.Context, db DBTX, arg RefreshTimeoutByParams) (pgtype.Timestamp, error) {
 	row := db.QueryRow(ctx, refreshTimeoutBy, arg.IncrementTimeoutBy, arg.Steprunid, arg.Tenantid)
-	var i StepRun
-	err := row.Scan(
-		&i.ID,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.DeletedAt,
-		&i.TenantId,
-		&i.JobRunId,
-		&i.StepId,
-		&i.Order,
-		&i.WorkerId,
-		&i.TickerId,
-		&i.Status,
-		&i.Input,
-		&i.Output,
-		&i.RequeueAfter,
-		&i.ScheduleTimeoutAt,
-		&i.Error,
-		&i.StartedAt,
-		&i.FinishedAt,
-		&i.TimeoutAt,
-		&i.CancelledAt,
-		&i.CancelledReason,
-		&i.CancelledError,
-		&i.InputSchema,
-		&i.CallerFiles,
-		&i.GitRepoBranch,
-		&i.RetryCount,
-		&i.SemaphoreReleased,
-		&i.Queue,
-		&i.Priority,
-	)
-	return &i, err
+	var timeoutAt pgtype.Timestamp
+	err := row.Scan(&timeoutAt)
+	return timeoutAt, err
 }
 
 const replayStepRunResetJobRun = `-- name: ReplayStepRunResetJobRun :one
@@ -2530,7 +2517,9 @@ SELECT
     true
 FROM
     updated_step_runs sr
-ON CONFLICT DO NOTHING
+ON CONFLICT ("stepRunId", "retryCount") DO UPDATE
+SET
+    "timeoutAt" = EXCLUDED."timeoutAt"
 `
 
 type UpdateStepRunsToAssignedParams struct {

--- a/pkg/repository/prisma/step_run.go
+++ b/pkg/repository/prisma/step_run.go
@@ -2480,7 +2480,7 @@ func sleepWithJitter(min, max time.Duration) {
 	}
 }
 
-func (s *stepRunEngineRepository) RefreshTimeoutBy(ctx context.Context, tenantId, stepRunId string, opts repository.RefreshTimeoutBy) (*dbsqlc.StepRun, error) {
+func (s *stepRunEngineRepository) RefreshTimeoutBy(ctx context.Context, tenantId, stepRunId string, opts repository.RefreshTimeoutBy) (pgtype.Timestamp, error) {
 	stepRunUUID := sqlchelpers.UUIDFromStr(stepRunId)
 	tenantUUID := sqlchelpers.UUIDFromStr(tenantId)
 
@@ -2489,17 +2489,29 @@ func (s *stepRunEngineRepository) RefreshTimeoutBy(ctx context.Context, tenantId
 	err := s.v.Validate(opts)
 
 	if err != nil {
-		return nil, err
+		return pgtype.Timestamp{}, err
 	}
 
-	res, err := s.queries.RefreshTimeoutBy(ctx, s.pool, dbsqlc.RefreshTimeoutByParams{
+	tx, commit, rollback, err := prepareTx(ctx, s.pool, s.l, 5000)
+
+	if err != nil {
+		return pgtype.Timestamp{}, err
+	}
+
+	defer rollback()
+
+	res, err := s.queries.RefreshTimeoutBy(ctx, tx, dbsqlc.RefreshTimeoutByParams{
 		Steprunid:          stepRunUUID,
 		Tenantid:           tenantUUID,
 		IncrementTimeoutBy: sqlchelpers.TextFromStr(incrementTimeoutBy),
 	})
 
 	if err != nil {
-		return nil, err
+		return pgtype.Timestamp{}, err
+	}
+
+	if err := commit(ctx); err != nil {
+		return pgtype.Timestamp{}, err
 	}
 
 	sev := dbsqlc.StepRunEventSeverityINFO

--- a/pkg/repository/step_run.go
+++ b/pkg/repository/step_run.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/db"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/dbsqlc"
 
+	"github.com/jackc/pgx/v5/pgtype"
+
 	"github.com/rs/zerolog"
 )
 
@@ -207,7 +209,7 @@ type StepRunEngineRepository interface {
 
 	ArchiveStepRunResult(ctx context.Context, tenantId, stepRunId string, err *string) error
 
-	RefreshTimeoutBy(ctx context.Context, tenantId, stepRunId string, opts RefreshTimeoutBy) (*dbsqlc.StepRun, error)
+	RefreshTimeoutBy(ctx context.Context, tenantId, stepRunId string, opts RefreshTimeoutBy) (pgtype.Timestamp, error)
 
 	DeferredStepRunEvent(
 		tenantId, stepRunId string,


### PR DESCRIPTION
# Description

Updates the `RefreshTimeoutBy` method to use the new TimeoutQueueItem mechanism.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)