### PR TITLE
increase rabbitmq consumer timeout

### DIFF
--- a/internal/msgqueue/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/rabbitmq/rabbitmq.go
@@ -355,7 +355,7 @@ func (t *MessageQueueImpl) initQueue(sub session, q msgqueue.Queue) (string, err
 	if q.DLX() != "" {
 		args["x-dead-letter-exchange"] = ""
 		args["x-dead-letter-routing-key"] = q.DLX()
-		args["x-consumer-timeout"] = 5000 // 5 seconds
+		args["x-consumer-timeout"] = 300000 // 5 minutes
 
 		dlqArgs := make(amqp.Table)
 

--- a/internal/services/controllers/workflows/controller.go
+++ b/internal/services/controllers/workflows/controller.go
@@ -164,7 +164,7 @@ func New(fs ...WorkflowsControllerOpt) (*WorkflowsControllerImpl, error) {
 
 	w.processWorkflowEventsOps = queueutils.NewOperationPool(w.l, time.Second*5, "process workflow events", w.processWorkflowEvents)
 	w.unpausedWorkflowRunsOps = queueutils.NewOperationPool(w.l, time.Second*5, "unpause workflow runs", w.unpauseWorkflowRuns)
-	w.bumpQueueOps = queueutils.NewOperationPool(w.l, time.Second*5, "bump queue", w.runPollActiveQueuesTenant)
+	w.bumpQueueOps = queueutils.NewOperationPool(w.l, time.Second*60, "bump queue", w.runPollActiveQueuesTenant)
 
 	return w, nil
 }

--- a/pkg/repository/prisma/workflow_run.go
+++ b/pkg/repository/prisma/workflow_run.go
@@ -1055,7 +1055,7 @@ func (w *workflowRunEngineRepository) PopWorkflowRunsCancelNewest(ctx context.Co
 
 func (w *workflowRunEngineRepository) PopWorkflowRunsRoundRobin(ctx context.Context, tenantId string, workflowVersionId string, maxRuns int) ([]*dbsqlc.WorkflowRun, []*dbsqlc.GetStepRunForEngineRow, error) {
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, w.pool, w.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, w.pool, w.l, 30000)
 
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
# Description

Increase the RabbitMQ delivery ack timeout from 5 seconds to 5 minutes. This shouldn't be set to such a low value, it should be greater than context timeouts.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)