### PR TITLE
config option for engine version, update modal

### DIFF
--- a/frontend/app/src/pages/main/tenant-settings/overview/index.tsx
+++ b/frontend/app/src/pages/main/tenant-settings/overview/index.tsx
@@ -88,8 +88,7 @@ const TenantVersionSwitcher = () => {
           Tenant Version
         </h2>
         <p className="text-sm text-muted-foreground">
-          Upgrade your tenant to v1 to access new features and improvements. v1
-          is currently in beta.
+          Upgrade your tenant to v1 to access new features and improvements.
         </p>
         <Button
           onClick={() => setShowUpgradeModal(true)}
@@ -97,14 +96,14 @@ const TenantVersionSwitcher = () => {
           className="w-fit"
         >
           {isPending ? <Spinner /> : null}
-          Upgrade to v1 (beta)
+          Upgrade to v1
         </Button>
       </div>
 
       <Dialog open={showUpgradeModal} onOpenChange={setShowUpgradeModal}>
         <DialogContent className="sm:max-w-[425px]">
           <DialogHeader>
-            <DialogTitle>Upgrade to v1 (beta)</DialogTitle>
+            <DialogTitle>Upgrade to v1</DialogTitle>
           </DialogHeader>
           {!upgradeRestrictedError && (
             <div className="space-y-4 py-4">

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -184,6 +184,9 @@ type ConfigFileRuntime struct {
 
 	// PreventTenantVersionUpgrade controls whether the server prevents tenant version upgrades
 	PreventTenantVersionUpgrade bool `mapstructure:"preventTenantVersionUpgrade" json:"preventTenantVersionUpgrade,omitempty" default:"false"`
+
+	// DefaultEngineVersion is the default engine version to use for new tenants
+	DefaultEngineVersion string `mapstructure:"defaultEngineVersion" json:"defaultEngineVersion,omitempty" default:"V0"`
 }
 
 type InternalClientTLSConfigFile struct {
@@ -537,6 +540,7 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("runtime.disableTenantPubs", "SERVER_DISABLE_TENANT_PUBS")
 	_ = v.BindEnv("runtime.maxInternalRetryCount", "SERVER_MAX_INTERNAL_RETRY_COUNT")
 	_ = v.BindEnv("runtime.preventTenantVersionUpgrade", "SERVER_PREVENT_TENANT_VERSION_UPGRADE")
+	_ = v.BindEnv("runtime.defaultEngineVersion", "SERVER_DEFAULT_ENGINE_VERSION")
 
 	// security check options
 	_ = v.BindEnv("securityCheck.enabled", "SERVER_SECURITY_CHECK_ENABLED")

--- a/pkg/repository/postgres/dbsqlc/tenants.sql
+++ b/pkg/repository/postgres/dbsqlc/tenants.sql
@@ -7,7 +7,7 @@ WITH active_controller_partitions AS (
     WHERE
         "lastHeartbeat" > NOW() - INTERVAL '1 minute'
 )
-INSERT INTO "Tenant" ("id", "name", "slug", "controllerPartitionId", "dataRetentionPeriod")
+INSERT INTO "Tenant" ("id", "name", "slug", "controllerPartitionId", "dataRetentionPeriod", "version")
 VALUES (
     sqlc.arg('id')::uuid,
     sqlc.arg('name')::text,
@@ -21,7 +21,8 @@ VALUES (
             random()
         LIMIT 1
     ),
-    COALESCE(sqlc.narg('dataRetentionPeriod')::text, '720h')
+    COALESCE(sqlc.narg('dataRetentionPeriod')::text, '720h'),
+    COALESCE(sqlc.narg('version')::"TenantMajorEngineVersion", 'V0')
 )
 RETURNING *;
 

--- a/pkg/repository/postgres/tenant.go
+++ b/pkg/repository/postgres/tenant.go
@@ -23,13 +23,15 @@ import (
 type tenantAPIRepository struct {
 	*sharedRepository
 
-	cache cache.Cacheable
+	cache                cache.Cacheable
+	defaultTenantVersion dbsqlc.TenantMajorEngineVersion
 }
 
-func NewTenantAPIRepository(shared *sharedRepository, cache cache.Cacheable) repository.TenantAPIRepository {
+func NewTenantAPIRepository(shared *sharedRepository, cache cache.Cacheable, defaultTenantVersion dbsqlc.TenantMajorEngineVersion) repository.TenantAPIRepository {
 	return &tenantAPIRepository{
-		sharedRepository: shared,
-		cache:            cache,
+		sharedRepository:     shared,
+		cache:                cache,
+		defaultTenantVersion: defaultTenantVersion,
 	}
 }
 
@@ -63,6 +65,10 @@ func (r *tenantAPIRepository) CreateTenant(ctx context.Context, opts *repository
 		Slug:                opts.Slug,
 		Name:                opts.Name,
 		DataRetentionPeriod: dataRetentionPeriod,
+		Version: dbsqlc.NullTenantMajorEngineVersion{
+			TenantMajorEngineVersion: r.defaultTenantVersion,
+			Valid:                    true,
+		},
 	})
 
 	if err != nil {


### PR DESCRIPTION
# Description

Adds a server env var `SERVER_DEFAULT_ENGINE_VERSION` which can be set to `V0` or `V1`. 

## Type of change

- [X] New feature (non-breaking change which adds functionality)