### PR TITLE
Fix: Events query performance improvements

### DIFF
--- a/api/v1/server/oas/transformers/v1/events.go
+++ b/api/v1/server/oas/transformers/v1/events.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
-	"github.com/hatchet-dev/hatchet/pkg/repository/v1/sqlcv1"
+	v1 "github.com/hatchet-dev/hatchet/pkg/repository/v1"
 )
 
 func parseTriggeredRuns(triggeredRuns []byte) ([]gen.V1EventTriggeredRun, error) {
@@ -49,7 +49,7 @@ func parseTriggeredRuns(triggeredRuns []byte) ([]gen.V1EventTriggeredRun, error)
 	return result, nil
 }
 
-func ToV1EventList(events []*sqlcv1.ListEventsRow, limit, offset, total int64) gen.V1EventList {
+func ToV1EventList(events []*v1.ListEventsRow, limit, offset, total int64) gen.V1EventList {
 	rows := make([]gen.V1Event, len(events))
 
 	numPages := int64(math.Ceil(float64(total) / float64(limit)))
@@ -86,15 +86,15 @@ func ToV1EventList(events []*sqlcv1.ListEventsRow, limit, offset, total int64) g
 				Id:        row.EventExternalID.String(),
 			},
 			WorkflowRunSummary: gen.V1EventWorkflowRunSummary{
-				Cancelled: row.CancelledCount.Int64,
-				Succeeded: row.CompletedCount.Int64,
-				Queued:    row.QueuedCount.Int64,
-				Failed:    row.FailedCount.Int64,
-				Running:   row.RunningCount.Int64,
+				Cancelled: row.CancelledCount,
+				Succeeded: row.CompletedCount,
+				Queued:    row.QueuedCount,
+				Failed:    row.FailedCount,
+				Running:   row.RunningCount,
 			},
 			Payload:       &payload,
 			SeenAt:        &row.EventSeenAt.Time,
-			Scope:         &row.EventScope.String,
+			Scope:         &row.EventScope,
 			TriggeredRuns: &triggeredRuns,
 		}
 	}

--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -1348,109 +1348,85 @@ WHERE
 ;
 
 
--- name: ListEvents :many
-WITH included_events AS (
-    SELECT
-        e.*,
-        JSON_AGG(JSON_BUILD_OBJECT('run_external_id', r.external_id, 'filter_id', etr.filter_id)) FILTER (WHERE r.external_id IS NOT NULL)::JSONB AS triggered_runs
-    FROM v1_event_lookup_table_olap elt
-    JOIN v1_events_olap e ON (elt.tenant_id, elt.event_id, elt.event_seen_at) = (e.tenant_id, e.id, e.seen_at)
-    LEFT JOIN v1_event_to_run_olap etr ON (e.id, e.seen_at) = (etr.event_id, etr.event_seen_at)
-    LEFT JOIN v1_runs_olap r ON (etr.run_id, etr.run_inserted_at) = (r.id, r.inserted_at)
-    WHERE
-        e.tenant_id = @tenantId
-        AND (
-            sqlc.narg('keys')::TEXT[] IS NULL OR
-            "key" = ANY(sqlc.narg('keys')::TEXT[])
-        )
-        AND e.seen_at >= @since::TIMESTAMPTZ
-        AND (
-            sqlc.narg('until')::TIMESTAMPTZ IS NULL OR
-            e.seen_at <= sqlc.narg('until')::TIMESTAMPTZ
-        )
-        AND (
-            sqlc.narg('workflowIds')::UUID[] IS NULL OR
-            r.workflow_id = ANY(sqlc.narg('workflowIds')::UUID[])
-        )
-        AND (
-            sqlc.narg('eventIds')::UUID[] IS NULL OR
-            elt.external_id = ANY(sqlc.narg('eventIds')::UUID[])
-        )
-        AND (
-            sqlc.narg('additionalMetadata')::JSONB IS NULL OR
-            e.additional_metadata @> sqlc.narg('additionalMetadata')::JSONB
-        )
-        AND (
-            CAST(sqlc.narg('statuses')::text[] AS v1_readable_status_olap[]) IS NULL OR
-            r.readable_status = ANY(CAST(sqlc.narg('statuses')::text[] AS v1_readable_status_olap[]))
-        )
-        AND (
-            sqlc.narg('scopes')::TEXT[] IS NULL OR
-            e.scope = ANY(sqlc.narg('scopes')::TEXT[])
-        )
-    GROUP BY
-        e.tenant_id,
-        e.id,
-        e.external_id,
-        e.seen_at,
-        e.key,
-        e.payload,
-        e.additional_metadata,
-        e.scope
-    ORDER BY e.seen_at DESC, e.id
-    OFFSET
-        COALESCE(sqlc.narg('offset')::BIGINT, 0)
-    LIMIT
-        COALESCE(sqlc.narg('limit')::BIGINT, 50)
-), status_counts AS (
-    SELECT
-        e.tenant_id,
-        e.id,
-        e.seen_at,
-        COUNT(*) FILTER (WHERE r.readable_status = 'QUEUED') AS queued_count,
-        COUNT(*) FILTER (WHERE r.readable_status = 'RUNNING') AS running_count,
-        COUNT(*) FILTER (WHERE r.readable_status = 'COMPLETED') AS completed_count,
-        COUNT(*) FILTER (WHERE r.readable_status = 'CANCELLED') AS cancelled_count,
-        COUNT(*) FILTER (WHERE r.readable_status = 'FAILED') AS failed_count
-    FROM
-        included_events e
-    LEFT JOIN
-        v1_event_to_run_olap etr ON (e.id, e.seen_at) = (etr.event_id, etr.event_seen_at)
-    LEFT JOIN
-        v1_runs_olap r ON (etr.run_id, etr.run_inserted_at) = (r.id, r.inserted_at)
-    GROUP BY
-        e.tenant_id, e.id, e.seen_at
-)
-
+-- name: PopulateEventData :many
 SELECT
-    e.tenant_id,
-    e.id AS event_id,
-    e.external_id AS event_external_id,
-    e.seen_at AS event_seen_at,
-    e.key AS event_key,
-    e.payload AS event_payload,
-    e.additional_metadata AS event_additional_metadata,
-    e.scope AS event_scope,
-    sc.queued_count,
-    sc.running_count,
-    sc.completed_count,
-    sc.cancelled_count,
-    sc.failed_count,
-    e.triggered_runs
-FROM
-    included_events e
-LEFT JOIN
-    status_counts sc ON (e.tenant_id, e.id, e.seen_at) = (sc.tenant_id, sc.id, sc.seen_at)
-ORDER BY e.seen_at DESC
+    e.external_id,
+    COUNT(*) FILTER (WHERE r.readable_status = 'QUEUED') AS queued_count,
+    COUNT(*) FILTER (WHERE r.readable_status = 'RUNNING') AS running_count,
+    COUNT(*) FILTER (WHERE r.readable_status = 'COMPLETED') AS completed_count,
+    COUNT(*) FILTER (WHERE r.readable_status = 'CANCELLED') AS cancelled_count,
+    COUNT(*) FILTER (WHERE r.readable_status = 'FAILED') AS failed_count,
+    JSON_AGG(JSON_BUILD_OBJECT('run_external_id', r.external_id, 'filter_id', etr.filter_id)) FILTER (WHERE r.external_id IS NOT NULL)::JSONB AS triggered_runs
+FROM v1_event_lookup_table_olap elt
+JOIN v1_events_olap e ON (elt.tenant_id, elt.event_id, elt.event_seen_at) = (e.tenant_id, e.id, e.seen_at)
+JOIN v1_event_to_run_olap etr ON (e.id, e.seen_at) = (etr.event_id, etr.event_seen_at)
+JOIN v1_runs_olap r ON (etr.run_id, etr.run_inserted_at) = (r.id, r.inserted_at)
+WHERE
+    elt.external_id = ANY(@eventExternalIds::uuid[])
+    AND elt.tenant_id = @tenantId::uuid
+;
+
+-- name: ListEvents :many
+SELECT e.*
+FROM v1_event_lookup_table_olap elt
+JOIN v1_events_olap e ON (elt.tenant_id, elt.event_id, elt.event_seen_at) = (e.tenant_id, e.id, e.seen_at)
+WHERE
+    e.tenant_id = @tenantId
+    AND (
+        sqlc.narg('keys')::TEXT[] IS NULL OR
+        "key" = ANY(sqlc.narg('keys')::TEXT[])
+    )
+    AND e.seen_at >= @since::TIMESTAMPTZ
+    AND (
+        sqlc.narg('until')::TIMESTAMPTZ IS NULL OR
+        e.seen_at <= sqlc.narg('until')::TIMESTAMPTZ
+    )
+    AND (
+        sqlc.narg('workflowIds')::UUID[] IS NULL OR
+        EXISTS (
+            SELECT 1
+            FROM v1_event_to_run_olap etr
+            JOIN v1_runs_olap r ON (etr.run_id, etr.run_inserted_at) = (r.id, r.inserted_at)
+            WHERE
+                (etr.event_id, etr.event_seen_at) = (e.id, e.seen_at)
+                AND r.workflow_id = ANY(sqlc.narg('workflowIds')::UUID[]::UUID[])
+        )
+    )
+    AND (
+        sqlc.narg('eventIds')::UUID[] IS NULL OR
+        elt.external_id = ANY(sqlc.narg('eventIds')::UUID[])
+    )
+    AND (
+        sqlc.narg('additionalMetadata')::JSONB IS NULL OR
+        e.additional_metadata @> sqlc.narg('additionalMetadata')::JSONB
+    )
+    AND (
+        CAST(sqlc.narg('statuses')::TEXT[] AS v1_readable_status_olap[]) IS NULL OR
+        EXISTS (
+            SELECT 1
+            FROM v1_event_to_run_olap etr
+            JOIN v1_runs_olap r ON (etr.run_id, etr.run_inserted_at) = (r.id, r.inserted_at)
+            WHERE
+                (etr.event_id, etr.event_seen_at) = (e.id, e.seen_at)
+                AND r.readable_status = ANY(CAST(sqlc.narg('statuses')::text[]::TEXT[] AS v1_readable_status_olap[]))
+        )
+    )
+    AND (
+        sqlc.narg('scopes')::TEXT[] IS NULL OR
+        e.scope = ANY(sqlc.narg('scopes')::TEXT[])
+    )
+ORDER BY e.seen_at DESC, e.id
+OFFSET
+    COALESCE(sqlc.narg('offset')::BIGINT, 0)
+LIMIT
+    COALESCE(sqlc.narg('limit')::BIGINT, 50)
 ;
 
 -- name: CountEvents :one
 WITH included_events AS (
-    SELECT DISTINCT e.*
+    SELECT e.*
     FROM v1_event_lookup_table_olap elt
     JOIN v1_events_olap e ON (elt.tenant_id, elt.event_id, elt.event_seen_at) = (e.tenant_id, e.id, e.seen_at)
-    LEFT JOIN v1_event_to_run_olap etr ON (e.id, e.seen_at) = (etr.event_id, etr.event_seen_at)
-    LEFT JOIN v1_runs_olap r ON (etr.run_id, etr.run_inserted_at) = (r.id, r.inserted_at)
     WHERE
         e.tenant_id = @tenantId
         AND (
@@ -1464,7 +1440,14 @@ WITH included_events AS (
         )
         AND (
             sqlc.narg('workflowIds')::UUID[] IS NULL OR
-            r.workflow_id = ANY(sqlc.narg('workflowIds')::UUID[])
+            EXISTS (
+                SELECT 1
+                FROM v1_event_to_run_olap etr
+                JOIN v1_runs_olap r ON (etr.run_id, etr.run_inserted_at) = (r.id, r.inserted_at)
+                WHERE
+                    (etr.event_id, etr.event_seen_at) = (e.id, e.seen_at)
+                    AND r.workflow_id = ANY(sqlc.narg('workflowIds')::UUID[]::UUID[])
+            )
         )
         AND (
             sqlc.narg('eventIds')::UUID[] IS NULL OR
@@ -1475,8 +1458,15 @@ WITH included_events AS (
             e.additional_metadata @> sqlc.narg('additionalMetadata')::JSONB
         )
         AND (
-            CAST(sqlc.narg('statuses')::text[] AS v1_readable_status_olap[]) IS NULL OR
-            r.readable_status = ANY(CAST(sqlc.narg('statuses')::text[] AS v1_readable_status_olap[]))
+            CAST(sqlc.narg('statuses')::TEXT[] AS v1_readable_status_olap[]) IS NULL OR
+            EXISTS (
+                SELECT 1
+                FROM v1_event_to_run_olap etr
+                JOIN v1_runs_olap r ON (etr.run_id, etr.run_inserted_at) = (r.id, r.inserted_at)
+                WHERE
+                    (etr.event_id, etr.event_seen_at) = (e.id, e.seen_at)
+                    AND r.readable_status = ANY(CAST(sqlc.narg('statuses')::text[]::TEXT[] AS v1_readable_status_olap[]))
+            )
         )
         AND (
             sqlc.narg('scopes')::TEXT[] IS NULL OR

--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -1350,7 +1350,7 @@ WHERE
 
 -- name: PopulateEventData :many
 SELECT
-    e.external_id,
+    elt.external_id,
     COUNT(*) FILTER (WHERE r.readable_status = 'QUEUED') AS queued_count,
     COUNT(*) FILTER (WHERE r.readable_status = 'RUNNING') AS running_count,
     COUNT(*) FILTER (WHERE r.readable_status = 'COMPLETED') AS completed_count,
@@ -1364,6 +1364,7 @@ JOIN v1_runs_olap r ON (etr.run_id, etr.run_inserted_at) = (r.id, r.inserted_at)
 WHERE
     elt.external_id = ANY(@eventExternalIds::uuid[])
     AND elt.tenant_id = @tenantId::uuid
+GROUP BY elt.external_id
 ;
 
 -- name: ListEvents :many

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -1532,7 +1532,7 @@ func (q *Queries) PopulateDAGMetadata(ctx context.Context, db DBTX, arg Populate
 
 const populateEventData = `-- name: PopulateEventData :many
 SELECT
-    e.external_id,
+    elt.external_id,
     COUNT(*) FILTER (WHERE r.readable_status = 'QUEUED') AS queued_count,
     COUNT(*) FILTER (WHERE r.readable_status = 'RUNNING') AS running_count,
     COUNT(*) FILTER (WHERE r.readable_status = 'COMPLETED') AS completed_count,
@@ -1546,6 +1546,7 @@ JOIN v1_runs_olap r ON (etr.run_id, etr.run_inserted_at) = (r.id, r.inserted_at)
 WHERE
     elt.external_id = ANY($1::uuid[])
     AND elt.tenant_id = $2::uuid
+GROUP BY elt.external_id
 `
 
 type PopulateEventDataParams struct {


### PR DESCRIPTION
# Description

Splitting out the events query into two separate queries to improve performance. The original left joins were taking a really long time, and this should be a lot better since the lookup by the ids should be fast

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

