### PR TITLE
fix: more efficient step run events, reduce caching on queue

### DIFF
--- a/internal/services/controllers/jobs/controller.go
+++ b/internal/services/controllers/jobs/controller.go
@@ -390,7 +390,7 @@ func (ec *JobsControllerImpl) handleJobRunCancelled(ctx context.Context, task *m
 
 		reason := "JOB_RUN_CANCELLED"
 
-		if payload.Reason != nil {
+		if payload.Reason != nil && *payload.Reason != "" {
 			reason = *payload.Reason
 		}
 

--- a/pkg/repository/buffer/bulk_events.go
+++ b/pkg/repository/buffer/bulk_events.go
@@ -212,6 +212,7 @@ func bulkStepRunEvents(
 	})
 
 	if err != nil {
+		l.Error().Err(err).Msg("could not create deferred step run event")
 		return fmt.Errorf("bulk_events - could not create deferred step run event: %w", err)
 	}
 

--- a/pkg/repository/prisma/dbsqlc/step_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql
@@ -1090,32 +1090,34 @@ WITH input_values AS (
         1 AS "count",
         unnest(@data::jsonb[]) AS "data"
 ),
+matched_rows AS (
+    SELECT DISTINCT ON (sre."stepRunId")
+        sre."stepRunId", sre."reason", sre."severity", sre."id"
+    FROM "StepRunEvent" sre
+    WHERE
+        sre."stepRunId" = ANY(@stepRunIds::uuid[])
+    ORDER BY sre."stepRunId", sre."id" DESC
+),
 locked_rows AS (
-    SELECT "id"
-    FROM "StepRunEvent"
-    WHERE "stepRunId" IN (SELECT unnest(@stepRunIds::uuid[]))
+    SELECT sre."id", iv.*
+    FROM "StepRunEvent" sre
+    JOIN
+        matched_rows mr ON sre."id" = mr."id"
+    JOIN
+        input_values iv ON sre."stepRunId" = iv."stepRunId" AND sre."reason" = iv."reason" AND sre."severity" = iv."severity"
     ORDER BY "id"
     FOR UPDATE
 ),
 updated AS (
     UPDATE "StepRunEvent"
     SET
-        "timeLastSeen" = input_values."timeLastSeen",
-        "message" = input_values."message",
+        "timeLastSeen" = locked_rows."timeLastSeen",
+        "message" = locked_rows."message",
         "count" = "StepRunEvent"."count" + 1,
-        "data" = input_values."data"
-    FROM input_values
+        "data" = locked_rows."data"
+    FROM locked_rows
     WHERE
-        "StepRunEvent"."stepRunId" = input_values."stepRunId"
-        AND "StepRunEvent"."reason" = input_values."reason"
-        AND "StepRunEvent"."severity" = input_values."severity"
-        AND "StepRunEvent"."id" = (
-            SELECT "id"
-            FROM "StepRunEvent"
-            WHERE "stepRunId" = input_values."stepRunId"
-            ORDER BY "id" DESC
-            LIMIT 1
-        )
+        "StepRunEvent"."id" = locked_rows."id"
     RETURNING "StepRunEvent".*
 )
 INSERT INTO "StepRunEvent" (
@@ -1139,7 +1141,7 @@ SELECT
     "data"
 FROM input_values
 WHERE NOT EXISTS (
-    SELECT 1 FROM updated WHERE "stepRunId" = input_values."stepRunId"
+    SELECT 1 FROM updated WHERE "stepRunId" = input_values."stepRunId" AND "reason" = input_values."reason" AND "severity" = input_values."severity"
 );
 
 -- name: CountStepRunEvents :one

--- a/pkg/repository/prisma/repository.go
+++ b/pkg/repository/prisma/repository.go
@@ -300,13 +300,15 @@ func NewEngineRepository(pool *pgxpool.Pool, cf *server.ConfigFileRuntime, fs ..
 	}
 
 	rlCache := cache.New(5 * time.Minute)
+	queueCache := cache.New(5 * time.Minute)
+
 	eventEngine, cleanupEventEngine, err := NewEventEngineRepository(pool, opts.v, opts.l, opts.metered)
 
 	if err != nil {
 		return nil, nil, err
 	}
 
-	stepRunEngine, cleanupStepRunEngine, err := NewStepRunEngineRepository(pool, opts.v, opts.l, cf, rlCache)
+	stepRunEngine, cleanupStepRunEngine, err := NewStepRunEngineRepository(pool, opts.v, opts.l, cf, rlCache, queueCache)
 
 	if err != nil {
 		return nil, nil, err
@@ -319,6 +321,7 @@ func NewEngineRepository(pool *pgxpool.Pool, cf *server.ConfigFileRuntime, fs ..
 
 	return func() error {
 			rlCache.Stop()
+			queueCache.Stop()
 
 			if err := cleanupStepRunEngine(); err != nil {
 				return err


### PR DESCRIPTION
# Description

Adds a query to make writing step run events more efficient by using `DISTINCT` on the stepRunId instead of a subquery for each row. Additionally reduces the caching on the `Queue` table as we want to frequently update the `lastActive` time on the queue. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking changes to code which doesn't change any behaviour)