### PR TITLE
fix: schedule latest version

### DIFF
--- a/pkg/repository/prisma/dbsqlc/tickers.sql.go
+++ b/pkg/repository/prisma/dbsqlc/tickers.sql.go
@@ -419,18 +419,28 @@ func (q *Queries) PollGetGroupKeyRuns(ctx context.Context, db DBTX, tickerid pgt
 const pollScheduledWorkflows = `-- name: PollScheduledWorkflows :many
 WITH not_run_scheduled_workflows AS (
     SELECT
+        latestVersions."version",
         scheduledWorkflow."id",
-        versions."id" AS "workflowVersionId",
+        latestVersions."id" AS "workflowVersionId",
         workflow."tenantId" AS "tenantId",
         scheduledWorkflow."additionalMetadata" AS "additionalMetadata"
     FROM
-        "WorkflowTriggerScheduledRef" as scheduledWorkflow
+        "WorkflowTriggerScheduledRef" AS scheduledWorkflow
     JOIN
-        "WorkflowVersion" as versions ON versions."id" = scheduledWorkflow."parentId"
+        "WorkflowVersion" AS versions ON versions."id" = scheduledWorkflow."parentId"
     JOIN
-        "Workflow" as workflow ON workflow."id" = versions."workflowId"
+        "Workflow" AS workflow ON workflow."id" = versions."workflowId"
+    JOIN
+        (
+            -- Subquery to get the latest version per workflow
+            SELECT DISTINCT ON ("workflowId")
+                "id", "workflowId", "version"
+            FROM "WorkflowVersion"
+            WHERE "deletedAt" IS NULL
+            ORDER BY "workflowId", "version" DESC
+        ) AS latestVersions ON latestVersions."workflowId" = workflow."id"
     LEFT JOIN
-        "WorkflowRunTriggeredBy" as runTriggeredBy ON runTriggeredBy."scheduledId" = scheduledWorkflow."id"
+        "WorkflowRunTriggeredBy" AS runTriggeredBy ON runTriggeredBy."scheduledId" = scheduledWorkflow."id"
     WHERE
         "triggerAt" <= NOW() + INTERVAL '5 seconds'
         AND runTriggeredBy IS NULL
@@ -446,7 +456,7 @@ WITH not_run_scheduled_workflows AS (
 ),
 active_scheduled_workflows AS (
     SELECT
-        id, "workflowVersionId", "tenantId", "additionalMetadata"
+        version, id, "workflowVersionId", "tenantId", "additionalMetadata"
     FROM
         not_run_scheduled_workflows
     FOR UPDATE SKIP LOCKED


### PR DESCRIPTION
# Description

Scheduled workflows were running the version at the time of scheduling which likely will not exist if a new version exists. 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## What's Changed

- [x] Scheduled runs will run the latest version on runtime
