### PR TITLE
fix: negative weights ranks are not excluded from the candidate workers pool

### DIFF
--- a/pkg/scheduling/v1/slot.go
+++ b/pkg/scheduling/v1/slot.go
@@ -169,6 +169,11 @@ func (r *rankedValidSlots) order() []*slot {
 	for i := len(sortedRanks) - 1; i >= 0; i-- {
 		rank := sortedRanks[i]
 
+		if rank < 0 {
+			// skip negative ranks, as they are not valid for scheduling
+			continue
+		}
+
 		if r.ranksToSlots[rank] != nil {
 			nonNegativeSlots = append(nonNegativeSlots, r.ranksToSlots[rank]...)
 		}

--- a/pkg/scheduling/v1/slot_test.go
+++ b/pkg/scheduling/v1/slot_test.go
@@ -96,6 +96,46 @@ func TestGetRankedSlots(t *testing.T) {
 			},
 			expectedWorker: []string{stableWorkerId2, stableWorkerId1},
 		},
+		{
+			name: "Affinity labels with strict requirements",
+			qi:   &sqlcv1.V1QueueItem{},
+			labels: []*sqlcv1.GetDesiredLabelsRow{
+				{
+					Key:        "key1",
+					Weight:     1,
+					Required:   true,
+					Comparator: sqlcv1.WorkerLabelComparatorEQUAL,
+					IntValue:   pgtype.Int4{Int32: 1, Valid: true},
+				},
+			},
+			slots: []*slot{
+				newSlot(&worker{ListActiveWorkersResult: &v1.ListActiveWorkersResult{ID: (stableWorkerId1), Labels: []*sqlcv1.ListManyWorkerLabelsRow{{
+					Key:      "key1",
+					IntValue: pgtype.Int4{Int32: 1, Valid: true},
+				}}}}, []string{}),
+			},
+			expectedWorker: []string{stableWorkerId1},
+		},
+		{
+			name: "Affinity labels with strict requirements and unsatisfiable conditions",
+			qi:   &sqlcv1.V1QueueItem{},
+			labels: []*sqlcv1.GetDesiredLabelsRow{
+				{
+					Key:        "key1",
+					Weight:     1,
+					Required:   true,
+					Comparator: sqlcv1.WorkerLabelComparatorEQUAL,
+					IntValue:   pgtype.Int4{Int32: 1, Valid: true},
+				},
+			},
+			slots: []*slot{
+				newSlot(&worker{ListActiveWorkersResult: &v1.ListActiveWorkersResult{ID: (stableWorkerId2), Labels: []*sqlcv1.ListManyWorkerLabelsRow{{
+					Key:      "key1",
+					IntValue: pgtype.Int4{Int32: 2, Valid: true},
+				}}}}, []string{}),
+			},
+			expectedWorker: []string{},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes: 
When using a strict worker affinity (`WorkerLabelComparator.EQUAL`), the tasks could still be scheduled in an incorrect worker 

This is caused because the validSlot ranking did not exclude negative weights from the candidate pool

Discussed here: https://discord.com/channels/1088927970518909068/1389514509470924872

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Exclude negative weights from the order method
