### PR TITLE
docs: update 404ing links to Hatchet Cloud

### DIFF
--- a/frontend/docs/pages/compute/getting-started.mdx
+++ b/frontend/docs/pages/compute/getting-started.mdx
@@ -7,7 +7,7 @@ Hatchet Compute is available in Hatchet Cloud.
 This guide will walk you through the process of setting up a Hatchet Compute project and assumes you have a basic understanding of Hatchet.
 If you'd like you can fork the [Hatchet Compute Example Repo](https://github.com/hatchet-dev/managed-compute-examples) to follow along.
 
-1. Sign in or sign up for Hatchet Cloud [here](https://hatchet.run/cloud).
+1. Sign in or sign up for Hatchet Cloud [here](https://cloud.onhatchet.run).
 2. Navigate to the Managed Compute view to configure your compute resources.
 3. Ensure your code is committed to a Git repository.
 4. Click **+ New Worker** to create a new managed compute worker pool.

--- a/frontend/v0-docs/pages/compute/getting-started.mdx
+++ b/frontend/v0-docs/pages/compute/getting-started.mdx
@@ -7,7 +7,7 @@ Hatchet Compute is available in Hatchet Cloud.
 This guide will walk you through the process of setting up a Hatchet Compute project and assumes you have a basic understanding of Hatchet.
 If you'd like you can fork the [Hatchet Compute Example Repo](https://github.com/hatchet-dev/managed-compute-examples) to follow along.
 
-1. Sign in or sign up for Hatchet Cloud [here](https://hatchet.run/cloud).
+1. Sign in or sign up for Hatchet Cloud [here](https://cloud.onhatchet.run).
 2. Navigate to the Managed Compute view to configure your compute resources.
 3. Ensure your code is committed to a Git repository.
 4. Click **+ New Worker** to create a new managed compute worker pool.


### PR DESCRIPTION
# Description

Looks like the <https://hatchet.run/cloud> vanity redirect might have been a victim of the V1 docs overhaul. Swap in direct links to <https://cloud.onhatchet.run> for now to get that sweet, sweet $$ flowing through the funnel again.

I couldn't find a referral link in my Hatchet Cloud panel so hopefully this will do /s

## Type of change

- [x] Documentation change (pure documentation change)

## What's Changed

- [x] Replaces broken links to <https://hatchet.run/cloud> with <https://cloud.onhatchet.run>
