### PR TITLE
don't need to filter on tenant id for step runs & some debug for buffers

### DIFF
--- a/pkg/repository/buffer/tenant_buffer.go
+++ b/pkg/repository/buffer/tenant_buffer.go
@@ -78,6 +78,8 @@ func NewTenantBufManager[T any, U any](opts TenantBufManagerOpts[T, U]) (*Tenant
 		defaultOpts.MaxCapacity = opts.FlushItemsThreshold
 	}
 
+	opts.L.Debug().Msgf("creating new tenant buffer manager %s with default flush period %s and max capacity %d", opts.Name, defaultOpts.FlushPeriod, defaultOpts.MaxCapacity)
+
 	return &TenantBufferManager[T, U]{
 		name:        opts.Name,
 		tenants:     sync.Map{},

--- a/pkg/repository/prisma/dbsqlc/job_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/job_runs.sql
@@ -19,8 +19,7 @@ WITH stepRuns AS (
             SELECT "jobRunId"
             FROM "StepRun"
             WHERE "id" = ANY(@stepRunIds::uuid[])
-        ) AND
-        "tenantId" = @tenantId::uuid
+        )
     GROUP BY runs."jobRunId"
 )
 UPDATE "JobRun"
@@ -56,7 +55,6 @@ END
 FROM stepRuns s
 WHERE
     "id" = s."jobRunId"
-    AND "tenantId" = @tenantId::uuid
 RETURNING "JobRun"."id";
 
 -- name: UpsertJobRunLookupData :exec

--- a/pkg/repository/prisma/dbsqlc/job_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/job_runs.sql.go
@@ -278,9 +278,8 @@ WITH stepRuns AS (
         "jobRunId" = ANY(
             SELECT "jobRunId"
             FROM "StepRun"
-            WHERE "id" = ANY($2::uuid[])
-        ) AND
-        "tenantId" = $1::uuid
+            WHERE "id" = ANY($1::uuid[])
+        )
     GROUP BY runs."jobRunId"
 )
 UPDATE "JobRun"
@@ -316,17 +315,11 @@ END
 FROM stepRuns s
 WHERE
     "id" = s."jobRunId"
-    AND "tenantId" = $1::uuid
 RETURNING "JobRun"."id"
 `
 
-type ResolveJobRunStatusParams struct {
-	Tenantid   pgtype.UUID   `json:"tenantid"`
-	Steprunids []pgtype.UUID `json:"steprunids"`
-}
-
-func (q *Queries) ResolveJobRunStatus(ctx context.Context, db DBTX, arg ResolveJobRunStatusParams) ([]pgtype.UUID, error) {
-	rows, err := db.Query(ctx, resolveJobRunStatus, arg.Tenantid, arg.Steprunids)
+func (q *Queries) ResolveJobRunStatus(ctx context.Context, db DBTX, steprunids []pgtype.UUID) ([]pgtype.UUID, error) {
+	rows, err := db.Query(ctx, resolveJobRunStatus, steprunids)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repository/prisma/step_run.go
+++ b/pkg/repository/prisma/step_run.go
@@ -2135,10 +2135,9 @@ func (s *stepRunEngineRepository) processStepRunUpdates(
 	// startResolveJobRunStatus := time.Now()
 
 	// update the job runs and workflow runs as well
-	jobRunIds, err := s.queries.ResolveJobRunStatus(ctx, tx, dbsqlc.ResolveJobRunStatusParams{
-		Steprunids: stepRunIds,
-		Tenantid:   pgTenantId,
-	})
+	jobRunIds, err := s.queries.ResolveJobRunStatus(ctx, tx,
+		stepRunIds,
+	)
 
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not resolve job run status: %w", err)
@@ -2292,10 +2291,7 @@ func (s *stepRunEngineRepository) processStepRunUpdatesV2(
 			}
 
 			// update the job runs and workflow runs as well
-			jobRunIds, err := s.queries.ResolveJobRunStatus(ctx, tx, dbsqlc.ResolveJobRunStatusParams{
-				Steprunids: batchStepRunIds,
-				Tenantid:   pgTenantId,
-			})
+			jobRunIds, err := s.queries.ResolveJobRunStatus(ctx, tx, batchStepRunIds)
 
 			if err != nil {
 				return fmt.Errorf("could not resolve job run status: %w", err)

--- a/pkg/repository/prisma/workflow_run.go
+++ b/pkg/repository/prisma/workflow_run.go
@@ -73,7 +73,7 @@ func (w *workflowRunAPIRepository) cleanup() error {
 func (w *workflowRunAPIRepository) startBuffer() error {
 
 	createWorkflowRunBufOpts := buffer.TenantBufManagerOpts[*repository.CreateWorkflowRunOpts, *dbsqlc.WorkflowRun]{
-		Name:       "create_workflow_run",
+		Name:       "api_create_workflow_run",
 		OutputFunc: w.BulkCreateWorkflowRuns,
 		SizeFunc:   sizeOfData,
 		L:          w.l,
@@ -540,7 +540,7 @@ func (w *workflowRunEngineRepository) cleanup() error {
 func (w *workflowRunEngineRepository) startBuffer() error {
 
 	createWorkflowRunBufOpts := buffer.TenantBufManagerOpts[*repository.CreateWorkflowRunOpts, *dbsqlc.WorkflowRun]{
-		Name:       "create_workflow_run",
+		Name:       "engine_create_workflow_run",
 		OutputFunc: w.BulkCreateWorkflowRuns,
 		SizeFunc:   sizeOfData,
 		L:          w.l,


### PR DESCRIPTION


- [ X] Bug fix (non-breaking change which fixes an issue)


Prevent a sequence scan for situations where all the tenantIDs are the same
