### PR TITLE
fix(v1): remove order by in olap query

### DIFF
--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -342,8 +342,6 @@ WITH latest_retry_count AS (
         AND task_id = @taskId::bigint
         AND task_inserted_at = @taskInsertedAt::timestamptz
         AND retry_count = (SELECT retry_count FROM latest_retry_count)
-    ORDER BY
-        event_timestamp DESC
 ), finished_at AS (
     SELECT
         MAX(event_timestamp) AS finished_at

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -907,8 +907,6 @@ WITH latest_retry_count AS (
         AND task_id = $2::bigint
         AND task_inserted_at = $3::timestamptz
         AND retry_count = (SELECT retry_count FROM latest_retry_count)
-    ORDER BY
-        event_timestamp DESC
 ), finished_at AS (
     SELECT
         MAX(event_timestamp) AS finished_at


### PR DESCRIPTION
# Description

Removes an unnecessary ORDER BY which may have been causing slow queries on the OLAP tables.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)