### PR TITLE
fix: don't allow UserCreate endpoint if no basic auth enabled

### DIFF
--- a/api/v1/server/handlers/users/create.go
+++ b/api/v1/server/handlers/users/create.go
@@ -16,6 +16,12 @@ import (
 )
 
 func (u *UserService) UserCreate(ctx echo.Context, request gen.UserCreateRequestObject) (gen.UserCreateResponseObject, error) {
+	// check that the server supports local registration
+	if !u.config.Auth.ConfigFile.BasicAuthEnabled {
+		return gen.UserCreate405JSONResponse(
+			apierrors.NewAPIErrors("local registration is not enabled"),
+		), nil
+	}
 
 	if !u.config.Runtime.AllowSignup {
 		return gen.UserCreate400JSONResponse(


### PR DESCRIPTION
# Description

The `UserCreate` endpoint should respect the basic auth enabled flag. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)