### PR TITLE
Fix: Date picker resetting on close

### DIFF
--- a/frontend/app/src/components/molecules/time-picker/date-time-picker.tsx
+++ b/frontend/app/src/components/molecules/time-picker/date-time-picker.tsx
@@ -9,7 +9,6 @@ import {
 } from '@/components/ui/popover';
 import { TimePicker } from './time-picker';
 import { CalendarIcon } from '@radix-ui/react-icons';
-import { useState } from 'react';
 
 type DateTimePickerProps = {
   date: Date | undefined;
@@ -18,8 +17,6 @@ type DateTimePickerProps = {
 };
 
 export function DateTimePicker({ date, setDate, label }: DateTimePickerProps) {
-  const [selectedDate, setSelectedDate] = useState<Date | undefined>(date);
-
   /**
    * carry over the current time when a user clicks a new day
    * instead of resetting to 00:00
@@ -39,13 +36,7 @@ export function DateTimePicker({ date, setDate, label }: DateTimePickerProps) {
   };
 
   return (
-    <Popover
-      onOpenChange={(isOpen) => {
-        if (!isOpen && selectedDate !== date) {
-          setDate(selectedDate);
-        }
-      }}
-    >
+    <Popover>
       <PopoverTrigger asChild>
         <Button
           variant={'outline'}
@@ -70,7 +61,7 @@ export function DateTimePicker({ date, setDate, label }: DateTimePickerProps) {
           initialFocus
         />
         <div className="p-3 border-t border-border">
-          <TimePicker setDate={setSelectedDate} date={selectedDate} />
+          <TimePicker setDate={setDate} date={date} />
         </div>
       </PopoverContent>
     </Popover>


### PR DESCRIPTION
# Description

Fixing date picker resetting when it's closed

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

Two issues here -

1. The `onOpenChange` callback was causing the date picker to reset when it was closed. AFAICT, that callback doesn't do anything, so I removed it
2. The time pickers were using derived state from inside the date picker instead of the selected date, so I removed the derived state and passed the selected date through, which seems to work correctly.

