### PR TITLE
feat: multiple non-workflow level concurrency slots

### DIFF
--- a/pkg/repository/v1/sqlcv1/concurrency.sql
+++ b/pkg/repository/v1/sqlcv1/concurrency.sql
@@ -191,7 +191,7 @@ WITH eligible_slots_per_group AS (
             AND wcs_all.strategy_id = @strategyId::bigint
         ORDER BY wcs_all.sort_id ASC
         LIMIT @maxRuns::int
-    ) wsc ON true
+    ) cs ON true
 ), schedule_timeout_slots AS (
     SELECT
         *
@@ -255,13 +255,27 @@ WITH eligible_slots_per_group AS (
         )
 )
 SELECT
-    *,
+    task_id,
+    task_inserted_at,
+    task_retry_count,
+    tenant_id,
+    next_strategy_ids,
+    external_id,
+    workflow_run_id,
+    queue_to_notify,
     'SCHEDULING_TIMED_OUT' AS "operation"
 FROM
     schedule_timeout_slots
 UNION ALL
 SELECT
-    *,
+    task_id,
+    task_inserted_at,
+    task_retry_count,
+    tenant_id,
+    next_strategy_ids,
+    external_id,
+    workflow_run_id,
+    queue_to_notify,
     'RUNNING' AS "operation"
 FROM
     updated_slots;
@@ -684,13 +698,27 @@ WITH slots AS (
         )
 )
 SELECT
-    *,
+    task_id,
+    task_inserted_at,
+    task_retry_count,
+    tenant_id,
+    next_strategy_ids,
+    external_id,
+    workflow_run_id,
+    queue_to_notify,
     'SCHEDULING_TIMED_OUT' AS "operation"
 FROM
     schedule_timeout_slots
 UNION ALL
 SELECT
-    *,
+    task_id,
+    task_inserted_at,
+    task_retry_count,
+    tenant_id,
+    next_strategy_ids,
+    external_id,
+    workflow_run_id,
+    queue_to_notify,
     'CANCELLED' AS "operation"
 FROM
     slots_to_cancel
@@ -706,7 +734,14 @@ WHERE
     )
 UNION ALL
 SELECT
-    *,
+    task_id,
+    task_inserted_at,
+    task_retry_count,
+    tenant_id,
+    next_strategy_ids,
+    external_id,
+    workflow_run_id,
+    queue_to_notify,
     'RUNNING' AS "operation"
 FROM
     updated_slots;
@@ -1038,13 +1073,27 @@ WITH slots AS (
         )
 )
 SELECT
-    *,
+    task_id,
+    task_inserted_at,
+    task_retry_count,
+    tenant_id,
+    next_strategy_ids,
+    external_id,
+    workflow_run_id,
+    queue_to_notify,
     'SCHEDULING_TIMED_OUT' AS "operation"
 FROM
     schedule_timeout_slots
 UNION ALL
 SELECT
-    *,
+    task_id,
+    task_inserted_at,
+    task_retry_count,
+    tenant_id,
+    next_strategy_ids,
+    external_id,
+    workflow_run_id,
+    queue_to_notify,
     'CANCELLED' AS "operation"
 FROM
     slots_to_cancel
@@ -1060,7 +1109,14 @@ WHERE
     )
 UNION ALL
 SELECT
-    *,
+    task_id,
+    task_inserted_at,
+    task_retry_count,
+    tenant_id,
+    next_strategy_ids,
+    external_id,
+    workflow_run_id,
+    queue_to_notify,
     'RUNNING' AS "operation"
 FROM
     updated_slots;

--- a/pkg/repository/v1/sqlcv1/concurrency.sql.go
+++ b/pkg/repository/v1/sqlcv1/concurrency.sql.go
@@ -358,13 +358,27 @@ WITH slots AS (
         )
 )
 SELECT
-    sort_id, task_id, task_inserted_at, task_retry_count, external_id, tenant_id, workflow_id, workflow_version_id, workflow_run_id, strategy_id, parent_strategy_id, priority, key, is_filled, next_parent_strategy_ids, next_strategy_ids, next_keys, queue_to_notify, schedule_timeout_at,
+    task_id,
+    task_inserted_at,
+    task_retry_count,
+    tenant_id,
+    next_strategy_ids,
+    external_id,
+    workflow_run_id,
+    queue_to_notify,
     'SCHEDULING_TIMED_OUT' AS "operation"
 FROM
     schedule_timeout_slots
 UNION ALL
 SELECT
-    sort_id, task_id, task_inserted_at, task_retry_count, external_id, tenant_id, workflow_id, workflow_version_id, workflow_run_id, strategy_id, parent_strategy_id, priority, key, is_filled, next_parent_strategy_ids, next_strategy_ids, next_keys, queue_to_notify, schedule_timeout_at,
+    task_id,
+    task_inserted_at,
+    task_retry_count,
+    tenant_id,
+    next_strategy_ids,
+    external_id,
+    workflow_run_id,
+    queue_to_notify,
     'CANCELLED' AS "operation"
 FROM
     slots_to_cancel
@@ -380,7 +394,14 @@ WHERE
     )
 UNION ALL
 SELECT
-    sort_id, task_id, task_inserted_at, task_retry_count, external_id, tenant_id, workflow_id, workflow_version_id, workflow_run_id, strategy_id, parent_strategy_id, priority, key, is_filled, next_parent_strategy_ids, next_strategy_ids, next_keys, queue_to_notify, schedule_timeout_at,
+    task_id,
+    task_inserted_at,
+    task_retry_count,
+    tenant_id,
+    next_strategy_ids,
+    external_id,
+    workflow_run_id,
+    queue_to_notify,
     'RUNNING' AS "operation"
 FROM
     updated_slots
@@ -393,26 +414,15 @@ type RunCancelInProgressParams struct {
 }
 
 type RunCancelInProgressRow struct {
-	SortID                pgtype.Int8        `json:"sort_id"`
-	TaskID                int64              `json:"task_id"`
-	TaskInsertedAt        pgtype.Timestamptz `json:"task_inserted_at"`
-	TaskRetryCount        int32              `json:"task_retry_count"`
-	ExternalID            pgtype.UUID        `json:"external_id"`
-	TenantID              pgtype.UUID        `json:"tenant_id"`
-	WorkflowID            pgtype.UUID        `json:"workflow_id"`
-	WorkflowVersionID     pgtype.UUID        `json:"workflow_version_id"`
-	WorkflowRunID         pgtype.UUID        `json:"workflow_run_id"`
-	StrategyID            int64              `json:"strategy_id"`
-	ParentStrategyID      pgtype.Int8        `json:"parent_strategy_id"`
-	Priority              int32              `json:"priority"`
-	Key                   string             `json:"key"`
-	IsFilled              bool               `json:"is_filled"`
-	NextParentStrategyIds []int64            `json:"next_parent_strategy_ids"`
-	NextStrategyIds       []int64            `json:"next_strategy_ids"`
-	NextKeys              []string           `json:"next_keys"`
-	QueueToNotify         string             `json:"queue_to_notify"`
-	ScheduleTimeoutAt     pgtype.Timestamp   `json:"schedule_timeout_at"`
-	Operation             string             `json:"operation"`
+	TaskID          int64              `json:"task_id"`
+	TaskInsertedAt  pgtype.Timestamptz `json:"task_inserted_at"`
+	TaskRetryCount  int32              `json:"task_retry_count"`
+	TenantID        pgtype.UUID        `json:"tenant_id"`
+	NextStrategyIds []int64            `json:"next_strategy_ids"`
+	ExternalID      pgtype.UUID        `json:"external_id"`
+	WorkflowRunID   pgtype.UUID        `json:"workflow_run_id"`
+	QueueToNotify   string             `json:"queue_to_notify"`
+	Operation       string             `json:"operation"`
 }
 
 func (q *Queries) RunCancelInProgress(ctx context.Context, db DBTX, arg RunCancelInProgressParams) ([]*RunCancelInProgressRow, error) {
@@ -425,25 +435,14 @@ func (q *Queries) RunCancelInProgress(ctx context.Context, db DBTX, arg RunCance
 	for rows.Next() {
 		var i RunCancelInProgressRow
 		if err := rows.Scan(
-			&i.SortID,
 			&i.TaskID,
 			&i.TaskInsertedAt,
 			&i.TaskRetryCount,
-			&i.ExternalID,
 			&i.TenantID,
-			&i.WorkflowID,
-			&i.WorkflowVersionID,
-			&i.WorkflowRunID,
-			&i.StrategyID,
-			&i.ParentStrategyID,
-			&i.Priority,
-			&i.Key,
-			&i.IsFilled,
-			&i.NextParentStrategyIds,
 			&i.NextStrategyIds,
-			&i.NextKeys,
+			&i.ExternalID,
+			&i.WorkflowRunID,
 			&i.QueueToNotify,
-			&i.ScheduleTimeoutAt,
 			&i.Operation,
 		); err != nil {
 			return nil, err
@@ -572,13 +571,27 @@ WITH slots AS (
         )
 )
 SELECT
-    sort_id, task_id, task_inserted_at, task_retry_count, external_id, tenant_id, workflow_id, workflow_version_id, workflow_run_id, strategy_id, parent_strategy_id, priority, key, is_filled, next_parent_strategy_ids, next_strategy_ids, next_keys, queue_to_notify, schedule_timeout_at,
+    task_id,
+    task_inserted_at,
+    task_retry_count,
+    tenant_id,
+    next_strategy_ids,
+    external_id,
+    workflow_run_id,
+    queue_to_notify,
     'SCHEDULING_TIMED_OUT' AS "operation"
 FROM
     schedule_timeout_slots
 UNION ALL
 SELECT
-    sort_id, task_id, task_inserted_at, task_retry_count, external_id, tenant_id, workflow_id, workflow_version_id, workflow_run_id, strategy_id, parent_strategy_id, priority, key, is_filled, next_parent_strategy_ids, next_strategy_ids, next_keys, queue_to_notify, schedule_timeout_at,
+    task_id,
+    task_inserted_at,
+    task_retry_count,
+    tenant_id,
+    next_strategy_ids,
+    external_id,
+    workflow_run_id,
+    queue_to_notify,
     'CANCELLED' AS "operation"
 FROM
     slots_to_cancel
@@ -594,7 +607,14 @@ WHERE
     )
 UNION ALL
 SELECT
-    sort_id, task_id, task_inserted_at, task_retry_count, external_id, tenant_id, workflow_id, workflow_version_id, workflow_run_id, strategy_id, parent_strategy_id, priority, key, is_filled, next_parent_strategy_ids, next_strategy_ids, next_keys, queue_to_notify, schedule_timeout_at,
+    task_id,
+    task_inserted_at,
+    task_retry_count,
+    tenant_id,
+    next_strategy_ids,
+    external_id,
+    workflow_run_id,
+    queue_to_notify,
     'RUNNING' AS "operation"
 FROM
     updated_slots
@@ -607,26 +627,15 @@ type RunCancelNewestParams struct {
 }
 
 type RunCancelNewestRow struct {
-	SortID                pgtype.Int8        `json:"sort_id"`
-	TaskID                int64              `json:"task_id"`
-	TaskInsertedAt        pgtype.Timestamptz `json:"task_inserted_at"`
-	TaskRetryCount        int32              `json:"task_retry_count"`
-	ExternalID            pgtype.UUID        `json:"external_id"`
-	TenantID              pgtype.UUID        `json:"tenant_id"`
-	WorkflowID            pgtype.UUID        `json:"workflow_id"`
-	WorkflowVersionID     pgtype.UUID        `json:"workflow_version_id"`
-	WorkflowRunID         pgtype.UUID        `json:"workflow_run_id"`
-	StrategyID            int64              `json:"strategy_id"`
-	ParentStrategyID      pgtype.Int8        `json:"parent_strategy_id"`
-	Priority              int32              `json:"priority"`
-	Key                   string             `json:"key"`
-	IsFilled              bool               `json:"is_filled"`
-	NextParentStrategyIds []int64            `json:"next_parent_strategy_ids"`
-	NextStrategyIds       []int64            `json:"next_strategy_ids"`
-	NextKeys              []string           `json:"next_keys"`
-	QueueToNotify         string             `json:"queue_to_notify"`
-	ScheduleTimeoutAt     pgtype.Timestamp   `json:"schedule_timeout_at"`
-	Operation             string             `json:"operation"`
+	TaskID          int64              `json:"task_id"`
+	TaskInsertedAt  pgtype.Timestamptz `json:"task_inserted_at"`
+	TaskRetryCount  int32              `json:"task_retry_count"`
+	TenantID        pgtype.UUID        `json:"tenant_id"`
+	NextStrategyIds []int64            `json:"next_strategy_ids"`
+	ExternalID      pgtype.UUID        `json:"external_id"`
+	WorkflowRunID   pgtype.UUID        `json:"workflow_run_id"`
+	QueueToNotify   string             `json:"queue_to_notify"`
+	Operation       string             `json:"operation"`
 }
 
 func (q *Queries) RunCancelNewest(ctx context.Context, db DBTX, arg RunCancelNewestParams) ([]*RunCancelNewestRow, error) {
@@ -639,25 +648,14 @@ func (q *Queries) RunCancelNewest(ctx context.Context, db DBTX, arg RunCancelNew
 	for rows.Next() {
 		var i RunCancelNewestRow
 		if err := rows.Scan(
-			&i.SortID,
 			&i.TaskID,
 			&i.TaskInsertedAt,
 			&i.TaskRetryCount,
-			&i.ExternalID,
 			&i.TenantID,
-			&i.WorkflowID,
-			&i.WorkflowVersionID,
-			&i.WorkflowRunID,
-			&i.StrategyID,
-			&i.ParentStrategyID,
-			&i.Priority,
-			&i.Key,
-			&i.IsFilled,
-			&i.NextParentStrategyIds,
 			&i.NextStrategyIds,
-			&i.NextKeys,
+			&i.ExternalID,
+			&i.WorkflowRunID,
 			&i.QueueToNotify,
-			&i.ScheduleTimeoutAt,
 			&i.Operation,
 		); err != nil {
 			return nil, err
@@ -1278,7 +1276,7 @@ func (q *Queries) RunChildGroupRoundRobin(ctx context.Context, db DBTX, arg RunC
 
 const runGroupRoundRobin = `-- name: RunGroupRoundRobin :many
 WITH eligible_slots_per_group AS (
-    SELECT
+    SELECT cs.sort_id, cs.task_id, cs.task_inserted_at, cs.task_retry_count, cs.external_id, cs.tenant_id, cs.workflow_id, cs.workflow_version_id, cs.workflow_run_id, cs.strategy_id, cs.parent_strategy_id, cs.priority, cs.key, cs.is_filled, cs.next_parent_strategy_ids, cs.next_strategy_ids, cs.next_keys, cs.queue_to_notify, cs.schedule_timeout_at
     FROM (
         SELECT DISTINCT key
         FROM v1_concurrency_slot
@@ -1295,7 +1293,7 @@ WITH eligible_slots_per_group AS (
             AND wcs_all.strategy_id = $2::bigint
         ORDER BY wcs_all.sort_id ASC
         LIMIT $3::int
-    ) wsc ON true
+    ) cs ON true
 ), schedule_timeout_slots AS (
     SELECT
         sort_id, task_id, task_inserted_at, task_retry_count, external_id, tenant_id, workflow_id, workflow_version_id, workflow_run_id, strategy_id, parent_strategy_id, priority, key, is_filled, next_parent_strategy_ids, next_strategy_ids, next_keys, queue_to_notify, schedule_timeout_at
@@ -1359,13 +1357,27 @@ WITH eligible_slots_per_group AS (
         )
 )
 SELECT
-    sort_id, task_id, task_inserted_at, task_retry_count, external_id, tenant_id, workflow_id, workflow_version_id, workflow_run_id, strategy_id, parent_strategy_id, priority, key, is_filled, next_parent_strategy_ids, next_strategy_ids, next_keys, queue_to_notify, schedule_timeout_at,
+    task_id,
+    task_inserted_at,
+    task_retry_count,
+    tenant_id,
+    next_strategy_ids,
+    external_id,
+    workflow_run_id,
+    queue_to_notify,
     'SCHEDULING_TIMED_OUT' AS "operation"
 FROM
     schedule_timeout_slots
 UNION ALL
 SELECT
-    sort_id, task_id, task_inserted_at, task_retry_count, external_id, tenant_id, workflow_id, workflow_version_id, workflow_run_id, strategy_id, parent_strategy_id, priority, key, is_filled, next_parent_strategy_ids, next_strategy_ids, next_keys, queue_to_notify, schedule_timeout_at,
+    task_id,
+    task_inserted_at,
+    task_retry_count,
+    tenant_id,
+    next_strategy_ids,
+    external_id,
+    workflow_run_id,
+    queue_to_notify,
     'RUNNING' AS "operation"
 FROM
     updated_slots
@@ -1378,26 +1390,15 @@ type RunGroupRoundRobinParams struct {
 }
 
 type RunGroupRoundRobinRow struct {
-	SortID                pgtype.Int8        `json:"sort_id"`
-	TaskID                int64              `json:"task_id"`
-	TaskInsertedAt        pgtype.Timestamptz `json:"task_inserted_at"`
-	TaskRetryCount        int32              `json:"task_retry_count"`
-	ExternalID            pgtype.UUID        `json:"external_id"`
-	TenantID              pgtype.UUID        `json:"tenant_id"`
-	WorkflowID            pgtype.UUID        `json:"workflow_id"`
-	WorkflowVersionID     pgtype.UUID        `json:"workflow_version_id"`
-	WorkflowRunID         pgtype.UUID        `json:"workflow_run_id"`
-	StrategyID            int64              `json:"strategy_id"`
-	ParentStrategyID      pgtype.Int8        `json:"parent_strategy_id"`
-	Priority              int32              `json:"priority"`
-	Key                   string             `json:"key"`
-	IsFilled              bool               `json:"is_filled"`
-	NextParentStrategyIds []int64            `json:"next_parent_strategy_ids"`
-	NextStrategyIds       []int64            `json:"next_strategy_ids"`
-	NextKeys              []string           `json:"next_keys"`
-	QueueToNotify         string             `json:"queue_to_notify"`
-	ScheduleTimeoutAt     pgtype.Timestamp   `json:"schedule_timeout_at"`
-	Operation             string             `json:"operation"`
+	TaskID          int64              `json:"task_id"`
+	TaskInsertedAt  pgtype.Timestamptz `json:"task_inserted_at"`
+	TaskRetryCount  int32              `json:"task_retry_count"`
+	TenantID        pgtype.UUID        `json:"tenant_id"`
+	NextStrategyIds []int64            `json:"next_strategy_ids"`
+	ExternalID      pgtype.UUID        `json:"external_id"`
+	WorkflowRunID   pgtype.UUID        `json:"workflow_run_id"`
+	QueueToNotify   string             `json:"queue_to_notify"`
+	Operation       string             `json:"operation"`
 }
 
 // Used for round-robin scheduling when a strategy doesn't have a parent strategy
@@ -1411,25 +1412,14 @@ func (q *Queries) RunGroupRoundRobin(ctx context.Context, db DBTX, arg RunGroupR
 	for rows.Next() {
 		var i RunGroupRoundRobinRow
 		if err := rows.Scan(
-			&i.SortID,
 			&i.TaskID,
 			&i.TaskInsertedAt,
 			&i.TaskRetryCount,
-			&i.ExternalID,
 			&i.TenantID,
-			&i.WorkflowID,
-			&i.WorkflowVersionID,
-			&i.WorkflowRunID,
-			&i.StrategyID,
-			&i.ParentStrategyID,
-			&i.Priority,
-			&i.Key,
-			&i.IsFilled,
-			&i.NextParentStrategyIds,
 			&i.NextStrategyIds,
-			&i.NextKeys,
+			&i.ExternalID,
+			&i.WorkflowRunID,
 			&i.QueueToNotify,
-			&i.ScheduleTimeoutAt,
 			&i.Operation,
 		); err != nil {
 			return nil, err

--- a/pkg/repository/v1/sqlcv1/workflows.sql
+++ b/pkg/repository/v1/sqlcv1/workflows.sql
@@ -447,7 +447,7 @@ VALUES (
     @workflowId::uuid,
     @workflowVersionId::uuid,
     @stepId::uuid,
-    @strategy::text,
+    @strategy::v1_concurrency_strategy,
     @expression::text,
     @tenantId::uuid,
     @maxConcurrency::integer

--- a/pkg/repository/v1/sqlcv1/workflows.sql.go
+++ b/pkg/repository/v1/sqlcv1/workflows.sql.go
@@ -202,7 +202,7 @@ VALUES (
     $1::uuid,
     $2::uuid,
     $3::uuid,
-    $4::text,
+    $4::v1_concurrency_strategy,
     $5::text,
     $6::uuid,
     $7::integer
@@ -210,13 +210,13 @@ VALUES (
 `
 
 type CreateStepConcurrencyParams struct {
-	Workflowid        pgtype.UUID `json:"workflowid"`
-	Workflowversionid pgtype.UUID `json:"workflowversionid"`
-	Stepid            pgtype.UUID `json:"stepid"`
-	Strategy          string      `json:"strategy"`
-	Expression        string      `json:"expression"`
-	Tenantid          pgtype.UUID `json:"tenantid"`
-	Maxconcurrency    int32       `json:"maxconcurrency"`
+	Workflowid        pgtype.UUID           `json:"workflowid"`
+	Workflowversionid pgtype.UUID           `json:"workflowversionid"`
+	Stepid            pgtype.UUID           `json:"stepid"`
+	Strategy          V1ConcurrencyStrategy `json:"strategy"`
+	Expression        string                `json:"expression"`
+	Tenantid          pgtype.UUID           `json:"tenantid"`
+	Maxconcurrency    int32                 `json:"maxconcurrency"`
 }
 
 func (q *Queries) CreateStepConcurrency(ctx context.Context, db DBTX, arg CreateStepConcurrencyParams) (*V1StepConcurrency, error) {

--- a/pkg/repository/v1/workflow.go
+++ b/pkg/repository/v1/workflow.go
@@ -784,7 +784,7 @@ func (r *workflowRepository) createJobTx(ctx context.Context, tx sqlcv1.DBTX, te
 						Tenantid:          tenantId,
 						Expression:        concurrency.Expression,
 						Maxconcurrency:    maxRuns,
-						Strategy:          string(strategy),
+						Strategy:          sqlcv1.V1ConcurrencyStrategy(strategy),
 					},
 				)
 

--- a/sdks/python/examples/concurrency_multiple_keys/test_multiple_concurrency_keys.py
+++ b/sdks/python/examples/concurrency_multiple_keys/test_multiple_concurrency_keys.py
@@ -112,7 +112,9 @@ async def test_priority(hatchet: Hatchet) -> None:
     }
 
     """The second Anna run should start after the first Anna run finishes"""
-    assert AdditionalMetadata.model_validate(last_run.additional_metadata).name == "Anna"
+    assert (
+        AdditionalMetadata.model_validate(last_run.additional_metadata).name == "Anna"
+    )
     assert (last_run.started_at or datetime.min) > (
         first_anna_run.finished_at or datetime.max
     )

--- a/sdks/python/examples/concurrency_multiple_keys/test_multiple_concurrency_keys.py
+++ b/sdks/python/examples/concurrency_multiple_keys/test_multiple_concurrency_keys.py
@@ -1,0 +1,121 @@
+import asyncio
+from datetime import datetime, timedelta
+from typing import Literal
+from uuid import uuid4
+
+import pytest
+from pydantic import BaseModel
+
+from examples.concurrency_multiple_keys.worker import (
+    SLEEP_TIME,
+    WorkflowInput,
+    concurrency_multiple_keys_workflow,
+)
+from hatchet_sdk import Hatchet, TriggerWorkflowOptions
+
+Character = Literal["Anna", "Vronsky", "Stiva", "Dolly", "Levin", "Karenin"]
+characters: list[Character] = [
+    "Anna",
+    "Vronsky",
+    "Stiva",
+    "Dolly",
+    "Levin",
+    "Karenin",
+]
+
+
+class AdditionalMetadata(BaseModel):
+    test_run_id: str
+    key: str
+    name: Character
+    digit: str
+
+
+@pytest.mark.asyncio()
+async def test_priority(hatchet: Hatchet) -> None:
+    test_run_id = str(uuid4())
+    tasks: list[tuple[Character, str]] = [
+        ("Anna", "1"),
+        ("Anna", "2"),
+        ("Vronsky", "1"),
+        ("Stiva", "1"),
+    ]
+
+    run_refs = await concurrency_multiple_keys_workflow.aio_run_many_no_wait(
+        [
+            concurrency_multiple_keys_workflow.create_bulk_run_item(
+                WorkflowInput(
+                    name=name,
+                    digit=digit,
+                ),
+                options=TriggerWorkflowOptions(
+                    additional_metadata={
+                        "test_run_id": test_run_id,
+                        "key": f"{name}-{digit}",
+                        "name": name,
+                        "digit": digit,
+                    },
+                ),
+            )
+            for name, digit in tasks
+        ]
+    )
+
+    await asyncio.gather(*[r.aio_result() for r in run_refs])
+
+    workflows = (
+        await hatchet.workflows.aio_list(
+            workflow_name=concurrency_multiple_keys_workflow.name
+        )
+    ).rows
+
+    assert workflows
+
+    workflow = next(
+        (w for w in workflows if w.name == concurrency_multiple_keys_workflow.name),
+        None,
+    )
+
+    assert workflow
+
+    assert workflow.name == concurrency_multiple_keys_workflow.name
+
+    runs = await hatchet.runs.aio_list(
+        workflow_ids=[workflow.metadata.id],
+        additional_metadata={
+            "test_run_id": test_run_id,
+        },
+    )
+
+    sorted_runs = sorted(runs.rows, key=lambda r: r.started_at or datetime.min)
+
+    first_task_started_at = sorted_runs[0].started_at or datetime.max
+    first_three_runs = sorted_runs[:3]
+
+    last_run = sorted_runs[-1]
+    first_anna_run = next(
+        (
+            r
+            for r in first_three_runs
+            if AdditionalMetadata.model_validate(r.additional_metadata).name == "Anna"
+        ),
+    )
+
+    """The two Anna runs should not be able to run concurrently, but everything else can"""
+    assert {
+        AdditionalMetadata.model_validate(r.additional_metadata).name
+        for r in first_three_runs
+    } == {
+        "Anna",
+        "Vronsky",
+        "Stiva",
+    }
+
+    """The second Anna run should start after the first Anna run finishes"""
+    assert AdditionalMetadata.model_validate(last_run.additional_metadata).name == "Anna"
+    assert (last_run.started_at or datetime.min) > (
+        first_anna_run.finished_at or datetime.max
+    )
+    assert (last_run.started_at or datetime.min) > first_task_started_at + timedelta(
+        seconds=SLEEP_TIME
+    )

--- a/sdks/python/examples/concurrency_multiple_keys/test_multiple_concurrency_keys.py
+++ b/sdks/python/examples/concurrency_multiple_keys/test_multiple_concurrency_keys.py
@@ -62,7 +62,6 @@ async def test_priority(hatchet: Hatchet) -> None:
     )
 
     await asyncio.gather(*[r.aio_result() for r in run_refs])
-    await asyncio.sleep(3)
 
     workflows = (
         await hatchet.workflows.aio_list(

--- a/sdks/python/examples/concurrency_multiple_keys/test_multiple_concurrency_keys.py
+++ b/sdks/python/examples/concurrency_multiple_keys/test_multiple_concurrency_keys.py
@@ -62,6 +62,7 @@ async def test_priority(hatchet: Hatchet) -> None:
     )
 
     await asyncio.gather(*[r.aio_result() for r in run_refs])
+    await asyncio.sleep(3)
 
     workflows = (
         await hatchet.workflows.aio_list(

--- a/sdks/python/examples/concurrency_multiple_keys/worker.py
+++ b/sdks/python/examples/concurrency_multiple_keys/worker.py
@@ -1,0 +1,59 @@
+import asyncio
+
+from pydantic import BaseModel
+
+from hatchet_sdk import (
+    ConcurrencyExpression,
+    ConcurrencyLimitStrategy,
+    Context,
+    Hatchet,
+)
+
+hatchet = Hatchet(debug=True)
+
+SLEEP_TIME = 3
+
+
+# ❓ Concurrency Strategy With Key
+class WorkflowInput(BaseModel):
+    name: str
+    digit: str
+
+
+concurrency_multiple_keys_workflow = hatchet.workflow(
+    name="ConcurrencyWorkflowManyKeys",
+    input_validator=WorkflowInput,
+)
+# ‼️
+
+
+@concurrency_multiple_keys_workflow.task(
+    concurrency=[
+        ConcurrencyExpression(
+            expression="input.digit",
+            max_runs=3,
+            limit_strategy=ConcurrencyLimitStrategy.GROUP_ROUND_ROBIN,
+        ),
+        ConcurrencyExpression(
+            expression="input.name",
+            max_runs=1,
+            limit_strategy=ConcurrencyLimitStrategy.GROUP_ROUND_ROBIN,
+        ),
+    ]
+)
+async def concurrency_task(input: WorkflowInput, ctx: Context) -> None:
+    await asyncio.sleep(SLEEP_TIME)
+
+
+def main() -> None:
+    worker = hatchet.worker(
+        "concurrency-worker-multiple-keys",
+        slots=10,
+        workflows=[concurrency_multiple_keys_workflow],
+    )
+
+    worker.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/sdks/python/examples/concurrency_multiple_keys/worker.py
+++ b/sdks/python/examples/concurrency_multiple_keys/worker.py
@@ -11,7 +11,9 @@ from hatchet_sdk import (
 
 hatchet = Hatchet(debug=True)
 
-SLEEP_TIME = 3
+SLEEP_TIME = 2
+DIGIT_MAX_RUNS = 8
+NAME_MAX_RUNS = 3
 
 
 # ❓ Concurrency Strategy With Key
@@ -31,12 +33,12 @@ concurrency_multiple_keys_workflow = hatchet.workflow(
     concurrency=[
         ConcurrencyExpression(
             expression="input.digit",
-            max_runs=3,
+            max_runs=DIGIT_MAX_RUNS,
             limit_strategy=ConcurrencyLimitStrategy.GROUP_ROUND_ROBIN,
         ),
         ConcurrencyExpression(
             expression="input.name",
-            max_runs=1,
+            max_runs=NAME_MAX_RUNS,
             limit_strategy=ConcurrencyLimitStrategy.GROUP_ROUND_ROBIN,
         ),
     ]

--- a/sdks/python/examples/worker.py
+++ b/sdks/python/examples/worker.py
@@ -3,6 +3,7 @@ from examples.bulk_fanout.worker import bulk_child_wf, bulk_parent_wf
 from examples.cancellation.worker import cancellation_workflow
 from examples.concurrency_limit.worker import concurrency_limit_workflow
 from examples.concurrency_limit_rr.worker import concurrency_limit_rr_workflow
+from examples.concurrency_multiple_keys.worker import concurrency_multiple_keys_workflow
 from examples.dag.worker import dag_workflow
 from examples.dedupe.worker import dedupe_child_wf, dedupe_parent_wf
 from examples.durable.worker import durable_workflow
@@ -28,6 +29,7 @@ def main() -> None:
             bulk_parent_wf,
             concurrency_limit_workflow,
             concurrency_limit_rr_workflow,
+            concurrency_multiple_keys_workflow,
             dag_workflow,
             dedupe_child_wf,
             dedupe_parent_wf,

--- a/sdks/python/hatchet_sdk/features/runs.py
+++ b/sdks/python/hatchet_sdk/features/runs.py
@@ -21,6 +21,7 @@ from hatchet_sdk.clients.v1.api_client import (
 )
 from hatchet_sdk.utils.aio import run_async_from_sync
 from hatchet_sdk.utils.typing import JSONSerializableMapping
+from hatchet_sdk.workflow_run import WorkflowRunRef
 
 
 class RunFilter(BaseModel):
@@ -220,3 +221,9 @@ class RunsClient(BaseRestClient):
         details = self.get(run_id)
 
         return details.run.output
+
+    def get_run_ref(self, workflow_run_id: str) -> WorkflowRunRef:
+        return WorkflowRunRef(
+            workflow_run_id=workflow_run_id,
+            config=self.client_config,
+        )

--- a/sdks/python/hatchet_sdk/runnables/standalone.py
+++ b/sdks/python/hatchet_sdk/runnables/standalone.py
@@ -25,6 +25,11 @@ class TaskRunRef(Generic[TWorkflowInput, R]):
         self._s = standalone
         self._wrr = workflow_run_ref
 
+        self.workflow_run_id = workflow_run_ref.workflow_run_id
+
+    def __str__(self) -> str:
+        return self.workflow_run_id
+
     async def aio_result(self) -> R:
         result = await self._wrr.workflow_listener.aio_result(self._wrr.workflow_run_id)
         return self._s._extract_result(result)

--- a/sdks/python/hatchet_sdk/runnables/workflow.py
+++ b/sdks/python/hatchet_sdk/runnables/workflow.py
@@ -274,7 +274,7 @@ class BaseWorkflow(Generic[TWorkflowInput]):
 
     @property
     def name(self) -> str:
-        return self.config.name
+        return self._get_name(self.client.config.namespace)
 
     def create_bulk_run_item(
         self,

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.2.4"
+version = "1.2.5"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
# Description

Fixes an scanning issue on DB rows for task-level concurrency slots. I've tested `CANCEL_NEWEST`, `CANCEL_IN_PROGRESS`, and `GROUP_ROUND_ROBIN` for multiple concurrency keys on the task level. Can use this branch for e2e tests.
 
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)