### PR TITLE
feat(go-sdk): blocking worker

### DIFF
--- a/internal/services/controllers/workflows/controller.go
+++ b/internal/services/controllers/workflows/controller.go
@@ -645,7 +645,7 @@ func (wc *WorkflowsControllerImpl) cancelGetGroupKeyRun(ctx context.Context, ten
 	})
 
 	if err != nil {
-		return fmt.Errorf("could not update step run: %w", err)
+		return fmt.Errorf("could not update get group key run: %w", err)
 	}
 
 	// cancel all existing jobs on the workflow run

--- a/pkg/repository/prisma/get_group_key_run.go
+++ b/pkg/repository/prisma/get_group_key_run.go
@@ -190,14 +190,16 @@ func (s *getGroupKeyRunRepository) UpdateGetGroupKeyRun(ctx context.Context, ten
 		return nil, err
 	}
 
-	if len(getGroupKeyRuns) == 0 {
-		return nil, fmt.Errorf("could not find get group key run for engine")
-	}
-
 	err = tx.Commit(ctx)
 
 	if err != nil {
 		return nil, err
+	}
+
+	// in this case, we've committed the update (so we can update timeouts), but we're hitting a case where the Workflow or
+	// WorkflowRun has been deleted, so we return an error.
+	if len(getGroupKeyRuns) == 0 {
+		return nil, fmt.Errorf("could not find get group key run for engine")
 	}
 
 	return getGroupKeyRuns[0], nil


### PR DESCRIPTION
# Description

Adds support for starting the Go worker in blocking mode with `.Run`. This allows users to handle errors related to being unable to establish the listener. 

Also: 
- Stops panics from being able to establish the listener
- Handles an edge case with get group key run which is throwing noisy logs in an endless loop

## Type of change

- [X] New feature (non-breaking change which adds functionality)