### PR TITLE
fix: change internal addresses for self-hosting

### DIFF
--- a/frontend/docs/pages/self-hosting/docker-compose.mdx
+++ b/frontend/docs/pages/self-hosting/docker-compose.mdx
@@ -95,6 +95,7 @@ services:
       SERVER_GRPC_INSECURE: "t"
       SERVER_GRPC_BROADCAST_ADDRESS: localhost:7077
       SERVER_DEFAULT_ENGINE_VERSION: "V1"
+      SERVER_INTERNAL_CLIENT_INTERNAL_GRPC_BROADCAST_ADDRESS: hatchet-engine:7077
     volumes:
       - hatchet_certs:/hatchet/certs
       - hatchet_config:/hatchet/config

--- a/frontend/docs/pages/self-hosting/hatchet-lite.mdx
+++ b/frontend/docs/pages/self-hosting/hatchet-lite.mdx
@@ -66,6 +66,7 @@ services:
       SERVER_URL: http://localhost:8888
       SERVER_AUTH_SET_EMAIL_VERIFIED: "t"
       SERVER_DEFAULT_ENGINE_VERSION: "V1"
+      SERVER_INTERNAL_CLIENT_INTERNAL_GRPC_BROADCAST_ADDRESS: localhost:7077
     volumes:
       - "hatchet_lite_rabbitmq_data:/var/lib/rabbitmq"
       - "hatchet_lite_config:/config"


### PR DESCRIPTION
# Description

Updates gRPC broadcast addresses for self-hosting for internal replay/cancel/trigger endpoints (not related to SDK behavior). 

## Type of change

- [X] Documentation change (pure documentation change)