### PR TITLE
fix: don't reset input for concurrency keys on replay

### DIFF
--- a/pkg/repository/prisma/dbsqlc/step_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql
@@ -1090,8 +1090,7 @@ SET
     "error" = NULL,
     "cancelledAt" = NULL,
     "cancelledReason" = NULL,
-    "cancelledError" = NULL,
-    "input" = NULL
+    "cancelledError" = NULL
 WHERE
     "workflowRunId" = @workflowRunId::uuid
 RETURNING *;

--- a/pkg/repository/prisma/dbsqlc/step_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql.go
@@ -2355,8 +2355,7 @@ SET
     "error" = NULL,
     "cancelledAt" = NULL,
     "cancelledReason" = NULL,
-    "cancelledError" = NULL,
-    "input" = NULL
+    "cancelledError" = NULL
 WHERE
     "workflowRunId" = $1::uuid
 RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "workerId", "tickerId", status, input, output, "requeueAfter", error, "startedAt", "finishedAt", "timeoutAt", "cancelledAt", "cancelledReason", "cancelledError", "workflowRunId", "scheduleTimeoutAt"


### PR DESCRIPTION
# Description

Avoids setting the `input` to `null` for get group key runs on workflow run replay, which causes problems on the workers and causes the workflow to get stuck. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)