### PR TITLE
fix: don't print output data in CEL exception

### DIFF
--- a/build/package/lite.dockerfile
+++ b/build/package/lite.dockerfile
@@ -25,7 +25,7 @@ RUN npm run build
 FROM alpine AS deployment
 
 # install bash via apk
-RUN apk update && apk add --no-cache bash gcc musl-dev openssl bash ca-certificates curl postgresql-client
+RUN apk update && apk add --no-cache bash gcc musl-dev openssl bash ca-certificates curl postgresql-client tzdata
 
 COPY --from=lite-binary-base /hatchet/hatchet-lite ./hatchet-lite
 COPY --from=admin-binary-base /hatchet/hatchet-admin ./hatchet-admin

--- a/build/package/loadtest.dockerfile
+++ b/build/package/loadtest.dockerfile
@@ -25,7 +25,7 @@ FROM alpine AS deployment
 WORKDIR /hatchet
 
 # openssl and bash needed for admin build
-RUN apk update && apk add --no-cache gcc musl-dev openssl bash ca-certificates
+RUN apk update && apk add --no-cache gcc musl-dev openssl bash ca-certificates tzdata
 
 COPY --from=build-go /hatchet/bin/hatchet-load-test /hatchet/
 

--- a/pkg/repository/v1/match.go
+++ b/pkg/repository/v1/match.go
@@ -666,7 +666,7 @@ func (m *sharedRepository) processCELExpressions(ctx context.Context, events []C
 				err := json.Unmarshal(event.Data, &outputEventData)
 
 				if err != nil {
-					m.l.Warn().Err(err).Msgf("[0] failed to unmarshal output event data %s", string(event.Data))
+					m.l.Warn().Err(err).Msgf("[0] failed to unmarshal output event data. id: %s, key: %s", event.ID, event.Key)
 					continue
 				}
 
@@ -674,14 +674,14 @@ func (m *sharedRepository) processCELExpressions(ctx context.Context, events []C
 					err = json.Unmarshal(outputEventData.Output, &outputData)
 
 					if err != nil {
-						m.l.Warn().Err(err).Msgf("failed to unmarshal output event data, output subfield %s", string(event.Data))
+						m.l.Warn().Err(err).Msgf("failed to unmarshal output event data, output subfield for task %d", outputEventData.TaskId)
 						continue
 					}
 				} else {
 					err = json.Unmarshal(event.Data, &inputData)
 
 					if err != nil {
-						m.l.Warn().Err(err).Msgf("[1] failed to unmarshal output event data %s", string(event.Data))
+						m.l.Warn().Err(err).Msgf("[1] failed to unmarshal output event data. id: %s, key: %s", event.ID, event.Key)
 						continue
 					}
 				}


### PR DESCRIPTION
# Description

Fixes warning logs when failing to unmarshal output data.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)