### PR TITLE
Hotfix: Empty scope

### DIFF
--- a/internal/services/controllers/v1/task/controller.go
+++ b/internal/services/controllers/v1/task/controller.go
@@ -945,6 +945,7 @@ func (tc *TasksControllerImpl) handleProcessUserEventTrigger(ctx context.Context
 				EventExternalId:         opts.ExternalId,
 				EventPayload:            opts.Data,
 				EventAdditionalMetadata: opts.AdditionalMetadata,
+				EventScope:              opts.Scope,
 			})
 		} else {
 			for _, run := range runs {


### PR DESCRIPTION
# Description

Fixes a bug where we fail to log the scope to the events table if no runs were created from an event

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

