### PR TITLE
fix: hard sticky strategy with no desired worker id

### DIFF
--- a/pkg/scheduling/v2/slot.go
+++ b/pkg/scheduling/v2/slot.go
@@ -186,10 +186,12 @@ func getRankedSlots(
 			continue
 		}
 
-		// if this is a HARD sticky strategy, it can only be assigned to the desired worker if the desired
-		// worker id is set. otherwise, it cannot be assigned.
+		// if this is a HARD sticky strategy, and there's a desired worker id, it can only be assigned to that
+		// worker. if there's no desired worker id, we assign to any worker.
 		if qi.Sticky.Valid && qi.Sticky.StickyStrategy == dbsqlc.StickyStrategyHARD {
 			if qi.DesiredWorkerId.Valid && workerId == sqlchelpers.UUIDToStr(qi.DesiredWorkerId) {
+				validSlots.addSlot(slot, 0)
+			} else if !qi.DesiredWorkerId.Valid {
 				validSlots.addSlot(slot, 0)
 			}
 


### PR DESCRIPTION
# Description

In the case of `stickyStrategy=HARD` and no desired worker id set, step runs can't be scheduled. This PR modifies the behavior to assign to any available worker in this case.  

We weren't seeing this behavior in most tests, because the workflows we were testing with `stickyStrategy=HARD` were child workflows spawned with `sticky=True`, where there's guaranteed to be a desired worker id. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)