### PR TITLE
fix(v1): reassignments consistent with v0 behavior

### DIFF
--- a/internal/services/controllers/v1/task/controller.go
+++ b/internal/services/controllers/v1/task/controller.go
@@ -379,7 +379,7 @@ func (tc *TasksControllerImpl) handleTaskFailed(ctx context.Context, tenantId st
 				TaskId:         msg.TaskId,
 				RetryCount:     msg.RetryCount,
 				EventType:      sqlcv1.V1EventTypeOlapFAILED,
-				EventTimestamp: msg.InsertedAt.Time,
+				EventTimestamp: time.Now().UTC(),
 				EventPayload:   msg.ErrorMsg,
 			},
 		)

--- a/internal/services/dispatcher/dispatcher_v1.go
+++ b/internal/services/dispatcher/dispatcher_v1.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -189,8 +190,8 @@ func (d *DispatcherImpl) handleTaskBulkAssignedTask(ctx context.Context, msg *ms
 
 				innerEg := errgroup.Group{}
 
-				// toRetry := []string{}
-				// toRetryMu := sync.Mutex{}
+				toRetry := []*sqlcv1.V1Task{}
+				toRetryMu := sync.Mutex{}
 
 				for _, stepRunId := range stepRunIds {
 					stepRunId := stepRunId
@@ -198,33 +199,17 @@ func (d *DispatcherImpl) handleTaskBulkAssignedTask(ctx context.Context, msg *ms
 					innerEg.Go(func() error {
 						task := taskIdToData[stepRunId]
 
-						// requeue := func() {
-						// 	toRetryMu.Lock()
-						// 	toRetry = append(toRetry, stepRunId)
-						// 	toRetryMu.Unlock()
-						// }
+						requeue := func() {
+							toRetryMu.Lock()
+							toRetry = append(toRetry, task)
+							toRetryMu.Unlock()
+						}
 
 						// if we've reached the context deadline, this should be requeued
 						if ctx.Err() != nil {
-							// FIXME
-							// requeue()
+							requeue()
 							return nil
 						}
-
-						// // if the step run has a job run in a non-running state, we should not send it to the worker
-						// if repository.IsFinalJobRunStatus(stepRun.JobRunStatus) {
-						// 	d.l.Debug().Msgf("job run %s is in a final state %s, ignoring", sqlchelpers.UUIDToStr(stepRun.JobRunId), string(stepRun.JobRunStatus))
-
-						// 	// release the semaphore
-						// 	return d.repo.StepRun().ReleaseStepRunSemaphore(ctx, metadata.TenantId, stepRunId, false)
-						// }
-
-						// // if the step run is in a final state, we should not send it to the worker
-						// if repository.IsFinalStepRunStatus(stepRun.Status) {
-						// 	d.l.Warn().Msgf("step run %s is in a final state %s, ignoring", stepRunId, string(stepRun.Status))
-
-						// 	return d.repo.StepRun().ReleaseStepRunSemaphore(ctx, metadata.TenantId, stepRunId, false)
-						// }
 
 						var multiErr error
 						var success bool
@@ -241,38 +226,11 @@ func (d *DispatcherImpl) handleTaskBulkAssignedTask(ctx context.Context, msg *ms
 							}
 						}
 
-						// now := time.Now().UTC()
-
 						if success {
-							// defer d.repo.StepRun().DeferredStepRunEvent(
-							// 	metadata.TenantId,
-							// 	repository.CreateStepRunEventOpts{
-							// 		StepRunId:     sqlchelpers.UUIDToStr(stepRun.SRID),
-							// 		EventMessage:  repository.StringPtr("Sent step run to the assigned worker"),
-							// 		EventReason:   repository.StepRunEventReasonPtr(dbsqlc.StepRunEventReasonSENTTOWORKER),
-							// 		EventSeverity: repository.StepRunEventSeverityPtr(dbsqlc.StepRunEventSeverityINFO),
-							// 		Timestamp:     &now,
-							// 		EventData:     map[string]interface{}{"worker_id": workerId},
-							// 	},
-							// )
-
 							return nil
 						}
 
-						// defer d.repo.StepRun().DeferredStepRunEvent(
-						// 	metadata.TenantId,
-						// 	repository.CreateStepRunEventOpts{
-						// 		StepRunId:     sqlchelpers.UUIDToStr(stepRun.SRID),
-						// 		EventMessage:  repository.StringPtr("Could not send step run to assigned worker"),
-						// 		EventReason:   repository.StepRunEventReasonPtr(dbsqlc.StepRunEventReasonREASSIGNED),
-						// 		EventSeverity: repository.StepRunEventSeverityPtr(dbsqlc.StepRunEventSeverityWARNING),
-						// 		Timestamp:     &now,
-						// 		EventData:     map[string]interface{}{"worker_id": workerId},
-						// 	},
-						// )
-
-						// requeue()
-						// FIXME
+						requeue()
 
 						return multiErr
 					})
@@ -280,46 +238,34 @@ func (d *DispatcherImpl) handleTaskBulkAssignedTask(ctx context.Context, msg *ms
 
 				innerErr := innerEg.Wait()
 
-				// if len(toRetry) > 0 {
-				// 	retryCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-				// 	defer cancel()
+				if len(toRetry) > 0 {
+					retryCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+					defer cancel()
 
-				// 	_, stepRunsToFail, err := d.repo.StepRun().InternalRetryStepRuns(retryCtx, metadata.TenantId, toRetry)
+					for _, task := range toRetry {
+						msg, err := tasktypesv1.FailedTaskMessage(
+							msg.TenantID,
+							task.ID,
+							task.InsertedAt,
+							sqlchelpers.UUIDToStr(task.ExternalID),
+							sqlchelpers.UUIDToStr(task.WorkflowRunID),
+							task.RetryCount,
+							false,
+							"Could not send task to worker",
+						)
 
-				// 	if err != nil {
-				// 		innerErr = multierror.Append(innerErr, fmt.Errorf("could not requeue step runs: %w", err))
-				// 	}
+						if err != nil {
+							innerErr = multierror.Append(innerErr, fmt.Errorf("could not create failed task message: %w", err))
+							continue
+						}
 
-				// 	if len(stepRunsToFail) > 0 {
-				// 		now := time.Now()
+						err = d.mqv1.SendMessage(retryCtx, msgqueuev1.TASK_PROCESSING_QUEUE, msg)
 
-				// 		batchErr := queueutils.BatchConcurrent(50, stepRunsToFail, func(stepRuns []*dbsqlc.GetStepRunForEngineRow) error {
-				// 			var innerBatchErr error
-
-				// 			for _, stepRun := range stepRuns {
-				// 				err := d.mq.SendMessage(
-				// 					retryCtx,
-				// 					msgqueuev1.JOB_PROCESSING_QUEUE,
-				// 					tasktypesv1.StepRunFailedToTask(
-				// 						stepRun,
-				// 						"Could not send step run to worker",
-				// 						&now,
-				// 					),
-				// 				)
-
-				// 				if err != nil {
-				// 					innerBatchErr = multierror.Append(innerBatchErr, err)
-				// 				}
-				// 			}
-
-				// 			return innerBatchErr
-				// 		})
-
-				// 		if batchErr != nil {
-				// 			innerErr = multierror.Append(innerErr, fmt.Errorf("could not fail step runs: %w", batchErr))
-				// 		}
-				// 	}
-				// }
+						if err != nil {
+							innerErr = multierror.Append(innerErr, fmt.Errorf("could not send failed task message: %w", err))
+						}
+					}
+				}
 
 				return innerErr
 			})

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -214,7 +214,7 @@ func (c *ConfigLoader) InitDataLayer() (res *database.Layer, err error) {
 		return nil, fmt.Errorf("could not parse retention period %s: %w", scf.Runtime.Limits.DefaultTenantRetentionPeriod, err)
 	}
 
-	v1, cleanupV1 := repov1.NewRepository(pool, &l, retentionPeriod, retentionPeriod)
+	v1, cleanupV1 := repov1.NewRepository(pool, &l, retentionPeriod, retentionPeriod, scf.Runtime.MaxInternalRetryCount)
 
 	apiRepo, cleanupApiRepo, err := postgresdb.NewAPIRepository(pool, &scf.Runtime, opts...)
 

--- a/pkg/repository/v1/repository.go
+++ b/pkg/repository/v1/repository.go
@@ -31,7 +31,7 @@ type repositoryImpl struct {
 	workflows WorkflowRepository
 }
 
-func NewRepository(pool *pgxpool.Pool, l *zerolog.Logger, taskRetentionPeriod, olapRetentionPeriod time.Duration) (Repository, func() error) {
+func NewRepository(pool *pgxpool.Pool, l *zerolog.Logger, taskRetentionPeriod, olapRetentionPeriod time.Duration, maxInternalRetryCount int32) (Repository, func() error) {
 	v := validator.NewDefaultValidator()
 
 	shared, cleanupShared := newSharedRepository(pool, v, l)
@@ -44,7 +44,7 @@ func NewRepository(pool *pgxpool.Pool, l *zerolog.Logger, taskRetentionPeriod, o
 
 	impl := &repositoryImpl{
 		triggers:  newTriggerRepository(shared),
-		tasks:     newTaskRepository(shared, taskRetentionPeriod),
+		tasks:     newTaskRepository(shared, taskRetentionPeriod, maxInternalRetryCount),
 		scheduler: newSchedulerRepository(shared),
 		matches:   matchRepo,
 		olap:      newOLAPRepository(shared, olapRetentionPeriod),


### PR DESCRIPTION
# Description

Includes several fixes for reassignments:
- [X] Triggers an internal retry when we fail to send a task through the action listener
- [X] Respects the `MaxInternalRetryCount` set in the config
- [X] Sends a failure event on reassignments when we don't retry, so the OLAP database knows the task has failed.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)