### PR TITLE
refactor(repository): improve usability of repository

### DIFF
--- a/internal/services/scheduler/scheduler.go
+++ b/internal/services/scheduler/scheduler.go
@@ -409,7 +409,7 @@ func (s *Scheduler) scheduleStepRuns(ctx context.Context, tenantId string, res *
 	return err
 }
 
-func (s *Scheduler) internalRetry(ctx context.Context, tenantId string, assigned ...*v2.AssignedQueueItem) {
+func (s *Scheduler) internalRetry(ctx context.Context, tenantId string, assigned ...*repository.AssignedItem) {
 	for _, a := range assigned {
 		stepRunId := sqlchelpers.UUIDToStr(a.QueueItem.StepRunId)
 

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -444,11 +444,9 @@ func GetServerConfigFromConfigfile(dc *database.Config, cf *server.ServerConfigF
 	v := validator.NewDefaultValidator()
 
 	schedulingPool, cleanupSchedulingPool, err := v2.NewSchedulingPool(
+		dc.EngineRepository.Scheduler(),
 		&queueLogger,
-		dc.QueuePool,
-		v,
 		cf.Runtime.SingleQueueLimit,
-		cf.Runtime.EventBuffer,
 	)
 
 	if err != nil {

--- a/pkg/repository/prisma/buffer_step_run_status.go
+++ b/pkg/repository/prisma/buffer_step_run_status.go
@@ -1,0 +1,164 @@
+package prisma
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/hatchet-dev/hatchet/pkg/repository"
+	"github.com/hatchet-dev/hatchet/pkg/repository/buffer"
+	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/dbsqlc"
+	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/sqlchelpers"
+)
+
+func newBulkStepRunStatusBuffer(shared *sharedRepository) (*buffer.TenantBufferManager[*updateStepRunQueueData, pgtype.UUID], error) {
+	statusBufOpts := buffer.TenantBufManagerOpts[*updateStepRunQueueData, pgtype.UUID]{
+		Name:       "update_step_run_status",
+		OutputFunc: shared.bulkUpdateStepRunStatuses,
+		SizeFunc:   sizeOfUpdateData,
+		L:          shared.l,
+		V:          shared.v,
+	}
+
+	var err error
+	manager, err := buffer.NewTenantBufManager(statusBufOpts)
+
+	if err != nil {
+		shared.l.Err(err).Msg("could not create tenant buffer manager")
+		return nil, err
+	}
+
+	return manager, nil
+}
+
+func (s *sharedRepository) bulkUpdateStepRunStatuses(ctx context.Context, opts []*updateStepRunQueueData) ([]*pgtype.UUID, error) {
+	stepRunIds := make([]*pgtype.UUID, 0, len(opts))
+
+	eventTimeSeen := make([]time.Time, 0, len(opts))
+	eventReasons := make([]dbsqlc.StepRunEventReason, 0, len(opts))
+	eventStepRunIds := make([]pgtype.UUID, 0, len(opts))
+	eventTenantIds := make([]string, 0, len(opts))
+	eventSeverities := make([]dbsqlc.StepRunEventSeverity, 0, len(opts))
+	eventMessages := make([]string, 0, len(opts))
+	eventData := make([]map[string]interface{}, 0, len(opts))
+
+	for _, item := range opts {
+		stepRunId := sqlchelpers.UUIDFromStr(item.StepRunId)
+		stepRunIds = append(stepRunIds, &stepRunId)
+
+		if item.Status == nil {
+			continue
+		}
+
+		switch dbsqlc.StepRunStatus(*item.Status) {
+		case dbsqlc.StepRunStatusRUNNING:
+			eventStepRunIds = append(eventStepRunIds, stepRunId)
+			eventTenantIds = append(eventTenantIds, item.TenantId)
+			eventTimeSeen = append(eventTimeSeen, *item.StartedAt)
+			eventReasons = append(eventReasons, dbsqlc.StepRunEventReasonSTARTED)
+			eventSeverities = append(eventSeverities, dbsqlc.StepRunEventSeverityINFO)
+			eventMessages = append(eventMessages, fmt.Sprintf("Step run started at %s", item.StartedAt.Format(time.RFC1123)))
+			eventData = append(eventData, map[string]interface{}{})
+		case dbsqlc.StepRunStatusFAILED:
+			eventTimeSeen = append(eventTimeSeen, *item.FinishedAt)
+
+			eventStepRunIds = append(eventStepRunIds, stepRunId)
+			eventTenantIds = append(eventTenantIds, item.TenantId)
+			eventMessage := fmt.Sprintf("Step run failed on %s", item.FinishedAt.Format(time.RFC1123))
+			eventReason := dbsqlc.StepRunEventReasonFAILED
+
+			if item.Error != nil && *item.Error == "TIMED_OUT" {
+				eventReason = dbsqlc.StepRunEventReasonTIMEDOUT
+				eventMessage = "Step exceeded timeout duration"
+			}
+
+			eventReasons = append(eventReasons, eventReason)
+			eventSeverities = append(eventSeverities, dbsqlc.StepRunEventSeverityCRITICAL)
+			eventMessages = append(eventMessages, eventMessage)
+			eventData = append(eventData, map[string]interface{}{
+				"retry_count": item.RetryCount,
+			})
+		case dbsqlc.StepRunStatusCANCELLED:
+			eventTimeSeen = append(eventTimeSeen, *item.CancelledAt)
+			eventStepRunIds = append(eventStepRunIds, stepRunId)
+			eventTenantIds = append(eventTenantIds, item.TenantId)
+			eventReasons = append(eventReasons, dbsqlc.StepRunEventReasonCANCELLED)
+			eventSeverities = append(eventSeverities, dbsqlc.StepRunEventSeverityWARNING)
+			eventMessages = append(eventMessages, fmt.Sprintf("Step run was cancelled on %s for the following reason: %s", item.CancelledAt.Format(time.RFC1123), *item.CancelledReason))
+			eventData = append(eventData, map[string]interface{}{})
+		case dbsqlc.StepRunStatusSUCCEEDED:
+			eventTimeSeen = append(eventTimeSeen, *item.FinishedAt)
+			eventStepRunIds = append(eventStepRunIds, stepRunId)
+			eventTenantIds = append(eventTenantIds, item.TenantId)
+			eventReasons = append(eventReasons, dbsqlc.StepRunEventReasonFINISHED)
+			eventSeverities = append(eventSeverities, dbsqlc.StepRunEventSeverityINFO)
+			eventMessages = append(eventMessages, fmt.Sprintf("Step run finished at %s", item.FinishedAt.Format(time.RFC1123)))
+			eventData = append(eventData, map[string]interface{}{})
+		}
+	}
+
+	eg := errgroup.Group{}
+
+	if len(opts) > 0 {
+		eg.Go(func() error {
+			insertInternalQITenantIds := make([]pgtype.UUID, 0, len(opts))
+			insertInternalQIQueues := make([]dbsqlc.InternalQueue, 0, len(opts))
+			insertInternalQIData := make([]any, 0, len(opts))
+
+			for _, item := range opts {
+				if item.Status == nil {
+					continue
+				}
+
+				itemCp := item
+
+				insertInternalQITenantIds = append(insertInternalQITenantIds, sqlchelpers.UUIDFromStr(itemCp.TenantId))
+				insertInternalQIQueues = append(insertInternalQIQueues, dbsqlc.InternalQueueSTEPRUNUPDATEV2)
+				insertInternalQIData = append(insertInternalQIData, itemCp)
+			}
+
+			err := bulkInsertInternalQueueItem(
+				ctx,
+				s.pool,
+				s.queries,
+				insertInternalQITenantIds,
+				insertInternalQIQueues,
+				insertInternalQIData,
+			)
+
+			if err != nil {
+				return err
+			}
+
+			return nil
+		})
+	}
+
+	if len(eventStepRunIds) > 0 {
+		for i, stepRunId := range eventStepRunIds {
+			err := s.bulkEventBuffer.FireForget(eventTenantIds[i], &repository.CreateStepRunEventOpts{
+				StepRunId:     sqlchelpers.UUIDToStr(stepRunId),
+				EventMessage:  &eventMessages[i],
+				EventReason:   &eventReasons[i],
+				EventSeverity: &eventSeverities[i],
+				Timestamp:     &eventTimeSeen[i],
+				EventData:     eventData[i],
+			})
+
+			if err != nil {
+				s.l.Err(err).Msg("could not buffer step run event")
+			}
+		}
+	}
+
+	err := eg.Wait()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return stepRunIds, nil
+}

--- a/pkg/repository/prisma/buffer_user_events.go
+++ b/pkg/repository/prisma/buffer_user_events.go
@@ -1,0 +1,118 @@
+package prisma
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/hatchet-dev/hatchet/internal/telemetry"
+	"github.com/hatchet-dev/hatchet/pkg/repository"
+	"github.com/hatchet-dev/hatchet/pkg/repository/buffer"
+	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/dbsqlc"
+	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/sqlchelpers"
+)
+
+func newUserEventBuffer(shared *sharedRepository, conf buffer.ConfigFileBuffer) (*buffer.TenantBufferManager[*repository.CreateEventOpts, dbsqlc.Event], error) {
+	userEventBufOpts := buffer.TenantBufManagerOpts[*repository.CreateEventOpts, dbsqlc.Event]{
+		Name:       "create_user_events",
+		OutputFunc: shared.bulkWriteUserEvents,
+		SizeFunc:   sizeOfEvent,
+		L:          shared.l,
+		V:          shared.v,
+		Config:     conf,
+	}
+
+	manager, err := buffer.NewTenantBufManager(userEventBufOpts)
+
+	if err != nil {
+		shared.l.Err(err).Msg("could not create tenant buffer manager")
+		return nil, err
+	}
+
+	return manager, nil
+}
+
+func sizeOfEvent(item *repository.CreateEventOpts) int {
+	return len(item.Data) + len(item.AdditionalMetadata)
+}
+
+func (r *sharedRepository) bulkWriteUserEvents(ctx context.Context, opts []*repository.CreateEventOpts) ([]*dbsqlc.Event, error) {
+	// need to do the metering beforehand
+	numberOfResources := len(opts)
+	if numberOfResources < math.MinInt32 || numberOfResources > math.MaxInt32 {
+		return nil, fmt.Errorf("number of resources is out of range")
+	}
+
+	ctx, span := telemetry.NewSpan(ctx, "db-bulk-create-event-shared-tenant")
+	defer span.End()
+
+	for _, opt := range opts {
+
+		if err := r.v.Validate(opt); err != nil {
+			return nil, err
+		}
+	}
+	params := make([]dbsqlc.CreateEventsParams, len(opts))
+	ids := make([]pgtype.UUID, len(opts))
+
+	for i, event := range opts {
+
+		if i > math.MaxInt32 || i < math.MinInt32 {
+			return nil, fmt.Errorf("number of resources is out of range for int 32")
+		}
+
+		eventId := uuid.New().String()
+
+		params[i] = dbsqlc.CreateEventsParams{
+			ID:                 sqlchelpers.UUIDFromStr(eventId),
+			Key:                event.Key,
+			TenantId:           sqlchelpers.UUIDFromStr(event.TenantId),
+			Data:               event.Data,
+			AdditionalMetadata: event.AdditionalMetadata,
+			InsertOrder:        sqlchelpers.ToInt(int32(i)),
+		}
+
+		if event.ReplayedEvent != nil {
+			params[i].ReplayedFromId = sqlchelpers.UUIDFromStr(*event.ReplayedEvent)
+		}
+
+		ids[i] = sqlchelpers.UUIDFromStr(eventId)
+	}
+
+	// start a transaction
+	tx, err := r.pool.Begin(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer sqlchelpers.DeferRollback(ctx, r.l, tx.Rollback)
+
+	insertCount, err := r.queries.CreateEvents(
+		ctx,
+		tx,
+		params,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("could not create events: %w", err)
+	}
+
+	r.l.Info().Msgf("inserted %d events", insertCount)
+
+	events, err := r.queries.GetInsertedEvents(ctx, tx, ids)
+
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve inserted events: %w", err)
+	}
+	err = tx.Commit(ctx)
+
+	if err != nil {
+		return nil, fmt.Errorf("could not commit transaction: %w", err)
+	}
+
+	return events, nil
+}

--- a/pkg/repository/prisma/buffer_workflow_run_create.go
+++ b/pkg/repository/prisma/buffer_workflow_run_create.go
@@ -1,0 +1,49 @@
+package prisma
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hatchet-dev/hatchet/pkg/repository"
+	"github.com/hatchet-dev/hatchet/pkg/repository/buffer"
+	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/dbsqlc"
+)
+
+func newCreateWorkflowRunBuffer(shared *sharedRepository, conf buffer.ConfigFileBuffer) (*buffer.TenantBufferManager[*repository.CreateWorkflowRunOpts, dbsqlc.WorkflowRun], error) {
+	workflowRunBufOpts := buffer.TenantBufManagerOpts[*repository.CreateWorkflowRunOpts, dbsqlc.WorkflowRun]{
+		Name:       "workflow_run_buffer",
+		OutputFunc: shared.bulkCreateWorkflowRuns,
+		SizeFunc:   sizeOfWorkflowRunData,
+		L:          shared.l,
+		V:          shared.v,
+		Config:     conf,
+	}
+
+	manager, err := buffer.NewTenantBufManager(workflowRunBufOpts)
+
+	if err != nil {
+		shared.l.Err(err).Msg("could not create tenant buffer manager")
+		return nil, err
+	}
+
+	return manager, nil
+}
+
+func sizeOfWorkflowRunData(data *repository.CreateWorkflowRunOpts) int {
+	size := 0
+
+	size += len(data.InputData)
+	size += len(data.AdditionalMetadata)
+	size += len(*data.DisplayName)
+	return size
+}
+
+func (w *sharedRepository) bulkCreateWorkflowRuns(ctx context.Context, opts []*repository.CreateWorkflowRunOpts) ([]*dbsqlc.WorkflowRun, error) {
+	if len(opts) == 0 {
+		return nil, fmt.Errorf("no workflow runs to create")
+	}
+
+	w.l.Debug().Msgf("bulk creating %d workflow runs", len(opts))
+
+	return createNewWorkflowRuns(ctx, w.pool, w.queries, w.l, opts)
+}

--- a/pkg/repository/prisma/scheduler.go
+++ b/pkg/repository/prisma/scheduler.go
@@ -1,0 +1,35 @@
+package prisma
+
+import "github.com/hatchet-dev/hatchet/pkg/repository"
+
+type schedulerRepository struct {
+	lease        repository.LeaseRepository
+	queueFactory repository.QueueFactoryRepository
+	rateLimit    repository.RateLimitRepository
+	assignment   repository.AssignmentRepository
+}
+
+func newSchedulerRepository(shared *sharedRepository) *schedulerRepository {
+	return &schedulerRepository{
+		lease:        newLeaseRepository(shared),
+		queueFactory: newQueueFactoryRepository(shared),
+		rateLimit:    newRateLimitRepository(shared),
+		assignment:   newAssignmentRepository(shared),
+	}
+}
+
+func (d *schedulerRepository) Lease() repository.LeaseRepository {
+	return d.lease
+}
+
+func (d *schedulerRepository) QueueFactory() repository.QueueFactoryRepository {
+	return d.queueFactory
+}
+
+func (d *schedulerRepository) RateLimit() repository.RateLimitRepository {
+	return d.rateLimit
+}
+
+func (d *schedulerRepository) Assignment() repository.AssignmentRepository {
+	return d.assignment
+}

--- a/pkg/repository/prisma/scheduler_assignment.go
+++ b/pkg/repository/prisma/scheduler_assignment.go
@@ -1,0 +1,37 @@
+package prisma
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/hatchet-dev/hatchet/internal/telemetry"
+	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/dbsqlc"
+)
+
+type assignmentRepository struct {
+	*sharedRepository
+}
+
+func newAssignmentRepository(shared *sharedRepository) *assignmentRepository {
+	return &assignmentRepository{
+		sharedRepository: shared,
+	}
+}
+
+func (d *assignmentRepository) ListActionsForWorkers(ctx context.Context, tenantId pgtype.UUID, workerIds []pgtype.UUID) ([]*dbsqlc.ListActionsForWorkersRow, error) {
+	ctx, span := telemetry.NewSpan(ctx, "list-actions-for-workers")
+	defer span.End()
+
+	return d.queries.ListActionsForWorkers(ctx, d.pool, dbsqlc.ListActionsForWorkersParams{
+		Tenantid:  tenantId,
+		Workerids: workerIds,
+	})
+}
+
+func (d *assignmentRepository) ListAvailableSlotsForWorkers(ctx context.Context, tenantId pgtype.UUID, params dbsqlc.ListAvailableSlotsForWorkersParams) ([]*dbsqlc.ListAvailableSlotsForWorkersRow, error) {
+	ctx, span := telemetry.NewSpan(ctx, "list-available-slots-for-workers")
+	defer span.End()
+
+	return d.queries.ListAvailableSlotsForWorkers(ctx, d.pool, params)
+}

--- a/pkg/repository/prisma/scheduler_lease.go
+++ b/pkg/repository/prisma/scheduler_lease.go
@@ -1,0 +1,155 @@
+package prisma
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/hatchet-dev/hatchet/internal/telemetry"
+	"github.com/hatchet-dev/hatchet/pkg/repository"
+	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/dbsqlc"
+	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/sqlchelpers"
+)
+
+type leaseRepository struct {
+	*sharedRepository
+}
+
+func newLeaseRepository(shared *sharedRepository) *leaseRepository {
+	return &leaseRepository{
+		sharedRepository: shared,
+	}
+}
+
+func (d *leaseRepository) AcquireOrExtendLeases(ctx context.Context, tenantId pgtype.UUID, kind dbsqlc.LeaseKind, resourceIds []string, existingLeases []*dbsqlc.Lease) ([]*dbsqlc.Lease, error) {
+	ctx, span := telemetry.NewSpan(ctx, "acquire-leases")
+	defer span.End()
+
+	leaseIds := make([]int64, len(existingLeases))
+
+	for i, lease := range existingLeases {
+		leaseIds[i] = lease.ID
+	}
+
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, d.pool, d.l, 5000)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer rollback()
+
+	err = d.queries.GetLeasesToAcquire(ctx, tx, dbsqlc.GetLeasesToAcquireParams{
+		Kind:        kind,
+		Resourceids: resourceIds,
+		Tenantid:    tenantId,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	leases, err := d.queries.AcquireOrExtendLeases(ctx, tx, dbsqlc.AcquireOrExtendLeasesParams{
+		Kind:             kind,
+		Resourceids:      resourceIds,
+		Tenantid:         tenantId,
+		Existingleaseids: leaseIds,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if err := commit(ctx); err != nil {
+		return nil, err
+	}
+
+	return leases, nil
+}
+
+func (d *leaseRepository) ReleaseLeases(ctx context.Context, tenantId pgtype.UUID, leases []*dbsqlc.Lease) error {
+	ctx, span := telemetry.NewSpan(ctx, "release-leases")
+	defer span.End()
+
+	leaseIds := make([]int64, len(leases))
+
+	for i, lease := range leases {
+		leaseIds[i] = lease.ID
+	}
+
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, d.pool, d.l, 5000)
+
+	if err != nil {
+		return err
+	}
+
+	defer rollback()
+
+	_, err = d.queries.ReleaseLeases(ctx, tx, leaseIds)
+
+	if err != nil {
+		return err
+	}
+
+	if err := commit(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *leaseRepository) ListQueues(ctx context.Context, tenantId pgtype.UUID) ([]*dbsqlc.Queue, error) {
+	ctx, span := telemetry.NewSpan(ctx, "list-queues")
+	defer span.End()
+
+	return d.queries.ListQueues(ctx, d.pool, tenantId)
+}
+
+func (d *leaseRepository) ListActiveWorkers(ctx context.Context, tenantId pgtype.UUID) ([]*repository.ListActiveWorkersResult, error) {
+	ctx, span := telemetry.NewSpan(ctx, "list-active-workers")
+	defer span.End()
+
+	activeWorkers, err := d.queries.ListActiveWorkers(ctx, d.pool, tenantId)
+
+	if err != nil {
+		return nil, err
+	}
+
+	workerIds := make([]pgtype.UUID, 0, len(activeWorkers))
+
+	for _, worker := range activeWorkers {
+		workerIds = append(workerIds, worker.ID)
+	}
+
+	labels, err := d.queries.ListManyWorkerLabels(ctx, d.pool, workerIds)
+
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return nil, err
+	}
+
+	workerIdsToLabels := make(map[string][]*dbsqlc.ListManyWorkerLabelsRow, len(labels))
+
+	for _, label := range labels {
+		wId := sqlchelpers.UUIDToStr(label.WorkerId)
+
+		if _, ok := workerIdsToLabels[wId]; !ok {
+			workerIdsToLabels[wId] = make([]*dbsqlc.ListManyWorkerLabelsRow, 0)
+		}
+
+		workerIdsToLabels[wId] = append(workerIdsToLabels[wId], label)
+	}
+
+	res := make([]*repository.ListActiveWorkersResult, 0, len(activeWorkers))
+
+	for _, worker := range activeWorkers {
+		wId := sqlchelpers.UUIDToStr(worker.ID)
+		res = append(res, &repository.ListActiveWorkersResult{
+			ID:     worker.ID,
+			Labels: workerIdsToLabels[wId],
+		})
+	}
+
+	return res, nil
+}

--- a/pkg/repository/prisma/scheduler_queue.go
+++ b/pkg/repository/prisma/scheduler_queue.go
@@ -1,0 +1,732 @@
+package prisma
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/hatchet-dev/hatchet/internal/telemetry"
+	"github.com/hatchet-dev/hatchet/pkg/repository"
+	"github.com/hatchet-dev/hatchet/pkg/repository/cache"
+	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/dbsqlc"
+	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/sqlchelpers"
+)
+
+type queueFactoryRepository struct {
+	*sharedRepository
+}
+
+func newQueueFactoryRepository(shared *sharedRepository) *queueFactoryRepository {
+	return &queueFactoryRepository{
+		sharedRepository: shared,
+	}
+}
+
+func (q *queueFactoryRepository) NewQueue(tenantId pgtype.UUID, queueName string) repository.QueueRepository {
+	return newQueueRepository(q.sharedRepository, tenantId, queueName)
+}
+
+type queueRepository struct {
+	*sharedRepository
+
+	tenantId  pgtype.UUID
+	queueName string
+
+	gtId   pgtype.Int8
+	gtIdMu sync.RWMutex
+
+	cachedStepIdHasRateLimit *cache.Cache
+}
+
+func newQueueRepository(shared *sharedRepository, tenantId pgtype.UUID, queueName string) *queueRepository {
+	c := cache.New(5 * time.Minute)
+
+	return &queueRepository{
+		sharedRepository:         shared,
+		tenantId:                 tenantId,
+		queueName:                queueName,
+		cachedStepIdHasRateLimit: c,
+	}
+}
+
+func (d *queueRepository) Cleanup() {
+	d.cachedStepIdHasRateLimit.Stop()
+}
+
+func (d *queueRepository) setMinId(id int64) {
+	d.gtIdMu.Lock()
+	defer d.gtIdMu.Unlock()
+
+	d.gtId = pgtype.Int8{
+		Int64: id,
+		Valid: true,
+	}
+}
+
+func (d *queueRepository) getMinId() pgtype.Int8 {
+	d.gtIdMu.RLock()
+	defer d.gtIdMu.RUnlock()
+
+	val := d.gtId
+
+	return val
+}
+
+func (d *queueRepository) ListQueueItems(ctx context.Context, limit int) ([]*dbsqlc.QueueItem, error) {
+	ctx, span := telemetry.NewSpan(ctx, "list-queue-items")
+	defer span.End()
+
+	start := time.Now()
+	checkpoint := start
+
+	qis, err := d.queries.ListQueueItemsForQueue(ctx, d.pool, dbsqlc.ListQueueItemsForQueueParams{
+		Tenantid: d.tenantId,
+		Queue:    d.queueName,
+		GtId:     d.getMinId(),
+		Limit: pgtype.Int4{
+			Int32: int32(limit), // nolint: gosec
+			Valid: true,
+		},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(qis) == 0 {
+		return nil, nil
+	}
+
+	listTime := time.Since(checkpoint)
+	checkpoint = time.Now()
+
+	resQis, err := d.removeInvalidStepRuns(ctx, qis)
+
+	if err != nil {
+		return nil, err
+	}
+
+	removeInvalidTime := time.Since(checkpoint)
+
+	if sinceStart := time.Since(start); sinceStart > 100*time.Millisecond {
+		d.l.Warn().Dur(
+			"list", listTime,
+		).Dur(
+			"remove_invalid", removeInvalidTime,
+		).Msgf(
+			"listing %d queue items for queue %s took longer than 100ms (%s)", len(resQis), d.queueName, sinceStart.String(),
+		)
+	}
+
+	return resQis, nil
+}
+
+// removeInvalidStepRuns removes all duplicate step runs and step runs which are in a finalized state from
+// the queue. It returns the remaining queue items and an error if one occurred.
+func (s *queueRepository) removeInvalidStepRuns(ctx context.Context, qis []*dbsqlc.ListQueueItemsForQueueRow) ([]*dbsqlc.QueueItem, error) {
+	if len(qis) == 0 {
+		return nil, nil
+	}
+
+	// remove duplicates
+	encountered := map[string]bool{}
+	remaining1 := make([]*dbsqlc.QueueItem, 0, len(qis))
+	cancelled := make([]int64, 0, len(qis))
+
+	for _, v := range qis {
+		stepRunId := sqlchelpers.UUIDToStr(v.QueueItem.StepRunId)
+
+		if encountered[stepRunId] {
+			cancelled = append(cancelled, v.QueueItem.ID)
+			continue
+		}
+
+		encountered[stepRunId] = true
+		remaining1 = append(remaining1, &v.QueueItem)
+	}
+
+	finalizedStepRunsMap := make(map[string]bool)
+
+	for _, v := range qis {
+		if v.Status == dbsqlc.StepRunStatusCANCELLED || v.Status == dbsqlc.StepRunStatusSUCCEEDED || v.Status == dbsqlc.StepRunStatusFAILED || v.Status == dbsqlc.StepRunStatusCANCELLING {
+			stepRunId := sqlchelpers.UUIDToStr(v.QueueItem.StepRunId)
+			s.l.Warn().Msgf("step run %s is in state %s, skipping queueing", stepRunId, string(v.Status))
+			finalizedStepRunsMap[stepRunId] = true
+		}
+	}
+
+	// remove cancelled step runs from the queue items
+	remaining2 := make([]*dbsqlc.QueueItem, 0, len(remaining1))
+
+	for _, qi := range remaining1 {
+		if _, ok := finalizedStepRunsMap[sqlchelpers.UUIDToStr(qi.StepRunId)]; ok {
+			cancelled = append(cancelled, qi.ID)
+			continue
+		}
+
+		remaining2 = append(remaining2, qi)
+	}
+
+	if len(cancelled) == 0 {
+		return remaining2, nil
+	}
+
+	// If we've reached this point, we have queue items to cancel. We prepare a transaction in order
+	// to set a statement timeout.
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, s.pool, s.l, 5000)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer rollback()
+
+	err = s.queries.BulkQueueItems(ctx, tx, cancelled)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if err := commit(ctx); err != nil {
+		return nil, err
+	}
+
+	return remaining2, nil
+}
+
+func (s *queueRepository) bulkStepRunsAssigned(
+	tenantId string,
+	assignedAt time.Time,
+	stepRunIds []pgtype.UUID,
+	workerIds []pgtype.UUID,
+) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	workerIdToStepRunIds := make(map[string][]string)
+
+	for i := range stepRunIds {
+		workerId := sqlchelpers.UUIDToStr(workerIds[i])
+
+		if _, ok := workerIdToStepRunIds[workerId]; !ok {
+			workerIdToStepRunIds[workerId] = make([]string, 0)
+		}
+
+		workerIdToStepRunIds[workerId] = append(workerIdToStepRunIds[workerId], sqlchelpers.UUIDToStr(stepRunIds[i]))
+		message := fmt.Sprintf("Assigned to worker %s", workerId)
+		timeSeen := assignedAt
+		reasons := dbsqlc.StepRunEventReasonASSIGNED
+		severity := dbsqlc.StepRunEventSeverityINFO
+		data := map[string]interface{}{"worker_id": workerId}
+
+		err := s.bulkEventBuffer.FireForget(tenantId, &repository.CreateStepRunEventOpts{
+			StepRunId:     sqlchelpers.UUIDToStr(stepRunIds[i]),
+			EventMessage:  &message,
+			EventReason:   &reasons,
+			EventSeverity: &severity,
+			Timestamp:     &timeSeen,
+			EventData:     data,
+		})
+
+		if err != nil {
+			s.l.Err(err).Msg("could not buffer step run event")
+		}
+	}
+
+	orderedWorkerIds := make([]pgtype.UUID, 0)
+	assignedStepRuns := make([][]byte, 0)
+
+	for workerId, stepRunIds := range workerIdToStepRunIds {
+		orderedWorkerIds = append(orderedWorkerIds, sqlchelpers.UUIDFromStr(workerId))
+		assignedStepRunsBytes, _ := json.Marshal(stepRunIds) // nolint: errcheck
+		assignedStepRuns = append(assignedStepRuns, assignedStepRunsBytes)
+	}
+
+	err := s.queries.CreateWorkerAssignEvents(ctx, s.pool, dbsqlc.CreateWorkerAssignEventsParams{
+		Workerids:        orderedWorkerIds,
+		Assignedstepruns: assignedStepRuns,
+	})
+
+	if err != nil {
+		s.l.Err(err).Msg("could not create worker assign events")
+	}
+}
+
+func (s *queueRepository) bulkStepRunsUnassigned(
+	tenantId string,
+	stepRunIds []pgtype.UUID,
+) {
+	for _, stepRunId := range stepRunIds {
+		message := "No worker available"
+		timeSeen := time.Now().UTC()
+		severity := dbsqlc.StepRunEventSeverityWARNING
+		reason := dbsqlc.StepRunEventReasonREQUEUEDNOWORKER
+		data := map[string]interface{}{}
+
+		err := s.bulkEventBuffer.FireForget(tenantId, &repository.CreateStepRunEventOpts{
+			StepRunId:     sqlchelpers.UUIDToStr(stepRunId),
+			EventMessage:  &message,
+			EventReason:   &reason,
+			EventSeverity: &severity,
+			Timestamp:     &timeSeen,
+			EventData:     data,
+		})
+
+		if err != nil {
+			s.l.Err(err).Msg("could not buffer step run event")
+		}
+	}
+}
+
+func (s *queueRepository) bulkStepRunsRateLimited(
+	tenantId string,
+	rateLimits []*repository.RateLimitResult,
+) {
+	for _, rlResult := range rateLimits {
+		message := fmt.Sprintf(
+			"Rate limit exceeded for key %s, attempting to consume %d units, but only had %d remaining",
+			rlResult.ExceededKey,
+			rlResult.ExceededUnits,
+			rlResult.ExceededVal,
+		)
+
+		reason := dbsqlc.StepRunEventReasonREQUEUEDRATELIMIT
+		severity := dbsqlc.StepRunEventSeverityWARNING
+		timeSeen := time.Now().UTC()
+		data := map[string]interface{}{
+			"rate_limit_key": rlResult.ExceededKey,
+		}
+
+		err := s.bulkEventBuffer.FireForget(tenantId, &repository.CreateStepRunEventOpts{
+			StepRunId:     sqlchelpers.UUIDToStr(rlResult.StepRunId),
+			EventMessage:  &message,
+			EventReason:   &reason,
+			EventSeverity: &severity,
+			Timestamp:     &timeSeen,
+			EventData:     data,
+		})
+
+		if err != nil {
+			s.l.Err(err).Msg("could not buffer step run event")
+		}
+	}
+}
+
+func (d *queueRepository) updateMinId() {
+	dbCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	minId, err := d.queries.GetMinUnprocessedQueueItemId(dbCtx, d.pool, dbsqlc.GetMinUnprocessedQueueItemIdParams{
+		Tenantid: d.tenantId,
+		Queue:    d.queueName,
+	})
+
+	if err != nil {
+		d.l.Error().Err(err).Msg("error getting min id")
+		return
+	}
+
+	if minId != 0 {
+		d.setMinId(minId)
+	}
+}
+
+func (d *queueRepository) MarkQueueItemsProcessed(ctx context.Context, r *repository.AssignResults) (succeeded []*repository.AssignedItem, failed []*repository.AssignedItem, err error) {
+	ctx, span := telemetry.NewSpan(ctx, "mark-queue-items-processed")
+	defer span.End()
+
+	start := time.Now()
+	checkpoint := start
+
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, d.pool, d.l, 5000)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	defer rollback()
+
+	durPrepare := time.Since(checkpoint)
+	checkpoint = time.Now()
+
+	idsToUnqueue := make([]int64, len(r.Assigned))
+	stepRunIds := make([]pgtype.UUID, len(r.Assigned))
+	workerIds := make([]pgtype.UUID, len(r.Assigned))
+	stepTimeouts := make([]string, len(r.Assigned))
+
+	for i, assignedItem := range r.Assigned {
+		idsToUnqueue[i] = assignedItem.QueueItem.ID
+		stepRunIds[i] = assignedItem.QueueItem.StepRunId
+		workerIds[i] = assignedItem.WorkerId
+		stepTimeouts[i] = assignedItem.QueueItem.StepTimeout.String
+	}
+
+	unassignedStepRunIds := make([]pgtype.UUID, 0, len(r.Unassigned))
+
+	for _, id := range r.Unassigned {
+		unassignedStepRunIds = append(unassignedStepRunIds, id.StepRunId)
+	}
+
+	timedOutStepRuns := make([]pgtype.UUID, 0, len(r.SchedulingTimedOut))
+
+	for _, id := range r.SchedulingTimedOut {
+		idsToUnqueue = append(idsToUnqueue, id.ID)
+		timedOutStepRuns = append(timedOutStepRuns, id.StepRunId)
+	}
+
+	_, err = d.queries.BulkMarkStepRunsAsCancelling(ctx, tx, timedOutStepRuns)
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not bulk mark step runs as cancelling: %w", err)
+	}
+
+	updatedStepRuns, err := d.queries.UpdateStepRunsToAssigned(ctx, tx, dbsqlc.UpdateStepRunsToAssignedParams{
+		Steprunids:      stepRunIds,
+		Workerids:       workerIds,
+		Stepruntimeouts: stepTimeouts,
+		Tenantid:        d.tenantId,
+	})
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	timeAfterUpdateStepRuns := time.Since(checkpoint)
+	checkpoint = time.Now()
+
+	err = d.queries.BulkQueueItems(ctx, tx, idsToUnqueue)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	timeAfterBulkQueueItems := time.Since(checkpoint)
+
+	if err := commit(ctx); err != nil {
+		return nil, nil, err
+	}
+
+	go func() {
+		// if we committed, we can update the min id
+		d.updateMinId()
+
+		assignedStepRuns := make([]pgtype.UUID, len(updatedStepRuns))
+		assignedWorkerIds := make([]pgtype.UUID, len(updatedStepRuns))
+
+		for i, row := range updatedStepRuns {
+			assignedStepRuns[i] = row.StepRunId
+			assignedWorkerIds[i] = row.WorkerId
+		}
+
+		d.bulkStepRunsAssigned(sqlchelpers.UUIDToStr(d.tenantId), time.Now().UTC(), assignedStepRuns, assignedWorkerIds)
+		d.bulkStepRunsUnassigned(sqlchelpers.UUIDToStr(d.tenantId), unassignedStepRunIds)
+		d.bulkStepRunsRateLimited(sqlchelpers.UUIDToStr(d.tenantId), r.RateLimited)
+	}()
+
+	stepRunIdToAssignedItem := make(map[string]*repository.AssignedItem, len(updatedStepRuns))
+
+	for _, assignedItem := range r.Assigned {
+		stepRunIdToAssignedItem[sqlchelpers.UUIDToStr(assignedItem.QueueItem.StepRunId)] = assignedItem
+	}
+
+	succeeded = make([]*repository.AssignedItem, 0, len(r.Assigned))
+	failed = make([]*repository.AssignedItem, 0, len(r.Assigned))
+
+	for _, row := range updatedStepRuns {
+		if assignedItem, ok := stepRunIdToAssignedItem[sqlchelpers.UUIDToStr(row.StepRunId)]; ok {
+			succeeded = append(succeeded, assignedItem)
+			delete(stepRunIdToAssignedItem, sqlchelpers.UUIDToStr(row.StepRunId))
+		}
+	}
+
+	for _, assignedItem := range stepRunIdToAssignedItem {
+		failed = append(failed, assignedItem)
+	}
+
+	if sinceStart := time.Since(start); sinceStart > 100*time.Millisecond {
+		d.l.Warn().Dur(
+			"duration", sinceStart,
+		).Dur(
+			"prepare", durPrepare,
+		).Dur(
+			"update", timeAfterUpdateStepRuns,
+		).Dur(
+			"bulkqueue", timeAfterBulkQueueItems,
+		).Int(
+			"assigned", len(succeeded),
+		).Int(
+			"failed", len(failed),
+		).Int(
+			"unassigned", len(unassignedStepRunIds),
+		).Int(
+			"timed_out", len(timedOutStepRuns),
+		).Msgf(
+			"marking queue items processed took longer than 100ms",
+		)
+	}
+
+	return succeeded, failed, nil
+}
+
+func (d *queueRepository) GetStepRunRateLimits(ctx context.Context, queueItems []*dbsqlc.QueueItem) (map[string]map[string]int32, error) {
+	ctx, span := telemetry.NewSpan(ctx, "get-step-run-rate-limits")
+	defer span.End()
+
+	stepRunIds := make([]pgtype.UUID, 0, len(queueItems))
+	stepIds := make([]pgtype.UUID, 0, len(queueItems))
+	stepsWithRateLimits := make(map[string]bool)
+
+	for _, item := range queueItems {
+		stepRunIds = append(stepRunIds, item.StepRunId)
+		stepIds = append(stepIds, item.StepId)
+	}
+
+	stepIdToStepRuns := make(map[string][]string)
+	stepRunIdToStepId := make(map[string]string)
+
+	for i, stepRunId := range stepRunIds {
+		stepId := sqlchelpers.UUIDToStr(stepIds[i])
+		stepRunIdStr := sqlchelpers.UUIDToStr(stepRunId)
+
+		if _, ok := stepIdToStepRuns[stepId]; !ok {
+			stepIdToStepRuns[stepId] = make([]string, 0)
+		}
+
+		stepIdToStepRuns[stepId] = append(stepIdToStepRuns[stepId], stepRunIdStr)
+		stepRunIdToStepId[stepRunIdStr] = stepId
+	}
+
+	// check if we have any rate limits for these step ids
+	skipRateLimiting := true
+
+	for stepIdStr := range stepIdToStepRuns {
+		if hasRateLimit, ok := d.cachedStepIdHasRateLimit.Get(stepIdStr); !ok || hasRateLimit.(bool) {
+			skipRateLimiting = false
+			break
+		}
+	}
+
+	if skipRateLimiting {
+		return nil, nil
+	}
+
+	// get all step run expression evals which correspond to rate limits, grouped by step run id
+	expressionEvals, err := d.queries.ListStepRunExpressionEvals(ctx, d.pool, stepRunIds)
+
+	if err != nil {
+		return nil, err
+	}
+
+	stepRunAndGlobalKeyToKey := make(map[string]string)
+	stepRunToKeys := make(map[string][]string)
+
+	for _, eval := range expressionEvals {
+		stepRunId := sqlchelpers.UUIDToStr(eval.StepRunId)
+		globalKey := eval.Key
+
+		// Only append if this is a key expression. Note that we have a uniqueness constraint on
+		// the stepRunId, kind, and key, so we will not insert duplicate values into the array.
+		if eval.Kind == dbsqlc.StepExpressionKindDYNAMICRATELIMITKEY {
+			stepsWithRateLimits[stepRunIdToStepId[stepRunId]] = true
+
+			k := eval.ValueStr.String
+
+			if _, ok := stepRunToKeys[stepRunId]; !ok {
+				stepRunToKeys[stepRunId] = make([]string, 0)
+			}
+
+			stepRunToKeys[stepRunId] = append(stepRunToKeys[stepRunId], k)
+
+			stepRunAndGlobalKey := fmt.Sprintf("%s-%s", stepRunId, globalKey)
+
+			stepRunAndGlobalKeyToKey[stepRunAndGlobalKey] = k
+		}
+	}
+
+	rateLimitKeyToEvals := make(map[string][]*dbsqlc.StepRunExpressionEval)
+
+	for _, eval := range expressionEvals {
+		k := stepRunAndGlobalKeyToKey[fmt.Sprintf("%s-%s", sqlchelpers.UUIDToStr(eval.StepRunId), eval.Key)]
+
+		if _, ok := rateLimitKeyToEvals[k]; !ok {
+			rateLimitKeyToEvals[k] = make([]*dbsqlc.StepRunExpressionEval, 0)
+		}
+
+		rateLimitKeyToEvals[k] = append(rateLimitKeyToEvals[k], eval)
+	}
+
+	upsertRateLimitBulkParams := dbsqlc.UpsertRateLimitsBulkParams{
+		Tenantid: d.tenantId,
+	}
+
+	stepRunToKeyToUnits := make(map[string]map[string]int32)
+
+	for key, evals := range rateLimitKeyToEvals {
+		var duration string
+		var limitValue int
+		var skip bool
+
+		for _, eval := range evals {
+			// add to stepRunToKeyToUnits
+			stepRunId := sqlchelpers.UUIDToStr(eval.StepRunId)
+
+			// throw an error if there are multiple rate limits with the same keys, but different limit values or durations
+			if eval.Kind == dbsqlc.StepExpressionKindDYNAMICRATELIMITWINDOW {
+				if duration == "" {
+					duration = eval.ValueStr.String
+				} else if duration != eval.ValueStr.String {
+					largerDuration, err := getLargerDuration(duration, eval.ValueStr.String)
+
+					if err != nil {
+						skip = true
+						break
+					}
+
+					message := fmt.Sprintf("Multiple rate limits with key %s have different durations: %s vs %s. Using longer window %s.", key, duration, eval.ValueStr.String, largerDuration)
+					timeSeen := time.Now().UTC()
+					reason := dbsqlc.StepRunEventReasonRATELIMITERROR
+					severity := dbsqlc.StepRunEventSeverityWARNING
+					data := map[string]interface{}{}
+
+					buffErr := d.bulkEventBuffer.FireForget(sqlchelpers.UUIDToStr(d.tenantId), &repository.CreateStepRunEventOpts{
+						StepRunId:     sqlchelpers.UUIDToStr(eval.StepRunId),
+						EventMessage:  &message,
+						EventReason:   &reason,
+						EventSeverity: &severity,
+						Timestamp:     &timeSeen,
+						EventData:     data,
+					})
+
+					if buffErr != nil {
+						d.l.Err(buffErr).Msg("could not buffer step run event")
+					}
+
+					duration = largerDuration
+				}
+			}
+
+			if eval.Kind == dbsqlc.StepExpressionKindDYNAMICRATELIMITVALUE {
+				if limitValue == 0 {
+					limitValue = int(eval.ValueInt.Int32)
+				} else if limitValue != int(eval.ValueInt.Int32) {
+					message := fmt.Sprintf("Multiple rate limits with key %s have different limit values: %d vs %d. Using lower value %d.", key, limitValue, eval.ValueInt.Int32, min(limitValue, int(eval.ValueInt.Int32)))
+					timeSeen := time.Now().UTC()
+					reason := dbsqlc.StepRunEventReasonRATELIMITERROR
+					severity := dbsqlc.StepRunEventSeverityWARNING
+					data := map[string]interface{}{}
+
+					buffErr := d.bulkEventBuffer.FireForget(sqlchelpers.UUIDToStr(d.tenantId), &repository.CreateStepRunEventOpts{
+						StepRunId:     sqlchelpers.UUIDToStr(eval.StepRunId),
+						EventMessage:  &message,
+						EventReason:   &reason,
+						EventSeverity: &severity,
+						Timestamp:     &timeSeen,
+						EventData:     data,
+					})
+
+					if buffErr != nil {
+						d.l.Err(buffErr).Msg("could not buffer step run event")
+					}
+
+					limitValue = min(limitValue, int(eval.ValueInt.Int32))
+				}
+			}
+
+			if eval.Kind == dbsqlc.StepExpressionKindDYNAMICRATELIMITUNITS {
+				if _, ok := stepRunToKeyToUnits[stepRunId]; !ok {
+					stepRunToKeyToUnits[stepRunId] = make(map[string]int32)
+				}
+
+				stepRunToKeyToUnits[stepRunId][key] = eval.ValueInt.Int32
+			}
+		}
+
+		if skip {
+			continue
+		}
+
+		upsertRateLimitBulkParams.Keys = append(upsertRateLimitBulkParams.Keys, key)
+		upsertRateLimitBulkParams.Windows = append(upsertRateLimitBulkParams.Windows, getWindowParamFromDurString(duration))
+		upsertRateLimitBulkParams.Limitvalues = append(upsertRateLimitBulkParams.Limitvalues, int32(limitValue)) // nolint: gosec
+	}
+
+	var stepRateLimits []*dbsqlc.StepRateLimit
+
+	if len(upsertRateLimitBulkParams.Keys) > 0 {
+		// upsert all rate limits based on the keys, limit values, and durations
+		err = d.queries.UpsertRateLimitsBulk(ctx, d.pool, upsertRateLimitBulkParams)
+
+		if err != nil {
+			return nil, fmt.Errorf("could not bulk upsert dynamic rate limits: %w", err)
+		}
+	}
+
+	// get all existing static rate limits for steps to the mapping, mapping back from step ids to step run ids
+	uniqueStepIds := make([]pgtype.UUID, 0, len(stepIdToStepRuns))
+
+	for stepId := range stepIdToStepRuns {
+		uniqueStepIds = append(uniqueStepIds, sqlchelpers.UUIDFromStr(stepId))
+	}
+
+	stepRateLimits, err = d.queries.ListRateLimitsForSteps(ctx, d.pool, dbsqlc.ListRateLimitsForStepsParams{
+		Tenantid: d.tenantId,
+		Stepids:  uniqueStepIds,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("could not list rate limits for steps: %w", err)
+	}
+
+	for _, row := range stepRateLimits {
+		stepsWithRateLimits[sqlchelpers.UUIDToStr(row.StepId)] = true
+		stepId := sqlchelpers.UUIDToStr(row.StepId)
+		stepRuns := stepIdToStepRuns[stepId]
+
+		for _, stepRunId := range stepRuns {
+			if _, ok := stepRunToKeyToUnits[stepRunId]; !ok {
+				stepRunToKeyToUnits[stepRunId] = make(map[string]int32)
+			}
+
+			stepRunToKeyToUnits[stepRunId][row.RateLimitKey] = row.Units
+		}
+	}
+
+	// store all step ids in the cache, so we can skip rate limiting for steps without rate limits
+	for stepId := range stepIdToStepRuns {
+		hasRateLimit := stepsWithRateLimits[stepId]
+		d.cachedStepIdHasRateLimit.Set(stepId, hasRateLimit)
+	}
+
+	return stepRunToKeyToUnits, nil
+}
+
+func (d *queueRepository) GetDesiredLabels(ctx context.Context, stepIds []pgtype.UUID) (map[string][]*dbsqlc.GetDesiredLabelsRow, error) {
+	ctx, span := telemetry.NewSpan(ctx, "get-desired-labels")
+	defer span.End()
+
+	uniqueStepIds := sqlchelpers.UniqueSet(stepIds)
+
+	labels, err := d.queries.GetDesiredLabels(ctx, d.pool, uniqueStepIds)
+
+	if err != nil {
+		return nil, err
+	}
+
+	stepIdToLabels := make(map[string][]*dbsqlc.GetDesiredLabelsRow)
+
+	for _, label := range labels {
+		stepId := sqlchelpers.UUIDToStr(label.StepId)
+
+		if _, ok := stepIdToLabels[stepId]; !ok {
+			stepIdToLabels[stepId] = make([]*dbsqlc.GetDesiredLabelsRow, 0)
+		}
+
+		stepIdToLabels[stepId] = append(stepIdToLabels[stepId], label)
+	}
+
+	return stepIdToLabels, nil
+}

--- a/pkg/repository/prisma/scheduler_rate_limit.go
+++ b/pkg/repository/prisma/scheduler_rate_limit.go
@@ -1,0 +1,84 @@
+package prisma
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/dbsqlc"
+	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/sqlchelpers"
+)
+
+type rateLimitRepository struct {
+	*sharedRepository
+}
+
+func newRateLimitRepository(shared *sharedRepository) *rateLimitRepository {
+	return &rateLimitRepository{
+		sharedRepository: shared,
+	}
+}
+
+func (d *rateLimitRepository) ListCandidateRateLimits(ctx context.Context, tenantId pgtype.UUID) ([]string, error) {
+	rls, err := d.queries.ListRateLimitsForTenantNoMutate(ctx, d.pool, dbsqlc.ListRateLimitsForTenantNoMutateParams{
+		Tenantid: tenantId,
+		Limit:    10000,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]string, len(rls))
+
+	for i, rl := range rls {
+		ids[i] = rl.Key
+	}
+
+	return ids, nil
+}
+
+func (d *rateLimitRepository) UpdateRateLimits(ctx context.Context, tenantId pgtype.UUID, updates map[string]int) (map[string]int, error) {
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, d.pool, d.l, 5000)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer rollback()
+
+	params := dbsqlc.BulkUpdateRateLimitsParams{
+		Tenantid: tenantId,
+		Keys:     make([]string, 0, len(updates)),
+		Units:    make([]int32, 0, len(updates)),
+	}
+
+	for k, v := range updates {
+		params.Keys = append(params.Keys, k)
+		params.Units = append(params.Units, int32(v)) // nolint: gosec
+	}
+
+	_, err = d.queries.BulkUpdateRateLimits(ctx, tx, params)
+
+	if err != nil {
+		return nil, err
+	}
+
+	newRls, err := d.queries.ListRateLimitsForTenantWithMutate(ctx, tx, tenantId)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if err := commit(ctx); err != nil {
+		return nil, err
+	}
+
+	res := make(map[string]int, len(newRls))
+
+	for _, rl := range newRls {
+		res[rl.Key] = int(rl.Value)
+	}
+
+	return res, err
+}

--- a/pkg/repository/prisma/shared.go
+++ b/pkg/repository/prisma/shared.go
@@ -1,0 +1,124 @@
+package prisma
+
+import (
+	"github.com/hashicorp/go-multierror"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog"
+
+	"github.com/hatchet-dev/hatchet/pkg/config/server"
+	"github.com/hatchet-dev/hatchet/pkg/repository"
+	"github.com/hatchet-dev/hatchet/pkg/repository/buffer"
+	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/dbsqlc"
+	"github.com/hatchet-dev/hatchet/pkg/validator"
+)
+
+type sharedRepository struct {
+	pool    *pgxpool.Pool
+	v       validator.Validator
+	l       *zerolog.Logger
+	queries *dbsqlc.Queries
+
+	bulkStatusBuffer      *buffer.TenantBufferManager[*updateStepRunQueueData, pgtype.UUID]
+	bulkEventBuffer       *buffer.TenantBufferManager[*repository.CreateStepRunEventOpts, int]
+	bulkSemaphoreReleaser *buffer.TenantBufferManager[semaphoreReleaseOpts, pgtype.UUID]
+	bulkQueuer            *buffer.TenantBufferManager[bulkQueueStepRunOpts, pgtype.UUID]
+	bulkUserEventBuffer   *buffer.TenantBufferManager[*repository.CreateEventOpts, dbsqlc.Event]
+	bulkWorkflowRunBuffer *buffer.TenantBufferManager[*repository.CreateWorkflowRunOpts, dbsqlc.WorkflowRun]
+}
+
+func newSharedRepository(pool *pgxpool.Pool, v validator.Validator, l *zerolog.Logger, cf *server.ConfigFileRuntime) (*sharedRepository, func() error, error) {
+	queries := dbsqlc.New()
+
+	s := &sharedRepository{
+		pool:    pool,
+		v:       v,
+		l:       l,
+		queries: queries,
+	}
+
+	statusBuffer, err := newBulkStepRunStatusBuffer(s)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	eventBuffer, err := newBulkEventWriter(s, cf.EventBuffer)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	semaphoreReleaser, err := NewBulkSemaphoreReleaser(s, cf.ReleaseSemaphoreBuffer)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	queuer, err := newBulkStepRunQueuer(s, cf.QueueStepRunBuffer)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	userEventBuffer, err := newUserEventBuffer(s, cf.EventBuffer)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	workflowRunBuffer, err := newCreateWorkflowRunBuffer(s, cf.WorkflowRunBuffer)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	s.bulkStatusBuffer = statusBuffer
+	s.bulkEventBuffer = eventBuffer
+	s.bulkSemaphoreReleaser = semaphoreReleaser
+	s.bulkQueuer = queuer
+	s.bulkUserEventBuffer = userEventBuffer
+	s.bulkWorkflowRunBuffer = workflowRunBuffer
+
+	return s, func() error {
+		var multiErr error
+
+		err := statusBuffer.Cleanup()
+
+		if err != nil {
+			multiErr = multierror.Append(multiErr, err)
+		}
+
+		err = eventBuffer.Cleanup()
+
+		if err != nil {
+			multiErr = multierror.Append(multiErr, err)
+		}
+
+		err = semaphoreReleaser.Cleanup()
+
+		if err != nil {
+			multiErr = multierror.Append(multiErr, err)
+		}
+
+		err = queuer.Cleanup()
+
+		if err != nil {
+			multiErr = multierror.Append(multiErr, err)
+		}
+
+		err = userEventBuffer.Cleanup()
+
+		if err != nil {
+			multiErr = multierror.Append(multiErr, err)
+		}
+
+		err = workflowRunBuffer.Cleanup()
+
+		if err != nil {
+			multiErr = multierror.Append(multiErr, err)
+		}
+
+		return multiErr
+	}, nil
+}

--- a/pkg/repository/prisma/step_run.go
+++ b/pkg/repository/prisma/step_run.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
-	"math/rand"
 	"sort"
 	"strings"
 	"sync"
@@ -22,12 +21,10 @@ import (
 	"github.com/hatchet-dev/hatchet/internal/telemetry"
 	"github.com/hatchet-dev/hatchet/pkg/config/server"
 	"github.com/hatchet-dev/hatchet/pkg/repository"
-	"github.com/hatchet-dev/hatchet/pkg/repository/buffer"
 	"github.com/hatchet-dev/hatchet/pkg/repository/cache"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/db"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/dbsqlc"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/sqlchelpers"
-	"github.com/hatchet-dev/hatchet/pkg/scheduling"
 	"github.com/hatchet-dev/hatchet/pkg/validator"
 )
 
@@ -259,85 +256,25 @@ func (s *stepRunAPIRepository) ListStepRunArchives(tenantId string, stepRunId st
 }
 
 type stepRunEngineRepository struct {
-	pool                     *pgxpool.Pool
-	v                        validator.Validator
-	l                        *zerolog.Logger
-	queries                  *dbsqlc.Queries
-	cf                       *server.ConfigFileRuntime
-	cachedMinQueuedIds       sync.Map
-	cachedStepIdHasRateLimit *cache.Cache
-	callbacks                []repository.TenantScopedCallback[*dbsqlc.ResolveWorkflowRunStatusRow]
+	*sharedRepository
 
-	bulkStatusBuffer       *buffer.TenantBufferManager[*updateStepRunQueueData, pgtype.UUID]
-	bulkEventBuffer        *buffer.BulkEventWriter
-	bulkSemaphoreReleaser  *buffer.BulkSemaphoreReleaser
-	bulkQueuer             *buffer.BulkStepRunQueuer
+	cf        *server.ConfigFileRuntime
+	callbacks []repository.TenantScopedCallback[*dbsqlc.ResolveWorkflowRunStatusRow]
+
 	queueActionTenantCache *cache.Cache
 
 	updateConcurrentFactor int
 	maxHashFactor          int
 }
 
-func (s *stepRunEngineRepository) cleanup() error {
-	if err := s.bulkStatusBuffer.Cleanup(); err != nil {
-		return err
+func NewStepRunEngineRepository(shared *sharedRepository, cf *server.ConfigFileRuntime, rlCache *cache.Cache, queueCache *cache.Cache) *stepRunEngineRepository {
+	return &stepRunEngineRepository{
+		sharedRepository:       shared,
+		cf:                     cf,
+		updateConcurrentFactor: cf.UpdateConcurrentFactor,
+		maxHashFactor:          cf.UpdateHashFactor,
+		queueActionTenantCache: queueCache,
 	}
-
-	if err := s.bulkSemaphoreReleaser.Cleanup(); err != nil {
-		return err
-	}
-
-	if err := s.bulkQueuer.Cleanup(); err != nil {
-		return err
-	}
-
-	return s.bulkEventBuffer.Cleanup()
-}
-
-func NewStepRunEngineRepository(pool *pgxpool.Pool, v validator.Validator, l *zerolog.Logger, cf *server.ConfigFileRuntime, rlCache *cache.Cache, queueCache *cache.Cache) (*stepRunEngineRepository, func() error, error) {
-	queries := dbsqlc.New()
-
-	eventBuffer, err := buffer.NewBulkEventWriter(pool, v, l, cf.EventBuffer)
-
-	if err != nil {
-		return nil, nil, err
-	}
-
-	semReleaser, err := buffer.NewBulkSemaphoreReleaser(pool, v, l, cf.ReleaseSemaphoreBuffer)
-
-	if err != nil {
-		return nil, nil, err
-	}
-
-	bulkQueuer, err := buffer.NewBulkStepRunQueuer(pool, v, l, cf.QueueStepRunBuffer)
-
-	if err != nil {
-		return nil, nil, err
-	}
-
-	s := &stepRunEngineRepository{
-		pool:                     pool,
-		v:                        v,
-		l:                        l,
-		queries:                  queries,
-		cf:                       cf,
-		cachedStepIdHasRateLimit: rlCache,
-		updateConcurrentFactor:   cf.UpdateConcurrentFactor,
-		maxHashFactor:            cf.UpdateHashFactor,
-		bulkEventBuffer:          eventBuffer,
-		bulkSemaphoreReleaser:    semReleaser,
-		bulkQueuer:               bulkQueuer,
-		queueActionTenantCache:   queueCache,
-	}
-
-	err = s.startBuffers()
-
-	if err != nil {
-		l.Err(err).Msg("could not start buffers")
-		return nil, nil, err
-	}
-
-	return s, s.cleanup, nil
 }
 
 func sizeOfUpdateData(item *updateStepRunQueueData) int {
@@ -349,154 +286,6 @@ func sizeOfUpdateData(item *updateStepRunQueueData) int {
 	}
 
 	return size
-}
-
-func (s *stepRunEngineRepository) startBuffers() error {
-	statusBufOpts := buffer.TenantBufManagerOpts[*updateStepRunQueueData, pgtype.UUID]{
-		Name:       "update_step_run_status",
-		OutputFunc: s.bulkUpdateStepRunStatuses,
-		SizeFunc:   sizeOfUpdateData,
-		L:          s.l,
-		V:          s.v,
-	}
-
-	var err error
-	s.bulkStatusBuffer, err = buffer.NewTenantBufManager(statusBufOpts)
-
-	if err != nil {
-		return err
-	}
-
-	return err
-}
-
-func (s *stepRunEngineRepository) bulkUpdateStepRunStatuses(ctx context.Context, opts []*updateStepRunQueueData) ([]pgtype.UUID, error) {
-	stepRunIds := make([]pgtype.UUID, 0, len(opts))
-
-	eventTimeSeen := make([]time.Time, 0, len(opts))
-	eventReasons := make([]dbsqlc.StepRunEventReason, 0, len(opts))
-	eventStepRunIds := make([]pgtype.UUID, 0, len(opts))
-	eventTenantIds := make([]string, 0, len(opts))
-	eventSeverities := make([]dbsqlc.StepRunEventSeverity, 0, len(opts))
-	eventMessages := make([]string, 0, len(opts))
-	eventData := make([]map[string]interface{}, 0, len(opts))
-
-	for _, item := range opts {
-		stepRunId := sqlchelpers.UUIDFromStr(item.StepRunId)
-		stepRunIds = append(stepRunIds, stepRunId)
-
-		if item.Status == nil {
-			continue
-		}
-
-		switch dbsqlc.StepRunStatus(*item.Status) {
-		case dbsqlc.StepRunStatusRUNNING:
-			eventStepRunIds = append(eventStepRunIds, stepRunId)
-			eventTenantIds = append(eventTenantIds, item.TenantId)
-			eventTimeSeen = append(eventTimeSeen, *item.StartedAt)
-			eventReasons = append(eventReasons, dbsqlc.StepRunEventReasonSTARTED)
-			eventSeverities = append(eventSeverities, dbsqlc.StepRunEventSeverityINFO)
-			eventMessages = append(eventMessages, fmt.Sprintf("Step run started at %s", item.StartedAt.Format(time.RFC1123)))
-			eventData = append(eventData, map[string]interface{}{})
-		case dbsqlc.StepRunStatusFAILED:
-			eventTimeSeen = append(eventTimeSeen, *item.FinishedAt)
-
-			eventStepRunIds = append(eventStepRunIds, stepRunId)
-			eventTenantIds = append(eventTenantIds, item.TenantId)
-			eventMessage := fmt.Sprintf("Step run failed on %s", item.FinishedAt.Format(time.RFC1123))
-			eventReason := dbsqlc.StepRunEventReasonFAILED
-
-			if item.Error != nil && *item.Error == "TIMED_OUT" {
-				eventReason = dbsqlc.StepRunEventReasonTIMEDOUT
-				eventMessage = "Step exceeded timeout duration"
-			}
-
-			eventReasons = append(eventReasons, eventReason)
-			eventSeverities = append(eventSeverities, dbsqlc.StepRunEventSeverityCRITICAL)
-			eventMessages = append(eventMessages, eventMessage)
-			eventData = append(eventData, map[string]interface{}{
-				"retry_count": item.RetryCount,
-			})
-		case dbsqlc.StepRunStatusCANCELLED:
-			eventTimeSeen = append(eventTimeSeen, *item.CancelledAt)
-			eventStepRunIds = append(eventStepRunIds, stepRunId)
-			eventTenantIds = append(eventTenantIds, item.TenantId)
-			eventReasons = append(eventReasons, dbsqlc.StepRunEventReasonCANCELLED)
-			eventSeverities = append(eventSeverities, dbsqlc.StepRunEventSeverityWARNING)
-			eventMessages = append(eventMessages, fmt.Sprintf("Step run was cancelled on %s for the following reason: %s", item.CancelledAt.Format(time.RFC1123), *item.CancelledReason))
-			eventData = append(eventData, map[string]interface{}{})
-		case dbsqlc.StepRunStatusSUCCEEDED:
-			eventTimeSeen = append(eventTimeSeen, *item.FinishedAt)
-			eventStepRunIds = append(eventStepRunIds, stepRunId)
-			eventTenantIds = append(eventTenantIds, item.TenantId)
-			eventReasons = append(eventReasons, dbsqlc.StepRunEventReasonFINISHED)
-			eventSeverities = append(eventSeverities, dbsqlc.StepRunEventSeverityINFO)
-			eventMessages = append(eventMessages, fmt.Sprintf("Step run finished at %s", item.FinishedAt.Format(time.RFC1123)))
-			eventData = append(eventData, map[string]interface{}{})
-		}
-	}
-
-	eg := errgroup.Group{}
-
-	if len(opts) > 0 {
-		eg.Go(func() error {
-			insertInternalQITenantIds := make([]pgtype.UUID, 0, len(opts))
-			insertInternalQIQueues := make([]dbsqlc.InternalQueue, 0, len(opts))
-			insertInternalQIData := make([]any, 0, len(opts))
-
-			for _, item := range opts {
-				if item.Status == nil {
-					continue
-				}
-
-				itemCp := item
-
-				insertInternalQITenantIds = append(insertInternalQITenantIds, sqlchelpers.UUIDFromStr(itemCp.TenantId))
-				insertInternalQIQueues = append(insertInternalQIQueues, dbsqlc.InternalQueueSTEPRUNUPDATEV2)
-				insertInternalQIData = append(insertInternalQIData, itemCp)
-			}
-
-			err := bulkInsertInternalQueueItem(
-				ctx,
-				s.pool,
-				s.queries,
-				insertInternalQITenantIds,
-				insertInternalQIQueues,
-				insertInternalQIData,
-			)
-
-			if err != nil {
-				return err
-			}
-
-			return nil
-		})
-	}
-
-	if len(eventStepRunIds) > 0 {
-		for i, stepRunId := range eventStepRunIds {
-			_, err := s.bulkEventBuffer.BuffItem(eventTenantIds[i], &repository.CreateStepRunEventOpts{
-				StepRunId:     sqlchelpers.UUIDToStr(stepRunId),
-				EventMessage:  &eventMessages[i],
-				EventReason:   &eventReasons[i],
-				EventSeverity: &eventSeverities[i],
-				Timestamp:     &eventTimeSeen[i],
-				EventData:     eventData[i],
-			})
-
-			if err != nil {
-				s.l.Err(err).Msg("could not buffer step run event")
-			}
-		}
-	}
-
-	err := eg.Wait()
-
-	if err != nil {
-		return nil, err
-	}
-
-	return stepRunIds, nil
 }
 
 func (s *stepRunEngineRepository) RegisterWorkflowRunCompletedCallback(callback repository.TenantScopedCallback[*dbsqlc.ResolveWorkflowRunStatusRow]) {
@@ -696,7 +485,7 @@ func (s *stepRunEngineRepository) ListStepRunsToReassign(ctx context.Context, te
 		severity := dbsqlc.StepRunEventSeverityCRITICAL
 		timeSeen := time.Now().UTC()
 
-		_, err := s.bulkEventBuffer.BuffItem(tenantId, &repository.CreateStepRunEventOpts{
+		err := s.bulkEventBuffer.FireForget(tenantId, &repository.CreateStepRunEventOpts{
 			StepRunId:     sqlchelpers.UUIDToStr(stepRunIdUUID),
 			EventMessage:  &message,
 			EventReason:   &reason,
@@ -847,129 +636,15 @@ func (s *stepRunEngineRepository) DeferredStepRunEvent(
 	)
 }
 
-func (s *stepRunEngineRepository) deferredStepRunEvent(
+func (s *sharedRepository) deferredStepRunEvent(
 	tenantId string,
 	opts repository.CreateStepRunEventOpts,
 ) {
 	// fire-and-forget for events
-	_, err := s.bulkEventBuffer.BuffItem(tenantId, &opts)
+	err := s.bulkEventBuffer.FireForget(tenantId, &opts)
 
 	if err != nil {
 		s.l.Error().Err(err).Msg("could not buffer event")
-	}
-}
-
-func (s *stepRunEngineRepository) bulkStepRunsAssigned(
-	tenantId string,
-	assignedAt time.Time,
-	stepRunIds []pgtype.UUID,
-	workerIds []pgtype.UUID,
-) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	workerIdToStepRunIds := make(map[string][]string)
-
-	for i := range stepRunIds {
-		workerId := sqlchelpers.UUIDToStr(workerIds[i])
-
-		if _, ok := workerIdToStepRunIds[workerId]; !ok {
-			workerIdToStepRunIds[workerId] = make([]string, 0)
-		}
-
-		workerIdToStepRunIds[workerId] = append(workerIdToStepRunIds[workerId], sqlchelpers.UUIDToStr(stepRunIds[i]))
-		message := fmt.Sprintf("Assigned to worker %s", workerId)
-		timeSeen := assignedAt
-		reasons := dbsqlc.StepRunEventReasonASSIGNED
-		severity := dbsqlc.StepRunEventSeverityINFO
-		data := map[string]interface{}{"worker_id": workerId}
-
-		_, err := s.bulkEventBuffer.BuffItem(tenantId, &repository.CreateStepRunEventOpts{
-			StepRunId:     sqlchelpers.UUIDToStr(stepRunIds[i]),
-			EventMessage:  &message,
-			EventReason:   &reasons,
-			EventSeverity: &severity,
-			Timestamp:     &timeSeen,
-			EventData:     data,
-		})
-
-		if err != nil {
-			s.l.Err(err).Msg("could not buffer step run event")
-		}
-	}
-
-	orderedWorkerIds := make([]pgtype.UUID, 0)
-	assignedStepRuns := make([][]byte, 0)
-
-	for workerId, stepRunIds := range workerIdToStepRunIds {
-		orderedWorkerIds = append(orderedWorkerIds, sqlchelpers.UUIDFromStr(workerId))
-		assignedStepRunsBytes, _ := json.Marshal(stepRunIds) // nolint: errcheck
-		assignedStepRuns = append(assignedStepRuns, assignedStepRunsBytes)
-	}
-
-	err := s.queries.CreateWorkerAssignEvents(ctx, s.pool, dbsqlc.CreateWorkerAssignEventsParams{
-		Workerids:        orderedWorkerIds,
-		Assignedstepruns: assignedStepRuns,
-	})
-
-	if err != nil {
-		s.l.Err(err).Msg("could not create worker assign events")
-	}
-}
-
-func (s *stepRunEngineRepository) bulkStepRunsUnassigned(
-	tenantId string,
-	stepRunIds []pgtype.UUID,
-) {
-	for _, stepRunId := range stepRunIds {
-		message := "No worker available"
-		timeSeen := time.Now().UTC()
-		severity := dbsqlc.StepRunEventSeverityWARNING
-		reason := dbsqlc.StepRunEventReasonREQUEUEDNOWORKER
-		data := map[string]interface{}{}
-
-		_, err := s.bulkEventBuffer.BuffItem(tenantId, &repository.CreateStepRunEventOpts{
-			StepRunId:     sqlchelpers.UUIDToStr(stepRunId),
-			EventMessage:  &message,
-			EventReason:   &reason,
-			EventSeverity: &severity,
-			Timestamp:     &timeSeen,
-			EventData:     data,
-		})
-
-		if err != nil {
-			s.l.Err(err).Msg("could not buffer step run event")
-		}
-	}
-}
-
-func (s *stepRunEngineRepository) bulkStepRunsRateLimited(
-	tenantId string,
-	rateLimits scheduling.RateLimitedResult,
-) {
-	stepRunIds := rateLimits.StepRuns
-
-	for i, stepRunId := range stepRunIds {
-		message := fmt.Sprintf("Rate limit exceeded for key %s, attempting to consume %d units", rateLimits.Keys[i], rateLimits.Units[i])
-		reason := dbsqlc.StepRunEventReasonREQUEUEDRATELIMIT
-		severity := dbsqlc.StepRunEventSeverityWARNING
-		timeSeen := time.Now().UTC()
-		data := map[string]interface{}{
-			"rate_limit_key": rateLimits.Keys[i],
-		}
-
-		_, err := s.bulkEventBuffer.BuffItem(tenantId, &repository.CreateStepRunEventOpts{
-			StepRunId:     sqlchelpers.UUIDToStr(stepRunId),
-			EventMessage:  &message,
-			EventReason:   &reason,
-			EventSeverity: &severity,
-			Timestamp:     &timeSeen,
-			EventData:     data,
-		})
-
-		if err != nil {
-			s.l.Err(err).Msg("could not buffer step run event")
-		}
 	}
 }
 
@@ -982,709 +657,6 @@ func UniqueSet[T any](i []T, keyFunc func(T) string) map[string]struct{} {
 	}
 
 	return set
-}
-
-func (s *stepRunEngineRepository) QueueStepRuns(ctx context.Context, qlp *zerolog.Logger, tenantId string) (repository.QueueStepRunsResult, error) {
-	ql := qlp.With().Str("tenant_id", tenantId).Logger()
-
-	ctx, span := telemetry.NewSpan(ctx, "queue-step-runs-database")
-	defer span.End()
-
-	startedAt := time.Now().UTC()
-
-	emptyRes := repository.QueueStepRunsResult{
-		Queued:             []repository.QueuedStepRun{},
-		SchedulingTimedOut: []string{},
-		Continue:           false,
-	}
-
-	if ctx.Err() != nil {
-		return emptyRes, ctx.Err()
-	}
-
-	pgTenantId := sqlchelpers.UUIDFromStr(tenantId)
-
-	limit := 100
-
-	if s.cf.SingleQueueLimit != 0 {
-		limit = s.cf.SingleQueueLimit
-	}
-
-	pgLimit := pgtype.Int4{
-		Int32: int32(limit), // nolint: gosec
-		Valid: true,
-	}
-
-	tx, err := s.pool.Begin(ctx)
-
-	if err != nil {
-		return emptyRes, err
-	}
-
-	defer sqlchelpers.DeferRollback(ctx, s.l, tx.Rollback)
-
-	durationPrepareTx := time.Since(startedAt)
-
-	startListQueues := time.Now().UTC()
-
-	// list queues
-	queues, err := s.queries.ListQueues(ctx, tx, pgTenantId)
-
-	if err != nil {
-		return emptyRes, fmt.Errorf("could not list queues: %w", err)
-	}
-
-	if len(queues) == 0 {
-		ql.Debug().Msg("no queues found")
-		return emptyRes, nil
-	}
-
-	// construct params for list queue items
-	query := []dbsqlc.ListQueueItemsParams{}
-
-	// randomly order queues
-	rand.New(rand.NewSource(time.Now().UnixNano())).Shuffle(len(queues), func(i, j int) { queues[i], queues[j] = queues[j], queues[i] }) // nolint:gosec
-
-	for _, queue := range queues {
-		name := queue.Name
-
-		q := dbsqlc.ListQueueItemsParams{
-			Tenantid: pgTenantId,
-			Queue:    name,
-			Limit:    pgLimit,
-		}
-
-		// lookup to see if we have a min queued id cached
-		minQueuedId, ok := s.cachedMinQueuedIds.Load(getCacheName(tenantId, name))
-
-		if ok {
-			if minQueuedIdInt, ok := minQueuedId.(int64); ok {
-				q.GtId = pgtype.Int8{
-					Int64: minQueuedIdInt,
-					Valid: true,
-				}
-			}
-		}
-
-		query = append(query, q)
-	}
-
-	durationListQueues := time.Since(startListQueues)
-	startedListQueueItems := time.Now().UTC()
-
-	results := s.queries.ListQueueItems(ctx, tx, query)
-	defer results.Close()
-
-	durationsOfQueueListResults := make([]string, 0)
-
-	queueItems := make([]*scheduling.QueueItemWithOrder, 0)
-
-	// TODO: verify whether this is multithreaded and if it is, whether thread safe
-	results.Query(func(i int, qi []*dbsqlc.QueueItem, err error) {
-		if err != nil {
-			ql.Err(err).Msg("could not list queue items")
-			return
-		}
-
-		queueName := ""
-
-		for i := range qi {
-			queueItems = append(queueItems, &scheduling.QueueItemWithOrder{
-				QueueItem: qi[i],
-				Order:     i,
-			})
-
-			queueName = qi[i].Queue
-		}
-
-		durationsOfQueueListResults = append(durationsOfQueueListResults, fmt.Sprintf("%s:%s:%s", queues[i].Name, queueName, time.Since(startedAt).String()))
-	})
-
-	err = results.Close()
-
-	if err != nil {
-		return emptyRes, fmt.Errorf("could not close queue items result: %w", err)
-	}
-
-	if len(queueItems) == 0 {
-		ql.Debug().Msg("no queue items found")
-		return emptyRes, nil
-	}
-
-	var duplicates []*scheduling.QueueItemWithOrder
-	var finalized []*scheduling.QueueItemWithOrder
-
-	queueItems, duplicates = removeDuplicates(queueItems)
-	queueItems, finalized, err = s.removeFinalizedStepRuns(ctx, tx, queueItems)
-
-	if err != nil {
-		return emptyRes, fmt.Errorf("could not remove cancelled step runs: %w", err)
-	}
-
-	// sort the queue items by Order from least to greatest, then by queue id
-	sort.Slice(queueItems, func(i, j int) bool {
-		// sort by priority, then by order, then by id
-		if queueItems[i].Priority == queueItems[j].Priority {
-			if queueItems[i].Order == queueItems[j].Order {
-				return queueItems[i].QueueItem.ID < queueItems[j].QueueItem.ID
-			}
-
-			return queueItems[i].Order < queueItems[j].Order
-		}
-
-		return queueItems[i].Priority > queueItems[j].Priority
-	})
-
-	durationListQueueItems := time.Since(startedListQueueItems)
-	startRateLimits := time.Now().UTC()
-
-	// get a list of unique actions
-	uniqueActions := make(map[string]bool)
-
-	for _, row := range queueItems {
-		uniqueActions[row.ActionId.String] = true
-	}
-
-	uniqueActionsArr := make([]string, 0, len(uniqueActions))
-
-	for action := range uniqueActions {
-		uniqueActionsArr = append(uniqueActionsArr, action)
-	}
-
-	// list rate limits for the tenant
-	rateLimits, currRateLimitValues, err := s.getStepRunRateLimits(ctx, tx, tenantId, queueItems)
-
-	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		return emptyRes, fmt.Errorf("could not list rate limits for tenant: %w", err)
-	}
-
-	durationListRateLimits := time.Since(startRateLimits)
-	startGetWorkerCounts := time.Now()
-
-	// list workers to assign
-	workers, err := s.queries.GetWorkerDispatcherActions(ctx, tx, dbsqlc.GetWorkerDispatcherActionsParams{
-		Tenantid:  pgTenantId,
-		Actionids: uniqueActionsArr,
-	})
-
-	if err != nil {
-		return emptyRes, fmt.Errorf("could not get worker dispatcher actions: %w", err)
-	}
-
-	workerIds := make([]pgtype.UUID, 0, len(workers))
-
-	for _, worker := range workers {
-		workerIds = append(workerIds, worker.ID)
-	}
-
-	availableSlots, err := s.queries.ListAvailableSlotsForWorkers(ctx, tx, dbsqlc.ListAvailableSlotsForWorkersParams{
-		Tenantid:  pgTenantId,
-		Workerids: workerIds,
-	})
-
-	if err != nil {
-		return emptyRes, fmt.Errorf("could not list available slots for workers: %w", err)
-	}
-
-	workersToCounts := make(map[string]int)
-
-	for _, worker := range availableSlots {
-		workersToCounts[sqlchelpers.UUIDToStr(worker.ID)] = int(worker.AvailableSlots)
-	}
-
-	slots := make([]*scheduling.Slot, 0)
-
-	for _, worker := range workers {
-		workerId := sqlchelpers.UUIDToStr(worker.ID)
-		dispatcherId := sqlchelpers.UUIDToStr(worker.DispatcherId)
-		actionId := worker.ActionId
-
-		count, ok := workersToCounts[workerId]
-
-		if !ok {
-			continue
-		}
-
-		for i := 0; i < count; i++ {
-			slots = append(slots, &scheduling.Slot{
-				ID:           fmt.Sprintf("%s-%d", workerId, i),
-				WorkerId:     workerId,
-				DispatcherId: dispatcherId,
-				ActionId:     actionId,
-			})
-		}
-	}
-
-	finishedGetWorkerCounts := time.Since(startGetWorkerCounts)
-	startGetLabels := time.Now().UTC()
-
-	// GET UNIQUE STEP IDS
-	stepIdSet := UniqueSet(queueItems, func(x *scheduling.QueueItemWithOrder) string {
-		return sqlchelpers.UUIDToStr(x.StepId)
-	})
-
-	desiredLabels := make(map[string][]*dbsqlc.GetDesiredLabelsRow)
-	hasDesired := false
-
-	// GET DESIRED LABELS
-	// OPTIMIZATION: CACHEABLE
-	stepIds := make([]pgtype.UUID, 0, len(stepIdSet))
-	for stepId := range stepIdSet {
-		stepIds = append(stepIds, sqlchelpers.UUIDFromStr(stepId))
-	}
-
-	labels, err := s.queries.GetDesiredLabels(ctx, tx, stepIds)
-
-	if err != nil {
-		return emptyRes, fmt.Errorf("could not get desired labels: %w", err)
-	}
-
-	for _, label := range labels {
-		stepId := sqlchelpers.UUIDToStr(label.StepId)
-		desiredLabels[stepId] = labels
-		hasDesired = true
-	}
-
-	var workerLabels = make(map[string][]*dbsqlc.GetWorkerLabelsRow)
-
-	if hasDesired {
-		// GET UNIQUE WORKER LABELS
-		workerIdSet := UniqueSet(slots, func(x *scheduling.Slot) string {
-			return x.WorkerId
-		})
-
-		for workerId := range workerIdSet {
-			labels, err := s.queries.GetWorkerLabels(ctx, tx, sqlchelpers.UUIDFromStr(workerId))
-			if err != nil {
-				return emptyRes, fmt.Errorf("could not get worker labels: %w", err)
-			}
-			workerLabels[workerId] = labels
-		}
-	}
-
-	durationGetLabels := time.Since(startGetLabels)
-	startScheduling := time.Now().UTC()
-
-	plan, err := scheduling.GeneratePlan(
-		ctx,
-		slots,
-		uniqueActionsArr,
-		queueItems,
-		rateLimits,
-		currRateLimitValues,
-		workerLabels,
-		desiredLabels,
-	)
-
-	if err != nil {
-		return emptyRes, fmt.Errorf("could not generate scheduling: %w", err)
-	}
-
-	durationScheduling := time.Since(startScheduling)
-	startUpdateRateLimits := time.Now()
-
-	// save rate limits as a subtransaction, but don't throw an error if it fails
-	func() {
-		updateKeys := []string{}
-		updateUnits := []int32{}
-		didConsume := false
-
-		for key, value := range plan.RateLimitUnitsConsumed {
-			if value == 0 {
-				continue
-			}
-
-			didConsume = true
-			updateKeys = append(updateKeys, key)
-			updateUnits = append(updateUnits, value)
-		}
-
-		if !didConsume {
-			return
-		}
-
-		subtx, err := tx.Begin(ctx)
-
-		if err != nil {
-			s.l.Err(err).Msg("could not start subtransaction")
-			return
-		}
-
-		defer sqlchelpers.DeferRollback(ctx, s.l, subtx.Rollback)
-
-		params := dbsqlc.BulkUpdateRateLimitsParams{
-			Tenantid: pgTenantId,
-			Keys:     updateKeys,
-			Units:    updateUnits,
-		}
-
-		_, err = s.queries.BulkUpdateRateLimits(ctx, subtx, params)
-
-		if err != nil {
-			s.l.Err(err).Msg("could not bulk update rate limits")
-			return
-		}
-
-		// throw a warning if any rate limits are below 0
-		for key, value := range plan.RateLimitUnitsConsumed {
-			if value < 0 {
-				s.l.Warn().Msgf("rate limit %s is below 0: %d", key, value)
-			}
-		}
-
-		err = subtx.Commit(ctx)
-
-		if err != nil {
-			s.l.Err(err).Msg("could not commit subtransaction")
-			return
-		}
-	}()
-
-	durationUpdateRateLimits := time.Since(startUpdateRateLimits)
-	startAssignTime := time.Now()
-
-	numAssigns := make(map[string]int)
-
-	for _, workerId := range plan.WorkerIds {
-		numAssigns[sqlchelpers.UUIDToStr(workerId)]++
-	}
-
-	_, err = s.queries.UpdateStepRunsToAssigned(ctx, tx, dbsqlc.UpdateStepRunsToAssignedParams{
-		Steprunids:      plan.StepRunIds,
-		Workerids:       plan.WorkerIds,
-		Stepruntimeouts: plan.StepRunTimeouts,
-		Tenantid:        pgTenantId,
-	})
-
-	if err != nil {
-		return emptyRes, fmt.Errorf("could not bulk assign step runs to workers: %w", err)
-	}
-
-	finishedAssignTime := time.Since(startAssignTime)
-
-	popItems := plan.QueuedItems
-
-	// we'd like to remove duplicates from the queue items as well
-	for _, item := range duplicates {
-		// print a warning for duplicates
-		s.l.Warn().Msgf("duplicate queue item: %d for step run %s", item.QueueItem.ID, sqlchelpers.UUIDToStr(item.QueueItem.StepRunId))
-
-		popItems = append(popItems, item.QueueItem.ID)
-	}
-
-	// we'd like to remove finalized step runs from the queue items as well
-	for _, item := range finalized {
-		popItems = append(popItems, item.QueueItem.ID)
-	}
-
-	startQueueTime := time.Now()
-
-	err = s.queries.BulkQueueItems(ctx, tx, popItems)
-
-	if err != nil {
-		return emptyRes, fmt.Errorf("could not bulk queue items: %w", err)
-	}
-
-	// if there are step runs to place in a cancelling state, do so
-	if len(plan.TimedOutStepRuns) > 0 {
-		_, err = s.queries.BulkMarkStepRunsAsCancelling(ctx, tx, plan.TimedOutStepRuns)
-
-		if err != nil {
-			return emptyRes, fmt.Errorf("could not bulk mark step runs as cancelling: %w", err)
-		}
-	}
-
-	finishQueueTime := time.Since(startQueueTime)
-
-	err = tx.Commit(ctx)
-
-	if err != nil {
-		return emptyRes, fmt.Errorf("could not commit transaction: %w", err)
-	}
-
-	defer s.bulkStepRunsAssigned(tenantId, time.Now().UTC(), plan.StepRunIds, plan.WorkerIds)
-	defer s.bulkStepRunsUnassigned(tenantId, plan.UnassignedStepRunIds)
-	defer s.bulkStepRunsRateLimited(tenantId, plan.RateLimitedStepRuns)
-
-	// update the cache with the min queued id
-	for name, qiId := range plan.MinQueuedIds {
-		s.cachedMinQueuedIds.Store(getCacheName(tenantId, name), qiId)
-	}
-
-	timedOutStepRunsStr := make([]string, len(plan.TimedOutStepRuns))
-
-	for i, id := range plan.TimedOutStepRuns {
-		timedOutStepRunsStr[i] = sqlchelpers.UUIDToStr(id)
-	}
-
-	defer printQueueDebugInfo(
-		ql,
-		tenantId,
-		queues,
-		queueItems,
-		duplicates,
-		finalized,
-		plan,
-		slots,
-		startedAt,
-		durationPrepareTx,
-		durationListQueues,
-		durationListQueueItems,
-		durationListRateLimits,
-		finishedGetWorkerCounts,
-		durationGetLabels,
-		durationScheduling,
-		durationUpdateRateLimits,
-		finishedAssignTime,
-		finishQueueTime,
-	)
-
-	return repository.QueueStepRunsResult{
-		Queued:             plan.QueuedStepRuns,
-		SchedulingTimedOut: timedOutStepRunsStr,
-		Continue:           plan.ShouldContinue,
-	}, nil
-}
-
-func (s *stepRunEngineRepository) getStepRunRateLimits(ctx context.Context, dbtx dbsqlc.DBTX, tenantId string, queueItems []*scheduling.QueueItemWithOrder) (map[string]map[string]int32, map[string]*dbsqlc.ListRateLimitsForTenantWithMutateRow, error) {
-	stepRunIds := make([]pgtype.UUID, 0, len(queueItems))
-	stepIds := make([]pgtype.UUID, 0, len(queueItems))
-	stepsWithRateLimits := make(map[string]bool)
-
-	for _, item := range queueItems {
-		stepRunIds = append(stepRunIds, item.StepRunId)
-		stepIds = append(stepIds, item.StepId)
-	}
-
-	stepIdToStepRuns := make(map[string][]string)
-	stepRunIdToStepId := make(map[string]string)
-
-	for i, stepRunId := range stepRunIds {
-		stepId := sqlchelpers.UUIDToStr(stepIds[i])
-		stepRunIdStr := sqlchelpers.UUIDToStr(stepRunId)
-
-		if _, ok := stepIdToStepRuns[stepId]; !ok {
-			stepIdToStepRuns[stepId] = make([]string, 0)
-		}
-
-		stepIdToStepRuns[stepId] = append(stepIdToStepRuns[stepId], stepRunIdStr)
-		stepRunIdToStepId[stepRunIdStr] = stepId
-	}
-
-	// check if we have any rate limits for these step ids
-	skipRateLimiting := true
-
-	for stepIdStr := range stepIdToStepRuns {
-		if hasRateLimit, ok := s.cachedStepIdHasRateLimit.Get(stepIdStr); !ok || hasRateLimit.(bool) {
-			skipRateLimiting = false
-			break
-		}
-	}
-
-	if skipRateLimiting {
-		return nil, nil, nil
-	}
-
-	// get all step run expression evals which correspond to rate limits, grouped by step run id
-	expressionEvals, err := s.queries.ListStepRunExpressionEvals(ctx, dbtx, stepRunIds)
-
-	if err != nil {
-		return nil, nil, err
-	}
-
-	stepRunAndGlobalKeyToKey := make(map[string]string)
-	stepRunToKeys := make(map[string][]string)
-
-	for _, eval := range expressionEvals {
-		stepRunId := sqlchelpers.UUIDToStr(eval.StepRunId)
-		globalKey := eval.Key
-
-		// Only append if this is a key expression. Note that we have a uniqueness constraint on
-		// the stepRunId, kind, and key, so we will not insert duplicate values into the array.
-		if eval.Kind == dbsqlc.StepExpressionKindDYNAMICRATELIMITKEY {
-			stepsWithRateLimits[stepRunIdToStepId[stepRunId]] = true
-
-			k := eval.ValueStr.String
-
-			if _, ok := stepRunToKeys[stepRunId]; !ok {
-				stepRunToKeys[stepRunId] = make([]string, 0)
-			}
-
-			stepRunToKeys[stepRunId] = append(stepRunToKeys[stepRunId], k)
-
-			stepRunAndGlobalKey := fmt.Sprintf("%s-%s", stepRunId, globalKey)
-
-			stepRunAndGlobalKeyToKey[stepRunAndGlobalKey] = k
-		}
-	}
-
-	rateLimitKeyToEvals := make(map[string][]*dbsqlc.StepRunExpressionEval)
-
-	for _, eval := range expressionEvals {
-		k := stepRunAndGlobalKeyToKey[fmt.Sprintf("%s-%s", sqlchelpers.UUIDToStr(eval.StepRunId), eval.Key)]
-
-		if _, ok := rateLimitKeyToEvals[k]; !ok {
-			rateLimitKeyToEvals[k] = make([]*dbsqlc.StepRunExpressionEval, 0)
-		}
-
-		rateLimitKeyToEvals[k] = append(rateLimitKeyToEvals[k], eval)
-	}
-
-	upsertRateLimitBulkParams := dbsqlc.UpsertRateLimitsBulkParams{
-		Tenantid: sqlchelpers.UUIDFromStr(tenantId),
-	}
-
-	stepRunToKeyToUnits := make(map[string]map[string]int32)
-
-	for key, evals := range rateLimitKeyToEvals {
-		var duration string
-		var limitValue int
-		var skip bool
-
-		for _, eval := range evals {
-			// add to stepRunToKeyToUnits
-			stepRunId := sqlchelpers.UUIDToStr(eval.StepRunId)
-
-			// throw an error if there are multiple rate limits with the same keys, but different limit values or durations
-			if eval.Kind == dbsqlc.StepExpressionKindDYNAMICRATELIMITWINDOW {
-				if duration == "" {
-					duration = eval.ValueStr.String
-				} else if duration != eval.ValueStr.String {
-					largerDuration, err := getLargerDuration(duration, eval.ValueStr.String)
-
-					if err != nil {
-						skip = true
-						break
-					}
-
-					message := fmt.Sprintf("Multiple rate limits with key %s have different durations: %s vs %s. Using longer window %s.", key, duration, eval.ValueStr.String, largerDuration)
-					timeSeen := time.Now().UTC()
-					reason := dbsqlc.StepRunEventReasonRATELIMITERROR
-					severity := dbsqlc.StepRunEventSeverityWARNING
-					data := map[string]interface{}{}
-
-					_, buffErr := s.bulkEventBuffer.BuffItem(tenantId, &repository.CreateStepRunEventOpts{
-						StepRunId:     sqlchelpers.UUIDToStr(eval.StepRunId),
-						EventMessage:  &message,
-						EventReason:   &reason,
-						EventSeverity: &severity,
-						Timestamp:     &timeSeen,
-						EventData:     data,
-					})
-
-					if buffErr != nil {
-						s.l.Err(buffErr).Msg("could not buffer step run event")
-					}
-
-					duration = largerDuration
-				}
-			}
-
-			if eval.Kind == dbsqlc.StepExpressionKindDYNAMICRATELIMITVALUE {
-				if limitValue == 0 {
-					limitValue = int(eval.ValueInt.Int32)
-				} else if limitValue != int(eval.ValueInt.Int32) {
-					message := fmt.Sprintf("Multiple rate limits with key %s have different limit values: %d vs %d. Using lower value %d.", key, limitValue, eval.ValueInt.Int32, min(limitValue, int(eval.ValueInt.Int32)))
-					timeSeen := time.Now().UTC()
-					reason := dbsqlc.StepRunEventReasonRATELIMITERROR
-					severity := dbsqlc.StepRunEventSeverityWARNING
-					data := map[string]interface{}{}
-
-					_, buffErr := s.bulkEventBuffer.BuffItem(tenantId, &repository.CreateStepRunEventOpts{
-						StepRunId:     sqlchelpers.UUIDToStr(eval.StepRunId),
-						EventMessage:  &message,
-						EventReason:   &reason,
-						EventSeverity: &severity,
-						Timestamp:     &timeSeen,
-						EventData:     data,
-					})
-
-					if buffErr != nil {
-						s.l.Err(buffErr).Msg("could not buffer step run event")
-					}
-
-					limitValue = min(limitValue, int(eval.ValueInt.Int32))
-				}
-			}
-
-			if eval.Kind == dbsqlc.StepExpressionKindDYNAMICRATELIMITUNITS {
-				if _, ok := stepRunToKeyToUnits[stepRunId]; !ok {
-					stepRunToKeyToUnits[stepRunId] = make(map[string]int32)
-				}
-
-				stepRunToKeyToUnits[stepRunId][key] = eval.ValueInt.Int32
-			}
-		}
-
-		if skip {
-			continue
-		}
-
-		upsertRateLimitBulkParams.Keys = append(upsertRateLimitBulkParams.Keys, key)
-		upsertRateLimitBulkParams.Windows = append(upsertRateLimitBulkParams.Windows, getWindowParamFromDurString(duration))
-		upsertRateLimitBulkParams.Limitvalues = append(upsertRateLimitBulkParams.Limitvalues, int32(limitValue)) // nolint: gosec
-	}
-
-	var stepRateLimits []*dbsqlc.StepRateLimit
-
-	if len(upsertRateLimitBulkParams.Keys) > 0 {
-		// upsert all rate limits based on the keys, limit values, and durations
-		err = s.queries.UpsertRateLimitsBulk(ctx, dbtx, upsertRateLimitBulkParams)
-
-		if err != nil {
-			return nil, nil, fmt.Errorf("could not bulk upsert dynamic rate limits: %w", err)
-		}
-	}
-
-	// get all existing static rate limits for steps to the mapping, mapping back from step ids to step run ids
-	uniqueStepIds := make([]pgtype.UUID, 0, len(stepIdToStepRuns))
-
-	for stepId := range stepIdToStepRuns {
-		uniqueStepIds = append(uniqueStepIds, sqlchelpers.UUIDFromStr(stepId))
-	}
-
-	stepRateLimits, err = s.queries.ListRateLimitsForSteps(ctx, dbtx, dbsqlc.ListRateLimitsForStepsParams{
-		Tenantid: sqlchelpers.UUIDFromStr(tenantId),
-		Stepids:  uniqueStepIds,
-	})
-
-	if err != nil {
-		return nil, nil, fmt.Errorf("could not list rate limits for steps: %w", err)
-	}
-
-	for _, row := range stepRateLimits {
-		stepsWithRateLimits[sqlchelpers.UUIDToStr(row.StepId)] = true
-		stepId := sqlchelpers.UUIDToStr(row.StepId)
-		stepRuns := stepIdToStepRuns[stepId]
-
-		for _, stepRunId := range stepRuns {
-			if _, ok := stepRunToKeyToUnits[stepRunId]; !ok {
-				stepRunToKeyToUnits[stepRunId] = make(map[string]int32)
-			}
-
-			stepRunToKeyToUnits[stepRunId][row.RateLimitKey] = row.Units
-		}
-	}
-
-	rateLimitsForTenant, err := s.queries.ListRateLimitsForTenantWithMutate(ctx, dbtx, sqlchelpers.UUIDFromStr(tenantId))
-
-	if err != nil {
-		return nil, nil, fmt.Errorf("could not list rate limits for tenant: %w", err)
-	}
-
-	mapRateLimitsForTenant := make(map[string]*dbsqlc.ListRateLimitsForTenantWithMutateRow)
-
-	for _, row := range rateLimitsForTenant {
-		mapRateLimitsForTenant[row.Key] = row
-	}
-
-	// store all step ids in the cache, so we can skip rate limiting for steps without rate limits
-	for stepId := range stepIdToStepRuns {
-		hasRateLimit := stepsWithRateLimits[stepId]
-		s.cachedStepIdHasRateLimit.Set(stepId, hasRateLimit)
-	}
-
-	return stepRunToKeyToUnits, mapRateLimitsForTenant, nil
 }
 
 func (s *stepRunEngineRepository) GetQueueCounts(ctx context.Context, tenantId string) (map[string]int, error) {
@@ -1705,92 +677,6 @@ func (s *stepRunEngineRepository) GetQueueCounts(ctx context.Context, tenantId s
 	}
 
 	return res, nil
-}
-
-func (s *stepRunEngineRepository) ProcessStepRunUpdates(ctx context.Context, qlp *zerolog.Logger, tenantId string) (repository.ProcessStepRunUpdatesResult, error) {
-	ql := qlp.With().Str("tenant_id", tenantId).Logger()
-	// startedAt := time.Now().UTC()
-
-	emptyRes := repository.ProcessStepRunUpdatesResult{
-		Continue: false,
-	}
-
-	ctx, span := telemetry.NewSpan(ctx, "process-step-run-updates-database")
-	defer span.End()
-
-	pgTenantId := sqlchelpers.UUIDFromStr(tenantId)
-
-	limit := 100
-
-	if s.cf.SingleQueueLimit != 0 {
-		limit = s.cf.SingleQueueLimit * 4 // we call update step run 4x
-	}
-
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, s.pool, s.l, 25000)
-
-	if err != nil {
-		return emptyRes, err
-	}
-
-	defer rollback()
-
-	// list queues
-	queueItems, err := s.queries.ListInternalQueueItems(ctx, tx, dbsqlc.ListInternalQueueItemsParams{
-		Tenantid: pgTenantId,
-		Queue:    dbsqlc.InternalQueueSTEPRUNUPDATE,
-		Limit: pgtype.Int4{
-			Int32: int32(limit), // nolint: gosec
-			Valid: true,
-		},
-	})
-
-	if err != nil {
-		return emptyRes, fmt.Errorf("could not list queues: %w", err)
-	}
-
-	data, err := toQueueItemData[updateStepRunQueueDataV0](queueItems)
-
-	if err != nil {
-		return emptyRes, fmt.Errorf("could not convert internal queue item data to worker semaphore queue data: %w", err)
-	}
-
-	succeededStepRuns, completedWorkflowRuns, err := s.processStepRunUpdates(ctx, &ql, tenantId, tx, data)
-
-	if err != nil {
-		return emptyRes, fmt.Errorf("could not process step run updates v0: %w", err)
-	}
-
-	qiIds := make([]int64, 0, len(data))
-
-	for _, item := range queueItems {
-		qiIds = append(qiIds, item.ID)
-	}
-
-	// update the processed semaphore queue items
-	err = s.queries.MarkInternalQueueItemsProcessed(ctx, tx, qiIds)
-
-	if err != nil {
-		return emptyRes, fmt.Errorf("could not mark worker semaphore queue items processed: %w", err)
-	}
-
-	err = commit(ctx)
-
-	if err != nil {
-		return emptyRes, fmt.Errorf("could not commit transaction: %w", err)
-	}
-
-	for _, cb := range s.callbacks {
-		for _, wr := range completedWorkflowRuns {
-			wrCp := wr
-			cb.Do(s.l, tenantId, wrCp)
-		}
-	}
-
-	return repository.ProcessStepRunUpdatesResult{
-		SucceededStepRuns:     succeededStepRuns,
-		CompletedWorkflowRuns: completedWorkflowRuns,
-		Continue:              len(queueItems) == limit,
-	}, nil
 }
 
 func (s *stepRunEngineRepository) ProcessStepRunUpdatesV2(ctx context.Context, qlp *zerolog.Logger, tenantId string) (repository.ProcessStepRunUpdatesResultV2, error) {
@@ -1890,221 +776,6 @@ func stableSortBatch(batch []updateStepRunQueueData) []updateStepRunQueueData {
 	})
 
 	return batch
-}
-
-func (s *stepRunEngineRepository) processStepRunUpdates(
-	ctx context.Context,
-	qlp *zerolog.Logger,
-	tenantId string,
-	tx dbsqlc.DBTX,
-	data []updateStepRunQueueDataV0,
-) (succeededStepRuns []*dbsqlc.GetStepRunForEngineRow, completedWorkflowRuns []*dbsqlc.ResolveWorkflowRunStatusRow, err error) {
-	// startedAt := time.Now().UTC()
-	pgTenantId := sqlchelpers.UUIDFromStr(tenantId)
-
-	startParams := dbsqlc.BulkStartStepRunParams{}
-	failParams := dbsqlc.BulkFailStepRunParams{}
-	cancelParams := dbsqlc.BulkCancelStepRunParams{}
-	finishParams := dbsqlc.BulkFinishStepRunParams{}
-
-	stepRunIds := make([]pgtype.UUID, 0, len(data))
-	eventTimeSeen := make([]time.Time, 0, len(data))
-	eventReasons := make([]dbsqlc.StepRunEventReason, 0, len(data))
-	eventStepRunIds := make([]pgtype.UUID, 0, len(data))
-	eventSeverities := make([]dbsqlc.StepRunEventSeverity, 0, len(data))
-	eventMessages := make([]string, 0, len(data))
-	eventData := make([]map[string]interface{}, 0, len(data))
-	dedupe := make(map[string]bool)
-
-	for _, item := range data {
-		stepRunId := sqlchelpers.UUIDFromStr(item.StepRunId)
-
-		if item.Event != nil {
-			if item.Event.EventMessage == nil || item.Event.EventReason == nil {
-				continue
-			}
-
-			dedupeKey := fmt.Sprintf("EVENT-%s-%s", item.StepRunId, *item.Event.EventReason)
-
-			if _, ok := dedupe[dedupeKey]; ok {
-				continue
-			}
-
-			dedupe[dedupeKey] = true
-
-			eventStepRunIds = append(eventStepRunIds, stepRunId)
-			eventMessages = append(eventMessages, *item.Event.EventMessage)
-			eventReasons = append(eventReasons, *item.Event.EventReason)
-
-			if item.Event.EventSeverity != nil {
-				eventSeverities = append(eventSeverities, *item.Event.EventSeverity)
-			} else {
-				eventSeverities = append(eventSeverities, dbsqlc.StepRunEventSeverityINFO)
-			}
-
-			if item.Event.EventData != nil {
-				eventData = append(eventData, item.Event.EventData)
-			} else {
-				eventData = append(eventData, map[string]interface{}{})
-			}
-
-			if item.Event.Timestamp != nil {
-				eventTimeSeen = append(eventTimeSeen, *item.Event.Timestamp)
-			} else {
-				eventTimeSeen = append(eventTimeSeen, time.Now().UTC())
-			}
-
-			continue
-		}
-
-		if item.Status == nil {
-			continue
-		}
-
-		stepRunIds = append(stepRunIds, stepRunId)
-
-		switch dbsqlc.StepRunStatus(*item.Status) {
-		case dbsqlc.StepRunStatusRUNNING:
-			startParams.Steprunids = append(startParams.Steprunids, stepRunId)
-			startParams.Startedats = append(startParams.Startedats, sqlchelpers.TimestampFromTime(*item.StartedAt))
-			eventStepRunIds = append(eventStepRunIds, stepRunId)
-			eventTimeSeen = append(eventTimeSeen, *item.StartedAt)
-			eventReasons = append(eventReasons, dbsqlc.StepRunEventReasonSTARTED)
-			eventSeverities = append(eventSeverities, dbsqlc.StepRunEventSeverityINFO)
-			eventMessages = append(eventMessages, fmt.Sprintf("Step run started at %s", item.StartedAt.Format(time.RFC1123)))
-			eventData = append(eventData, map[string]interface{}{})
-		case dbsqlc.StepRunStatusFAILED:
-			failParams.Steprunids = append(failParams.Steprunids, stepRunId)
-			failParams.Finishedats = append(failParams.Finishedats, sqlchelpers.TimestampFromTime(*item.FinishedAt))
-			eventTimeSeen = append(eventTimeSeen, *item.FinishedAt)
-			failParams.Errors = append(failParams.Errors, *item.Error)
-
-			eventStepRunIds = append(eventStepRunIds, stepRunId)
-			eventMessage := fmt.Sprintf("Step run failed on %s", item.FinishedAt.Format(time.RFC1123))
-			eventReason := dbsqlc.StepRunEventReasonFAILED
-
-			if item.Error != nil && *item.Error == "TIMED_OUT" {
-				eventReason = dbsqlc.StepRunEventReasonTIMEDOUT
-				eventMessage = "Step exceeded timeout duration"
-			}
-
-			eventReasons = append(eventReasons, eventReason)
-			eventSeverities = append(eventSeverities, dbsqlc.StepRunEventSeverityCRITICAL)
-			eventMessages = append(eventMessages, eventMessage)
-			eventData = append(eventData, map[string]interface{}{
-				"retry_count": item.RetryCount,
-			})
-		case dbsqlc.StepRunStatusCANCELLED:
-			cancelParams.Steprunids = append(cancelParams.Steprunids, stepRunId)
-			cancelParams.Cancelledats = append(cancelParams.Cancelledats, sqlchelpers.TimestampFromTime(*item.CancelledAt))
-			cancelParams.Finishedats = append(cancelParams.Finishedats, sqlchelpers.TimestampFromTime(*item.CancelledAt))
-			eventTimeSeen = append(eventTimeSeen, *item.CancelledAt)
-			cancelParams.Cancelledreasons = append(cancelParams.Cancelledreasons, *item.CancelledReason)
-			eventStepRunIds = append(eventStepRunIds, stepRunId)
-			eventReasons = append(eventReasons, dbsqlc.StepRunEventReasonCANCELLED)
-			eventSeverities = append(eventSeverities, dbsqlc.StepRunEventSeverityWARNING)
-			eventMessages = append(eventMessages, fmt.Sprintf("Step run was cancelled on %s for the following reason: %s", item.CancelledAt.Format(time.RFC1123), *item.CancelledReason))
-			eventData = append(eventData, map[string]interface{}{})
-		case dbsqlc.StepRunStatusSUCCEEDED:
-			finishParams.Steprunids = append(finishParams.Steprunids, stepRunId)
-			finishParams.Finishedats = append(finishParams.Finishedats, sqlchelpers.TimestampFromTime(*item.FinishedAt))
-			eventTimeSeen = append(eventTimeSeen, *item.FinishedAt)
-			finishParams.Outputs = append(finishParams.Outputs, item.Output)
-			eventStepRunIds = append(eventStepRunIds, stepRunId)
-			eventReasons = append(eventReasons, dbsqlc.StepRunEventReasonFINISHED)
-			eventSeverities = append(eventSeverities, dbsqlc.StepRunEventSeverityINFO)
-			eventMessages = append(eventMessages, fmt.Sprintf("Step run finished at %s", item.FinishedAt.Format(time.RFC1123)))
-			eventData = append(eventData, map[string]interface{}{})
-		}
-	}
-
-	if len(startParams.Steprunids) > 0 {
-		err = s.queries.BulkStartStepRun(ctx, tx, startParams)
-
-		if err != nil {
-			return nil, nil, fmt.Errorf("could not start step runs: %w", err)
-		}
-	}
-
-	if len(failParams.Steprunids) > 0 {
-		err = s.queries.BulkFailStepRun(ctx, tx, failParams)
-
-		if err != nil {
-			return nil, nil, fmt.Errorf("could not fail step runs: %w", err)
-		}
-	}
-
-	if len(cancelParams.Steprunids) > 0 {
-		err = s.queries.BulkCancelStepRun(ctx, tx, cancelParams)
-
-		if err != nil {
-			return nil, nil, fmt.Errorf("could not cancel step runs: %w", err)
-		}
-	}
-
-	if len(finishParams.Steprunids) > 0 {
-		err = s.queries.BulkFinishStepRun(ctx, tx, finishParams)
-
-		if err != nil {
-			return nil, nil, fmt.Errorf("could not finish step runs: %w", err)
-		}
-	}
-
-	// durationUpdateStepRuns := time.Since(startedAt)
-
-	// startResolveJobRunStatus := time.Now()
-
-	// update the job runs and workflow runs as well
-	jobRunIds, err := s.queries.ResolveJobRunStatus(ctx, tx,
-		stepRunIds,
-	)
-
-	if err != nil {
-		return nil, nil, fmt.Errorf("could not resolve job run status: %w", err)
-	}
-
-	// durationResolveJobRunStatus := time.Since(startResolveJobRunStatus)
-
-	// startResolveWorkflowRuns := time.Now()
-
-	succeededStepRuns, err = s.queries.GetStepRunForEngine(ctx, tx, dbsqlc.GetStepRunForEngineParams{
-		Ids:      finishParams.Steprunids,
-		TenantId: pgTenantId,
-	})
-
-	if err != nil {
-		return nil, nil, fmt.Errorf("could not get succeeded step runs: %w", err)
-	}
-
-	completedWorkflowRuns, err = s.queries.ResolveWorkflowRunStatus(ctx, tx, dbsqlc.ResolveWorkflowRunStatusParams{
-		Jobrunids: jobRunIds,
-		Tenantid:  pgTenantId,
-	})
-
-	if err != nil {
-		return nil, nil, fmt.Errorf("could not resolve workflow run status: %w", err)
-	}
-
-	// durationResolveWorkflowRuns := time.Since(startResolveWorkflowRuns)
-
-	for i, stepRunId := range eventStepRunIds {
-		_, err = s.bulkEventBuffer.BuffItem(tenantId, &repository.CreateStepRunEventOpts{
-			StepRunId:     sqlchelpers.UUIDToStr(stepRunId),
-			EventMessage:  &eventMessages[i],
-			EventReason:   &eventReasons[i],
-			EventSeverity: &eventSeverities[i],
-			Timestamp:     &eventTimeSeen[i],
-			EventData:     eventData[i],
-		})
-
-		if err != nil {
-			s.l.Err(err).Msg("could not buffer step run event")
-		}
-	}
-
-	// defer printProcessStepRunUpdateInfo(ql, tenantId, startedAt, len(stepRunIds), durationUpdateStepRuns, durationResolveJobRunStatus, durationResolveWorkflowRuns, durationMarkQueueItemsProcessed, durationRunEvents)
-
-	return succeededStepRuns, completedWorkflowRuns, nil
 }
 
 func (s *stepRunEngineRepository) processStepRunUpdatesV2(
@@ -2508,7 +1179,7 @@ func (s *stepRunEngineRepository) StepRunStarted(ctx context.Context, tenantId, 
 		Status:    &running,
 	}
 
-	_, err := s.bulkStatusBuffer.BuffItem(tenantId, data)
+	err := s.bulkStatusBuffer.FireForget(tenantId, data)
 
 	if err != nil {
 		return fmt.Errorf("could not buffer event: %w", err)
@@ -2531,10 +1202,10 @@ func (s *stepRunEngineRepository) StepRunAcked(ctx context.Context, tenantId, wo
 		EventReason:   &ack,
 	}
 
-	_, err := s.bulkEventBuffer.BuffItem(tenantId, data)
+	err := s.bulkEventBuffer.FireForget(tenantId, data)
 
 	if err != nil {
-		return fmt.Errorf("could not buffer event: %w", err)
+		return fmt.Errorf("could not buffer step run acked event: %w", err)
 	}
 
 	return nil
@@ -2590,24 +1261,10 @@ func (s *stepRunEngineRepository) StepRunSucceeded(ctx context.Context, tenantId
 
 	// we write to the buffer after updating the job run lookup data so we don't start a step run (which has multiple
 	// parents) before the job run lookup data is updated
-	done, err := s.bulkStatusBuffer.BuffItem(tenantId, data)
+	_, err = s.bulkStatusBuffer.FireAndWait(ctx, tenantId, data)
 
 	if err != nil {
 		return fmt.Errorf("could not buffer step run succeeded: %w", err)
-	}
-
-	var response *buffer.FlushResponse[pgtype.UUID]
-
-	select {
-	case response = <-done:
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-time.After(20 * time.Second):
-		return fmt.Errorf("timeout waiting for step run succeeded to be flushed to db")
-	}
-
-	if response.Err != nil {
-		return fmt.Errorf("could not flush step run succeeded: %w", response.Err)
 	}
 
 	return nil
@@ -2635,7 +1292,7 @@ func (s *stepRunEngineRepository) StepRunCancelled(ctx context.Context, tenantId
 		Status:          &cancelled,
 	}
 
-	_, err = s.bulkStatusBuffer.BuffItem(tenantId, data)
+	err = s.bulkStatusBuffer.FireForget(tenantId, data)
 
 	if err != nil {
 		return fmt.Errorf("could not buffer step run cancelled: %w", err)
@@ -2655,7 +1312,7 @@ func (s *stepRunEngineRepository) StepRunCancelled(ctx context.Context, tenantId
 			cancelled := string(dbsqlc.StepRunStatusCANCELLED)
 			reason := "PREVIOUS_STEP_CANCELLED"
 
-			_, err := s.bulkStatusBuffer.BuffItem(tenantId, &updateStepRunQueueData{
+			err := s.bulkStatusBuffer.FireForget(tenantId, &updateStepRunQueueData{
 				Hash:            hashToBucket(sqlchelpers.UUIDFromStr(workflowRunId), s.maxHashFactor),
 				StepRunId:       laterStepRunId,
 				TenantId:        tenantId,
@@ -2698,10 +1355,10 @@ func (s *stepRunEngineRepository) StepRunFailed(ctx context.Context, tenantId, w
 		Status:     &failed,
 	}
 
-	_, err = s.bulkStatusBuffer.BuffItem(tenantId, data)
+	err = s.bulkStatusBuffer.FireForget(tenantId, data)
 
 	if err != nil {
-		return fmt.Errorf("could not buffer step run succeeded: %w", err)
+		return fmt.Errorf("could not buffer step run failed: %w", err)
 	}
 
 	laterStepRuns, err := s.queries.GetLaterStepRuns(ctx, s.pool, sqlchelpers.UUIDFromStr(stepRunId))
@@ -2722,7 +1379,7 @@ func (s *stepRunEngineRepository) StepRunFailed(ctx context.Context, tenantId, w
 			reason = "PREVIOUS_STEP_TIMED_OUT"
 		}
 
-		_, err := s.bulkStatusBuffer.BuffItem(tenantId, &updateStepRunQueueData{
+		err := s.bulkStatusBuffer.FireForget(tenantId, &updateStepRunQueueData{
 			Hash:            hashToBucket(sqlchelpers.UUIDFromStr(workflowRunId), s.maxHashFactor),
 			StepRunId:       laterStepRunId,
 			TenantId:        tenantId,
@@ -3021,7 +1678,7 @@ func (s *stepRunEngineRepository) UpdateStepRunInputSchema(ctx context.Context, 
 	return inputSchema, nil
 }
 
-func (s *stepRunEngineRepository) doCachedUpsertOfQueue(ctx context.Context, tx dbsqlc.DBTX, tenantId string, innerStepRun *dbsqlc.GetStepRunForEngineRow) error {
+func (s *stepRunEngineRepository) doCachedUpsertOfQueue(ctx context.Context, tenantId string, innerStepRun *dbsqlc.GetStepRunForEngineRow) error {
 	cacheKey := fmt.Sprintf("t-%s-q-%s", tenantId, innerStepRun.SRQueue)
 
 	_, err := cache.MakeCacheable(s.queueActionTenantCache, cacheKey, func() (*bool, error) {
@@ -3067,23 +1724,7 @@ func (s *stepRunEngineRepository) QueueStepRun(ctx context.Context, tenantId, st
 		return nil, err
 	}
 
-	queueParams := dbsqlc.QueueStepRunParams{
-		ID:       sqlchelpers.UUIDFromStr(stepRunId),
-		Tenantid: sqlchelpers.UUIDFromStr(tenantId),
-	}
-
 	priority := 1
-
-	if opts.Input != nil {
-		queueParams.Input = opts.Input
-	}
-
-	if opts.IsRetry {
-		queueParams.IsRetry = pgtype.Bool{
-			Bool:  true,
-			Valid: true,
-		}
-	}
 
 	if len(opts.ExpressionEvals) > 0 {
 		err := s.createExpressionEvals(ctx, s.pool, stepRunId, opts.ExpressionEvals)
@@ -3099,7 +1740,7 @@ func (s *stepRunEngineRepository) QueueStepRun(ctx context.Context, tenantId, st
 		return nil, err
 	}
 
-	err = s.doCachedUpsertOfQueue(ctx, s.pool, tenantId, innerStepRun)
+	err = s.doCachedUpsertOfQueue(ctx, tenantId, innerStepRun)
 
 	if err != nil {
 		return nil, fmt.Errorf("could not upsert queue with actionId: %w", err)
@@ -3133,7 +1774,7 @@ func (s *stepRunEngineRepository) QueueStepRun(ctx context.Context, tenantId, st
 		priority = 4
 	}
 
-	done, err := s.bulkQueuer.BuffItem(tenantId, buffer.BulkQueueStepRunOpts{
+	_, err = s.bulkQueuer.FireAndWait(ctx, tenantId, bulkQueueStepRunOpts{
 		GetStepRunForEngineRow: innerStepRun,
 		Priority:               priority,
 		IsRetry:                opts.IsRetry,
@@ -3144,26 +1785,10 @@ func (s *stepRunEngineRepository) QueueStepRun(ctx context.Context, tenantId, st
 		return nil, err
 	}
 
-	_, err = s.bulkSemaphoreReleaser.BuffItem(tenantId, buffer.SemaphoreReleaseOpts{
-		StepRunId: sqlchelpers.UUIDFromStr(stepRunId),
-		TenantId:  sqlchelpers.UUIDFromStr(tenantId),
-	})
+	err = s.releaseWorkerSemaphoreSlot(ctx, tenantId, stepRunId)
 
 	if err != nil {
-		return nil, fmt.Errorf("could not buffer semaphore release: %w", err)
-	}
-
-	var response *buffer.FlushResponse[pgtype.UUID]
-
-	select {
-	case response = <-done:
-		if response.Err != nil {
-			return nil, response.Err
-		}
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-time.After(15 * time.Second):
-		return nil, fmt.Errorf("timeout waiting for queue item to be flushed to db")
+		return nil, err
 	}
 
 	return innerStepRun, nil
@@ -3450,68 +2075,14 @@ func (s *stepRunEngineRepository) ClearStepRunPayloadData(ctx context.Context, t
 	return hasMore, nil
 }
 
-func getCacheName(tenantId, queue string) string {
-	return fmt.Sprintf("%s:%s", tenantId, queue)
-}
-
-func (s *stepRunEngineRepository) removeFinalizedStepRuns(ctx context.Context, tx pgx.Tx, qis []*scheduling.QueueItemWithOrder) ([]*scheduling.QueueItemWithOrder, []*scheduling.QueueItemWithOrder, error) {
-	currStepRunIds := make([]pgtype.UUID, len(qis))
-
-	for i, qi := range qis {
-		currStepRunIds[i] = qi.StepRunId
-	}
-
-	finalizedStepRuns, err := s.queries.GetFinalizedStepRuns(ctx, tx, currStepRunIds)
-
-	if err != nil {
-		return nil, nil, err
-	}
-
-	finalizedStepRunsMap := make(map[string]bool, len(finalizedStepRuns))
-
-	for _, sr := range finalizedStepRuns {
-		s.l.Warn().Msgf("step run %s is in state %s, skipping queueing", sqlchelpers.UUIDToStr(sr.ID), string(sr.Status))
-		finalizedStepRunsMap[sqlchelpers.UUIDToStr(sr.ID)] = true
-	}
-
-	// remove cancelled step runs from the queue items
-	remaining := make([]*scheduling.QueueItemWithOrder, 0, len(qis))
-	cancelled := make([]*scheduling.QueueItemWithOrder, 0, len(qis))
-
-	for _, qi := range qis {
-		if _, ok := finalizedStepRunsMap[sqlchelpers.UUIDToStr(qi.StepRunId)]; ok {
-			cancelled = append(cancelled, qi)
-			continue
-		}
-
-		remaining = append(remaining, qi)
-	}
-
-	return remaining, cancelled, nil
-}
-
 func (s *stepRunEngineRepository) releaseWorkerSemaphoreSlot(ctx context.Context, tenantId, stepRunId string) error {
-	done, err := s.bulkSemaphoreReleaser.BuffItem(tenantId, buffer.SemaphoreReleaseOpts{
+	_, err := s.bulkSemaphoreReleaser.FireAndWait(ctx, tenantId, semaphoreReleaseOpts{
 		StepRunId: sqlchelpers.UUIDFromStr(stepRunId),
 		TenantId:  sqlchelpers.UUIDFromStr(tenantId),
 	})
 
 	if err != nil {
 		return fmt.Errorf("could not buffer semaphore release: %w", err)
-	}
-
-	var response *buffer.FlushResponse[pgtype.UUID]
-
-	select {
-	case response = <-done:
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-time.After(15 * time.Second):
-		return fmt.Errorf("timeout waiting for semaphore slot to be flushed to db")
-	}
-
-	if response.Err != nil {
-		return fmt.Errorf("could not release worker semaphore slot: %w", response.Err)
 	}
 
 	return nil
@@ -3552,42 +2123,6 @@ type updateStepRunQueueData struct {
 	Status          *string    `json:"status,omitempty"`
 }
 
-type updateStepRunQueueDataV0 struct {
-	StepRunId  string `json:"step_run_id"`
-	TenantId   string `json:"tenant_id"`
-	RetryCount int    `json:"retry_count,omitempty"`
-
-	Event *repository.CreateStepRunEventOpts `json:"event,omitempty"`
-
-	StartedAt       *time.Time `json:"started_at,omitempty"`
-	FinishedAt      *time.Time `json:"finished_at,omitempty"`
-	CancelledAt     *time.Time `json:"cancelled_at,omitempty"`
-	Output          []byte     `json:"output"`
-	CancelledReason *string    `json:"cancelled_reason,omitempty"`
-	Error           *string    `json:"error,omitempty"`
-	Status          *string    `json:"status,omitempty"`
-}
-
-// func insertStepRunQueueItem(
-// 	ctx context.Context,
-// 	dbtx dbsqlc.DBTX,
-// 	queries *dbsqlc.Queries,
-// 	tenantId string,
-// 	data updateStepRunQueueData,
-// ) error {
-// 	insertData := make([]any, 1)
-// 	insertData[0] = data
-
-// 	return bulkInsertInternalQueueItem(
-// 		ctx,
-// 		dbtx,
-// 		queries,
-// 		tenantId,
-// 		dbsqlc.InternalQueueSTEPRUNUPDATEV2,
-// 		insertData,
-// 	)
-// }
-
 func bulkInsertInternalQueueItem(
 	ctx context.Context,
 	dbtx dbsqlc.DBTX,
@@ -3626,96 +2161,6 @@ func bulkInsertInternalQueueItem(
 	}
 
 	return nil
-}
-
-// removes duplicates from a slice of queue items by step run id
-func removeDuplicates(qis []*scheduling.QueueItemWithOrder) ([]*scheduling.QueueItemWithOrder, []*scheduling.QueueItemWithOrder) {
-	encountered := map[string]bool{}
-	result := []*scheduling.QueueItemWithOrder{}
-	duplicates := []*scheduling.QueueItemWithOrder{}
-
-	for _, v := range qis {
-		stepRunId := sqlchelpers.UUIDToStr(v.StepRunId)
-		if encountered[stepRunId] {
-			duplicates = append(duplicates, v)
-			continue
-		}
-
-		encountered[stepRunId] = true
-		result = append(result, v)
-	}
-
-	return result, duplicates
-}
-
-func printQueueDebugInfo(
-	l zerolog.Logger,
-	tenantId string,
-	queues []*dbsqlc.Queue,
-	queueItems []*scheduling.QueueItemWithOrder,
-	duplicates []*scheduling.QueueItemWithOrder,
-	cancelled []*scheduling.QueueItemWithOrder,
-	plan scheduling.SchedulePlan,
-	slots []*scheduling.Slot,
-	startedAt time.Time,
-	durationPrepareTx,
-	durationListQueues,
-	durationListQueueItems,
-	durationListRateLimits,
-	durationGetWorkerCounts,
-	durationGetLabels,
-	durationScheduling,
-	durationUpdateRateLimits,
-	durationAssignQueueItems,
-	durationPopQueueItems time.Duration,
-) {
-	duration := time.Since(startedAt)
-
-	e := l.Debug()
-	msg := "queue debug information"
-
-	if duration > 100*time.Millisecond {
-		e = l.Warn()
-		msg = fmt.Sprintf("queue duration was greater than 100ms (%s) for %d assignments", duration, len(plan.StepRunIds))
-	}
-
-	e.Str(
-		"tenant_id", tenantId,
-	).Int(
-		"num_queues", len(queues),
-	).Int(
-		"total_step_runs", len(queueItems),
-	).Int(
-		"total_step_runs_assigned", len(plan.StepRunIds),
-	).Int(
-		"total_slots", len(slots),
-	).Int(
-		"num_duplicates", len(duplicates),
-	).Int(
-		"num_cancelled", len(cancelled),
-	).Dur(
-		"total_duration", duration,
-	).Dur(
-		"duration_prepare_tx", durationPrepareTx,
-	).Dur(
-		"duration_list_queues", durationListQueues,
-	).Dur(
-		"duration_list_queue_items", durationListQueueItems,
-	).Dur(
-		"duration_list_rate_limits", durationListRateLimits,
-	).Dur(
-		"duration_get_worker_counts", durationGetWorkerCounts,
-	).Dur(
-		"duration_get_labels", durationGetLabels,
-	).Dur(
-		"duration_scheduling", durationScheduling,
-	).Dur(
-		"duration_update_rate_limits", durationUpdateRateLimits,
-	).Dur(
-		"duration_assign_queue_items", durationAssignQueueItems,
-	).Dur(
-		"duration_pop_queue_items", durationPopQueueItems,
-	).Msg(msg)
 }
 
 func hashToBucket(id pgtype.UUID, buckets int) int {

--- a/pkg/repository/prisma/workflow_run.go
+++ b/pkg/repository/prisma/workflow_run.go
@@ -21,75 +21,29 @@ import (
 	"github.com/hatchet-dev/hatchet/internal/telemetry"
 	"github.com/hatchet-dev/hatchet/pkg/config/server"
 	"github.com/hatchet-dev/hatchet/pkg/repository"
-	"github.com/hatchet-dev/hatchet/pkg/repository/buffer"
 	"github.com/hatchet-dev/hatchet/pkg/repository/metered"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/db"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/dbsqlc"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/sqlchelpers"
-	"github.com/hatchet-dev/hatchet/pkg/validator"
 )
 
 type workflowRunAPIRepository struct {
-	client  *db.PrismaClient
-	pool    *pgxpool.Pool
-	v       validator.Validator
-	queries *dbsqlc.Queries
-	l       *zerolog.Logger
-	m       *metered.Metered
-	cf      *server.ConfigFileRuntime
+	*sharedRepository
+
+	client *db.PrismaClient
+	m      *metered.Metered
+	cf     *server.ConfigFileRuntime
 
 	createCallbacks []repository.TenantScopedCallback[*dbsqlc.WorkflowRun]
-
-	bulkCreateBuffer *buffer.TenantBufferManager[*repository.CreateWorkflowRunOpts, *dbsqlc.WorkflowRun]
 }
 
-func NewWorkflowRunRepository(client *db.PrismaClient, pool *pgxpool.Pool, v validator.Validator, l *zerolog.Logger, m *metered.Metered, cf *server.ConfigFileRuntime) (repository.WorkflowRunAPIRepository, func() error, error) {
-	queries := dbsqlc.New()
-
-	w := workflowRunAPIRepository{
-		client:  client,
-		v:       v,
-		pool:    pool,
-		queries: queries,
-		l:       l,
-		m:       m,
-		cf:      cf,
+func NewWorkflowRunRepository(client *db.PrismaClient, shared *sharedRepository, m *metered.Metered, cf *server.ConfigFileRuntime) repository.WorkflowRunAPIRepository {
+	return &workflowRunAPIRepository{
+		sharedRepository: shared,
+		client:           client,
+		m:                m,
+		cf:               cf,
 	}
-
-	err := w.startBuffer(cf.WorkflowRunBuffer)
-
-	if err != nil {
-		l.Error().Err(err).Msg("could not start buffer")
-	}
-
-	return &w, w.cleanup, nil
-
-}
-
-func (w *workflowRunAPIRepository) cleanup() error {
-
-	return w.bulkCreateBuffer.Cleanup()
-}
-func (w *workflowRunAPIRepository) startBuffer(conf buffer.ConfigFileBuffer) error {
-
-	createWorkflowRunBufOpts := buffer.TenantBufManagerOpts[*repository.CreateWorkflowRunOpts, *dbsqlc.WorkflowRun]{
-		Name:       "api_create_workflow_run",
-		OutputFunc: w.BulkCreateWorkflowRuns,
-		SizeFunc:   sizeOfData,
-		L:          w.l,
-		V:          w.v,
-	}
-
-	b, err := buffer.NewTenantBufManager(createWorkflowRunBufOpts)
-
-	if err != nil {
-		return err
-	}
-
-	w.bulkCreateBuffer = b
-
-	return nil
-
 }
 
 func (w *workflowRunAPIRepository) RegisterCreateCallback(callback repository.TenantScopedCallback[*dbsqlc.WorkflowRun]) {
@@ -281,20 +235,14 @@ func (w *workflowRunAPIRepository) CreateNewWorkflowRun(ctx context.Context, ten
 			return nil, nil, err
 		}
 		var wfr *dbsqlc.WorkflowRun
+		var err error
 
 		if w.cf.BufferCreateWorkflowRuns {
-			wfrChan, err := w.bulkCreateBuffer.BuffItem(tenantId, opts)
+			wfr, err = w.bulkWorkflowRunBuffer.FireAndWait(ctx, tenantId, opts)
+
 			if err != nil {
 				return nil, nil, err
 			}
-
-			res := <-wfrChan
-
-			if res.Err != nil {
-				return nil, nil, res.Err
-			}
-			wfr = res.Result
-
 		} else {
 			workflowRuns, err := createNewWorkflowRuns(ctx, w.pool, w.queries, w.l, []*repository.CreateWorkflowRunOpts{opts})
 
@@ -633,77 +581,23 @@ func (w *workflowRunAPIRepository) GetStepRunsForJobRuns(ctx context.Context, te
 }
 
 type workflowRunEngineRepository struct {
-	pool              *pgxpool.Pool
-	v                 validator.Validator
-	queries           *dbsqlc.Queries
-	l                 *zerolog.Logger
+	*sharedRepository
+
 	m                 *metered.Metered
 	cf                *server.ConfigFileRuntime
 	stepRunRepository *stepRunEngineRepository
 
 	createCallbacks []repository.TenantScopedCallback[*dbsqlc.WorkflowRun]
 	queuedCallbacks []repository.TenantScopedCallback[pgtype.UUID]
-
-	bulkCreateBuffer *buffer.TenantBufferManager[*repository.CreateWorkflowRunOpts, *dbsqlc.WorkflowRun]
 }
 
-func NewWorkflowRunEngineRepository(stepRunRepository *stepRunEngineRepository, pool *pgxpool.Pool, v validator.Validator, l *zerolog.Logger, m *metered.Metered, cf *server.ConfigFileRuntime, cbs ...repository.TenantScopedCallback[*dbsqlc.WorkflowRun]) (repository.WorkflowRunEngineRepository, func() error, error) {
-	queries := dbsqlc.New()
-
-	w := workflowRunEngineRepository{
-		v:                 v,
-		pool:              pool,
-		queries:           queries,
-		l:                 l,
-		m:                 m,
-		createCallbacks:   cbs,
-		stepRunRepository: stepRunRepository,
-		cf:                cf,
+func NewWorkflowRunEngineRepository(shared *sharedRepository, m *metered.Metered, cf *server.ConfigFileRuntime, cbs ...repository.TenantScopedCallback[*dbsqlc.WorkflowRun]) repository.WorkflowRunEngineRepository {
+	return &workflowRunEngineRepository{
+		sharedRepository: shared,
+		m:                m,
+		createCallbacks:  cbs,
+		cf:               cf,
 	}
-	err := w.startBuffer(cf.WorkflowRunBuffer)
-
-	if err != nil {
-		l.Error().Err(err).Msg("could not start buffer")
-	}
-
-	return &w, w.cleanup, nil
-
-}
-
-func (w *workflowRunEngineRepository) cleanup() error {
-
-	return w.bulkCreateBuffer.Cleanup()
-}
-func (w *workflowRunEngineRepository) startBuffer(conf buffer.ConfigFileBuffer) error {
-
-	createWorkflowRunBufOpts := buffer.TenantBufManagerOpts[*repository.CreateWorkflowRunOpts, *dbsqlc.WorkflowRun]{
-		Name:       "engine_create_workflow_run",
-		OutputFunc: w.BulkCreateWorkflowRuns,
-		SizeFunc:   sizeOfData,
-		L:          w.l,
-		V:          w.v,
-		Config:     conf,
-	}
-
-	b, err := buffer.NewTenantBufManager(createWorkflowRunBufOpts)
-
-	if err != nil {
-		return err
-	}
-
-	w.bulkCreateBuffer = b
-
-	return nil
-
-}
-
-func sizeOfData(data *repository.CreateWorkflowRunOpts) int {
-	size := 0
-
-	size += len(data.InputData)
-	size += len(data.AdditionalMetadata)
-	size += len(*data.DisplayName)
-	return size
 }
 
 func (w *workflowRunEngineRepository) RegisterCreateCallback(callback repository.TenantScopedCallback[*dbsqlc.WorkflowRun]) {
@@ -952,16 +846,6 @@ func (w *workflowRunAPIRepository) BulkCreateWorkflowRuns(ctx context.Context, o
 	return createNewWorkflowRuns(ctx, w.pool, w.queries, w.l, opts)
 }
 
-func (w *workflowRunEngineRepository) BulkCreateWorkflowRuns(ctx context.Context, opts []*repository.CreateWorkflowRunOpts) ([]*dbsqlc.WorkflowRun, error) {
-	if len(opts) == 0 {
-		return nil, fmt.Errorf("no workflow runs to create")
-	}
-
-	w.l.Debug().Msgf("bulk creating %d workflow runs", len(opts))
-
-	return createNewWorkflowRuns(ctx, w.pool, w.queries, w.l, opts)
-}
-
 // this is single tenant
 func (w *workflowRunEngineRepository) CreateNewWorkflowRuns(ctx context.Context, tenantId string, opts []*repository.CreateWorkflowRunOpts) ([]*dbsqlc.WorkflowRun, error) {
 
@@ -1023,20 +907,14 @@ func (w *workflowRunEngineRepository) CreateNewWorkflowRun(ctx context.Context, 
 		}
 
 		var workflowRun *dbsqlc.WorkflowRun
+		var err error
 
 		if w.cf.BufferCreateWorkflowRuns {
-			wfr, err := w.bulkCreateBuffer.BuffItem(tenantId, opts)
+			workflowRun, err = w.bulkWorkflowRunBuffer.FireAndWait(ctx, tenantId, opts)
 
 			if err != nil {
 				return nil, nil, err
 			}
-
-			res := <-wfr
-
-			if res.Err != nil {
-				return nil, nil, res.Err
-			}
-			workflowRun = res.Result
 		} else {
 			wfrs, err := createNewWorkflowRuns(ctx, w.pool, w.queries, w.l, []*repository.CreateWorkflowRunOpts{opts})
 			if err != nil {

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -117,7 +117,7 @@ func WithPostCommitCallback[T any](cb TenantScopedCallback[T]) CallbackOptFunc[T
 }
 
 func RunPreCommit[T any](l *zerolog.Logger, tenantId string, v T, opts []CallbackOptFunc[T]) {
-	// initilize the opts
+	// initialize the opts
 	o := &TenantCallbackOpts[T]{
 		cbs: make([]TenantScopedCallback[T], 0),
 	}
@@ -131,7 +131,7 @@ func RunPreCommit[T any](l *zerolog.Logger, tenantId string, v T, opts []Callbac
 }
 
 func RunPostCommit[T any](l *zerolog.Logger, tenantId string, v T, opts []CallbackOptFunc[T]) {
-	// initilize the opts
+	// initialize the opts
 	o := &TenantCallbackOpts[T]{
 		cbs: make([]TenantScopedCallback[T], 0),
 	}

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -45,6 +45,7 @@ type EngineRepository interface {
 	Log() LogsEngineRepository
 	RateLimit() RateLimitEngineRepository
 	WebhookWorker() WebhookWorkerEngineRepository
+	Scheduler() SchedulerRepository
 }
 
 type EntitlementsRepository interface {
@@ -99,4 +100,56 @@ func (c UnscopedCallback[T]) Do(l *zerolog.Logger, v T) {
 			l.Error().Err(err).Msg("callback failed")
 		}
 	}()
+}
+
+type CallbackOptFunc[T any] func(*TenantCallbackOpts[T])
+
+func WithPreCommitCallback[T any](cb TenantScopedCallback[T]) CallbackOptFunc[T] {
+	return func(opts *TenantCallbackOpts[T]) {
+		opts.cbs = append(opts.cbs, cb)
+	}
+}
+
+func WithPostCommitCallback[T any](cb TenantScopedCallback[T]) CallbackOptFunc[T] {
+	return func(opts *TenantCallbackOpts[T]) {
+		opts.cbs = append(opts.cbs, cb)
+	}
+}
+
+func RunPreCommit[T any](l *zerolog.Logger, tenantId string, v T, opts []CallbackOptFunc[T]) {
+	// initilize the opts
+	o := &TenantCallbackOpts[T]{
+		cbs: make([]TenantScopedCallback[T], 0),
+	}
+
+	// apply the opts
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	o.Run(l, tenantId, v)
+}
+
+func RunPostCommit[T any](l *zerolog.Logger, tenantId string, v T, opts []CallbackOptFunc[T]) {
+	// initilize the opts
+	o := &TenantCallbackOpts[T]{
+		cbs: make([]TenantScopedCallback[T], 0),
+	}
+
+	// apply the opts
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	o.Run(l, tenantId, v)
+}
+
+type TenantCallbackOpts[T any] struct {
+	cbs []TenantScopedCallback[T]
+}
+
+func (o *TenantCallbackOpts[T]) Run(l *zerolog.Logger, tenantId string, v T) {
+	for _, cb := range o.cbs {
+		cb.Do(l, tenantId, v)
+	}
 }

--- a/pkg/repository/scheduler.go
+++ b/pkg/repository/scheduler.go
@@ -1,0 +1,71 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/dbsqlc"
+)
+
+type SchedulerRepository interface {
+	Lease() LeaseRepository
+	QueueFactory() QueueFactoryRepository
+	RateLimit() RateLimitRepository
+	Assignment() AssignmentRepository
+}
+
+type ListActiveWorkersResult struct {
+	ID     pgtype.UUID
+	Labels []*dbsqlc.ListManyWorkerLabelsRow
+}
+
+type LeaseRepository interface {
+	ListQueues(ctx context.Context, tenantId pgtype.UUID) ([]*dbsqlc.Queue, error)
+	ListActiveWorkers(ctx context.Context, tenantId pgtype.UUID) ([]*ListActiveWorkersResult, error)
+
+	AcquireOrExtendLeases(ctx context.Context, tenantId pgtype.UUID, kind dbsqlc.LeaseKind, resourceIds []string, existingLeases []*dbsqlc.Lease) ([]*dbsqlc.Lease, error)
+	ReleaseLeases(ctx context.Context, tenantId pgtype.UUID, leases []*dbsqlc.Lease) error
+}
+
+type RateLimitResult struct {
+	ExceededKey   string
+	ExceededUnits int32
+	ExceededVal   int32
+	StepRunId     pgtype.UUID
+}
+
+type AssignedItem struct {
+	WorkerId pgtype.UUID
+
+	QueueItem *dbsqlc.QueueItem
+}
+
+type AssignResults struct {
+	Assigned           []*AssignedItem
+	Unassigned         []*dbsqlc.QueueItem
+	SchedulingTimedOut []*dbsqlc.QueueItem
+	RateLimited        []*RateLimitResult
+}
+
+type QueueFactoryRepository interface {
+	NewQueue(tenantId pgtype.UUID, queueName string) QueueRepository
+}
+
+type QueueRepository interface {
+	ListQueueItems(ctx context.Context, limit int) ([]*dbsqlc.QueueItem, error)
+	MarkQueueItemsProcessed(ctx context.Context, r *AssignResults) (succeeded []*AssignedItem, failed []*AssignedItem, err error)
+	GetStepRunRateLimits(ctx context.Context, queueItems []*dbsqlc.QueueItem) (map[string]map[string]int32, error)
+	GetDesiredLabels(ctx context.Context, stepIds []pgtype.UUID) (map[string][]*dbsqlc.GetDesiredLabelsRow, error)
+	Cleanup()
+}
+
+type RateLimitRepository interface {
+	ListCandidateRateLimits(ctx context.Context, tenantId pgtype.UUID) ([]string, error)
+	UpdateRateLimits(ctx context.Context, tenantId pgtype.UUID, updates map[string]int) (map[string]int, error)
+}
+
+type AssignmentRepository interface {
+	ListActionsForWorkers(ctx context.Context, tenantId pgtype.UUID, workerIds []pgtype.UUID) ([]*dbsqlc.ListActionsForWorkersRow, error)
+	ListAvailableSlotsForWorkers(ctx context.Context, tenantId pgtype.UUID, params dbsqlc.ListAvailableSlotsForWorkersParams) ([]*dbsqlc.ListAvailableSlotsForWorkersRow, error)
+}

--- a/pkg/repository/step_run.go
+++ b/pkg/repository/step_run.go
@@ -156,18 +156,6 @@ type QueuedStepRun struct {
 	DispatcherId string
 }
 
-type QueueStepRunsResult struct {
-	Queued             []QueuedStepRun
-	SchedulingTimedOut []string
-	Continue           bool
-}
-
-type ProcessStepRunUpdatesResult struct {
-	SucceededStepRuns     []*dbsqlc.GetStepRunForEngineRow
-	CompletedWorkflowRuns []*dbsqlc.ResolveWorkflowRunStatusRow
-	Continue              bool
-}
-
 type ProcessStepRunUpdatesResultV2 struct {
 	SucceededStepRuns     []*dbsqlc.GetStepRunForEngineRow
 	CompletedWorkflowRuns []*dbsqlc.ResolveWorkflowRunStatusRow
@@ -227,11 +215,7 @@ type StepRunEngineRepository interface {
 
 	GetQueueCounts(ctx context.Context, tenantId string) (map[string]int, error)
 
-	ProcessStepRunUpdates(ctx context.Context, qlp *zerolog.Logger, tenantId string) (ProcessStepRunUpdatesResult, error)
-
 	ProcessStepRunUpdatesV2(ctx context.Context, qlp *zerolog.Logger, tenantId string) (ProcessStepRunUpdatesResultV2, error)
-
-	QueueStepRuns(ctx context.Context, ql *zerolog.Logger, tenantId string) (QueueStepRunsResult, error)
 
 	CleanupQueueItems(ctx context.Context, tenantId string) error
 

--- a/pkg/scheduling/v2/queuer.go
+++ b/pkg/scheduling/v2/queuer.go
@@ -84,6 +84,8 @@ func newQueuer(conf *sharedConfig, tenantId pgtype.UUID, queueName string, s *Sc
 
 		q.isCleanedUp = true
 		cancel()
+
+		queueRepo.Cleanup()
 	}
 
 	go q.loopQueue(ctx)

--- a/pkg/scheduling/v2/queuer.go
+++ b/pkg/scheduling/v2/queuer.go
@@ -2,735 +2,21 @@ package v2
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog"
 
 	"github.com/hatchet-dev/hatchet/internal/telemetry"
 	"github.com/hatchet-dev/hatchet/pkg/repository"
-	"github.com/hatchet-dev/hatchet/pkg/repository/buffer"
-	"github.com/hatchet-dev/hatchet/pkg/repository/cache"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/dbsqlc"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/sqlchelpers"
 )
 
-type queuerRepo interface {
-	ListQueueItems(ctx context.Context, limit int) ([]*dbsqlc.QueueItem, error)
-	MarkQueueItemsProcessed(ctx context.Context, r *assignResults) (succeeded []*AssignedQueueItem, failed []*AssignedQueueItem, err error)
-	GetStepRunRateLimits(ctx context.Context, queueItems []*dbsqlc.QueueItem) (map[string]map[string]int32, error)
-	GetDesiredLabels(ctx context.Context, stepIds []pgtype.UUID) (map[string][]*dbsqlc.GetDesiredLabelsRow, error)
-}
-
-type queuerDbQueries struct {
-	tenantId  pgtype.UUID
-	queueName string
-
-	queries *dbsqlc.Queries
-	pool    *pgxpool.Pool
-	l       *zerolog.Logger
-
-	gtId   pgtype.Int8
-	gtIdMu sync.RWMutex
-
-	eventBuffer              *buffer.BulkEventWriter
-	cachedStepIdHasRateLimit *cache.Cache
-}
-
-func newQueueItemDbQueries(cf *sharedConfig, tenantId pgtype.UUID, eventBuffer *buffer.BulkEventWriter, queueName string,
-) (*queuerDbQueries, func()) {
-	c := cache.New(5 * time.Minute)
-	return &queuerDbQueries{
-		tenantId:                 tenantId,
-		queueName:                queueName,
-		queries:                  cf.queries,
-		pool:                     cf.pool,
-		l:                        cf.l,
-		eventBuffer:              eventBuffer,
-		cachedStepIdHasRateLimit: c,
-	}, c.Stop
-}
-
-func (d *queuerDbQueries) setMinId(id int64) {
-	d.gtIdMu.Lock()
-	defer d.gtIdMu.Unlock()
-
-	d.gtId = pgtype.Int8{
-		Int64: id,
-		Valid: true,
-	}
-}
-
-func (d *queuerDbQueries) getMinId() pgtype.Int8 {
-	d.gtIdMu.RLock()
-	defer d.gtIdMu.RUnlock()
-
-	val := d.gtId
-
-	return val
-}
-
-func (d *queuerDbQueries) ListQueueItems(ctx context.Context, limit int) ([]*dbsqlc.QueueItem, error) {
-	ctx, span := telemetry.NewSpan(ctx, "list-queue-items")
-	defer span.End()
-
-	start := time.Now()
-	checkpoint := start
-
-	qis, err := d.queries.ListQueueItemsForQueue(ctx, d.pool, dbsqlc.ListQueueItemsForQueueParams{
-		Tenantid: d.tenantId,
-		Queue:    d.queueName,
-		GtId:     d.getMinId(),
-		Limit: pgtype.Int4{
-			Int32: int32(limit), // nolint: gosec
-			Valid: true,
-		},
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	if len(qis) == 0 {
-		return nil, nil
-	}
-
-	listTime := time.Since(checkpoint)
-	checkpoint = time.Now()
-
-	resQis, err := d.removeInvalidStepRuns(ctx, qis)
-
-	if err != nil {
-		return nil, err
-	}
-
-	removeInvalidTime := time.Since(checkpoint)
-
-	if sinceStart := time.Since(start); sinceStart > 100*time.Millisecond {
-		d.l.Warn().Dur(
-			"list", listTime,
-		).Dur(
-			"remove_invalid", removeInvalidTime,
-		).Msgf(
-			"listing %d queue items for queue %s took longer than 100ms (%s)", len(resQis), d.queueName, sinceStart.String(),
-		)
-	}
-
-	return resQis, nil
-}
-
-// removeInvalidStepRuns removes all duplicate step runs and step runs which are in a finalized state from
-// the queue. It returns the remaining queue items and an error if one occurred.
-func (s *queuerDbQueries) removeInvalidStepRuns(ctx context.Context, qis []*dbsqlc.ListQueueItemsForQueueRow) ([]*dbsqlc.QueueItem, error) {
-	if len(qis) == 0 {
-		return nil, nil
-	}
-
-	// remove duplicates
-	encountered := map[string]bool{}
-	remaining1 := make([]*dbsqlc.QueueItem, 0, len(qis))
-	cancelled := make([]int64, 0, len(qis))
-
-	for _, v := range qis {
-		stepRunId := sqlchelpers.UUIDToStr(v.QueueItem.StepRunId)
-
-		if encountered[stepRunId] {
-			cancelled = append(cancelled, v.QueueItem.ID)
-			continue
-		}
-
-		encountered[stepRunId] = true
-		remaining1 = append(remaining1, &v.QueueItem)
-	}
-
-	finalizedStepRunsMap := make(map[string]bool)
-
-	for _, v := range qis {
-		if v.Status == dbsqlc.StepRunStatusCANCELLED || v.Status == dbsqlc.StepRunStatusSUCCEEDED || v.Status == dbsqlc.StepRunStatusFAILED || v.Status == dbsqlc.StepRunStatusCANCELLING {
-			stepRunId := sqlchelpers.UUIDToStr(v.QueueItem.StepRunId)
-			s.l.Warn().Msgf("step run %s is in state %s, skipping queueing", stepRunId, string(v.Status))
-			finalizedStepRunsMap[stepRunId] = true
-		}
-	}
-
-	// remove cancelled step runs from the queue items
-	remaining2 := make([]*dbsqlc.QueueItem, 0, len(remaining1))
-
-	for _, qi := range remaining1 {
-		if _, ok := finalizedStepRunsMap[sqlchelpers.UUIDToStr(qi.StepRunId)]; ok {
-			cancelled = append(cancelled, qi.ID)
-			continue
-		}
-
-		remaining2 = append(remaining2, qi)
-	}
-
-	if len(cancelled) == 0 {
-		return remaining2, nil
-	}
-
-	// If we've reached this point, we have queue items to cancel. We prepare a transaction in order
-	// to set a statement timeout.
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, s.pool, s.l, 5000)
-
-	if err != nil {
-		return nil, err
-	}
-
-	defer rollback()
-
-	err = s.queries.BulkQueueItems(ctx, tx, cancelled)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if err := commit(ctx); err != nil {
-		return nil, err
-	}
-
-	return remaining2, nil
-}
-
-func (s *queuerDbQueries) bulkStepRunsAssigned(
-	tenantId string,
-	assignedAt time.Time,
-	stepRunIds []pgtype.UUID,
-	workerIds []pgtype.UUID,
-) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	workerIdToStepRunIds := make(map[string][]string)
-
-	for i := range stepRunIds {
-		workerId := sqlchelpers.UUIDToStr(workerIds[i])
-
-		if _, ok := workerIdToStepRunIds[workerId]; !ok {
-			workerIdToStepRunIds[workerId] = make([]string, 0)
-		}
-
-		workerIdToStepRunIds[workerId] = append(workerIdToStepRunIds[workerId], sqlchelpers.UUIDToStr(stepRunIds[i]))
-		message := fmt.Sprintf("Assigned to worker %s", workerId)
-		timeSeen := assignedAt
-		reasons := dbsqlc.StepRunEventReasonASSIGNED
-		severity := dbsqlc.StepRunEventSeverityINFO
-		data := map[string]interface{}{"worker_id": workerId}
-
-		_, err := s.eventBuffer.BuffItem(tenantId, &repository.CreateStepRunEventOpts{
-			StepRunId:     sqlchelpers.UUIDToStr(stepRunIds[i]),
-			EventMessage:  &message,
-			EventReason:   &reasons,
-			EventSeverity: &severity,
-			Timestamp:     &timeSeen,
-			EventData:     data,
-		})
-
-		if err != nil {
-			s.l.Err(err).Msg("could not buffer step run event")
-		}
-	}
-
-	orderedWorkerIds := make([]pgtype.UUID, 0)
-	assignedStepRuns := make([][]byte, 0)
-
-	for workerId, stepRunIds := range workerIdToStepRunIds {
-		orderedWorkerIds = append(orderedWorkerIds, sqlchelpers.UUIDFromStr(workerId))
-		assignedStepRunsBytes, _ := json.Marshal(stepRunIds) // nolint: errcheck
-		assignedStepRuns = append(assignedStepRuns, assignedStepRunsBytes)
-	}
-
-	err := s.queries.CreateWorkerAssignEvents(ctx, s.pool, dbsqlc.CreateWorkerAssignEventsParams{
-		Workerids:        orderedWorkerIds,
-		Assignedstepruns: assignedStepRuns,
-	})
-
-	if err != nil {
-		s.l.Err(err).Msg("could not create worker assign events")
-	}
-}
-
-func (s *queuerDbQueries) bulkStepRunsUnassigned(
-	tenantId string,
-	stepRunIds []pgtype.UUID,
-) {
-	for _, stepRunId := range stepRunIds {
-		message := "No worker available"
-		timeSeen := time.Now().UTC()
-		severity := dbsqlc.StepRunEventSeverityWARNING
-		reason := dbsqlc.StepRunEventReasonREQUEUEDNOWORKER
-		data := map[string]interface{}{}
-
-		_, err := s.eventBuffer.BuffItem(tenantId, &repository.CreateStepRunEventOpts{
-			StepRunId:     sqlchelpers.UUIDToStr(stepRunId),
-			EventMessage:  &message,
-			EventReason:   &reason,
-			EventSeverity: &severity,
-			Timestamp:     &timeSeen,
-			EventData:     data,
-		})
-
-		if err != nil {
-			s.l.Err(err).Msg("could not buffer step run event")
-		}
-	}
-}
-
-func (s *queuerDbQueries) bulkStepRunsRateLimited(
-	tenantId string,
-	rateLimits []*scheduleRateLimitResult,
-) {
-	for _, rlResult := range rateLimits {
-		message := fmt.Sprintf(
-			"Rate limit exceeded for key %s, attempting to consume %d units, but only had %d remaining",
-			rlResult.exceededKey,
-			rlResult.exceededUnits,
-			rlResult.exceededVal,
-		)
-
-		reason := dbsqlc.StepRunEventReasonREQUEUEDRATELIMIT
-		severity := dbsqlc.StepRunEventSeverityWARNING
-		timeSeen := time.Now().UTC()
-		data := map[string]interface{}{
-			"rate_limit_key": rlResult.exceededKey,
-		}
-
-		_, err := s.eventBuffer.BuffItem(tenantId, &repository.CreateStepRunEventOpts{
-			StepRunId:     rlResult.stepRunId,
-			EventMessage:  &message,
-			EventReason:   &reason,
-			EventSeverity: &severity,
-			Timestamp:     &timeSeen,
-			EventData:     data,
-		})
-
-		if err != nil {
-			s.l.Err(err).Msg("could not buffer step run event")
-		}
-	}
-}
-
-func (d *queuerDbQueries) updateMinId() {
-	dbCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	minId, err := d.queries.GetMinUnprocessedQueueItemId(dbCtx, d.pool, dbsqlc.GetMinUnprocessedQueueItemIdParams{
-		Tenantid: d.tenantId,
-		Queue:    d.queueName,
-	})
-
-	if err != nil {
-		d.l.Error().Err(err).Msg("error getting min id")
-		return
-	}
-
-	if minId != 0 {
-		d.setMinId(minId)
-	}
-}
-
-func (d *queuerDbQueries) MarkQueueItemsProcessed(ctx context.Context, r *assignResults) (
-	succeeded []*AssignedQueueItem, failed []*AssignedQueueItem, err error,
-) {
-	ctx, span := telemetry.NewSpan(ctx, "mark-queue-items-processed")
-	defer span.End()
-
-	start := time.Now()
-	checkpoint := start
-
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, d.pool, d.l, 5000)
-
-	if err != nil {
-		return nil, nil, err
-	}
-
-	defer rollback()
-
-	durPrepare := time.Since(checkpoint)
-	checkpoint = time.Now()
-
-	idsToUnqueue := make([]int64, len(r.assigned))
-	stepRunIds := make([]pgtype.UUID, len(r.assigned))
-	workerIds := make([]pgtype.UUID, len(r.assigned))
-	stepTimeouts := make([]string, len(r.assigned))
-
-	for i, assignedItem := range r.assigned {
-		idsToUnqueue[i] = assignedItem.QueueItem.ID
-		stepRunIds[i] = assignedItem.QueueItem.StepRunId
-		workerIds[i] = assignedItem.WorkerId
-		stepTimeouts[i] = assignedItem.QueueItem.StepTimeout.String
-	}
-
-	unassignedStepRunIds := make([]pgtype.UUID, 0, len(r.unassigned))
-
-	for _, id := range r.unassigned {
-		unassignedStepRunIds = append(unassignedStepRunIds, id.StepRunId)
-	}
-
-	timedOutStepRuns := make([]pgtype.UUID, 0, len(r.schedulingTimedOut))
-
-	for _, id := range r.schedulingTimedOut {
-		idsToUnqueue = append(idsToUnqueue, id.ID)
-		timedOutStepRuns = append(timedOutStepRuns, id.StepRunId)
-	}
-
-	_, err = d.queries.BulkMarkStepRunsAsCancelling(ctx, tx, timedOutStepRuns)
-
-	if err != nil {
-		return nil, nil, fmt.Errorf("could not bulk mark step runs as cancelling: %w", err)
-	}
-
-	updatedStepRuns, err := d.queries.UpdateStepRunsToAssigned(ctx, tx, dbsqlc.UpdateStepRunsToAssignedParams{
-		Steprunids:      stepRunIds,
-		Workerids:       workerIds,
-		Stepruntimeouts: stepTimeouts,
-		Tenantid:        d.tenantId,
-	})
-
-	if err != nil {
-		return nil, nil, err
-	}
-
-	timeAfterUpdateStepRuns := time.Since(checkpoint)
-	checkpoint = time.Now()
-
-	err = d.queries.BulkQueueItems(ctx, tx, idsToUnqueue)
-
-	if err != nil {
-		return nil, nil, err
-	}
-
-	timeAfterBulkQueueItems := time.Since(checkpoint)
-
-	if err := commit(ctx); err != nil {
-		return nil, nil, err
-	}
-
-	go func() {
-		// if we committed, we can update the min id
-		d.updateMinId()
-
-		assignedStepRuns := make([]pgtype.UUID, len(updatedStepRuns))
-		assignedWorkerIds := make([]pgtype.UUID, len(updatedStepRuns))
-
-		for i, row := range updatedStepRuns {
-			assignedStepRuns[i] = row.StepRunId
-			assignedWorkerIds[i] = row.WorkerId
-		}
-
-		d.bulkStepRunsAssigned(sqlchelpers.UUIDToStr(d.tenantId), time.Now().UTC(), assignedStepRuns, assignedWorkerIds)
-		d.bulkStepRunsUnassigned(sqlchelpers.UUIDToStr(d.tenantId), unassignedStepRunIds)
-		d.bulkStepRunsRateLimited(sqlchelpers.UUIDToStr(d.tenantId), r.rateLimited)
-	}()
-
-	stepRunIdToAssignedItem := make(map[string]*AssignedQueueItem, len(updatedStepRuns))
-
-	for _, assignedItem := range r.assigned {
-		stepRunIdToAssignedItem[sqlchelpers.UUIDToStr(assignedItem.QueueItem.StepRunId)] = assignedItem
-	}
-
-	succeeded = make([]*AssignedQueueItem, 0, len(r.assigned))
-	failed = make([]*AssignedQueueItem, 0, len(r.assigned))
-
-	for _, row := range updatedStepRuns {
-		succeeded = append(succeeded, stepRunIdToAssignedItem[sqlchelpers.UUIDToStr(row.StepRunId)])
-		delete(stepRunIdToAssignedItem, sqlchelpers.UUIDToStr(row.StepRunId))
-	}
-
-	for _, assignedItem := range stepRunIdToAssignedItem {
-		failed = append(failed, assignedItem)
-	}
-
-	if sinceStart := time.Since(start); sinceStart > 100*time.Millisecond {
-		d.l.Warn().Dur(
-			"duration", sinceStart,
-		).Dur(
-			"prepare", durPrepare,
-		).Dur(
-			"update", timeAfterUpdateStepRuns,
-		).Dur(
-			"bulkqueue", timeAfterBulkQueueItems,
-		).Int(
-			"assigned", len(succeeded),
-		).Int(
-			"failed", len(failed),
-		).Int(
-			"unassigned", len(unassignedStepRunIds),
-		).Int(
-			"timed_out", len(timedOutStepRuns),
-		).Msgf(
-			"marking queue items processed took longer than 100ms",
-		)
-	}
-
-	return succeeded, failed, nil
-}
-
-func (d *queuerDbQueries) GetStepRunRateLimits(ctx context.Context, queueItems []*dbsqlc.QueueItem) (map[string]map[string]int32, error) {
-	ctx, span := telemetry.NewSpan(ctx, "get-step-run-rate-limits")
-	defer span.End()
-
-	stepRunIds := make([]pgtype.UUID, 0, len(queueItems))
-	stepIds := make([]pgtype.UUID, 0, len(queueItems))
-	stepsWithRateLimits := make(map[string]bool)
-
-	for _, item := range queueItems {
-		stepRunIds = append(stepRunIds, item.StepRunId)
-		stepIds = append(stepIds, item.StepId)
-	}
-
-	stepIdToStepRuns := make(map[string][]string)
-	stepRunIdToStepId := make(map[string]string)
-
-	for i, stepRunId := range stepRunIds {
-		stepId := sqlchelpers.UUIDToStr(stepIds[i])
-		stepRunIdStr := sqlchelpers.UUIDToStr(stepRunId)
-
-		if _, ok := stepIdToStepRuns[stepId]; !ok {
-			stepIdToStepRuns[stepId] = make([]string, 0)
-		}
-
-		stepIdToStepRuns[stepId] = append(stepIdToStepRuns[stepId], stepRunIdStr)
-		stepRunIdToStepId[stepRunIdStr] = stepId
-	}
-
-	// check if we have any rate limits for these step ids
-	skipRateLimiting := true
-
-	for stepIdStr := range stepIdToStepRuns {
-		if hasRateLimit, ok := d.cachedStepIdHasRateLimit.Get(stepIdStr); !ok || hasRateLimit.(bool) {
-			skipRateLimiting = false
-			break
-		}
-	}
-
-	if skipRateLimiting {
-		return nil, nil
-	}
-
-	// get all step run expression evals which correspond to rate limits, grouped by step run id
-	expressionEvals, err := d.queries.ListStepRunExpressionEvals(ctx, d.pool, stepRunIds)
-
-	if err != nil {
-		return nil, err
-	}
-
-	stepRunAndGlobalKeyToKey := make(map[string]string)
-	stepRunToKeys := make(map[string][]string)
-
-	for _, eval := range expressionEvals {
-		stepRunId := sqlchelpers.UUIDToStr(eval.StepRunId)
-		globalKey := eval.Key
-
-		// Only append if this is a key expression. Note that we have a uniqueness constraint on
-		// the stepRunId, kind, and key, so we will not insert duplicate values into the array.
-		if eval.Kind == dbsqlc.StepExpressionKindDYNAMICRATELIMITKEY {
-			stepsWithRateLimits[stepRunIdToStepId[stepRunId]] = true
-
-			k := eval.ValueStr.String
-
-			if _, ok := stepRunToKeys[stepRunId]; !ok {
-				stepRunToKeys[stepRunId] = make([]string, 0)
-			}
-
-			stepRunToKeys[stepRunId] = append(stepRunToKeys[stepRunId], k)
-
-			stepRunAndGlobalKey := fmt.Sprintf("%s-%s", stepRunId, globalKey)
-
-			stepRunAndGlobalKeyToKey[stepRunAndGlobalKey] = k
-		}
-	}
-
-	rateLimitKeyToEvals := make(map[string][]*dbsqlc.StepRunExpressionEval)
-
-	for _, eval := range expressionEvals {
-		k := stepRunAndGlobalKeyToKey[fmt.Sprintf("%s-%s", sqlchelpers.UUIDToStr(eval.StepRunId), eval.Key)]
-
-		if _, ok := rateLimitKeyToEvals[k]; !ok {
-			rateLimitKeyToEvals[k] = make([]*dbsqlc.StepRunExpressionEval, 0)
-		}
-
-		rateLimitKeyToEvals[k] = append(rateLimitKeyToEvals[k], eval)
-	}
-
-	upsertRateLimitBulkParams := dbsqlc.UpsertRateLimitsBulkParams{
-		Tenantid: d.tenantId,
-	}
-
-	stepRunToKeyToUnits := make(map[string]map[string]int32)
-
-	for key, evals := range rateLimitKeyToEvals {
-		var duration string
-		var limitValue int
-		var skip bool
-
-		for _, eval := range evals {
-			// add to stepRunToKeyToUnits
-			stepRunId := sqlchelpers.UUIDToStr(eval.StepRunId)
-
-			// throw an error if there are multiple rate limits with the same keys, but different limit values or durations
-			if eval.Kind == dbsqlc.StepExpressionKindDYNAMICRATELIMITWINDOW {
-				if duration == "" {
-					duration = eval.ValueStr.String
-				} else if duration != eval.ValueStr.String {
-					largerDuration, err := getLargerDuration(duration, eval.ValueStr.String)
-
-					if err != nil {
-						skip = true
-						break
-					}
-
-					message := fmt.Sprintf("Multiple rate limits with key %s have different durations: %s vs %s. Using longer window %s.", key, duration, eval.ValueStr.String, largerDuration)
-					timeSeen := time.Now().UTC()
-					reason := dbsqlc.StepRunEventReasonRATELIMITERROR
-					severity := dbsqlc.StepRunEventSeverityWARNING
-					data := map[string]interface{}{}
-
-					_, buffErr := d.eventBuffer.BuffItem(sqlchelpers.UUIDToStr(d.tenantId), &repository.CreateStepRunEventOpts{
-						StepRunId:     sqlchelpers.UUIDToStr(eval.StepRunId),
-						EventMessage:  &message,
-						EventReason:   &reason,
-						EventSeverity: &severity,
-						Timestamp:     &timeSeen,
-						EventData:     data,
-					})
-
-					if buffErr != nil {
-						d.l.Err(buffErr).Msg("could not buffer step run event")
-					}
-
-					duration = largerDuration
-				}
-			}
-
-			if eval.Kind == dbsqlc.StepExpressionKindDYNAMICRATELIMITVALUE {
-				if limitValue == 0 {
-					limitValue = int(eval.ValueInt.Int32)
-				} else if limitValue != int(eval.ValueInt.Int32) {
-					message := fmt.Sprintf("Multiple rate limits with key %s have different limit values: %d vs %d. Using lower value %d.", key, limitValue, eval.ValueInt.Int32, min(limitValue, int(eval.ValueInt.Int32)))
-					timeSeen := time.Now().UTC()
-					reason := dbsqlc.StepRunEventReasonRATELIMITERROR
-					severity := dbsqlc.StepRunEventSeverityWARNING
-					data := map[string]interface{}{}
-
-					_, buffErr := d.eventBuffer.BuffItem(sqlchelpers.UUIDToStr(d.tenantId), &repository.CreateStepRunEventOpts{
-						StepRunId:     sqlchelpers.UUIDToStr(eval.StepRunId),
-						EventMessage:  &message,
-						EventReason:   &reason,
-						EventSeverity: &severity,
-						Timestamp:     &timeSeen,
-						EventData:     data,
-					})
-
-					if buffErr != nil {
-						d.l.Err(buffErr).Msg("could not buffer step run event")
-					}
-
-					limitValue = min(limitValue, int(eval.ValueInt.Int32))
-				}
-			}
-
-			if eval.Kind == dbsqlc.StepExpressionKindDYNAMICRATELIMITUNITS {
-				if _, ok := stepRunToKeyToUnits[stepRunId]; !ok {
-					stepRunToKeyToUnits[stepRunId] = make(map[string]int32)
-				}
-
-				stepRunToKeyToUnits[stepRunId][key] = eval.ValueInt.Int32
-			}
-		}
-
-		if skip {
-			continue
-		}
-
-		upsertRateLimitBulkParams.Keys = append(upsertRateLimitBulkParams.Keys, key)
-		upsertRateLimitBulkParams.Windows = append(upsertRateLimitBulkParams.Windows, getWindowParamFromDurString(duration))
-		upsertRateLimitBulkParams.Limitvalues = append(upsertRateLimitBulkParams.Limitvalues, int32(limitValue)) // nolint: gosec
-	}
-
-	var stepRateLimits []*dbsqlc.StepRateLimit
-
-	if len(upsertRateLimitBulkParams.Keys) > 0 {
-		// upsert all rate limits based on the keys, limit values, and durations
-		err = d.queries.UpsertRateLimitsBulk(ctx, d.pool, upsertRateLimitBulkParams)
-
-		if err != nil {
-			return nil, fmt.Errorf("could not bulk upsert dynamic rate limits: %w", err)
-		}
-	}
-
-	// get all existing static rate limits for steps to the mapping, mapping back from step ids to step run ids
-	uniqueStepIds := make([]pgtype.UUID, 0, len(stepIdToStepRuns))
-
-	for stepId := range stepIdToStepRuns {
-		uniqueStepIds = append(uniqueStepIds, sqlchelpers.UUIDFromStr(stepId))
-	}
-
-	stepRateLimits, err = d.queries.ListRateLimitsForSteps(ctx, d.pool, dbsqlc.ListRateLimitsForStepsParams{
-		Tenantid: d.tenantId,
-		Stepids:  uniqueStepIds,
-	})
-
-	if err != nil {
-		return nil, fmt.Errorf("could not list rate limits for steps: %w", err)
-	}
-
-	for _, row := range stepRateLimits {
-		stepsWithRateLimits[sqlchelpers.UUIDToStr(row.StepId)] = true
-		stepId := sqlchelpers.UUIDToStr(row.StepId)
-		stepRuns := stepIdToStepRuns[stepId]
-
-		for _, stepRunId := range stepRuns {
-			if _, ok := stepRunToKeyToUnits[stepRunId]; !ok {
-				stepRunToKeyToUnits[stepRunId] = make(map[string]int32)
-			}
-
-			stepRunToKeyToUnits[stepRunId][row.RateLimitKey] = row.Units
-		}
-	}
-
-	// store all step ids in the cache, so we can skip rate limiting for steps without rate limits
-	for stepId := range stepIdToStepRuns {
-		hasRateLimit := stepsWithRateLimits[stepId]
-		d.cachedStepIdHasRateLimit.Set(stepId, hasRateLimit)
-	}
-
-	return stepRunToKeyToUnits, nil
-}
-
-func (d *queuerDbQueries) GetDesiredLabels(ctx context.Context, stepIds []pgtype.UUID) (map[string][]*dbsqlc.GetDesiredLabelsRow, error) {
-	ctx, span := telemetry.NewSpan(ctx, "get-desired-labels")
-	defer span.End()
-
-	uniqueStepIds := sqlchelpers.UniqueSet(stepIds)
-
-	labels, err := d.queries.GetDesiredLabels(ctx, d.pool, uniqueStepIds)
-
-	if err != nil {
-		return nil, err
-	}
-
-	stepIdToLabels := make(map[string][]*dbsqlc.GetDesiredLabelsRow)
-
-	for _, label := range labels {
-		stepId := sqlchelpers.UUIDToStr(label.StepId)
-
-		if _, ok := stepIdToLabels[stepId]; !ok {
-			stepIdToLabels[stepId] = make([]*dbsqlc.GetDesiredLabelsRow, 0)
-		}
-
-		stepIdToLabels[stepId] = append(stepIdToLabels[stepId], label)
-	}
-
-	return stepIdToLabels, nil
-}
-
 type Queuer struct {
-	repo      queuerRepo
+	repo      repository.QueueRepository
 	tenantId  pgtype.UUID
 	queueName string
 
@@ -759,19 +45,19 @@ type Queuer struct {
 	unassignedMu mutex
 }
 
-func newQueuer(conf *sharedConfig, tenantId pgtype.UUID, queueName string, s *Scheduler, eventBuffer *buffer.BulkEventWriter, resultsCh chan<- *QueueResults) *Queuer {
+func newQueuer(conf *sharedConfig, tenantId pgtype.UUID, queueName string, s *Scheduler, resultsCh chan<- *QueueResults) *Queuer {
 	defaultLimit := 100
 
 	if conf.singleQueueLimit > 0 {
 		defaultLimit = conf.singleQueueLimit
 	}
 
-	repo, cleanupRepo := newQueueItemDbQueries(conf, tenantId, eventBuffer, queueName)
+	queueRepo := conf.repo.QueueFactory().NewQueue(tenantId, queueName)
 
 	notifyQueueCh := make(chan map[string]string, 1)
 
 	q := &Queuer{
-		repo:          repo,
+		repo:          queueRepo,
 		tenantId:      tenantId,
 		queueName:     queueName,
 		l:             conf.l,
@@ -797,7 +83,6 @@ func newQueuer(conf *sharedConfig, tenantId pgtype.UUID, queueName string, s *Sc
 		}
 
 		q.isCleanedUp = true
-		cleanupRepo()
 		cancel()
 	}
 
@@ -1024,7 +309,7 @@ func (q *Queuer) refillQueue(ctx context.Context) ([]*dbsqlc.QueueItem, error) {
 
 type QueueResults struct {
 	TenantId pgtype.UUID
-	Assigned []*AssignedQueueItem
+	Assigned []*repository.AssignedItem
 
 	// A list of step run ids that were not assigned because they reached the scheduling
 	// timeout
@@ -1085,7 +370,34 @@ func (q *Queuer) flushToDatabase(ctx context.Context, r *assignResults) int {
 		return 0
 	}
 
-	succeeded, failed, err := q.repo.MarkQueueItemsProcessed(ctx, r)
+	opts := &repository.AssignResults{
+		Assigned:           make([]*repository.AssignedItem, 0, len(r.assigned)),
+		Unassigned:         r.unassigned,
+		SchedulingTimedOut: r.schedulingTimedOut,
+		RateLimited:        make([]*repository.RateLimitResult, 0, len(r.rateLimited)),
+	}
+
+	stepRunIdsToAcks := make(map[string]int, len(r.assigned))
+
+	for _, assignedItem := range r.assigned {
+		stepRunIdsToAcks[sqlchelpers.UUIDToStr(assignedItem.QueueItem.StepRunId)] = assignedItem.AckId
+
+		opts.Assigned = append(opts.Assigned, &repository.AssignedItem{
+			WorkerId:  assignedItem.WorkerId,
+			QueueItem: assignedItem.QueueItem,
+		})
+	}
+
+	for _, rateLimitedItem := range r.rateLimited {
+		opts.RateLimited = append(opts.RateLimited, &repository.RateLimitResult{
+			ExceededKey:   rateLimitedItem.exceededKey,
+			ExceededUnits: rateLimitedItem.exceededUnits,
+			ExceededVal:   rateLimitedItem.exceededVal,
+			StepRunId:     rateLimitedItem.qi.StepRunId,
+		})
+	}
+
+	succeeded, failed, err := q.repo.MarkQueueItemsProcessed(ctx, opts)
 
 	if err != nil {
 		q.l.Error().Err(err).Msg("error marking queue items processed")
@@ -1105,11 +417,13 @@ func (q *Queuer) flushToDatabase(ctx context.Context, r *assignResults) int {
 	ackIds := make([]int, 0, len(succeeded))
 
 	for _, failedItem := range failed {
-		nackIds = append(nackIds, failedItem.AckId)
+		nackId := stepRunIdsToAcks[sqlchelpers.UUIDToStr(failedItem.QueueItem.StepRunId)]
+		nackIds = append(nackIds, nackId)
 	}
 
 	for _, assignedItem := range succeeded {
-		ackIds = append(ackIds, assignedItem.AckId)
+		ackId := stepRunIdsToAcks[sqlchelpers.UUIDToStr(assignedItem.QueueItem.StepRunId)]
+		ackIds = append(ackIds, ackId)
 	}
 
 	q.s.nack(nackIds)

--- a/pkg/scheduling/v2/slot_test.go
+++ b/pkg/scheduling/v2/slot_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/dbsqlc"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/sqlchelpers"
 )
@@ -29,8 +30,8 @@ func TestGetRankedSlots(t *testing.T) {
 				DesiredWorkerId: sqlchelpers.UUIDFromStr(stableWorkerId1),
 			},
 			slots: []*slot{
-				newSlot(&worker{ListActiveWorkersResult: &ListActiveWorkersResult{ID: sqlchelpers.UUIDFromStr(stableWorkerId1)}}, []string{}),
-				newSlot(&worker{ListActiveWorkersResult: &ListActiveWorkersResult{ID: sqlchelpers.UUIDFromStr(uuid.New().String())}}, []string{}),
+				newSlot(&worker{ListActiveWorkersResult: &repository.ListActiveWorkersResult{ID: sqlchelpers.UUIDFromStr(stableWorkerId1)}}, []string{}),
+				newSlot(&worker{ListActiveWorkersResult: &repository.ListActiveWorkersResult{ID: sqlchelpers.UUIDFromStr(uuid.New().String())}}, []string{}),
 			},
 			expectedWorker: []string{stableWorkerId1},
 		},
@@ -41,8 +42,8 @@ func TestGetRankedSlots(t *testing.T) {
 				DesiredWorkerId: sqlchelpers.UUIDFromStr(uuid.New().String()),
 			},
 			slots: []*slot{
-				newSlot(&worker{ListActiveWorkersResult: &ListActiveWorkersResult{ID: sqlchelpers.UUIDFromStr(uuid.New().String())}}, []string{}),
-				newSlot(&worker{ListActiveWorkersResult: &ListActiveWorkersResult{ID: sqlchelpers.UUIDFromStr(uuid.New().String())}}, []string{}),
+				newSlot(&worker{ListActiveWorkersResult: &repository.ListActiveWorkersResult{ID: sqlchelpers.UUIDFromStr(uuid.New().String())}}, []string{}),
+				newSlot(&worker{ListActiveWorkersResult: &repository.ListActiveWorkersResult{ID: sqlchelpers.UUIDFromStr(uuid.New().String())}}, []string{}),
 			},
 			expectedWorker: []string{},
 		},
@@ -53,9 +54,9 @@ func TestGetRankedSlots(t *testing.T) {
 				DesiredWorkerId: sqlchelpers.UUIDFromStr(stableWorkerId1),
 			},
 			slots: []*slot{
-				newSlot(&worker{ListActiveWorkersResult: &ListActiveWorkersResult{ID: sqlchelpers.UUIDFromStr(stableWorkerId2)}}, []string{}),
-				newSlot(&worker{ListActiveWorkersResult: &ListActiveWorkersResult{ID: sqlchelpers.UUIDFromStr(stableWorkerId1)}}, []string{}),
-				newSlot(&worker{ListActiveWorkersResult: &ListActiveWorkersResult{ID: sqlchelpers.UUIDFromStr(stableWorkerId1)}}, []string{}),
+				newSlot(&worker{ListActiveWorkersResult: &repository.ListActiveWorkersResult{ID: sqlchelpers.UUIDFromStr(stableWorkerId2)}}, []string{}),
+				newSlot(&worker{ListActiveWorkersResult: &repository.ListActiveWorkersResult{ID: sqlchelpers.UUIDFromStr(stableWorkerId1)}}, []string{}),
+				newSlot(&worker{ListActiveWorkersResult: &repository.ListActiveWorkersResult{ID: sqlchelpers.UUIDFromStr(stableWorkerId1)}}, []string{}),
 			},
 			expectedWorker: []string{stableWorkerId1, stableWorkerId1, stableWorkerId2},
 		},
@@ -79,11 +80,11 @@ func TestGetRankedSlots(t *testing.T) {
 				},
 			},
 			slots: []*slot{
-				newSlot(&worker{ListActiveWorkersResult: &ListActiveWorkersResult{ID: sqlchelpers.UUIDFromStr(stableWorkerId1), Labels: []*dbsqlc.ListManyWorkerLabelsRow{{
+				newSlot(&worker{ListActiveWorkersResult: &repository.ListActiveWorkersResult{ID: sqlchelpers.UUIDFromStr(stableWorkerId1), Labels: []*dbsqlc.ListManyWorkerLabelsRow{{
 					Key:      "key1",
 					IntValue: pgtype.Int4{Int32: 2, Valid: true},
 				}}}}, []string{}),
-				newSlot(&worker{ListActiveWorkersResult: &ListActiveWorkersResult{ID: sqlchelpers.UUIDFromStr(stableWorkerId2), Labels: []*dbsqlc.ListManyWorkerLabelsRow{{
+				newSlot(&worker{ListActiveWorkersResult: &repository.ListActiveWorkersResult{ID: sqlchelpers.UUIDFromStr(stableWorkerId2), Labels: []*dbsqlc.ListManyWorkerLabelsRow{{
 					Key:      "key1",
 					IntValue: pgtype.Int4{Int32: 4, Valid: true},
 				}, {

--- a/pkg/scheduling/v2/worker.go
+++ b/pkg/scheduling/v2/worker.go
@@ -1,11 +1,12 @@
 package v2
 
 import (
+	"github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/prisma/dbsqlc"
 )
 
 type worker struct {
-	*ListActiveWorkersResult
+	*repository.ListActiveWorkersResult
 }
 
 // computeWeight computes the weight of a worker based on the desired labels. If the worker does not


### PR DESCRIPTION
# Description

This PR consolidates the repository methods which had become fractured so they're all defined in a single package. It moves the buffers and the scheduler repositories into the same package as other repository methods. It also introduces 3 patterns for recent issues we've seen while developing complex features:

1. Transactions may need to be shared between methods that are defined on separate repositories. For example, to get transactional safety for workflow run versus step run state as part of #1085, we need to run queries against step runs which were previous in the `StepRunRepository`. The solution in that PR (and elsewhere in the repo) was to pass `StepRunRepository` as a field dependency of `WorkflowRunRepository`. 

    There is now a `sharedRepository` which can be used to share underlying methods and transactions. As an example, I've modified the `DeferredStepRunEvent` (previously called from WorkflowRunRepository) to:

    ```go 
      func (s *sharedRepository) deferredStepRunEvent(
	    tenantId string,
	    opts repository.CreateStepRunEventOpts,
    ) {
	    // fire-and-forget for events
	    err := s.bulkEventBuffer.FireForget(tenantId, &opts)
    
	    if err != nil {
		    s.l.Error().Err(err).Msg("could not buffer event")
	    }
    }
    ```
    Each repository should embed `*sharedRepository`. This also makes initializing repositories a bit cleaner, as we don't need to pass the same validator, logger, or pgxpool around everywhere. 

2. Similar to the above, buffers are now defined on the `sharedRepository`, which gives us a single place where we need to track buffers and ensure they're cleaned up. They can also be called across multiple separate repositories. I've made the additional change of changing the buffer signature from `BuffItem`, which previously returned a `chan` with a result or error, and modified the signature to the following:

    ```go
    func FireForget(item T) error 
    
    func FireAndWait(ctx context.Context, item T) (*U, error)
    ```

    The reasoning here is that these are the only 2 patterns that have been used in the repository for buffering items, and dealing with multiple channels and context passed back to the caller is incredibly error-prone (I found a few instances of results not being awaited when they should have been). This also makes it much easier for a buffered write to respect a context timeout (we were previously setting a timer and adding an additional case for timeouts when awaiting results). 

3. Callback patterns -- there are several instances where we've wanted to hook into a pub/sub message or other type of callback inside of repository methods ( this was a challenge with #1075 ), but we've been hesitant to do this because we don't want to pass a pub/sub dependency through to the repository. 

    There's now an easy way to define callbacks on repository methods via the following:
  
    ```go
    // In the core repository package, when defining the repository's interface:
    RepositoryMethod(ctx context.Context, p params, opts ...CallbackOptFunc[string]) error
    
    // In the method implementation
    func (w *repository) RepositoryMethod(ctx context.Context, p params, opts ...CallbackOptFunc[string]) error {
        // start tx
    
        repository.RunPreCommit(w.l, tenantId, workflowRunId, opts)
    
        // commit tx
    
        repository.RunPostCommit(w.l, tenantId, workflowRunId, opts)
    
        return nil
    }
    ```
  
    The callbacks are utilizing the same underlying `Do` method as previously, which is non-blocking and only logs errors. We may have to tweak signatures here if we want a failed pre-commit hook to fail the transaction. 

## Type of change

- [X] Refactor (non-breaking changes to code which doesn't change any behaviour)