### PR TITLE
Add default Grafana dashboards for Prometheus metrics

### DIFF
--- a/hack/dev/grafana/dashboards/tenant-performance-metrics.json
+++ b/hack/dev/grafana/dashboards/tenant-performance-metrics.json
@@ -102,7 +102,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, rate(hatchet_tenant_queued_to_assigned_time_seconds_bucket{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m]))",
+          "expr": "histogram_quantile(0.95, rate(hatchet_tenant_queued_to_assigned_time_seconds_bucket{tenant_id=~\"$tenant_id\"}[5m]))",
           "interval": "",
           "legendFormat": "95th percentile",
           "refId": "A"
@@ -112,7 +112,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.50, rate(hatchet_tenant_queued_to_assigned_time_seconds_bucket{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m]))",
+          "expr": "histogram_quantile(0.50, rate(hatchet_tenant_queued_to_assigned_time_seconds_bucket{tenant_id=~\"$tenant_id\"}[5m]))",
           "interval": "",
           "legendFormat": "50th percentile",
           "refId": "B"
@@ -122,7 +122,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.99, rate(hatchet_tenant_queued_to_assigned_time_seconds_bucket{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m]))",
+          "expr": "histogram_quantile(0.99, rate(hatchet_tenant_queued_to_assigned_time_seconds_bucket{tenant_id=~\"$tenant_id\"}[5m]))",
           "interval": "",
           "legendFormat": "99th percentile",
           "refId": "C"
@@ -191,7 +191,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, rate(hatchet_tenant_queued_to_assigned_time_seconds_bucket{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m]))",
+          "expr": "histogram_quantile(0.95, rate(hatchet_tenant_queued_to_assigned_time_seconds_bucket{tenant_id=~\"$tenant_id\"}[5m]))",
           "interval": "",
           "legendFormat": "Queue Time (95th percentile)",
           "refId": "A"
@@ -280,7 +280,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(hatchet_tenant_queued_to_assigned{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m])",
+          "expr": "rate(hatchet_tenant_queued_to_assigned{tenant_id=~\"$tenant_id\"}[5m])",
           "interval": "",
           "legendFormat": "Tasks Assigned from Queue",
           "refId": "A"
@@ -369,7 +369,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(hatchet_tenant_queue_invocations{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m])",
+          "expr": "rate(hatchet_tenant_queue_invocations{tenant_id=~\"$tenant_id\"}[5m])",
           "interval": "",
           "legendFormat": "Queue Invocations",
           "refId": "A"
@@ -428,7 +428,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hatchet_tenant_succeeded_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"} * 100 / hatchet_tenant_created_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}",
+          "expr": "hatchet_tenant_succeeded_tasks{tenant_id=~\"$tenant_id\"} * 100 / hatchet_tenant_created_tasks{tenant_id=~\"$tenant_id\"}",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -466,7 +466,35 @@
     "performance"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(hatchet_tenant_created_tasks, tenant_id)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Tenant ID",
+        "multi": false,
+        "name": "tenant_id",
+        "options": [],
+        "query": {
+          "query": "label_values(hatchet_tenant_created_tasks, tenant_id)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
   },
   "time": {
     "from": "now-1h",

--- a/hack/dev/grafana/dashboards/tenant-performance-metrics.json
+++ b/hack/dev/grafana/dashboards/tenant-performance-metrics.json
@@ -1,0 +1,481 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, rate(hatchet_tenant_queued_to_assigned_time_seconds_bucket{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m]))",
+          "interval": "",
+          "legendFormat": "95th percentile",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.50, rate(hatchet_tenant_queued_to_assigned_time_seconds_bucket{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m]))",
+          "interval": "",
+          "legendFormat": "50th percentile",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, rate(hatchet_tenant_queued_to_assigned_time_seconds_bucket{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m]))",
+          "interval": "",
+          "legendFormat": "99th percentile",
+          "refId": "C"
+        }
+      ],
+      "title": "Queue-to-Assignment Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 15
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.5.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, rate(hatchet_tenant_queued_to_assigned_time_seconds_bucket{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m]))",
+          "interval": "",
+          "legendFormat": "Queue Time (95th percentile)",
+          "refId": "A"
+        }
+      ],
+      "title": "Current Queue Performance",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(hatchet_tenant_queued_to_assigned{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m])",
+          "interval": "",
+          "legendFormat": "Tasks Assigned from Queue",
+          "refId": "A"
+        }
+      ],
+      "title": "Queue Processing Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(hatchet_tenant_queue_invocations{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m])",
+          "interval": "",
+          "legendFormat": "Queue Invocations",
+          "refId": "A"
+        }
+      ],
+      "title": "Queue System Activity",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "8.5.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "hatchet_tenant_succeeded_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"} * 100 / hatchet_tenant_created_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Success Rate",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "job": true,
+              "instance": true,
+              "tenant_id": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Success Rate (%)"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [
+    "hatchet",
+    "tenant",
+    "performance"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Hatchet Tenant Performance Metrics",
+  "uid": "hatchet-tenant-performance",
+  "version": 1,
+  "weekStart": ""
+}

--- a/hack/dev/grafana/dashboards/tenant-task-metrics.json
+++ b/hack/dev/grafana/dashboards/tenant-task-metrics.json
@@ -1,0 +1,546 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Created"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "blue"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Succeeded"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Retried"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(hatchet_tenant_created_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m])",
+          "interval": "",
+          "legendFormat": "Created",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(hatchet_tenant_succeeded_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m])",
+          "interval": "",
+          "legendFormat": "Succeeded",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(hatchet_tenant_failed_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m])",
+          "interval": "",
+          "legendFormat": "Failed",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(hatchet_tenant_retried_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m])",
+          "interval": "",
+          "legendFormat": "Retried",
+          "refId": "D"
+        }
+      ],
+      "title": "Task Lifecycle Rates",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "8.5.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "hatchet_tenant_created_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "hatchet_tenant_succeeded_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "hatchet_tenant_cancelled_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "hatchet_tenant_assigned_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "D"
+        }
+      ],
+      "title": "Task Counters Summary",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "job": true,
+              "instance": true,
+              "tenant_id": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "__name__": "Metric",
+              "Value": "Count"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(hatchet_tenant_assigned_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m])",
+          "interval": "",
+          "legendFormat": "Assigned",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(hatchet_tenant_scheduling_timed_out{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m])",
+          "interval": "",
+          "legendFormat": "Scheduling Timeout",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(hatchet_tenant_rate_limited{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m])",
+          "interval": "",
+          "legendFormat": "Rate Limited",
+          "refId": "C"
+        }
+      ],
+      "title": "Task Scheduling Metrics",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "hatchet_tenant_cancelled_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}",
+          "interval": "",
+          "legendFormat": "Cancelled Tasks",
+          "refId": "A"
+        }
+      ],
+      "title": "Cancelled Tasks",
+      "type": "stat"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [
+    "hatchet",
+    "tenant",
+    "tasks"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Hatchet Tenant Task Metrics",
+  "uid": "hatchet-tenant-tasks",
+  "version": 1,
+  "weekStart": ""
+}

--- a/hack/dev/grafana/dashboards/tenant-task-metrics.json
+++ b/hack/dev/grafana/dashboards/tenant-task-metrics.json
@@ -163,7 +163,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(hatchet_tenant_created_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m])",
+          "expr": "rate(hatchet_tenant_created_tasks{tenant_id=~\"$tenant_id\"}[5m])",
           "interval": "",
           "legendFormat": "Created",
           "refId": "A"
@@ -173,7 +173,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(hatchet_tenant_succeeded_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m])",
+          "expr": "rate(hatchet_tenant_succeeded_tasks{tenant_id=~\"$tenant_id\"}[5m])",
           "interval": "",
           "legendFormat": "Succeeded",
           "refId": "B"
@@ -183,7 +183,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(hatchet_tenant_failed_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m])",
+          "expr": "rate(hatchet_tenant_failed_tasks{tenant_id=~\"$tenant_id\"}[5m])",
           "interval": "",
           "legendFormat": "Failed",
           "refId": "C"
@@ -193,7 +193,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(hatchet_tenant_retried_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m])",
+          "expr": "rate(hatchet_tenant_retried_tasks{tenant_id=~\"$tenant_id\"}[5m])",
           "interval": "",
           "legendFormat": "Retried",
           "refId": "D"
@@ -201,148 +201,6 @@
       ],
       "title": "Task Lifecycle Rates",
       "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "displayMode": "auto",
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "showHeader": true
-      },
-      "pluginVersion": "8.5.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "hatchet_tenant_created_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "hatchet_tenant_succeeded_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "hatchet_tenant_cancelled_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "hatchet_tenant_assigned_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "D"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "hatchet_tenant_reassigned_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"} or on() vector(0)",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "E"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "hatchet_tenant_failed_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"} or on() vector(0)",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "F"
-        }
-      ],
-      "title": "Task Counters Summary",
-      "transformations": [
-        {
-          "id": "merge",
-          "options": {}
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "job": true,
-              "instance": true,
-              "tenant_id": true
-            },
-            "indexByName": {},
-            "renameByName": {
-              "__name__": "Metric",
-              "Value": "Count"
-            }
-          }
-        }
-      ],
-      "type": "table"
     },
     {
       "datasource": {
@@ -424,7 +282,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(hatchet_tenant_assigned_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m])",
+          "expr": "rate(hatchet_tenant_assigned_tasks{tenant_id=~\"$tenant_id\"}[5m])",
           "interval": "",
           "legendFormat": "Assigned",
           "refId": "A"
@@ -434,7 +292,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(hatchet_tenant_scheduling_timed_out{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m])",
+          "expr": "rate(hatchet_tenant_scheduling_timed_out{tenant_id=~\"$tenant_id\"}[5m])",
           "interval": "",
           "legendFormat": "Scheduling Timeout",
           "refId": "B"
@@ -444,7 +302,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(hatchet_tenant_rate_limited{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m])",
+          "expr": "rate(hatchet_tenant_rate_limited{tenant_id=~\"$tenant_id\"}[5m])",
           "interval": "",
           "legendFormat": "Rate Limited",
           "refId": "C"
@@ -454,7 +312,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(hatchet_tenant_reassigned_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m])",
+          "expr": "rate(hatchet_tenant_reassigned_tasks{tenant_id=~\"$tenant_id\"}[5m])",
           "interval": "",
           "legendFormat": "Reassigned",
           "refId": "D"
@@ -546,7 +404,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hatchet_tenant_cancelled_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}",
+          "expr": "hatchet_tenant_cancelled_tasks{tenant_id=~\"$tenant_id\"}",
           "interval": "",
           "legendFormat": "Cancelled Tasks",
           "refId": "A"
@@ -609,7 +467,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hatchet_tenant_reassigned_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"} or on() vector(0)",
+          "expr": "hatchet_tenant_reassigned_tasks{tenant_id=~\"$tenant_id\"}",
           "interval": "",
           "legendFormat": "Reassigned Tasks",
           "refId": "A"
@@ -672,7 +530,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "hatchet_tenant_failed_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"} or on() vector(0)",
+          "expr": "hatchet_tenant_failed_tasks{tenant_id=~\"$tenant_id\"}",
           "interval": "",
           "legendFormat": "Failed Tasks",
           "refId": "A"
@@ -680,6 +538,115 @@
       ],
       "title": "Failed Tasks Total",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.50, rate(hatchet_tenant_workflow_duration_milliseconds{tenant_id=~\"$tenant_id\"}[5m]))",
+          "interval": "",
+          "legendFormat": "50th percentile - {{workflow_name}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, rate(hatchet_tenant_workflow_duration_milliseconds{tenant_id=~\"$tenant_id\"}[5m]))",
+          "interval": "",
+          "legendFormat": "95th percentile - {{workflow_name}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, rate(hatchet_tenant_workflow_duration_milliseconds{tenant_id=~\"$tenant_id\"}[5m]))",
+          "interval": "",
+          "legendFormat": "99th percentile - {{workflow_name}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Workflow Duration by Workflow Name",
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",
@@ -691,7 +658,35 @@
     "tasks"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(hatchet_tenant_created_tasks, tenant_id)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Tenant ID",
+        "multi": false,
+        "name": "tenant_id",
+        "options": [],
+        "query": {
+          "query": "label_values(hatchet_tenant_created_tasks, tenant_id)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
   },
   "time": {
     "from": "now-1h",
@@ -700,7 +695,7 @@
   "timepicker": {},
   "timezone": "",
   "title": "Hatchet Tenant Task Metrics",
-  "uid": "hatchet-tenant-tasks",
-  "version": 1,
+  "uid": "hatchet-tenant-tasks-v2",
+  "version": 2,
   "weekStart": ""
 }

--- a/hack/dev/grafana/dashboards/tenant-task-metrics.json
+++ b/hack/dev/grafana/dashboards/tenant-task-metrics.json
@@ -293,6 +293,30 @@
           "interval": "",
           "legendFormat": "",
           "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "hatchet_tenant_reassigned_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"} or on() vector(0)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "hatchet_tenant_failed_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"} or on() vector(0)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "F"
         }
       ],
       "title": "Task Counters Summary",
@@ -424,6 +448,16 @@
           "interval": "",
           "legendFormat": "Rate Limited",
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(hatchet_tenant_reassigned_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m])",
+          "interval": "",
+          "legendFormat": "Reassigned",
+          "refId": "D"
         }
       ],
       "title": "Task Scheduling Metrics",
@@ -519,6 +553,132 @@
         }
       ],
       "title": "Cancelled Tasks",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "hatchet_tenant_reassigned_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"} or on() vector(0)",
+          "interval": "",
+          "legendFormat": "Reassigned Tasks",
+          "refId": "A"
+        }
+      ],
+      "title": "Reassigned Tasks Total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "hatchet_tenant_failed_tasks{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"} or on() vector(0)",
+          "interval": "",
+          "legendFormat": "Failed Tasks",
+          "refId": "A"
+        }
+      ],
+      "title": "Failed Tasks Total",
       "type": "stat"
     }
   ],

--- a/hack/dev/grafana/dashboards/tenant-workflow-metrics.json
+++ b/hack/dev/grafana/dashboards/tenant-workflow-metrics.json
@@ -1,0 +1,320 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, rate(hatchet_tenant_workflow_duration_milliseconds_bucket{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m]))",
+          "interval": "",
+          "legendFormat": "95th percentile",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.50, rate(hatchet_tenant_workflow_duration_milliseconds_bucket{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m]))",
+          "interval": "",
+          "legendFormat": "50th percentile",
+          "refId": "B"
+        }
+      ],
+      "title": "Workflow Duration Percentiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.5.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(hatchet_tenant_workflow_duration_milliseconds_count{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m]) * 60",
+          "interval": "",
+          "legendFormat": "Workflows per minute",
+          "refId": "A"
+        }
+      ],
+      "title": "Workflow Execution Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(hatchet_tenant_workflow_duration_milliseconds_count{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\", status=\"COMPLETED\"}[5m])",
+          "interval": "",
+          "legendFormat": "Succeeded - {{workflow_name}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(hatchet_tenant_workflow_duration_milliseconds_count{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\", status=\"FAILED\"}[5m])",
+          "interval": "",
+          "legendFormat": "Failed - {{workflow_name}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(hatchet_tenant_workflow_duration_milliseconds_count{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\", status=\"CANCELLED\"}[5m])",
+          "interval": "",
+          "legendFormat": "Cancelled - {{workflow_name}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Workflow Status by Name",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [
+    "hatchet",
+    "tenant",
+    "workflow"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Hatchet Tenant Workflow Metrics",
+  "uid": "hatchet-tenant-workflow",
+  "version": 1,
+  "weekStart": ""
+}

--- a/hack/dev/grafana/dashboards/tenant-workflow-metrics.json
+++ b/hack/dev/grafana/dashboards/tenant-workflow-metrics.json
@@ -102,7 +102,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, rate(hatchet_tenant_workflow_duration_milliseconds_bucket{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m]))",
+          "expr": "histogram_quantile(0.95, rate(hatchet_tenant_workflow_duration_milliseconds_bucket{tenant_id=~\"$tenant_id\", workflow_name=~\"$workflow_name\"}[5m]))",
           "interval": "",
           "legendFormat": "95th percentile",
           "refId": "A"
@@ -112,7 +112,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.50, rate(hatchet_tenant_workflow_duration_milliseconds_bucket{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m]))",
+          "expr": "histogram_quantile(0.50, rate(hatchet_tenant_workflow_duration_milliseconds_bucket{tenant_id=~\"$tenant_id\", workflow_name=~\"$workflow_name\"}[5m]))",
           "interval": "",
           "legendFormat": "50th percentile",
           "refId": "B"
@@ -177,9 +177,9 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(hatchet_tenant_workflow_duration_milliseconds_count{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\"}[5m]) * 60",
+          "expr": "rate(hatchet_tenant_workflow_duration_milliseconds_count{tenant_id=~\"$tenant_id\", workflow_name=~\"$workflow_name\"}[5m]) * 60",
           "interval": "",
-          "legendFormat": "Workflows per minute",
+          "legendFormat": "{{workflow_name}}",
           "refId": "A"
         }
       ],
@@ -266,7 +266,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(hatchet_tenant_workflow_duration_milliseconds_count{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\", status=\"COMPLETED\"}[5m])",
+          "expr": "rate(hatchet_tenant_workflow_duration_milliseconds_count{tenant_id=~\"$tenant_id\", status=\"COMPLETED\", workflow_name=~\"$workflow_name\"}[5m])",
           "interval": "",
           "legendFormat": "Succeeded - {{workflow_name}}",
           "refId": "A"
@@ -276,7 +276,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(hatchet_tenant_workflow_duration_milliseconds_count{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\", status=\"FAILED\"}[5m])",
+          "expr": "rate(hatchet_tenant_workflow_duration_milliseconds_count{tenant_id=~\"$tenant_id\", status=\"FAILED\", workflow_name=~\"$workflow_name\"}[5m])",
           "interval": "",
           "legendFormat": "Failed - {{workflow_name}}",
           "refId": "B"
@@ -286,7 +286,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(hatchet_tenant_workflow_duration_milliseconds_count{tenant_id=\"707d0855-80ab-4e1f-a156-f1c4546cbf52\", status=\"CANCELLED\"}[5m])",
+          "expr": "rate(hatchet_tenant_workflow_duration_milliseconds_count{tenant_id=~\"$tenant_id\", status=\"CANCELLED\", workflow_name=~\"$workflow_name\"}[5m])",
           "interval": "",
           "legendFormat": "Cancelled - {{workflow_name}}",
           "refId": "C"
@@ -305,7 +305,62 @@
     "workflow"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(hatchet_tenant_workflow_duration_milliseconds_count, tenant_id)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Tenant ID",
+        "multi": false,
+        "name": "tenant_id",
+        "options": [],
+        "query": {
+          "query": "label_values(hatchet_tenant_workflow_duration_milliseconds_count, tenant_id)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(hatchet_tenant_workflow_duration_milliseconds_count{tenant_id=~\"$tenant_id\"}, workflow_name)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Workflow",
+        "multi": false,
+        "name": "workflow_name",
+        "options": [],
+        "query": {
+          "query": "label_values(hatchet_tenant_workflow_duration_milliseconds_count{tenant_id=~\"$tenant_id\"}, workflow_name)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
   },
   "time": {
     "from": "now-1h",

--- a/hack/dev/grafana/provisioning/dashboards/dashboards.yml
+++ b/hack/dev/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: 'hatchet-dashboards'
+    orgId: 1
+    folder: 'Hatchet'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/hack/dev/grafana/provisioning/datasources/prometheus.yaml
+++ b/hack/dev/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+    basicAuth: true
+    basicAuthUser: admin
+    secureJsonData:
+      basicAuthPassword: admin


### PR DESCRIPTION
# Description

We export Prometheus metrics but have no examples of how to visualize them.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## What's Changed

- [x] Add default Grafana dashboards for metrics
