### PR TITLE
fix(v1): improved query plans for replay and task outputs, reassignment + timeout tweaks

### DIFF
--- a/internal/services/controllers/v1/task/process_reassignments.go
+++ b/internal/services/controllers/v1/task/process_reassignments.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
 	msgqueue "github.com/hatchet-dev/hatchet/internal/msgqueue/v1"
 	tasktypes "github.com/hatchet-dev/hatchet/internal/services/shared/tasktypes/v1"
 	"github.com/hatchet-dev/hatchet/internal/telemetry"
@@ -40,62 +39,49 @@ func (tc *TasksControllerImpl) processTaskReassignments(ctx context.Context, ten
 	ctx, span := telemetry.NewSpan(ctx, "process-task-reassignments")
 	defer span.End()
 
-	tasks, shouldContinue, err := tc.repov1.Tasks().ProcessTaskReassignments(ctx, tenantId)
+	res, shouldContinue, err := tc.repov1.Tasks().ProcessTaskReassignments(ctx, tenantId)
 
 	if err != nil {
 		return false, fmt.Errorf("could not list step runs to reassign for tenant %s: %w", tenantId, err)
 	}
 
-	if num := len(tasks); num > 0 {
-		tc.l.Info().Msgf("reassigning %d step runs", num)
-	}
+	for _, task := range res.ReleasedTasks {
+		var workerId *string
 
-	for _, task := range tasks {
-		workerId := sqlchelpers.UUIDToStr(task.WorkerID)
-		taskId := task.ID
-
-		monitoringEvent := tasktypes.CreateMonitoringEventPayload{
-			TaskId:         taskId,
-			RetryCount:     task.RetryCount,
-			WorkerId:       &workerId,
-			EventTimestamp: time.Now(),
+		if task.WorkerID.Valid {
+			workerIdStr := sqlchelpers.UUIDToStr(task.WorkerID)
+			workerId = &workerIdStr
 		}
-
-		switch task.Operation {
-		case "REASSIGNED":
-			monitoringEvent.EventType = sqlcv1.V1EventTypeOlapREASSIGNED
-		case "FAILED":
-			monitoringEvent.EventType = sqlcv1.V1EventTypeOlapFAILED
-			monitoringEvent.EventPayload = "Worker became inactive, and we reached the maximum number of internal retries"
-		default:
-			tc.l.Error().Msgf("unknown operation %s", task.Operation)
-			continue
-		}
-
-		olapMsg, innerErr := tasktypes.MonitoringEventMessageFromInternal(
+		// send failed tasks to the olap repository
+		olapMsg, err := tasktypes.MonitoringEventMessageFromInternal(
 			tenantId,
-			monitoringEvent,
+			tasktypes.CreateMonitoringEventPayload{
+				TaskId:         task.ID,
+				RetryCount:     task.RetryCount,
+				EventType:      sqlcv1.V1EventTypeOlapREASSIGNED,
+				EventTimestamp: time.Now(),
+				EventMessage:   "Worker did not send a heartbeat for 30 seconds",
+				WorkerId:       workerId,
+			},
 		)
 
-		if innerErr != nil {
-			err = multierror.Append(err, fmt.Errorf("could not create monitoring event message: %w", err))
+		if err != nil {
+			tc.l.Error().Err(err).Msg("could not create monitoring event message")
 			continue
 		}
 
-		innerErr = tc.pubBuffer.Pub(
-			ctx,
-			msgqueue.OLAP_QUEUE,
-			olapMsg,
-			false,
-		)
+		err = tc.pubBuffer.Pub(ctx, msgqueue.OLAP_QUEUE, olapMsg, false)
 
-		if innerErr != nil {
-			err = multierror.Append(err, fmt.Errorf("could not publish monitoring event message: %w", err))
+		if err != nil {
+			tc.l.Error().Err(err).Msg("could not create monitoring event message")
+			continue
 		}
 	}
 
+	err = tc.processFailTasksResponse(ctx, tenantId, res)
+
 	if err != nil {
-		return false, fmt.Errorf("could not list step runs to reassign for tenant %s: %w", tenantId, err)
+		return false, fmt.Errorf("could not process fail tasks response: %w", err)
 	}
 
 	return shouldContinue, nil

--- a/internal/services/dispatcher/server_v1.go
+++ b/internal/services/dispatcher/server_v1.go
@@ -332,30 +332,6 @@ func (s *DispatcherImpl) handleTaskFailed(inputCtx context.Context, task *sqlcv1
 	tenant := inputCtx.Value("tenant").(*dbsqlc.Tenant)
 	tenantId := sqlchelpers.UUIDToStr(tenant.ID)
 
-	// if request.RetryCount == nil {
-	// 	return nil, fmt.Errorf("retry count is required in v2")
-	// }
-
-	go func() {
-		olapMsg, err := tasktypes.MonitoringEventMessageFromActionEvent(
-			tenantId,
-			task.ID,
-			retryCount,
-			request,
-		)
-
-		if err != nil {
-			s.l.Error().Err(err).Msg("could not create monitoring event message")
-			return
-		}
-
-		err = s.pubBuffer.Pub(inputCtx, msgqueue.OLAP_QUEUE, olapMsg, false)
-
-		if err != nil {
-			s.l.Error().Err(err).Msg("could not publish to OLAP queue")
-		}
-	}()
-
 	msg, err := tasktypes.FailedTaskMessage(
 		tenantId,
 		task.ID,

--- a/pkg/repository/v1/sqlcv1/tasks.sql
+++ b/pkg/repository/v1/sqlcv1/tasks.sql
@@ -684,10 +684,14 @@ WITH RECURSIVE augmented_tasks AS (
         t.child_key
     FROM
         v1_task t
-    JOIN
-        augmented_tasks at ON at.id = t.id AND at.inserted_at = t.inserted_at
     WHERE
-        t.tenant_id = @tenantId::uuid
+        (t.id, t.inserted_at) IN (
+            SELECT
+                id, inserted_at
+            FROM
+                augmented_tasks
+        )
+        AND t.tenant_id = @tenantId::uuid
     -- order by the task id to get a stable lock order
     ORDER BY
         id

--- a/pkg/repository/v1/sqlcv1/tasks.sql
+++ b/pkg/repository/v1/sqlcv1/tasks.sql
@@ -759,6 +759,7 @@ WITH RECURSIVE augmented_tasks AS (
                 unnest(@taskInsertedAts::timestamptz[])
         )
         AND tenant_id = @tenantId::uuid
+        AND dag_id IS NOT NULL
 
     UNION
 

--- a/pkg/repository/v1/sqlcv1/tasks.sql
+++ b/pkg/repository/v1/sqlcv1/tasks.sql
@@ -222,6 +222,7 @@ SELECT
     t.step_readable_id,
     r.worker_id,
     i.retry_count::int AS retry_count,
+    t.retry_count = i.retry_count AS is_current_retry,
     t.concurrency_strategy_ids
 FROM
     v1_task t
@@ -322,7 +323,7 @@ RETURNING
     v1_task.inserted_at,
     v1_task.retry_count;
 
--- name: ProcessTaskTimeouts :many
+-- name: ListTasksToTimeout :many
 WITH expired_runtimes AS (
     SELECT
         task_id,
@@ -339,63 +340,31 @@ WITH expired_runtimes AS (
     LIMIT
         COALESCE(sqlc.narg('limit')::integer, 1000)
     FOR UPDATE SKIP LOCKED
-), locked_tasks AS (
-    SELECT
-        v1_task.id,
-        v1_task.inserted_at,
-        v1_task.retry_count,
-        v1_task.step_id,
-        v1_task.external_id,
-        v1_task.workflow_run_id,
-        v1_task.step_timeout,
-        expired_runtimes.worker_id
-    FROM
-        v1_task
-    JOIN
-        -- NOTE: we only join when retry count matches
-        expired_runtimes ON expired_runtimes.task_id = v1_task.id AND expired_runtimes.task_inserted_at = v1_task.inserted_at AND expired_runtimes.retry_count = v1_task.retry_count
-    -- order by the task id to get a stable lock order
-    ORDER BY
-        id, inserted_at, retry_count
-    FOR UPDATE
-), deleted_tqis AS (
-    DELETE FROM
-        v1_task_runtime
-    WHERE
-        (task_id, task_inserted_at, retry_count) IN (SELECT task_id, task_inserted_at, retry_count FROM expired_runtimes)
-), tasks_to_steps AS (
-    SELECT
-        t.id,
-        t.step_id,
-        s."retries"
-    FROM
-        locked_tasks t
-    JOIN
-        "Step" s ON s."id" = t.step_id
-), updated_tasks AS (
-    UPDATE
-        v1_task
-    SET
-        retry_count = retry_count + 1,
-        app_retry_count = app_retry_count + 1
-    FROM
-        tasks_to_steps
-    WHERE
-        (v1_task.id, v1_task.inserted_at) IN (SELECT id, inserted_at FROM locked_tasks)
-        AND tasks_to_steps."retries" > v1_task.app_retry_count
 )
 SELECT
-    *
+    v1_task.id,
+    v1_task.inserted_at,
+    v1_task.retry_count,
+    v1_task.step_id,
+    v1_task.external_id,
+    v1_task.workflow_run_id,
+    v1_task.step_timeout,
+    v1_task.app_retry_count,
+    v1_task.retry_backoff_factor,
+    v1_task.retry_max_backoff,
+    expired_runtimes.worker_id
 FROM
-    locked_tasks;
+    v1_task
+JOIN
+    -- NOTE: we only join when retry count matches
+    expired_runtimes ON expired_runtimes.task_id = v1_task.id AND expired_runtimes.task_inserted_at = v1_task.inserted_at AND expired_runtimes.retry_count = v1_task.retry_count;
 
--- name: ProcessTaskReassignments :many
+-- name: ListTasksToReassign :many
 WITH tasks_on_inactive_workers AS (
     SELECT
         runtime.task_id,
         runtime.task_inserted_at,
-        runtime.retry_count,
-        runtime.worker_id
+        runtime.retry_count
     FROM
         "Worker" w
     JOIN
@@ -405,87 +374,16 @@ WITH tasks_on_inactive_workers AS (
         AND w."lastHeartbeatAt" < NOW() - INTERVAL '30 seconds'
     LIMIT
         COALESCE(sqlc.narg('limit')::integer, 1000)
-), locked_runtimes AS (
-    SELECT
-        v1_task_runtime.task_id,
-        v1_task_runtime.task_inserted_at,
-        v1_task_runtime.retry_count,
-        tasks_on_inactive_workers.worker_id
-    FROM
-        v1_task_runtime
-    JOIN
-        tasks_on_inactive_workers USING (task_id, task_inserted_at, retry_count)
-    ORDER BY
-        task_id
-    -- We do a SKIP LOCKED because a lock on v1_task_runtime means its being deleted
-    FOR UPDATE SKIP LOCKED
-), locked_tasks AS (
-    SELECT
-        v1_task.id,
-        v1_task.inserted_at,
-        v1_task.retry_count,
-        lrs.worker_id
-    FROM
-        v1_task
-    JOIN
-        -- NOTE: we only join when retry count matches
-        locked_runtimes lrs ON lrs.task_id = v1_task.id AND lrs.task_inserted_at = v1_task.inserted_at AND lrs.retry_count = v1_task.retry_count
-    -- order by the task id to get a stable lock order
-    ORDER BY
-        id
-    FOR UPDATE
-), deleted_runtimes AS (
-    DELETE FROM
-        v1_task_runtime
-    WHERE
-        (task_id, task_inserted_at, retry_count) IN (SELECT task_id, task_inserted_at, retry_count FROM locked_runtimes)
-), update_tasks AS (
-    UPDATE
-        v1_task
-    SET
-        retry_count = v1_task.retry_count + 1,
-        internal_retry_count = v1_task.internal_retry_count + 1
-    FROM
-        locked_tasks
-    WHERE
-        (v1_task.id, v1_task.inserted_at) IN (SELECT id, inserted_at FROM locked_tasks)
-        AND @maxInternalRetries::int > v1_task.internal_retry_count
-    RETURNING
-        v1_task.id,
-        v1_task.inserted_at,
-        v1_task.retry_count
-), updated_tasks AS (
-    SELECT
-        *
-    FROM
-        locked_tasks
-    WHERE
-        id IN (SELECT id FROM update_tasks)
-), failed_tasks AS (
-    SELECT
-        *
-    FROM
-        locked_tasks
-    WHERE
-        id NOT IN (SELECT id FROM update_tasks)
 )
 SELECT
-    t1.id,
-    t1.inserted_at,
-    t1.retry_count,
-    t1.worker_id,
-    'REASSIGNED' AS "operation"
+    v1_task.id,
+    v1_task.inserted_at,
+    v1_task.retry_count
 FROM
-    updated_tasks t1
-UNION ALL
-SELECT
-    t2.id,
-    t2.inserted_at,
-    t2.retry_count,
-    t2.worker_id,
-    'FAILED' AS "operation"
-FROM
-    failed_tasks t2;
+    v1_task
+JOIN
+    -- NOTE: we only join when retry count matches
+    tasks_on_inactive_workers lrs ON lrs.task_id = v1_task.id AND lrs.task_inserted_at = v1_task.inserted_at AND lrs.retry_count = v1_task.retry_count;
 
 -- name: ProcessRetryQueueItems :many
 WITH rqis_to_delete AS (

--- a/pkg/repository/v1/sqlcv1/tasks.sql.go
+++ b/pkg/repository/v1/sqlcv1/tasks.sql.go
@@ -774,6 +774,7 @@ WITH RECURSIVE augmented_tasks AS (
                 unnest($2::timestamptz[])
         )
         AND tenant_id = $3::uuid
+        AND dag_id IS NOT NULL
 
     UNION
 

--- a/pkg/repository/v1/sqlcv1/tasks.sql.go
+++ b/pkg/repository/v1/sqlcv1/tasks.sql.go
@@ -1014,10 +1014,14 @@ WITH RECURSIVE augmented_tasks AS (
         t.child_key
     FROM
         v1_task t
-    JOIN
-        augmented_tasks at ON at.id = t.id AND at.inserted_at = t.inserted_at
     WHERE
-        t.tenant_id = $3::uuid
+        (t.id, t.inserted_at) IN (
+            SELECT
+                id, inserted_at
+            FROM
+                augmented_tasks
+        )
+        AND t.tenant_id = $3::uuid
     -- order by the task id to get a stable lock order
     ORDER BY
         id

--- a/pkg/repository/v1/sqlcv1/tasks.sql.go
+++ b/pkg/repository/v1/sqlcv1/tasks.sql.go
@@ -1139,6 +1139,152 @@ func (q *Queries) ListTasksForReplay(ctx context.Context, db DBTX, arg ListTasks
 	return items, nil
 }
 
+const listTasksToReassign = `-- name: ListTasksToReassign :many
+WITH tasks_on_inactive_workers AS (
+    SELECT
+        runtime.task_id,
+        runtime.task_inserted_at,
+        runtime.retry_count
+    FROM
+        "Worker" w
+    JOIN
+        v1_task_runtime runtime ON w."id" = runtime.worker_id
+    WHERE
+        w."tenantId" = $1::uuid
+        AND w."lastHeartbeatAt" < NOW() - INTERVAL '30 seconds'
+    LIMIT
+        COALESCE($2::integer, 1000)
+)
+SELECT
+    v1_task.id,
+    v1_task.inserted_at,
+    v1_task.retry_count
+FROM
+    v1_task
+JOIN
+    -- NOTE: we only join when retry count matches
+    tasks_on_inactive_workers lrs ON lrs.task_id = v1_task.id AND lrs.task_inserted_at = v1_task.inserted_at AND lrs.retry_count = v1_task.retry_count
+`
+
+type ListTasksToReassignParams struct {
+	Tenantid pgtype.UUID `json:"tenantid"`
+	Limit    pgtype.Int4 `json:"limit"`
+}
+
+type ListTasksToReassignRow struct {
+	ID         int64              `json:"id"`
+	InsertedAt pgtype.Timestamptz `json:"inserted_at"`
+	RetryCount int32              `json:"retry_count"`
+}
+
+func (q *Queries) ListTasksToReassign(ctx context.Context, db DBTX, arg ListTasksToReassignParams) ([]*ListTasksToReassignRow, error) {
+	rows, err := db.Query(ctx, listTasksToReassign, arg.Tenantid, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*ListTasksToReassignRow
+	for rows.Next() {
+		var i ListTasksToReassignRow
+		if err := rows.Scan(&i.ID, &i.InsertedAt, &i.RetryCount); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listTasksToTimeout = `-- name: ListTasksToTimeout :many
+WITH expired_runtimes AS (
+    SELECT
+        task_id,
+        task_inserted_at,
+        retry_count,
+        worker_id
+    FROM
+        v1_task_runtime
+    WHERE
+        tenant_id = $1::uuid
+        AND timeout_at <= NOW()
+    ORDER BY
+        task_id, task_inserted_at, retry_count
+    LIMIT
+        COALESCE($2::integer, 1000)
+    FOR UPDATE SKIP LOCKED
+)
+SELECT
+    v1_task.id,
+    v1_task.inserted_at,
+    v1_task.retry_count,
+    v1_task.step_id,
+    v1_task.external_id,
+    v1_task.workflow_run_id,
+    v1_task.step_timeout,
+    v1_task.app_retry_count,
+    v1_task.retry_backoff_factor,
+    v1_task.retry_max_backoff,
+    expired_runtimes.worker_id
+FROM
+    v1_task
+JOIN
+    -- NOTE: we only join when retry count matches
+    expired_runtimes ON expired_runtimes.task_id = v1_task.id AND expired_runtimes.task_inserted_at = v1_task.inserted_at AND expired_runtimes.retry_count = v1_task.retry_count
+`
+
+type ListTasksToTimeoutParams struct {
+	Tenantid pgtype.UUID `json:"tenantid"`
+	Limit    pgtype.Int4 `json:"limit"`
+}
+
+type ListTasksToTimeoutRow struct {
+	ID                 int64              `json:"id"`
+	InsertedAt         pgtype.Timestamptz `json:"inserted_at"`
+	RetryCount         int32              `json:"retry_count"`
+	StepID             pgtype.UUID        `json:"step_id"`
+	ExternalID         pgtype.UUID        `json:"external_id"`
+	WorkflowRunID      pgtype.UUID        `json:"workflow_run_id"`
+	StepTimeout        pgtype.Text        `json:"step_timeout"`
+	AppRetryCount      int32              `json:"app_retry_count"`
+	RetryBackoffFactor pgtype.Float8      `json:"retry_backoff_factor"`
+	RetryMaxBackoff    pgtype.Int4        `json:"retry_max_backoff"`
+	WorkerID           pgtype.UUID        `json:"worker_id"`
+}
+
+func (q *Queries) ListTasksToTimeout(ctx context.Context, db DBTX, arg ListTasksToTimeoutParams) ([]*ListTasksToTimeoutRow, error) {
+	rows, err := db.Query(ctx, listTasksToTimeout, arg.Tenantid, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*ListTasksToTimeoutRow
+	for rows.Next() {
+		var i ListTasksToTimeoutRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.InsertedAt,
+			&i.RetryCount,
+			&i.StepID,
+			&i.ExternalID,
+			&i.WorkflowRunID,
+			&i.StepTimeout,
+			&i.AppRetryCount,
+			&i.RetryBackoffFactor,
+			&i.RetryMaxBackoff,
+			&i.WorkerID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const lockDAGsForReplay = `-- name: LockDAGsForReplay :many
 SELECT
     id
@@ -1547,258 +1693,6 @@ func (q *Queries) ProcessRetryQueueItems(ctx context.Context, db DBTX, arg Proce
 	return items, nil
 }
 
-const processTaskReassignments = `-- name: ProcessTaskReassignments :many
-WITH tasks_on_inactive_workers AS (
-    SELECT
-        runtime.task_id,
-        runtime.task_inserted_at,
-        runtime.retry_count,
-        runtime.worker_id
-    FROM
-        "Worker" w
-    JOIN
-        v1_task_runtime runtime ON w."id" = runtime.worker_id
-    WHERE
-        w."tenantId" = $1::uuid
-        AND w."lastHeartbeatAt" < NOW() - INTERVAL '30 seconds'
-    LIMIT
-        COALESCE($2::integer, 1000)
-), locked_runtimes AS (
-    SELECT
-        v1_task_runtime.task_id,
-        v1_task_runtime.task_inserted_at,
-        v1_task_runtime.retry_count,
-        tasks_on_inactive_workers.worker_id
-    FROM
-        v1_task_runtime
-    JOIN
-        tasks_on_inactive_workers USING (task_id, task_inserted_at, retry_count)
-    ORDER BY
-        task_id
-    -- We do a SKIP LOCKED because a lock on v1_task_runtime means its being deleted
-    FOR UPDATE SKIP LOCKED
-), locked_tasks AS (
-    SELECT
-        v1_task.id,
-        v1_task.inserted_at,
-        v1_task.retry_count,
-        lrs.worker_id
-    FROM
-        v1_task
-    JOIN
-        -- NOTE: we only join when retry count matches
-        locked_runtimes lrs ON lrs.task_id = v1_task.id AND lrs.task_inserted_at = v1_task.inserted_at AND lrs.retry_count = v1_task.retry_count
-    -- order by the task id to get a stable lock order
-    ORDER BY
-        id
-    FOR UPDATE
-), deleted_runtimes AS (
-    DELETE FROM
-        v1_task_runtime
-    WHERE
-        (task_id, task_inserted_at, retry_count) IN (SELECT task_id, task_inserted_at, retry_count FROM locked_runtimes)
-), update_tasks AS (
-    UPDATE
-        v1_task
-    SET
-        retry_count = v1_task.retry_count + 1,
-        internal_retry_count = v1_task.internal_retry_count + 1
-    FROM
-        locked_tasks
-    WHERE
-        (v1_task.id, v1_task.inserted_at) IN (SELECT id, inserted_at FROM locked_tasks)
-        AND $3::int > v1_task.internal_retry_count
-    RETURNING
-        v1_task.id,
-        v1_task.inserted_at,
-        v1_task.retry_count
-), updated_tasks AS (
-    SELECT
-        id, inserted_at, retry_count, worker_id
-    FROM
-        locked_tasks
-    WHERE
-        id IN (SELECT id FROM update_tasks)
-), failed_tasks AS (
-    SELECT
-        id, inserted_at, retry_count, worker_id
-    FROM
-        locked_tasks
-    WHERE
-        id NOT IN (SELECT id FROM update_tasks)
-)
-SELECT
-    t1.id,
-    t1.inserted_at,
-    t1.retry_count,
-    t1.worker_id,
-    'REASSIGNED' AS "operation"
-FROM
-    updated_tasks t1
-UNION ALL
-SELECT
-    t2.id,
-    t2.inserted_at,
-    t2.retry_count,
-    t2.worker_id,
-    'FAILED' AS "operation"
-FROM
-    failed_tasks t2
-`
-
-type ProcessTaskReassignmentsParams struct {
-	Tenantid           pgtype.UUID `json:"tenantid"`
-	Limit              pgtype.Int4 `json:"limit"`
-	Maxinternalretries int32       `json:"maxinternalretries"`
-}
-
-type ProcessTaskReassignmentsRow struct {
-	ID         int64              `json:"id"`
-	InsertedAt pgtype.Timestamptz `json:"inserted_at"`
-	RetryCount int32              `json:"retry_count"`
-	WorkerID   pgtype.UUID        `json:"worker_id"`
-	Operation  string             `json:"operation"`
-}
-
-func (q *Queries) ProcessTaskReassignments(ctx context.Context, db DBTX, arg ProcessTaskReassignmentsParams) ([]*ProcessTaskReassignmentsRow, error) {
-	rows, err := db.Query(ctx, processTaskReassignments, arg.Tenantid, arg.Limit, arg.Maxinternalretries)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*ProcessTaskReassignmentsRow
-	for rows.Next() {
-		var i ProcessTaskReassignmentsRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.InsertedAt,
-			&i.RetryCount,
-			&i.WorkerID,
-			&i.Operation,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const processTaskTimeouts = `-- name: ProcessTaskTimeouts :many
-WITH expired_runtimes AS (
-    SELECT
-        task_id,
-        task_inserted_at,
-        retry_count,
-        worker_id
-    FROM
-        v1_task_runtime
-    WHERE
-        tenant_id = $1::uuid
-        AND timeout_at <= NOW()
-    ORDER BY
-        task_id, task_inserted_at, retry_count
-    LIMIT
-        COALESCE($2::integer, 1000)
-    FOR UPDATE SKIP LOCKED
-), locked_tasks AS (
-    SELECT
-        v1_task.id,
-        v1_task.inserted_at,
-        v1_task.retry_count,
-        v1_task.step_id,
-        v1_task.external_id,
-        v1_task.workflow_run_id,
-        v1_task.step_timeout,
-        expired_runtimes.worker_id
-    FROM
-        v1_task
-    JOIN
-        -- NOTE: we only join when retry count matches
-        expired_runtimes ON expired_runtimes.task_id = v1_task.id AND expired_runtimes.task_inserted_at = v1_task.inserted_at AND expired_runtimes.retry_count = v1_task.retry_count
-    -- order by the task id to get a stable lock order
-    ORDER BY
-        id, inserted_at, retry_count
-    FOR UPDATE
-), deleted_tqis AS (
-    DELETE FROM
-        v1_task_runtime
-    WHERE
-        (task_id, task_inserted_at, retry_count) IN (SELECT task_id, task_inserted_at, retry_count FROM expired_runtimes)
-), tasks_to_steps AS (
-    SELECT
-        t.id,
-        t.step_id,
-        s."retries"
-    FROM
-        locked_tasks t
-    JOIN
-        "Step" s ON s."id" = t.step_id
-), updated_tasks AS (
-    UPDATE
-        v1_task
-    SET
-        retry_count = retry_count + 1,
-        app_retry_count = app_retry_count + 1
-    FROM
-        tasks_to_steps
-    WHERE
-        (v1_task.id, v1_task.inserted_at) IN (SELECT id, inserted_at FROM locked_tasks)
-        AND tasks_to_steps."retries" > v1_task.app_retry_count
-)
-SELECT
-    id, inserted_at, retry_count, step_id, external_id, workflow_run_id, step_timeout, worker_id
-FROM
-    locked_tasks
-`
-
-type ProcessTaskTimeoutsParams struct {
-	Tenantid pgtype.UUID `json:"tenantid"`
-	Limit    pgtype.Int4 `json:"limit"`
-}
-
-type ProcessTaskTimeoutsRow struct {
-	ID            int64              `json:"id"`
-	InsertedAt    pgtype.Timestamptz `json:"inserted_at"`
-	RetryCount    int32              `json:"retry_count"`
-	StepID        pgtype.UUID        `json:"step_id"`
-	ExternalID    pgtype.UUID        `json:"external_id"`
-	WorkflowRunID pgtype.UUID        `json:"workflow_run_id"`
-	StepTimeout   pgtype.Text        `json:"step_timeout"`
-	WorkerID      pgtype.UUID        `json:"worker_id"`
-}
-
-func (q *Queries) ProcessTaskTimeouts(ctx context.Context, db DBTX, arg ProcessTaskTimeoutsParams) ([]*ProcessTaskTimeoutsRow, error) {
-	rows, err := db.Query(ctx, processTaskTimeouts, arg.Tenantid, arg.Limit)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*ProcessTaskTimeoutsRow
-	for rows.Next() {
-		var i ProcessTaskTimeoutsRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.InsertedAt,
-			&i.RetryCount,
-			&i.StepID,
-			&i.ExternalID,
-			&i.WorkflowRunID,
-			&i.StepTimeout,
-			&i.WorkerID,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const refreshTimeoutBy = `-- name: RefreshTimeoutBy :one
 WITH task AS (
     SELECT
@@ -1947,6 +1841,7 @@ SELECT
     t.step_readable_id,
     r.worker_id,
     i.retry_count::int AS retry_count,
+    t.retry_count = i.retry_count AS is_current_retry,
     t.concurrency_strategy_ids
 FROM
     v1_task t
@@ -1970,6 +1865,7 @@ type ReleaseTasksRow struct {
 	StepReadableID         string             `json:"step_readable_id"`
 	WorkerID               pgtype.UUID        `json:"worker_id"`
 	RetryCount             int32              `json:"retry_count"`
+	IsCurrentRetry         bool               `json:"is_current_retry"`
 	ConcurrencyStrategyIds []int64            `json:"concurrency_strategy_ids"`
 }
 
@@ -1990,6 +1886,7 @@ func (q *Queries) ReleaseTasks(ctx context.Context, db DBTX, arg ReleaseTasksPar
 			&i.StepReadableID,
 			&i.WorkerID,
 			&i.RetryCount,
+			&i.IsCurrentRetry,
 			&i.ConcurrencyStrategyIds,
 		); err != nil {
 			return nil, err

--- a/pkg/repository/v1/task.go
+++ b/pkg/repository/v1/task.go
@@ -153,6 +153,8 @@ type FinalizedTaskResponse struct {
 type RetriedTask struct {
 	*TaskIdInsertedAtRetryCount
 
+	IsAppError bool
+
 	AppRetryCount int32
 
 	RetryBackoffFactor pgtype.Float8
@@ -164,6 +166,12 @@ type FailTasksResponse struct {
 	*FinalizedTaskResponse
 
 	RetriedTasks []RetriedTask
+}
+
+type TimeoutTasksResponse struct {
+	*FailTasksResponse
+
+	TimeoutTasks []*sqlcv1.ListTasksToTimeoutRow
 }
 
 type ListFinalizedWorkflowRunsResponse struct {
@@ -204,9 +212,9 @@ type TaskRepository interface {
 	// with the v1 engine, and shouldn't be called from new v1 endpoints.
 	ListTaskParentOutputs(ctx context.Context, tenantId string, tasks []*sqlcv1.V1Task) (map[int64][]*TaskOutputEvent, error)
 
-	ProcessTaskTimeouts(ctx context.Context, tenantId string) ([]*sqlcv1.ProcessTaskTimeoutsRow, bool, error)
+	ProcessTaskTimeouts(ctx context.Context, tenantId string) (*TimeoutTasksResponse, bool, error)
 
-	ProcessTaskReassignments(ctx context.Context, tenantId string) ([]*sqlcv1.ProcessTaskReassignmentsRow, bool, error)
+	ProcessTaskReassignments(ctx context.Context, tenantId string) (*FailTasksResponse, bool, error)
 
 	ProcessTaskRetryQueueItems(ctx context.Context, tenantId string) ([]*sqlcv1.V1RetryQueueItem, bool, error)
 
@@ -509,27 +517,22 @@ func (r *TaskRepositoryImpl) CompleteTasks(ctx context.Context, tenantId string,
 		return nil, fmt.Errorf("failed to release all tasks")
 	}
 
-	datas := make([][]byte, len(releasedTasks))
-	insertedAts := make([]pgtype.Timestamptz, len(releasedTasks))
-	externalIds := make([]string, len(releasedTasks))
+	outputs := make([][]byte, len(releasedTasks))
 
 	for i, releasedTask := range releasedTasks {
-		out := NewCompletedTaskOutputEvent(releasedTask, tasks[i].Output)
+		out := NewCompletedTaskOutputEvent(releasedTask, tasks[i].Output).Bytes()
 
-		datas[i] = out.Bytes()
-		insertedAts[i] = releasedTask.InsertedAt
-		externalIds[i] = sqlchelpers.UUIDToStr(releasedTask.ExternalID)
+		outputs[i] = out
 	}
 
-	internalEvents, err := r.createTaskEvents(
+	internalEvents, err := r.createTaskEventsAfterRelease(
 		ctx,
 		tx,
 		tenantId,
 		taskIdRetryCounts,
-		externalIds,
-		datas,
-		makeEventTypeArr(sqlcv1.V1TaskEventTypeCOMPLETED, len(tasks)),
-		make([]string, len(tasks)),
+		outputs,
+		releasedTasks,
+		sqlcv1.V1TaskEventTypeCOMPLETED,
 	)
 
 	if err != nil {
@@ -548,6 +551,29 @@ func (r *TaskRepositoryImpl) CompleteTasks(ctx context.Context, tenantId string,
 }
 
 func (r *TaskRepositoryImpl) FailTasks(ctx context.Context, tenantId string, failureOpts []FailTaskOpts) (*FailTasksResponse, error) {
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 5000)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer rollback()
+
+	res, err := r.failTasksTx(ctx, tx, tenantId, failureOpts)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// commit the transaction
+	if err := commit(ctx); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (r *TaskRepositoryImpl) failTasksTx(ctx context.Context, tx sqlcv1.DBTX, tenantId string, failureOpts []FailTaskOpts) (*FailTasksResponse, error) {
 	// TODO: ADD BACK VALIDATION
 	// if err := r.v.Validate(tasks); err != nil {
 	// 	fmt.Println("FAILED VALIDATION HERE!!!")
@@ -575,14 +601,6 @@ func (r *TaskRepositoryImpl) FailTasks(ctx context.Context, tenantId string, fai
 
 	tasks = uniqueSet(tasks)
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 5000)
-
-	if err != nil {
-		return nil, err
-	}
-
-	defer rollback()
-
 	retriedTasks := make([]RetriedTask, 0)
 
 	// write app failures
@@ -604,6 +622,7 @@ func (r *TaskRepositoryImpl) FailTasks(ctx context.Context, tenantId string, fai
 					InsertedAt: task.InsertedAt,
 					RetryCount: task.RetryCount,
 				},
+				IsAppError:         true,
 				AppRetryCount:      task.AppRetryCount,
 				RetryBackoffFactor: task.RetryBackoffFactor,
 				RetryMaxBackoff:    task.RetryMaxBackoff,
@@ -645,38 +664,25 @@ func (r *TaskRepositoryImpl) FailTasks(ctx context.Context, tenantId string, fai
 		return nil, err
 	}
 
-	if len(tasks) != len(releasedTasks) {
-		return nil, fmt.Errorf("failed to release all tasks")
-	}
-
-	datas := make([][]byte, len(releasedTasks))
-	externalIds := make([]string, len(releasedTasks))
+	outputs := make([][]byte, len(releasedTasks))
 
 	for i, releasedTask := range releasedTasks {
-		out := NewFailedTaskOutputEvent(releasedTask, failureOpts[i].ErrorMessage)
+		out := NewFailedTaskOutputEvent(releasedTask, failureOpts[i].ErrorMessage).Bytes()
 
-		datas[i] = out.Bytes()
-		externalIds[i] = sqlchelpers.UUIDToStr(releasedTask.ExternalID)
+		outputs[i] = out
 	}
 
-	// write task events
-	internalEvents, err := r.createTaskEvents(
+	internalEvents, err := r.createTaskEventsAfterRelease(
 		ctx,
 		tx,
 		tenantId,
 		tasks,
-		externalIds,
-		datas,
-		makeEventTypeArr(sqlcv1.V1TaskEventTypeFAILED, len(tasks)),
-		make([]string, len(tasks)),
+		outputs,
+		releasedTasks,
+		sqlcv1.V1TaskEventTypeFAILED,
 	)
 
 	if err != nil {
-		return nil, err
-	}
-
-	// commit the transaction
-	if err := commit(ctx); err != nil {
 		return nil, err
 	}
 
@@ -863,32 +869,22 @@ func (r *sharedRepository) cancelTasks(ctx context.Context, dbtx sqlcv1.DBTX, te
 		return nil, err
 	}
 
-	if len(tasks) != len(releasedTasks) {
-		return nil, fmt.Errorf("failed to release all tasks")
-	}
-
-	datas := make([][]byte, len(releasedTasks))
-	insertedAts := make([]pgtype.Timestamptz, len(releasedTasks))
-	externalIds := make([]string, len(releasedTasks))
+	outputs := make([][]byte, len(releasedTasks))
 
 	for i, releasedTask := range releasedTasks {
-		out := NewCancelledTaskOutputEvent(releasedTask)
+		out := NewCancelledTaskOutputEvent(releasedTask).Bytes()
 
-		datas[i] = out.Bytes()
-		insertedAts[i] = releasedTask.InsertedAt
-		externalIds[i] = sqlchelpers.UUIDToStr(releasedTask.ExternalID)
+		outputs[i] = out
 	}
 
-	// write task events
-	internalEvents, err := r.createTaskEvents(
+	internalEvents, err := r.createTaskEventsAfterRelease(
 		ctx,
 		dbtx,
 		tenantId,
 		tasks,
-		externalIds,
-		datas,
-		makeEventTypeArr(sqlcv1.V1TaskEventTypeCANCELLED, len(tasks)),
-		make([]string, len(tasks)),
+		outputs,
+		releasedTasks,
+		sqlcv1.V1TaskEventTypeCANCELLED,
 	)
 
 	if err != nil {
@@ -957,7 +953,7 @@ func (r *TaskRepositoryImpl) ListTaskMetas(ctx context.Context, tenantId string,
 	})
 }
 
-func (r *TaskRepositoryImpl) ProcessTaskTimeouts(ctx context.Context, tenantId string) ([]*sqlcv1.ProcessTaskTimeoutsRow, bool, error) {
+func (r *TaskRepositoryImpl) ProcessTaskTimeouts(ctx context.Context, tenantId string) (*TimeoutTasksResponse, bool, error) {
 	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 5000)
 
 	if err != nil {
@@ -970,7 +966,7 @@ func (r *TaskRepositoryImpl) ProcessTaskTimeouts(ctx context.Context, tenantId s
 	limit := 1000
 
 	// get task timeouts
-	res, err := r.queries.ProcessTaskTimeouts(ctx, tx, sqlcv1.ProcessTaskTimeoutsParams{
+	toTimeout, err := r.queries.ListTasksToTimeout(ctx, tx, sqlcv1.ListTasksToTimeoutParams{
 		Tenantid: sqlchelpers.UUIDFromStr(tenantId),
 		Limit: pgtype.Int4{
 			Int32: int32(limit),
@@ -982,15 +978,40 @@ func (r *TaskRepositoryImpl) ProcessTaskTimeouts(ctx context.Context, tenantId s
 		return nil, false, err
 	}
 
+	// parse into FailTaskOpts
+	failOpts := make([]FailTaskOpts, 0, len(toTimeout))
+
+	for _, task := range toTimeout {
+		failOpts = append(failOpts, FailTaskOpts{
+			TaskIdInsertedAtRetryCount: &TaskIdInsertedAtRetryCount{
+				Id:         task.ID,
+				InsertedAt: task.InsertedAt,
+				RetryCount: task.RetryCount,
+			},
+			IsAppError:   true,
+			ErrorMessage: fmt.Sprintf("Task exceeded timeout of %s", task.StepTimeout.String),
+		})
+	}
+
+	// fail the tasks
+	failResp, err := r.failTasksTx(ctx, tx, tenantId, failOpts)
+
+	if err != nil {
+		return nil, false, err
+	}
+
 	// commit the transaction
 	if err := commit(ctx); err != nil {
 		return nil, false, err
 	}
 
-	return res, len(res) == limit, nil
+	return &TimeoutTasksResponse{
+		FailTasksResponse: failResp,
+		TimeoutTasks:      toTimeout,
+	}, len(toTimeout) == limit, nil
 }
 
-func (r *TaskRepositoryImpl) ProcessTaskReassignments(ctx context.Context, tenantId string) ([]*sqlcv1.ProcessTaskReassignmentsRow, bool, error) {
+func (r *TaskRepositoryImpl) ProcessTaskReassignments(ctx context.Context, tenantId string) (*FailTasksResponse, bool, error) {
 	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 5000)
 
 	if err != nil {
@@ -1002,10 +1023,8 @@ func (r *TaskRepositoryImpl) ProcessTaskReassignments(ctx context.Context, tenan
 	// TODO: make limit configurable
 	limit := 1000
 
-	// get task reassignments
-	res, err := r.queries.ProcessTaskReassignments(ctx, tx, sqlcv1.ProcessTaskReassignmentsParams{
-		Tenantid:           sqlchelpers.UUIDFromStr(tenantId),
-		Maxinternalretries: MAX_INTERNAL_RETRIES,
+	toReassign, err := r.queries.ListTasksToReassign(ctx, tx, sqlcv1.ListTasksToReassignParams{
+		Tenantid: sqlchelpers.UUIDFromStr(tenantId),
 		Limit: pgtype.Int4{
 			Int32: int32(limit),
 			Valid: true,
@@ -1016,36 +1035,25 @@ func (r *TaskRepositoryImpl) ProcessTaskReassignments(ctx context.Context, tenan
 		return nil, false, err
 	}
 
-	// write failed tasks as task events
-	failedTasks := make([]TaskIdInsertedAtRetryCount, 0)
+	// parse into FailTaskOpts
+	failOpts := make([]FailTaskOpts, 0, len(toReassign))
 
-	for _, task := range res {
-		if task.Operation == "FAILED" {
-			failedTasks = append(failedTasks, TaskIdInsertedAtRetryCount{
+	for _, task := range toReassign {
+		failOpts = append(failOpts, FailTaskOpts{
+			TaskIdInsertedAtRetryCount: &TaskIdInsertedAtRetryCount{
 				Id:         task.ID,
 				InsertedAt: task.InsertedAt,
 				RetryCount: task.RetryCount,
-			})
-		}
+			},
+			IsAppError: false,
+		})
 	}
 
-	// failedTaskDatas := make([][]byte, len(failedTasks))
+	// fail the tasks
+	res, err := r.failTasksTx(ctx, tx, tenantId, failOpts)
 
-	if len(failedTasks) > 0 {
-		// TODO: FIX REASSIGNMENTS
-		// _, err = r.createTaskEvents(
-		// 	ctx,
-		// 	tx,
-		// 	tenantId,
-		// 	failedTasks,
-		// 	failedTaskDatas,
-		// 	sqlcv1.V1TaskEventTypeFAILED,
-		// 	make([]string, len(failedTasks)),
-		// )
-
-		// if err != nil {
-		// 	return nil, false, err
-		// }
+	if err != nil {
+		return nil, false, err
 	}
 
 	// commit the transaction
@@ -1053,7 +1061,7 @@ func (r *TaskRepositoryImpl) ProcessTaskReassignments(ctx context.Context, tenan
 		return nil, false, err
 	}
 
-	return res, len(res) == limit, nil
+	return res, len(toReassign) == limit, nil
 }
 
 func (r *TaskRepositoryImpl) ProcessTaskRetryQueueItems(ctx context.Context, tenantId string) ([]*sqlcv1.V1RetryQueueItem, bool, error) {
@@ -2059,6 +2067,56 @@ func (r *sharedRepository) getStepExpressions(
 	}
 
 	return stepIdToExpressions, nil
+}
+
+func (r *sharedRepository) createTaskEventsAfterRelease(
+	ctx context.Context,
+	tx sqlcv1.DBTX,
+	tenantId string,
+	taskIdRetryCounts []TaskIdInsertedAtRetryCount,
+	outputs [][]byte,
+	releasedTasks []*sqlcv1.ReleaseTasksRow,
+	eventType sqlcv1.V1TaskEventType,
+) ([]InternalTaskEvent, error) {
+	if len(taskIdRetryCounts) != len(releasedTasks) || len(taskIdRetryCounts) != len(outputs) {
+		return nil, fmt.Errorf("failed to release all tasks")
+	}
+
+	datas := make([][]byte, len(releasedTasks))
+	externalIds := make([]string, len(releasedTasks))
+	isCurrentRetry := make([]bool, len(releasedTasks))
+
+	for i, releasedTask := range releasedTasks {
+		datas[i] = outputs[i]
+		externalIds[i] = sqlchelpers.UUIDToStr(releasedTask.ExternalID)
+		isCurrentRetry[i] = releasedTask.IsCurrentRetry
+	}
+
+	// filter out any rows which are not the current retry
+	filteredTaskIdRetryCounts := make([]TaskIdInsertedAtRetryCount, 0)
+	filteredDatas := make([][]byte, 0)
+	filteredExternalIds := make([]string, 0)
+
+	for i := range len(datas) {
+		if !isCurrentRetry[i] {
+			continue
+		}
+
+		filteredTaskIdRetryCounts = append(filteredTaskIdRetryCounts, taskIdRetryCounts[i])
+		filteredDatas = append(filteredDatas, datas[i])
+		filteredExternalIds = append(filteredExternalIds, externalIds[i])
+	}
+
+	return r.createTaskEvents(
+		ctx,
+		tx,
+		tenantId,
+		filteredTaskIdRetryCounts,
+		filteredExternalIds,
+		filteredDatas,
+		makeEventTypeArr(eventType, len(filteredExternalIds)),
+		make([]string, len(filteredExternalIds)),
+	)
 }
 
 func (r *sharedRepository) createTaskEvents(

--- a/pkg/repository/v1/task.go
+++ b/pkg/repository/v1/task.go
@@ -2751,6 +2751,12 @@ func (r *TaskRepositoryImpl) ListTaskParentOutputs(ctx context.Context, tenantId
 		}
 	}
 
+	resMap := make(map[int64][]*TaskOutputEvent)
+
+	if len(taskIds) == 0 {
+		return resMap, nil
+	}
+
 	res, err := r.queries.ListTaskParentOutputs(ctx, r.pool, sqlcv1.ListTaskParentOutputsParams{
 		Tenantid:        sqlchelpers.UUIDFromStr(tenantId),
 		Taskids:         taskIds,
@@ -2777,8 +2783,6 @@ func (r *TaskRepositoryImpl) ListTaskParentOutputs(ctx context.Context, tenantId
 			workflowRunIdsToOutputs[wrId] = append(workflowRunIdsToOutputs[wrId], e)
 		}
 	}
-
-	resMap := make(map[int64][]*TaskOutputEvent)
 
 	for _, task := range tasks {
 		if task.WorkflowRunID.Valid {

--- a/pkg/scheduling/v0/rate_limit.go
+++ b/pkg/scheduling/v0/rate_limit.go
@@ -116,12 +116,14 @@ func (r *rateLimiter) use(ctx context.Context, stepRunId string, rls map[string]
 
 	// determine if we can use all the rate limits in the set
 	for k, v := range rls {
-		if currRls[k].val < int(v) {
-			res.exceededKey = k
-			res.exceededUnits = v
-			res.exceededVal = int32(currRls[k].val) // nolint: gosec
+		if currRl, ok := currRls[k]; ok {
+			if currRl.val < int(v) {
+				res.exceededKey = k
+				res.exceededUnits = v
+				res.exceededVal = int32(currRl.val) // nolint: gosec
 
-			return res
+				return res
+			}
 		}
 	}
 

--- a/pkg/scheduling/v1/rate_limit.go
+++ b/pkg/scheduling/v1/rate_limit.go
@@ -116,12 +116,14 @@ func (r *rateLimiter) use(ctx context.Context, taskId int64, rls map[string]int3
 
 	// determine if we can use all the rate limits in the set
 	for k, v := range rls {
-		if currRls[k].val < int(v) {
-			res.exceededKey = k
-			res.exceededUnits = v
-			res.exceededVal = int32(currRls[k].val) // nolint: gosec
+		if currRl, ok := currRls[k]; ok {
+			if currRl.val < int(v) {
+				res.exceededKey = k
+				res.exceededUnits = v
+				res.exceededVal = int32(currRl.val) // nolint: gosec
 
-			return res
+				return res
+			}
 		}
 	}
 


### PR DESCRIPTION
# Description

Fixes several bugs in the v1 engine related to timeouts and reassignments, and improves performance of the replay query:
- [X] Uses the same logic as task failure when processing a timeout or reassignment (within the same transaction), so we don't miss edge cases. We were currently missing the failure event on reassignments which prevented internal match triggers from firing, and we weren't deleting the concurrency slot on a reassignment.
- [X] Fixes a panic in the rate limiter
- [X] Improves query performance of listing tasks for replay in a non-obvious way -- adding the `ORDER BY` with a `JOIN` condition was making the query extremely slow on large datasets. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)