### PR TITLE
fix(v1): cancellations, failures, and retries edge case

### DIFF
--- a/pkg/repository/v1/sqlcv1/tasks.sql
+++ b/pkg/repository/v1/sqlcv1/tasks.sql
@@ -249,6 +249,11 @@ WITH input AS (
         step_id
     FROM
         v1_task
+    -- only fail tasks which have a v1_task_runtime equivalent to the current retry count. otherwise,
+    -- a cancellation which deletes the v1_task_runtime might lead to a future failure event, which triggers
+    -- a retry.
+    JOIN
+        v1_task_runtime rt ON rt.task_id = v1_task.id AND rt.task_inserted_at = v1_task.inserted_at AND rt.retry_count = v1_task.retry_count
     WHERE
         (id, inserted_at) IN (SELECT task_id, task_inserted_at FROM input)
         AND tenant_id = @tenantId::uuid
@@ -300,6 +305,11 @@ WITH input AS (
         id
     FROM
         v1_task
+    -- only fail tasks which have a v1_task_runtime equivalent to the current retry count. otherwise,
+    -- a cancellation which deletes the v1_task_runtime might lead to a future failure event, which triggers
+    -- a retry.
+    JOIN
+        v1_task_runtime rt ON rt.task_id = v1_task.id AND rt.task_inserted_at = v1_task.inserted_at AND rt.retry_count = v1_task.retry_count
     WHERE
         (id, inserted_at) IN (SELECT task_id, task_inserted_at FROM input)
         AND tenant_id = @tenantId::uuid

--- a/pkg/repository/v1/sqlcv1/tasks.sql.go
+++ b/pkg/repository/v1/sqlcv1/tasks.sql.go
@@ -91,6 +91,11 @@ WITH input AS (
         step_id
     FROM
         v1_task
+    -- only fail tasks which have a v1_task_runtime equivalent to the current retry count. otherwise,
+    -- a cancellation which deletes the v1_task_runtime might lead to a future failure event, which triggers
+    -- a retry.
+    JOIN
+        v1_task_runtime rt ON rt.task_id = v1_task.id AND rt.task_inserted_at = v1_task.inserted_at AND rt.retry_count = v1_task.retry_count
     WHERE
         (id, inserted_at) IN (SELECT task_id, task_inserted_at FROM input)
         AND tenant_id = $3::uuid
@@ -185,6 +190,11 @@ WITH input AS (
         id
     FROM
         v1_task
+    -- only fail tasks which have a v1_task_runtime equivalent to the current retry count. otherwise,
+    -- a cancellation which deletes the v1_task_runtime might lead to a future failure event, which triggers
+    -- a retry.
+    JOIN
+        v1_task_runtime rt ON rt.task_id = v1_task.id AND rt.task_inserted_at = v1_task.inserted_at AND rt.retry_count = v1_task.retry_count
     WHERE
         (id, inserted_at) IN (SELECT task_id, task_inserted_at FROM input)
         AND tenant_id = $4::uuid


### PR DESCRIPTION
# Description

Fixes an edge case where:
1. Task was started with a `CANCEL_IN_PROGRESS` concurrency strategy and retries
2. Task was cancelled
3. Task sent a failure event to the engine (likely the cancellation was ignored by the SDK)
4. This incorrectly triggers a retry on the engine. 

We should instead ensure that nothing else has modified the `v1_task_runtime` before the failure event (any event that deletes the runtime -- succeeded, cancelled, failed, reassigned, or timed out -- should not result in a retry on the second runtime-modifying event)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)