### PR TITLE
[Python] Fix: Don't retry gRPC requests on 4xx

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixes a bug in `aio_sleep_for` and the `SleepCondition` that did not allow duplicate sleeps to be awaited correctly.
+- Stops retrying gRPC requests on 4XX failures, since retrying won't help
 
 ## [1.16.2] - 2025-07-22
 

--- a/sdks/python/hatchet_sdk/clients/rest/tenacity_utils.py
+++ b/sdks/python/hatchet_sdk/clients/rest/tenacity_utils.py
@@ -33,5 +33,9 @@ def tenacity_should_retry(ex: BaseException) -> bool:
         return ex.code() not in [
             grpc.StatusCode.UNIMPLEMENTED,
             grpc.StatusCode.NOT_FOUND,
+            grpc.StatusCode.INVALID_ARGUMENT,
+            grpc.StatusCode.ALREADY_EXISTS,
+            grpc.StatusCode.UNAUTHENTICATED,
+            grpc.StatusCode.PERMISSION_DENIED,
         ]
     return False


### PR DESCRIPTION
# Description

Removing retries for 4XX-level gRPC errors

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

