### PR TITLE
fix: set otel insecure flag for all telemetry instantiations

### DIFF
--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -124,6 +124,7 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig) ([]Teardown, erro
 		ServiceName:  sc.OpenTelemetry.ServiceName,
 		CollectorURL: sc.OpenTelemetry.CollectorURL,
 		TraceIdRatio: sc.OpenTelemetry.TraceIdRatio,
+		Insecure:     sc.OpenTelemetry.Insecure,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize tracer: %w", err)
@@ -491,6 +492,7 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig) ([]Teardown, erro
 		ServiceName:  sc.OpenTelemetry.ServiceName,
 		CollectorURL: sc.OpenTelemetry.CollectorURL,
 		TraceIdRatio: sc.OpenTelemetry.TraceIdRatio,
+		Insecure:     sc.OpenTelemetry.Insecure,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize tracer: %w", err)

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -572,6 +572,7 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("otel.serviceName", "SERVER_OTEL_SERVICE_NAME")
 	_ = v.BindEnv("otel.collectorURL", "SERVER_OTEL_COLLECTOR_URL")
 	_ = v.BindEnv("otel.traceIdRatio", "SERVER_OTEL_TRACE_ID_RATIO")
+	_ = v.BindEnv("otel.insecure", "SERVER_OTEL_INSECURE")
 
 	// tenant alerting options
 	_ = v.BindEnv("tenantAlerting.slack.enabled", "SERVER_TENANT_ALERTING_SLACK_ENABLED")

--- a/pkg/config/shared/shared.go
+++ b/pkg/config/shared/shared.go
@@ -23,4 +23,5 @@ type OpenTelemetryConfigFile struct {
 	CollectorURL string `mapstructure:"collectorURL" json:"collectorURL,omitempty"`
 	ServiceName  string `mapstructure:"serviceName" json:"serviceName,omitempty" default:"server"`
 	TraceIdRatio string `mapstructure:"traceIdRatio" json:"traceIdRatio,omitempty" default:"1"`
+	Insecure     bool   `mapstructure:"insecure" json:"insecure,omitempty" default:"false"`
 }


### PR DESCRIPTION
# Description

Ensures that the `insecure` flag is set properly for the opentelemetry config in all instances of the telemetry collector. Previously this was only set in one of the two instances. 
 
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)