### PR TITLE
add timeout and context to queue metrics

### DIFF
--- a/api/v1/server/handlers/tenants/get_queue_metrics.go
+++ b/api/v1/server/handlers/tenants/get_queue_metrics.go
@@ -38,7 +38,7 @@ func (t *TenantService) TenantGetQueueMetrics(ctx echo.Context, request gen.Tena
 		opts.WorkflowIds = *request.Params.Workflows
 	}
 
-	metrics, err := t.config.APIRepository.Tenant().GetQueueMetrics(tenant.ID, &opts)
+	metrics, err := t.config.APIRepository.Tenant().GetQueueMetrics(ctx.Request().Context(), tenant.ID, &opts)
 
 	if err != nil {
 		return nil, err

--- a/pkg/repository/tenant.go
+++ b/pkg/repository/tenant.go
@@ -98,7 +98,7 @@ type TenantAPIRepository interface {
 	DeleteTenantMember(memberId string) (*db.TenantMemberModel, error)
 
 	// GetQueueMetrics returns the queue metrics for the given tenant
-	GetQueueMetrics(tenantId string, opts *GetQueueMetricsOpts) (*GetQueueMetricsResponse, error)
+	GetQueueMetrics(ctx context.Context, tenantId string, opts *GetQueueMetricsOpts) (*GetQueueMetricsResponse, error)
 }
 
 type TenantEngineRepository interface {


### PR DESCRIPTION
# Description

Adds a timeout and uses request context as a fallback for getting tenant queue metrics. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)