### PR TITLE
fix: remove fk constraint on crons

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20250414130637_v1_0_12.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20250414130637_v1_0_12.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE "WorkflowRunTriggeredBy" DROP CONSTRAINT "WorkflowRunTriggeredBy_cronParentId_cronSchedule_cronName_fkey";
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE "WorkflowRunTriggeredBy" ADD CONSTRAINT "WorkflowRunTriggeredBy_cronParentId_cronSchedule_cronName_fkey" FOREIGN KEY ("cronParentId", "cronSchedule", "cronName") REFERENCES "WorkflowTriggerCronRef"("parentId", "cron", "name") ON DELETE SET NULL ON UPDATE CASCADE;
+-- +goose StatementEnd


### PR DESCRIPTION
# Description

With workflows that have many cron expressions (>200) and have run a large number of workflows, we're timing out when creating a new workflow version. 

The issue is that updating the `"WorkflowTriggerCronRef"` to use the new workflow version updates its primary key, which cascades to all workflow runs (specifically `WorkflowRunTriggeredBy`) which have linked this cron as a trigger (not a problem in v1, but a problem when migrating from v0 -> v1). 

This FK constraint doesn't seem to be used for associating an existing cron with a trigger, since the schedule is rendered based on the `cronSchedule` column on `WorkflowRunTriggeredBy`, so there should be no impact to this change. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)