### PR TITLE
Update rate limit example, await hatchet.ratelimits.upsert

### DIFF
--- a/examples/typescript/rate_limit/workflow.ts
+++ b/examples/typescript/rate_limit/workflow.ts
@@ -2,7 +2,7 @@ import { RateLimitDuration } from '@hatchet-dev/typescript-sdk/protoc/v1/workflo
 import { hatchet } from '../hatchet-client';
 
 // > Upsert Rate Limit
-hatchet.ratelimits.upsert({
+await hatchet.ratelimits.upsert({
   key: 'api-service-rate-limit',
   limit: 10,
   duration: RateLimitDuration.SECOND,


### PR DESCRIPTION
The docs here https://docs.hatchet.run/home/rate-limits#static-rate-limits have this example referenced but there should be an `await`.

`hatchet.ratelimits.upsert()` returns a promise and should be awaited

#### Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
- Documentation change (pure documentation change)