### PR TITLE
fix: panic when rate limit units are passed as nil

### DIFF
--- a/pkg/repository/v1/workflow.go
+++ b/pkg/repository/v1/workflow.go
@@ -797,7 +797,7 @@ func (r *workflowRepository) createJobTx(ctx context.Context, tx sqlcv1.DBTX, te
 
 					if rateLimit.UnitsExpr != nil {
 						unitsExpr = *rateLimit.UnitsExpr
-					} else {
+					} else if rateLimit.Units != nil {
 						unitsExpr = cel.Int(*rateLimit.Units)
 					}
 


### PR DESCRIPTION
# Description

Fixes a panic when no units or unitsexpr are passed through the API (a bug on the SDK side, but still worth fixing on the engine). 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)