### PR TITLE
Feat: Propagate Error Through Context

### DIFF
--- a/examples/on-failure/main.go
+++ b/examples/on-failure/main.go
@@ -27,7 +27,7 @@ func StepOne(ctx worker.HatchetContext) (result *stepOneOutput, err error) {
 func OnFailure(ctx worker.HatchetContext) (result *stepOneOutput, err error) {
 	// run cleanup code or notifications here
 
-	// you can access the error from the failed step(s) like this
+	// 👀 you can access the error from the failed step(s) like this
 	fmt.Println(ctx.StepRunErrors())
 
 	return &stepOneOutput{

--- a/examples/on-failure/main.go
+++ b/examples/on-failure/main.go
@@ -26,6 +26,10 @@ func StepOne(ctx worker.HatchetContext) (result *stepOneOutput, err error) {
 
 func OnFailure(ctx worker.HatchetContext) (result *stepOneOutput, err error) {
 	// run cleanup code or notifications here
+
+	// you can access the error from the failed step(s) like this
+	fmt.Println(ctx.StepRunErrors())
+
 	return &stepOneOutput{
 		Message: "Failure!",
 	}, nil

--- a/internal/datautils/job_data.go
+++ b/internal/datautils/job_data.go
@@ -26,4 +26,7 @@ type StepRunData struct {
 
 	// overrides set from the playground
 	Overrides map[string]interface{} `json:"overrides"`
+
+	// errors in upstream steps (only used in on-failure step)
+	Errors map[string]string `json:"errors,omitempty"`
 }

--- a/internal/datautils/job_data.go
+++ b/internal/datautils/job_data.go
@@ -28,5 +28,5 @@ type StepRunData struct {
 	Overrides map[string]interface{} `json:"overrides"`
 
 	// errors in upstream steps (only used in on-failure step)
-	Errors map[string]string `json:"errors,omitempty"`
+	StepRunErrors map[string]string `json:"errors,omitempty"`
 }

--- a/internal/datautils/job_data.go
+++ b/internal/datautils/job_data.go
@@ -28,5 +28,5 @@ type StepRunData struct {
 	Overrides map[string]interface{} `json:"overrides"`
 
 	// errors in upstream steps (only used in on-failure step)
-	StepRunErrors map[string]string `json:"errors,omitempty"`
+	StepRunErrors map[string]string `json:"step_run_errors,omitempty"`
 }

--- a/internal/services/controllers/jobs/controller.go
+++ b/internal/services/controllers/jobs/controller.go
@@ -786,12 +786,12 @@ func (ec *JobsControllerImpl) queueStepRun(ctx context.Context, tenantId, stepId
 
 			// input data is the triggering event data and any parent step data
 			inputData := datautils.StepRunData{
-				Input:       lookupData.Input,
-				TriggeredBy: lookupData.TriggeredBy,
-				Parents:     lookupData.Steps,
-				UserData:    userData,
-				Overrides:   map[string]interface{}{},
-				Errors:      upstreamErrors,
+				Input:         lookupData.Input,
+				TriggeredBy:   lookupData.TriggeredBy,
+				Parents:       lookupData.Steps,
+				UserData:      userData,
+				Overrides:     map[string]interface{}{},
+				StepRunErrors: upstreamErrors,
 			}
 
 			inputDataBytes, err = json.Marshal(inputData)

--- a/internal/services/controllers/jobs/controller.go
+++ b/internal/services/controllers/jobs/controller.go
@@ -757,7 +757,7 @@ func (ec *JobsControllerImpl) queueStepRun(ctx context.Context, tenantId, stepId
 
 			if err == nil {
 				for _, failedStepError := range failedStepErrors {
-					upstreamErrors[failedStepError.StepReadableId.String] = failedStepError.Error.String
+					upstreamErrors[failedStepError.StepReadableId.String] = failedStepError.StepRunError.String
 				}
 			}
 		}

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql
@@ -1554,7 +1554,7 @@ WHERE
 
 -- name: GetUpstreamErrorsForOnFailureStep :many
 WITH workflow_run AS (
-    SELECT wr."id"
+    SELECT wr.*
     FROM "WorkflowRun" wr
     JOIN "JobRun" jr ON wr."id" = jr."workflowRunId"
     JOIN "StepRun" sr ON jr."id" = sr."jobRunId"
@@ -1564,10 +1564,8 @@ SELECT
     sr."id" AS "stepRunId",
     s."readableId" AS "stepReadableId",
     sr."error" AS "stepRunError"
-FROM "WorkflowRun" wr
+FROM workflow_run wr
 JOIN "JobRun" jr ON wr."id" = jr."workflowRunId"
 JOIN "StepRun" sr ON jr."id" = sr."jobRunId"
 JOIN "Step" s ON sr."stepId" = s."id"
-WHERE
-    wr."id" = (SELECT "id" FROM workflow_run)
-    AND sr."error" IS NOT NULL;
+WHERE sr."error" IS NOT NULL;

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql
@@ -1568,9 +1568,6 @@ FROM "WorkflowRun" wr
 JOIN "JobRun" jr ON wr."id" = jr."workflowRunId"
 JOIN "StepRun" sr ON jr."id" = sr."jobRunId"
 JOIN "Step" s ON sr."stepId" = s."id"
-JOIN "Job" j ON jr."jobId" = j.id
 WHERE
     wr."id" = (SELECT "id" FROM workflow_run)
-    -- Don't include the on-failure step in the step runs listed
-    AND j."kind" <> 'ON_FAILURE'
     AND sr."error" IS NOT NULL;

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql
@@ -1563,7 +1563,7 @@ WITH workflow_run AS (
 SELECT
     sr."id" AS "stepRunId",
     s."readableId" AS "stepReadableId",
-    sr."error"
+    sr."error" AS "stepRunError"
 FROM "WorkflowRun" wr
 JOIN "JobRun" jr ON wr."id" = jr."workflowRunId"
 JOIN "StepRun" sr ON jr."id" = sr."jobRunId"

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql
@@ -1552,13 +1552,13 @@ DELETE FROM "WorkflowTriggerScheduledRef"
 WHERE
     "id" = @scheduleId::uuid;
 
--- name: GetUpstreamErrors :many
+-- name: GetUpstreamErrorsForOnFailureStep :many
 WITH workflow_run AS (
     SELECT wr."id"
     FROM "WorkflowRun" wr
     JOIN "JobRun" jr ON wr."id" = jr."workflowRunId"
     JOIN "StepRun" sr ON jr."id" = sr."jobRunId"
-    WHERE sr."id" = @stepRunId::uuid
+    WHERE sr."id" = @onFailureStepRunId::uuid
 )
 SELECT
     sr."id" AS "stepRunId",

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql
@@ -1552,7 +1552,7 @@ DELETE FROM "WorkflowTriggerScheduledRef"
 WHERE
     "id" = @scheduleId::uuid;
 
--- name: GetUpstreamErrors :one
+-- name: GetUpstreamErrors :many
 WITH workflow_run AS (
     SELECT wr."id"
     FROM "WorkflowRun" wr

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
@@ -1598,7 +1598,7 @@ func (q *Queries) GetStepsForWorkflowVersion(ctx context.Context, db DBTX, workf
 
 const getUpstreamErrorsForOnFailureStep = `-- name: GetUpstreamErrorsForOnFailureStep :many
 WITH workflow_run AS (
-    SELECT wr."id"
+    SELECT wr."createdAt", wr."updatedAt", wr."deletedAt", wr."tenantId", wr."workflowVersionId", wr.status, wr.error, wr."startedAt", wr."finishedAt", wr."concurrencyGroupId", wr."displayName", wr.id, wr."childIndex", wr."childKey", wr."parentId", wr."parentStepRunId", wr."additionalMetadata", wr.duration, wr.priority, wr."insertOrder"
     FROM "WorkflowRun" wr
     JOIN "JobRun" jr ON wr."id" = jr."workflowRunId"
     JOIN "StepRun" sr ON jr."id" = sr."jobRunId"
@@ -1608,13 +1608,11 @@ SELECT
     sr."id" AS "stepRunId",
     s."readableId" AS "stepReadableId",
     sr."error" AS "stepRunError"
-FROM "WorkflowRun" wr
+FROM workflow_run wr
 JOIN "JobRun" jr ON wr."id" = jr."workflowRunId"
 JOIN "StepRun" sr ON jr."id" = sr."jobRunId"
 JOIN "Step" s ON sr."stepId" = s."id"
-WHERE
-    wr."id" = (SELECT "id" FROM workflow_run)
-    AND sr."error" IS NOT NULL
+WHERE sr."error" IS NOT NULL
 `
 
 type GetUpstreamErrorsForOnFailureStepRow struct {

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
@@ -1596,7 +1596,7 @@ func (q *Queries) GetStepsForWorkflowVersion(ctx context.Context, db DBTX, workf
 	return items, nil
 }
 
-const getUpstreamErrors = `-- name: GetUpstreamErrors :many
+const getUpstreamErrorsForOnFailureStep = `-- name: GetUpstreamErrorsForOnFailureStep :many
 WITH workflow_run AS (
     SELECT wr."id"
     FROM "WorkflowRun" wr
@@ -1620,21 +1620,21 @@ WHERE
     AND sr."error" IS NOT NULL
 `
 
-type GetUpstreamErrorsRow struct {
+type GetUpstreamErrorsForOnFailureStepRow struct {
 	StepRunId      pgtype.UUID `json:"stepRunId"`
 	StepReadableId pgtype.Text `json:"stepReadableId"`
 	Error          pgtype.Text `json:"error"`
 }
 
-func (q *Queries) GetUpstreamErrors(ctx context.Context, db DBTX, steprunid pgtype.UUID) ([]*GetUpstreamErrorsRow, error) {
-	rows, err := db.Query(ctx, getUpstreamErrors, steprunid)
+func (q *Queries) GetUpstreamErrorsForOnFailureStep(ctx context.Context, db DBTX, onfailuresteprunid pgtype.UUID) ([]*GetUpstreamErrorsForOnFailureStepRow, error) {
+	rows, err := db.Query(ctx, getUpstreamErrorsForOnFailureStep, onfailuresteprunid)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*GetUpstreamErrorsRow
+	var items []*GetUpstreamErrorsForOnFailureStepRow
 	for rows.Next() {
-		var i GetUpstreamErrorsRow
+		var i GetUpstreamErrorsForOnFailureStepRow
 		if err := rows.Scan(&i.StepRunId, &i.StepReadableId, &i.Error); err != nil {
 			return nil, err
 		}

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
@@ -1607,7 +1607,7 @@ WITH workflow_run AS (
 SELECT
     sr."id" AS "stepRunId",
     s."readableId" AS "stepReadableId",
-    sr."error"
+    sr."error" AS "stepRunError"
 FROM "WorkflowRun" wr
 JOIN "JobRun" jr ON wr."id" = jr."workflowRunId"
 JOIN "StepRun" sr ON jr."id" = sr."jobRunId"
@@ -1620,7 +1620,7 @@ WHERE
 type GetUpstreamErrorsForOnFailureStepRow struct {
 	StepRunId      pgtype.UUID `json:"stepRunId"`
 	StepReadableId pgtype.Text `json:"stepReadableId"`
-	Error          pgtype.Text `json:"error"`
+	StepRunError   pgtype.Text `json:"stepRunError"`
 }
 
 func (q *Queries) GetUpstreamErrorsForOnFailureStep(ctx context.Context, db DBTX, onfailuresteprunid pgtype.UUID) ([]*GetUpstreamErrorsForOnFailureStepRow, error) {
@@ -1632,7 +1632,7 @@ func (q *Queries) GetUpstreamErrorsForOnFailureStep(ctx context.Context, db DBTX
 	var items []*GetUpstreamErrorsForOnFailureStepRow
 	for rows.Next() {
 		var i GetUpstreamErrorsForOnFailureStepRow
-		if err := rows.Scan(&i.StepRunId, &i.StepReadableId, &i.Error); err != nil {
+		if err := rows.Scan(&i.StepRunId, &i.StepReadableId, &i.StepRunError); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)

--- a/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/workflow_runs.sql.go
@@ -1612,11 +1612,8 @@ FROM "WorkflowRun" wr
 JOIN "JobRun" jr ON wr."id" = jr."workflowRunId"
 JOIN "StepRun" sr ON jr."id" = sr."jobRunId"
 JOIN "Step" s ON sr."stepId" = s."id"
-JOIN "Job" j ON jr."jobId" = j.id
 WHERE
     wr."id" = (SELECT "id" FROM workflow_run)
-    -- Don't include the on-failure step in the step runs listed
-    AND j."kind" <> 'ON_FAILURE'
     AND sr."error" IS NOT NULL
 `
 

--- a/pkg/repository/prisma/workflow_run.go
+++ b/pkg/repository/prisma/workflow_run.go
@@ -1247,6 +1247,17 @@ func (w *workflowRunAPIRepository) BulkCreateWorkflowRuns(ctx context.Context, o
 	return createNewWorkflowRuns(ctx, w.pool, w.queries, w.l, opts)
 }
 
+func (w *workflowRunEngineRepository) GetUpstreamErrorsForOnFailureStep(
+	ctx context.Context,
+	onFailureStepRunId string,
+) ([]*dbsqlc.GetUpstreamErrorsForOnFailureStepRow, error) {
+	return w.queries.GetUpstreamErrorsForOnFailureStep(
+		ctx,
+		w.pool,
+		sqlchelpers.UUIDFromStr(onFailureStepRunId),
+	)
+}
+
 // this is single tenant
 func (w *workflowRunEngineRepository) CreateNewWorkflowRuns(ctx context.Context, tenantId string, opts []*repository.CreateWorkflowRunOpts) ([]*dbsqlc.WorkflowRun, error) {
 
@@ -2265,13 +2276,4 @@ func bulkWorkflowRunEvents(
 	if err != nil {
 		l.Err(err).Msg("could not create bulk workflow run event")
 	}
-}
-
-func getFailedStepErrors(
-	ctx context.Context,
-	queries *dbsqlc.Queries,
-	dbtx dbsqlc.DBTX,
-	stepRunId pgtype.UUID,
-) ([]*dbsqlc.GetUpstreamErrorsForOnFailureStepRow, error) {
-	return queries.GetUpstreamErrorsForOnFailureStep(ctx, dbtx, stepRunId)
 }

--- a/pkg/repository/prisma/workflow_run.go
+++ b/pkg/repository/prisma/workflow_run.go
@@ -2266,3 +2266,12 @@ func bulkWorkflowRunEvents(
 		l.Err(err).Msg("could not create bulk workflow run event")
 	}
 }
+
+func getFailedStepErrors(
+	ctx context.Context,
+	queries *dbsqlc.Queries,
+	dbtx dbsqlc.DBTX,
+	stepRunId pgtype.UUID,
+) ([]*dbsqlc.GetUpstreamErrorsForOnFailureStepRow, error) {
+	return queries.GetUpstreamErrorsForOnFailureStep(ctx, dbtx, stepRunId)
+}

--- a/pkg/repository/workflow_run.go
+++ b/pkg/repository/workflow_run.go
@@ -557,4 +557,6 @@ type WorkflowRunEngineRepository interface {
 	// DeleteExpiredWorkflowRuns deletes workflow runs that were created before the given time. It returns the number of deleted runs
 	// and the number of non-deleted runs that match the conditions.
 	SoftDeleteExpiredWorkflowRuns(ctx context.Context, tenantId string, statuses []dbsqlc.WorkflowRunStatus, before time.Time) (bool, error)
+
+	GetUpstreamErrorsForOnFailureStep(ctx context.Context, onFailureStepRunId string) ([]*dbsqlc.GetUpstreamErrorsForOnFailureStepRow, error)
 }

--- a/pkg/worker/context.go
+++ b/pkg/worker/context.go
@@ -198,7 +198,13 @@ func (h *hatchetContext) WorkflowInput(target interface{}) error {
 }
 
 func (h *hatchetContext) StepRunErrors() map[string]string {
-	return h.stepData.StepRunErrors
+	errors := h.stepData.StepRunErrors
+
+	if len(errors) == 0 {
+		h.Log("No step run errors found. `ctx.StepRunErrors` is intended to be run in an on-failure step, and will only work on engine versions more recent than v0.53.10")
+	}
+
+	return errors
 }
 
 func (h *hatchetContext) UserData(target interface{}) error {

--- a/pkg/worker/context.go
+++ b/pkg/worker/context.go
@@ -37,6 +37,8 @@ type HatchetContext interface {
 
 	StepOutput(step string, target interface{}) error
 
+	StepRunErrors() map[string]string
+
 	TriggeredByEvent() bool
 
 	WorkflowInput(target interface{}) error
@@ -96,6 +98,7 @@ type StepRunData struct {
 	Parents            map[string]StepData    `json:"parents"`
 	AdditionalMetadata map[string]string      `json:"additional_metadata"`
 	UserData           map[string]interface{} `json:"user_data"`
+	StepRunErrors      map[string]string      `json:"step_run_errors,omitempty"`
 }
 
 type StepData map[string]interface{}
@@ -192,6 +195,10 @@ func (h *hatchetContext) TriggeredByEvent() bool {
 
 func (h *hatchetContext) WorkflowInput(target interface{}) error {
 	return toTarget(h.stepData.Input, target)
+}
+
+func (h *hatchetContext) StepRunErrors() map[string]string {
+	return h.stepData.StepRunErrors
 }
 
 func (h *hatchetContext) UserData(target interface{}) error {

--- a/pkg/worker/context.go
+++ b/pkg/worker/context.go
@@ -201,7 +201,7 @@ func (h *hatchetContext) StepRunErrors() map[string]string {
 	errors := h.stepData.StepRunErrors
 
 	if len(errors) == 0 {
-		h.Log("No step run errors found. `ctx.StepRunErrors` is intended to be run in an on-failure step, and will only work on engine versions more recent than v0.53.10")
+		h.l.Error().Msg("No step run errors found. `ctx.StepRunErrors` is intended to be run in an on-failure step, and will only work on engine versions more recent than v0.53.10")
 	}
 
 	return errors

--- a/pkg/worker/middleware_test.go
+++ b/pkg/worker/middleware_test.go
@@ -36,6 +36,10 @@ func (c *testHatchetContext) UserData(target interface{}) error {
 	return nil
 }
 
+func (c *testHatchetContext) StepRunErrors() map[string]string {
+	return make(map[string]string)
+}
+
 func (c *testHatchetContext) AdditionalMetadata() map[string]string {
 	return nil
 }


### PR DESCRIPTION
Propagating errors in upstream step runs through the context by attaching a new field to the `input` that's `errors`, which is a dictionary of key-value pairs where the keys are the step names.

Really not sure if this is implemented in a reasonable way, but it does seem to work - would love some feedback here :) 

Example input from running the on failure example in Go:

```
{
  "input": {},
  "errors": {
    "step-one": "\"test on failure\""
  },
  "parents": {},
  "overrides": {},
  "user_data": null,
  "triggered_by": "manual"
}
```