### PR TITLE
Fix: Partition pruning for `PreflightCheckTasksForReplay`

### DIFF
--- a/pkg/repository/v1/sqlcv1/tasks.sql
+++ b/pkg/repository/v1/sqlcv1/tasks.sql
@@ -820,21 +820,18 @@ WITH input AS (
         UNNEST(@taskIds::bigint[]) AS task_id,
         UNNEST(@taskInsertedAts::timestamptz[]) AS task_inserted_at
 ), relevant_tasks AS (
-    SELECT
-        t.id,
-        t.dag_id
+    SELECT *
     FROM
         v1_task t
     JOIN
         input i ON i.task_id = t.id AND i.task_inserted_at = t.inserted_at
     WHERE
+        -- prune partitions with minInsertedAt
         t.inserted_at >= @minInsertedAt::TIMESTAMPTZ
 )
 
-SELECT t.*
+SELECT t.id, t.dag_id
 FROM relevant_tasks t
-LEFT JOIN
-    v1_task_event e ON e.task_id = t.id AND e.task_inserted_at = t.inserted_at AND e.retry_count = t.retry_count AND e.event_type = ANY('{COMPLETED, FAILED, CANCELLED}'::v1_task_event_type[])
 LEFT JOIN
     v1_task_runtime tr ON tr.task_id = t.id AND tr.task_inserted_at = t.inserted_at AND tr.retry_count = t.retry_count
 LEFT JOIN
@@ -843,8 +840,17 @@ LEFT JOIN
     v1_retry_queue_item rqi ON rqi.task_id = t.id AND rqi.task_inserted_at = t.inserted_at AND rqi.task_retry_count = t.retry_count
 WHERE
     t.tenant_id = @tenantId::uuid
-    AND e.id IS NULL
-    AND (tr.task_id IS NOT NULL OR cs.task_id IS NOT NULL OR rqi.task_id IS NOT NULL);
+    AND NOT EXISTS (
+        SELECT 1
+        FROM v1_task_event e
+        WHERE
+            -- prune partitions with minInsertedAt
+            e.task_inserted_at >= @minInsertedAt::TIMESTAMPTZ
+            AND (e.task_id, e.task_inserted_at, e.retry_count) = (t.id, t.inserted_at, t.retry_count)
+            AND e.event_type = ANY('{COMPLETED, FAILED, CANCELLED}'::v1_task_event_type[])
+    )
+    AND (tr.task_id IS NOT NULL OR cs.task_id IS NOT NULL OR rqi.task_id IS NOT NULL)
+;
 
 -- name: ListAllTasksInDags :many
 SELECT

--- a/pkg/repository/v1/sqlcv1/tasks.sql
+++ b/pkg/repository/v1/sqlcv1/tasks.sql
@@ -842,6 +842,7 @@ LEFT JOIN
     v1_retry_queue_item rqi ON rqi.task_id = t.id AND rqi.task_inserted_at = t.inserted_at AND rqi.task_retry_count = t.retry_count
 WHERE
     t.tenant_id = @tenantId::uuid
+    AND t.inserted_at >= @minInsertedAt::TIMESTAMPTZ
     AND e.id IS NULL
     AND (tr.task_id IS NOT NULL OR cs.task_id IS NOT NULL OR rqi.task_id IS NOT NULL);
 

--- a/pkg/repository/v1/sqlcv1/tasks.sql
+++ b/pkg/repository/v1/sqlcv1/tasks.sql
@@ -817,21 +817,22 @@ FROM
 -- concurrency slots, or retry queue items. Returns the tasks which cannot be replayed.
 WITH input AS (
     SELECT
-        *
+        UNNEST(@taskIds::bigint[]) AS task_id,
+        UNNEST(@taskInsertedAts::timestamptz[]) AS task_inserted_at
+), relevant_tasks AS (
+    SELECT
+        t.id,
+        t.dag_id
     FROM
-        (
-            SELECT
-                unnest(@taskIds::bigint[]) AS task_id,
-                unnest(@taskInsertedAts::timestamptz[]) AS task_inserted_at
-        ) AS subquery
+        v1_task t
+    JOIN
+        input i ON i.task_id = t.id AND i.task_inserted_at = t.inserted_at
+    WHERE
+        t.inserted_at >= @minInsertedAt::TIMESTAMPTZ
 )
-SELECT
-    t.id,
-    t.dag_id
-FROM
-    v1_task t
-JOIN
-    input i ON i.task_id = t.id AND i.task_inserted_at = t.inserted_at
+
+SELECT t.*
+FROM relevant_tasks t
 LEFT JOIN
     v1_task_event e ON e.task_id = t.id AND e.task_inserted_at = t.inserted_at AND e.retry_count = t.retry_count AND e.event_type = ANY('{COMPLETED, FAILED, CANCELLED}'::v1_task_event_type[])
 LEFT JOIN
@@ -842,7 +843,6 @@ LEFT JOIN
     v1_retry_queue_item rqi ON rqi.task_id = t.id AND rqi.task_inserted_at = t.inserted_at AND rqi.task_retry_count = t.retry_count
 WHERE
     t.tenant_id = @tenantId::uuid
-    AND t.inserted_at >= @minInsertedAt::TIMESTAMPTZ
     AND e.id IS NULL
     AND (tr.task_id IS NOT NULL OR cs.task_id IS NOT NULL OR rqi.task_id IS NOT NULL);
 

--- a/pkg/repository/v1/sqlcv1/tasks.sql.go
+++ b/pkg/repository/v1/sqlcv1/tasks.sql.go
@@ -1643,24 +1643,21 @@ func (q *Queries) PreflightCheckDAGsForReplay(ctx context.Context, db DBTX, arg 
 const preflightCheckTasksForReplay = `-- name: PreflightCheckTasksForReplay :many
 WITH input AS (
     SELECT
-        UNNEST($2::bigint[]) AS task_id,
-        UNNEST($3::timestamptz[]) AS task_inserted_at
+        UNNEST($3::bigint[]) AS task_id,
+        UNNEST($4::timestamptz[]) AS task_inserted_at
 ), relevant_tasks AS (
-    SELECT
-        t.id,
-        t.dag_id
+    SELECT id, inserted_at, tenant_id, queue, action_id, step_id, step_readable_id, workflow_id, workflow_version_id, workflow_run_id, schedule_timeout, step_timeout, priority, sticky, desired_worker_id, external_id, display_name, input, retry_count, internal_retry_count, app_retry_count, step_index, additional_metadata, dag_id, dag_inserted_at, parent_task_external_id, parent_task_id, parent_task_inserted_at, child_index, child_key, initial_state, initial_state_reason, concurrency_parent_strategy_ids, concurrency_strategy_ids, concurrency_keys, retry_backoff_factor, retry_max_backoff, task_id, task_inserted_at
     FROM
         v1_task t
     JOIN
         input i ON i.task_id = t.id AND i.task_inserted_at = t.inserted_at
     WHERE
-        t.inserted_at >= $4::TIMESTAMPTZ
+        -- prune partitions with minInsertedAt
+        t.inserted_at >= $2::TIMESTAMPTZ
 )
 
 SELECT t.id, t.dag_id
 FROM relevant_tasks t
-LEFT JOIN
-    v1_task_event e ON e.task_id = t.id AND e.task_inserted_at = t.inserted_at AND e.retry_count = t.retry_count AND e.event_type = ANY('{COMPLETED, FAILED, CANCELLED}'::v1_task_event_type[])
 LEFT JOIN
     v1_task_runtime tr ON tr.task_id = t.id AND tr.task_inserted_at = t.inserted_at AND tr.retry_count = t.retry_count
 LEFT JOIN
@@ -1669,15 +1666,23 @@ LEFT JOIN
     v1_retry_queue_item rqi ON rqi.task_id = t.id AND rqi.task_inserted_at = t.inserted_at AND rqi.task_retry_count = t.retry_count
 WHERE
     t.tenant_id = $1::uuid
-    AND e.id IS NULL
+    AND NOT EXISTS (
+        SELECT 1
+        FROM v1_task_event e
+        WHERE
+            -- prune partitions with minInsertedAt
+            e.task_inserted_at >= $2::TIMESTAMPTZ
+            AND (e.task_id, e.task_inserted_at, e.retry_count) = (t.id, t.inserted_at, t.retry_count)
+            AND e.event_type = ANY('{COMPLETED, FAILED, CANCELLED}'::v1_task_event_type[])
+    )
     AND (tr.task_id IS NOT NULL OR cs.task_id IS NOT NULL OR rqi.task_id IS NOT NULL)
 `
 
 type PreflightCheckTasksForReplayParams struct {
 	Tenantid        pgtype.UUID          `json:"tenantid"`
+	Mininsertedat   pgtype.Timestamptz   `json:"mininsertedat"`
 	Taskids         []int64              `json:"taskids"`
 	Taskinsertedats []pgtype.Timestamptz `json:"taskinsertedats"`
-	Mininsertedat   pgtype.Timestamptz   `json:"mininsertedat"`
 }
 
 type PreflightCheckTasksForReplayRow struct {
@@ -1690,9 +1695,9 @@ type PreflightCheckTasksForReplayRow struct {
 func (q *Queries) PreflightCheckTasksForReplay(ctx context.Context, db DBTX, arg PreflightCheckTasksForReplayParams) ([]*PreflightCheckTasksForReplayRow, error) {
 	rows, err := db.Query(ctx, preflightCheckTasksForReplay,
 		arg.Tenantid,
+		arg.Mininsertedat,
 		arg.Taskids,
 		arg.Taskinsertedats,
-		arg.Mininsertedat,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/repository/v1/task.go
+++ b/pkg/repository/v1/task.go
@@ -420,7 +420,7 @@ func (r *sharedRepository) lookupExternalIds(ctx context.Context, tx sqlcv1.DBTX
 func (r *TaskRepositoryImpl) verifyAllTasksFinalized(ctx context.Context, tx sqlcv1.DBTX, tenantId string, flattenedTasks []*sqlcv1.FlattenExternalIdsRow) ([]string, map[string]int64, error) {
 	taskIdsToCheck := make([]int64, 0, len(flattenedTasks))
 	taskIdsToTasks := make(map[int64]*sqlcv1.FlattenExternalIdsRow)
-	minInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now().Add(-24 * time.Hour)) // 1d ago as a placeholder
+	minInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now()) // current time as a placeholder - will be overwritten
 
 	for _, task := range flattenedTasks {
 		taskIdsToCheck = append(taskIdsToCheck, task.ID)
@@ -2473,7 +2473,7 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId string, t
 	subtreeStepIds := make(map[int64]map[string]bool) // dag id -> step id -> true
 	subtreeExternalIds := make(map[string]struct{})
 	dagIdsToLockMap := make(map[int64]struct{})
-	minInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now().Add(-time.Hour * 24)) // 1d ago as a placeholder
+	minInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now()) // current time as a placeholder - will be overwritten
 
 	for i, task := range lockedTasks {
 		lockedTaskIds[i] = task.ID

--- a/pkg/repository/v1/task.go
+++ b/pkg/repository/v1/task.go
@@ -420,7 +420,7 @@ func (r *sharedRepository) lookupExternalIds(ctx context.Context, tx sqlcv1.DBTX
 func (r *TaskRepositoryImpl) verifyAllTasksFinalized(ctx context.Context, tx sqlcv1.DBTX, tenantId string, flattenedTasks []*sqlcv1.FlattenExternalIdsRow) ([]string, map[string]int64, error) {
 	taskIdsToCheck := make([]int64, 0, len(flattenedTasks))
 	taskIdsToTasks := make(map[int64]*sqlcv1.FlattenExternalIdsRow)
-	minInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now().Add(-1 * r.taskRetentionPeriod))
+	minInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now().Add(-24 * time.Hour)) // 1d ago as a placeholder
 
 	for _, task := range flattenedTasks {
 		taskIdsToCheck = append(taskIdsToCheck, task.ID)
@@ -2473,7 +2473,7 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId string, t
 	subtreeStepIds := make(map[int64]map[string]bool) // dag id -> step id -> true
 	subtreeExternalIds := make(map[string]struct{})
 	dagIdsToLockMap := make(map[int64]struct{})
-	minInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now().Add(-time.Hour * 24 * 14)) // 14d ago as a placeholder
+	minInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now().Add(-time.Hour * 24)) // 1d ago as a placeholder
 
 	for i, task := range lockedTasks {
 		lockedTaskIds[i] = task.ID


### PR DESCRIPTION
# Description

Pruning partitions in `PreflightCheckTasksForReplay` by passing a `minInsertedAt` time

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

