### PR TITLE
set default jitter value to 0

### DIFF
--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -96,7 +96,7 @@ type ConfigFileSampling struct {
 
 type ConfigFileOperations struct {
 	// Jitter is the jitter duration for operations pools in milliseconds
-	Jitter int `mapstructure:"jitter" json:"jitter,omitempty" default:"1500"`
+	Jitter int `mapstructure:"jitter" json:"jitter,omitempty" default:"0"`
 
 	// PollInterval is the polling interval for operations in seconds
 	PollInterval int `mapstructure:"pollInterval" json:"pollInterval,omitempty" default:"2"`


### PR DESCRIPTION
# Description

Sets the default value of jitter to 0 as it blocks operations from running and should be used sparingly. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)