### PR TITLE
Fix: Change which exceptions retry

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -269,6 +269,7 @@ func newFromOpts(opts *ClientOpts) (Client, error) {
 
 	if !opts.noGrpcRetry {
 		retryOnCodes := []codes.Code{
+			codes.ResourceExhausted,
 			codes.DeadlineExceeded,
 			codes.FailedPrecondition,
 			codes.Internal,

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -269,7 +269,10 @@ func newFromOpts(opts *ClientOpts) (Client, error) {
 
 	if !opts.noGrpcRetry {
 		retryOnCodes := []codes.Code{
-			codes.ResourceExhausted,
+			codes.DeadlineExceeded,
+			codes.FailedPrecondition,
+			codes.Internal,
+			codes.Unavailable,
 		}
 
 		retryOpts := []grpc_retry.CallOption{


### PR DESCRIPTION
Fixing which types of exceptions retry in the Go SDK - basically what it says on the tin. `ResourceExhausted` shouldn't be retried, but these other ones probably should

- [x] Bug fix (non-breaking change which fixes an issue)

Tested by running the `simple` example when the engine wasn't running on local. 

On main:

```
matt@Matts-MacBook-Pro hatchet % (cd examples/simple && go run main.go)
{"level":"debug","service":"client","time":"2025-01-16T15:09:33.072857-05:00","message":"connecting to grpc.dev.hatchet-tools.com:443 with TLS server name grpc.dev.hatchet-tools.com"}
panic: error registering workflow: could not create workflow simple: rpc error: code = Unavailable desc = unexpected HTTP status code received from server: 502 (Bad Gateway); malformed header: missing HTTP content-type

goroutine 1 [running]:
main.main()
        /Users/matt/Documents/GitHub/hatchet/examples/simple/main.go:36 +0xdc
exit status 2
```

On this branch:

```
matt@Matts-MacBook-Pro hatchet % (cd examples/simple && go run main.go)
{"level":"debug","service":"client","time":"2025-01-16T15:08:20.533618-05:00","message":"connecting to grpc.dev.hatchet-tools.com:443 with TLS server name grpc.dev.hatchet-tools.com"}
{"level":"debug","service":"client","time":"2025-01-16T15:08:25.954563-05:00","message":"grpc_retry attempt: 1, backoff for rpc error: code = Unavailable desc = unexpected HTTP status code received from server: 502 (Bad Gateway); malformed header: missing HTTP content-type"}
{"level":"debug","service":"client","time":"2025-01-16T15:08:35.414001-05:00","message":"grpc_retry attempt: 2, backoff for rpc error: code = Unavailable desc = unexpected HTTP status code received from server: 502 (Bad Gateway); malformed header: missing HTTP content-type"}
{"level":"debug","service":"client","time":"2025-01-16T15:08:54.188588-05:00","message":"grpc_retry attempt: 3, backoff for rpc error: code = Unavailable desc = unexpected HTTP status code received from server: 502 (Bad Gateway); malformed header: missing HTTP content-type"}
```