### PR TITLE
fix(v1): use inserted_at to join dags, tasks in olap queries

### DIFF
--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -270,9 +270,9 @@ ORDER BY a.time_first_seen DESC, t.event_timestamp DESC;
 
 -- name: ListTaskEventsForWorkflowRun :many
 WITH tasks AS (
-    SELECT dt.task_id
+    SELECT dt.task_id, dt.task_inserted_at
     FROM v1_lookup_table_olap lt
-    JOIN v1_dag_to_task_olap dt ON lt.dag_id = dt.dag_id
+    JOIN v1_dag_to_task_olap dt ON lt.dag_id = dt.dag_id AND lt.dag_inserted_at = dt.dag_inserted_at
     WHERE
         lt.external_id = @workflowRunId::uuid
         AND lt.tenant_id = @tenantId::uuid
@@ -290,7 +290,7 @@ WITH tasks AS (
   FROM v1_task_events_olap
   WHERE
     tenant_id = @tenantId::uuid
-    AND task_id IN (SELECT task_id FROM tasks)
+    AND (task_id, task_inserted_at) IN (SELECT task_id, task_inserted_at FROM tasks)
   GROUP BY tenant_id, task_id, task_inserted_at, retry_count, event_type
 )
 SELECT

--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -272,7 +272,7 @@ ORDER BY a.time_first_seen DESC, t.event_timestamp DESC;
 WITH tasks AS (
     SELECT dt.task_id, dt.task_inserted_at
     FROM v1_lookup_table_olap lt
-    JOIN v1_dag_to_task_olap dt ON lt.dag_id = dt.dag_id AND lt.dag_inserted_at = dt.dag_inserted_at
+    JOIN v1_dag_to_task_olap dt ON lt.dag_id = dt.dag_id AND lt.inserted_at = dt.dag_inserted_at
     WHERE
         lt.external_id = @workflowRunId::uuid
         AND lt.tenant_id = @tenantId::uuid

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -481,7 +481,7 @@ const listTaskEventsForWorkflowRun = `-- name: ListTaskEventsForWorkflowRun :man
 WITH tasks AS (
     SELECT dt.task_id, dt.task_inserted_at
     FROM v1_lookup_table_olap lt
-    JOIN v1_dag_to_task_olap dt ON lt.dag_id = dt.dag_id AND lt.dag_inserted_at = dt.dag_inserted_at
+    JOIN v1_dag_to_task_olap dt ON lt.dag_id = dt.dag_id AND lt.inserted_at = dt.dag_inserted_at
     WHERE
         lt.external_id = $1::uuid
         AND lt.tenant_id = $2::uuid

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -479,9 +479,9 @@ func (q *Queries) ListTaskEvents(ctx context.Context, db DBTX, arg ListTaskEvent
 
 const listTaskEventsForWorkflowRun = `-- name: ListTaskEventsForWorkflowRun :many
 WITH tasks AS (
-    SELECT dt.task_id
+    SELECT dt.task_id, dt.task_inserted_at
     FROM v1_lookup_table_olap lt
-    JOIN v1_dag_to_task_olap dt ON lt.dag_id = dt.dag_id
+    JOIN v1_dag_to_task_olap dt ON lt.dag_id = dt.dag_id AND lt.dag_inserted_at = dt.dag_inserted_at
     WHERE
         lt.external_id = $1::uuid
         AND lt.tenant_id = $2::uuid
@@ -499,7 +499,7 @@ WITH tasks AS (
   FROM v1_task_events_olap
   WHERE
     tenant_id = $2::uuid
-    AND task_id IN (SELECT task_id FROM tasks)
+    AND (task_id, task_inserted_at) IN (SELECT task_id, task_inserted_at FROM tasks)
   GROUP BY tenant_id, task_id, task_inserted_at, retry_count, event_type
 )
 SELECT


### PR DESCRIPTION
# Description

Adds an additional `inserted_at` field to the dag/task queries to prevent task collisions from different tenants. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)