### PR TITLE
fix: create code-defined cron schedules properly

### DIFF
--- a/pkg/repository/prisma/workflow.go
+++ b/pkg/repository/prisma/workflow.go
@@ -1086,6 +1086,10 @@ func (r *workflowEngineRepository) createWorkflowVersionTxs(ctx context.Context,
 				Workflowtriggersid: sqlcWorkflowTriggers.ID,
 				Crontrigger:        cronTrigger,
 				Input:              opts.CronInput,
+				Name: pgtype.Text{
+					String: "",
+					Valid:  true,
+				},
 			},
 		)
 


### PR DESCRIPTION
# Description

Code-defined cron schedules are created with a `NULL` value for the name, causing an FK constraint to break on workflow run inserts.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)