### PR TITLE
fix: get values for checksum after ordering

### DIFF
--- a/internal/dagutils/checksum.go
+++ b/internal/dagutils/checksum.go
@@ -7,13 +7,6 @@ import (
 )
 
 func Checksum(opts *repository.CreateWorkflowVersionOpts) (string, error) {
-	// compute a checksum for the workflow
-	declaredValues, err := datautils.ToJSONMap(opts)
-
-	if err != nil {
-		return "", err
-	}
-
 	// ensure no cycles
 	for i, job := range opts.Jobs {
 		if HasCycle(job.Steps) {
@@ -28,6 +21,13 @@ func Checksum(opts *repository.CreateWorkflowVersionOpts) (string, error) {
 		if err != nil {
 			return "", err
 		}
+	}
+
+	// compute a checksum for the workflow
+	declaredValues, err := datautils.ToJSONMap(opts)
+
+	if err != nil {
+		return "", err
 	}
 
 	workflowChecksum, err := digest.DigestValues(declaredValues)

--- a/pkg/repository/v1/workflow.go
+++ b/pkg/repository/v1/workflow.go
@@ -843,14 +843,15 @@ func (r *workflowRepository) createJobTx(ctx context.Context, tx sqlcv1.DBTX, te
 }
 
 func checksumV1(opts *CreateWorkflowVersionOpts) (string, error) {
-	// compute a checksum for the workflow
-	declaredValues, err := datautils.ToJSONMap(opts)
+	var err error
+	opts.Tasks, err = orderWorkflowStepsV1(opts.Tasks)
 
 	if err != nil {
 		return "", err
 	}
 
-	opts.Tasks, err = orderWorkflowStepsV1(opts.Tasks)
+	// compute a checksum for the workflow
+	declaredValues, err := datautils.ToJSONMap(opts)
 
 	if err != nil {
 		return "", err


### PR DESCRIPTION
# Description

Hotfixes an issue from #1410 where we need to use the updated, sorted values in the checksum computation.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)