### PR TITLE
Fix: filter lookup not retaining scope information

### DIFF
--- a/pkg/repository/v1/sqlcv1/filters.sql
+++ b/pkg/repository/v1/sqlcv1/filters.sql
@@ -91,7 +91,7 @@ GROUP BY workflow_id
 
 -- name: ListFiltersForEventTriggers :many
 WITH inputs AS (
-    SELECT
+    SELECT DISTINCT
         UNNEST(sqlc.narg(workflowIds)::UUID[]) AS workflow_id,
         UNNEST(sqlc.narg(scopes)::TEXT[]) AS scope
 )

--- a/pkg/repository/v1/sqlcv1/filters.sql.go
+++ b/pkg/repository/v1/sqlcv1/filters.sql.go
@@ -312,7 +312,7 @@ func (q *Queries) ListFilters(ctx context.Context, db DBTX, arg ListFiltersParam
 
 const listFiltersForEventTriggers = `-- name: ListFiltersForEventTriggers :many
 WITH inputs AS (
-    SELECT
+    SELECT DISTINCT
         UNNEST($4::UUID[]) AS workflow_id,
         UNNEST($5::TEXT[]) AS scope
 )

--- a/pkg/repository/v1/trigger.go
+++ b/pkg/repository/v1/trigger.go
@@ -319,7 +319,7 @@ func (r *TriggerRepositoryImpl) TriggerFromEvents(ctx context.Context, tenantId 
 		hasAnyFilters := numFilters > 0
 
 		for _, opt := range opts {
-			var filters []*sqlcv1.V1Filter
+			var filters = []*sqlcv1.V1Filter{}
 
 			if opt.Scope != nil {
 				key := WorkflowAndScope{

--- a/sdks/python/examples/events/test_event.py
+++ b/sdks/python/examples/events/test_event.py
@@ -44,6 +44,7 @@ async def event_filter(
     test_run_id: str,
     expression: str | None = None,
     payload: dict[str, str] = {},
+    scope: str | None = None,
 ) -> AsyncGenerator[None, None]:
     expression = (
         expression
@@ -53,7 +54,7 @@ async def event_filter(
     f = await hatchet.filters.aio_create(
         workflow_id=event_workflow.id,
         expression=expression,
-        scope=test_run_id,
+        scope=scope or test_run_id,
         payload={"test_run_id": test_run_id, **payload},
     )
 
@@ -529,3 +530,40 @@ async def test_multiple_runs_for_multiple_scope_matches(
             assert len(runs) == 2
 
             assert {r.output.get("filter_id") for r in runs} == {"1", "2"}
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_multi_scope_bug(hatchet: Hatchet, test_run_id: str) -> None:
+    async with event_filter(hatchet, test_run_id, expression="1 == 1", scope="a"):
+        async with event_filter(
+            hatchet,
+            test_run_id,
+            expression="2 == 2",
+            scope="b",
+        ):
+            events = await hatchet.event.aio_bulk_push(
+                [
+                    BulkPushEventWithMetadata(
+                        key=EVENT_KEY,
+                        payload={
+                            "should_skip": False,
+                        },
+                        additional_metadata={
+                            "should_have_runs": True,
+                            "test_run_id": test_run_id,
+                        },
+                        scope="a" if i % 2 == 0 else "b",
+                    )
+                    for i in range(100)
+                ],
+            )
+
+            await asyncio.sleep(15)
+
+            for event in events:
+                runs = await hatchet.runs.aio_list(
+                    triggering_event_external_id=event.eventId,
+                    additional_metadata={"test_run_id": test_run_id},
+                )
+
+                assert len(runs.rows) == 1


### PR DESCRIPTION
# Description

Fixing an issue where multiple messages are read off the queue with events that reference the same workflow, but many different scopes. We'd create a single mapping with a workflow id to a list of filters, but this was incorrect because it'd intermingle the scopes from the different events. Instead, we need to key on both the workflow id _and_ the scope.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
