### PR TITLE
docs: concurrency strategy section

### DIFF
--- a/frontend/docs/pages/home/features/concurrency/overview.mdx
+++ b/frontend/docs/pages/home/features/concurrency/overview.mdx
@@ -18,16 +18,12 @@ There are several reasons why you might want to use concurrency control in your 
 
 5. **Spike Protection**: When you have workflows that are triggered by external events, such as webhooks or user actions, you may experience spikes in traffic that can overwhelm your system. Concurrency control can help you manage these spikes by limiting the number of concurrent runs and queuing new runs until resources become available.
 
-### Configuring concurrency control
+### Available Strategies:
 
-To configure concurrency control for a workflow in Hatchet, you can add a `concurrency` field to your workflow definition. The `concurrency` field is an object with the following properties:
+- [`CANCEL_IN_PROGRESS`](./cancel-in-progress): Cancel the currently running workflow instances for the same concurrency key to free up slots for the new instance.
+- [`GROUP_ROUND_ROBIN`](./round-robin): Distribute workflow instances across available slots in a round-robin fashion based on the `key` function.
 
-- `name` (required): A string identifier for the concurrency limit. This is used to identify the limit in logs and the dashboard.
-- `maxRuns` (optional): The maximum number of concurrent runs allowed for a given concurrency key. If not specified, there is no limit.
-- `limitStrategy` (optional): The strategy to use when the concurrency limit is reached. Can be one of:
-  - [`CANCEL_IN_PROGRESS`](./cancel-in-progress): Cancel the currently running workflow instances for the same concurrency key to free up slots for the new instance.
-  - [`GROUP_ROUND_ROBIN`](./round-robin): Distribute workflow instances across available slots in a round-robin fashion based on the `key` function.
-- `key` (required): A function that takes the workflow context and returns a string key. This key is used to group runs for the purpose of concurrency limiting. For example, you could use this to limit concurrency on a per-user basis.
+> We're always open to adding more strategies to fit your needs. Join our [discord](https://discord.gg/ZMeUafwH89) to let us know.
 
 ### Setting concurrency on workers
 

--- a/frontend/docs/pages/home/features/rate-limits.mdx
+++ b/frontend/docs/pages/home/features/rate-limits.mdx
@@ -106,6 +106,10 @@ err = w.RegisterWorkflow(
   </Tabs.Tab>
 </Tabs>
 
+<Callout type="info">
+  Note: Dynamic keys are a shared resource, this means the same rendered cel on
+  multiple steps will be treated as one global rate limit.
+</Callout>
 ## Static Rate Limits
 
 Static Rate Limits (formerly known as Global Rate Limits) are defined as part of your worker startup lifecycle prior to runtime. This model provides a single "source of truth" for pre-defined resources such as:

--- a/frontend/docs/pages/home/features/rate-limits.mdx
+++ b/frontend/docs/pages/home/features/rate-limits.mdx
@@ -25,9 +25,14 @@ This pattern is especially useful for:
 
 ### How It Works
 
-1. Define the dynamic rate limit with a CEL (Common Expression Language) Expression on the key, referencing either `input` or `additional_metadata`.
+1. Define the dynamic rate limit key with a CEL (Common Expression Language) Expression on the key, referencing either `input` or `additional_metadata`.
 2. Provide this key as part of the workflow trigger or event `input` or `additional_metadata` at runtime.
 3. Hatchet will create or update the rate limit based on the provided key and enforce it for the step run.
+
+<Callout type="info">
+  Note: Dynamic keys are a shared resource, this means the same rendered cel on
+  multiple steps will be treated as one global rate limit.
+</Callout>
 
 ### Declaring and Consuming Dynamic Rate Limits
 
@@ -106,10 +111,6 @@ err = w.RegisterWorkflow(
   </Tabs.Tab>
 </Tabs>
 
-<Callout type="info">
-  Note: Dynamic keys are a shared resource, this means the same rendered cel on
-  multiple steps will be treated as one global rate limit.
-</Callout>
 ## Static Rate Limits
 
 Static Rate Limits (formerly known as Global Rate Limits) are defined as part of your worker startup lifecycle prior to runtime. This model provides a single "source of truth" for pre-defined resources such as:


### PR DESCRIPTION
# Description

Drop out dated concurrency config.

## Type of change


- [x] Documentation change (pure documentation change)

