### PR TITLE
fix: recursive queries should use PKs

### DIFF
--- a/pkg/repository/v1/sqlcv1/tasks.sql
+++ b/pkg/repository/v1/sqlcv1/tasks.sql
@@ -628,6 +628,7 @@ WITH RECURSIVE augmented_tasks AS (
         id,
         tenant_id,
         dag_id,
+        dag_inserted_at,
         step_id
     FROM
         v1_task
@@ -646,15 +647,16 @@ WITH RECURSIVE augmented_tasks AS (
         t.id,
         t.tenant_id,
         t.dag_id,
+        t.dag_inserted_at,
         t.step_id
     FROM
         augmented_tasks at
     JOIN
         "Step" s1 ON s1."id" = at.step_id
     JOIN
-        v1_dag_to_task dt ON dt.dag_id = at.dag_id
+        v1_dag_to_task dt ON dt.dag_id = at.dag_id AND dt.dag_inserted_at = at.dag_inserted_at
     JOIN
-        v1_task t ON t.id = dt.task_id
+        v1_task t ON t.id = dt.task_id AND t.inserted_at = dt.task_inserted_at
     JOIN
         "Step" s2 ON s2."id" = t.step_id
     JOIN
@@ -774,9 +776,9 @@ WITH RECURSIVE augmented_tasks AS (
     JOIN
         "Step" s1 ON s1."id" = at.step_id
     JOIN
-        v1_dag_to_task dt ON dt.dag_id = at.dag_id
+        v1_dag_to_task dt ON dt.dag_id = at.dag_id AND dt.dag_inserted_at = at.dag_inserted_at
     JOIN
-        v1_task t ON t.id = dt.task_id
+        v1_task t ON t.id = dt.task_id AND t.inserted_at = dt.task_inserted_at
     JOIN
         "Step" s2 ON s2."id" = t.step_id
     JOIN

--- a/pkg/repository/v1/sqlcv1/tasks.sql.go
+++ b/pkg/repository/v1/sqlcv1/tasks.sql.go
@@ -794,9 +794,9 @@ WITH RECURSIVE augmented_tasks AS (
     JOIN
         "Step" s1 ON s1."id" = at.step_id
     JOIN
-        v1_dag_to_task dt ON dt.dag_id = at.dag_id
+        v1_dag_to_task dt ON dt.dag_id = at.dag_id AND dt.dag_inserted_at = at.dag_inserted_at
     JOIN
-        v1_task t ON t.id = dt.task_id
+        v1_task t ON t.id = dt.task_id AND t.inserted_at = dt.task_inserted_at
     JOIN
         "Step" s2 ON s2."id" = t.step_id
     JOIN
@@ -957,6 +957,7 @@ WITH RECURSIVE augmented_tasks AS (
         id,
         tenant_id,
         dag_id,
+        dag_inserted_at,
         step_id
     FROM
         v1_task
@@ -975,15 +976,16 @@ WITH RECURSIVE augmented_tasks AS (
         t.id,
         t.tenant_id,
         t.dag_id,
+        t.dag_inserted_at,
         t.step_id
     FROM
         augmented_tasks at
     JOIN
         "Step" s1 ON s1."id" = at.step_id
     JOIN
-        v1_dag_to_task dt ON dt.dag_id = at.dag_id
+        v1_dag_to_task dt ON dt.dag_id = at.dag_id AND dt.dag_inserted_at = at.dag_inserted_at
     JOIN
-        v1_task t ON t.id = dt.task_id
+        v1_task t ON t.id = dt.task_id AND t.inserted_at = dt.task_inserted_at
     JOIN
         "Step" s2 ON s2."id" = t.step_id
     JOIN


### PR DESCRIPTION
# Description

The recursive queries for DAG parents and replays were not using PKs, making them slow on large datasets. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)