### PR TITLE
fix: circuit breaker for dispatcher reassignment

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 
 	"github.com/hatchet-dev/hatchet/pkg/client/loader"
@@ -255,8 +256,15 @@ func newFromOpts(opts *ClientOpts) (Client, error) {
 		transportCreds = credentials.NewTLS(opts.tls)
 	}
 
+	keepAliveParams := keepalive.ClientParameters{
+		Time:                10 * time.Second, // grpc.keepalive_time_ms: 10 * 1000
+		Timeout:             60 * time.Second, // grpc.keepalive_timeout_ms: 60 * 1000
+		PermitWithoutStream: true,             // grpc.keepalive_permit_without_calls: 1
+	}
+
 	grpcOpts := []grpc.DialOption{
 		grpc.WithTransportCredentials(transportCreds),
+		grpc.WithKeepaliveParams(keepAliveParams),
 	}
 
 	if !opts.noGrpcRetry {

--- a/pkg/repository/prisma/dbsqlc/step_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql
@@ -757,6 +757,111 @@ SELECT
 FROM
     step_runs_to_fail srs2;
 
+-- name: InternalRetryStepRuns :many
+WITH step_runs AS (
+    SELECT
+        sr."id",
+        sr."tenantId",
+        sr."scheduleTimeoutAt",
+        sr."retryCount",
+        sr."internalRetryCount",
+        s."actionId",
+        s."id" AS "stepId",
+        s."timeout" AS "stepTimeout",
+        s."scheduleTimeout" AS "scheduleTimeout"
+    FROM
+        "StepRun" sr
+    JOIN
+        "Step" s ON sr."stepId" = s."id"
+    WHERE
+        sr."tenantId" = @tenantId::uuid
+        AND sr."id" = ANY(@stepRunIds::uuid[])
+),
+step_runs_to_reassign AS (
+    SELECT
+        *
+    FROM
+        step_runs
+    WHERE
+        "internalRetryCount" < @maxInternalRetryCount::int
+),
+step_runs_to_fail AS (
+    SELECT
+        *
+    FROM
+        step_runs
+    WHERE
+        "internalRetryCount" >= @maxInternalRetryCount::int
+),
+deleted_sqis AS (
+    DELETE FROM
+        "SemaphoreQueueItem" sqi
+    USING
+        step_runs srs
+    WHERE
+        sqi."stepRunId" = srs."id"
+),
+deleted_tqis AS (
+    DELETE FROM
+        "TimeoutQueueItem" tqi
+    -- delete when step run id AND retry count tuples match
+    USING
+        step_runs srs
+    WHERE
+        tqi."stepRunId" = srs."id"
+        AND tqi."retryCount" = srs."retryCount"
+),
+inserted_queue_items AS (
+    INSERT INTO "QueueItem" (
+        "stepRunId",
+        "stepId",
+        "actionId",
+        "scheduleTimeoutAt",
+        "stepTimeout",
+        "priority",
+        "isQueued",
+        "tenantId",
+        "queue"
+    )
+    SELECT
+        srs."id",
+        srs."stepId",
+        srs."actionId",
+        CURRENT_TIMESTAMP + COALESCE(convert_duration_to_interval(srs."scheduleTimeout"), INTERVAL '5 minutes'),
+        srs."stepTimeout",
+        -- Queue with priority 4 so that reassignment gets highest priority
+        4,
+        true,
+        srs."tenantId",
+        srs."actionId"
+    FROM
+        step_runs_to_reassign srs
+),
+updated_step_runs AS (
+    UPDATE "StepRun" sr
+    SET
+        "status" = 'PENDING_ASSIGNMENT',
+        "scheduleTimeoutAt" = CURRENT_TIMESTAMP + COALESCE(convert_duration_to_interval(srs."scheduleTimeout"), INTERVAL '5 minutes'),
+        "updatedAt" = CURRENT_TIMESTAMP,
+        "internalRetryCount" = sr."internalRetryCount" + 1
+    FROM step_runs_to_reassign srs
+    WHERE sr."id" = srs."id"
+    RETURNING sr."id"
+)
+SELECT
+    srs1."id",
+    srs1."retryCount",
+    'REASSIGNED' AS "operation"
+FROM
+    step_runs_to_reassign srs1
+UNION ALL
+SELECT
+    srs2."id",
+    srs2."retryCount",
+    'FAILED' AS "operation"
+FROM
+    step_runs_to_fail srs2;
+
 -- name: ListStepRunsToTimeout :many
 SELECT "id"
 FROM "StepRun"

--- a/pkg/repository/step_run.go
+++ b/pkg/repository/step_run.go
@@ -172,6 +172,8 @@ type StepRunEngineRepository interface {
 	// ListStepRunsToReassign returns a list of step runs which are in a reassignable state.
 	ListStepRunsToReassign(ctx context.Context, tenantId string) (reassignedStepRunIds []string, failedStepRuns []*dbsqlc.GetStepRunForEngineRow, err error)
 
+	InternalRetryStepRuns(ctx context.Context, tenantId string, srIdsIn []string) (reassignedStepRunIds []string, failedStepRuns []*dbsqlc.GetStepRunForEngineRow, err error)
+
 	ListStepRunsToTimeout(ctx context.Context, tenantId string) (bool, []*dbsqlc.GetStepRunForEngineRow, error)
 
 	StepRunAcked(ctx context.Context, tenantId, workflowRunId, stepRunId string, ackedAt time.Time) error


### PR DESCRIPTION
# Description

Adds a circuit breaker based on the internal retry count to the dispatcher. Note that we only have a single `internalRetryCount` field, which is used by both reassignment from the dispatcher and for worker visibility timeouts. It would be ideal to reset the retry count when step runs have been successfully sent, but we'd like to avoid the extra write.  

Also modifies the grpc Go client to have keepalive parameters consistent with our other SDKs, and adds improved logging to the dispatcher for catching failures. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)