### PR TITLE
Fix: Improve `UpdateDAGStatuses` and `UpdateTaskStatuses`

### DIFF
--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -1140,10 +1140,21 @@ func (r *OLAPRepositoryImpl) UpdateTaskStatuses(ctx context.Context, tenantIds [
 
 			defer rollback()
 
+			minInsertedAt, err := r.queries.FindMinInsertedAtForTaskStatusUpdates(ctx, tx, sqlcv1.FindMinInsertedAtForTaskStatusUpdatesParams{
+				Partitionnumber: int32(partitionNumber), // nolint: gosec
+				Tenantids:       tenantIdUUIDs,
+				Eventlimit:      limit,
+			})
+
+			if err != nil {
+				return fmt.Errorf("failed to find min inserted at for task status updates: %w", err)
+			}
+
 			statusUpdateRes, err := r.queries.UpdateTaskStatuses(ctx, tx, sqlcv1.UpdateTaskStatusesParams{
 				Partitionnumber: int32(partitionNumber), // nolint: gosec
 				Tenantids:       tenantIdUUIDs,
 				Eventlimit:      limit,
+				Mininsertedat:   minInsertedAt,
 			})
 
 			if err != nil {

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -1218,10 +1218,21 @@ func (r *OLAPRepositoryImpl) UpdateDAGStatuses(ctx context.Context, tenantIds []
 
 			defer rollback()
 
+			minInsertedAt, err := r.queries.FindMinInsertedAtForDAGStatusUpdates(ctx, tx, sqlcv1.FindMinInsertedAtForDAGStatusUpdatesParams{
+				Partitionnumber: int32(partitionNumber), // nolint: gosec
+				Tenantids:       tenantIdUUIDs,
+				Eventlimit:      limit,
+			})
+
+			if err != nil {
+				return fmt.Errorf("failed to find min inserted at for DAG status updates: %w", err)
+			}
+
 			statusUpdateRes, err := r.queries.UpdateDAGStatuses(ctx, tx, sqlcv1.UpdateDAGStatusesParams{
 				Partitionnumber: int32(partitionNumber), // nolint: gosec
 				Tenantids:       tenantIdUUIDs,
 				Eventlimit:      limit,
+				Mininsertedat:   minInsertedAt,
 			})
 
 			if err != nil {

--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -819,7 +819,7 @@ WITH tenants AS (
 )
 
 SELECT
-    MIN(u.inserted_at)
+    MIN(u.dag_inserted_at)::TIMESTAMPTZ AS min_inserted_at
 FROM tenants t,
     LATERAL list_task_status_updates_tmp(
         @partitionNumber::int,

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -212,7 +212,7 @@ WITH tenants AS (
 )
 
 SELECT
-    MIN(u.inserted_at)
+    MIN(u.dag_inserted_at)::TIMESTAMPTZ AS min_inserted_at
 FROM tenants t,
     LATERAL list_task_status_updates_tmp(
         $1::int,
@@ -227,11 +227,11 @@ type FindMinInsertedAtForDAGStatusUpdatesParams struct {
 	Tenantids       []pgtype.UUID `json:"tenantids"`
 }
 
-func (q *Queries) FindMinInsertedAtForDAGStatusUpdates(ctx context.Context, db DBTX, arg FindMinInsertedAtForDAGStatusUpdatesParams) (interface{}, error) {
+func (q *Queries) FindMinInsertedAtForDAGStatusUpdates(ctx context.Context, db DBTX, arg FindMinInsertedAtForDAGStatusUpdatesParams) (pgtype.Timestamptz, error) {
 	row := db.QueryRow(ctx, findMinInsertedAtForDAGStatusUpdates, arg.Partitionnumber, arg.Eventlimit, arg.Tenantids)
-	var min interface{}
-	err := row.Scan(&min)
-	return min, err
+	var min_inserted_at pgtype.Timestamptz
+	err := row.Scan(&min_inserted_at)
+	return min_inserted_at, err
 }
 
 const flattenTasksByExternalIds = `-- name: FlattenTasksByExternalIds :many

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -2351,11 +2351,14 @@ WITH tenants AS (
         d.total_tasks
     FROM
         v1_dags_olap d
-    JOIN
-        distinct_dags dd ON
-            (d.tenant_id, d.id, d.inserted_at) = (dd.tenant_id, dd.dag_id, dd.dag_inserted_at)
+    WHERE (d.inserted_at, d.id, d.tenant_id) IN (
+        SELECT
+            dd.dag_inserted_at, dd.dag_id, dd.tenant_id
+        FROM
+            distinct_dags dd
+    )
     ORDER BY
-        d.id, d.inserted_at
+        d.inserted_at, d.id
     FOR UPDATE
 ), dag_task_counts AS (
     SELECT
@@ -2409,10 +2412,11 @@ WITH tenants AS (
         e.dag_inserted_at
     FROM
         locked_events e
-    LEFT JOIN
-        locked_dags d ON (e.tenant_id, e.dag_id, e.dag_inserted_at) = (d.tenant_id, d.id, d.inserted_at)
-    WHERE
-        d.id IS NULL
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM locked_dags d
+        WHERE (e.dag_inserted_at, e.dag_id, e.tenant_id) = (d.inserted_at, d.id, d.tenant_id)
+    )
 ), deleted_events AS (
     DELETE FROM
         v1_task_status_updates_tmp


### PR DESCRIPTION
# Description

Some small optimizations for the `UpdateDAGStatuses` query

1. Using PKs for more joins, orders, etc.
2. Wrote a "setup" query to do partition pruning by first selected the min inserted at to consider, and then using that to prune partitions so we need to scan fewer of them

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

