### PR TITLE
fix: add back loaders and redirect out of auth pages faster

### DIFF
--- a/frontend/app/src/pages/authenticated.tsx
+++ b/frontend/app/src/pages/authenticated.tsx
@@ -13,6 +13,7 @@ export default function Authenticated() {
 
   const userQuery = useQuery({
     queryKey: ['user:get:current'],
+    retry: false,
     queryFn: async () => {
       const res = await api.userGetCurrent();
       return res.data;
@@ -21,6 +22,7 @@ export default function Authenticated() {
 
   const invitesQuery = useQuery({
     queryKey: ['user:list-tenant-invites'],
+    retry: false,
     queryFn: async () => {
       const res = await api.userListTenantInvites();
       return res.data.rows || [];
@@ -29,6 +31,7 @@ export default function Authenticated() {
 
   const listMembershipsQuery = useQuery({
     ...queries.user.listTenantMemberships,
+    retry: false,
   });
 
   const ctx = useContextFromParent({

--- a/frontend/app/src/router.tsx
+++ b/frontend/app/src/router.tsx
@@ -53,6 +53,7 @@ export const routes: RouteObject[] = [
           import('./pages/onboarding/verify-email').then((res) => {
             return {
               Component: res.default,
+              loader: res.loader,
             };
           }),
       },
@@ -99,6 +100,7 @@ export const routes: RouteObject[] = [
               import('./pages/onboarding/invites').then((res) => {
                 return {
                   Component: res.default,
+                  loader: res.loader,
                 };
               }),
           },


### PR DESCRIPTION
# Description

Adds back loaders which were removed from `router.tsx` during the rewrite. Also sets `retry: false` on queries so users can get redirected to `/auth/login` faster when they hit an authenticated route.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)