### PR TITLE
fix: write rate limit duration on workflow put

### DIFF
--- a/internal/services/admin/server.go
+++ b/internal/services/admin/server.go
@@ -596,6 +596,11 @@ func getCreateJobOpts(req *contracts.CreateWorkflowJobOpts, kind string) (*repos
 				UnitsExpr: rateLimit.UnitsExpr,
 			}
 
+			if rateLimit.Duration != nil {
+				dur := rateLimit.Duration.String()
+				opt.Duration = &dur
+			}
+
 			if rateLimit.Units != nil {
 				units := int(*rateLimit.Units)
 				opt.Units = &units


### PR DESCRIPTION
# Description

We were missing writing the rate limit duration for dynamic rate limits on workflow put so rate limits would default to Minute.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

