### PR TITLE
feat: add `HATCHET_CLIENT_SERVER_URL` to client config

### DIFF
--- a/pkg/client/loader/loader.go
+++ b/pkg/client/loader/loader.go
@@ -57,11 +57,11 @@ func GetClientConfigFromConfigFile(cf *client.ClientConfigFile) (res *client.Cli
 
 	// if token is empty, throw an error
 	if cf.Token == "" {
-		return nil, fmt.Errorf("API token is required. Set it via the HATCHET_CLIENT_TOKEN environment variable.")
+		return nil, fmt.Errorf("API token is required. Set it via the HATCHET_CLIENT_TOKEN environment variable")
 	}
 
 	grpcBroadcastAddress := cf.HostPort
-	serverURL := cf.HostPort
+	serverURL := cf.ServerURL
 
 	tokenConf, err := getConfFromJWT(cf.Token)
 
@@ -70,14 +70,19 @@ func GetClientConfigFromConfigFile(cf *client.ClientConfigFile) (res *client.Cli
 			grpcBroadcastAddress = tokenConf.grpcBroadcastAddress
 		}
 
-		if tokenConf.serverURL != "" {
+		if serverURL == "" && tokenConf.serverURL != "" {
 			serverURL = tokenConf.serverURL
 		}
 	}
 
 	// if there's no broadcast address at this point, throw an error
 	if grpcBroadcastAddress == "" {
-		return nil, fmt.Errorf("GRPC broadcast address is required. Set it via the HATCHET_CLIENT_HOST_PORT environment variable.")
+		return nil, fmt.Errorf("gRPC broadcast address is required. Set it via the HATCHET_CLIENT_HOST_PORT environment variable")
+	}
+
+	// if there's no server URL at this point, throw an error
+	if serverURL == "" {
+		return nil, fmt.Errorf("server URL is required. Set it via the HATCHET_CLIENT_SERVER_URL environment variable")
 	}
 
 	if cf.TenantId == "" {

--- a/pkg/config/client/client.go
+++ b/pkg/config/client/client.go
@@ -15,13 +15,18 @@ type ClientConfigFile struct {
 
 	HostPort string `mapstructure:"hostPort" json:"hostPort,omitempty"`
 
+	// ServerURL is the URL of the Hatchet API server, not to be confused with HostPort, which is the host and port
+	// corresponding to the gRPC engine service.
+	ServerURL string `mapstructure:"serverURL" json:"serverURL,omitempty"`
+
 	TLS ClientTLSConfigFile `mapstructure:"tls" json:"tls,omitempty"`
 
 	Namespace string `mapstructure:"namespace" json:"namespace,omitempty"`
 
 	NoGrpcRetry bool `mapstructure:"noGrpcRetry" json:"noGrpcRetry,omitempty"`
 
-	CloudRegisterID    *string  `mapstructure:"cloudRegisterID" json:"cloudRegisterID,omitempty"`
+	CloudRegisterID *string `mapstructure:"cloudRegisterID" json:"cloudRegisterID,omitempty"`
+
 	RawRunnableActions []string `mapstructure:"runnableActions" json:"runnableActions,omitempty"`
 
 	AutoscalingTarget string `mapstructure:"autoscalingTarget" json:"autoscalingTarget,omitempty"`
@@ -56,6 +61,7 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("tenantId", "HATCHET_CLIENT_TENANT_ID")
 	_ = v.BindEnv("token", "HATCHET_CLIENT_TOKEN")
 	_ = v.BindEnv("hostPort", "HATCHET_CLIENT_HOST_PORT")
+	_ = v.BindEnv("serverURL", "HATCHET_CLIENT_SERVER_URL")
 	_ = v.BindEnv("namespace", "HATCHET_CLIENT_NAMESPACE")
 
 	_ = v.BindEnv("cloudRegisterID", "HATCHET_CLOUD_REGISTER_ID")

--- a/pkg/v1/client.go
+++ b/pkg/v1/client.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	"github.com/hatchet-dev/hatchet/pkg/client"
 	v0Client "github.com/hatchet-dev/hatchet/pkg/client"
 	"github.com/hatchet-dev/hatchet/pkg/client/create"
 	v0Config "github.com/hatchet-dev/hatchet/pkg/config/client"
@@ -36,7 +35,7 @@ type HatchetClient interface {
 	Workflows() features.WorkflowsClient
 	Crons() features.CronsClient
 	Schedules() features.SchedulesClient
-	Events() client.EventClient
+	Events() v0Client.EventClient
 
 	// TODO Run, RunNoWait, bulk
 }
@@ -94,7 +93,7 @@ func (c *v1HatchetClientImpl) Workflow(opts create.WorkflowCreateOpts[any]) work
 	return workflow.NewWorkflowDeclaration[any, any](opts, c.v0)
 }
 
-func (c *v1HatchetClientImpl) Events() client.EventClient {
+func (c *v1HatchetClientImpl) Events() v0Client.EventClient {
 	return c.V0().Event()
 }
 

--- a/pkg/v1/config.go
+++ b/pkg/v1/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	TenantId           string
 	Token              string
 	HostPort           string
+	ServerURL          string
 	Namespace          string
 	NoGrpcRetry        bool
 	CloudRegisterID    string
@@ -30,6 +31,7 @@ func mapConfigToCF(opts Config) *v0Config.ClientConfigFile {
 	cf.TenantId = opts.TenantId
 	cf.Token = opts.Token
 	cf.HostPort = opts.HostPort
+	cf.ServerURL = opts.ServerURL
 	cf.Namespace = opts.Namespace
 	cf.NoGrpcRetry = opts.NoGrpcRetry
 	cf.CloudRegisterID = &opts.CloudRegisterID


### PR DESCRIPTION
# Description

Adds support for an override env var `HATCHET_CLIENT_SERVER_URL` in the Go SDK. If not set, this will default to the server URL encoded in the JWT token. 

## Type of change

- [X] New feature (non-breaking change which adds functionality)