### PR TITLE
fix: run crons and schedules in singleton mode

### DIFF
--- a/internal/services/ticker/cron.go
+++ b/internal/services/ticker/cron.go
@@ -15,6 +15,9 @@ import (
 	"github.com/hatchet-dev/hatchet/pkg/repository/postgres/sqlchelpers"
 )
 
+// runPollCronSchedules acquires a list of cron schedules from the database and schedules any which are not
+// already scheduled. This job runs in "singleton" mode, meaning that only one instance of this job will run at
+// a time.
 func (t *TickerImpl) runPollCronSchedules(ctx context.Context) func() {
 	return func() {
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)

--- a/internal/services/ticker/ticker.go
+++ b/internal/services/ticker/ticker.go
@@ -209,6 +209,7 @@ func (t *TickerImpl) Start() (func() error, error) {
 		gocron.NewTask(
 			t.runPollCronSchedules(ctx),
 		),
+		gocron.WithSingletonMode(gocron.LimitModeReschedule),
 	)
 
 	if err != nil {
@@ -222,6 +223,7 @@ func (t *TickerImpl) Start() (func() error, error) {
 		gocron.NewTask(
 			t.runPollSchedules(ctx),
 		),
+		gocron.WithSingletonMode(gocron.LimitModeReschedule),
 	)
 
 	if err != nil {


### PR DESCRIPTION
# Description

One theory of goroutine leakage that we're seeing from crons and some race conditions on schedules is that the jobs which acquire schedules from the database are overlapping. We shouldn't overlap these processes anyway, so this should both be more stable and may solve some leaks that we're seeing.  

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)