### PR TITLE
fix: increase workflow run pop timeout, fix broken concurrency query

### DIFF
--- a/internal/services/controllers/workflows/controller.go
+++ b/internal/services/controllers/workflows/controller.go
@@ -164,7 +164,7 @@ func New(fs ...WorkflowsControllerOpt) (*WorkflowsControllerImpl, error) {
 
 	w.processWorkflowEventsOps = queueutils.NewOperationPool(w.l, time.Second*5, "process workflow events", w.processWorkflowEvents)
 	w.unpausedWorkflowRunsOps = queueutils.NewOperationPool(w.l, time.Second*5, "unpause workflow runs", w.unpauseWorkflowRuns)
-	w.bumpQueueOps = queueutils.NewOperationPool(w.l, time.Second*30, "bump queue", w.runPollActiveQueuesTenant)
+	w.bumpQueueOps = queueutils.NewOperationPool(w.l, time.Second*5, "bump queue", w.runPollActiveQueuesTenant)
 
 	return w, nil
 }

--- a/internal/services/controllers/workflows/controller.go
+++ b/internal/services/controllers/workflows/controller.go
@@ -164,7 +164,7 @@ func New(fs ...WorkflowsControllerOpt) (*WorkflowsControllerImpl, error) {
 
 	w.processWorkflowEventsOps = queueutils.NewOperationPool(w.l, time.Second*5, "process workflow events", w.processWorkflowEvents)
 	w.unpausedWorkflowRunsOps = queueutils.NewOperationPool(w.l, time.Second*5, "unpause workflow runs", w.unpauseWorkflowRuns)
-	w.bumpQueueOps = queueutils.NewOperationPool(w.l, time.Second*5, "bump queue", w.runPollActiveQueuesTenant)
+	w.bumpQueueOps = queueutils.NewOperationPool(w.l, time.Second*30, "bump queue", w.runPollActiveQueuesTenant)
 
 	return w, nil
 }

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql
@@ -313,19 +313,20 @@ WITH workflow_runs AS (
     SELECT
         id,
         "concurrencyGroupId",
-        "rn"
+        "rn",
+        "seqnum"
     FROM workflow_runs
     WHERE "rn" <= (@maxRuns::int) -- we limit the number of runs per group to maxRuns
 ), eligible_runs AS (
     SELECT
-        id
-    FROM workflow_runs
-    WHERE id IN (
+        wr."id"
+    FROM "WorkflowRun" wr
+    WHERE wr."id" IN (
         SELECT
             id
         FROM eligible_runs_per_group
         ORDER BY "rn", "seqnum" ASC
-        LIMIT (@maxRuns::int) * (SELECT COUNT(DISTINCT "concurrencyGroupId") FROM workflow_runs)
+        LIMIT LEAST(500, (@maxRuns::int) * (SELECT COUNT(DISTINCT "concurrencyGroupId") FROM workflow_runs))
     )
     FOR UPDATE SKIP LOCKED
 )

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql
@@ -321,7 +321,7 @@ WITH workflow_runs AS (
     SELECT
         wr."id"
     FROM "WorkflowRun" wr
-    WHERE 
+    WHERE
         wr."id" IN (
             SELECT
                 id

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql
@@ -297,8 +297,9 @@ WITH workflow_runs AS (
         r2.id,
         r2."status",
         r2."concurrencyGroupId",
-        row_number() OVER (PARTITION BY r2."concurrencyGroupId" ORDER BY r2."createdAt", r2."insertOrder", r2.id) AS "rn",
-        row_number() OVER (ORDER BY r2."createdAt", r2."insertOrder", r2.id) AS "seqnum"
+        row_number() OVER (PARTITION BY r2."concurrencyGroupId" ORDER BY r2."createdAt", r2.id) AS "rn",
+        -- we order by r2.id as a second parameter to get a pseudo-random, stable order
+        row_number() OVER (ORDER BY r2."createdAt", r2.id) AS "seqnum"
     FROM
         "WorkflowRun" r2
     LEFT JOIN

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
@@ -2823,7 +2823,7 @@ WITH workflow_runs AS (
     SELECT
         wr."id"
     FROM "WorkflowRun" wr
-    WHERE 
+    WHERE
         wr."id" IN (
             SELECT
                 id

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
@@ -2799,8 +2799,9 @@ WITH workflow_runs AS (
         r2.id,
         r2."status",
         r2."concurrencyGroupId",
-        row_number() OVER (PARTITION BY r2."concurrencyGroupId" ORDER BY r2."createdAt", r2."insertOrder", r2.id) AS "rn",
-        row_number() OVER (ORDER BY r2."createdAt", r2."insertOrder", r2.id) AS "seqnum"
+        row_number() OVER (PARTITION BY r2."concurrencyGroupId" ORDER BY r2."createdAt", r2.id) AS "rn",
+        -- we order by r2.id as a second parameter to get a pseudo-random, stable order
+        row_number() OVER (ORDER BY r2."createdAt", r2.id) AS "seqnum"
     FROM
         "WorkflowRun" r2
     LEFT JOIN

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
@@ -2815,19 +2815,20 @@ WITH workflow_runs AS (
     SELECT
         id,
         "concurrencyGroupId",
-        "rn"
+        "rn",
+        "seqnum"
     FROM workflow_runs
     WHERE "rn" <= ($3::int) -- we limit the number of runs per group to maxRuns
 ), eligible_runs AS (
     SELECT
-        id
-    FROM workflow_runs
-    WHERE id IN (
+        wr."id"
+    FROM "WorkflowRun" wr
+    WHERE wr."id" IN (
         SELECT
             id
         FROM eligible_runs_per_group
         ORDER BY "rn", "seqnum" ASC
-        LIMIT ($3::int) * (SELECT COUNT(DISTINCT "concurrencyGroupId") FROM workflow_runs)
+        LIMIT LEAST(500, ($3::int) * (SELECT COUNT(DISTINCT "concurrencyGroupId") FROM workflow_runs))
     )
     FOR UPDATE SKIP LOCKED
 )

--- a/pkg/repository/prisma/workflow_run.go
+++ b/pkg/repository/prisma/workflow_run.go
@@ -1055,7 +1055,7 @@ func (w *workflowRunEngineRepository) PopWorkflowRunsCancelNewest(ctx context.Co
 
 func (w *workflowRunEngineRepository) PopWorkflowRunsRoundRobin(ctx context.Context, tenantId string, workflowVersionId string, maxRuns int) ([]*dbsqlc.WorkflowRun, []*dbsqlc.GetStepRunForEngineRow, error) {
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, w.pool, w.l, 15000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, w.pool, w.l, 25000)
 
 	if err != nil {
 		return nil, nil, err

--- a/pkg/repository/prisma/workflow_run.go
+++ b/pkg/repository/prisma/workflow_run.go
@@ -1055,7 +1055,7 @@ func (w *workflowRunEngineRepository) PopWorkflowRunsCancelNewest(ctx context.Co
 
 func (w *workflowRunEngineRepository) PopWorkflowRunsRoundRobin(ctx context.Context, tenantId string, workflowVersionId string, maxRuns int) ([]*dbsqlc.WorkflowRun, []*dbsqlc.GetStepRunForEngineRow, error) {
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, w.pool, w.l, 25000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, w.pool, w.l, 5000)
 
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
# Description

Fixes:
- Adds a limit to the `PopWorkflowRuns...` query so we don't accidentally update too many rows (we should potentially increase this further)
- Increases the timeout allocated to this query
- Fixes a random `seqnum` cross product issue which was making the query slow

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)