### PR TITLE
fix: improve performance of signal events query

### DIFF
--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -6,6 +6,7 @@ on:
       - 'api/**'
       - 'api-contracts/**'
       - 'internal/**'
+      - 'pkg/**'
       - 'sdks/python/**'
   push:
     branches:

--- a/.github/workflows/sdk-typescript.yml
+++ b/.github/workflows/sdk-typescript.yml
@@ -6,6 +6,7 @@ on:
       - 'api/**'
       - 'api-contracts/**'
       - 'internal/**'
+      - 'pkg/**'
       - 'sdks/typescript/**'
   push:
     branches:

--- a/pkg/repository/v1/sqlcv1/tasks.sql
+++ b/pkg/repository/v1/sqlcv1/tasks.sql
@@ -466,13 +466,17 @@ SELECT
     e.data
 FROM
     v1_task_event e
-JOIN
-    input i ON i.task_id = e.task_id AND i.task_inserted_at = e.task_inserted_at AND i.event_key = e.event_key
 WHERE
-    e.tenant_id = @tenantId::uuid
+    (e.task_id, e.task_inserted_at, e.event_key) IN (
+        SELECT
+            task_id, task_inserted_at, event_key
+        FROM
+            input
+    )
+    AND e.tenant_id = @tenantId::uuid
     AND e.event_type = 'SIGNAL_CREATED'
 ORDER BY
-    e.id
+    e.task_id, e.task_inserted_at, e.id
 FOR UPDATE;
 
 -- name: ListMatchingSignalEvents :many
@@ -510,7 +514,7 @@ WITH input AS (
         ) AS subquery
 ), matching_events AS (
     SELECT
-        e.id
+        e.task_id, e.task_inserted_at, e.id
     FROM
         v1_task_event e
     JOIN
@@ -525,7 +529,7 @@ WITH input AS (
 DELETE FROM
     v1_task_event
 WHERE
-    id IN (SELECT id FROM matching_events);
+    (task_id, task_inserted_at, id) IN (SELECT task_id, task_inserted_at, id FROM matching_events);
 
 -- name: ListTasksForReplay :many
 -- Lists tasks for replay by recursively selecting all tasks that are children of the input tasks,


### PR DESCRIPTION
# Description

Ensures that the `ORDER BY` expression in the `LockSignalCreatedEvents` matches the pkey and filter expressions to improve performance. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)