### PR TITLE
fix: deadlocks on events and incorrect step run ordering query

### DIFF
--- a/examples/bulk_workflows/main.go
+++ b/examples/bulk_workflows/main.go
@@ -2,10 +2,14 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"time"
 
 	"github.com/joho/godotenv"
 
+	"github.com/hatchet-dev/hatchet/pkg/client"
 	"github.com/hatchet-dev/hatchet/pkg/cmdutils"
+	"github.com/hatchet-dev/hatchet/pkg/worker"
 )
 
 type userCreateEvent struct {
@@ -26,25 +30,124 @@ func main() {
 
 	ch := cmdutils.InterruptChan()
 
-	cleanup, err := runBulk()
-
 	if err != nil {
 		panic(err)
 	}
+	workflowName := "simple-bulk-workflow"
+	c, err := client.New()
 
-	cleanupSecond, err := runSingles()
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("error creating client: %w", err))
+	}
+
+	_, err = registerWorkflow(c, workflowName)
+
+	if err != nil {
+		panic(fmt.Errorf("error registering workflow: %w", err))
+	}
+
+	quantity := 999
+
+	overallStart := time.Now()
+	iterations := 10
+	for i := 0; i < iterations; i++ {
+		startTime := time.Now()
+
+		fmt.Printf("Running the %dth bulk workflow \n", i)
+
+		err = runBulk(workflowName, quantity)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("Time taken to queue %dth bulk workflow: %v\n", i, time.Since(startTime))
+	}
+	fmt.Println("Overall time taken: ", time.Since(overallStart))
+	fmt.Printf("That is %d workflows per second\n", int(float64(quantity*iterations)/time.Since(overallStart).Seconds()))
+	fmt.Println("Starting the worker")
+
+	// err = runSingles(workflowName, quantity)
+	// if err != nil {
+	// 	panic(err)
+	// }
+
+	if err != nil {
+		panic(fmt.Errorf("error creating client: %w", err))
+	}
+
+	// I want to start the wofklow worker here
+
+	w, err := registerWorkflow(c, workflowName)
+	if err != nil {
+		panic(fmt.Errorf("error creating worker: %w", err))
+	}
+
+	cleanup, err := w.Start()
+	fmt.Println("Starting the worker")
+
+	if err != nil {
+		panic(fmt.Errorf("error starting worker: %w", err))
 	}
 
 	<-ch
 
 	if err := cleanup(); err != nil {
-		panic(fmt.Errorf("cleanup() error = %v", err))
+		panic(fmt.Errorf("error cleaning up: %w", err))
 	}
 
-	if err := cleanupSecond(); err != nil {
-		panic(fmt.Errorf("cleanupSecond() error = %v", err))
+}
+
+func registerWorkflow(c client.Client, workflowName string) (w *worker.Worker, err error) {
+
+	w, err = worker.NewWorker(
+		worker.WithClient(
+			c,
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error creating worker: %w", err)
 	}
 
+	err = w.RegisterWorkflow(
+		&worker.WorkflowJob{
+			On:          worker.Events("user:create:bulk-simple"),
+			Name:        workflowName,
+			Description: "This runs after an update to the user model.",
+			Steps: []*worker.WorkflowStep{
+				worker.Fn(func(ctx worker.HatchetContext) (result *stepOneOutput, err error) {
+					input := &userCreateEvent{}
+
+					err = ctx.WorkflowInput(input)
+
+					if err != nil {
+						return nil, err
+					}
+
+					log.Printf("step-one")
+
+					return &stepOneOutput{
+						Message: "Username is: " + input.Username,
+					}, nil
+				},
+				).SetName("step-one"),
+				worker.Fn(func(ctx worker.HatchetContext) (result *stepOneOutput, err error) {
+					input := &stepOneOutput{}
+					err = ctx.StepOutput("step-one", input)
+
+					if err != nil {
+						return nil, err
+					}
+
+					log.Printf("step-two")
+
+					return &stepOneOutput{
+						Message: "Above message is: " + input.Message,
+					}, nil
+				}).SetName("step-two").AddParents("step-one"),
+			},
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error registering workflow: %w", err)
+	}
+	return w, nil
 }

--- a/pkg/repository/prisma/dbsqlc/step_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql
@@ -359,8 +359,22 @@ WHERE
     "StepRun"."id" = input."id";
 
 -- name: BulkCancelStepRun :exec
-UPDATE
-    "StepRun"
+WITH input AS (
+    SELECT
+        unnest(@stepRunIds::uuid[]) AS "id",
+        unnest(@finishedAts::timestamp[]) AS "finishedAt",
+        unnest(@cancelledAts::timestamp[]) AS "cancelledAt",
+        unnest(@cancelledReasons::text[]) AS "cancelledReason",
+        unnest(@cancelledErrors::text[]) AS "cancelledError"
+),
+locked_rows AS (
+    SELECT "id"
+    FROM "StepRun"
+    WHERE "id" IN (SELECT "id" FROM input)
+    ORDER BY "id" asc
+    FOR UPDATE
+)
+UPDATE "StepRun"
 SET
     "status" = CASE
         -- Final states are final, cannot be updated
@@ -371,16 +385,9 @@ SET
     "cancelledAt" = input."cancelledAt",
     "cancelledReason" = input."cancelledReason",
     "cancelledError" = input."cancelledError"
-FROM (
-    SELECT
-        unnest(@stepRunIds::uuid[]) AS "id",
-        unnest(@finishedAts::timestamp[]) AS "finishedAt",
-        unnest(@cancelledAts::timestamp[]) AS "cancelledAt",
-        unnest(@cancelledReasons::text[]) AS "cancelledReason",
-        unnest(@cancelledErrors::text[]) AS "cancelledError"
-) AS input
-WHERE
-    "StepRun"."id" = input."id";
+FROM input
+WHERE "StepRun"."id" = input."id";
+
 
 -- name: BulkFailStepRun :exec
 UPDATE
@@ -968,6 +975,13 @@ WITH input_values AS (
         unnest(@messages::text[]) AS "message",
         1 AS "count",
         unnest(@data::jsonb[]) AS "data"
+),
+locked_rows AS (
+    SELECT "id"
+    FROM "StepRunEvent"
+    WHERE "stepRunId" IN (SELECT unnest(@stepRunIds::uuid[]))
+    ORDER BY "id"
+    FOR UPDATE
 ),
 updated AS (
     UPDATE "StepRunEvent"

--- a/pkg/repository/prisma/dbsqlc/step_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql
@@ -366,13 +366,6 @@ WITH input AS (
         unnest(@cancelledAts::timestamp[]) AS "cancelledAt",
         unnest(@cancelledReasons::text[]) AS "cancelledReason",
         unnest(@cancelledErrors::text[]) AS "cancelledError"
-),
-locked_rows AS (
-    SELECT "id"
-    FROM "StepRun"
-    WHERE "id" IN (SELECT "id" FROM input)
-    ORDER BY "id" asc
-    FOR UPDATE
 )
 UPDATE "StepRun"
 SET

--- a/pkg/repository/prisma/dbsqlc/step_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql.go
@@ -116,13 +116,6 @@ WITH input AS (
         unnest($3::timestamp[]) AS "cancelledAt",
         unnest($4::text[]) AS "cancelledReason",
         unnest($5::text[]) AS "cancelledError"
-),
-locked_rows AS (
-    SELECT "id"
-    FROM "StepRun"
-    WHERE "id" IN (SELECT "id" FROM input)
-    ORDER BY "id" asc
-    FOR UPDATE
 )
 UPDATE "StepRun"
 SET

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql
@@ -1008,21 +1008,26 @@ RETURNING
 
 -- name: LinkStepRunParents :exec
 WITH step_runs AS (
-    SELECT "id", "stepId"
+    SELECT "id", "stepId", "jobRunId"
     FROM "StepRun"
     WHERE "id" = ANY(@stepRunIds::uuid[])
-    FOR UPDATE
+), parent_child_step_runs AS (
+    SELECT
+        parent_run."id" AS "A",
+        child_run."id" AS "B"
+    FROM
+        "_StepOrder" AS step_order
+    JOIN
+        step_runs AS parent_run ON parent_run."stepId" = step_order."A"
+    JOIN
+        step_runs AS child_run ON child_run."stepId" = step_order."B" AND child_run."jobRunId" = parent_run."jobRunId"
 )
 INSERT INTO "_StepRunOrder" ("A", "B")
 SELECT
-    parent_run."id" AS "A",
-    child_run."id" AS "B"
+    parent_child_step_runs."A" AS "A",
+    parent_child_step_runs."B" AS "B"
 FROM
-    "_StepOrder" AS step_order
-JOIN
-    step_runs AS parent_run ON parent_run."stepId" = step_order."A"
-JOIN
-    step_runs AS child_run ON child_run."stepId" = step_order."B";
+    parent_child_step_runs;
 
 -- name: GetWorkflowRun :many
 SELECT

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql
@@ -1011,6 +1011,7 @@ WITH step_runs AS (
     SELECT "id", "stepId"
     FROM "StepRun"
     WHERE "id" = ANY(@stepRunIds::uuid[])
+    FOR UPDATE
 )
 INSERT INTO "_StepRunOrder" ("A", "B")
 SELECT

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
@@ -1932,21 +1932,26 @@ func (q *Queries) GetWorkflowRunsInsertedInThisTxn(ctx context.Context, db DBTX)
 
 const linkStepRunParents = `-- name: LinkStepRunParents :exec
 WITH step_runs AS (
-    SELECT "id", "stepId"
+    SELECT "id", "stepId", "jobRunId"
     FROM "StepRun"
     WHERE "id" = ANY($1::uuid[])
-    FOR UPDATE
+), parent_child_step_runs AS (
+    SELECT
+        parent_run."id" AS "A",
+        child_run."id" AS "B"
+    FROM
+        "_StepOrder" AS step_order
+    JOIN
+        step_runs AS parent_run ON parent_run."stepId" = step_order."A"
+    JOIN
+        step_runs AS child_run ON child_run."stepId" = step_order."B" AND child_run."jobRunId" = parent_run."jobRunId"
 )
 INSERT INTO "_StepRunOrder" ("A", "B")
 SELECT
-    parent_run."id" AS "A",
-    child_run."id" AS "B"
+    parent_child_step_runs."A" AS "A",
+    parent_child_step_runs."B" AS "B"
 FROM
-    "_StepOrder" AS step_order
-JOIN
-    step_runs AS parent_run ON parent_run."stepId" = step_order."A"
-JOIN
-    step_runs AS child_run ON child_run."stepId" = step_order."B"
+    parent_child_step_runs
 `
 
 func (q *Queries) LinkStepRunParents(ctx context.Context, db DBTX, steprunids []pgtype.UUID) error {

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
@@ -1935,6 +1935,7 @@ WITH step_runs AS (
     SELECT "id", "stepId"
     FROM "StepRun"
     WHERE "id" = ANY($1::uuid[])
+    FOR UPDATE
 )
 INSERT INTO "_StepRunOrder" ("A", "B")
 SELECT

--- a/pkg/repository/prisma/workflow_run.go
+++ b/pkg/repository/prisma/workflow_run.go
@@ -1859,6 +1859,6 @@ func bulkWorkflowRunEvents(
 	})
 
 	if err != nil {
-		l.Err(err).Msg("could not create deferred step run event")
+		l.Err(err).Msg("could not create bulk workflow run event")
 	}
 }

--- a/pkg/scheduling/v2/lease_manager.go
+++ b/pkg/scheduling/v2/lease_manager.go
@@ -13,6 +13,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/hatchet-dev/hatchet/internal/telemetry"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/dbsqlc"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/sqlchelpers"
 )
@@ -51,6 +52,9 @@ func newLeaseDbQueries(tenantId pgtype.UUID, queries *dbsqlc.Queries, pool *pgxp
 }
 
 func (d *leaseDbQueries) AcquireLeases(ctx context.Context, kind dbsqlc.LeaseKind, resourceIds []string, existingLeases []*dbsqlc.Lease) ([]*dbsqlc.Lease, error) {
+	ctx, span := telemetry.NewSpan(ctx, "acquire-leases")
+	defer span.End()
+
 	leaseIds := make([]int64, len(existingLeases))
 
 	for i, lease := range existingLeases {
@@ -95,6 +99,9 @@ func (d *leaseDbQueries) AcquireLeases(ctx context.Context, kind dbsqlc.LeaseKin
 }
 
 func (d *leaseDbQueries) ReleaseLeases(ctx context.Context, leases []*dbsqlc.Lease) error {
+	ctx, span := telemetry.NewSpan(ctx, "release-leases")
+	defer span.End()
+
 	leaseIds := make([]int64, len(leases))
 
 	for i, lease := range leases {
@@ -123,10 +130,16 @@ func (d *leaseDbQueries) ReleaseLeases(ctx context.Context, leases []*dbsqlc.Lea
 }
 
 func (d *leaseDbQueries) ListQueues(ctx context.Context, tenantId pgtype.UUID) ([]*dbsqlc.Queue, error) {
+	ctx, span := telemetry.NewSpan(ctx, "list-queues")
+	defer span.End()
+
 	return d.queries.ListQueues(ctx, d.pool, tenantId)
 }
 
 func (d *leaseDbQueries) ListActiveWorkers(ctx context.Context, tenantId pgtype.UUID) ([]*ListActiveWorkersResult, error) {
+	ctx, span := telemetry.NewSpan(ctx, "list-active-workers")
+	defer span.End()
+
 	activeWorkers, err := d.queries.ListActiveWorkers(ctx, d.pool, tenantId)
 
 	if err != nil {

--- a/pkg/scheduling/v2/mu.go
+++ b/pkg/scheduling/v2/mu.go
@@ -1,0 +1,67 @@
+package v2
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+type debugMu struct {
+	l *zerolog.Logger
+}
+
+func (d debugMu) print(start time.Time) {
+	if since := time.Since(start); since > 50*time.Millisecond {
+		// get the line number of the caller
+		_, file, line, ok := runtime.Caller(2)
+
+		caller := "unknown"
+		if ok {
+			caller = fmt.Sprintf("%s:%d", file, line)
+		}
+
+		d.l.Warn().Dur("duration", since).Msgf("long lock %s", caller)
+	}
+}
+
+type mutex struct {
+	*sync.Mutex
+	debugMu
+}
+
+func newMu(l *zerolog.Logger) mutex {
+	return mutex{
+		Mutex:   &sync.Mutex{},
+		debugMu: debugMu{l: l},
+	}
+}
+
+func (m mutex) Lock() {
+	defer m.debugMu.print(time.Now())
+	m.Mutex.Lock()
+}
+
+type rwMutex struct {
+	*sync.RWMutex
+	debugMu
+}
+
+func newRWMu(l *zerolog.Logger) rwMutex {
+	return rwMutex{
+		RWMutex: &sync.RWMutex{},
+		debugMu: debugMu{l: l},
+	}
+}
+
+func (m rwMutex) Lock() {
+	defer m.debugMu.print(time.Now())
+	m.RWMutex.Lock()
+}
+
+func (m rwMutex) RLock() {
+	defer m.debugMu.print(time.Now())
+	m.RWMutex.RLock()
+}

--- a/pkg/scheduling/v2/queuer.go
+++ b/pkg/scheduling/v2/queuer.go
@@ -728,7 +728,7 @@ func newQueuer(conf *sharedConfig, tenantId pgtype.UUID, queueName string, s *Sc
 
 	repo, cleanupRepo := newQueueItemDbQueries(conf, tenantId, eventBuffer, queueName, int32(defaultLimit)) // nolint: gosec
 
-	notifyQueueCh := make(chan struct{})
+	notifyQueueCh := make(chan struct{}, 1)
 
 	q := &Queuer{
 		repo:          repo,


### PR DESCRIPTION
Fixes bugs with the latest `v0.50.0-alpha.0` release:
- Writing step run events was deadlocking, which is fixed by properly ordering and locking the step run event rows which are being updated
- Fixes `panic: close on closed channel` caused by multiple calls to the lease manager's cleanup method
- Fixes the `_StepRunOrder` insert query which was unintentionally linking every parent step run to every child step run in the bulk insert. This was causing slowdown on bulk inserts and also a proliferation of _StepRunOrder rows, causing more deadlocks and other slowness. 
