### PR TITLE
Hotfix: Add available slots back to worker page

### DIFF
--- a/frontend/app/src/pages/main/v1/workers/components/worker-columns.tsx
+++ b/frontend/app/src/pages/main/v1/workers/components/worker-columns.tsx
@@ -70,6 +70,19 @@ export const columns: (tenantId: string) => ColumnDef<Worker>[] = (
     enableHiding: true,
   },
   {
+    accessorKey: 'slots',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Available Slots" />
+    ),
+    cell: ({ row }) => (
+      <div>
+        {row.original.availableRuns} / {row.original.maxRuns}
+      </div>
+    ),
+    enableSorting: false,
+    enableHiding: true,
+  },
+  {
     accessorKey: 'lastHeartbeatAt',
     header: ({ column }) => (
       <DataTableColumnHeader

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.1] - 2025-07-11
+
+### Added
+
+- Correctly sends SDK info to the engine when a worker is created
+
 ## [1.15.0] - 2025-07-10
 
 ### Added

--- a/sdks/python/hatchet_sdk/clients/dispatcher/dispatcher.py
+++ b/sdks/python/hatchet_sdk/clients/dispatcher/dispatcher.py
@@ -1,3 +1,6 @@
+import platform
+from importlib.metadata import version
+from sys import version_info
 from typing import cast
 
 import grpc.aio
@@ -11,6 +14,7 @@ from hatchet_sdk.clients.rest.tenacity_utils import tenacity_retry
 from hatchet_sdk.config import ClientConfig
 from hatchet_sdk.connection import new_conn
 from hatchet_sdk.contracts.dispatcher_pb2 import (
+    SDKS,
     STEP_EVENT_TYPE_COMPLETED,
     STEP_EVENT_TYPE_FAILED,
     ActionEventResponse,
@@ -19,6 +23,7 @@ from hatchet_sdk.contracts.dispatcher_pb2 import (
     OverridesData,
     RefreshTimeoutRequest,
     ReleaseSlotRequest,
+    RuntimeInfo,
     StepActionEvent,
     StepActionEventType,
     UpsertWorkerLabelsRequest,
@@ -72,6 +77,12 @@ class DispatcherClient:
                     services=req.services,
                     maxRuns=req.slots,
                     labels=req.labels,
+                    runtimeInfo=RuntimeInfo(
+                        sdkVersion=version("hatchet_sdk"),
+                        language=SDKS.PYTHON,
+                        languageVersion=f"{version_info.major}.{version_info.minor}.{version_info.micro}",
+                        os=platform.system().lower(),
+                    ),
                 ),
                 timeout=DEFAULT_REGISTER_TIMEOUT,
                 metadata=get_metadata(self.token),

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.15.0"
+version = "1.15.1"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
# Description

Adds available slots + send worker runtime info correctly

<img width="1406" height="273" alt="Screenshot 2025-07-11 at 8 50 48 AM" src="https://github.com/user-attachments/assets/481045b2-16ca-4bab-94f2-19599df753a4" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
