### PR TITLE
fix: don't crash on additional meta being null

### DIFF
--- a/frontend/app/src/pages/main/workflow-runs/$run/index.tsx
+++ b/frontend/app/src/pages/main/workflow-runs/$run/index.tsx
@@ -136,7 +136,11 @@ export default function ExpandedWorkflowRun() {
             <CodeHighlighter
               className="my-4"
               language="json"
-              code={JSON.stringify(shape.data?.additionalMetadata, null, 2)}
+              code={JSON.stringify(
+                shape.data?.additionalMetadata || {},
+                null,
+                2,
+              )}
             />
           </TabsContent>
         </Tabs>


### PR DESCRIPTION
# Description

If additional meta is set to `null`, it causes the page to crash when the user clicks on that tab. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)