### PR TITLE
Fix: Validate payloads + metadata and error on illegal unicode

### DIFF
--- a/api/v1/server/handlers/workflows/create_cron.go
+++ b/api/v1/server/handlers/workflows/create_cron.go
@@ -1,6 +1,7 @@
 package workflows
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/labstack/echo/v4"
@@ -31,6 +32,26 @@ func (t *WorkflowService) CronWorkflowTriggerCreate(ctx echo.Context, request ge
 
 	if request.Body.Priority != nil {
 		priority = *request.Body.Priority
+	}
+
+	inputBytes, err := json.Marshal(request.Body.Input)
+
+	if err != nil {
+		return gen.CronWorkflowTriggerCreate400JSONResponse(apierrors.NewAPIErrors("invalid input format")), nil
+	}
+
+	if err := repository.ValidateJSONB(inputBytes, "input"); err != nil {
+		return gen.CronWorkflowTriggerCreate400JSONResponse(apierrors.NewAPIErrors(err.Error())), nil
+	}
+
+	additionalMetaBytes, err := json.Marshal(request.Body.AdditionalMetadata)
+
+	if err != nil {
+		return gen.CronWorkflowTriggerCreate400JSONResponse(apierrors.NewAPIErrors("invalid additional metadata format")), nil
+	}
+
+	if err := repository.ValidateJSONB(additionalMetaBytes, "additionalMetadata"); err != nil {
+		return gen.CronWorkflowTriggerCreate400JSONResponse(apierrors.NewAPIErrors(err.Error())), nil
 	}
 
 	cronTrigger, err := t.config.APIRepository.Workflow().CreateCronWorkflow(

--- a/internal/services/admin/server.go
+++ b/internal/services/admin/server.go
@@ -369,13 +369,23 @@ func (a *AdminServiceImpl) ScheduleWorkflow(ctx context.Context, req *contracts.
 		additionalMetadata = []byte(*req.AdditionalMetadata)
 	}
 
+	if err := repository.ValidateJSONB(additionalMetadata, "additionalMetadata"); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Invalid request: %s", err)
+	}
+
+	payloadBytes := []byte(req.Input)
+
+	if err := repository.ValidateJSONB(payloadBytes, "payload"); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Invalid request: %s", err)
+	}
+
 	scheduledRef, err := a.repo.Workflow().CreateSchedules(
 		ctx,
 		tenantId,
 		workflowVersionId,
 		&repository.CreateWorkflowSchedulesOpts{
 			ScheduledTriggers:  dbSchedules,
-			Input:              []byte(req.Input),
+			Input:              payloadBytes,
 			AdditionalMetadata: additionalMetadata,
 			Priority:           req.Priority,
 		},

--- a/internal/services/admin/server_v1.go
+++ b/internal/services/admin/server_v1.go
@@ -8,6 +8,7 @@ import (
 	msgqueue "github.com/hatchet-dev/hatchet/internal/msgqueue/v1"
 	"github.com/hatchet-dev/hatchet/internal/services/admin/contracts"
 	tasktypes "github.com/hatchet-dev/hatchet/internal/services/shared/tasktypes/v1"
+	"github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/postgres/dbsqlc"
 	"github.com/hatchet-dev/hatchet/pkg/repository/postgres/sqlchelpers"
 	v1 "github.com/hatchet-dev/hatchet/pkg/repository/v1"
@@ -62,6 +63,14 @@ func (a *AdminServiceImpl) triggerWorkflowV1(ctx context.Context, req *contracts
 
 	if err != nil {
 		return nil, fmt.Errorf("could not create trigger opt: %w", err)
+	}
+
+	if err := repository.ValidateJSONB(opt.Data, "payload"); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Invalid request: %s", err)
+	}
+
+	if err := repository.ValidateJSONB(opt.AdditionalMetadata, "additionalMetadata"); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Invalid request: %s", err)
 	}
 
 	err = a.generateExternalIds(ctx, tenantId, []*v1.WorkflowNameTriggerOpts{opt})

--- a/internal/services/admin/server_v1.go
+++ b/internal/services/admin/server_v1.go
@@ -107,6 +107,14 @@ func (a *AdminServiceImpl) bulkTriggerWorkflowV1(ctx context.Context, req *contr
 			return nil, fmt.Errorf("could not create trigger opt: %w", err)
 		}
 
+		if err := repository.ValidateJSONB(opt.Data, "payload"); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "Invalid request: %s", err)
+		}
+
+		if err := repository.ValidateJSONB(opt.AdditionalMetadata, "additionalMetadata"); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "Invalid request: %s", err)
+		}
+
 		opts[i] = opt
 	}
 

--- a/internal/services/dispatcher/server_v1.go
+++ b/internal/services/dispatcher/server_v1.go
@@ -556,7 +556,6 @@ func (s *DispatcherImpl) sendStepActionEventV1(ctx context.Context, request *con
 
 	if request.EventType == contracts.StepActionEventType_STEP_EVENT_TYPE_COMPLETED {
 		if err := repository.ValidateJSONB([]byte(request.EventPayload), "taskOutput"); err != nil {
-			fmt.Println("Invalid JSONB payload for task output:", err)
 			request.EventPayload = err.Error()
 			request.EventType = contracts.StepActionEventType_STEP_EVENT_TYPE_FAILED
 		}

--- a/internal/services/ingestor/server.go
+++ b/internal/services/ingestor/server.go
@@ -28,6 +28,16 @@ func (i *IngestorImpl) Push(ctx context.Context, req *contracts.PushEventRequest
 		additionalMeta = []byte(*req.AdditionalMetadata)
 	}
 
+	if err := repository.ValidateJSONB(&additionalMeta, "additionalMetadata"); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Invalid request: %s", err)
+	}
+
+	payloadBytes := []byte(req.Payload)
+
+	if err := repository.ValidateJSONB(&payloadBytes, "payload"); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Invalid request: %s", err)
+	}
+
 	event, err := i.IngestEvent(ctx, tenant, req.Key, []byte(req.Payload), additionalMeta, req.Priority, req.Scope)
 
 	if err == metered.ErrResourceExhausted {
@@ -68,10 +78,21 @@ func (i *IngestorImpl) BulkPush(ctx context.Context, req *contracts.BulkPushEven
 		if e.AdditionalMetadata != nil {
 			additionalMeta = []byte(*e.AdditionalMetadata)
 		}
+
+		if err := repository.ValidateJSONB(&additionalMeta, "additionalMetadata"); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "Invalid request: %s", err)
+		}
+
+		payloadBytes := []byte(e.Payload)
+
+		if err := repository.ValidateJSONB(&payloadBytes, "payload"); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "Invalid request: %s", err)
+		}
+
 		events = append(events, &repository.CreateEventOpts{
 			TenantId:           tenantId,
 			Key:                e.Key,
-			Data:               []byte(e.Payload),
+			Data:               payloadBytes,
 			AdditionalMetadata: additionalMeta,
 			Priority:           e.Priority,
 			Scope:              e.Scope,

--- a/internal/services/ingestor/server.go
+++ b/internal/services/ingestor/server.go
@@ -28,13 +28,13 @@ func (i *IngestorImpl) Push(ctx context.Context, req *contracts.PushEventRequest
 		additionalMeta = []byte(*req.AdditionalMetadata)
 	}
 
-	if err := repository.ValidateJSONB(&additionalMeta, "additionalMetadata"); err != nil {
+	if err := repository.ValidateJSONB(additionalMeta, "additionalMetadata"); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid request: %s", err)
 	}
 
 	payloadBytes := []byte(req.Payload)
 
-	if err := repository.ValidateJSONB(&payloadBytes, "payload"); err != nil {
+	if err := repository.ValidateJSONB(payloadBytes, "payload"); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid request: %s", err)
 	}
 
@@ -79,13 +79,13 @@ func (i *IngestorImpl) BulkPush(ctx context.Context, req *contracts.BulkPushEven
 			additionalMeta = []byte(*e.AdditionalMetadata)
 		}
 
-		if err := repository.ValidateJSONB(&additionalMeta, "additionalMetadata"); err != nil {
+		if err := repository.ValidateJSONB(additionalMeta, "additionalMetadata"); err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "Invalid request: %s", err)
 		}
 
 		payloadBytes := []byte(e.Payload)
 
-		if err := repository.ValidateJSONB(&payloadBytes, "payload"); err != nil {
+		if err := repository.ValidateJSONB(payloadBytes, "payload"); err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "Invalid request: %s", err)
 		}
 

--- a/internal/services/ingestor/server_v1.go
+++ b/internal/services/ingestor/server_v1.go
@@ -8,6 +8,7 @@ import (
 	msgqueue "github.com/hatchet-dev/hatchet/internal/msgqueue/v1"
 	"github.com/hatchet-dev/hatchet/internal/services/ingestor/contracts"
 	tasktypes "github.com/hatchet-dev/hatchet/internal/services/shared/tasktypes/v1"
+	"github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/postgres/dbsqlc"
 	"github.com/hatchet-dev/hatchet/pkg/repository/postgres/sqlchelpers"
 	v1 "github.com/hatchet-dev/hatchet/pkg/repository/v1"
@@ -113,6 +114,10 @@ func (i *IngestorImpl) putLogV1(ctx context.Context, tenant *dbsqlc.Tenant, req 
 		return nil, err
 	} else if apiErrors != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid request: %s", apiErrors.String())
+	}
+
+	if err := repository.ValidateJSONB(opts.Metadata, "additionalMetadata"); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Invalid request: %s", err)
 	}
 
 	err = i.repov1.Logs().PutLog(ctx, tenantId, opts)

--- a/pkg/repository/jsonb.go
+++ b/pkg/repository/jsonb.go
@@ -5,12 +5,12 @@ import (
 	"strings"
 )
 
-func ValidateJSONB(jsonb *[]byte, fieldName string) error {
-	if jsonb == nil || len(*jsonb) == 0 {
+func ValidateJSONB(jsonb []byte, fieldName string) error {
+	if len(jsonb) == 0 {
 		return nil
 	}
 
-	if strings.Contains(string(*jsonb), "\\u0000") {
+	if strings.Contains(string(jsonb), "\\u0000") {
 		return fmt.Errorf("encoded jsonb contains invalid null character \\u0000 in field `%s`", fieldName)
 	}
 

--- a/pkg/repository/jsonb.go
+++ b/pkg/repository/jsonb.go
@@ -1,0 +1,18 @@
+package repository
+
+import (
+	"fmt"
+	"strings"
+)
+
+func ValidateJSONB(jsonb *[]byte, fieldName string) error {
+	if jsonb == nil || len(*jsonb) == 0 {
+		return nil
+	}
+
+	if strings.Contains(string(*jsonb), "\\u0000") {
+		return fmt.Errorf("encoded jsonb contains invalid null character \\u0000 in field `%s`", fieldName)
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Description

Attempting to fix The Unicode Error with the `\u0000` escape sequence being illegal in JSONB in PG by:

1. Throwing 400s out of various endpoints (event push, workflow trigger, schedule create, cron create)
2. Marking a task that returned that in the payload as failed instead of succeeded, and overwriting the task's output to show the error (so it propagates to the UI)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
