### PR TITLE
fix(v1): rate limit queries

### DIFF
--- a/pkg/repository/postgres/dbsqlc/rate_limits.sql.go
+++ b/pkg/repository/postgres/dbsqlc/rate_limits.sql.go
@@ -18,8 +18,8 @@ WITH input AS (
     FROM
         (
             SELECT
-                unnest($2::text[]) AS "key",
-                unnest($3::int[]) AS "units"
+                unnest($1::text[]) AS "key",
+                unnest($2::int[]) AS "units"
         ) AS subquery
 ), rls_to_update AS (
     SELECT
@@ -27,16 +27,16 @@ WITH input AS (
     FROM
         "RateLimit" rl
     WHERE
-        rl."tenantId" = $1::uuid
+        rl."tenantId" = $3::uuid
         AND rl."key" = ANY(SELECT "key" FROM input)
     ORDER BY
         rl."tenantId" ASC, rl."key" ASC
     FOR UPDATE
 )
 UPDATE
-    "RateLimit"
+    "RateLimit" rl
 SET
-    "value" = get_refill_value(rl) - input."units",
+    "value" = get_refill_value(rl) - (SELECT "units" FROM input WHERE "key" = rl."key"),
     "lastRefill" = CASE
         WHEN NOW() - rl."lastRefill" >= rl."window"::INTERVAL THEN
             CURRENT_TIMESTAMP
@@ -44,38 +44,28 @@ SET
             rl."lastRefill"
     END
 FROM
-    rls_to_update rl
-JOIN input ON rl."key" = input."key"
+    rls_to_update rl2
 WHERE
-    rl."key" = input."key"
-    AND rl."tenantId" = $1::uuid
+    rl2."tenantId" = rl."tenantId"
+    AND rl2."key" = rl."key"
 RETURNING rl."tenantId", rl.key, rl."limitValue", rl.value, rl."window", rl."lastRefill"
 `
 
 type BulkUpdateRateLimitsParams struct {
-	Tenantid pgtype.UUID `json:"tenantid"`
 	Keys     []string    `json:"keys"`
 	Units    []int32     `json:"units"`
+	Tenantid pgtype.UUID `json:"tenantid"`
 }
 
-type BulkUpdateRateLimitsRow struct {
-	TenantId   pgtype.UUID      `json:"tenantId"`
-	Key        string           `json:"key"`
-	LimitValue int32            `json:"limitValue"`
-	Value      int32            `json:"value"`
-	Window     string           `json:"window"`
-	LastRefill pgtype.Timestamp `json:"lastRefill"`
-}
-
-func (q *Queries) BulkUpdateRateLimits(ctx context.Context, db DBTX, arg BulkUpdateRateLimitsParams) ([]*BulkUpdateRateLimitsRow, error) {
-	rows, err := db.Query(ctx, bulkUpdateRateLimits, arg.Tenantid, arg.Keys, arg.Units)
+func (q *Queries) BulkUpdateRateLimits(ctx context.Context, db DBTX, arg BulkUpdateRateLimitsParams) ([]*RateLimit, error) {
+	rows, err := db.Query(ctx, bulkUpdateRateLimits, arg.Keys, arg.Units, arg.Tenantid)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*BulkUpdateRateLimitsRow
+	var items []*RateLimit
 	for rows.Next() {
-		var i BulkUpdateRateLimitsRow
+		var i RateLimit
 		if err := rows.Scan(
 			&i.TenantId,
 			&i.Key,
@@ -292,6 +282,17 @@ WITH rls_to_update AS (
         AND rl."key" = rls_to_update."key"
     RETURNING rl."tenantId", rl.key, rl."limitValue", rl.value, rl."window", rl."lastRefill"
 )
+SELECT
+    rl."tenantId", rl.key, rl."limitValue", rl.value, rl."window", rl."lastRefill",
+    (rl."lastRefill" + rl."window"::INTERVAL)::timestamp AS "nextRefillAt"
+FROM
+    "RateLimit" rl
+WHERE
+    rl."tenantId" = $1::uuid
+    AND rl."key" NOT IN (SELECT "key" FROM refill)
+
+UNION ALL
+
 SELECT
     refill."tenantId", refill.key, refill."limitValue", refill.value, refill."window", refill."lastRefill",
     -- return the next refill time

--- a/pkg/repository/v1/sqlcv1/rate_limits.sql
+++ b/pkg/repository/v1/sqlcv1/rate_limits.sql
@@ -92,6 +92,17 @@ WITH rls_to_update AS (
     RETURNING rl.*
 )
 SELECT
+    rl.*,
+    (rl."lastRefill" + rl."window"::INTERVAL)::timestamp AS "nextRefillAt"
+FROM
+    "RateLimit" rl
+WHERE
+    rl."tenantId" = @tenantId::uuid
+    AND rl."key" NOT IN (SELECT "key" FROM refill)
+
+UNION ALL
+
+SELECT
     refill.*,
     -- return the next refill time
     (refill."lastRefill" + refill."window"::INTERVAL)::timestamp AS "nextRefillAt"
@@ -130,9 +141,9 @@ WITH input AS (
     FOR UPDATE
 )
 UPDATE
-    "RateLimit"
+    "RateLimit" rl
 SET
-    "value" = get_refill_value(rl) - input."units",
+    "value" = get_refill_value(rl) - (SELECT "units" FROM input WHERE "key" = rl."key"),
     "lastRefill" = CASE
         WHEN NOW() - rl."lastRefill" >= rl."window"::INTERVAL THEN
             CURRENT_TIMESTAMP
@@ -140,9 +151,8 @@ SET
             rl."lastRefill"
     END
 FROM
-    rls_to_update rl
-JOIN input ON rl."key" = input."key"
+    rls_to_update rl2
 WHERE
-    rl."key" = input."key"
-    AND rl."tenantId" = @tenantId::uuid
+    rl2."tenantId" = rl."tenantId"
+    AND rl2."key" = rl."key"
 RETURNING rl.*;

--- a/pkg/repository/v1/sqlcv1/rate_limits.sql.go
+++ b/pkg/repository/v1/sqlcv1/rate_limits.sql.go
@@ -18,8 +18,8 @@ WITH input AS (
     FROM
         (
             SELECT
-                unnest($2::text[]) AS "key",
-                unnest($3::int[]) AS "units"
+                unnest($1::text[]) AS "key",
+                unnest($2::int[]) AS "units"
         ) AS subquery
 ), rls_to_update AS (
     SELECT
@@ -27,16 +27,16 @@ WITH input AS (
     FROM
         "RateLimit" rl
     WHERE
-        rl."tenantId" = $1::uuid
+        rl."tenantId" = $3::uuid
         AND rl."key" = ANY(SELECT "key" FROM input)
     ORDER BY
         rl."tenantId" ASC, rl."key" ASC
     FOR UPDATE
 )
 UPDATE
-    "RateLimit"
+    "RateLimit" rl
 SET
-    "value" = get_refill_value(rl) - input."units",
+    "value" = get_refill_value(rl) - (SELECT "units" FROM input WHERE "key" = rl."key"),
     "lastRefill" = CASE
         WHEN NOW() - rl."lastRefill" >= rl."window"::INTERVAL THEN
             CURRENT_TIMESTAMP
@@ -44,38 +44,28 @@ SET
             rl."lastRefill"
     END
 FROM
-    rls_to_update rl
-JOIN input ON rl."key" = input."key"
+    rls_to_update rl2
 WHERE
-    rl."key" = input."key"
-    AND rl."tenantId" = $1::uuid
+    rl2."tenantId" = rl."tenantId"
+    AND rl2."key" = rl."key"
 RETURNING rl."tenantId", rl.key, rl."limitValue", rl.value, rl."window", rl."lastRefill"
 `
 
 type BulkUpdateRateLimitsParams struct {
-	Tenantid pgtype.UUID `json:"tenantid"`
 	Keys     []string    `json:"keys"`
 	Units    []int32     `json:"units"`
+	Tenantid pgtype.UUID `json:"tenantid"`
 }
 
-type BulkUpdateRateLimitsRow struct {
-	TenantId   pgtype.UUID      `json:"tenantId"`
-	Key        string           `json:"key"`
-	LimitValue int32            `json:"limitValue"`
-	Value      int32            `json:"value"`
-	Window     string           `json:"window"`
-	LastRefill pgtype.Timestamp `json:"lastRefill"`
-}
-
-func (q *Queries) BulkUpdateRateLimits(ctx context.Context, db DBTX, arg BulkUpdateRateLimitsParams) ([]*BulkUpdateRateLimitsRow, error) {
-	rows, err := db.Query(ctx, bulkUpdateRateLimits, arg.Tenantid, arg.Keys, arg.Units)
+func (q *Queries) BulkUpdateRateLimits(ctx context.Context, db DBTX, arg BulkUpdateRateLimitsParams) ([]*RateLimit, error) {
+	rows, err := db.Query(ctx, bulkUpdateRateLimits, arg.Keys, arg.Units, arg.Tenantid)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*BulkUpdateRateLimitsRow
+	var items []*RateLimit
 	for rows.Next() {
-		var i BulkUpdateRateLimitsRow
+		var i RateLimit
 		if err := rows.Scan(
 			&i.TenantId,
 			&i.Key,
@@ -243,6 +233,17 @@ WITH rls_to_update AS (
         AND rl."key" = rls_to_update."key"
     RETURNING rl."tenantId", rl.key, rl."limitValue", rl.value, rl."window", rl."lastRefill"
 )
+SELECT
+    rl."tenantId", rl.key, rl."limitValue", rl.value, rl."window", rl."lastRefill",
+    (rl."lastRefill" + rl."window"::INTERVAL)::timestamp AS "nextRefillAt"
+FROM
+    "RateLimit" rl
+WHERE
+    rl."tenantId" = $1::uuid
+    AND rl."key" NOT IN (SELECT "key" FROM refill)
+
+UNION ALL
+
 SELECT
     refill."tenantId", refill.key, refill."limitValue", refill.value, refill."window", refill."lastRefill",
     -- return the next refill time


### PR DESCRIPTION
# Description

Fixes some issues on the rate limit queries:
- [X] Returning rate limits after update only returned updated rows, while the application expects all rows for the tenant to be returned
- [X] Bulk updates were happening on all rate limits on the tenant, which resulted in a lot of incorrect rate limits
 
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)