### PR TITLE
Fix: Streaming Bugs

### DIFF
--- a/internal/msgqueue/v1/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/v1/rabbitmq/rabbitmq.go
@@ -231,7 +231,7 @@ func (t *MessageQueueImpl) pubMessage(ctx context.Context, q msgqueue.Queue, msg
 	}
 
 	// if this is a tenant msg, publish to the tenant exchange
-	if (!t.disableTenantExchangePubs || msg.ID != "task-stream-event") && msg.TenantID != "" {
+	if (!t.disableTenantExchangePubs || msg.ID == "task-stream-event") && msg.TenantID != "" {
 		// determine if the tenant exchange exists
 		if _, ok := t.tenantIdCache.Get(msg.TenantID); !ok {
 			// register the tenant exchange

--- a/internal/msgqueue/v1/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/v1/rabbitmq/rabbitmq.go
@@ -231,7 +231,7 @@ func (t *MessageQueueImpl) pubMessage(ctx context.Context, q msgqueue.Queue, msg
 	}
 
 	// if this is a tenant msg, publish to the tenant exchange
-	if !t.disableTenantExchangePubs && msg.TenantID != "" && msg.ID != "task-stream-event" {
+	if (!t.disableTenantExchangePubs || msg.ID != "task-stream-event") && msg.TenantID != "" {
 		// determine if the tenant exchange exists
 		if _, ok := t.tenantIdCache.Get(msg.TenantID); !ok {
 			// register the tenant exchange

--- a/internal/msgqueue/v1/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/v1/rabbitmq/rabbitmq.go
@@ -231,7 +231,7 @@ func (t *MessageQueueImpl) pubMessage(ctx context.Context, q msgqueue.Queue, msg
 	}
 
 	// if this is a tenant msg, publish to the tenant exchange
-	if !t.disableTenantExchangePubs && msg.TenantID != "" {
+	if !t.disableTenantExchangePubs && msg.TenantID != "" && msg.ID != "task-stream-event" {
 		// determine if the tenant exchange exists
 		if _, ok := t.tenantIdCache.Get(msg.TenantID); !ok {
 			// register the tenant exchange

--- a/internal/services/dispatcher/server_v1.go
+++ b/internal/services/dispatcher/server_v1.go
@@ -923,7 +923,7 @@ func (s *DispatcherImpl) subscribeToWorkflowEventsByWorkflowRunIdV1(workflowRunI
 					}
 
 					isWorkflowRunCompletedEvent := e.ResourceType == contracts.ResourceType_RESOURCE_TYPE_WORKFLOW_RUN &&
-						e.EventType == contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED
+						(e.EventType == contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED || e.EventType == contracts.ResourceEventType_RESOURCE_EVENT_TYPE_FAILED || e.EventType == contracts.ResourceEventType_RESOURCE_EVENT_TYPE_CANCELLED)
 
 					if isWorkflowRunCompletedEvent {
 						e.Hangup = true

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -417,6 +417,11 @@ type TaskMetadata struct {
 
 func ParseTaskMetadata(jsonData []byte) ([]TaskMetadata, error) {
 	var tasks []TaskMetadata
+
+	if len(jsonData) == 0 {
+		return tasks, nil
+	}
+
 	err := json.Unmarshal(jsonData, &tasks)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

Fixing two bugs in streaming:

1. We'd sometimes (maybe like 1/4 of the time) get an error about an unexpected end to JSON input, which turned out to be because we were `Unmarshal`ling `nil` sometimes (an empty byte array). I think this is probably caused by a race or something but I'm not sure - in any case, seems like just short circuiting fixes it
2. We weren't hanging up on failure or cancelled events, which caused the listeners in the SDK to just hang
3. Publish stream events even if tenant pubs is disabled

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
