### PR TITLE
fix: timeout race condition

### DIFF
--- a/pkg/repository/prisma/step_run.go
+++ b/pkg/repository/prisma/step_run.go
@@ -1828,12 +1828,6 @@ func (s *stepRunEngineRepository) QueueStepRun(ctx context.Context, tenantId, st
 		return nil, err
 	}
 
-	err = s.releaseWorkerSemaphoreSlot(ctx, tenantId, stepRunId)
-
-	if err != nil {
-		return nil, err
-	}
-
 	return innerStepRun, nil
 }
 


### PR DESCRIPTION
# Description

Fixes a race condition on timeouts where we delete timeout queue items immediately after queueing a step run. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)