### PR TITLE
Fix: Blocking event loop on log puts

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.2] - 2025-07-12
+
+### Changed
+
+- Fixes an issue in `capture_logs` where the `log` call was blocking the event loop.
+
 ## [1.15.1] - 2025-07-11
 
 ### Added

--- a/sdks/python/hatchet_sdk/worker/runner/utils/capture_logs.py
+++ b/sdks/python/hatchet_sdk/worker/runner/utils/capture_logs.py
@@ -67,8 +67,10 @@ class AsyncLogSender:
                 break
 
             try:
-                self.event_client.log(
-                    message=record.message, step_run_id=record.step_run_id
+                await asyncio.to_thread(
+                    self.event_client.log,
+                    message=record.message,
+                    step_run_id=record.step_run_id,
                 )
             except Exception as e:
                 logger.error(f"Error logging: {e}")

--- a/sdks/python/hatchet_sdk/worker/runner/utils/capture_logs.py
+++ b/sdks/python/hatchet_sdk/worker/runner/utils/capture_logs.py
@@ -73,7 +73,7 @@ class AsyncLogSender:
                     step_run_id=record.step_run_id,
                 )
             except Exception as e:
-                logger.error(f"Error logging: {e}")
+                logger.error(f"Failed to send log to Hatchet: {e}")
 
     def publish(self, record: LogRecord | STOP_LOOP_TYPE) -> None:
         try:

--- a/sdks/python/hatchet_sdk/worker/runner/utils/capture_logs.py
+++ b/sdks/python/hatchet_sdk/worker/runner/utils/capture_logs.py
@@ -72,8 +72,8 @@ class AsyncLogSender:
                     message=record.message,
                     step_run_id=record.step_run_id,
                 )
-            except Exception as e:
-                logger.error(f"Failed to send log to Hatchet: {e}")
+            except Exception:
+                logger.exception("Failed to send log to Hatchet")
 
     def publish(self, record: LogRecord | STOP_LOOP_TYPE) -> None:
         try:

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.15.1"
+version = "1.15.2"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
# Description

Fixes yet another blocked event loop issue on log puts

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

