### PR TITLE
fix(v1): tenant alerter should respect workflow run failure settings

### DIFF
--- a/pkg/repository/v1/sqlcv1/ticker.sql
+++ b/pkg/repository/v1/sqlcv1/ticker.sql
@@ -9,7 +9,8 @@ WITH active_setting AS (
         (
             "lastAlertedAt" IS NULL OR
             "lastAlertedAt" <= NOW() - convert_duration_to_interval(alerts."maxFrequency")
-        )
+        ) AND
+        "enableWorkflowRunFailureAlerts" = true
 )
 SELECT
     EXISTS (

--- a/pkg/repository/v1/sqlcv1/ticker.sql.go
+++ b/pkg/repository/v1/sqlcv1/ticker.sql.go
@@ -22,7 +22,8 @@ WITH active_setting AS (
         (
             "lastAlertedAt" IS NULL OR
             "lastAlertedAt" <= NOW() - convert_duration_to_interval(alerts."maxFrequency")
-        )
+        ) AND
+        "enableWorkflowRunFailureAlerts" = true
 )
 SELECT
     EXISTS (


### PR DESCRIPTION
# Description

v1 alerts are currently ignoring the `enableWorkflowRunFailureAlerts` settings.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)