### PR TITLE
Refactor `RunWithMiddlewares` to use hatchetmiddleware 

### DIFF
--- a/api/v1/server/oas/gen/codegen.yaml
+++ b/api/v1/server/oas/gen/codegen.yaml
@@ -146,20 +146,17 @@ output-options:
     "strict/strict-echo.tmpl": >-
       type StrictHandlerFunc func(ctx echo.Context, args interface{}) (interface{}, error)
 
-      type StrictMiddlewareFunc func(f StrictHandlerFunc, operationID string) StrictHandlerFunc
-
-      func NewStrictHandler(ssi StrictServerInterface, middlewares []StrictMiddlewareFunc) ServerInterface {
-          return &strictHandler{ssi: ssi, middlewares: middlewares}
+      func NewStrictHandler(ssi StrictServerInterface) ServerInterface {
+          return &strictHandler{ssi: ssi}
       }
 
       type strictHandler struct {
           ssi StrictServerInterface
-          middlewares []StrictMiddlewareFunc
       }
 
       {{range .}}
           {{$opid := .OperationId}}
-          // {{$opid}} operation middleware
+          // {{$opid}} operation
           func (sh *strictHandler) {{.OperationId}}(ctx echo.Context{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params {{.OperationId}}Params{{end}}) error {
               var request {{$opid | ucFirst}}RequestObject
 
@@ -216,9 +213,6 @@ output-options:
 
               handler := func(ctx echo.Context, request interface{}) (interface{}, error){
                   return sh.ssi.{{.OperationId}}(ctx, request.({{$opid | ucFirst}}RequestObject))
-              }
-              for _, middleware := range sh.middlewares {
-                  handler = middleware(handler, "{{.OperationId}}")
               }
 
               response, err := handler(ctx, request)

--- a/api/v1/server/oas/gen/openapi.gen.go
+++ b/api/v1/server/oas/gen/openapi.gen.go
@@ -11165,26 +11165,21 @@ type StrictServerInterface interface {
 	WorkflowVersionGet(ctx echo.Context, request WorkflowVersionGetRequestObject) (WorkflowVersionGetResponseObject, error)
 }
 type StrictHandlerFunc func(ctx echo.Context, args interface{}) (interface{}, error)
-type StrictMiddlewareFunc func(f StrictHandlerFunc, operationID string) StrictHandlerFunc
 
-func NewStrictHandler(ssi StrictServerInterface, middlewares []StrictMiddlewareFunc) ServerInterface {
-	return &strictHandler{ssi: ssi, middlewares: middlewares}
+func NewStrictHandler(ssi StrictServerInterface) ServerInterface {
+	return &strictHandler{ssi: ssi}
 }
 
 type strictHandler struct {
-	ssi         StrictServerInterface
-	middlewares []StrictMiddlewareFunc
+	ssi StrictServerInterface
 }
 
-// LivenessGet operation middleware
+// LivenessGet operation
 func (sh *strictHandler) LivenessGet(ctx echo.Context) error {
 	var request LivenessGetRequestObject
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.LivenessGet(ctx, request.(LivenessGetRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "LivenessGet")
 	}
 
 	response, err := handler(ctx, request)
@@ -11199,15 +11194,12 @@ func (sh *strictHandler) LivenessGet(ctx echo.Context) error {
 	return nil
 }
 
-// ReadinessGet operation middleware
+// ReadinessGet operation
 func (sh *strictHandler) ReadinessGet(ctx echo.Context) error {
 	var request ReadinessGetRequestObject
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.ReadinessGet(ctx, request.(ReadinessGetRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "ReadinessGet")
 	}
 
 	response, err := handler(ctx, request)
@@ -11222,7 +11214,7 @@ func (sh *strictHandler) ReadinessGet(ctx echo.Context) error {
 	return nil
 }
 
-// AlertEmailGroupDelete operation middleware
+// AlertEmailGroupDelete operation
 func (sh *strictHandler) AlertEmailGroupDelete(ctx echo.Context, alertEmailGroup openapi_types.UUID) error {
 	var request AlertEmailGroupDeleteRequestObject
 
@@ -11230,9 +11222,6 @@ func (sh *strictHandler) AlertEmailGroupDelete(ctx echo.Context, alertEmailGroup
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.AlertEmailGroupDelete(ctx, request.(AlertEmailGroupDeleteRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "AlertEmailGroupDelete")
 	}
 
 	response, err := handler(ctx, request)
@@ -11247,7 +11236,7 @@ func (sh *strictHandler) AlertEmailGroupDelete(ctx echo.Context, alertEmailGroup
 	return nil
 }
 
-// AlertEmailGroupUpdate operation middleware
+// AlertEmailGroupUpdate operation
 func (sh *strictHandler) AlertEmailGroupUpdate(ctx echo.Context, alertEmailGroup openapi_types.UUID) error {
 	var request AlertEmailGroupUpdateRequestObject
 
@@ -11262,9 +11251,6 @@ func (sh *strictHandler) AlertEmailGroupUpdate(ctx echo.Context, alertEmailGroup
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.AlertEmailGroupUpdate(ctx, request.(AlertEmailGroupUpdateRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "AlertEmailGroupUpdate")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -11278,7 +11264,7 @@ func (sh *strictHandler) AlertEmailGroupUpdate(ctx echo.Context, alertEmailGroup
 	return nil
 }
 
-// ApiTokenUpdateRevoke operation middleware
+// ApiTokenUpdateRevoke operation
 func (sh *strictHandler) ApiTokenUpdateRevoke(ctx echo.Context, apiToken openapi_types.UUID) error {
 	var request ApiTokenUpdateRevokeRequestObject
 
@@ -11286,9 +11272,6 @@ func (sh *strictHandler) ApiTokenUpdateRevoke(ctx echo.Context, apiToken openapi
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.ApiTokenUpdateRevoke(ctx, request.(ApiTokenUpdateRevokeRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "ApiTokenUpdateRevoke")
 	}
 
 	response, err := handler(ctx, request)
@@ -11303,15 +11286,12 @@ func (sh *strictHandler) ApiTokenUpdateRevoke(ctx echo.Context, apiToken openapi
 	return nil
 }
 
-// CloudMetadataGet operation middleware
+// CloudMetadataGet operation
 func (sh *strictHandler) CloudMetadataGet(ctx echo.Context) error {
 	var request CloudMetadataGetRequestObject
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.CloudMetadataGet(ctx, request.(CloudMetadataGetRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "CloudMetadataGet")
 	}
 
 	response, err := handler(ctx, request)
@@ -11326,7 +11306,7 @@ func (sh *strictHandler) CloudMetadataGet(ctx echo.Context) error {
 	return nil
 }
 
-// EventGet operation middleware
+// EventGet operation
 func (sh *strictHandler) EventGet(ctx echo.Context, event openapi_types.UUID) error {
 	var request EventGetRequestObject
 
@@ -11334,9 +11314,6 @@ func (sh *strictHandler) EventGet(ctx echo.Context, event openapi_types.UUID) er
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.EventGet(ctx, request.(EventGetRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "EventGet")
 	}
 
 	response, err := handler(ctx, request)
@@ -11351,7 +11328,7 @@ func (sh *strictHandler) EventGet(ctx echo.Context, event openapi_types.UUID) er
 	return nil
 }
 
-// EventDataGet operation middleware
+// EventDataGet operation
 func (sh *strictHandler) EventDataGet(ctx echo.Context, event openapi_types.UUID) error {
 	var request EventDataGetRequestObject
 
@@ -11359,9 +11336,6 @@ func (sh *strictHandler) EventDataGet(ctx echo.Context, event openapi_types.UUID
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.EventDataGet(ctx, request.(EventDataGetRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "EventDataGet")
 	}
 
 	response, err := handler(ctx, request)
@@ -11376,15 +11350,12 @@ func (sh *strictHandler) EventDataGet(ctx echo.Context, event openapi_types.UUID
 	return nil
 }
 
-// MetadataGet operation middleware
+// MetadataGet operation
 func (sh *strictHandler) MetadataGet(ctx echo.Context) error {
 	var request MetadataGetRequestObject
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.MetadataGet(ctx, request.(MetadataGetRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "MetadataGet")
 	}
 
 	response, err := handler(ctx, request)
@@ -11399,15 +11370,12 @@ func (sh *strictHandler) MetadataGet(ctx echo.Context) error {
 	return nil
 }
 
-// MetadataListIntegrations operation middleware
+// MetadataListIntegrations operation
 func (sh *strictHandler) MetadataListIntegrations(ctx echo.Context) error {
 	var request MetadataListIntegrationsRequestObject
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.MetadataListIntegrations(ctx, request.(MetadataListIntegrationsRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "MetadataListIntegrations")
 	}
 
 	response, err := handler(ctx, request)
@@ -11422,7 +11390,7 @@ func (sh *strictHandler) MetadataListIntegrations(ctx echo.Context) error {
 	return nil
 }
 
-// MonitoringPostRunProbe operation middleware
+// MonitoringPostRunProbe operation
 func (sh *strictHandler) MonitoringPostRunProbe(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request MonitoringPostRunProbeRequestObject
 
@@ -11430,9 +11398,6 @@ func (sh *strictHandler) MonitoringPostRunProbe(ctx echo.Context, tenant openapi
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.MonitoringPostRunProbe(ctx, request.(MonitoringPostRunProbeRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "MonitoringPostRunProbe")
 	}
 
 	response, err := handler(ctx, request)
@@ -11447,7 +11412,7 @@ func (sh *strictHandler) MonitoringPostRunProbe(ctx echo.Context, tenant openapi
 	return nil
 }
 
-// SlackWebhookDelete operation middleware
+// SlackWebhookDelete operation
 func (sh *strictHandler) SlackWebhookDelete(ctx echo.Context, slack openapi_types.UUID) error {
 	var request SlackWebhookDeleteRequestObject
 
@@ -11455,9 +11420,6 @@ func (sh *strictHandler) SlackWebhookDelete(ctx echo.Context, slack openapi_type
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.SlackWebhookDelete(ctx, request.(SlackWebhookDeleteRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "SlackWebhookDelete")
 	}
 
 	response, err := handler(ctx, request)
@@ -11472,7 +11434,7 @@ func (sh *strictHandler) SlackWebhookDelete(ctx echo.Context, slack openapi_type
 	return nil
 }
 
-// SnsDelete operation middleware
+// SnsDelete operation
 func (sh *strictHandler) SnsDelete(ctx echo.Context, sns openapi_types.UUID) error {
 	var request SnsDeleteRequestObject
 
@@ -11480,9 +11442,6 @@ func (sh *strictHandler) SnsDelete(ctx echo.Context, sns openapi_types.UUID) err
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.SnsDelete(ctx, request.(SnsDeleteRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "SnsDelete")
 	}
 
 	response, err := handler(ctx, request)
@@ -11497,7 +11456,7 @@ func (sh *strictHandler) SnsDelete(ctx echo.Context, sns openapi_types.UUID) err
 	return nil
 }
 
-// SnsUpdate operation middleware
+// SnsUpdate operation
 func (sh *strictHandler) SnsUpdate(ctx echo.Context, tenant openapi_types.UUID, event string) error {
 	var request SnsUpdateRequestObject
 
@@ -11506,9 +11465,6 @@ func (sh *strictHandler) SnsUpdate(ctx echo.Context, tenant openapi_types.UUID, 
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.SnsUpdate(ctx, request.(SnsUpdateRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "SnsUpdate")
 	}
 
 	response, err := handler(ctx, request)
@@ -11523,7 +11479,7 @@ func (sh *strictHandler) SnsUpdate(ctx echo.Context, tenant openapi_types.UUID, 
 	return nil
 }
 
-// V1DagListTasks operation middleware
+// V1DagListTasks operation
 func (sh *strictHandler) V1DagListTasks(ctx echo.Context, params V1DagListTasksParams) error {
 	var request V1DagListTasksRequestObject
 
@@ -11531,9 +11487,6 @@ func (sh *strictHandler) V1DagListTasks(ctx echo.Context, params V1DagListTasksP
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1DagListTasks(ctx, request.(V1DagListTasksRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1DagListTasks")
 	}
 
 	response, err := handler(ctx, request)
@@ -11548,7 +11501,7 @@ func (sh *strictHandler) V1DagListTasks(ctx echo.Context, params V1DagListTasksP
 	return nil
 }
 
-// V1TaskGet operation middleware
+// V1TaskGet operation
 func (sh *strictHandler) V1TaskGet(ctx echo.Context, task openapi_types.UUID, params V1TaskGetParams) error {
 	var request V1TaskGetRequestObject
 
@@ -11557,9 +11510,6 @@ func (sh *strictHandler) V1TaskGet(ctx echo.Context, task openapi_types.UUID, pa
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1TaskGet(ctx, request.(V1TaskGetRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1TaskGet")
 	}
 
 	response, err := handler(ctx, request)
@@ -11574,7 +11524,7 @@ func (sh *strictHandler) V1TaskGet(ctx echo.Context, task openapi_types.UUID, pa
 	return nil
 }
 
-// V1LogLineList operation middleware
+// V1LogLineList operation
 func (sh *strictHandler) V1LogLineList(ctx echo.Context, task openapi_types.UUID) error {
 	var request V1LogLineListRequestObject
 
@@ -11582,9 +11532,6 @@ func (sh *strictHandler) V1LogLineList(ctx echo.Context, task openapi_types.UUID
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1LogLineList(ctx, request.(V1LogLineListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1LogLineList")
 	}
 
 	response, err := handler(ctx, request)
@@ -11599,7 +11546,7 @@ func (sh *strictHandler) V1LogLineList(ctx echo.Context, task openapi_types.UUID
 	return nil
 }
 
-// V1TaskEventList operation middleware
+// V1TaskEventList operation
 func (sh *strictHandler) V1TaskEventList(ctx echo.Context, task openapi_types.UUID, params V1TaskEventListParams) error {
 	var request V1TaskEventListRequestObject
 
@@ -11608,9 +11555,6 @@ func (sh *strictHandler) V1TaskEventList(ctx echo.Context, task openapi_types.UU
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1TaskEventList(ctx, request.(V1TaskEventListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1TaskEventList")
 	}
 
 	response, err := handler(ctx, request)
@@ -11625,7 +11569,7 @@ func (sh *strictHandler) V1TaskEventList(ctx echo.Context, task openapi_types.UU
 	return nil
 }
 
-// V1CelDebug operation middleware
+// V1CelDebug operation
 func (sh *strictHandler) V1CelDebug(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request V1CelDebugRequestObject
 
@@ -11640,9 +11584,6 @@ func (sh *strictHandler) V1CelDebug(ctx echo.Context, tenant openapi_types.UUID)
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1CelDebug(ctx, request.(V1CelDebugRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1CelDebug")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -11656,7 +11597,7 @@ func (sh *strictHandler) V1CelDebug(ctx echo.Context, tenant openapi_types.UUID)
 	return nil
 }
 
-// V1EventList operation middleware
+// V1EventList operation
 func (sh *strictHandler) V1EventList(ctx echo.Context, tenant openapi_types.UUID, params V1EventListParams) error {
 	var request V1EventListRequestObject
 
@@ -11665,9 +11606,6 @@ func (sh *strictHandler) V1EventList(ctx echo.Context, tenant openapi_types.UUID
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1EventList(ctx, request.(V1EventListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1EventList")
 	}
 
 	response, err := handler(ctx, request)
@@ -11682,7 +11620,7 @@ func (sh *strictHandler) V1EventList(ctx echo.Context, tenant openapi_types.UUID
 	return nil
 }
 
-// V1EventKeyList operation middleware
+// V1EventKeyList operation
 func (sh *strictHandler) V1EventKeyList(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request V1EventKeyListRequestObject
 
@@ -11690,9 +11628,6 @@ func (sh *strictHandler) V1EventKeyList(ctx echo.Context, tenant openapi_types.U
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1EventKeyList(ctx, request.(V1EventKeyListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1EventKeyList")
 	}
 
 	response, err := handler(ctx, request)
@@ -11707,7 +11642,7 @@ func (sh *strictHandler) V1EventKeyList(ctx echo.Context, tenant openapi_types.U
 	return nil
 }
 
-// V1FilterList operation middleware
+// V1FilterList operation
 func (sh *strictHandler) V1FilterList(ctx echo.Context, tenant openapi_types.UUID, params V1FilterListParams) error {
 	var request V1FilterListRequestObject
 
@@ -11716,9 +11651,6 @@ func (sh *strictHandler) V1FilterList(ctx echo.Context, tenant openapi_types.UUI
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1FilterList(ctx, request.(V1FilterListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1FilterList")
 	}
 
 	response, err := handler(ctx, request)
@@ -11733,7 +11665,7 @@ func (sh *strictHandler) V1FilterList(ctx echo.Context, tenant openapi_types.UUI
 	return nil
 }
 
-// V1FilterCreate operation middleware
+// V1FilterCreate operation
 func (sh *strictHandler) V1FilterCreate(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request V1FilterCreateRequestObject
 
@@ -11748,9 +11680,6 @@ func (sh *strictHandler) V1FilterCreate(ctx echo.Context, tenant openapi_types.U
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1FilterCreate(ctx, request.(V1FilterCreateRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1FilterCreate")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -11764,7 +11693,7 @@ func (sh *strictHandler) V1FilterCreate(ctx echo.Context, tenant openapi_types.U
 	return nil
 }
 
-// V1FilterDelete operation middleware
+// V1FilterDelete operation
 func (sh *strictHandler) V1FilterDelete(ctx echo.Context, tenant openapi_types.UUID, v1Filter openapi_types.UUID) error {
 	var request V1FilterDeleteRequestObject
 
@@ -11773,9 +11702,6 @@ func (sh *strictHandler) V1FilterDelete(ctx echo.Context, tenant openapi_types.U
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1FilterDelete(ctx, request.(V1FilterDeleteRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1FilterDelete")
 	}
 
 	response, err := handler(ctx, request)
@@ -11790,7 +11716,7 @@ func (sh *strictHandler) V1FilterDelete(ctx echo.Context, tenant openapi_types.U
 	return nil
 }
 
-// V1FilterGet operation middleware
+// V1FilterGet operation
 func (sh *strictHandler) V1FilterGet(ctx echo.Context, tenant openapi_types.UUID, v1Filter openapi_types.UUID) error {
 	var request V1FilterGetRequestObject
 
@@ -11799,9 +11725,6 @@ func (sh *strictHandler) V1FilterGet(ctx echo.Context, tenant openapi_types.UUID
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1FilterGet(ctx, request.(V1FilterGetRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1FilterGet")
 	}
 
 	response, err := handler(ctx, request)
@@ -11816,7 +11739,7 @@ func (sh *strictHandler) V1FilterGet(ctx echo.Context, tenant openapi_types.UUID
 	return nil
 }
 
-// V1FilterUpdate operation middleware
+// V1FilterUpdate operation
 func (sh *strictHandler) V1FilterUpdate(ctx echo.Context, tenant openapi_types.UUID, v1Filter openapi_types.UUID) error {
 	var request V1FilterUpdateRequestObject
 
@@ -11832,9 +11755,6 @@ func (sh *strictHandler) V1FilterUpdate(ctx echo.Context, tenant openapi_types.U
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1FilterUpdate(ctx, request.(V1FilterUpdateRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1FilterUpdate")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -11848,7 +11768,7 @@ func (sh *strictHandler) V1FilterUpdate(ctx echo.Context, tenant openapi_types.U
 	return nil
 }
 
-// V1TaskListStatusMetrics operation middleware
+// V1TaskListStatusMetrics operation
 func (sh *strictHandler) V1TaskListStatusMetrics(ctx echo.Context, tenant openapi_types.UUID, params V1TaskListStatusMetricsParams) error {
 	var request V1TaskListStatusMetricsRequestObject
 
@@ -11857,9 +11777,6 @@ func (sh *strictHandler) V1TaskListStatusMetrics(ctx echo.Context, tenant openap
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1TaskListStatusMetrics(ctx, request.(V1TaskListStatusMetricsRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1TaskListStatusMetrics")
 	}
 
 	response, err := handler(ctx, request)
@@ -11874,7 +11791,7 @@ func (sh *strictHandler) V1TaskListStatusMetrics(ctx echo.Context, tenant openap
 	return nil
 }
 
-// V1TaskGetPointMetrics operation middleware
+// V1TaskGetPointMetrics operation
 func (sh *strictHandler) V1TaskGetPointMetrics(ctx echo.Context, tenant openapi_types.UUID, params V1TaskGetPointMetricsParams) error {
 	var request V1TaskGetPointMetricsRequestObject
 
@@ -11883,9 +11800,6 @@ func (sh *strictHandler) V1TaskGetPointMetrics(ctx echo.Context, tenant openapi_
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1TaskGetPointMetrics(ctx, request.(V1TaskGetPointMetricsRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1TaskGetPointMetrics")
 	}
 
 	response, err := handler(ctx, request)
@@ -11900,7 +11814,7 @@ func (sh *strictHandler) V1TaskGetPointMetrics(ctx echo.Context, tenant openapi_
 	return nil
 }
 
-// V1TaskCancel operation middleware
+// V1TaskCancel operation
 func (sh *strictHandler) V1TaskCancel(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request V1TaskCancelRequestObject
 
@@ -11915,9 +11829,6 @@ func (sh *strictHandler) V1TaskCancel(ctx echo.Context, tenant openapi_types.UUI
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1TaskCancel(ctx, request.(V1TaskCancelRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1TaskCancel")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -11931,7 +11842,7 @@ func (sh *strictHandler) V1TaskCancel(ctx echo.Context, tenant openapi_types.UUI
 	return nil
 }
 
-// V1TaskReplay operation middleware
+// V1TaskReplay operation
 func (sh *strictHandler) V1TaskReplay(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request V1TaskReplayRequestObject
 
@@ -11946,9 +11857,6 @@ func (sh *strictHandler) V1TaskReplay(ctx echo.Context, tenant openapi_types.UUI
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1TaskReplay(ctx, request.(V1TaskReplayRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1TaskReplay")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -11962,7 +11870,7 @@ func (sh *strictHandler) V1TaskReplay(ctx echo.Context, tenant openapi_types.UUI
 	return nil
 }
 
-// V1WorkflowRunList operation middleware
+// V1WorkflowRunList operation
 func (sh *strictHandler) V1WorkflowRunList(ctx echo.Context, tenant openapi_types.UUID, params V1WorkflowRunListParams) error {
 	var request V1WorkflowRunListRequestObject
 
@@ -11971,9 +11879,6 @@ func (sh *strictHandler) V1WorkflowRunList(ctx echo.Context, tenant openapi_type
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1WorkflowRunList(ctx, request.(V1WorkflowRunListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1WorkflowRunList")
 	}
 
 	response, err := handler(ctx, request)
@@ -11988,7 +11893,7 @@ func (sh *strictHandler) V1WorkflowRunList(ctx echo.Context, tenant openapi_type
 	return nil
 }
 
-// V1WorkflowRunDisplayNamesList operation middleware
+// V1WorkflowRunDisplayNamesList operation
 func (sh *strictHandler) V1WorkflowRunDisplayNamesList(ctx echo.Context, tenant openapi_types.UUID, params V1WorkflowRunDisplayNamesListParams) error {
 	var request V1WorkflowRunDisplayNamesListRequestObject
 
@@ -11997,9 +11902,6 @@ func (sh *strictHandler) V1WorkflowRunDisplayNamesList(ctx echo.Context, tenant 
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1WorkflowRunDisplayNamesList(ctx, request.(V1WorkflowRunDisplayNamesListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1WorkflowRunDisplayNamesList")
 	}
 
 	response, err := handler(ctx, request)
@@ -12014,7 +11916,7 @@ func (sh *strictHandler) V1WorkflowRunDisplayNamesList(ctx echo.Context, tenant 
 	return nil
 }
 
-// V1WorkflowRunCreate operation middleware
+// V1WorkflowRunCreate operation
 func (sh *strictHandler) V1WorkflowRunCreate(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request V1WorkflowRunCreateRequestObject
 
@@ -12029,9 +11931,6 @@ func (sh *strictHandler) V1WorkflowRunCreate(ctx echo.Context, tenant openapi_ty
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1WorkflowRunCreate(ctx, request.(V1WorkflowRunCreateRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1WorkflowRunCreate")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -12045,7 +11944,7 @@ func (sh *strictHandler) V1WorkflowRunCreate(ctx echo.Context, tenant openapi_ty
 	return nil
 }
 
-// V1WorkflowRunGet operation middleware
+// V1WorkflowRunGet operation
 func (sh *strictHandler) V1WorkflowRunGet(ctx echo.Context, v1WorkflowRun openapi_types.UUID) error {
 	var request V1WorkflowRunGetRequestObject
 
@@ -12053,9 +11952,6 @@ func (sh *strictHandler) V1WorkflowRunGet(ctx echo.Context, v1WorkflowRun openap
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1WorkflowRunGet(ctx, request.(V1WorkflowRunGetRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1WorkflowRunGet")
 	}
 
 	response, err := handler(ctx, request)
@@ -12070,7 +11966,7 @@ func (sh *strictHandler) V1WorkflowRunGet(ctx echo.Context, v1WorkflowRun openap
 	return nil
 }
 
-// V1WorkflowRunGetStatus operation middleware
+// V1WorkflowRunGetStatus operation
 func (sh *strictHandler) V1WorkflowRunGetStatus(ctx echo.Context, v1WorkflowRun openapi_types.UUID) error {
 	var request V1WorkflowRunGetStatusRequestObject
 
@@ -12078,9 +11974,6 @@ func (sh *strictHandler) V1WorkflowRunGetStatus(ctx echo.Context, v1WorkflowRun 
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1WorkflowRunGetStatus(ctx, request.(V1WorkflowRunGetStatusRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1WorkflowRunGetStatus")
 	}
 
 	response, err := handler(ctx, request)
@@ -12095,7 +11988,7 @@ func (sh *strictHandler) V1WorkflowRunGetStatus(ctx echo.Context, v1WorkflowRun 
 	return nil
 }
 
-// V1WorkflowRunTaskEventsList operation middleware
+// V1WorkflowRunTaskEventsList operation
 func (sh *strictHandler) V1WorkflowRunTaskEventsList(ctx echo.Context, v1WorkflowRun openapi_types.UUID, params V1WorkflowRunTaskEventsListParams) error {
 	var request V1WorkflowRunTaskEventsListRequestObject
 
@@ -12104,9 +11997,6 @@ func (sh *strictHandler) V1WorkflowRunTaskEventsList(ctx echo.Context, v1Workflo
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1WorkflowRunTaskEventsList(ctx, request.(V1WorkflowRunTaskEventsListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1WorkflowRunTaskEventsList")
 	}
 
 	response, err := handler(ctx, request)
@@ -12121,7 +12011,7 @@ func (sh *strictHandler) V1WorkflowRunTaskEventsList(ctx echo.Context, v1Workflo
 	return nil
 }
 
-// V1WorkflowRunGetTimings operation middleware
+// V1WorkflowRunGetTimings operation
 func (sh *strictHandler) V1WorkflowRunGetTimings(ctx echo.Context, v1WorkflowRun openapi_types.UUID, params V1WorkflowRunGetTimingsParams) error {
 	var request V1WorkflowRunGetTimingsRequestObject
 
@@ -12130,9 +12020,6 @@ func (sh *strictHandler) V1WorkflowRunGetTimings(ctx echo.Context, v1WorkflowRun
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.V1WorkflowRunGetTimings(ctx, request.(V1WorkflowRunGetTimingsRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "V1WorkflowRunGetTimings")
 	}
 
 	response, err := handler(ctx, request)
@@ -12147,7 +12034,7 @@ func (sh *strictHandler) V1WorkflowRunGetTimings(ctx echo.Context, v1WorkflowRun
 	return nil
 }
 
-// StepRunListArchives operation middleware
+// StepRunListArchives operation
 func (sh *strictHandler) StepRunListArchives(ctx echo.Context, stepRun openapi_types.UUID, params StepRunListArchivesParams) error {
 	var request StepRunListArchivesRequestObject
 
@@ -12156,9 +12043,6 @@ func (sh *strictHandler) StepRunListArchives(ctx echo.Context, stepRun openapi_t
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.StepRunListArchives(ctx, request.(StepRunListArchivesRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "StepRunListArchives")
 	}
 
 	response, err := handler(ctx, request)
@@ -12173,7 +12057,7 @@ func (sh *strictHandler) StepRunListArchives(ctx echo.Context, stepRun openapi_t
 	return nil
 }
 
-// StepRunListEvents operation middleware
+// StepRunListEvents operation
 func (sh *strictHandler) StepRunListEvents(ctx echo.Context, stepRun openapi_types.UUID, params StepRunListEventsParams) error {
 	var request StepRunListEventsRequestObject
 
@@ -12182,9 +12066,6 @@ func (sh *strictHandler) StepRunListEvents(ctx echo.Context, stepRun openapi_typ
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.StepRunListEvents(ctx, request.(StepRunListEventsRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "StepRunListEvents")
 	}
 
 	response, err := handler(ctx, request)
@@ -12199,7 +12080,7 @@ func (sh *strictHandler) StepRunListEvents(ctx echo.Context, stepRun openapi_typ
 	return nil
 }
 
-// LogLineList operation middleware
+// LogLineList operation
 func (sh *strictHandler) LogLineList(ctx echo.Context, stepRun openapi_types.UUID, params LogLineListParams) error {
 	var request LogLineListRequestObject
 
@@ -12208,9 +12089,6 @@ func (sh *strictHandler) LogLineList(ctx echo.Context, stepRun openapi_types.UUI
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.LogLineList(ctx, request.(LogLineListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "LogLineList")
 	}
 
 	response, err := handler(ctx, request)
@@ -12225,7 +12103,7 @@ func (sh *strictHandler) LogLineList(ctx echo.Context, stepRun openapi_types.UUI
 	return nil
 }
 
-// TenantCreate operation middleware
+// TenantCreate operation
 func (sh *strictHandler) TenantCreate(ctx echo.Context) error {
 	var request TenantCreateRequestObject
 
@@ -12237,9 +12115,6 @@ func (sh *strictHandler) TenantCreate(ctx echo.Context) error {
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.TenantCreate(ctx, request.(TenantCreateRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "TenantCreate")
 	}
 
 	response, err := handler(ctx, request)
@@ -12254,7 +12129,7 @@ func (sh *strictHandler) TenantCreate(ctx echo.Context) error {
 	return nil
 }
 
-// TenantGet operation middleware
+// TenantGet operation
 func (sh *strictHandler) TenantGet(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request TenantGetRequestObject
 
@@ -12262,9 +12137,6 @@ func (sh *strictHandler) TenantGet(ctx echo.Context, tenant openapi_types.UUID) 
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.TenantGet(ctx, request.(TenantGetRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "TenantGet")
 	}
 
 	response, err := handler(ctx, request)
@@ -12279,7 +12151,7 @@ func (sh *strictHandler) TenantGet(ctx echo.Context, tenant openapi_types.UUID) 
 	return nil
 }
 
-// TenantUpdate operation middleware
+// TenantUpdate operation
 func (sh *strictHandler) TenantUpdate(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request TenantUpdateRequestObject
 
@@ -12294,9 +12166,6 @@ func (sh *strictHandler) TenantUpdate(ctx echo.Context, tenant openapi_types.UUI
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.TenantUpdate(ctx, request.(TenantUpdateRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "TenantUpdate")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -12310,7 +12179,7 @@ func (sh *strictHandler) TenantUpdate(ctx echo.Context, tenant openapi_types.UUI
 	return nil
 }
 
-// AlertEmailGroupList operation middleware
+// AlertEmailGroupList operation
 func (sh *strictHandler) AlertEmailGroupList(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request AlertEmailGroupListRequestObject
 
@@ -12318,9 +12187,6 @@ func (sh *strictHandler) AlertEmailGroupList(ctx echo.Context, tenant openapi_ty
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.AlertEmailGroupList(ctx, request.(AlertEmailGroupListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "AlertEmailGroupList")
 	}
 
 	response, err := handler(ctx, request)
@@ -12335,7 +12201,7 @@ func (sh *strictHandler) AlertEmailGroupList(ctx echo.Context, tenant openapi_ty
 	return nil
 }
 
-// AlertEmailGroupCreate operation middleware
+// AlertEmailGroupCreate operation
 func (sh *strictHandler) AlertEmailGroupCreate(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request AlertEmailGroupCreateRequestObject
 
@@ -12350,9 +12216,6 @@ func (sh *strictHandler) AlertEmailGroupCreate(ctx echo.Context, tenant openapi_
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.AlertEmailGroupCreate(ctx, request.(AlertEmailGroupCreateRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "AlertEmailGroupCreate")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -12366,7 +12229,7 @@ func (sh *strictHandler) AlertEmailGroupCreate(ctx echo.Context, tenant openapi_
 	return nil
 }
 
-// TenantAlertingSettingsGet operation middleware
+// TenantAlertingSettingsGet operation
 func (sh *strictHandler) TenantAlertingSettingsGet(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request TenantAlertingSettingsGetRequestObject
 
@@ -12374,9 +12237,6 @@ func (sh *strictHandler) TenantAlertingSettingsGet(ctx echo.Context, tenant open
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.TenantAlertingSettingsGet(ctx, request.(TenantAlertingSettingsGetRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "TenantAlertingSettingsGet")
 	}
 
 	response, err := handler(ctx, request)
@@ -12391,7 +12251,7 @@ func (sh *strictHandler) TenantAlertingSettingsGet(ctx echo.Context, tenant open
 	return nil
 }
 
-// ApiTokenList operation middleware
+// ApiTokenList operation
 func (sh *strictHandler) ApiTokenList(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request ApiTokenListRequestObject
 
@@ -12399,9 +12259,6 @@ func (sh *strictHandler) ApiTokenList(ctx echo.Context, tenant openapi_types.UUI
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.ApiTokenList(ctx, request.(ApiTokenListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "ApiTokenList")
 	}
 
 	response, err := handler(ctx, request)
@@ -12416,7 +12273,7 @@ func (sh *strictHandler) ApiTokenList(ctx echo.Context, tenant openapi_types.UUI
 	return nil
 }
 
-// ApiTokenCreate operation middleware
+// ApiTokenCreate operation
 func (sh *strictHandler) ApiTokenCreate(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request ApiTokenCreateRequestObject
 
@@ -12431,9 +12288,6 @@ func (sh *strictHandler) ApiTokenCreate(ctx echo.Context, tenant openapi_types.U
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.ApiTokenCreate(ctx, request.(ApiTokenCreateRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "ApiTokenCreate")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -12447,7 +12301,7 @@ func (sh *strictHandler) ApiTokenCreate(ctx echo.Context, tenant openapi_types.U
 	return nil
 }
 
-// EventList operation middleware
+// EventList operation
 func (sh *strictHandler) EventList(ctx echo.Context, tenant openapi_types.UUID, params EventListParams) error {
 	var request EventListRequestObject
 
@@ -12456,9 +12310,6 @@ func (sh *strictHandler) EventList(ctx echo.Context, tenant openapi_types.UUID, 
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.EventList(ctx, request.(EventListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "EventList")
 	}
 
 	response, err := handler(ctx, request)
@@ -12473,7 +12324,7 @@ func (sh *strictHandler) EventList(ctx echo.Context, tenant openapi_types.UUID, 
 	return nil
 }
 
-// EventCreate operation middleware
+// EventCreate operation
 func (sh *strictHandler) EventCreate(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request EventCreateRequestObject
 
@@ -12488,9 +12339,6 @@ func (sh *strictHandler) EventCreate(ctx echo.Context, tenant openapi_types.UUID
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.EventCreate(ctx, request.(EventCreateRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "EventCreate")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -12504,7 +12352,7 @@ func (sh *strictHandler) EventCreate(ctx echo.Context, tenant openapi_types.UUID
 	return nil
 }
 
-// EventCreateBulk operation middleware
+// EventCreateBulk operation
 func (sh *strictHandler) EventCreateBulk(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request EventCreateBulkRequestObject
 
@@ -12519,9 +12367,6 @@ func (sh *strictHandler) EventCreateBulk(ctx echo.Context, tenant openapi_types.
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.EventCreateBulk(ctx, request.(EventCreateBulkRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "EventCreateBulk")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -12535,7 +12380,7 @@ func (sh *strictHandler) EventCreateBulk(ctx echo.Context, tenant openapi_types.
 	return nil
 }
 
-// EventUpdateCancel operation middleware
+// EventUpdateCancel operation
 func (sh *strictHandler) EventUpdateCancel(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request EventUpdateCancelRequestObject
 
@@ -12550,9 +12395,6 @@ func (sh *strictHandler) EventUpdateCancel(ctx echo.Context, tenant openapi_type
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.EventUpdateCancel(ctx, request.(EventUpdateCancelRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "EventUpdateCancel")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -12566,7 +12408,7 @@ func (sh *strictHandler) EventUpdateCancel(ctx echo.Context, tenant openapi_type
 	return nil
 }
 
-// EventKeyList operation middleware
+// EventKeyList operation
 func (sh *strictHandler) EventKeyList(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request EventKeyListRequestObject
 
@@ -12574,9 +12416,6 @@ func (sh *strictHandler) EventKeyList(ctx echo.Context, tenant openapi_types.UUI
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.EventKeyList(ctx, request.(EventKeyListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "EventKeyList")
 	}
 
 	response, err := handler(ctx, request)
@@ -12591,7 +12430,7 @@ func (sh *strictHandler) EventKeyList(ctx echo.Context, tenant openapi_types.UUI
 	return nil
 }
 
-// EventUpdateReplay operation middleware
+// EventUpdateReplay operation
 func (sh *strictHandler) EventUpdateReplay(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request EventUpdateReplayRequestObject
 
@@ -12606,9 +12445,6 @@ func (sh *strictHandler) EventUpdateReplay(ctx echo.Context, tenant openapi_type
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.EventUpdateReplay(ctx, request.(EventUpdateReplayRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "EventUpdateReplay")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -12622,7 +12458,7 @@ func (sh *strictHandler) EventUpdateReplay(ctx echo.Context, tenant openapi_type
 	return nil
 }
 
-// TenantInviteList operation middleware
+// TenantInviteList operation
 func (sh *strictHandler) TenantInviteList(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request TenantInviteListRequestObject
 
@@ -12630,9 +12466,6 @@ func (sh *strictHandler) TenantInviteList(ctx echo.Context, tenant openapi_types
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.TenantInviteList(ctx, request.(TenantInviteListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "TenantInviteList")
 	}
 
 	response, err := handler(ctx, request)
@@ -12647,7 +12480,7 @@ func (sh *strictHandler) TenantInviteList(ctx echo.Context, tenant openapi_types
 	return nil
 }
 
-// TenantInviteCreate operation middleware
+// TenantInviteCreate operation
 func (sh *strictHandler) TenantInviteCreate(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request TenantInviteCreateRequestObject
 
@@ -12662,9 +12495,6 @@ func (sh *strictHandler) TenantInviteCreate(ctx echo.Context, tenant openapi_typ
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.TenantInviteCreate(ctx, request.(TenantInviteCreateRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "TenantInviteCreate")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -12678,7 +12508,7 @@ func (sh *strictHandler) TenantInviteCreate(ctx echo.Context, tenant openapi_typ
 	return nil
 }
 
-// TenantInviteDelete operation middleware
+// TenantInviteDelete operation
 func (sh *strictHandler) TenantInviteDelete(ctx echo.Context, tenant openapi_types.UUID, tenantInvite openapi_types.UUID) error {
 	var request TenantInviteDeleteRequestObject
 
@@ -12687,9 +12517,6 @@ func (sh *strictHandler) TenantInviteDelete(ctx echo.Context, tenant openapi_typ
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.TenantInviteDelete(ctx, request.(TenantInviteDeleteRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "TenantInviteDelete")
 	}
 
 	response, err := handler(ctx, request)
@@ -12704,7 +12531,7 @@ func (sh *strictHandler) TenantInviteDelete(ctx echo.Context, tenant openapi_typ
 	return nil
 }
 
-// TenantInviteUpdate operation middleware
+// TenantInviteUpdate operation
 func (sh *strictHandler) TenantInviteUpdate(ctx echo.Context, tenant openapi_types.UUID, tenantInvite openapi_types.UUID) error {
 	var request TenantInviteUpdateRequestObject
 
@@ -12720,9 +12547,6 @@ func (sh *strictHandler) TenantInviteUpdate(ctx echo.Context, tenant openapi_typ
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.TenantInviteUpdate(ctx, request.(TenantInviteUpdateRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "TenantInviteUpdate")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -12736,7 +12560,7 @@ func (sh *strictHandler) TenantInviteUpdate(ctx echo.Context, tenant openapi_typ
 	return nil
 }
 
-// TenantMemberList operation middleware
+// TenantMemberList operation
 func (sh *strictHandler) TenantMemberList(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request TenantMemberListRequestObject
 
@@ -12744,9 +12568,6 @@ func (sh *strictHandler) TenantMemberList(ctx echo.Context, tenant openapi_types
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.TenantMemberList(ctx, request.(TenantMemberListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "TenantMemberList")
 	}
 
 	response, err := handler(ctx, request)
@@ -12761,7 +12582,7 @@ func (sh *strictHandler) TenantMemberList(ctx echo.Context, tenant openapi_types
 	return nil
 }
 
-// TenantMemberDelete operation middleware
+// TenantMemberDelete operation
 func (sh *strictHandler) TenantMemberDelete(ctx echo.Context, tenant openapi_types.UUID, member openapi_types.UUID) error {
 	var request TenantMemberDeleteRequestObject
 
@@ -12770,9 +12591,6 @@ func (sh *strictHandler) TenantMemberDelete(ctx echo.Context, tenant openapi_typ
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.TenantMemberDelete(ctx, request.(TenantMemberDeleteRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "TenantMemberDelete")
 	}
 
 	response, err := handler(ctx, request)
@@ -12787,7 +12605,7 @@ func (sh *strictHandler) TenantMemberDelete(ctx echo.Context, tenant openapi_typ
 	return nil
 }
 
-// TenantGetPrometheusMetrics operation middleware
+// TenantGetPrometheusMetrics operation
 func (sh *strictHandler) TenantGetPrometheusMetrics(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request TenantGetPrometheusMetricsRequestObject
 
@@ -12795,9 +12613,6 @@ func (sh *strictHandler) TenantGetPrometheusMetrics(ctx echo.Context, tenant ope
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.TenantGetPrometheusMetrics(ctx, request.(TenantGetPrometheusMetricsRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "TenantGetPrometheusMetrics")
 	}
 
 	response, err := handler(ctx, request)
@@ -12812,7 +12627,7 @@ func (sh *strictHandler) TenantGetPrometheusMetrics(ctx echo.Context, tenant ope
 	return nil
 }
 
-// TenantGetQueueMetrics operation middleware
+// TenantGetQueueMetrics operation
 func (sh *strictHandler) TenantGetQueueMetrics(ctx echo.Context, tenant openapi_types.UUID, params TenantGetQueueMetricsParams) error {
 	var request TenantGetQueueMetricsRequestObject
 
@@ -12821,9 +12636,6 @@ func (sh *strictHandler) TenantGetQueueMetrics(ctx echo.Context, tenant openapi_
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.TenantGetQueueMetrics(ctx, request.(TenantGetQueueMetricsRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "TenantGetQueueMetrics")
 	}
 
 	response, err := handler(ctx, request)
@@ -12838,7 +12650,7 @@ func (sh *strictHandler) TenantGetQueueMetrics(ctx echo.Context, tenant openapi_
 	return nil
 }
 
-// RateLimitList operation middleware
+// RateLimitList operation
 func (sh *strictHandler) RateLimitList(ctx echo.Context, tenant openapi_types.UUID, params RateLimitListParams) error {
 	var request RateLimitListRequestObject
 
@@ -12847,9 +12659,6 @@ func (sh *strictHandler) RateLimitList(ctx echo.Context, tenant openapi_types.UU
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.RateLimitList(ctx, request.(RateLimitListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "RateLimitList")
 	}
 
 	response, err := handler(ctx, request)
@@ -12864,7 +12673,7 @@ func (sh *strictHandler) RateLimitList(ctx echo.Context, tenant openapi_types.UU
 	return nil
 }
 
-// TenantResourcePolicyGet operation middleware
+// TenantResourcePolicyGet operation
 func (sh *strictHandler) TenantResourcePolicyGet(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request TenantResourcePolicyGetRequestObject
 
@@ -12872,9 +12681,6 @@ func (sh *strictHandler) TenantResourcePolicyGet(ctx echo.Context, tenant openap
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.TenantResourcePolicyGet(ctx, request.(TenantResourcePolicyGetRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "TenantResourcePolicyGet")
 	}
 
 	response, err := handler(ctx, request)
@@ -12889,7 +12695,7 @@ func (sh *strictHandler) TenantResourcePolicyGet(ctx echo.Context, tenant openap
 	return nil
 }
 
-// SlackWebhookList operation middleware
+// SlackWebhookList operation
 func (sh *strictHandler) SlackWebhookList(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request SlackWebhookListRequestObject
 
@@ -12897,9 +12703,6 @@ func (sh *strictHandler) SlackWebhookList(ctx echo.Context, tenant openapi_types
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.SlackWebhookList(ctx, request.(SlackWebhookListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "SlackWebhookList")
 	}
 
 	response, err := handler(ctx, request)
@@ -12914,7 +12717,7 @@ func (sh *strictHandler) SlackWebhookList(ctx echo.Context, tenant openapi_types
 	return nil
 }
 
-// UserUpdateSlackOauthStart operation middleware
+// UserUpdateSlackOauthStart operation
 func (sh *strictHandler) UserUpdateSlackOauthStart(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request UserUpdateSlackOauthStartRequestObject
 
@@ -12922,9 +12725,6 @@ func (sh *strictHandler) UserUpdateSlackOauthStart(ctx echo.Context, tenant open
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.UserUpdateSlackOauthStart(ctx, request.(UserUpdateSlackOauthStartRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "UserUpdateSlackOauthStart")
 	}
 
 	response, err := handler(ctx, request)
@@ -12939,7 +12739,7 @@ func (sh *strictHandler) UserUpdateSlackOauthStart(ctx echo.Context, tenant open
 	return nil
 }
 
-// SnsList operation middleware
+// SnsList operation
 func (sh *strictHandler) SnsList(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request SnsListRequestObject
 
@@ -12947,9 +12747,6 @@ func (sh *strictHandler) SnsList(ctx echo.Context, tenant openapi_types.UUID) er
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.SnsList(ctx, request.(SnsListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "SnsList")
 	}
 
 	response, err := handler(ctx, request)
@@ -12964,7 +12761,7 @@ func (sh *strictHandler) SnsList(ctx echo.Context, tenant openapi_types.UUID) er
 	return nil
 }
 
-// SnsCreate operation middleware
+// SnsCreate operation
 func (sh *strictHandler) SnsCreate(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request SnsCreateRequestObject
 
@@ -12979,9 +12776,6 @@ func (sh *strictHandler) SnsCreate(ctx echo.Context, tenant openapi_types.UUID) 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.SnsCreate(ctx, request.(SnsCreateRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "SnsCreate")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -12995,7 +12789,7 @@ func (sh *strictHandler) SnsCreate(ctx echo.Context, tenant openapi_types.UUID) 
 	return nil
 }
 
-// TenantGetStepRunQueueMetrics operation middleware
+// TenantGetStepRunQueueMetrics operation
 func (sh *strictHandler) TenantGetStepRunQueueMetrics(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request TenantGetStepRunQueueMetricsRequestObject
 
@@ -13003,9 +12797,6 @@ func (sh *strictHandler) TenantGetStepRunQueueMetrics(ctx echo.Context, tenant o
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.TenantGetStepRunQueueMetrics(ctx, request.(TenantGetStepRunQueueMetricsRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "TenantGetStepRunQueueMetrics")
 	}
 
 	response, err := handler(ctx, request)
@@ -13020,7 +12811,7 @@ func (sh *strictHandler) TenantGetStepRunQueueMetrics(ctx echo.Context, tenant o
 	return nil
 }
 
-// StepRunGet operation middleware
+// StepRunGet operation
 func (sh *strictHandler) StepRunGet(ctx echo.Context, tenant openapi_types.UUID, stepRun openapi_types.UUID) error {
 	var request StepRunGetRequestObject
 
@@ -13029,9 +12820,6 @@ func (sh *strictHandler) StepRunGet(ctx echo.Context, tenant openapi_types.UUID,
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.StepRunGet(ctx, request.(StepRunGetRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "StepRunGet")
 	}
 
 	response, err := handler(ctx, request)
@@ -13046,7 +12834,7 @@ func (sh *strictHandler) StepRunGet(ctx echo.Context, tenant openapi_types.UUID,
 	return nil
 }
 
-// StepRunUpdateCancel operation middleware
+// StepRunUpdateCancel operation
 func (sh *strictHandler) StepRunUpdateCancel(ctx echo.Context, tenant openapi_types.UUID, stepRun openapi_types.UUID) error {
 	var request StepRunUpdateCancelRequestObject
 
@@ -13055,9 +12843,6 @@ func (sh *strictHandler) StepRunUpdateCancel(ctx echo.Context, tenant openapi_ty
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.StepRunUpdateCancel(ctx, request.(StepRunUpdateCancelRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "StepRunUpdateCancel")
 	}
 
 	response, err := handler(ctx, request)
@@ -13072,7 +12857,7 @@ func (sh *strictHandler) StepRunUpdateCancel(ctx echo.Context, tenant openapi_ty
 	return nil
 }
 
-// StepRunUpdateRerun operation middleware
+// StepRunUpdateRerun operation
 func (sh *strictHandler) StepRunUpdateRerun(ctx echo.Context, tenant openapi_types.UUID, stepRun openapi_types.UUID) error {
 	var request StepRunUpdateRerunRequestObject
 
@@ -13088,9 +12873,6 @@ func (sh *strictHandler) StepRunUpdateRerun(ctx echo.Context, tenant openapi_typ
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.StepRunUpdateRerun(ctx, request.(StepRunUpdateRerunRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "StepRunUpdateRerun")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -13104,7 +12886,7 @@ func (sh *strictHandler) StepRunUpdateRerun(ctx echo.Context, tenant openapi_typ
 	return nil
 }
 
-// StepRunGetSchema operation middleware
+// StepRunGetSchema operation
 func (sh *strictHandler) StepRunGetSchema(ctx echo.Context, tenant openapi_types.UUID, stepRun openapi_types.UUID) error {
 	var request StepRunGetSchemaRequestObject
 
@@ -13113,9 +12895,6 @@ func (sh *strictHandler) StepRunGetSchema(ctx echo.Context, tenant openapi_types
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.StepRunGetSchema(ctx, request.(StepRunGetSchemaRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "StepRunGetSchema")
 	}
 
 	response, err := handler(ctx, request)
@@ -13130,7 +12909,7 @@ func (sh *strictHandler) StepRunGetSchema(ctx echo.Context, tenant openapi_types
 	return nil
 }
 
-// WebhookList operation middleware
+// WebhookList operation
 func (sh *strictHandler) WebhookList(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request WebhookListRequestObject
 
@@ -13138,9 +12917,6 @@ func (sh *strictHandler) WebhookList(ctx echo.Context, tenant openapi_types.UUID
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WebhookList(ctx, request.(WebhookListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WebhookList")
 	}
 
 	response, err := handler(ctx, request)
@@ -13155,7 +12931,7 @@ func (sh *strictHandler) WebhookList(ctx echo.Context, tenant openapi_types.UUID
 	return nil
 }
 
-// WebhookCreate operation middleware
+// WebhookCreate operation
 func (sh *strictHandler) WebhookCreate(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request WebhookCreateRequestObject
 
@@ -13170,9 +12946,6 @@ func (sh *strictHandler) WebhookCreate(ctx echo.Context, tenant openapi_types.UU
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WebhookCreate(ctx, request.(WebhookCreateRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WebhookCreate")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -13186,7 +12959,7 @@ func (sh *strictHandler) WebhookCreate(ctx echo.Context, tenant openapi_types.UU
 	return nil
 }
 
-// WorkerList operation middleware
+// WorkerList operation
 func (sh *strictHandler) WorkerList(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request WorkerListRequestObject
 
@@ -13194,9 +12967,6 @@ func (sh *strictHandler) WorkerList(ctx echo.Context, tenant openapi_types.UUID)
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkerList(ctx, request.(WorkerListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkerList")
 	}
 
 	response, err := handler(ctx, request)
@@ -13211,7 +12981,7 @@ func (sh *strictHandler) WorkerList(ctx echo.Context, tenant openapi_types.UUID)
 	return nil
 }
 
-// WorkflowRunUpdateReplay operation middleware
+// WorkflowRunUpdateReplay operation
 func (sh *strictHandler) WorkflowRunUpdateReplay(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request WorkflowRunUpdateReplayRequestObject
 
@@ -13226,9 +12996,6 @@ func (sh *strictHandler) WorkflowRunUpdateReplay(ctx echo.Context, tenant openap
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkflowRunUpdateReplay(ctx, request.(WorkflowRunUpdateReplayRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkflowRunUpdateReplay")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -13242,7 +13009,7 @@ func (sh *strictHandler) WorkflowRunUpdateReplay(ctx echo.Context, tenant openap
 	return nil
 }
 
-// WorkflowRunGet operation middleware
+// WorkflowRunGet operation
 func (sh *strictHandler) WorkflowRunGet(ctx echo.Context, tenant openapi_types.UUID, workflowRun openapi_types.UUID) error {
 	var request WorkflowRunGetRequestObject
 
@@ -13251,9 +13018,6 @@ func (sh *strictHandler) WorkflowRunGet(ctx echo.Context, tenant openapi_types.U
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkflowRunGet(ctx, request.(WorkflowRunGetRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkflowRunGet")
 	}
 
 	response, err := handler(ctx, request)
@@ -13268,7 +13032,7 @@ func (sh *strictHandler) WorkflowRunGet(ctx echo.Context, tenant openapi_types.U
 	return nil
 }
 
-// WorkflowRunGetInput operation middleware
+// WorkflowRunGetInput operation
 func (sh *strictHandler) WorkflowRunGetInput(ctx echo.Context, tenant openapi_types.UUID, workflowRun openapi_types.UUID) error {
 	var request WorkflowRunGetInputRequestObject
 
@@ -13277,9 +13041,6 @@ func (sh *strictHandler) WorkflowRunGetInput(ctx echo.Context, tenant openapi_ty
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkflowRunGetInput(ctx, request.(WorkflowRunGetInputRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkflowRunGetInput")
 	}
 
 	response, err := handler(ctx, request)
@@ -13294,7 +13055,7 @@ func (sh *strictHandler) WorkflowRunGetInput(ctx echo.Context, tenant openapi_ty
 	return nil
 }
 
-// WorkflowRunGetShape operation middleware
+// WorkflowRunGetShape operation
 func (sh *strictHandler) WorkflowRunGetShape(ctx echo.Context, tenant openapi_types.UUID, workflowRun openapi_types.UUID) error {
 	var request WorkflowRunGetShapeRequestObject
 
@@ -13303,9 +13064,6 @@ func (sh *strictHandler) WorkflowRunGetShape(ctx echo.Context, tenant openapi_ty
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkflowRunGetShape(ctx, request.(WorkflowRunGetShapeRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkflowRunGetShape")
 	}
 
 	response, err := handler(ctx, request)
@@ -13320,7 +13078,7 @@ func (sh *strictHandler) WorkflowRunGetShape(ctx echo.Context, tenant openapi_ty
 	return nil
 }
 
-// WorkflowRunListStepRunEvents operation middleware
+// WorkflowRunListStepRunEvents operation
 func (sh *strictHandler) WorkflowRunListStepRunEvents(ctx echo.Context, tenant openapi_types.UUID, workflowRun openapi_types.UUID, params WorkflowRunListStepRunEventsParams) error {
 	var request WorkflowRunListStepRunEventsRequestObject
 
@@ -13330,9 +13088,6 @@ func (sh *strictHandler) WorkflowRunListStepRunEvents(ctx echo.Context, tenant o
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkflowRunListStepRunEvents(ctx, request.(WorkflowRunListStepRunEventsRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkflowRunListStepRunEvents")
 	}
 
 	response, err := handler(ctx, request)
@@ -13347,7 +13102,7 @@ func (sh *strictHandler) WorkflowRunListStepRunEvents(ctx echo.Context, tenant o
 	return nil
 }
 
-// WorkflowList operation middleware
+// WorkflowList operation
 func (sh *strictHandler) WorkflowList(ctx echo.Context, tenant openapi_types.UUID, params WorkflowListParams) error {
 	var request WorkflowListRequestObject
 
@@ -13356,9 +13111,6 @@ func (sh *strictHandler) WorkflowList(ctx echo.Context, tenant openapi_types.UUI
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkflowList(ctx, request.(WorkflowListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkflowList")
 	}
 
 	response, err := handler(ctx, request)
@@ -13373,7 +13125,7 @@ func (sh *strictHandler) WorkflowList(ctx echo.Context, tenant openapi_types.UUI
 	return nil
 }
 
-// WorkflowRunCancel operation middleware
+// WorkflowRunCancel operation
 func (sh *strictHandler) WorkflowRunCancel(ctx echo.Context, tenant openapi_types.UUID) error {
 	var request WorkflowRunCancelRequestObject
 
@@ -13388,9 +13140,6 @@ func (sh *strictHandler) WorkflowRunCancel(ctx echo.Context, tenant openapi_type
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkflowRunCancel(ctx, request.(WorkflowRunCancelRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkflowRunCancel")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -13404,7 +13153,7 @@ func (sh *strictHandler) WorkflowRunCancel(ctx echo.Context, tenant openapi_type
 	return nil
 }
 
-// CronWorkflowList operation middleware
+// CronWorkflowList operation
 func (sh *strictHandler) CronWorkflowList(ctx echo.Context, tenant openapi_types.UUID, params CronWorkflowListParams) error {
 	var request CronWorkflowListRequestObject
 
@@ -13413,9 +13162,6 @@ func (sh *strictHandler) CronWorkflowList(ctx echo.Context, tenant openapi_types
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.CronWorkflowList(ctx, request.(CronWorkflowListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "CronWorkflowList")
 	}
 
 	response, err := handler(ctx, request)
@@ -13430,7 +13176,7 @@ func (sh *strictHandler) CronWorkflowList(ctx echo.Context, tenant openapi_types
 	return nil
 }
 
-// WorkflowCronDelete operation middleware
+// WorkflowCronDelete operation
 func (sh *strictHandler) WorkflowCronDelete(ctx echo.Context, tenant openapi_types.UUID, cronWorkflow openapi_types.UUID) error {
 	var request WorkflowCronDeleteRequestObject
 
@@ -13439,9 +13185,6 @@ func (sh *strictHandler) WorkflowCronDelete(ctx echo.Context, tenant openapi_typ
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkflowCronDelete(ctx, request.(WorkflowCronDeleteRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkflowCronDelete")
 	}
 
 	response, err := handler(ctx, request)
@@ -13456,7 +13199,7 @@ func (sh *strictHandler) WorkflowCronDelete(ctx echo.Context, tenant openapi_typ
 	return nil
 }
 
-// WorkflowCronGet operation middleware
+// WorkflowCronGet operation
 func (sh *strictHandler) WorkflowCronGet(ctx echo.Context, tenant openapi_types.UUID, cronWorkflow openapi_types.UUID) error {
 	var request WorkflowCronGetRequestObject
 
@@ -13465,9 +13208,6 @@ func (sh *strictHandler) WorkflowCronGet(ctx echo.Context, tenant openapi_types.
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkflowCronGet(ctx, request.(WorkflowCronGetRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkflowCronGet")
 	}
 
 	response, err := handler(ctx, request)
@@ -13482,7 +13222,7 @@ func (sh *strictHandler) WorkflowCronGet(ctx echo.Context, tenant openapi_types.
 	return nil
 }
 
-// WorkflowRunList operation middleware
+// WorkflowRunList operation
 func (sh *strictHandler) WorkflowRunList(ctx echo.Context, tenant openapi_types.UUID, params WorkflowRunListParams) error {
 	var request WorkflowRunListRequestObject
 
@@ -13491,9 +13231,6 @@ func (sh *strictHandler) WorkflowRunList(ctx echo.Context, tenant openapi_types.
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkflowRunList(ctx, request.(WorkflowRunListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkflowRunList")
 	}
 
 	response, err := handler(ctx, request)
@@ -13508,7 +13245,7 @@ func (sh *strictHandler) WorkflowRunList(ctx echo.Context, tenant openapi_types.
 	return nil
 }
 
-// WorkflowRunGetMetrics operation middleware
+// WorkflowRunGetMetrics operation
 func (sh *strictHandler) WorkflowRunGetMetrics(ctx echo.Context, tenant openapi_types.UUID, params WorkflowRunGetMetricsParams) error {
 	var request WorkflowRunGetMetricsRequestObject
 
@@ -13517,9 +13254,6 @@ func (sh *strictHandler) WorkflowRunGetMetrics(ctx echo.Context, tenant openapi_
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkflowRunGetMetrics(ctx, request.(WorkflowRunGetMetricsRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkflowRunGetMetrics")
 	}
 
 	response, err := handler(ctx, request)
@@ -13534,7 +13268,7 @@ func (sh *strictHandler) WorkflowRunGetMetrics(ctx echo.Context, tenant openapi_
 	return nil
 }
 
-// WorkflowScheduledList operation middleware
+// WorkflowScheduledList operation
 func (sh *strictHandler) WorkflowScheduledList(ctx echo.Context, tenant openapi_types.UUID, params WorkflowScheduledListParams) error {
 	var request WorkflowScheduledListRequestObject
 
@@ -13543,9 +13277,6 @@ func (sh *strictHandler) WorkflowScheduledList(ctx echo.Context, tenant openapi_
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkflowScheduledList(ctx, request.(WorkflowScheduledListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkflowScheduledList")
 	}
 
 	response, err := handler(ctx, request)
@@ -13560,7 +13291,7 @@ func (sh *strictHandler) WorkflowScheduledList(ctx echo.Context, tenant openapi_
 	return nil
 }
 
-// WorkflowScheduledDelete operation middleware
+// WorkflowScheduledDelete operation
 func (sh *strictHandler) WorkflowScheduledDelete(ctx echo.Context, tenant openapi_types.UUID, scheduledWorkflowRun openapi_types.UUID) error {
 	var request WorkflowScheduledDeleteRequestObject
 
@@ -13569,9 +13300,6 @@ func (sh *strictHandler) WorkflowScheduledDelete(ctx echo.Context, tenant openap
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkflowScheduledDelete(ctx, request.(WorkflowScheduledDeleteRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkflowScheduledDelete")
 	}
 
 	response, err := handler(ctx, request)
@@ -13586,7 +13314,7 @@ func (sh *strictHandler) WorkflowScheduledDelete(ctx echo.Context, tenant openap
 	return nil
 }
 
-// WorkflowScheduledGet operation middleware
+// WorkflowScheduledGet operation
 func (sh *strictHandler) WorkflowScheduledGet(ctx echo.Context, tenant openapi_types.UUID, scheduledWorkflowRun openapi_types.UUID) error {
 	var request WorkflowScheduledGetRequestObject
 
@@ -13595,9 +13323,6 @@ func (sh *strictHandler) WorkflowScheduledGet(ctx echo.Context, tenant openapi_t
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkflowScheduledGet(ctx, request.(WorkflowScheduledGetRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkflowScheduledGet")
 	}
 
 	response, err := handler(ctx, request)
@@ -13612,7 +13337,7 @@ func (sh *strictHandler) WorkflowScheduledGet(ctx echo.Context, tenant openapi_t
 	return nil
 }
 
-// CronWorkflowTriggerCreate operation middleware
+// CronWorkflowTriggerCreate operation
 func (sh *strictHandler) CronWorkflowTriggerCreate(ctx echo.Context, tenant openapi_types.UUID, workflow string) error {
 	var request CronWorkflowTriggerCreateRequestObject
 
@@ -13628,9 +13353,6 @@ func (sh *strictHandler) CronWorkflowTriggerCreate(ctx echo.Context, tenant open
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.CronWorkflowTriggerCreate(ctx, request.(CronWorkflowTriggerCreateRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "CronWorkflowTriggerCreate")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -13644,7 +13366,7 @@ func (sh *strictHandler) CronWorkflowTriggerCreate(ctx echo.Context, tenant open
 	return nil
 }
 
-// ScheduledWorkflowRunCreate operation middleware
+// ScheduledWorkflowRunCreate operation
 func (sh *strictHandler) ScheduledWorkflowRunCreate(ctx echo.Context, tenant openapi_types.UUID, workflow string) error {
 	var request ScheduledWorkflowRunCreateRequestObject
 
@@ -13660,9 +13382,6 @@ func (sh *strictHandler) ScheduledWorkflowRunCreate(ctx echo.Context, tenant ope
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.ScheduledWorkflowRunCreate(ctx, request.(ScheduledWorkflowRunCreateRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "ScheduledWorkflowRunCreate")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -13676,7 +13395,7 @@ func (sh *strictHandler) ScheduledWorkflowRunCreate(ctx echo.Context, tenant ope
 	return nil
 }
 
-// WorkflowGetWorkersCount operation middleware
+// WorkflowGetWorkersCount operation
 func (sh *strictHandler) WorkflowGetWorkersCount(ctx echo.Context, tenant openapi_types.UUID, workflow openapi_types.UUID) error {
 	var request WorkflowGetWorkersCountRequestObject
 
@@ -13685,9 +13404,6 @@ func (sh *strictHandler) WorkflowGetWorkersCount(ctx echo.Context, tenant openap
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkflowGetWorkersCount(ctx, request.(WorkflowGetWorkersCountRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkflowGetWorkersCount")
 	}
 
 	response, err := handler(ctx, request)
@@ -13702,15 +13418,12 @@ func (sh *strictHandler) WorkflowGetWorkersCount(ctx echo.Context, tenant openap
 	return nil
 }
 
-// UserGetCurrent operation middleware
+// UserGetCurrent operation
 func (sh *strictHandler) UserGetCurrent(ctx echo.Context) error {
 	var request UserGetCurrentRequestObject
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.UserGetCurrent(ctx, request.(UserGetCurrentRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "UserGetCurrent")
 	}
 
 	response, err := handler(ctx, request)
@@ -13725,15 +13438,12 @@ func (sh *strictHandler) UserGetCurrent(ctx echo.Context) error {
 	return nil
 }
 
-// UserUpdateGithubOauthCallback operation middleware
+// UserUpdateGithubOauthCallback operation
 func (sh *strictHandler) UserUpdateGithubOauthCallback(ctx echo.Context) error {
 	var request UserUpdateGithubOauthCallbackRequestObject
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.UserUpdateGithubOauthCallback(ctx, request.(UserUpdateGithubOauthCallbackRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "UserUpdateGithubOauthCallback")
 	}
 
 	response, err := handler(ctx, request)
@@ -13748,15 +13458,12 @@ func (sh *strictHandler) UserUpdateGithubOauthCallback(ctx echo.Context) error {
 	return nil
 }
 
-// UserUpdateGithubOauthStart operation middleware
+// UserUpdateGithubOauthStart operation
 func (sh *strictHandler) UserUpdateGithubOauthStart(ctx echo.Context) error {
 	var request UserUpdateGithubOauthStartRequestObject
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.UserUpdateGithubOauthStart(ctx, request.(UserUpdateGithubOauthStartRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "UserUpdateGithubOauthStart")
 	}
 
 	response, err := handler(ctx, request)
@@ -13771,15 +13478,12 @@ func (sh *strictHandler) UserUpdateGithubOauthStart(ctx echo.Context) error {
 	return nil
 }
 
-// UserUpdateGoogleOauthCallback operation middleware
+// UserUpdateGoogleOauthCallback operation
 func (sh *strictHandler) UserUpdateGoogleOauthCallback(ctx echo.Context) error {
 	var request UserUpdateGoogleOauthCallbackRequestObject
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.UserUpdateGoogleOauthCallback(ctx, request.(UserUpdateGoogleOauthCallbackRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "UserUpdateGoogleOauthCallback")
 	}
 
 	response, err := handler(ctx, request)
@@ -13794,15 +13498,12 @@ func (sh *strictHandler) UserUpdateGoogleOauthCallback(ctx echo.Context) error {
 	return nil
 }
 
-// UserUpdateGoogleOauthStart operation middleware
+// UserUpdateGoogleOauthStart operation
 func (sh *strictHandler) UserUpdateGoogleOauthStart(ctx echo.Context) error {
 	var request UserUpdateGoogleOauthStartRequestObject
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.UserUpdateGoogleOauthStart(ctx, request.(UserUpdateGoogleOauthStartRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "UserUpdateGoogleOauthStart")
 	}
 
 	response, err := handler(ctx, request)
@@ -13817,15 +13518,12 @@ func (sh *strictHandler) UserUpdateGoogleOauthStart(ctx echo.Context) error {
 	return nil
 }
 
-// UserListTenantInvites operation middleware
+// UserListTenantInvites operation
 func (sh *strictHandler) UserListTenantInvites(ctx echo.Context) error {
 	var request UserListTenantInvitesRequestObject
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.UserListTenantInvites(ctx, request.(UserListTenantInvitesRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "UserListTenantInvites")
 	}
 
 	response, err := handler(ctx, request)
@@ -13840,7 +13538,7 @@ func (sh *strictHandler) UserListTenantInvites(ctx echo.Context) error {
 	return nil
 }
 
-// TenantInviteAccept operation middleware
+// TenantInviteAccept operation
 func (sh *strictHandler) TenantInviteAccept(ctx echo.Context) error {
 	var request TenantInviteAcceptRequestObject
 
@@ -13852,9 +13550,6 @@ func (sh *strictHandler) TenantInviteAccept(ctx echo.Context) error {
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.TenantInviteAccept(ctx, request.(TenantInviteAcceptRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "TenantInviteAccept")
 	}
 
 	response, err := handler(ctx, request)
@@ -13869,7 +13564,7 @@ func (sh *strictHandler) TenantInviteAccept(ctx echo.Context) error {
 	return nil
 }
 
-// TenantInviteReject operation middleware
+// TenantInviteReject operation
 func (sh *strictHandler) TenantInviteReject(ctx echo.Context) error {
 	var request TenantInviteRejectRequestObject
 
@@ -13881,9 +13576,6 @@ func (sh *strictHandler) TenantInviteReject(ctx echo.Context) error {
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.TenantInviteReject(ctx, request.(TenantInviteRejectRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "TenantInviteReject")
 	}
 
 	response, err := handler(ctx, request)
@@ -13898,7 +13590,7 @@ func (sh *strictHandler) TenantInviteReject(ctx echo.Context) error {
 	return nil
 }
 
-// UserUpdateLogin operation middleware
+// UserUpdateLogin operation
 func (sh *strictHandler) UserUpdateLogin(ctx echo.Context) error {
 	var request UserUpdateLoginRequestObject
 
@@ -13910,9 +13602,6 @@ func (sh *strictHandler) UserUpdateLogin(ctx echo.Context) error {
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.UserUpdateLogin(ctx, request.(UserUpdateLoginRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "UserUpdateLogin")
 	}
 
 	response, err := handler(ctx, request)
@@ -13927,15 +13616,12 @@ func (sh *strictHandler) UserUpdateLogin(ctx echo.Context) error {
 	return nil
 }
 
-// UserUpdateLogout operation middleware
+// UserUpdateLogout operation
 func (sh *strictHandler) UserUpdateLogout(ctx echo.Context) error {
 	var request UserUpdateLogoutRequestObject
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.UserUpdateLogout(ctx, request.(UserUpdateLogoutRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "UserUpdateLogout")
 	}
 
 	response, err := handler(ctx, request)
@@ -13950,15 +13636,12 @@ func (sh *strictHandler) UserUpdateLogout(ctx echo.Context) error {
 	return nil
 }
 
-// TenantMembershipsList operation middleware
+// TenantMembershipsList operation
 func (sh *strictHandler) TenantMembershipsList(ctx echo.Context) error {
 	var request TenantMembershipsListRequestObject
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.TenantMembershipsList(ctx, request.(TenantMembershipsListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "TenantMembershipsList")
 	}
 
 	response, err := handler(ctx, request)
@@ -13973,7 +13656,7 @@ func (sh *strictHandler) TenantMembershipsList(ctx echo.Context) error {
 	return nil
 }
 
-// UserUpdatePassword operation middleware
+// UserUpdatePassword operation
 func (sh *strictHandler) UserUpdatePassword(ctx echo.Context) error {
 	var request UserUpdatePasswordRequestObject
 
@@ -13985,9 +13668,6 @@ func (sh *strictHandler) UserUpdatePassword(ctx echo.Context) error {
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.UserUpdatePassword(ctx, request.(UserUpdatePasswordRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "UserUpdatePassword")
 	}
 
 	response, err := handler(ctx, request)
@@ -14002,7 +13682,7 @@ func (sh *strictHandler) UserUpdatePassword(ctx echo.Context) error {
 	return nil
 }
 
-// UserCreate operation middleware
+// UserCreate operation
 func (sh *strictHandler) UserCreate(ctx echo.Context) error {
 	var request UserCreateRequestObject
 
@@ -14014,9 +13694,6 @@ func (sh *strictHandler) UserCreate(ctx echo.Context) error {
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.UserCreate(ctx, request.(UserCreateRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "UserCreate")
 	}
 
 	response, err := handler(ctx, request)
@@ -14031,15 +13708,12 @@ func (sh *strictHandler) UserCreate(ctx echo.Context) error {
 	return nil
 }
 
-// UserUpdateSlackOauthCallback operation middleware
+// UserUpdateSlackOauthCallback operation
 func (sh *strictHandler) UserUpdateSlackOauthCallback(ctx echo.Context) error {
 	var request UserUpdateSlackOauthCallbackRequestObject
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.UserUpdateSlackOauthCallback(ctx, request.(UserUpdateSlackOauthCallbackRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "UserUpdateSlackOauthCallback")
 	}
 
 	response, err := handler(ctx, request)
@@ -14054,15 +13728,12 @@ func (sh *strictHandler) UserUpdateSlackOauthCallback(ctx echo.Context) error {
 	return nil
 }
 
-// InfoGetVersion operation middleware
+// InfoGetVersion operation
 func (sh *strictHandler) InfoGetVersion(ctx echo.Context) error {
 	var request InfoGetVersionRequestObject
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.InfoGetVersion(ctx, request.(InfoGetVersionRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "InfoGetVersion")
 	}
 
 	response, err := handler(ctx, request)
@@ -14077,7 +13748,7 @@ func (sh *strictHandler) InfoGetVersion(ctx echo.Context) error {
 	return nil
 }
 
-// WebhookDelete operation middleware
+// WebhookDelete operation
 func (sh *strictHandler) WebhookDelete(ctx echo.Context, webhook openapi_types.UUID) error {
 	var request WebhookDeleteRequestObject
 
@@ -14085,9 +13756,6 @@ func (sh *strictHandler) WebhookDelete(ctx echo.Context, webhook openapi_types.U
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WebhookDelete(ctx, request.(WebhookDeleteRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WebhookDelete")
 	}
 
 	response, err := handler(ctx, request)
@@ -14102,7 +13770,7 @@ func (sh *strictHandler) WebhookDelete(ctx echo.Context, webhook openapi_types.U
 	return nil
 }
 
-// WebhookRequestsList operation middleware
+// WebhookRequestsList operation
 func (sh *strictHandler) WebhookRequestsList(ctx echo.Context, webhook openapi_types.UUID) error {
 	var request WebhookRequestsListRequestObject
 
@@ -14110,9 +13778,6 @@ func (sh *strictHandler) WebhookRequestsList(ctx echo.Context, webhook openapi_t
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WebhookRequestsList(ctx, request.(WebhookRequestsListRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WebhookRequestsList")
 	}
 
 	response, err := handler(ctx, request)
@@ -14127,7 +13792,7 @@ func (sh *strictHandler) WebhookRequestsList(ctx echo.Context, webhook openapi_t
 	return nil
 }
 
-// WorkerGet operation middleware
+// WorkerGet operation
 func (sh *strictHandler) WorkerGet(ctx echo.Context, worker openapi_types.UUID) error {
 	var request WorkerGetRequestObject
 
@@ -14135,9 +13800,6 @@ func (sh *strictHandler) WorkerGet(ctx echo.Context, worker openapi_types.UUID) 
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkerGet(ctx, request.(WorkerGetRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkerGet")
 	}
 
 	response, err := handler(ctx, request)
@@ -14152,7 +13814,7 @@ func (sh *strictHandler) WorkerGet(ctx echo.Context, worker openapi_types.UUID) 
 	return nil
 }
 
-// WorkerUpdate operation middleware
+// WorkerUpdate operation
 func (sh *strictHandler) WorkerUpdate(ctx echo.Context, worker openapi_types.UUID) error {
 	var request WorkerUpdateRequestObject
 
@@ -14167,9 +13829,6 @@ func (sh *strictHandler) WorkerUpdate(ctx echo.Context, worker openapi_types.UUI
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkerUpdate(ctx, request.(WorkerUpdateRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkerUpdate")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -14183,7 +13842,7 @@ func (sh *strictHandler) WorkerUpdate(ctx echo.Context, worker openapi_types.UUI
 	return nil
 }
 
-// WorkflowDelete operation middleware
+// WorkflowDelete operation
 func (sh *strictHandler) WorkflowDelete(ctx echo.Context, workflow openapi_types.UUID) error {
 	var request WorkflowDeleteRequestObject
 
@@ -14191,9 +13850,6 @@ func (sh *strictHandler) WorkflowDelete(ctx echo.Context, workflow openapi_types
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkflowDelete(ctx, request.(WorkflowDeleteRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkflowDelete")
 	}
 
 	response, err := handler(ctx, request)
@@ -14208,7 +13864,7 @@ func (sh *strictHandler) WorkflowDelete(ctx echo.Context, workflow openapi_types
 	return nil
 }
 
-// WorkflowGet operation middleware
+// WorkflowGet operation
 func (sh *strictHandler) WorkflowGet(ctx echo.Context, workflow openapi_types.UUID) error {
 	var request WorkflowGetRequestObject
 
@@ -14216,9 +13872,6 @@ func (sh *strictHandler) WorkflowGet(ctx echo.Context, workflow openapi_types.UU
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkflowGet(ctx, request.(WorkflowGetRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkflowGet")
 	}
 
 	response, err := handler(ctx, request)
@@ -14233,7 +13886,7 @@ func (sh *strictHandler) WorkflowGet(ctx echo.Context, workflow openapi_types.UU
 	return nil
 }
 
-// WorkflowUpdate operation middleware
+// WorkflowUpdate operation
 func (sh *strictHandler) WorkflowUpdate(ctx echo.Context, workflow openapi_types.UUID) error {
 	var request WorkflowUpdateRequestObject
 
@@ -14248,9 +13901,6 @@ func (sh *strictHandler) WorkflowUpdate(ctx echo.Context, workflow openapi_types
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkflowUpdate(ctx, request.(WorkflowUpdateRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkflowUpdate")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -14264,7 +13914,7 @@ func (sh *strictHandler) WorkflowUpdate(ctx echo.Context, workflow openapi_types
 	return nil
 }
 
-// WorkflowGetMetrics operation middleware
+// WorkflowGetMetrics operation
 func (sh *strictHandler) WorkflowGetMetrics(ctx echo.Context, workflow openapi_types.UUID, params WorkflowGetMetricsParams) error {
 	var request WorkflowGetMetricsRequestObject
 
@@ -14273,9 +13923,6 @@ func (sh *strictHandler) WorkflowGetMetrics(ctx echo.Context, workflow openapi_t
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkflowGetMetrics(ctx, request.(WorkflowGetMetricsRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkflowGetMetrics")
 	}
 
 	response, err := handler(ctx, request)
@@ -14290,7 +13937,7 @@ func (sh *strictHandler) WorkflowGetMetrics(ctx echo.Context, workflow openapi_t
 	return nil
 }
 
-// WorkflowRunCreate operation middleware
+// WorkflowRunCreate operation
 func (sh *strictHandler) WorkflowRunCreate(ctx echo.Context, workflow openapi_types.UUID, params WorkflowRunCreateParams) error {
 	var request WorkflowRunCreateRequestObject
 
@@ -14306,9 +13953,6 @@ func (sh *strictHandler) WorkflowRunCreate(ctx echo.Context, workflow openapi_ty
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkflowRunCreate(ctx, request.(WorkflowRunCreateRequestObject))
 	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkflowRunCreate")
-	}
 
 	response, err := handler(ctx, request)
 
@@ -14322,7 +13966,7 @@ func (sh *strictHandler) WorkflowRunCreate(ctx echo.Context, workflow openapi_ty
 	return nil
 }
 
-// WorkflowVersionGet operation middleware
+// WorkflowVersionGet operation
 func (sh *strictHandler) WorkflowVersionGet(ctx echo.Context, workflow openapi_types.UUID, params WorkflowVersionGetParams) error {
 	var request WorkflowVersionGetRequestObject
 
@@ -14331,9 +13975,6 @@ func (sh *strictHandler) WorkflowVersionGet(ctx echo.Context, workflow openapi_t
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.WorkflowVersionGet(ctx, request.(WorkflowVersionGetRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "WorkflowVersionGet")
 	}
 
 	response, err := handler(ctx, request)


### PR DESCRIPTION
# Description

We do not 2 different ways to add middlewares to our Echo server. Simply use the current way we use middlewares and add any additional middlewares there.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)
