### PR TITLE
fix: link to billing limits in resource exhausted email.

### DIFF
--- a/internal/integrations/alerting/alerter.go
+++ b/internal/integrations/alerting/alerter.go
@@ -247,7 +247,7 @@ func (t *TenantAlertManager) SendTenantResourceLimitAlert(tenantId string, alert
 	}
 
 	payload := &alerttypes.ResourceLimitAlert{
-		Link:          fmt.Sprintf("%s/tenant-settings/resource-limits?tenant=%s", t.serverURL, tenantId),
+		Link:          fmt.Sprintf("%s/tenant-settings/billing-and-limits?tenant=%s", t.serverURL, tenantId),
 		Resource:      string(alert.Resource),
 		AlertType:     string(alert.AlertType),
 		CurrentValue:  int(alert.Value),


### PR DESCRIPTION
# Description

The path in the resource exhausted email does not point to the billing and limits page

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

