### PR TITLE
fix: register naming

### DIFF
--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Background task orchestration & visibility for developers",
   "types": "dist/index.d.ts",
   "files": [

--- a/sdks/typescript/src/v1/client/worker.ts
+++ b/sdks/typescript/src/v1/client/worker.ts
@@ -32,9 +32,9 @@ export interface CreateWorkerOpts {
   /** @deprecated Use slots instead */
   maxRuns?: number;
 
-  /** (optional) Array of workflows to register 
+  /** (optional) Array of workflows to register
    * @deprecated use register instead
-  */
+   */
   workflows?: BaseWorkflowDeclaration<any, any>[] | V0Workflow[];
 }
 

--- a/sdks/typescript/src/v1/client/worker.ts
+++ b/sdks/typescript/src/v1/client/worker.ts
@@ -16,17 +16,26 @@ const DEFAULT_DURABLE_SLOTS = 1_000;
 export interface CreateWorkerOpts {
   /** (optional) Maximum number of concurrent runs on this worker, defaults to 100 */
   slots?: number;
+
   /** (optional) Array of workflows to register */
-  workflows?: BaseWorkflowDeclaration<any, any>[] | V0Workflow[];
+  register?: BaseWorkflowDeclaration<any, any>[] | V0Workflow[];
+
   /** (optional) Worker labels for affinity-based assignment */
   labels?: WorkerLabels;
+
   /** (optional) Whether to handle kill signals */
   handleKill?: boolean;
-  /** @deprecated Use slots instead */
-  maxRuns?: number;
 
   /** (optional) Maximum number of concurrent runs on the durable worker, defaults to 1,000 */
   durableSlots?: number;
+
+  /** @deprecated Use slots instead */
+  maxRuns?: number;
+
+  /** (optional) Array of workflows to register 
+   * @deprecated use register instead
+  */
+  workflows?: BaseWorkflowDeclaration<any, any>[] | V0Workflow[];
 }
 
 /**
@@ -76,8 +85,13 @@ export class Worker {
       ...options,
       maxRuns: options.slots || options.maxRuns,
     });
+
+    if (options.register && options.workflows) {
+      throw new Error('register and workflows are both set, use register instead');
+    }
+
     const worker = new Worker(v1, v0, v0worker, options, name);
-    await worker.registerWorkflows(options.workflows);
+    await worker.registerWorkflows(options.register || options.workflows);
     return worker;
   }
 

--- a/sdks/typescript/src/v1/examples/cancellations/worker.ts
+++ b/sdks/typescript/src/v1/examples/cancellations/worker.ts
@@ -5,7 +5,7 @@ import { cancellation } from './workflow';
 async function main() {
   const worker = await hatchet.worker('cancellation-worker', {
     // 👀 Declare the workflows that the worker can execute
-    workflows: [cancellation],
+    register: [cancellation],
     // 👀 Declare the number of concurrent task runs the worker can accept
     slots: 100,
   });

--- a/sdks/typescript/src/v1/examples/child_workflows/worker.ts
+++ b/sdks/typescript/src/v1/examples/child_workflows/worker.ts
@@ -3,7 +3,7 @@ import { parent, child } from './workflow';
 
 async function main() {
   const worker = await hatchet.worker('child-workflow-worker', {
-    workflows: [parent, child],
+    register: [parent, child],
     slots: 100,
   });
 

--- a/sdks/typescript/src/v1/examples/concurrency-rr/worker.ts
+++ b/sdks/typescript/src/v1/examples/concurrency-rr/worker.ts
@@ -3,7 +3,7 @@ import { simpleConcurrency } from './workflow';
 
 async function main() {
   const worker = await hatchet.worker('simple-concurrency-worker', {
-    workflows: [simpleConcurrency],
+    register: [simpleConcurrency],
   });
 
   await worker.start();

--- a/sdks/typescript/src/v1/examples/dag/worker.ts
+++ b/sdks/typescript/src/v1/examples/dag/worker.ts
@@ -3,7 +3,7 @@ import { dag } from './workflow';
 
 async function main() {
   const worker = await hatchet.worker('dag-worker', {
-    workflows: [dag],
+    register: [dag],
   });
 
   await worker.start();

--- a/sdks/typescript/src/v1/examples/dag_match_condition/worker.ts
+++ b/sdks/typescript/src/v1/examples/dag_match_condition/worker.ts
@@ -3,7 +3,7 @@ import { dagWithConditions } from './workflow';
 
 async function main() {
   const worker = await hatchet.worker('dag-worker', {
-    workflows: [dagWithConditions],
+    register: [dagWithConditions],
   });
 
   await worker.start();

--- a/sdks/typescript/src/v1/examples/deep/worker.ts
+++ b/sdks/typescript/src/v1/examples/deep/worker.ts
@@ -3,7 +3,7 @@ import { parent, child1, child2, child3, child4, child5 } from './workflow';
 
 async function main() {
   const worker = await hatchet.worker('simple-worker', {
-    workflows: [parent, child1, child2, child3, child4, child5],
+    register: [parent, child1, child2, child3, child4, child5],
     slots: 5000,
   });
 

--- a/sdks/typescript/src/v1/examples/durable-event/worker.ts
+++ b/sdks/typescript/src/v1/examples/durable-event/worker.ts
@@ -3,7 +3,7 @@ import { durableEvent } from './workflow';
 
 async function main() {
   const worker = await hatchet.worker('durable-event-worker', {
-    workflows: [durableEvent],
+    register: [durableEvent],
   });
 
   await worker.start();

--- a/sdks/typescript/src/v1/examples/durable-sleep/worker.ts
+++ b/sdks/typescript/src/v1/examples/durable-sleep/worker.ts
@@ -3,7 +3,7 @@ import { durableSleep } from './workflow';
 
 async function main() {
   const worker = await hatchet.worker('sleep-worker', {
-    workflows: [durableSleep],
+    register: [durableSleep],
   });
 
   await worker.start();

--- a/sdks/typescript/src/v1/examples/inferred-typing/worker.ts
+++ b/sdks/typescript/src/v1/examples/inferred-typing/worker.ts
@@ -3,7 +3,7 @@ import { declaredType, inferredType, inferredTypeDurable, crazyWorkflow } from '
 
 async function main() {
   const worker = await hatchet.worker('simple-worker', {
-    workflows: [declaredType, inferredType, inferredTypeDurable, crazyWorkflow],
+    register: [declaredType, inferredType, inferredTypeDurable, crazyWorkflow],
   });
 
   await worker.start();

--- a/sdks/typescript/src/v1/examples/landing_page/task-routing.ts
+++ b/sdks/typescript/src/v1/examples/landing_page/task-routing.ts
@@ -21,7 +21,7 @@ export const simple = hatchet.task({
 });
 
 hatchet.worker('task-routing-worker', {
-  workflows: [simple],
+  register: [simple],
   labels: {
     cpu: process.env.CPU_LABEL,
   },

--- a/sdks/typescript/src/v1/examples/legacy/worker.ts
+++ b/sdks/typescript/src/v1/examples/legacy/worker.ts
@@ -3,7 +3,7 @@ import { simple } from './workflow';
 
 async function main() {
   const worker = await hatchet.worker('legacy-worker', {
-    workflows: [simple],
+    register: [simple],
   });
 
   await worker.start();

--- a/sdks/typescript/src/v1/examples/non_retryable/worker.ts
+++ b/sdks/typescript/src/v1/examples/non_retryable/worker.ts
@@ -3,7 +3,7 @@ import { nonRetryableWorkflow } from './workflow';
 
 async function main() {
   const worker = await hatchet.worker('no-retry-worker', {
-    workflows: [nonRetryableWorkflow],
+    register: [nonRetryableWorkflow],
   });
 
   await worker.start();

--- a/sdks/typescript/src/v1/examples/on_cron/worker.ts
+++ b/sdks/typescript/src/v1/examples/on_cron/worker.ts
@@ -3,7 +3,7 @@ import { onCron } from './workflow';
 
 async function main() {
   const worker = await hatchet.worker('on-cron-worker', {
-    workflows: [onCron],
+    register: [onCron],
   });
 
   await worker.start();

--- a/sdks/typescript/src/v1/examples/on_event copy/worker.ts
+++ b/sdks/typescript/src/v1/examples/on_event copy/worker.ts
@@ -3,7 +3,7 @@ import { lower, upper } from './workflow';
 
 async function main() {
   const worker = await hatchet.worker('on-event-worker', {
-    workflows: [lower, upper],
+    register: [lower, upper],
   });
 
   await worker.start();

--- a/sdks/typescript/src/v1/examples/on_event/worker.ts
+++ b/sdks/typescript/src/v1/examples/on_event/worker.ts
@@ -3,7 +3,7 @@ import { lower, upper } from './workflow';
 
 async function main() {
   const worker = await hatchet.worker('on-event-worker', {
-    workflows: [lower, upper],
+    register: [lower, upper],
   });
 
   await worker.start();

--- a/sdks/typescript/src/v1/examples/on_failure/worker.ts
+++ b/sdks/typescript/src/v1/examples/on_failure/worker.ts
@@ -3,7 +3,7 @@ import { failureWorkflow } from './workflow';
 
 async function main() {
   const worker = await hatchet.worker('always-fail-worker', {
-    workflows: [failureWorkflow],
+    register: [failureWorkflow],
   });
 
   await worker.start();

--- a/sdks/typescript/src/v1/examples/on_success/worker.ts
+++ b/sdks/typescript/src/v1/examples/on_success/worker.ts
@@ -3,7 +3,7 @@ import { onSuccessDag } from './workflow';
 
 async function main() {
   const worker = await hatchet.worker('always-succeed-worker', {
-    workflows: [onSuccessDag],
+    register: [onSuccessDag],
   });
 
   await worker.start();

--- a/sdks/typescript/src/v1/examples/retries/worker.ts
+++ b/sdks/typescript/src/v1/examples/retries/worker.ts
@@ -3,7 +3,7 @@ import { retries } from './workflow';
 
 async function main() {
   const worker = await hatchet.worker('always-fail-worker', {
-    workflows: [retries],
+    register: [retries],
   });
 
   await worker.start();

--- a/sdks/typescript/src/v1/examples/simple/worker.ts
+++ b/sdks/typescript/src/v1/examples/simple/worker.ts
@@ -6,7 +6,7 @@ import { parent, child } from './workflow-with-child';
 async function main() {
   const worker = await hatchet.worker('simple-worker', {
     // 👀 Declare the workflows that the worker can execute
-    workflows: [simple, parent, child],
+    register: [simple, parent, child],
     // 👀 Declare the number of concurrent task runs the worker can accept
     slots: 100,
   });

--- a/sdks/typescript/src/v1/examples/sticky/worker.ts
+++ b/sdks/typescript/src/v1/examples/sticky/worker.ts
@@ -3,7 +3,7 @@ import { retries } from '../retries/workflow';
 
 async function main() {
   const worker = await hatchet.worker('always-fail-worker', {
-    workflows: [retries],
+    register: [retries],
   });
 
   await worker.start();

--- a/sdks/typescript/src/v1/examples/timeouts/worker.ts
+++ b/sdks/typescript/src/v1/examples/timeouts/worker.ts
@@ -5,7 +5,7 @@ import { cancellation } from './workflow';
 async function main() {
   const worker = await hatchet.worker('cancellation-worker', {
     // 👀 Declare the workflows that the worker can execute
-    workflows: [cancellation],
+    register: [cancellation],
     // 👀 Declare the number of concurrent task runs the worker can accept
     slots: 100,
   });


### PR DESCRIPTION
# Description

The worker create workflow param was confusing for registering both tasks and workflows

Changes to a more generic "register" param.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

