### PR TITLE
fix: don't need acks on queue checks

### DIFF
--- a/internal/msgqueue/msgqueue.go
+++ b/internal/msgqueue/msgqueue.go
@@ -136,6 +136,9 @@ type Message struct {
 	// RetryDelay is the delay between retries.
 	RetryDelay int `json:"retry_delay"`
 
+	// Whether the message should immediately expire if it reaches the queue without an active consumer.
+	ImmediatelyExpire bool `json:"immediately_expire"`
+
 	// OtelCarrier is the OpenTelemetry carrier for the task.
 	OtelCarrier map[string]string `json:"otel_carrier"`
 }

--- a/internal/msgqueue/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/rabbitmq/rabbitmq.go
@@ -341,9 +341,15 @@ func (t *MessageQueueImpl) startPublishing() func() error {
 
 						t.l.Debug().Msgf("publishing msg %s to queue %s", msg.ID, msg.q.Name())
 
-						err = pub.PublishWithContext(ctx, "", msg.q.Name(), false, false, amqp.Publishing{
+						pubMsg := amqp.Publishing{
 							Body: body,
-						})
+						}
+
+						if msg.ImmediatelyExpire {
+							pubMsg.Expiration = "0"
+						}
+
+						err = pub.PublishWithContext(ctx, "", msg.q.Name(), false, false, pubMsg)
 
 						// retry failed delivery on the next session
 						if err != nil {

--- a/internal/services/controllers/workflows/controller.go
+++ b/internal/services/controllers/workflows/controller.go
@@ -267,7 +267,11 @@ func (wc *WorkflowsControllerImpl) Start() (func() error, error) {
 		return nil
 	}
 
-	cleanupQueue2, err := wc.mq.Subscribe(msgqueue.QueueTypeFromPartitionIDAndController(wc.p.GetControllerPartitionId(), msgqueue.WorkflowController), f2, msgqueue.NoOpHook)
+	cleanupQueue2, err := wc.mq.Subscribe(
+		msgqueue.QueueTypeFromPartitionIDAndController(wc.p.GetControllerPartitionId(), msgqueue.WorkflowController),
+		msgqueue.NoOpHook, // the only handler is to check the queue, so we acknowledge immediately with the NoOpHook
+		f2,
+	)
 
 	if err != nil {
 		cancel()

--- a/internal/services/shared/tasktypes/job.go
+++ b/internal/services/shared/tasktypes/job.go
@@ -40,10 +40,11 @@ func CheckTenantQueueToTask(tenantId string) *msgqueue.Message {
 	})
 
 	return &msgqueue.Message{
-		ID:       "check-tenant-queue",
-		Payload:  nil,
-		Metadata: metadata,
-		Retries:  3,
+		ID:                "check-tenant-queue",
+		Payload:           nil,
+		Metadata:          metadata,
+		ImmediatelyExpire: true,
+		Retries:           3,
 	}
 }
 


### PR DESCRIPTION
# Description

Removes the need for acks when checking the tenant queue. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)