### PR TITLE
Bigger workflow visualizer

### DIFF
--- a/frontend/app/src/pages/main/workflow-runs/$run/v2components/workflow-run-visualizer-v2.tsx
+++ b/frontend/app/src/pages/main/workflow-runs/$run/v2components/workflow-run-visualizer-v2.tsx
@@ -168,7 +168,7 @@ const WorkflowRunVisualizer = ({
   }, [theme]);
 
   return (
-    <div className="w-full h-[300px]">
+    <div className="w-full h-[800px]">
       <ReactFlow
         nodes={dagrNodes}
         edges={dagrEdges}


### PR DESCRIPTION
# Description

We have somewhat big workflows, and looking at them with the small window of react-flow is quite annoying.

This is a suggestion to make the workflow view bigger. For us it would make sense that it _JUST_ is bigger, but it might be that this should be changed to be adjustable.

Fixes # (issue)
- Increased react-flow height from 300 to 800px. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (changes which are not directly related to any business logic)

## What's Changed

- [x] Made react-flow view bigger for workflows
