### PR TITLE
feat(go-sdk): expose user data

### DIFF
--- a/pkg/client/admin.go
+++ b/pkg/client/admin.go
@@ -506,11 +506,18 @@ func (a *adminClientImpl) getJobOpts(jobName string, job *types.WorkflowJob) (*a
 			return nil, fmt.Errorf("could not marshal step inputs: %w", err)
 		}
 
+		userDataBytes, err := json.Marshal(step.UserData)
+
+		if err != nil {
+			return nil, fmt.Errorf("could not marshal step user data: %w", err)
+		}
+
 		stepOpt := &admincontracts.CreateWorkflowStepOpts{
 			ReadableId:        step.ID,
 			Action:            step.ActionID,
 			Timeout:           step.Timeout,
 			Inputs:            string(inputBytes),
+			UserData:          string(userDataBytes),
 			Parents:           step.Parents,
 			Retries:           int32(step.Retries), // nolint: gosec
 			BackoffFactor:     step.RetryBackoffFactor,

--- a/pkg/client/types/file.go
+++ b/pkg/client/types/file.go
@@ -108,11 +108,15 @@ type DesiredWorkerLabel struct {
 }
 
 type WorkflowStep struct {
-	Name                   string                         `yaml:"name,omitempty"`
-	ID                     string                         `yaml:"id,omitempty"`
-	ActionID               string                         `yaml:"action"`
-	Timeout                string                         `yaml:"timeout,omitempty"`
-	With                   map[string]interface{}         `yaml:"with,omitempty"`
+	Name     string `yaml:"name,omitempty"`
+	ID       string `yaml:"id,omitempty"`
+	ActionID string `yaml:"action"`
+	Timeout  string `yaml:"timeout,omitempty"`
+
+	// Deprecated: this field has no effect and will be removed in a future release.
+	With map[string]interface{} `yaml:"with,omitempty"`
+
+	UserData               map[string]interface{}         `yaml:"userData,omitempty"`
 	Parents                []string                       `yaml:"parents,omitempty"`
 	Retries                int                            `yaml:"retries"`
 	RateLimits             []RateLimit                    `yaml:"rateLimits,omitempty"`

--- a/pkg/worker/context.go
+++ b/pkg/worker/context.go
@@ -41,6 +41,8 @@ type HatchetContext interface {
 
 	WorkflowInput(target interface{}) error
 
+	UserData(target interface{}) error
+
 	AdditionalMetadata() map[string]string
 
 	StepName() string
@@ -91,6 +93,7 @@ type StepRunData struct {
 	TriggeredBy        TriggeredBy            `json:"triggered_by"`
 	Parents            map[string]StepData    `json:"parents"`
 	AdditionalMetadata map[string]string      `json:"additional_metadata"`
+	UserData           map[string]interface{} `json:"user_data"`
 }
 
 type StepData map[string]interface{}
@@ -187,6 +190,10 @@ func (h *hatchetContext) TriggeredByEvent() bool {
 
 func (h *hatchetContext) WorkflowInput(target interface{}) error {
 	return toTarget(h.stepData.Input, target)
+}
+
+func (h *hatchetContext) UserData(target interface{}) error {
+	return toTarget(h.stepData.UserData, target)
 }
 
 func (h *hatchetContext) AdditionalMetadata() map[string]string {

--- a/pkg/worker/middleware_test.go
+++ b/pkg/worker/middleware_test.go
@@ -32,6 +32,10 @@ func (c *testHatchetContext) WorkflowInput(target interface{}) error {
 	return nil
 }
 
+func (c *testHatchetContext) UserData(target interface{}) error {
+	return nil
+}
+
 func (c *testHatchetContext) AdditionalMetadata() map[string]string {
 	return nil
 }


### PR DESCRIPTION
# Description

Exposes a `UserData` field on the Go SDK for use in `PutWorkflow`, and additionally adds the field to the context. Example usage:

```go
type userData struct {
	Username string `json:"username"`
}

func StepOne(ctx worker.HatchetContext) (result *stepOneOutput, err error) {
	userData := &userData{}

	ctx.UserData(&userData)

	fmt.Println(userData.Username)

	return &stepOneOutput{
		Message: "Username is: " + userData.Username,
	}, nil
}

client.Admin().PutWorkflow(&types.Workflow{
		Name: "api-workflow",
		Jobs: map[string]types.WorkflowJob{
			"api-workflow": {
				Description: "This runs after an update to the user model.",
				Steps: []types.WorkflowStep{
					{
						ID:       "step-one",
						Name:     "step-one",
						ActionID: "test:step-one",
						UserData: map[string]interface{}{
							"username": "test-username",
						},
					},
				},
			},
		},
	})
```
 
## Type of change

- [X] New feature (non-breaking change which adds functionality)