### PR TITLE
fix: make race condition on reassignment more rare

### DIFF
--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
 	"github.com/rs/zerolog"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/hatchet-dev/hatchet/internal/datautils"
 	"github.com/hatchet-dev/hatchet/internal/msgqueue"
@@ -465,7 +466,7 @@ func (d *DispatcherImpl) handleStepRunAssignedTask(ctx context.Context, task *ms
 
 	// if the step run has a job run in a non-running state, we should not send it to the worker
 	if repository.IsFinalJobRunStatus(stepRun.JobRunStatus) {
-		d.l.Warn().Msgf("job run %s is in a final state %s, ignoring", sqlchelpers.UUIDToStr(stepRun.JobRunId), string(stepRun.JobRunStatus))
+		d.l.Debug().Msgf("job run %s is in a final state %s, ignoring", sqlchelpers.UUIDToStr(stepRun.JobRunId), string(stepRun.JobRunStatus))
 
 		// release the semaphore
 		return d.repo.StepRun().ReleaseStepRunSemaphore(ctx, metadata.TenantId, payload.StepRunId, false)
@@ -553,6 +554,11 @@ func (d *DispatcherImpl) handleStepRunBulkAssignedTask(ctx context.Context, task
 	ctx, span := telemetry.NewSpanWithCarrier(ctx, "step-run-assigned-bulk", task.OtelCarrier)
 	defer span.End()
 
+	// we set a timeout of 25 seconds because we don't want to hold the semaphore for longer than the visibility timeout (30 seconds)
+	// on the worker
+	ctx, cancel := context.WithTimeout(ctx, 25*time.Second)
+	defer cancel()
+
 	payload := tasktypes.StepRunAssignedBulkTaskPayload{}
 	metadata := tasktypes.StepRunAssignedBulkTaskMetadata{}
 
@@ -588,97 +594,119 @@ func (d *DispatcherImpl) handleStepRunBulkAssignedTask(ctx context.Context, task
 		stepRunIdToData[sqlchelpers.UUIDToStr(sr.SRID)] = sr
 	}
 
-	var outerErr error
+	outerEg := errgroup.Group{}
 
 	for workerId, stepRunIds := range payload.WorkerIdToStepRunIds {
 		workerId := workerId
 
-		d.l.Debug().Msgf("worker %s has %d step runs", workerId, len(stepRunIds))
+		outerEg.Go(func() error {
+			d.l.Debug().Msgf("worker %s has %d step runs", workerId, len(stepRunIds))
 
-		// get the worker for this task
-		workers, err := d.workers.Get(workerId)
+			// get the worker for this task
+			workers, err := d.workers.Get(workerId)
 
-		if err != nil && !errors.Is(err, ErrWorkerNotFound) {
-			outerErr = multierror.Append(outerErr, fmt.Errorf("could not get worker: %w", err))
-			continue
-		}
-
-		for _, stepRunId := range stepRunIds {
-			stepRunId := stepRunId
-
-			stepRun := stepRunIdToData[stepRunId]
-
-			// if the step run has a job run in a non-running state, we should not send it to the worker
-			if repository.IsFinalJobRunStatus(stepRun.JobRunStatus) {
-				d.l.Warn().Msgf("job run %s is in a final state %s, ignoring", sqlchelpers.UUIDToStr(stepRun.JobRunId), string(stepRun.JobRunStatus))
-
-				// release the semaphore
-				return d.repo.StepRun().ReleaseStepRunSemaphore(ctx, metadata.TenantId, stepRunId, false)
+			if err != nil && !errors.Is(err, ErrWorkerNotFound) {
+				return fmt.Errorf("could not get worker: %w", err)
 			}
 
-			// if the step run is in a final state, we should not send it to the worker
-			if repository.IsFinalStepRunStatus(stepRun.Status) {
-				d.l.Warn().Msgf("step run %s is in a final state %s, ignoring", stepRunId, string(stepRun.Status))
+			innerEg := errgroup.Group{}
 
-				return d.repo.StepRun().ReleaseStepRunSemaphore(ctx, metadata.TenantId, stepRunId, false)
+			for _, stepRunId := range stepRunIds {
+				stepRunId := stepRunId
+
+				innerEg.Go(func() error {
+					stepRun := stepRunIdToData[stepRunId]
+
+					requeue := func() error {
+						// we were unable to send the step run to any worker, requeue the step run with an internal retry
+						_, err = d.repo.StepRun().QueueStepRun(ctx, metadata.TenantId, sqlchelpers.UUIDToStr(stepRun.SRID), &repository.QueueStepRunOpts{
+							IsInternalRetry: true,
+						})
+
+						if err != nil && !errors.Is(err, repository.ErrAlreadyRunning) {
+							return fmt.Errorf("💥 could not requeue step run in dispatcher: %w", err)
+						}
+
+						return nil
+					}
+
+					// if we've reached the context deadline, this should be requeued
+					if ctx.Err() != nil {
+						return requeue()
+					}
+
+					// if the step run has a job run in a non-running state, we should not send it to the worker
+					if repository.IsFinalJobRunStatus(stepRun.JobRunStatus) {
+						d.l.Debug().Msgf("job run %s is in a final state %s, ignoring", sqlchelpers.UUIDToStr(stepRun.JobRunId), string(stepRun.JobRunStatus))
+
+						// release the semaphore
+						return d.repo.StepRun().ReleaseStepRunSemaphore(ctx, metadata.TenantId, stepRunId, false)
+					}
+
+					// if the step run is in a final state, we should not send it to the worker
+					if repository.IsFinalStepRunStatus(stepRun.Status) {
+						d.l.Warn().Msgf("step run %s is in a final state %s, ignoring", stepRunId, string(stepRun.Status))
+
+						return d.repo.StepRun().ReleaseStepRunSemaphore(ctx, metadata.TenantId, stepRunId, false)
+					}
+
+					var multiErr error
+					var success bool
+
+					for i, w := range workers {
+						err = w.StartStepRunFromBulk(ctx, metadata.TenantId, stepRun)
+
+						if err != nil {
+							multiErr = multierror.Append(multiErr, fmt.Errorf("could not send step action to worker (%d): %w", i, err))
+						} else {
+							success = true
+							break
+						}
+					}
+
+					now := time.Now().UTC()
+
+					if success {
+						defer d.repo.StepRun().DeferredStepRunEvent(
+							metadata.TenantId,
+							repository.CreateStepRunEventOpts{
+								StepRunId:     sqlchelpers.UUIDToStr(stepRun.SRID),
+								EventMessage:  repository.StringPtr("Sent step run to the assigned worker"),
+								EventReason:   repository.StepRunEventReasonPtr(dbsqlc.StepRunEventReasonSENTTOWORKER),
+								EventSeverity: repository.StepRunEventSeverityPtr(dbsqlc.StepRunEventSeverityINFO),
+								Timestamp:     &now,
+								EventData:     map[string]interface{}{"worker_id": workerId},
+							},
+						)
+
+						return nil
+					}
+
+					defer d.repo.StepRun().DeferredStepRunEvent(
+						metadata.TenantId,
+						repository.CreateStepRunEventOpts{
+							StepRunId:     sqlchelpers.UUIDToStr(stepRun.SRID),
+							EventMessage:  repository.StringPtr("Could not send step run to assigned worker"),
+							EventReason:   repository.StepRunEventReasonPtr(dbsqlc.StepRunEventReasonREASSIGNED),
+							EventSeverity: repository.StepRunEventSeverityPtr(dbsqlc.StepRunEventSeverityWARNING),
+							Timestamp:     &now,
+							EventData:     map[string]interface{}{"worker_id": workerId},
+						},
+					)
+
+					if err := requeue(); err != nil {
+						multiErr = multierror.Append(multiErr, err)
+					}
+
+					return multiErr
+				})
 			}
 
-			var multiErr error
-			var success bool
-
-			for i, w := range workers {
-				err = w.StartStepRunFromBulk(ctx, metadata.TenantId, stepRun)
-
-				if err != nil {
-					multiErr = multierror.Append(multiErr, fmt.Errorf("could not send step action to worker (%d): %w", i, err))
-				} else {
-					success = true
-					break
-				}
-			}
-
-			now := time.Now().UTC()
-
-			if success {
-				defer d.repo.StepRun().DeferredStepRunEvent(
-					metadata.TenantId,
-					repository.CreateStepRunEventOpts{
-						StepRunId:     sqlchelpers.UUIDToStr(stepRun.SRID),
-						EventMessage:  repository.StringPtr("Sent step run to the assigned worker"),
-						EventReason:   repository.StepRunEventReasonPtr(dbsqlc.StepRunEventReasonSENTTOWORKER),
-						EventSeverity: repository.StepRunEventSeverityPtr(dbsqlc.StepRunEventSeverityINFO),
-						Timestamp:     &now,
-						EventData:     map[string]interface{}{"worker_id": workerId},
-					},
-				)
-
-				continue
-			}
-
-			defer d.repo.StepRun().DeferredStepRunEvent(
-				metadata.TenantId,
-				repository.CreateStepRunEventOpts{
-					StepRunId:     sqlchelpers.UUIDToStr(stepRun.SRID),
-					EventMessage:  repository.StringPtr("Could not send step run to assigned worker"),
-					EventReason:   repository.StepRunEventReasonPtr(dbsqlc.StepRunEventReasonREASSIGNED),
-					EventSeverity: repository.StepRunEventSeverityPtr(dbsqlc.StepRunEventSeverityWARNING),
-					Timestamp:     &now,
-					EventData:     map[string]interface{}{"worker_id": workerId},
-				},
-			)
-
-			// we were unable to send the step run to any worker, requeue the step run with an internal retry
-			_, err = d.repo.StepRun().QueueStepRun(ctx, metadata.TenantId, sqlchelpers.UUIDToStr(stepRun.SRID), &repository.QueueStepRunOpts{
-				IsInternalRetry: true,
-			})
-
-			if err != nil && !errors.Is(err, repository.ErrAlreadyRunning) {
-				outerErr = multierror.Append(outerErr, fmt.Errorf("💥 could not requeue step run in dispatcher: %w", err))
-			}
-		}
+			return innerEg.Wait()
+		})
 	}
 
-	return outerErr
+	return outerEg.Wait()
 }
 
 func (d *DispatcherImpl) handleStepRunCancelled(ctx context.Context, task *msgqueue.Message) error {

--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -654,7 +654,7 @@ func (d *DispatcherImpl) handleStepRunBulkAssignedTask(ctx context.Context, task
 					var success bool
 
 					for i, w := range workers {
-						err = w.StartStepRunFromBulk(ctx, metadata.TenantId, stepRun)
+						err := w.StartStepRunFromBulk(ctx, metadata.TenantId, stepRun)
 
 						if err != nil {
 							multiErr = multierror.Append(multiErr, fmt.Errorf("could not send step action to worker (%d): %w", i, err))

--- a/pkg/repository/prisma/step_run.go
+++ b/pkg/repository/prisma/step_run.go
@@ -3010,18 +3010,6 @@ func (s *stepRunEngineRepository) QueueStepRun(ctx context.Context, tenantId, st
 		}
 	}
 
-	if opts.IsRetry || opts.IsInternalRetry {
-		// if this is a retry, write a queue item to release the worker semaphore
-		err := s.releaseWorkerSemaphoreSlot(ctx, tenantId, stepRunId)
-
-		if err != nil {
-			return nil, fmt.Errorf("could not release worker semaphore queue items: %w", err)
-		}
-
-		// retries get highest priority to ensure that they're run immediately
-		priority = 4
-	}
-
 	if len(opts.ExpressionEvals) > 0 {
 		err := s.createExpressionEvals(ctx, s.pool, stepRunId, opts.ExpressionEvals)
 
@@ -3052,6 +3040,22 @@ func (s *stepRunEngineRepository) QueueStepRun(ctx context.Context, tenantId, st
 	// if this is not a retry, and the step run is already in a pending assignment state, this is a no-op
 	if !opts.IsRetry && !opts.IsInternalRetry && innerStepRun.SRStatus == dbsqlc.StepRunStatusPENDINGASSIGNMENT {
 		return nil, repository.ErrAlreadyQueued
+	}
+
+	if opts.IsRetry || opts.IsInternalRetry {
+		// if this is a retry, write a queue item to release the worker semaphore
+		//
+		// FIXME: there is a race condition here where we can delete a worker semaphore slot that has already been reassigned,
+		// but the step run was not in a RUNNING state. The fix for this would be to track an total retry count on the step run
+		// and use this to identify semaphore slots, but this involves a big refactor of semaphore slots.
+		err := s.releaseWorkerSemaphoreSlot(ctx, tenantId, stepRunId)
+
+		if err != nil {
+			return nil, fmt.Errorf("could not release worker semaphore queue items: %w", err)
+		}
+
+		// retries get highest priority to ensure that they're run immediately
+		priority = 4
 	}
 
 	_, err = s.bulkQueuer.BuffItem(tenantId, buffer.BulkQueueStepRunOpts{


### PR DESCRIPTION
# Description

There is currently a race condition when a step run cannot be sent to a worker and we've spent longer than 30 seconds trying to send it. The race condition occurs because we reassign the step run to a different worker while we have still been trying to send it to the old worker. We release the semaphore slot in the old process, which unintentionally releases it from the the new worker. 

This isn't a complete fix for this issue, but should make it much rarer. The complete fix would be to track total retry counts and key semaphore slots on total retry counts, so we can concurrently assign slots when we know the old reassignment will fail. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)