### PR TITLE
Fix: Unique index on filters should include payload

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20250617185713_v1_0_26.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20250617185713_v1_0_26.sql
@@ -1,0 +1,20 @@
+-- +goose NO TRANSACTION
+
+-- +goose Up
+DROP INDEX v1_filter_unique_idx;
+CREATE UNIQUE INDEX CONCURRENTLY v1_filter_unique_tenant_workflow_id_scope_expression_payload ON v1_filter (
+    tenant_id ASC,
+    workflow_id ASC,
+    scope ASC,
+    expression ASC,
+    payload
+);
+
+-- +goose Down
+DROP INDEX v1_filter_unique_tenant_workflow_id_scope_expression_payload;
+CREATE UNIQUE INDEX CONCURRENTLY v1_filter_unique_idx ON v1_filter (
+    tenant_id ASC,
+    workflow_id ASC,
+    scope ASC,
+    expression ASC
+);

--- a/cmd/hatchet-migrate/migrate/migrations/20250617185713_v1_0_26.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20250617185713_v1_0_26.sql
@@ -1,20 +1,9 @@
--- +goose NO TRANSACTION
-
 -- +goose Up
-DROP INDEX CONCURRENTLY v1_filter_unique_idx;
-CREATE UNIQUE INDEX CONCURRENTLY v1_filter_unique_tenant_workflow_id_scope_expression_payload ON v1_filter (
-    tenant_id ASC,
-    workflow_id ASC,
-    scope ASC,
-    expression ASC,
-    payload
-);
+-- +goose StatementBegin
+ALTER TABLE v1_filter ADD COLUMN payload_hash TEXT GENERATED ALWAYS AS (MD5(payload::TEXT)) STORED;
+-- +goose StatementEnd
 
 -- +goose Down
-DROP INDEX CONCURRENTLY v1_filter_unique_tenant_workflow_id_scope_expression_payload;
-CREATE UNIQUE INDEX CONCURRENTLY v1_filter_unique_idx ON v1_filter (
-    tenant_id ASC,
-    workflow_id ASC,
-    scope ASC,
-    expression ASC
-);
+-- +goose StatementBegin
+ALTER TABLE v1_filter DROP COLUMN payload_hash;
+-- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20250617185713_v1_0_26.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20250617185713_v1_0_26.sql
@@ -1,7 +1,7 @@
 -- +goose NO TRANSACTION
 
 -- +goose Up
-DROP INDEX v1_filter_unique_idx;
+DROP INDEX CONCURRENTLY v1_filter_unique_idx;
 CREATE UNIQUE INDEX CONCURRENTLY v1_filter_unique_tenant_workflow_id_scope_expression_payload ON v1_filter (
     tenant_id ASC,
     workflow_id ASC,
@@ -11,7 +11,7 @@ CREATE UNIQUE INDEX CONCURRENTLY v1_filter_unique_tenant_workflow_id_scope_expre
 );
 
 -- +goose Down
-DROP INDEX v1_filter_unique_tenant_workflow_id_scope_expression_payload;
+DROP INDEX CONCURRENTLY v1_filter_unique_tenant_workflow_id_scope_expression_payload;
 CREATE UNIQUE INDEX CONCURRENTLY v1_filter_unique_idx ON v1_filter (
     tenant_id ASC,
     workflow_id ASC,

--- a/cmd/hatchet-migrate/migrate/migrations/20250617192510_v1_0_27.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20250617192510_v1_0_27.sql
@@ -1,0 +1,20 @@
+-- +goose NO TRANSACTION
+
+-- +goose Up
+DROP INDEX CONCURRENTLY v1_filter_unique_idx;
+CREATE UNIQUE INDEX CONCURRENTLY v1_filter_unique_tenant_workflow_id_scope_expression_payload ON v1_filter (
+    tenant_id ASC,
+    workflow_id ASC,
+    scope ASC,
+    expression ASC,
+    payload_hash
+);
+
+-- +goose Down
+DROP INDEX CONCURRENTLY v1_filter_unique_tenant_workflow_id_scope_expression_payload;
+CREATE UNIQUE INDEX CONCURRENTLY v1_filter_unique_idx ON v1_filter (
+    tenant_id ASC,
+    workflow_id ASC,
+    scope ASC,
+    expression ASC
+);

--- a/pkg/repository/v1/sqlcv1/filters.sql
+++ b/pkg/repository/v1/sqlcv1/filters.sql
@@ -14,14 +14,6 @@ INSERT INTO v1_filter (
     @payload::JSONB,
     false
 )
-ON CONFLICT (tenant_id, workflow_id, scope, expression) DO UPDATE
-SET
-    payload = EXCLUDED.payload,
-    updated_at = NOW()
-WHERE v1_filter.tenant_id = @tenantId::UUID
-  AND v1_filter.workflow_id = @workflowId::UUID
-  AND v1_filter.scope = @scope::TEXT
-  AND v1_filter.expression = @expression::TEXT
 RETURNING *;
 
 -- name: BulkUpsertDeclarativeFilters :many

--- a/pkg/repository/v1/sqlcv1/filters.sql.go
+++ b/pkg/repository/v1/sqlcv1/filters.sql.go
@@ -41,7 +41,7 @@ SELECT
     payload,
     true
 FROM inputs
-RETURNING id, tenant_id, workflow_id, scope, expression, payload, is_declarative, inserted_at, updated_at
+RETURNING id, tenant_id, workflow_id, scope, expression, payload, payload_hash, is_declarative, inserted_at, updated_at
 `
 
 type BulkUpsertDeclarativeFiltersParams struct {
@@ -76,6 +76,7 @@ func (q *Queries) BulkUpsertDeclarativeFilters(ctx context.Context, db DBTX, arg
 			&i.Scope,
 			&i.Expression,
 			&i.Payload,
+			&i.PayloadHash,
 			&i.IsDeclarative,
 			&i.InsertedAt,
 			&i.UpdatedAt,
@@ -106,7 +107,7 @@ INSERT INTO v1_filter (
     $5::JSONB,
     false
 )
-RETURNING id, tenant_id, workflow_id, scope, expression, payload, is_declarative, inserted_at, updated_at
+RETURNING id, tenant_id, workflow_id, scope, expression, payload, payload_hash, is_declarative, inserted_at, updated_at
 `
 
 type CreateFilterParams struct {
@@ -133,6 +134,7 @@ func (q *Queries) CreateFilter(ctx context.Context, db DBTX, arg CreateFilterPar
 		&i.Scope,
 		&i.Expression,
 		&i.Payload,
+		&i.PayloadHash,
 		&i.IsDeclarative,
 		&i.InsertedAt,
 		&i.UpdatedAt,
@@ -145,7 +147,7 @@ DELETE FROM v1_filter
 WHERE
     tenant_id = $1::UUID
     AND id = $2::UUID
-RETURNING id, tenant_id, workflow_id, scope, expression, payload, is_declarative, inserted_at, updated_at
+RETURNING id, tenant_id, workflow_id, scope, expression, payload, payload_hash, is_declarative, inserted_at, updated_at
 `
 
 type DeleteFilterParams struct {
@@ -163,6 +165,7 @@ func (q *Queries) DeleteFilter(ctx context.Context, db DBTX, arg DeleteFilterPar
 		&i.Scope,
 		&i.Expression,
 		&i.Payload,
+		&i.PayloadHash,
 		&i.IsDeclarative,
 		&i.InsertedAt,
 		&i.UpdatedAt,
@@ -171,7 +174,7 @@ func (q *Queries) DeleteFilter(ctx context.Context, db DBTX, arg DeleteFilterPar
 }
 
 const getFilter = `-- name: GetFilter :one
-SELECT id, tenant_id, workflow_id, scope, expression, payload, is_declarative, inserted_at, updated_at
+SELECT id, tenant_id, workflow_id, scope, expression, payload, payload_hash, is_declarative, inserted_at, updated_at
 FROM v1_filter
 WHERE
     tenant_id = $1::UUID
@@ -193,6 +196,7 @@ func (q *Queries) GetFilter(ctx context.Context, db DBTX, arg GetFilterParams) (
 		&i.Scope,
 		&i.Expression,
 		&i.Payload,
+		&i.PayloadHash,
 		&i.IsDeclarative,
 		&i.InsertedAt,
 		&i.UpdatedAt,
@@ -253,7 +257,7 @@ SET
 WHERE
     tenant_id = $4::UUID
     AND id = $5::UUID
-RETURNING id, tenant_id, workflow_id, scope, expression, payload, is_declarative, inserted_at, updated_at
+RETURNING id, tenant_id, workflow_id, scope, expression, payload, payload_hash, is_declarative, inserted_at, updated_at
 `
 
 type UpdateFilterParams struct {
@@ -280,6 +284,7 @@ func (q *Queries) UpdateFilter(ctx context.Context, db DBTX, arg UpdateFilterPar
 		&i.Scope,
 		&i.Expression,
 		&i.Payload,
+		&i.PayloadHash,
 		&i.IsDeclarative,
 		&i.InsertedAt,
 		&i.UpdatedAt,

--- a/pkg/repository/v1/sqlcv1/filters.sql.go
+++ b/pkg/repository/v1/sqlcv1/filters.sql.go
@@ -106,14 +106,6 @@ INSERT INTO v1_filter (
     $5::JSONB,
     false
 )
-ON CONFLICT (tenant_id, workflow_id, scope, expression) DO UPDATE
-SET
-    payload = EXCLUDED.payload,
-    updated_at = NOW()
-WHERE v1_filter.tenant_id = $1::UUID
-  AND v1_filter.workflow_id = $2::UUID
-  AND v1_filter.scope = $3::TEXT
-  AND v1_filter.expression = $4::TEXT
 RETURNING id, tenant_id, workflow_id, scope, expression, payload, is_declarative, inserted_at, updated_at
 `
 

--- a/pkg/repository/v1/sqlcv1/models.go
+++ b/pkg/repository/v1/sqlcv1/models.go
@@ -2555,6 +2555,7 @@ type V1Filter struct {
 	Scope         string             `json:"scope"`
 	Expression    string             `json:"expression"`
 	Payload       []byte             `json:"payload"`
+	PayloadHash   pgtype.Text        `json:"payload_hash"`
 	IsDeclarative bool               `json:"is_declarative"`
 	InsertedAt    pgtype.Timestamptz `json:"inserted_at"`
 	UpdatedAt     pgtype.Timestamptz `json:"updated_at"`

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -486,11 +486,12 @@ CREATE TABLE v1_filter (
     PRIMARY KEY (tenant_id, id)
 );
 
-CREATE UNIQUE INDEX v1_filter_unique_idx ON v1_filter (
+CREATE UNIQUE INDEX v1_filter_unique_tenant_workflow_id_scope_expression_payload ON v1_filter (
     tenant_id ASC,
     workflow_id ASC,
     scope ASC,
-    expression ASC
+    expression ASC,
+    payload
 );
 
 CREATE INDEX v1_match_condition_filter_idx ON v1_match_condition (

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -478,6 +478,7 @@ CREATE TABLE v1_filter (
     scope TEXT NOT NULL,
     expression TEXT NOT NULL,
     payload JSONB NOT NULL DEFAULT '{}'::JSONB,
+    payload_hash TEXT GENERATED ALWAYS AS (MD5(payload::TEXT)) STORED,
     is_declarative BOOLEAN NOT NULL DEFAULT FALSE,
 
     inserted_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -491,7 +492,7 @@ CREATE UNIQUE INDEX v1_filter_unique_tenant_workflow_id_scope_expression_payload
     workflow_id ASC,
     scope ASC,
     expression ASC,
-    payload
+    payload_hash
 );
 
 CREATE INDEX v1_match_condition_filter_idx ON v1_match_condition (


### PR DESCRIPTION
# Description

Allowing multiple payloads for a single expression-scope pair.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

