### PR TITLE
Fix: Doc Light Mode

### DIFF
--- a/frontend/docs/pages/_meta.js
+++ b/frontend/docs/pages/_meta.js
@@ -3,6 +3,9 @@ export default {
     "title": "User Guide",
     "type": "page"
   },
+  "_setup": {
+    "display": "hidden"
+  },
   "compute": {
     "title": "Managed Compute",
     "type": "page",

--- a/frontend/docs/styles/global.css
+++ b/frontend/docs/styles/global.css
@@ -151,6 +151,15 @@
 /* ========================= */
 /* Dark Mode Fixes (Nextra)  */
 /* ========================= */
+html {
+  background-color: hsl(var(--background));
+}
+
+body {
+  background-color: hsl(var(--background));
+  color: hsl(var(--foreground));
+}
+
 html.dark main,
 html.dark body,
 html.dark .nx-fixed,

--- a/frontend/docs/styles/global.css
+++ b/frontend/docs/styles/global.css
@@ -47,32 +47,32 @@
 
   .dark {
     --background: 222.2 84% 4.9%;
-    --foreground: 0 0% 98%;
+    --foreground: 210 40% 98%;
 
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
 
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
 
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
 
-    --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
 
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
 
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
 
     --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
+    --destructive-foreground: 210 40% 98%;
 
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
 
     /* Dark Mode Chart Colors */
     --chart-1: 220 70% 50%;

--- a/frontend/docs/styles/global.css
+++ b/frontend/docs/styles/global.css
@@ -46,7 +46,7 @@
   }
 
   .dark {
-    --background: 0 0% 3.9%;
+    --background: 222.2 84% 4.9%;
     --foreground: 0 0% 98%;
 
     --card: 0 0% 3.9%;

--- a/frontend/docs/styles/global.css
+++ b/frontend/docs/styles/global.css
@@ -2,96 +2,99 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
-}
-
+/* ========================= */
+/* Root Variables & Theming  */
+/* ========================= */
 @layer base {
   :root {
     --background: 0 0% 100%;
     --foreground: 0 0% 3.9%;
+
     --card: 0 0% 100%;
     --card-foreground: 0 0% 3.9%;
+
     --popover: 0 0% 100%;
     --popover-foreground: 0 0% 3.9%;
+
     --primary: 0 0% 9%;
     --primary-foreground: 0 0% 98%;
+
     --secondary: 0 0% 96.1%;
     --secondary-foreground: 0 0% 9%;
+
     --muted: 0 0% 96.1%;
     --muted-foreground: 0 0% 45.1%;
+
     --accent: 0 0% 96.1%;
     --accent-foreground: 0 0% 9%;
+
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
+
     --border: 0 0% 89.8%;
     --input: 0 0% 89.8%;
     --ring: 0 0% 3.9%;
+
+    /* Chart Colors */
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
+
     --radius: 0.5rem;
   }
+
   .dark {
     --background: 0 0% 3.9%;
     --foreground: 0 0% 98%;
+
     --card: 0 0% 3.9%;
     --card-foreground: 0 0% 98%;
+
     --popover: 0 0% 3.9%;
     --popover-foreground: 0 0% 98%;
+
     --primary: 0 0% 98%;
     --primary-foreground: 0 0% 9%;
+
     --secondary: 0 0% 14.9%;
     --secondary-foreground: 0 0% 98%;
+
     --muted: 0 0% 14.9%;
     --muted-foreground: 0 0% 63.9%;
+
     --accent: 0 0% 14.9%;
     --accent-foreground: 0 0% 98%;
+
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
+
     --border: 0 0% 14.9%;
     --input: 0 0% 14.9%;
     --ring: 0 0% 83.1%;
+
+    /* Dark Mode Chart Colors */
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
   }
+
+  * {
+    @apply border-border;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+    height: 100vh;
+  }
 }
 
-body {
-  height: 100vh;
-}
-
+/* ========================= */
+/* Custom UI Components      */
+/* ========================= */
 .step-run-card {
   --transition: 0.25s;
   --spark: 3s;
@@ -105,13 +108,24 @@ body {
 }
 
 .step-run-card.active .step-run-backdrop {
-  background: 222.2 84% 4.9%;
+  background: var(--background);
 }
 
 .step-run-card.active {
   transform: scale(1.05);
 }
 
+.step-run-backdrop {
+  position: absolute;
+  inset: 1px;
+  background: var(--background);
+  border-radius: 10px;
+  transition: background var(--transition), opacity var(--transition);
+}
+
+/* ========================= */
+/* Animation Effects         */
+/* ========================= */
 .spark {
   position: absolute;
   inset: 0;
@@ -128,72 +142,34 @@ body {
   }
 }
 
-.spark:before {
-  content: "";
-  position: absolute;
-  width: 200%;
-  aspect-ratio: 1;
-  inset: 0 auto auto 50%;
-  z-index: -1;
-  translate: -50% -15%;
-  rotate: 0;
-  transform: rotate(-90deg);
-  opacity: 1;
-  background: conic-gradient(from 0deg, transparent 0 340deg, white 360deg);
-  transition: opacity var(--transition);
-  animation: rotate var(--spark) linear infinite both;
-}
-
-.step-run-backdrop {
-  position: absolute;
-  inset: 1px;
-  background: 222.2 84% 4.9%;
-  border-radius: 10px;
-  transition: background var(--transition) opacity var(--transition);
-}
-
 @keyframes rotate {
   to {
     transform: rotate(90deg);
   }
 }
 
-.text {
-  z-index: 1;
-  color: rgb(203 213 225);
-}
-
-/* Code block styles */
-html.dark .nextra-code-block pre {
-  background-color: #1e293b !important;
-}
-
-/* Base dark mode styles */
-html.dark main {
-  background-color: #020817;
-}
-
-html.dark body {
-  background-color: var(--background) !important;
-}
-
-/* Fix for Nextra 3 theme-switcher and sidebar footer */
+/* ========================= */
+/* Dark Mode Fixes (Nextra)  */
+/* ========================= */
+html.dark main,
+html.dark body,
 html.dark .nx-fixed,
 html.dark ._fixed,
 html.dark .dark\:nx-bg-dark,
 html.dark .dark\:_bg-dark,
 html.dark .nx-bg-white,
-html.dark ._bg-white {
-  background-color: #020817 !important;
+html.dark ._bg-white,
+html.dark div.nx-sticky.nx-bottom-0,
+html.dark div._sticky._bottom-0,
+html.dark div.nextra-nav-container {
+  background-color: var(--background) !important;
 }
 
-/* Fix for system preferences button in theme switcher */
 html.dark .nx-text-gray-800,
 html.dark ._text-gray-800 {
   color: #f8fafc !important;
 }
 
-/* Fix for theme switcher borders */
 html.dark .nx-border-gray-200,
 html.dark ._border-gray-200,
 html.dark .nx-border,
@@ -201,14 +177,37 @@ html.dark ._border {
   border-color: #1e293b !important;
 }
 
-/* Bottom nav container */
-html.dark div.nx-sticky.nx-bottom-0,
-html.dark div._sticky._bottom-0 {
-  background-color: #020817 !important;
+/* ========================= */
+/* Code Block Styling        */
+/* ========================= */
+html.dark .nextra-code-block pre,
+.dark .shiki {
+  background-color: #1e293b !important;
 }
 
-html.dark div.nextra-nav-container {
-  background-color: #020817 !important;
+.shiki {
+  padding: 15px !important;
+  border-radius: 10px !important;
+  background-color: rgba(40, 99, 159, 0.05) !important;
+}
+
+pre.shiki {
+  overflow-x: auto;
+}
+
+/* ========================= */
+/* Miscellaneous Fixes       */
+/* ========================= */
+.nextra-steps h3::before {
+  line-height: 25px;
+}
+
+.dark .nextra-breadcrumb a,
+.dark .nextra-breadcrumb a:visited,
+.dark .nextra-breadcrumb a:hover,
+.dark .nextra-breadcrumb a:active {
+  background: none !important;
+  -webkit-text-fill-color: var(--ash-gray) !important;
 }
 
 .nextra-nav-container-blur {
@@ -222,45 +221,4 @@ nav {
 .dark .nx-sticky,
 .dark ._sticky {
   box-shadow: none !important;
-}
-
-/* Center numbers in steps */
-.nextra-steps h3::before {
-    line-height: 25px;
-}
-
-/* Breadcrumb link styles in dark mode */
-.dark .nextra-breadcrumb a,
-.dark .nextra-breadcrumb a:visited,
-.dark .nextra-breadcrumb a:hover,
-.dark .nextra-breadcrumb a:active {
-  background: none !important;
-  -webkit-text-fill-color: var(--ash-gray) !important;
-}
-
-:is(html[class~="dark"]) .nextra-nav-container-blur.nx-pointer-events-none {
-  background-color: var(--background) !important;
-}
-
-.shiki {
-  padding: 15px !important;
-  border-radius: 10px !important;
-  background-color: rgba(40, 99, 159, 0.05) !important;
-}
-
-pre.shiki {
-  overflow-x: auto;
-}
-
-.dark .shiki {
-  background-color: #1e293b !important;
-}
-
-@layer base {
-  * {
-    @apply border-border;
-  }
-  body {
-    @apply bg-background text-foreground;
-  }
 }

--- a/frontend/docs/theme.config.tsx
+++ b/frontend/docs/theme.config.tsx
@@ -17,11 +17,11 @@ const config = {
   },
   primaryHue: {
     dark: 210,
-    light: 210
+    light: 210,
   },
   primarySaturation: {
     dark: 60,
-    light: 60
+    light: 60,
   },
   logoLink: "https://github.com/hatchet-dev/hatchet",
   project: {
@@ -37,9 +37,7 @@ const config = {
     useLink: (...args: unknown[]) =>
       `https://github.com/hatchet-dev/hatchet/issues/new`,
   },
-  footer: {
-    content: null,
-  },
+  footer: false,
   sidebar: {
     defaultMenuCollapseLevel: 2,
     toggleButton: true,
@@ -51,16 +49,15 @@ const config = {
   darkMode: true,
   nextThemes: {
     defaultTheme: "dark",
-    forcedTheme: "dark"
   },
   themeSwitch: {
     useOptions() {
       return {
         dark: "Dark",
-        light: "Light"
-      }
-    }
-  }
+        light: "Light",
+      };
+    },
+  },
 };
 
 export default config;


### PR DESCRIPTION
Fixing doc light mode. Had to change a bunch of stuff in the `globals.css` and remove the `forcedTheme` thing. Also removed the rogue footer


#### Dark

<img width="1660" alt="Screenshot 2025-04-01 at 3 23 47 PM" src="https://github.com/user-attachments/assets/0bd8a33c-de80-4a03-a2e4-5d99d9365a61" />


#### Light

<img width="1542" alt="Screenshot 2025-04-01 at 3 23 55 PM" src="https://github.com/user-attachments/assets/e315ccfa-6c00-4aa8-80b6-23c4053c1735" />
