### PR TITLE
Fix: Trigger workflow run form

### DIFF
--- a/frontend/app/src/pages/main/v1/workflows/$workflow/components/trigger-workflow-form.tsx
+++ b/frontend/app/src/pages/main/v1/workflows/$workflow/components/trigger-workflow-form.tsx
@@ -12,7 +12,7 @@ import api, {
   V1WorkflowRunDetails,
   Workflow,
 } from '@/lib/api';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Button } from '@/components/v1/ui/button';
 import invariant from 'tiny-invariant';
 import { useApiError } from '@/lib/hooks';
@@ -66,6 +66,18 @@ export function TriggerWorkflowForm({
   const [selectedWorkflowId, setSelectedWorkflowId] = useState(
     defaultWorkflow?.metadata.id,
   );
+
+  const handleClose = useCallback(() => {
+    onClose();
+    setInput('{}');
+    setAddlMeta('{}');
+    setErrors([]);
+    setSelectedWorkflowId(defaultWorkflow?.metadata.id);
+    setTimingOption(defaultTimingOption);
+    setScheduleTime(new Date());
+    setCronExpression('* * * * *');
+    setCronName('');
+  }, [onClose, defaultWorkflow, defaultTimingOption]);
 
   const cronPretty = useMemo(() => {
     try {
@@ -150,7 +162,7 @@ export function TriggerWorkflowForm({
       if (!workflowRun) {
         return;
       }
-      onClose();
+      handleClose();
       navigate(`/v1/scheduled`);
     },
     onError: handleApiError,
@@ -188,7 +200,7 @@ export function TriggerWorkflowForm({
       if (!workflowRun) {
         return;
       }
-      onClose();
+      handleClose();
       navigate(`/v1/cron-jobs`);
     },
     onError: handleApiError,
@@ -238,7 +250,7 @@ export function TriggerWorkflowForm({
         open={show}
         onOpenChange={(open) => {
           if (!open) {
-            onClose();
+            handleClose();
           }
         }}
       >
@@ -259,7 +271,7 @@ export function TriggerWorkflowForm({
       open={show}
       onOpenChange={(open) => {
         if (!open) {
-          onClose();
+          handleClose();
         }
       }}
     >
@@ -422,7 +434,8 @@ export function TriggerWorkflowForm({
             disabled={
               triggerNowMutation.isPending ||
               triggerScheduleMutation.isPending ||
-              triggerCronMutation.isPending
+              triggerCronMutation.isPending ||
+              !selectedWorkflow
             }
             onClick={handleSubmit}
           >


### PR DESCRIPTION
# Description

Fixing some state handling issues in the workflow run trigger form. TL;DR is we were using this `workflow` variable that was quietly defaulting to the first workflow or the previous selected one but not showing up correctly, leading to unexpected behavior.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
