### PR TITLE
Feat: Fix switching tenants not working

### DIFF
--- a/frontend/app/src/components/molecules/analytics-provider.tsx
+++ b/frontend/app/src/components/molecules/analytics-provider.tsx
@@ -14,7 +14,7 @@ const AnalyticsProvider: React.FC<
 
   const [loaded, setLoaded] = React.useState(false);
 
-  const [tenant] = useTenantContext();
+  const { tenant } = useTenantContext();
 
   const config = useMemo(() => {
     return meta.data?.posthog;

--- a/frontend/app/src/components/molecules/analytics-provider.tsx
+++ b/frontend/app/src/components/molecules/analytics-provider.tsx
@@ -1,5 +1,5 @@
 import { User } from '@/lib/api';
-import { useTenantContext } from '@/lib/atoms';
+import { useTenant } from '@/lib/atoms';
 import useApiMeta from '@/pages/auth/hooks/use-api-meta';
 import React, { PropsWithChildren, useEffect, useMemo } from 'react';
 
@@ -14,7 +14,7 @@ const AnalyticsProvider: React.FC<
 
   const [loaded, setLoaded] = React.useState(false);
 
-  const { tenant } = useTenantContext();
+  const { tenant } = useTenant();
 
   const config = useMemo(() => {
     return meta.data?.posthog;

--- a/frontend/app/src/components/molecules/nav-bar/tenant-switcher.tsx
+++ b/frontend/app/src/components/molecules/nav-bar/tenant-switcher.tsx
@@ -37,7 +37,7 @@ export function TenantSwitcher({
   currTenant,
 }: TenantSwitcherProps) {
   const meta = useApiMeta();
-  const setCurrTenant = useTenantContext()[1];
+  const { setTenant: setCurrTenant } = useTenantContext();
   const [open, setOpen] = React.useState(false);
 
   if (!currTenant) {

--- a/frontend/app/src/components/molecules/nav-bar/tenant-switcher.tsx
+++ b/frontend/app/src/components/molecules/nav-bar/tenant-switcher.tsx
@@ -22,7 +22,7 @@ import {
   PopoverContent,
 } from '@radix-ui/react-popover';
 import React from 'react';
-import { useTenantContext } from '@/lib/atoms';
+import { useTenant } from '@/lib/atoms';
 import { Spinner } from '@/components/ui/loading.tsx';
 import useApiMeta from '@/pages/auth/hooks/use-api-meta';
 
@@ -37,7 +37,7 @@ export function TenantSwitcher({
   currTenant,
 }: TenantSwitcherProps) {
   const meta = useApiMeta();
-  const { setTenant: setCurrTenant } = useTenantContext();
+  const { setTenant: setCurrTenant } = useTenant();
   const [open, setOpen] = React.useState(false);
 
   if (!currTenant) {

--- a/frontend/app/src/components/molecules/support-chat.tsx
+++ b/frontend/app/src/components/molecules/support-chat.tsx
@@ -13,7 +13,7 @@ const SupportChat: React.FC<PropsWithChildren & SupportChatProps> = ({
 }) => {
   const meta = useApiMeta();
 
-  const [tenant] = useTenantContext();
+  const { tenant } = useTenantContext();
 
   const APP_ID = useMemo(() => {
     if (!meta.data?.pylonAppId) {

--- a/frontend/app/src/components/molecules/support-chat.tsx
+++ b/frontend/app/src/components/molecules/support-chat.tsx
@@ -1,5 +1,5 @@
 import { User } from '@/lib/api';
-import { useTenantContext } from '@/lib/atoms';
+import { useTenant } from '@/lib/atoms';
 import useApiMeta from '@/pages/auth/hooks/use-api-meta';
 import React, { PropsWithChildren, useEffect, useMemo } from 'react';
 
@@ -13,7 +13,7 @@ const SupportChat: React.FC<PropsWithChildren & SupportChatProps> = ({
 }) => {
   const meta = useApiMeta();
 
-  const { tenant } = useTenantContext();
+  const { tenant } = useTenant();
 
   const APP_ID = useMemo(() => {
     if (!meta.data?.pylonAppId) {

--- a/frontend/app/src/lib/atoms.ts
+++ b/frontend/app/src/lib/atoms.ts
@@ -38,8 +38,8 @@ type TenantContext = {
 // search param sets the tenant, the last tenant set is used if the search param is empty,
 // otherwise the first membership is used
 export function useTenant(): TenantContext {
-  const [searchParams, setSearchParams] = useSearchParams();
   const [lastTenant, setLastTenant] = useAtom(lastTenantAtom);
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const setTenant = (tenant: Tenant) => {
     const newSearchParams = new URLSearchParams(searchParams);

--- a/frontend/app/src/lib/atoms.ts
+++ b/frontend/app/src/lib/atoms.ts
@@ -37,7 +37,7 @@ type TenantContext = {
 
 // search param sets the tenant, the last tenant set is used if the search param is empty,
 // otherwise the first membership is used
-export function useTenantContext(): TenantContext {
+export function useTenant(): TenantContext {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const setTenant = (tenant: Tenant) => {

--- a/frontend/app/src/pages/main/index.tsx
+++ b/frontend/app/src/pages/main/index.tsx
@@ -19,7 +19,7 @@ import {
   UserContextType,
   useContextFromParent,
 } from '@/lib/outlet';
-import { useTenantContext } from '@/lib/atoms';
+import { useTenant } from '@/lib/atoms';
 import { Loading } from '@/components/ui/loading.tsx';
 import { useSidebar } from '@/components/sidebar-provider';
 import { TenantSwitcher } from '@/components/molecules/nav-bar/tenant-switcher';
@@ -32,7 +32,7 @@ function Main() {
 
   const { user, memberships } = ctx;
 
-  const { tenant: currTenant } = useTenantContext();
+  const { tenant: currTenant } = useTenant();
 
   const childCtx = useContextFromParent({
     user,

--- a/frontend/app/src/pages/main/index.tsx
+++ b/frontend/app/src/pages/main/index.tsx
@@ -32,7 +32,7 @@ function Main() {
 
   const { user, memberships } = ctx;
 
-  const [currTenant] = useTenantContext();
+  const { tenant: currTenant } = useTenantContext();
 
   const childCtx = useContextFromParent({
     user,

--- a/frontend/app/src/pages/main/tenant-settings/alerting/index.tsx
+++ b/frontend/app/src/pages/main/tenant-settings/alerting/index.tsx
@@ -9,7 +9,7 @@ import api, {
   UpdateTenantRequest,
   queries,
 } from '@/lib/api';
-import { useTenantContext } from '@/lib/atoms';
+import { useTenant } from '@/lib/atoms';
 import { Spinner } from '@/components/ui/loading';
 import { UpdateTenantAlertingSettings } from './components/update-tenant-alerting-settings-form';
 import invariant from 'tiny-invariant';
@@ -52,7 +52,7 @@ export default function Alerting() {
 }
 
 const AlertingSettings: React.FC = () => {
-  const { tenant } = useTenantContext();
+  const { tenant } = useTenant();
 
   invariant(tenant, 'tenant should be defined');
 

--- a/frontend/app/src/pages/main/tenant-settings/alerting/index.tsx
+++ b/frontend/app/src/pages/main/tenant-settings/alerting/index.tsx
@@ -52,7 +52,7 @@ export default function Alerting() {
 }
 
 const AlertingSettings: React.FC = () => {
-  const [tenant] = useTenantContext();
+  const { tenant } = useTenantContext();
 
   invariant(tenant, 'tenant should be defined');
 

--- a/frontend/app/src/pages/main/workflows/$workflow/index.tsx
+++ b/frontend/app/src/pages/main/workflows/$workflow/index.tsx
@@ -17,7 +17,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import WorkflowGeneralSettings from './components/workflow-general-settings';
 import { WorkflowRunsTable } from '../../workflow-runs/components/workflow-runs-table';
 import { ConfirmDialog } from '@/components/molecules/confirm-dialog';
-import { useTenantContext } from '@/lib/atoms';
+import { useTenant } from '@/lib/atoms';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -26,7 +26,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 
 export default function ExpandedWorkflow() {
-  const { tenant } = useTenantContext();
+  const { tenant } = useTenant();
 
   // TODO list previous versions and make selectable
   const [selectedVersion] = useState<string | undefined>();

--- a/frontend/app/src/pages/main/workflows/$workflow/index.tsx
+++ b/frontend/app/src/pages/main/workflows/$workflow/index.tsx
@@ -26,7 +26,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 
 export default function ExpandedWorkflow() {
-  const [tenant] = useTenantContext();
+  const { tenant } = useTenantContext();
 
   // TODO list previous versions and make selectable
   const [selectedVersion] = useState<string | undefined>();

--- a/frontend/app/src/pages/onboarding/get-started/index.tsx
+++ b/frontend/app/src/pages/onboarding/get-started/index.tsx
@@ -56,7 +56,7 @@ const PLATFORMS: {
 export default function GetStarted() {
   const ctx = useOutletContext<UserContextType & MembershipsContextType>();
   const { user, memberships } = ctx;
-  const [currTenant] = useTenantContext();
+  const { tenant: currTenant } = useTenantContext();
 
   const [steps, setSteps] = useState(DEFAULT_OPEN);
   const [platform, setPlatform] = useState<(typeof PLATFORMS)[0] | undefined>();

--- a/frontend/app/src/pages/onboarding/get-started/index.tsx
+++ b/frontend/app/src/pages/onboarding/get-started/index.tsx
@@ -1,5 +1,5 @@
 import { Loading } from '@/components/ui/loading';
-import { useTenantContext } from '@/lib/atoms';
+import { useTenant } from '@/lib/atoms';
 import { UserContextType, MembershipsContextType } from '@/lib/outlet';
 import { useOutletContext } from 'react-router-dom';
 import {
@@ -56,7 +56,7 @@ const PLATFORMS: {
 export default function GetStarted() {
   const ctx = useOutletContext<UserContextType & MembershipsContextType>();
   const { user, memberships } = ctx;
-  const { tenant: currTenant } = useTenantContext();
+  const { tenant: currTenant } = useTenant();
 
   const [steps, setSteps] = useState(DEFAULT_OPEN);
   const [platform, setPlatform] = useState<(typeof PLATFORMS)[0] | undefined>();


### PR DESCRIPTION
Switching tenants right now in production doesn't work right away (works on refresh). I think it's because of the state handling in the `useTenantContext` relying on `useState` for derived data (from the search params) as opposed to getting and setting the search params directly

Also renamed `useTenantContext` -> `useTenant` since I think `Context` is a bit of a "reserved" thing in React (since this isn't really a Context, just a hook). And I also changed the return type of `useTenant` from `[Tenant | undefined, (string) -> void]` to an object so we can unpack that object as we need as opposed to needing e.g. indexing like `[1]` to get the setter out