### PR TITLE
v1 hotfixes

### DIFF
--- a/api/v1/server/handlers/users/list_tenant_invites.go
+++ b/api/v1/server/handlers/users/list_tenant_invites.go
@@ -20,7 +20,7 @@ func (t *UserService) UserListTenantInvites(ctx echo.Context, request gen.UserLi
 	rows := make([]gen.TenantInvite, len(invites))
 
 	for i := range invites {
-		rows[i] = *transformers.ToTenantInviteLink(invites[i])
+		rows[i] = *transformers.ToUserTenantInviteLink(invites[i])
 	}
 
 	return gen.UserListTenantInvites200JSONResponse(gen.TenantInviteList200JSONResponse{

--- a/api/v1/server/oas/transformers/tenant_invite.go
+++ b/api/v1/server/oas/transformers/tenant_invite.go
@@ -17,3 +17,16 @@ func ToTenantInviteLink(invite *dbsqlc.TenantInviteLink) *gen.TenantInvite {
 
 	return res
 }
+
+func ToUserTenantInviteLink(invite *dbsqlc.ListTenantInvitesByEmailRow) *gen.TenantInvite {
+	res := &gen.TenantInvite{
+		Metadata:   *toAPIMetadata(sqlchelpers.UUIDToStr(invite.ID), invite.CreatedAt.Time, invite.UpdatedAt.Time),
+		Email:      invite.InviteeEmail,
+		Expires:    invite.Expires.Time,
+		Role:       gen.TenantMemberRole(invite.Role),
+		TenantId:   sqlchelpers.UUIDToStr(invite.TenantId),
+		TenantName: &invite.TenantName,
+	}
+
+	return res
+}

--- a/frontend/app/src/lib/atoms.ts
+++ b/frontend/app/src/lib/atoms.ts
@@ -136,6 +136,10 @@ export function useTenant(): TenantContext {
       return;
     }
 
+    if (pathname.startsWith('/onboarding')) {
+      return;
+    }
+
     setLastRedirected(tenant?.slug);
 
     if (tenant?.version == TenantVersion.V0 && pathname.startsWith('/v1')) {
@@ -151,8 +155,6 @@ export function useTenant(): TenantContext {
         search: params.toString(),
       });
     }
-
-    console.log(tenant?.version);
   }, [lastRedirected, navigate, params, pathname, tenant]);
 
   if (!tenant) {

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -560,7 +560,7 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 		cf.Runtime.Monitoring.TLSRootCAFile = cf.TLS.TLSRootCAFile
 	}
 
-	internalClientFactory, err := loadInternalClient(&l, &cf.InternalClient, cf.TLS, cf.Runtime.GRPCBroadcastAddress)
+	internalClientFactory, err := loadInternalClient(&l, &cf.InternalClient, cf.TLS, cf.Runtime.GRPCBroadcastAddress, cf.Runtime.GRPCInsecure)
 
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not load internal client: %w", err)
@@ -688,7 +688,7 @@ func loadEncryptionSvc(cf *server.ServerConfigFile) (encryption.EncryptionServic
 	return encryptionSvc, nil
 }
 
-func loadInternalClient(l *zerolog.Logger, conf *server.InternalClientTLSConfigFile, baseServerTLS shared.TLSConfigFile, grpcBroadcastAddress string) (*clientv1.GRPCClientFactory, error) {
+func loadInternalClient(l *zerolog.Logger, conf *server.InternalClientTLSConfigFile, baseServerTLS shared.TLSConfigFile, grpcBroadcastAddress string, grpcInsecure bool) (*clientv1.GRPCClientFactory, error) {
 	// get gRPC broadcast address
 	broadcastAddress := grpcBroadcastAddress
 
@@ -714,6 +714,10 @@ func loadInternalClient(l *zerolog.Logger, conf *server.InternalClientTLSConfigF
 
 	if conf.InheritBase {
 		base = baseServerTLS
+
+		if grpcInsecure {
+			base.TLSStrategy = "none"
+		}
 	} else {
 		base = conf.Base
 	}

--- a/pkg/repository/postgres/dbsqlc/tenant_invites.sql
+++ b/pkg/repository/postgres/dbsqlc/tenant_invites.sql
@@ -46,13 +46,16 @@ WHERE
 
 -- name: ListTenantInvitesByEmail :many
 SELECT
-    *
+    iv.*,
+    t."name" as "tenantName"
 FROM
-    "TenantInviteLink"
+    "TenantInviteLink" iv
+JOIN
+    "Tenant" t ON iv."tenantId" = t."id"
 WHERE
-    "inviteeEmail" = @inviteeEmail::text
-    AND "status" = 'PENDING'
-    AND "expires" > now();
+    iv."inviteeEmail" = @inviteeEmail::text
+    AND iv."status" = 'PENDING'
+    AND iv."expires" > now();
 
 -- name: ListInvitesByTenantId :many
 SELECT

--- a/pkg/repository/postgres/tenant_invite.go
+++ b/pkg/repository/postgres/tenant_invite.go
@@ -98,7 +98,7 @@ func (r *tenantInviteRepository) GetTenantInvite(ctx context.Context, id string)
 	)
 }
 
-func (r *tenantInviteRepository) ListTenantInvitesByEmail(ctx context.Context, email string) ([]*dbsqlc.TenantInviteLink, error) {
+func (r *tenantInviteRepository) ListTenantInvitesByEmail(ctx context.Context, email string) ([]*dbsqlc.ListTenantInvitesByEmailRow, error) {
 	return r.queries.ListTenantInvitesByEmail(
 		ctx,
 		r.pool,

--- a/pkg/repository/tenant_invite.go
+++ b/pkg/repository/tenant_invite.go
@@ -49,7 +49,7 @@ type TenantInviteRepository interface {
 
 	// ListTenantInvitesByEmail returns the list of tenant invites for the given invitee email for invites
 	// which are not expired
-	ListTenantInvitesByEmail(ctx context.Context, email string) ([]*dbsqlc.TenantInviteLink, error)
+	ListTenantInvitesByEmail(ctx context.Context, email string) ([]*dbsqlc.ListTenantInvitesByEmailRow, error)
 
 	// ListTenantInvitesByTenantId returns the list of tenant invites for the given tenant id
 	ListTenantInvitesByTenantId(ctx context.Context, tenantId string, opts *ListTenantInvitesOpts) ([]*dbsqlc.TenantInviteLink, error)


### PR DESCRIPTION

# Description

Includes the following:
- [X] When `GRPC_INSECURE` is set to `true` and the internal client inherits TLS settings from the base config, we don't use TLS on the internal client
- [X] Fixes `undefined` in tenant invite link
- [X] Fixes redirects on `/onboarding` routes and properly navigates after tenant invite acceptance

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)