### PR TITLE
fix: webhook workers on rebalance

### DIFF
--- a/frontend/app/src/components/cloud/logging/logs.tsx
+++ b/frontend/app/src/components/cloud/logging/logs.tsx
@@ -150,9 +150,12 @@ const LoggingComponent: React.FC<LogProps> = ({
         </div>
       )}
       {sortedLogs.map((log, i) => {
-        const sanitizedHtml = DOMPurify.sanitize(convert.toHtml(log.line), {
-          USE_PROFILES: { html: true },
-        });
+        const sanitizedHtml = DOMPurify.sanitize(
+          convert.toHtml(log.line || ''),
+          {
+            USE_PROFILES: { html: true },
+          },
+        );
 
         const logHash = log.timestamp + generateHash(log.line);
 
@@ -188,7 +191,10 @@ const LoggingComponent: React.FC<LogProps> = ({
   );
 };
 
-const generateHash = (input: string): string => {
+const generateHash = (input: string | undefined): string => {
+  if (!input) {
+    return Math.random().toString(36).substring(2, 15);
+  }
   const trimmedInput = input.substring(0, 50);
   return cyrb53(trimmedInput) + '';
 };

--- a/internal/services/webhooks/webhooks.go
+++ b/internal/services/webhooks/webhooks.go
@@ -112,7 +112,7 @@ func (c *WebhooksController) check(ctx context.Context, id string) (bool, error)
 	}
 	cleanupWG.Wait()
 
-	return true, nil
+	return false, nil
 }
 
 func (c *WebhooksController) processWebhookWorker(ww *dbsqlc.WebhookWorker) {

--- a/internal/services/webhooks/webhooks.go
+++ b/internal/services/webhooks/webhooks.go
@@ -52,7 +52,7 @@ func (c *WebhooksController) Start() (func() error, error) {
 		for {
 			select {
 			case <-ticker.C:
-				c.checkOps.RunOrContinue("check-webhooks")
+				c.checkOps.RunOrContinue(c.p.GetWorkerPartitionId())
 			case <-ctx.Done():
 				ticker.Stop()
 				return

--- a/internal/services/webhooks/webhooks.go
+++ b/internal/services/webhooks/webhooks.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hatchet-dev/hatchet/internal/queueutils"
 	"github.com/hatchet-dev/hatchet/internal/services/partition"
 	"github.com/hatchet-dev/hatchet/internal/whrequest"
 	"github.com/hatchet-dev/hatchet/pkg/config/server"
@@ -26,15 +27,21 @@ type WebhooksController struct {
 	cleanups            map[string]func() error
 	p                   *partition.Partition
 	mu                  sync.Mutex // Add a mutex for concurrent map access
+	checkOps            *queueutils.OperationPool
 }
 
 func New(sc *server.ServerConfig, p *partition.Partition) *WebhooksController {
-	return &WebhooksController{
+
+	wc := &WebhooksController{
 		sc:                  sc,
 		registeredWorkerIds: map[string]bool{},
 		cleanups:            map[string]func() error{},
 		p:                   p,
 	}
+
+	wc.checkOps = queueutils.NewOperationPool(sc.Logger, time.Second*5, "check webhooks", wc.check)
+
+	return wc
 }
 
 func (c *WebhooksController) Start() (func() error, error) {
@@ -45,9 +52,7 @@ func (c *WebhooksController) Start() (func() error, error) {
 		for {
 			select {
 			case <-ticker.C:
-				if err := c.check(); err != nil {
-					c.sc.Logger.Warn().Err(err).Msgf("error checking webhooks")
-				}
+				c.checkOps.RunOrContinue("check-webhooks")
 			case <-ctx.Done():
 				ticker.Stop()
 				return
@@ -70,14 +75,14 @@ func (c *WebhooksController) Start() (func() error, error) {
 	}, nil
 }
 
-func (c *WebhooksController) check() error {
+func (c *WebhooksController) check(ctx context.Context, id string) (bool, error) {
 	wws, err := c.sc.EngineRepository.WebhookWorker().ListWebhookWorkersByPartitionId(
-		context.Background(),
+		ctx,
 		c.p.GetWorkerPartitionId(),
 	)
 
 	if err != nil {
-		return fmt.Errorf("could not get webhook workers: %w", err)
+		return false, fmt.Errorf("could not get webhook workers: %w", err)
 	}
 
 	currentRegisteredWorkerIds := map[string]bool{}
@@ -107,7 +112,7 @@ func (c *WebhooksController) check() error {
 	}
 	cleanupWG.Wait()
 
-	return nil
+	return true, nil
 }
 
 func (c *WebhooksController) processWebhookWorker(ww *dbsqlc.WebhookWorker) {

--- a/pkg/worker/worker_webhook.go
+++ b/pkg/worker/worker_webhook.go
@@ -100,13 +100,6 @@ func (w *Worker) StartWebhook(ww WebhookWorkerOpts) (func() error, error) {
 	cleanup := func() error {
 		cancel()
 
-		w.l.Debug().Msgf("worker %s is stopping...", w.name)
-
-		err := listener.Unregister()
-		if err != nil {
-			return fmt.Errorf("could not unregister worker: %w", err)
-		}
-
 		w.l.Debug().Msgf("worker %s stopped", w.name)
 
 		return nil


### PR DESCRIPTION
# Description

On controller rebalance it was possible that multiple webhook workers could be run on multiple controllers.  In the worst case, the cleanup on the first controller can remove the dispatcher stream to the new worker.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Remove workers on the controller if it is no longer on the partition
- [x] Remove unregister on cleanup to prevent race condition removal of stream from dispatcher
- [x] UI Edge case for log stream
