### PR TITLE
fix: remove essential pool to prevent bottleneck on heartbeats

### DIFF
--- a/pkg/config/database/config.go
+++ b/pkg/config/database/config.go
@@ -56,8 +56,6 @@ type Layer struct {
 
 	Pool *pgxpool.Pool
 
-	EssentialPool *pgxpool.Pool
-
 	ReadReplicaPool *pgxpool.Pool
 
 	QueuePool *pgxpool.Pool

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -188,23 +188,6 @@ func (c *ConfigLoader) InitDataLayer() (res *database.Layer, err error) {
 		config.BeforeAcquire = debugger.beforeAcquire
 	}
 
-	// a smaller pool for essential services like the heartbeat
-	essentialConfig := config.Copy()
-	essentialConfig.MinConns = 1
-
-	essentialConfig.MaxConns /= 100
-	if essentialConfig.MaxConns < 1 {
-		essentialConfig.MaxConns = 1
-	}
-
-	config.MaxConns -= essentialConfig.MaxConns
-
-	essentialPool, err := pgxpool.NewWithConfig(context.Background(), essentialConfig)
-
-	if err != nil {
-		return nil, fmt.Errorf("could not connect to database: %w", err)
-	}
-
 	pool, err := pgxpool.NewWithConfig(context.Background(), config)
 
 	if err != nil {
@@ -257,7 +240,7 @@ func (c *ConfigLoader) InitDataLayer() (res *database.Layer, err error) {
 		opts = append(opts, postgresdb.WithLogsEngineRepository(c.RepositoryOverrides.LogsEngineRepository))
 	}
 
-	cleanupEngine, engineRepo, err := postgresdb.NewEngineRepository(pool, essentialPool, &scf.Runtime, opts...)
+	cleanupEngine, engineRepo, err := postgresdb.NewEngineRepository(pool, &scf.Runtime, opts...)
 
 	if err != nil {
 		return nil, fmt.Errorf("could not create engine repository: %w", err)
@@ -301,7 +284,6 @@ func (c *ConfigLoader) InitDataLayer() (res *database.Layer, err error) {
 			return cleanupApiRepo()
 		},
 		Pool:                  pool,
-		EssentialPool:         essentialPool,
 		QueuePool:             pool,
 		APIRepository:         apiRepo,
 		EngineRepository:      engineRepo,

--- a/pkg/repository/postgres/dispatcher.go
+++ b/pkg/repository/postgres/dispatcher.go
@@ -14,22 +14,20 @@ import (
 )
 
 type dispatcherRepository struct {
-	pool          *pgxpool.Pool
-	essentialPool *pgxpool.Pool
-	v             validator.Validator
-	queries       *dbsqlc.Queries
-	l             *zerolog.Logger
+	pool    *pgxpool.Pool
+	v       validator.Validator
+	queries *dbsqlc.Queries
+	l       *zerolog.Logger
 }
 
-func NewDispatcherRepository(pool *pgxpool.Pool, essentialPool *pgxpool.Pool, v validator.Validator, l *zerolog.Logger) repository.DispatcherEngineRepository {
+func NewDispatcherRepository(pool *pgxpool.Pool, v validator.Validator, l *zerolog.Logger) repository.DispatcherEngineRepository {
 	queries := dbsqlc.New()
 
 	return &dispatcherRepository{
-		pool:          pool,
-		essentialPool: essentialPool,
-		queries:       queries,
-		v:             v,
-		l:             l,
+		pool:    pool,
+		queries: queries,
+		v:       v,
+		l:       l,
 	}
 }
 
@@ -46,7 +44,7 @@ func (d *dispatcherRepository) UpdateDispatcher(ctx context.Context, dispatcherI
 		return nil, err
 	}
 
-	return d.queries.UpdateDispatcher(ctx, d.essentialPool, dbsqlc.UpdateDispatcherParams{
+	return d.queries.UpdateDispatcher(ctx, d.pool, dbsqlc.UpdateDispatcherParams{
 		ID:              sqlchelpers.UUIDFromStr(dispatcherId),
 		LastHeartbeatAt: sqlchelpers.TimestampFromTime(opts.LastHeartbeatAt.UTC()),
 	})

--- a/pkg/repository/postgres/repository.go
+++ b/pkg/repository/postgres/repository.go
@@ -329,7 +329,7 @@ func (r *engineRepository) MessageQueue() repository.MessageQueueRepository {
 	return r.mq
 }
 
-func NewEngineRepository(pool *pgxpool.Pool, essentialPool *pgxpool.Pool, cf *server.ConfigFileRuntime, fs ...PostgresRepositoryOpt) (func() error, repository.EngineRepository, error) {
+func NewEngineRepository(pool *pgxpool.Pool, cf *server.ConfigFileRuntime, fs ...PostgresRepositoryOpt) (func() error, repository.EngineRepository, error) {
 	opts := defaultPostgresRepositoryOpts()
 
 	for _, f := range fs {
@@ -376,7 +376,7 @@ func NewEngineRepository(pool *pgxpool.Pool, essentialPool *pgxpool.Pool, cf *se
 		}, &engineRepository{
 			health:         NewHealthEngineRepository(pool),
 			apiToken:       NewAPITokenRepository(shared, opts.cache),
-			dispatcher:     NewDispatcherRepository(pool, essentialPool, opts.v, opts.l),
+			dispatcher:     NewDispatcherRepository(pool, opts.v, opts.l),
 			event:          NewEventEngineRepository(shared, opts.metered, cf.EventBuffer),
 			getGroupKeyRun: NewGetGroupKeyRunRepository(pool, opts.v, opts.l),
 			jobRun:         NewJobRunEngineRepository(shared),
@@ -385,7 +385,7 @@ func NewEngineRepository(pool *pgxpool.Pool, essentialPool *pgxpool.Pool, cf *se
 			tenant:         NewTenantEngineRepository(pool, opts.v, opts.l, opts.cache),
 			tenantAlerting: NewTenantAlertingRepository(shared, opts.cache),
 			ticker:         NewTickerRepository(pool, opts.v, opts.l),
-			worker:         NewWorkerEngineRepository(pool, essentialPool, opts.v, opts.l, opts.metered),
+			worker:         NewWorkerEngineRepository(pool, opts.v, opts.l, opts.metered),
 			workflow:       NewWorkflowEngineRepository(shared, opts.metered, opts.cache),
 			workflowRun:    NewWorkflowRunEngineRepository(shared, opts.metered, cf),
 			streamEvent:    NewStreamEventsEngineRepository(pool, opts.v, opts.l),

--- a/pkg/repository/postgres/worker.go
+++ b/pkg/repository/postgres/worker.go
@@ -207,24 +207,22 @@ func (w *workerAPIRepository) UpdateWorker(tenantId, workerId string, opts repos
 }
 
 type workerEngineRepository struct {
-	pool          *pgxpool.Pool
-	essentialPool *pgxpool.Pool
-	v             validator.Validator
-	queries       *dbsqlc.Queries
-	l             *zerolog.Logger
-	m             *metered.Metered
+	pool    *pgxpool.Pool
+	v       validator.Validator
+	queries *dbsqlc.Queries
+	l       *zerolog.Logger
+	m       *metered.Metered
 }
 
-func NewWorkerEngineRepository(pool *pgxpool.Pool, essentialPool *pgxpool.Pool, v validator.Validator, l *zerolog.Logger, m *metered.Metered) repository.WorkerEngineRepository {
+func NewWorkerEngineRepository(pool *pgxpool.Pool, v validator.Validator, l *zerolog.Logger, m *metered.Metered) repository.WorkerEngineRepository {
 	queries := dbsqlc.New()
 
 	return &workerEngineRepository{
-		pool:          pool,
-		essentialPool: essentialPool,
-		v:             v,
-		queries:       queries,
-		l:             l,
-		m:             m,
+		pool:    pool,
+		v:       v,
+		queries: queries,
+		l:       l,
+		m:       m,
 	}
 }
 
@@ -500,8 +498,7 @@ func (w *workerEngineRepository) UpdateWorker(ctx context.Context, tenantId, wor
 }
 
 func (w *workerEngineRepository) UpdateWorkerHeartbeat(ctx context.Context, tenantId, workerId string, lastHeartbeat time.Time) error {
-
-	_, err := w.queries.UpdateWorkerHeartbeat(ctx, w.essentialPool, dbsqlc.UpdateWorkerHeartbeatParams{
+	_, err := w.queries.UpdateWorkerHeartbeat(ctx, w.pool, dbsqlc.UpdateWorkerHeartbeatParams{
 		ID:              sqlchelpers.UUIDFromStr(workerId),
 		LastHeartbeatAt: sqlchelpers.TimestampFromTime(lastHeartbeat),
 	})


### PR DESCRIPTION
# Description

On most deployments of the engine we only have 1 connection available which artificially bottlenecks heartbeats. This was needed when the `grpc-api` layer of the engine did much more work than it currently does. Connections shouldn't be under contention anymore so we're better off trying to utilize all connections.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)