### PR TITLE
config: allow buffer settings to be configurable

### DIFF
--- a/internal/msgqueue/v1/mq_pub_buffer.go
+++ b/internal/msgqueue/v1/mq_pub_buffer.go
@@ -3,14 +3,47 @@ package v1
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"strconv"
 	"sync"
 	"time"
 )
 
-const PUB_FLUSH_INTERVAL = 10 * time.Millisecond
-const PUB_BUFFER_SIZE = 1000
-const PUB_MAX_CONCURRENCY = 1
-const PUB_TIMEOUT = 10 * time.Second
+// nolint: staticcheck
+var (
+	PUB_FLUSH_INTERVAL  = 10 * time.Millisecond
+	PUB_BUFFER_SIZE     = 1000
+	PUB_MAX_CONCURRENCY = 1
+	PUB_TIMEOUT         = 10 * time.Second
+)
+
+func init() {
+	if os.Getenv("SERVER_DEFAULT_BUFFER_FLUSH_INTERVAL") != "" {
+		if v, err := time.ParseDuration(os.Getenv("SERVER_DEFAULT_BUFFER_FLUSH_INTERVAL")); err == nil {
+			PUB_FLUSH_INTERVAL = v
+		}
+	}
+
+	if os.Getenv("SERVER_DEFAULT_BUFFER_SIZE") != "" {
+		v := os.Getenv("SERVER_DEFAULT_BUFFER_SIZE")
+
+		maxSize, err := strconv.Atoi(v)
+
+		if err == nil {
+			PUB_BUFFER_SIZE = maxSize
+		}
+	}
+
+	if os.Getenv("SERVER_DEFAULT_BUFFER_CONCURRENCY") != "" {
+		v := os.Getenv("SERVER_DEFAULT_BUFFER_CONCURRENCY")
+
+		maxConcurrency, err := strconv.Atoi(v)
+
+		if err == nil {
+			PUB_MAX_CONCURRENCY = maxConcurrency
+		}
+	}
+}
 
 type PubFunc func(m *Message) error
 

--- a/internal/msgqueue/v1/mq_sub_buffer.go
+++ b/internal/msgqueue/v1/mq_sub_buffer.go
@@ -4,14 +4,46 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strconv"
 	"sync"
 	"time"
 )
 
-// default values for the buffer
-const SUB_FLUSH_INTERVAL = 10 * time.Millisecond
-const SUB_BUFFER_SIZE = 1000
-const SUB_MAX_CONCURRENCY = 10
+// nolint: staticcheck
+var (
+	SUB_FLUSH_INTERVAL  = 10 * time.Millisecond
+	SUB_BUFFER_SIZE     = 1000
+	SUB_MAX_CONCURRENCY = 10
+)
+
+func init() {
+	if os.Getenv("SERVER_DEFAULT_BUFFER_FLUSH_INTERVAL") != "" {
+		if v, err := time.ParseDuration(os.Getenv("SERVER_DEFAULT_BUFFER_FLUSH_INTERVAL")); err == nil {
+			SUB_FLUSH_INTERVAL = v
+		}
+	}
+
+	if os.Getenv("SERVER_DEFAULT_BUFFER_SIZE") != "" {
+		v := os.Getenv("SERVER_DEFAULT_BUFFER_SIZE")
+
+		maxSize, err := strconv.Atoi(v)
+
+		if err == nil {
+			SUB_BUFFER_SIZE = maxSize
+		}
+	}
+
+	if os.Getenv("SERVER_DEFAULT_BUFFER_CONCURRENCY") != "" {
+		v := os.Getenv("SERVER_DEFAULT_BUFFER_CONCURRENCY")
+
+		maxConcurrency, err := strconv.Atoi(v)
+
+		if err == nil {
+			SUB_MAX_CONCURRENCY = maxConcurrency
+		}
+	}
+}
 
 type DstFunc func(tenantId, msgId string, payloads [][]byte) error
 


### PR DESCRIPTION
# Description

Adds three environment variables for setting default buffer configuration. For example:

```
SERVER_DEFAULT_BUFFER_FLUSH_INTERVAL=20ms
SERVER_DEFAULT_BUFFER_SIZE=500
SERVER_DEFAULT_BUFFER_CONCURRENCY=5
```

## Type of change

- [X] New feature (non-breaking change which adds functionality)