### PR TITLE
fix: add guard to min id query

### DIFF
--- a/pkg/repository/prisma/scheduler_queue.go
+++ b/pkg/repository/prisma/scheduler_queue.go
@@ -39,6 +39,8 @@ type queueRepository struct {
 	gtId   pgtype.Int8
 	gtIdMu sync.RWMutex
 
+	updateMinIdMu sync.Mutex
+
 	cachedStepIdHasRateLimit *cache.Cache
 }
 
@@ -317,6 +319,11 @@ func (s *queueRepository) bulkStepRunsRateLimited(
 }
 
 func (d *queueRepository) updateMinId() {
+	if !d.updateMinIdMu.TryLock() {
+		return
+	}
+	defer d.updateMinIdMu.Unlock()
+
 	dbCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 


### PR DESCRIPTION
# Description

Adds a guarding mutex to the query for min id to prevent concurrent and unnecessary reads. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
