### PR TITLE
fix: propagate schedule timeouts to children

### DIFF
--- a/internal/services/scheduler/scheduler.go
+++ b/internal/services/scheduler/scheduler.go
@@ -423,8 +423,9 @@ func (s *Scheduler) internalRetry(ctx context.Context, tenantId string, assigned
 
 func getStepRunCancelTask(tenantId, stepRunId, reason string) *msgqueue.Message {
 	payload, _ := datautils.ToJSONMap(tasktypes.StepRunCancelTaskPayload{
-		StepRunId:       stepRunId,
-		CancelledReason: reason,
+		StepRunId:           stepRunId,
+		CancelledReason:     reason,
+		PropagateToChildren: true,
 	})
 
 	metadata, _ := datautils.ToJSONMap(tasktypes.StepRunCancelTaskMetadata{


### PR DESCRIPTION
# Description

Propagates the cancellation of a step run which has timed out to all children of the step run, ensuring that the workflow run ends up in a finalized state. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)