### PR TITLE
fix: ratelimit and invalid output blocking queue

### DIFF
--- a/pkg/repository/prisma/dbsqlc/step_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql
@@ -433,6 +433,9 @@ FROM (
 WHERE
     "StepRun"."id" = input."id";
 
+-- name: ValidatesAsJson :exec
+SELECT @input::jsonb AS "is_valid";
+
 -- name: BulkFinishStepRun :exec
 UPDATE
     "StepRun"

--- a/pkg/repository/prisma/dbsqlc/step_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql.go
@@ -3050,6 +3050,15 @@ func (q *Queries) UpsertDesiredWorkerLabel(ctx context.Context, db DBTX, arg Ups
 	return &i, err
 }
 
+const validatesAsJson = `-- name: ValidatesAsJson :exec
+SELECT $1::jsonb AS "is_valid"
+`
+
+func (q *Queries) ValidatesAsJson(ctx context.Context, db DBTX, input []byte) error {
+	_, err := db.Exec(ctx, validatesAsJson, input)
+	return err
+}
+
 const verifiedStepRunTenantIds = `-- name: VerifiedStepRunTenantIds :many
 WITH input AS (
     SELECT

--- a/pkg/repository/prisma/step_run.go
+++ b/pkg/repository/prisma/step_run.go
@@ -2126,7 +2126,7 @@ func (s *stepRunEngineRepository) processStepRunUpdatesV2(
 
 			if err != nil && strings.Contains(err.Error(), "SQLSTATE 22P02") {
 				// attempt to validate json for outputs
-				finishParams := dbsqlc.BulkFinishStepRunParams{}
+				finishParams = dbsqlc.BulkFinishStepRunParams{}
 
 				for _, item := range batch {
 					stepRunId := sqlchelpers.UUIDFromStr(item.StepRunId)

--- a/pkg/repository/prisma/step_run.go
+++ b/pkg/repository/prisma/step_run.go
@@ -2129,8 +2129,6 @@ func (s *stepRunEngineRepository) processStepRunUpdatesV2(
 
 			if err != nil {
 				// attempt to validate json for outputs
-
-				failParams := dbsqlc.BulkFailStepRunParams{}
 				finishParams := dbsqlc.BulkFinishStepRunParams{}
 
 				for _, item := range batch {

--- a/pkg/repository/prisma/step_run.go
+++ b/pkg/repository/prisma/step_run.go
@@ -2080,10 +2080,6 @@ func (s *stepRunEngineRepository) processStepRunUpdatesV2(
 		batch := item.Hash % s.updateConcurrentFactor
 
 		batches[batch] = append(batches[batch], item)
-
-		if item.Status != nil && dbsqlc.StepRunStatus(*item.Status) == dbsqlc.StepRunStatusSUCCEEDED {
-			completedStepRunIds = append(completedStepRunIds, sqlchelpers.UUIDFromStr(item.StepRunId))
-		}
 	}
 
 	var wrMu sync.Mutex
@@ -2164,6 +2160,7 @@ func (s *stepRunEngineRepository) processStepRunUpdatesV2(
 
 			wrMu.Lock()
 			completedWorkflowRuns = append(completedWorkflowRuns, innerCompletedWorkflowRuns...)
+			completedStepRunIds = append(completedStepRunIds, finishParams.Steprunids...)
 			wrMu.Unlock()
 
 			return nil


### PR DESCRIPTION
# Description

Fixes blocking queue case when reaching an error case fetching rate limit.
Fixes invalid json output blocking queue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

