### PR TITLE
fix: only reacquire lease if expiring

### DIFF
--- a/pkg/repository/postgres/scheduler_lease.go
+++ b/pkg/repository/postgres/scheduler_lease.go
@@ -41,16 +41,6 @@ func (d *leaseRepository) AcquireOrExtendLeases(ctx context.Context, tenantId pg
 
 	defer rollback()
 
-	err = d.queries.GetLeasesToAcquire(ctx, tx, dbsqlc.GetLeasesToAcquireParams{
-		Kind:        kind,
-		Resourceids: resourceIds,
-		Tenantid:    tenantId,
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
 	leases, err := d.queries.AcquireOrExtendLeases(ctx, tx, dbsqlc.AcquireOrExtendLeasesParams{
 		Kind:             kind,
 		Resourceids:      resourceIds,

--- a/pkg/repository/v1/scheduler_lease.go
+++ b/pkg/repository/v1/scheduler_lease.go
@@ -46,16 +46,6 @@ func (d *leaseRepository) AcquireOrExtendLeases(ctx context.Context, tenantId pg
 
 	defer rollback()
 
-	err = d.queries.GetLeasesToAcquire(ctx, tx, sqlcv1.GetLeasesToAcquireParams{
-		Kind:        kind,
-		Resourceids: resourceIds,
-		Tenantid:    tenantId,
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
 	leases, err := d.queries.AcquireOrExtendLeases(ctx, tx, sqlcv1.AcquireOrExtendLeasesParams{
 		Kind:             kind,
 		Resourceids:      resourceIds,


### PR DESCRIPTION
# Description

Fixes Excessive UPDATE operations on the Lease table causing high database load.
Every active worker/queue/concurrency strategy gets sent to AcquireOrExtendLeases() every second, triggering unnecessary lease updates.

The Scale
Frequency: Updates every 1 second
Scope: All active resources (workers + queues + concurrency strategies)
SQL Impact: ON CONFLICT ... DO UPDATE fires for every resource every second
Example: 10 workers + 5 queues = 15 updates/second = 1.3M updates/day

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## What's Changed

- [x] only write the lease update if close to expiration
