### PR TITLE
fix: revert lease updates

### DIFF
--- a/pkg/repository/postgres/dbsqlc/lease.sql
+++ b/pkg/repository/postgres/dbsqlc/lease.sql
@@ -34,10 +34,7 @@ SET
     "expiresAt" = EXCLUDED."expiresAt"
 WHERE
     "Lease"."expiresAt" < now() OR
-    (
-        "Lease"."id" = ANY(@existingLeaseIds::bigint[]) AND
-        "Lease"."expiresAt" < now() + INTERVAL '10 seconds'
-    )
+    "Lease"."id" = ANY(@existingLeaseIds::bigint[])
 RETURNING *;
 
 -- name: ReleaseLeases :many

--- a/pkg/repository/postgres/dbsqlc/lease.sql.go
+++ b/pkg/repository/postgres/dbsqlc/lease.sql.go
@@ -32,10 +32,7 @@ SET
     "expiresAt" = EXCLUDED."expiresAt"
 WHERE
     "Lease"."expiresAt" < now() OR
-    (
-        "Lease"."id" = ANY($5::bigint[]) AND
-        "Lease"."expiresAt" < now() + INTERVAL '10 seconds'
-    )
+    "Lease"."id" = ANY($5::bigint[])
 RETURNING id, "expiresAt", "tenantId", "resourceId", kind
 `
 


### PR DESCRIPTION
# Description

Reverts the update to the leasing logic as it introduces a bug where leases are canceled often because we don't return them from the query. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)