### PR TITLE
Relax prometheus-client version constraint to ">=0.22" to avoid dependency conflicts

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -32,7 +32,7 @@ opentelemetry-instrumentation = { version = ">=0.49b0", optional = true }
 opentelemetry-distro = { version = ">=0.49b0", optional = true }
 opentelemetry-exporter-otlp = { version = "^1.28.0", optional = true }
 opentelemetry-exporter-otlp-proto-http = { version = "^1.28.0", optional = true }
-prometheus-client = "^0.21.1"
+prometheus-client = ">=0.22",
 pydantic-settings = "^2.7.1"
 
 [tool.poetry.group.lint.dependencies]


### PR DESCRIPTION
# Description

This MR relaxes the version constraint of `prometheus-client` from `^0.21.1` to `>=0.22`. The reason for this change is that the previous constraint was too strict and caused dependency conflicts in Poetry when used alongside other packages that require a newer version. Since `prometheus-client>=0.22` is backward compatible, this update is safe and avoids unnecessary version resolution issues.

Fixes # (none)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (changes which are not directly related to any business logic)

## What's Changed

- Updated `pyproject.toml` to change `prometheus-client = "^0.21.1"` to `prometheus-client = ">=0.22"`
