### PR TITLE
fix: always use retention on queues, optional data/worker

### DIFF
--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -243,14 +243,17 @@ func RunWithConfig(ctx context.Context, sc *server.ServerConfig) ([]Teardown, er
 		})
 	}
 
-	if sc.HasService("retention") && sc.EnableDataRetention {
+	if sc.HasService("retention") {
 		rc, err := retention.New(
 			retention.WithAlerter(sc.Alerter),
 			retention.WithRepository(sc.EngineRepository),
 			retention.WithLogger(sc.Logger),
 			retention.WithTenantAlerter(sc.TenantAlerter),
 			retention.WithPartition(p),
+			retention.WithDataRetention(sc.EnableDataRetention),
+			retention.WithWorkerRetention(sc.EnableWorkerRetention),
 		)
+
 		if err != nil {
 			return nil, fmt.Errorf("could not create retention controller: %w", err)
 		}

--- a/internal/services/controllers/retention/controller.go
+++ b/internal/services/controllers/retention/controller.go
@@ -21,24 +21,30 @@ type RetentionController interface {
 }
 
 type RetentionControllerImpl struct {
-	l             *zerolog.Logger
-	repo          repository.EngineRepository
-	dv            datautils.DataDecoderValidator
-	s             gocron.Scheduler
-	tenantAlerter *alerting.TenantAlertManager
-	a             *hatcheterrors.Wrapped
-	p             *partition.Partition
+	l               *zerolog.Logger
+	repo            repository.EngineRepository
+	dv              datautils.DataDecoderValidator
+	s               gocron.Scheduler
+	tenantAlerter   *alerting.TenantAlertManager
+	a               *hatcheterrors.Wrapped
+	p               *partition.Partition
+	dataRetention   bool
+	workerRetention bool
+	queueRetention  bool
 }
 
 type RetentionControllerOpt func(*RetentionControllerOpts)
 
 type RetentionControllerOpts struct {
-	l       *zerolog.Logger
-	repo    repository.EngineRepository
-	dv      datautils.DataDecoderValidator
-	ta      *alerting.TenantAlertManager
-	alerter hatcheterrors.Alerter
-	p       *partition.Partition
+	l               *zerolog.Logger
+	repo            repository.EngineRepository
+	dv              datautils.DataDecoderValidator
+	ta              *alerting.TenantAlertManager
+	alerter         hatcheterrors.Alerter
+	p               *partition.Partition
+	dataRetention   bool
+	workerRetention bool
+	queueRetention  bool
 }
 
 func defaultRetentionControllerOpts() *RetentionControllerOpts {
@@ -46,9 +52,12 @@ func defaultRetentionControllerOpts() *RetentionControllerOpts {
 	alerter := hatcheterrors.NoOpAlerter{}
 
 	return &RetentionControllerOpts{
-		l:       &logger,
-		dv:      datautils.NewDataDecoderValidator(),
-		alerter: alerter,
+		l:               &logger,
+		dv:              datautils.NewDataDecoderValidator(),
+		alerter:         alerter,
+		dataRetention:   true,
+		queueRetention:  true,
+		workerRetention: false,
 	}
 }
 
@@ -85,6 +94,18 @@ func WithTenantAlerter(ta *alerting.TenantAlertManager) RetentionControllerOpt {
 func WithPartition(p *partition.Partition) RetentionControllerOpt {
 	return func(opts *RetentionControllerOpts) {
 		opts.p = p
+	}
+}
+
+func WithDataRetention(b bool) RetentionControllerOpt {
+	return func(opts *RetentionControllerOpts) {
+		opts.dataRetention = b
+	}
+}
+
+func WithWorkerRetention(b bool) RetentionControllerOpt {
+	return func(opts *RetentionControllerOpts) {
+		opts.workerRetention = b
 	}
 }
 
@@ -135,91 +156,102 @@ func (rc *RetentionControllerImpl) Start() (func() error, error) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	interval := time.Second * 60 // run every 60 seconds
+	if rc.dataRetention {
+		dataInterval := time.Second * 60 // run every 60 seconds
 
-	_, err := rc.s.NewJob(
-		gocron.DurationJob(interval),
-		gocron.NewTask(
-			rc.runDeleteExpiredWorkflowRuns(ctx),
-		),
-	)
+		_, err := rc.s.NewJob(
+			gocron.DurationJob(dataInterval),
+			gocron.NewTask(
+				rc.runDeleteExpiredWorkflowRuns(ctx),
+			),
+		)
 
-	if err != nil {
-		cancel()
-		return nil, fmt.Errorf("could not set up runDeleteExpiredWorkflowRuns: %w", err)
+		if err != nil {
+			cancel()
+			return nil, fmt.Errorf("could not set up runDeleteExpiredWorkflowRuns: %w", err)
+		}
+
+		_, err = rc.s.NewJob(
+			gocron.DurationJob(dataInterval),
+			gocron.NewTask(
+				rc.runDeleteExpiredEvents(ctx),
+			),
+		)
+
+		if err != nil {
+			cancel()
+			return nil, fmt.Errorf("could not set up runDeleteExpiredEvents: %w", err)
+		}
+
+		_, err = rc.s.NewJob(
+			gocron.DurationJob(dataInterval),
+			gocron.NewTask(
+				rc.runDeleteExpiredStepRuns(ctx),
+			),
+		)
+
+		if err != nil {
+			cancel()
+			return nil, fmt.Errorf("could not set up runDeleteExpiredStepRuns: %w", err)
+		}
+
+		_, err = rc.s.NewJob(
+			gocron.DurationJob(dataInterval),
+			gocron.NewTask(
+				rc.runDeleteExpiredJobRuns(ctx),
+			),
+		)
+
+		if err != nil {
+			cancel()
+			return nil, fmt.Errorf("could not set up runDeleteExpiredJobRuns: %w", err)
+		}
 	}
 
-	_, err = rc.s.NewJob(
-		gocron.DurationJob(interval),
-		gocron.NewTask(
-			rc.runDeleteExpiredEvents(ctx),
-		),
-	)
+	if rc.workerRetention {
+		workerInterval := time.Hour * 60 // run every 1 hour
 
-	if err != nil {
-		cancel()
-		return nil, fmt.Errorf("could not set up runDeleteExpiredEvents: %w", err)
+		_, err := rc.s.NewJob(
+			gocron.DurationJob(workerInterval),
+			gocron.NewTask(
+				rc.runDeleteOldWorkers(ctx),
+			),
+		)
+
+		if err != nil {
+			cancel()
+			return nil, fmt.Errorf("could not set up runDeleteOldWorkers: %w", err)
+		}
 	}
 
-	_, err = rc.s.NewJob(
-		gocron.DurationJob(interval),
-		gocron.NewTask(
-			rc.runDeleteExpiredStepRuns(ctx),
-		),
-	)
+	if rc.queueRetention {
+		queueInterval := time.Second * 60
 
-	if err != nil {
-		cancel()
-		return nil, fmt.Errorf("could not set up runDeleteExpiredStepRuns: %w", err)
+		_, err := rc.s.NewJob(
+			gocron.DurationJob(queueInterval),
+			gocron.NewTask(
+				rc.runDeleteQueueItems(ctx),
+			),
+		)
+
+		if err != nil {
+			cancel()
+			return nil, fmt.Errorf("could not set up runDeleteQueueItems: %w", err)
+		}
+
+		_, err = rc.s.NewJob(
+			gocron.DurationJob(queueInterval),
+			gocron.NewTask(
+				rc.runDeleteInternalQueueItems(ctx),
+			),
+		)
+
+		if err != nil {
+			cancel()
+			return nil, fmt.Errorf("could not set up runDeleteInternalQueueItems: %w", err)
+		}
 	}
 
-	_, err = rc.s.NewJob(
-		gocron.DurationJob(interval),
-		gocron.NewTask(
-			rc.runDeleteOldWorkers(ctx),
-		),
-	)
-
-	if err != nil {
-		cancel()
-		return nil, fmt.Errorf("could not set up runDeleteOldWorkers: %w", err)
-	}
-
-	_, err = rc.s.NewJob(
-		gocron.DurationJob(interval),
-		gocron.NewTask(
-			rc.runDeleteQueueItems(ctx),
-		),
-	)
-
-	if err != nil {
-		cancel()
-		return nil, fmt.Errorf("could not set up runDeleteQueueItems: %w", err)
-	}
-
-	_, err = rc.s.NewJob(
-		gocron.DurationJob(interval),
-		gocron.NewTask(
-			rc.runDeleteInternalQueueItems(ctx),
-		),
-	)
-
-	if err != nil {
-		cancel()
-		return nil, fmt.Errorf("could not set up runDeleteInternalQueueItems: %w", err)
-	}
-
-	_, err = rc.s.NewJob(
-		gocron.DurationJob(interval),
-		gocron.NewTask(
-			rc.runDeleteExpiredJobRuns(ctx),
-		),
-	)
-
-	if err != nil {
-		cancel()
-		return nil, fmt.Errorf("could not set up runDeleteExpiredJobRuns: %w", err)
-	}
 	rc.s.Start()
 
 	cleanup := func() error {

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -441,6 +441,7 @@ func GetServerConfigFromConfigfile(dc *database.Config, cf *server.ServerConfigF
 		AdditionalOAuthConfigs: additionalOAuthConfigs,
 		AdditionalLoggers:      cf.AdditionalLoggers,
 		EnableDataRetention:    cf.EnableDataRetention,
+		EnableWorkerRetention:  cf.EnableWorkerRetention,
 	}, nil
 }
 

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -41,6 +41,8 @@ type ServerConfigFile struct {
 
 	EnableDataRetention bool `mapstructure:"enableDataRetention" json:"enableDataRetention,omitempty" default:"true"`
 
+	EnableWorkerRetention bool `mapstructure:"enableWorkerRetention" json:"enableWorkerRetention,omitempty" default:"false"`
+
 	TLS shared.TLSConfigFile `mapstructure:"tls" json:"tls,omitempty"`
 
 	Logger shared.LoggerConfigFile `mapstructure:"logger" json:"logger,omitempty"`
@@ -346,6 +348,8 @@ type ServerConfig struct {
 
 	EnableDataRetention bool
 
+	EnableWorkerRetention bool
+
 	Namespaces []string
 
 	MessageQueue msgqueue.MessageQueue
@@ -393,6 +397,7 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("runtime.shutdownWait", "SERVER_SHUTDOWN_WAIT")
 	_ = v.BindEnv("services", "SERVER_SERVICES")
 	_ = v.BindEnv("enableDataRetention", "SERVER_ENABLE_DATA_RETENTION")
+	_ = v.BindEnv("enableWorkerRetention", "SERVER_ENABLE_WORKER_RETENTION")
 	_ = v.BindEnv("runtime.enforceLimits", "SERVER_ENFORCE_LIMITS")
 	_ = v.BindEnv("runtime.allowSignup", "SERVER_ALLOW_SIGNUP")
 	_ = v.BindEnv("runtime.allowInvites", "SERVER_ALLOW_INVITES")


### PR DESCRIPTION
# Description

Adds option to enable data/worker retention, but always keeps queue retention on if the retention service is enabled. 
 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)