### PR TITLE
Fix: Retry + Cancel Bugs

### DIFF
--- a/internal/services/dispatcher/dispatcher_v1.go
+++ b/internal/services/dispatcher/dispatcher_v1.go
@@ -35,7 +35,7 @@ func (worker *subscribedWorker) StartTaskFromBulk(
 		inputBytes = task.Input
 	}
 
-	action := populateAssignedAction(tenantId, task)
+	action := populateAssignedAction(tenantId, task, task.RetryCount)
 
 	action.ActionType = contracts.ActionType_START_STEP_RUN
 	action.ActionPayload = string(inputBytes)
@@ -50,11 +50,12 @@ func (worker *subscribedWorker) CancelTask(
 	ctx context.Context,
 	tenantId string,
 	task *sqlcv1.V1Task,
+	retryCount int32,
 ) error {
 	ctx, span := telemetry.NewSpan(ctx, "cancel-task") // nolint:ineffassign
 	defer span.End()
 
-	action := populateAssignedAction(tenantId, task)
+	action := populateAssignedAction(tenantId, task, retryCount)
 
 	action.ActionType = contracts.ActionType_CANCEL_STEP_RUN
 
@@ -64,9 +65,9 @@ func (worker *subscribedWorker) CancelTask(
 	return worker.stream.Send(action)
 }
 
-func populateAssignedAction(tenantId string, task *sqlcv1.V1Task) *contracts.AssignedAction {
+func populateAssignedAction(tenantID string, task *sqlcv1.V1Task, retryCount int32) *contracts.AssignedAction {
 	action := &contracts.AssignedAction{
-		TenantId:      tenantId,
+		TenantId:      tenantID,
 		JobId:         sqlchelpers.UUIDToStr(task.StepID), // FIXME
 		JobName:       task.StepReadableID,
 		JobRunId:      sqlchelpers.UUIDToStr(task.ExternalID), // FIXME
@@ -75,7 +76,7 @@ func populateAssignedAction(tenantId string, task *sqlcv1.V1Task) *contracts.Ass
 		ActionId:      task.ActionID,
 		StepName:      task.StepReadableID,
 		WorkflowRunId: sqlchelpers.UUIDToStr(task.WorkflowRunID),
-		RetryCount:    task.RetryCount,
+		RetryCount:    retryCount,
 		Priority:      task.Priority.Int32,
 	}
 
@@ -314,10 +315,10 @@ func (d *DispatcherImpl) handleTaskCancelled(ctx context.Context, msg *msgqueuev
 
 	msgs := msgqueuev1.JSONConvert[tasktypesv1.SignalTaskCancelledPayload](msg.Payloads)
 
-	taskIdsToRetryCounts := make(map[int64]int32)
+	taskIdsToRetryCounts := make(map[int64][]int32)
 
 	for _, innerMsg := range msgs {
-		taskIdsToRetryCounts[innerMsg.TaskId] = innerMsg.RetryCount
+		taskIdsToRetryCounts[innerMsg.TaskId] = append(taskIdsToRetryCounts[innerMsg.TaskId], innerMsg.RetryCount)
 	}
 
 	taskIds := make([]int64, 0)
@@ -352,17 +353,10 @@ func (d *DispatcherImpl) handleTaskCancelled(ctx context.Context, msg *msgqueuev
 			continue
 		}
 
-		retryCount, ok := taskIdsToRetryCounts[msg.TaskId]
 		if !ok {
 			d.l.Warn().Msgf("task %d not found in retry counts", msg.TaskId)
 			continue
 		}
-
-		// Since we're handling cancellations, we need to use
-		// the _incoming_ retry count, not the one in the database,
-		// since we want to cancel the retry count of the task that was
-		// passed in.
-		task.RetryCount = retryCount
 
 		workerIdToTasks[msg.WorkerId] = append(workerIdToTasks[msg.WorkerId], task)
 	}
@@ -383,10 +377,19 @@ func (d *DispatcherImpl) handleTaskCancelled(ctx context.Context, msg *msgqueuev
 
 		for _, w := range workers {
 			for _, task := range tasks {
-				err = w.CancelTask(ctx, msg.TenantID, task)
+				retryCounts, ok := taskIdsToRetryCounts[task.ID]
 
-				if err != nil {
-					multiErr = multierror.Append(multiErr, fmt.Errorf("could not send job to worker: %w", err))
+				if !ok {
+					d.l.Warn().Msgf("task %d not found in retry counts", task.ID)
+					continue
+				}
+
+				for _, retryCount := range retryCounts {
+					err = w.CancelTask(ctx, msg.TenantID, task, retryCount)
+
+					if err != nil {
+						multiErr = multierror.Append(multiErr, fmt.Errorf("could not send job to worker: %w", err))
+					}
 				}
 			}
 		}

--- a/sdks/python/hatchet_sdk/clients/dispatcher/action_listener.py
+++ b/sdks/python/hatchet_sdk/clients/dispatcher/action_listener.py
@@ -146,6 +146,11 @@ class Action(BaseModel):
 
     @property
     def key(self) -> ActionKey:
+        """
+        This key is used to uniquely identify a single step run by its id + retry count.
+        It's used when storing references to a task, a context, etc. in a dictionary so that
+        we can look up those items in the dictionary by a unique key.
+        """
         if self.action_type == ActionType.START_GET_GROUP_KEY:
             return f"{self.get_group_key_run_id}/{self.retry_count}"
         else:

--- a/sdks/python/hatchet_sdk/clients/dispatcher/action_listener.py
+++ b/sdks/python/hatchet_sdk/clients/dispatcher/action_listener.py
@@ -88,6 +88,9 @@ class ActionType(str, Enum):
     START_GET_GROUP_KEY = "START_GET_GROUP_KEY"
 
 
+ActionKey = str
+
+
 class Action(BaseModel):
     worker_id: str
     tenant_id: str
@@ -140,6 +143,13 @@ class Action(BaseModel):
         }
 
         return {k: v for k, v in attrs.items() if v}
+
+    @property
+    def key(self) -> ActionKey:
+        if self.action_type == ActionType.START_GET_GROUP_KEY:
+            return f"{self.get_group_key_run_id}/{self.retry_count}"
+        else:
+            return f"{self.step_run_id}/{self.retry_count}"
 
 
 def parse_additional_metadata(additional_metadata: str) -> JSONSerializableMapping:

--- a/sdks/python/hatchet_sdk/context/context.py
+++ b/sdks/python/hatchet_sdk/context/context.py
@@ -127,15 +127,18 @@ class Context:
     def workflow_run_id(self) -> str:
         return self.action.workflow_run_id
 
+    def _set_cancellation_flag(self) -> None:
+        self.exit_flag = True
+
     def cancel(self) -> None:
         logger.debug("cancelling step...")
         self.runs_client.cancel(self.step_run_id)
-        self.exit_flag = True
+        self._set_cancellation_flag()
 
     async def aio_cancel(self) -> None:
         logger.debug("cancelling step...")
         await self.runs_client.aio_cancel(self.step_run_id)
-        self.exit_flag = True
+        self._set_cancellation_flag()
 
     # done returns true if the context has been cancelled
     def done(self) -> bool:

--- a/sdks/python/hatchet_sdk/opentelemetry/instrumentor.py
+++ b/sdks/python/hatchet_sdk/opentelemetry/instrumentor.py
@@ -272,12 +272,12 @@ class HatchetInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         args: tuple[Action],
         kwargs: Any,
     ) -> Exception | None:
-        step_run_id = args[0]
+        action = args[0]
 
         with self._tracer.start_as_current_span(
             "hatchet.cancel_step_run",
             attributes={
-                "hatchet.step_run_id": step_run_id,
+                "hatchet.step_run_id": action.step_run_id,
             },
         ):
             return await wrapped(*args, **kwargs)

--- a/sdks/python/hatchet_sdk/opentelemetry/instrumentor.py
+++ b/sdks/python/hatchet_sdk/opentelemetry/instrumentor.py
@@ -267,9 +267,9 @@ class HatchetInstrumentor(BaseInstrumentor):  # type: ignore[misc]
     ## IMPORTANT: Keep these types in sync with the wrapped method's signature
     async def _wrap_handle_cancel_action(
         self,
-        wrapped: Callable[[str], Coroutine[None, None, Exception | None]],
+        wrapped: Callable[[Action], Coroutine[None, None, Exception | None]],
         instance: Runner,
-        args: tuple[str],
+        args: tuple[Action],
         kwargs: Any,
     ) -> Exception | None:
         step_run_id = args[0]

--- a/sdks/python/hatchet_sdk/worker/runner/runner.py
+++ b/sdks/python/hatchet_sdk/worker/runner/runner.py
@@ -120,7 +120,7 @@ class Runner:
             case ActionType.CANCEL_STEP_RUN:
                 log = f"cancel: step run:  {action.action_id}/{action.step_run_id}/{action.retry_count}"
                 logger.info(log)
-                asyncio.create_task(self.handle_cancel_action(action.key))
+                asyncio.create_task(self.handle_cancel_action(action))
             case ActionType.START_GET_GROUP_KEY:
                 log = f"run: get group key:  {action.action_id}/{action.get_group_key_run_id}"
                 logger.info(log)
@@ -416,7 +416,8 @@ class Runner:
             logger.exception(f"Failed to terminate thread: {e}")
 
     ## IMPORTANT: Keep this method's signature in sync with the wrapper in the OTel instrumentor
-    async def handle_cancel_action(self, key: ActionKey) -> None:
+    async def handle_cancel_action(self, action: Action) -> None:
+        key = action.key
         try:
             # call cancel to signal the context to stop
             if key in self.contexts:

--- a/sdks/python/hatchet_sdk/worker/runner/runner.py
+++ b/sdks/python/hatchet_sdk/worker/runner/runner.py
@@ -129,9 +129,7 @@ class Runner:
                 log = f"unknown action type: {action.action_type}"
                 logger.error(log)
 
-    def step_run_callback(
-        self, action: Action, action_task: "Task[TWorkflowInput, R]"
-    ) -> Callable[[asyncio.Task[Any]], None]:
+    def step_run_callback(self, action: Action) -> Callable[[asyncio.Task[Any]], None]:
         def inner_callback(task: asyncio.Task[Any]) -> None:
             self.cleanup_run_id(action.key)
 
@@ -335,7 +333,7 @@ class Runner:
                 self.async_wrapped_action_func(context, action_func, action)
             )
 
-            task.add_done_callback(self.step_run_callback(action, action_func))
+            task.add_done_callback(self.step_run_callback(action))
             self.tasks[action.key] = task
 
             try:

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.6.3"
+version = "1.6.4"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Background task orchestration & visibility for developers",
   "types": "dist/index.d.ts",
   "files": [

--- a/sdks/typescript/src/clients/dispatcher/action-listener.ts
+++ b/sdks/typescript/src/clients/dispatcher/action-listener.ts
@@ -1,4 +1,4 @@
-import { DispatcherClient as PbDispatcherClient, AssignedAction } from '@hatchet/protoc/dispatcher';
+import { DispatcherClient as PbDispatcherClient, AssignedAction, ActionType } from '@hatchet/protoc/dispatcher';
 
 import { Status } from 'nice-grpc';
 import { ClientConfig } from '@clients/hatchet-client/client-config';
@@ -8,6 +8,7 @@ import { Logger } from '@hatchet/util/logger';
 
 import { DispatcherClient } from './dispatcher-client';
 import { Heartbeat } from './heartbeat/heartbeat-controller';
+import { StepRun } from '../rest/generated/data-contracts';
 
 const DEFAULT_ACTION_LISTENER_RETRY_INTERVAL = 5000; // milliseconds
 const DEFAULT_ACTION_LISTENER_RETRY_COUNT = 20;
@@ -19,6 +20,24 @@ enum ListenStrategy {
 }
 
 export interface Action extends AssignedAction {}
+
+export type ActionKey = string
+
+export function createActionKey(
+  action: Action
+): ActionKey {
+  switch (action.actionType) {
+    case ActionType.START_GET_GROUP_KEY:
+      return `${action.getGroupKeyRunId}/${action.retryCount}`;
+    case ActionType.CANCEL_STEP_RUN:
+    case ActionType.START_STEP_RUN:
+    case ActionType.UNRECOGNIZED:
+      return `${action.stepRunId}/${action.retryCount}`
+    default:
+      const exhaustivenessCheck: never = action.actionType;
+      throw new Error(`Unhandled action type: ${exhaustivenessCheck}`);
+  }
+}
 
 export class ActionListener {
   config: ClientConfig;

--- a/sdks/typescript/src/clients/dispatcher/action-listener.ts
+++ b/sdks/typescript/src/clients/dispatcher/action-listener.ts
@@ -1,4 +1,8 @@
-import { DispatcherClient as PbDispatcherClient, AssignedAction, ActionType } from '@hatchet/protoc/dispatcher';
+import {
+  DispatcherClient as PbDispatcherClient,
+  AssignedAction,
+  ActionType,
+} from '@hatchet/protoc/dispatcher';
 
 import { Status } from 'nice-grpc';
 import { ClientConfig } from '@clients/hatchet-client/client-config';
@@ -8,7 +12,6 @@ import { Logger } from '@hatchet/util/logger';
 
 import { DispatcherClient } from './dispatcher-client';
 import { Heartbeat } from './heartbeat/heartbeat-controller';
-import { StepRun } from '../rest/generated/data-contracts';
 
 const DEFAULT_ACTION_LISTENER_RETRY_INTERVAL = 5000; // milliseconds
 const DEFAULT_ACTION_LISTENER_RETRY_COUNT = 20;
@@ -21,19 +24,18 @@ enum ListenStrategy {
 
 export interface Action extends AssignedAction {}
 
-export type ActionKey = string
+export type ActionKey = string;
 
-export function createActionKey(
-  action: Action
-): ActionKey {
+export function createActionKey(action: Action): ActionKey {
   switch (action.actionType) {
     case ActionType.START_GET_GROUP_KEY:
       return `${action.getGroupKeyRunId}/${action.retryCount}`;
     case ActionType.CANCEL_STEP_RUN:
     case ActionType.START_STEP_RUN:
     case ActionType.UNRECOGNIZED:
-      return `${action.stepRunId}/${action.retryCount}`
+      return `${action.stepRunId}/${action.retryCount}`;
     default:
+      // eslint-disable-next-line no-case-declarations
       const exhaustivenessCheck: never = action.actionType;
       throw new Error(`Unhandled action type: ${exhaustivenessCheck}`);
   }

--- a/sdks/typescript/src/clients/worker/worker.ts
+++ b/sdks/typescript/src/clients/worker/worker.ts
@@ -2,7 +2,12 @@
 /* eslint-disable no-nested-ternary */
 import { InternalHatchetClient } from '@clients/hatchet-client';
 import HatchetError from '@util/errors/hatchet-error';
-import { Action, ActionKey, ActionListener, createActionKey } from '@clients/dispatcher/action-listener';
+import {
+  Action,
+  ActionKey,
+  ActionListener,
+  createActionKey,
+} from '@clients/dispatcher/action-listener';
 import {
   StepActionEvent,
   StepActionEventType,
@@ -34,7 +39,6 @@ import {
 import { taskConditionsToPb } from '@hatchet/v1/conditions/transformer';
 import { Context, CreateStep, DurableContext, mapRateLimit, StepRunFunction } from '../../step';
 import { WorkerLabels } from '../dispatcher/dispatcher-client';
-import { create } from 'domain';
 
 export type ActionRegistry = Record<Action['actionId'], Function>;
 


### PR DESCRIPTION
# Description

Fixing a couple of bugs that were popping up around retries + cancels:

* The retry count of the cancel event being sent from the engine was of the latest task, causing a race where a more recent task (a retry) could start, and then immediately be cancelled, leaving the old one running still
* Fixing a bug in the Python SDK where a cancellation signal would cause the `cancel` method to be called on the API and cancel the retry too (basically multiple cancellations)
* Fixing how the SDK keys actions to identify them by pairs of step run id + retry count

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)



TODO: Still need to fix the Go SDK here