### PR TITLE
fix: concurrent workflow version on put

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20250417143656_v1_0_14.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20250417143656_v1_0_14.sql
@@ -1,0 +1,186 @@
+-- +goose Up
+-- +goose StatementBegin
+WITH all_crons AS (
+    -- Get all API cron triggers for a specific tenant
+    SELECT 
+        t."id" AS trigger_parent_id,
+        t."workflowVersionId",
+        c."id" AS cron_id,
+        c."cron",
+        c."name" AS cron_name,
+        c."method"
+    FROM "WorkflowTriggers" t
+    JOIN "WorkflowTriggerCronRef" c ON c."parentId" = t."id"
+    WHERE c."method" = 'API'
+),
+workflow_info AS (
+    -- Get workflow information for each version
+    SELECT
+        v."id" AS version_id,
+        v."workflowId",
+        v."order",
+        v."version"
+    FROM "WorkflowVersion" v
+    WHERE v."deletedAt" IS NULL
+),
+latest_versions AS (
+    -- Find the latest version for each workflow
+    SELECT DISTINCT ON ("workflowId")
+        "workflowId",
+        "id" AS latest_version_id,
+        "order" AS latest_order
+    FROM "WorkflowVersion"
+    WHERE "deletedAt" IS NULL
+    ORDER BY "workflowId", "order" DESC
+),
+latest_triggers AS (
+    -- Find the latest trigger parent ID for each workflow
+    SELECT
+        lv."workflowId",
+        lv.latest_version_id,
+        t."id" AS latest_trigger_id,
+        t."tenantId"
+    FROM latest_versions lv
+    JOIN "WorkflowTriggers" t ON t."workflowVersionId" = lv.latest_version_id
+    WHERE t."deletedAt" IS NULL
+),
+crons_to_update AS (
+    -- Identify cron triggers that need to be updated (not on latest version)
+    SELECT 
+        ac.cron_id,
+        ac.trigger_parent_id AS current_parent_id,
+        lt.latest_trigger_id AS target_parent_id,
+        ac.cron_name,
+        ac.cron,
+        wi."workflowId",
+        wi."order" AS current_version_order,
+        lv.latest_order,
+        lt."tenantId"
+    FROM all_crons ac
+    JOIN workflow_info wi ON wi.version_id = ac."workflowVersionId"
+    JOIN latest_versions lv ON lv."workflowId" = wi."workflowId"
+    JOIN latest_triggers lt ON lt."workflowId" = wi."workflowId"
+    WHERE wi."order" < lv.latest_order -- Only include crons not on the latest version
+),
+conflicting_records AS (
+    SELECT 
+        ctu.cron_id
+    FROM crons_to_update ctu
+    JOIN "WorkflowTriggerCronRef" wcr ON 
+        wcr."parentId" = ctu.target_parent_id AND
+        wcr."cron" = ctu.cron AND
+        wcr."name" = ctu.cron_name
+    WHERE wcr."id" != ctu.cron_id
+),
+to_update AS (
+    -- Final list of records to update (excluding conflicting ones)
+    SELECT *
+    FROM crons_to_update
+    WHERE cron_id NOT IN (SELECT cron_id FROM conflicting_records)
+)
+UPDATE "WorkflowTriggerCronRef"
+SET "parentId" = ctu.target_parent_id
+FROM to_update ctu
+WHERE "WorkflowTriggerCronRef"."id" = ctu.cron_id;
+
+
+WITH all_scheduled AS (
+    -- Get all scheduled triggers
+    SELECT 
+        t."id" AS trigger_parent_id,
+        t."workflowVersionId",
+        s."id" AS scheduled_id,
+        s."triggerAt",
+        s."method",
+        s."tickerId",
+        s."input",
+        s."childIndex",
+        s."childKey",
+        s."parentStepRunId",
+        s."parentWorkflowRunId",
+        s."additionalMetadata",
+        s."priority"
+    FROM "WorkflowTriggers" t
+    JOIN "WorkflowTriggerScheduledRef" s ON s."parentId" = t."id"
+    WHERE s."method" = 'API'
+),
+workflow_info AS (
+    -- Get workflow information for each version
+    SELECT
+        v."id" AS version_id,
+        v."workflowId",
+        v."order",
+        v."version"
+    FROM "WorkflowVersion" v
+    WHERE v."deletedAt" IS NULL
+),
+latest_versions AS (
+    -- Find the latest version for each workflow
+    SELECT DISTINCT ON ("workflowId")
+        "workflowId",
+        "id" AS latest_version_id,
+        "order" AS latest_order
+    FROM "WorkflowVersion"
+    WHERE "deletedAt" IS NULL
+    ORDER BY "workflowId", "order" DESC
+),
+latest_triggers AS (
+    -- Find the latest trigger parent ID for each workflow
+    SELECT
+        lv."workflowId",
+        lv.latest_version_id,
+        t."id" AS latest_trigger_id,
+        t."tenantId"
+    FROM latest_versions lv
+    JOIN "WorkflowTriggers" t ON t."workflowVersionId" = lv.latest_version_id
+    WHERE t."deletedAt" IS NULL
+),
+scheduled_to_update AS (
+    -- Identify scheduled triggers that need to be updated (not on latest version)
+    SELECT 
+        als.scheduled_id,
+        als.trigger_parent_id AS current_parent_id,
+        lt.latest_trigger_id AS target_parent_id,
+        als."triggerAt",
+        als."method",
+        als."tickerId",
+        als."input",
+        als."childIndex",
+        als."childKey",
+        als."parentStepRunId",
+        als."parentWorkflowRunId",
+        als."additionalMetadata",
+        als."priority",
+        wi."workflowId",
+        wi."order" AS current_version_order,
+        lv.latest_order,
+        lt."tenantId"
+    FROM all_scheduled als
+    JOIN workflow_info wi ON wi.version_id = als."workflowVersionId"
+    JOIN latest_versions lv ON lv."workflowId" = wi."workflowId"
+    JOIN latest_triggers lt ON lt."workflowId" = wi."workflowId"
+    WHERE wi."order" < lv.latest_order -- Only include scheduled triggers not on the latest version
+),
+conflicting_records AS (
+    -- Identify records that would cause conflicts with the unique constraint
+    SELECT 
+        stu.scheduled_id
+    FROM scheduled_to_update stu
+    JOIN "WorkflowTriggerScheduledRef" wsr ON 
+        wsr."parentId" = stu.target_parent_id AND
+        wsr."parentStepRunId" = stu."parentStepRunId" AND
+        wsr."childKey" = stu."childKey"
+    WHERE wsr."id" != stu.scheduled_id
+),
+to_update AS (
+    -- Final list of records to update (excluding conflicting ones)
+    SELECT *
+    FROM scheduled_to_update
+    WHERE scheduled_id NOT IN (SELECT scheduled_id FROM conflicting_records)
+)
+
+UPDATE "WorkflowTriggerScheduledRef"
+SET "parentId" = tu.target_parent_id
+FROM to_update tu
+WHERE "WorkflowTriggerScheduledRef"."id" = tu.scheduled_id;
+-- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20250417143656_v1_0_14.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20250417143656_v1_0_14.sql
@@ -2,7 +2,7 @@
 -- +goose StatementBegin
 WITH all_crons AS (
     -- Get all API cron triggers for a specific tenant
-    SELECT 
+    SELECT
         t."id" AS trigger_parent_id,
         t."workflowVersionId",
         c."id" AS cron_id,
@@ -46,7 +46,7 @@ latest_triggers AS (
 ),
 crons_to_update AS (
     -- Identify cron triggers that need to be updated (not on latest version)
-    SELECT 
+    SELECT
         ac.cron_id,
         ac.trigger_parent_id AS current_parent_id,
         lt.latest_trigger_id AS target_parent_id,
@@ -63,10 +63,10 @@ crons_to_update AS (
     WHERE wi."order" < lv.latest_order -- Only include crons not on the latest version
 ),
 conflicting_records AS (
-    SELECT 
+    SELECT
         ctu.cron_id
     FROM crons_to_update ctu
-    JOIN "WorkflowTriggerCronRef" wcr ON 
+    JOIN "WorkflowTriggerCronRef" wcr ON
         wcr."parentId" = ctu.target_parent_id AND
         wcr."cron" = ctu.cron AND
         wcr."name" = ctu.cron_name
@@ -86,7 +86,7 @@ WHERE "WorkflowTriggerCronRef"."id" = ctu.cron_id;
 
 WITH all_scheduled AS (
     -- Get all scheduled triggers
-    SELECT 
+    SELECT
         t."id" AS trigger_parent_id,
         t."workflowVersionId",
         s."id" AS scheduled_id,
@@ -137,7 +137,7 @@ latest_triggers AS (
 ),
 scheduled_to_update AS (
     -- Identify scheduled triggers that need to be updated (not on latest version)
-    SELECT 
+    SELECT
         als.scheduled_id,
         als.trigger_parent_id AS current_parent_id,
         lt.latest_trigger_id AS target_parent_id,
@@ -163,10 +163,10 @@ scheduled_to_update AS (
 ),
 conflicting_records AS (
     -- Identify records that would cause conflicts with the unique constraint
-    SELECT 
+    SELECT
         stu.scheduled_id
     FROM scheduled_to_update stu
-    JOIN "WorkflowTriggerScheduledRef" wsr ON 
+    JOIN "WorkflowTriggerScheduledRef" wsr ON
         wsr."parentId" = stu.target_parent_id AND
         wsr."parentStepRunId" = stu."parentStepRunId" AND
         wsr."childKey" = stu."childKey"

--- a/internal/services/admin/server.go
+++ b/internal/services/admin/server.go
@@ -236,12 +236,6 @@ func (a *AdminServiceImpl) PutWorkflow(ctx context.Context, req *contracts.PutWo
 		}
 	} else {
 
-		// Lock the previous workflow version to prevent concurrent version creation
-		_, err := a.repo.Workflow().LockWorkflowVersion(ctx, tenantId, sqlchelpers.UUIDToStr(currWorkflow.ID))
-		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			return nil, fmt.Errorf("failed to lock previous workflow version: %w", err)
-		}
-
 		oldWorkflowVersion, err = a.repo.Workflow().GetLatestWorkflowVersion(
 			ctx,
 			tenantId,

--- a/internal/services/admin/server.go
+++ b/internal/services/admin/server.go
@@ -235,6 +235,13 @@ func (a *AdminServiceImpl) PutWorkflow(ctx context.Context, req *contracts.PutWo
 			return nil, err
 		}
 	} else {
+
+		// Lock the previous workflow version to prevent concurrent version creation
+		_, err := a.repo.Workflow().LockWorkflowVersion(ctx, tenantId, sqlchelpers.UUIDToStr(currWorkflow.ID))
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("failed to lock previous workflow version: %w", err)
+		}
+
 		oldWorkflowVersion, err = a.repo.Workflow().GetLatestWorkflowVersion(
 			ctx,
 			tenantId,

--- a/pkg/repository/postgres/dbsqlc/workflows.sql
+++ b/pkg/repository/postgres/dbsqlc/workflows.sql
@@ -862,3 +862,16 @@ WHERE
 DELETE FROM "WorkflowTriggerCronRef"
 WHERE
     "id" = @id::uuid;
+
+-- name: LockWorkflowVersion :one
+SELECT
+    "id"
+FROM
+    "WorkflowVersion"
+WHERE
+    "workflowId" = @workflowId::uuid AND
+    "deletedAt" IS NULL
+ORDER BY
+    "order" DESC
+LIMIT 1
+FOR UPDATE;

--- a/pkg/repository/postgres/workflow.go
+++ b/pkg/repository/postgres/workflow.go
@@ -564,6 +564,16 @@ func (r *workflowEngineRepository) CreateNewWorkflow(ctx context.Context, tenant
 	return workflowVersion[0], nil
 }
 
+func (r *workflowEngineRepository) LockWorkflowVersion(ctx context.Context, tenantId, workflowId string) (*pgtype.UUID, error) {
+	lockedWorkflowVersionId, err := r.queries.LockWorkflowVersion(ctx, r.pool, sqlchelpers.UUIDFromStr(workflowId))
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &lockedWorkflowVersionId, nil
+}
+
 func (r *workflowEngineRepository) CreateWorkflowVersion(ctx context.Context, tenantId string, opts *repository.CreateWorkflowVersionOpts, oldWorkflowVersion *dbsqlc.GetWorkflowVersionForEngineRow) (*dbsqlc.GetWorkflowVersionForEngineRow, error) {
 	if err := r.v.Validate(opts); err != nil {
 		return nil, err

--- a/pkg/repository/v1/sqlcv1/workflows.sql
+++ b/pkg/repository/v1/sqlcv1/workflows.sql
@@ -565,3 +565,16 @@ FROM
 WHERE
     step_id = ANY(@stepIds::uuid[])
     AND tenant_id = @tenantId::uuid;
+
+-- name: LockWorkflowVersion :one
+SELECT
+    "id"
+FROM
+    "WorkflowVersion"
+WHERE
+    "workflowId" = @workflowId::uuid AND
+    "deletedAt" IS NULL
+ORDER BY
+    "order" DESC
+LIMIT 1
+FOR UPDATE;

--- a/pkg/repository/v1/sqlcv1/workflows.sql.go
+++ b/pkg/repository/v1/sqlcv1/workflows.sql.go
@@ -1313,6 +1313,27 @@ func (q *Queries) ListWorkflowNamesByIds(ctx context.Context, db DBTX, ids []pgt
 	return items, nil
 }
 
+const lockWorkflowVersion = `-- name: LockWorkflowVersion :one
+SELECT
+    "id"
+FROM
+    "WorkflowVersion"
+WHERE
+    "workflowId" = $1::uuid AND
+    "deletedAt" IS NULL
+ORDER BY
+    "order" DESC
+LIMIT 1
+FOR UPDATE
+`
+
+func (q *Queries) LockWorkflowVersion(ctx context.Context, db DBTX, workflowid pgtype.UUID) (pgtype.UUID, error) {
+	row := db.QueryRow(ctx, lockWorkflowVersion, workflowid)
+	var id pgtype.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
 const moveCronTriggerToNewWorkflowTriggers = `-- name: MoveCronTriggerToNewWorkflowTriggers :exec
 WITH triggersToUpdate AS (
     SELECT cronTrigger."id" FROM "WorkflowTriggerCronRef" cronTrigger

--- a/pkg/repository/workflow.go
+++ b/pkg/repository/workflow.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hatchet-dev/hatchet/pkg/repository/postgres/dbsqlc"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 var ErrDagParentNotFound = errors.New("dag parent not found")
@@ -308,6 +309,9 @@ type WorkflowEngineRepository interface {
 	// CreateWorkflowVersion creates a new workflow version for a given tenant. This will fail if there is
 	// not a parent workflow with the same name already in the database.
 	CreateWorkflowVersion(ctx context.Context, tenantId string, opts *CreateWorkflowVersionOpts, oldWorkflowVersion *dbsqlc.GetWorkflowVersionForEngineRow) (*dbsqlc.GetWorkflowVersionForEngineRow, error)
+
+	// LockWorkflowVersion locks a workflow version for a given tenant.
+	LockWorkflowVersion(ctx context.Context, tenantId, workflowId string) (*pgtype.UUID, error)
 
 	// CreateSchedules creates schedules for a given workflow version.
 	CreateSchedules(ctx context.Context, tenantId, workflowVersionId string, opts *CreateWorkflowSchedulesOpts) ([]*dbsqlc.WorkflowTriggerScheduledRef, error)

--- a/pkg/repository/workflow.go
+++ b/pkg/repository/workflow.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/hatchet-dev/hatchet/pkg/repository/postgres/dbsqlc"
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 var ErrDagParentNotFound = errors.New("dag parent not found")
@@ -309,9 +308,6 @@ type WorkflowEngineRepository interface {
 	// CreateWorkflowVersion creates a new workflow version for a given tenant. This will fail if there is
 	// not a parent workflow with the same name already in the database.
 	CreateWorkflowVersion(ctx context.Context, tenantId string, opts *CreateWorkflowVersionOpts, oldWorkflowVersion *dbsqlc.GetWorkflowVersionForEngineRow) (*dbsqlc.GetWorkflowVersionForEngineRow, error)
-
-	// LockWorkflowVersion locks a workflow version for a given tenant.
-	LockWorkflowVersion(ctx context.Context, tenantId, workflowId string) (*pgtype.UUID, error)
 
 	// CreateSchedules creates schedules for a given workflow version.
 	CreateSchedules(ctx context.Context, tenantId, workflowVersionId string, opts *CreateWorkflowSchedulesOpts) ([]*dbsqlc.WorkflowTriggerScheduledRef, error)


### PR DESCRIPTION
# Description

A rare race condition on worker start could simultaneously create two workflow versions which could bind existing APIs and schedules to an old version preventing executions and display in the ui.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

