### PR TITLE
fix(v1): boundary conditions on 1-second rate limiters

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20250320210345_v1_0_6.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20250320210345_v1_0_6.sql
@@ -1,0 +1,33 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION get_refill_value(rate_limit "RateLimit")
+RETURNS INTEGER AS $$
+DECLARE
+    refill_amount INTEGER;
+BEGIN
+    IF (NOW() - rate_limit."lastRefill") >= (rate_limit."window"::INTERVAL - INTERVAL '10 milliseconds') THEN
+        refill_amount := rate_limit."limitValue";
+    ELSE
+        refill_amount := rate_limit."value";
+    END IF;
+    RETURN refill_amount;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION get_refill_value(rate_limit "RateLimit")
+RETURNS INTEGER AS $$
+DECLARE
+    refill_amount INTEGER;
+BEGIN
+    IF (NOW() - rate_limit."lastRefill") >= (rate_limit."window"::INTERVAL) THEN
+        refill_amount := rate_limit."limitValue";
+    ELSE
+        refill_amount := rate_limit."value";
+    END IF;
+    RETURN refill_amount;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/pkg/repository/v1/scheduler.go
+++ b/pkg/repository/v1/scheduler.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"time"
 
 	"github.com/hatchet-dev/hatchet/pkg/repository/v1/sqlcv1"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -39,7 +40,7 @@ type QueueRepository interface {
 
 type RateLimitRepository interface {
 	ListCandidateRateLimits(ctx context.Context, tenantId pgtype.UUID) ([]string, error)
-	UpdateRateLimits(ctx context.Context, tenantId pgtype.UUID, updates map[string]int) (map[string]int, error)
+	UpdateRateLimits(ctx context.Context, tenantId pgtype.UUID, updates map[string]int) (map[string]int, *time.Time, error)
 }
 
 type AssignmentRepository interface {


### PR DESCRIPTION
# Description

When a 1-second rate limit is used, there's a boundary condition where the rate limit will only be refilled once every 2 seconds due to the deferred flush nature of the rate limiter. 

This PR subtracts 10 milliseconds from the rate limit window to account for boundary conditions and adds an extra time value to the rate limiter which we can check to see whether we should replenish rate limiters. I was originally worried that subtracting 10 ms would lead to the effective rate limit being higher than the current value, but because we're using deferred writes to the database which occur once per second, this still shouldn't increase the effective rate limit.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)