### PR TITLE
fix: cron list orderby

### DIFF
--- a/api/v1/server/handlers/workflows/list_crons.go
+++ b/api/v1/server/handlers/workflows/list_crons.go
@@ -22,7 +22,7 @@ func (t *WorkflowService) CronWorkflowList(ctx echo.Context, request gen.CronWor
 	limit := 50
 	offset := 0
 	orderDirection := "DESC"
-	orderBy := "triggerAt"
+	orderBy := "createdAt"
 
 	listOpts := &repository.ListCronWorkflowsOpts{
 		Limit:          &limit,

--- a/pkg/repository/workflow_run.go
+++ b/pkg/repository/workflow_run.go
@@ -428,7 +428,7 @@ type ListCronWorkflowsOpts struct {
 	Limit *int
 
 	// (optional) the order by field
-	OrderBy *string `validate:"omitempty,oneof=createdAt finishedAt startedAt duration"`
+	OrderBy *string `validate:"omitempty,oneof=createdAt"`
 
 	// (optional) the order direction
 	OrderDirection *string `validate:"omitempty,oneof=ASC DESC"`


### PR DESCRIPTION
# Description

Go validator had invalid orderby columns

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
