### PR TITLE
fix: match condition writes and retry counts on failure

### DIFF
--- a/internal/services/admin/v1/server.go
+++ b/internal/services/admin/v1/server.go
@@ -711,6 +711,36 @@ func getCreateTaskOpts(tasks []*contracts.CreateTaskOpts, kind string) ([]v1.Cre
 					})
 				}
 			}
+
+		}
+
+		if stepCp.Concurrency != nil {
+			for _, concurrency := range stepCp.Concurrency {
+				// Skip nil concurrency
+				if concurrency == nil {
+					continue
+				}
+
+				if concurrency.Expression == "" {
+					return nil, status.Error(
+						codes.InvalidArgument,
+						fmt.Sprintf("CEL expression is required for concurrency (step %s)", stepCp.ReadableId),
+					)
+				}
+
+				var limitStrategy *string
+
+				if concurrency.LimitStrategy != nil && concurrency.LimitStrategy.String() != "" {
+					s := concurrency.LimitStrategy.String()
+					limitStrategy = &s
+				}
+
+				steps[j].Concurrency = append(steps[j].Concurrency, v1.CreateConcurrencyOpts{
+					Expression:    concurrency.Expression,
+					MaxRuns:       concurrency.MaxRuns,
+					LimitStrategy: limitStrategy,
+				})
+			}
 		}
 	}
 

--- a/nodemon.api.json
+++ b/nodemon.api.json
@@ -1,13 +1,6 @@
 {
-    "restartable": "rs",
-    "verbose": true,
-    "ext": "go,mod,sum",
-    "watch": [
-        "cmd/hatchet-api",
-        "api",
-        "internal",
-        "go.mod",
-        "go.sum"
-    ]
-
+  "restartable": "rs",
+  "verbose": true,
+  "ext": "go,mod,sum",
+  "watch": ["cmd/hatchet-api", "api", "internal", "pkg", "go.mod", "go.sum"]
 }

--- a/nodemon.engine.json
+++ b/nodemon.engine.json
@@ -1,11 +1,6 @@
 {
-    "restartable": "rs",
-    "verbose": true,
-    "ext": "go,mod,sum",
-    "watch": [
-        "cmd/hatchet-engine",
-        "internal",
-        "go.mod",
-        "go.sum"
-    ]
+  "restartable": "rs",
+  "verbose": true,
+  "ext": "go,mod,sum",
+  "watch": ["cmd/hatchet-engine", "internal", "pkg", "go.mod", "go.sum"]
 }


### PR DESCRIPTION
# Description

Fixes an issue related to replaying a workflow which has the following conditions:
- Multi-step DAG
- Workflow has CEL-based concurrency expression
- Parent step in the DAG failed and the child was cancelled
- The workflow is a child workflow
- Replaying the parent step in the DAG which failed would cause an `input is nil` error while parsing the CEL expression

This was due to an ordering issue when inserting matches into the database which unintentionally scrambled the `SIGNAL` conditions with the `TRIGGER` conditions (this is why the workflow needed to be both a child workflow and a DAG). 

Also improves handling of the failure events: the previous logic would ignore `v1_task_runtimes` which weren't associated with the most recent retry count on the task, which could cause the `v1_task_runtime` to never get removed from the DB in rare cases. This moves the check on retry count to the query which determines whether the failure event should trigger a retry, which ensures that we call `releaseTasks` on the runtimes which are still in the DB but shouldn't be. 

There are some additional OLAP improvements to make here (most importantly, not sending reassigned/timed out events which corresponded to a no-op in the database).  

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)