### PR TITLE
Feat: Sample Sentries in the Engine

### DIFF
--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -334,6 +334,7 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 		alerter, err = sentry.NewSentryAlerter(&sentry.SentryAlerterOpts{
 			DSN:         cf.Alerting.Sentry.DSN,
 			Environment: cf.Alerting.Sentry.Environment,
+			SampleRate:  cf.Alerting.Sentry.SampleRate,
 		})
 
 		if err != nil {

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -218,6 +218,9 @@ type SentryConfigFile struct {
 
 	// Environment is the environment that the instance is running in
 	Environment string `mapstructure:"environment" json:"environment,omitempty" default:"development"`
+
+	// Sample rate is the rate at which to sample events. Default is 1.0 to sample all events.
+	SampleRate float64 `mapstructure:"sampleRate" json:"sampleRate,omitempty" default:"1.0"`
 }
 
 type AnalyticsConfigFile struct {

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -558,6 +558,7 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("alerting.sentry.enabled", "SERVER_ALERTING_SENTRY_ENABLED")
 	_ = v.BindEnv("alerting.sentry.dsn", "SERVER_ALERTING_SENTRY_DSN")
 	_ = v.BindEnv("alerting.sentry.environment", "SERVER_ALERTING_SENTRY_ENVIRONMENT")
+	_ = v.BindEnv("alerting.sentry.sampleRate", "SERVER_ALERTING_SENTRY_SAMPLE_RATE")
 
 	// analytics options
 	_ = v.BindEnv("analytics.posthog.enabled", "SERVER_ANALYTICS_POSTHOG_ENABLED")

--- a/pkg/errors/sentry/sentry.go
+++ b/pkg/errors/sentry/sentry.go
@@ -26,6 +26,7 @@ func NewSentryAlerter(opts *SentryAlerterOpts) (*SentryAlerter, error) {
 		AttachStacktrace: true,
 		Integrations:     noIntegrations,
 		Environment:      opts.Environment,
+		SampleRate:       0.025,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/errors/sentry/sentry.go
+++ b/pkg/errors/sentry/sentry.go
@@ -3,8 +3,6 @@ package sentry
 import (
 	"context"
 	"fmt"
-	"os"
-	"strconv"
 
 	"github.com/getsentry/sentry-go"
 )
@@ -20,28 +18,18 @@ func noIntegrations(ints []sentry.Integration) []sentry.Integration {
 type SentryAlerterOpts struct {
 	DSN         string
 	Environment string
+	SampleRate  float64
 }
 
 func NewSentryAlerter(opts *SentryAlerterOpts) (*SentryAlerter, error) {
-	value, exists := os.LookupEnv("SENTRY_SAMPLE_RATE")
-
-	if !exists {
-		value = "1.0"
-	}
-
-	sampleRate, err := strconv.ParseFloat(value, 64)
-
-	if err != nil {
-		sampleRate = 1.0
-	}
-
 	sentryClient, err := sentry.NewClient(sentry.ClientOptions{
 		Dsn:              opts.DSN,
 		AttachStacktrace: true,
 		Integrations:     noIntegrations,
 		Environment:      opts.Environment,
-		SampleRate:       sampleRate,
+		SampleRate:       opts.SampleRate,
 	})
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/errors/sentry/sentry.go
+++ b/pkg/errors/sentry/sentry.go
@@ -3,6 +3,8 @@ package sentry
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 
 	"github.com/getsentry/sentry-go"
 )
@@ -21,12 +23,24 @@ type SentryAlerterOpts struct {
 }
 
 func NewSentryAlerter(opts *SentryAlerterOpts) (*SentryAlerter, error) {
+	value, exists := os.LookupEnv("SENTRY_SAMPLE_RATE")
+
+	if !exists {
+		value = "1.0"
+	}
+
+	sampleRate, err := strconv.ParseFloat(value, 64)
+
+	if err != nil {
+		sampleRate = 1.0
+	}
+
 	sentryClient, err := sentry.NewClient(sentry.ClientOptions{
 		Dsn:              opts.DSN,
 		AttachStacktrace: true,
 		Integrations:     noIntegrations,
 		Environment:      opts.Environment,
-		SampleRate:       0.025,
+		SampleRate:       sampleRate,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Setting up sampling for Sentries in the engine so we don't flood our quota. Configurable via an env var which should default to 1.0

- [x] New feature (non-breaking change which adds functionality)

