### PR TITLE
Make sure Go's zero value does not hinder with task initial state

### DIFF
--- a/pkg/repository/v1/match.go
+++ b/pkg/repository/v1/match.go
@@ -501,6 +501,7 @@ func (m *sharedRepository) processEventMatches(ctx context.Context, tx sqlcv1.DB
 						StepId:             sqlchelpers.UUIDToStr(match.TriggerStepID),
 						StepIndex:          int(match.TriggerStepIndex.Int64),
 						AdditionalMetadata: additionalMetadata,
+						InitialState:       sqlcv1.V1TaskInitialStateQUEUED,
 					}
 
 					switch matchData.Action() {

--- a/pkg/repository/v1/task.go
+++ b/pkg/repository/v1/task.go
@@ -1586,6 +1586,9 @@ func (r *sharedRepository) insertTasks(
 		}
 
 		initialStates[i] = string(task.InitialState)
+		if initialStates[i] == "" {
+			initialStates[i] = string(sqlcv1.V1TaskInitialStateQUEUED)
+		}
 
 		if len(task.AdditionalMetadata) > 0 {
 			additionalMetadatas[i] = task.AdditionalMetadata
@@ -1996,6 +1999,9 @@ func (r *sharedRepository) replayTasks(
 			inputs[i] = r.ToV1StepRunData(task.Input).Bytes()
 		}
 		initialStates[i] = string(task.InitialState)
+		if initialStates[i] == "" {
+			initialStates[i] = string(sqlcv1.V1TaskInitialStateQUEUED)
+		}
 
 		if len(task.AdditionalMetadata) > 0 {
 			additionalMetadatas[i] = task.AdditionalMetadata


### PR DESCRIPTION
# Description

We are doing `string(task.InitialState)` which can lead to an empty string given Go's zero value semantics and can lead to SQL errors. We need to enforce the default initial state in code. A better way would have been to use pointers so that `sqlc` can leverage its emitted Go classes but since we want to do bulk queries based on slice indices, we might have to use another patch-fix for this, for now.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Reinforce default task initial state in Go code
