### PR TITLE
fix: divide by zero panic

### DIFF
--- a/pkg/scheduling/v2/scheduler.go
+++ b/pkg/scheduling/v2/scheduler.go
@@ -539,7 +539,14 @@ func (s *Scheduler) tryAssignBatch(
 
 		wg.Add(1)
 
-		childRingOffset := newRingOffset % len(candidateSlots)
+		denom := len(candidateSlots)
+
+		if denom == 0 {
+			res[i].noSlots = true
+			wg.Done()
+		}
+
+		childRingOffset := newRingOffset % denom
 
 		go func(i int) {
 			defer wg.Done()

--- a/pkg/scheduling/v2/scheduler.go
+++ b/pkg/scheduling/v2/scheduler.go
@@ -544,6 +544,8 @@ func (s *Scheduler) tryAssignBatch(
 		if denom == 0 {
 			res[i].noSlots = true
 			wg.Done()
+
+			continue
 		}
 
 		childRingOffset := newRingOffset % denom


### PR DESCRIPTION
# Description

Fixes a rare `runtime error: integer divide by zero`. Even though `candidateSlots` is guarded with a mutex and we've checked for whether it has slots, there's a case in between reading and unlocking the actions array and acquiring a lock on the action where the slots could be overwritten. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
