### PR TITLE
Feat: Python Tweaks, Part II

### DIFF
--- a/frontend/docs/pages/home/migration-guide-python.mdx
+++ b/frontend/docs/pages/home/migration-guide-python.mdx
@@ -72,3 +72,4 @@ Other miscellaneous changes:
 There are a handful of other new features that will make interfacing with the SDK easier, which are listed below.
 
 1. Concurrency keys using the `input` to a workflow are now checked for validity at runtime. If the workflow's `input_validator` does not contain a field that's used in a key, Hatchet will reject the workflow when it's created. For example, if the key is `input.user_id`, the `input_validator` Pydantic model _must_ contain a `user_id` field.
+2. There is now an `on_success_task` on the `Workflow` object, which works just like an on-failure task, but it runs after all upstream tasks in the workflow have _succeeded_.

--- a/sdks/python/examples/bulk_fanout/bulk_trigger.py
+++ b/sdks/python/examples/bulk_fanout/bulk_trigger.py
@@ -8,7 +8,7 @@ hatchet = Hatchet()
 
 
 async def main() -> None:
-    workflow_run_refs = bulk_parent_wf.run_many(
+    results = bulk_parent_wf.run_many(
         workflows=[
             bulk_parent_wf.create_run_workflow_config(
                 input=ParentInput(n=i),
@@ -23,16 +23,8 @@ async def main() -> None:
         ],
     )
 
-    results = await asyncio.gather(
-        *[ref.aio_result() for ref in workflow_run_refs],
-        return_exceptions=True,
-    )
-
     for result in results:
-        if isinstance(result, Exception):
-            print(f"An error occurred: {result}")  # Handle the exception here
-        else:
-            print(result)
+        print(result)
 
 
 if __name__ == "__main__":

--- a/sdks/python/examples/bulk_fanout/worker.py
+++ b/sdks/python/examples/bulk_fanout/worker.py
@@ -1,4 +1,3 @@
-import asyncio
 from datetime import timedelta
 from typing import Any
 
@@ -24,7 +23,7 @@ bulk_child_wf = hatchet.workflow(name="BulkFanoutChild", input_validator=ChildIn
 
 # ❓ BulkFanoutParent
 @bulk_parent_wf.task(execution_timeout=timedelta(minutes=5))
-async def spawn(input: ParentInput, ctx: Context) -> dict[str, list[Any]]:
+async def spawn(input: ParentInput, ctx: Context) -> dict[str, list[dict[str, Any]]]:
     # 👀 Create each workflow run to spawn
     child_workflow_runs = [
         bulk_child_wf.create_run_workflow_config(
@@ -38,12 +37,7 @@ async def spawn(input: ParentInput, ctx: Context) -> dict[str, list[Any]]:
     # 👀 Run workflows in bulk to improve performance
     spawn_results = await bulk_child_wf.aio_run_many(child_workflow_runs)
 
-    results = await asyncio.gather(
-        *[workflowRunRef.aio_result() for workflowRunRef in spawn_results],
-        return_exceptions=True,
-    )
-
-    return {"results": results}
+    return {"results": spawn_results}
 
 
 # ‼️

--- a/sdks/python/examples/durable/worker.py
+++ b/sdks/python/examples/durable/worker.py
@@ -1,13 +1,6 @@
 from datetime import timedelta
 
-from hatchet_sdk import (
-    Context,
-    DurableContext,
-    EmptyModel,
-    Hatchet,
-    SleepCondition,
-    UserEventCondition,
-)
+from hatchet_sdk import Context, DurableContext, EmptyModel, Hatchet, UserEventCondition
 
 hatchet = Hatchet(debug=True)
 
@@ -32,11 +25,11 @@ async def ephemeral_task(input: EmptyModel, ctx: Context) -> None:
 @durable_workflow.durable_task()
 async def durable_task(input: EmptyModel, ctx: DurableContext) -> None:
     print("Waiting for sleep")
-    await ctx.wait_for("sleep", SleepCondition(duration=timedelta(seconds=SLEEP_TIME)))
+    await ctx.aio_wait_for_sleep(duration=timedelta(seconds=SLEEP_TIME))
     print("Sleep finished")
 
     print("Waiting for event")
-    await ctx.wait_for(
+    await ctx.aio_wait_for(
         "event",
         UserEventCondition(event_key=EVENT_KEY, expression="true"),
     )

--- a/sdks/python/examples/fanout/worker.py
+++ b/sdks/python/examples/fanout/worker.py
@@ -1,4 +1,3 @@
-import asyncio
 from datetime import timedelta
 from typing import Any
 
@@ -28,7 +27,7 @@ child_wf = hatchet.workflow(name="FanoutChild", input_validator=ChildInput)
 async def spawn(input: ParentInput, ctx: Context) -> dict[str, Any]:
     print("spawning child")
 
-    children = await child_wf.aio_run_many(
+    result = await child_wf.aio_run_many(
         [
             child_wf.create_run_workflow_config(
                 input=ChildInput(a=str(i)),
@@ -40,7 +39,6 @@ async def spawn(input: ParentInput, ctx: Context) -> dict[str, Any]:
         ]
     )
 
-    result = await asyncio.gather(*[child.aio_result() for child in children])
     print(f"results {result}")
 
     return {"results": result}

--- a/sdks/python/examples/fanout_sync/worker.py
+++ b/sdks/python/examples/fanout_sync/worker.py
@@ -23,10 +23,10 @@ sync_fanout_child = hatchet.workflow(name="SyncFanoutChild", input_validator=Chi
 
 
 @sync_fanout_parent.task(execution_timeout=timedelta(minutes=5))
-def spawn(input: ParentInput, ctx: Context) -> dict[str, Any]:
+def spawn(input: ParentInput, ctx: Context) -> dict[str, list[dict[str, Any]]]:
     print("spawning child")
 
-    runs = sync_fanout_child.run_many(
+    results = sync_fanout_child.run_many(
         [
             sync_fanout_child.create_run_workflow_config(
                 input=ChildInput(a=str(i)),
@@ -36,8 +36,6 @@ def spawn(input: ParentInput, ctx: Context) -> dict[str, Any]:
             for i in range(input.n)
         ],
     )
-
-    results = [r.result() for r in runs]
 
     print(f"results {results}")
 

--- a/sdks/python/examples/on_success/trigger.py
+++ b/sdks/python/examples/on_success/trigger.py
@@ -1,0 +1,3 @@
+from examples.on_success.worker import on_success_workflow
+
+on_success_workflow.run_no_wait()

--- a/sdks/python/examples/on_success/worker.py
+++ b/sdks/python/examples/on_success/worker.py
@@ -1,0 +1,39 @@
+from hatchet_sdk import Context, EmptyModel, Hatchet
+
+hatchet = Hatchet(debug=True)
+
+on_success_workflow = hatchet.workflow(name="OnSuccessWorkflow")
+
+
+@on_success_workflow.task()
+def first_task(input: EmptyModel, ctx: Context) -> None:
+    print("First task completed successfully")
+
+
+@on_success_workflow.task(parents=[first_task])
+def second_task(input: EmptyModel, ctx: Context) -> None:
+    print("Second task completed successfully")
+
+
+@on_success_workflow.task(parents=[first_task, second_task])
+def third_task(input: EmptyModel, ctx: Context) -> None:
+    print("Third task completed successfully")
+
+
+@on_success_workflow.task()
+def fourth_task(input: EmptyModel, ctx: Context) -> None:
+    print("Fourth task completed successfully")
+
+
+@on_success_workflow.on_success_task()
+def on_success_task(input: EmptyModel, ctx: Context) -> None:
+    print("On success task completed successfully")
+
+
+def main() -> None:
+    worker = hatchet.worker("on-success-worker", workflows=[on_success_workflow])
+    worker.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/sdks/python/hatchet_sdk/clients/durable_event_listener.py
+++ b/sdks/python/hatchet_sdk/clients/durable_event_listener.py
@@ -3,13 +3,13 @@ import json
 from collections.abc import AsyncIterator
 from typing import Any, Literal, cast
 
-from hatchet_sdk.clients.rest.tenacity_utils import tenacity_retry
 import grpc
 import grpc.aio
 from grpc._cython import cygrpc  # type: ignore[attr-defined]
 from pydantic import BaseModel, ConfigDict
 
 from hatchet_sdk.clients.event_ts import ThreadSafeEvent, read_with_interrupt
+from hatchet_sdk.clients.rest.tenacity_utils import tenacity_retry
 from hatchet_sdk.config import ClientConfig
 from hatchet_sdk.connection import new_conn
 from hatchet_sdk.contracts.v1.dispatcher_pb2 import (

--- a/sdks/python/hatchet_sdk/clients/durable_event_listener.py
+++ b/sdks/python/hatchet_sdk/clients/durable_event_listener.py
@@ -3,6 +3,7 @@ import json
 from collections.abc import AsyncIterator
 from typing import Any, Literal, cast
 
+from hatchet_sdk.clients.rest.tenacity_utils import tenacity_retry
 import grpc
 import grpc.aio
 from grpc._cython import cygrpc  # type: ignore[attr-defined]
@@ -307,6 +308,7 @@ class DurableEventListener:
 
         raise ValueError("Failed to connect to durable event listener")
 
+    @tenacity_retry
     def register_durable_event(
         self, request: RegisterDurableEventRequest
     ) -> Literal[True]:
@@ -318,6 +320,7 @@ class DurableEventListener:
 
         return True
 
+    @tenacity_retry
     async def result(self, task_id: str, signal_key: str) -> dict[str, Any]:
         event = await self.subscribe(task_id, signal_key)
 

--- a/sdks/python/hatchet_sdk/context/context.py
+++ b/sdks/python/hatchet_sdk/context/context.py
@@ -22,7 +22,7 @@ from hatchet_sdk.clients.run_event_listener import RunEventListenerClient
 from hatchet_sdk.clients.workflow_listener import PooledWorkflowRunListener
 from hatchet_sdk.context.worker_context import WorkerContext
 from hatchet_sdk.logger import logger
-from hatchet_sdk.utils.timedelta_to_expression import timedelta_to_expr
+from hatchet_sdk.utils.timedelta_to_expression import Duration, timedelta_to_expr
 from hatchet_sdk.utils.typing import JSONSerializableMapping, WorkflowValidator
 from hatchet_sdk.waits import SleepCondition, UserEventCondition
 
@@ -270,4 +270,15 @@ class DurableContext(Context):
         return await self.durable_event_listener.result(
             task_id,
             signal_key,
+        )
+
+    async def wait_for_sleep(self, duration: Duration) -> dict[str, Any]:
+        """
+        Lightweight wrapper for durable sleep. Allows for shorthand usage of `ctx.wait_for` when specifying a sleep condition.
+
+        For more complicated conditions, use `ctx.wait_for` directly.
+        """
+
+        return await self.wait_for(
+            f"sleep:{timedelta_to_expr(duration)}", SleepCondition(duration=duration)
         )

--- a/sdks/python/hatchet_sdk/context/context.py
+++ b/sdks/python/hatchet_sdk/context/context.py
@@ -251,7 +251,7 @@ class Context:
 
 
 class DurableContext(Context):
-    async def wait_for(
+    async def aio_wait_for(
         self, signal_key: str, *conditions: SleepCondition | UserEventCondition
     ) -> dict[str, Any]:
         if self.durable_event_listener is None:
@@ -272,13 +272,13 @@ class DurableContext(Context):
             signal_key,
         )
 
-    async def wait_for_sleep(self, duration: Duration) -> dict[str, Any]:
+    async def aio_wait_for_sleep(self, duration: Duration) -> dict[str, Any]:
         """
-        Lightweight wrapper for durable sleep. Allows for shorthand usage of `ctx.wait_for` when specifying a sleep condition.
+        Lightweight wrapper for durable sleep. Allows for shorthand usage of `ctx.aio_wait_for` when specifying a sleep condition.
 
-        For more complicated conditions, use `ctx.wait_for` directly.
+        For more complicated conditions, use `ctx.aio_wait_for` directly.
         """
 
-        return await self.wait_for(
+        return await self.aio_wait_for(
             f"sleep:{timedelta_to_expr(duration)}", SleepCondition(duration=duration)
         )

--- a/sdks/python/hatchet_sdk/runnables/types.py
+++ b/sdks/python/hatchet_sdk/runnables/types.py
@@ -98,8 +98,8 @@ class WorkflowConfig(BaseModel):
 
 class StepType(str, Enum):
     DEFAULT = "default"
-    CONCURRENCY = "concurrency"
     ON_FAILURE = "on_failure"
+    ON_SUCCESS = "on_success"
 
 
 AsyncFunc = Callable[[TWorkflowInput, Context], Awaitable[R]]

--- a/sdks/python/hatchet_sdk/runnables/workflow.py
+++ b/sdks/python/hatchet_sdk/runnables/workflow.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Generic, cast, overload
 
@@ -313,12 +314,32 @@ class Workflow(Generic[TWorkflowInput]):
     def run_many(
         self,
         workflows: list[WorkflowRunTriggerConfig],
+    ) -> list[dict[str, Any]]:
+        refs = self.client.admin.run_workflows(
+            workflows=workflows,
+        )
+
+        return [ref.result() for ref in refs]
+
+    async def aio_run_many(
+        self,
+        workflows: list[WorkflowRunTriggerConfig],
+    ) -> list[dict[str, Any]]:
+        refs = await self.client.admin.aio_run_workflows(
+            workflows=workflows,
+        )
+
+        return await asyncio.gather(*[ref.aio_result() for ref in refs])
+
+    def run_many_no_wait(
+        self,
+        workflows: list[WorkflowRunTriggerConfig],
     ) -> list[WorkflowRunRef]:
         return self.client.admin.run_workflows(
             workflows=workflows,
         )
 
-    async def aio_run_many(
+    async def aio_run_many_no_wait(
         self,
         workflows: list[WorkflowRunTriggerConfig],
     ) -> list[WorkflowRunRef]:

--- a/sdks/python/hatchet_sdk/runnables/workflow.py
+++ b/sdks/python/hatchet_sdk/runnables/workflow.py
@@ -78,6 +78,7 @@ class Workflow(Generic[TWorkflowInput]):
         self._default_tasks: list[Task[TWorkflowInput, Any]] = []
         self._durable_tasks: list[Task[TWorkflowInput, Any]] = []
         self._on_failure_task: Task[TWorkflowInput, Any] | None = None
+        self._on_success_task: Task[TWorkflowInput, Any] | None = None
         self.client = client
 
     def _get_service_name(self, namespace: str) -> str:
@@ -130,9 +131,20 @@ class Workflow(Generic[TWorkflowInput]):
             limit_strategy=concurrency.limit_strategy,
         )
 
+    @overload
     def _validate_task(
         self, task: "Task[TWorkflowInput, R]", service_name: str
-    ) -> CreateTaskOpts:
+    ) -> CreateTaskOpts: ...
+
+    @overload
+    def _validate_task(self, task: None, service_name: str) -> None: ...
+
+    def _validate_task(
+        self, task: "Task[TWorkflowInput, R]" | None, service_name: str
+    ) -> CreateTaskOpts | None:
+        if not task:
+            return None
+
         return CreateTaskOpts(
             readable_id=task.name,
             action=service_name + ":" + task.name,
@@ -198,11 +210,23 @@ class Workflow(Generic[TWorkflowInput]):
             user_event_conditions=user_events,
         )
 
+    def _is_leaf_task(self, task: Task[TWorkflowInput, Any]) -> bool:
+        return not any(task in t.parents for t in self.tasks if task != t)
+
     def _get_create_opts(self, namespace: str) -> CreateWorkflowVersionRequest:
         service_name = self._get_service_name(namespace)
 
         name = self._get_name(namespace)
         event_triggers = [namespace + event for event in self.config.on_events]
+
+        if self._on_success_task:
+            self._on_success_task.parents = [
+                task
+                for task in self.tasks
+                if task.type == StepType.DEFAULT and self._is_leaf_task(task)
+            ]
+
+        on_success_task = self._validate_task(self._on_success_task, service_name)
 
         tasks = [
             self._validate_task(task, service_name)
@@ -210,16 +234,14 @@ class Workflow(Generic[TWorkflowInput]):
             if task.type == StepType.DEFAULT
         ]
 
-        on_failure_job = (
-            self._validate_task(self._on_failure_task, service_name)
-            if self._on_failure_task
-            else None
-        )
+        if on_success_task:
+            tasks += [on_success_task]
+
+        on_failure_task = self._validate_task(self._on_failure_task, service_name)
 
         return CreateWorkflowVersionRequest(
             name=name,
-            ## TODO: Fix this
-            description=None,
+            description=self.config.description,
             version=self.config.version,
             event_triggers=event_triggers,
             cron_triggers=self.config.on_crons,
@@ -227,7 +249,7 @@ class Workflow(Generic[TWorkflowInput]):
             concurrency=self._concurrency_to_proto(self.config.concurrency),
             ## TODO: Fix this
             cron_input=None,
-            on_failure_task=on_failure_job,
+            on_failure_task=on_failure_task,
             sticky=convert_python_enum_to_proto(self.config.sticky, StickyStrategyProto),  # type: ignore[arg-type]
         )
 
@@ -243,6 +265,9 @@ class Workflow(Generic[TWorkflowInput]):
 
         if self._on_failure_task:
             tasks += [self._on_failure_task]
+
+        if self._on_success_task:
+            tasks += [self._on_success_task]
 
         return tasks
 
@@ -634,6 +659,67 @@ class Workflow(Generic[TWorkflowInput]):
             )
 
             self._on_failure_task = task
+
+            return task
+
+        return inner
+
+    def on_success_task(
+        self,
+        name: str | None = None,
+        schedule_timeout: Duration = DEFAULT_SCHEDULE_TIMEOUT,
+        execution_timeout: Duration = DEFAULT_EXECUTION_TIMEOUT,
+        retries: int = 0,
+        rate_limits: list[RateLimit] = [],
+        backoff_factor: float | None = None,
+        backoff_max_seconds: int | None = None,
+        concurrency: list[ConcurrencyExpression] = [],
+    ) -> Callable[[Callable[[TWorkflowInput, Context], R]], Task[TWorkflowInput, R]]:
+        """
+        A decorator to transform a function into a Hatchet on-success task that runs as the last step in a workflow that had all upstream tasks succeed.
+
+        :param name: The name of the on-success task. If not specified, defaults to the name of the function being wrapped by the `on_failure_task` decorator.
+        :type name: str | None
+
+        :param timeout: The execution timeout of the on-success task. Defaults to 60 minutes.
+        :type timeout: datetime.timedelta | str
+
+        :param retries: The number of times to retry the on-success task before failing. Default: `0`
+        :type retries: int
+
+        :param rate_limits: A list of rate limit configurations for the on-success task. Defaults to an empty list (no rate limits).
+        :type rate_limits: list[RateLimit]
+
+        :param backoff_factor: The backoff factor for controlling exponential backoff in retries. Default: `None`
+        :type backoff_factor: float | None
+
+        :param backoff_max_seconds: The maximum number of seconds to allow retries with exponential backoff to continue. Default: `None`
+        :type backoff_max_seconds: int | None
+
+        :returns: A decorator which creates a `Task` object.
+        :rtype: Callable[[Callable[[Type[BaseModel], Context], R]], Task[Type[BaseModel], R]]
+        """
+
+        def inner(
+            func: Callable[[TWorkflowInput, Context], R]
+        ) -> Task[TWorkflowInput, R]:
+            task = Task(
+                is_durable=False,
+                _fn=func,
+                workflow=self,
+                type=StepType.ON_SUCCESS,
+                name=self._parse_task_name(name, func),
+                execution_timeout=execution_timeout,
+                schedule_timeout=schedule_timeout,
+                retries=retries,
+                rate_limits=[r.to_proto() for r in rate_limits],
+                backoff_factor=backoff_factor,
+                backoff_max_seconds=backoff_max_seconds,
+                concurrency=concurrency,
+                parents=[],
+            )
+
+            self._on_success_task = task
 
             return task
 

--- a/sdks/python/hatchet_sdk/runnables/workflow.py
+++ b/sdks/python/hatchet_sdk/runnables/workflow.py
@@ -1,6 +1,6 @@
 import asyncio
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Callable, Generic, cast, overload
+from typing import TYPE_CHECKING, Any, Callable, Generic, Union, cast, overload
 
 from google.protobuf import timestamp_pb2
 from pydantic import BaseModel
@@ -140,7 +140,7 @@ class Workflow(Generic[TWorkflowInput]):
     def _validate_task(self, task: None, service_name: str) -> None: ...
 
     def _validate_task(
-        self, task: "Task[TWorkflowInput, R]" | None, service_name: str
+        self, task: Union["Task[TWorkflowInput, R]", None], service_name: str
     ) -> CreateTaskOpts | None:
         if not task:
             return None
@@ -648,7 +648,7 @@ class Workflow(Generic[TWorkflowInput]):
                 _fn=func,
                 workflow=self,
                 type=StepType.ON_FAILURE,
-                name=self._parse_task_name(name, func),
+                name=self._parse_task_name(name, func) + "-on-failure",
                 execution_timeout=execution_timeout,
                 schedule_timeout=schedule_timeout,
                 retries=retries,
@@ -708,7 +708,7 @@ class Workflow(Generic[TWorkflowInput]):
                 _fn=func,
                 workflow=self,
                 type=StepType.ON_SUCCESS,
-                name=self._parse_task_name(name, func),
+                name=self._parse_task_name(name, func) + "-on-success",
                 execution_timeout=execution_timeout,
                 schedule_timeout=schedule_timeout,
                 retries=retries,


### PR DESCRIPTION
# Description

Couple small features / tweaks in Python:

1. Added `run_many_no_wait` and `aio_run_many_no_wait` for bulk spawning
2. Added an `on_success` task
3. Added some retry logic around the durable event listener
4. Renamed `wait_for` to `aio_wait_for` and added a lightweight `aio_wait_for_sleep` wrapper for making durable sleep a one liner with just a duration

- [x] New feature (non-breaking change which adds functionality)

Example of the on-success task:

<img width="1347" alt="Screenshot 2025-03-25 at 12 46 49 PM" src="https://github.com/user-attachments/assets/7368f958-2314-48af-bc65-17f029fdbd3d" />
