### PR TITLE
fix: limit subqueries

### DIFF
--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -365,6 +365,7 @@ WITH latest_retry_count AS (
         relevant_events
     WHERE
         event_type = 'FINISHED'
+    LIMIT 1
 ), status AS (
     SELECT
         readable_status
@@ -390,9 +391,9 @@ WITH latest_retry_count AS (
         SELECT external_id
         FROM v1_tasks_olap
         WHERE id = @taskId::bigint
+        LIMIT 1
     )
 )
-
 SELECT
     t.*,
     st.readable_status::v1_readable_status_olap as status,

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -929,6 +929,7 @@ WITH latest_retry_count AS (
         relevant_events
     WHERE
         event_type = 'FINISHED'
+    LIMIT 1
 ), status AS (
     SELECT
         readable_status
@@ -954,9 +955,9 @@ WITH latest_retry_count AS (
         SELECT external_id
         FROM v1_tasks_olap
         WHERE id = $2::bigint
+        LIMIT 1
     )
 )
-
 SELECT
     t.tenant_id, t.id, t.inserted_at, t.external_id, t.queue, t.action_id, t.step_id, t.workflow_id, t.workflow_version_id, t.workflow_run_id, t.schedule_timeout, t.step_timeout, t.priority, t.sticky, t.desired_worker_id, t.display_name, t.input, t.additional_metadata, t.readable_status, t.latest_retry_count, t.latest_worker_id, t.dag_id, t.dag_inserted_at, t.parent_task_external_id,
     st.readable_status::v1_readable_status_olap as status,


### PR DESCRIPTION
# Description

Limits subqueries in task populator to only return 1 row. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)