### PR TITLE
Fix: Add `get_run_ref` to `runs` client

### DIFF
--- a/sdks/python/hatchet_sdk/features/runs.py
+++ b/sdks/python/hatchet_sdk/features/runs.py
@@ -21,6 +21,7 @@ from hatchet_sdk.clients.v1.api_client import (
 )
 from hatchet_sdk.utils.aio import run_async_from_sync
 from hatchet_sdk.utils.typing import JSONSerializableMapping
+from hatchet_sdk.workflow_run import WorkflowRunRef
 
 
 class RunFilter(BaseModel):
@@ -220,3 +221,9 @@ class RunsClient(BaseRestClient):
         details = self.get(run_id)
 
         return details.run.output
+
+    def get_run_ref(self, workflow_run_id: str) -> WorkflowRunRef:
+        return WorkflowRunRef(
+            workflow_run_id=workflow_run_id,
+            config=self.client_config,
+        )

--- a/sdks/python/hatchet_sdk/runnables/standalone.py
+++ b/sdks/python/hatchet_sdk/runnables/standalone.py
@@ -25,6 +25,11 @@ class TaskRunRef(Generic[TWorkflowInput, R]):
         self._s = standalone
         self._wrr = workflow_run_ref
 
+        self.workflow_run_id = workflow_run_ref.workflow_run_id
+
+    def __str__(self) -> str:
+        return self.workflow_run_id
+
     async def aio_result(self) -> R:
         result = await self._wrr.workflow_listener.aio_result(self._wrr.workflow_run_id)
         return self._s._extract_result(result)

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.2.4"
+version = "1.2.5"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
Adding `get_run_ref` to make it easier to reconstruct a `WorkflowRunRef` from only the `workflow_run_id`