### PR TITLE
fix: remove metrics views from non-top level workflow runs views

### DIFF
--- a/frontend/app/src/pages/main/workflow-runs/$run/v2components/step-run-detail/step-run-detail.tsx
+++ b/frontend/app/src/pages/main/workflow-runs/$run/v2components/step-run-detail/step-run-detail.tsx
@@ -370,6 +370,7 @@ export function ChildWorkflowRuns({
       initColumnVisibility={{
         'Triggered by': false,
       }}
+      createdAfter={stepRun?.metadata.createdAt}
     />
   );
 }

--- a/frontend/app/src/pages/main/workflow-runs/components/workflow-runs-metrics.tsx
+++ b/frontend/app/src/pages/main/workflow-runs/components/workflow-runs-metrics.tsx
@@ -7,6 +7,7 @@ interface WorkflowRunsMetricsProps {
   metrics: WorkflowRunsMetrics;
   onClick?: (status?: WorkflowRunStatus) => void;
   onViewQueueMetricsClick?: () => void;
+  showQueueMetrics?: boolean;
 }
 
 const calculatePercentage = (value: number, total: number): number => {
@@ -21,6 +22,7 @@ const calculatePercentage = (value: number, total: number): number => {
 
 export const WorkflowRunsMetricsView: React.FC<WorkflowRunsMetricsProps> = ({
   metrics: { counts },
+  showQueueMetrics = false,
   onClick = () => {},
   onViewQueueMetricsClick = () => {},
 }) => {
@@ -80,13 +82,15 @@ export const WorkflowRunsMetricsView: React.FC<WorkflowRunsMetricsProps> = ({
       >
         {counts?.QUEUED?.toLocaleString('en-US')} Queued ({queuedPercentage}%)
       </Badge>
-      <Badge
-        variant="outline"
-        className="cursor-pointer rounded-sm font-normal text-sm px-2 py-1 w-fit"
-        onClick={() => onViewQueueMetricsClick()}
-      >
-        Queue metrics
-      </Badge>
+      {showQueueMetrics && (
+        <Badge
+          variant="outline"
+          className="cursor-pointer rounded-sm font-normal text-sm px-2 py-1 w-fit"
+          onClick={() => onViewQueueMetricsClick()}
+        >
+          Queue metrics
+        </Badge>
+      )}
     </dl>
   );
 };

--- a/frontend/app/src/pages/main/workflow-runs/index.tsx
+++ b/frontend/app/src/pages/main/workflow-runs/index.tsx
@@ -9,7 +9,7 @@ export default function WorkflowRuns() {
           Workflow Runs
         </h2>
         <Separator className="my-4" />
-        <WorkflowRunsTable />
+        <WorkflowRunsTable showMetrics={true} />
       </div>
     </div>
   );


### PR DESCRIPTION
# Description

Removes metrics graph (and time selector/queue metrics) from views which aren't the very top level, for example child workflow runs views. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)