### PR TITLE
Update worker active status only when needed

### DIFF
--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -461,7 +461,7 @@ func (s *DispatcherImpl) ListenV2(request *contracts.WorkerListenRequest, stream
 
 	sessionEstablished := time.Now().UTC()
 
-	_, err = s.repo.Worker().UpdateWorkerActiveStatus(ctx, tenantId, request.WorkerId, true, sessionEstablished)
+	err = s.repo.Worker().UpdateWorkerActiveStatus(ctx, tenantId, request.WorkerId, true, sessionEstablished)
 
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -498,7 +498,7 @@ func (s *DispatcherImpl) ListenV2(request *contracts.WorkerListenRequest, stream
 		case <-fin:
 			s.l.Debug().Msgf("closing stream for worker id: %s", request.WorkerId)
 
-			_, err = s.repo.Worker().UpdateWorkerActiveStatus(ctx, tenantId, request.WorkerId, false, sessionEstablished)
+			err = s.repo.Worker().UpdateWorkerActiveStatus(ctx, tenantId, request.WorkerId, false, sessionEstablished)
 
 			if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 				s.l.Error().Err(err).Msgf("could not update worker %s active status to false due to worker stream closing (session established %s)", request.WorkerId, sessionEstablished.String())
@@ -512,7 +512,7 @@ func (s *DispatcherImpl) ListenV2(request *contracts.WorkerListenRequest, stream
 			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 			defer cancel()
 
-			_, err = s.repo.Worker().UpdateWorkerActiveStatus(ctx, tenantId, request.WorkerId, false, sessionEstablished)
+			err = s.repo.Worker().UpdateWorkerActiveStatus(ctx, tenantId, request.WorkerId, false, sessionEstablished)
 
 			if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 				s.l.Error().Err(err).Msgf("could not update worker %s active status due to worker disconnecting (session established %s)", request.WorkerId, sessionEstablished.String())

--- a/pkg/repository/postgres/dbsqlc/workers.sql
+++ b/pkg/repository/postgres/dbsqlc/workers.sql
@@ -250,7 +250,7 @@ WHERE
   "webhookId" = @webhookId::uuid
 RETURNING *;
 
--- name: UpdateWorkerActiveStatus :one
+-- name: UpdateWorkerActiveStatus :exec
 UPDATE "Worker"
 SET
     "isActive" = @isActive::boolean,
@@ -258,10 +258,10 @@ SET
 WHERE
     "id" = @id::uuid
     AND (
-        "lastListenerEstablished" IS NULL
-        OR "lastListenerEstablished" <= sqlc.narg('lastListenerEstablished')::timestamp
-        )
-RETURNING *;
+        "isActive" != @isActive::boolean
+        OR "lastListenerEstablished" IS NULL
+        OR "lastListenerEstablished" < sqlc.narg('lastListenerEstablished')::timestamp - INTERVAL '100 milliseconds'
+    );
 
 -- name: ListWorkerLabels :many
 SELECT

--- a/pkg/repository/postgres/worker.go
+++ b/pkg/repository/postgres/worker.go
@@ -524,18 +524,18 @@ func (w *workerEngineRepository) UpdateWorkersByWebhookId(ctx context.Context, p
 	return err
 }
 
-func (w *workerEngineRepository) UpdateWorkerActiveStatus(ctx context.Context, tenantId, workerId string, isActive bool, timestamp time.Time) (*dbsqlc.Worker, error) {
-	worker, err := w.queries.UpdateWorkerActiveStatus(ctx, w.pool, dbsqlc.UpdateWorkerActiveStatusParams{
+func (w *workerEngineRepository) UpdateWorkerActiveStatus(ctx context.Context, tenantId, workerId string, isActive bool, timestamp time.Time) error {
+	err := w.queries.UpdateWorkerActiveStatus(ctx, w.pool, dbsqlc.UpdateWorkerActiveStatusParams{
 		ID:                      sqlchelpers.UUIDFromStr(workerId),
 		Isactive:                isActive,
 		LastListenerEstablished: sqlchelpers.TimestampFromTime(timestamp),
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("could not update worker active status: %w", err)
+		return fmt.Errorf("could not update worker active status: %w", err)
 	}
 
-	return worker, nil
+	return nil
 }
 
 func (w *workerEngineRepository) UpsertWorkerLabels(ctx context.Context, workerId pgtype.UUID, opts []repository.UpsertWorkerLabelOpts) ([]*dbsqlc.WorkerLabel, error) {

--- a/pkg/repository/worker.go
+++ b/pkg/repository/worker.go
@@ -112,7 +112,7 @@ type WorkerEngineRepository interface {
 
 	GetWorkerForEngine(ctx context.Context, tenantId, workerId string) (*dbsqlc.GetWorkerForEngineRow, error)
 
-	UpdateWorkerActiveStatus(ctx context.Context, tenantId, workerId string, isActive bool, timestamp time.Time) (*dbsqlc.Worker, error)
+	UpdateWorkerActiveStatus(ctx context.Context, tenantId, workerId string, isActive bool, timestamp time.Time) error
 
 	UpsertWorkerLabels(ctx context.Context, workerId pgtype.UUID, opts []UpsertWorkerLabelOpts) ([]*dbsqlc.WorkerLabel, error)
 


### PR DESCRIPTION
# Description

We seem to be returning the entire `Worker` whenever we try to update worker active status.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)

## What's Changed

- [x] Do not return anything when updating worker active status
- [x] Prevent redundant updates in the span of 100 ms
