### PR TITLE
fix: run workflows which are scheduled on older versions don't run

### DIFF
--- a/pkg/repository/prisma/dbsqlc/tickers.sql
+++ b/pkg/repository/prisma/dbsqlc/tickers.sql
@@ -144,15 +144,7 @@ RETURNING cronSchedules.*, active_cron_schedules."workflowVersionId", active_cro
 -- name: PollScheduledWorkflows :many
 -- Finds workflows that are either past their execution time or will be in the next 5 seconds and assigns them
 -- to a ticker, or finds workflows that were assigned to a ticker that is no longer active
-WITH latest_workflow_versions AS (
-    SELECT
-        "workflowId",
-        MAX("order") as max_order
-    FROM
-        "WorkflowVersion"
-    GROUP BY "workflowId"
-),
-not_run_scheduled_workflows AS (
+WITH not_run_scheduled_workflows AS (
     SELECT
         scheduledWorkflow."id",
         versions."id" AS "workflowVersionId",
@@ -162,8 +154,6 @@ not_run_scheduled_workflows AS (
         "WorkflowTriggerScheduledRef" as scheduledWorkflow
     JOIN
         "WorkflowVersion" as versions ON versions."id" = scheduledWorkflow."parentId"
-    JOIN
-        latest_workflow_versions l ON versions."workflowId" = l."workflowId" AND versions."order" = l.max_order
     JOIN
         "Workflow" as workflow ON workflow."id" = versions."workflowId"
     LEFT JOIN

--- a/pkg/repository/prisma/dbsqlc/tickers.sql.go
+++ b/pkg/repository/prisma/dbsqlc/tickers.sql.go
@@ -417,15 +417,7 @@ func (q *Queries) PollGetGroupKeyRuns(ctx context.Context, db DBTX, tickerid pgt
 }
 
 const pollScheduledWorkflows = `-- name: PollScheduledWorkflows :many
-WITH latest_workflow_versions AS (
-    SELECT
-        "workflowId",
-        MAX("order") as max_order
-    FROM
-        "WorkflowVersion"
-    GROUP BY "workflowId"
-),
-not_run_scheduled_workflows AS (
+WITH not_run_scheduled_workflows AS (
     SELECT
         scheduledWorkflow."id",
         versions."id" AS "workflowVersionId",
@@ -435,8 +427,6 @@ not_run_scheduled_workflows AS (
         "WorkflowTriggerScheduledRef" as scheduledWorkflow
     JOIN
         "WorkflowVersion" as versions ON versions."id" = scheduledWorkflow."parentId"
-    JOIN
-        latest_workflow_versions l ON versions."workflowId" = l."workflowId" AND versions."order" = l.max_order
     JOIN
         "Workflow" as workflow ON workflow."id" = versions."workflowId"
     LEFT JOIN


### PR DESCRIPTION
# Description

Scheduled runs which were scheduled on an older version of a workflow aren't triggering due to the query conditions in the poller. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)