### PR TITLE
fix: cancel if behavior

### DIFF
--- a/pkg/repository/v1/trigger.go
+++ b/pkg/repository/v1/trigger.go
@@ -1314,27 +1314,25 @@ func getParentInDAGGroupMatch(
 					Action:            sqlcv1.V1MatchConditionActionCANCEL,
 				})
 		}
+	} else {
+		res = append(res, GroupMatchCondition{
+			GroupId:           cancelGroupId,
+			EventType:         sqlcv1.V1EventTypeINTERNAL,
+			EventKey:          string(sqlcv1.V1TaskEventTypeFAILED),
+			ReadableDataKey:   parentReadableId,
+			EventResourceHint: &parentExternalId,
+			Expression:        "true",
+			Action:            sqlcv1.V1MatchConditionActionCANCEL,
+		}, GroupMatchCondition{
+			GroupId:           cancelGroupId,
+			EventType:         sqlcv1.V1EventTypeINTERNAL,
+			EventKey:          string(sqlcv1.V1TaskEventTypeCANCELLED),
+			ReadableDataKey:   parentReadableId,
+			EventResourceHint: &parentExternalId,
+			Expression:        "true",
+			Action:            sqlcv1.V1MatchConditionActionCANCEL,
+		})
 	}
-
-	// always add the original cancel group match conditions. these can't be modified otherwise DAGs risk
-	// getting stuck in a concurrency queue.
-	res = append(res, GroupMatchCondition{
-		GroupId:           cancelGroupId,
-		EventType:         sqlcv1.V1EventTypeINTERNAL,
-		EventKey:          string(sqlcv1.V1TaskEventTypeFAILED),
-		ReadableDataKey:   parentReadableId,
-		EventResourceHint: &parentExternalId,
-		Expression:        "true",
-		Action:            sqlcv1.V1MatchConditionActionCANCEL,
-	}, GroupMatchCondition{
-		GroupId:           cancelGroupId,
-		EventType:         sqlcv1.V1EventTypeINTERNAL,
-		EventKey:          string(sqlcv1.V1TaskEventTypeCANCELLED),
-		ReadableDataKey:   parentReadableId,
-		EventResourceHint: &parentExternalId,
-		Expression:        "true",
-		Action:            sqlcv1.V1MatchConditionActionCANCEL,
-	})
 
 	return res
 }

--- a/pkg/repository/v1/trigger.go
+++ b/pkg/repository/v1/trigger.go
@@ -1283,16 +1283,36 @@ func getParentInDAGGroupMatch(
 
 	if len(actionsToOverrides[sqlcv1.V1MatchConditionActionCANCEL]) > 0 {
 		for _, override := range actionsToOverrides[sqlcv1.V1MatchConditionActionCANCEL] {
-			res = append(res, GroupMatchCondition{
-				GroupId:   sqlchelpers.UUIDToStr(override.OrGroupID),
-				EventType: sqlcv1.V1EventTypeINTERNAL,
-				// The custom cancel condition matches on the completed event
-				EventKey:          string(sqlcv1.V1TaskEventTypeCOMPLETED),
-				ReadableDataKey:   parentReadableId,
-				EventResourceHint: &parentExternalId,
-				Expression:        override.Expression.String,
-				Action:            sqlcv1.V1MatchConditionActionCANCEL,
-			})
+			res = append(res,
+				GroupMatchCondition{
+					GroupId:   sqlchelpers.UUIDToStr(override.OrGroupID),
+					EventType: sqlcv1.V1EventTypeINTERNAL,
+					// The custom cancel condition matches on the completed event
+					EventKey:          string(sqlcv1.V1TaskEventTypeCOMPLETED),
+					ReadableDataKey:   parentReadableId,
+					EventResourceHint: &parentExternalId,
+					Expression:        override.Expression.String,
+					Action:            sqlcv1.V1MatchConditionActionCANCEL,
+				},
+				// always add the original cancel group match conditions. these can't be modified otherwise DAGs risk
+				// getting stuck in a concurrency queue.
+				GroupMatchCondition{
+					GroupId:           sqlchelpers.UUIDToStr(override.OrGroupID),
+					EventType:         sqlcv1.V1EventTypeINTERNAL,
+					EventKey:          string(sqlcv1.V1TaskEventTypeFAILED),
+					ReadableDataKey:   parentReadableId,
+					EventResourceHint: &parentExternalId,
+					Expression:        "true",
+					Action:            sqlcv1.V1MatchConditionActionCANCEL,
+				}, GroupMatchCondition{
+					GroupId:           sqlchelpers.UUIDToStr(override.OrGroupID),
+					EventType:         sqlcv1.V1EventTypeINTERNAL,
+					EventKey:          string(sqlcv1.V1TaskEventTypeCANCELLED),
+					ReadableDataKey:   parentReadableId,
+					EventResourceHint: &parentExternalId,
+					Expression:        "true",
+					Action:            sqlcv1.V1MatchConditionActionCANCEL,
+				})
 		}
 	}
 

--- a/pkg/repository/v1/trigger.go
+++ b/pkg/repository/v1/trigger.go
@@ -1284,34 +1284,37 @@ func getParentInDAGGroupMatch(
 	if len(actionsToOverrides[sqlcv1.V1MatchConditionActionCANCEL]) > 0 {
 		for _, override := range actionsToOverrides[sqlcv1.V1MatchConditionActionCANCEL] {
 			res = append(res, GroupMatchCondition{
-				GroupId:           sqlchelpers.UUIDToStr(override.OrGroupID),
-				EventType:         sqlcv1.V1EventTypeINTERNAL,
-				EventKey:          string(sqlcv1.V1TaskEventTypeFAILED),
+				GroupId:   sqlchelpers.UUIDToStr(override.OrGroupID),
+				EventType: sqlcv1.V1EventTypeINTERNAL,
+				// The custom cancel condition matches on the completed event
+				EventKey:          string(sqlcv1.V1TaskEventTypeCOMPLETED),
 				ReadableDataKey:   parentReadableId,
 				EventResourceHint: &parentExternalId,
 				Expression:        override.Expression.String,
 				Action:            sqlcv1.V1MatchConditionActionCANCEL,
 			})
 		}
-	} else {
-		res = append(res, GroupMatchCondition{
-			GroupId:           cancelGroupId,
-			EventType:         sqlcv1.V1EventTypeINTERNAL,
-			EventKey:          string(sqlcv1.V1TaskEventTypeFAILED),
-			ReadableDataKey:   parentReadableId,
-			EventResourceHint: &parentExternalId,
-			Expression:        "true",
-			Action:            sqlcv1.V1MatchConditionActionCANCEL,
-		}, GroupMatchCondition{
-			GroupId:           cancelGroupId,
-			EventType:         sqlcv1.V1EventTypeINTERNAL,
-			EventKey:          string(sqlcv1.V1TaskEventTypeCANCELLED),
-			ReadableDataKey:   parentReadableId,
-			EventResourceHint: &parentExternalId,
-			Expression:        "true",
-			Action:            sqlcv1.V1MatchConditionActionCANCEL,
-		})
 	}
+
+	// always add the original cancel group match conditions. these can't be modified otherwise DAGs risk
+	// getting stuck in a concurrency queue.
+	res = append(res, GroupMatchCondition{
+		GroupId:           cancelGroupId,
+		EventType:         sqlcv1.V1EventTypeINTERNAL,
+		EventKey:          string(sqlcv1.V1TaskEventTypeFAILED),
+		ReadableDataKey:   parentReadableId,
+		EventResourceHint: &parentExternalId,
+		Expression:        "true",
+		Action:            sqlcv1.V1MatchConditionActionCANCEL,
+	}, GroupMatchCondition{
+		GroupId:           cancelGroupId,
+		EventType:         sqlcv1.V1EventTypeINTERNAL,
+		EventKey:          string(sqlcv1.V1TaskEventTypeCANCELLED),
+		ReadableDataKey:   parentReadableId,
+		EventResourceHint: &parentExternalId,
+		Expression:        "true",
+		Action:            sqlcv1.V1MatchConditionActionCANCEL,
+	})
 
 	return res
 }


### PR DESCRIPTION
# Description

Fixes the behavior of `cancel_if` so that if a user overrides the behavior, we still register the cancellations on failure and upstream cancellation. The `cancel_if` behavior can only be overwritten based on a completed upstream task. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)