### PR TITLE
feat: allow insecure option for otel collector address

### DIFF
--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -41,7 +41,7 @@ func init() {
 
 	var insecureBool bool
 
-	if insecureStr := strings.TrimSpace(insecure); insecureStr == "t" || insecureStr == "true" {
+	if insecureStr := strings.ToLower(strings.TrimSpace(insecure)); insecureStr == "t" || insecureStr == "true" {
 		insecureBool = true
 	}
 

--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/hatchet-dev/hatchet/internal/services/admin"
@@ -35,7 +36,14 @@ type Teardown struct {
 func init() {
 	svcName := os.Getenv("SERVER_OTEL_SERVICE_NAME")
 	collectorURL := os.Getenv("SERVER_OTEL_COLLECTOR_URL")
+	insecure := os.Getenv("SERVER_OTEL_INSECURE")
 	traceIdRatio := os.Getenv("SERVER_OTEL_TRACE_ID_RATIO")
+
+	var insecureBool bool
+
+	if insecureStr := strings.TrimSpace(insecure); insecureStr == "t" || insecureStr == "true" {
+		insecureBool = true
+	}
 
 	// we do this to we get the tracer set globally, which is needed by some of the otel
 	// integrations for the database before start
@@ -43,6 +51,7 @@ func init() {
 		ServiceName:  svcName,
 		CollectorURL: collectorURL,
 		TraceIdRatio: traceIdRatio,
+		Insecure:     insecureBool,
 	})
 
 	if err != nil {

--- a/frontend/docs/pages/self-hosting/configuration-options.mdx
+++ b/frontend/docs/pages/self-hosting/configuration-options.mdx
@@ -131,10 +131,11 @@ The Hatchet server and engine can be configured via `SERVER` and `DATABASE` envi
 
 ## OpenTelemetry Configuration
 
-| Variable                    | Description                     | Default Value |
-| --------------------------- | ------------------------------- | ------------- |
-| `SERVER_OTEL_SERVICE_NAME`  | Service name for OpenTelemetry  |               |
-| `SERVER_OTEL_COLLECTOR_URL` | Collector URL for OpenTelemetry |               |
+| Variable                    | Description                                                | Default Value |
+| --------------------------- | ---------------------------------------------------------- | ------------- |
+| `SERVER_OTEL_SERVICE_NAME`  | Service name for OpenTelemetry                             |               |
+| `SERVER_OTEL_COLLECTOR_URL` | Collector URL for OpenTelemetry                            |               |
+| `SERVER_OTEL_INSECURE`      | Whether to use an insecure connection to the collector URL |               |
 
 ## Tenant Alerting Configuration
 


### PR DESCRIPTION
# Description

Allows setting `SERVER_OTEL_INSECURE` to `t` or `true` to connect over an insecure collector address.

## Type of change

- [X] New feature (non-breaking change which adds functionality)