### PR TITLE
[Python]: Refactor: Remove validator registry

### DIFF
--- a/sdks/python/hatchet_sdk/context/context.py
+++ b/sdks/python/hatchet_sdk/context/context.py
@@ -72,14 +72,12 @@ class Context:
         if self.was_skipped(task):
             raise ValueError("{task.name} was skipped")
 
-        workflow_validator = task.validators
-
         try:
             parent_step_data = cast(R, self.data.parents[task.name])
         except KeyError:
             raise ValueError(f"Step output for '{task.name}' not found")
 
-        if parent_step_data and (v := workflow_validator.step_output):
+        if parent_step_data and (v := task.validators.step_output):
             return cast(R, v.model_validate(parent_step_data))
 
         return parent_step_data

--- a/sdks/python/hatchet_sdk/runnables/task.py
+++ b/sdks/python/hatchet_sdk/runnables/task.py
@@ -29,7 +29,7 @@ from hatchet_sdk.runnables.types import (
     is_sync_fn,
 )
 from hatchet_sdk.utils.timedelta_to_expression import Duration, timedelta_to_expr
-from hatchet_sdk.utils.typing import WorkflowValidator, is_basemodel_subclass
+from hatchet_sdk.utils.typing import TaskIOValidator, is_basemodel_subclass
 from hatchet_sdk.waits import (
     Action,
     Condition,
@@ -110,7 +110,7 @@ class Task(Generic[TWorkflowInput, R]):
 
         return_type = get_type_hints(_fn).get("return")
 
-        self.validators: WorkflowValidator = WorkflowValidator(
+        self.validators: TaskIOValidator = TaskIOValidator(
             workflow_input=workflow.config.input_validator,
             step_output=return_type if is_basemodel_subclass(return_type) else None,
         )

--- a/sdks/python/hatchet_sdk/runnables/task.py
+++ b/sdks/python/hatchet_sdk/runnables/task.py
@@ -7,6 +7,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    get_type_hints,
 )
 
 from hatchet_sdk.context.context import Context, DurableContext
@@ -28,6 +29,7 @@ from hatchet_sdk.runnables.types import (
     is_sync_fn,
 )
 from hatchet_sdk.utils.timedelta_to_expression import Duration, timedelta_to_expr
+from hatchet_sdk.utils.typing import WorkflowValidator, is_basemodel_subclass
 from hatchet_sdk.waits import (
     Action,
     Condition,
@@ -105,6 +107,13 @@ class Task(Generic[TWorkflowInput, R]):
         self.wait_for = self._flatten_conditions(wait_for)
         self.skip_if = self._flatten_conditions(skip_if)
         self.cancel_if = self._flatten_conditions(cancel_if)
+
+        return_type = get_type_hints(_fn).get("return")
+
+        self.validators: WorkflowValidator = WorkflowValidator(
+            workflow_input=workflow.config.input_validator,
+            step_output=return_type if is_basemodel_subclass(return_type) else None,
+        )
 
     def _flatten_conditions(
         self, conditions: list[Condition | OrGroup]

--- a/sdks/python/hatchet_sdk/utils/typing.py
+++ b/sdks/python/hatchet_sdk/utils/typing.py
@@ -10,7 +10,7 @@ def is_basemodel_subclass(model: Any) -> TypeGuard[Type[BaseModel]]:
         return False
 
 
-class WorkflowValidator(BaseModel):
+class TaskIOValidator(BaseModel):
     workflow_input: Type[BaseModel] | None = None
     step_output: Type[BaseModel] | None = None
 

--- a/sdks/python/hatchet_sdk/utils/typing.py
+++ b/sdks/python/hatchet_sdk/utils/typing.py
@@ -1,8 +1,6 @@
-from typing import Any, Mapping, Type, TypeGuard, TypeVar
+from typing import Any, Mapping, Type, TypeGuard
 
 from pydantic import BaseModel
-
-T = TypeVar("T", bound=BaseModel)
 
 
 def is_basemodel_subclass(model: Any) -> TypeGuard[Type[BaseModel]]:

--- a/sdks/python/hatchet_sdk/worker/runner/run_loop_manager.py
+++ b/sdks/python/hatchet_sdk/worker/runner/run_loop_manager.py
@@ -8,7 +8,6 @@ from hatchet_sdk.clients.dispatcher.action_listener import Action
 from hatchet_sdk.config import ClientConfig
 from hatchet_sdk.logger import logger
 from hatchet_sdk.runnables.task import Task
-from hatchet_sdk.utils.typing import WorkflowValidator
 from hatchet_sdk.worker.action_listener_process import ActionEvent
 from hatchet_sdk.worker.runner.runner import Runner
 from hatchet_sdk.worker.runner.utils.capture_logs import capture_logs
@@ -24,7 +23,6 @@ class WorkerActionRunLoopManager:
         self,
         name: str,
         action_registry: dict[str, Task[Any, Any]],
-        validator_registry: dict[str, WorkflowValidator],
         slots: int | None,
         config: ClientConfig,
         action_queue: "Queue[Action | STOP_LOOP_TYPE]",
@@ -36,7 +34,6 @@ class WorkerActionRunLoopManager:
     ) -> None:
         self.name = name
         self.action_registry = action_registry
-        self.validator_registry = validator_registry
         self.slots = slots
         self.config = config
         self.action_queue = action_queue
@@ -88,7 +85,6 @@ class WorkerActionRunLoopManager:
             self.slots,
             self.handle_kill,
             self.action_registry,
-            self.validator_registry,
             self.labels,
         )
 

--- a/sdks/python/hatchet_sdk/worker/runner/runner.py
+++ b/sdks/python/hatchet_sdk/worker/runner/runner.py
@@ -43,7 +43,6 @@ from hatchet_sdk.runnables.contextvars import (
 )
 from hatchet_sdk.runnables.task import Task
 from hatchet_sdk.runnables.types import R, TWorkflowInput
-from hatchet_sdk.utils.typing import WorkflowValidator
 from hatchet_sdk.worker.action_listener_process import ActionEvent
 from hatchet_sdk.worker.runner.utils.capture_logs import copy_context_vars
 
@@ -63,7 +62,6 @@ class Runner:
         slots: int | None = None,
         handle_kill: bool = True,
         action_registry: dict[str, Task[TWorkflowInput, R]] = {},
-        validator_registry: dict[str, WorkflowValidator] = {},
         labels: dict[str, str | int] = {},
     ):
         # We store the config so we can dynamically create clients for the dispatcher client.
@@ -73,7 +71,6 @@ class Runner:
         self.tasks: dict[str, asyncio.Task[Any]] = {}  # Store run ids and futures
         self.contexts: dict[str, Context] = {}  # Store run ids and contexts
         self.action_registry = action_registry
-        self.validator_registry = validator_registry
 
         self.event_queue = event_queue
 
@@ -305,7 +302,6 @@ class Runner:
             event_client=self.event_client,
             durable_event_listener=self.durable_event_listener,
             worker=self.worker_context,
-            validator_registry=self.validator_registry,
             runs_client=self.runs_client,
         )
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.3.1"
+version = "1.3.2"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
# Description

Removing the `validator_registry` from the SDK (finally) in favor of the task class storing its own validators, which lets us also get rid of another place where we needed to parse and dispatch work based on the action id (or in this case the result of splitting it) which is risky. This should be a lot safer and require less indirection.

(Internal only - no user-facing changes)

## Type of change

- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)
