### PR TITLE
feat(logging)!: add client & worker option to pass a custom logger

### DIFF
--- a/api/v1/server/handlers/monitoring/probe.go
+++ b/api/v1/server/handlers/monitoring/probe.go
@@ -125,19 +125,15 @@ type stepOneOutput struct {
 
 func (m *MonitoringService) run(ctx context.Context, cf clientconfig.ClientConfigFile, workflowName string, events chan<- string, stepChan chan<- string, errors chan<- error) (func(), error) {
 
-	c, err := client.NewFromConfigFile(
-		&cf, client.WithLogLevel(m.l.GetLevel().String()),
-	)
+	c, err := client.NewFromConfigFile(&cf, client.WithLogger(m.l))
 
 	if err != nil {
 		return nil, fmt.Errorf("error creating client: %w", err)
 	}
 
 	w, err := worker.NewWorker(
-
-		worker.WithClient(
-			c,
-		), worker.WithLogLevel(m.l.GetLevel().String()),
+		worker.WithClient(c),
+		worker.WithLogger(m.l),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating worker: %w", err)

--- a/examples/loadtest/cli/run.go
+++ b/examples/loadtest/cli/run.go
@@ -19,22 +19,12 @@ func getConcurrencyKey(ctx worker.HatchetContext) (string, error) {
 }
 
 func run(ctx context.Context, delay time.Duration, executions chan<- time.Duration, concurrency int) (int64, int64) {
-	c, err := client.New(
-		client.WithLogLevel("warn"),
-	)
-
+	c, err := client.New()
 	if err != nil {
 		panic(err)
 	}
 
-	w, err := worker.NewWorker(
-		worker.WithClient(
-			c,
-		),
-		worker.WithLogLevel("warn"),
-		worker.WithMaxRuns(200),
-	)
-
+	w, err := worker.NewWorker(worker.WithClient(c), worker.WithMaxRuns(200))
 	if err != nil {
 		panic(err)
 	}

--- a/examples/loadtest/rampup/run.go
+++ b/examples/loadtest/rampup/run.go
@@ -19,22 +19,12 @@ func getConcurrencyKey(ctx worker.HatchetContext) (string, error) {
 }
 
 func run(ctx context.Context, delay time.Duration, concurrency int, maxAcceptableDuration time.Duration, hook chan<- time.Duration, executedCh chan<- int64) (int64, int64) {
-	c, err := client.New(
-		client.WithLogLevel("warn"),
-	)
-
+	c, err := client.New()
 	if err != nil {
 		panic(err)
 	}
 
-	w, err := worker.NewWorker(
-		worker.WithClient(
-			c,
-		),
-		worker.WithLogLevel("warn"),
-		worker.WithMaxRuns(200),
-	)
-
+	w, err := worker.NewWorker(worker.WithClient(c), worker.WithMaxRuns(200))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -135,16 +135,9 @@ func defaultClientOpts(token *string, cf *client.ClientConfigFile) *ClientOpts {
 	}
 }
 
-func WithLogLevel(lvl string) ClientOpt {
+func WithLogger(l *zerolog.Logger) ClientOpt {
 	return func(opts *ClientOpts) {
-		logger := logger.NewDefaultLogger("client")
-		lvl, err := zerolog.ParseLevel(lvl)
-
-		if err == nil {
-			logger = logger.Level(lvl)
-		}
-
-		opts.l = &logger
+		opts.l = l
 	}
 }
 

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -133,16 +133,11 @@ func defaultWorkerOpts() *WorkerOpts {
 	}
 }
 
-func WithLogLevel(lvl string) WorkerOpt {
+func WithLogger(l *zerolog.Logger) WorkerOpt {
 	return func(opts *WorkerOpts) {
-		logger := logger.NewDefaultLogger("worker")
-		lvl, err := zerolog.ParseLevel(lvl)
-
-		if err == nil {
-			logger = logger.Level(lvl)
+		if l != nil {
+			opts.l = l
 		}
-
-		opts.l = &logger
 	}
 }
 


### PR DESCRIPTION
# Description

We're actively using and building on Hatchet and enjoy it a lot. Not being able to plug our logger into the system is an issue for us though. This PR aims to provide a solution that seamlessly fits into the existing Hatchet SDK.

Adds `WithLogger()` option to the client and worker. The option replaces the `WithLogLevel()` option as its possible to supply a logger with the desired log-level and pass it to `WithLogger()`.

**Note:** Since the removal of `WithLogLevel` technically is a breaking change, I'd be fine with rolling this part back despite the functional redundancy.

**Note:** PR is incomplete on purpose; wanted to validate the contribution before completing it. 

Relates to  #1170

### Examples

Setting a custom logger:

```go
logger := zerolog.New(os.Stdout)

// Client
hatchet, err := client.New(
    client.WithLogger(&logger),
    // other options ...
)

// Worker
worker, err := worker.NewWorker(
    worker.WithLogger(&logger),
    // other options ...
)
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [x] Add `client.WithLogger` option
- [x] Remove `client.WithLogLevel` option
- [x] Add `worker.WithLogger` option
- [x] Remove `worker.WithLogLevel` option

##  Extra

Thank you for building Hatchet, really enjoy working with it and I'd love to contribute more in the future. Cheers to you guys :)