### PR TITLE
add in worker logging using zerolog and logrus

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.23"
+          cache: true
+          cache-dependency-path: go.sum
+
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -56,6 +59,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.23"
+          cache: true
+          cache-dependency-path: go.sum
+
 
       - name: Go deps
         run: go mod download
@@ -80,6 +86,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.23"
+          cache: true
+          cache-dependency-path: go.sum
+
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -125,6 +134,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.23"
+          cache: true
+          cache-dependency-path: go.sum
+
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -212,6 +224,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.22"
+          cache: true
+          cache-dependency-path: go.sum
+
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -301,6 +316,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.23"
+          cache: true
+          cache-dependency-path: go.sum
+
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -376,6 +394,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.22"
+          cache: true
+          cache-dependency-path: go.sum
+
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/examples/logging/main.go
+++ b/examples/logging/main.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/joho/godotenv"
+	"github.com/rs/zerolog"
+	"github.com/sirupsen/logrus"
+
+	"github.com/hatchet-dev/hatchet/pkg/client"
+	"github.com/hatchet-dev/hatchet/pkg/cmdutils"
+	"github.com/hatchet-dev/hatchet/pkg/worker"
+)
+
+type loggerEvent struct {
+	Username string            `json:"username"`
+	UserID   string            `json:"user_id"`
+	Data     map[string]string `json:"data"`
+}
+
+type stepOneOutput struct {
+	Message string `json:"message"`
+}
+
+func main() {
+	err := godotenv.Load()
+	if err != nil {
+		panic(err)
+	}
+
+	interrupt := cmdutils.InterruptChan()
+
+	cleanup, err := run()
+	if err != nil {
+		panic(err)
+	}
+
+	<-interrupt
+
+	if err := cleanup(); err != nil {
+		panic(fmt.Errorf("error cleaning up: %w", err))
+	}
+}
+
+func run() (func() error, error) {
+	c, err := client.New()
+
+	if err != nil {
+		return nil, fmt.Errorf("error creating client: %w", err)
+	}
+
+	w, err := worker.NewWorker(
+		worker.WithClient(
+			c,
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error creating worker: %w", err)
+	}
+
+	eventName := "logs:create:simple"
+
+	err = w.RegisterWorkflow(
+		&worker.WorkflowJob{
+			On:          worker.Events(eventName),
+			Name:        "logger",
+			Description: "This runs a simple logger",
+			Steps: []*worker.WorkflowStep{
+
+				worker.Fn(step1).SetName("step-one"),
+			},
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error registering workflow: %w", err)
+	}
+
+	go func() {
+		testEvent := loggerEvent{}
+
+		// push an event
+		err := c.Event().Push(
+			context.Background(),
+			eventName,
+			testEvent,
+			client.WithEventMetadata(map[string]string{
+				"hello": "world",
+			}),
+		)
+		if err != nil {
+			panic(fmt.Errorf("error pushing event: %w", err))
+		}
+	}()
+
+	cleanup, err := w.Start()
+	if err != nil {
+		panic(err)
+	}
+
+	return cleanup, nil
+}
+
+func step1(context worker.HatchetContext) error {
+	zerologLogger := zerolog.New(os.Stdout)
+
+	// Create a combined logger that forwards to Hatchet
+	combinedLogger := context.NewCombinedZerologLogger(zerologLogger)
+
+	logrusLogger := logrus.New()
+	combinedLogrus := context.NewCombinedLogrusLogger(logrusLogger)
+
+	for i := 0; i < 333; i++ {
+		context.Log(fmt.Sprintf("Logging message %d", i))
+		// Log messages using the combined logger
+		combinedLogger.Info().Msg("This is a zerolog log message")
+		combinedLogger.Error().Str("key", "value").Msg("This is an error log with structured data")
+
+		combinedLogrus.Info("This is a logrus log message")
+		combinedLogrus.WithField("key", "value").Error("This is an error log with structured data")
+
+	}
+
+	return nil
+}

--- a/frontend/docs/pages/sdks/go-sdk/_meta.json
+++ b/frontend/docs/pages/sdks/go-sdk/_meta.json
@@ -12,5 +12,6 @@
   "creating-a-workflow": "Creating a Workflow",
   "creating-a-worker": "Creating a Worker",
   "pushing-events": "Pushing Events",
-  "scheduling-workflows": "Scheduling Workflows"
+  "scheduling-workflows": "Scheduling Workflows",
+  "logging": "Logging"
 }

--- a/frontend/docs/pages/sdks/go-sdk/logging.mdx
+++ b/frontend/docs/pages/sdks/go-sdk/logging.mdx
@@ -29,6 +29,7 @@ func step1(context worker.HatchetContext) (map[string]string, error) {
     return  nil
 }
 ```
+
 ## Using Zerolog Logger
 
 Hatchet allows you to forward logs from a `zerolog` logger to the Hatchet logging system. This is done using the `NewCombinedZerologLogger` method on the `HatchetContext`.

--- a/frontend/docs/pages/sdks/go-sdk/logging.mdx
+++ b/frontend/docs/pages/sdks/go-sdk/logging.mdx
@@ -1,0 +1,75 @@
+# Logging in Hatchet (Go)
+
+Hatchet provides built-in support for logging within your workflows, enabling you to capture debug messages, monitor workflow activity, and track logs step-by-step. Hatchet integrates seamlessly with popular logging libraries such as `logrus` and `zerolog`. You can also use the `HatchetContext.Log` method for simpler logging needs.
+
+---
+
+## Using Logrus Logger
+
+Hatchet allows you to forward logs from a `logrus` logger to the Hatchet logging system. This is done using the `NewCombinedLogrusLogger` method on the `HatchetContext`.
+
+### Example
+
+```go
+import (
+    "github.com/sirupsen/logrus"
+    "github.com/hatchet-dev/hatchet/pkg/worker"
+)
+
+func step1(context worker.HatchetContext) (map[string]string, error) {
+    logrusLogger := logrus.New()
+
+    // Create a combined logger that forwards to Hatchet
+    combinedLogger := context.NewCombinedLogrusLogger(logrusLogger)
+
+    // Log messages using the combined logger
+    combinedLogger.Info("This is a logrus log message")
+    combinedLogger.WithField("key", "value").Error("This is an error log with structured data")
+
+    return  nil
+}
+```
+## Using Zerolog Logger
+
+Hatchet allows you to forward logs from a `zerolog` logger to the Hatchet logging system. This is done using the `NewCombinedZerologLogger` method on the `HatchetContext`.
+
+### Example
+
+```go
+import (
+    "github.com/rs/zerolog"
+    "os"
+    "github.com/hatchet-dev/hatchet/pkg/worker"
+)
+
+func step1(context worker.HatchetContext) ( error) {
+    zerologLogger := zerolog.New(os.Stdout)
+
+    // Create a combined logger that forwards to Hatchet
+    combinedLogger := context.NewCombinedZerologLogger(zerologLogger)
+
+    // Log messages using the combined logger
+    combinedLogger.Info().Msg("This is a zerolog log message")
+    combinedLogger.Error().Str("key", "value").Msg("This is an error log with structured data")
+
+    return  nil
+}
+```
+
+## Using the `HatchetContext.Log` method
+
+You can also use the `HatchetContext.Log` method to log messages from your workflows. This method is available on the `HatchetContext` object that is passed to each step in your workflow. For example:
+
+```go
+func step1(context worker.HatchetContext) (map[string]string, error) {
+    for i := 0; i < 1000; i++ {
+        context.Log("Logging message %d", i)
+    }
+
+    return map[string]string{
+        "status": "success",
+    }, nil
+}
+```
+
+Logs are limited to 1000 per step.

--- a/go.mod
+++ b/go.mod
@@ -145,6 +145,7 @@ require (
 	github.com/rabbitmq/amqp091-go v1.10.0
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rs/zerolog v1.33.0
+	github.com/sirupsen/logrus v1.9.3
 	github.com/slack-go/slack v0.15.0
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -240,6 +240,8 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/slack-go/slack v0.15.0 h1:LE2lj2y9vqqiOf+qIIy0GvEoxgF1N5yLGZffmEZykt0=
 github.com/slack-go/slack v0.15.0/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
@@ -343,6 +345,7 @@ golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/worker/context.go
+++ b/pkg/worker/context.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/rs/zerolog"
+	"github.com/sirupsen/logrus"
 
 	"github.com/hatchet-dev/hatchet/pkg/client"
 )
@@ -54,6 +55,10 @@ type HatchetContext interface {
 	WorkflowRunId() string
 
 	Log(message string)
+
+	NewCombinedLogrusLogger(logger *logrus.Logger) *logrus.Logger
+
+	NewCombinedZerologLogger(logger zerolog.Logger) zerolog.Logger
 
 	StreamEvent(message []byte)
 

--- a/pkg/worker/logger.go
+++ b/pkg/worker/logger.go
@@ -1,0 +1,64 @@
+package worker
+
+import (
+	"github.com/rs/zerolog"
+	"github.com/sirupsen/logrus"
+)
+
+type LogrusForwardHook struct {
+	levels []logrus.Level
+	hc     HatchetContext
+}
+
+func NewLogrusForwardHook(hc HatchetContext, levels []logrus.Level) *LogrusForwardHook {
+	return &LogrusForwardHook{
+		levels: levels,
+		hc:     hc,
+	}
+}
+
+func (h *LogrusForwardHook) Levels() []logrus.Level {
+	return h.levels
+}
+
+func (h *LogrusForwardHook) Fire(entry *logrus.Entry) error {
+	logMessage, err := entry.String()
+	if err != nil {
+		return err
+	}
+	h.hc.Log(logMessage)
+	return nil
+}
+
+type ZerologForwardHook struct {
+	hc HatchetContext
+}
+
+func (h *ZerologForwardHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
+	h.hc.Log(msg)
+}
+
+func (hc *hatchetContext) NewCombinedLogrusLogger(originalLogger *logrus.Logger) *logrus.Logger {
+	newLogger := logrus.New()
+	newLogger.Out = originalLogger.Out
+	newLogger.Formatter = originalLogger.Formatter
+	newLogger.Hooks = originalLogger.Hooks
+	newLogger.Level = originalLogger.Level
+	newLogger.ExitFunc = originalLogger.ExitFunc
+	newLogger.ReportCaller = originalLogger.ReportCaller
+
+	newLogger.Hooks = make(logrus.LevelHooks)
+	for level, hooks := range originalLogger.Hooks {
+		newLogger.Hooks[level] = append([]logrus.Hook{}, hooks...)
+	}
+
+	hook := NewLogrusForwardHook(hc, logrus.AllLevels)
+	newLogger.AddHook(hook)
+	return newLogger
+}
+
+func (hc *hatchetContext) NewCombinedZerologLogger(originalLogger zerolog.Logger) zerolog.Logger {
+	newLogger := originalLogger
+	hook := &ZerologForwardHook{hc: hc}
+	return newLogger.Hook(hook)
+}

--- a/pkg/worker/middleware_test.go
+++ b/pkg/worker/middleware_test.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/rs/zerolog"
+	"github.com/sirupsen/logrus"
+
 	"github.com/hatchet-dev/hatchet/pkg/client"
 )
 
@@ -100,6 +103,14 @@ func (c *testHatchetContext) client() client.Client {
 }
 
 func (c *testHatchetContext) Worker() HatchetWorkerContext {
+	panic("not implemented")
+}
+
+func (c *testHatchetContext) NewCombinedLogrusLogger(originalLogger *logrus.Logger) *logrus.Logger {
+	panic("not implemented")
+}
+
+func (c *testHatchetContext) NewCombinedZerologLogger(originalLogger zerolog.Logger) zerolog.Logger {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change


- [x] New feature (non-breaking change which adds functionality)

## What's Changed

Added combined logging to the worker. Now users can bring their own logger and by calling 
```
logger := context.NewCombinedLogrusLogger(logrusLogger)
```
or 
```
logger  := context.NewCombinedZerologLogger(zerologLogger)
```

they can log to hatchet and to their local logging.

