### PR TITLE
fix: don't append invalid slots with a hard sticky strategy

### DIFF
--- a/pkg/scheduling/v2/slot.go
+++ b/pkg/scheduling/v2/slot.go
@@ -175,8 +175,9 @@ func getRankedSlots(
 		if qi.Sticky.Valid && qi.Sticky.StickyStrategy == dbsqlc.StickyStrategyHARD {
 			if qi.DesiredWorkerId.Valid && workerId == sqlchelpers.UUIDToStr(qi.DesiredWorkerId) {
 				validSlots.addSlot(slot, 0)
-				continue
 			}
+
+			continue
 		}
 
 		// if this step has affinity labels, check if the worker has the desired labels, and rank by


### PR DESCRIPTION
# Description

Fixes an issue seen in `v0.50.0-alpha.1` where sticky strategy set to `HARD` isn't respected when discovering valid slots. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)