### PR TITLE
Fix: Persist tenant to local storage

### DIFF
--- a/frontend/app/src/components/molecules/nav-bar/tenant-switcher.tsx
+++ b/frontend/app/src/components/molecules/nav-bar/tenant-switcher.tsx
@@ -72,7 +72,7 @@ export function TenantSwitcher({
                   setOpen(false);
 
                   if (membership.tenant.version === TenantVersion.V1) {
-                    // Hack to wait for next event loop tick so localstorage is updated
+                    // Hack to wait for next event loop tick so local storage is updated
                     setTimeout(() => {
                       window.location.href = `/tenants/${membership.tenant?.metadata.id}`;
                     }, 0);

--- a/frontend/app/src/components/molecules/nav-bar/tenant-switcher.tsx
+++ b/frontend/app/src/components/molecules/nav-bar/tenant-switcher.tsx
@@ -72,7 +72,10 @@ export function TenantSwitcher({
                   setOpen(false);
 
                   if (membership.tenant.version === TenantVersion.V1) {
-                    window.location.href = `/tenants/${membership.tenant?.metadata.id}`;
+                    // Hack to wait for next event loop tick so localstorage is updated
+                    setTimeout(() => {
+                      window.location.href = `/tenants/${membership.tenant?.metadata.id}`;
+                    }, 0);
                   }
                 }}
                 value={membership.tenant?.slug}

--- a/frontend/app/src/components/v1/molecules/nav-bar/tenant-switcher.tsx
+++ b/frontend/app/src/components/v1/molecules/nav-bar/tenant-switcher.tsx
@@ -70,7 +70,10 @@ export function TenantSwitcher({
                   setOpen(false);
 
                   if (membership.tenant.version === TenantVersion.V0) {
-                    window.location.href = `/workflow-runs?tenant=${membership.tenant?.metadata.id}`;
+                    // Hack to wait for next event loop tick so localstorage is updated
+                    setTimeout(() => {
+                      window.location.href = `/workflow-runs?tenant=${membership.tenant?.metadata.id}`;
+                    }, 0);
                   }
                 }}
                 value={membership.tenant?.slug}

--- a/frontend/app/src/components/v1/molecules/nav-bar/tenant-switcher.tsx
+++ b/frontend/app/src/components/v1/molecules/nav-bar/tenant-switcher.tsx
@@ -70,7 +70,7 @@ export function TenantSwitcher({
                   setOpen(false);
 
                   if (membership.tenant.version === TenantVersion.V0) {
-                    // Hack to wait for next event loop tick so localstorage is updated
+                    // Hack to wait for next event loop tick so local storage is updated
                     setTimeout(() => {
                       window.location.href = `/workflow-runs?tenant=${membership.tenant?.metadata.id}`;
                     }, 0);

--- a/frontend/app/src/hooks/use-tenant.tsx
+++ b/frontend/app/src/hooks/use-tenant.tsx
@@ -43,11 +43,11 @@ export function useTenantDetails() {
   const tenantId = params.tenant;
 
   const setTenantInLocalStorage = useCallback(async (tenantId: string) => {
-    localStorage.setItem('__hatchet.tenantId', tenantId);
+    localStorage.setItem('tenantId', tenantId);
   }, []);
 
   const getTenantFromLocalStorage = useCallback(() => {
-    return localStorage.getItem('__hatchet.tenantId') as string | undefined;
+    return localStorage.getItem('tenantId') as string | undefined;
   }, []);
 
   const membershipsQuery = useQuery({

--- a/frontend/app/src/hooks/use-tenant.tsx
+++ b/frontend/app/src/hooks/use-tenant.tsx
@@ -42,6 +42,14 @@ export function useTenantDetails() {
   const params = useParams();
   const tenantId = params.tenant;
 
+  const setTenantInLocalStorage = useCallback(async (tenantId: string) => {
+    localStorage.setItem('__hatchet.tenantId', tenantId);
+  }, []);
+
+  const getTenantFromLocalStorage = useCallback(() => {
+    return localStorage.getItem('__hatchet.tenantId') as string | undefined;
+  }, []);
+
   const membershipsQuery = useQuery({
     ...queries.user.listTenantMemberships,
   });
@@ -56,7 +64,8 @@ export function useTenantDetails() {
   const navigate = useNavigate();
 
   const setTenant = useCallback(
-    (tenantId?: string) => {
+    (tenantId: string) => {
+      console.log('Switching tenant to:', tenantId);
       const currentPath = location.pathname;
 
       const newPath = currentPath.replace(
@@ -64,6 +73,7 @@ export function useTenantDetails() {
         `/tenants/${tenantId}`,
       );
 
+      setTenantInLocalStorage(tenantId);
       navigate(newPath);
     },
     [navigate, location.pathname],
@@ -80,7 +90,7 @@ export function useTenantDetails() {
   }, [tenantId, memberships]);
 
   const tenant = membership?.tenant;
-  const defaultTenant = memberships?.[0]?.tenant;
+  const defaultTenant = getTenantFromLocalStorage() ?? memberships?.[0]?.tenant;
 
   const createTenantMutation = useMutation({
     mutationKey: ['tenant:create'],

--- a/frontend/app/src/hooks/use-tenant.tsx
+++ b/frontend/app/src/hooks/use-tenant.tsx
@@ -65,7 +65,6 @@ export function useTenantDetails() {
 
   const setTenant = useCallback(
     (tenantId: string) => {
-      console.log('Switching tenant to:', tenantId);
       const currentPath = location.pathname;
 
       const newPath = currentPath.replace(

--- a/frontend/app/src/hooks/use-tenant.tsx
+++ b/frontend/app/src/hooks/use-tenant.tsx
@@ -42,12 +42,8 @@ export function useTenantDetails() {
   const params = useParams();
   const tenantId = params.tenant;
 
-  const setTenantInLocalStorage = useCallback(async (tenantId: string) => {
+  const setTenantInLocalStorage = useCallback((tenantId: string) => {
     localStorage.setItem('tenantId', tenantId);
-  }, []);
-
-  const getTenantFromLocalStorage = useCallback(() => {
-    return localStorage.getItem('tenantId') as string | undefined;
   }, []);
 
   const membershipsQuery = useQuery({
@@ -75,7 +71,7 @@ export function useTenantDetails() {
       setTenantInLocalStorage(tenantId);
       navigate(newPath);
     },
-    [navigate, location.pathname],
+    [navigate, location.pathname, setTenantInLocalStorage],
   );
 
   const membership = useMemo(() => {
@@ -89,7 +85,6 @@ export function useTenantDetails() {
   }, [tenantId, memberships]);
 
   const tenant = membership?.tenant;
-  const defaultTenant = getTenantFromLocalStorage() ?? memberships?.[0]?.tenant;
 
   const createTenantMutation = useMutation({
     mutationKey: ['tenant:create'],
@@ -189,7 +184,6 @@ export function useTenantDetails() {
   return {
     tenantId,
     tenant,
-    defaultTenant,
     isLoading: membershipsQuery.isLoading,
     membership: membership?.role,
     setTenant,

--- a/frontend/app/src/lib/atoms.ts
+++ b/frontend/app/src/lib/atoms.ts
@@ -62,11 +62,11 @@ export function useTenant(): TenantContext {
   const pathParams = useParams();
 
   const setTenantInLocalStorage = useCallback(async (tenantId: string) => {
-    localStorage.setItem('__hatchet.tenantId', tenantId);
+    localStorage.setItem('tenantId', tenantId);
   }, []);
 
   const getTenantFromLocalStorage = useCallback(() => {
-    return localStorage.getItem('__hatchet.tenantId') as string | undefined;
+    return localStorage.getItem('tenantId') as string | undefined;
   }, []);
 
   const setTenant = useCallback(

--- a/frontend/app/src/lib/atoms.ts
+++ b/frontend/app/src/lib/atoms.ts
@@ -80,7 +80,7 @@ export function useTenant(): TenantContext {
       newSearchParams.set('tenant', tenant.metadata.id);
       setSearchParams(newSearchParams, { replace: true });
     },
-    [searchParams, setSearchParams],
+    [searchParams, setSearchParams, setTenantInLocalStorage],
   );
 
   const membershipsQuery = useQuery({
@@ -136,7 +136,7 @@ export function useTenant(): TenantContext {
     const firstMembershipTenant = memberships.at(0)?.tenant;
 
     return firstMembershipTenant;
-  }, [memberships, searchParams, findTenant, pathParams.tenant]);
+  }, [memberships, searchParams, findTenant, pathParams.tenant, getTenantFromLocalStorage]);
 
   const currTenantId = searchParams.get('tenant');
   const currTenant = currTenantId ? findTenant(currTenantId) : undefined;

--- a/frontend/app/src/lib/atoms.ts
+++ b/frontend/app/src/lib/atoms.ts
@@ -136,7 +136,13 @@ export function useTenant(): TenantContext {
     const firstMembershipTenant = memberships.at(0)?.tenant;
 
     return firstMembershipTenant;
-  }, [memberships, searchParams, findTenant, pathParams.tenant, getTenantFromLocalStorage]);
+  }, [
+    memberships,
+    searchParams,
+    findTenant,
+    pathParams.tenant,
+    getTenantFromLocalStorage,
+  ]);
 
   const currTenantId = searchParams.get('tenant');
   const currTenant = currTenantId ? findTenant(currTenantId) : undefined;

--- a/frontend/app/src/lib/atoms.ts
+++ b/frontend/app/src/lib/atoms.ts
@@ -154,7 +154,6 @@ export function useTenant(): TenantContext {
   // NOTE: This is helpful mostly for debugging to easily grab
   // the tenant from the URL.
   useEffect(() => {
-    console.log('Calling useEffect to set tenant from search params');
     const currentTenantParam = searchParams.get('tenant');
     if (!currentTenantParam && tenant) {
       setTenant(tenant);

--- a/frontend/app/src/lib/atoms.ts
+++ b/frontend/app/src/lib/atoms.ts
@@ -1,4 +1,4 @@
-import { atom, useAtom } from 'jotai';
+import { atom } from 'jotai';
 import { Tenant, TenantVersion, queries } from './api';
 import {
   useLocation,
@@ -25,18 +25,6 @@ const getInitialValue = <T>(key: string, defaultValue?: T): T | undefined => {
 
   return;
 };
-
-const lastTenantKey = 'lastTenant';
-
-const lastTenantAtomInit = atom(getInitialValue<Tenant>(lastTenantKey));
-
-const lastTenantAtom = atom(
-  (get) => get(lastTenantAtomInit),
-  (_get, set, newVal: Tenant) => {
-    set(lastTenantAtomInit, newVal);
-    localStorage.setItem(lastTenantKey, JSON.stringify(newVal));
-  },
-);
 
 type Plan = 'free' | 'starter' | 'growth';
 
@@ -70,21 +58,29 @@ type TenantContext = TenantContextPresent | TenantContextMissing;
 // search param sets the tenant, the last tenant set is used if the search param is empty,
 // otherwise the first membership is used
 export function useTenant(): TenantContext {
-  const [lastTenant, setLastTenant] = useAtom(lastTenantAtom);
   const [searchParams, setSearchParams] = useSearchParams();
   const pathParams = useParams();
 
+  const setTenantInLocalStorage = useCallback(async (tenantId: string) => {
+    localStorage.setItem('__hatchet.tenantId', tenantId);
+  }, []);
+
+  const getTenantFromLocalStorage = useCallback(() => {
+    return localStorage.getItem('__hatchet.tenantId') as string | undefined;
+  }, []);
+
   const setTenant = useCallback(
     (tenant: Tenant) => {
+      setTenantInLocalStorage(tenant.metadata.id);
+
       if (tenant.version === TenantVersion.V1) {
         return;
       }
       const newSearchParams = new URLSearchParams(searchParams);
       newSearchParams.set('tenant', tenant.metadata.id);
       setSearchParams(newSearchParams, { replace: true });
-      setLastTenant(tenant);
     },
-    [searchParams, setSearchParams, setLastTenant],
+    [searchParams, setSearchParams],
   );
 
   const membershipsQuery = useQuery({
@@ -107,7 +103,7 @@ export function useTenant(): TenantContext {
   const computedCurrTenant = useMemo(() => {
     const tenantFromPath = pathParams.tenant;
     const currTenantId = searchParams.get('tenant') || undefined;
-    const lastTenantId = lastTenant?.metadata.id || undefined;
+    const lastTenantId = getTenantFromLocalStorage();
 
     if (tenantFromPath) {
       const tenant = findTenant(tenantFromPath);
@@ -140,7 +136,7 @@ export function useTenant(): TenantContext {
     const firstMembershipTenant = memberships.at(0)?.tenant;
 
     return firstMembershipTenant;
-  }, [memberships, searchParams, findTenant, lastTenant, pathParams.tenant]);
+  }, [memberships, searchParams, findTenant, pathParams.tenant]);
 
   const currTenantId = searchParams.get('tenant');
   const currTenant = currTenantId ? findTenant(currTenantId) : undefined;
@@ -152,6 +148,7 @@ export function useTenant(): TenantContext {
   // NOTE: This is helpful mostly for debugging to easily grab
   // the tenant from the URL.
   useEffect(() => {
+    console.log('Calling useEffect to set tenant from search params');
     const currentTenantParam = searchParams.get('tenant');
     if (!currentTenantParam && tenant) {
       setTenant(tenant);

--- a/frontend/app/src/pages/onboarding/create-tenant/index.tsx
+++ b/frontend/app/src/pages/onboarding/create-tenant/index.tsx
@@ -26,11 +26,14 @@ export default function CreateTenant() {
       setTenant(tenant);
       await listMembershipsQuery.refetch();
 
-      if (tenant.version === TenantVersion.V1) {
-        window.location.href = `/tenants/${tenant.metadata.id}/onboarding/get-started`;
-      } else {
-        window.location.href = `/onboarding/get-started?tenant=${tenant.metadata.id}`;
-      }
+      // Hack to wait for next event loop tick so localstorage is updated
+      setTimeout(() => {
+        if (tenant.version === TenantVersion.V1) {
+          window.location.href = `/tenants/${tenant.metadata.id}/onboarding/get-started`;
+        } else {
+          window.location.href = `/onboarding/get-started?tenant=${tenant.metadata.id}`;
+        }
+      }, 0);
     },
     onError: handleApiError,
   });

--- a/frontend/app/src/pages/onboarding/create-tenant/index.tsx
+++ b/frontend/app/src/pages/onboarding/create-tenant/index.tsx
@@ -26,7 +26,7 @@ export default function CreateTenant() {
       setTenant(tenant);
       await listMembershipsQuery.refetch();
 
-      // Hack to wait for next event loop tick so localstorage is updated
+      // Hack to wait for next event loop tick so local storage is updated
       setTimeout(() => {
         if (tenant.version === TenantVersion.V1) {
           window.location.href = `/tenants/${tenant.metadata.id}/onboarding/get-started`;


### PR DESCRIPTION
# Description

Persisting tenant id to local storage (and switching it when we redirect) so that we can correctly load the previous tenant when someone comes back to the root, logs in, etc.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
