### PR TITLE
fix: memory leak in go-sdk

### DIFF
--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -499,6 +499,7 @@ func (w *Worker) startStepRun(ctx context.Context, assignedAction *client.Action
 	runContext, cancel := context.WithCancel(context.Background())
 
 	w.cancelMap.Store(assignedAction.StepRunId, cancel)
+	defer w.cancelMap.Delete(assignedAction.StepRunId)
 
 	hCtx, err := newHatchetContext(runContext, assignedAction, w.client, w.l, w)
 


### PR DESCRIPTION
# Description

Fixes a memory leak out of the `cancelMap` object in the SDK. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)