### PR TITLE
fix(docker compose): specify user for pg_isready

### DIFF
--- a/frontend/docs/pages/self-hosting/docker-compose.mdx
+++ b/frontend/docs/pages/self-hosting/docker-compose.mdx
@@ -40,7 +40,7 @@ services:
     volumes:
       - hatchet_postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready", "-d", "hatchet"]
+      test: ["CMD-SHELL", "pg_isready -d hatchet -U hatchet"]
       interval: 10s
       timeout: 10s
       retries: 5

--- a/frontend/docs/pages/self-hosting/hatchet-lite.mdx
+++ b/frontend/docs/pages/self-hosting/hatchet-lite.mdx
@@ -31,7 +31,7 @@ services:
     volumes:
       - hatchet_lite_postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready", "-d", "hatchet"]
+      test: ["CMD-SHELL", "pg_isready -d hatchet -U hatchet"]
       interval: 10s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
# Description

Current behavior:
 - Both docker compose files print `postgres-1      | 2024-10-02 23:13:13.028 UTC [47] FATAL:  role "root" does not exist` every 10seconds

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation change (pure documentation change)

## What's Changed

 - This PR fixes the CMD-SHELL syntax and provides a specific user, `hatchet`, as a `-U` flag to `pg_isready` to stop it from incorrectly using `root`

See pg_isready docs at https://www.postgresql.org/docs/current/app-pg-isready.html

There was also a syntax error in CMD-SHELL usage,
where the params were chained as sepeate commands
to CMD-SHELL, whereas it should be a single string passed along.

For an example from the docker compose spec
itself, see here (spec.md line 1188):

https://github.com/compose-spec/compose-spec/blob/6336cc86f121a095e24bf022656c9ff53488667b/spec.md?plain=1#L1188