### PR TITLE
add an essential pool for heatbeats

### DIFF
--- a/pkg/config/database/config.go
+++ b/pkg/config/database/config.go
@@ -50,6 +50,8 @@ type Config struct {
 
 	Pool *pgxpool.Pool
 
+	EssentialPool *pgxpool.Pool
+
 	QueuePool *pgxpool.Pool
 
 	APIRepository repository.APIRepository

--- a/pkg/repository/prisma/repository.go
+++ b/pkg/repository/prisma/repository.go
@@ -283,7 +283,7 @@ func (r *engineRepository) WebhookWorker() repository.WebhookWorkerEngineReposit
 	return r.webhookWorker
 }
 
-func NewEngineRepository(pool *pgxpool.Pool, cf *server.ConfigFileRuntime, fs ...PrismaRepositoryOpt) (func() error, repository.EngineRepository, error) {
+func NewEngineRepository(pool *pgxpool.Pool, essentialPool *pgxpool.Pool, cf *server.ConfigFileRuntime, fs ...PrismaRepositoryOpt) (func() error, repository.EngineRepository, error) {
 	opts := defaultPrismaRepositoryOpts()
 
 	for _, f := range fs {
@@ -344,7 +344,7 @@ func NewEngineRepository(pool *pgxpool.Pool, cf *server.ConfigFileRuntime, fs ..
 			tenant:         NewTenantEngineRepository(pool, opts.v, opts.l, opts.cache),
 			tenantAlerting: NewTenantAlertingEngineRepository(pool, opts.v, opts.l, opts.cache),
 			ticker:         NewTickerRepository(pool, opts.v, opts.l),
-			worker:         NewWorkerEngineRepository(pool, opts.v, opts.l, opts.metered),
+			worker:         NewWorkerEngineRepository(pool, essentialPool, opts.v, opts.l, opts.metered),
 			workflow:       NewWorkflowEngineRepository(pool, opts.v, opts.l, opts.metered, opts.cache),
 			workflowRun:    workflowRunEngine,
 			streamEvent:    NewStreamEventsEngineRepository(pool, opts.v, opts.l),

--- a/pkg/repository/prisma/worker.go
+++ b/pkg/repository/prisma/worker.go
@@ -193,22 +193,24 @@ func (w *workerAPIRepository) UpdateWorker(tenantId, workerId string, opts repos
 }
 
 type workerEngineRepository struct {
-	pool    *pgxpool.Pool
-	v       validator.Validator
-	queries *dbsqlc.Queries
-	l       *zerolog.Logger
-	m       *metered.Metered
+	pool          *pgxpool.Pool
+	essentialPool *pgxpool.Pool
+	v             validator.Validator
+	queries       *dbsqlc.Queries
+	l             *zerolog.Logger
+	m             *metered.Metered
 }
 
-func NewWorkerEngineRepository(pool *pgxpool.Pool, v validator.Validator, l *zerolog.Logger, m *metered.Metered) repository.WorkerEngineRepository {
+func NewWorkerEngineRepository(pool *pgxpool.Pool, essentialPool *pgxpool.Pool, v validator.Validator, l *zerolog.Logger, m *metered.Metered) repository.WorkerEngineRepository {
 	queries := dbsqlc.New()
 
 	return &workerEngineRepository{
-		pool:    pool,
-		v:       v,
-		queries: queries,
-		l:       l,
-		m:       m,
+		pool:          pool,
+		essentialPool: essentialPool,
+		v:             v,
+		queries:       queries,
+		l:             l,
+		m:             m,
 	}
 }
 
@@ -468,7 +470,7 @@ func (w *workerEngineRepository) UpdateWorker(ctx context.Context, tenantId, wor
 
 func (w *workerEngineRepository) UpdateWorkerHeartbeat(ctx context.Context, tenantId, workerId string, lastHeartbeat time.Time) error {
 
-	_, err := w.queries.UpdateWorkerHeartbeat(ctx, w.pool, dbsqlc.UpdateWorkerHeartbeatParams{
+	_, err := w.queries.UpdateWorkerHeartbeat(ctx, w.essentialPool, dbsqlc.UpdateWorkerHeartbeatParams{
 		ID:              sqlchelpers.UUIDFromStr(workerId),
 		LastHeartbeatAt: sqlchelpers.TimestampFromTime(lastHeartbeat),
 	})


### PR DESCRIPTION
# Description

- [X ] New feature (non-breaking change which adds functionality)

Adding an essential pool for heartbeats so that we don't miss heartbeats from workers under periods of high contention for database connections.

Min set to 1 and max set to 1/100 of max connections
