### PR TITLE
Fix: Tenant switching, part II

### DIFF
--- a/frontend/app/src/lib/atoms.ts
+++ b/frontend/app/src/lib/atoms.ts
@@ -1,7 +1,7 @@
 import { atom, useAtom } from 'jotai';
 import { Tenant, queries } from './api';
 import { useSearchParams } from 'react-router-dom';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 const getInitialValue = <T>(key: string, defaultValue?: T): T | undefined => {
@@ -30,10 +30,19 @@ export const lastTenantAtom = atom(
   },
 );
 
-type TenantContext = {
-  tenant: Tenant | undefined;
+type TenantContextPresent = {
+  tenant: Tenant;
+  tenantId: string;
   setTenant: (tenant: Tenant) => void;
-};
+}
+
+type TenantContextMissing = {
+  tenant: undefined;
+  tenantId: undefined;
+  setTenant: (tenant: Tenant) => void;
+}
+
+type TenantContext = TenantContextPresent | TenantContextMissing;
 
 // search param sets the tenant, the last tenant set is used if the search param is empty,
 // otherwise the first membership is used
@@ -88,7 +97,7 @@ export function useTenant(): TenantContext {
 
     // Finally, if neither a current tenant is set as a query param
     // nor if a tenant was set in Jotai, use the first membership as a fallback
-    const firstMembershipTenant = memberships?.[0]?.tenant;
+    const firstMembershipTenant = memberships.at(0)?.tenant;
 
     return firstMembershipTenant;
   }, [memberships, searchParams, findTenant, lastTenant]);
@@ -96,8 +105,30 @@ export function useTenant(): TenantContext {
   const currTenantId = searchParams.get('tenant');
   const currTenant = currTenantId ? findTenant(currTenantId) : undefined;
 
+  const tenant = currTenant || computedCurrTenant;
+
+  // If the tenant is not set as a query param at any point,
+  // set it.
+  // NOTE: This is helpful mostly for debugging to easily grab
+  // the tenant from the URL.
+  useEffect(() => {
+    const currentTenantParam = searchParams.get('tenant');
+    if (!currentTenantParam && tenant) {
+      setTenant(tenant);
+    }
+  }, [searchParams, tenant])
+
+  if (!tenant) {
+    return {
+      tenant: undefined,
+      tenantId: undefined,
+      setTenant,
+    };
+  }
+
   return {
-    tenant: currTenant || computedCurrTenant,
+    tenant,
+    tenantId: tenant.metadata.id,
     setTenant,
   };
 }

--- a/frontend/app/src/lib/atoms.ts
+++ b/frontend/app/src/lib/atoms.ts
@@ -34,13 +34,13 @@ type TenantContextPresent = {
   tenant: Tenant;
   tenantId: string;
   setTenant: (tenant: Tenant) => void;
-}
+};
 
 type TenantContextMissing = {
   tenant: undefined;
   tenantId: undefined;
   setTenant: (tenant: Tenant) => void;
-}
+};
 
 type TenantContext = TenantContextPresent | TenantContextMissing;
 
@@ -50,12 +50,15 @@ export function useTenant(): TenantContext {
   const [lastTenant, setLastTenant] = useAtom(lastTenantAtom);
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const setTenant = (tenant: Tenant) => {
-    const newSearchParams = new URLSearchParams(searchParams);
-    newSearchParams.set('tenant', tenant.metadata.id);
-    setSearchParams(newSearchParams, { replace: true });
-    setLastTenant(tenant);
-  };
+  const setTenant = useCallback(
+    (tenant: Tenant) => {
+      const newSearchParams = new URLSearchParams(searchParams);
+      newSearchParams.set('tenant', tenant.metadata.id);
+      setSearchParams(newSearchParams, { replace: true });
+      setLastTenant(tenant);
+    },
+    [searchParams, setSearchParams, setLastTenant],
+  );
 
   const membershipsQuery = useQuery({
     ...queries.user.listTenantMemberships,
@@ -116,7 +119,7 @@ export function useTenant(): TenantContext {
     if (!currentTenantParam && tenant) {
       setTenant(tenant);
     }
-  }, [searchParams, tenant])
+  }, [searchParams, tenant, setTenant]);
 
   if (!tenant) {
     return {

--- a/frontend/app/src/pages/onboarding/create-tenant/index.tsx
+++ b/frontend/app/src/pages/onboarding/create-tenant/index.tsx
@@ -3,12 +3,14 @@ import { useApiError } from '@/lib/hooks';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { TenantCreateForm } from './components/tenant-create-form';
+import { useTenant } from '@/lib/atoms';
 
 export default function CreateTenant() {
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const { handleApiError } = useApiError({
     setFieldErrors: setFieldErrors,
   });
+  const { setTenant } = useTenant();
 
   const listMembershipsQuery = useQuery({
     ...queries.user.listTenantMemberships,
@@ -21,6 +23,7 @@ export default function CreateTenant() {
       return tenant.data;
     },
     onSuccess: async (tenant) => {
+      setTenant(tenant);
       await listMembershipsQuery.refetch();
       window.location.href = `/onboarding/get-started?tenant=${tenant.metadata.id}`;
     },


### PR DESCRIPTION
# Description

Fixing two more small issues in switching tenants:

1. Adding a `useEffect` hook to the `useTenant` hook to always set the tenant as a query param (mostly helps with debugging)
2. Ensuring that we correctly switch to the newly created tenant when a new tenant is created by calling `setTenant` explicitly

- [x] Bug fix (non-breaking change which fixes an issue)

