### PR TITLE
Fix: Task output

### DIFF
--- a/frontend/docs/pages/home/dags.mdx
+++ b/frontend/docs/pages/home/dags.mdx
@@ -132,7 +132,7 @@ def first_task(input: EmptyModel, ctx: Context) -> dict:
 @simple.task(parents=[first_task])
 def second_task(input: EmptyModel, ctx: Context) -> dict:
     # Access output from parent task
-    first_result = ctx.get_parent_output(first_task)
+    first_result = ctx.task_output(first_task)
     print(f"First task said: {first_result['result']}")
     return {"final_result": "Completed"}
 ```
@@ -179,7 +179,7 @@ As shown in the examples above, tasks can access outputs from their parent tasks
 <Tabs.Tab title="Python">
 ```python
 # Inside a task with parent dependencies
-parent_output = ctx.get_parent_output(parent_task_name)
+parent_output = ctx.task_output(parent_task_name)
 ```
 </Tabs.Tab>
 <Tabs.Tab title="Typescript">


### PR DESCRIPTION
# Description

Fixes an incorrect method name in the docs. [See this comment](https://github.com/hatchet-dev/hatchet/pull/1404#issuecomment-2792579986)

## Type of change

- [x] Documentation change (pure documentation change)

Related to #1404 