### PR TITLE
[Python]: Flag to enable / disable gRPC fork support, modify valid task return type

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.4] - 2025-07-28
+
+### Added
+
+- Adds a new config option `grpc_enable_fork_support` to allow users to enable or disable gRPC fork support. This is useful for environments where gRPC fork support is not needed or causes issues. Previously was set to `False` by default, which would cause issues with e.g. Gunicorn setups. Can also be set with the `HATCHET_CLIENT_GRPC_ENABLE_FORK_SUPPORT` environment variable.
+
 ## [1.16.3] - 2025-07-23
 
 ### Added

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Adds a new config option `grpc_enable_fork_support` to allow users to enable or disable gRPC fork support. This is useful for environments where gRPC fork support is not needed or causes issues. Previously was set to `False` by default, which would cause issues with e.g. Gunicorn setups. Can also be set with the `HATCHET_CLIENT_GRPC_ENABLE_FORK_SUPPORT` environment variable.
 
+### Changed
+
+- Changes `ValidTaskReturnType` to allow `Mapping[str, Any]` instead of `dict[str, Any]` to allow for more flexible return types in tasks, including using `TypedDict`.
+
 ## [1.16.3] - 2025-07-23
 
 ### Added

--- a/sdks/python/hatchet_sdk/config.py
+++ b/sdks/python/hatchet_sdk/config.py
@@ -1,6 +1,6 @@
 import json
 from logging import Logger, getLogger
-from typing import overload
+from typing import Literal, overload
 
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -84,6 +84,7 @@ class ClientConfig(BaseSettings):
 
     terminate_worker_after_num_tasks: int | None = None
     disable_log_capture: bool = False
+    grpc_enable_fork_support: Literal["True", "False"] = "False"
 
     @model_validator(mode="after")
     def validate_token_and_tenant(self) -> "ClientConfig":

--- a/sdks/python/hatchet_sdk/config.py
+++ b/sdks/python/hatchet_sdk/config.py
@@ -1,6 +1,6 @@
 import json
 from logging import Logger, getLogger
-from typing import Literal, overload
+from typing import overload
 
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -84,7 +84,7 @@ class ClientConfig(BaseSettings):
 
     terminate_worker_after_num_tasks: int | None = None
     disable_log_capture: bool = False
-    grpc_enable_fork_support: Literal["True", "False"] = "False"
+    grpc_enable_fork_support: bool = False
 
     @model_validator(mode="after")
     def validate_token_and_tenant(self) -> "ClientConfig":

--- a/sdks/python/hatchet_sdk/connection.py
+++ b/sdks/python/hatchet_sdk/connection.py
@@ -60,7 +60,7 @@ def new_conn(config: ClientConfig, aio: bool) -> grpc.Channel | grpc.aio.Channel
 
     # Set environment variable to disable fork support. Reference: https://github.com/grpc/grpc/issues/28557
     # When steps execute via os.fork, we see `TSI_DATA_CORRUPTED` errors.
-    os.environ["GRPC_ENABLE_FORK_SUPPORT"] = "False"
+    os.environ["GRPC_ENABLE_FORK_SUPPORT"] = config.grpc_enable_fork_support
 
     if config.tls_config.strategy == "none":
         conn = start.insecure_channel(

--- a/sdks/python/hatchet_sdk/connection.py
+++ b/sdks/python/hatchet_sdk/connection.py
@@ -60,7 +60,12 @@ def new_conn(config: ClientConfig, aio: bool) -> grpc.Channel | grpc.aio.Channel
 
     # Set environment variable to disable fork support. Reference: https://github.com/grpc/grpc/issues/28557
     # When steps execute via os.fork, we see `TSI_DATA_CORRUPTED` errors.
-    os.environ["GRPC_ENABLE_FORK_SUPPORT"] = config.grpc_enable_fork_support
+    # needs to be the string "True" or "False"
+    os.environ["GRPC_ENABLE_FORK_SUPPORT"] = str(config.grpc_enable_fork_support)
+
+    if config.grpc_enable_fork_support:
+        # See discussion: https://github.com/hatchet-dev/hatchet/pull/2057#discussion_r2243233357
+        os.environ["GRPC_POLL_STRATEGY"] = "poll"
 
     if config.tls_config.strategy == "none":
         conn = start.insecure_channel(

--- a/sdks/python/hatchet_sdk/runnables/types.py
+++ b/sdks/python/hatchet_sdk/runnables/types.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from enum import Enum
 from typing import Any, ParamSpec, TypeGuard, TypeVar
 
@@ -12,7 +12,7 @@ from hatchet_sdk.contracts.v1.workflows_pb2 import DefaultFilter as DefaultFilte
 from hatchet_sdk.utils.timedelta_to_expression import Duration
 from hatchet_sdk.utils.typing import AwaitableLike, JSONSerializableMapping
 
-ValidTaskReturnType = BaseModel | JSONSerializableMapping | None
+ValidTaskReturnType = BaseModel | Mapping[str, Any] | None
 
 R = TypeVar("R", bound=ValidTaskReturnType)
 P = ParamSpec("P")

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.16.3"
+version = "1.16.4"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
# Description

## [1.16.4] - 2025-07-28

### Added

- Adds a new config option `grpc_enable_fork_support` to allow users to enable or disable gRPC fork support. This is useful for environments where gRPC fork support is not needed or causes issues. Previously was set to `False` by default, which would cause issues with e.g. Gunicorn setups. Can also be set with the `HATCHET_CLIENT_GRPC_ENABLE_FORK_SUPPORT` environment variable.

### Changed

- Changes `ValidTaskReturnType` to allow `Mapping[str, Any]` instead of `dict[str, Any]` to allow for more flexible return types in tasks, including using `TypedDict`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

