### PR TITLE
[V1] Fix: Reset page index when filters change

### DIFF
--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/column-filters.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/column-filters.tsx
@@ -7,6 +7,7 @@ import {
 import { useCallback, useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { TaskRunColumn } from '../components/v1/task-runs-columns';
+import { usePagination } from './pagination';
 
 export type TimeWindow = '1h' | '6h' | '1d' | '7d';
 
@@ -89,6 +90,7 @@ const parseTimeRange = ({
 
 export const useColumnFilters = () => {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { pageIndexParamName } = usePagination();
 
   const timeWindowFilter = (searchParams.get(queryParamNames.timeWindow) ||
     '1d') as TimeWindow;
@@ -156,10 +158,12 @@ export const useColumnFilters = () => {
           }
         });
 
+        newParams.set(pageIndexParamName, '0');
+
         return newParams;
       });
     },
-    [setSearchParams],
+    [setSearchParams, pageIndexParamName],
   );
 
   // create a timer which updates the defaultTimeWindowStartAt date every minute

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/pagination.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/pagination.tsx
@@ -5,10 +5,13 @@ import { useSearchParams } from 'react-router-dom';
 export const usePagination = () => {
   const [searchParams, setSearchParams] = useSearchParams();
 
+  const pageSizeParamName = 'pageSize';
+  const pageIndexParamName = 'pageIndex';
+
   const pagination = useMemo(
     () => ({
-      pageIndex: Number(searchParams.get('pageIndex')) || 0,
-      pageSize: Number(searchParams.get('pageSize')) || 50,
+      pageIndex: Number(searchParams.get(pageSizeParamName)) || 0,
+      pageSize: Number(searchParams.get(pageIndexParamName)) || 50,
     }),
     [searchParams],
   );
@@ -22,8 +25,8 @@ export const usePagination = () => {
 
       setSearchParams((prev) => {
         const newParams = new URLSearchParams(prev);
-        newParams.set('pageSize', String(newValues.pageSize));
-        newParams.set('pageIndex', String(newValues.pageIndex));
+        newParams.set(pageSizeParamName, String(newValues.pageSize));
+        newParams.set(pageIndexParamName, String(newValues.pageIndex));
         return newParams;
       });
     },
@@ -35,7 +38,7 @@ export const usePagination = () => {
       setSearchParams((prev) => {
         const newParams = new URLSearchParams(prev);
 
-        newParams.set('pageSize', String(newPageSize));
+        newParams.set(pageSizeParamName, String(newPageSize));
 
         return newParams;
       });
@@ -56,5 +59,6 @@ export const usePagination = () => {
     setPagination,
     setPageSize,
     offset,
+    pageIndexParamName,
   };
 };


### PR DESCRIPTION
Resetting the page index when column filters change so we no longer have weird pagination issues where people go to the second page then add a filter and nothing shows up

- [x] Bug fix (non-breaking change which fixes an issue)

