### PR TITLE
fix: tenant race conditions, cleanup logic, old workers getting assigned

### DIFF
--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -553,14 +553,7 @@ func (s *DispatcherImpl) Heartbeat(ctx context.Context, req *contracts.Heartbeat
 		return nil, err
 	}
 
-	// if we haven't seen the dispatcher for 6 seconds (one interval plus latency), reject the heartbeat as the client
-	// should reconnect
-	if worker.DispatcherLastHeartbeatAt.Time.Before(time.Now().Add(-6 * time.Second)) {
-		span.RecordError(err)
-		span.SetStatus(telemetry_codes.Error, "dispatcher latency")
-		return nil, status.Errorf(codes.FailedPrecondition, "Heartbeat rejected: dispatcher latency: %s, %s", req.WorkerId, sqlchelpers.UUIDToStr(worker.DispatcherId))
-	}
-
+	// if the worker is not active, the listener should reconnect
 	if worker.LastListenerEstablished.Valid && !worker.IsActive {
 		span.RecordError(err)
 		span.SetStatus(telemetry_codes.Error, "worker stream is not active")

--- a/pkg/repository/prisma/dbsqlc/queue.sql
+++ b/pkg/repository/prisma/dbsqlc/queue.sql
@@ -517,7 +517,11 @@ LEFT JOIN
     "Action" a ON atw."A" = a."id"
 WHERE
     w."tenantId" = @tenantId::uuid
-    AND w."id" = ANY(@workerIds::uuid[]);
+    AND w."id" = ANY(@workerIds::uuid[])
+    AND w."dispatcherId" IS NOT NULL
+    AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+    AND w."isActive" = true
+    AND w."isPaused" = false;
 
 -- name: ListActionsForAvailableWorkers :many
 SELECT

--- a/pkg/repository/prisma/dbsqlc/queue.sql.go
+++ b/pkg/repository/prisma/dbsqlc/queue.sql.go
@@ -516,6 +516,10 @@ LEFT JOIN
 WHERE
     w."tenantId" = $1::uuid
     AND w."id" = ANY($2::uuid[])
+    AND w."dispatcherId" IS NOT NULL
+    AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+    AND w."isActive" = true
+    AND w."isPaused" = false
 `
 
 type ListActionsForWorkersParams struct {

--- a/pkg/scheduling/v2/tenant_manager.go
+++ b/pkg/scheduling/v2/tenant_manager.go
@@ -75,10 +75,7 @@ func (t *tenantManager) Cleanup() error {
 
 	err := t.leaseManager.cleanup(cleanupCtx)
 
-	if err != nil {
-		return err
-	}
-
+	// clean up the other resources even if the lease manager fails to clean up
 	t.queuersMu.RLock()
 	defer t.queuersMu.RUnlock()
 
@@ -88,7 +85,7 @@ func (t *tenantManager) Cleanup() error {
 
 	t.rl.cleanup()
 
-	return nil
+	return err
 }
 
 func (t *tenantManager) listenForWorkerLeases(ctx context.Context) {


### PR DESCRIPTION
# Description

Fixes an issue where tenant schedulers may leak, causing old workers to get assigned work. This adds a safeguard to the scheduler to ignore old workers (shouldn't add any query latency since we're already selecting the workers) and fixes the logic around cleaning up lease managers and assigning new tenant managers. 

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)