### PR TITLE
feat(v1): switches the default msgqueue kind to postgres in `hatchet-lite` deployments

### DIFF
--- a/build/package/lite.dockerfile
+++ b/build/package/lite.dockerfile
@@ -21,13 +21,11 @@ RUN corepack pnpm@9.15.4 install --frozen-lockfile && corepack pnpm@9.15.4 store
 COPY ./frontend/app ./
 RUN npm run build
 
-# Stage 3: run in rabbitmq alpine image
-FROM rabbitmq:alpine as rabbitmq
+# Stage 3: deployment image from alpine
+FROM alpine AS deployment
 
 # install bash via apk
 RUN apk update && apk add --no-cache bash gcc musl-dev openssl bash ca-certificates curl postgresql-client
-
-RUN curl -sSf https://atlasgo.sh | sh
 
 COPY --from=lite-binary-base /hatchet/hatchet-lite ./hatchet-lite
 COPY --from=admin-binary-base /hatchet/hatchet-admin ./hatchet-admin

--- a/cmd/hatchet-lite/main.go
+++ b/cmd/hatchet-lite/main.go
@@ -85,6 +85,13 @@ func start(cf *loader.ConfigLoader, interruptCh <-chan interface{}, version stri
 		runtimePort = "8082"
 	}
 
+	// we hard code the msg queue kind to postgres
+	err := os.Setenv("SERVER_MSGQUEUE_KIND", "postgres")
+
+	if err != nil {
+		return fmt.Errorf("error setting SERVER_MSGQUEUE_KIND to postgres: %w", err)
+	}
+
 	feURL, err := url.Parse(fmt.Sprintf("http://localhost:%s", frontendPort))
 
 	if err != nil {


### PR DESCRIPTION
# Description

Removes the bundled RabbitMQ dependency from `hatchet-lite` and replaces it with a PG-backed message queue. This should make the `lite` image considerably lighter, and will hopefully result in fewer issues.

## Type of change

- [X] New feature (non-breaking change which adds functionality)