### PR TITLE
Fix: Empty string workflow run status

### DIFF
--- a/api/v1/server/oas/transformers/workflow_run.go
+++ b/api/v1/server/oas/transformers/workflow_run.go
@@ -516,10 +516,11 @@ func ToScheduledWorkflowsFromSQLC(scheduled *dbsqlc.ListScheduledWorkflowsRow) *
 		}
 	}
 
-	var workflowRunStatus gen.WorkflowRunStatus
+	var workflowRunStatus *gen.WorkflowRunStatus
 
 	if scheduled.WorkflowRunStatus.Valid {
-		workflowRunStatus = gen.WorkflowRunStatus(scheduled.WorkflowRunStatus.WorkflowRunStatus)
+		status := gen.WorkflowRunStatus(scheduled.WorkflowRunStatus.WorkflowRunStatus)
+		workflowRunStatus = &status
 	}
 
 	var workflowRunIdPtr *uuid.UUID
@@ -538,7 +539,7 @@ func ToScheduledWorkflowsFromSQLC(scheduled *dbsqlc.ListScheduledWorkflowsRow) *
 		TriggerAt:            scheduled.TriggerAt.Time,
 		AdditionalMetadata:   &additionalMetadata,
 		WorkflowRunCreatedAt: &scheduled.WorkflowRunCreatedAt.Time,
-		WorkflowRunStatus:    &workflowRunStatus,
+		WorkflowRunStatus:    workflowRunStatus,
 		WorkflowRunId:        workflowRunIdPtr,
 		WorkflowRunName:      &scheduled.WorkflowRunName.String,
 		Method:               gen.ScheduledWorkflowsMethod(scheduled.Method),


### PR DESCRIPTION
Bug fix for https://discord.com/channels/1088927970518909068/1331450119861829664

TL;DR is that the workflow run status seems to get serialized as an empty string instead of `nil` since it's initialized as a string, which then makes Pydantic fail downstream since it wants an enum or None

- [x] Bug fix (non-breaking change which fixes an issue)
