### PR TITLE
fix: self-hosting doc, migrate container start command

### DIFF
--- a/build/package/servers.dockerfile
+++ b/build/package/servers.dockerfile
@@ -65,6 +65,7 @@ FROM alpine AS deployment
 
 # can be set to "api", "engine", "admin" or "lite"
 ARG SERVER_TARGET=engine
+ENV SERVER_TARGET=${SERVER_TARGET}
 
 WORKDIR /hatchet
 
@@ -79,4 +80,5 @@ COPY /hack/db/atlas-apply.sh ./atlas-apply.sh
 RUN chmod +x ./atlas-apply.sh
 
 EXPOSE 8080
-CMD /hatchet/hatchet-${SERVER_TARGET}
+
+CMD ["/bin/sh", "-c", "/hatchet/hatchet-${SERVER_TARGET}"]

--- a/frontend/docs/pages/self-hosting/docker-compose.mdx
+++ b/frontend/docs/pages/self-hosting/docker-compose.mdx
@@ -72,6 +72,7 @@ services:
       retries: 5
   migration:
     image: ghcr.io/hatchet-dev/hatchet/hatchet-migrate:latest
+    command: /hatchet/hatchet-migrate
     environment:
       DATABASE_URL: "postgres://hatchet:hatchet@postgres:5432/hatchet"
     depends_on:

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/hatchet-dev/hatchet
 
 go 1.23.0
 
-toolchain go1.24.1
-
 require (
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/creasty/defaults v1.8.0


### PR DESCRIPTION
# Description

Fixes an issue with the start command in the self-hosting doc, and also changes the entrypoint of the server dockerfiles so it can interpolate the `SERVER_TARGET` env var.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)