### PR TITLE
Fix: Duration conversion to Go duration strings

### DIFF
--- a/sdks/python/hatchet_sdk/utils/timedelta_to_expression.py
+++ b/sdks/python/hatchet_sdk/utils/timedelta_to_expression.py
@@ -7,12 +7,15 @@ Duration = timedelta | str
 
 
 def timedelta_to_expr(td: Duration) -> str:
-    ## IMPORTANT: We only support hours, minutes, and seconds on the engine
     if isinstance(td, str):
         return td
 
-    seconds = td.seconds
+    ## `total_seconds` gives the entire duration,
+    ## while `seconds` gives the seconds component of the timedelta
+    ## e.g. 1 day and 1 second would give 86401 total seconds but 1 second
+    seconds = int(td.total_seconds())
 
+    ## IMPORTANT: We only support hours, minutes, and seconds on the engine
     if seconds % HOUR == 0:
         return f"{seconds // HOUR}h"
     elif seconds % MINUTE == 0:

--- a/sdks/python/hatchet_sdk/utils/timedelta_to_expression.py
+++ b/sdks/python/hatchet_sdk/utils/timedelta_to_expression.py
@@ -1,6 +1,5 @@
 from datetime import timedelta
 
-DAY = 86400
 HOUR = 3600
 MINUTE = 60
 
@@ -8,14 +7,13 @@ Duration = timedelta | str
 
 
 def timedelta_to_expr(td: Duration) -> str:
+    ## IMPORTANT: We only support hours, minutes, and seconds on the engine
     if isinstance(td, str):
         return td
 
     seconds = td.seconds
 
-    if seconds % DAY == 0:
-        return f"{seconds // DAY}d"
-    elif seconds % HOUR == 0:
+    if seconds % HOUR == 0:
         return f"{seconds // HOUR}h"
     elif seconds % MINUTE == 0:
         return f"{seconds // MINUTE}m"

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.6.1"
+version = "1.6.2"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"

--- a/sdks/python/tests/test_durations.py
+++ b/sdks/python/tests/test_durations.py
@@ -1,0 +1,12 @@
+from datetime import timedelta
+
+from hatchet_sdk.utils.timedelta_to_expression import timedelta_to_expr
+
+
+def test_timedelta_to_expr():
+    assert timedelta_to_expr(timedelta(seconds=3600)) == "1h"
+    assert timedelta_to_expr(timedelta(seconds=60)) == "1m"
+    assert timedelta_to_expr(timedelta(seconds=1)) == "1s"
+    assert timedelta_to_expr(timedelta(seconds=3661)) == "3661s"
+    assert timedelta_to_expr(timedelta(hours=96)) == "96h"
+    assert timedelta_to_expr(timedelta(hours=96, seconds=1)) == "345601s"

--- a/sdks/python/tests/test_durations.py
+++ b/sdks/python/tests/test_durations.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from hatchet_sdk.utils.timedelta_to_expression import timedelta_to_expr
 
 
-def test_timedelta_to_expr():
+def test_timedelta_to_expr() -> None:
     assert timedelta_to_expr(timedelta(seconds=3600)) == "1h"
     assert timedelta_to_expr(timedelta(seconds=60)) == "1m"
     assert timedelta_to_expr(timedelta(seconds=1)) == "1s"


### PR DESCRIPTION
# Description

Fixes two bugs in converting timedeltas to Go duration strings:

1. The engine only supports `s`, `m`, and `h`
2. `total_seconds` gives the entire duration of the timedelta, while `seconds` only gives the seconds part


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

