### PR TITLE
fix: v1 event push on REST API, namespace

### DIFF
--- a/api/v1/server/handlers/events/create.go
+++ b/api/v1/server/handlers/events/create.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/transformers"
 	"github.com/hatchet-dev/hatchet/pkg/repository/metered"
 	"github.com/hatchet-dev/hatchet/pkg/repository/postgres/dbsqlc"
-	"github.com/hatchet-dev/hatchet/pkg/repository/postgres/sqlchelpers"
 )
 
 func (t *EventService) EventCreate(ctx echo.Context, request gen.EventCreateRequestObject) (gen.EventCreateResponseObject, error) {
@@ -45,13 +44,7 @@ func (t *EventService) EventCreate(ctx echo.Context, request gen.EventCreateRequ
 		return nil, err
 	}
 
-	dbNewEvent, err := t.config.APIRepository.Event().GetEventById(ctx.Request().Context(), sqlchelpers.UUIDToStr(newEvent.ID))
-
-	if err != nil {
-		return nil, err
-	}
-
 	return gen.EventCreate200JSONResponse(
-		transformers.ToEvent(dbNewEvent),
+		transformers.ToEvent(newEvent),
 	), nil
 }

--- a/pkg/v1/task/task.go
+++ b/pkg/v1/task/task.go
@@ -145,12 +145,11 @@ func makeContractTaskOpts(t *TaskShared, taskDefaults *create.TaskDefaults) *con
 	}
 
 	if t.ExecutionTimeout != nil {
-		executionTimeout := t.ExecutionTimeout.String()
-		taskOpts.Timeout = executionTimeout
+		taskOpts.Timeout = durationToSeconds(*t.ExecutionTimeout)
 	}
 
 	if t.ScheduleTimeout != nil {
-		scheduleTimeout := t.ScheduleTimeout.String()
+		scheduleTimeout := durationToSeconds(*t.ScheduleTimeout)
 		taskOpts.ScheduleTimeout = &scheduleTimeout
 	}
 
@@ -174,12 +173,11 @@ func makeContractTaskOpts(t *TaskShared, taskDefaults *create.TaskDefaults) *con
 		}
 
 		if t.ExecutionTimeout == nil && taskDefaults.ExecutionTimeout != 0 {
-			executionTimeout := taskDefaults.ExecutionTimeout.String()
-			taskOpts.Timeout = executionTimeout
+			taskOpts.Timeout = durationToSeconds(taskDefaults.ExecutionTimeout)
 		}
 
 		if t.ScheduleTimeout == nil && taskDefaults.ScheduleTimeout != 0 {
-			scheduleTimeout := taskDefaults.ScheduleTimeout.String()
+			scheduleTimeout := durationToSeconds(taskDefaults.ScheduleTimeout)
 			taskOpts.ScheduleTimeout = &scheduleTimeout
 		}
 
@@ -238,6 +236,14 @@ func (t *TaskDeclaration[I]) Dump(workflowName string, taskDefaults *create.Task
 	}
 
 	return base
+}
+
+func durationToSeconds(d time.Duration) string {
+	if d == 0 {
+		return "0s"
+	}
+
+	return fmt.Sprintf("%ds", int(d.Seconds()))
 }
 
 func (t *DurableTaskDeclaration[I]) Dump(workflowName string, taskDefaults *create.TaskDefaults) *contracts.CreateTaskOpts {

--- a/pkg/v1/workflow/declaration.go
+++ b/pkg/v1/workflow/declaration.go
@@ -165,8 +165,21 @@ func NewWorkflowDeclaration[I any, O any](opts create.WorkflowCreateOpts[I], v0 
 
 	workflowName := opts.Name
 
-	if ns := v0.Namespace(); ns != "" && !strings.HasPrefix(opts.Name, ns) {
+	ns := v0.Namespace()
+
+	if ns != "" && !strings.HasPrefix(opts.Name, ns) {
 		workflowName = fmt.Sprintf("%s%s", ns, workflowName)
+	}
+
+	onEvents := opts.OnEvents
+
+	if ns != "" && len(onEvents) > 0 {
+		// Prefix the events with the namespace
+		onEvents = make([]string, len(opts.OnEvents))
+
+		for i, event := range opts.OnEvents {
+			onEvents[i] = fmt.Sprintf("%s%s", ns, event)
+		}
 	}
 
 	wf := &workflowDeclarationImpl[I, O]{
@@ -176,7 +189,7 @@ func NewWorkflowDeclaration[I any, O any](opts create.WorkflowCreateOpts[I], v0 
 		metrics:     metrics,
 		workflows:   workflows,
 		Name:        workflowName,
-		OnEvents:    opts.OnEvents,
+		OnEvents:    onEvents,
 		OnCron:      opts.OnCron,
 		Concurrency: opts.Concurrency,
 		// OnFailureTask:    opts.OnFailureTask, // TODO: add this back in


### PR DESCRIPTION
# Description

Fixes two issues related to event pushes:

- [X] When an event is pushed via the REST API for a v1 tenant, the handler would return a 500-level response (#1542)
- [X] Adding `OnEvents` to a V1 Go SDK workflow does not respect namespacing
- [X] Ensures Go duration strings are sent as `%ds` formatted strings, because we convert these duration strings to Postgres intervals in the database

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)