### PR TITLE
fix: memory

### DIFF
--- a/pkg/scheduling/v2/extension.go
+++ b/pkg/scheduling/v2/extension.go
@@ -11,11 +11,7 @@ import (
 type PostScheduleInput struct {
 	Workers map[string]*WorkerCp
 
-	Slots []*SlotCp
-
 	Unassigned []*dbsqlc.QueueItem
-
-	ActionsToSlots map[string][]*SlotCp
 }
 
 type WorkerCp struct {

--- a/pkg/scheduling/v2/extension.go
+++ b/pkg/scheduling/v2/extension.go
@@ -9,9 +9,14 @@ import (
 )
 
 type PostScheduleInput struct {
-	Workers map[string]*WorkerCp
+	Workers               map[string]*WorkerCp
+	HasUnassignedStepRuns bool
+	WorkerSlotUtilization map[string]*SlotUtilization
+}
 
-	Unassigned []*dbsqlc.QueueItem
+type SlotUtilization struct {
+	UtilizedSlots    int
+	NonUtilizedSlots int
 }
 
 type WorkerCp struct {

--- a/pkg/scheduling/v2/scheduler.go
+++ b/pkg/scheduling/v2/scheduler.go
@@ -765,88 +765,26 @@ func (s *Scheduler) tryAssign(
 }
 
 func (s *Scheduler) getExtensionInput(results []*assignResults) *PostScheduleInput {
-	// Pre-allocate maps and slices with capacity to reduce reallocations
-	unassigned := make([]*dbsqlc.QueueItem, 0, len(results)*10) // Estimate capacity
+	unassigned := make([]*dbsqlc.QueueItem, 0)
+
+	for _, res := range results {
+		unassigned = append(unassigned, res.unassigned...)
+	}
+
 	workers := s.getWorkers()
 
 	res := &PostScheduleInput{
-		Workers:    make(map[string]*WorkerCp, len(workers)),
-		Slots:      make([]*SlotCp, 0, 1000), // Set reasonable initial capacity
+		Workers:    make(map[string]*WorkerCp),
 		Unassigned: unassigned,
 	}
 
-	// Reuse worker IDs where possible instead of converting UUID multiple times
-	workerIDCache := make(map[pgtype.UUID]string, len(workers))
-
 	for workerId, worker := range workers {
-		// Cache the string version of worker ID
-		workerIDCache[worker.ListActiveWorkersResult.ID] = workerId
-
 		res.Workers[workerId] = &WorkerCp{
 			WorkerId: workerId,
 			MaxRuns:  worker.MaxRuns,
 			Labels:   worker.Labels,
 		}
 	}
-
-	for _, r := range results {
-		unassigned = append(unassigned, r.unassigned...)
-	}
-
-	// Get action keys once
-	s.actionsMu.RLock()
-	actionKeys := make([]string, 0, len(s.actions))
-	for actionId := range s.actions {
-		actionKeys = append(actionKeys, actionId)
-	}
-	s.actionsMu.RUnlock()
-
-	// Use a map to deduplicate slots with a reasonable initial capacity
-	uniqueSlots := make(map[*slot]struct{}, 1000)
-	actionsToSlots := make(map[string][]*SlotCp, len(actionKeys))
-
-	// Preallocate slot copies to reduce GC pressure
-	slotCopies := make([]*SlotCp, 0, 1000)
-
-	for _, actionId := range actionKeys {
-		s.actionsMu.RLock()
-		action, ok := s.actions[actionId]
-		s.actionsMu.RUnlock()
-
-		if !ok || action == nil {
-			continue
-		}
-
-		action.mu.RLock()
-		// Pre-allocate the slice for this action's slots
-		actionsToSlots[action.actionId] = make([]*SlotCp, 0, len(action.slots))
-
-		for _, slot := range action.slots {
-			if _, exists := uniqueSlots[slot]; exists {
-				continue
-			}
-			uniqueSlots[slot] = struct{}{}
-
-			// Reuse cached worker ID instead of converting UUID again
-			workerId := workerIDCache[slot.worker.ID]
-
-			// Create slot copy
-			slotCp := &SlotCp{
-				WorkerId: workerId,
-				Used:     slot.used,
-			}
-			slotCopies = append(slotCopies, slotCp)
-
-			// Reference the same slot copy in actionsToSlots
-			actionsToSlots[action.actionId] = append(actionsToSlots[action.actionId], slotCp)
-		}
-		action.mu.RUnlock()
-	}
-
-	// Set final slots slice
-	res.Slots = slotCopies
-	res.ActionsToSlots = actionsToSlots
-	res.Unassigned = unassigned
 
 	return res
 }

--- a/pkg/scheduling/v2/scheduler.go
+++ b/pkg/scheduling/v2/scheduler.go
@@ -839,6 +839,8 @@ func (s *Scheduler) getExtensionInput(results []*assignResults) *PostScheduleInp
 
 	res.WorkerSlotUtilization = workerSlotUtilization
 
+	res.HasUnassignedStepRuns = len(unassigned) > 0
+
 	return res
 }
 


### PR DESCRIPTION
# Description

Deadcode in the scheduler can lead to Num Slots * Workers * Actions memory overhead which can OOM schedulers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## What's Changed

- [x] Removed unused code
