### PR TITLE
fix: dont bump deleted workflow versions

### DIFF
--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql
@@ -1210,6 +1210,8 @@ WITH QueuedRuns AS (
         wr."tenantId" = @tenantId::uuid
         AND wr."status" = 'QUEUED'
 		AND wr."concurrencyGroupId" IS NOT NULL
+        AND wr."deletedAt" IS NULL
+        AND wv."deletedAt" IS NULL
     ORDER BY wr."workflowVersionId"
 )
 SELECT

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
@@ -2152,6 +2152,8 @@ WITH QueuedRuns AS (
         wr."tenantId" = $1::uuid
         AND wr."status" = 'QUEUED'
 		AND wr."concurrencyGroupId" IS NOT NULL
+        AND wr."deletedAt" IS NULL
+        AND wv."deletedAt" IS NULL
     ORDER BY wr."workflowVersionId"
 )
 SELECT


### PR DESCRIPTION
# Description

Fixes non-breaking bug which attempts to bump queues for deleted workflows.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

