### PR TITLE
fix(v1): add exponential backoff for internal retries

### DIFF
--- a/internal/msgqueue/v1/rabbitmq/channel_pool.go
+++ b/internal/msgqueue/v1/rabbitmq/channel_pool.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hatchet-dev/hatchet/internal/queueutils"
+
 	"github.com/jackc/puddle/v2"
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/rs/zerolog"
@@ -103,7 +105,7 @@ func newChannelPool(ctx context.Context, l *zerolog.Logger, url string) (*channe
 
 				if err != nil {
 					l.Error().Msgf("cannot (re)dial: %v: %q", err, p.url)
-					sleepWithExponentialBackoff(10*time.Millisecond, 5*time.Second, retries)
+					queueutils.SleepWithExponentialBackoff(10*time.Millisecond, 5*time.Second, retries)
 					retries++
 					continue
 				}

--- a/internal/queueutils/backoff.go
+++ b/internal/queueutils/backoff.go
@@ -1,0 +1,33 @@
+package queueutils
+
+import (
+	"math/rand"
+	"time"
+)
+
+// SleepWithExponentialBackoff sleeps for a duration calculated using exponential backoff and jitter,
+// based on the retry count. The base sleep time and maximum sleep time are provided as inputs.
+// retryCount determines the exponential backoff multiplier.
+func SleepWithExponentialBackoff(base, max time.Duration, retryCount int) { // nolint: revive
+	if retryCount < 0 {
+		retryCount = 0
+	}
+
+	// Calculate exponential backoff
+	backoff := base * (1 << retryCount)
+	if backoff > max {
+		backoff = max
+	}
+
+	backoffInterval := backoff / 2
+
+	if backoffInterval < 1*time.Millisecond {
+		backoffInterval = 1 * time.Millisecond
+	}
+
+	// Apply jitter
+	jitter := time.Duration(rand.Int63n(int64(backoffInterval))) // nolint: gosec
+	sleepDuration := backoffInterval + jitter
+
+	time.Sleep(sleepDuration)
+}

--- a/internal/services/admin/server_v1.go
+++ b/internal/services/admin/server_v1.go
@@ -34,7 +34,7 @@ func (a *AdminServiceImpl) triggerWorkflowV1(ctx context.Context, req *contracts
 	if !canCreateWR {
 		return nil, status.Error(
 			codes.ResourceExhausted,
-			fmt.Sprintf("tenant has reached the limit of %d workflow runs", wrLimit),
+			fmt.Sprintf("tenant has reached %d%% of its workflow runs limit", wrLimit),
 		)
 	}
 
@@ -54,7 +54,7 @@ func (a *AdminServiceImpl) triggerWorkflowV1(ctx context.Context, req *contracts
 	if !canCreateTR {
 		return nil, status.Error(
 			codes.ResourceExhausted,
-			fmt.Sprintf("tenant has reached the limit of %d task runs", trLimit),
+			fmt.Sprintf("tenant has reached %d%% of its task runs limit", trLimit),
 		)
 	}
 

--- a/internal/services/admin/v1/server.go
+++ b/internal/services/admin/v1/server.go
@@ -287,7 +287,7 @@ func (a *AdminServiceImpl) TriggerWorkflowRun(ctx context.Context, req *contract
 	if !canCreateWR {
 		return nil, status.Error(
 			codes.ResourceExhausted,
-			fmt.Sprintf("tenant has reached the limit of %d workflow runs", wrLimit),
+			fmt.Sprintf("tenant has reached reached %d%% of its workflow runs limit", wrLimit),
 		)
 	}
 
@@ -307,7 +307,7 @@ func (a *AdminServiceImpl) TriggerWorkflowRun(ctx context.Context, req *contract
 	if !canCreateTR {
 		return nil, status.Error(
 			codes.ResourceExhausted,
-			fmt.Sprintf("tenant has reached the limit of %d task runs", trLimit),
+			fmt.Sprintf("tenant has reached %d%% of its task runs limit", trLimit),
 		)
 	}
 

--- a/internal/services/controllers/v1/task/controller.go
+++ b/internal/services/controllers/v1/task/controller.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"sync"
 	"time"
 
 	"github.com/go-co-op/gocron/v2"
@@ -203,7 +202,6 @@ func New(fs ...TasksControllerOpt) (*TasksControllerImpl, error) {
 
 func (tc *TasksControllerImpl) Start() (func() error, error) {
 	mqBuffer := msgqueue.NewMQSubBuffer(msgqueue.TASK_PROCESSING_QUEUE, tc.mq, tc.handleBufferedMsgs)
-	wg := sync.WaitGroup{}
 
 	tc.s.Start()
 
@@ -293,8 +291,6 @@ func (tc *TasksControllerImpl) Start() (func() error, error) {
 		if err := tc.s.Shutdown(); err != nil {
 			return fmt.Errorf("could not shutdown scheduler: %w", err)
 		}
-
-		wg.Wait()
 
 		return nil
 	}

--- a/internal/services/ingestor/ingestor_v1.go
+++ b/internal/services/ingestor/ingestor_v1.go
@@ -44,7 +44,7 @@ func (i *IngestorImpl) ingestEventV1(ctx context.Context, tenant *dbsqlc.Tenant,
 	if !canCreateEvents {
 		return nil, status.Error(
 			codes.ResourceExhausted,
-			fmt.Sprintf("tenant has reached the limit of %d events", eLimit),
+			fmt.Sprintf("tenant has reached %d%% of its events limit", eLimit),
 		)
 	}
 
@@ -103,7 +103,7 @@ func (i *IngestorImpl) bulkIngestEventV1(ctx context.Context, tenant *dbsqlc.Ten
 	if !canCreateEvents {
 		return nil, status.Error(
 			codes.ResourceExhausted,
-			fmt.Sprintf("tenant has reached the limit of %d events", eLimit),
+			fmt.Sprintf("tenant has reached %d%% of its events limit", eLimit),
 		)
 	}
 

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -150,8 +150,8 @@ type ConfigFileRuntime struct {
 	// DisableTenantPubs controls whether tenant pubsub is disabled
 	DisableTenantPubs bool `mapstructure:"disableTenantPubs" json:"disableTenantPubs,omitempty"`
 
-	// MaxInternalRetryCount is the maximum number of internal retries before a step run is considered failed (default: 3)
-	MaxInternalRetryCount int32 `mapstructure:"maxInternalRetryCount" json:"maxInternalRetryCount,omitempty" default:"3"`
+	// MaxInternalRetryCount is the maximum number of internal retries before a step run is considered failed (default: 10)
+	MaxInternalRetryCount int32 `mapstructure:"maxInternalRetryCount" json:"maxInternalRetryCount,omitempty" default:"10"`
 
 	// WaitForFlush is the time to wait for the buffer to flush used for exerting some back pressure on writers
 	WaitForFlush time.Duration `mapstructure:"waitForFlush" json:"waitForFlush,omitempty" default:"1"`


### PR DESCRIPTION
# Description

Adds exponential backoff when we internally reassign a task because the listener channel is no longer active. Otherwise, we end up reassigning the task too quickly, which often means that the task gets assigned to the same worker. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)