### PR TITLE
[Go]: Fix: Add `ToPB` implementation for `parentCondition`

### DIFF
--- a/pkg/worker/condition/condition.go
+++ b/pkg/worker/condition/condition.go
@@ -134,6 +134,19 @@ func ParentCondition(parent NamedTask, expression string) *parentCondition {
 	}
 }
 
+func (p *parentCondition) ToPB(action contracts.Action) *ConditionMulti {
+	parent := &contracts.ParentOverrideMatchCondition{
+		Base:             p.baseCondition.baseCondition(action),
+		ParentReadableId: p.parentReadableId,
+	}
+
+	return &ConditionMulti{
+		SleepConditions:     nil,
+		UserEventConditions: nil,
+		ParentConditions:    []*contracts.ParentOverrideMatchCondition{parent},
+	}
+}
+
 type orGroup struct {
 	orGroupID  uuid.UUID
 	conditions []Condition


### PR DESCRIPTION
# Description

We were missing a `ToPB`, which was causing us to fall back to the default and drop conditions

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

