### PR TITLE
Fix: Wire up outputs in REST API

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20250422170746_v1_0_16.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20250422170746_v1_0_16.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE v1_tasks_olap
+ADD COLUMN step_readable_id TEXT NOT NULL DEFAULT '';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE v1_tasks_olap
+DROP COLUMN step_readable_id;
+-- +goose StatementEnd

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -396,6 +396,7 @@ func (r *OLAPRepositoryImpl) ReadWorkflowRun(ctx context.Context, workflowRunExt
 			WorkflowVersionId:    row.WorkflowVersionID,
 			Input:                row.Input,
 			ParentTaskExternalId: &row.ParentTaskExternalID,
+			Output:               &row.Output,
 		},
 		TaskMetadata: taskMetadata,
 	}, nil

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -396,7 +396,6 @@ func (r *OLAPRepositoryImpl) ReadWorkflowRun(ctx context.Context, workflowRunExt
 			WorkflowVersionId:    row.WorkflowVersionID,
 			Input:                row.Input,
 			ParentTaskExternalId: &row.ParentTaskExternalID,
-			Output:               &row.Output,
 		},
 		TaskMetadata: taskMetadata,
 	}, nil
@@ -1145,6 +1144,7 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId string
 			DagInsertedAt:        task.DagInsertedAt,
 			ParentTaskExternalID: task.ParentTaskExternalID,
 			WorkflowRunID:        task.WorkflowRunID,
+			StepReadableID:       task.StepReadableID,
 		})
 	}
 

--- a/pkg/repository/v1/sqlcv1/copyfrom.go
+++ b/pkg/repository/v1/sqlcv1/copyfrom.go
@@ -251,6 +251,7 @@ func (r iteratorForCreateTasksOLAP) Values() ([]interface{}, error) {
 		r.rows[0].DagID,
 		r.rows[0].DagInsertedAt,
 		r.rows[0].ParentTaskExternalID,
+		r.rows[0].StepReadableID,
 	}, nil
 }
 
@@ -259,7 +260,7 @@ func (r iteratorForCreateTasksOLAP) Err() error {
 }
 
 func (q *Queries) CreateTasksOLAP(ctx context.Context, db DBTX, arg []CreateTasksOLAPParams) (int64, error) {
-	return db.CopyFrom(ctx, []string{"v1_tasks_olap"}, []string{"tenant_id", "id", "inserted_at", "queue", "action_id", "step_id", "workflow_id", "workflow_version_id", "workflow_run_id", "schedule_timeout", "step_timeout", "priority", "sticky", "desired_worker_id", "external_id", "display_name", "input", "additional_metadata", "dag_id", "dag_inserted_at", "parent_task_external_id"}, &iteratorForCreateTasksOLAP{rows: arg})
+	return db.CopyFrom(ctx, []string{"v1_tasks_olap"}, []string{"tenant_id", "id", "inserted_at", "queue", "action_id", "step_id", "workflow_id", "workflow_version_id", "workflow_run_id", "schedule_timeout", "step_timeout", "priority", "sticky", "desired_worker_id", "external_id", "display_name", "input", "additional_metadata", "dag_id", "dag_inserted_at", "parent_task_external_id", "step_readable_id"}, &iteratorForCreateTasksOLAP{rows: arg})
 }
 
 // iteratorForInsertLogLine implements pgx.CopyFromSource.

--- a/pkg/repository/v1/sqlcv1/models.go
+++ b/pkg/repository/v1/sqlcv1/models.go
@@ -2747,6 +2747,7 @@ type V1TasksOlap struct {
 	Queue                string               `json:"queue"`
 	ActionID             string               `json:"action_id"`
 	StepID               pgtype.UUID          `json:"step_id"`
+	StepReadableID       string               `json:"step_readable_id"`
 	WorkflowID           pgtype.UUID          `json:"workflow_id"`
 	WorkflowVersionID    pgtype.UUID          `json:"workflow_version_id"`
 	WorkflowRunID        pgtype.UUID          `json:"workflow_run_id"`

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -1484,9 +1484,18 @@ WITH runs AS (
         MIN(e.inserted_at)::timestamptz AS created_at,
         MIN(e.inserted_at) FILTER (WHERE e.readable_status = 'RUNNING')::timestamptz AS started_at,
         MAX(e.inserted_at) FILTER (WHERE e.readable_status IN ('COMPLETED', 'CANCELLED', 'FAILED'))::timestamptz AS finished_at,
-        JSON_AGG(JSON_BUILD_OBJECT('task_id', e.task_id,'task_inserted_at', e.task_inserted_at)) AS task_metadata
+        JSON_AGG(JSON_BUILD_OBJECT('task_id', e.task_id,'task_inserted_at', e.task_inserted_at)) AS task_metadata,
+        JSONB_OBJECT_AGG(
+            t.step_readable_id,
+            e.output
+        ) FILTER (
+            WHERE e.readable_status = 'COMPLETED'
+            AND e.output IS NOT NULL
+            AND t.step_readable_id <> ''
+        )::JSONB AS output
     FROM
         relevant_events e
+    JOIN v1_tasks_olap t ON (e.task_id, e.task_inserted_at) = (t.id, t.inserted_at)
     JOIN max_retry_counts mrc ON (e.task_id, e.retry_count) = (mrc.task_id, mrc.max_retry_count)
 ), error_message AS (
     SELECT
@@ -1505,7 +1514,8 @@ SELECT
     m.started_at,
     m.finished_at,
     e.error_message,
-    m.task_metadata
+    m.task_metadata,
+    m.output
 FROM runs r
 LEFT JOIN metadata m ON true
 LEFT JOIN error_message e ON true
@@ -1532,6 +1542,7 @@ type ReadWorkflowRunByExternalIdRow struct {
 	FinishedAt           pgtype.Timestamptz   `json:"finished_at"`
 	ErrorMessage         pgtype.Text          `json:"error_message"`
 	TaskMetadata         []byte               `json:"task_metadata"`
+	Output               []byte               `json:"output"`
 }
 
 func (q *Queries) ReadWorkflowRunByExternalId(ctx context.Context, db DBTX, workflowrunexternalid pgtype.UUID) (*ReadWorkflowRunByExternalIdRow, error) {
@@ -1557,6 +1568,7 @@ func (q *Queries) ReadWorkflowRunByExternalId(ctx context.Context, db DBTX, work
 		&i.FinishedAt,
 		&i.ErrorMessage,
 		&i.TaskMetadata,
+		&i.Output,
 	)
 	return &i, err
 }

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -1479,7 +1479,8 @@ WITH runs AS (
         MIN(e.inserted_at)::timestamptz AS created_at,
         MIN(e.inserted_at) FILTER (WHERE e.readable_status = 'RUNNING')::timestamptz AS started_at,
         MAX(e.inserted_at) FILTER (WHERE e.readable_status IN ('COMPLETED', 'CANCELLED', 'FAILED'))::timestamptz AS finished_at,
-        JSON_AGG(JSON_BUILD_OBJECT('task_id', e.task_id,'task_inserted_at', e.task_inserted_at)) AS task_metadata
+        JSON_AGG(JSON_BUILD_OBJECT('task_id', e.task_id,'task_inserted_at', e.task_inserted_at)) AS task_metadata,
+        MAX(output::TEXT) FILTER (WHERE e.readable_status = 'COMPLETED')::JSONB AS output
     FROM
         relevant_events e
     JOIN max_retry_counts mrc ON (e.task_id, e.retry_count) = (mrc.task_id, mrc.max_retry_count)
@@ -1500,7 +1501,8 @@ SELECT
     m.started_at,
     m.finished_at,
     e.error_message,
-    m.task_metadata
+    m.task_metadata,
+    m.output
 FROM runs r
 LEFT JOIN metadata m ON true
 LEFT JOIN error_message e ON true
@@ -1527,6 +1529,7 @@ type ReadWorkflowRunByExternalIdRow struct {
 	FinishedAt           pgtype.Timestamptz   `json:"finished_at"`
 	ErrorMessage         pgtype.Text          `json:"error_message"`
 	TaskMetadata         []byte               `json:"task_metadata"`
+	Output               []byte               `json:"output"`
 }
 
 func (q *Queries) ReadWorkflowRunByExternalId(ctx context.Context, db DBTX, workflowrunexternalid pgtype.UUID) (*ReadWorkflowRunByExternalIdRow, error) {
@@ -1552,6 +1555,7 @@ func (q *Queries) ReadWorkflowRunByExternalId(ctx context.Context, db DBTX, work
 		&i.FinishedAt,
 		&i.ErrorMessage,
 		&i.TaskMetadata,
+		&i.Output,
 	)
 	return &i, err
 }

--- a/sdks/python/examples/cancellation/test_cancellation.py
+++ b/sdks/python/examples/cancellation/test_cancellation.py
@@ -22,7 +22,6 @@ async def test_cancellation(hatchet: Hatchet) -> None:
             continue
 
         assert run.run.status == V1TaskStatus.CANCELLED
-        assert not run.run.output
 
         break
     else:

--- a/sql/schema/v1-olap.sql
+++ b/sql/schema/v1-olap.sql
@@ -143,6 +143,7 @@ CREATE TABLE v1_tasks_olap (
     queue TEXT NOT NULL,
     action_id TEXT NOT NULL,
     step_id UUID NOT NULL,
+    step_readable_id TEXT NOT NULL DEFAULT '',
     workflow_id UUID NOT NULL,
     workflow_version_id UUID NOT NULL,
     workflow_run_id UUID NOT NULL,


### PR DESCRIPTION
# Description

Sending back outputs with the `V1WorkflowRunDetails` correctly over the API


- [x] Bug fix (non-breaking change which fixes an issue)

