### PR TITLE
docs: improves release_slot warning

### DIFF
--- a/frontend/docs/pages/home/features/advanced/manual-slot-release.mdx
+++ b/frontend/docs/pages/home/features/advanced/manual-slot-release.mdx
@@ -10,7 +10,9 @@ In some cases, you may have a step in your workflow that is resource-intensive a
 <Callout type="warning">
   This is an advanced feature and should be used with caution. Manually
   releasing the slot can have unintended side effects on system performance and
-  concurrency.
+  concurrency. For example, if the worker running the step dies, the step will
+  not be reassigned and will remain in a running state untill manually
+  terminated.
 </Callout>
 
 ## Using Manual Slot Release

--- a/frontend/docs/pages/home/features/advanced/manual-slot-release.mdx
+++ b/frontend/docs/pages/home/features/advanced/manual-slot-release.mdx
@@ -11,7 +11,7 @@ In some cases, you may have a step in your workflow that is resource-intensive a
   This is an advanced feature and should be used with caution. Manually
   releasing the slot can have unintended side effects on system performance and
   concurrency. For example, if the worker running the step dies, the step will
-  not be reassigned and will remain in a running state untill manually
+  not be reassigned and will remain in a running state until manually
   terminated.
 </Callout>
 


### PR DESCRIPTION
# Description

Improves release_slot warning. Alerts for the danger of having zombie workflows that will never be reassigned nor expire.

## Type of change

- [x] Documentation change (pure documentation change)

Follows the discord discussion

<img width="458" alt="image" src="https://github.com/user-attachments/assets/209327bd-d9aa-4cb8-ad36-aa3b168b953b">

<img width="498" alt="image" src="https://github.com/user-attachments/assets/12c6c5ee-0857-44c0-9a6b-9d5b8f66daf5">
