### PR TITLE
feat: add helpful context to alert email

### DIFF
--- a/internal/integrations/alerting/alerttypes/resource_limit_alert.go
+++ b/internal/integrations/alerting/alerttypes/resource_limit_alert.go
@@ -1,10 +1,12 @@
 package alerttypes
 
 type ResourceLimitAlert struct {
-	Link         string `json:"link"`
-	Resource     string `json:"resource"`
-	AlertType    string `json:"alert_type"`
-	CurrentValue int    `json:"current_value"`
-	LimitValue   int    `json:"limit_value"`
-	Percentage   int    `json:"percentage"`
+	Link          string `json:"link"`
+	Resource      string `json:"resource"`
+	AlertType     string `json:"alert_type"`
+	CurrentValue  int    `json:"current_value"`
+	LimitValue    int    `json:"limit_value"`
+	Percentage    int    `json:"percentage"`
+	LastRefillAgo string `json:"refill_date_time"`
+	LimitWindow   string `json:"limit_window"`
 }

--- a/internal/integrations/alerting/email.go
+++ b/internal/integrations/alerting/email.go
@@ -76,15 +76,15 @@ func (t *TenantAlertManager) sendEmailTenantResourceLimitAlert(tenant *dbsqlc.Te
 	resource = cases.Title(language.English).String(resource)
 
 	if payload.AlertType == string(dbsqlc.TenantResourceLimitAlertTypeAlarm) {
-		subject = fmt.Sprintf("%s has exhausted %d%% of its limit (%d/%d)", resource, payload.Percentage, payload.CurrentValue, payload.LimitValue)
+		subject = fmt.Sprintf("%s has exhausted %d%% of its %s limit (%d/%d)", resource, payload.Percentage, payload.LimitWindow, payload.CurrentValue, payload.LimitValue)
 		summary = "We're sending you this alert because a resource on your Hatchet tenant is approaching its usage limit."
-		summary2 = "Once the limit is reached, any further resource usage will be denied."
+		summary2 = fmt.Sprintf("Once the %s limit is reached, any further resource usage will be denied. Last refilled %s.", payload.LimitWindow, payload.LastRefillAgo)
 	}
 
 	if payload.AlertType == string(dbsqlc.TenantResourceLimitAlertTypeExhausted) {
-		subject = fmt.Sprintf("%s has exhausted 100%% of its limit (%d/%d)", payload.Resource, payload.CurrentValue, payload.LimitValue)
+		subject = fmt.Sprintf("%s has exhausted 100%% of its %s limit (%d/%d)", payload.Resource, payload.LimitWindow, payload.CurrentValue, payload.LimitValue)
 		summary = "We're sending you this alert because a resource on your Hatchet tenant has exhausted its usage limit."
-		summary2 = "Any further resource usage will be denied until the limit is increased."
+		summary2 = fmt.Sprintf("Any further resource usage will be denied until the limit is increased or its refill window is reached. Last refilled %s.", payload.LastRefillAgo)
 	}
 
 	return t.email.SendTenantResourceLimitAlert(

--- a/pkg/repository/prisma/tenant_alerting.go
+++ b/pkg/repository/prisma/tenant_alerting.go
@@ -225,3 +225,13 @@ func (r *tenantAlertingEngineRepository) UpdateTenantAlertingSettings(ctx contex
 
 	return err
 }
+
+func (r *tenantAlertingEngineRepository) GetTenantResourceLimitState(ctx context.Context, tenantId string, resource string) (*dbsqlc.GetTenantResourceLimitRow, error) {
+	return r.queries.GetTenantResourceLimit(ctx, r.pool, dbsqlc.GetTenantResourceLimitParams{
+		Tenantid: sqlchelpers.UUIDFromStr(tenantId),
+		Resource: dbsqlc.NullLimitResource{
+			LimitResource: dbsqlc.LimitResource(resource),
+			Valid:         true,
+		},
+	})
+}

--- a/pkg/repository/tenant_alerting.go
+++ b/pkg/repository/tenant_alerting.go
@@ -64,4 +64,6 @@ type TenantAlertingEngineRepository interface {
 	GetTenantAlertingSettings(ctx context.Context, tenantId string) (*GetTenantAlertingSettingsResponse, error)
 
 	UpdateTenantAlertingSettings(ctx context.Context, tenantId string, opts *UpdateTenantAlertingSettingsOpts) error
+
+	GetTenantResourceLimitState(ctx context.Context, tenantId string, resource string) (*dbsqlc.GetTenantResourceLimitRow, error)
 }


### PR DESCRIPTION
# Description

Adds context to limit alert emails (window and last refill)

## Type of change


- [x] New feature (non-breaking change which adds functionality)

## TODO

- [ ] test since I don't have metering enabled locally
