### PR TITLE
fix: streaming order improvements, go sdk stability

### DIFF
--- a/internal/msgqueue/v1/shared_tenant_reader.go
+++ b/internal/msgqueue/v1/shared_tenant_reader.go
@@ -28,7 +28,90 @@ func NewSharedTenantReader(mq MessageQueue) *SharedTenantReader {
 	}
 }
 
-func (s *SharedTenantReader) Subscribe(tenantId string, f DstFunc) (func() error, error) {
+func (s *SharedTenantReader) Subscribe(tenantId string, postAck AckHook) (func() error, error) {
+	tenant, _ := s.tenants.LoadOrStore(tenantId, &sharedTenantSub{
+		fs: &sync.Map{},
+	})
+
+	t := tenant.(*sharedTenantSub)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.counter++
+
+	subId := t.counter
+
+	t.fs.Store(subId, postAck)
+
+	if !t.isRunning {
+		t.isRunning = true
+
+		q := TenantEventConsumerQueue(tenantId)
+
+		err := s.mq.RegisterTenant(context.Background(), tenantId)
+
+		if err != nil {
+			return nil, err
+		}
+
+		cleanupSingleSub, err := s.mq.Subscribe(q, NoOpHook, func(task *Message) error {
+			var innerErr error
+
+			t.fs.Range(func(key, value interface{}) bool {
+				f := value.(AckHook)
+
+				if err := f(task); err != nil {
+					innerErr = multierror.Append(innerErr, err)
+				}
+
+				return true
+			})
+
+			return innerErr
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		t.cleanup = cleanupSingleSub
+	}
+
+	return func() error {
+		t.mu.Lock()
+		defer t.mu.Unlock()
+
+		t.fs.Delete(subId)
+
+		if lenSyncMap(t.fs) == 0 {
+			// shut down the subscription
+			if t.cleanup != nil {
+				if err := t.cleanup(); err != nil {
+					return err
+				}
+			}
+
+			t.isRunning = false
+		}
+
+		return nil
+	}, nil
+}
+
+type SharedBufferedTenantReader struct {
+	tenants *sync.Map
+	mq      MessageQueue
+}
+
+func NewSharedBufferedTenantReader(mq MessageQueue) *SharedBufferedTenantReader {
+	return &SharedBufferedTenantReader{
+		tenants: &sync.Map{},
+		mq:      mq,
+	}
+}
+
+func (s *SharedBufferedTenantReader) Subscribe(tenantId string, f DstFunc) (func() error, error) {
 	tenant, _ := s.tenants.LoadOrStore(tenantId, &sharedTenantSub{
 		fs: &sync.Map{},
 	})

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -824,6 +824,20 @@ func (w *workflowRunAcks) getNonAckdWorkflowRuns() []string {
 	return ids
 }
 
+func (w *workflowRunAcks) getNonAckdWorkflowRunsMap() map[string]bool {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	// copy ids to a new map
+	acks := make(map[string]bool, len(w.acks))
+	for id, ack := range w.acks {
+		if !ack {
+			acks[id] = ack
+		}
+	}
+	return acks
+}
+
 func (w *workflowRunAcks) ackWorkflowRun(id string) {
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/internal/services/dispatcher/server_v1.go
+++ b/internal/services/dispatcher/server_v1.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -111,6 +112,28 @@ func (s *DispatcherImpl) subscribeToWorkflowRunsV1(server contracts.Dispatcher_S
 		return nil
 	}
 
+	f := func(tenantId, msgId string, payloads [][]byte) error {
+		wg.Add(1)
+		defer wg.Done()
+
+		workflowRunIds := acks.getNonAckdWorkflowRunsMap()
+
+		if matchedWorkflowRunIds, ok := s.isMatchingWorkflowRunV1(msgId, payloads, workflowRunIds); ok {
+			if err := iter(matchedWorkflowRunIds); err != nil {
+				s.l.Error().Err(err).Msg("could not iterate over workflow runs")
+			}
+		}
+
+		return nil
+	}
+
+	// subscribe to the task queue for the tenant
+	cleanupQueue, err := s.sharedReaderv1.Subscribe(tenantId, f)
+
+	if err != nil {
+		return err
+	}
+
 	// start a new goroutine to handle client-side streaming
 	go func() {
 		for {
@@ -161,9 +184,9 @@ func (s *DispatcherImpl) subscribeToWorkflowRunsV1(server contracts.Dispatcher_S
 
 	<-ctx.Done()
 
-	// if err := cleanupQueue(); err != nil {
-	// 	return fmt.Errorf("could not cleanup queue: %w", err)
-	// }
+	if err := cleanupQueue(); err != nil {
+		return fmt.Errorf("could not cleanup queue: %w", err)
+	}
 
 	waitFor(&wg, 60*time.Second, s.l)
 
@@ -517,12 +540,13 @@ func (s *DispatcherImpl) subscribeToWorkflowEventsByWorkflowRunIdV1(workflowRunI
 	var mu sync.Mutex     // Mutex to protect activeRunIds
 	var sendMu sync.Mutex // Mutex to protect sending messages
 
-	f := func(task *msgqueue.Message) error {
+	f := func(tenantId, msgId string, payloads [][]byte) error {
 		wg.Add(1)
 		defer wg.Done()
 
 		events, err := s.msgsToWorkflowEvent(
-			task,
+			msgId,
+			payloads,
 			func(events []*contracts.WorkflowEvent) ([]*contracts.WorkflowEvent, error) {
 				workflowRunIds := make([]string, 0)
 				workflowRunIdsToEvents := make(map[string][]*contracts.WorkflowEvent)
@@ -639,12 +663,13 @@ func (s *DispatcherImpl) subscribeToWorkflowEventsByAdditionalMetaV1(key string,
 	var mu sync.Mutex     // Mutex to protect activeRunIds
 	var sendMu sync.Mutex // Mutex to protect sending messages
 
-	f := func(task *msgqueue.Message) error {
+	f := func(tenantId, msgId string, payloads [][]byte) error {
 		wg.Add(1)
 		defer wg.Done()
 
 		events, err := s.msgsToWorkflowEvent(
-			task,
+			msgId,
+			payloads,
 			func(events []*contracts.WorkflowEvent) ([]*contracts.WorkflowEvent, error) {
 				workflowRunIds := make([]string, 0)
 				workflowRunIdsToEvents := make(map[string][]*contracts.WorkflowEvent)
@@ -812,12 +837,12 @@ func (s *DispatcherImpl) listWorkflowRuns(ctx context.Context, tenantId string, 
 	return res, nil
 }
 
-func (s *DispatcherImpl) msgsToWorkflowEvent(msg *msgqueue.Message, filter func(tasks []*contracts.WorkflowEvent) ([]*contracts.WorkflowEvent, error), hangupFunc func(tasks []*contracts.WorkflowEvent) ([]*contracts.WorkflowEvent, error)) ([]*contracts.WorkflowEvent, error) {
+func (s *DispatcherImpl) msgsToWorkflowEvent(msgId string, payloads [][]byte, filter func(tasks []*contracts.WorkflowEvent) ([]*contracts.WorkflowEvent, error), hangupFunc func(tasks []*contracts.WorkflowEvent) ([]*contracts.WorkflowEvent, error)) ([]*contracts.WorkflowEvent, error) {
 	workflowEvents := []*contracts.WorkflowEvent{}
 
-	switch msg.ID {
+	switch msgId {
 	case "created-task":
-		payloads := msgqueue.JSONConvert[tasktypes.CreatedTaskPayload](msg.Payloads)
+		payloads := msgqueue.JSONConvert[tasktypes.CreatedTaskPayload](payloads)
 
 		for _, payload := range payloads {
 			workflowEvents = append(workflowEvents, &contracts.WorkflowEvent{
@@ -825,12 +850,12 @@ func (s *DispatcherImpl) msgsToWorkflowEvent(msg *msgqueue.Message, filter func(
 				ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
 				ResourceId:     sqlchelpers.UUIDToStr(payload.ExternalID),
 				EventType:      contracts.ResourceEventType_RESOURCE_EVENT_TYPE_STARTED,
-				EventTimestamp: timestamppb.New(time.Now()),
+				EventTimestamp: timestamppb.New(payload.InsertedAt.Time),
 				RetryCount:     &payload.RetryCount,
 			})
 		}
 	case "task-completed":
-		payloads := msgqueue.JSONConvert[tasktypes.CompletedTaskPayload](msg.Payloads)
+		payloads := msgqueue.JSONConvert[tasktypes.CompletedTaskPayload](payloads)
 
 		for _, payload := range payloads {
 			workflowEvents = append(workflowEvents, &contracts.WorkflowEvent{
@@ -844,7 +869,7 @@ func (s *DispatcherImpl) msgsToWorkflowEvent(msg *msgqueue.Message, filter func(
 			})
 		}
 	case "task-failed":
-		payloads := msgqueue.JSONConvert[tasktypes.FailedTaskPayload](msg.Payloads)
+		payloads := msgqueue.JSONConvert[tasktypes.FailedTaskPayload](payloads)
 
 		for _, payload := range payloads {
 			workflowEvents = append(workflowEvents, &contracts.WorkflowEvent{
@@ -858,7 +883,7 @@ func (s *DispatcherImpl) msgsToWorkflowEvent(msg *msgqueue.Message, filter func(
 			})
 		}
 	case "task-cancelled":
-		payloads := msgqueue.JSONConvert[tasktypes.CancelledTaskPayload](msg.Payloads)
+		payloads := msgqueue.JSONConvert[tasktypes.CancelledTaskPayload](payloads)
 
 		for _, payload := range payloads {
 			workflowEvents = append(workflowEvents, &contracts.WorkflowEvent{
@@ -871,7 +896,7 @@ func (s *DispatcherImpl) msgsToWorkflowEvent(msg *msgqueue.Message, filter func(
 			})
 		}
 	case "task-stream-event":
-		payloads := msgqueue.JSONConvert[tasktypes.StreamEventPayload](msg.Payloads)
+		payloads := msgqueue.JSONConvert[tasktypes.StreamEventPayload](payloads)
 
 		for _, payload := range payloads {
 			workflowEvents = append(workflowEvents, &contracts.WorkflowEvent{
@@ -879,12 +904,12 @@ func (s *DispatcherImpl) msgsToWorkflowEvent(msg *msgqueue.Message, filter func(
 				ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
 				ResourceId:     payload.StepRunId,
 				EventType:      contracts.ResourceEventType_RESOURCE_EVENT_TYPE_STREAM,
-				EventTimestamp: timestamppb.New(time.Now()),
+				EventTimestamp: timestamppb.New(payload.CreatedAt),
 				EventPayload:   string(payload.Payload),
 			})
 		}
 	case "workflow-run-finished":
-		payloads := msgqueue.JSONConvert[tasktypes.NotifyFinalizedPayload](msg.Payloads)
+		payloads := msgqueue.JSONConvert[tasktypes.NotifyFinalizedPayload](payloads)
 
 		for _, payload := range payloads {
 			eventType := contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED
@@ -920,5 +945,46 @@ func (s *DispatcherImpl) msgsToWorkflowEvent(msg *msgqueue.Message, filter func(
 		return nil, err
 	}
 
+	// order matches
+	slices.SortFunc(matches, func(a, b *contracts.WorkflowEvent) int {
+		// anything with a hangup should be last
+		if a.Hangup && !b.Hangup {
+			return 1
+		} else if !a.Hangup && b.Hangup {
+			return -1
+		}
+
+		if a.EventTimestamp.AsTime().Before(b.EventTimestamp.AsTime()) {
+			return -1
+		}
+
+		if a.EventTimestamp.AsTime().After(b.EventTimestamp.AsTime()) {
+			return 1
+		}
+
+		return 0
+	})
+
 	return matches, nil
+}
+
+func (s *DispatcherImpl) isMatchingWorkflowRunV1(msgId string, payloadBytes [][]byte, workflowRunIds map[string]bool) ([]string, bool) {
+	if msgId != "workflow-run-finished" {
+		return nil, false
+	}
+
+	payloads := msgqueue.JSONConvert[tasktypes.NotifyFinalizedPayload](payloadBytes)
+	res := make([]string, 0)
+
+	for _, payload := range payloads {
+		if _, ok := workflowRunIds[payload.ExternalId]; ok {
+			res = append(res, payload.ExternalId)
+		}
+	}
+
+	if len(res) == 0 {
+		return nil, false
+	}
+
+	return res, true
 }

--- a/pkg/repository/v1/sqlcv1/tasks.sql.go
+++ b/pkg/repository/v1/sqlcv1/tasks.sql.go
@@ -1597,23 +1597,18 @@ SELECT
     t.dag_id
 FROM
     v1_task t
+JOIN
+    input i ON i.task_id = t.id AND i.task_inserted_at = t.inserted_at
 LEFT JOIN
     v1_task_event e ON e.task_id = t.id AND e.task_inserted_at = t.inserted_at AND e.retry_count = t.retry_count AND e.event_type = ANY('{COMPLETED, FAILED, CANCELLED}'::v1_task_event_type[])
 LEFT JOIN
-    v1_task_runtime tr ON tr.task_id = t.id
+    v1_task_runtime tr ON tr.task_id = t.id AND tr.task_inserted_at = t.inserted_at AND tr.retry_count = t.retry_count
 LEFT JOIN
-    v1_concurrency_slot cs ON cs.task_id = t.id
+    v1_concurrency_slot cs ON cs.task_id = t.id AND cs.task_inserted_at = t.inserted_at AND cs.task_retry_count = t.retry_count
 LEFT JOIN
-    v1_retry_queue_item rqi ON rqi.task_id = t.id
+    v1_retry_queue_item rqi ON rqi.task_id = t.id AND rqi.task_inserted_at = t.inserted_at AND rqi.task_retry_count = t.retry_count
 WHERE
-    (t.id, t.inserted_at) IN (
-        SELECT
-            task_id,
-            task_inserted_at
-        FROM
-            input
-    )
-    AND t.tenant_id = $1::uuid
+    t.tenant_id = $1::uuid
     AND e.id IS NULL
     AND (tr.task_id IS NOT NULL OR cs.task_id IS NOT NULL OR rqi.task_id IS NOT NULL)
 `


### PR DESCRIPTION
# Description

Adds several streaming-related improvements.

Adds a stream-based trigger for querying completed workflow runs on the workflow runs listener. 

Improves streaming ordering by:
1. Only reading stream events from a single channel, utilizing the buffered reader 
2. Ordering events within the same buffer

This is still not completely immune to edge cases, when there are more than 1000 concurrent stream events sent within the same 20ms time window, or when we lose precision when casting from `timestamppb` to `time`. 

Also properly handles unsubscribing from workflow runs on the Go SDK.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)