### PR TITLE
fix: use essential pool for dispatcher heartbeats too

### DIFF
--- a/pkg/repository/prisma/dispatcher.go
+++ b/pkg/repository/prisma/dispatcher.go
@@ -14,20 +14,22 @@ import (
 )
 
 type dispatcherRepository struct {
-	pool    *pgxpool.Pool
-	v       validator.Validator
-	queries *dbsqlc.Queries
-	l       *zerolog.Logger
+	pool          *pgxpool.Pool
+	essentialPool *pgxpool.Pool
+	v             validator.Validator
+	queries       *dbsqlc.Queries
+	l             *zerolog.Logger
 }
 
-func NewDispatcherRepository(pool *pgxpool.Pool, v validator.Validator, l *zerolog.Logger) repository.DispatcherEngineRepository {
+func NewDispatcherRepository(pool *pgxpool.Pool, essentialPool *pgxpool.Pool, v validator.Validator, l *zerolog.Logger) repository.DispatcherEngineRepository {
 	queries := dbsqlc.New()
 
 	return &dispatcherRepository{
-		pool:    pool,
-		queries: queries,
-		v:       v,
-		l:       l,
+		pool:          pool,
+		essentialPool: essentialPool,
+		queries:       queries,
+		v:             v,
+		l:             l,
 	}
 }
 
@@ -44,7 +46,7 @@ func (d *dispatcherRepository) UpdateDispatcher(ctx context.Context, dispatcherI
 		return nil, err
 	}
 
-	return d.queries.UpdateDispatcher(ctx, d.pool, dbsqlc.UpdateDispatcherParams{
+	return d.queries.UpdateDispatcher(ctx, d.essentialPool, dbsqlc.UpdateDispatcherParams{
 		ID:              sqlchelpers.UUIDFromStr(dispatcherId),
 		LastHeartbeatAt: sqlchelpers.TimestampFromTime(opts.LastHeartbeatAt.UTC()),
 	})

--- a/pkg/repository/prisma/repository.go
+++ b/pkg/repository/prisma/repository.go
@@ -335,7 +335,7 @@ func NewEngineRepository(pool *pgxpool.Pool, essentialPool *pgxpool.Pool, cf *se
 		}, &engineRepository{
 			health:         NewHealthEngineRepository(pool),
 			apiToken:       NewEngineTokenRepository(pool, opts.v, opts.l, opts.cache),
-			dispatcher:     NewDispatcherRepository(pool, opts.v, opts.l),
+			dispatcher:     NewDispatcherRepository(pool, essentialPool, opts.v, opts.l),
 			event:          eventEngine,
 			getGroupKeyRun: NewGetGroupKeyRunRepository(pool, opts.v, opts.l),
 			jobRun:         NewJobRunEngineRepository(pool, opts.v, opts.l),


### PR DESCRIPTION
# Description

Uses the essential pool for dispatcher heartbeats, which can impact worker health in the same way as worker heartbeats. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)