### PR TITLE
feat(v1): workflow-based concurrency

### DIFF
--- a/internal/services/admin/v1/server.go
+++ b/internal/services/admin/v1/server.go
@@ -160,7 +160,7 @@ func (a *AdminServiceImpl) ReplayTasks(ctx context.Context, req *contracts.Repla
 			since       = req.Filter.Since.AsTime()
 			until       *time.Time
 			workflowIds       = []uuid.UUID{}
-			limit       int64 = 20000
+			limit       int64 = 1000
 			offset      int64
 		)
 
@@ -237,6 +237,8 @@ func (a *AdminServiceImpl) ReplayTasks(ctx context.Context, req *contracts.Repla
 			RetryCount: task.RetryCount,
 		})
 	}
+
+	// FIXME: group tasks by their workflow run id, and send in batches of 50 workflow run ids...
 
 	// send the payload to the tasks controller, and send the list of tasks back to the client
 	toReplay := tasktypes.ReplayTasksPayload{

--- a/internal/services/controllers/v1/task/process_timeouts.go
+++ b/internal/services/controllers/v1/task/process_timeouts.go
@@ -69,6 +69,7 @@ func (tc *TasksControllerImpl) processTaskTimeouts(ctx context.Context, tenantId
 			ExternalId:    sqlchelpers.UUIDToStr(task.ExternalID),
 			WorkflowRunId: sqlchelpers.UUIDToStr(task.WorkflowRunID),
 			EventType:     sqlcv1.V1EventTypeOlapTIMEDOUT,
+			EventMessage:  fmt.Sprintf("Task exceeded timeout of %s", task.StepTimeout.String),
 			ShouldNotify:  true,
 		})
 	}

--- a/internal/services/scheduler/v1/scheduler.go
+++ b/internal/services/scheduler/v1/scheduler.go
@@ -509,6 +509,7 @@ func (s *Scheduler) scheduleStepRuns(ctx context.Context, tenantId string, res *
 				sqlchelpers.UUIDToStr(schedulingTimedOut.WorkflowRunID),
 				schedulingTimedOut.RetryCount,
 				sqlcv1.V1EventTypeOlapSCHEDULINGTIMEDOUT,
+				"",
 				false,
 			)
 
@@ -627,11 +628,14 @@ func (s *Scheduler) notifyAfterConcurrency(ctx context.Context, tenantId string,
 	// handle cancellations
 	for _, cancelled := range res.Cancelled {
 		eventType := sqlcv1.V1EventTypeOlapCANCELLED
+		eventMessage := ""
 		shouldNotify := true
 
 		if cancelled.CancelledReason == "SCHEDULING_TIMED_OUT" {
 			eventType = sqlcv1.V1EventTypeOlapSCHEDULINGTIMEDOUT
 			shouldNotify = false
+		} else {
+			eventMessage = "Cancelled due to concurrency strategy"
 		}
 
 		msg, err := tasktypes.CancelledTaskMessage(
@@ -642,6 +646,7 @@ func (s *Scheduler) notifyAfterConcurrency(ctx context.Context, tenantId string,
 			cancelled.WorkflowRunId,
 			cancelled.TaskIdInsertedAtRetryCount.RetryCount,
 			eventType,
+			eventMessage,
 			shouldNotify,
 		)
 

--- a/internal/services/shared/tasktypes/v1/task.go
+++ b/internal/services/shared/tasktypes/v1/task.go
@@ -129,6 +129,9 @@ type CancelledTaskPayload struct {
 	// (required) the retry count
 	RetryCount int32
 
+	// (optional) the event message
+	EventMessage string
+
 	// (required) the reason for cancellation
 	EventType sqlcv1.V1EventTypeOlap
 
@@ -144,6 +147,7 @@ func CancelledTaskMessage(
 	workflowRunId string,
 	retryCount int32,
 	eventType sqlcv1.V1EventTypeOlap,
+	eventMessage string,
 	shouldNotify bool,
 ) (*msgqueue.Message, error) {
 	return msgqueue.NewTenantMessage(
@@ -158,6 +162,7 @@ func CancelledTaskMessage(
 			WorkflowRunId: workflowRunId,
 			RetryCount:    retryCount,
 			EventType:     eventType,
+			EventMessage:  eventMessage,
 			ShouldNotify:  shouldNotify,
 		},
 	)

--- a/pkg/repository/v1/input.go
+++ b/pkg/repository/v1/input.go
@@ -22,6 +22,18 @@ func (s *sharedRepository) DesiredWorkerId(t *TaskInput) *string {
 	return nil
 }
 
+func (s *sharedRepository) newTaskInputFromExistingBytes(inputBytes []byte) *TaskInput {
+	i := &TaskInput{}
+
+	err := json.Unmarshal(inputBytes, i)
+
+	if err != nil {
+		s.l.Error().Err(err).Msg("failed to unmarshal input bytes")
+	}
+
+	return i
+}
+
 func (s *sharedRepository) newTaskInput(inputBytes []byte, triggerData *MatchData) *TaskInput {
 	var input map[string]interface{}
 

--- a/pkg/repository/v1/match.go
+++ b/pkg/repository/v1/match.go
@@ -380,7 +380,7 @@ func (m *sharedRepository) processInternalEventMatches(ctx context.Context, tx s
 			replayedTasks, err := m.replayTasks(ctx, tx, tenantId, replayTaskOpts)
 
 			if err != nil {
-				return nil, fmt.Errorf("failed to replay tasks: %w", err)
+				return nil, fmt.Errorf("failed to replay %d tasks: %w", len(replayTaskOpts), err)
 			}
 
 			res.ReplayedTasks = replayedTasks

--- a/pkg/repository/v1/scheduler_concurrency.go
+++ b/pkg/repository/v1/scheduler_concurrency.go
@@ -164,7 +164,6 @@ func (c *ConcurrencyRepositoryImpl) runGroupRoundRobin(
 			Tenantid:         tenantId,
 			Strategyid:       strategy.ID,
 			Parentstrategyid: strategy.ParentStrategyID.Int64,
-			// Maxruns:    strategy.MaxConcurrency,
 		})
 
 		if err != nil {

--- a/pkg/repository/v1/scheduler_concurrency.go
+++ b/pkg/repository/v1/scheduler_concurrency.go
@@ -2,11 +2,14 @@ package v1
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hatchet-dev/hatchet/pkg/repository/postgres/sqlchelpers"
 	"github.com/hatchet-dev/hatchet/pkg/repository/v1/sqlcv1"
 	"github.com/jackc/pgx/v5/pgtype"
 )
+
+const PARENT_STRATEGY_LOCK_OFFSET = 1000000000000 // 1 trillion
 
 type TaskWithQueue struct {
 	*TaskIdInsertedAtRetryCount
@@ -134,50 +137,119 @@ func (c *ConcurrencyRepositoryImpl) runGroupRoundRobin(
 		return nil, err
 	}
 
-	poppedResults, err := c.queries.RunGroupRoundRobin(ctx, tx, sqlcv1.RunGroupRoundRobinParams{
-		Tenantid:   tenantId,
-		Strategyid: strategy.ID,
-		Maxruns:    strategy.MaxConcurrency,
-	})
+	var queued []TaskWithQueue
+	var cancelled []TaskWithCancelledReason
+	var nextConcurrencyStrategies []int64
 
-	if err != nil {
-		return nil, err
+	if strategy.ParentStrategyID.Valid {
+		acquired, err := c.queries.TryConcurrencyAdvisoryLock(ctx, tx, PARENT_STRATEGY_LOCK_OFFSET+strategy.ParentStrategyID.Int64)
+
+		if err != nil {
+			return nil, err
+		}
+
+		if acquired {
+			err = c.queries.RunParentGroupRoundRobin(ctx, tx, sqlcv1.RunParentGroupRoundRobinParams{
+				Tenantid:   tenantId,
+				Strategyid: strategy.ParentStrategyID.Int64,
+				Maxruns:    strategy.MaxConcurrency,
+			})
+
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		poppedResults, err := c.queries.RunChildGroupRoundRobin(ctx, tx, sqlcv1.RunChildGroupRoundRobinParams{
+			Tenantid:         tenantId,
+			Strategyid:       strategy.ID,
+			Parentstrategyid: strategy.ParentStrategyID.Int64,
+			// Maxruns:    strategy.MaxConcurrency,
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		queued = make([]TaskWithQueue, 0, len(poppedResults))
+		cancelled = make([]TaskWithCancelledReason, 0, len(poppedResults))
+		nextConcurrencyStrategies = make([]int64, 0, len(poppedResults))
+
+		for _, r := range poppedResults {
+			idRetryCount := &TaskIdInsertedAtRetryCount{
+				Id:         r.TaskID,
+				InsertedAt: r.TaskInsertedAt,
+				RetryCount: r.TaskRetryCount,
+			}
+
+			switch {
+			case len(r.NextStrategyIds) > 0:
+				nextConcurrencyStrategies = append(nextConcurrencyStrategies, r.NextStrategyIds[0])
+			case r.Operation == "SCHEDULING_TIMED_OUT":
+				cancelled = append(cancelled, TaskWithCancelledReason{
+					TaskIdInsertedAtRetryCount: idRetryCount,
+					CancelledReason:            "SCHEDULING_TIMED_OUT",
+					TaskExternalId:             sqlchelpers.UUIDToStr(r.ExternalID),
+					WorkflowRunId:              sqlchelpers.UUIDToStr(r.WorkflowRunID),
+				})
+			default:
+				queued = append(queued, TaskWithQueue{
+					TaskIdInsertedAtRetryCount: &TaskIdInsertedAtRetryCount{
+						Id:         r.TaskID,
+						InsertedAt: r.TaskInsertedAt,
+						RetryCount: r.TaskRetryCount,
+					},
+					Queue: r.QueueToNotify,
+				})
+			}
+		}
+	} else {
+		poppedResults, err := c.queries.RunGroupRoundRobin(ctx, tx, sqlcv1.RunGroupRoundRobinParams{
+			Tenantid:   tenantId,
+			Strategyid: strategy.ID,
+			Maxruns:    strategy.MaxConcurrency,
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		queued = make([]TaskWithQueue, 0, len(poppedResults))
+		cancelled = make([]TaskWithCancelledReason, 0, len(poppedResults))
+		nextConcurrencyStrategies = make([]int64, 0, len(poppedResults))
+
+		for _, r := range poppedResults {
+			idRetryCount := &TaskIdInsertedAtRetryCount{
+				Id:         r.TaskID,
+				InsertedAt: r.TaskInsertedAt,
+				RetryCount: r.TaskRetryCount,
+			}
+
+			switch {
+			case len(r.NextStrategyIds) > 0:
+				nextConcurrencyStrategies = append(nextConcurrencyStrategies, r.NextStrategyIds[0])
+			case r.Operation == "SCHEDULING_TIMED_OUT":
+				cancelled = append(cancelled, TaskWithCancelledReason{
+					TaskIdInsertedAtRetryCount: idRetryCount,
+					CancelledReason:            "SCHEDULING_TIMED_OUT",
+					TaskExternalId:             sqlchelpers.UUIDToStr(r.ExternalID),
+					WorkflowRunId:              sqlchelpers.UUIDToStr(r.WorkflowRunID),
+				})
+			default:
+				queued = append(queued, TaskWithQueue{
+					TaskIdInsertedAtRetryCount: &TaskIdInsertedAtRetryCount{
+						Id:         r.TaskID,
+						InsertedAt: r.TaskInsertedAt,
+						RetryCount: r.TaskRetryCount,
+					},
+					Queue: r.QueueToNotify,
+				})
+			}
+		}
 	}
 
 	if err = commit(ctx); err != nil {
 		return nil, err
-	}
-
-	queued := make([]TaskWithQueue, 0, len(poppedResults))
-	cancelled := make([]TaskWithCancelledReason, 0, len(poppedResults))
-	nextConcurrencyStrategies := make([]int64, 0, len(poppedResults))
-
-	for _, r := range poppedResults {
-		idRetryCount := &TaskIdInsertedAtRetryCount{
-			Id:         r.TaskID,
-			InsertedAt: r.TaskInsertedAt,
-			RetryCount: r.TaskRetryCount,
-		}
-
-		if len(r.NextStrategyIds) > 0 {
-			nextConcurrencyStrategies = append(nextConcurrencyStrategies, r.NextStrategyIds[0])
-		} else if r.Operation == "SCHEDULING_TIMED_OUT" {
-			cancelled = append(cancelled, TaskWithCancelledReason{
-				TaskIdInsertedAtRetryCount: idRetryCount,
-				CancelledReason:            "SCHEDULING_TIMED_OUT",
-				TaskExternalId:             sqlchelpers.UUIDToStr(r.ExternalID),
-				WorkflowRunId:              sqlchelpers.UUIDToStr(r.WorkflowRunID),
-			})
-		} else {
-			queued = append(queued, TaskWithQueue{
-				TaskIdInsertedAtRetryCount: &TaskIdInsertedAtRetryCount{
-					Id:         r.TaskID,
-					InsertedAt: r.TaskInsertedAt,
-					RetryCount: r.TaskRetryCount,
-				},
-				Queue: r.QueueToNotify,
-			})
-		}
 	}
 
 	return &RunConcurrencyResult{
@@ -206,80 +278,177 @@ func (c *ConcurrencyRepositoryImpl) runCancelInProgress(
 		return nil, err
 	}
 
-	poppedResults, err := c.queries.RunCancelInProgress(ctx, tx, sqlcv1.RunCancelInProgressParams{
-		Tenantid:   tenantId,
-		Strategyid: strategy.ID,
-		Maxruns:    strategy.MaxConcurrency,
-	})
+	var queued []TaskWithQueue
+	var cancelled []TaskWithCancelledReason
+	var nextConcurrencyStrategies []int64
 
-	if err != nil {
-		return nil, err
-	}
+	if strategy.ParentStrategyID.Valid {
+		err := c.queries.ConcurrencyAdvisoryLock(ctx, tx, PARENT_STRATEGY_LOCK_OFFSET+strategy.ParentStrategyID.Int64)
 
-	// for any cancelled tasks, call cancelTasks
-	cancelledTasks := make([]TaskIdInsertedAtRetryCount, 0, len(poppedResults))
+		if err != nil {
+			return nil, err
+		}
 
-	for _, r := range poppedResults {
-		if r.Operation == "CANCELLED" {
-			cancelledTasks = append(cancelledTasks, TaskIdInsertedAtRetryCount{
+		_, err = tx.Exec(
+			ctx,
+			`
+-- name: CreateParentTempTable :exec
+CREATE TEMP TABLE tmp_workflow_concurrency_slot ON COMMIT DROP AS
+SELECT *
+FROM v1_workflow_concurrency_slot
+WHERE tenant_id = $1::uuid AND strategy_id = $2::bigint;`,
+			tenantId,
+			strategy.ParentStrategyID.Int64,
+		)
+
+		if err != nil {
+			return nil, fmt.Errorf("error creating parent temp table: %w", err)
+		}
+
+		err = c.queries.RunParentCancelInProgress(ctx, tx, sqlcv1.RunParentCancelInProgressParams{
+			Tenantid:   tenantId,
+			Strategyid: strategy.ParentStrategyID.Int64,
+			Maxruns:    strategy.MaxConcurrency,
+		})
+
+		if err != nil {
+			return nil, fmt.Errorf("error running parent cancel in progress: %w", err)
+		}
+
+		poppedResults, err := c.queries.RunChildCancelInProgress(ctx, tx, sqlcv1.RunChildCancelInProgressParams{
+			Tenantid:   tenantId,
+			Strategyid: strategy.ID,
+			Maxruns:    strategy.MaxConcurrency,
+		})
+
+		if err != nil {
+			return nil, fmt.Errorf("error running child cancel in progress: %w", err)
+		}
+
+		queued = make([]TaskWithQueue, 0, len(poppedResults))
+		cancelled = make([]TaskWithCancelledReason, 0, len(poppedResults))
+		nextConcurrencyStrategies = make([]int64, 0, len(poppedResults))
+
+		for _, r := range poppedResults {
+			idRetryCount := &TaskIdInsertedAtRetryCount{
 				Id:         r.TaskID,
 				InsertedAt: r.TaskInsertedAt,
 				RetryCount: r.TaskRetryCount,
-			})
+			}
+
+			switch {
+			case len(r.NextStrategyIds) > 0:
+				nextConcurrencyStrategies = append(nextConcurrencyStrategies, r.NextStrategyIds[0])
+			case r.Operation == "CANCELLED":
+				cancelled = append(cancelled, TaskWithCancelledReason{
+					TaskIdInsertedAtRetryCount: idRetryCount,
+					CancelledReason:            "CONCURRENCY_LIMIT",
+					TaskExternalId:             sqlchelpers.UUIDToStr(r.ExternalID),
+					WorkflowRunId:              sqlchelpers.UUIDToStr(r.WorkflowRunID),
+				})
+			case r.Operation == "SCHEDULING_TIMED_OUT":
+				cancelled = append(cancelled, TaskWithCancelledReason{
+					TaskIdInsertedAtRetryCount: idRetryCount,
+					CancelledReason:            "SCHEDULING_TIMED_OUT",
+					TaskExternalId:             sqlchelpers.UUIDToStr(r.ExternalID),
+					WorkflowRunId:              sqlchelpers.UUIDToStr(r.WorkflowRunID),
+				})
+			default:
+				queued = append(queued, TaskWithQueue{
+					TaskIdInsertedAtRetryCount: &TaskIdInsertedAtRetryCount{
+						Id:         r.TaskID,
+						InsertedAt: r.TaskInsertedAt,
+						RetryCount: r.TaskRetryCount,
+					},
+					Queue: r.QueueToNotify,
+				})
+			}
 		}
-	}
+	} else {
+		poppedResults, err := c.queries.RunCancelInProgress(ctx, tx, sqlcv1.RunCancelInProgressParams{
+			Tenantid:   tenantId,
+			Strategyid: strategy.ID,
+			Maxruns:    strategy.MaxConcurrency,
+		})
 
-	taskIds := make([]int64, len(cancelledTasks))
-	retryCounts := make([]int32, len(cancelledTasks))
+		if err != nil {
+			return nil, err
+		}
 
-	for i, task := range cancelledTasks {
-		taskIds[i] = task.Id
-		retryCounts[i] = task.RetryCount
-	}
+		// for any cancelled tasks, call cancelTasks
+		cancelledTasks := make([]TaskIdInsertedAtRetryCount, 0, len(poppedResults))
 
-	// remove tasks from queue
-	err = c.queries.DeleteTasksFromQueue(ctx, tx, sqlcv1.DeleteTasksFromQueueParams{
-		Taskids:     taskIds,
-		Retrycounts: retryCounts,
-	})
+		for _, r := range poppedResults {
+			if r.Operation == "CANCELLED" {
+				cancelledTasks = append(cancelledTasks, TaskIdInsertedAtRetryCount{
+					Id:         r.TaskID,
+					InsertedAt: r.TaskInsertedAt,
+					RetryCount: r.TaskRetryCount,
+				})
+			}
+		}
 
-	if err != nil {
-		return nil, err
+		taskIds := make([]int64, len(cancelledTasks))
+		retryCounts := make([]int32, len(cancelledTasks))
+
+		for i, task := range cancelledTasks {
+			taskIds[i] = task.Id
+			retryCounts[i] = task.RetryCount
+		}
+
+		// remove tasks from queue
+		err = c.queries.DeleteTasksFromQueue(ctx, tx, sqlcv1.DeleteTasksFromQueueParams{
+			Taskids:     taskIds,
+			Retrycounts: retryCounts,
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		queued = make([]TaskWithQueue, 0, len(poppedResults))
+		cancelled = make([]TaskWithCancelledReason, 0, len(poppedResults))
+		nextConcurrencyStrategies = make([]int64, 0, len(poppedResults))
+
+		for _, r := range poppedResults {
+			idRetryCount := &TaskIdInsertedAtRetryCount{
+				Id:         r.TaskID,
+				InsertedAt: r.TaskInsertedAt,
+				RetryCount: r.TaskRetryCount,
+			}
+
+			switch {
+			case len(r.NextStrategyIds) > 0:
+				nextConcurrencyStrategies = append(nextConcurrencyStrategies, r.NextStrategyIds[0])
+			case r.Operation == "CANCELLED":
+				cancelled = append(cancelled, TaskWithCancelledReason{
+					TaskIdInsertedAtRetryCount: idRetryCount,
+					CancelledReason:            "CONCURRENCY_LIMIT",
+					TaskExternalId:             sqlchelpers.UUIDToStr(r.ExternalID),
+					WorkflowRunId:              sqlchelpers.UUIDToStr(r.WorkflowRunID),
+				})
+			case r.Operation == "SCHEDULING_TIMED_OUT":
+				cancelled = append(cancelled, TaskWithCancelledReason{
+					TaskIdInsertedAtRetryCount: idRetryCount,
+					CancelledReason:            "SCHEDULING_TIMED_OUT",
+					TaskExternalId:             sqlchelpers.UUIDToStr(r.ExternalID),
+					WorkflowRunId:              sqlchelpers.UUIDToStr(r.WorkflowRunID),
+				})
+			default:
+				queued = append(queued, TaskWithQueue{
+					TaskIdInsertedAtRetryCount: &TaskIdInsertedAtRetryCount{
+						Id:         r.TaskID,
+						InsertedAt: r.TaskInsertedAt,
+						RetryCount: r.TaskRetryCount,
+					},
+					Queue: r.QueueToNotify,
+				})
+			}
+		}
 	}
 
 	if err = commit(ctx); err != nil {
 		return nil, err
-	}
-
-	queued := make([]TaskWithQueue, 0, len(poppedResults))
-	cancelled := make([]TaskWithCancelledReason, 0, len(poppedResults))
-	nextConcurrencyStrategies := make([]int64, 0, len(poppedResults))
-
-	for _, r := range poppedResults {
-		idRetryCount := &TaskIdInsertedAtRetryCount{
-			Id:         r.TaskID,
-			InsertedAt: r.TaskInsertedAt,
-			RetryCount: r.TaskRetryCount,
-		}
-
-		if len(r.NextStrategyIds) > 0 {
-			nextConcurrencyStrategies = append(nextConcurrencyStrategies, r.NextStrategyIds[0])
-		} else if r.Operation == "CANCELLED" {
-			cancelled = append(cancelled, TaskWithCancelledReason{
-				TaskIdInsertedAtRetryCount: idRetryCount,
-				CancelledReason:            "CONCURRENCY_LIMIT",
-			})
-		} else if r.Operation == "SCHEDULING_TIMED_OUT" {
-			cancelled = append(cancelled, TaskWithCancelledReason{
-				TaskIdInsertedAtRetryCount: idRetryCount,
-				CancelledReason:            "SCHEDULING_TIMED_OUT",
-			})
-		} else {
-			queued = append(queued, TaskWithQueue{
-				TaskIdInsertedAtRetryCount: idRetryCount,
-				Queue:                      r.QueueToNotify,
-			})
-		}
 	}
 
 	return &RunConcurrencyResult{
@@ -308,80 +477,208 @@ func (c *ConcurrencyRepositoryImpl) runCancelNewest(
 		return nil, err
 	}
 
-	poppedResults, err := c.queries.RunCancelNewest(ctx, tx, sqlcv1.RunCancelNewestParams{
-		Tenantid:   tenantId,
-		Strategyid: strategy.ID,
-		Maxruns:    strategy.MaxConcurrency,
-	})
+	var queued []TaskWithQueue
+	var cancelled []TaskWithCancelledReason
+	var nextConcurrencyStrategies []int64
 
-	if err != nil {
-		return nil, err
-	}
+	if strategy.ParentStrategyID.Valid {
+		err := c.queries.ConcurrencyAdvisoryLock(ctx, tx, PARENT_STRATEGY_LOCK_OFFSET+strategy.ParentStrategyID.Int64)
 
-	// for any cancelled tasks, call cancelTasks
-	cancelledTasks := make([]TaskIdInsertedAtRetryCount, 0, len(poppedResults))
+		if err != nil {
+			return nil, err
+		}
 
-	for _, r := range poppedResults {
-		if r.Operation == "CANCELLED" {
-			cancelledTasks = append(cancelledTasks, TaskIdInsertedAtRetryCount{
+		_, err = tx.Exec(
+			ctx,
+			`
+-- name: CreateParentTempTable :exec
+CREATE TEMP TABLE tmp_workflow_concurrency_slot ON COMMIT DROP AS
+SELECT *
+FROM v1_workflow_concurrency_slot
+WHERE tenant_id = $1::uuid AND strategy_id = $2::bigint;`,
+			tenantId,
+			strategy.ParentStrategyID.Int64,
+		)
+
+		if err != nil {
+			return nil, fmt.Errorf("error creating parent temp table: %w", err)
+		}
+
+		err = c.queries.RunParentCancelNewest(ctx, tx, sqlcv1.RunParentCancelNewestParams{
+			Tenantid:   tenantId,
+			Strategyid: strategy.ParentStrategyID.Int64,
+			Maxruns:    strategy.MaxConcurrency,
+		})
+
+		if err != nil {
+			return nil, fmt.Errorf("error running parent cancel newest: %w", err)
+		}
+
+		poppedResults, err := c.queries.RunChildCancelNewest(ctx, tx, sqlcv1.RunChildCancelNewestParams{
+			Tenantid:   tenantId,
+			Strategyid: strategy.ID,
+			Maxruns:    strategy.MaxConcurrency,
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		// for any cancelled tasks, call cancelTasks
+		cancelledTasks := make([]TaskIdInsertedAtRetryCount, 0, len(poppedResults))
+
+		for _, r := range poppedResults {
+			if r.Operation == "CANCELLED" {
+				cancelledTasks = append(cancelledTasks, TaskIdInsertedAtRetryCount{
+					Id:         r.TaskID,
+					InsertedAt: r.TaskInsertedAt,
+					RetryCount: r.TaskRetryCount,
+				})
+			}
+		}
+
+		taskIds := make([]int64, len(cancelledTasks))
+		retryCounts := make([]int32, len(cancelledTasks))
+
+		for i, task := range cancelledTasks {
+			taskIds[i] = task.Id
+			retryCounts[i] = task.RetryCount
+		}
+
+		// remove tasks from queue
+		err = c.queries.DeleteTasksFromQueue(ctx, tx, sqlcv1.DeleteTasksFromQueueParams{
+			Taskids:     taskIds,
+			Retrycounts: retryCounts,
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		queued = make([]TaskWithQueue, 0, len(poppedResults))
+		cancelled = make([]TaskWithCancelledReason, 0, len(poppedResults))
+		nextConcurrencyStrategies = make([]int64, 0, len(poppedResults))
+
+		for _, r := range poppedResults {
+			idRetryCount := &TaskIdInsertedAtRetryCount{
 				Id:         r.TaskID,
 				InsertedAt: r.TaskInsertedAt,
 				RetryCount: r.TaskRetryCount,
-			})
+			}
+
+			switch {
+			case len(r.NextStrategyIds) > 0:
+				nextConcurrencyStrategies = append(nextConcurrencyStrategies, r.NextStrategyIds[0])
+			case r.Operation == "CANCELLED":
+				cancelled = append(cancelled, TaskWithCancelledReason{
+					TaskIdInsertedAtRetryCount: idRetryCount,
+					CancelledReason:            "CONCURRENCY_LIMIT",
+					TaskExternalId:             sqlchelpers.UUIDToStr(r.ExternalID),
+					WorkflowRunId:              sqlchelpers.UUIDToStr(r.WorkflowRunID),
+				})
+			case r.Operation == "SCHEDULING_TIMED_OUT":
+				cancelled = append(cancelled, TaskWithCancelledReason{
+					TaskIdInsertedAtRetryCount: idRetryCount,
+					CancelledReason:            "SCHEDULING_TIMED_OUT",
+					TaskExternalId:             sqlchelpers.UUIDToStr(r.ExternalID),
+					WorkflowRunId:              sqlchelpers.UUIDToStr(r.WorkflowRunID),
+				})
+			default:
+				queued = append(queued, TaskWithQueue{
+					TaskIdInsertedAtRetryCount: &TaskIdInsertedAtRetryCount{
+						Id:         r.TaskID,
+						InsertedAt: r.TaskInsertedAt,
+						RetryCount: r.TaskRetryCount,
+					},
+					Queue: r.QueueToNotify,
+				})
+			}
 		}
-	}
+	} else {
+		poppedResults, err := c.queries.RunCancelNewest(ctx, tx, sqlcv1.RunCancelNewestParams{
+			Tenantid:   tenantId,
+			Strategyid: strategy.ID,
+			Maxruns:    strategy.MaxConcurrency,
+		})
 
-	taskIds := make([]int64, len(cancelledTasks))
-	retryCounts := make([]int32, len(cancelledTasks))
+		if err != nil {
+			return nil, err
+		}
 
-	for i, task := range cancelledTasks {
-		taskIds[i] = task.Id
-		retryCounts[i] = task.RetryCount
-	}
+		// for any cancelled tasks, call cancelTasks
+		cancelledTasks := make([]TaskIdInsertedAtRetryCount, 0, len(poppedResults))
 
-	// remove tasks from queue
-	err = c.queries.DeleteTasksFromQueue(ctx, tx, sqlcv1.DeleteTasksFromQueueParams{
-		Taskids:     taskIds,
-		Retrycounts: retryCounts,
-	})
+		for _, r := range poppedResults {
+			if r.Operation == "CANCELLED" {
+				cancelledTasks = append(cancelledTasks, TaskIdInsertedAtRetryCount{
+					Id:         r.TaskID,
+					InsertedAt: r.TaskInsertedAt,
+					RetryCount: r.TaskRetryCount,
+				})
+			}
+		}
 
-	if err != nil {
-		return nil, err
+		taskIds := make([]int64, len(cancelledTasks))
+		retryCounts := make([]int32, len(cancelledTasks))
+
+		for i, task := range cancelledTasks {
+			taskIds[i] = task.Id
+			retryCounts[i] = task.RetryCount
+		}
+
+		// remove tasks from queue
+		err = c.queries.DeleteTasksFromQueue(ctx, tx, sqlcv1.DeleteTasksFromQueueParams{
+			Taskids:     taskIds,
+			Retrycounts: retryCounts,
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		queued = make([]TaskWithQueue, 0, len(poppedResults))
+		cancelled = make([]TaskWithCancelledReason, 0, len(poppedResults))
+		nextConcurrencyStrategies = make([]int64, 0, len(poppedResults))
+
+		for _, r := range poppedResults {
+			idRetryCount := &TaskIdInsertedAtRetryCount{
+				Id:         r.TaskID,
+				InsertedAt: r.TaskInsertedAt,
+				RetryCount: r.TaskRetryCount,
+			}
+
+			switch {
+			case len(r.NextStrategyIds) > 0:
+				nextConcurrencyStrategies = append(nextConcurrencyStrategies, r.NextStrategyIds[0])
+			case r.Operation == "CANCELLED":
+				cancelled = append(cancelled, TaskWithCancelledReason{
+					TaskIdInsertedAtRetryCount: idRetryCount,
+					CancelledReason:            "CONCURRENCY_LIMIT",
+					TaskExternalId:             sqlchelpers.UUIDToStr(r.ExternalID),
+					WorkflowRunId:              sqlchelpers.UUIDToStr(r.WorkflowRunID),
+				})
+			case r.Operation == "SCHEDULING_TIMED_OUT":
+				cancelled = append(cancelled, TaskWithCancelledReason{
+					TaskIdInsertedAtRetryCount: idRetryCount,
+					CancelledReason:            "SCHEDULING_TIMED_OUT",
+					TaskExternalId:             sqlchelpers.UUIDToStr(r.ExternalID),
+					WorkflowRunId:              sqlchelpers.UUIDToStr(r.WorkflowRunID),
+				})
+			default:
+				queued = append(queued, TaskWithQueue{
+					TaskIdInsertedAtRetryCount: &TaskIdInsertedAtRetryCount{
+						Id:         r.TaskID,
+						InsertedAt: r.TaskInsertedAt,
+						RetryCount: r.TaskRetryCount,
+					},
+					Queue: r.QueueToNotify,
+				})
+			}
+		}
 	}
 
 	if err = commit(ctx); err != nil {
 		return nil, err
-	}
-
-	queued := make([]TaskWithQueue, 0, len(poppedResults))
-	cancelled := make([]TaskWithCancelledReason, 0, len(poppedResults))
-	nextConcurrencyStrategies := make([]int64, 0, len(poppedResults))
-
-	for _, r := range poppedResults {
-		idRetryCount := &TaskIdInsertedAtRetryCount{
-			Id:         r.TaskID,
-			InsertedAt: r.TaskInsertedAt,
-			RetryCount: r.TaskRetryCount,
-		}
-
-		if len(r.NextStrategyIds) > 0 {
-			nextConcurrencyStrategies = append(nextConcurrencyStrategies, r.NextStrategyIds[0])
-		} else if r.Operation == "CANCELLED" {
-			cancelled = append(cancelled, TaskWithCancelledReason{
-				TaskIdInsertedAtRetryCount: idRetryCount,
-				CancelledReason:            "CONCURRENCY_LIMIT",
-			})
-		} else if r.Operation == "SCHEDULING_TIMED_OUT" {
-			cancelled = append(cancelled, TaskWithCancelledReason{
-				TaskIdInsertedAtRetryCount: idRetryCount,
-				CancelledReason:            "SCHEDULING_TIMED_OUT",
-			})
-		} else {
-			queued = append(queued, TaskWithQueue{
-				TaskIdInsertedAtRetryCount: idRetryCount,
-				Queue:                      r.QueueToNotify,
-			})
-		}
 	}
 
 	return &RunConcurrencyResult{

--- a/pkg/repository/v1/sqlcv1/concurrency-additional-tables.sql
+++ b/pkg/repository/v1/sqlcv1/concurrency-additional-tables.sql
@@ -1,0 +1,2 @@
+-- sqlc needs this table model in order to generate queries, though this is never written to the schema
+CREATE TABLE tmp_workflow_concurrency_slot (LIKE v1_workflow_concurrency_slot INCLUDING ALL);

--- a/pkg/repository/v1/sqlcv1/matches.sql.go
+++ b/pkg/repository/v1/sqlcv1/matches.sql.go
@@ -141,9 +141,7 @@ WITH input AS (
         input i ON i.match_id = m.v1_match_id AND i.condition_id = m.id
     ORDER BY
         m.id
-    -- We can afford a SKIP LOCKED because a match condition can only be satisfied by 1 event
-    -- at a time
-    FOR UPDATE SKIP LOCKED
+    FOR UPDATE
 ), updated_conditions AS (
     UPDATE
         v1_match_condition
@@ -312,6 +310,24 @@ WITH match_counts AS (
             OR (mc.total_cancel_groups > 0 AND mc.total_cancel_groups = mc.satisfied_cancel_groups)
             OR (mc.total_skip_groups > 0 AND mc.total_skip_groups = mc.satisfied_skip_groups)
         )
+), locked_conditions AS (
+    SELECT
+        m.v1_match_id,
+        m.id
+    FROM
+        v1_match_condition m
+    JOIN
+        result_matches r ON r.id = m.v1_match_id
+    ORDER BY
+        m.id
+    FOR UPDATE
+), deleted_conditions AS (
+    DELETE FROM
+        v1_match_condition
+    WHERE
+        (v1_match_id, id) IN (SELECT v1_match_id, id FROM locked_conditions)
+    RETURNING
+        v1_match_id AS id
 ), matches_with_data AS (
     SELECT
         m.id,
@@ -336,23 +352,7 @@ WITH match_counts AS (
     DELETE FROM
         v1_match
     WHERE
-        id IN (SELECT id FROM result_matches)
-), locked_conditions AS (
-    SELECT
-        m.v1_match_id,
-        m.id
-    FROM
-        v1_match_condition m
-    JOIN
-        result_matches r ON r.id = m.v1_match_id
-    ORDER BY
-        m.id
-    FOR UPDATE
-), deleted_conditions AS (
-    DELETE FROM
-        v1_match_condition
-    WHERE
-        (v1_match_id, id) IN (SELECT v1_match_id, id FROM locked_conditions)
+        id IN (SELECT id FROM deleted_conditions)
 )
 SELECT
     result_matches.id, tenant_id, kind, is_satisfied, signal_task_id, signal_task_inserted_at, signal_external_id, signal_key, trigger_dag_id, trigger_dag_inserted_at, trigger_step_id, trigger_step_index, trigger_external_id, trigger_workflow_run_id, trigger_parent_task_external_id, trigger_parent_task_id, trigger_parent_task_inserted_at, trigger_child_index, trigger_child_key, trigger_existing_task_id, trigger_existing_task_inserted_at, d.id, mc_aggregated_data,

--- a/pkg/repository/v1/sqlcv1/sqlc.yaml
+++ b/pkg/repository/v1/sqlcv1/sqlc.yaml
@@ -20,6 +20,7 @@ sql:
       - ../../../../sql/schema/v0.sql
       - ../../../../sql/schema/v1-core.sql
       - ../../../../sql/schema/v1-olap.sql
+      - ./concurrency-additional-tables.sql
     strict_order_by: false
     gen:
       go:
@@ -30,3 +31,9 @@ sql:
         emit_methods_with_db_argument: true
         emit_result_struct_pointers: true
         emit_json_tags: true
+        overrides:
+          - column: "v1_task.concurrency_parent_strategy_ids"
+            go_type:
+              import: "github.com/jackc/pgx/v5/pgtype"
+              type: "Int8"
+              slice: true

--- a/pkg/repository/v1/sqlcv1/workers.sql.go
+++ b/pkg/repository/v1/sqlcv1/workers.sql.go
@@ -118,7 +118,7 @@ func (q *Queries) ListManyWorkerLabels(ctx context.Context, db DBTX, workerids [
 
 const listSemaphoreSlotsWithStateForWorker = `-- name: ListSemaphoreSlotsWithStateForWorker :many
 SELECT
-    task_id, task_inserted_at, runtime.retry_count, worker_id, runtime.tenant_id, timeout_at, id, inserted_at, v1_task.tenant_id, queue, action_id, step_id, step_readable_id, workflow_id, workflow_version_id, workflow_run_id, schedule_timeout, step_timeout, priority, sticky, desired_worker_id, external_id, display_name, input, v1_task.retry_count, internal_retry_count, app_retry_count, step_index, additional_metadata, dag_id, dag_inserted_at, parent_task_external_id, parent_task_id, parent_task_inserted_at, child_index, child_key, initial_state, initial_state_reason, concurrency_strategy_ids, concurrency_keys, retry_backoff_factor, retry_max_backoff
+    task_id, task_inserted_at, runtime.retry_count, worker_id, runtime.tenant_id, timeout_at, id, inserted_at, v1_task.tenant_id, queue, action_id, step_id, step_readable_id, workflow_id, workflow_version_id, workflow_run_id, schedule_timeout, step_timeout, priority, sticky, desired_worker_id, external_id, display_name, input, v1_task.retry_count, internal_retry_count, app_retry_count, step_index, additional_metadata, dag_id, dag_inserted_at, parent_task_external_id, parent_task_id, parent_task_inserted_at, child_index, child_key, initial_state, initial_state_reason, concurrency_parent_strategy_ids, concurrency_strategy_ids, concurrency_keys, retry_backoff_factor, retry_max_backoff
 FROM
     v1_task_runtime runtime
 JOIN
@@ -137,48 +137,49 @@ type ListSemaphoreSlotsWithStateForWorkerParams struct {
 }
 
 type ListSemaphoreSlotsWithStateForWorkerRow struct {
-	TaskID                 int64              `json:"task_id"`
-	TaskInsertedAt         pgtype.Timestamptz `json:"task_inserted_at"`
-	RetryCount             int32              `json:"retry_count"`
-	WorkerID               pgtype.UUID        `json:"worker_id"`
-	TenantID               pgtype.UUID        `json:"tenant_id"`
-	TimeoutAt              pgtype.Timestamp   `json:"timeout_at"`
-	ID                     int64              `json:"id"`
-	InsertedAt             pgtype.Timestamptz `json:"inserted_at"`
-	TenantID_2             pgtype.UUID        `json:"tenant_id_2"`
-	Queue                  string             `json:"queue"`
-	ActionID               string             `json:"action_id"`
-	StepID                 pgtype.UUID        `json:"step_id"`
-	StepReadableID         string             `json:"step_readable_id"`
-	WorkflowID             pgtype.UUID        `json:"workflow_id"`
-	WorkflowVersionID      pgtype.UUID        `json:"workflow_version_id"`
-	WorkflowRunID          pgtype.UUID        `json:"workflow_run_id"`
-	ScheduleTimeout        string             `json:"schedule_timeout"`
-	StepTimeout            pgtype.Text        `json:"step_timeout"`
-	Priority               pgtype.Int4        `json:"priority"`
-	Sticky                 V1StickyStrategy   `json:"sticky"`
-	DesiredWorkerID        pgtype.UUID        `json:"desired_worker_id"`
-	ExternalID             pgtype.UUID        `json:"external_id"`
-	DisplayName            string             `json:"display_name"`
-	Input                  []byte             `json:"input"`
-	RetryCount_2           int32              `json:"retry_count_2"`
-	InternalRetryCount     int32              `json:"internal_retry_count"`
-	AppRetryCount          int32              `json:"app_retry_count"`
-	StepIndex              int64              `json:"step_index"`
-	AdditionalMetadata     []byte             `json:"additional_metadata"`
-	DagID                  pgtype.Int8        `json:"dag_id"`
-	DagInsertedAt          pgtype.Timestamptz `json:"dag_inserted_at"`
-	ParentTaskExternalID   pgtype.UUID        `json:"parent_task_external_id"`
-	ParentTaskID           pgtype.Int8        `json:"parent_task_id"`
-	ParentTaskInsertedAt   pgtype.Timestamptz `json:"parent_task_inserted_at"`
-	ChildIndex             pgtype.Int8        `json:"child_index"`
-	ChildKey               pgtype.Text        `json:"child_key"`
-	InitialState           V1TaskInitialState `json:"initial_state"`
-	InitialStateReason     pgtype.Text        `json:"initial_state_reason"`
-	ConcurrencyStrategyIds []int64            `json:"concurrency_strategy_ids"`
-	ConcurrencyKeys        []string           `json:"concurrency_keys"`
-	RetryBackoffFactor     pgtype.Float8      `json:"retry_backoff_factor"`
-	RetryMaxBackoff        pgtype.Int4        `json:"retry_max_backoff"`
+	TaskID                       int64              `json:"task_id"`
+	TaskInsertedAt               pgtype.Timestamptz `json:"task_inserted_at"`
+	RetryCount                   int32              `json:"retry_count"`
+	WorkerID                     pgtype.UUID        `json:"worker_id"`
+	TenantID                     pgtype.UUID        `json:"tenant_id"`
+	TimeoutAt                    pgtype.Timestamp   `json:"timeout_at"`
+	ID                           int64              `json:"id"`
+	InsertedAt                   pgtype.Timestamptz `json:"inserted_at"`
+	TenantID_2                   pgtype.UUID        `json:"tenant_id_2"`
+	Queue                        string             `json:"queue"`
+	ActionID                     string             `json:"action_id"`
+	StepID                       pgtype.UUID        `json:"step_id"`
+	StepReadableID               string             `json:"step_readable_id"`
+	WorkflowID                   pgtype.UUID        `json:"workflow_id"`
+	WorkflowVersionID            pgtype.UUID        `json:"workflow_version_id"`
+	WorkflowRunID                pgtype.UUID        `json:"workflow_run_id"`
+	ScheduleTimeout              string             `json:"schedule_timeout"`
+	StepTimeout                  pgtype.Text        `json:"step_timeout"`
+	Priority                     pgtype.Int4        `json:"priority"`
+	Sticky                       V1StickyStrategy   `json:"sticky"`
+	DesiredWorkerID              pgtype.UUID        `json:"desired_worker_id"`
+	ExternalID                   pgtype.UUID        `json:"external_id"`
+	DisplayName                  string             `json:"display_name"`
+	Input                        []byte             `json:"input"`
+	RetryCount_2                 int32              `json:"retry_count_2"`
+	InternalRetryCount           int32              `json:"internal_retry_count"`
+	AppRetryCount                int32              `json:"app_retry_count"`
+	StepIndex                    int64              `json:"step_index"`
+	AdditionalMetadata           []byte             `json:"additional_metadata"`
+	DagID                        pgtype.Int8        `json:"dag_id"`
+	DagInsertedAt                pgtype.Timestamptz `json:"dag_inserted_at"`
+	ParentTaskExternalID         pgtype.UUID        `json:"parent_task_external_id"`
+	ParentTaskID                 pgtype.Int8        `json:"parent_task_id"`
+	ParentTaskInsertedAt         pgtype.Timestamptz `json:"parent_task_inserted_at"`
+	ChildIndex                   pgtype.Int8        `json:"child_index"`
+	ChildKey                     pgtype.Text        `json:"child_key"`
+	InitialState                 V1TaskInitialState `json:"initial_state"`
+	InitialStateReason           pgtype.Text        `json:"initial_state_reason"`
+	ConcurrencyParentStrategyIds []pgtype.Int8      `json:"concurrency_parent_strategy_ids"`
+	ConcurrencyStrategyIds       []int64            `json:"concurrency_strategy_ids"`
+	ConcurrencyKeys              []string           `json:"concurrency_keys"`
+	RetryBackoffFactor           pgtype.Float8      `json:"retry_backoff_factor"`
+	RetryMaxBackoff              pgtype.Int4        `json:"retry_max_backoff"`
 }
 
 func (q *Queries) ListSemaphoreSlotsWithStateForWorker(ctx context.Context, db DBTX, arg ListSemaphoreSlotsWithStateForWorkerParams) ([]*ListSemaphoreSlotsWithStateForWorkerRow, error) {
@@ -229,6 +230,7 @@ func (q *Queries) ListSemaphoreSlotsWithStateForWorker(ctx context.Context, db D
 			&i.ChildKey,
 			&i.InitialState,
 			&i.InitialStateReason,
+			&i.ConcurrencyParentStrategyIds,
 			&i.ConcurrencyStrategyIds,
 			&i.ConcurrencyKeys,
 			&i.RetryBackoffFactor,

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -87,10 +87,28 @@ CREATE TYPE v1_task_initial_state AS ENUM ('QUEUED', 'CANCELLED', 'SKIPPED', 'FA
 -- enqueue if the strategy is removed.
 CREATE TYPE v1_concurrency_strategy AS ENUM ('NONE', 'GROUP_ROUND_ROBIN', 'CANCEL_IN_PROGRESS', 'CANCEL_NEWEST');
 
+CREATE TABLE v1_workflow_concurrency (
+    -- We need an id used for stable ordering to prevent deadlocks. We must process all concurrency
+    -- strategies on a workflow in the same order.
+    id bigint GENERATED ALWAYS AS IDENTITY,
+    workflow_id UUID NOT NULL,
+    workflow_version_id UUID NOT NULL,
+    -- If the strategy is NONE and we've removed all concurrency slots, we can set is_active to false
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    strategy v1_concurrency_strategy NOT NULL,
+    child_strategy_ids BIGINT[],
+    expression TEXT NOT NULL,
+    tenant_id UUID NOT NULL,
+    max_concurrency INTEGER NOT NULL,
+    CONSTRAINT v1_workflow_concurrency_pkey PRIMARY KEY (workflow_id, workflow_version_id, id)
+);
+
 CREATE TABLE v1_step_concurrency (
     -- We need an id used for stable ordering to prevent deadlocks. We must process all concurrency
     -- strategies on a step in the same order.
     id bigint GENERATED ALWAYS AS IDENTITY,
+    -- The parent_strategy_id exists if concurrency is defined at the workflow level
+    parent_strategy_id BIGINT,
     workflow_id UUID NOT NULL,
     workflow_version_id UUID NOT NULL,
     step_id UUID NOT NULL,
@@ -105,42 +123,78 @@ CREATE TABLE v1_step_concurrency (
 
 CREATE OR REPLACE FUNCTION create_v1_step_concurrency()
 RETURNS trigger AS $$
+DECLARE
+  wf_concurrency_row v1_workflow_concurrency%ROWTYPE;
+  child_ids bigint[];
 BEGIN
   IF NEW."concurrencyGroupExpression" IS NOT NULL THEN
-    WITH steps AS (
-        -- Select only steps which don't have a parent according to _StepOrder
-        SELECT
-            s."id",
-            wf."id" AS "workflowId",
-            wv."id" AS "workflowVersionId",
-            wf."tenantId"
-        FROM "Step" s
-        JOIN "Job" j ON s."jobId" = j."id"
-        JOIN "WorkflowVersion" wv ON j."workflowVersionId" = wv."id"
-        JOIN "Workflow" wf ON wv."workflowId" = wf."id"
-        WHERE
-            wv."id" = NEW."workflowVersionId"
-            AND j."kind" = 'DEFAULT'
-    )
-    INSERT INTO v1_step_concurrency (
+    -- Insert into v1_workflow_concurrency and capture the inserted row.
+    INSERT INTO v1_workflow_concurrency (
       workflow_id,
       workflow_version_id,
-      step_id,
       strategy,
       expression,
       tenant_id,
       max_concurrency
     )
     SELECT
-      s."workflowId",
-      s."workflowVersionId",
-      s."id",
+      wf."id",
+      wv."id",
       NEW."limitStrategy"::VARCHAR::v1_concurrency_strategy,
       NEW."concurrencyGroupExpression",
-      s."tenantId",
+      wf."tenantId",
       NEW."maxRuns"
-    FROM steps s;
+    FROM "WorkflowVersion" wv
+    JOIN "Workflow" wf ON wv."workflowId" = wf."id"
+    WHERE wv."id" = NEW."workflowVersionId"
+    RETURNING * INTO wf_concurrency_row;
 
+    -- Insert into v1_step_concurrency and capture the inserted rows into a variable.
+    WITH inserted_steps AS (
+      INSERT INTO v1_step_concurrency (
+        parent_strategy_id,
+        workflow_id,
+        workflow_version_id,
+        step_id,
+        strategy,
+        expression,
+        tenant_id,
+        max_concurrency
+      )
+      SELECT
+        wf_concurrency_row.id,
+        s."workflowId",
+        s."workflowVersionId",
+        s."id",
+        NEW."limitStrategy"::VARCHAR::v1_concurrency_strategy,
+        NEW."concurrencyGroupExpression",
+        s."tenantId",
+        NEW."maxRuns"
+      FROM (
+        SELECT
+          s."id",
+          wf."id" AS "workflowId",
+          wv."id" AS "workflowVersionId",
+          wf."tenantId"
+        FROM "Step" s
+        JOIN "Job" j ON s."jobId" = j."id"
+        JOIN "WorkflowVersion" wv ON j."workflowVersionId" = wv."id"
+        JOIN "Workflow" wf ON wv."workflowId" = wf."id"
+        WHERE
+          wv."id" = NEW."workflowVersionId"
+          AND j."kind" = 'DEFAULT'
+      ) s
+      RETURNING *
+    )
+    SELECT array_remove(array_agg(t.id), NULL)::bigint[] INTO child_ids
+    FROM inserted_steps t;
+
+    -- Update the workflow concurrency row using its primary key.
+    UPDATE v1_workflow_concurrency
+    SET child_strategy_ids = child_ids
+    WHERE workflow_id = wf_concurrency_row.workflow_id
+      AND workflow_version_id = wf_concurrency_row.workflow_version_id
+      AND id = wf_concurrency_row.id;
   END IF;
   RETURN NEW;
 END;
@@ -187,6 +241,7 @@ CREATE TABLE v1_task (
     child_key TEXT,
     initial_state v1_task_initial_state NOT NULL DEFAULT 'QUEUED',
     initial_state_reason TEXT,
+    concurrency_parent_strategy_ids BIGINT[],
     concurrency_strategy_ids BIGINT[],
     concurrency_keys TEXT[],
     retry_backoff_factor DOUBLE PRECISION,
@@ -412,26 +467,219 @@ CREATE TABLE v1_dag_data (
 );
 
 -- CreateTable
+CREATE TABLE v1_workflow_concurrency_slot (
+    sort_id BIGINT NOT NULL,
+    tenant_id UUID NOT NULL,
+    workflow_id UUID NOT NULL,
+    workflow_version_id UUID NOT NULL,
+    workflow_run_id UUID NOT NULL,
+    strategy_id BIGINT NOT NULL,
+    completed_child_strategy_ids BIGINT[],
+    child_strategy_ids BIGINT[],
+    priority INTEGER NOT NULL DEFAULT 1,
+    key TEXT NOT NULL,
+    is_filled BOOLEAN NOT NULL DEFAULT FALSE,
+    CONSTRAINT v1_workflow_concurrency_slot_pkey PRIMARY KEY (strategy_id, workflow_version_id, workflow_run_id)
+);
+
+CREATE INDEX v1_workflow_concurrency_slot_query_idx ON v1_workflow_concurrency_slot (tenant_id, strategy_id ASC, key ASC, priority DESC, sort_id ASC);
+
+-- CreateTable
 CREATE TABLE v1_concurrency_slot (
+    sort_id BIGINT GENERATED ALWAYS AS IDENTITY,
     task_id BIGINT NOT NULL,
     task_inserted_at TIMESTAMPTZ NOT NULL,
     task_retry_count INTEGER NOT NULL,
     external_id UUID NOT NULL,
     tenant_id UUID NOT NULL,
     workflow_id UUID NOT NULL,
+    workflow_version_id UUID NOT NULL,
     workflow_run_id UUID NOT NULL,
     strategy_id BIGINT NOT NULL,
+    parent_strategy_id BIGINT,
     priority INTEGER NOT NULL DEFAULT 1,
     key TEXT NOT NULL,
     is_filled BOOLEAN NOT NULL DEFAULT FALSE,
+    next_parent_strategy_ids BIGINT[],
     next_strategy_ids BIGINT[],
     next_keys TEXT[],
     queue_to_notify TEXT NOT NULL,
     schedule_timeout_at TIMESTAMP(3) NOT NULL,
     CONSTRAINT v1_concurrency_slot_pkey PRIMARY KEY (task_id, task_inserted_at, task_retry_count, strategy_id)
-) PARTITION BY RANGE(task_inserted_at);
+);
 
-CREATE INDEX v1_concurrency_slot_query_idx ON v1_concurrency_slot (tenant_id, strategy_id ASC, key ASC, priority DESC);
+CREATE INDEX v1_concurrency_slot_query_idx ON v1_concurrency_slot (tenant_id, strategy_id ASC, key ASC, sort_id ASC);
+
+-- When concurrency slot is CREATED, we should check whether the parent concurrency slot exists; if not, we should create
+-- the parent concurrency slot as well.
+CREATE OR REPLACE FUNCTION after_v1_concurrency_slot_insert_function()
+RETURNS trigger AS $$
+BEGIN
+    WITH parent_slot AS (
+        SELECT
+            cs.workflow_id, cs.workflow_version_id, cs.workflow_run_id, cs.strategy_id, cs.parent_strategy_id
+        FROM
+            new_table cs
+        WHERE
+            cs.parent_strategy_id IS NOT NULL
+    ), parent_to_child_strategy_ids AS (
+        SELECT
+            wc.child_strategy_ids, wc.id
+        FROM
+            parent_slot ps
+        JOIN v1_workflow_concurrency wc ON wc.workflow_id = ps.workflow_id AND wc.workflow_version_id = ps.workflow_version_id AND wc.id = ps.parent_strategy_id
+    )
+    INSERT INTO v1_workflow_concurrency_slot (
+        sort_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        strategy_id,
+        child_strategy_ids,
+        priority,
+        key
+    )
+    SELECT
+        cs.sort_id,
+        cs.tenant_id,
+        cs.workflow_id,
+        cs.workflow_version_id,
+        cs.workflow_run_id,
+        cs.parent_strategy_id,
+        pcs.child_strategy_ids,
+        cs.priority,
+        cs.key
+    FROM
+        new_table cs
+    JOIN
+        parent_to_child_strategy_ids pcs ON pcs.id = cs.parent_strategy_id
+    WHERE
+        cs.parent_strategy_id IS NOT NULL
+    ON CONFLICT (strategy_id, workflow_version_id, workflow_run_id) DO NOTHING;
+
+    -- If the v1_step_concurrency strategy is not active, we set it to active.
+    WITH inactive_strategies AS (
+        SELECT
+            strategy.*
+        FROM
+            new_table cs
+        JOIN
+            v1_step_concurrency strategy ON strategy.workflow_id = cs.workflow_id AND strategy.workflow_version_id = cs.workflow_version_id AND strategy.id = cs.strategy_id
+        WHERE
+            strategy.is_active = FALSE
+        ORDER BY
+            strategy.id
+        FOR UPDATE
+    )
+    UPDATE v1_step_concurrency strategy
+    SET is_active = TRUE
+    FROM inactive_strategies
+    WHERE
+        strategy.workflow_id = inactive_strategies.workflow_id AND
+        strategy.workflow_version_id = inactive_strategies.workflow_version_id AND
+        strategy.step_id = inactive_strategies.step_id AND
+        strategy.id = inactive_strategies.id;
+
+    RETURN NULL;
+END;
+
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER after_v1_concurrency_slot_insert
+AFTER INSERT ON v1_concurrency_slot
+REFERENCING NEW TABLE AS new_table
+FOR EACH STATEMENT
+EXECUTE FUNCTION after_v1_concurrency_slot_insert_function();
+
+CREATE OR REPLACE FUNCTION after_v1_concurrency_slot_delete_function()
+RETURNS trigger AS $$
+BEGIN
+    -- When v1_concurrency_slot is DELETED, we add it to the completed_child_strategy_ids on the parent.
+    WITH parent_slot AS (
+        SELECT
+            cs.workflow_id,
+            cs.workflow_version_id,
+            cs.workflow_run_id,
+            cs.strategy_id,
+            cs.parent_strategy_id
+        FROM
+            deleted_rows cs
+        WHERE
+            cs.parent_strategy_id IS NOT NULL
+    ), locked_parent_slots AS (
+        SELECT
+            wcs.strategy_id,
+            wcs.workflow_version_id,
+            wcs.workflow_run_id,
+            cs.strategy_id AS child_strategy_id
+        FROM
+            v1_workflow_concurrency_slot wcs
+        JOIN
+            parent_slot cs ON (wcs.strategy_id, wcs.workflow_version_id, wcs.workflow_run_id) = (cs.parent_strategy_id, cs.workflow_version_id, cs.workflow_run_id)
+        ORDER BY
+            wcs.strategy_id,
+            wcs.workflow_version_id,
+            wcs.workflow_run_id
+        FOR UPDATE
+    )
+    UPDATE v1_workflow_concurrency_slot wcs
+    SET completed_child_strategy_ids = ARRAY(
+        SELECT DISTINCT UNNEST(ARRAY_APPEND(wcs.completed_child_strategy_ids, cs.child_strategy_id))
+    )
+    FROM locked_parent_slots cs
+    WHERE
+        wcs.strategy_id = cs.strategy_id
+        AND wcs.workflow_version_id = cs.workflow_version_id
+        AND wcs.workflow_run_id = cs.workflow_run_id;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER after_v1_concurrency_slot_delete
+AFTER DELETE ON v1_concurrency_slot
+REFERENCING OLD TABLE AS deleted_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION after_v1_concurrency_slot_delete_function();
+
+-- After we update the v1_workflow_concurrency_slot, we'd like to check whether all child_strategy_ids are
+-- in the completed_child_strategy_ids. If so, we should delete the v1_workflow_concurrency_slot.
+CREATE OR REPLACE FUNCTION after_v1_workflow_concurrency_slot_update_function()
+RETURNS trigger AS $$
+BEGIN
+    -- place a lock on new_table
+    WITH slots_to_delete AS (
+        SELECT
+            wcs.strategy_id, wcs.workflow_version_id, wcs.workflow_run_id
+        FROM
+            new_table wcs
+        WHERE
+            CARDINALITY(wcs.child_strategy_ids) = CARDINALITY(wcs.completed_child_strategy_ids)
+        ORDER BY
+            wcs.strategy_id, wcs.workflow_version_id, wcs.workflow_run_id
+        FOR UPDATE
+    )
+    DELETE FROM
+        v1_workflow_concurrency_slot wcs
+    WHERE
+        (strategy_id, workflow_version_id, workflow_run_id) IN (
+            SELECT
+                strategy_id, workflow_version_id, workflow_run_id
+            FROM
+                slots_to_delete
+        );
+
+    RETURN NULL;
+END;
+
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER after_v1_workflow_concurrency_slot_update
+AFTER UPDATE ON v1_workflow_concurrency_slot
+REFERENCING NEW TABLE AS new_table
+FOR EACH STATEMENT
+EXECUTE FUNCTION after_v1_workflow_concurrency_slot_update_function();
 
 CREATE OR REPLACE FUNCTION after_v1_task_runtime_delete_function()
 RETURNS trigger AS $$
@@ -479,9 +727,58 @@ CREATE TABLE v1_retry_queue_item (
 CREATE INDEX v1_retry_queue_item_tenant_id_retry_after_idx ON v1_retry_queue_item (tenant_id ASC, retry_after ASC);
 
 CREATE OR REPLACE FUNCTION v1_task_insert_function()
-RETURNS TRIGGER AS
-$$
+RETURNS TRIGGER AS $$
+DECLARE
+    rec RECORD;
 BEGIN
+    FOR rec IN SELECT * FROM new_table WHERE initial_state = 'QUEUED' AND concurrency_strategy_ids[1] IS NOT NULL AND concurrency_keys[1] IS NULL LOOP
+        RAISE WARNING 'New table row: %', row_to_json(rec);
+    END LOOP;
+
+    -- When a task is inserted in a non-queued state, we should add all relevant completed_child_strategy_ids to the parent
+    -- concurrency slots.
+    WITH parent_slots AS (
+        SELECT
+            nt.workflow_id,
+            nt.workflow_version_id,
+            nt.workflow_run_id,
+            UNNEST(nt.concurrency_strategy_ids) AS strategy_id,
+            UNNEST(nt.concurrency_parent_strategy_ids) AS parent_strategy_id
+        FROM
+            new_table nt
+        WHERE
+            cardinality(nt.concurrency_parent_strategy_ids) > 0
+            AND nt.initial_state != 'QUEUED'
+    ), locked_parent_slots AS (
+        SELECT
+            wcs.workflow_id,
+            wcs.workflow_version_id,
+            wcs.workflow_run_id,
+            wcs.strategy_id,
+            cs.strategy_id AS child_strategy_id
+        FROM
+            v1_workflow_concurrency_slot wcs
+        JOIN
+            parent_slots cs ON (wcs.strategy_id, wcs.workflow_version_id, wcs.workflow_run_id) = (cs.parent_strategy_id, cs.workflow_version_id, cs.workflow_run_id)
+        ORDER BY
+            wcs.strategy_id, wcs.workflow_version_id, wcs.workflow_run_id
+        FOR UPDATE
+    )
+    UPDATE
+        v1_workflow_concurrency_slot wcs
+    SET
+        -- get unique completed_child_strategy_ids after append with cs.strategy_id
+        completed_child_strategy_ids = ARRAY(
+            SELECT
+                DISTINCT UNNEST(ARRAY_APPEND(wcs.completed_child_strategy_ids, cs.child_strategy_id))
+        )
+    FROM
+        locked_parent_slots cs
+    WHERE
+        wcs.strategy_id = cs.strategy_id
+        AND wcs.workflow_version_id = cs.workflow_version_id
+        AND wcs.workflow_run_id = cs.workflow_run_id;
+
     WITH new_slot_rows AS (
         SELECT
             id,
@@ -489,6 +786,11 @@ BEGIN
             retry_count,
             tenant_id,
             priority,
+            concurrency_parent_strategy_ids[1] AS parent_strategy_id,
+            CASE
+                WHEN array_length(concurrency_parent_strategy_ids, 1) > 1 THEN concurrency_parent_strategy_ids[2:array_length(concurrency_parent_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_parent_strategy_ids,
             concurrency_strategy_ids[1] AS strategy_id,
             external_id,
             workflow_run_id,
@@ -502,6 +804,7 @@ BEGIN
                 ELSE '{}'::text[]
             END AS next_keys,
             workflow_id,
+            workflow_version_id,
             queue,
             CURRENT_TIMESTAMP + convert_duration_to_interval(schedule_timeout) AS schedule_timeout_at
         FROM new_table
@@ -514,7 +817,10 @@ BEGIN
         external_id,
         tenant_id,
         workflow_id,
+        workflow_version_id,
         workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
         strategy_id,
         next_strategy_ids,
         priority,
@@ -530,7 +836,10 @@ BEGIN
         external_id,
         tenant_id,
         workflow_id,
+        workflow_version_id,
         workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
         strategy_id,
         next_strategy_ids,
         COALESCE(priority, 1),
@@ -657,6 +966,11 @@ BEGIN
             nt.tenant_id,
             nt.workflow_run_id,
             nt.external_id,
+            nt.concurrency_parent_strategy_ids[1] AS parent_strategy_id,
+            CASE
+                WHEN array_length(nt.concurrency_parent_strategy_ids, 1) > 1 THEN nt.concurrency_parent_strategy_ids[2:array_length(nt.concurrency_parent_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_parent_strategy_ids,
             nt.concurrency_strategy_ids[1] AS strategy_id,
             CASE
                 WHEN array_length(nt.concurrency_strategy_ids, 1) > 1 THEN nt.concurrency_strategy_ids[2:array_length(nt.concurrency_strategy_ids, 1)]
@@ -668,6 +982,7 @@ BEGIN
                 ELSE '{}'::text[]
             END AS next_keys,
             nt.workflow_id,
+            nt.workflow_version_id,
             nt.queue,
             CURRENT_TIMESTAMP + convert_duration_to_interval(nt.schedule_timeout) AS schedule_timeout_at
         FROM new_table nt
@@ -684,7 +999,10 @@ BEGIN
         external_id,
         tenant_id,
         workflow_id,
+        workflow_version_id,
         workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
         strategy_id,
         next_strategy_ids,
         priority,
@@ -700,7 +1018,10 @@ BEGIN
         external_id,
         tenant_id,
         workflow_id,
+        workflow_version_id,
         workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
         strategy_id,
         next_strategy_ids,
         4,
@@ -773,6 +1094,11 @@ BEGIN
             t.tenant_id,
             t.workflow_run_id,
             t.external_id,
+            t.concurrency_parent_strategy_ids[1] AS parent_strategy_id,
+            CASE
+                WHEN array_length(t.concurrency_parent_strategy_ids, 1) > 1 THEN t.concurrency_parent_strategy_ids[2:array_length(t.concurrency_parent_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_parent_strategy_ids,
             t.concurrency_strategy_ids[1] AS strategy_id,
             CASE
                 WHEN array_length(t.concurrency_strategy_ids, 1) > 1 THEN t.concurrency_strategy_ids[2:array_length(t.concurrency_strategy_ids, 1)]
@@ -784,6 +1110,7 @@ BEGIN
                 ELSE '{}'::text[]
             END AS next_keys,
             t.workflow_id,
+            t.workflow_version_id,
             t.queue,
             CURRENT_TIMESTAMP + convert_duration_to_interval(t.schedule_timeout) AS schedule_timeout_at
         FROM deleted_rows dr
@@ -801,7 +1128,10 @@ BEGIN
         external_id,
         tenant_id,
         workflow_id,
+        workflow_version_id,
         workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
         strategy_id,
         next_strategy_ids,
         priority,
@@ -817,7 +1147,10 @@ BEGIN
         external_id,
         tenant_id,
         workflow_id,
+        workflow_version_id,
         workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
         strategy_id,
         next_strategy_ids,
         4,
@@ -899,6 +1232,11 @@ BEGIN
             t.queue,
             t.workflow_run_id,
             t.external_id,
+            nt.next_parent_strategy_ids[1] AS parent_strategy_id,
+            CASE
+                WHEN array_length(nt.next_parent_strategy_ids, 1) > 1 THEN nt.next_parent_strategy_ids[2:array_length(nt.next_parent_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_parent_strategy_ids,
             nt.next_strategy_ids[1] AS strategy_id,
             CASE
                 WHEN array_length(nt.next_strategy_ids, 1) > 1 THEN nt.next_strategy_ids[2:array_length(nt.next_strategy_ids, 1)]
@@ -910,6 +1248,7 @@ BEGIN
                 ELSE '{}'::text[]
             END AS next_keys,
             t.workflow_id,
+            t.workflow_version_id,
             CURRENT_TIMESTAMP + convert_duration_to_interval(t.schedule_timeout) AS schedule_timeout_at
         FROM new_table nt
         JOIN old_table ot USING (task_id, task_inserted_at, task_retry_count, key)
@@ -926,7 +1265,10 @@ BEGIN
         external_id,
         tenant_id,
         workflow_id,
+        workflow_version_id,
         workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
         strategy_id,
         next_strategy_ids,
         priority,
@@ -942,7 +1284,10 @@ BEGIN
         external_id,
         tenant_id,
         workflow_id,
+        workflow_version_id,
         workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
         strategy_id,
         next_strategy_ids,
         COALESCE(priority, 1),
@@ -987,9 +1332,11 @@ BEGIN
         queue,
         id,
         inserted_at,
+        external_id,
         action_id,
         step_id,
         workflow_id,
+        workflow_run_id,
         CURRENT_TIMESTAMP + convert_duration_to_interval(schedule_timeout),
         step_timeout,
         COALESCE(priority, 1),


### PR DESCRIPTION
# Description

Adds support for workflow-based concurrency to the v1 engine to match existing behavior. Additionally fixes the following:
- [X] Adds a migration script for migrating existing workflow versions to the v1 engine so we can import over existing concurrency settings
- [X] Fixes an edge case on task inserts and replays where `pgx` can't handle multi-dimensional arrays of differing sizes. Need to file a bug report upstream to get this fixed.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)