### PR TITLE
Fix: Internal blocking calls in admin client

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.1] - 2025-06-05
+
+### Changed
+
+- Fixes a couple of blocking calls buried in the admin client causing loop blockages on child spawning
+
 ## [1.11.0] - 2025-05-29
 
 ### Changed

--- a/sdks/python/hatchet_sdk/clients/admin.py
+++ b/sdks/python/hatchet_sdk/clients/admin.py
@@ -361,7 +361,8 @@ class AdminClient:
         try:
             resp = cast(
                 v0_workflow_protos.TriggerWorkflowResponse,
-                client.TriggerWorkflow(
+                await asyncio.to_thread(
+                    client.TriggerWorkflow,
                     request,
                     metadata=get_metadata(self.token),
                 ),
@@ -450,7 +451,8 @@ class AdminClient:
 
             resp = cast(
                 v0_workflow_protos.BulkTriggerWorkflowResponse,
-                client.BulkTriggerWorkflow(
+                await asyncio.to_thread(
+                    client.BulkTriggerWorkflow,
                     bulk_request,
                     metadata=get_metadata(self.token),
                 ),

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.11.0"
+version = "1.11.1"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
# Description

Fixes a couple admin client blocking calls that were adding some ms of blocking time on child spawning, which would add up if many children were being spawned concurrently

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

