### PR TITLE
Fix: Skip invalid CELs when computing matches

### DIFF
--- a/pkg/repository/v1/match.go
+++ b/pkg/repository/v1/match.go
@@ -635,13 +635,15 @@ func (m *sharedRepository) processCELExpressions(ctx context.Context, events []C
 		ast, issues := m.env.Compile(expr)
 
 		if issues != nil {
-			return nil, issues.Err()
+			m.l.Error().Msgf("failed to compile CEL expression: %s", issues.String())
+			continue
 		}
 
 		program, err := m.env.Program(ast)
 
 		if err != nil {
-			return nil, err
+			m.l.Error().Err(err).Msgf("failed to create CEL program: %s", expr)
+			continue
 		}
 
 		programs[condition.ID] = program


### PR DESCRIPTION
# Description

Event matches were seemingly permanently broken if an invalid CEL was provided because we'd short-circuit and error on the invalid expression, and then would never recover since the invalid expression would never be deleted from the db.

This modifies that to log an error but otherwise just ignore the invalid expression. It'll still be persisted, but it won't block future work.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
