### PR TITLE
docs: fix rabbit mq docker-compose volume mount

### DIFF
--- a/frontend/docs/pages/self-hosting/hatchet-lite.mdx
+++ b/frontend/docs/pages/self-hosting/hatchet-lite.mdx
@@ -65,7 +65,7 @@ services:
       DATABASE_LOGGER_LEVEL: warn
       DATABASE_LOGGER_FORMAT: console
     volumes:
-      - "hatchet_lite_rabbitmq_data:/var/lib/rabbitmq/mnesia"
+      - "hatchet_lite_rabbitmq_data:/var/lib/rabbitmq"
       - "hatchet_lite_config:/config"
 
 volumes:


### PR DESCRIPTION
# Description

The previously recommended hatchet lite creates an anonymous volume because the rabbitmq image itself creates a volume. Changing our named volume to match this default volume path prevents the double volume creation.

## Type of change

- [x] Documentation change (pure documentation change)


