### PR TITLE
Update workers.mdx with valid "quickstart" link

### DIFF
--- a/frontend/docs/pages/home/basics/workers.mdx
+++ b/frontend/docs/pages/home/basics/workers.mdx
@@ -85,7 +85,7 @@ In the above examples:
 2. We register the workflow(s) that the worker is capable of executing using the `registerWorkflow` method.
 3. Finally, we start the worker process using the `start` method, allowing it to begin listening for tasks from the Hatchet engine.
 
-Run your worker process from command line with relevant environment variables set. Refer to the [quick start](https://docs.hatchet.run/home/quickstart/first-workflow) for more details on how to set up your worker.
+Run your worker process from command line with relevant environment variables set. Refer to the [quick start](https://docs.hatchet.run/self-hosting) for more details on how to set up your worker.
 
 ## Best Practices for Managing Workers
 


### PR DESCRIPTION
# Description

The existing link (https://docs.hatchet.run/home/quickstart/first-workflow) is a 404.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Documentation change (pure documentation change)

## What's Changed

- Changed the link to https://docs.hatchet.run/self-hosting
