### PR TITLE
fix: poll for stuck

### DIFF
--- a/internal/msgqueue/postgres/msgqueue.go
+++ b/internal/msgqueue/postgres/msgqueue.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/hashicorp/go-multierror"
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
 
@@ -149,8 +148,13 @@ func (p *PostgresMessageQueue) Subscribe(queue msgqueue.Queue, preAck msgqueue.A
 		}
 	}()
 
+	taskWg := sync.WaitGroup{}
+
 	doTask := func(task msgqueue.Message, ackId *int64) error {
-		err = preAck(&task)
+		taskWg.Add(1)
+		defer taskWg.Done()
+
+		err := preAck(&task)
 
 		if err != nil {
 			p.l.Error().Err(err).Msg("error pre-acking message")
@@ -177,26 +181,34 @@ func (p *PostgresMessageQueue) Subscribe(queue msgqueue.Queue, preAck msgqueue.A
 	}
 
 	do := func(messages []*dbsqlc.ReadMessagesRow) error {
-		var errs error
+		var eg errgroup.Group
+
 		for _, message := range messages {
-			var task msgqueue.Message
+			payload := message.Payload
 
-			err := json.Unmarshal(message.Payload, &task)
+			eg.Go(func() error {
+				var task msgqueue.Message
 
-			if err != nil {
-				p.l.Error().Err(err).Msg("error unmarshalling message")
-				errs = multierror.Append(errs, err)
-			}
+				err := json.Unmarshal(payload, &task)
 
-			err = doTask(task, &message.ID)
+				if err != nil {
+					p.l.Error().Err(err).Msg("error unmarshalling message")
+					return err
+				}
 
-			if err != nil {
-				p.l.Error().Err(err).Msg("error running task")
-				errs = multierror.Append(errs, err)
-			}
+				err = doTask(task, &message.ID)
+
+				if err != nil {
+					p.l.Error().Err(err).Msg("error running task")
+					return err
+				}
+
+				return nil
+
+			})
 		}
 
-		return errs
+		return eg.Wait()
 	}
 
 	op := queueutils.NewOperationPool(p.l, 60*time.Second, "postgresmq", queueutils.OpMethod(func(ctx context.Context, id string) (bool, error) {
@@ -204,18 +216,14 @@ func (p *PostgresMessageQueue) Subscribe(queue msgqueue.Queue, preAck msgqueue.A
 
 		if err != nil {
 			p.l.Error().Err(err).Msg("error reading messages")
+			return false, err
 		}
 
-		var eg errgroup.Group
-
-		eg.Go(func() error {
-			return do(messages)
-		})
-
-		err = eg.Wait()
+		err = do(messages)
 
 		if err != nil {
 			p.l.Error().Err(err).Msg("error processing messages")
+			return false, err
 		}
 
 		return len(messages) == p.qos, nil
@@ -271,6 +279,7 @@ func (p *PostgresMessageQueue) Subscribe(queue msgqueue.Queue, preAck msgqueue.A
 		cancel()
 		ticker.Stop()
 		close(newMsgCh)
+		taskWg.Wait()
 		return nil
 	}, nil
 }

--- a/internal/services/ticker/ticker.go
+++ b/internal/services/ticker/ticker.go
@@ -339,11 +339,6 @@ func (t *TickerImpl) runPollOrphanedStepRuns(ctx context.Context) any {
 			t.l.Debug().Msgf("ticker: orphaned step run %s", sqlchelpers.UUIDToStr(orphanedStepRun.ID))
 		}
 
-		// err := t.repo.WorkflowRun().PollStuckWorkflowRuns(ctx)
-
-		// if err != nil {
-		// 	t.l.Err(err).Msg("could not poll stuck workflow runs")
-		// }
 	}
 }
 

--- a/pkg/repository/prisma/dbsqlc/tickers.sql
+++ b/pkg/repository/prisma/dbsqlc/tickers.sql
@@ -378,4 +378,5 @@ WHERE NOT EXISTS (
     WHERE tqi."stepRunId" = sr."id"
 )
 AND sr."status" = 'RUNNING'
-AND sr."deletedAt" IS NULL;
+AND sr."deletedAt" IS NULL
+AND sr."tenantId" = @tenantId::uuid;

--- a/pkg/repository/prisma/dbsqlc/tickers.sql.go
+++ b/pkg/repository/prisma/dbsqlc/tickers.sql.go
@@ -431,6 +431,7 @@ WHERE NOT EXISTS (
 )
 AND sr."status" = 'RUNNING'
 AND sr."deletedAt" IS NULL
+AND sr."tenantId" = $1::uuid
 `
 
 type PollOrphanedStepRunsRow struct {
@@ -467,8 +468,8 @@ type PollOrphanedStepRunsRow struct {
 	InternalRetryCount int32            `json:"internalRetryCount"`
 }
 
-func (q *Queries) PollOrphanedStepRuns(ctx context.Context, db DBTX) ([]*PollOrphanedStepRunsRow, error) {
-	rows, err := db.Query(ctx, pollOrphanedStepRuns)
+func (q *Queries) PollOrphanedStepRuns(ctx context.Context, db DBTX, tenantid pgtype.UUID) ([]*PollOrphanedStepRunsRow, error) {
+	rows, err := db.Query(ctx, pollOrphanedStepRuns, tenantid)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repository/prisma/step_run.go
+++ b/pkg/repository/prisma/step_run.go
@@ -534,7 +534,7 @@ func (s *stepRunEngineRepository) ListStepRunsToTimeout(ctx context.Context, ten
 
 	// mark the step runs as cancelling
 	defer func() {
-		_, err = s.queries.BulkMarkStepRunsAsCancelling(ctx, s.pool, stepRunIds)
+		_, err := s.queries.BulkMarkStepRunsAsCancelling(ctx, s.pool, stepRunIds)
 
 		if err != nil {
 			s.l.Err(err).Msg("could not bulk mark step runs as cancelling")

--- a/pkg/repository/prisma/ticker.go
+++ b/pkg/repository/prisma/ticker.go
@@ -113,6 +113,6 @@ func (t *tickerRepository) PollUnresolvedFailedStepRuns(ctx context.Context) ([]
 	return t.queries.PollUnresolvedFailedStepRuns(ctx, t.pool)
 }
 
-func (t *tickerRepository) PollOrphanedStepRuns(ctx context.Context) ([]*dbsqlc.PollOrphanedStepRunsRow, error) {
-	return t.queries.PollOrphanedStepRuns(ctx, t.pool)
+func (t *tickerRepository) PollOrphanedStepRuns(ctx context.Context, tenantId string) ([]*dbsqlc.PollOrphanedStepRunsRow, error) {
+	return t.queries.PollOrphanedStepRuns(ctx, t.pool, sqlchelpers.UUIDFromStr(tenantId))
 }

--- a/pkg/repository/prisma/ticker.go
+++ b/pkg/repository/prisma/ticker.go
@@ -112,3 +112,7 @@ func (t *tickerRepository) PollTenantResourceLimitAlerts(ctx context.Context) ([
 func (t *tickerRepository) PollUnresolvedFailedStepRuns(ctx context.Context) ([]*dbsqlc.PollUnresolvedFailedStepRunsRow, error) {
 	return t.queries.PollUnresolvedFailedStepRuns(ctx, t.pool)
 }
+
+func (t *tickerRepository) PollOrphanedStepRuns(ctx context.Context) ([]*dbsqlc.PollOrphanedStepRunsRow, error) {
+	return t.queries.PollOrphanedStepRuns(ctx, t.pool)
+}

--- a/pkg/repository/ticker.go
+++ b/pkg/repository/ticker.go
@@ -51,7 +51,7 @@ type TickerEngineRepository interface {
 
 	PollUnresolvedFailedStepRuns(ctx context.Context) ([]*dbsqlc.PollUnresolvedFailedStepRunsRow, error)
 
-	PollOrphanedStepRuns(ctx context.Context) ([]*dbsqlc.PollOrphanedStepRunsRow, error)
+	PollOrphanedStepRuns(ctx context.Context, tenantId string) ([]*dbsqlc.PollOrphanedStepRunsRow, error)
 	// // AddJobRun assigns a job run to a ticker.
 	// AddJobRun(tickerId string, jobRun *db.JobRunModel) (*db.TickerModel, error)
 

--- a/pkg/repository/ticker.go
+++ b/pkg/repository/ticker.go
@@ -51,6 +51,7 @@ type TickerEngineRepository interface {
 
 	PollUnresolvedFailedStepRuns(ctx context.Context) ([]*dbsqlc.PollUnresolvedFailedStepRunsRow, error)
 
+	PollOrphanedStepRuns(ctx context.Context) ([]*dbsqlc.PollOrphanedStepRunsRow, error)
 	// // AddJobRun assigns a job run to a ticker.
 	// AddJobRun(tickerId string, jobRun *db.JobRunModel) (*db.TickerModel, error)
 


### PR DESCRIPTION
# Description

It is unlikely, but possible that a step completion write successfully removes semaphore queue and timeout queue items but fails to write the step run status update or step run events.

As a temporary workaround to prevent these runs from existing indefinitely, we poll for this state and cancel over the mq.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Adds a poll to detect and cancel stuck step runs
