### PR TITLE
fix: empty billing context

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,18 +7,18 @@ assignees: ''
 
 ---
 
-**Describe the issue**  
+**Describe the issue**
 Briefly describe what’s going wrong — runtime error, broken link, incorrect example, UI issue, etc.
 
-**Environment**  
-- SDK: [e.g. TypeScript v1.2.3]  
+**Environment**
+- SDK: [e.g. TypeScript v1.2.3]
 - Engine: [Cloud or Self-hosted v1.5.0]
 
-**Expected behavior**  
+**Expected behavior**
 What did you expect to happen instead?
 
-**Code to Reproduce, Logs, or Screenshots**  
+**Code to Reproduce, Logs, or Screenshots**
 Include a minimal code snippet that reproduces the issue, error logs around the event, or screenshots, if applicable.
 
-**Additional context**  
+**Additional context**
 Anything else that might help us understand or reproduce the problem — e.g. specific page URL, logged-in vs logged-out, related docs or workflows.

--- a/frontend/app/src/lib/atoms.ts
+++ b/frontend/app/src/lib/atoms.ts
@@ -48,7 +48,7 @@ type TenantContextPresent = {
   tenant: Tenant;
   tenantId: string;
   setTenant: (tenant: Tenant) => void;
-  billing: BillingContext;
+  billing?: BillingContext;
   can: Can;
 };
 
@@ -209,14 +209,23 @@ export function useTenant(): TenantContext {
     return (billingState.data?.paymentMethods?.length || 0) > 0;
   }, [billingState.data?.paymentMethods]);
 
-  const billingContext: BillingContext = useMemo(() => {
+  const billingContext: BillingContext | undefined = useMemo(() => {
+    if (!cloudMeta?.data.canBill) {
+      return;
+    }
+
     return {
       state: billingState.data,
       setPollBilling,
       plan: subscriptionPlan,
       hasPaymentMethods,
     };
-  }, [billingState.data, setPollBilling, subscriptionPlan, hasPaymentMethods]);
+  }, [
+    cloudMeta?.data.canBill,
+    billingState.data,
+    subscriptionPlan,
+    hasPaymentMethods,
+  ]);
 
   const can = useCallback(
     (evalFn: Evaluate) => {


### PR DESCRIPTION
# Description

If the tenant should not bill, there should be an undefined billing context.