### PR TITLE
Feat: A bunch more path filters for GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: build
 on:
   pull_request:
+    paths-ignore:
+      - 'sdks/**'
+      - 'frontend/docs/**'
 
 jobs:
   check_path:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,8 @@
 name: "frontend / docs"
 on:
   pull_request:
+    paths:
+      - 'frontend/docs/**'
 
 jobs:
   check_path:

--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -2,8 +2,11 @@ name: python
 on:
   pull_request:
     paths:
-      - 'sdks/python/**'
       - '.github/**'
+      - 'api/**'
+      - 'api-contracts/**'
+      - 'internal/**'
+      - 'sdks/python/**'
   push:
     branches:
       - main

--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -9,7 +9,6 @@ on:
       - main
     paths:
       - 'sdks/python/**'
-      - '.github/**'
 
 defaults:
   run:

--- a/.github/workflows/sdk-typescript.yml
+++ b/.github/workflows/sdk-typescript.yml
@@ -2,8 +2,11 @@ name: typescript
 on:
   pull_request:
     paths:
-      - 'sdks/typescript/**'
       - '.github/**'
+      - 'api/**'
+      - 'api-contracts/**'
+      - 'internal/**'
+      - 'sdks/typescript/**'
   push:
     branches:
       - main

--- a/.github/workflows/sdk-typescript.yml
+++ b/.github/workflows/sdk-typescript.yml
@@ -9,7 +9,6 @@ on:
       - main
     paths:
       - 'sdks/typescript/**'
-      - '.github/**'
 
 defaults:
   run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: test
 on:
   pull_request:
+    paths-ignore:
+      - 'sdks/**'
+      - 'frontend/docs/**'
 
 jobs:
   check_path:


### PR DESCRIPTION
Setting up a bunch of misc. path filtering in CI:

* Run SDK CI on PRs that touch the SDKs, the engine, or the API
* Don't run engine tests + build on docs- and SDK-only changes
* Only run docs CI on docs changes

## Type of change

- [x] CI (any automation pipeline changes)

