### PR TITLE
Hotfix: Check if `scheduled` is nil before accessing tenant

### DIFF
--- a/api/v1/server/run/run.go
+++ b/api/v1/server/run/run.go
@@ -287,8 +287,12 @@ func (t *APIServer) registerSpec(g *echo.Group, spec *openapi3.T) (*populator.Po
 	populatorMW.RegisterGetter("scheduled-workflow-run", func(config *server.ServerConfig, parentId, id string) (result interface{}, uniqueParentId string, err error) {
 		scheduled, err := config.APIRepository.WorkflowRun().GetScheduledWorkflow(context.Background(), parentId, id)
 
-		if err != nil || scheduled == nil {
+		if err != nil {
 			return nil, "", err
+		}
+
+		if scheduled == nil {
+			return nil, "", fmt.Errorf("scheduled workflow run not found")
 		}
 
 		return scheduled, sqlchelpers.UUIDToStr(scheduled.TenantId), nil

--- a/api/v1/server/run/run.go
+++ b/api/v1/server/run/run.go
@@ -287,7 +287,7 @@ func (t *APIServer) registerSpec(g *echo.Group, spec *openapi3.T) (*populator.Po
 	populatorMW.RegisterGetter("scheduled-workflow-run", func(config *server.ServerConfig, parentId, id string) (result interface{}, uniqueParentId string, err error) {
 		scheduled, err := config.APIRepository.WorkflowRun().GetScheduledWorkflow(context.Background(), parentId, id)
 
-		if err != nil {
+		if err != nil || scheduled == nil {
 			return nil, "", err
 		}
 


### PR DESCRIPTION
# Description

Check if `scheduled` is nil before trying to access `scheduled.TenantId`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
