### PR TITLE
fix(v1): spawn workflows should handle on failure properly, lite improvements

### DIFF
--- a/hack/lite/start.sh
+++ b/hack/lite/start.sh
@@ -1,22 +1,5 @@
 #!/bin/bash
 
-rabbitmq-server &
-
-# Wait up to 60 seconds for RabbitMQ to be ready
-echo "Waiting for RabbitMQ to be ready..."
-
-timeout 60s bash -c '
-until rabbitmqctl status; do
-  sleep 2
-  echo "Waiting for RabbitMQ to start..."
-done
-'
-
-if [ $? -eq 124 ]; then
-  echo "Timed out waiting for the database to be ready"
-  exit 1
-fi
-
 # Run migration script
 ./hatchet-migrate
 if [ $? -ne 0 ]; then

--- a/internal/services/controllers/v1/task/controller.go
+++ b/internal/services/controllers/v1/task/controller.go
@@ -2,7 +2,6 @@ package task
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -1228,7 +1227,7 @@ func (tc *TasksControllerImpl) signalTasksCreatedAndFailed(ctx context.Context, 
 	for _, task := range tasks {
 		taskExternalId := sqlchelpers.UUIDToStr(task.ExternalID)
 
-		dataBytes := v1.NewFailedTaskOutputEventFromTask(task, task.InitialStateReason.String).Bytes()
+		dataBytes := v1.NewFailedTaskOutputEventFromTask(task).Bytes()
 
 		internalEvents = append(internalEvents, v1.InternalTaskEvent{
 			TenantID:       tenantId,
@@ -1284,13 +1283,7 @@ func (tc *TasksControllerImpl) signalTasksCreatedAndSkipped(ctx context.Context,
 	for _, task := range tasks {
 		taskExternalId := sqlchelpers.UUIDToStr(task.ExternalID)
 
-		outputMap := map[string]bool{
-			"skipped": true,
-		}
-
-		outputMapBytes, _ := json.Marshal(outputMap) // nolint: errcheck
-
-		dataBytes := v1.NewSkippedTaskOutputEventFromTask(task, outputMapBytes).Bytes()
+		dataBytes := v1.NewSkippedTaskOutputEventFromTask(task).Bytes()
 
 		internalEvents = append(internalEvents, v1.InternalTaskEvent{
 			TenantID:       tenantId,

--- a/pkg/repository/v1/ids.go
+++ b/pkg/repository/v1/ids.go
@@ -222,7 +222,7 @@ func (s *sharedRepository) generateExternalIdsForChildWorkflows(ctx context.Cont
 		taskIds,
 		taskExternalIds,
 		datas,
-		sqlcv1.V1TaskEventTypeSIGNALCREATED,
+		makeEventTypeArr(sqlcv1.V1TaskEventTypeSIGNALCREATED, len(taskIds)),
 		newEventKeys,
 	)
 

--- a/pkg/repository/v1/match.go
+++ b/pkg/repository/v1/match.go
@@ -416,7 +416,7 @@ func (m *sharedRepository) processInternalEventMatches(ctx context.Context, tx s
 			taskIds,
 			externalIds,
 			datas,
-			sqlcv1.V1TaskEventTypeSIGNALCOMPLETED,
+			makeEventTypeArr(sqlcv1.V1TaskEventTypeSIGNALCOMPLETED, len(taskIds)),
 			eventKeys,
 		)
 


### PR DESCRIPTION
# Description

Fixes an issue where child workflows weren't returning to the parent if an on failure step was defined, and cleans up the hatchet-lite image a little bit.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)