### PR TITLE
fix: increase PutWorkflowVersion timeout to 25 seconds

### DIFF
--- a/pkg/repository/v1/workflow.go
+++ b/pkg/repository/v1/workflow.go
@@ -232,7 +232,7 @@ func (r *workflowRepository) PutWorkflowVersion(ctx context.Context, tenantId st
 		return nil, err
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 10000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 25000)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

Increases the timeout for this specific query as it occasionally has to migrate lots of cron and scheduled workflow data (eventually we'll need to refactor this to make it more performant). 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)