### PR TITLE
improve ttl cache on pgmq

### DIFF
--- a/internal/msgqueue/postgres/msgqueue.go
+++ b/internal/msgqueue/postgres/msgqueue.go
@@ -73,6 +73,7 @@ func NewPostgresMQ(repo repository.MessageQueueRepository, fs ...MessageQueueImp
 			repo:     repo,
 			l:        opts.l,
 			qos:      opts.qos,
+			ttlCache: c,
 			configFs: fs,
 		}
 }


### PR DESCRIPTION
# Description

Improves the cache behavior on pgmq to only cache for a short duration of time. Otherwise exclusive queues whose listeners get removed and re-added will error out. 
 
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)