### PR TITLE
fix(go-sdk): RunWorkflow and SpawnWorkflow should respond with consistent APIs

### DIFF
--- a/examples/manual-trigger/trigger/main.go
+++ b/examples/manual-trigger/trigger/main.go
@@ -38,7 +38,7 @@ func run(ch <-chan interface{}, events chan<- string) error {
 	time.Sleep(1 * time.Second)
 
 	// trigger workflow
-	workflowRunId, err := c.Admin().RunWorkflow(
+	workflow, err := c.Admin().RunWorkflow(
 		"post-user-update",
 		&userCreateEvent{
 			Username: "echo-test",
@@ -56,12 +56,12 @@ func run(ch <-chan interface{}, events chan<- string) error {
 		return fmt.Errorf("error running workflow: %w", err)
 	}
 
-	fmt.Println("workflow run id:", workflowRunId)
+	fmt.Println("workflow run id:", workflow.WorkflowRunId())
 
 	interruptCtx, cancel := cmdutils.InterruptContextFromChan(ch)
 	defer cancel()
 
-	err = c.Subscribe().On(interruptCtx, workflowRunId, func(event client.WorkflowEvent) error {
+	err = c.Subscribe().On(interruptCtx, workflow.WorkflowRunId(), func(event client.WorkflowEvent) error {
 		fmt.Println(event.EventPayload)
 
 		return nil

--- a/examples/procedural/main.go
+++ b/examples/procedural/main.go
@@ -74,7 +74,7 @@ func run(events chan<- string) (func() error, error) {
 			Steps: []*worker.WorkflowStep{
 				worker.Fn(
 					func(ctx worker.HatchetContext) (result *proceduralParentOutput, err error) {
-						childWorkflows := make([]*worker.ChildWorkflow, NUM_CHILDREN)
+						childWorkflows := make([]*client.Workflow, NUM_CHILDREN)
 
 						for i := 0; i < NUM_CHILDREN; i++ {
 							childInput := proceduralChildInput{
@@ -104,7 +104,7 @@ func run(events chan<- string) (func() error, error) {
 						childOutputsMu := sync.Mutex{}
 
 						for i, childWorkflow := range childWorkflows {
-							eg.Go(func(i int, childWorkflow *worker.ChildWorkflow) func() error {
+							eg.Go(func(i int, childWorkflow *client.Workflow) func() error {
 								return func() error {
 									childResult, err := childWorkflow.Result()
 

--- a/examples/stream-event/main.go
+++ b/examples/stream-event/main.go
@@ -82,7 +82,7 @@ func main() {
 		panic(fmt.Errorf("error cleaning up: %w", err))
 	}
 
-	workflowRunId, err := c.Admin().RunWorkflow("stream-event-workflow", &streamEventInput{
+	workflow, err := c.Admin().RunWorkflow("stream-event-workflow", &streamEventInput{
 		Index: 0,
 	})
 
@@ -90,7 +90,7 @@ func main() {
 		panic(err)
 	}
 
-	err = c.Subscribe().Stream(interruptCtx, workflowRunId, func(event client.StreamEvent) error {
+	err = c.Subscribe().Stream(interruptCtx, workflow.WorkflowRunId(), func(event client.StreamEvent) error {
 		fmt.Println(string(event.Message))
 
 		return nil

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -232,10 +232,11 @@ func newFromOpts(opts *ClientOpts) (Client, error) {
 		ctxLoader: newContextLoader(opts.token),
 	}
 
-	admin := newAdmin(conn, shared)
+	subscribe := newSubscribe(conn, shared)
+	admin := newAdmin(conn, shared, subscribe)
 	dispatcher := newDispatcher(conn, shared)
 	event := newEvent(conn, shared)
-	subscribe := newSubscribe(conn, shared)
+
 	rest, err := rest.NewClientWithResponses(opts.serverURL, rest.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", opts.token))
 		return nil

--- a/pkg/worker/middleware_test.go
+++ b/pkg/worker/middleware_test.go
@@ -36,10 +36,10 @@ func (c *testHatchetContext) AdditionalMetadata() map[string]string {
 	return nil
 }
 
-func (c *testHatchetContext) SpawnWorkflow(workflowName string, input any, opts *SpawnWorkflowOpts) (*ChildWorkflow, error) {
+func (c *testHatchetContext) SpawnWorkflow(workflowName string, input any, opts *SpawnWorkflowOpts) (*client.Workflow, error) {
 	panic("not implemented")
 }
-func (c *testHatchetContext) SpawnWorkflows(opts []*SpawnWorkflowsOpts) ([]*ChildWorkflow, error) {
+func (c *testHatchetContext) SpawnWorkflows(opts []*SpawnWorkflowsOpts) ([]*client.Workflow, error) {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
# Description

Improves the Go SDK so that RunWorkflow returns a result similar to the SpawnWorkflow results. Docs will need updating.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)