### PR TITLE
fix: faster processing of timeout queue items

### DIFF
--- a/frontend/app/src/components/molecules/data-table/data-table.tsx
+++ b/frontend/app/src/components/molecules/data-table/data-table.tsx
@@ -126,7 +126,7 @@ export function DataTable<TData extends IDGetter, TValue>({
             cell: () => <Skeleton className="h-4 w-[100px]" />,
           }))
         : columns,
-    [isLoading, columns],
+    [loadingNoData, columns],
   );
 
   const table = useReactTable({

--- a/pkg/repository/prisma/dbsqlc/step_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql
@@ -789,7 +789,11 @@ WHERE
 UPDATE
     "StepRun" sr
 SET
-    "status" = 'CANCELLING',
+    "status" = CASE
+        -- Final states are final, we cannot go from a final state to cancelling
+        WHEN "status" IN ('SUCCEEDED', 'FAILED', 'CANCELLED') THEN "status"
+        ELSE 'CANCELLING'
+    END,
     "updatedAt" = CURRENT_TIMESTAMP
 FROM (
     SELECT

--- a/pkg/repository/prisma/dbsqlc/step_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql.go
@@ -298,7 +298,11 @@ const bulkMarkStepRunsAsCancelling = `-- name: BulkMarkStepRunsAsCancelling :man
 UPDATE
     "StepRun" sr
 SET
-    "status" = 'CANCELLING',
+    "status" = CASE
+        -- Final states are final, we cannot go from a final state to cancelling
+        WHEN "status" IN ('SUCCEEDED', 'FAILED', 'CANCELLED') THEN "status"
+        ELSE 'CANCELLING'
+    END,
     "updatedAt" = CURRENT_TIMESTAMP
 FROM (
     SELECT

--- a/pkg/repository/step_run.go
+++ b/pkg/repository/step_run.go
@@ -175,7 +175,7 @@ type StepRunEngineRepository interface {
 	// ListStepRunsToReassign returns a list of step runs which are in a reassignable state.
 	ListStepRunsToReassign(ctx context.Context, tenantId string) ([]string, error)
 
-	ListStepRunsToTimeout(ctx context.Context, tenantId string) ([]*dbsqlc.GetStepRunForEngineRow, error)
+	ListStepRunsToTimeout(ctx context.Context, tenantId string) (bool, []*dbsqlc.GetStepRunForEngineRow, error)
 
 	StepRunStarted(ctx context.Context, tenantId, stepRunId string, startedAt time.Time) error
 


### PR DESCRIPTION
# Description

We were previously timing out a maximum of 100 queue items at a time. This allows us to continue timing queue items until they're all processed. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)