### PR TITLE
fix: don't run iter in same loop as recv

### DIFF
--- a/internal/services/dispatcher/server_v1.go
+++ b/internal/services/dispatcher/server_v1.go
@@ -457,13 +457,6 @@ func (s *DispatcherImpl) subscribeToWorkflowRunsV1(server contracts.Dispatcher_S
 			}
 
 			acks.addWorkflowRun(req.WorkflowRunId)
-
-			err = iter([]string{req.WorkflowRunId})
-
-			if err != nil {
-				s.l.Error().Err(err).Msgf("could not iterate over workflow run %s", req.WorkflowRunId)
-				continue
-			}
 		}
 	}()
 


### PR DESCRIPTION
# Description

Accidentally running blocking `iter` in same loop as the client's message retrieved via `Recv`, causing additional latency. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)