### PR TITLE
fix: critical deadlock bug in scheduler

### DIFF
--- a/internal/services/scheduler/v1/scheduler.go
+++ b/internal/services/scheduler/v1/scheduler.go
@@ -193,8 +193,9 @@ func (s *Scheduler) Start() (func() error, error) {
 	_, err := s.s.NewJob(
 		gocron.DurationJob(time.Second*1),
 		gocron.NewTask(
-			s.runTenantSetQueues(ctx),
+			s.runSetTenants(ctx),
 		),
+		gocron.WithSingletonMode(gocron.LimitModeReschedule),
 	)
 
 	if err != nil {
@@ -332,7 +333,7 @@ func (s *Scheduler) handleCheckQueue(ctx context.Context, msg *msgqueue.Message)
 	return nil
 }
 
-func (s *Scheduler) runTenantSetQueues(ctx context.Context) func() {
+func (s *Scheduler) runSetTenants(ctx context.Context) func() {
 	return func() {
 		s.l.Debug().Msgf("partition: checking step run requeue")
 

--- a/pkg/repository/v1/scheduler.go
+++ b/pkg/repository/v1/scheduler.go
@@ -39,7 +39,6 @@ type QueueRepository interface {
 }
 
 type RateLimitRepository interface {
-	ListCandidateRateLimits(ctx context.Context, tenantId pgtype.UUID) ([]string, error)
 	UpdateRateLimits(ctx context.Context, tenantId pgtype.UUID, updates map[string]int) (map[string]int, *time.Time, error)
 }
 

--- a/pkg/repository/v1/scheduler_concurrency.go
+++ b/pkg/repository/v1/scheduler_concurrency.go
@@ -68,7 +68,7 @@ func (c *ConcurrencyRepositoryImpl) UpdateConcurrencyStrategyIsActive(
 
 	defer rollback()
 
-	err = c.queries.ConcurrencyAdvisoryLock(ctx, tx, strategy.ID)
+	err = c.queries.AdvisoryLock(ctx, tx, strategy.ID)
 
 	if err != nil {
 		return err
@@ -131,7 +131,7 @@ func (c *ConcurrencyRepositoryImpl) runGroupRoundRobin(
 
 	defer rollback()
 
-	err = c.queries.ConcurrencyAdvisoryLock(ctx, tx, strategy.ID)
+	err = c.queries.AdvisoryLock(ctx, tx, strategy.ID)
 
 	if err != nil {
 		return nil, err
@@ -142,7 +142,7 @@ func (c *ConcurrencyRepositoryImpl) runGroupRoundRobin(
 	var nextConcurrencyStrategies []int64
 
 	if strategy.ParentStrategyID.Valid {
-		acquired, err := c.queries.TryConcurrencyAdvisoryLock(ctx, tx, PARENT_STRATEGY_LOCK_OFFSET+strategy.ParentStrategyID.Int64)
+		acquired, err := c.queries.TryAdvisoryLock(ctx, tx, PARENT_STRATEGY_LOCK_OFFSET+strategy.ParentStrategyID.Int64)
 
 		if err != nil {
 			return nil, err
@@ -271,7 +271,7 @@ func (c *ConcurrencyRepositoryImpl) runCancelInProgress(
 
 	defer rollback()
 
-	err = c.queries.ConcurrencyAdvisoryLock(ctx, tx, strategy.ID)
+	err = c.queries.AdvisoryLock(ctx, tx, strategy.ID)
 
 	if err != nil {
 		return nil, err
@@ -282,7 +282,7 @@ func (c *ConcurrencyRepositoryImpl) runCancelInProgress(
 	var nextConcurrencyStrategies []int64
 
 	if strategy.ParentStrategyID.Valid {
-		err := c.queries.ConcurrencyAdvisoryLock(ctx, tx, PARENT_STRATEGY_LOCK_OFFSET+strategy.ParentStrategyID.Int64)
+		err := c.queries.AdvisoryLock(ctx, tx, PARENT_STRATEGY_LOCK_OFFSET+strategy.ParentStrategyID.Int64)
 
 		if err != nil {
 			return nil, err
@@ -470,7 +470,7 @@ func (c *ConcurrencyRepositoryImpl) runCancelNewest(
 
 	defer rollback()
 
-	err = c.queries.ConcurrencyAdvisoryLock(ctx, tx, strategy.ID)
+	err = c.queries.AdvisoryLock(ctx, tx, strategy.ID)
 
 	if err != nil {
 		return nil, err
@@ -481,7 +481,7 @@ func (c *ConcurrencyRepositoryImpl) runCancelNewest(
 	var nextConcurrencyStrategies []int64
 
 	if strategy.ParentStrategyID.Valid {
-		err := c.queries.ConcurrencyAdvisoryLock(ctx, tx, PARENT_STRATEGY_LOCK_OFFSET+strategy.ParentStrategyID.Int64)
+		err := c.queries.AdvisoryLock(ctx, tx, PARENT_STRATEGY_LOCK_OFFSET+strategy.ParentStrategyID.Int64)
 
 		if err != nil {
 			return nil, err

--- a/pkg/repository/v1/sqlcv1/concurrency.sql
+++ b/pkg/repository/v1/sqlcv1/concurrency.sql
@@ -115,10 +115,10 @@ WHERE
     step_id = @stepId::uuid AND
     id = @strategyId::bigint;
 
--- name: ConcurrencyAdvisoryLock :exec
+-- name: AdvisoryLock :exec
 SELECT pg_advisory_xact_lock(@key::bigint);
 
--- name: TryConcurrencyAdvisoryLock :one
+-- name: TryAdvisoryLock :one
 SELECT pg_try_advisory_xact_lock(@key::bigint) AS "locked";
 
 -- name: RunParentGroupRoundRobin :exec

--- a/pkg/scheduling/v1/queuer.go
+++ b/pkg/scheduling/v1/queuer.go
@@ -2,7 +2,6 @@ package v2
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -511,60 +510,4 @@ func (q *Queuer) flushToDatabase(ctx context.Context, r *assignResults) int {
 	}
 
 	return len(succeeded) + len(r.schedulingTimedOut)
-}
-
-func getLargerDuration(s1, s2 string) (string, error) {
-	i1, err := getDurationIndex(s1)
-	if err != nil {
-		return "", err
-	}
-
-	i2, err := getDurationIndex(s2)
-	if err != nil {
-		return "", err
-	}
-
-	if i1 > i2 {
-		return s1, nil
-	}
-
-	return s2, nil
-}
-
-func getDurationIndex(s string) (int, error) {
-	for i, d := range durationStrings {
-		if d == s {
-			return i, nil
-		}
-	}
-
-	return -1, fmt.Errorf("invalid duration string: %s", s)
-}
-
-var durationStrings = []string{
-	"SECOND",
-	"MINUTE",
-	"HOUR",
-	"DAY",
-	"WEEK",
-	"MONTH",
-	"YEAR",
-}
-
-func getWindowParamFromDurString(dur string) string {
-	// validate duration string
-	found := false
-
-	for _, d := range durationStrings {
-		if d == dur {
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		return "MINUTE"
-	}
-
-	return fmt.Sprintf("1 %s", dur)
 }


### PR DESCRIPTION
# Description

Fixes a deadlock when cleaning up a tenant in the scheduler, which can happen when a tenant is moved to a different partition during restarts or redeploys.  

The deadlock happens when the `Cleanup()` method is called on the `LeaseManager`. The lease manager is responsible for acquiring leases on workers, queues, and concurrency strategies. Leases are refreshed very often, and if we're not processing the lease operations, the queues, workers, and strategies that we're processing will all remain constant.  

The deadlocking was due to mutexes being acquired out of order:
1. The `Cleanup` method acquires a lock the `cleanupMu` and then acquires a lock on the worker, queue, and concurrency strategy mutexes. 
2. In the `acquire<Resource>Leases` methods, we acquire a lock on the worker, queue or concurrency strategy mutexes, and then acquire a lock on the `cleanupMu`. 

So we could end up in a state where one of the `acquire` methods are waiting for the `cleanupMu` lock and the `Cleanup` method is waiting for a resource lock. 

This led to some interesting downstream impact:
1. Because the lease manager wasn't updating its queues, each of the existing queues would continue to process, sometimes with or without workers. So this would lead to random `scheduling timed out` or `no worker available` errors because the lease's were completely out of sync (for example, a queue lease still being held with all worker leases expired). 

3. While the `queuer` is somewhat concurrency-safe since we use `for update skip locked`, the queue items would be read properly but there would be additional locks on other tables, like rate limits. This led to observed deadlocking on the rate limit tables (which we will get to later). 

The fix here simplifies lock management of the `LeaseManager` to a single process-level lock, which guards any lease-modifying operation from running concurrently. The resource-level locks aren't necessary after we added the cleanup mutex, which was effectively trying to operate as a process mutex. 

Based on the behavior observed downstream, there's an additional fix for guarding the rate limiter with an advisory lock in the database based on an FNV hash of the tenant id. The chance of collisions here is extremely unlikely (something like 1 in the 10^12). 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)