### PR TITLE
fix: add slot expiry and delete actions from scheduler properly

### DIFF
--- a/pkg/scheduling/v2/scheduler.go
+++ b/pkg/scheduling/v2/scheduler.go
@@ -331,7 +331,7 @@ func (s *Scheduler) replenish(ctx context.Context, mustReplenish bool) error {
 
 	// third pass: remove any actions which have no slots
 	for actionId, storedAction := range s.actions {
-		if len(storedAction.slots) == 0 {
+		if storedAction.activeCount() == 0 {
 			delete(s.actions, actionId)
 		}
 	}

--- a/pkg/scheduling/v2/scheduler.go
+++ b/pkg/scheduling/v2/scheduler.go
@@ -277,10 +277,12 @@ func (s *Scheduler) replenish(ctx context.Context, mustReplenish bool) error {
 		slots := make([]*slot, 0)
 
 		for i := 0; i < int(worker.AvailableSlots)-len(unackedSlots); i++ {
-			slots = append(slots, &slot{
-				actions: actions,
-				worker:  workers[workerId],
-			})
+			slots = append(slots, newSlot(workers[workerId], actions))
+		}
+
+		// extend expiry of all unacked slots
+		for _, unackedSlot := range unackedSlots {
+			unackedSlot.extendExpiry()
 		}
 
 		slots = append(slots, unackedSlots...)


### PR DESCRIPTION
# Description

Adds back slot expiry so we don't keep requeueing on slots which no longer have a worker. Also deletes actions when they have no more active slots available.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)