### PR TITLE
fix(go-sdk): actionId casing

### DIFF
--- a/pkg/v1/task/task.go
+++ b/pkg/v1/task/task.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	contracts "github.com/hatchet-dev/hatchet/internal/services/shared/proto/v1"
@@ -197,7 +198,7 @@ func makeContractTaskOpts(t *TaskShared, taskDefaults *create.TaskDefaults) *con
 func (t *TaskDeclaration[I]) Dump(workflowName string, taskDefaults *create.TaskDefaults) *contracts.CreateTaskOpts {
 	base := makeContractTaskOpts(&t.TaskShared, taskDefaults)
 	base.ReadableId = t.Name
-	base.Action = fmt.Sprintf("%s:%s", workflowName, t.Name)
+	base.Action = getActionID(workflowName, t.Name)
 	base.Parents = make([]string, len(t.Parents))
 	copy(base.Parents, t.Parents)
 
@@ -249,7 +250,7 @@ func durationToSeconds(d time.Duration) string {
 func (t *DurableTaskDeclaration[I]) Dump(workflowName string, taskDefaults *create.TaskDefaults) *contracts.CreateTaskOpts {
 	base := makeContractTaskOpts(&t.TaskShared, taskDefaults)
 	base.ReadableId = t.Name
-	base.Action = fmt.Sprintf("%s:%s", workflowName, t.Name)
+	base.Action = getActionID(workflowName, t.Name)
 	base.Parents = make([]string, len(t.Parents))
 	copy(base.Parents, t.Parents)
 	return base
@@ -260,7 +261,7 @@ func (t *OnFailureTaskDeclaration[I]) Dump(workflowName string, taskDefaults *cr
 	base := makeContractTaskOpts(&t.TaskShared, taskDefaults)
 
 	base.ReadableId = "on-failure"
-	base.Action = fmt.Sprintf("%s:%s", workflowName, "on-failure")
+	base.Action = getActionID(workflowName, "on-failure")
 
 	return base
 }
@@ -278,4 +279,8 @@ func (t *DurableTaskDeclaration[I]) GetName() string {
 // Implement GetName for NamedTask
 func (t *NamedTaskImpl) GetName() string {
 	return t.Name
+}
+
+func getActionID(workflowName, taskName string) string {
+	return strings.ToLower(fmt.Sprintf("%s:%s", workflowName, taskName))
 }

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -354,13 +354,12 @@ func (w *Worker) RegisterAction(actionId string, method any) error {
 }
 
 func (w *Worker) registerAction(service, verb string, method any, compute *compute.Compute) error {
-
-	actionId := fmt.Sprintf("%s:%s", service, verb)
+	actionID := strings.ToLower(fmt.Sprintf("%s:%s", service, verb))
 
 	// if the service is "concurrency", then this is a special action
 	if service == "concurrency" {
-		w.actions[actionId] = &actionImpl{
-			name:                 actionId,
+		w.actions[actionID] = &actionImpl{
+			name:                 actionID,
 			runConcurrencyAction: method.(GetWorkflowConcurrencyGroupFn),
 			method:               method,
 			service:              service,
@@ -378,14 +377,14 @@ func (w *Worker) registerAction(service, verb string, method any, compute *compu
 	}
 
 	// if action has already been registered, ensure that the method is the same
-	if currMethod, ok := w.actions[actionId]; ok {
+	if currMethod, ok := w.actions[actionID]; ok {
 		if reflect.ValueOf(currMethod.MethodFn()).Pointer() != reflect.ValueOf(method).Pointer() {
-			return fmt.Errorf("action %s is already registered with function %s", actionId, getFnName(currMethod.MethodFn()))
+			return fmt.Errorf("action %s is already registered with function %s", actionID, getFnName(currMethod.MethodFn()))
 		}
 	}
 
-	w.actions[actionId] = &actionImpl{
-		name:    actionId,
+	w.actions[actionID] = &actionImpl{
+		name:    actionID,
 		run:     actionFunc,
 		method:  method,
 		service: service,


### PR DESCRIPTION
# Description

Sending a capitalized workflow name in the Go SDK for v1 results in an internal server error. This lowercases the action id before sending. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)