### PR TITLE
feat(go-sdk): adds preset labels on workers for autoscaling

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -86,8 +86,9 @@ type ClientOpts struct {
 	cloudRegisterID *string
 	runnableActions []string
 
-	filesLoader   filesLoaderFunc
-	initWorkflows bool
+	filesLoader        filesLoaderFunc
+	initWorkflows      bool
+	presetWorkerLabels map[string]string
 }
 
 func defaultClientOpts(token *string, cf *client.ClientConfigFile) *ClientOpts {
@@ -119,19 +120,20 @@ func defaultClientOpts(token *string, cf *client.ClientConfigFile) *ClientOpts {
 	logger := logger.NewDefaultLogger("client")
 
 	return &ClientOpts{
-		tenantId:        clientConfig.TenantId,
-		token:           clientConfig.Token,
-		l:               &logger,
-		v:               validator.NewDefaultValidator(),
-		tls:             clientConfig.TLSConfig,
-		hostPort:        clientConfig.GRPCBroadcastAddress,
-		serverURL:       clientConfig.ServerURL,
-		filesLoader:     types.DefaultLoader,
-		namespace:       clientConfig.Namespace,
-		cloudRegisterID: clientConfig.CloudRegisterID,
-		runnableActions: clientConfig.RunnableActions,
-		noGrpcRetry:     clientConfig.NoGrpcRetry,
-		sharedMeta:      make(map[string]string),
+		tenantId:           clientConfig.TenantId,
+		token:              clientConfig.Token,
+		l:                  &logger,
+		v:                  validator.NewDefaultValidator(),
+		tls:                clientConfig.TLSConfig,
+		hostPort:           clientConfig.GRPCBroadcastAddress,
+		serverURL:          clientConfig.ServerURL,
+		filesLoader:        types.DefaultLoader,
+		namespace:          clientConfig.Namespace,
+		cloudRegisterID:    clientConfig.CloudRegisterID,
+		runnableActions:    clientConfig.RunnableActions,
+		noGrpcRetry:        clientConfig.NoGrpcRetry,
+		sharedMeta:         make(map[string]string),
+		presetWorkerLabels: clientConfig.PresetWorkerLabels,
 	}
 }
 
@@ -308,7 +310,7 @@ func newFromOpts(opts *ClientOpts) (Client, error) {
 
 	subscribe := newSubscribe(conn, shared)
 	admin := newAdmin(conn, shared, subscribe)
-	dispatcher := newDispatcher(conn, shared)
+	dispatcher := newDispatcher(conn, shared, opts.presetWorkerLabels)
 	event := newEvent(conn, shared)
 
 	rest, err := rest.NewClientWithResponses(opts.serverURL, rest.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {

--- a/pkg/client/loader/loader.go
+++ b/pkg/client/loader/loader.go
@@ -119,6 +119,12 @@ func GetClientConfigFromConfigFile(cf *client.ClientConfigFile) (res *client.Cli
 		}
 	}
 
+	presetLabels := make(map[string]string)
+
+	if cf.AutoscalingTarget != "" {
+		presetLabels["hatchet-autoscaling-target"] = cf.AutoscalingTarget
+	}
+
 	return &client.ClientConfig{
 		TenantId:             cf.TenantId,
 		TLSConfig:            tlsConf,
@@ -129,6 +135,7 @@ func GetClientConfigFromConfigFile(cf *client.ClientConfigFile) (res *client.Cli
 		CloudRegisterID:      cf.CloudRegisterID,
 		RunnableActions:      rawRunnableActions,
 		NoGrpcRetry:          cf.NoGrpcRetry,
+		PresetWorkerLabels:   presetLabels,
 	}, nil
 }
 

--- a/pkg/config/client/client.go
+++ b/pkg/config/client/client.go
@@ -61,7 +61,7 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("cloudRegisterID", "HATCHET_CLOUD_REGISTER_ID")
 	_ = v.BindEnv("runnableActions", "HATCHET_CLOUD_ACTIONS")
 	_ = v.BindEnv("noGrpcRetry", "HATCHET_CLIENT_NO_GRPC_RETRY")
-	_ = v.BindEnv("autoscalingTarget", "HATCHET_AUTOSCALING_TARGET")
+	_ = v.BindEnv("autoscalingTarget", "HATCHET_CLIENT_AUTOSCALING_TARGET")
 
 	// tls options
 	_ = v.BindEnv("tls.base.tlsStrategy", "HATCHET_CLIENT_TLS_STRATEGY")

--- a/pkg/config/client/client.go
+++ b/pkg/config/client/client.go
@@ -23,6 +23,8 @@ type ClientConfigFile struct {
 
 	CloudRegisterID    *string  `mapstructure:"cloudRegisterID" json:"cloudRegisterID,omitempty"`
 	RawRunnableActions []string `mapstructure:"runnableActions" json:"runnableActions,omitempty"`
+
+	AutoscalingTarget string `mapstructure:"autoscalingTarget" json:"autoscalingTarget,omitempty"`
 }
 
 type ClientTLSConfigFile struct {
@@ -46,6 +48,8 @@ type ClientConfig struct {
 
 	CloudRegisterID *string
 	RunnableActions []string
+
+	PresetWorkerLabels map[string]string
 }
 
 func BindAllEnv(v *viper.Viper) {
@@ -57,6 +61,7 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("cloudRegisterID", "HATCHET_CLOUD_REGISTER_ID")
 	_ = v.BindEnv("runnableActions", "HATCHET_CLOUD_ACTIONS")
 	_ = v.BindEnv("noGrpcRetry", "HATCHET_CLIENT_NO_GRPC_RETRY")
+	_ = v.BindEnv("autoscalingTarget", "HATCHET_AUTOSCALING_TARGET")
 
 	// tls options
 	_ = v.BindEnv("tls.base.tlsStrategy", "HATCHET_CLIENT_TLS_STRATEGY")


### PR DESCRIPTION
# Description

Adds an option to the Go SDK to parse the environment variable `HATCHET_AUTOSCALING_TARGET` and set it as a label on workers. This is required to get autoscaling to work properly, as it gives us a mechanism to identify a group of workers that belong to the same autoscaling group. 

There's a decent amount of annoying config-drilling down to the dispatcher, but fixing that would require a rewrite of the client that we're not going to tackle right now. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)