### PR TITLE
fix: correct the number of rows selected in Workflow Runs table, afte…

### DIFF
--- a/frontend/app/src/pages/main/workflow-runs/components/workflow-runs-table.tsx
+++ b/frontend/app/src/pages/main/workflow-runs/components/workflow-runs-table.tsx
@@ -11,11 +11,11 @@ import {
 import { useMutation, useQuery } from '@tanstack/react-query';
 import invariant from 'tiny-invariant';
 import api, {
+  queries,
   ReplayWorkflowRunsRequest,
   WorkflowRunOrderByDirection,
   WorkflowRunOrderByField,
   WorkflowRunStatus,
-  queries,
 } from '@/lib/api';
 import { TenantContextType } from '@/lib/outlet';
 import { useOutletContext, useSearchParams } from 'react-router-dom';
@@ -181,6 +181,13 @@ export function WorkflowRunsTable({
     return { pageIndex, pageSize };
   });
 
+  const setPageSize = (newPageSize: number) => {
+    setPagination((prev) => ({
+      ...prev,
+      pageSize: newPageSize,
+    }));
+  };
+
   useEffect(() => {
     const newSearchParams = new URLSearchParams(searchParams);
     if (sorting.length) {
@@ -216,8 +223,6 @@ export function WorkflowRunsTable({
     setSearchParams,
     searchParams,
   ]);
-
-  const [pageSize, setPageSize] = useState<number>(50);
 
   const offset = useMemo(() => {
     if (!pagination) {
@@ -295,7 +300,7 @@ export function WorkflowRunsTable({
   const listWorkflowRunsQuery = useQuery({
     ...queries.workflowRuns.list(tenant.metadata.id, {
       offset,
-      limit: pageSize,
+      limit: pagination.pageSize,
       statuses,
       workflowId: workflow,
       parentWorkflowRunId,


### PR DESCRIPTION
…r refresh of web page

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # After changing the number of rows that can be seen in the Workflow Runs page and then refreshing the page, the URL argument "pageSize" and the "Rows per page" value remain the same, but the number of rows actually displaying goes back to the standard 50 rows. This fix corrects this issue, keeping the variation made before the refresh

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...
