### PR TITLE
fix: improve baseline wait latency to rely less on polling

### DIFF
--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -826,11 +826,15 @@ func (w *workflowRunAcks) getNonAckdWorkflowRuns() []string {
 	return ids
 }
 
-func (w *workflowRunAcks) ackWorkflowRun(id string) {
+func (w *workflowRunAcks) ackWorkflowRun(id string) bool {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	w.acks[id] = true
+	_, contains := w.acks[id]
+
+	delete(w.acks, id)
+
+	return contains
 }
 
 func (w *workflowRunAcks) hasWorkflowRun(id string) bool {
@@ -959,7 +963,7 @@ func (s *DispatcherImpl) subscribeToWorkflowRunsV0(server contracts.Dispatcher_S
 			return err
 		}
 
-		acks.ackWorkflowRun(e.WorkflowRunId)
+		_ = acks.ackWorkflowRun(e.WorkflowRunId)
 
 		return nil
 	}

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -826,15 +826,11 @@ func (w *workflowRunAcks) getNonAckdWorkflowRuns() []string {
 	return ids
 }
 
-func (w *workflowRunAcks) ackWorkflowRun(id string) bool {
+func (w *workflowRunAcks) ackWorkflowRun(id string) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	_, contains := w.acks[id]
-
 	delete(w.acks, id)
-
-	return contains
 }
 
 func (w *workflowRunAcks) hasWorkflowRun(id string) bool {
@@ -963,7 +959,7 @@ func (s *DispatcherImpl) subscribeToWorkflowRunsV0(server contracts.Dispatcher_S
 			return err
 		}
 
-		_ = acks.ackWorkflowRun(e.WorkflowRunId)
+		acks.ackWorkflowRun(e.WorkflowRunId)
 
 		return nil
 	}


### PR DESCRIPTION
# Description

Improves latency for returning task results in the v1 dispatcher by getting rid of the serialized iterator. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)