### PR TITLE
fix(v1): dag statuses should wait for all tasks to be created

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20250327185734_v1_0_9.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20250327185734_v1_0_9.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE v1_dags_olap ADD COLUMN total_tasks INT NOT NULL DEFAULT 1;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE v1_dags_olap DROP COLUMN total_tasks;
+-- +goose StatementEnd

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -1169,6 +1169,7 @@ func (r *OLAPRepositoryImpl) writeDAGBatch(ctx context.Context, tenantId string,
 			Input:                dag.Input,
 			AdditionalMetadata:   dag.AdditionalMetadata,
 			ParentTaskExternalID: parentTaskExternalID,
+			TotalTasks:           int32(dag.TotalTasks), // nolint: gosec
 		})
 	}
 

--- a/pkg/repository/v1/sqlcv1/copyfrom.go
+++ b/pkg/repository/v1/sqlcv1/copyfrom.go
@@ -74,6 +74,7 @@ func (r iteratorForCreateDAGsOLAP) Values() ([]interface{}, error) {
 		r.rows[0].Input,
 		r.rows[0].AdditionalMetadata,
 		r.rows[0].ParentTaskExternalID,
+		r.rows[0].TotalTasks,
 	}, nil
 }
 
@@ -82,7 +83,7 @@ func (r iteratorForCreateDAGsOLAP) Err() error {
 }
 
 func (q *Queries) CreateDAGsOLAP(ctx context.Context, db DBTX, arg []CreateDAGsOLAPParams) (int64, error) {
-	return db.CopyFrom(ctx, []string{"v1_dags_olap"}, []string{"tenant_id", "id", "inserted_at", "external_id", "display_name", "workflow_id", "workflow_version_id", "input", "additional_metadata", "parent_task_external_id"}, &iteratorForCreateDAGsOLAP{rows: arg})
+	return db.CopyFrom(ctx, []string{"v1_dags_olap"}, []string{"tenant_id", "id", "inserted_at", "external_id", "display_name", "workflow_id", "workflow_version_id", "input", "additional_metadata", "parent_task_external_id", "total_tasks"}, &iteratorForCreateDAGsOLAP{rows: arg})
 }
 
 // iteratorForCreateMatchConditions implements pgx.CopyFromSource.

--- a/pkg/repository/v1/sqlcv1/models.go
+++ b/pkg/repository/v1/sqlcv1/models.go
@@ -2469,6 +2469,7 @@ type V1DagsOlap struct {
 	Input                []byte               `json:"input"`
 	AdditionalMetadata   []byte               `json:"additional_metadata"`
 	ParentTaskExternalID pgtype.UUID          `json:"parent_task_external_id"`
+	TotalTasks           int32                `json:"total_tasks"`
 }
 
 type V1DurableSleep struct {

--- a/pkg/repository/v1/trigger.go
+++ b/pkg/repository/v1/trigger.go
@@ -870,6 +870,8 @@ type DAGWithData struct {
 	AdditionalMetadata []byte
 
 	ParentTaskExternalID *pgtype.UUID
+
+	TotalTasks int
 }
 
 func (r *TriggerRepositoryImpl) createDAGs(ctx context.Context, tx sqlcv1.DBTX, tenantId string, opts []createDAGOpts) ([]*DAGWithData, error) {
@@ -958,6 +960,7 @@ func (r *TriggerRepositoryImpl) createDAGs(ctx context.Context, tx sqlcv1.DBTX, 
 			Input:                input,
 			AdditionalMetadata:   additionalMeta,
 			ParentTaskExternalID: &parentTaskExternalID,
+			TotalTasks:           len(opt.TaskIds),
 		})
 	}
 

--- a/sql/schema/v1-olap.sql
+++ b/sql/schema/v1-olap.sql
@@ -183,6 +183,7 @@ CREATE TABLE v1_dags_olap (
     input JSONB NOT NULL,
     additional_metadata JSONB,
     parent_task_external_id UUID,
+    total_tasks INT NOT NULL DEFAULT 1,
     PRIMARY KEY (inserted_at, id, readable_status)
 ) PARTITION BY RANGE(inserted_at);
 


### PR DESCRIPTION
# Description

When a task is in a waiting state (to wait for a trigger condition), the UI displays the parent DAG in a final state instead of displaying it in a running state. 
 
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)