### PR TITLE
feat: use non-root nginx for frontend container

### DIFF
--- a/build/package/frontend.dockerfile
+++ b/build/package/frontend.dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine as build
+FROM node:18-alpine AS build
 
 WORKDIR /app
 
@@ -10,12 +10,11 @@ COPY ./frontend/app ./
 RUN npm run build
 
 # Stage 2: Serve the built app with NGINX
-FROM nginx:alpine
+FROM nginxinc/nginx-unprivileged:alpine
 
 ARG APP_TARGET=client
 
 COPY ./build/package/nginx.conf /etc/nginx/nginx.conf
-RUN rm -rf /usr/share/nginx/html/*
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/build/package/frontend.dockerfile
+++ b/build/package/frontend.dockerfile
@@ -12,6 +12,10 @@ RUN npm run build
 # Stage 2: Serve the built app with NGINX
 FROM nginxinc/nginx-unprivileged:alpine
 
+USER root
+RUN rm -rf /usr/share/nginx/html/*
+USER nginx
+
 ARG APP_TARGET=client
 
 COPY ./build/package/nginx.conf /etc/nginx/nginx.conf

--- a/build/package/nginx.conf
+++ b/build/package/nginx.conf
@@ -2,6 +2,8 @@ worker_processes 4;
 
 events { worker_connections 1024; }
 
+pid /tmp/nginx.pid; # To allow non-root container
+
 http {
     server {
         listen 80;
@@ -13,4 +15,11 @@ http {
             try_files $uri /index.html;
         }
     }
+
+    # To allow for non-root user on container
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path       /tmp/proxy_temp_path;
+    fastcgi_temp_path     /tmp/fastcgi_temp;
+    uwsgi_temp_path       /tmp/uwsgi_temp;
+    scgi_temp_path        /tmp/scgi_temp;
 }


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue) - no issue number, discussed on discord here: https://discord.com/channels/1088927970518909068/1380541399929192559/1380665213447045171

- Changes the frontend container to use `nginx-unprivileged`, which runs without the root user.
- Updated config to support non-root user, see docs here: https://hub.docker.com/_/nginx


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] frontend container now runs as non-root user
