### PR TITLE
fix: make extension less memory intensive

### DIFF
--- a/pkg/scheduling/v2/randomticker/ticker.go
+++ b/pkg/scheduling/v2/randomticker/ticker.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2020 Filip Wojciechowski
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package randomticker
+
+import (
+	"math/rand"
+	"time"
+)
+
+// RandomTicker is similar to time.Ticker but ticks at random intervals between
+// the min and max duration values (stored internally as int64 nanosecond
+// counts).
+type RandomTicker struct {
+	C     chan time.Time
+	stopc chan chan struct{}
+	min   int64
+	max   int64
+}
+
+// NewRandomTicker returns a pointer to an initialized instance of the
+// RandomTicker. Min and max are durations of the shortest and longest allowed
+// ticks. Ticker will run in a goroutine until explicitly stopped.
+func NewRandomTicker(minDuration, maxDuration time.Duration) *RandomTicker {
+	rt := &RandomTicker{
+		C:     make(chan time.Time),
+		stopc: make(chan chan struct{}),
+		min:   minDuration.Nanoseconds(),
+		max:   maxDuration.Nanoseconds(),
+	}
+	go rt.loop()
+	return rt
+}
+
+// Stop terminates the ticker goroutine and closes the C channel.
+func (rt *RandomTicker) Stop() {
+	c := make(chan struct{})
+	rt.stopc <- c
+	<-c
+}
+
+func (rt *RandomTicker) loop() {
+	defer close(rt.C)
+	t := time.NewTimer(rt.nextInterval())
+	for {
+		// either a stop signal or a timeout
+		select {
+		case c := <-rt.stopc:
+			t.Stop()
+			close(c)
+			return
+		case <-t.C:
+			select {
+			case rt.C <- time.Now():
+				t.Stop()
+				t = time.NewTimer(rt.nextInterval())
+			default:
+				// there could be noone receiving...
+			}
+		}
+	}
+}
+
+func (rt *RandomTicker) nextInterval() time.Duration {
+	interval := rand.Int63n(rt.max-rt.min) + rt.min // nolint: gosec
+	return time.Duration(interval) * time.Nanosecond
+}

--- a/pkg/scheduling/v2/randomticker/ticker_test.go
+++ b/pkg/scheduling/v2/randomticker/ticker_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2020 Filip Wojciechowski
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package randomticker_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/pkg/scheduling/v2/randomticker"
+)
+
+func TestRandomTicker(t *testing.T) {
+	t.Parallel()
+
+	minDuration := time.Duration(10)
+	maxDuration := time.Duration(20)
+
+	// tick can take a little longer since we're not adjusting it to account for
+	// processing.
+	precision := time.Duration(4)
+
+	rt := randomticker.NewRandomTicker(minDuration*time.Millisecond, maxDuration*time.Millisecond)
+	for i := 0; i < 5; i++ {
+		t0 := time.Now()
+		t1 := <-rt.C
+		td := t1.Sub(t0)
+		if td < minDuration*time.Millisecond {
+			t.Fatalf("tick was shorter than expected: %s", td)
+		} else if td > (maxDuration+precision)*time.Millisecond {
+			t.Fatalf("tick was longer than expected: %s", td)
+		}
+	}
+	rt.Stop()
+	time.Sleep((maxDuration + precision) * time.Millisecond)
+	select {
+	case v, ok := <-rt.C:
+		if ok || !v.IsZero() {
+			t.Fatal("ticker did not shut down")
+		}
+	default:
+		t.Fatal("expected to receive close channel signal")
+	}
+}


### PR DESCRIPTION
# Description

Introduces sampling for a snapshot of the worker utilization state in the scheduler, instead of snapshotting after every queue event. Separates extension `PostAssign` hooks from snapshot hooks. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)