### PR TITLE
fix: test duration and penultimate in prerelease

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        migrate-strategy: ["latest", "penultimate"]
+        migrate-strategy: ["latest"]
         rabbitmq-enabled: ["true", "false"]
         pg-version: ["15-alpine", "16-alpine", "17-alpine"]
 
@@ -34,7 +34,7 @@ jobs:
 
       - name: Test
         run: |
-          go test -tags load ./... -p 5 -v -race -failfast
+          go test -tags load ./... -p 5 -v -race -failfast -timeout 20m
         env:
           TESTING_MATRIX_MIGRATE: ${{ matrix.migrate-strategy }}
           TESTING_MATRIX_RABBITMQ_ENABLED: ${{ matrix.rabbitmq-enabled }}


### PR DESCRIPTION
# Description

Updates test duration for load tests to 20 minutes and removes penultimate from the matrix.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)