### PR TITLE
Fixed problem in the Python version of the example worker.

### DIFF
--- a/frontend/docs/pages/self-hosting/docker-compose.mdx
+++ b/frontend/docs/pages/self-hosting/docker-compose.mdx
@@ -222,10 +222,11 @@ class MyWorkflow:
             "result": "success"
         }
 
-worker = hatchet.worker('first-worker')
-worker.register_workflow(MyWorkflow())
+if __name__ == "__main__":
+    worker = hatchet.worker('first-worker')
+    worker.register_workflow(MyWorkflow())
 
-worker.start()
+    worker.start()
 ```
 
 Open a new terminal and start the worker with:


### PR DESCRIPTION
# Description

If we run the worker without (if __name__ == __main__), I have observed that we could get the following error:

--------------------------------------------------------------------

failed to start action listener: 
An attempt has been made to start a new process before the current process has finished its bootstrapping phase. This probably means that you are not using fork to start your child processes and you have forgotten to use the proper idiom in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

The "freeze_support()" line can be omitted if the program is not going to be frozen to produce an executable. To fix this issue, refer to the "Safe importing of main module" section in https://docs.python.org/3/library/multiprocessing.html.

--------------------------------------------------------------------

Adding (if __name__ == "__main__") fixes the issue, and wouldn't break already working setups.

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [ x  ] Added if __name__ == "__main__"
