### PR TITLE
fix: make retries with exp backoff atomic, and fix issues related to cancelling states

### DIFF
--- a/examples/concurrency/main.go
+++ b/examples/concurrency/main.go
@@ -74,11 +74,15 @@ func run(events chan<- string) (func() error, error) {
 					err = ctx.WorkflowInput(input)
 
 					// we sleep to simulate a long running task
-					time.Sleep(30 * time.Second)
+					time.Sleep(10 * time.Second)
 
 					if err != nil {
 
 						return nil, err
+					}
+
+					if ctx.Err() != nil {
+						return nil, ctx.Err()
 					}
 
 					log.Printf("step-one")
@@ -95,6 +99,10 @@ func run(events chan<- string) (func() error, error) {
 
 					if err != nil {
 						return nil, err
+					}
+
+					if ctx.Err() != nil {
+						return nil, ctx.Err()
 					}
 
 					log.Printf("step-two")

--- a/pkg/repository/prisma/dbsqlc/step_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql
@@ -356,7 +356,7 @@ WHERE
     "JobRun"."deletedAt" IS NULL AND
     "StepRun"."tenantId" = @tenantId::uuid AND
     "StepRun"."jobRunId" = @jobRunId::uuid AND
-    "StepRun"."status" = ANY(ARRAY['PENDING', 'PENDING_ASSIGNMENT', 'ASSIGNED', 'RUNNING']::"StepRunStatus"[]);
+    "StepRun"."status" = ANY(ARRAY['PENDING', 'PENDING_ASSIGNMENT', 'ASSIGNED', 'RUNNING', 'CANCELLING']::"StepRunStatus"[]);
 
 -- name: QueueStepRun :exec
 UPDATE

--- a/pkg/repository/prisma/dbsqlc/step_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql.go
@@ -2047,7 +2047,7 @@ WHERE
     "JobRun"."deletedAt" IS NULL AND
     "StepRun"."tenantId" = $1::uuid AND
     "StepRun"."jobRunId" = $2::uuid AND
-    "StepRun"."status" = ANY(ARRAY['PENDING', 'PENDING_ASSIGNMENT', 'ASSIGNED', 'RUNNING']::"StepRunStatus"[])
+    "StepRun"."status" = ANY(ARRAY['PENDING', 'PENDING_ASSIGNMENT', 'ASSIGNED', 'RUNNING', 'CANCELLING']::"StepRunStatus"[])
 `
 
 type ListStepRunsToCancelParams struct {

--- a/pkg/repository/prisma/step_run.go
+++ b/pkg/repository/prisma/step_run.go
@@ -1407,29 +1407,17 @@ func (s *stepRunEngineRepository) StepRunRetryBackoff(ctx context.Context, tenan
 	})
 }
 
-func (s *stepRunEngineRepository) ListRetryableStepRuns(ctx context.Context, tenantId string) (bool, []*dbsqlc.GetStepRunForEngineRow, error) {
-	ctx, span := telemetry.NewSpan(ctx, "list-retryable-step-runs-db")
+func (s *stepRunEngineRepository) RetryStepRuns(ctx context.Context, tenantId string) (bool, error) {
+	ctx, span := telemetry.NewSpan(ctx, "retry-step-runs-db")
 	defer span.End()
 
-	rows, err := s.queries.ListStepRunsToRetry(ctx, s.pool, sqlchelpers.UUIDFromStr(tenantId))
+	count, err := s.queries.RetryStepRuns(ctx, s.pool, sqlchelpers.UUIDFromStr(tenantId))
 
 	if err != nil {
-		return false, nil, fmt.Errorf("could not list retryable step runs: %w", err)
+		return false, fmt.Errorf("could not list retryable step runs: %w", err)
 	}
 
-	ids := make([]pgtype.UUID, 0, len(rows))
-
-	for _, row := range rows {
-		ids = append(ids, row.StepRunId)
-	}
-
-	// get step runs for engine
-	stepRuns, err := s.queries.GetStepRunForEngine(ctx, s.pool, dbsqlc.GetStepRunForEngineParams{
-		Ids:      ids,
-		TenantId: sqlchelpers.UUIDFromStr(tenantId),
-	})
-
-	return len(stepRuns) == 1000, stepRuns, err
+	return count == 1000, err
 }
 
 func (s *stepRunEngineRepository) ReplayStepRun(ctx context.Context, tenantId, stepRunId string, input []byte) (*dbsqlc.GetStepRunForEngineRow, error) {

--- a/pkg/repository/step_run.go
+++ b/pkg/repository/step_run.go
@@ -186,7 +186,7 @@ type StepRunEngineRepository interface {
 
 	StepRunRetryBackoff(ctx context.Context, tenantId, stepRunId string, retryAfter time.Time) error
 
-	ListRetryableStepRuns(ctx context.Context, tenantId string) (bool, []*dbsqlc.GetStepRunForEngineRow, error)
+	RetryStepRuns(ctx context.Context, tenantId string) (bool, error)
 
 	ReplayStepRun(ctx context.Context, tenantId, stepRunId string, input []byte) (*dbsqlc.GetStepRunForEngineRow, error)
 


### PR DESCRIPTION
# Description

Fixes the following issues:
- Makes the retry query atomic by placing retried step runs in the same queue as part of the same transaction. 
- Fixes an issue where step runs in a `CANCELLING` state are never popped successfully from the `RetryQueueItem` table, as we were ignoring cancelling states in that query. This means that when a timeout occurred, it would not trigger the backoff loop.
- When timeouts occur, step runs are placed in a `CANCELLING` state -- if downstream operations fail, and the step run remains in the `CANCELLING` state, users cannot cancel the workflow from the UI, as cancelling steps are ignored. This removes the check for cancelling states, so that cancellations via the UI and API always go through.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)