### PR TITLE
Fix: Extend query timeout for scheduled run polling

### DIFF
--- a/internal/services/ticker/schedule_workflow.go
+++ b/internal/services/ticker/schedule_workflow.go
@@ -15,7 +15,7 @@ import (
 
 func (t *TickerImpl) runPollSchedules(ctx context.Context) func() {
 	return func() {
-		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 		defer cancel()
 
 		t.l.Debug().Msgf("ticker: polling workflow schedules")

--- a/internal/services/ticker/schedule_workflow.go
+++ b/internal/services/ticker/schedule_workflow.go
@@ -15,7 +15,7 @@ import (
 
 func (t *TickerImpl) runPollSchedules(ctx context.Context) func() {
 	return func() {
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
 
 		t.l.Debug().Msgf("ticker: polling workflow schedules")


### PR DESCRIPTION
# Description

Extend timeout of scheduled run polling query

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

