### PR TITLE
fix: two bugs in how concurrency works for Round Robin

### DIFF
--- a/examples/limit-concurrency/group-round-robin-advanced/main.go
+++ b/examples/limit-concurrency/group-round-robin-advanced/main.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/joho/godotenv"
+
+	"github.com/hatchet-dev/hatchet/pkg/client"
+	"github.com/hatchet-dev/hatchet/pkg/client/types"
+	"github.com/hatchet-dev/hatchet/pkg/cmdutils"
+	"github.com/hatchet-dev/hatchet/pkg/worker"
+)
+
+type concurrencyLimitEvent struct {
+	ConcurrencyKey string `json:"concurrency_key"`
+	UserId         int    `json:"user_id"`
+}
+
+type stepOneOutput struct {
+	Message                 string `json:"message"`
+	ConcurrencyWhenFinished int    `json:"concurrency_when_finished"`
+}
+
+func main() {
+	err := godotenv.Load()
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := cmdutils.NewInterruptContext()
+	defer cancel()
+
+	if err := run(ctx); err != nil {
+		panic(err)
+	}
+}
+
+func getConcurrencyKey(ctx worker.HatchetContext) (string, error) {
+	return "concurrency", nil
+}
+
+var done = make(chan struct{})
+
+var workflowCount int
+var countMux sync.Mutex
+
+func run(ctx context.Context) error {
+	c, err := client.New()
+
+	if err != nil {
+		return fmt.Errorf("error creating client: %w", err)
+	}
+
+	w, err := worker.NewWorker(
+		worker.WithClient(
+			c,
+		),
+	)
+	if err != nil {
+		return fmt.Errorf("error creating worker: %w", err)
+	}
+
+	// runningCount := 0
+
+	countMux := sync.Mutex{}
+
+	var countMap = make(map[string]int)
+	maxConcurrent := 2
+
+	err = w.RegisterWorkflow(
+
+		&worker.WorkflowJob{
+			Name:        "concurrency-limit-round-robin-existing-workflows",
+			Description: "This limits concurrency to maxConcurrent runs at a time.",
+			On:          worker.Events("test:concurrency-limit-round-robin-existing-workflows"),
+			Concurrency: worker.Expression("input.concurrency_key").MaxRuns(int32(maxConcurrent)).LimitStrategy(types.GroupRoundRobin),
+
+			Steps: []*worker.WorkflowStep{
+				worker.Fn(func(ctx worker.HatchetContext) (result *stepOneOutput, err error) {
+					input := &concurrencyLimitEvent{}
+
+					err = ctx.WorkflowInput(input)
+
+					if err != nil {
+						return nil, fmt.Errorf("error getting input: %w", err)
+					}
+					concurrencyKey := input.ConcurrencyKey
+					countMux.Lock()
+
+					if countMap[concurrencyKey]+1 > maxConcurrent {
+						countMux.Unlock()
+						return nil, fmt.Errorf("concurrency limit exceeded for %d we have %d workers running", input.UserId, countMap[concurrencyKey])
+					}
+					countMap[concurrencyKey]++
+
+					countMux.Unlock()
+
+					fmt.Println("received event", input.UserId)
+
+					time.Sleep(10 * time.Second)
+
+					fmt.Println("processed event", input.UserId)
+
+					countMux.Lock()
+					countMap[concurrencyKey]--
+					countMux.Unlock()
+
+					done <- struct{}{}
+
+					return &stepOneOutput{}, nil
+				},
+				).SetName("step-one"),
+			},
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("error registering workflow: %w", err)
+	}
+
+	go func() {
+		var workflowRuns []*client.WorkflowRun
+
+		for i := 0; i < 1; i++ {
+			workflowCount++
+			event := concurrencyLimitEvent{
+				ConcurrencyKey: "key",
+				UserId:         i,
+			}
+			workflowRuns = append(workflowRuns, &client.WorkflowRun{
+				Name:  "concurrency-limit-round-robin-existing-workflows",
+				Input: event,
+			})
+
+		}
+
+		// create a second one with a different key
+
+		// so the bug we are testing here is that total concurrency for any one group should be 2
+		// but if we have more than one group we end up with 4 running when only 2 + 1 are eligible to run
+
+		for i := 0; i < 3; i++ {
+			workflowCount++
+
+			event := concurrencyLimitEvent{
+				ConcurrencyKey: "secondKey",
+				UserId:         i,
+			}
+			workflowRuns = append(workflowRuns, &client.WorkflowRun{
+				Name:  "concurrency-limit-round-robin-existing-workflows",
+				Input: event,
+			})
+
+		}
+
+		_, err := c.Admin().BulkRunWorkflow(workflowRuns)
+		if err != nil {
+			fmt.Println("error running workflow", err)
+		}
+
+		fmt.Println("ran workflows")
+
+	}()
+
+	time.Sleep(2 * time.Second)
+	cleanup, err := w.Start()
+	if err != nil {
+		return fmt.Errorf("error starting worker: %w", err)
+	}
+	defer cleanup()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(20 * time.Second):
+			return fmt.Errorf("timeout")
+		case <-done:
+			countMux.Lock()
+			workflowCount--
+			countMux.Unlock()
+			if workflowCount == 0 {
+				time.Sleep(1 * time.Second)
+				return nil
+			}
+
+		}
+	}
+}

--- a/examples/limit-concurrency/group-round-robin-advanced/main_e2e_test.go
+++ b/examples/limit-concurrency/group-round-robin-advanced/main_e2e_test.go
@@ -1,0 +1,34 @@
+//go:build e2e
+
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"testing"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/internal/testutils"
+)
+
+func TestAdvancedConcurrency(t *testing.T) {
+	testutils.Prepare(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt)
+	go func() {
+		<-ctx.Done()
+		ch <- os.Interrupt
+	}()
+
+	err := run(ctx)
+
+	if err != nil {
+		t.Fatalf("/run() error = %v", err)
+	}
+
+}

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
@@ -2547,12 +2547,12 @@ WHERE
         runs."finishedAt" <= $15::timestamp
     )
 ORDER BY
-    case when $16 = 'createdAt ASC' THEN runs."createdAt" END ASC ,
-    case when $16 = 'createdAt DESC' THEN runs."createdAt" END DESC,
+    case when $16 = 'createdAt ASC' THEN (runs."createdAt", runs."insertOrder") END ASC ,
+    case when $16 = 'createdAt DESC' THEN (runs."createdAt", runs."insertOrder") END DESC,
     case when $16 = 'finishedAt ASC' THEN runs."finishedAt" END ASC ,
     case when $16 = 'finishedAt DESC' THEN runs."finishedAt" END DESC,
-    case when $16 = 'startedAt ASC' THEN runs."startedAt" END ASC ,
-    case when $16 = 'startedAt DESC' THEN runs."startedAt" END DESC,
+    case when $16 = 'startedAt ASC' THEN (runs."startedAt" ,runs."insertOrder") END ASC ,
+    case when $16 = 'startedAt DESC' THEN (runs."startedAt" ,runs."insertOrder") END DESC,
     case when $16 = 'duration ASC' THEN runs."duration" END ASC NULLS FIRST,
     case when $16 = 'duration DESC' THEN runs."duration" END DESC NULLS LAST,
     runs."id" ASC
@@ -2798,8 +2798,9 @@ WITH workflow_runs AS (
     SELECT
         r2.id,
         r2."status",
-        row_number() OVER (PARTITION BY r2."concurrencyGroupId" ORDER BY r2."createdAt") AS rn,
-        row_number() over (order by r2."createdAt" ASC) as seqnum
+        r2."concurrencyGroupId",
+        row_number() OVER (PARTITION BY r2."concurrencyGroupId" ORDER BY r2."createdAt", r2."insertOrder", r2.id) AS "rn",
+        row_number() OVER (ORDER BY r2."createdAt", r2."insertOrder", r2.id) AS "seqnum"
     FROM
         "WorkflowRun" r2
     LEFT JOIN
@@ -2810,39 +2811,24 @@ WITH workflow_runs AS (
         workflowVersion."deletedAt" IS NULL AND
         (r2."status" = 'QUEUED' OR r2."status" = 'RUNNING') AND
         workflowVersion."id" = $2::uuid
-    ORDER BY
-        rn, seqnum ASC
-), min_rn AS (
+), eligible_runs_per_group AS (
     SELECT
-        MIN(rn) as min_rn
-    FROM
-        workflow_runs
-), total_group_count AS ( -- counts the number of groups
-    SELECT
-        COUNT(*) as count
-    FROM
-        workflow_runs
-    WHERE
-        rn = (SELECT min_rn FROM min_rn)
+        id,
+        "concurrencyGroupId",
+        "rn"
+    FROM workflow_runs
+    WHERE "rn" <= ($3::int) -- Ensure each group has at most maxRuns
 ), eligible_runs AS (
     SELECT
         id
-    FROM
-        "WorkflowRun" wr
-    WHERE
-        wr."id" IN (
-            SELECT
-                id
-            FROM
-                workflow_runs
-            ORDER BY
-                rn, seqnum ASC
-            LIMIT
-                -- We can run up to maxRuns per group, so we multiple max runs by the number of groups, then subtract the
-                -- total number of running workflows.
-                ($3::int) * (SELECT count FROM total_group_count)
-        ) AND
-        wr."status" = 'QUEUED'
+    FROM workflow_runs
+    WHERE id IN (
+        SELECT
+            id
+        FROM eligible_runs_per_group
+        ORDER BY "rn", "seqnum" ASC
+        LIMIT ($3::int) * (SELECT COUNT(DISTINCT "concurrencyGroupId") FROM workflow_runs)
+    )
     FOR UPDATE SKIP LOCKED
 )
 UPDATE "WorkflowRun"

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
@@ -2817,7 +2817,7 @@ WITH workflow_runs AS (
         "concurrencyGroupId",
         "rn"
     FROM workflow_runs
-    WHERE "rn" <= ($3::int) -- Ensure each group has at most maxRuns
+    WHERE "rn" <= ($3::int) -- we limit the number of runs per group to maxRuns
 ), eligible_runs AS (
     SELECT
         id

--- a/pkg/repository/prisma/workflow_run.go
+++ b/pkg/repository/prisma/workflow_run.go
@@ -1103,6 +1103,7 @@ func (w *workflowRunEngineRepository) PopWorkflowRunsRoundRobin(ctx context.Cont
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not commit transaction: %w", err)
 	}
+
 	return poppedWorkflowRuns, startableStepRuns, nil
 }
 func (w *workflowRunEngineRepository) QueueWorkflowRunJobs(ctx context.Context, tenantId, workflowRunId string) ([]*dbsqlc.GetStepRunForEngineRow, error) {


### PR DESCRIPTION
Bug 1: Multiple workflow runs can have the same createdAt, either when they have been created in the same txn (for bulk or buffer) or when they are created close together (we only store timestamp(3) so lose some timestamp info). This leads to inconsistent ordering and so we could return them in the wrong order

Bug 2: When we don't fully fill a group we were allowing other groups to fill the group up to maxRuns X totalNumber of groups. All groups should be limited to maxRuns. 

# Description

- [x] Bug fix (non-breaking change which fixes an issue)


## What's Changed

- [ ] Add a list of tasks or features here...
