### PR TITLE
fix: server config in database config loader

### DIFF
--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -104,7 +104,14 @@ func (c *ConfigLoader) InitDataLayer() (res *database.Layer, err error) {
 		return nil, err
 	}
 
-	scf, err := LoadServerConfigFile(configFileBytes...)
+	serverSharedFilePath := filepath.Join(c.directory, "server.yaml")
+	serverConfigFileBytes, err := loaderutils.GetConfigBytes(serverSharedFilePath)
+
+	if err != nil {
+		return nil, err
+	}
+
+	scf, err := LoadServerConfigFile(serverConfigFileBytes...)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

Server YAML config was not being read loaded correctly when initializing the database config. This is unlikely to have significantly impacted any instances, as the database config uses a small subset of shared fields from the server config for tenant limits, and only impacts instances that rely on YAML-based config. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)