### PR TITLE
feat: sampling

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,47 +1,62 @@
-run:
-  timeout: 5m
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-    - gofmt
-    - unused
-    - gosimple
-    - exportloopref
+    - errcheck
     - gocritic
     - gosec
-    - errcheck
-    - goimports
+    - govet
+    - ineffassign
     - revive
     - staticcheck
-    - vet
-    - stylecheck
     - unconvert
-    - ineffassign
-
-linters-settings:
-  goimports:
-    local-prefixes: github.com/hatchet-dev/hatchet
-  staticcheck:
-    checks:
-      - all
-      - "-ST1003"
-      - "-SA4006"
-      - "-SA1029"
-  stylecheck:
-    checks:
-      - all
-      - "-ST1003"
-      - "-SA4006"
-      - "-ST1016"
-      - "-ST1005"
-
-issues:
-  exclude-files: []
-  exclude:
-    - "by other packages, and that stutters; consider calling this"
-    - "var-naming:"
-    - "receiver-naming:"
-    - "unexported-return:"
-    - "unused-parameter: parameter"
-    - "context-keys-type: should not use basic type string"
-    - "error strings should not be capitalized"
+    - unused
+  settings:
+    staticcheck:
+      checks:
+        - -SA1029
+        - -SA4006
+        - -ST1003
+        - -ST1005
+        - -ST1016
+        - all
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - path: (.+)\.go$
+        text: by other packages, and that stutters; consider calling this
+      - path: (.+)\.go$
+        text: 'var-naming:'
+      - path: (.+)\.go$
+        text: 'receiver-naming:'
+      - path: (.+)\.go$
+        text: 'unexported-return:'
+      - path: (.+)\.go$
+        text: 'unused-parameter: parameter'
+      - path: (.+)\.go$
+        text: 'context-keys-type: should not use basic type string'
+      - path: (.+)\.go$
+        text: error strings should not be capitalized
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/hatchet-dev/hatchet
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: trailing-whitespace
       - id: check-yaml
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.62.0
+    rev: v2.1.2
     hooks:
       - id: golangci-lint
         args: ["--config=.golangci.yml"]

--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -374,6 +374,7 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig) ([]Teardown, erro
 			olap.WithLogger(sc.Logger),
 			olap.WithPartition(p),
 			olap.WithTenantAlertManager(sc.TenantAlerter),
+			olap.WithSamplingConfig(sc.Sampling),
 		)
 
 		if err != nil {
@@ -818,6 +819,7 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig) ([]Teardown, erro
 			olap.WithLogger(sc.Logger),
 			olap.WithPartition(p),
 			olap.WithTenantAlertManager(sc.TenantAlerter),
+			olap.WithSamplingConfig(sc.Sampling),
 		)
 
 		if err != nil {

--- a/frontend/docs/pages/self-hosting/_meta.js
+++ b/frontend/docs/pages/self-hosting/_meta.js
@@ -26,4 +26,5 @@ export default {
   benchmarking: "Benchmarking",
   "data-retention": "Data Retention",
   "improving-performance": "Improving Performance",
+  sampling: "Sampling",
 };

--- a/frontend/docs/pages/self-hosting/_meta.js
+++ b/frontend/docs/pages/self-hosting/_meta.js
@@ -26,5 +26,5 @@ export default {
   benchmarking: "Benchmarking",
   "data-retention": "Data Retention",
   "improving-performance": "Improving Performance",
-  sampling: "Sampling",
+  sampling: "Trace Sampling",
 };

--- a/frontend/docs/pages/self-hosting/sampling.mdx
+++ b/frontend/docs/pages/self-hosting/sampling.mdx
@@ -1,0 +1,13 @@
+# Sampling
+
+For a very high-volume setup, it may be desirable to sample results for the dashboard for the purpose of limiting the amount of data stored in the Hatchet database. This can be done by setting the following environment variables:
+
+```bash
+SERVER_SAMPLING_ENABLED=t
+SERVER_SAMPLING_RATE=0.1 # only 10% of results will be sampled
+```
+
+Sampling is done at the workflow run level, so all tasks within the same workflow will be sampled, along with all of their events. Sampling has the following limitations:
+
+- Parent tasks which spawn child tasks are not guaranteed to be sampled, even if their children are. This means that the child task may be shown in the dashboard without a corresponding parent task, and vice versa.
+- There is no way to configure sampling to ensure that failure events are sampled.

--- a/frontend/docs/pages/self-hosting/sampling.mdx
+++ b/frontend/docs/pages/self-hosting/sampling.mdx
@@ -1,6 +1,6 @@
-# Sampling
+# Trace Sampling
 
-For a very high-volume setup, it may be desirable to sample results for the dashboard for the purpose of limiting the amount of data stored in the Hatchet database. This can be done by setting the following environment variables:
+For a very high-volume setup, it may be desirable to sample results for the dashboard for the purpose of limiting the amount of data stored in the Hatchet database. **This does not impact the behavior of the Hatchet engine and all tasks will still be processed.** This can be done by setting the following environment variables:
 
 ```bash
 SERVER_SAMPLING_ENABLED=t
@@ -11,3 +11,4 @@ Sampling is done at the workflow run level, so all tasks within the same workflo
 
 - Parent tasks which spawn child tasks are not guaranteed to be sampled, even if their children are. This means that the child task may be shown in the dashboard without a corresponding parent task, and vice versa.
 - There is no way to configure sampling to ensure that failure events are sampled.
+- Only tasks which are sampled can be cancelled or replayed via the REST APIs: do not use this feature if dependent on programmatic cancellations and replays.

--- a/internal/services/controllers/v1/olap/controller.go
+++ b/internal/services/controllers/v1/olap/controller.go
@@ -483,7 +483,7 @@ func (tc *OLAPControllerImpl) sample(workflowRunID string) bool {
 
 	bucket := hashToBucket(workflowRunID, 100)
 
-	return int64(bucket) <= *tc.samplingHashThreshold
+	return int64(bucket) < *tc.samplingHashThreshold
 }
 
 func hashToBucket(workflowRunID string, buckets int) int {

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -611,6 +611,7 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 		SchedulingPool:         schedulingPool,
 		SchedulingPoolV1:       schedulingPoolV1,
 		Version:                version,
+		Sampling:               cf.Sampling,
 	}, nil
 }
 

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -70,6 +70,8 @@ type ServerConfigFile struct {
 	Email ConfigFileEmail `mapstructure:"email" json:"email,omitempty"`
 
 	Monitoring ConfigFileMonitoring `mapstructure:"monitoring" json:"monitoring,omitempty"`
+
+	Sampling ConfigFileSampling `mapstructure:"sampling" json:"sampling,omitempty"`
 }
 
 type ConfigFileAdditionalLoggers struct {
@@ -78,6 +80,14 @@ type ConfigFileAdditionalLoggers struct {
 
 	// PgxStats is a custom logger config for the pgx stats service
 	PgxStats shared.LoggerConfigFile `mapstructure:"pgxStats" json:"pgxStats,omitempty"`
+}
+
+type ConfigFileSampling struct {
+	// Enabled controls whether sampling is enabled for this Hatchet instance.
+	Enabled bool `mapstructure:"enabled" json:"enabled,omitempty" default:"false"`
+
+	// SamplingRate is the rate at which to sample events. Default is 1.0 to sample all events.
+	SamplingRate float64 `mapstructure:"samplingRate" json:"samplingRate,omitempty" default:"1.0"`
 }
 
 // General server runtime options
@@ -506,6 +516,8 @@ type ServerConfig struct {
 
 	SchedulingPoolV1 *v1.SchedulingPool
 
+	Sampling ConfigFileSampling
+
 	Version string
 }
 
@@ -733,4 +745,7 @@ func BindAllEnv(v *viper.Viper) {
 	// we will fill this in from the server config if it is not set
 	_ = v.BindEnv("runtime.monitoring.tlsRootCAFile", "SERVER_MONITORING_TLS_ROOT_CA_FILE")
 
+	// sampling options
+	_ = v.BindEnv("sampling.enabled", "SERVER_SAMPLING_ENABLED")
+	_ = v.BindEnv("sampling.samplingRate", "SERVER_SAMPLING_RATE")
 }

--- a/pkg/repository/v1/sqlcv1/tasks.sql
+++ b/pkg/repository/v1/sqlcv1/tasks.sql
@@ -127,7 +127,8 @@ SELECT
     inserted_at,
     external_id,
     retry_count,
-    workflow_id
+    workflow_id,
+    workflow_run_id
 FROM
     v1_task
 WHERE

--- a/pkg/repository/v1/sqlcv1/tasks.sql.go
+++ b/pkg/repository/v1/sqlcv1/tasks.sql.go
@@ -729,7 +729,8 @@ SELECT
     inserted_at,
     external_id,
     retry_count,
-    workflow_id
+    workflow_id,
+    workflow_run_id
 FROM
     v1_task
 WHERE
@@ -743,11 +744,12 @@ type ListTaskMetasParams struct {
 }
 
 type ListTaskMetasRow struct {
-	ID         int64              `json:"id"`
-	InsertedAt pgtype.Timestamptz `json:"inserted_at"`
-	ExternalID pgtype.UUID        `json:"external_id"`
-	RetryCount int32              `json:"retry_count"`
-	WorkflowID pgtype.UUID        `json:"workflow_id"`
+	ID            int64              `json:"id"`
+	InsertedAt    pgtype.Timestamptz `json:"inserted_at"`
+	ExternalID    pgtype.UUID        `json:"external_id"`
+	RetryCount    int32              `json:"retry_count"`
+	WorkflowID    pgtype.UUID        `json:"workflow_id"`
+	WorkflowRunID pgtype.UUID        `json:"workflow_run_id"`
 }
 
 func (q *Queries) ListTaskMetas(ctx context.Context, db DBTX, arg ListTaskMetasParams) ([]*ListTaskMetasRow, error) {
@@ -765,6 +767,7 @@ func (q *Queries) ListTaskMetas(ctx context.Context, db DBTX, arg ListTaskMetasP
 			&i.ExternalID,
 			&i.RetryCount,
 			&i.WorkflowID,
+			&i.WorkflowRunID,
 		); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
# Description

Adds sampling for the monitoring controller. Can be enabled via env vars:

```
SERVER_SAMPLING_ENABLED=t
SERVER_SAMPLING_RATE=0.1
```

Known issues:
- Parent/child workflows don't maintain sampling consistency
- Should have a way to retain all failed
- Workflow runs can't be accessed directly in the UI if they're not sampled (which we can eventually fix with proxying to the gRPC service)

## Type of change

- [X] New feature (non-breaking change which adds functionality)