### PR TITLE
fix: don't prepend to error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/hatchet-dev/hatchet
 
 go 1.23.0
 
-toolchain go1.24.1
-
 require (
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/creasty/defaults v1.8.0

--- a/pkg/client/workflow.go
+++ b/pkg/client/workflow.go
@@ -40,7 +40,7 @@ func (r *WorkflowResult) StepOutput(key string, v interface{}) error {
 	for _, stepRunResult := range r.workflowRun.Results {
 		if stepRunResult.StepReadableId == key {
 			if stepRunResult.Error != nil {
-				return fmt.Errorf("step run failed: %s", *stepRunResult.Error)
+				return fmt.Errorf("%s", *stepRunResult.Error)
 			}
 
 			if stepRunResult.Output != nil {


### PR DESCRIPTION
# Description

Removes the prepend of `step run failed` on the Go SDK when returning a step run error to the user.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)