### PR TITLE
Feat: Add cron filters to the API

### DIFF
--- a/api-contracts/openapi/paths/workflow/workflow.yaml
+++ b/api-contracts/openapi/paths/workflow/workflow.yaml
@@ -1309,6 +1309,18 @@ cronsList:
           format: uuid
           minLength: 36
           maxLength: 36
+      - description: The workflow name to get runs for.
+        in: query
+        name: workflowName
+        required: false
+        schema:
+          type: string
+      - description: The cron name to get runs for.
+        in: query
+        name: cronName
+        required: false
+        schema:
+          type: string
       - description: A list of metadata key value pairs to filter by
         in: query
         name: additionalMetadata

--- a/api/v1/server/handlers/workflows/list_crons.go
+++ b/api/v1/server/handlers/workflows/list_crons.go
@@ -58,6 +58,14 @@ func (t *WorkflowService) CronWorkflowList(ctx echo.Context, request gen.CronWor
 		listOpts.WorkflowId = &workflowIdStr
 	}
 
+	if request.Params.CronName != nil {
+		listOpts.CronName = request.Params.CronName
+	}
+
+	if request.Params.WorkflowName != nil {
+		listOpts.WorkflowName = request.Params.WorkflowName
+	}
+
 	if request.Params.AdditionalMetadata != nil {
 		additionalMetadata := make(map[string]interface{}, len(*request.Params.AdditionalMetadata))
 

--- a/api/v1/server/oas/gen/openapi.gen.go
+++ b/api/v1/server/oas/gen/openapi.gen.go
@@ -2058,6 +2058,12 @@ type CronWorkflowListParams struct {
 	// WorkflowId The workflow id to get runs for.
 	WorkflowId *openapi_types.UUID `form:"workflowId,omitempty" json:"workflowId,omitempty"`
 
+	// WorkflowName The workflow name to get runs for.
+	WorkflowName *string `form:"workflowName,omitempty" json:"workflowName,omitempty"`
+
+	// CronName The cron name to get runs for.
+	CronName *string `form:"cronName,omitempty" json:"cronName,omitempty"`
+
 	// AdditionalMetadata A list of metadata key value pairs to filter by
 	AdditionalMetadata *[]string `form:"additionalMetadata,omitempty" json:"additionalMetadata,omitempty"`
 
@@ -4529,6 +4535,20 @@ func (w *ServerInterfaceWrapper) CronWorkflowList(ctx echo.Context) error {
 	err = runtime.BindQueryParameter("form", true, false, "workflowId", ctx.QueryParams(), &params.WorkflowId)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter workflowId: %s", err))
+	}
+
+	// ------------- Optional query parameter "workflowName" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "workflowName", ctx.QueryParams(), &params.WorkflowName)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter workflowName: %s", err))
+	}
+
+	// ------------- Optional query parameter "cronName" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "cronName", ctx.QueryParams(), &params.CronName)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter cronName: %s", err))
 	}
 
 	// ------------- Optional query parameter "additionalMetadata" -------------
@@ -13037,41 +13057,41 @@ var swaggerSpec = []string{
 	"RerWDRtsjTrWZ8+x+AV5X6bb72TAygE8A5h4g1OWtHIKvQjIHbQlPwGYDEJr9pO3b0zZTzYQudemzIYu",
 	"ebrYmi29sV9Alrhf57vJQux0M8Faulk0rzIdUwjvQBYR/8NhryAqNpGYSc39fpHJefl3b/zksQnMk4pP",
 	"9lfimzC7usue1dtbq0z0psZ0LNvpAW8MSDCtXPbUWUyvvl6nfk/CkeEaDCxi1KtXJa+6iGfU3R41JF3i",
-	"ZLOJmxt8EKRJ3GyR0FbeX8k4B4qkaDJpDJ84SZP4VZspO5M1Um0sCum0E0iUSbzfkBzYdnBbdfLiXcoM",
-	"XJOrcvzk3Yl8mCtLmanzGXZPmzl+Wl/mTE1tbjh3ZgEZS9iwnWIy2LEVTbAmg5aqpYOf9D978le3YhBV",
-	"VeV8NUAJZ8dLQ6jV28AqYHTzxSEcqzgYN7HLy1muqmBGUztvfpEgbp57dddtSzLXLgfwbDFnrUl1dmpz",
-	"F1zfrZT1CuSDm/5mNODq59ad78239905cpvPkbIwvushkrVf7wlyq4+3FLg5SCnSLDe6JbB44++6j29D",
-	"8BneYxthE3enm3ILFNCGCSAZhk7FjWTbRY60I9ZXHC5dgLtHcegEFWvYGqQvKA6bodl5DwpBM+iBOwpo",
-	"JabwEWD5xE9fgv/m8M3R3iH939Xh4Qf2v/+x4F50P6YTmIk3BATuUSh811p9FOIxvEtSuE6QP7IZVglz",
-	"DZbvUIzwdHGYZf+N4nlVQK8U0+vzCFbdb6/WH1i2HbtjzVqiCNfjCGSBgy7JcoEnQKOKrsj+evZcx/jg",
-	"XS732JnhnRm+eTO8sy072/JFXgbgJcujMgHUpfFu1u9rKFWa63kKaphFVD02eA1Vy0X8hyPZufMibrMX",
-	"cX3nIkUAOxUu0RlTnTG1M8ZUvoxcVK/EN+tUd14xuPLSbrhwe1XCdF6H1VolFgtgvXbJwU/1514l00lj",
-	"VJIZ5JY2y47HJhlwYM3sa0T11oYrmXe3i1cqxytZ8NQuIMFCGw2RSythwJ2u1rNT3LdOddyp4l2Pa1qv",
-	"HHEzDFQyg+f8DU1tPU/gxfDR/pLG/SHNFe+wO+mH60+v+itYc/aCWtA2WmnUsA1tKoNYN3+j6R/bBXnq",
-	"WZPt8HdicfPlD7cu5aQQdHVUvp5HjJosLviRzfJYWgRCIrvbgxVTYpjFnRTepBSWO6BtQBv5a7UbNliq",
-	"qb05qkvgV3nS7MSvk/gVBkmTTbxykcvzmO8FSRaThhAd1kZmhZIJ+MEDQBEYR5BJX03cmE/jnyHhedLx",
-	"CZtx50VvU/KuHU/eV9isBY/enFQ4+XTecMsdfQFJi6X0K7J/hmGKD4IsTWE9Z2N+OuANPdqtwr3XGKaf",
-	"ITkRg62R7uhMLemMQdyVgnn5UjAwyFJEnpgYD5LkHsHjjMquP2+oqCo9biuSmyR3tv0GMp4gMs3GBwGI",
-	"ojEI7q3kfJLM5hEkkNP0BZ3fM+ojOhEvhPGZDX1BcXkihy8R+NvDNw33CYGYN6zOO4UgFFXfooRvhrHK",
-	"oBLrzyVkFnAnF1icwxF9mIDULgpG9OtiiGNd22ONwbN+nDHoWiIsSSYRXA+9saF/cXrj6FsxveWI++Xo",
-	"DcUPiECX0pDSGuYdmNHtpL7pCFes70DMtUYtrk/kFD8RISw3prjAzl50VqssO2oJeznlXRlOiAXaOwBB",
-	"AOfE7nk7Zt+x8rCJSSrUpm8+7+Ovx5/EB+cTNZcurKE+vnIT/XVRAHn9foakyt6701cKWZ7Bmppm9Hs7",
-	"+uJ9/HVVCKODr4C++Mo7+mqo306RtAB9RckExXayOksm2EOxB5hu3K8xMM7YQOuhJaaC6fgbqrHqdI6O",
-	"kskEhh6Ku+PzVh2fi2qdUo3rOTlKJklGGpghyYgbNyTZy/t6BI0mW1ZxqCPSBmOUUY8r2c7gbAxTPEXz",
-	"FkcgrZPbMYirkK95N/GMaK0Ebp60/XlIR1F3JlrkTKRjsJkk5wDjxyStiUTgYlJIUk+2rxOpl3LM9dkY",
-	"J1MQT9RE22RsBAyyUCGqE+c7JM45WRUp3YGJUjihgiytO/TxFrjWIlFxOutiGwnGNjGMRF53zbUTdrok",
-	"IVebB0cguF/LDcOIjrzFFwwNoqbljcMDTLEAoba4rWgn41cwTB8MNuIgvks+Q/JNDLrS0h4apHlGh6P9",
-	"w/1DU84ILWzkT9X1xqFqx1XNYkuhcjXk/B16KSRZGheQV7KzqZTK4hjFk3yKH3tyyL1kzp+o5rPJTXuE",
-	"42mS3O+JKKKDn+IHh/d4VFOI1tUoI/67+1M7MZA9ikdNtOEgHse3axK+Ti+8vF4ov5fTydQauiNa3Dgx",
-	"x4HAs8shWTaVZfHqOUbYPdg1scbW8s1qgt849Dz2TaCGYmYoJrRJXZU3VGBHbVfHnlvEnswnUNmitjyq",
-	"eJP98exQ6dpgbXAKc3yYKiIE6wJODTp+d8JNWwf+iRV33rBKRGnltQ41musDSJlZTamQBNMaX1ctIfNW",
-	"O0PLa3AlMAQU9IZNVwgMZBJlm3vE4shrHLKO08ycJhhiGWYraZPyywynzCQqfNwpFUKLc9FWPm9ok9VD",
-	"Adi9rtr86yrTcUijmAUfN/SaLCx3Tmhhcr2GVz4LvuzpeOuleUt/QrQMY7mYfe7c1c4O3AoGW1/laY4M",
-	"14fO3OoqctmmjUMniVA2Dzt5YDUQl2POBjPRKb0+3aRiHn3FeA/qpsOqKVuk098GfjaktOQJKVdQb2jx",
-	"akNmwCZpks1ZntAcBLlRVlBYpy/wyW/M4bBmIbFk7m55qdSl795Ca2KhfOGtBJfMK2ONDZEpEdpmelko",
-	"wctWSq4rA7vse4M75t3GGaUOGPYYV0WAQEwUTyHs3UESTGFoyyadC/4tN6QEGSyYNebFcsVo8LZKEtOl",
-	"hulSw6whNUwr0SxkA3a41SpociexLGJrdsgF8yvI5TVLORkwtZwp2Mm7rTIBc1Jc1AQsB/6NIUhhqgL/",
-	"esZQQBZJxuVBlkb+B99/vnn+fwEAAP//hXFPsxF1AgA=",
+	"ZLOJmxt8EKRJ3GyR0FbeX8k4B4qkaDJpDJ84SZP4VZspO5M1Um0sCum0E0iUSbzfkBzYdnBbw1mXztwW",
+	"vPMmU8o4JaP4NtPRDu2n2s28xzWZOMdP3p3I9rmyhKC6FMHuSUHHT+vLC6oZBRvODFpAxhIWeqd2DVZ6",
+	"Rc+tyVynSvfgJ/3PnvzVrdRFVRE7X3xQwtnxwhdq9TawChjdfOkLxxoVxk3sso6Wa0aY0dTurqJIEDfP",
+	"vbrLxCWZa5fDk7aYs9akOju1uQuO/VbKegXywU1/Mxpw9eLrVwvNsQndKXmbT8my7L/roZC13+D5eBsP",
+	"73OQUqRZ7qtLYPHG33UP5obgM7w2N8ImbobXC9ex8VGGhwkgGYZOpZtk20WOtCPWVxwuXYC7R3HoBBVr",
+	"2BqkLygOm6HZeQ8KQTPogTsKaCVi8hFg+YBRX4L/5vDN0d4h/d/V4eEH9r//sXqoWPdjOoGZeENA4B6F",
+	"wnetREghHsO7JIXrBPkjm2GVMNdg+Q7FCE8Xh1n23yieVwX0SjG9Po9g1f32av2BZduxO9asJUZyPY5A",
+	"FhbpkgoYeAI0quiK7K/nBnaMft7lYpadGd6Z4Zs3wzvbsrMtX+TdA16y+CsTQF2S8mb9voZCrLmep6CG",
+	"WUTVY4PXULVcxH84kp07L+I2exHXdy5SBLBT4RKdMdUZUztjTOXLyEX1SnyzTlX1FYMrL+2Gy9JXJUzn",
+	"dVitVWKxANZrlxz8VH/uVfK4NEYlmUFuabPseGySAQfWvMVGVG9tuJJ5d7t4pXK8kgVP7QISLLTRELm0",
+	"Egbc6VpEO8V961THnSre9bim9coRN8NApWp4zl8I1VYrBV4MH+3vhNyfCV3xDruTXLn5xUp9boZa0DZa",
+	"R9WwDW3qnlg3f6PJLdsFeeo5oe3wd2Jx88Udty6hphB0dVS+nieamiwu+JHN8lhaBEIiu9uDFVNimMWd",
+	"FN6kFJY7oG1AG/lrtRs2WIiqvTmqS+BXedLsxK+T+BUGSZNNvHKRy7O07wVJFpOGEB3WRua8kuUFwANA",
+	"ERhHkElfTdyYT+OfIeFZ4PEJm3HnRW9TarIdT01Y2KwFj96cVDj5dN5wyx19AUmLJSwssn+GYYoPgixN",
+	"YT1nY3464A092q3CvdcYpp8hORGDrZHu6Ewt6YxB3BW6eflCNzDIUkSemBgPkuQeweOMyq4/b6ioKj1u",
+	"K5KbJHe2/QYyniAyzcYHAYiiMQjureR8kszmESSQ0/QFnd8z6iM6ES/z8ZkNfUFxeSKHLxH428M3DfcJ",
+	"gZg3rM47hSAUNe2ihG+GsYaiEuvPJWQWcCcXWJzDEX2YgNQuCkb062KIY13bY43Bs36cMehaIixJJhFc",
+	"D72xoX9xeuPoWzG95Yj75egNxQ+IQJfCl9Ia5h2Y0e2kvukIV6zvQMy1Ri2uT+QUPxEhLDemuMDOXnRW",
+	"qyz3awl7OeVdGU6IBdo7AEEA58TueTtm37HysIlJKtSmbz7v46/Hn8QH5xM1F2asoT6+chP9dVEAirw4",
+	"tit7705fKWRZFGsqttHv7eiL9/HXVf+MDr4C+uIr7+iroTo9RdIC9BUlExTbyeosmWAPxR5gunG/xsA4",
+	"YwOth5aYCqbjb6iCrNM5OkomExh6KO6Oz1t1fC6qdUo1rufkKJkkGWlghiQjbtyQZC/v6xE0mmxZPaWO",
+	"SBuMUUY9rmQ7g7MxTPEUzVscgbRObscgrkK+5t3EM6K1Erh50vbnIR1F3ZlokTORjsFmkpwDjB+TtCYS",
+	"gYtJIUk92b5OpF7KMddnY5xMQTxRE22TsREwyEKFqE6c75A452RVpHQHJkrhhAqytO7Qx1vgWotExems",
+	"i20kGNvEMBJ53TXXTtjpkoRcbR4cgeB+LTcMIzryFl8wNIialjcODzDFAoTa0r2inYxfwTB9MNiIg/gu",
+	"+QzJNzHoSguXaJDmGR2O9g/3D005I7SwkT9V1xuHmiRXNYsthcrVkPN36KWQZGlcQF7JzqZSKotjFE/y",
+	"KX7sySH3kjl/oprPJjftEY6nSXK/J6KIDn6KHxze41FNIVpXo4z47+5P7cRA9igeNdGGg3gc365J+Dq9",
+	"8PJ6ofxeTidTa+iOaHHjxBwHAs8uh2TZVBb9q+cYYfdg18QaW8s3qwl+49Dz2DeBGoqZoZjQJnVV3lCB",
+	"HbVdHXtuEXsyn0Bli9ryqOJN9sezQx1vg7XBKczxYaqIEKwLODXo+N0JN20d+CdW3HnDKhGlldc61Giu",
+	"DyBlZjWlQhJMa3xdtYTMW+0MLa/BlcAQUNAbNl0hMJBJlG3uEYsjr3HIOk4zc5pgiGWYraRNyi8znDKT",
+	"qPBxp1QILc5FW/m8oU1WDwVg97pq86+rTMchjWIWfNzQa7Kw3Dmhhcn1Gl75LPiyp+Otl+Yt/QnRMozl",
+	"Yva5c1c7O3ArGGx9dbU5MlwfOnOrq8hlmzYOnSRC2Tzs5IHVQFyOORvMRKf0+nSTinn0FeM9qJsOq6Zs",
+	"kU5/G/jZkNKSJ6RcQb2hxasNmQGbpEk2Z3lCcxDkRllBYZ2+wCe/MYfDmoXEkrm75aVSl757C62JhfKF",
+	"txJcMq+MNTZEpkRom+lloQQvWym5rgzssu8N7ph3G2eUOmDYY1wVAQIxUTyFsHcHSTCFoS2bdC74t9yQ",
+	"EmSwYNaYF8sVo8HbKklMlxqmSw2zhtQwrUSzkA3Y4VaroMmdxLKIrdkhF8yvIJfXLOVkwNRypmAn77bK",
+	"BMxJcVETsBz4N4YghakK/OsZQwFZJBmXB1ka+R98//nm+f8FAAD//zEI5IvvdQIA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/frontend/app/src/lib/api/generated/Api.ts
+++ b/frontend/app/src/lib/api/generated/Api.ts
@@ -1732,6 +1732,10 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
        * @maxLength 36
        */
       workflowId?: string;
+      /** The workflow name to get runs for. */
+      workflowName?: string;
+      /** The cron name to get runs for. */
+      cronName?: string;
       /**
        * A list of metadata key value pairs to filter by
        * @example ["key1:value1","key2:value2"]

--- a/frontend/docs/pages/sdks/python/client.mdx
+++ b/frontend/docs/pages/sdks/python/client.mdx
@@ -1,6 +1,6 @@
 # Hatchet Python SDK Reference
 
-This is the Python SDK reference, documenting methods available for interacting with Hatchet resources. Check out the [user guide](../../home) for an introduction for getting your first tasks running.
+This is the Python SDK reference, documenting methods available for interacting with Hatchet resources. Check out the [user guide](../../home) for an introduction for getting your first tasks running
 
 ## The Hatchet Python Client
 

--- a/frontend/docs/pages/sdks/python/feature-clients/cron.mdx
+++ b/frontend/docs/pages/sdks/python/feature-clients/cron.mdx
@@ -78,14 +78,16 @@ Retrieve a list of all workflow cron triggers matching the criteria.
 
 Parameters:
 
-| Name                  | Type                                  | Description                            | Default |
-| --------------------- | ------------------------------------- | -------------------------------------- | ------- |
-| `offset`              | `int \| None`                         | The offset to start the list from.     | `None`  |
-| `limit`               | `int \| None`                         | The maximum number of items to return. | `None`  |
-| `workflow_id`         | `str \| None`                         | The ID of the workflow to filter by.   | `None`  |
-| `additional_metadata` | `JSONSerializableMapping \| None`     | Filter by additional metadata keys.    | `None`  |
-| `order_by_field`      | `CronWorkflowsOrderByField \| None`   | The field to order the list by.        | `None`  |
-| `order_by_direction`  | `WorkflowRunOrderByDirection \| None` | The direction to order the list by.    | `None`  |
+| Name                  | Type                                  | Description                                | Default |
+| --------------------- | ------------------------------------- | ------------------------------------------ | ------- |
+| `offset`              | `int \| None`                         | The offset to start the list from.         | `None`  |
+| `limit`               | `int \| None`                         | The maximum number of items to return.     | `None`  |
+| `workflow_id`         | `str \| None`                         | The ID of the workflow to filter by.       | `None`  |
+| `additional_metadata` | `JSONSerializableMapping \| None`     | Filter by additional metadata keys.        | `None`  |
+| `order_by_field`      | `CronWorkflowsOrderByField \| None`   | The field to order the list by.            | `None`  |
+| `order_by_direction`  | `WorkflowRunOrderByDirection \| None` | The direction to order the list by.        | `None`  |
+| `workflow_name`       | `str \| None`                         | The name of the workflow to filter by.     | `None`  |
+| `cron_name`           | `str \| None`                         | The name of the cron trigger to filter by. | `None`  |
 
 Returns:
 
@@ -152,14 +154,16 @@ Retrieve a list of all workflow cron triggers matching the criteria.
 
 Parameters:
 
-| Name                  | Type                                  | Description                            | Default |
-| --------------------- | ------------------------------------- | -------------------------------------- | ------- |
-| `offset`              | `int \| None`                         | The offset to start the list from.     | `None`  |
-| `limit`               | `int \| None`                         | The maximum number of items to return. | `None`  |
-| `workflow_id`         | `str \| None`                         | The ID of the workflow to filter by.   | `None`  |
-| `additional_metadata` | `JSONSerializableMapping \| None`     | Filter by additional metadata keys.    | `None`  |
-| `order_by_field`      | `CronWorkflowsOrderByField \| None`   | The field to order the list by.        | `None`  |
-| `order_by_direction`  | `WorkflowRunOrderByDirection \| None` | The direction to order the list by.    | `None`  |
+| Name                  | Type                                  | Description                                | Default |
+| --------------------- | ------------------------------------- | ------------------------------------------ | ------- |
+| `offset`              | `int \| None`                         | The offset to start the list from.         | `None`  |
+| `limit`               | `int \| None`                         | The maximum number of items to return.     | `None`  |
+| `workflow_id`         | `str \| None`                         | The ID of the workflow to filter by.       | `None`  |
+| `additional_metadata` | `JSONSerializableMapping \| None`     | Filter by additional metadata keys.        | `None`  |
+| `order_by_field`      | `CronWorkflowsOrderByField \| None`   | The field to order the list by.            | `None`  |
+| `order_by_direction`  | `WorkflowRunOrderByDirection \| None` | The direction to order the list by.        | `None`  |
+| `workflow_name`       | `str \| None`                         | The name of the workflow to filter by.     | `None`  |
+| `cron_name`           | `str \| None`                         | The name of the cron trigger to filter by. | `None`  |
 
 Returns:
 

--- a/frontend/docs/pages/sdks/python/feature-clients/runs.mdx
+++ b/frontend/docs/pages/sdks/python/feature-clients/runs.mdx
@@ -66,18 +66,18 @@ List task runs according to a set of filters.
 
 Parameters:
 
-| Name                      | Type                         | Description                                         | Default                      |
-| ------------------------- | ---------------------------- | --------------------------------------------------- | ---------------------------- |
-| `since`                   | `datetime`                   | The start time for filtering task runs.             | `now() - timedelta(hours=1)` |
-| `only_tasks`              | `bool`                       | Whether to only list task runs.                     | `False`                      |
-| `offset`                  | `int \| None`                | The offset for pagination.                          | `None`                       |
-| `limit`                   | `int \| None`                | The maximum number of task runs to return.          | `None`                       |
-| `statuses`                | `list[V1TaskStatus] \| None` | The statuses to filter task runs by.                | `None`                       |
-| `until`                   | `datetime \| None`           | The end time for filtering task runs.               | `None`                       |
-| `additional_metadata`     | `dict[str, str] \| None`     | Additional metadata to filter task runs by.         | `None`                       |
-| `workflow_ids`            | `list[str] \| None`          | The workflow IDs to filter task runs by.            | `None`                       |
-| `worker_id`               | `str \| None`                | The worker ID to filter task runs by.               | `None`                       |
-| `parent_task_external_id` | `str \| None`                | The parent task external ID to filter task runs by. | `None`                       |
+| Name                      | Type                         | Description                                         | Default |
+| ------------------------- | ---------------------------- | --------------------------------------------------- | ------- |
+| `since`                   | `datetime \| None`           | The start time for filtering task runs.             | `None`  |
+| `only_tasks`              | `bool`                       | Whether to only list task runs.                     | `False` |
+| `offset`                  | `int \| None`                | The offset for pagination.                          | `None`  |
+| `limit`                   | `int \| None`                | The maximum number of task runs to return.          | `None`  |
+| `statuses`                | `list[V1TaskStatus] \| None` | The statuses to filter task runs by.                | `None`  |
+| `until`                   | `datetime \| None`           | The end time for filtering task runs.               | `None`  |
+| `additional_metadata`     | `dict[str, str] \| None`     | Additional metadata to filter task runs by.         | `None`  |
+| `workflow_ids`            | `list[str] \| None`          | The workflow IDs to filter task runs by.            | `None`  |
+| `worker_id`               | `str \| None`                | The worker ID to filter task runs by.               | `None`  |
+| `parent_task_external_id` | `str \| None`                | The parent task external ID to filter task runs by. | `None`  |
 
 Returns:
 
@@ -91,18 +91,18 @@ List task runs according to a set of filters.
 
 Parameters:
 
-| Name                      | Type                         | Description                                         | Default                      |
-| ------------------------- | ---------------------------- | --------------------------------------------------- | ---------------------------- |
-| `since`                   | `datetime`                   | The start time for filtering task runs.             | `now() - timedelta(hours=1)` |
-| `only_tasks`              | `bool`                       | Whether to only list task runs.                     | `False`                      |
-| `offset`                  | `int \| None`                | The offset for pagination.                          | `None`                       |
-| `limit`                   | `int \| None`                | The maximum number of task runs to return.          | `None`                       |
-| `statuses`                | `list[V1TaskStatus] \| None` | The statuses to filter task runs by.                | `None`                       |
-| `until`                   | `datetime \| None`           | The end time for filtering task runs.               | `None`                       |
-| `additional_metadata`     | `dict[str, str] \| None`     | Additional metadata to filter task runs by.         | `None`                       |
-| `workflow_ids`            | `list[str] \| None`          | The workflow IDs to filter task runs by.            | `None`                       |
-| `worker_id`               | `str \| None`                | The worker ID to filter task runs by.               | `None`                       |
-| `parent_task_external_id` | `str \| None`                | The parent task external ID to filter task runs by. | `None`                       |
+| Name                      | Type                         | Description                                         | Default |
+| ------------------------- | ---------------------------- | --------------------------------------------------- | ------- |
+| `since`                   | `datetime \| None`           | The start time for filtering task runs.             | `None`  |
+| `only_tasks`              | `bool`                       | Whether to only list task runs.                     | `False` |
+| `offset`                  | `int \| None`                | The offset for pagination.                          | `None`  |
+| `limit`                   | `int \| None`                | The maximum number of task runs to return.          | `None`  |
+| `statuses`                | `list[V1TaskStatus] \| None` | The statuses to filter task runs by.                | `None`  |
+| `until`                   | `datetime \| None`           | The end time for filtering task runs.               | `None`  |
+| `additional_metadata`     | `dict[str, str] \| None`     | Additional metadata to filter task runs by.         | `None`  |
+| `workflow_ids`            | `list[str] \| None`          | The workflow IDs to filter task runs by.            | `None`  |
+| `worker_id`               | `str \| None`                | The worker ID to filter task runs by.               | `None`  |
+| `parent_task_external_id` | `str \| None`                | The parent task external ID to filter task runs by. | `None`  |
 
 Returns:
 

--- a/frontend/docs/pages/sdks/python/runnables.mdx
+++ b/frontend/docs/pages/sdks/python/runnables.mdx
@@ -47,7 +47,7 @@ Methods:
 | Name                   | Description                                                                                                                                      |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `task`                 | A decorator to transform a function into a Hatchet task that runs as part of a workflow.                                                         |
-| `durable_task`         | A decorator to transform a function into a durable Hatchet task that run as part of a workflow.                                                  |
+| `durable_task`         | A decorator to transform a function into a durable Hatchet task that runs as part of a workflow.                                                 |
 | `on_failure_task`      | A decorator to transform a function into a Hatchet on-failure task that runs as the last step in a workflow that had at least one task fail.     |
 | `on_success_task`      | A decorator to transform a function into a Hatchet on-success task that runs as the last step in a workflow that had all upstream tasks succeed. |
 | `run`                  | Run the workflow synchronously and wait for it to complete.                                                                                      |
@@ -62,6 +62,8 @@ Methods:
 | `aio_schedule`         | Schedule a workflow to run at a specific time.                                                                                                   |
 | `create_cron`          | Create a cron job for the workflow.                                                                                                              |
 | `aio_create_cron`      | Create a cron job for the workflow.                                                                                                              |
+| `list_runs`            | List runs of the workflow.                                                                                                                       |
+| `aio_list_runs`        | List runs of the workflow.                                                                                                                       |
 
 ### Functions
 
@@ -95,7 +97,7 @@ Returns:
 
 #### `durable_task`
 
-A decorator to transform a function into a durable Hatchet task that run as part of a workflow.
+A decorator to transform a function into a durable Hatchet task that runs as part of a workflow.
 
 **IMPORTANT:** This decorator creates a _durable_ task, which works using Hatchet's durable execution capabilities. This is an advanced feature of Hatchet.
 
@@ -387,6 +389,54 @@ Returns:
 | --------------- | ----------------------------------------------------------- |
 | `CronWorkflows` | A `CronWorkflows` object representing the created cron job. |
 
+#### `list_runs`
+
+List runs of the workflow.
+
+Parameters:
+
+| Name                      | Type                         | Description                                 | Default |
+| ------------------------- | ---------------------------- | ------------------------------------------- | ------- |
+| `since`                   | `datetime \| None`           | The start time for the runs to be listed.   | `None`  |
+| `until`                   | `datetime \| None`           | The end time for the runs to be listed.     | `None`  |
+| `limit`                   | `int`                        | The maximum number of runs to be listed.    | `100`   |
+| `offset`                  | `int \| None`                | The offset for pagination.                  | `None`  |
+| `statuses`                | `list[V1TaskStatus] \| None` | The statuses of the runs to be listed.      | `None`  |
+| `additional_metadata`     | `dict[str, str] \| None`     | Additional metadata for filtering the runs. | `None`  |
+| `worker_id`               | `str \| None`                | The ID of the worker that ran the tasks.    | `None`  |
+| `parent_task_external_id` | `str \| None`                | The external ID of the parent task.         | `None`  |
+| `only_tasks`              | `bool`                       | Whether to list only task runs.             | `False` |
+
+Returns:
+
+| Type                  | Description                                                              |
+| --------------------- | ------------------------------------------------------------------------ |
+| `list[V1TaskSummary]` | A list of `V1TaskSummary` objects representing the runs of the workflow. |
+
+#### `aio_list_runs`
+
+List runs of the workflow.
+
+Parameters:
+
+| Name                      | Type                         | Description                                 | Default |
+| ------------------------- | ---------------------------- | ------------------------------------------- | ------- |
+| `since`                   | `datetime \| None`           | The start time for the runs to be listed.   | `None`  |
+| `until`                   | `datetime \| None`           | The end time for the runs to be listed.     | `None`  |
+| `limit`                   | `int`                        | The maximum number of runs to be listed.    | `100`   |
+| `offset`                  | `int \| None`                | The offset for pagination.                  | `None`  |
+| `statuses`                | `list[V1TaskStatus] \| None` | The statuses of the runs to be listed.      | `None`  |
+| `additional_metadata`     | `dict[str, str] \| None`     | Additional metadata for filtering the runs. | `None`  |
+| `worker_id`               | `str \| None`                | The ID of the worker that ran the tasks.    | `None`  |
+| `parent_task_external_id` | `str \| None`                | The external ID of the parent task.         | `None`  |
+| `only_tasks`              | `bool`                       | Whether to list only task runs.             | `False` |
+
+Returns:
+
+| Type                  | Description                                                              |
+| --------------------- | ------------------------------------------------------------------------ |
+| `list[V1TaskSummary]` | A list of `V1TaskSummary` objects representing the runs of the workflow. |
+
 ## Standalone
 
 Bases: `BaseWorkflow[TWorkflowInput]`, `Generic[TWorkflowInput, R]`
@@ -407,6 +457,8 @@ Methods:
 | `aio_schedule`         | Schedule a workflow to run at a specific time.                            |
 | `create_cron`          | Create a cron job for the workflow.                                       |
 | `aio_create_cron`      | Create a cron job for the workflow.                                       |
+| `list_runs`            | List runs of the workflow.                                                |
+| `aio_list_runs`        | List runs of the workflow.                                                |
 
 ### Functions
 
@@ -625,3 +677,49 @@ Returns:
 | Type            | Description                                                 |
 | --------------- | ----------------------------------------------------------- |
 | `CronWorkflows` | A `CronWorkflows` object representing the created cron job. |
+
+#### `list_runs`
+
+List runs of the workflow.
+
+Parameters:
+
+| Name                      | Type                         | Description                                 | Default |
+| ------------------------- | ---------------------------- | ------------------------------------------- | ------- |
+| `since`                   | `datetime \| None`           | The start time for the runs to be listed.   | `None`  |
+| `until`                   | `datetime \| None`           | The end time for the runs to be listed.     | `None`  |
+| `limit`                   | `int`                        | The maximum number of runs to be listed.    | `100`   |
+| `offset`                  | `int \| None`                | The offset for pagination.                  | `None`  |
+| `statuses`                | `list[V1TaskStatus] \| None` | The statuses of the runs to be listed.      | `None`  |
+| `additional_metadata`     | `dict[str, str] \| None`     | Additional metadata for filtering the runs. | `None`  |
+| `worker_id`               | `str \| None`                | The ID of the worker that ran the tasks.    | `None`  |
+| `parent_task_external_id` | `str \| None`                | The external ID of the parent task.         | `None`  |
+
+Returns:
+
+| Type                  | Description                                                              |
+| --------------------- | ------------------------------------------------------------------------ |
+| `list[V1TaskSummary]` | A list of `V1TaskSummary` objects representing the runs of the workflow. |
+
+#### `aio_list_runs`
+
+List runs of the workflow.
+
+Parameters:
+
+| Name                      | Type                         | Description                                 | Default |
+| ------------------------- | ---------------------------- | ------------------------------------------- | ------- |
+| `since`                   | `datetime \| None`           | The start time for the runs to be listed.   | `None`  |
+| `until`                   | `datetime \| None`           | The end time for the runs to be listed.     | `None`  |
+| `limit`                   | `int`                        | The maximum number of runs to be listed.    | `100`   |
+| `offset`                  | `int \| None`                | The offset for pagination.                  | `None`  |
+| `statuses`                | `list[V1TaskStatus] \| None` | The statuses of the runs to be listed.      | `None`  |
+| `additional_metadata`     | `dict[str, str] \| None`     | Additional metadata for filtering the runs. | `None`  |
+| `worker_id`               | `str \| None`                | The ID of the worker that ran the tasks.    | `None`  |
+| `parent_task_external_id` | `str \| None`                | The external ID of the parent task.         | `None`  |
+
+Returns:
+
+| Type                  | Description                                                              |
+| --------------------- | ------------------------------------------------------------------------ |
+| `list[V1TaskSummary]` | A list of `V1TaskSummary` objects representing the runs of the workflow. |

--- a/pkg/client/rest/gen.go
+++ b/pkg/client/rest/gen.go
@@ -2055,6 +2055,12 @@ type CronWorkflowListParams struct {
 	// WorkflowId The workflow id to get runs for.
 	WorkflowId *openapi_types.UUID `form:"workflowId,omitempty" json:"workflowId,omitempty"`
 
+	// WorkflowName The workflow name to get runs for.
+	WorkflowName *string `form:"workflowName,omitempty" json:"workflowName,omitempty"`
+
+	// CronName The cron name to get runs for.
+	CronName *string `form:"cronName,omitempty" json:"cronName,omitempty"`
+
 	// AdditionalMetadata A list of metadata key value pairs to filter by
 	AdditionalMetadata *[]string `form:"additionalMetadata,omitempty" json:"additionalMetadata,omitempty"`
 
@@ -8121,6 +8127,38 @@ func NewCronWorkflowListRequest(server string, tenant openapi_types.UUID, params
 		if params.WorkflowId != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "workflowId", runtime.ParamLocationQuery, *params.WorkflowId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.WorkflowName != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "workflowName", runtime.ParamLocationQuery, *params.WorkflowName); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.CronName != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cronName", runtime.ParamLocationQuery, *params.CronName); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err

--- a/pkg/repository/postgres/dbsqlc/workflows.sql
+++ b/pkg/repository/postgres/dbsqlc/workflows.sql
@@ -814,8 +814,8 @@ WHERE
     AND (@workflowId::uuid IS NULL OR w."id" = @workflowId::uuid)
     AND (sqlc.narg('additionalMetadata')::jsonb IS NULL OR
         c."additionalMetadata" @> sqlc.narg('additionalMetadata')::jsonb)
-    AND (@cronName::TEXT IS NULL OR c."name" = @cronName::TEXT)
-    AND (@workflowName::TEXT IS NULL OR w."name" = @workflowName::TEXT)
+    AND (sqlc.narg('cronName')::TEXT IS NULL OR c."name" = sqlc.narg('cronName')::TEXT)
+    AND (sqlc.narg('workflowName')::TEXT IS NULL OR w."name" = sqlc.narg('workflowName')::TEXT)
 ORDER BY
     case when @orderBy = 'name ASC' THEN w."name" END ASC,
     case when @orderBy = 'name DESC' THEN w."name" END DESC,
@@ -858,7 +858,10 @@ WHERE
     AND (@cronTriggerId::uuid IS NULL OR c."id" = @cronTriggerId::uuid)
     AND (@workflowId::uuid IS NULL OR w."id" = @workflowId::uuid)
     AND (sqlc.narg('additionalMetadata')::jsonb IS NULL OR
-        c."additionalMetadata" @> sqlc.narg('additionalMetadata')::jsonb);
+        c."additionalMetadata" @> sqlc.narg('additionalMetadata')::jsonb)
+    AND (sqlc.narg('cronName')::TEXT IS NULL OR c."name" = sqlc.narg('cronName')::TEXT)
+    AND (sqlc.narg('workflowName')::TEXT IS NULL OR w."name" = sqlc.narg('workflowName')::TEXT)
+;
 
 -- name: DeleteWorkflowTriggerCronRef :exec
 DELETE FROM "WorkflowTriggerCronRef"

--- a/pkg/repository/postgres/dbsqlc/workflows.sql
+++ b/pkg/repository/postgres/dbsqlc/workflows.sql
@@ -814,6 +814,8 @@ WHERE
     AND (@workflowId::uuid IS NULL OR w."id" = @workflowId::uuid)
     AND (sqlc.narg('additionalMetadata')::jsonb IS NULL OR
         c."additionalMetadata" @> sqlc.narg('additionalMetadata')::jsonb)
+    AND (@cronName::TEXT IS NULL OR c."name" = @cronName::TEXT)
+    AND (@workflowName::TEXT IS NULL OR w."name" = @workflowName::TEXT)
 ORDER BY
     case when @orderBy = 'name ASC' THEN w."name" END ASC,
     case when @orderBy = 'name DESC' THEN w."name" END DESC,

--- a/pkg/repository/postgres/dbsqlc/workflows.sql.go
+++ b/pkg/repository/postgres/dbsqlc/workflows.sql.go
@@ -80,6 +80,8 @@ WHERE
     AND ($3::uuid IS NULL OR w."id" = $3::uuid)
     AND ($4::jsonb IS NULL OR
         c."additionalMetadata" @> $4::jsonb)
+    AND ($5::TEXT IS NULL OR c."name" = $5::TEXT)
+    AND ($6::TEXT IS NULL OR w."name" = $6::TEXT)
 `
 
 type CountCronWorkflowsParams struct {
@@ -87,6 +89,8 @@ type CountCronWorkflowsParams struct {
 	Crontriggerid      pgtype.UUID `json:"crontriggerid"`
 	Workflowid         pgtype.UUID `json:"workflowid"`
 	AdditionalMetadata []byte      `json:"additionalMetadata"`
+	CronName           pgtype.Text `json:"cronName"`
+	WorkflowName       pgtype.Text `json:"workflowName"`
 }
 
 // Get all of the latest workflow versions for the tenant
@@ -96,6 +100,8 @@ func (q *Queries) CountCronWorkflows(ctx context.Context, db DBTX, arg CountCron
 		arg.Crontriggerid,
 		arg.Workflowid,
 		arg.AdditionalMetadata,
+		arg.CronName,
+		arg.WorkflowName,
 	)
 	var count int64
 	err := row.Scan(&count)
@@ -1659,8 +1665,8 @@ type ListCronWorkflowsParams struct {
 	Crontriggerid      pgtype.UUID `json:"crontriggerid"`
 	Workflowid         pgtype.UUID `json:"workflowid"`
 	AdditionalMetadata []byte      `json:"additionalMetadata"`
-	Cronname           string      `json:"cronname"`
-	Workflowname       string      `json:"workflowname"`
+	CronName           pgtype.Text `json:"cronName"`
+	WorkflowName       pgtype.Text `json:"workflowName"`
 	Orderby            interface{} `json:"orderby"`
 	Offset             interface{} `json:"offset"`
 	Limit              interface{} `json:"limit"`
@@ -1701,8 +1707,8 @@ func (q *Queries) ListCronWorkflows(ctx context.Context, db DBTX, arg ListCronWo
 		arg.Crontriggerid,
 		arg.Workflowid,
 		arg.AdditionalMetadata,
-		arg.Cronname,
-		arg.Workflowname,
+		arg.CronName,
+		arg.WorkflowName,
 		arg.Orderby,
 		arg.Offset,
 		arg.Limit,

--- a/pkg/repository/postgres/dbsqlc/workflows.sql.go
+++ b/pkg/repository/postgres/dbsqlc/workflows.sql.go
@@ -1640,16 +1640,18 @@ WHERE
     AND ($3::uuid IS NULL OR w."id" = $3::uuid)
     AND ($4::jsonb IS NULL OR
         c."additionalMetadata" @> $4::jsonb)
+    AND ($5::TEXT IS NULL OR c."name" = $5::TEXT)
+    AND ($6::TEXT IS NULL OR w."name" = $6::TEXT)
 ORDER BY
-    case when $5 = 'name ASC' THEN w."name" END ASC,
-    case when $5 = 'name DESC' THEN w."name" END DESC,
-    case when $5 = 'createdAt ASC' THEN c."createdAt" END ASC ,
-    case when $5 = 'createdAt DESC' THEN c."createdAt" END DESC,
+    case when $7 = 'name ASC' THEN w."name" END ASC,
+    case when $7 = 'name DESC' THEN w."name" END DESC,
+    case when $7 = 'createdAt ASC' THEN c."createdAt" END ASC ,
+    case when $7 = 'createdAt DESC' THEN c."createdAt" END DESC,
     t."id" ASC
 OFFSET
-    COALESCE($6, 0)
+    COALESCE($8, 0)
 LIMIT
-    COALESCE($7, 50)
+    COALESCE($9, 50)
 `
 
 type ListCronWorkflowsParams struct {
@@ -1657,6 +1659,8 @@ type ListCronWorkflowsParams struct {
 	Crontriggerid      pgtype.UUID `json:"crontriggerid"`
 	Workflowid         pgtype.UUID `json:"workflowid"`
 	AdditionalMetadata []byte      `json:"additionalMetadata"`
+	Cronname           string      `json:"cronname"`
+	Workflowname       string      `json:"workflowname"`
 	Orderby            interface{} `json:"orderby"`
 	Offset             interface{} `json:"offset"`
 	Limit              interface{} `json:"limit"`
@@ -1697,6 +1701,8 @@ func (q *Queries) ListCronWorkflows(ctx context.Context, db DBTX, arg ListCronWo
 		arg.Crontriggerid,
 		arg.Workflowid,
 		arg.AdditionalMetadata,
+		arg.Cronname,
+		arg.Workflowname,
 		arg.Orderby,
 		arg.Offset,
 		arg.Limit,

--- a/pkg/repository/postgres/workflow.go
+++ b/pkg/repository/postgres/workflow.go
@@ -332,6 +332,14 @@ func (w *workflowAPIRepository) ListCronWorkflows(ctx context.Context, tenantId 
 		countOpts.Workflowid = sqlchelpers.UUIDFromStr(*opts.WorkflowId)
 	}
 
+	if opts.CronName != nil {
+		listOpts.Cronname = *opts.CronName
+	}
+
+	if opts.WorkflowName != nil {
+		listOpts.Workflowname = *opts.WorkflowName
+	}
+
 	cronWorkflows, err := w.queries.ListCronWorkflows(ctx, w.pool, listOpts)
 	if err != nil {
 		return nil, 0, err

--- a/pkg/repository/postgres/workflow.go
+++ b/pkg/repository/postgres/workflow.go
@@ -333,14 +333,17 @@ func (w *workflowAPIRepository) ListCronWorkflows(ctx context.Context, tenantId 
 	}
 
 	if opts.CronName != nil {
-		listOpts.Cronname = *opts.CronName
+		listOpts.CronName = sqlchelpers.TextFromStr(*opts.CronName)
+		countOpts.CronName = sqlchelpers.TextFromStr(*opts.CronName)
 	}
 
 	if opts.WorkflowName != nil {
-		listOpts.Workflowname = *opts.WorkflowName
+		listOpts.WorkflowName = sqlchelpers.TextFromStr(*opts.WorkflowName)
+		countOpts.WorkflowName = sqlchelpers.TextFromStr(*opts.WorkflowName)
 	}
 
 	cronWorkflows, err := w.queries.ListCronWorkflows(ctx, w.pool, listOpts)
+
 	if err != nil {
 		return nil, 0, err
 	}

--- a/pkg/repository/workflow_run.go
+++ b/pkg/repository/workflow_run.go
@@ -444,6 +444,12 @@ type ListCronWorkflowsOpts struct {
 
 	// (optional) additional metadata for the workflow run
 	AdditionalMetadata map[string]interface{} `validate:"omitempty"`
+
+	// (optional) the name of the cron to filter by
+	CronName *string `validate:"omitempty"`
+
+	// (optional) the name of the workflow to filter by
+	WorkflowName *string `validate:"omitempty"`
 }
 
 type WorkflowRunAPIRepository interface {

--- a/sdks/python/docs/runnables.md
+++ b/sdks/python/docs/runnables.md
@@ -30,6 +30,8 @@
         - name
         - tasks
         - is_durable
+        - list_runs
+        - aio_list_runs
 
 ## Standalone
 
@@ -50,3 +52,5 @@
         - aio_create_cron
         - create_bulk_run_item
         - is_durable
+        - list_runs
+        - aio_list_runs

--- a/sdks/python/hatchet_sdk/clients/admin.py
+++ b/sdks/python/hatchet_sdk/clients/admin.py
@@ -141,19 +141,6 @@ class AdminClient:
             priority=_options.priority,
         )
 
-    def _prepare_put_workflow_request(
-        self,
-        name: str,
-        workflow: workflow_protos.CreateWorkflowVersionRequest,
-        overrides: workflow_protos.CreateWorkflowVersionRequest | None = None,
-    ) -> workflow_protos.CreateWorkflowVersionRequest:
-        if overrides is not None:
-            workflow.MergeFrom(overrides)
-
-        workflow.name = name
-
-        return workflow
-
     def _parse_schedule(
         self, schedule: datetime | timestamp_pb2.Timestamp
     ) -> timestamp_pb2.Timestamp:
@@ -191,11 +178,9 @@ class AdminClient:
     @tenacity_retry
     async def aio_put_workflow(
         self,
-        name: str,
         workflow: workflow_protos.CreateWorkflowVersionRequest,
-        overrides: workflow_protos.CreateWorkflowVersionRequest | None = None,
     ) -> workflow_protos.CreateWorkflowVersionResponse:
-        return await asyncio.to_thread(self.put_workflow, name, workflow, overrides)
+        return await asyncio.to_thread(self.put_workflow, workflow)
 
     @tenacity_retry
     async def aio_put_rate_limit(
@@ -221,12 +206,8 @@ class AdminClient:
     @tenacity_retry
     def put_workflow(
         self,
-        name: str,
         workflow: workflow_protos.CreateWorkflowVersionRequest,
-        overrides: workflow_protos.CreateWorkflowVersionRequest | None = None,
     ) -> workflow_protos.CreateWorkflowVersionResponse:
-        opts = self._prepare_put_workflow_request(name, workflow, overrides)
-
         if self.client is None:
             conn = new_conn(self.config, False)
             self.client = AdminServiceStub(conn)
@@ -234,7 +215,7 @@ class AdminClient:
         return cast(
             workflow_protos.CreateWorkflowVersionResponse,
             self.client.PutWorkflow(
-                opts,
+                workflow,
                 metadata=get_metadata(self.token),
             ),
         )
@@ -324,6 +305,9 @@ class AdminClient:
             additional_metadata=options.additional_metadata,
             desired_worker_id=desired_worker_id,
             priority=options.priority,
+            namespace=options.namespace,
+            sticky=options.sticky,
+            key=options.key,
         )
 
         namespace = options.namespace or self.namespace

--- a/sdks/python/hatchet_sdk/clients/rest/api/workflow_api.py
+++ b/sdks/python/hatchet_sdk/clients/rest/api/workflow_api.py
@@ -88,6 +88,12 @@ class WorkflowApi:
             Optional[Annotated[str, Field(min_length=36, strict=True, max_length=36)]],
             Field(description="The workflow id to get runs for."),
         ] = None,
+        workflow_name: Annotated[
+            Optional[StrictStr], Field(description="The workflow name to get runs for.")
+        ] = None,
+        cron_name: Annotated[
+            Optional[StrictStr], Field(description="The cron name to get runs for.")
+        ] = None,
         additional_metadata: Annotated[
             Optional[List[StrictStr]],
             Field(description="A list of metadata key value pairs to filter by"),
@@ -123,6 +129,10 @@ class WorkflowApi:
         :type limit: int
         :param workflow_id: The workflow id to get runs for.
         :type workflow_id: str
+        :param workflow_name: The workflow name to get runs for.
+        :type workflow_name: str
+        :param cron_name: The cron name to get runs for.
+        :type cron_name: str
         :param additional_metadata: A list of metadata key value pairs to filter by
         :type additional_metadata: List[str]
         :param order_by_field: The order by field
@@ -156,6 +166,8 @@ class WorkflowApi:
             offset=offset,
             limit=limit,
             workflow_id=workflow_id,
+            workflow_name=workflow_name,
+            cron_name=cron_name,
             additional_metadata=additional_metadata,
             order_by_field=order_by_field,
             order_by_direction=order_by_direction,
@@ -198,6 +210,12 @@ class WorkflowApi:
             Optional[Annotated[str, Field(min_length=36, strict=True, max_length=36)]],
             Field(description="The workflow id to get runs for."),
         ] = None,
+        workflow_name: Annotated[
+            Optional[StrictStr], Field(description="The workflow name to get runs for.")
+        ] = None,
+        cron_name: Annotated[
+            Optional[StrictStr], Field(description="The cron name to get runs for.")
+        ] = None,
         additional_metadata: Annotated[
             Optional[List[StrictStr]],
             Field(description="A list of metadata key value pairs to filter by"),
@@ -233,6 +251,10 @@ class WorkflowApi:
         :type limit: int
         :param workflow_id: The workflow id to get runs for.
         :type workflow_id: str
+        :param workflow_name: The workflow name to get runs for.
+        :type workflow_name: str
+        :param cron_name: The cron name to get runs for.
+        :type cron_name: str
         :param additional_metadata: A list of metadata key value pairs to filter by
         :type additional_metadata: List[str]
         :param order_by_field: The order by field
@@ -266,6 +288,8 @@ class WorkflowApi:
             offset=offset,
             limit=limit,
             workflow_id=workflow_id,
+            workflow_name=workflow_name,
+            cron_name=cron_name,
             additional_metadata=additional_metadata,
             order_by_field=order_by_field,
             order_by_direction=order_by_direction,
@@ -308,6 +332,12 @@ class WorkflowApi:
             Optional[Annotated[str, Field(min_length=36, strict=True, max_length=36)]],
             Field(description="The workflow id to get runs for."),
         ] = None,
+        workflow_name: Annotated[
+            Optional[StrictStr], Field(description="The workflow name to get runs for.")
+        ] = None,
+        cron_name: Annotated[
+            Optional[StrictStr], Field(description="The cron name to get runs for.")
+        ] = None,
         additional_metadata: Annotated[
             Optional[List[StrictStr]],
             Field(description="A list of metadata key value pairs to filter by"),
@@ -343,6 +373,10 @@ class WorkflowApi:
         :type limit: int
         :param workflow_id: The workflow id to get runs for.
         :type workflow_id: str
+        :param workflow_name: The workflow name to get runs for.
+        :type workflow_name: str
+        :param cron_name: The cron name to get runs for.
+        :type cron_name: str
         :param additional_metadata: A list of metadata key value pairs to filter by
         :type additional_metadata: List[str]
         :param order_by_field: The order by field
@@ -376,6 +410,8 @@ class WorkflowApi:
             offset=offset,
             limit=limit,
             workflow_id=workflow_id,
+            workflow_name=workflow_name,
+            cron_name=cron_name,
             additional_metadata=additional_metadata,
             order_by_field=order_by_field,
             order_by_direction=order_by_direction,
@@ -401,6 +437,8 @@ class WorkflowApi:
         offset,
         limit,
         workflow_id,
+        workflow_name,
+        cron_name,
         additional_metadata,
         order_by_field,
         order_by_direction,
@@ -440,6 +478,14 @@ class WorkflowApi:
         if workflow_id is not None:
 
             _query_params.append(("workflowId", workflow_id))
+
+        if workflow_name is not None:
+
+            _query_params.append(("workflowName", workflow_name))
+
+        if cron_name is not None:
+
+            _query_params.append(("cronName", cron_name))
 
         if additional_metadata is not None:
 

--- a/sdks/python/hatchet_sdk/features/cron.py
+++ b/sdks/python/hatchet_sdk/features/cron.py
@@ -172,6 +172,8 @@ class CronClient(BaseRestClient):
         additional_metadata: JSONSerializableMapping | None = None,
         order_by_field: CronWorkflowsOrderByField | None = None,
         order_by_direction: WorkflowRunOrderByDirection | None = None,
+        workflow_name: str | None = None,
+        cron_name: str | None = None,
     ) -> CronWorkflowsList:
         """
         Retrieve a list of all workflow cron triggers matching the criteria.
@@ -182,6 +184,8 @@ class CronClient(BaseRestClient):
         :param additional_metadata: Filter by additional metadata keys.
         :param order_by_field: The field to order the list by.
         :param order_by_direction: The direction to order the list by.
+        :param workflow_name: The name of the workflow to filter by.
+        :param cron_name: The name of the cron trigger to filter by.
 
         :return: A list of cron workflows.
         """
@@ -193,6 +197,8 @@ class CronClient(BaseRestClient):
             additional_metadata=additional_metadata,
             order_by_field=order_by_field,
             order_by_direction=order_by_direction,
+            workflow_name=workflow_name,
+            cron_name=cron_name,
         )
 
     def list(
@@ -203,6 +209,8 @@ class CronClient(BaseRestClient):
         additional_metadata: JSONSerializableMapping | None = None,
         order_by_field: CronWorkflowsOrderByField | None = None,
         order_by_direction: WorkflowRunOrderByDirection | None = None,
+        workflow_name: str | None = None,
+        cron_name: str | None = None,
     ) -> CronWorkflowsList:
         """
         Retrieve a list of all workflow cron triggers matching the criteria.
@@ -213,6 +221,8 @@ class CronClient(BaseRestClient):
         :param additional_metadata: Filter by additional metadata keys.
         :param order_by_field: The field to order the list by.
         :param order_by_direction: The direction to order the list by.
+        :param workflow_name: The name of the workflow to filter by.
+        :param cron_name: The name of the cron trigger to filter by.
 
         :return: A list of cron workflows.
         """
@@ -227,6 +237,8 @@ class CronClient(BaseRestClient):
                 ),
                 order_by_field=order_by_field,
                 order_by_direction=order_by_direction,
+                workflow_name=workflow_name,
+                cron_name=cron_name,
             )
 
     def get(self, cron_id: str) -> CronWorkflows:

--- a/sdks/python/hatchet_sdk/features/runs.py
+++ b/sdks/python/hatchet_sdk/features/runs.py
@@ -131,7 +131,7 @@ class RunsClient(BaseRestClient):
 
     async def aio_list(
         self,
-        since: datetime = datetime.now() - timedelta(hours=1),
+        since: datetime | None = None,
         only_tasks: bool = False,
         offset: int | None = None,
         limit: int | None = None,
@@ -160,7 +160,7 @@ class RunsClient(BaseRestClient):
         """
         return await asyncio.to_thread(
             self.list,
-            since=since,
+            since=since or datetime.now() - timedelta(days=1),
             only_tasks=only_tasks,
             offset=offset,
             limit=limit,
@@ -174,7 +174,7 @@ class RunsClient(BaseRestClient):
 
     def list(
         self,
-        since: datetime = datetime.now() - timedelta(hours=1),
+        since: datetime | None = None,
         only_tasks: bool = False,
         offset: int | None = None,
         limit: int | None = None,
@@ -204,7 +204,7 @@ class RunsClient(BaseRestClient):
         with self.client() as client:
             return self._wra(client).v1_workflow_run_list(
                 tenant=self.client_config.tenant_id,
-                since=since,
+                since=since or datetime.now() - timedelta(days=1),
                 only_tasks=only_tasks,
                 offset=offset,
                 limit=limit,

--- a/sdks/python/hatchet_sdk/runnables/standalone.py
+++ b/sdks/python/hatchet_sdk/runnables/standalone.py
@@ -1,4 +1,5 @@
-from datetime import datetime
+import asyncio
+from datetime import datetime, timedelta
 from typing import Any, Generic, cast, get_type_hints
 
 from hatchet_sdk.clients.admin import (
@@ -7,7 +8,10 @@ from hatchet_sdk.clients.admin import (
     WorkflowRunTriggerConfig,
 )
 from hatchet_sdk.clients.rest.models.cron_workflows import CronWorkflows
+from hatchet_sdk.clients.rest.models.v1_task_status import V1TaskStatus
+from hatchet_sdk.clients.rest.models.v1_task_summary import V1TaskSummary
 from hatchet_sdk.contracts.workflows_pb2 import WorkflowVersion
+from hatchet_sdk.logger import logger
 from hatchet_sdk.runnables.task import Task
 from hatchet_sdk.runnables.types import EmptyModel, R, TWorkflowInput
 from hatchet_sdk.runnables.workflow import BaseWorkflow, Workflow
@@ -294,3 +298,88 @@ class Standalone(BaseWorkflow[TWorkflowInput], Generic[TWorkflowInput, R]):
 
     def to_task(self) -> Task[TWorkflowInput, R]:
         return self._task
+
+    def list_runs(
+        self,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        limit: int = 100,
+        offset: int | None = None,
+        statuses: list[V1TaskStatus] | None = None,
+        additional_metadata: dict[str, str] | None = None,
+        worker_id: str | None = None,
+        parent_task_external_id: str | None = None,
+    ) -> list[V1TaskSummary]:
+        """
+        List runs of the workflow.
+
+        :param since: The start time for the runs to be listed.
+        :param until: The end time for the runs to be listed.
+        :param limit: The maximum number of runs to be listed.
+        :param offset: The offset for pagination.
+        :param statuses: The statuses of the runs to be listed.
+        :param additional_metadata: Additional metadata for filtering the runs.
+        :param worker_id: The ID of the worker that ran the tasks.
+        :param parent_task_external_id: The external ID of the parent task.
+
+        :returns: A list of `V1TaskSummary` objects representing the runs of the workflow.
+        """
+        workflows = self.client.workflows.list(workflow_name=self._workflow.name)
+
+        if not workflows.rows:
+            logger.warning(f"No runs found for {self.name}")
+            return []
+
+        workflow = workflows.rows[0]
+
+        response = self.client.runs.list(
+            workflow_ids=[workflow.metadata.id],
+            since=since or datetime.now() - timedelta(days=1),
+            only_tasks=True,
+            offset=offset,
+            limit=limit,
+            statuses=statuses,
+            until=until,
+            additional_metadata=additional_metadata,
+            worker_id=worker_id,
+            parent_task_external_id=parent_task_external_id,
+        )
+
+        return response.rows
+
+    async def aio_list_runs(
+        self,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        limit: int = 100,
+        offset: int | None = None,
+        statuses: list[V1TaskStatus] | None = None,
+        additional_metadata: dict[str, str] | None = None,
+        worker_id: str | None = None,
+        parent_task_external_id: str | None = None,
+    ) -> list[V1TaskSummary]:
+        """
+        List runs of the workflow.
+
+        :param since: The start time for the runs to be listed.
+        :param until: The end time for the runs to be listed.
+        :param limit: The maximum number of runs to be listed.
+        :param offset: The offset for pagination.
+        :param statuses: The statuses of the runs to be listed.
+        :param additional_metadata: Additional metadata for filtering the runs.
+        :param worker_id: The ID of the worker that ran the tasks.
+        :param parent_task_external_id: The external ID of the parent task.
+
+        :returns: A list of `V1TaskSummary` objects representing the runs of the workflow.
+        """
+        return await asyncio.to_thread(
+            self.list_runs,
+            since=since or datetime.now() - timedelta(days=1),
+            offset=offset,
+            limit=limit,
+            statuses=statuses,
+            until=until,
+            additional_metadata=additional_metadata,
+            worker_id=worker_id,
+            parent_task_external_id=parent_task_external_id,
+        )

--- a/sdks/python/hatchet_sdk/worker/worker.py
+++ b/sdks/python/hatchet_sdk/worker/worker.py
@@ -147,7 +147,7 @@ class Worker:
 
     def register_workflow_from_opts(self, opts: CreateWorkflowVersionRequest) -> None:
         try:
-            self.client.admin.put_workflow(opts.name, opts)
+            self.client.admin.put_workflow(opts)
         except Exception as e:
             logger.error(f"failed to register workflow: {opts.name}")
             logger.error(e)
@@ -159,11 +159,8 @@ class Worker:
                 "workflow must have at least one task registered before registering"
             )
 
-        opts = workflow.to_proto()
-        name = workflow.name
-
         try:
-            self.client.admin.put_workflow(name, opts)
+            self.client.admin.put_workflow(workflow.to_proto())
         except Exception as e:
             logger.error(f"failed to register workflow: {workflow.name}")
             logger.error(e)

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.6.5"
+version = "1.7.0"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Background task orchestration & visibility for developers",
   "types": "dist/index.d.ts",
   "files": [

--- a/sdks/typescript/src/clients/rest/generated/Api.ts
+++ b/sdks/typescript/src/clients/rest/generated/Api.ts
@@ -120,12 +120,10 @@ import {
   WorkflowUpdateRequest,
   WorkflowVersion,
   WorkflowWorkersCount,
-} from "./data-contracts";
-import { ContentType, HttpClient, RequestParams } from "./http-client";
+} from './data-contracts';
+import { ContentType, HttpClient, RequestParams } from './http-client';
 
-export class Api<
-  SecurityDataType = unknown,
-> extends HttpClient<SecurityDataType> {
+export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
   /**
    * @description Get a task by id
    *
@@ -138,9 +136,9 @@ export class Api<
   v1TaskGet = (task: string, params: RequestParams = {}) =>
     this.request<V1TaskSummary, APIErrors>({
       path: `/api/v1/stable/tasks/${task}`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -166,14 +164,14 @@ export class Api<
        */
       limit?: number;
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<V1TaskEventList, APIErrors>({
       path: `/api/v1/stable/tasks/${task}/task-events`,
-      method: "GET",
+      method: 'GET',
       query: query,
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -188,9 +186,9 @@ export class Api<
   v1LogLineList = (task: string, params: RequestParams = {}) =>
     this.request<V1LogLineList, APIErrors>({
       path: `/api/v1/stable/tasks/${task}/logs`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -202,14 +200,10 @@ export class Api<
    * @request POST:/api/v1/stable/tenants/{tenant}/tasks/cancel
    * @secure
    */
-  v1TaskCancel = (
-    tenant: string,
-    data: V1CancelTaskRequest,
-    params: RequestParams = {},
-  ) =>
+  v1TaskCancel = (tenant: string, data: V1CancelTaskRequest, params: RequestParams = {}) =>
     this.request<void, APIErrors>({
       path: `/api/v1/stable/tenants/${tenant}/tasks/cancel`,
-      method: "POST",
+      method: 'POST',
       body: data,
       secure: true,
       type: ContentType.Json,
@@ -224,14 +218,10 @@ export class Api<
    * @request POST:/api/v1/stable/tenants/{tenant}/tasks/replay
    * @secure
    */
-  v1TaskReplay = (
-    tenant: string,
-    data: V1ReplayTaskRequest,
-    params: RequestParams = {},
-  ) =>
+  v1TaskReplay = (tenant: string, data: V1ReplayTaskRequest, params: RequestParams = {}) =>
     this.request<void, APIErrors>({
       path: `/api/v1/stable/tenants/${tenant}/tasks/replay`,
-      method: "POST",
+      method: 'POST',
       body: data,
       secure: true,
       type: ContentType.Json,
@@ -258,14 +248,14 @@ export class Api<
        */
       tenant: string;
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<V1DagChildren[], APIErrors>({
       path: `/api/v1/stable/dags/tasks`,
-      method: "GET",
+      method: 'GET',
       query: query,
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -323,14 +313,14 @@ export class Api<
        */
       parent_task_external_id?: string;
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<V1TaskSummaryList, APIErrors>({
       path: `/api/v1/stable/tenants/${tenant}/workflow-runs`,
-      method: "GET",
+      method: 'GET',
       query: query,
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -348,14 +338,14 @@ export class Api<
       /** The external ids of the workflow runs to get display names for */
       external_ids: string[];
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<V1WorkflowRunDisplayNameList, APIErrors>({
       path: `/api/v1/stable/tenants/${tenant}/workflow-runs/display-names`,
-      method: "GET",
+      method: 'GET',
       query: query,
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -370,15 +360,15 @@ export class Api<
   v1WorkflowRunCreate = (
     tenant: string,
     data: V1TriggerWorkflowRunRequest,
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<V1WorkflowRunDetails, APIErrors>({
       path: `/api/v1/stable/tenants/${tenant}/workflow-runs/trigger`,
-      method: "POST",
+      method: 'POST',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -393,9 +383,9 @@ export class Api<
   v1WorkflowRunGet = (v1WorkflowRun: string, params: RequestParams = {}) =>
     this.request<V1WorkflowRunDetails, APIErrors>({
       path: `/api/v1/stable/workflow-runs/${v1WorkflowRun}`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -421,14 +411,14 @@ export class Api<
        */
       limit?: number;
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<V1TaskEventList, APIErrors>({
       path: `/api/v1/stable/workflow-runs/${v1WorkflowRun}/task-events`,
-      method: "GET",
+      method: 'GET',
       query: query,
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -458,14 +448,14 @@ export class Api<
        */
       parent_task_external_id?: string;
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<V1TaskRunMetrics, APIErrors>({
       path: `/api/v1/stable/tenants/${tenant}/task-metrics`,
-      method: "GET",
+      method: 'GET',
       query: query,
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -493,14 +483,14 @@ export class Api<
        */
       finishedBefore?: string;
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<V1TaskPointMetrics, APIErrors>({
       path: `/api/v1/stable/tenants/${tenant}/task-point-metrics`,
-      method: "GET",
+      method: 'GET',
       query: query,
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -514,7 +504,7 @@ export class Api<
   readinessGet = (params: RequestParams = {}) =>
     this.request<void, void>({
       path: `/api/ready`,
-      method: "GET",
+      method: 'GET',
       ...params,
     });
   /**
@@ -528,7 +518,7 @@ export class Api<
   livenessGet = (params: RequestParams = {}) =>
     this.request<void, void>({
       path: `/api/live`,
-      method: "GET",
+      method: 'GET',
       ...params,
     });
   /**
@@ -542,8 +532,8 @@ export class Api<
   metadataGet = (params: RequestParams = {}) =>
     this.request<APIMeta, APIErrors>({
       path: `/api/v1/meta`,
-      method: "GET",
-      format: "json",
+      method: 'GET',
+      format: 'json',
       ...params,
     });
   /**
@@ -557,8 +547,8 @@ export class Api<
   cloudMetadataGet = (params: RequestParams = {}) =>
     this.request<APIErrors, APIErrors>({
       path: `/api/v1/cloud/metadata`,
-      method: "GET",
-      format: "json",
+      method: 'GET',
+      format: 'json',
       ...params,
     });
   /**
@@ -573,9 +563,9 @@ export class Api<
   metadataListIntegrations = (params: RequestParams = {}) =>
     this.request<ListAPIMetaIntegration, APIErrors>({
       path: `/api/v1/meta/integrations`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -589,10 +579,10 @@ export class Api<
   userUpdateLogin = (data: UserLoginRequest, params: RequestParams = {}) =>
     this.request<User, APIErrors>({
       path: `/api/v1/users/login`,
-      method: "POST",
+      method: 'POST',
       body: data,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -606,7 +596,7 @@ export class Api<
   userUpdateGoogleOauthStart = (params: RequestParams = {}) =>
     this.request<any, void>({
       path: `/api/v1/users/google/start`,
-      method: "GET",
+      method: 'GET',
       ...params,
     });
   /**
@@ -620,7 +610,7 @@ export class Api<
   userUpdateGoogleOauthCallback = (params: RequestParams = {}) =>
     this.request<any, void>({
       path: `/api/v1/users/google/callback`,
-      method: "GET",
+      method: 'GET',
       ...params,
     });
   /**
@@ -634,7 +624,7 @@ export class Api<
   userUpdateGithubOauthStart = (params: RequestParams = {}) =>
     this.request<any, void>({
       path: `/api/v1/users/github/start`,
-      method: "GET",
+      method: 'GET',
       ...params,
     });
   /**
@@ -648,7 +638,7 @@ export class Api<
   userUpdateGithubOauthCallback = (params: RequestParams = {}) =>
     this.request<any, void>({
       path: `/api/v1/users/github/callback`,
-      method: "GET",
+      method: 'GET',
       ...params,
     });
   /**
@@ -663,7 +653,7 @@ export class Api<
   userUpdateSlackOauthStart = (tenant: string, params: RequestParams = {}) =>
     this.request<any, void>({
       path: `/api/v1/tenants/${tenant}/slack/start`,
-      method: "GET",
+      method: 'GET',
       secure: true,
       ...params,
     });
@@ -679,7 +669,7 @@ export class Api<
   userUpdateSlackOauthCallback = (params: RequestParams = {}) =>
     this.request<any, void>({
       path: `/api/v1/users/slack/callback`,
-      method: "GET",
+      method: 'GET',
       secure: true,
       ...params,
     });
@@ -694,7 +684,7 @@ export class Api<
   snsUpdate = (tenant: string, event: string, params: RequestParams = {}) =>
     this.request<void, APIErrors>({
       path: `/api/v1/sns/${tenant}/${event}`,
-      method: "POST",
+      method: 'POST',
       ...params,
     });
   /**
@@ -709,9 +699,9 @@ export class Api<
   snsList = (tenant: string, params: RequestParams = {}) =>
     this.request<ListSNSIntegrations, APIErrors>({
       path: `/api/v1/tenants/${tenant}/sns`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -723,18 +713,14 @@ export class Api<
    * @request POST:/api/v1/tenants/{tenant}/sns
    * @secure
    */
-  snsCreate = (
-    tenant: string,
-    data: CreateSNSIntegrationRequest,
-    params: RequestParams = {},
-  ) =>
+  snsCreate = (tenant: string, data: CreateSNSIntegrationRequest, params: RequestParams = {}) =>
     this.request<SNSIntegration, APIErrors>({
       path: `/api/v1/tenants/${tenant}/sns`,
-      method: "POST",
+      method: 'POST',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -749,15 +735,15 @@ export class Api<
   alertEmailGroupCreate = (
     tenant: string,
     data: CreateTenantAlertEmailGroupRequest,
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<TenantAlertEmailGroup, APIErrors | APIError>({
       path: `/api/v1/tenants/${tenant}/alerting-email-groups`,
-      method: "POST",
+      method: 'POST',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -772,9 +758,9 @@ export class Api<
   alertEmailGroupList = (tenant: string, params: RequestParams = {}) =>
     this.request<TenantAlertEmailGroupList, APIErrors | APIError>({
       path: `/api/v1/tenants/${tenant}/alerting-email-groups`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -789,9 +775,9 @@ export class Api<
   tenantResourcePolicyGet = (tenant: string, params: RequestParams = {}) =>
     this.request<TenantResourcePolicy, APIErrors | APIError>({
       path: `/api/v1/tenants/${tenant}/resource-policy`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -806,15 +792,15 @@ export class Api<
   alertEmailGroupUpdate = (
     alertEmailGroup: string,
     data: UpdateTenantAlertEmailGroupRequest,
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<TenantAlertEmailGroup, APIErrors | APIError>({
       path: `/api/v1/alerting-email-groups/${alertEmailGroup}`,
-      method: "PATCH",
+      method: 'PATCH',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -826,13 +812,10 @@ export class Api<
    * @request DELETE:/api/v1/alerting-email-groups/{alert-email-group}
    * @secure
    */
-  alertEmailGroupDelete = (
-    alertEmailGroup: string,
-    params: RequestParams = {},
-  ) =>
+  alertEmailGroupDelete = (alertEmailGroup: string, params: RequestParams = {}) =>
     this.request<void, APIErrors | APIError>({
       path: `/api/v1/alerting-email-groups/${alertEmailGroup}`,
-      method: "DELETE",
+      method: 'DELETE',
       secure: true,
       ...params,
     });
@@ -848,7 +831,7 @@ export class Api<
   snsDelete = (sns: string, params: RequestParams = {}) =>
     this.request<void, APIErrors>({
       path: `/api/v1/sns/${sns}`,
-      method: "DELETE",
+      method: 'DELETE',
       secure: true,
       ...params,
     });
@@ -864,9 +847,9 @@ export class Api<
   slackWebhookList = (tenant: string, params: RequestParams = {}) =>
     this.request<ListSlackWebhooks, APIErrors>({
       path: `/api/v1/tenants/${tenant}/slack`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -881,7 +864,7 @@ export class Api<
   slackWebhookDelete = (slack: string, params: RequestParams = {}) =>
     this.request<void, APIErrors>({
       path: `/api/v1/slack/${slack}`,
-      method: "DELETE",
+      method: 'DELETE',
       secure: true,
       ...params,
     });
@@ -897,9 +880,9 @@ export class Api<
   userGetCurrent = (params: RequestParams = {}) =>
     this.request<User, APIErrors>({
       path: `/api/v1/users/current`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -911,17 +894,14 @@ export class Api<
    * @request POST:/api/v1/users/password
    * @secure
    */
-  userUpdatePassword = (
-    data: UserChangePasswordRequest,
-    params: RequestParams = {},
-  ) =>
+  userUpdatePassword = (data: UserChangePasswordRequest, params: RequestParams = {}) =>
     this.request<User, APIErrors>({
       path: `/api/v1/users/password`,
-      method: "POST",
+      method: 'POST',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -935,10 +915,10 @@ export class Api<
   userCreate = (data: UserRegisterRequest, params: RequestParams = {}) =>
     this.request<User, APIErrors>({
       path: `/api/v1/users/register`,
-      method: "POST",
+      method: 'POST',
       body: data,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -953,9 +933,9 @@ export class Api<
   userUpdateLogout = (params: RequestParams = {}) =>
     this.request<User, APIErrors>({
       path: `/api/v1/users/logout`,
-      method: "POST",
+      method: 'POST',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -970,9 +950,9 @@ export class Api<
   tenantMembershipsList = (params: RequestParams = {}) =>
     this.request<UserTenantMembershipsList, APIErrors>({
       path: `/api/v1/users/memberships`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -987,9 +967,9 @@ export class Api<
   userListTenantInvites = (params: RequestParams = {}) =>
     this.request<TenantInviteList, APIErrors>({
       path: `/api/v1/users/invites`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1001,13 +981,10 @@ export class Api<
    * @request POST:/api/v1/users/invites/accept
    * @secure
    */
-  tenantInviteAccept = (
-    data: AcceptInviteRequest,
-    params: RequestParams = {},
-  ) =>
+  tenantInviteAccept = (data: AcceptInviteRequest, params: RequestParams = {}) =>
     this.request<void, APIErrors | APIError>({
       path: `/api/v1/users/invites/accept`,
-      method: "POST",
+      method: 'POST',
       body: data,
       secure: true,
       type: ContentType.Json,
@@ -1022,13 +999,10 @@ export class Api<
    * @request POST:/api/v1/users/invites/reject
    * @secure
    */
-  tenantInviteReject = (
-    data: RejectInviteRequest,
-    params: RequestParams = {},
-  ) =>
+  tenantInviteReject = (data: RejectInviteRequest, params: RequestParams = {}) =>
     this.request<void, APIErrors | APIError>({
       path: `/api/v1/users/invites/reject`,
-      method: "POST",
+      method: 'POST',
       body: data,
       secure: true,
       type: ContentType.Json,
@@ -1046,11 +1020,11 @@ export class Api<
   tenantCreate = (data: CreateTenantRequest, params: RequestParams = {}) =>
     this.request<Tenant, APIErrors | APIError>({
       path: `/api/v1/tenants`,
-      method: "POST",
+      method: 'POST',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1062,18 +1036,14 @@ export class Api<
    * @request PATCH:/api/v1/tenants/{tenant}
    * @secure
    */
-  tenantUpdate = (
-    tenant: string,
-    data: UpdateTenantRequest,
-    params: RequestParams = {},
-  ) =>
+  tenantUpdate = (tenant: string, data: UpdateTenantRequest, params: RequestParams = {}) =>
     this.request<Tenant, APIErrors | APIError>({
       path: `/api/v1/tenants/${tenant}`,
-      method: "PATCH",
+      method: 'PATCH',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1088,9 +1058,9 @@ export class Api<
   tenantAlertingSettingsGet = (tenant: string, params: RequestParams = {}) =>
     this.request<TenantAlertingSettings, APIErrors | APIError>({
       path: `/api/v1/tenants/${tenant}/alerting/settings`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1105,15 +1075,15 @@ export class Api<
   tenantInviteCreate = (
     tenant: string,
     data: CreateTenantInviteRequest,
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<TenantInvite, APIErrors | APIError>({
       path: `/api/v1/tenants/${tenant}/invites`,
-      method: "POST",
+      method: 'POST',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1128,9 +1098,9 @@ export class Api<
   tenantInviteList = (tenant: string, params: RequestParams = {}) =>
     this.request<TenantInviteList, APIErrors | APIError>({
       path: `/api/v1/tenants/${tenant}/invites`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1145,15 +1115,15 @@ export class Api<
     tenant: string,
     tenantInvite: string,
     data: UpdateTenantInviteRequest,
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<TenantInvite, APIErrors>({
       path: `/api/v1/tenants/${tenant}/invites/${tenantInvite}`,
-      method: "PATCH",
+      method: 'PATCH',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1164,16 +1134,12 @@ export class Api<
    * @request DELETE:/api/v1/tenants/{tenant}/invites/{tenant-invite}
    * @secure
    */
-  tenantInviteDelete = (
-    tenant: string,
-    tenantInvite: string,
-    params: RequestParams = {},
-  ) =>
+  tenantInviteDelete = (tenant: string, tenantInvite: string, params: RequestParams = {}) =>
     this.request<TenantInvite, APIErrors>({
       path: `/api/v1/tenants/${tenant}/invites/${tenantInvite}`,
-      method: "DELETE",
+      method: 'DELETE',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1185,18 +1151,14 @@ export class Api<
    * @request POST:/api/v1/tenants/{tenant}/api-tokens
    * @secure
    */
-  apiTokenCreate = (
-    tenant: string,
-    data: CreateAPITokenRequest,
-    params: RequestParams = {},
-  ) =>
+  apiTokenCreate = (tenant: string, data: CreateAPITokenRequest, params: RequestParams = {}) =>
     this.request<CreateAPITokenResponse, APIErrors>({
       path: `/api/v1/tenants/${tenant}/api-tokens`,
-      method: "POST",
+      method: 'POST',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1211,9 +1173,9 @@ export class Api<
   apiTokenList = (tenant: string, params: RequestParams = {}) =>
     this.request<ListAPITokensResponse, APIErrors>({
       path: `/api/v1/tenants/${tenant}/api-tokens`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1228,7 +1190,7 @@ export class Api<
   apiTokenUpdateRevoke = (apiToken: string, params: RequestParams = {}) =>
     this.request<void, APIErrors>({
       path: `/api/v1/api-tokens/${apiToken}`,
-      method: "POST",
+      method: 'POST',
       secure: true,
       ...params,
     });
@@ -1252,14 +1214,14 @@ export class Api<
        */
       additionalMetadata?: string[];
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<TenantQueueMetrics, APIErrors>({
       path: `/api/v1/tenants/${tenant}/queue-metrics`,
-      method: "GET",
+      method: 'GET',
       query: query,
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1274,9 +1236,9 @@ export class Api<
   tenantGetStepRunQueueMetrics = (tenant: string, params: RequestParams = {}) =>
     this.request<TenantStepRunQueueMetrics, APIErrors>({
       path: `/api/v1/tenants/${tenant}/step-run-queue-metrics`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1321,14 +1283,14 @@ export class Api<
       /** A list of event ids to filter by */
       eventIds?: string[];
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<EventList, APIErrors>({
       path: `/api/v1/tenants/${tenant}/events`,
-      method: "GET",
+      method: 'GET',
       query: query,
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1340,18 +1302,14 @@ export class Api<
    * @request POST:/api/v1/tenants/{tenant}/events
    * @secure
    */
-  eventCreate = (
-    tenant: string,
-    data: CreateEventRequest,
-    params: RequestParams = {},
-  ) =>
+  eventCreate = (tenant: string, data: CreateEventRequest, params: RequestParams = {}) =>
     this.request<Event, APIErrors>({
       path: `/api/v1/tenants/${tenant}/events`,
-      method: "POST",
+      method: 'POST',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1363,18 +1321,14 @@ export class Api<
    * @request POST:/api/v1/tenants/{tenant}/events/bulk
    * @secure
    */
-  eventCreateBulk = (
-    tenant: string,
-    data: BulkCreateEventRequest,
-    params: RequestParams = {},
-  ) =>
+  eventCreateBulk = (tenant: string, data: BulkCreateEventRequest, params: RequestParams = {}) =>
     this.request<BulkCreateEventResponse, APIErrors>({
       path: `/api/v1/tenants/${tenant}/events/bulk`,
-      method: "POST",
+      method: 'POST',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1386,18 +1340,14 @@ export class Api<
    * @request POST:/api/v1/tenants/{tenant}/events/replay
    * @secure
    */
-  eventUpdateReplay = (
-    tenant: string,
-    data: ReplayEventRequest,
-    params: RequestParams = {},
-  ) =>
+  eventUpdateReplay = (tenant: string, data: ReplayEventRequest, params: RequestParams = {}) =>
     this.request<EventList, APIErrors>({
       path: `/api/v1/tenants/${tenant}/events/replay`,
-      method: "POST",
+      method: 'POST',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1409,11 +1359,7 @@ export class Api<
    * @request POST:/api/v1/tenants/{tenant}/events/cancel
    * @secure
    */
-  eventUpdateCancel = (
-    tenant: string,
-    data: CancelEventRequest,
-    params: RequestParams = {},
-  ) =>
+  eventUpdateCancel = (tenant: string, data: CancelEventRequest, params: RequestParams = {}) =>
     this.request<
       {
         workflowRunIds?: string[];
@@ -1421,11 +1367,11 @@ export class Api<
       APIErrors
     >({
       path: `/api/v1/tenants/${tenant}/events/cancel`,
-      method: "POST",
+      method: 'POST',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1457,14 +1403,14 @@ export class Api<
       /** The order direction */
       orderByDirection?: RateLimitOrderByDirection;
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<RateLimitList, APIErrors>({
       path: `/api/v1/tenants/${tenant}/rate-limits`,
-      method: "GET",
+      method: 'GET',
       query: query,
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1479,9 +1425,9 @@ export class Api<
   tenantMemberList = (tenant: string, params: RequestParams = {}) =>
     this.request<TenantMemberList, APIErrors | APIError>({
       path: `/api/v1/tenants/${tenant}/members`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1493,16 +1439,12 @@ export class Api<
    * @request DELETE:/api/v1/tenants/{tenant}/members/{member}
    * @secure
    */
-  tenantMemberDelete = (
-    tenant: string,
-    member: string,
-    params: RequestParams = {},
-  ) =>
+  tenantMemberDelete = (tenant: string, member: string, params: RequestParams = {}) =>
     this.request<TenantMember, APIErrors>({
       path: `/api/v1/tenants/${tenant}/members/${member}`,
-      method: "DELETE",
+      method: 'DELETE',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1517,9 +1459,9 @@ export class Api<
   eventGet = (event: string, params: RequestParams = {}) =>
     this.request<Event, APIErrors>({
       path: `/api/v1/events/${event}`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1534,9 +1476,9 @@ export class Api<
   eventDataGet = (event: string, params: RequestParams = {}) =>
     this.request<EventData, APIErrors>({
       path: `/api/v1/events/${event}/data`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1551,9 +1493,9 @@ export class Api<
   eventKeyList = (tenant: string, params: RequestParams = {}) =>
     this.request<EventKeyList, APIErrors>({
       path: `/api/v1/tenants/${tenant}/events/keys`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1583,14 +1525,14 @@ export class Api<
       /** Search by name */
       name?: string;
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<WorkflowList, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflows`,
-      method: "GET",
+      method: 'GET',
       query: query,
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1606,15 +1548,15 @@ export class Api<
     tenant: string,
     workflow: string,
     data: ScheduleWorkflowRunRequest,
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<ScheduledWorkflows, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflows/${workflow}/scheduled`,
-      method: "POST",
+      method: 'POST',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1672,14 +1614,14 @@ export class Api<
       /** A list of scheduled run statuses to filter by */
       statuses?: ScheduledRunStatus[];
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<ScheduledWorkflowsList, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflows/scheduled`,
-      method: "GET",
+      method: 'GET',
       query: query,
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1694,13 +1636,13 @@ export class Api<
   workflowScheduledGet = (
     tenant: string,
     scheduledWorkflowRun: string,
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<ScheduledWorkflows, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflows/scheduled/${scheduledWorkflowRun}`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1715,11 +1657,11 @@ export class Api<
   workflowScheduledDelete = (
     tenant: string,
     scheduledWorkflowRun: string,
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<void, APIErrors | APIError>({
       path: `/api/v1/tenants/${tenant}/workflows/scheduled/${scheduledWorkflowRun}`,
-      method: "DELETE",
+      method: 'DELETE',
       secure: true,
       ...params,
     });
@@ -1736,15 +1678,15 @@ export class Api<
     tenant: string,
     workflow: string,
     data: CreateCronWorkflowTriggerRequest,
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<CronWorkflows, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflows/${workflow}/crons`,
-      method: "POST",
+      method: 'POST',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1790,14 +1732,14 @@ export class Api<
       /** The order by direction */
       orderByDirection?: WorkflowRunOrderByDirection;
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<CronWorkflowsList, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflows/crons`,
-      method: "GET",
+      method: 'GET',
       query: query,
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1809,16 +1751,12 @@ export class Api<
    * @request GET:/api/v1/tenants/{tenant}/workflows/crons/{cron-workflow}
    * @secure
    */
-  workflowCronGet = (
-    tenant: string,
-    cronWorkflow: string,
-    params: RequestParams = {},
-  ) =>
+  workflowCronGet = (tenant: string, cronWorkflow: string, params: RequestParams = {}) =>
     this.request<CronWorkflows, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflows/crons/${cronWorkflow}`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1830,14 +1768,10 @@ export class Api<
    * @request DELETE:/api/v1/tenants/{tenant}/workflows/crons/{cron-workflow}
    * @secure
    */
-  workflowCronDelete = (
-    tenant: string,
-    cronWorkflow: string,
-    params: RequestParams = {},
-  ) =>
+  workflowCronDelete = (tenant: string, cronWorkflow: string, params: RequestParams = {}) =>
     this.request<void, APIErrors | APIError>({
       path: `/api/v1/tenants/${tenant}/workflows/crons/${cronWorkflow}`,
-      method: "DELETE",
+      method: 'DELETE',
       secure: true,
       ...params,
     });
@@ -1853,7 +1787,7 @@ export class Api<
   workflowRunCancel = (
     tenant: string,
     data: WorkflowRunsCancelRequest,
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<
       {
@@ -1862,11 +1796,11 @@ export class Api<
       APIErrors
     >({
       path: `/api/v1/tenants/${tenant}/workflows/cancel`,
-      method: "POST",
+      method: 'POST',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1881,9 +1815,9 @@ export class Api<
   workflowGet = (workflow: string, params: RequestParams = {}) =>
     this.request<Workflow, APIErrors>({
       path: `/api/v1/workflows/${workflow}`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1898,7 +1832,7 @@ export class Api<
   workflowDelete = (workflow: string, params: RequestParams = {}) =>
     this.request<void, APIErrors>({
       path: `/api/v1/workflows/${workflow}`,
-      method: "DELETE",
+      method: 'DELETE',
       secure: true,
       ...params,
     });
@@ -1911,18 +1845,14 @@ export class Api<
    * @request PATCH:/api/v1/workflows/{workflow}
    * @secure
    */
-  workflowUpdate = (
-    workflow: string,
-    data: WorkflowUpdateRequest,
-    params: RequestParams = {},
-  ) =>
+  workflowUpdate = (workflow: string, data: WorkflowUpdateRequest, params: RequestParams = {}) =>
     this.request<Workflow, APIErrors>({
       path: `/api/v1/workflows/${workflow}`,
-      method: "PATCH",
+      method: 'PATCH',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1945,14 +1875,14 @@ export class Api<
        */
       version?: string;
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<WorkflowVersion, APIErrors>({
       path: `/api/v1/workflows/${workflow}/versions`,
-      method: "GET",
+      method: 'GET',
       query: query,
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -1976,16 +1906,16 @@ export class Api<
        */
       version?: string;
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<WorkflowRun, APIErrors>({
       path: `/api/v1/workflows/${workflow}/trigger`,
-      method: "POST",
+      method: 'POST',
       query: query,
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2005,14 +1935,14 @@ export class Api<
       /** A group key to filter metrics by */
       groupKey?: string;
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<WorkflowMetrics, APIErrors>({
       path: `/api/v1/workflows/${workflow}/metrics`,
-      method: "GET",
+      method: 'GET',
       query: query,
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2046,14 +1976,14 @@ export class Api<
       /** The order direction */
       orderByDirection?: LogLineOrderByDirection;
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<LogLineList, APIErrors>({
       path: `/api/v1/step-runs/${stepRun}/logs`,
-      method: "GET",
+      method: 'GET',
       query: query,
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2079,14 +2009,14 @@ export class Api<
        */
       limit?: number;
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<StepRunEventList, APIErrors>({
       path: `/api/v1/step-runs/${stepRun}/events`,
-      method: "GET",
+      method: 'GET',
       query: query,
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2108,14 +2038,14 @@ export class Api<
        */
       lastId?: number;
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<StepRunEventList, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflow-runs/${workflowRun}/step-run-events`,
-      method: "GET",
+      method: 'GET',
       query: query,
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2141,14 +2071,14 @@ export class Api<
        */
       limit?: number;
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<StepRunArchiveList, APIErrors>({
       path: `/api/v1/step-runs/${stepRun}/archives`,
-      method: "GET",
+      method: 'GET',
       query: query,
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2160,16 +2090,12 @@ export class Api<
    * @request GET:/api/v1/tenants/{tenant}/workflows/{workflow}/worker-count
    * @secure
    */
-  workflowGetWorkersCount = (
-    tenant: string,
-    workflow: string,
-    params: RequestParams = {},
-  ) =>
+  workflowGetWorkersCount = (tenant: string, workflow: string, params: RequestParams = {}) =>
     this.request<WorkflowWorkersCount, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflows/${workflow}/worker-count`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2260,14 +2186,14 @@ export class Api<
       /** The order by direction */
       orderByDirection?: WorkflowRunOrderByDirection;
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<WorkflowRunList, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflows/runs`,
-      method: "GET",
+      method: 'GET',
       query: query,
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2282,15 +2208,15 @@ export class Api<
   workflowRunUpdateReplay = (
     tenant: string,
     data: ReplayWorkflowRunsRequest,
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<ReplayWorkflowRunsResponse, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflow-runs/replay`,
-      method: "POST",
+      method: 'POST',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2351,14 +2277,14 @@ export class Api<
        */
       createdBefore?: string;
     },
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<WorkflowRunsMetrics, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflows/runs/metrics`,
-      method: "GET",
+      method: 'GET',
       query: query,
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2370,16 +2296,12 @@ export class Api<
    * @request GET:/api/v1/tenants/{tenant}/workflow-runs/{workflow-run}
    * @secure
    */
-  workflowRunGet = (
-    tenant: string,
-    workflowRun: string,
-    params: RequestParams = {},
-  ) =>
+  workflowRunGet = (tenant: string, workflowRun: string, params: RequestParams = {}) =>
     this.request<WorkflowRun, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflow-runs/${workflowRun}`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2391,16 +2313,12 @@ export class Api<
    * @request GET:/api/v1/tenants/{tenant}/workflow-runs/{workflow-run}/shape
    * @secure
    */
-  workflowRunGetShape = (
-    tenant: string,
-    workflowRun: string,
-    params: RequestParams = {},
-  ) =>
+  workflowRunGetShape = (tenant: string, workflowRun: string, params: RequestParams = {}) =>
     this.request<WorkflowRunShape, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflow-runs/${workflowRun}/shape`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2415,9 +2333,9 @@ export class Api<
   stepRunGet = (tenant: string, stepRun: string, params: RequestParams = {}) =>
     this.request<StepRun, APIErrors>({
       path: `/api/v1/tenants/${tenant}/step-runs/${stepRun}`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2433,15 +2351,15 @@ export class Api<
     tenant: string,
     stepRun: string,
     data: RerunStepRunRequest,
-    params: RequestParams = {},
+    params: RequestParams = {}
   ) =>
     this.request<StepRun, APIErrors>({
       path: `/api/v1/tenants/${tenant}/step-runs/${stepRun}/rerun`,
-      method: "POST",
+      method: 'POST',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2453,16 +2371,12 @@ export class Api<
    * @request POST:/api/v1/tenants/{tenant}/step-runs/{step-run}/cancel
    * @secure
    */
-  stepRunUpdateCancel = (
-    tenant: string,
-    stepRun: string,
-    params: RequestParams = {},
-  ) =>
+  stepRunUpdateCancel = (tenant: string, stepRun: string, params: RequestParams = {}) =>
     this.request<StepRun, APIErrors>({
       path: `/api/v1/tenants/${tenant}/step-runs/${stepRun}/cancel`,
-      method: "POST",
+      method: 'POST',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2474,16 +2388,12 @@ export class Api<
    * @request GET:/api/v1/tenants/{tenant}/step-runs/{step-run}/schema
    * @secure
    */
-  stepRunGetSchema = (
-    tenant: string,
-    stepRun: string,
-    params: RequestParams = {},
-  ) =>
+  stepRunGetSchema = (tenant: string, stepRun: string, params: RequestParams = {}) =>
     this.request<object, APIErrors>({
       path: `/api/v1/tenants/${tenant}/step-runs/${stepRun}/schema`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2498,9 +2408,9 @@ export class Api<
   workerList = (tenant: string, params: RequestParams = {}) =>
     this.request<WorkerList, APIErrors>({
       path: `/api/v1/tenants/${tenant}/worker`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2512,18 +2422,14 @@ export class Api<
    * @request PATCH:/api/v1/workers/{worker}
    * @secure
    */
-  workerUpdate = (
-    worker: string,
-    data: UpdateWorkerRequest,
-    params: RequestParams = {},
-  ) =>
+  workerUpdate = (worker: string, data: UpdateWorkerRequest, params: RequestParams = {}) =>
     this.request<Worker, APIErrors>({
       path: `/api/v1/workers/${worker}`,
-      method: "PATCH",
+      method: 'PATCH',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2538,9 +2444,9 @@ export class Api<
   workerGet = (worker: string, params: RequestParams = {}) =>
     this.request<Worker, APIErrors>({
       path: `/api/v1/workers/${worker}`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2554,9 +2460,9 @@ export class Api<
   webhookList = (tenant: string, params: RequestParams = {}) =>
     this.request<WebhookWorkerListResponse, APIErrors>({
       path: `/api/v1/tenants/${tenant}/webhook-workers`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2567,18 +2473,14 @@ export class Api<
    * @request POST:/api/v1/tenants/{tenant}/webhook-workers
    * @secure
    */
-  webhookCreate = (
-    tenant: string,
-    data: WebhookWorkerCreateRequest,
-    params: RequestParams = {},
-  ) =>
+  webhookCreate = (tenant: string, data: WebhookWorkerCreateRequest, params: RequestParams = {}) =>
     this.request<WebhookWorkerCreated, APIErrors>({
       path: `/api/v1/tenants/${tenant}/webhook-workers`,
-      method: "POST",
+      method: 'POST',
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2592,7 +2494,7 @@ export class Api<
   webhookDelete = (webhook: string, params: RequestParams = {}) =>
     this.request<void, APIErrors>({
       path: `/api/v1/webhook-workers/${webhook}`,
-      method: "DELETE",
+      method: 'DELETE',
       secure: true,
       ...params,
     });
@@ -2607,9 +2509,9 @@ export class Api<
   webhookRequestsList = (webhook: string, params: RequestParams = {}) =>
     this.request<WebhookWorkerRequestListResponse, APIErrors>({
       path: `/api/v1/webhook-workers/${webhook}/requests`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2621,16 +2523,12 @@ export class Api<
    * @request GET:/api/v1/tenants/{tenant}/workflow-runs/{workflow-run}/input
    * @secure
    */
-  workflowRunGetInput = (
-    tenant: string,
-    workflowRun: string,
-    params: RequestParams = {},
-  ) =>
+  workflowRunGetInput = (tenant: string, workflowRun: string, params: RequestParams = {}) =>
     this.request<Record<string, any>, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflow-runs/${workflowRun}/input`,
-      method: "GET",
+      method: 'GET',
       secure: true,
-      format: "json",
+      format: 'json',
       ...params,
     });
   /**
@@ -2644,7 +2542,7 @@ export class Api<
   monitoringPostRunProbe = (tenant: string, params: RequestParams = {}) =>
     this.request<void, APIErrors>({
       path: `/api/v1/monitoring/${tenant}/probe`,
-      method: "POST",
+      method: 'POST',
       secure: true,
       ...params,
     });
@@ -2664,8 +2562,8 @@ export class Api<
       any
     >({
       path: `/api/v1/version`,
-      method: "GET",
-      format: "json",
+      method: 'GET',
+      format: 'json',
       ...params,
     });
 }

--- a/sdks/typescript/src/clients/rest/generated/Api.ts
+++ b/sdks/typescript/src/clients/rest/generated/Api.ts
@@ -120,10 +120,12 @@ import {
   WorkflowUpdateRequest,
   WorkflowVersion,
   WorkflowWorkersCount,
-} from './data-contracts';
-import { ContentType, HttpClient, RequestParams } from './http-client';
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
 
-export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+export class Api<
+  SecurityDataType = unknown,
+> extends HttpClient<SecurityDataType> {
   /**
    * @description Get a task by id
    *
@@ -136,9 +138,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   v1TaskGet = (task: string, params: RequestParams = {}) =>
     this.request<V1TaskSummary, APIErrors>({
       path: `/api/v1/stable/tasks/${task}`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -164,14 +166,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
        */
       limit?: number;
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<V1TaskEventList, APIErrors>({
       path: `/api/v1/stable/tasks/${task}/task-events`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -186,9 +188,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   v1LogLineList = (task: string, params: RequestParams = {}) =>
     this.request<V1LogLineList, APIErrors>({
       path: `/api/v1/stable/tasks/${task}/logs`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -200,10 +202,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request POST:/api/v1/stable/tenants/{tenant}/tasks/cancel
    * @secure
    */
-  v1TaskCancel = (tenant: string, data: V1CancelTaskRequest, params: RequestParams = {}) =>
+  v1TaskCancel = (
+    tenant: string,
+    data: V1CancelTaskRequest,
+    params: RequestParams = {},
+  ) =>
     this.request<void, APIErrors>({
       path: `/api/v1/stable/tenants/${tenant}/tasks/cancel`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
@@ -218,10 +224,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request POST:/api/v1/stable/tenants/{tenant}/tasks/replay
    * @secure
    */
-  v1TaskReplay = (tenant: string, data: V1ReplayTaskRequest, params: RequestParams = {}) =>
+  v1TaskReplay = (
+    tenant: string,
+    data: V1ReplayTaskRequest,
+    params: RequestParams = {},
+  ) =>
     this.request<void, APIErrors>({
       path: `/api/v1/stable/tenants/${tenant}/tasks/replay`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
@@ -248,14 +258,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
        */
       tenant: string;
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<V1DagChildren[], APIErrors>({
       path: `/api/v1/stable/dags/tasks`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -313,14 +323,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
        */
       parent_task_external_id?: string;
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<V1TaskSummaryList, APIErrors>({
       path: `/api/v1/stable/tenants/${tenant}/workflow-runs`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -338,14 +348,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
       /** The external ids of the workflow runs to get display names for */
       external_ids: string[];
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<V1WorkflowRunDisplayNameList, APIErrors>({
       path: `/api/v1/stable/tenants/${tenant}/workflow-runs/display-names`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -360,15 +370,15 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   v1WorkflowRunCreate = (
     tenant: string,
     data: V1TriggerWorkflowRunRequest,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<V1WorkflowRunDetails, APIErrors>({
       path: `/api/v1/stable/tenants/${tenant}/workflow-runs/trigger`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -383,9 +393,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   v1WorkflowRunGet = (v1WorkflowRun: string, params: RequestParams = {}) =>
     this.request<V1WorkflowRunDetails, APIErrors>({
       path: `/api/v1/stable/workflow-runs/${v1WorkflowRun}`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -411,14 +421,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
        */
       limit?: number;
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<V1TaskEventList, APIErrors>({
       path: `/api/v1/stable/workflow-runs/${v1WorkflowRun}/task-events`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -448,14 +458,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
        */
       parent_task_external_id?: string;
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<V1TaskRunMetrics, APIErrors>({
       path: `/api/v1/stable/tenants/${tenant}/task-metrics`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -483,14 +493,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
        */
       finishedBefore?: string;
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<V1TaskPointMetrics, APIErrors>({
       path: `/api/v1/stable/tenants/${tenant}/task-point-metrics`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -504,7 +514,7 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   readinessGet = (params: RequestParams = {}) =>
     this.request<void, void>({
       path: `/api/ready`,
-      method: 'GET',
+      method: "GET",
       ...params,
     });
   /**
@@ -518,7 +528,7 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   livenessGet = (params: RequestParams = {}) =>
     this.request<void, void>({
       path: `/api/live`,
-      method: 'GET',
+      method: "GET",
       ...params,
     });
   /**
@@ -532,8 +542,8 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   metadataGet = (params: RequestParams = {}) =>
     this.request<APIMeta, APIErrors>({
       path: `/api/v1/meta`,
-      method: 'GET',
-      format: 'json',
+      method: "GET",
+      format: "json",
       ...params,
     });
   /**
@@ -547,8 +557,8 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   cloudMetadataGet = (params: RequestParams = {}) =>
     this.request<APIErrors, APIErrors>({
       path: `/api/v1/cloud/metadata`,
-      method: 'GET',
-      format: 'json',
+      method: "GET",
+      format: "json",
       ...params,
     });
   /**
@@ -563,9 +573,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   metadataListIntegrations = (params: RequestParams = {}) =>
     this.request<ListAPIMetaIntegration, APIErrors>({
       path: `/api/v1/meta/integrations`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -579,10 +589,10 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   userUpdateLogin = (data: UserLoginRequest, params: RequestParams = {}) =>
     this.request<User, APIErrors>({
       path: `/api/v1/users/login`,
-      method: 'POST',
+      method: "POST",
       body: data,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -596,7 +606,7 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   userUpdateGoogleOauthStart = (params: RequestParams = {}) =>
     this.request<any, void>({
       path: `/api/v1/users/google/start`,
-      method: 'GET',
+      method: "GET",
       ...params,
     });
   /**
@@ -610,7 +620,7 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   userUpdateGoogleOauthCallback = (params: RequestParams = {}) =>
     this.request<any, void>({
       path: `/api/v1/users/google/callback`,
-      method: 'GET',
+      method: "GET",
       ...params,
     });
   /**
@@ -624,7 +634,7 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   userUpdateGithubOauthStart = (params: RequestParams = {}) =>
     this.request<any, void>({
       path: `/api/v1/users/github/start`,
-      method: 'GET',
+      method: "GET",
       ...params,
     });
   /**
@@ -638,7 +648,7 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   userUpdateGithubOauthCallback = (params: RequestParams = {}) =>
     this.request<any, void>({
       path: `/api/v1/users/github/callback`,
-      method: 'GET',
+      method: "GET",
       ...params,
     });
   /**
@@ -653,7 +663,7 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   userUpdateSlackOauthStart = (tenant: string, params: RequestParams = {}) =>
     this.request<any, void>({
       path: `/api/v1/tenants/${tenant}/slack/start`,
-      method: 'GET',
+      method: "GET",
       secure: true,
       ...params,
     });
@@ -669,7 +679,7 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   userUpdateSlackOauthCallback = (params: RequestParams = {}) =>
     this.request<any, void>({
       path: `/api/v1/users/slack/callback`,
-      method: 'GET',
+      method: "GET",
       secure: true,
       ...params,
     });
@@ -684,7 +694,7 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   snsUpdate = (tenant: string, event: string, params: RequestParams = {}) =>
     this.request<void, APIErrors>({
       path: `/api/v1/sns/${tenant}/${event}`,
-      method: 'POST',
+      method: "POST",
       ...params,
     });
   /**
@@ -699,9 +709,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   snsList = (tenant: string, params: RequestParams = {}) =>
     this.request<ListSNSIntegrations, APIErrors>({
       path: `/api/v1/tenants/${tenant}/sns`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -713,14 +723,18 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request POST:/api/v1/tenants/{tenant}/sns
    * @secure
    */
-  snsCreate = (tenant: string, data: CreateSNSIntegrationRequest, params: RequestParams = {}) =>
+  snsCreate = (
+    tenant: string,
+    data: CreateSNSIntegrationRequest,
+    params: RequestParams = {},
+  ) =>
     this.request<SNSIntegration, APIErrors>({
       path: `/api/v1/tenants/${tenant}/sns`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -735,15 +749,15 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   alertEmailGroupCreate = (
     tenant: string,
     data: CreateTenantAlertEmailGroupRequest,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<TenantAlertEmailGroup, APIErrors | APIError>({
       path: `/api/v1/tenants/${tenant}/alerting-email-groups`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -758,9 +772,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   alertEmailGroupList = (tenant: string, params: RequestParams = {}) =>
     this.request<TenantAlertEmailGroupList, APIErrors | APIError>({
       path: `/api/v1/tenants/${tenant}/alerting-email-groups`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -775,9 +789,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   tenantResourcePolicyGet = (tenant: string, params: RequestParams = {}) =>
     this.request<TenantResourcePolicy, APIErrors | APIError>({
       path: `/api/v1/tenants/${tenant}/resource-policy`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -792,15 +806,15 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   alertEmailGroupUpdate = (
     alertEmailGroup: string,
     data: UpdateTenantAlertEmailGroupRequest,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<TenantAlertEmailGroup, APIErrors | APIError>({
       path: `/api/v1/alerting-email-groups/${alertEmailGroup}`,
-      method: 'PATCH',
+      method: "PATCH",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -812,10 +826,13 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request DELETE:/api/v1/alerting-email-groups/{alert-email-group}
    * @secure
    */
-  alertEmailGroupDelete = (alertEmailGroup: string, params: RequestParams = {}) =>
+  alertEmailGroupDelete = (
+    alertEmailGroup: string,
+    params: RequestParams = {},
+  ) =>
     this.request<void, APIErrors | APIError>({
       path: `/api/v1/alerting-email-groups/${alertEmailGroup}`,
-      method: 'DELETE',
+      method: "DELETE",
       secure: true,
       ...params,
     });
@@ -831,7 +848,7 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   snsDelete = (sns: string, params: RequestParams = {}) =>
     this.request<void, APIErrors>({
       path: `/api/v1/sns/${sns}`,
-      method: 'DELETE',
+      method: "DELETE",
       secure: true,
       ...params,
     });
@@ -847,9 +864,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   slackWebhookList = (tenant: string, params: RequestParams = {}) =>
     this.request<ListSlackWebhooks, APIErrors>({
       path: `/api/v1/tenants/${tenant}/slack`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -864,7 +881,7 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   slackWebhookDelete = (slack: string, params: RequestParams = {}) =>
     this.request<void, APIErrors>({
       path: `/api/v1/slack/${slack}`,
-      method: 'DELETE',
+      method: "DELETE",
       secure: true,
       ...params,
     });
@@ -880,9 +897,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   userGetCurrent = (params: RequestParams = {}) =>
     this.request<User, APIErrors>({
       path: `/api/v1/users/current`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -894,14 +911,17 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request POST:/api/v1/users/password
    * @secure
    */
-  userUpdatePassword = (data: UserChangePasswordRequest, params: RequestParams = {}) =>
+  userUpdatePassword = (
+    data: UserChangePasswordRequest,
+    params: RequestParams = {},
+  ) =>
     this.request<User, APIErrors>({
       path: `/api/v1/users/password`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -915,10 +935,10 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   userCreate = (data: UserRegisterRequest, params: RequestParams = {}) =>
     this.request<User, APIErrors>({
       path: `/api/v1/users/register`,
-      method: 'POST',
+      method: "POST",
       body: data,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -933,9 +953,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   userUpdateLogout = (params: RequestParams = {}) =>
     this.request<User, APIErrors>({
       path: `/api/v1/users/logout`,
-      method: 'POST',
+      method: "POST",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -950,9 +970,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   tenantMembershipsList = (params: RequestParams = {}) =>
     this.request<UserTenantMembershipsList, APIErrors>({
       path: `/api/v1/users/memberships`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -967,9 +987,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   userListTenantInvites = (params: RequestParams = {}) =>
     this.request<TenantInviteList, APIErrors>({
       path: `/api/v1/users/invites`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -981,10 +1001,13 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request POST:/api/v1/users/invites/accept
    * @secure
    */
-  tenantInviteAccept = (data: AcceptInviteRequest, params: RequestParams = {}) =>
+  tenantInviteAccept = (
+    data: AcceptInviteRequest,
+    params: RequestParams = {},
+  ) =>
     this.request<void, APIErrors | APIError>({
       path: `/api/v1/users/invites/accept`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
@@ -999,10 +1022,13 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request POST:/api/v1/users/invites/reject
    * @secure
    */
-  tenantInviteReject = (data: RejectInviteRequest, params: RequestParams = {}) =>
+  tenantInviteReject = (
+    data: RejectInviteRequest,
+    params: RequestParams = {},
+  ) =>
     this.request<void, APIErrors | APIError>({
       path: `/api/v1/users/invites/reject`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
@@ -1020,11 +1046,11 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   tenantCreate = (data: CreateTenantRequest, params: RequestParams = {}) =>
     this.request<Tenant, APIErrors | APIError>({
       path: `/api/v1/tenants`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1036,14 +1062,18 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request PATCH:/api/v1/tenants/{tenant}
    * @secure
    */
-  tenantUpdate = (tenant: string, data: UpdateTenantRequest, params: RequestParams = {}) =>
+  tenantUpdate = (
+    tenant: string,
+    data: UpdateTenantRequest,
+    params: RequestParams = {},
+  ) =>
     this.request<Tenant, APIErrors | APIError>({
       path: `/api/v1/tenants/${tenant}`,
-      method: 'PATCH',
+      method: "PATCH",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1058,9 +1088,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   tenantAlertingSettingsGet = (tenant: string, params: RequestParams = {}) =>
     this.request<TenantAlertingSettings, APIErrors | APIError>({
       path: `/api/v1/tenants/${tenant}/alerting/settings`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1075,15 +1105,15 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   tenantInviteCreate = (
     tenant: string,
     data: CreateTenantInviteRequest,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<TenantInvite, APIErrors | APIError>({
       path: `/api/v1/tenants/${tenant}/invites`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1098,9 +1128,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   tenantInviteList = (tenant: string, params: RequestParams = {}) =>
     this.request<TenantInviteList, APIErrors | APIError>({
       path: `/api/v1/tenants/${tenant}/invites`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1115,15 +1145,15 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
     tenant: string,
     tenantInvite: string,
     data: UpdateTenantInviteRequest,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<TenantInvite, APIErrors>({
       path: `/api/v1/tenants/${tenant}/invites/${tenantInvite}`,
-      method: 'PATCH',
+      method: "PATCH",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1134,12 +1164,16 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request DELETE:/api/v1/tenants/{tenant}/invites/{tenant-invite}
    * @secure
    */
-  tenantInviteDelete = (tenant: string, tenantInvite: string, params: RequestParams = {}) =>
+  tenantInviteDelete = (
+    tenant: string,
+    tenantInvite: string,
+    params: RequestParams = {},
+  ) =>
     this.request<TenantInvite, APIErrors>({
       path: `/api/v1/tenants/${tenant}/invites/${tenantInvite}`,
-      method: 'DELETE',
+      method: "DELETE",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1151,14 +1185,18 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request POST:/api/v1/tenants/{tenant}/api-tokens
    * @secure
    */
-  apiTokenCreate = (tenant: string, data: CreateAPITokenRequest, params: RequestParams = {}) =>
+  apiTokenCreate = (
+    tenant: string,
+    data: CreateAPITokenRequest,
+    params: RequestParams = {},
+  ) =>
     this.request<CreateAPITokenResponse, APIErrors>({
       path: `/api/v1/tenants/${tenant}/api-tokens`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1173,9 +1211,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   apiTokenList = (tenant: string, params: RequestParams = {}) =>
     this.request<ListAPITokensResponse, APIErrors>({
       path: `/api/v1/tenants/${tenant}/api-tokens`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1190,7 +1228,7 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   apiTokenUpdateRevoke = (apiToken: string, params: RequestParams = {}) =>
     this.request<void, APIErrors>({
       path: `/api/v1/api-tokens/${apiToken}`,
-      method: 'POST',
+      method: "POST",
       secure: true,
       ...params,
     });
@@ -1214,14 +1252,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
        */
       additionalMetadata?: string[];
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<TenantQueueMetrics, APIErrors>({
       path: `/api/v1/tenants/${tenant}/queue-metrics`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1236,9 +1274,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   tenantGetStepRunQueueMetrics = (tenant: string, params: RequestParams = {}) =>
     this.request<TenantStepRunQueueMetrics, APIErrors>({
       path: `/api/v1/tenants/${tenant}/step-run-queue-metrics`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1283,14 +1321,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
       /** A list of event ids to filter by */
       eventIds?: string[];
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<EventList, APIErrors>({
       path: `/api/v1/tenants/${tenant}/events`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1302,14 +1340,18 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request POST:/api/v1/tenants/{tenant}/events
    * @secure
    */
-  eventCreate = (tenant: string, data: CreateEventRequest, params: RequestParams = {}) =>
+  eventCreate = (
+    tenant: string,
+    data: CreateEventRequest,
+    params: RequestParams = {},
+  ) =>
     this.request<Event, APIErrors>({
       path: `/api/v1/tenants/${tenant}/events`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1321,14 +1363,18 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request POST:/api/v1/tenants/{tenant}/events/bulk
    * @secure
    */
-  eventCreateBulk = (tenant: string, data: BulkCreateEventRequest, params: RequestParams = {}) =>
+  eventCreateBulk = (
+    tenant: string,
+    data: BulkCreateEventRequest,
+    params: RequestParams = {},
+  ) =>
     this.request<BulkCreateEventResponse, APIErrors>({
       path: `/api/v1/tenants/${tenant}/events/bulk`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1340,14 +1386,18 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request POST:/api/v1/tenants/{tenant}/events/replay
    * @secure
    */
-  eventUpdateReplay = (tenant: string, data: ReplayEventRequest, params: RequestParams = {}) =>
+  eventUpdateReplay = (
+    tenant: string,
+    data: ReplayEventRequest,
+    params: RequestParams = {},
+  ) =>
     this.request<EventList, APIErrors>({
       path: `/api/v1/tenants/${tenant}/events/replay`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1359,7 +1409,11 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request POST:/api/v1/tenants/{tenant}/events/cancel
    * @secure
    */
-  eventUpdateCancel = (tenant: string, data: CancelEventRequest, params: RequestParams = {}) =>
+  eventUpdateCancel = (
+    tenant: string,
+    data: CancelEventRequest,
+    params: RequestParams = {},
+  ) =>
     this.request<
       {
         workflowRunIds?: string[];
@@ -1367,11 +1421,11 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
       APIErrors
     >({
       path: `/api/v1/tenants/${tenant}/events/cancel`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1403,14 +1457,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
       /** The order direction */
       orderByDirection?: RateLimitOrderByDirection;
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<RateLimitList, APIErrors>({
       path: `/api/v1/tenants/${tenant}/rate-limits`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1425,9 +1479,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   tenantMemberList = (tenant: string, params: RequestParams = {}) =>
     this.request<TenantMemberList, APIErrors | APIError>({
       path: `/api/v1/tenants/${tenant}/members`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1439,12 +1493,16 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request DELETE:/api/v1/tenants/{tenant}/members/{member}
    * @secure
    */
-  tenantMemberDelete = (tenant: string, member: string, params: RequestParams = {}) =>
+  tenantMemberDelete = (
+    tenant: string,
+    member: string,
+    params: RequestParams = {},
+  ) =>
     this.request<TenantMember, APIErrors>({
       path: `/api/v1/tenants/${tenant}/members/${member}`,
-      method: 'DELETE',
+      method: "DELETE",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1459,9 +1517,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   eventGet = (event: string, params: RequestParams = {}) =>
     this.request<Event, APIErrors>({
       path: `/api/v1/events/${event}`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1476,9 +1534,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   eventDataGet = (event: string, params: RequestParams = {}) =>
     this.request<EventData, APIErrors>({
       path: `/api/v1/events/${event}/data`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1493,9 +1551,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   eventKeyList = (tenant: string, params: RequestParams = {}) =>
     this.request<EventKeyList, APIErrors>({
       path: `/api/v1/tenants/${tenant}/events/keys`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1525,14 +1583,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
       /** Search by name */
       name?: string;
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<WorkflowList, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflows`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1548,15 +1606,15 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
     tenant: string,
     workflow: string,
     data: ScheduleWorkflowRunRequest,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<ScheduledWorkflows, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflows/${workflow}/scheduled`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1614,14 +1672,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
       /** A list of scheduled run statuses to filter by */
       statuses?: ScheduledRunStatus[];
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<ScheduledWorkflowsList, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflows/scheduled`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1636,13 +1694,13 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   workflowScheduledGet = (
     tenant: string,
     scheduledWorkflowRun: string,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<ScheduledWorkflows, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflows/scheduled/${scheduledWorkflowRun}`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1657,11 +1715,11 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   workflowScheduledDelete = (
     tenant: string,
     scheduledWorkflowRun: string,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<void, APIErrors | APIError>({
       path: `/api/v1/tenants/${tenant}/workflows/scheduled/${scheduledWorkflowRun}`,
-      method: 'DELETE',
+      method: "DELETE",
       secure: true,
       ...params,
     });
@@ -1678,15 +1736,15 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
     tenant: string,
     workflow: string,
     data: CreateCronWorkflowTriggerRequest,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<CronWorkflows, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflows/${workflow}/crons`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1718,6 +1776,10 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
        * @maxLength 36
        */
       workflowId?: string;
+      /** The workflow name to get runs for. */
+      workflowName?: string;
+      /** The cron name to get runs for. */
+      cronName?: string;
       /**
        * A list of metadata key value pairs to filter by
        * @example ["key1:value1","key2:value2"]
@@ -1728,14 +1790,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
       /** The order by direction */
       orderByDirection?: WorkflowRunOrderByDirection;
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<CronWorkflowsList, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflows/crons`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1747,12 +1809,16 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request GET:/api/v1/tenants/{tenant}/workflows/crons/{cron-workflow}
    * @secure
    */
-  workflowCronGet = (tenant: string, cronWorkflow: string, params: RequestParams = {}) =>
+  workflowCronGet = (
+    tenant: string,
+    cronWorkflow: string,
+    params: RequestParams = {},
+  ) =>
     this.request<CronWorkflows, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflows/crons/${cronWorkflow}`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1764,10 +1830,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request DELETE:/api/v1/tenants/{tenant}/workflows/crons/{cron-workflow}
    * @secure
    */
-  workflowCronDelete = (tenant: string, cronWorkflow: string, params: RequestParams = {}) =>
+  workflowCronDelete = (
+    tenant: string,
+    cronWorkflow: string,
+    params: RequestParams = {},
+  ) =>
     this.request<void, APIErrors | APIError>({
       path: `/api/v1/tenants/${tenant}/workflows/crons/${cronWorkflow}`,
-      method: 'DELETE',
+      method: "DELETE",
       secure: true,
       ...params,
     });
@@ -1783,7 +1853,7 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   workflowRunCancel = (
     tenant: string,
     data: WorkflowRunsCancelRequest,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<
       {
@@ -1792,11 +1862,11 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
       APIErrors
     >({
       path: `/api/v1/tenants/${tenant}/workflows/cancel`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1811,9 +1881,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   workflowGet = (workflow: string, params: RequestParams = {}) =>
     this.request<Workflow, APIErrors>({
       path: `/api/v1/workflows/${workflow}`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1828,7 +1898,7 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   workflowDelete = (workflow: string, params: RequestParams = {}) =>
     this.request<void, APIErrors>({
       path: `/api/v1/workflows/${workflow}`,
-      method: 'DELETE',
+      method: "DELETE",
       secure: true,
       ...params,
     });
@@ -1841,14 +1911,18 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request PATCH:/api/v1/workflows/{workflow}
    * @secure
    */
-  workflowUpdate = (workflow: string, data: WorkflowUpdateRequest, params: RequestParams = {}) =>
+  workflowUpdate = (
+    workflow: string,
+    data: WorkflowUpdateRequest,
+    params: RequestParams = {},
+  ) =>
     this.request<Workflow, APIErrors>({
       path: `/api/v1/workflows/${workflow}`,
-      method: 'PATCH',
+      method: "PATCH",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1871,14 +1945,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
        */
       version?: string;
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<WorkflowVersion, APIErrors>({
       path: `/api/v1/workflows/${workflow}/versions`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1902,16 +1976,16 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
        */
       version?: string;
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<WorkflowRun, APIErrors>({
       path: `/api/v1/workflows/${workflow}/trigger`,
-      method: 'POST',
+      method: "POST",
       query: query,
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1931,14 +2005,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
       /** A group key to filter metrics by */
       groupKey?: string;
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<WorkflowMetrics, APIErrors>({
       path: `/api/v1/workflows/${workflow}/metrics`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -1972,14 +2046,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
       /** The order direction */
       orderByDirection?: LogLineOrderByDirection;
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<LogLineList, APIErrors>({
       path: `/api/v1/step-runs/${stepRun}/logs`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -2005,14 +2079,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
        */
       limit?: number;
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<StepRunEventList, APIErrors>({
       path: `/api/v1/step-runs/${stepRun}/events`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -2034,14 +2108,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
        */
       lastId?: number;
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<StepRunEventList, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflow-runs/${workflowRun}/step-run-events`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -2067,14 +2141,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
        */
       limit?: number;
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<StepRunArchiveList, APIErrors>({
       path: `/api/v1/step-runs/${stepRun}/archives`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -2086,12 +2160,16 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request GET:/api/v1/tenants/{tenant}/workflows/{workflow}/worker-count
    * @secure
    */
-  workflowGetWorkersCount = (tenant: string, workflow: string, params: RequestParams = {}) =>
+  workflowGetWorkersCount = (
+    tenant: string,
+    workflow: string,
+    params: RequestParams = {},
+  ) =>
     this.request<WorkflowWorkersCount, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflows/${workflow}/worker-count`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -2182,14 +2260,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
       /** The order by direction */
       orderByDirection?: WorkflowRunOrderByDirection;
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<WorkflowRunList, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflows/runs`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -2204,15 +2282,15 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   workflowRunUpdateReplay = (
     tenant: string,
     data: ReplayWorkflowRunsRequest,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<ReplayWorkflowRunsResponse, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflow-runs/replay`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -2273,14 +2351,14 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
        */
       createdBefore?: string;
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<WorkflowRunsMetrics, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflows/runs/metrics`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -2292,12 +2370,16 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request GET:/api/v1/tenants/{tenant}/workflow-runs/{workflow-run}
    * @secure
    */
-  workflowRunGet = (tenant: string, workflowRun: string, params: RequestParams = {}) =>
+  workflowRunGet = (
+    tenant: string,
+    workflowRun: string,
+    params: RequestParams = {},
+  ) =>
     this.request<WorkflowRun, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflow-runs/${workflowRun}`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -2309,12 +2391,16 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request GET:/api/v1/tenants/{tenant}/workflow-runs/{workflow-run}/shape
    * @secure
    */
-  workflowRunGetShape = (tenant: string, workflowRun: string, params: RequestParams = {}) =>
+  workflowRunGetShape = (
+    tenant: string,
+    workflowRun: string,
+    params: RequestParams = {},
+  ) =>
     this.request<WorkflowRunShape, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflow-runs/${workflowRun}/shape`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -2329,9 +2415,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   stepRunGet = (tenant: string, stepRun: string, params: RequestParams = {}) =>
     this.request<StepRun, APIErrors>({
       path: `/api/v1/tenants/${tenant}/step-runs/${stepRun}`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -2347,15 +2433,15 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
     tenant: string,
     stepRun: string,
     data: RerunStepRunRequest,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<StepRun, APIErrors>({
       path: `/api/v1/tenants/${tenant}/step-runs/${stepRun}/rerun`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -2367,12 +2453,16 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request POST:/api/v1/tenants/{tenant}/step-runs/{step-run}/cancel
    * @secure
    */
-  stepRunUpdateCancel = (tenant: string, stepRun: string, params: RequestParams = {}) =>
+  stepRunUpdateCancel = (
+    tenant: string,
+    stepRun: string,
+    params: RequestParams = {},
+  ) =>
     this.request<StepRun, APIErrors>({
       path: `/api/v1/tenants/${tenant}/step-runs/${stepRun}/cancel`,
-      method: 'POST',
+      method: "POST",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -2384,12 +2474,16 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request GET:/api/v1/tenants/{tenant}/step-runs/{step-run}/schema
    * @secure
    */
-  stepRunGetSchema = (tenant: string, stepRun: string, params: RequestParams = {}) =>
+  stepRunGetSchema = (
+    tenant: string,
+    stepRun: string,
+    params: RequestParams = {},
+  ) =>
     this.request<object, APIErrors>({
       path: `/api/v1/tenants/${tenant}/step-runs/${stepRun}/schema`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -2404,9 +2498,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   workerList = (tenant: string, params: RequestParams = {}) =>
     this.request<WorkerList, APIErrors>({
       path: `/api/v1/tenants/${tenant}/worker`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -2418,14 +2512,18 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request PATCH:/api/v1/workers/{worker}
    * @secure
    */
-  workerUpdate = (worker: string, data: UpdateWorkerRequest, params: RequestParams = {}) =>
+  workerUpdate = (
+    worker: string,
+    data: UpdateWorkerRequest,
+    params: RequestParams = {},
+  ) =>
     this.request<Worker, APIErrors>({
       path: `/api/v1/workers/${worker}`,
-      method: 'PATCH',
+      method: "PATCH",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -2440,9 +2538,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   workerGet = (worker: string, params: RequestParams = {}) =>
     this.request<Worker, APIErrors>({
       path: `/api/v1/workers/${worker}`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -2456,9 +2554,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   webhookList = (tenant: string, params: RequestParams = {}) =>
     this.request<WebhookWorkerListResponse, APIErrors>({
       path: `/api/v1/tenants/${tenant}/webhook-workers`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -2469,14 +2567,18 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request POST:/api/v1/tenants/{tenant}/webhook-workers
    * @secure
    */
-  webhookCreate = (tenant: string, data: WebhookWorkerCreateRequest, params: RequestParams = {}) =>
+  webhookCreate = (
+    tenant: string,
+    data: WebhookWorkerCreateRequest,
+    params: RequestParams = {},
+  ) =>
     this.request<WebhookWorkerCreated, APIErrors>({
       path: `/api/v1/tenants/${tenant}/webhook-workers`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -2490,7 +2592,7 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   webhookDelete = (webhook: string, params: RequestParams = {}) =>
     this.request<void, APIErrors>({
       path: `/api/v1/webhook-workers/${webhook}`,
-      method: 'DELETE',
+      method: "DELETE",
       secure: true,
       ...params,
     });
@@ -2505,9 +2607,9 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   webhookRequestsList = (webhook: string, params: RequestParams = {}) =>
     this.request<WebhookWorkerRequestListResponse, APIErrors>({
       path: `/api/v1/webhook-workers/${webhook}/requests`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -2519,12 +2621,16 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
    * @request GET:/api/v1/tenants/{tenant}/workflow-runs/{workflow-run}/input
    * @secure
    */
-  workflowRunGetInput = (tenant: string, workflowRun: string, params: RequestParams = {}) =>
+  workflowRunGetInput = (
+    tenant: string,
+    workflowRun: string,
+    params: RequestParams = {},
+  ) =>
     this.request<Record<string, any>, APIErrors>({
       path: `/api/v1/tenants/${tenant}/workflow-runs/${workflowRun}/input`,
-      method: 'GET',
+      method: "GET",
       secure: true,
-      format: 'json',
+      format: "json",
       ...params,
     });
   /**
@@ -2538,7 +2644,7 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
   monitoringPostRunProbe = (tenant: string, params: RequestParams = {}) =>
     this.request<void, APIErrors>({
       path: `/api/v1/monitoring/${tenant}/probe`,
-      method: 'POST',
+      method: "POST",
       secure: true,
       ...params,
     });
@@ -2558,8 +2664,8 @@ export class Api<SecurityDataType = unknown> extends HttpClient<SecurityDataType
       any
     >({
       path: `/api/v1/version`,
-      method: 'GET',
-      format: 'json',
+      method: "GET",
+      format: "json",
       ...params,
     });
 }

--- a/sdks/typescript/src/clients/rest/generated/data-contracts.ts
+++ b/sdks/typescript/src/clients/rest/generated/data-contracts.ts
@@ -11,190 +11,190 @@
  */
 
 export enum V1LogLineLevel {
-  DEBUG = 'DEBUG',
-  INFO = 'INFO',
-  WARN = 'WARN',
-  ERROR = 'ERROR',
+  DEBUG = "DEBUG",
+  INFO = "INFO",
+  WARN = "WARN",
+  ERROR = "ERROR",
 }
 
 export enum V1TaskRunStatus {
-  PENDING = 'PENDING',
-  RUNNING = 'RUNNING',
-  COMPLETED = 'COMPLETED',
-  FAILED = 'FAILED',
-  CANCELLED = 'CANCELLED',
+  PENDING = "PENDING",
+  RUNNING = "RUNNING",
+  COMPLETED = "COMPLETED",
+  FAILED = "FAILED",
+  CANCELLED = "CANCELLED",
 }
 
 export enum V1TaskStatus {
-  QUEUED = 'QUEUED',
-  RUNNING = 'RUNNING',
-  COMPLETED = 'COMPLETED',
-  CANCELLED = 'CANCELLED',
-  FAILED = 'FAILED',
+  QUEUED = "QUEUED",
+  RUNNING = "RUNNING",
+  COMPLETED = "COMPLETED",
+  CANCELLED = "CANCELLED",
+  FAILED = "FAILED",
 }
 
 export enum WebhookWorkerRequestMethod {
-  GET = 'GET',
-  POST = 'POST',
-  PUT = 'PUT',
+  GET = "GET",
+  POST = "POST",
+  PUT = "PUT",
 }
 
 export enum LogLineOrderByDirection {
-  Asc = 'asc',
-  Desc = 'desc',
+  Asc = "asc",
+  Desc = "desc",
 }
 
 export enum LogLineOrderByField {
-  CreatedAt = 'createdAt',
+  CreatedAt = "createdAt",
 }
 
 export enum LogLineLevel {
-  DEBUG = 'DEBUG',
-  INFO = 'INFO',
-  WARN = 'WARN',
-  ERROR = 'ERROR',
+  DEBUG = "DEBUG",
+  INFO = "INFO",
+  WARN = "WARN",
+  ERROR = "ERROR",
 }
 
 export enum PullRequestState {
-  Open = 'open',
-  Closed = 'closed',
+  Open = "open",
+  Closed = "closed",
 }
 
 export enum WorkerRuntimeSDKs {
-  GOLANG = 'GOLANG',
-  PYTHON = 'PYTHON',
-  TYPESCRIPT = 'TYPESCRIPT',
+  GOLANG = "GOLANG",
+  PYTHON = "PYTHON",
+  TYPESCRIPT = "TYPESCRIPT",
 }
 
 export enum StepRunEventSeverity {
-  INFO = 'INFO',
-  WARNING = 'WARNING',
-  CRITICAL = 'CRITICAL',
+  INFO = "INFO",
+  WARNING = "WARNING",
+  CRITICAL = "CRITICAL",
 }
 
 export enum StepRunEventReason {
-  REQUEUED_NO_WORKER = 'REQUEUED_NO_WORKER',
-  REQUEUED_RATE_LIMIT = 'REQUEUED_RATE_LIMIT',
-  SCHEDULING_TIMED_OUT = 'SCHEDULING_TIMED_OUT',
-  ASSIGNED = 'ASSIGNED',
-  STARTED = 'STARTED',
-  ACKNOWLEDGED = 'ACKNOWLEDGED',
-  FINISHED = 'FINISHED',
-  FAILED = 'FAILED',
-  RETRYING = 'RETRYING',
-  CANCELLED = 'CANCELLED',
-  TIMEOUT_REFRESHED = 'TIMEOUT_REFRESHED',
-  REASSIGNED = 'REASSIGNED',
-  TIMED_OUT = 'TIMED_OUT',
-  SLOT_RELEASED = 'SLOT_RELEASED',
-  RETRIED_BY_USER = 'RETRIED_BY_USER',
-  WORKFLOW_RUN_GROUP_KEY_SUCCEEDED = 'WORKFLOW_RUN_GROUP_KEY_SUCCEEDED',
-  WORKFLOW_RUN_GROUP_KEY_FAILED = 'WORKFLOW_RUN_GROUP_KEY_FAILED',
+  REQUEUED_NO_WORKER = "REQUEUED_NO_WORKER",
+  REQUEUED_RATE_LIMIT = "REQUEUED_RATE_LIMIT",
+  SCHEDULING_TIMED_OUT = "SCHEDULING_TIMED_OUT",
+  ASSIGNED = "ASSIGNED",
+  STARTED = "STARTED",
+  ACKNOWLEDGED = "ACKNOWLEDGED",
+  FINISHED = "FINISHED",
+  FAILED = "FAILED",
+  RETRYING = "RETRYING",
+  CANCELLED = "CANCELLED",
+  TIMEOUT_REFRESHED = "TIMEOUT_REFRESHED",
+  REASSIGNED = "REASSIGNED",
+  TIMED_OUT = "TIMED_OUT",
+  SLOT_RELEASED = "SLOT_RELEASED",
+  RETRIED_BY_USER = "RETRIED_BY_USER",
+  WORKFLOW_RUN_GROUP_KEY_SUCCEEDED = "WORKFLOW_RUN_GROUP_KEY_SUCCEEDED",
+  WORKFLOW_RUN_GROUP_KEY_FAILED = "WORKFLOW_RUN_GROUP_KEY_FAILED",
 }
 
 export enum StepRunStatus {
-  PENDING = 'PENDING',
-  PENDING_ASSIGNMENT = 'PENDING_ASSIGNMENT',
-  ASSIGNED = 'ASSIGNED',
-  RUNNING = 'RUNNING',
-  SUCCEEDED = 'SUCCEEDED',
-  FAILED = 'FAILED',
-  CANCELLED = 'CANCELLED',
-  CANCELLING = 'CANCELLING',
-  BACKOFF = 'BACKOFF',
+  PENDING = "PENDING",
+  PENDING_ASSIGNMENT = "PENDING_ASSIGNMENT",
+  ASSIGNED = "ASSIGNED",
+  RUNNING = "RUNNING",
+  SUCCEEDED = "SUCCEEDED",
+  FAILED = "FAILED",
+  CANCELLED = "CANCELLED",
+  CANCELLING = "CANCELLING",
+  BACKOFF = "BACKOFF",
 }
 
 export enum JobRunStatus {
-  PENDING = 'PENDING',
-  RUNNING = 'RUNNING',
-  SUCCEEDED = 'SUCCEEDED',
-  FAILED = 'FAILED',
-  CANCELLED = 'CANCELLED',
-  BACKOFF = 'BACKOFF',
+  PENDING = "PENDING",
+  RUNNING = "RUNNING",
+  SUCCEEDED = "SUCCEEDED",
+  FAILED = "FAILED",
+  CANCELLED = "CANCELLED",
+  BACKOFF = "BACKOFF",
 }
 
 export enum WorkflowKind {
-  FUNCTION = 'FUNCTION',
-  DURABLE = 'DURABLE',
-  DAG = 'DAG',
+  FUNCTION = "FUNCTION",
+  DURABLE = "DURABLE",
+  DAG = "DAG",
 }
 
 export enum WorkflowRunStatus {
-  PENDING = 'PENDING',
-  RUNNING = 'RUNNING',
-  SUCCEEDED = 'SUCCEEDED',
-  FAILED = 'FAILED',
-  CANCELLED = 'CANCELLED',
-  QUEUED = 'QUEUED',
-  BACKOFF = 'BACKOFF',
+  PENDING = "PENDING",
+  RUNNING = "RUNNING",
+  SUCCEEDED = "SUCCEEDED",
+  FAILED = "FAILED",
+  CANCELLED = "CANCELLED",
+  QUEUED = "QUEUED",
+  BACKOFF = "BACKOFF",
 }
 
 export enum WorkflowRunOrderByDirection {
-  ASC = 'ASC',
-  DESC = 'DESC',
+  ASC = "ASC",
+  DESC = "DESC",
 }
 
 export enum WorkflowRunOrderByField {
-  CreatedAt = 'createdAt',
-  StartedAt = 'startedAt',
-  FinishedAt = 'finishedAt',
-  Duration = 'duration',
+  CreatedAt = "createdAt",
+  StartedAt = "startedAt",
+  FinishedAt = "finishedAt",
+  Duration = "duration",
 }
 
 export enum CronWorkflowsOrderByField {
-  Name = 'name',
-  CreatedAt = 'createdAt',
+  Name = "name",
+  CreatedAt = "createdAt",
 }
 
 export enum ScheduledRunStatus {
-  PENDING = 'PENDING',
-  RUNNING = 'RUNNING',
-  SUCCEEDED = 'SUCCEEDED',
-  FAILED = 'FAILED',
-  CANCELLED = 'CANCELLED',
-  QUEUED = 'QUEUED',
-  SCHEDULED = 'SCHEDULED',
+  PENDING = "PENDING",
+  RUNNING = "RUNNING",
+  SUCCEEDED = "SUCCEEDED",
+  FAILED = "FAILED",
+  CANCELLED = "CANCELLED",
+  QUEUED = "QUEUED",
+  SCHEDULED = "SCHEDULED",
 }
 
 export enum ScheduledWorkflowsOrderByField {
-  TriggerAt = 'triggerAt',
-  CreatedAt = 'createdAt',
+  TriggerAt = "triggerAt",
+  CreatedAt = "createdAt",
 }
 
 export enum RateLimitOrderByDirection {
-  Asc = 'asc',
-  Desc = 'desc',
+  Asc = "asc",
+  Desc = "desc",
 }
 
 export enum RateLimitOrderByField {
-  Key = 'key',
-  Value = 'value',
-  LimitValue = 'limitValue',
+  Key = "key",
+  Value = "value",
+  LimitValue = "limitValue",
 }
 
 export enum EventOrderByDirection {
-  Asc = 'asc',
-  Desc = 'desc',
+  Asc = "asc",
+  Desc = "desc",
 }
 
 export enum EventOrderByField {
-  CreatedAt = 'createdAt',
+  CreatedAt = "createdAt",
 }
 
 export enum TenantResource {
-  WORKER = 'WORKER',
-  WORKER_SLOT = 'WORKER_SLOT',
-  EVENT = 'EVENT',
-  WORKFLOW_RUN = 'WORKFLOW_RUN',
-  TASK_RUN = 'TASK_RUN',
-  CRON = 'CRON',
-  SCHEDULE = 'SCHEDULE',
+  WORKER = "WORKER",
+  WORKER_SLOT = "WORKER_SLOT",
+  EVENT = "EVENT",
+  WORKFLOW_RUN = "WORKFLOW_RUN",
+  TASK_RUN = "TASK_RUN",
+  CRON = "CRON",
+  SCHEDULE = "SCHEDULE",
 }
 
 export enum TenantMemberRole {
-  OWNER = 'OWNER',
-  ADMIN = 'ADMIN',
-  MEMBER = 'MEMBER',
+  OWNER = "OWNER",
+  ADMIN = "ADMIN",
+  MEMBER = "MEMBER",
 }
 
 export interface APIMeta {
@@ -404,7 +404,7 @@ export interface Tenant {
   /** Whether to alert tenant members. */
   alertMemberEmails?: boolean;
   /** The version of the tenant. */
-  version: 'V0' | 'V1';
+  version: "V0" | "V1";
 }
 
 export interface TenantMember {
@@ -737,7 +737,11 @@ export interface WorkflowConcurrency {
    */
   maxRuns: number;
   /** The strategy to use when the concurrency limit is reached. */
-  limitStrategy: 'CANCEL_IN_PROGRESS' | 'DROP_NEWEST' | 'QUEUE_NEWEST' | 'GROUP_ROUND_ROBIN';
+  limitStrategy:
+    | "CANCEL_IN_PROGRESS"
+    | "DROP_NEWEST"
+    | "QUEUE_NEWEST"
+    | "GROUP_ROUND_ROBIN";
   /** An action which gets the concurrency group for the WorkflowRun. */
   getConcurrencyGroup: string;
 }
@@ -944,7 +948,7 @@ export interface ScheduledWorkflows {
    * @example "bb214807-246e-43a5-a25d-41761d1cff9e"
    */
   workflowRunId?: string;
-  method: 'DEFAULT' | 'API';
+  method: "DEFAULT" | "API";
   /**
    * @format int32
    * @min 1
@@ -969,7 +973,7 @@ export interface CronWorkflows {
   input?: Record<string, any>;
   additionalMetadata?: Record<string, any>;
   enabled: boolean;
-  method: 'DEFAULT' | 'API';
+  method: "DEFAULT" | "API";
   /**
    * @format int32
    * @min 1
@@ -1177,7 +1181,7 @@ export interface Worker {
   metadata: APIResourceMeta;
   /** The name of the worker. */
   name: string;
-  type: 'SELFHOSTED' | 'MANAGED' | 'WEBHOOK';
+  type: "SELFHOSTED" | "MANAGED" | "WEBHOOK";
   /**
    * The time this worker last sent a heartbeat.
    * @format date-time
@@ -1197,7 +1201,7 @@ export interface Worker {
   /** The recent step runs for the worker. */
   recentStepRuns?: RecentStepRuns[];
   /** The status of the worker. */
-  status?: 'ACTIVE' | 'INACTIVE' | 'PAUSED';
+  status?: "ACTIVE" | "INACTIVE" | "PAUSED";
   /** The maximum number of runs this worker can execute concurrently. */
   maxRuns?: number;
   /** The number of runs this worker can execute concurrently. */
@@ -1543,7 +1547,7 @@ export interface V1TaskSummary {
    */
   tenantId: string;
   /** The type of the workflow (whether it's a DAG or a task) */
-  type: 'DAG' | 'TASK';
+  type: "DAG" | "TASK";
   /** @format uuid */
   workflowId: string;
   workflowName?: string;
@@ -1574,26 +1578,26 @@ export interface V1TaskEventList {
     /** @format date-time */
     timestamp: string;
     eventType:
-      | 'REQUEUED_NO_WORKER'
-      | 'REQUEUED_RATE_LIMIT'
-      | 'SCHEDULING_TIMED_OUT'
-      | 'ASSIGNED'
-      | 'STARTED'
-      | 'FINISHED'
-      | 'FAILED'
-      | 'RETRYING'
-      | 'CANCELLED'
-      | 'TIMED_OUT'
-      | 'REASSIGNED'
-      | 'SLOT_RELEASED'
-      | 'TIMEOUT_REFRESHED'
-      | 'RETRIED_BY_USER'
-      | 'SENT_TO_WORKER'
-      | 'RATE_LIMIT_ERROR'
-      | 'ACKNOWLEDGED'
-      | 'CREATED'
-      | 'QUEUED'
-      | 'SKIPPED';
+      | "REQUEUED_NO_WORKER"
+      | "REQUEUED_RATE_LIMIT"
+      | "SCHEDULING_TIMED_OUT"
+      | "ASSIGNED"
+      | "STARTED"
+      | "FINISHED"
+      | "FAILED"
+      | "RETRYING"
+      | "CANCELLED"
+      | "TIMED_OUT"
+      | "REASSIGNED"
+      | "SLOT_RELEASED"
+      | "TIMEOUT_REFRESHED"
+      | "RETRIED_BY_USER"
+      | "SENT_TO_WORKER"
+      | "RATE_LIMIT_ERROR"
+      | "ACKNOWLEDGED"
+      | "CREATED"
+      | "QUEUED"
+      | "SKIPPED";
     message: string;
     errorMessage?: string;
     output?: string;

--- a/sdks/typescript/src/clients/rest/generated/data-contracts.ts
+++ b/sdks/typescript/src/clients/rest/generated/data-contracts.ts
@@ -11,190 +11,190 @@
  */
 
 export enum V1LogLineLevel {
-  DEBUG = "DEBUG",
-  INFO = "INFO",
-  WARN = "WARN",
-  ERROR = "ERROR",
+  DEBUG = 'DEBUG',
+  INFO = 'INFO',
+  WARN = 'WARN',
+  ERROR = 'ERROR',
 }
 
 export enum V1TaskRunStatus {
-  PENDING = "PENDING",
-  RUNNING = "RUNNING",
-  COMPLETED = "COMPLETED",
-  FAILED = "FAILED",
-  CANCELLED = "CANCELLED",
+  PENDING = 'PENDING',
+  RUNNING = 'RUNNING',
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
+  CANCELLED = 'CANCELLED',
 }
 
 export enum V1TaskStatus {
-  QUEUED = "QUEUED",
-  RUNNING = "RUNNING",
-  COMPLETED = "COMPLETED",
-  CANCELLED = "CANCELLED",
-  FAILED = "FAILED",
+  QUEUED = 'QUEUED',
+  RUNNING = 'RUNNING',
+  COMPLETED = 'COMPLETED',
+  CANCELLED = 'CANCELLED',
+  FAILED = 'FAILED',
 }
 
 export enum WebhookWorkerRequestMethod {
-  GET = "GET",
-  POST = "POST",
-  PUT = "PUT",
+  GET = 'GET',
+  POST = 'POST',
+  PUT = 'PUT',
 }
 
 export enum LogLineOrderByDirection {
-  Asc = "asc",
-  Desc = "desc",
+  Asc = 'asc',
+  Desc = 'desc',
 }
 
 export enum LogLineOrderByField {
-  CreatedAt = "createdAt",
+  CreatedAt = 'createdAt',
 }
 
 export enum LogLineLevel {
-  DEBUG = "DEBUG",
-  INFO = "INFO",
-  WARN = "WARN",
-  ERROR = "ERROR",
+  DEBUG = 'DEBUG',
+  INFO = 'INFO',
+  WARN = 'WARN',
+  ERROR = 'ERROR',
 }
 
 export enum PullRequestState {
-  Open = "open",
-  Closed = "closed",
+  Open = 'open',
+  Closed = 'closed',
 }
 
 export enum WorkerRuntimeSDKs {
-  GOLANG = "GOLANG",
-  PYTHON = "PYTHON",
-  TYPESCRIPT = "TYPESCRIPT",
+  GOLANG = 'GOLANG',
+  PYTHON = 'PYTHON',
+  TYPESCRIPT = 'TYPESCRIPT',
 }
 
 export enum StepRunEventSeverity {
-  INFO = "INFO",
-  WARNING = "WARNING",
-  CRITICAL = "CRITICAL",
+  INFO = 'INFO',
+  WARNING = 'WARNING',
+  CRITICAL = 'CRITICAL',
 }
 
 export enum StepRunEventReason {
-  REQUEUED_NO_WORKER = "REQUEUED_NO_WORKER",
-  REQUEUED_RATE_LIMIT = "REQUEUED_RATE_LIMIT",
-  SCHEDULING_TIMED_OUT = "SCHEDULING_TIMED_OUT",
-  ASSIGNED = "ASSIGNED",
-  STARTED = "STARTED",
-  ACKNOWLEDGED = "ACKNOWLEDGED",
-  FINISHED = "FINISHED",
-  FAILED = "FAILED",
-  RETRYING = "RETRYING",
-  CANCELLED = "CANCELLED",
-  TIMEOUT_REFRESHED = "TIMEOUT_REFRESHED",
-  REASSIGNED = "REASSIGNED",
-  TIMED_OUT = "TIMED_OUT",
-  SLOT_RELEASED = "SLOT_RELEASED",
-  RETRIED_BY_USER = "RETRIED_BY_USER",
-  WORKFLOW_RUN_GROUP_KEY_SUCCEEDED = "WORKFLOW_RUN_GROUP_KEY_SUCCEEDED",
-  WORKFLOW_RUN_GROUP_KEY_FAILED = "WORKFLOW_RUN_GROUP_KEY_FAILED",
+  REQUEUED_NO_WORKER = 'REQUEUED_NO_WORKER',
+  REQUEUED_RATE_LIMIT = 'REQUEUED_RATE_LIMIT',
+  SCHEDULING_TIMED_OUT = 'SCHEDULING_TIMED_OUT',
+  ASSIGNED = 'ASSIGNED',
+  STARTED = 'STARTED',
+  ACKNOWLEDGED = 'ACKNOWLEDGED',
+  FINISHED = 'FINISHED',
+  FAILED = 'FAILED',
+  RETRYING = 'RETRYING',
+  CANCELLED = 'CANCELLED',
+  TIMEOUT_REFRESHED = 'TIMEOUT_REFRESHED',
+  REASSIGNED = 'REASSIGNED',
+  TIMED_OUT = 'TIMED_OUT',
+  SLOT_RELEASED = 'SLOT_RELEASED',
+  RETRIED_BY_USER = 'RETRIED_BY_USER',
+  WORKFLOW_RUN_GROUP_KEY_SUCCEEDED = 'WORKFLOW_RUN_GROUP_KEY_SUCCEEDED',
+  WORKFLOW_RUN_GROUP_KEY_FAILED = 'WORKFLOW_RUN_GROUP_KEY_FAILED',
 }
 
 export enum StepRunStatus {
-  PENDING = "PENDING",
-  PENDING_ASSIGNMENT = "PENDING_ASSIGNMENT",
-  ASSIGNED = "ASSIGNED",
-  RUNNING = "RUNNING",
-  SUCCEEDED = "SUCCEEDED",
-  FAILED = "FAILED",
-  CANCELLED = "CANCELLED",
-  CANCELLING = "CANCELLING",
-  BACKOFF = "BACKOFF",
+  PENDING = 'PENDING',
+  PENDING_ASSIGNMENT = 'PENDING_ASSIGNMENT',
+  ASSIGNED = 'ASSIGNED',
+  RUNNING = 'RUNNING',
+  SUCCEEDED = 'SUCCEEDED',
+  FAILED = 'FAILED',
+  CANCELLED = 'CANCELLED',
+  CANCELLING = 'CANCELLING',
+  BACKOFF = 'BACKOFF',
 }
 
 export enum JobRunStatus {
-  PENDING = "PENDING",
-  RUNNING = "RUNNING",
-  SUCCEEDED = "SUCCEEDED",
-  FAILED = "FAILED",
-  CANCELLED = "CANCELLED",
-  BACKOFF = "BACKOFF",
+  PENDING = 'PENDING',
+  RUNNING = 'RUNNING',
+  SUCCEEDED = 'SUCCEEDED',
+  FAILED = 'FAILED',
+  CANCELLED = 'CANCELLED',
+  BACKOFF = 'BACKOFF',
 }
 
 export enum WorkflowKind {
-  FUNCTION = "FUNCTION",
-  DURABLE = "DURABLE",
-  DAG = "DAG",
+  FUNCTION = 'FUNCTION',
+  DURABLE = 'DURABLE',
+  DAG = 'DAG',
 }
 
 export enum WorkflowRunStatus {
-  PENDING = "PENDING",
-  RUNNING = "RUNNING",
-  SUCCEEDED = "SUCCEEDED",
-  FAILED = "FAILED",
-  CANCELLED = "CANCELLED",
-  QUEUED = "QUEUED",
-  BACKOFF = "BACKOFF",
+  PENDING = 'PENDING',
+  RUNNING = 'RUNNING',
+  SUCCEEDED = 'SUCCEEDED',
+  FAILED = 'FAILED',
+  CANCELLED = 'CANCELLED',
+  QUEUED = 'QUEUED',
+  BACKOFF = 'BACKOFF',
 }
 
 export enum WorkflowRunOrderByDirection {
-  ASC = "ASC",
-  DESC = "DESC",
+  ASC = 'ASC',
+  DESC = 'DESC',
 }
 
 export enum WorkflowRunOrderByField {
-  CreatedAt = "createdAt",
-  StartedAt = "startedAt",
-  FinishedAt = "finishedAt",
-  Duration = "duration",
+  CreatedAt = 'createdAt',
+  StartedAt = 'startedAt',
+  FinishedAt = 'finishedAt',
+  Duration = 'duration',
 }
 
 export enum CronWorkflowsOrderByField {
-  Name = "name",
-  CreatedAt = "createdAt",
+  Name = 'name',
+  CreatedAt = 'createdAt',
 }
 
 export enum ScheduledRunStatus {
-  PENDING = "PENDING",
-  RUNNING = "RUNNING",
-  SUCCEEDED = "SUCCEEDED",
-  FAILED = "FAILED",
-  CANCELLED = "CANCELLED",
-  QUEUED = "QUEUED",
-  SCHEDULED = "SCHEDULED",
+  PENDING = 'PENDING',
+  RUNNING = 'RUNNING',
+  SUCCEEDED = 'SUCCEEDED',
+  FAILED = 'FAILED',
+  CANCELLED = 'CANCELLED',
+  QUEUED = 'QUEUED',
+  SCHEDULED = 'SCHEDULED',
 }
 
 export enum ScheduledWorkflowsOrderByField {
-  TriggerAt = "triggerAt",
-  CreatedAt = "createdAt",
+  TriggerAt = 'triggerAt',
+  CreatedAt = 'createdAt',
 }
 
 export enum RateLimitOrderByDirection {
-  Asc = "asc",
-  Desc = "desc",
+  Asc = 'asc',
+  Desc = 'desc',
 }
 
 export enum RateLimitOrderByField {
-  Key = "key",
-  Value = "value",
-  LimitValue = "limitValue",
+  Key = 'key',
+  Value = 'value',
+  LimitValue = 'limitValue',
 }
 
 export enum EventOrderByDirection {
-  Asc = "asc",
-  Desc = "desc",
+  Asc = 'asc',
+  Desc = 'desc',
 }
 
 export enum EventOrderByField {
-  CreatedAt = "createdAt",
+  CreatedAt = 'createdAt',
 }
 
 export enum TenantResource {
-  WORKER = "WORKER",
-  WORKER_SLOT = "WORKER_SLOT",
-  EVENT = "EVENT",
-  WORKFLOW_RUN = "WORKFLOW_RUN",
-  TASK_RUN = "TASK_RUN",
-  CRON = "CRON",
-  SCHEDULE = "SCHEDULE",
+  WORKER = 'WORKER',
+  WORKER_SLOT = 'WORKER_SLOT',
+  EVENT = 'EVENT',
+  WORKFLOW_RUN = 'WORKFLOW_RUN',
+  TASK_RUN = 'TASK_RUN',
+  CRON = 'CRON',
+  SCHEDULE = 'SCHEDULE',
 }
 
 export enum TenantMemberRole {
-  OWNER = "OWNER",
-  ADMIN = "ADMIN",
-  MEMBER = "MEMBER",
+  OWNER = 'OWNER',
+  ADMIN = 'ADMIN',
+  MEMBER = 'MEMBER',
 }
 
 export interface APIMeta {
@@ -404,7 +404,7 @@ export interface Tenant {
   /** Whether to alert tenant members. */
   alertMemberEmails?: boolean;
   /** The version of the tenant. */
-  version: "V0" | "V1";
+  version: 'V0' | 'V1';
 }
 
 export interface TenantMember {
@@ -737,11 +737,7 @@ export interface WorkflowConcurrency {
    */
   maxRuns: number;
   /** The strategy to use when the concurrency limit is reached. */
-  limitStrategy:
-    | "CANCEL_IN_PROGRESS"
-    | "DROP_NEWEST"
-    | "QUEUE_NEWEST"
-    | "GROUP_ROUND_ROBIN";
+  limitStrategy: 'CANCEL_IN_PROGRESS' | 'DROP_NEWEST' | 'QUEUE_NEWEST' | 'GROUP_ROUND_ROBIN';
   /** An action which gets the concurrency group for the WorkflowRun. */
   getConcurrencyGroup: string;
 }
@@ -948,7 +944,7 @@ export interface ScheduledWorkflows {
    * @example "bb214807-246e-43a5-a25d-41761d1cff9e"
    */
   workflowRunId?: string;
-  method: "DEFAULT" | "API";
+  method: 'DEFAULT' | 'API';
   /**
    * @format int32
    * @min 1
@@ -973,7 +969,7 @@ export interface CronWorkflows {
   input?: Record<string, any>;
   additionalMetadata?: Record<string, any>;
   enabled: boolean;
-  method: "DEFAULT" | "API";
+  method: 'DEFAULT' | 'API';
   /**
    * @format int32
    * @min 1
@@ -1181,7 +1177,7 @@ export interface Worker {
   metadata: APIResourceMeta;
   /** The name of the worker. */
   name: string;
-  type: "SELFHOSTED" | "MANAGED" | "WEBHOOK";
+  type: 'SELFHOSTED' | 'MANAGED' | 'WEBHOOK';
   /**
    * The time this worker last sent a heartbeat.
    * @format date-time
@@ -1201,7 +1197,7 @@ export interface Worker {
   /** The recent step runs for the worker. */
   recentStepRuns?: RecentStepRuns[];
   /** The status of the worker. */
-  status?: "ACTIVE" | "INACTIVE" | "PAUSED";
+  status?: 'ACTIVE' | 'INACTIVE' | 'PAUSED';
   /** The maximum number of runs this worker can execute concurrently. */
   maxRuns?: number;
   /** The number of runs this worker can execute concurrently. */
@@ -1547,7 +1543,7 @@ export interface V1TaskSummary {
    */
   tenantId: string;
   /** The type of the workflow (whether it's a DAG or a task) */
-  type: "DAG" | "TASK";
+  type: 'DAG' | 'TASK';
   /** @format uuid */
   workflowId: string;
   workflowName?: string;
@@ -1578,26 +1574,26 @@ export interface V1TaskEventList {
     /** @format date-time */
     timestamp: string;
     eventType:
-      | "REQUEUED_NO_WORKER"
-      | "REQUEUED_RATE_LIMIT"
-      | "SCHEDULING_TIMED_OUT"
-      | "ASSIGNED"
-      | "STARTED"
-      | "FINISHED"
-      | "FAILED"
-      | "RETRYING"
-      | "CANCELLED"
-      | "TIMED_OUT"
-      | "REASSIGNED"
-      | "SLOT_RELEASED"
-      | "TIMEOUT_REFRESHED"
-      | "RETRIED_BY_USER"
-      | "SENT_TO_WORKER"
-      | "RATE_LIMIT_ERROR"
-      | "ACKNOWLEDGED"
-      | "CREATED"
-      | "QUEUED"
-      | "SKIPPED";
+      | 'REQUEUED_NO_WORKER'
+      | 'REQUEUED_RATE_LIMIT'
+      | 'SCHEDULING_TIMED_OUT'
+      | 'ASSIGNED'
+      | 'STARTED'
+      | 'FINISHED'
+      | 'FAILED'
+      | 'RETRYING'
+      | 'CANCELLED'
+      | 'TIMED_OUT'
+      | 'REASSIGNED'
+      | 'SLOT_RELEASED'
+      | 'TIMEOUT_REFRESHED'
+      | 'RETRIED_BY_USER'
+      | 'SENT_TO_WORKER'
+      | 'RATE_LIMIT_ERROR'
+      | 'ACKNOWLEDGED'
+      | 'CREATED'
+      | 'QUEUED'
+      | 'SKIPPED';
     message: string;
     errorMessage?: string;
     output?: string;

--- a/sdks/typescript/src/clients/rest/generated/http-client.ts
+++ b/sdks/typescript/src/clients/rest/generated/http-client.ts
@@ -16,13 +16,13 @@ import type {
   AxiosResponse,
   HeadersDefaults,
   ResponseType,
-} from "axios";
-import axios from "axios";
+} from 'axios';
+import axios from 'axios';
 
 export type QueryParamsType = Record<string | number, any>;
 
 export interface FullRequestParams
-  extends Omit<AxiosRequestConfig, "data" | "params" | "url" | "responseType"> {
+  extends Omit<AxiosRequestConfig, 'data' | 'params' | 'url' | 'responseType'> {
   /** set parameter to `true` for call `securityWorker` for this request */
   secure?: boolean;
   /** request path */
@@ -37,31 +37,28 @@ export interface FullRequestParams
   body?: unknown;
 }
 
-export type RequestParams = Omit<
-  FullRequestParams,
-  "body" | "method" | "query" | "path"
->;
+export type RequestParams = Omit<FullRequestParams, 'body' | 'method' | 'query' | 'path'>;
 
 export interface ApiConfig<SecurityDataType = unknown>
-  extends Omit<AxiosRequestConfig, "data" | "cancelToken"> {
+  extends Omit<AxiosRequestConfig, 'data' | 'cancelToken'> {
   securityWorker?: (
-    securityData: SecurityDataType | null,
+    securityData: SecurityDataType | null
   ) => Promise<AxiosRequestConfig | void> | AxiosRequestConfig | void;
   secure?: boolean;
   format?: ResponseType;
 }
 
 export enum ContentType {
-  Json = "application/json",
-  FormData = "multipart/form-data",
-  UrlEncoded = "application/x-www-form-urlencoded",
-  Text = "text/plain",
+  Json = 'application/json',
+  FormData = 'multipart/form-data',
+  UrlEncoded = 'application/x-www-form-urlencoded',
+  Text = 'text/plain',
 }
 
 export class HttpClient<SecurityDataType = unknown> {
   public instance: AxiosInstance;
   private securityData: SecurityDataType | null = null;
-  private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
+  private securityWorker?: ApiConfig<SecurityDataType>['securityWorker'];
   private secure?: boolean;
   private format?: ResponseType;
 
@@ -73,7 +70,7 @@ export class HttpClient<SecurityDataType = unknown> {
   }: ApiConfig<SecurityDataType> = {}) {
     this.instance = axios.create({
       ...axiosConfig,
-      baseURL: axiosConfig.baseURL || "",
+      baseURL: axiosConfig.baseURL || '',
     });
     this.secure = secure;
     this.format = format;
@@ -86,7 +83,7 @@ export class HttpClient<SecurityDataType = unknown> {
 
   protected mergeRequestParams(
     params1: AxiosRequestConfig,
-    params2?: AxiosRequestConfig,
+    params2?: AxiosRequestConfig
   ): AxiosRequestConfig {
     const method = params1.method || (params2 && params2.method);
 
@@ -96,9 +93,7 @@ export class HttpClient<SecurityDataType = unknown> {
       ...(params2 || {}),
       headers: {
         ...((method &&
-          this.instance.defaults.headers[
-            method.toLowerCase() as keyof HeadersDefaults
-          ]) ||
+          this.instance.defaults.headers[method.toLowerCase() as keyof HeadersDefaults]) ||
           {}),
         ...(params1.headers || {}),
         ...((params2 && params2.headers) || {}),
@@ -107,7 +102,7 @@ export class HttpClient<SecurityDataType = unknown> {
   }
 
   protected stringifyFormItem(formItem: unknown) {
-    if (typeof formItem === "object" && formItem !== null) {
+    if (typeof formItem === 'object' && formItem !== null) {
       return JSON.stringify(formItem);
     } else {
       return `${formItem}`;
@@ -120,15 +115,11 @@ export class HttpClient<SecurityDataType = unknown> {
     }
     return Object.keys(input || {}).reduce((formData, key) => {
       const property = input[key];
-      const propertyContent: any[] =
-        property instanceof Array ? property : [property];
+      const propertyContent: any[] = property instanceof Array ? property : [property];
 
       for (const formItem of propertyContent) {
         const isFileType = formItem instanceof Blob || formItem instanceof File;
-        formData.append(
-          key,
-          isFileType ? formItem : this.stringifyFormItem(formItem),
-        );
+        formData.append(key, isFileType ? formItem : this.stringifyFormItem(formItem));
       }
 
       return formData;
@@ -145,28 +136,18 @@ export class HttpClient<SecurityDataType = unknown> {
     ...params
   }: FullRequestParams): Promise<AxiosResponse<T>> => {
     const secureParams =
-      ((typeof secure === "boolean" ? secure : this.secure) &&
+      ((typeof secure === 'boolean' ? secure : this.secure) &&
         this.securityWorker &&
         (await this.securityWorker(this.securityData))) ||
       {};
     const requestParams = this.mergeRequestParams(params, secureParams);
     const responseFormat = format || this.format || undefined;
 
-    if (
-      type === ContentType.FormData &&
-      body &&
-      body !== null &&
-      typeof body === "object"
-    ) {
+    if (type === ContentType.FormData && body && body !== null && typeof body === 'object') {
       body = this.createFormData(body as Record<string, unknown>);
     }
 
-    if (
-      type === ContentType.Text &&
-      body &&
-      body !== null &&
-      typeof body !== "string"
-    ) {
+    if (type === ContentType.Text && body && body !== null && typeof body !== 'string') {
       body = JSON.stringify(body);
     }
 
@@ -174,7 +155,7 @@ export class HttpClient<SecurityDataType = unknown> {
       ...requestParams,
       headers: {
         ...(requestParams.headers || {}),
-        ...(type ? { "Content-Type": type } : {}),
+        ...(type ? { 'Content-Type': type } : {}),
       },
       params: query,
       responseType: responseFormat,

--- a/sdks/typescript/src/clients/rest/generated/http-client.ts
+++ b/sdks/typescript/src/clients/rest/generated/http-client.ts
@@ -16,13 +16,13 @@ import type {
   AxiosResponse,
   HeadersDefaults,
   ResponseType,
-} from 'axios';
-import axios from 'axios';
+} from "axios";
+import axios from "axios";
 
 export type QueryParamsType = Record<string | number, any>;
 
 export interface FullRequestParams
-  extends Omit<AxiosRequestConfig, 'data' | 'params' | 'url' | 'responseType'> {
+  extends Omit<AxiosRequestConfig, "data" | "params" | "url" | "responseType"> {
   /** set parameter to `true` for call `securityWorker` for this request */
   secure?: boolean;
   /** request path */
@@ -37,28 +37,31 @@ export interface FullRequestParams
   body?: unknown;
 }
 
-export type RequestParams = Omit<FullRequestParams, 'body' | 'method' | 'query' | 'path'>;
+export type RequestParams = Omit<
+  FullRequestParams,
+  "body" | "method" | "query" | "path"
+>;
 
 export interface ApiConfig<SecurityDataType = unknown>
-  extends Omit<AxiosRequestConfig, 'data' | 'cancelToken'> {
+  extends Omit<AxiosRequestConfig, "data" | "cancelToken"> {
   securityWorker?: (
-    securityData: SecurityDataType | null
+    securityData: SecurityDataType | null,
   ) => Promise<AxiosRequestConfig | void> | AxiosRequestConfig | void;
   secure?: boolean;
   format?: ResponseType;
 }
 
 export enum ContentType {
-  Json = 'application/json',
-  FormData = 'multipart/form-data',
-  UrlEncoded = 'application/x-www-form-urlencoded',
-  Text = 'text/plain',
+  Json = "application/json",
+  FormData = "multipart/form-data",
+  UrlEncoded = "application/x-www-form-urlencoded",
+  Text = "text/plain",
 }
 
 export class HttpClient<SecurityDataType = unknown> {
   public instance: AxiosInstance;
   private securityData: SecurityDataType | null = null;
-  private securityWorker?: ApiConfig<SecurityDataType>['securityWorker'];
+  private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
   private secure?: boolean;
   private format?: ResponseType;
 
@@ -70,7 +73,7 @@ export class HttpClient<SecurityDataType = unknown> {
   }: ApiConfig<SecurityDataType> = {}) {
     this.instance = axios.create({
       ...axiosConfig,
-      baseURL: axiosConfig.baseURL || '',
+      baseURL: axiosConfig.baseURL || "",
     });
     this.secure = secure;
     this.format = format;
@@ -83,7 +86,7 @@ export class HttpClient<SecurityDataType = unknown> {
 
   protected mergeRequestParams(
     params1: AxiosRequestConfig,
-    params2?: AxiosRequestConfig
+    params2?: AxiosRequestConfig,
   ): AxiosRequestConfig {
     const method = params1.method || (params2 && params2.method);
 
@@ -93,7 +96,9 @@ export class HttpClient<SecurityDataType = unknown> {
       ...(params2 || {}),
       headers: {
         ...((method &&
-          this.instance.defaults.headers[method.toLowerCase() as keyof HeadersDefaults]) ||
+          this.instance.defaults.headers[
+            method.toLowerCase() as keyof HeadersDefaults
+          ]) ||
           {}),
         ...(params1.headers || {}),
         ...((params2 && params2.headers) || {}),
@@ -102,7 +107,7 @@ export class HttpClient<SecurityDataType = unknown> {
   }
 
   protected stringifyFormItem(formItem: unknown) {
-    if (typeof formItem === 'object' && formItem !== null) {
+    if (typeof formItem === "object" && formItem !== null) {
       return JSON.stringify(formItem);
     } else {
       return `${formItem}`;
@@ -115,11 +120,15 @@ export class HttpClient<SecurityDataType = unknown> {
     }
     return Object.keys(input || {}).reduce((formData, key) => {
       const property = input[key];
-      const propertyContent: any[] = property instanceof Array ? property : [property];
+      const propertyContent: any[] =
+        property instanceof Array ? property : [property];
 
       for (const formItem of propertyContent) {
         const isFileType = formItem instanceof Blob || formItem instanceof File;
-        formData.append(key, isFileType ? formItem : this.stringifyFormItem(formItem));
+        formData.append(
+          key,
+          isFileType ? formItem : this.stringifyFormItem(formItem),
+        );
       }
 
       return formData;
@@ -136,18 +145,28 @@ export class HttpClient<SecurityDataType = unknown> {
     ...params
   }: FullRequestParams): Promise<AxiosResponse<T>> => {
     const secureParams =
-      ((typeof secure === 'boolean' ? secure : this.secure) &&
+      ((typeof secure === "boolean" ? secure : this.secure) &&
         this.securityWorker &&
         (await this.securityWorker(this.securityData))) ||
       {};
     const requestParams = this.mergeRequestParams(params, secureParams);
     const responseFormat = format || this.format || undefined;
 
-    if (type === ContentType.FormData && body && body !== null && typeof body === 'object') {
+    if (
+      type === ContentType.FormData &&
+      body &&
+      body !== null &&
+      typeof body === "object"
+    ) {
       body = this.createFormData(body as Record<string, unknown>);
     }
 
-    if (type === ContentType.Text && body && body !== null && typeof body !== 'string') {
+    if (
+      type === ContentType.Text &&
+      body &&
+      body !== null &&
+      typeof body !== "string"
+    ) {
       body = JSON.stringify(body);
     }
 
@@ -155,7 +174,7 @@ export class HttpClient<SecurityDataType = unknown> {
       ...requestParams,
       headers: {
         ...(requestParams.headers || {}),
-        ...(type ? { 'Content-Type': type } : {}),
+        ...(type ? { "Content-Type": type } : {}),
       },
       params: query,
       responseType: responseFormat,


### PR DESCRIPTION
# Description

Adding two more filters to the crons API, `workflowName` and `cronName`, so you can optionally filter by those over the API + in the SDKs

Also bundled in a handful of misc Python changes / requests from #1636 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

