### PR TITLE
Fix: Cron validation

### DIFF
--- a/pkg/v1/features/crons.go
+++ b/pkg/v1/features/crons.go
@@ -2,9 +2,10 @@ package features
 
 import (
 	"context"
-	"regexp"
 
 	"github.com/google/uuid"
+	"github.com/robfig/cron/v3"
+
 	"github.com/hatchet-dev/hatchet/pkg/client/rest"
 )
 
@@ -62,9 +63,10 @@ func NewCronsClient(
 
 // ValidateCronExpression validates that a string is a valid cron expression.
 func ValidateCronExpression(expression string) bool {
-	// Basic cron validation regex matching the TypeScript implementation
-	cronRegex := regexp.MustCompile(`^(\*|([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])|\*\/([0-9]|1[0-9]|2[0-3])) (\*|([0-9]|1[0-9]|2[0-3])|\*\/([0-9]|1[0-9]|2[0-3])) (\*|([1-9]|1[0-9]|2[0-9]|3[0-1])|\*\/([1-9]|1[0-9]|2[0-9]|3[0-1])) (\*|([1-9]|1[0-2])|\*\/([1-9]|1[0-2])) (\*|([0-6])|\*\/([0-6]))$`)
-	return cronRegex.MatchString(expression)
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	_, err := parser.Parse(expression)
+
+	return err == nil
 }
 
 // Create creates a new cron workflow trigger.


### PR DESCRIPTION
# Description

Fixing cron validation by replacing our buggy regex with a parser from the cron library we're using

Tested with these crons:

```
[
    "* * * * *",
    "*/5 * * * *",
    "1 * * * *",
    "17 0,12 1-15 * 1-5",
    "23 15 * * 6",
    "0 4 8-14 * 0",
    "*/10 */4 15 1,6,12 *",
]
```

also tried `@hourly` and `@daily` which the parser is happy with too, but Pydantic is not

- [x] Bug fix (non-breaking change which fixes an issue)