### PR TITLE
fix: attempt to optimize match condition query

### DIFF
--- a/pkg/repository/v1/sqlcv1/matches-overwrite.sql
+++ b/pkg/repository/v1/sqlcv1/matches-overwrite.sql
@@ -22,8 +22,14 @@ SELECT
 FROM
     v1_match_condition m
 JOIN
-    input i ON (m.tenant_id, m.event_type, m.event_key, m.is_satisfied, COALESCE(m.event_resource_hint, '')::text) =
-        (@tenantId::uuid, @eventType::v1_event_type, i.event_key, FALSE, COALESCE(i.event_resource_hint, '')::text);
+    input i ON m.tenant_id = @tenantId::uuid
+        AND m.event_type = @eventType::v1_event_type
+        AND m.event_key = i.event_key
+        AND m.is_satisfied = FALSE
+        AND (
+            (m.event_resource_hint IS NULL AND i.event_resource_hint IS NULL)
+            OR m.event_resource_hint = i.event_resource_hint
+        );
 
 -- name: CreateMatchesForDAGTriggers :many
 WITH input AS (

--- a/pkg/repository/v1/sqlcv1/matches-overwrite.sql
+++ b/pkg/repository/v1/sqlcv1/matches-overwrite.sql
@@ -1,34 +1,5 @@
--- name: ListMatchConditionsForEvent :many
-WITH input AS (
-    SELECT
-        unnest(@eventKeys::text[]) AS event_key,
-        -- NOTE: nullable field
-        unnest(@eventResourceHints::text[]) AS event_resource_hint
-)
-SELECT
-    v1_match_id,
-    id,
-    registered_at,
-    event_type,
-    m.event_key,
-    m.event_resource_hint,
-    readable_data_key,
-    expression
-FROM
-    v1_match_condition m
-WHERE
-    m.tenant_id = @tenantId::uuid
-    AND m.event_type = @eventType::v1_event_type
-    AND m.is_satisfied = FALSE
-    AND EXISTS (
-        SELECT 1
-        FROM input i
-        WHERE m.event_key = i.event_key
-        AND (
-            (m.event_resource_hint IS NULL AND i.event_resource_hint IS NULL)
-            OR m.event_resource_hint = i.event_resource_hint
-        )
-    );
+-- NOTE: this file doesn't typically get generated, it's just used for generating boilerplate
+-- for queries
 
 -- name: CreateMatchesForDAGTriggers :many
 WITH input AS (

--- a/pkg/repository/v1/sqlcv1/matches-overwrite.sql.go
+++ b/pkg/repository/v1/sqlcv1/matches-overwrite.sql.go
@@ -6,7 +6,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-const listMatchConditionsForEvent = `-- name: ListMatchConditionsForEvent :many
+const listMatchConditionsForEventWithHint = `-- name: ListMatchConditionsForEventWithHint :many
 WITH input AS (
     SELECT
         event_key, event_resource_hint
@@ -33,14 +33,14 @@ WHERE
     AND m.event_type = $2::v1_event_type
     AND m.event_key = i.event_key
     AND m.is_satisfied = FALSE
-    AND m.event_resource_hint IS NOT DISTINCT FROM i.event_resource_hint
+    AND m.event_resource_hint = i.event_resource_hint
 `
 
-type ListMatchConditionsForEventParams struct {
-	Tenantid           pgtype.UUID   `json:"tenantid"`
-	Eventtype          V1EventType   `json:"eventtype"`
-	Eventkeys          []string      `json:"eventkeys"`
-	Eventresourcehints []pgtype.Text `json:"eventresourcehints"`
+type ListMatchConditionsForEventWithHintParams struct {
+	Tenantid           pgtype.UUID `json:"tenantid"`
+	Eventtype          V1EventType `json:"eventtype"`
+	Eventkeys          []string    `json:"eventkeys"`
+	Eventresourcehints []string    `json:"eventresourcehints"`
 }
 
 type ListMatchConditionsForEventRow struct {
@@ -54,12 +54,80 @@ type ListMatchConditionsForEventRow struct {
 	Expression        pgtype.Text        `json:"expression"`
 }
 
-func (q *Queries) ListMatchConditionsForEvent(ctx context.Context, db DBTX, arg ListMatchConditionsForEventParams) ([]*ListMatchConditionsForEventRow, error) {
-	rows, err := db.Query(ctx, listMatchConditionsForEvent,
+func (q *Queries) ListMatchConditionsForEventWithHint(ctx context.Context, db DBTX, arg ListMatchConditionsForEventWithHintParams) ([]*ListMatchConditionsForEventRow, error) {
+	rows, err := db.Query(ctx, listMatchConditionsForEventWithHint,
 		arg.Tenantid,
 		arg.Eventtype,
 		arg.Eventkeys,
 		arg.Eventresourcehints,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*ListMatchConditionsForEventRow
+	for rows.Next() {
+		var i ListMatchConditionsForEventRow
+		if err := rows.Scan(
+			&i.V1MatchID,
+			&i.ID,
+			&i.RegisteredAt,
+			&i.EventType,
+			&i.EventKey,
+			&i.EventResourceHint,
+			&i.ReadableDataKey,
+			&i.Expression,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listMatchConditionsForEventWithoutHint = `-- name: ListMatchConditionsForEventWithoutHint :many
+WITH input AS (
+    SELECT
+        event_key
+    FROM
+        (
+            SELECT
+                unnest($3::text[]) AS event_key
+        ) AS subquery
+)
+SELECT
+    v1_match_id,
+    id,
+    registered_at,
+    event_type,
+    m.event_key,
+    m.event_resource_hint,
+    readable_data_key,
+    expression
+FROM
+    v1_match_condition m, input i
+WHERE
+    m.tenant_id = $1::uuid
+    AND m.event_type = $2::v1_event_type
+    AND m.event_key = i.event_key
+    AND m.is_satisfied = FALSE
+    AND m.event_resource_hint IS NULL
+`
+
+type ListMatchConditionsForEventWithoutHintParams struct {
+	Tenantid  pgtype.UUID `json:"tenantid"`
+	Eventtype V1EventType `json:"eventtype"`
+	Eventkeys []string    `json:"eventkeys"`
+}
+
+func (q *Queries) ListMatchConditionsForEventWithoutHint(ctx context.Context, db DBTX, arg ListMatchConditionsForEventWithoutHintParams) ([]*ListMatchConditionsForEventRow, error) {
+	rows, err := db.Query(ctx, listMatchConditionsForEventWithoutHint,
+		arg.Tenantid,
+		arg.Eventtype,
+		arg.Eventkeys,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/repository/v1/sqlcv1/matches-overwrite.sql.go
+++ b/pkg/repository/v1/sqlcv1/matches-overwrite.sql.go
@@ -14,7 +14,6 @@ WITH input AS (
         (
             SELECT
                 unnest($3::text[]) AS event_key,
-                -- NOTE: nullable field
                 unnest($4::text[]) AS event_resource_hint
         ) AS subquery
 )
@@ -30,8 +29,14 @@ SELECT
 FROM
     v1_match_condition m
 JOIN
-    input i ON (m.tenant_id, m.event_type, m.event_key, m.is_satisfied, COALESCE(m.event_resource_hint, '')::text) =
-        ($1::uuid, $2::v1_event_type, i.event_key, FALSE, COALESCE(i.event_resource_hint, '')::text)
+    input i ON m.tenant_id = $1::uuid
+        AND m.event_type = $2::v1_event_type
+        AND m.event_key = i.event_key
+        AND m.is_satisfied = FALSE
+        AND (
+            (m.event_resource_hint IS NULL AND i.event_resource_hint IS NULL)
+            OR m.event_resource_hint = i.event_resource_hint
+        )
 `
 
 type ListMatchConditionsForEventParams struct {


### PR DESCRIPTION
# Description

Improves queries for match conditions which involve filtering for an `event_resource_hint`. This hint is used for filtering the number of potential match conditions for an event -- we use it internally to determine whether a task in a DAG should be triggered. 

This query was using `COALESCE` to select for both null and not null rows on the match condition, which basically skips the index. I then tried `IS NOT DISTINCT FROM`, but this is also not indexable in Postgres. 

I ended up splitting this query in two, one query which looks for match conditions using the `event_resource_hint`, and one query which doesn't. I analyzed some queries against large datasets (1.5M conditions) and saw sub-millisecond responses, where previously we would see >500ms response times. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)