### PR TITLE
Update types to be covariant

### DIFF
--- a/sdks/python/hatchet_sdk/runnables/types.py
+++ b/sdks/python/hatchet_sdk/runnables/types.py
@@ -14,7 +14,7 @@ from hatchet_sdk.utils.typing import AwaitableLike, JSONSerializableMapping
 
 ValidTaskReturnType = BaseModel | JSONSerializableMapping | None
 
-R = TypeVar("R", bound=ValidTaskReturnType)
+R = TypeVar("R", bound=ValidTaskReturnType, covariant=True)
 P = ParamSpec("P")
 
 
@@ -56,7 +56,7 @@ class ConcurrencyExpression(BaseModel):
         )
 
 
-TWorkflowInput = TypeVar("TWorkflowInput", bound=BaseModel)
+TWorkflowInput = TypeVar("TWorkflowInput", bound=BaseModel, covariant=True)
 
 
 class TaskDefaults(BaseModel):


### PR DESCRIPTION
# Description

Allowing `TWorkflowInput` and `R` to be `covariant` allows base specs for input/output schemas to be shared among tasks/workflows, and then to have those tasks/workflows to be grouped up and resolve to their common in/output types.


## Type of change

<!-- Please delete options that are not relevant. -->

- [x ] New feature (non-breaking change which adds functionality)

## What's Changed

- [ ] `runnables.types.TWorkflowInput`
- [ ] `runnables.types.R`

