### PR TITLE
Fix: Add docs redirects to Python SDK reference

### DIFF
--- a/frontend/docs/next.config.mjs
+++ b/frontend/docs/next.config.mjs
@@ -140,6 +140,16 @@ const nextConfig = {
         destination: "/home/child-spawning",
         permanent: false,
       },
+      {
+        source: "/sdks/python-sdk/:path*",
+        destination: "/sdks/python/client",
+        permanent: false,
+      },
+      {
+        source: "/sdks/python",
+        destination: "/sdks/python/client",
+        permanent: false,
+      }
     ];
   },
 }


### PR DESCRIPTION
# Description

Adding redirects from the old routes to the new one. Paths are broken so just redirecting to the root

## Type of change

- [x] Documentation change (pure documentation change)

