### PR TITLE
Fix: Fix status assign to 500

### DIFF
--- a/api/v1/server/run/run.go
+++ b/api/v1/server/run/run.go
@@ -439,6 +439,12 @@ func (t *APIServer) registerSpec(g *echo.Group, spec *openapi3.T) (*populator.Po
 		LogValuesFunc: func(c echo.Context, v middleware.RequestLoggerValues) error {
 			statusCode := v.Status
 
+			// note that the status code is not set yet as it gets picked up by the global err handler
+			// see here: https://github.com/labstack/echo/issues/2310#issuecomment-1288196898
+			if v.Error != nil && statusCode == 200 {
+				statusCode = 500
+			}
+
 			var e *zerolog.Event
 
 			switch {

--- a/api/v1/server/run/run.go
+++ b/api/v1/server/run/run.go
@@ -439,12 +439,6 @@ func (t *APIServer) registerSpec(g *echo.Group, spec *openapi3.T) (*populator.Po
 		LogValuesFunc: func(c echo.Context, v middleware.RequestLoggerValues) error {
 			statusCode := v.Status
 
-			// note that the status code is not set yet as it gets picked up by the global err handler
-			// see here: https://github.com/labstack/echo/issues/2310#issuecomment-1288196898
-			if v.Error != nil {
-				statusCode = 500
-			}
-
 			var e *zerolog.Event
 
 			switch {


### PR DESCRIPTION
# Description

Stops manually setting 500 on non-500-level logs (which are incorrectly labeled as 200 somehow, even though 4XXs correctly are labeled as 4XX 🤦) so we don't get incorrect 500-level error logs when the API is returning a non-500 code (e.g. on auth errors)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

