### PR TITLE
Add notice that prom metrics only work with v1 tenants

### DIFF
--- a/frontend/docs/pages/home/prometheus-metrics.mdx
+++ b/frontend/docs/pages/home/prometheus-metrics.mdx
@@ -10,9 +10,7 @@ Hatchet exports Prometheus Metrics for your tenant which can be scraped with ser
 
 ## Tenant Metrics
 
-<Callout type="warning">
-  Only works with v1 tenants
-</Callout>
+<Callout type="warning">Only works with v1 tenants</Callout>
 
 Metrics for individual tenants are available in Prometheus Text Format via a REST API endpoint.
 

--- a/frontend/docs/pages/home/prometheus-metrics.mdx
+++ b/frontend/docs/pages/home/prometheus-metrics.mdx
@@ -3,12 +3,16 @@ import { Callout } from "nextra/components";
 # Prometheus Metrics
 
 <Callout type="info">
-  Only available in the Growth tier and above on Hatchet Cloud.
+  Only available in the Growth tier and above on Hatchet Cloud
 </Callout>
 
 Hatchet exports Prometheus Metrics for your tenant which can be scraped with services like Grafana and DataDog.
 
 ## Tenant Metrics
+
+<Callout type="warning">
+  Only works with v1 tenants
+</Callout>
 
 Metrics for individual tenants are available in Prometheus Text Format via a REST API endpoint.
 

--- a/frontend/docs/pages/self-hosting/prometheus-metrics.mdx
+++ b/frontend/docs/pages/self-hosting/prometheus-metrics.mdx
@@ -2,9 +2,7 @@ import { Callout } from "nextra/components";
 
 ## Prometheus Metrics for Hatchet
 
-<Callout type="warning">
-  Only works with v1 tenants
-</Callout>
+<Callout type="warning">Only works with v1 tenants</Callout>
 
 This document provides an overview of the Prometheus metrics exposed by Hatchet, setup instructions for the metrics endpoint, and example PromQL queries to analyze them.
 

--- a/frontend/docs/pages/self-hosting/prometheus-metrics.mdx
+++ b/frontend/docs/pages/self-hosting/prometheus-metrics.mdx
@@ -1,4 +1,10 @@
+import { Callout } from "nextra/components";
+
 ## Prometheus Metrics for Hatchet
+
+<Callout type="warning">
+  Only works with v1 tenants
+</Callout>
 
 This document provides an overview of the Prometheus metrics exposed by Hatchet, setup instructions for the metrics endpoint, and example PromQL queries to analyze them.
 


### PR DESCRIPTION
# Description

Prometheus metrics work only with v1 tenants and we should add a notice about it in the docs.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Documentation change (pure documentation change)