### PR TITLE
fix: stable order

### DIFF
--- a/pkg/repository/prisma/dbsqlc/step_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql
@@ -530,20 +530,33 @@ WHERE
 
 -- name: BulkBackoffStepRun :exec
 UPDATE
-    "StepRun"
+    "StepRun" sr
 SET
-    "status" = 'BACKOFF'
-WHERE
-    "id" = ANY(@stepRunIds::uuid[]);
+    sr."status" = 'BACKOFF'
+FROM (
+    SELECT "id"
+    FROM "StepRun" sr2
+    WHERE sr2."id" = ANY(@stepRunIds::uuid[])
+    ORDER BY  sr2."id"
+    FOR UPDATE
+) upd
+WHERE sr."id" = upd."id";
+
 
 
 -- name: BulkRetryStepRun :exec
 UPDATE
-    "StepRun"
+    "StepRun" sr
 SET
-    "status" = 'PENDING_ASSIGNMENT'
-WHERE
-    "id" = ANY(@stepRunIds::uuid[]);
+    sr."status" = 'PENDING_ASSIGNMENT'
+FROM (
+    SELECT "id"
+    FROM "StepRun" sr2
+    WHERE sr2."id" = ANY(@stepRunIds::uuid[])
+    ORDER BY  sr2."id"
+    FOR UPDATE
+) upd
+WHERE sr."id" = upd."id";
 
 -- name: ResolveLaterStepRuns :many
 WITH RECURSIVE currStepRun AS (

--- a/pkg/repository/prisma/dbsqlc/step_runs.sql
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql
@@ -532,7 +532,7 @@ WHERE
 UPDATE
     "StepRun" sr
 SET
-    sr."status" = 'BACKOFF'
+    "status" = 'BACKOFF'
 FROM (
     SELECT "id"
     FROM "StepRun" sr2
@@ -548,7 +548,7 @@ WHERE sr."id" = upd."id";
 UPDATE
     "StepRun" sr
 SET
-    sr."status" = 'PENDING_ASSIGNMENT'
+    "status" = 'PENDING_ASSIGNMENT'
 FROM (
     SELECT "id"
     FROM "StepRun" sr2

--- a/pkg/repository/prisma/dbsqlc/step_runs.sql.go
+++ b/pkg/repository/prisma/dbsqlc/step_runs.sql.go
@@ -112,7 +112,7 @@ const bulkBackoffStepRun = `-- name: BulkBackoffStepRun :exec
 UPDATE
     "StepRun" sr
 SET
-    sr."status" = 'BACKOFF'
+    "status" = 'BACKOFF'
 FROM (
     SELECT "id"
     FROM "StepRun" sr2
@@ -365,7 +365,7 @@ const bulkRetryStepRun = `-- name: BulkRetryStepRun :exec
 UPDATE
     "StepRun" sr
 SET
-    sr."status" = 'PENDING_ASSIGNMENT'
+    "status" = 'PENDING_ASSIGNMENT'
 FROM (
     SELECT "id"
     FROM "StepRun" sr2


### PR DESCRIPTION
# Description

Adds stable sort to bulk update operation (https://stackoverflow.com/questions/27007196/avoiding-postgresql-deadlocks-when-performing-bulk-update-and-delete-operations)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

