### PR TITLE
add: CoroutineLike & AwaitableLike types

### DIFF
--- a/sdks/python/examples/dag/worker.py
+++ b/sdks/python/examples/dag/worker.py
@@ -33,7 +33,7 @@ async def step2(input: EmptyModel, ctx: Context) -> StepOutput:
 @dag_workflow.task(parents=[step1, step2])
 async def step3(input: EmptyModel, ctx: Context) -> RandomSum:
     one = ctx.task_output(step1).random_number
-    two = (await ctx.task_output(step2)).random_number
+    two = ctx.task_output(step2).random_number
 
     return RandomSum(sum=one + two)
 
@@ -45,7 +45,7 @@ async def step4(input: EmptyModel, ctx: Context) -> dict[str, str]:
         time.strftime("%H:%M:%S", time.localtime()),
         input,
         ctx.task_output(step1),
-        await ctx.task_output(step3),
+        ctx.task_output(step3),
     )
     return {
         "step4": "step4",

--- a/sdks/python/examples/simple/test_simple_workflow.py
+++ b/sdks/python/examples/simple/test_simple_workflow.py
@@ -1,0 +1,36 @@
+import pytest
+
+from examples.simple.worker import step1
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_simple_workflow_running_options() -> None:
+    x1 = step1.run()
+    x2 = await step1.aio_run()
+
+    x3 = step1.run_many([step1.create_bulk_run_item()])[0]
+    x4 = (await step1.aio_run_many([step1.create_bulk_run_item()]))[0]
+
+    x5 = step1.run_no_wait().result()
+    x6 = (await step1.aio_run_no_wait()).result()
+    x7 = [x.result() for x in step1.run_many_no_wait([step1.create_bulk_run_item()])][0]
+    x8 = [
+        x.result()
+        for x in await step1.aio_run_many_no_wait([step1.create_bulk_run_item()])
+    ][0]
+
+    x9 = await step1.run_no_wait().aio_result()
+    x10 = await (await step1.aio_run_no_wait()).aio_result()
+    x11 = [
+        await x.aio_result()
+        for x in step1.run_many_no_wait([step1.create_bulk_run_item()])
+    ][0]
+    x12 = [
+        await x.aio_result()
+        for x in await step1.aio_run_many_no_wait([step1.create_bulk_run_item()])
+    ][0]
+
+    assert all(
+        x == {"result": "Hello, world!"}
+        for x in [x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12]
+    )

--- a/sdks/python/examples/simple/worker.py
+++ b/sdks/python/examples/simple/worker.py
@@ -6,12 +6,12 @@ hatchet = Hatchet(debug=True)
 
 
 @hatchet.task(name="SimpleWorkflow")
-def step1(input: EmptyModel, ctx: Context) -> None:
-    print("executed step1")
+def step1(input: EmptyModel, ctx: Context) -> dict[str, str]:
+    return {"result": "Hello, world!"}
 
 
 def main() -> None:
-    worker = hatchet.worker("test-worker", slots=1, workflows=[step1])
+    worker = hatchet.worker("test-worker", workflows=[step1])
     worker.start()
 
 

--- a/sdks/python/examples/simple/worker.py
+++ b/sdks/python/examples/simple/worker.py
@@ -6,14 +6,8 @@ hatchet = Hatchet(debug=True)
 
 
 @hatchet.task(name="SimpleWorkflow")
-async def step1(input: EmptyModel, ctx: Context) -> dict[str, str]:
+def step1(input: EmptyModel, ctx: Context) -> None:
     print("executed step1")
-    return {
-        "step1": "step1",
-    }
-
-
-x = step1.run()
 
 
 def main() -> None:

--- a/sdks/python/examples/simple/worker.py
+++ b/sdks/python/examples/simple/worker.py
@@ -6,8 +6,14 @@ hatchet = Hatchet(debug=True)
 
 
 @hatchet.task(name="SimpleWorkflow")
-def step1(input: EmptyModel, ctx: Context) -> None:
+async def step1(input: EmptyModel, ctx: Context) -> dict[str, str]:
     print("executed step1")
+    return {
+        "step1": "step1",
+    }
+
+
+x = step1.run()
 
 
 def main() -> None:

--- a/sdks/python/examples/worker.py
+++ b/sdks/python/examples/worker.py
@@ -16,6 +16,7 @@ from examples.lifespans.simple import lifespan, lifespan_task
 from examples.logger.workflow import logging_workflow
 from examples.non_retryable.worker import non_retryable_workflow
 from examples.on_failure.worker import on_failure_wf, on_failure_wf_with_details
+from examples.simple.worker import step1
 from examples.timeout.worker import refresh_timeout_wf, timeout_wf
 from examples.waits.worker import task_condition_workflow
 from hatchet_sdk import Hatchet
@@ -52,6 +53,7 @@ def main() -> None:
             non_retryable_workflow,
             concurrency_workflow_level_workflow,
             lifespan_task,
+            step1,
         ],
         lifespan=lifespan,
     )

--- a/sdks/python/hatchet_sdk/context/context.py
+++ b/sdks/python/hatchet_sdk/context/context.py
@@ -86,16 +86,6 @@ class Context:
         return parent_step_data
 
     def task_output(self, task: "Task[TWorkflowInput, R]") -> "R":
-        from hatchet_sdk.runnables.types import R
-
-        ## If the task is async, we need to wrap its output in a coroutine
-        ## so that the type checker behaves right
-        async def _aio_output() -> "R":
-            return self._task_output(task)
-
-        if task.is_async_function:
-            return cast(R, _aio_output())
-
         return self._task_output(task)
 
     def aio_task_output(self, task: "Task[TWorkflowInput, R]") -> "R":

--- a/sdks/python/hatchet_sdk/context/context.py
+++ b/sdks/python/hatchet_sdk/context/context.py
@@ -69,7 +69,7 @@ class Context:
     def trigger_data(self) -> JSONSerializableMapping:
         return self.data.triggers
 
-    def _task_output(self, task: "Task[TWorkflowInput, R]") -> "R":
+    def task_output(self, task: "Task[TWorkflowInput, R]") -> "R":
         from hatchet_sdk.runnables.types import R
 
         if self.was_skipped(task):
@@ -84,9 +84,6 @@ class Context:
             return cast(R, v.model_validate(parent_step_data))
 
         return parent_step_data
-
-    def task_output(self, task: "Task[TWorkflowInput, R]") -> "R":
-        return self._task_output(task)
 
     def aio_task_output(self, task: "Task[TWorkflowInput, R]") -> "R":
         warn(

--- a/sdks/python/hatchet_sdk/hatchet.py
+++ b/sdks/python/hatchet_sdk/hatchet.py
@@ -32,6 +32,7 @@ from hatchet_sdk.runnables.types import (
 )
 from hatchet_sdk.runnables.workflow import BaseWorkflow, Workflow
 from hatchet_sdk.utils.timedelta_to_expression import Duration
+from hatchet_sdk.utils.typing import CoroutineLike
 from hatchet_sdk.worker.worker import LifespanFn, Worker
 
 
@@ -300,7 +301,10 @@ class Hatchet:
         desired_worker_labels: dict[str, DesiredWorkerLabel] = {},
         backoff_factor: float | None = None,
         backoff_max_seconds: int | None = None,
-    ) -> Callable[[Callable[[EmptyModel, Context], R]], Standalone[EmptyModel, R]]: ...
+    ) -> Callable[
+        [Callable[[EmptyModel, Context], R | CoroutineLike[R]]],
+        Standalone[EmptyModel, R],
+    ]: ...
 
     @overload
     def task(
@@ -323,7 +327,8 @@ class Hatchet:
         backoff_factor: float | None = None,
         backoff_max_seconds: int | None = None,
     ) -> Callable[
-        [Callable[[TWorkflowInput, Context], R]], Standalone[TWorkflowInput, R]
+        [Callable[[TWorkflowInput, Context], R | CoroutineLike[R]]],
+        Standalone[TWorkflowInput, R],
     ]: ...
 
     def task(
@@ -346,9 +351,13 @@ class Hatchet:
         backoff_factor: float | None = None,
         backoff_max_seconds: int | None = None,
     ) -> (
-        Callable[[Callable[[EmptyModel, Context], R]], Standalone[EmptyModel, R]]
+        Callable[
+            [Callable[[EmptyModel, Context], R | CoroutineLike[R]]],
+            Standalone[EmptyModel, R],
+        ]
         | Callable[
-            [Callable[[TWorkflowInput, Context], R]], Standalone[TWorkflowInput, R]
+            [Callable[[TWorkflowInput, Context], R | CoroutineLike[R]]],
+            Standalone[TWorkflowInput, R],
         ]
     ):
         """
@@ -426,7 +435,7 @@ class Hatchet:
         )
 
         def inner(
-            func: Callable[[TWorkflowInput, Context], R]
+            func: Callable[[TWorkflowInput, Context], R | CoroutineLike[R]],
         ) -> Standalone[TWorkflowInput, R]:
             created_task = task_wrapper(func)
 
@@ -458,7 +467,8 @@ class Hatchet:
         backoff_factor: float | None = None,
         backoff_max_seconds: int | None = None,
     ) -> Callable[
-        [Callable[[EmptyModel, DurableContext], R]], Standalone[EmptyModel, R]
+        [Callable[[EmptyModel, DurableContext], R | CoroutineLike[R]]],
+        Standalone[EmptyModel, R],
     ]: ...
 
     @overload
@@ -482,7 +492,8 @@ class Hatchet:
         backoff_factor: float | None = None,
         backoff_max_seconds: int | None = None,
     ) -> Callable[
-        [Callable[[TWorkflowInput, DurableContext], R]], Standalone[TWorkflowInput, R]
+        [Callable[[TWorkflowInput, DurableContext], R | CoroutineLike[R]]],
+        Standalone[TWorkflowInput, R],
     ]: ...
 
     def durable_task(
@@ -505,9 +516,12 @@ class Hatchet:
         backoff_factor: float | None = None,
         backoff_max_seconds: int | None = None,
     ) -> (
-        Callable[[Callable[[EmptyModel, DurableContext], R]], Standalone[EmptyModel, R]]
+        Callable[
+            [Callable[[EmptyModel, DurableContext], R | CoroutineLike[R]]],
+            Standalone[EmptyModel, R],
+        ]
         | Callable[
-            [Callable[[TWorkflowInput, DurableContext], R]],
+            [Callable[[TWorkflowInput, DurableContext], R | CoroutineLike[R]]],
             Standalone[TWorkflowInput, R],
         ]
     ):
@@ -579,7 +593,7 @@ class Hatchet:
         )
 
         def inner(
-            func: Callable[[TWorkflowInput, DurableContext], R]
+            func: Callable[[TWorkflowInput, DurableContext], R | CoroutineLike[R]],
         ) -> Standalone[TWorkflowInput, R]:
             created_task = task_wrapper(func)
 

--- a/sdks/python/hatchet_sdk/runnables/task.py
+++ b/sdks/python/hatchet_sdk/runnables/task.py
@@ -2,7 +2,6 @@ from datetime import timedelta
 from typing import (
     TYPE_CHECKING,
     Any,
-    Awaitable,
     Callable,
     Generic,
     Union,
@@ -27,7 +26,12 @@ from hatchet_sdk.runnables.types import (
     is_sync_fn,
 )
 from hatchet_sdk.utils.timedelta_to_expression import Duration, timedelta_to_expr
-from hatchet_sdk.utils.typing import TaskIOValidator, is_basemodel_subclass
+from hatchet_sdk.utils.typing import (
+    AwaitableLike,
+    CoroutineLike,
+    TaskIOValidator,
+    is_basemodel_subclass,
+)
 from hatchet_sdk.waits import (
     Action,
     Condition,
@@ -45,10 +49,10 @@ class Task(Generic[TWorkflowInput, R]):
     def __init__(
         self,
         _fn: Union[
-            Callable[[TWorkflowInput, Context], R]
-            | Callable[[TWorkflowInput, Context], Awaitable[R]],
-            Callable[[TWorkflowInput, DurableContext], R]
-            | Callable[[TWorkflowInput, DurableContext], Awaitable[R]],
+            Callable[[TWorkflowInput, Context], R | CoroutineLike[R]]
+            | Callable[[TWorkflowInput, Context], AwaitableLike[R]],
+            Callable[[TWorkflowInput, DurableContext], R | CoroutineLike[R]]
+            | Callable[[TWorkflowInput, DurableContext], AwaitableLike[R]],
         ],
         is_durable: bool,
         type: StepType,

--- a/sdks/python/hatchet_sdk/runnables/task.py
+++ b/sdks/python/hatchet_sdk/runnables/task.py
@@ -1,13 +1,5 @@
 from datetime import timedelta
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Generic,
-    Union,
-    cast,
-    get_type_hints,
-)
+from typing import TYPE_CHECKING, Any, Callable, Generic, Union, cast, get_type_hints
 
 from hatchet_sdk.context.context import Context, DurableContext
 from hatchet_sdk.contracts.v1.shared.condition_pb2 import TaskConditions

--- a/sdks/python/hatchet_sdk/runnables/types.py
+++ b/sdks/python/hatchet_sdk/runnables/types.py
@@ -1,17 +1,17 @@
 import asyncio
 from enum import Enum
-from typing import Any, Awaitable, Callable, ParamSpec, Type, TypeGuard, TypeVar, Union
+from typing import Any, Callable, ParamSpec, Type, TypeGuard, TypeVar, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from hatchet_sdk.context.context import Context, DurableContext
 from hatchet_sdk.contracts.v1.workflows_pb2 import Concurrency
 from hatchet_sdk.utils.timedelta_to_expression import Duration
-from hatchet_sdk.utils.typing import JSONSerializableMapping
+from hatchet_sdk.utils.typing import AwaitableLike, JSONSerializableMapping
 
 ValidTaskReturnType = Union[BaseModel, JSONSerializableMapping, None]
 
-R = TypeVar("R", bound=Union[ValidTaskReturnType, Awaitable[ValidTaskReturnType]])
+R = TypeVar("R", bound=ValidTaskReturnType)
 P = ParamSpec("P")
 
 
@@ -87,7 +87,7 @@ class StepType(str, Enum):
     ON_SUCCESS = "on_success"
 
 
-AsyncFunc = Callable[[TWorkflowInput, Context], Awaitable[R]]
+AsyncFunc = Callable[[TWorkflowInput, Context], AwaitableLike[R]]
 SyncFunc = Callable[[TWorkflowInput, Context], R]
 TaskFunc = Union[AsyncFunc[TWorkflowInput, R], SyncFunc[TWorkflowInput, R]]
 
@@ -104,7 +104,7 @@ def is_sync_fn(
     return not asyncio.iscoroutinefunction(fn)
 
 
-DurableAsyncFunc = Callable[[TWorkflowInput, DurableContext], Awaitable[R]]
+DurableAsyncFunc = Callable[[TWorkflowInput, DurableContext], AwaitableLike[R]]
 DurableSyncFunc = Callable[[TWorkflowInput, DurableContext], R]
 DurableTaskFunc = Union[
     DurableAsyncFunc[TWorkflowInput, R], DurableSyncFunc[TWorkflowInput, R]

--- a/sdks/python/hatchet_sdk/runnables/workflow.py
+++ b/sdks/python/hatchet_sdk/runnables/workflow.py
@@ -35,7 +35,7 @@ from hatchet_sdk.runnables.types import (
 )
 from hatchet_sdk.utils.proto_enums import convert_python_enum_to_proto
 from hatchet_sdk.utils.timedelta_to_expression import Duration
-from hatchet_sdk.utils.typing import JSONSerializableMapping
+from hatchet_sdk.utils.typing import CoroutineLike, JSONSerializableMapping
 from hatchet_sdk.waits import Condition, OrGroup
 from hatchet_sdk.workflow_run import WorkflowRunRef
 
@@ -569,7 +569,10 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
         wait_for: list[Condition | OrGroup] = [],
         skip_if: list[Condition | OrGroup] = [],
         cancel_if: list[Condition | OrGroup] = [],
-    ) -> Callable[[Callable[[TWorkflowInput, Context], R]], Task[TWorkflowInput, R]]:
+    ) -> Callable[
+        [Callable[[TWorkflowInput, Context], R | CoroutineLike[R]]],
+        Task[TWorkflowInput, R],
+    ]:
         """
         A decorator to transform a function into a Hatchet task that runs as part of a workflow.
 
@@ -612,7 +615,7 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
         )
 
         def inner(
-            func: Callable[[TWorkflowInput, Context], R]
+            func: Callable[[TWorkflowInput, Context], R | CoroutineLike[R]],
         ) -> Task[TWorkflowInput, R]:
             task = Task(
                 _fn=func,
@@ -659,7 +662,8 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
         skip_if: list[Condition | OrGroup] = [],
         cancel_if: list[Condition | OrGroup] = [],
     ) -> Callable[
-        [Callable[[TWorkflowInput, DurableContext], R]], Task[TWorkflowInput, R]
+        [Callable[[TWorkflowInput, DurableContext], R | CoroutineLike[R]]],
+        Task[TWorkflowInput, R],
     ]:
         """
         A decorator to transform a function into a durable Hatchet task that runs as part of a workflow.
@@ -707,7 +711,7 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
         )
 
         def inner(
-            func: Callable[[TWorkflowInput, DurableContext], R]
+            func: Callable[[TWorkflowInput, DurableContext], R | CoroutineLike[R]],
         ) -> Task[TWorkflowInput, R]:
             task = Task(
                 _fn=func,
@@ -748,7 +752,10 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
         backoff_factor: float | None = None,
         backoff_max_seconds: int | None = None,
         concurrency: list[ConcurrencyExpression] = [],
-    ) -> Callable[[Callable[[TWorkflowInput, Context], R]], Task[TWorkflowInput, R]]:
+    ) -> Callable[
+        [Callable[[TWorkflowInput, Context], R | CoroutineLike[R]]],
+        Task[TWorkflowInput, R],
+    ]:
         """
         A decorator to transform a function into a Hatchet on-failure task that runs as the last step in a workflow that had at least one task fail.
 
@@ -772,7 +779,7 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
         """
 
         def inner(
-            func: Callable[[TWorkflowInput, Context], R]
+            func: Callable[[TWorkflowInput, Context], R | CoroutineLike[R]],
         ) -> Task[TWorkflowInput, R]:
             task = Task(
                 is_durable=False,
@@ -808,7 +815,10 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
         backoff_factor: float | None = None,
         backoff_max_seconds: int | None = None,
         concurrency: list[ConcurrencyExpression] = [],
-    ) -> Callable[[Callable[[TWorkflowInput, Context], R]], Task[TWorkflowInput, R]]:
+    ) -> Callable[
+        [Callable[[TWorkflowInput, Context], R | CoroutineLike[R]]],
+        Task[TWorkflowInput, R],
+    ]:
         """
         A decorator to transform a function into a Hatchet on-success task that runs as the last step in a workflow that had all upstream tasks succeed.
 
@@ -832,7 +842,7 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
         """
 
         def inner(
-            func: Callable[[TWorkflowInput, Context], R]
+            func: Callable[[TWorkflowInput, Context], R | CoroutineLike[R]],
         ) -> Task[TWorkflowInput, R]:
             task = Task(
                 is_durable=False,

--- a/sdks/python/hatchet_sdk/runnables/workflow.py
+++ b/sdks/python/hatchet_sdk/runnables/workflow.py
@@ -545,10 +545,7 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
     def _parse_task_name(
         self,
         name: str | None,
-        func: (
-            Callable[[TWorkflowInput, Context], R | CoroutineLike[R]]
-            | Callable[[TWorkflowInput, DurableContext], R | CoroutineLike[R]]
-        ),
+        func: Callable[..., Any],
     ) -> str:
         non_null_name = name or func.__name__
 

--- a/sdks/python/hatchet_sdk/runnables/workflow.py
+++ b/sdks/python/hatchet_sdk/runnables/workflow.py
@@ -546,8 +546,8 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
         self,
         name: str | None,
         func: (
-            Callable[[TWorkflowInput, Context], R]
-            | Callable[[TWorkflowInput, DurableContext], R]
+            Callable[[TWorkflowInput, Context], R | CoroutineLike[R]]
+            | Callable[[TWorkflowInput, DurableContext], R | CoroutineLike[R]]
         ),
     ) -> str:
         non_null_name = name or func.__name__

--- a/sdks/python/hatchet_sdk/utils/typing.py
+++ b/sdks/python/hatchet_sdk/utils/typing.py
@@ -1,4 +1,15 @@
-from typing import Any, Mapping, Type, TypeGuard
+import sys
+from typing import (
+    Any,
+    Awaitable,
+    Coroutine,
+    Generator,
+    Mapping,
+    Type,
+    TypeAlias,
+    TypeGuard,
+    TypeVar,
+)
 
 from pydantic import BaseModel
 
@@ -16,3 +27,13 @@ class TaskIOValidator(BaseModel):
 
 
 JSONSerializableMapping = Mapping[str, Any]
+
+
+_T_co = TypeVar("_T_co", covariant=True)
+
+if sys.version_info >= (3, 12):
+    AwaitableLike: TypeAlias = Awaitable[_T_co]  # noqa: Y047
+    CoroutineLike: TypeAlias = Coroutine[Any, Any, _T_co]  # noqa: Y047
+else:
+    AwaitableLike: TypeAlias = Generator[Any, None, _T_co] | Awaitable[_T_co]
+    CoroutineLike: TypeAlias = Generator[Any, None, _T_co] | Coroutine[Any, Any, _T_co]

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.8.2"
+version = "1.9.0"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
# Description

Fixes types for a situation like
```python
@hatchet.task(name="step1", input_validator=SimpleInput)
async def simple_task(input: SimpleInput, ctx: Context) -> SimpleOutput:
    print("executed step1: ", input.message)
    return SimpleOutput(transformed_message=input.message.upper())

task_result1 = simple_task.aio_run(SimpleInput(message="Hello, World!"))

# reveal_type(task_result1)
#
#   Pylance: Type of "task_result1" is "Coroutine[Any, Any, Coroutine[Any, Any, SimpleOutput]]"
#   Mypy:    Revealed type is "typing.Coroutine[Any, Any, typing.Coroutine[Any, Any, worker.SimpleOutput]]"
```

This is not correct; `R` in [`runnables/types.py`](https://github.com/hatchet-dev/hatchet/blob/1db5cb5ee68ba98d4c75f22f8d7394d14722bf08/sdks/python/hatchet_sdk/runnables/types.py#L14) is defined with `Awaitable[ValidTaskReturnType]`, which, isn't what should be forwarded to `Standalone`/`Task`; we want just the result of awaiting the Coroutine passed to the `*.task(...)` decorators.

This causes problems if you use the type hints:

```python
task_result1 = simple_task.aio_run(SimpleInput(message="Hello, World!"))
task_result2 = simple_task.aio_run(SimpleInput(message="Hello, Moon!"))

# (variable) task_result1: Coroutine[Any, Any, Coroutine[Any, Any, SimpleOutput]]

for t_result in asyncio.as_completed([task_result1, task_result2]):

    # (variable) t_result: Future[Coroutine[Any, Any, SimpleOutput]]
    v = await t_result

    # (variable) v: Coroutine[Any, Any, SimpleOutput]
    # [!!] This should be SimpleOutput
    print(await v)  # ruh roh!
```

```python-traceback
Traceback (most recent call last):
  File "/Users/workspace/repos/main-sweetspot/client.py", line 34, in <module>
    asyncio.run(main())
  File "/Users/workspace/.pyenv/versions/3.11.11/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/Users/workspace/.pyenv/versions/3.11.11/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/workspace/.pyenv/versions/3.11.11/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/workspace/repos/main-sweetspot/client.py", line 19, in main
    print(await v)
          ^^^^^^^
TypeError: object SimpleOutput can't be used in 'await' expression
```

This PR introduces some subtle type changes to properly hint the return of `.aio_run()` et. al. as `Coroutine[Any, Any, R]`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)

## What's Changed

- Introduces `CoroutineLike[T]` and `AwaitableLike[T]` where `T` is covariant (helpfully borrowed from pylance typeshed).
- Adjust `R` TypeVar to only accept `ValidTaskReturnType`, rather than a Union including Awaitable
- Adjust type of `*.task(...)` & `*.durable_task(...)` to accept a `CoroutineLike[R]` object & returns a narrowed `Standalone[TWorkflowInput, R]`/`Task[TWorkflowInput, R]` which returns `R` (non-awaitable)
