### PR TITLE
fix: scheduled workflows query

### DIFF
--- a/pkg/repository/prisma/dbsqlc/tickers.sql
+++ b/pkg/repository/prisma/dbsqlc/tickers.sql
@@ -104,6 +104,8 @@ WITH latest_workflow_versions AS (
         MAX("order") as max_order
     FROM
         "WorkflowVersion"
+    WHERE
+        "deletedAt" IS NULL
     GROUP BY "workflowId"
 ),
 active_cron_schedules AS (
@@ -151,6 +153,8 @@ WITH latest_workflow_versions AS (
         "id"
     FROM
         "WorkflowVersion"
+    WHERE
+        "deletedAt" IS NULL
     ORDER BY "workflowId", "order" DESC
 ), not_run_scheduled_workflows AS (
     SELECT

--- a/pkg/repository/prisma/dbsqlc/tickers.sql
+++ b/pkg/repository/prisma/dbsqlc/tickers.sql
@@ -144,9 +144,16 @@ RETURNING cronSchedules.*, active_cron_schedules."workflowVersionId", active_cro
 -- name: PollScheduledWorkflows :many
 -- Finds workflows that are either past their execution time or will be in the next 5 seconds and assigns them
 -- to a ticker, or finds workflows that were assigned to a ticker that is no longer active
-WITH not_run_scheduled_workflows AS (
+WITH latest_workflow_versions AS (
     SELECT
-        latestVersions."version",
+        DISTINCT ON("workflowId")
+        "workflowId",
+        "id"
+    FROM
+        "WorkflowVersion"
+    ORDER BY "workflowId", "order" DESC
+), not_run_scheduled_workflows AS (
+    SELECT
         scheduledWorkflow."id",
         latestVersions."id" AS "workflowVersionId",
         workflow."tenantId" AS "tenantId",
@@ -158,14 +165,7 @@ WITH not_run_scheduled_workflows AS (
     JOIN
         "Workflow" AS workflow ON workflow."id" = versions."workflowId"
     JOIN
-        (
-            -- Subquery to get the latest version per workflow
-            SELECT DISTINCT ON ("workflowId")
-                "id", "workflowId", "version"
-            FROM "WorkflowVersion"
-            WHERE "deletedAt" IS NULL
-            ORDER BY "workflowId", "version" DESC
-        ) AS latestVersions ON latestVersions."workflowId" = workflow."id"
+        latest_workflow_versions AS latestVersions ON latestVersions."workflowId" = workflow."id" AND latestVersions."id" = versions."id"
     LEFT JOIN
         "WorkflowRunTriggeredBy" AS runTriggeredBy ON runTriggeredBy."scheduledId" = scheduledWorkflow."id"
     WHERE

--- a/pkg/repository/prisma/dbsqlc/tickers.sql.go
+++ b/pkg/repository/prisma/dbsqlc/tickers.sql.go
@@ -417,9 +417,16 @@ func (q *Queries) PollGetGroupKeyRuns(ctx context.Context, db DBTX, tickerid pgt
 }
 
 const pollScheduledWorkflows = `-- name: PollScheduledWorkflows :many
-WITH not_run_scheduled_workflows AS (
+WITH latest_workflow_versions AS (
     SELECT
-        latestVersions."version",
+        DISTINCT ON("workflowId")
+        "workflowId",
+        "id"
+    FROM
+        "WorkflowVersion"
+    ORDER BY "workflowId", "order" DESC
+), not_run_scheduled_workflows AS (
+    SELECT
         scheduledWorkflow."id",
         latestVersions."id" AS "workflowVersionId",
         workflow."tenantId" AS "tenantId",
@@ -431,14 +438,7 @@ WITH not_run_scheduled_workflows AS (
     JOIN
         "Workflow" AS workflow ON workflow."id" = versions."workflowId"
     JOIN
-        (
-            -- Subquery to get the latest version per workflow
-            SELECT DISTINCT ON ("workflowId")
-                "id", "workflowId", "version"
-            FROM "WorkflowVersion"
-            WHERE "deletedAt" IS NULL
-            ORDER BY "workflowId", "version" DESC
-        ) AS latestVersions ON latestVersions."workflowId" = workflow."id"
+        latest_workflow_versions AS latestVersions ON latestVersions."workflowId" = workflow."id" AND latestVersions."id" = versions."id"
     LEFT JOIN
         "WorkflowRunTriggeredBy" AS runTriggeredBy ON runTriggeredBy."scheduledId" = scheduledWorkflow."id"
     WHERE
@@ -456,7 +456,7 @@ WITH not_run_scheduled_workflows AS (
 ),
 active_scheduled_workflows AS (
     SELECT
-        version, id, "workflowVersionId", "tenantId", "additionalMetadata"
+        id, "workflowVersionId", "tenantId", "additionalMetadata"
     FROM
         not_run_scheduled_workflows
     FOR UPDATE SKIP LOCKED

--- a/pkg/repository/prisma/dbsqlc/tickers.sql.go
+++ b/pkg/repository/prisma/dbsqlc/tickers.sql.go
@@ -192,6 +192,8 @@ WITH latest_workflow_versions AS (
         MAX("order") as max_order
     FROM
         "WorkflowVersion"
+    WHERE
+        "deletedAt" IS NULL
     GROUP BY "workflowId"
 ),
 active_cron_schedules AS (
@@ -424,6 +426,8 @@ WITH latest_workflow_versions AS (
         "id"
     FROM
         "WorkflowVersion"
+    WHERE
+        "deletedAt" IS NULL
     ORDER BY "workflowId", "order" DESC
 ), not_run_scheduled_workflows AS (
     SELECT


### PR DESCRIPTION
# Description

(bug introduced in `v0.54.8`)

The scheduled workflows query was incorrectly sorting by `"version" DESC`, which is essentially a random ordering. `version` is a user-friendly display name for the version, but `order` is the source of truth for workflow versioning. 

This was causing scheduled workflows to essentially execute a random version of the workflow. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)