### PR TITLE
fix: latency issues on queueing caused by race condition

### DIFF
--- a/frontend/app/src/pages/main/managed-workers/$managed-worker/components/update-form.tsx
+++ b/frontend/app/src/pages/main/managed-workers/$managed-worker/components/update-form.tsx
@@ -464,7 +464,12 @@ export default function UpdateWorkerForm({
                   </TabsTrigger>
                 </TabsList>
                 <TabsContent value="iac" className="pt-4 grid gap-4">
-                  TODO: LINK TO DOCS!
+                  <a
+                    href="https://docs.hatchet.run/compute/cpu"
+                    className="underline"
+                  >
+                    Learn how to configure infra-as-code.
+                  </a>
                 </TabsContent>
                 <TabsContent value="ui" className="pt-4 grid gap-4">
                   <Label htmlFor="region">Region</Label>

--- a/frontend/app/src/pages/main/managed-workers/create/components/create-worker-form.tsx
+++ b/frontend/app/src/pages/main/managed-workers/create/components/create-worker-form.tsx
@@ -628,7 +628,12 @@ export default function CreateWorkerForm({
                 </TabsTrigger>
               </TabsList>
               <TabsContent value="iac" className="pt-4 grid gap-4">
-                TODO: LINK TO DOCS!
+                <a
+                  href="https://docs.hatchet.run/compute/cpu"
+                  className="underline"
+                >
+                  Learn how to configure infra-as-code.
+                </a>
               </TabsContent>
               <TabsContent value="ui" className="pt-4 grid gap-4">
                 <Label htmlFor="region">Region</Label>

--- a/internal/services/controllers/workflows/queue.go
+++ b/internal/services/controllers/workflows/queue.go
@@ -28,7 +28,7 @@ func (wc *WorkflowsControllerImpl) handleWorkflowRunQueued(ctx context.Context, 
 	// TODO remove de dupes and fail if they are clashing
 	// write a cancellation step run for the failed workflow run (failWorkflowRun)
 
-	ctx, span := telemetry.NewSpan(ctx, "handle-workflow-run-queued")
+	ctx, span := telemetry.NewSpanWithCarrier(ctx, "handle-workflow-run-queued", task.OtelCarrier)
 	defer span.End()
 
 	payload := tasktypes.WorkflowRunQueuedTaskPayload{}

--- a/internal/services/scheduler/scheduler.go
+++ b/internal/services/scheduler/scheduler.go
@@ -269,7 +269,7 @@ func (s *Scheduler) handleTask(ctx context.Context, task *msgqueue.Message) (err
 }
 
 func (s *Scheduler) handleCheckQueue(ctx context.Context, task *msgqueue.Message) error {
-	_, span := telemetry.NewSpanWithCarrier(ctx, "handle-check-queue", task.OtelCarrier)
+	ctx, span := telemetry.NewSpanWithCarrier(ctx, "handle-check-queue", task.OtelCarrier)
 	defer span.End()
 
 	payload := tasktypes.CheckTenantQueuePayload{}

--- a/pkg/scheduling/v2/pool.go
+++ b/pkg/scheduling/v2/pool.go
@@ -154,7 +154,7 @@ func (p *SchedulingPool) Replenish(ctx context.Context, tenantId string) {
 
 func (p *SchedulingPool) Queue(ctx context.Context, tenantId string, queueName string) {
 	if tm := p.getTenantManager(tenantId, false); tm != nil {
-		tm.queue(queueName)
+		tm.queue(ctx, queueName)
 	}
 }
 

--- a/pkg/scheduling/v2/tenant_manager.go
+++ b/pkg/scheduling/v2/tenant_manager.go
@@ -151,7 +151,7 @@ func (t *tenantManager) refreshAll(ctx context.Context) {
 
 		eg.Go(func() error {
 			queuer := t.queuers[index]
-			queuer.queue()
+			queuer.queue(ctx)
 			return nil
 		})
 	}
@@ -171,13 +171,13 @@ func (t *tenantManager) replenish(ctx context.Context) {
 	}
 }
 
-func (t *tenantManager) queue(queueName string) {
+func (t *tenantManager) queue(ctx context.Context, queueName string) {
 	t.queuersMu.RLock()
 
 	for _, q := range t.queuers {
 		if q.queueName == queueName {
 			t.queuersMu.RUnlock()
-			q.queue()
+			q.queue(ctx)
 			return
 		}
 	}


### PR DESCRIPTION
# Description

We weren't waiting the buffered write to the `QueueItem` table, causing a race condition when we check the queue and miss the item. We weren't seeing this under high load but it's very noticeable in tests with low volume. 

Also improves telemetry so we can trace from events -> workflow runs -> queueing. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)