### PR TITLE
fix: select the max retry count from the DAG data

### DIFF
--- a/pkg/repository/v1/sqlcv1/tasks.sql.go
+++ b/pkg/repository/v1/sqlcv1/tasks.sql.go
@@ -786,47 +786,65 @@ WITH input AS (
     FROM
         (
             SELECT
-                unnest($2::bigint[]) AS task_id,
-                unnest($3::timestamptz[]) AS task_inserted_at
+                unnest($1::bigint[]) AS task_id,
+                unnest($2::timestamptz[]) AS task_inserted_at
         ) AS subquery
+), task_outputs AS (
+    SELECT
+        DISTINCT ON (t.id, t.inserted_at, t.retry_count)
+        t.id,
+        t.inserted_at,
+        t.retry_count,
+        t.tenant_id,
+        t.dag_id,
+        t.dag_inserted_at,
+        t.step_readable_id,
+        t.workflow_run_id,
+        t.step_id,
+        t.workflow_id,
+        e.data AS output
+    FROM
+        v1_task t1
+    JOIN
+        v1_dag_to_task dt ON dt.dag_id = t1.dag_id AND dt.dag_inserted_at = t1.dag_inserted_at
+    JOIN
+        v1_task t ON t.id = dt.task_id AND t.inserted_at = dt.task_inserted_at
+    JOIN
+        v1_task_event e ON e.task_id = t.id AND e.task_inserted_at = t.inserted_at AND e.event_type = 'COMPLETED'
+    WHERE
+        (t1.id, t1.inserted_at) IN (
+            SELECT
+                task_id,
+                task_inserted_at
+            FROM
+                input
+        )
+        AND t1.tenant_id = $3::uuid
+        AND t1.dag_id IS NOT NULL
+), max_retry_counts AS (
+    SELECT
+        id,
+        inserted_at,
+        MAX(retry_count) AS max_retry_count
+    FROM
+        task_outputs
+    GROUP BY
+        id, inserted_at
 )
 SELECT
-    DISTINCT ON (t.id, t.inserted_at, t.retry_count)
-    t.id,
-    t.inserted_at,
-    t.retry_count,
-    t.tenant_id,
-    t.dag_id,
-    t.dag_inserted_at,
-    t.step_readable_id,
-    t.workflow_run_id,
-    t.step_id,
-    t.workflow_id,
-    e.data AS output
+    task_outputs.id, task_outputs.inserted_at, task_outputs.retry_count, task_outputs.tenant_id, task_outputs.dag_id, task_outputs.dag_inserted_at, task_outputs.step_readable_id, task_outputs.workflow_run_id, task_outputs.step_id, task_outputs.workflow_id, task_outputs.output
 FROM
-    v1_task t1
+    task_outputs
 JOIN
-    v1_dag_to_task dt ON dt.dag_id = t1.dag_id AND dt.dag_inserted_at = t1.dag_inserted_at
-JOIN
-    v1_task t ON t.id = dt.task_id AND t.inserted_at = dt.task_inserted_at
-JOIN
-    v1_task_event e ON e.task_id = t.id AND e.task_inserted_at = t.inserted_at AND e.event_type = 'COMPLETED'
-WHERE
-    (t1.id, t1.inserted_at) IN (
-        SELECT
-            task_id,
-            task_inserted_at
-        FROM
-            input
-    )
-    AND t1.tenant_id = $1::uuid
-    AND t1.dag_id IS NOT NULL
+    max_retry_counts mrc ON task_outputs.id = mrc.id
+        AND task_outputs.inserted_at = mrc.inserted_at
+        AND task_outputs.retry_count = mrc.max_retry_count
 `
 
 type ListTaskParentOutputsParams struct {
-	Tenantid        pgtype.UUID          `json:"tenantid"`
 	Taskids         []int64              `json:"taskids"`
 	Taskinsertedats []pgtype.Timestamptz `json:"taskinsertedats"`
+	Tenantid        pgtype.UUID          `json:"tenantid"`
 }
 
 type ListTaskParentOutputsRow struct {
@@ -846,7 +864,7 @@ type ListTaskParentOutputsRow struct {
 // Lists the outputs of parent steps for a list of tasks. This is recursive because it looks at all grandparents
 // of the tasks as well.
 func (q *Queries) ListTaskParentOutputs(ctx context.Context, db DBTX, arg ListTaskParentOutputsParams) ([]*ListTaskParentOutputsRow, error) {
-	rows, err := db.Query(ctx, listTaskParentOutputs, arg.Tenantid, arg.Taskids, arg.Taskinsertedats)
+	rows, err := db.Query(ctx, listTaskParentOutputs, arg.Taskids, arg.Taskinsertedats, arg.Tenantid)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

On a replay, the query for getting all parent DAG data does not currently filter by the max retry count, which means that any (old retry) data from a parent step may be passed in as input to the child step in the DAG. 

This ensures that only the latest completed events get passed in.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)