### PR TITLE
fix: scheduled-workflow-run nil check

### DIFF
--- a/api/v1/server/run/run.go
+++ b/api/v1/server/run/run.go
@@ -291,6 +291,10 @@ func (t *APIServer) registerSpec(g *echo.Group, spec *openapi3.T) (*populator.Po
 			return nil, "", err
 		}
 
+		if scheduled == nil {
+			return nil, "", fmt.Errorf("scheduled workflow not found")
+		}
+
 		return scheduled, sqlchelpers.UUIDToStr(scheduled.TenantId), nil
 	})
 


### PR DESCRIPTION
# Description

Fixes nil panic when deleting to access a `scheduled-workflow-run` that doesn't exist.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...
