### PR TITLE
fix: checksums on DAGs

### DIFF
--- a/internal/dagutils/checksum.go
+++ b/internal/dagutils/checksum.go
@@ -1,0 +1,40 @@
+package dagutils
+
+import (
+	"github.com/hatchet-dev/hatchet/internal/datautils"
+	"github.com/hatchet-dev/hatchet/internal/digest"
+	"github.com/hatchet-dev/hatchet/pkg/repository"
+)
+
+func Checksum(opts *repository.CreateWorkflowVersionOpts) (string, error) {
+	// compute a checksum for the workflow
+	declaredValues, err := datautils.ToJSONMap(opts)
+
+	if err != nil {
+		return "", err
+	}
+
+	// ensure no cycles
+	for i, job := range opts.Jobs {
+		if HasCycle(job.Steps) {
+			return "", &repository.JobRunHasCycleError{
+				JobName: job.Name,
+			}
+		}
+
+		var err error
+		opts.Jobs[i].Steps, err = OrderWorkflowSteps(job.Steps)
+
+		if err != nil {
+			return "", err
+		}
+	}
+
+	workflowChecksum, err := digest.DigestValues(declaredValues)
+
+	if err != nil {
+		return "", err
+	}
+
+	return workflowChecksum.String(), nil
+}

--- a/internal/services/admin/server.go
+++ b/internal/services/admin/server.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/hatchet-dev/hatchet/internal/dagutils"
 	"github.com/hatchet-dev/hatchet/internal/msgqueue"
 	"github.com/hatchet-dev/hatchet/internal/services/admin/contracts"
 	"github.com/hatchet-dev/hatchet/internal/services/shared/tasktypes"
@@ -245,7 +246,7 @@ func (a *AdminServiceImpl) PutWorkflow(ctx context.Context, req *contracts.PutWo
 		}
 
 		// workflow exists, look at checksum
-		newCS, err := createOpts.Checksum()
+		newCS, err := dagutils.Checksum(createOpts)
 
 		if err != nil {
 			return nil, err

--- a/pkg/repository/postgres/workflow.go
+++ b/pkg/repository/postgres/workflow.go
@@ -902,7 +902,7 @@ func (r *workflowEngineRepository) createWorkflowVersionTxs(ctx context.Context,
 		version = sqlchelpers.TextFromStr(*opts.Version)
 	}
 
-	cs, err := opts.Checksum()
+	cs, err := dagutils.Checksum(opts)
 
 	if err != nil {
 		return "", err

--- a/pkg/repository/workflow.go
+++ b/pkg/repository/workflow.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hatchet-dev/hatchet/internal/datautils"
-	"github.com/hatchet-dev/hatchet/internal/digest"
 	"github.com/hatchet-dev/hatchet/pkg/repository/postgres/dbsqlc"
 )
 
@@ -83,23 +81,6 @@ type CreateWorkflowConcurrencyOpts struct {
 
 	// (optional) a concurrency expression for evaluating the concurrency key
 	Expression *string `validate:"omitempty,celworkflowrunstr"`
-}
-
-func (o *CreateWorkflowVersionOpts) Checksum() (string, error) {
-	// compute a checksum for the workflow
-	declaredValues, err := datautils.ToJSONMap(o)
-
-	if err != nil {
-		return "", err
-	}
-
-	workflowChecksum, err := digest.DigestValues(declaredValues)
-
-	if err != nil {
-		return "", err
-	}
-
-	return workflowChecksum.String(), nil
 }
 
 type CreateWorkflowSchedulesOpts struct {


### PR DESCRIPTION
# Description

When we compute a checksum on DAGs to determine if we need a new version, it's dependent on the ordering of steps which are passed in. We're getting two different checksums for the same DAG because we were computing it pre-order and post-order. This adds ordering to the DAG before computing the checksum. 

This also adds checksum support for v1 workflows.
 
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)