### PR TITLE
Fix: Replay bugs

### DIFF
--- a/frontend/app/src/pages/main/v1/task-runs-v1/actions.tsx
+++ b/frontend/app/src/pages/main/v1/task-runs-v1/actions.tsx
@@ -78,9 +78,11 @@ type TaskRunActionsParams =
     };
 
 export const useTaskRunActions = ({
+  onActionProcessed,
   onActionSubmit,
 }: {
-  onActionSubmit: (ids: string[]) => void;
+  onActionProcessed: (ids: string[]) => void;
+  onActionSubmit: () => void;
 }) => {
   const { tenantId } = useCurrentTenantId();
 
@@ -103,6 +105,9 @@ export const useTaskRunActions = ({
       }
     },
     onError: handleApiError,
+    onMutate: () => {
+      onActionSubmit();
+    },
   });
 
   const handleTaskRunAction = useCallback(
@@ -110,10 +115,10 @@ export const useTaskRunActions = ({
       const resp = await handleAction(params);
 
       if (resp.data?.ids) {
-        onActionSubmit(resp.data.ids);
+        onActionProcessed(resp.data.ids);
       }
     },
-    [handleAction, onActionSubmit],
+    [handleAction, onActionProcessed],
   );
 
   return { handleTaskRunAction };
@@ -370,6 +375,7 @@ const BaseActionButton = ({
   icon,
   label,
   showModal,
+  onActionProcessed,
   onActionSubmit,
 }: {
   disabled: boolean;
@@ -377,10 +383,14 @@ const BaseActionButton = ({
   icon: JSX.Element;
   label: string;
   showModal: boolean;
-  onActionSubmit: (ids: string[]) => void;
+  onActionProcessed: (ids: string[]) => void;
+  onActionSubmit: () => void;
 }) => {
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
-  const { handleTaskRunAction } = useTaskRunActions({ onActionSubmit });
+  const { handleTaskRunAction } = useTaskRunActions({
+    onActionProcessed,
+    onActionSubmit,
+  });
 
   const handleAction = useCallback(() => {
     if (params.externalIds?.length) {
@@ -434,13 +444,15 @@ export const TaskRunActionButton = ({
   disabled,
   params,
   showModal,
+  onActionProcessed,
   onActionSubmit,
 }: {
   actionType: ActionType;
   disabled: boolean;
   params: BaseTaskRunActionParams;
   showModal: boolean;
-  onActionSubmit: (ids: string[]) => void;
+  onActionProcessed: (ids: string[]) => void;
+  onActionSubmit: () => void;
 }) => {
   switch (actionType) {
     case 'cancel':
@@ -451,6 +463,7 @@ export const TaskRunActionButton = ({
           icon={<XCircleIcon className="w-4 h-4" />}
           label={'Cancel'}
           showModal={showModal}
+          onActionProcessed={onActionProcessed}
           onActionSubmit={onActionSubmit}
         />
       );
@@ -462,6 +475,7 @@ export const TaskRunActionButton = ({
           icon={<ArrowPathIcon className="w-4 h-4" />}
           label={'Replay'}
           showModal={showModal}
+          onActionProcessed={onActionProcessed}
           onActionSubmit={onActionSubmit}
         />
       );

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/header.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/header.tsx
@@ -37,7 +37,7 @@ export const V1RunDetailHeader = () => {
     isLoading: loading,
   } = useWorkflowDetails();
 
-  const onActionSubmit = useCallback(
+  const onActionProcessed = useCallback(
     (action: 'cancel' | 'replay') => {
       const prefix = action === 'cancel' ? 'Canceling' : 'Replaying';
 
@@ -97,14 +97,26 @@ export const V1RunDetailHeader = () => {
                 !TASK_RUN_TERMINAL_STATUSES.includes(workflowRun.status)
               }
               showModal={false}
-              onActionSubmit={() => onActionSubmit('replay')}
+              onActionProcessed={() => onActionProcessed('replay')}
+              onActionSubmit={() => {
+                toast({
+                  title: 'Replay request submitted',
+                  description: "No need to hit 'Replay' again.",
+                });
+              }}
             />
             <TaskRunActionButton
               actionType="cancel"
               params={{ externalIds: [workflowRun.metadata.id] }}
               disabled={TASK_RUN_TERMINAL_STATUSES.includes(workflowRun.status)}
               showModal={false}
-              onActionSubmit={() => onActionSubmit('cancel')}
+              onActionProcessed={() => onActionProcessed('cancel')}
+              onActionSubmit={() => {
+                toast({
+                  title: 'Cancel request submitted',
+                  description: "No need to hit 'Cancel' again.",
+                });
+              }}
             />
           </div>
         </div>

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail.tsx
@@ -113,7 +113,7 @@ export const TaskRunDetail = ({
     },
   });
 
-  const onActionSubmit = useCallback(
+  const onActionProcessed = useCallback(
     (action: 'cancel' | 'replay') => {
       const prefix = action === 'cancel' ? 'Canceling' : 'Replaying';
 
@@ -169,14 +169,26 @@ export const TaskRunDetail = ({
           params={{ externalIds: [taskRunId] }}
           disabled={!TASK_RUN_TERMINAL_STATUSES.includes(taskRun.status)}
           showModal={false}
-          onActionSubmit={() => onActionSubmit('replay')}
+          onActionProcessed={() => onActionProcessed('replay')}
+          onActionSubmit={() => {
+            toast({
+              title: 'Replay request submitted',
+              description: "No need to hit 'Replay' again.",
+            });
+          }}
         />
         <TaskRunActionButton
           actionType="cancel"
           params={{ externalIds: [taskRunId] }}
           disabled={TASK_RUN_TERMINAL_STATUSES.includes(taskRun.status)}
           showModal={false}
-          onActionSubmit={() => onActionSubmit('cancel')}
+          onActionProcessed={() => onActionProcessed('cancel')}
+          onActionSubmit={() => {
+            toast({
+              title: 'Cancel request submitted',
+              description: "No need to hit 'Cancel' again.",
+            });
+          }}
         />
         <TaskRunPermalinkOrBacklink
           taskRun={taskRun}

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table.tsx
@@ -194,7 +194,7 @@ export function TaskRunsTable({
 
   const isFetching = !hasLoaded && (isTaskRunsFetching || isMetricsFetching);
 
-  const onActionSubmit = useCallback(
+  const onActionProcessed = useCallback(
     (action: 'cancel' | 'replay', ids: string[]) => {
       const prefix = action === 'cancel' ? 'Canceling' : 'Replaying';
       const count = ids.length;
@@ -228,7 +228,13 @@ export function TaskRunsTable({
             : { filter: v1TaskFilters }
         }
         showModal
-        onActionSubmit={(ids) => onActionSubmit('cancel', ids)}
+        onActionProcessed={(ids) => onActionProcessed('cancel', ids)}
+        onActionSubmit={() => {
+          toast({
+            title: 'Cancel request submitted',
+            description: "No need to hit 'Cancel' again.",
+          });
+        }}
       />,
       <TaskRunActionButton
         key="replay"
@@ -243,7 +249,13 @@ export function TaskRunsTable({
             : { filter: v1TaskFilters }
         }
         showModal
-        onActionSubmit={(ids) => onActionSubmit('replay', ids)}
+        onActionProcessed={(ids) => onActionProcessed('replay', ids)}
+        onActionSubmit={() => {
+          toast({
+            title: 'Replay request submitted',
+            description: "No need to hit 'Replay' again.",
+          });
+        }}
       />,
       <Button
         key="refresh"
@@ -285,8 +297,9 @@ export function TaskRunsTable({
     refetchTaskRuns,
     refetchMetrics,
     rotate,
-    onActionSubmit,
+    onActionProcessed,
     taskIdsPendingAction.length,
+    toast,
   ]);
 
   const handleSetSelectedAdditionalMetaRunId = useCallback(

--- a/internal/services/admin/v1/server.go
+++ b/internal/services/admin/v1/server.go
@@ -254,6 +254,7 @@ func (a *AdminServiceImpl) ReplayTasks(ctx context.Context, req *contracts.Repla
 				RetryCount: task.RetryCount,
 			},
 			WorkflowRunExternalId: task.WorkflowRunID,
+			TaskExternalId:        task.ExternalID,
 		}
 
 		if _, exists := existingReplays[record]; exists {
@@ -326,7 +327,7 @@ func (a *AdminServiceImpl) ReplayTasks(ctx context.Context, req *contracts.Repla
 		}
 
 		for _, task := range batch {
-			replayedIds = append(replayedIds, task.WorkflowRunExternalId.String())
+			replayedIds = append(replayedIds, task.TaskExternalId.String())
 		}
 
 		time.Sleep(200 * time.Millisecond)

--- a/internal/services/admin/v1/server.go
+++ b/internal/services/admin/v1/server.go
@@ -252,9 +252,10 @@ func (a *AdminServiceImpl) ReplayTasks(ctx context.Context, req *contracts.Repla
 
 	for _, task := range tasks {
 		record := v1.TaskIdInsertedAtRetryCount{
-			Id:         task.ID,
-			InsertedAt: task.InsertedAt,
-			RetryCount: task.RetryCount,
+			Id:                    task.ID,
+			InsertedAt:            task.InsertedAt,
+			RetryCount:            task.RetryCount,
+			WorkflowRunExternalId: &task.WorkflowRunExternalID,
 		}
 
 		if _, exists := taskIdInsertedAtRetryCountToExternalId[record]; !exists {

--- a/internal/services/admin/v1/server.go
+++ b/internal/services/admin/v1/server.go
@@ -256,12 +256,15 @@ func (a *AdminServiceImpl) ReplayTasks(ctx context.Context, req *contracts.Repla
 			InsertedAt: task.InsertedAt,
 			RetryCount: task.RetryCount,
 		}
-		tasksToReplay = append(tasksToReplay, TaskIdInsertedAtRetryCountWithWorkflowRunId{
-			TaskIdInsertedAtRetryCount: record,
-			WorkflowRunId:              task.WorkflowRunExternalID,
-		})
 
-		taskIdInsertedAtRetryCountToExternalId[record] = task.WorkflowRunExternalID
+		if _, exists := taskIdInsertedAtRetryCountToExternalId[record]; !exists {
+			tasksToReplay = append(tasksToReplay, TaskIdInsertedAtRetryCountWithWorkflowRunId{
+				TaskIdInsertedAtRetryCount: record,
+				WorkflowRunId:              task.WorkflowRunExternalID,
+			})
+
+			taskIdInsertedAtRetryCountToExternalId[record] = task.WorkflowRunExternalID
+		}
 	}
 
 	workflowRunIdToTasksToReplay := make(map[pgtype.UUID][]v1.TaskIdInsertedAtRetryCount)

--- a/internal/services/shared/tasktypes/v1/task.go
+++ b/internal/services/shared/tasktypes/v1/task.go
@@ -191,8 +191,13 @@ type CancelTasksPayload struct {
 	Tasks []v1.TaskIdInsertedAtRetryCount `json:"tasks"`
 }
 
+type TaskIdInsertedAtRetryCountWithExternalId struct {
+	v1.TaskIdInsertedAtRetryCount `json:"task"`
+	WorkflowRunExternalId         pgtype.UUID `json:"workflow_run_external_id,omitempty"`
+}
+
 type ReplayTasksPayload struct {
-	Tasks []v1.TaskIdInsertedAtRetryCount `json:"tasks"`
+	Tasks []TaskIdInsertedAtRetryCountWithExternalId `json:"tasks"`
 }
 
 type NotifyFinalizedPayload struct {

--- a/internal/services/shared/tasktypes/v1/task.go
+++ b/internal/services/shared/tasktypes/v1/task.go
@@ -194,6 +194,7 @@ type CancelTasksPayload struct {
 type TaskIdInsertedAtRetryCountWithExternalId struct {
 	v1.TaskIdInsertedAtRetryCount `json:"task"`
 	WorkflowRunExternalId         pgtype.UUID `json:"workflow_run_external_id,omitempty"`
+	TaskExternalId                pgtype.UUID `json:"task_external_id,omitempty"`
 }
 
 type ReplayTasksPayload struct {

--- a/pkg/repository/v1/task.go
+++ b/pkg/repository/v1/task.go
@@ -111,9 +111,6 @@ type TaskIdInsertedAtRetryCount struct {
 
 	// (required) the retry count
 	RetryCount int32
-
-	// (optional - used for replays) the workflow run external id
-	WorkflowRunExternalId *pgtype.UUID
 }
 
 type TaskIdInsertedAtSignalKey struct {

--- a/pkg/repository/v1/task.go
+++ b/pkg/repository/v1/task.go
@@ -111,6 +111,9 @@ type TaskIdInsertedAtRetryCount struct {
 
 	// (required) the retry count
 	RetryCount int32
+
+	// (optional - used for replays) the workflow run external id
+	WorkflowRunExternalId *pgtype.UUID
 }
 
 type TaskIdInsertedAtSignalKey struct {
@@ -2436,7 +2439,7 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId string, t
 		return nil, err
 	}
 
-	err = r.queries.AdvisoryLock(ctx, tx, hash("replay_" + tenantId))
+	err = r.queries.AdvisoryLock(ctx, tx, hash("replay_"+tenantId))
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to acquire advisory lock: %w", err)


### PR DESCRIPTION
# Description

Attempting to fix a couple replay bugs:

1. Optimistically showing one toast to say the request was submitted
2. Batching by workflow run id
3. Deduplicating ids before returning to the FE

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

