### PR TITLE
Feat: Python Standalones

### DIFF
--- a/frontend/docs/pages/home/migration-guide-python.mdx
+++ b/frontend/docs/pages/home/migration-guide-python.mdx
@@ -22,7 +22,7 @@ First, a simple example of how to define a workflow with the V1 SDK:
 
 The API has changed significantly in the V1 SDK. Even in this simple example, there are some notable highlights:
 
-1. Workflows are now declared with `hatchet.workflow`, and then have their corresponding tasks registered with `workflow.task`.
+1. Tasks can now be declared with `hatchet.task`, meaning you no longer _have_ to create a workflow explicitly to define a task. This should feel similar to how e.g. Celery handles task definition. Note that we recommend declaring a workflow in many cases, but the simplest possible way to get set up is to use `hatchet.task`.
 2. Tasks have a new signature. They now take two arguments: `input` and `context`. The `input` is either of type `input_validator` (a Pydantic model you provide to the workflow), or is an `EmptyModel`, which is a helper Pydantic model Hatchet provides and uses as a default. The `context` is once again the Hatchet `Context` object.
 3. Workflows can now be registered on a worker by using the `workflows` keyword argument to the `worker` method, although the old `register_workflows` method is still available.
 4. `max_runs` on the worker has been renamed to `slots`.
@@ -35,9 +35,10 @@ Hatchet's V1 SDK makes heavy use of Pydantic models, and recommends you do too! 
 
 In this example, we use a few more new SDK features:
 
-1. We define two Pydantic models, `ParentInput` and `ChildInput`, and pass them to the parent and child workflows as `input_validator`s. Note that now, the `input` parameters for the tasks in those two workflows are Pydantic models of those types, and we can treat them as such. This replaces the old `context.workflow_input` for accessing the input to the workflow / task - now, we just can access the input directly.
-2. When we want to spawn the child workflow, we can use the `run` methods on the `child_workflow` object, which is a Hatchet `Workflow`, instead of needing to refer to the workflow by its name (a string). The `input` field to `run()` is now also properly typed as `ChildInput`.
-3. The child workflow makes use of some of Hatchet's DAG features, such as defining parent tasks. In the new SDK, `parents` of a task are defined as a list of `Task` objects as opposed to as a list of strings, so now, `process2` has `process` (the `Task`) as its parent, as opposed to `"process"` (the string). This also allows us to use `ctx.task_output(process)` to access the output of the `process` task in the `process2` task, and know the type of that output at type checking time.
+1. Workflows are now declared with `hatchet.workflow`, and then have their corresponding tasks registered with `workflow.task`.
+2. We define two Pydantic models, `ParentInput` and `ChildInput`, and pass them to the parent and child workflows as `input_validator`s. Note that now, the `input` parameters for the tasks in those two workflows are Pydantic models of those types, and we can treat them as such. This replaces the old `context.workflow_input` for accessing the input to the workflow / task - now, we just can access the input directly.
+3. When we want to spawn the child workflow, we can use the `run` methods on the `child_workflow` object, which is a Hatchet `Workflow`, instead of needing to refer to the workflow by its name (a string). The `input` field to `run()` is now also properly typed as `ChildInput`.
+4. The child workflow makes use of some of Hatchet's DAG features, such as defining parent tasks. In the new SDK, `parents` of a task are defined as a list of `Task` objects as opposed to as a list of strings, so now, `process2` has `process` (the `Task`) as its parent, as opposed to `"process"` (the string). This also allows us to use `ctx.task_output(process)` to access the output of the `process` task in the `process2` task, and know the type of that output at type checking time.
 
 See our [Pydantic documentation](./pydantic.mdx) for more.
 

--- a/sdks/python/examples/durable/worker.py
+++ b/sdks/python/examples/durable/worker.py
@@ -25,7 +25,7 @@ async def ephemeral_task(input: EmptyModel, ctx: Context) -> None:
 @durable_workflow.durable_task()
 async def durable_task(input: EmptyModel, ctx: DurableContext) -> None:
     print("Waiting for sleep")
-    await ctx.aio_wait_for_sleep(duration=timedelta(seconds=SLEEP_TIME))
+    await ctx.aio_sleep_for(duration=timedelta(seconds=SLEEP_TIME))
     print("Sleep finished")
 
     print("Waiting for event")

--- a/sdks/python/examples/simple/trigger.py
+++ b/sdks/python/examples/simple/trigger.py
@@ -1,3 +1,3 @@
-from examples.simple.worker import simple
+from examples.simple.worker import step1
 
-simple.run()
+step1.run()

--- a/sdks/python/examples/simple/worker.py
+++ b/sdks/python/examples/simple/worker.py
@@ -4,16 +4,14 @@ from hatchet_sdk import Context, EmptyModel, Hatchet
 
 hatchet = Hatchet(debug=True)
 
-simple = hatchet.workflow(name="SimpleWorkflow")
 
-
-@simple.task()
+@hatchet.task(name="SimpleWorkflow")
 def step1(input: EmptyModel, ctx: Context) -> None:
     print("executed step1")
 
 
 def main() -> None:
-    worker = hatchet.worker("test-worker", slots=1, workflows=[simple])
+    worker = hatchet.worker("test-worker", slots=1, workflows=[step1])
     worker.start()
 
 

--- a/sdks/python/hatchet_sdk/context/context.py
+++ b/sdks/python/hatchet_sdk/context/context.py
@@ -272,7 +272,7 @@ class DurableContext(Context):
             signal_key,
         )
 
-    async def aio_wait_for_sleep(self, duration: Duration) -> dict[str, Any]:
+    async def aio_sleep_for(self, duration: Duration) -> dict[str, Any]:
         """
         Lightweight wrapper for durable sleep. Allows for shorthand usage of `ctx.aio_wait_for` when specifying a sleep condition.
 

--- a/sdks/python/hatchet_sdk/context/context.py
+++ b/sdks/python/hatchet_sdk/context/context.py
@@ -90,7 +90,7 @@ class Context:
         return self.data.parents.get(task.name, {}).get("skipped", False)
 
     @property
-    def event_triggers(self) -> JSONSerializableMapping:
+    def trigger_data(self) -> JSONSerializableMapping:
         return self.data.triggers
 
     def task_output(self, task: "Task[TWorkflowInput, R]") -> "R":

--- a/sdks/python/hatchet_sdk/hatchet.py
+++ b/sdks/python/hatchet_sdk/hatchet.py
@@ -29,7 +29,6 @@ from hatchet_sdk.runnables.types import (
 )
 from hatchet_sdk.runnables.workflow import BaseWorkflow, Workflow
 from hatchet_sdk.utils.timedelta_to_expression import Duration
-from hatchet_sdk.waits import Condition, OrGroup
 from hatchet_sdk.worker.worker import Worker
 
 
@@ -268,9 +267,6 @@ class Hatchet:
         desired_worker_labels: dict[str, DesiredWorkerLabel] = {},
         backoff_factor: float | None = None,
         backoff_max_seconds: int | None = None,
-        wait_for: list[Condition | OrGroup] = [],
-        skip_if: list[Condition | OrGroup] = [],
-        cancel_if: list[Condition | OrGroup] = [],
     ) -> Callable[[Callable[[EmptyModel, Context], R]], Standalone[EmptyModel, R]]: ...
 
     @overload
@@ -293,9 +289,6 @@ class Hatchet:
         desired_worker_labels: dict[str, DesiredWorkerLabel] = {},
         backoff_factor: float | None = None,
         backoff_max_seconds: int | None = None,
-        wait_for: list[Condition | OrGroup] = [],
-        skip_if: list[Condition | OrGroup] = [],
-        cancel_if: list[Condition | OrGroup] = [],
     ) -> Callable[
         [Callable[[TWorkflowInput, Context], R]], Standalone[TWorkflowInput, R]
     ]: ...
@@ -319,9 +312,6 @@ class Hatchet:
         desired_worker_labels: dict[str, DesiredWorkerLabel] = {},
         backoff_factor: float | None = None,
         backoff_max_seconds: int | None = None,
-        wait_for: list[Condition | OrGroup] = [],
-        skip_if: list[Condition | OrGroup] = [],
-        cancel_if: list[Condition | OrGroup] = [],
     ) -> (
         Callable[[Callable[[EmptyModel, Context], R]], Standalone[EmptyModel, R]]
         | Callable[
@@ -379,15 +369,6 @@ class Hatchet:
         :param backoff_max_seconds: The maximum number of seconds to allow retries with exponential backoff to continue. Default: None
         :type backoff_max_seconds: int | None
 
-        :param wait_for: A list of conditions that must be met before the task can start. Default: Empty list
-        :type wait_for: list[Condition | OrGroup]
-
-        :param skip_if: A list of conditions that, if true, will cause the task to be skipped. Default: Empty list
-        :type skip_if: list[Condition | OrGroup]
-
-        :param cancel_if: A list of conditions that, if true, will cause the task to be canceled. Default: Empty list
-        :type cancel_if: list[Condition | OrGroup]
-
         :returns: A decorator which creates a `Standalone` task object.
         :rtype: Callable[[Callable[[TWorkflowInput, Context], R]], Standalone[TWorkflowInput, R]]
         """
@@ -418,9 +399,6 @@ class Hatchet:
             backoff_factor=backoff_factor,
             backoff_max_seconds=backoff_max_seconds,
             concurrency=[concurrency] if concurrency else [],
-            wait_for=wait_for,
-            skip_if=skip_if,
-            cancel_if=cancel_if,
         )
 
         def inner(
@@ -455,9 +433,6 @@ class Hatchet:
         desired_worker_labels: dict[str, DesiredWorkerLabel] = {},
         backoff_factor: float | None = None,
         backoff_max_seconds: int | None = None,
-        wait_for: list[Condition | OrGroup] = [],
-        skip_if: list[Condition | OrGroup] = [],
-        cancel_if: list[Condition | OrGroup] = [],
     ) -> Callable[
         [Callable[[EmptyModel, DurableContext], R]], Standalone[EmptyModel, R]
     ]: ...
@@ -482,9 +457,6 @@ class Hatchet:
         desired_worker_labels: dict[str, DesiredWorkerLabel] = {},
         backoff_factor: float | None = None,
         backoff_max_seconds: int | None = None,
-        wait_for: list[Condition | OrGroup] = [],
-        skip_if: list[Condition | OrGroup] = [],
-        cancel_if: list[Condition | OrGroup] = [],
     ) -> Callable[
         [Callable[[TWorkflowInput, DurableContext], R]], Standalone[TWorkflowInput, R]
     ]: ...
@@ -508,9 +480,6 @@ class Hatchet:
         desired_worker_labels: dict[str, DesiredWorkerLabel] = {},
         backoff_factor: float | None = None,
         backoff_max_seconds: int | None = None,
-        wait_for: list[Condition | OrGroup] = [],
-        skip_if: list[Condition | OrGroup] = [],
-        cancel_if: list[Condition | OrGroup] = [],
     ) -> (
         Callable[[Callable[[EmptyModel, DurableContext], R]], Standalone[EmptyModel, R]]
         | Callable[
@@ -569,15 +538,6 @@ class Hatchet:
         :param backoff_max_seconds: The maximum number of seconds to allow retries with exponential backoff to continue. Default: None
         :type backoff_max_seconds: int | None
 
-        :param wait_for: A list of conditions that must be met before the task can start. Default: Empty list
-        :type wait_for: list[Condition | OrGroup]
-
-        :param skip_if: A list of conditions that, if true, will cause the task to be skipped. Default: Empty list
-        :type skip_if: list[Condition | OrGroup]
-
-        :param cancel_if: A list of conditions that, if true, will cause the task to be canceled. Default: Empty list
-        :type cancel_if: list[Condition | OrGroup]
-
         :returns: A decorator which creates a `Standalone` task object.
         :rtype: Callable[[Callable[[TWorkflowInput, Context], R]], Standalone[TWorkflowInput, R]]
         """
@@ -608,9 +568,6 @@ class Hatchet:
             backoff_factor=backoff_factor,
             backoff_max_seconds=backoff_max_seconds,
             concurrency=[concurrency] if concurrency else [],
-            wait_for=wait_for,
-            skip_if=skip_if,
-            cancel_if=cancel_if,
         )
 
         def inner(

--- a/sdks/python/hatchet_sdk/hatchet.py
+++ b/sdks/python/hatchet_sdk/hatchet.py
@@ -27,7 +27,7 @@ from hatchet_sdk.runnables.types import (
     TWorkflowInput,
     WorkflowConfig,
 )
-from hatchet_sdk.runnables.workflow import Workflow
+from hatchet_sdk.runnables.workflow import BaseWorkflow, Workflow
 from hatchet_sdk.utils.timedelta_to_expression import Duration
 from hatchet_sdk.waits import Condition, OrGroup
 from hatchet_sdk.worker.worker import Worker
@@ -112,7 +112,7 @@ class Hatchet:
         name: str,
         slots: int = 100,
         labels: dict[str, str | int] = {},
-        workflows: list[Workflow[Any] | Standalone[Any, Any]] = [],
+        workflows: list[BaseWorkflow[Any]] = [],
     ) -> Worker:
         """
         Create a Hatchet worker on which to run workflows.

--- a/sdks/python/hatchet_sdk/runnables/standalone.py
+++ b/sdks/python/hatchet_sdk/runnables/standalone.py
@@ -1,0 +1,122 @@
+import asyncio
+from typing import Any, Generic, cast, get_type_hints
+
+from hatchet_sdk.clients.admin import TriggerWorkflowOptions, WorkflowRunTriggerConfig
+from hatchet_sdk.runnables.types import R, TWorkflowInput
+from hatchet_sdk.runnables.workflow import Workflow
+from hatchet_sdk.utils.aio_utils import get_active_event_loop
+from hatchet_sdk.utils.typing import is_basemodel_subclass
+from hatchet_sdk.workflow_run import WorkflowRunRef
+
+
+class TaskRunRef(Generic[TWorkflowInput, R]):
+    def __init__(
+        self,
+        standalone: "Standalone[TWorkflowInput, R]",
+        workflow_run_ref: WorkflowRunRef,
+    ):
+        self._s = standalone
+        self._wrr = workflow_run_ref
+
+    async def aio_result(self) -> R:
+        result = await self._wrr.workflow_listener.result(self._wrr.workflow_run_id)
+        return self._s._extract_result(result)
+
+    def result(self) -> R:
+        coro = self._wrr.workflow_listener.result(self._wrr.workflow_run_id)
+
+        loop = get_active_event_loop()
+
+        if loop is None:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
+                result = loop.run_until_complete(coro)
+            finally:
+                asyncio.set_event_loop(None)
+        else:
+            result = loop.run_until_complete(coro)
+
+        return self._s._extract_result(result)
+
+
+class Standalone(Generic[TWorkflowInput, R]):
+    def __init__(self, workflow: Workflow[TWorkflowInput]) -> None:
+        self._workflow = workflow
+        self._task = workflow.tasks[0]
+
+        return_type = get_type_hints(self._task.fn).get("return")
+
+        self._output_validator = (
+            return_type if is_basemodel_subclass(return_type) else None
+        )
+
+    def _extract_result(self, result: dict[str, Any]) -> R:
+        output = result.get(self._task.name)
+
+        if not output:
+            raise ValueError(f"Task {self._task.name} did not return any output")
+
+        if not self._output_validator:
+            return cast(R, output)
+
+        return cast(R, self._output_validator.model_validate(output))
+
+    def run(
+        self,
+        input: TWorkflowInput | None = None,
+        options: TriggerWorkflowOptions = TriggerWorkflowOptions(),
+    ) -> R:
+        return self._extract_result(self._workflow.run(input, options))
+
+    async def aio_run(
+        self,
+        input: TWorkflowInput | None = None,
+        options: TriggerWorkflowOptions = TriggerWorkflowOptions(),
+    ) -> R:
+        result = await self._workflow.aio_run(input, options)
+        return self._extract_result(result)
+
+    def run_no_wait(
+        self,
+        input: TWorkflowInput | None = None,
+        options: TriggerWorkflowOptions = TriggerWorkflowOptions(),
+    ) -> TaskRunRef[TWorkflowInput, R]:
+        ref = self._workflow.run_no_wait(input, options)
+
+        return TaskRunRef[TWorkflowInput, R](self, ref)
+
+    async def aio_run_no_wait(
+        self,
+        input: TWorkflowInput | None = None,
+        options: TriggerWorkflowOptions = TriggerWorkflowOptions(),
+    ) -> TaskRunRef[TWorkflowInput, R]:
+        ref = await self._workflow.aio_run_no_wait(input, options)
+
+        return TaskRunRef[TWorkflowInput, R](self, ref)
+
+    def run_many(self, workflows: list[WorkflowRunTriggerConfig]) -> list[R]:
+        return [
+            self._extract_result(result)
+            for result in self._workflow.run_many(workflows)
+        ]
+
+    async def aio_run_many(self, workflows: list[WorkflowRunTriggerConfig]) -> list[R]:
+        return [
+            self._extract_result(result)
+            for result in await self._workflow.aio_run_many(workflows)
+        ]
+
+    def run_many_no_wait(
+        self, workflows: list[WorkflowRunTriggerConfig]
+    ) -> list[TaskRunRef[TWorkflowInput, R]]:
+        refs = self._workflow.run_many_no_wait(workflows)
+
+        return [TaskRunRef[TWorkflowInput, R](self, ref) for ref in refs]
+
+    async def aio_run_many_no_wait(
+        self, workflows: list[WorkflowRunTriggerConfig]
+    ) -> list[TaskRunRef[TWorkflowInput, R]]:
+        refs = await self._workflow.aio_run_many_no_wait(workflows)
+
+        return [TaskRunRef[TWorkflowInput, R](self, ref) for ref in refs]

--- a/sdks/python/hatchet_sdk/runnables/standalone.py
+++ b/sdks/python/hatchet_sdk/runnables/standalone.py
@@ -13,7 +13,7 @@ from hatchet_sdk.clients.rest.models.cron_workflows import CronWorkflows
 from hatchet_sdk.contracts.workflows_pb2 import WorkflowVersion
 from hatchet_sdk.runnables.task import Task
 from hatchet_sdk.runnables.types import R, TWorkflowInput
-from hatchet_sdk.runnables.workflow import Workflow
+from hatchet_sdk.runnables.workflow import BaseWorkflow, Workflow
 from hatchet_sdk.utils.aio_utils import get_active_event_loop
 from hatchet_sdk.utils.typing import JSONSerializableMapping, is_basemodel_subclass
 from hatchet_sdk.workflow_run import WorkflowRunRef
@@ -50,7 +50,7 @@ class TaskRunRef(Generic[TWorkflowInput, R]):
         return self._s._extract_result(result)
 
 
-class Standalone(Generic[TWorkflowInput, R]):
+class Standalone(BaseWorkflow[TWorkflowInput], Generic[TWorkflowInput, R]):
     def __init__(
         self, workflow: Workflow[TWorkflowInput], task: Task[TWorkflowInput, R]
     ) -> None:
@@ -62,6 +62,8 @@ class Standalone(Generic[TWorkflowInput, R]):
         self._output_validator = (
             return_type if is_basemodel_subclass(return_type) else None
         )
+
+        self.config = self._workflow.config
 
     def _extract_result(self, result: dict[str, Any]) -> R:
         output = result.get(self._task.name)

--- a/sdks/python/hatchet_sdk/runnables/standalone.py
+++ b/sdks/python/hatchet_sdk/runnables/standalone.py
@@ -54,6 +54,8 @@ class Standalone(BaseWorkflow[TWorkflowInput], Generic[TWorkflowInput, R]):
     def __init__(
         self, workflow: Workflow[TWorkflowInput], task: Task[TWorkflowInput, R]
     ) -> None:
+        super().__init__(config=workflow.config, client=workflow.client)
+
         self._workflow = workflow
         self._task = task
 

--- a/sdks/python/hatchet_sdk/runnables/standalone.py
+++ b/sdks/python/hatchet_sdk/runnables/standalone.py
@@ -181,3 +181,6 @@ class Standalone(Generic[TWorkflowInput, R]):
             input=input,
             additional_metadata=additional_metadata,
         )
+
+    def to_task(self) -> Task[TWorkflowInput, R]:
+        return self._task

--- a/sdks/python/hatchet_sdk/runnables/standalone.py
+++ b/sdks/python/hatchet_sdk/runnables/standalone.py
@@ -56,6 +56,9 @@ class Standalone(BaseWorkflow[TWorkflowInput], Generic[TWorkflowInput, R]):
     ) -> None:
         super().__init__(config=workflow.config, client=workflow.client)
 
+        ## NOTE: This is a hack to assign the task back to the base workflow
+        self._default_tasks = [task]
+
         self._workflow = workflow
         self._task = task
 

--- a/sdks/python/hatchet_sdk/runnables/standalone.py
+++ b/sdks/python/hatchet_sdk/runnables/standalone.py
@@ -56,7 +56,8 @@ class Standalone(BaseWorkflow[TWorkflowInput], Generic[TWorkflowInput, R]):
     ) -> None:
         super().__init__(config=workflow.config, client=workflow.client)
 
-        ## NOTE: This is a hack to assign the task back to the base workflow
+        ## NOTE: This is a hack to assign the task back to the base workflow,
+        ## since the decorator to mutate the tasks is not being called.
         self._default_tasks = [task]
 
         self._workflow = workflow

--- a/sdks/python/hatchet_sdk/runnables/workflow.py
+++ b/sdks/python/hatchet_sdk/runnables/workflow.py
@@ -24,7 +24,6 @@ from hatchet_sdk.contracts.workflows_pb2 import WorkflowVersion
 from hatchet_sdk.labels import DesiredWorkerLabel
 from hatchet_sdk.logger import logger
 from hatchet_sdk.rate_limit import RateLimit
-from hatchet_sdk.runnables.standalone import Standalone
 from hatchet_sdk.runnables.task import Task
 from hatchet_sdk.runnables.types import (
     DEFAULT_EXECUTION_TIMEOUT,
@@ -50,6 +49,7 @@ from hatchet_sdk.workflow_run import WorkflowRunRef
 
 if TYPE_CHECKING:
     from hatchet_sdk import Hatchet
+    from hatchet_sdk.runnables.standalone import Standalone
 
 
 def transform_desired_worker_label(d: DesiredWorkerLabel) -> DesiredWorkerLabels:
@@ -728,7 +728,7 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
 
         return inner
 
-    def add_task(self, task: Standalone[TWorkflowInput, Any]) -> None:
+    def add_task(self, task: "Standalone[TWorkflowInput, Any]") -> None:
         """
         Add a task to a workflow. Intended to be used with a previously existing task (a Standalone),
         such as one created with `@hatchet.task()`, which has been converted to a `Task` object using `to_task`.

--- a/sdks/python/hatchet_sdk/runnables/workflow.py
+++ b/sdks/python/hatchet_sdk/runnables/workflow.py
@@ -67,12 +67,7 @@ class TypedTriggerWorkflowRunConfig(BaseModel, Generic[TWorkflowInput]):
     options: TriggerWorkflowOptions
 
 
-class Workflow(Generic[TWorkflowInput]):
-    """
-    A Hatchet workflow, which allows you to define tasks to be run and perform actions on the workflow, such as
-    running / spawning children and scheduling future runs.
-    """
-
+class BaseWorkflow(Generic[TWorkflowInput]):
     def __init__(self, config: WorkflowConfig, client: "Hatchet") -> None:
         self.config = config
         self._default_tasks: list[Task[TWorkflowInput, Any]] = []
@@ -287,6 +282,13 @@ class Workflow(Generic[TWorkflowInput]):
             options=options,
             key=key,
         )
+
+
+class Workflow(BaseWorkflow[TWorkflowInput]):
+    """
+    A Hatchet workflow, which allows you to define tasks to be run and perform actions on the workflow, such as
+    running / spawning children and scheduling future runs.
+    """
 
     def run_no_wait(
         self,

--- a/sdks/python/hatchet_sdk/utils/typing.py
+++ b/sdks/python/hatchet_sdk/utils/typing.py
@@ -1,11 +1,11 @@
-from typing import Any, Mapping, Type, TypeVar
+from typing import Any, Mapping, Type, TypeGuard, TypeVar
 
 from pydantic import BaseModel
 
 T = TypeVar("T", bound=BaseModel)
 
 
-def is_basemodel_subclass(model: Any) -> bool:
+def is_basemodel_subclass(model: Any) -> TypeGuard[Type[BaseModel]]:
     try:
         return issubclass(model, BaseModel)
     except TypeError:

--- a/sdks/python/hatchet_sdk/worker/worker.py
+++ b/sdks/python/hatchet_sdk/worker/worker.py
@@ -23,9 +23,8 @@ from hatchet_sdk.clients.dispatcher.action_listener import Action
 from hatchet_sdk.config import ClientConfig
 from hatchet_sdk.contracts.v1.workflows_pb2 import CreateWorkflowVersionRequest
 from hatchet_sdk.logger import logger
-from hatchet_sdk.runnables.standalone import Standalone
 from hatchet_sdk.runnables.task import Task
-from hatchet_sdk.runnables.workflow import Workflow
+from hatchet_sdk.runnables.workflow import BaseWorkflow
 from hatchet_sdk.utils.typing import WorkflowValidator, is_basemodel_subclass
 from hatchet_sdk.worker.action_listener_process import (
     ActionEvent,
@@ -70,7 +69,7 @@ class Worker:
         debug: bool = False,
         owned_loop: bool = True,
         handle_kill: bool = True,
-        workflows: list[Workflow[Any] | Standalone[Any, Any]] = [],
+        workflows: list[BaseWorkflow[Any]] = [],
     ) -> None:
         self.config = config
         self.name = self.config.namespace + name
@@ -128,7 +127,7 @@ class Worker:
             logger.error(e)
             sys.exit(1)
 
-    def register_workflow(self, workflow: Workflow[Any] | Standalone[Any, Any]) -> None:
+    def register_workflow(self, workflow: BaseWorkflow[Any]) -> None:
         namespace = self.client.config.namespace
 
         opts = workflow._get_create_opts(namespace)
@@ -160,9 +159,7 @@ class Worker:
                 step_output=return_type if is_basemodel_subclass(return_type) else None,
             )
 
-    def register_workflows(
-        self, workflows: list[Workflow[Any] | Standalone[Any, Any]]
-    ) -> None:
+    def register_workflows(self, workflows: list[BaseWorkflow[Any]]) -> None:
         for workflow in workflows:
             self.register_workflow(workflow)
 

--- a/sdks/python/hatchet_sdk/workflow_run.py
+++ b/sdks/python/hatchet_sdk/workflow_run.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Coroutine
+from typing import Any
 
 from hatchet_sdk.clients.run_event_listener import (
     RunEventListener,
@@ -26,8 +26,8 @@ class WorkflowRunRef:
     def stream(self) -> RunEventListener:
         return self.workflow_run_event_listener.stream(self.workflow_run_id)
 
-    def aio_result(self) -> Coroutine[None, None, dict[str, Any]]:
-        return self.workflow_listener.result(self.workflow_run_id)
+    async def aio_result(self) -> dict[str, Any]:
+        return await self.workflow_listener.result(self.workflow_run_id)
 
     def result(self) -> dict[str, Any]:
         coro = self.workflow_listener.result(self.workflow_run_id)


### PR DESCRIPTION
Implements "standalones", which use the `hatchet.task` and `hatchet.durable_task` decorators to declare standalone tasks (basically a workflow that gets created behind the scenes).

Did this by creating a `BaseWorkflow` and hacking around some inheritance patterns to get everything working right

Usage is:

```python
hatchet.task()
def my_task(input, ctx):
  pass
```

I wrote wrappers for the `Workflow` methods, which is also a bit of a hack but seemed necessary to limit the amount of code we duplicate, especially since Python doesn't allow for nicely overriding methods the way I want to be able to here, so to get around it those wrappers just call `self.workflow.<< method >>` and then parse the result back to the generic type