### PR TITLE
docs: seed and extra env var

### DIFF
--- a/frontend/docs/components/DynamicLottie.tsx
+++ b/frontend/docs/components/DynamicLottie.tsx
@@ -15,4 +15,4 @@ function DynamicLottie(props: DynamicLottieProps) {
 }
 
 // Using CommonJS export
-export default DynamicLottie; 
+export default DynamicLottie;

--- a/frontend/docs/pages/self-hosting/kubernetes-helm-configuration.mdx
+++ b/frontend/docs/pages/self-hosting/kubernetes-helm-configuration.mdx
@@ -57,3 +57,21 @@ sharedConfig:
 ```
 
 This will set the environment variable `MY_ENV_VAR` to `"my-value"` for all backend services. These values will override any default environment settings for the services.
+
+### Seeding Data
+
+The `sharedConfig` object also allows you to seed the database with a default tenant and user. The following environment variables are used for seeding:
+
+````yaml
+The following environment variables are used to seed the database:
+
+```yaml
+seed:
+  defaultAdminEmail: "admin@example.com" # in exposed/production environments, change this to a valid email
+  defaultAdminPassword: "Admin123!!" # in exposed/production environments, change this to a secure password
+  env:
+    ADMIN_NAME: "Admin User"
+    DEFAULT_TENANT_NAME: "Default"
+    DEFAULT_TENANT_SLUG: "default"
+    DEFAULT_TENANT_ID: "707d0855-80ab-4e1f-a156-f1c4546cbf52"
+````

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/hatchet-dev/hatchet
 
 go 1.23.0
 
-toolchain go1.24.1
-
 require (
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/creasty/defaults v1.8.0

--- a/pkg/config/database/config.go
+++ b/pkg/config/database/config.go
@@ -86,6 +86,7 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("seed.adminName", "ADMIN_NAME")
 	_ = v.BindEnv("seed.defaultTenantName", "DEFAULT_TENANT_NAME")
 	_ = v.BindEnv("seed.defaultTenantSlug", "DEFAULT_TENANT_SLUG")
+	_ = v.BindEnv("seed.defaultTenantId", "DEFAULT_TENANT_ID")
 	_ = v.BindEnv("seed.isDevelopment", "SEED_DEVELOPMENT")
 
 	_ = v.BindEnv("logger.level", "DATABASE_LOGGER_LEVEL")


### PR DESCRIPTION
# Description

Adds support for setting `DEFAULT_TENANT_ID` and documents how to seed data in the helm chart.

## Type of change

- [X] Documentation change (pure documentation change)
- [X] New feature (non-breaking change which adds functionality)