### PR TITLE
TS client: added support for grpc_max_recv_message_length and grpc_max_send_message_length

### DIFF
--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "Background task orchestration & visibility for developers",
   "types": "dist/index.d.ts",
   "files": [

--- a/sdks/typescript/src/clients/hatchet-client/client-config.ts
+++ b/sdks/typescript/src/clients/hatchet-client/client-config.ts
@@ -1,31 +1,31 @@
-import { ChannelCredentials } from "nice-grpc";
-import { z } from "zod";
-import { Logger, LogLevel } from "@util/logger";
+import { ChannelCredentials } from 'nice-grpc';
+import { z } from 'zod';
+import { Logger, LogLevel } from '@util/logger';
 
 const ClientTLSConfigSchema = z.object({
-	tls_strategy: z.enum(["tls", "mtls", "none"]).optional(),
-	cert_file: z.string().optional(),
-	ca_file: z.string().optional(),
-	key_file: z.string().optional(),
-	server_name: z.string().optional(),
+  tls_strategy: z.enum(['tls', 'mtls', 'none']).optional(),
+  cert_file: z.string().optional(),
+  ca_file: z.string().optional(),
+  key_file: z.string().optional(),
+  server_name: z.string().optional(),
 });
 
 export const ClientConfigSchema = z.object({
-	token: z.string(),
-	tls_config: ClientTLSConfigSchema,
-	host_port: z.string(),
-	api_url: z.string(),
-	log_level: z.enum(["OFF", "DEBUG", "INFO", "WARN", "ERROR"]).optional(),
-	tenant_id: z.string(),
-	namespace: z.string().optional(),
-	// Optional gRPC message size limits (bytes)
-	grpc_max_recv_message_length: z.number().optional(),
-	grpc_max_send_message_length: z.number().optional(),
+  token: z.string(),
+  tls_config: ClientTLSConfigSchema,
+  host_port: z.string(),
+  api_url: z.string(),
+  log_level: z.enum(['OFF', 'DEBUG', 'INFO', 'WARN', 'ERROR']).optional(),
+  tenant_id: z.string(),
+  namespace: z.string().optional(),
+  // Optional gRPC message size limits (bytes)
+  grpc_max_recv_message_length: z.number().optional(),
+  grpc_max_send_message_length: z.number().optional(),
 });
 
 export type LogConstructor = (context: string, logLevel?: LogLevel) => Logger;
 
 export type ClientConfig = z.infer<typeof ClientConfigSchema> & {
-	credentials?: ChannelCredentials;
+  credentials?: ChannelCredentials;
 } & { logger: LogConstructor };
 export type ClientTLSConfig = z.infer<typeof ClientTLSConfigSchema>;

--- a/sdks/typescript/src/clients/hatchet-client/client-config.ts
+++ b/sdks/typescript/src/clients/hatchet-client/client-config.ts
@@ -1,28 +1,31 @@
-import { ChannelCredentials } from 'nice-grpc';
-import { z } from 'zod';
-import { Logger, LogLevel } from '@util/logger';
+import { ChannelCredentials } from "nice-grpc";
+import { z } from "zod";
+import { Logger, LogLevel } from "@util/logger";
 
 const ClientTLSConfigSchema = z.object({
-  tls_strategy: z.enum(['tls', 'mtls', 'none']).optional(),
-  cert_file: z.string().optional(),
-  ca_file: z.string().optional(),
-  key_file: z.string().optional(),
-  server_name: z.string().optional(),
+	tls_strategy: z.enum(["tls", "mtls", "none"]).optional(),
+	cert_file: z.string().optional(),
+	ca_file: z.string().optional(),
+	key_file: z.string().optional(),
+	server_name: z.string().optional(),
 });
 
 export const ClientConfigSchema = z.object({
-  token: z.string(),
-  tls_config: ClientTLSConfigSchema,
-  host_port: z.string(),
-  api_url: z.string(),
-  log_level: z.enum(['OFF', 'DEBUG', 'INFO', 'WARN', 'ERROR']).optional(),
-  tenant_id: z.string(),
-  namespace: z.string().optional(),
+	token: z.string(),
+	tls_config: ClientTLSConfigSchema,
+	host_port: z.string(),
+	api_url: z.string(),
+	log_level: z.enum(["OFF", "DEBUG", "INFO", "WARN", "ERROR"]).optional(),
+	tenant_id: z.string(),
+	namespace: z.string().optional(),
+	// Optional gRPC message size limits (bytes)
+	grpc_max_recv_message_length: z.number().optional(),
+	grpc_max_send_message_length: z.number().optional(),
 });
 
 export type LogConstructor = (context: string, logLevel?: LogLevel) => Logger;
 
 export type ClientConfig = z.infer<typeof ClientConfigSchema> & {
-  credentials?: ChannelCredentials;
+	credentials?: ChannelCredentials;
 } & { logger: LogConstructor };
 export type ClientTLSConfig = z.infer<typeof ClientTLSConfigSchema>;

--- a/sdks/typescript/src/util/config-loader/config-loader.ts
+++ b/sdks/typescript/src/util/config-loader/config-loader.ts
@@ -1,151 +1,192 @@
-import { parse } from 'yaml';
-import { readFileSync } from 'fs';
-import * as p from 'path';
-import { z } from 'zod';
-import { ClientConfig, ClientConfigSchema } from '@clients/hatchet-client';
-import { ChannelCredentials } from 'nice-grpc';
-import { LogLevel } from '@util/logger';
-import { getAddressesFromJWT, getTenantIdFromJWT } from './token';
+import { parse } from "yaml";
+import { readFileSync } from "fs";
+import * as p from "path";
+import { z } from "zod";
+import { ClientConfig, ClientConfigSchema } from "@clients/hatchet-client";
+import { ChannelCredentials } from "nice-grpc";
+import { LogLevel } from "@util/logger";
+import { getAddressesFromJWT, getTenantIdFromJWT } from "./token";
 
 type EnvVars =
-  | 'HATCHET_CLIENT_TOKEN'
-  | 'HATCHET_CLIENT_TLS_STRATEGY'
-  | 'HATCHET_CLIENT_HOST_PORT'
-  | 'HATCHET_CLIENT_API_URL'
-  | 'HATCHET_CLIENT_TLS_CERT_FILE'
-  | 'HATCHET_CLIENT_TLS_KEY_FILE'
-  | 'HATCHET_CLIENT_TLS_ROOT_CA_FILE'
-  | 'HATCHET_CLIENT_TLS_SERVER_NAME'
-  | 'HATCHET_CLIENT_LOG_LEVEL'
-  | 'HATCHET_CLIENT_NAMESPACE';
+	| "HATCHET_CLIENT_TOKEN"
+	| "HATCHET_CLIENT_TLS_STRATEGY"
+	| "HATCHET_CLIENT_HOST_PORT"
+	| "HATCHET_CLIENT_API_URL"
+	| "HATCHET_CLIENT_TLS_CERT_FILE"
+	| "HATCHET_CLIENT_TLS_KEY_FILE"
+	| "HATCHET_CLIENT_TLS_ROOT_CA_FILE"
+	| "HATCHET_CLIENT_TLS_SERVER_NAME"
+	| "HATCHET_CLIENT_LOG_LEVEL"
+	| "HATCHET_CLIENT_NAMESPACE"
+	| "HATCHET_CLIENT_GRPC_MAX_RECV_MESSAGE_LENGTH"
+	| "HATCHET_CLIENT_GRPC_MAX_SEND_MESSAGE_LENGTH";
 
-type TLSStrategy = 'tls' | 'mtls';
+type TLSStrategy = "tls" | "mtls";
 
 interface LoadClientConfigOptions {
-  path?: string;
+	path?: string;
 }
 
-const DEFAULT_CONFIG_FILE = '.hatchet.yaml';
+const DEFAULT_CONFIG_FILE = ".hatchet.yaml";
 
 export class ConfigLoader {
-  static loadClientConfig(
-    override?: Partial<ClientConfig>,
-    config?: LoadClientConfigOptions
-  ): Partial<ClientConfig> {
-    const yaml = this.loadYamlConfig(config?.path);
-    const tlsConfig = override?.tls_config ?? {
-      tls_strategy:
-        yaml?.tls_config?.tls_strategy ??
-        (this.env('HATCHET_CLIENT_TLS_STRATEGY') as TLSStrategy | undefined) ??
-        'tls',
-      cert_file: yaml?.tls_config?.cert_file ?? this.env('HATCHET_CLIENT_TLS_CERT_FILE')!,
-      key_file: yaml?.tls_config?.key_file ?? this.env('HATCHET_CLIENT_TLS_KEY_FILE')!,
-      ca_file: yaml?.tls_config?.ca_file ?? this.env('HATCHET_CLIENT_TLS_ROOT_CA_FILE')!,
-      server_name: yaml?.tls_config?.server_name ?? this.env('HATCHET_CLIENT_TLS_SERVER_NAME')!,
-    };
+	static loadClientConfig(
+		override?: Partial<ClientConfig>,
+		config?: LoadClientConfigOptions,
+	): Partial<ClientConfig> {
+		const yaml = this.loadYamlConfig(config?.path);
+		const tlsConfig = override?.tls_config ?? {
+			tls_strategy:
+				yaml?.tls_config?.tls_strategy ??
+				(this.env("HATCHET_CLIENT_TLS_STRATEGY") as TLSStrategy | undefined) ??
+				"tls",
+			cert_file:
+				yaml?.tls_config?.cert_file ??
+				this.env("HATCHET_CLIENT_TLS_CERT_FILE")!,
+			key_file:
+				yaml?.tls_config?.key_file ?? this.env("HATCHET_CLIENT_TLS_KEY_FILE")!,
+			ca_file:
+				yaml?.tls_config?.ca_file ??
+				this.env("HATCHET_CLIENT_TLS_ROOT_CA_FILE")!,
+			server_name:
+				yaml?.tls_config?.server_name ??
+				this.env("HATCHET_CLIENT_TLS_SERVER_NAME")!,
+		};
 
-    const token = override?.token ?? yaml?.token ?? this.env('HATCHET_CLIENT_TOKEN');
+		const token =
+			override?.token ?? yaml?.token ?? this.env("HATCHET_CLIENT_TOKEN");
 
-    if (!token) {
-      throw new Error(
-        'No token provided. Provide it by setting the HATCHET_CLIENT_TOKEN environment variable.'
-      );
-    }
+		if (!token) {
+			throw new Error(
+				"No token provided. Provide it by setting the HATCHET_CLIENT_TOKEN environment variable.",
+			);
+		}
 
-    let grpcBroadcastAddress: string | undefined;
-    let apiUrl: string | undefined;
-    const tenantId = getTenantIdFromJWT(token!);
+		let grpcBroadcastAddress: string | undefined;
+		let apiUrl: string | undefined;
+		const tenantId = getTenantIdFromJWT(token!);
 
-    if (!tenantId) {
-      throw new Error('Tenant ID not found in subject claim of token');
-    }
+		if (!tenantId) {
+			throw new Error("Tenant ID not found in subject claim of token");
+		}
 
-    try {
-      const addresses = getAddressesFromJWT(token!);
+		try {
+			const addresses = getAddressesFromJWT(token!);
 
-      grpcBroadcastAddress =
-        override?.host_port ??
-        yaml?.host_port ??
-        this.env('HATCHET_CLIENT_HOST_PORT') ??
-        addresses.grpcBroadcastAddress;
+			grpcBroadcastAddress =
+				override?.host_port ??
+				yaml?.host_port ??
+				this.env("HATCHET_CLIENT_HOST_PORT") ??
+				addresses.grpcBroadcastAddress;
 
-      apiUrl =
-        override?.api_url ??
-        yaml?.api_url ??
-        this.env('HATCHET_CLIENT_API_URL') ??
-        addresses.serverUrl;
-    } catch (e) {
-      grpcBroadcastAddress =
-        override?.host_port ?? yaml?.host_port ?? this.env('HATCHET_CLIENT_HOST_PORT');
-      apiUrl = override?.api_url ?? yaml?.api_url ?? this.env('HATCHET_CLIENT_API_URL');
-    }
+			apiUrl =
+				override?.api_url ??
+				yaml?.api_url ??
+				this.env("HATCHET_CLIENT_API_URL") ??
+				addresses.serverUrl;
+		} catch (e) {
+			grpcBroadcastAddress =
+				override?.host_port ??
+				yaml?.host_port ??
+				this.env("HATCHET_CLIENT_HOST_PORT");
+			apiUrl =
+				override?.api_url ??
+				yaml?.api_url ??
+				this.env("HATCHET_CLIENT_API_URL");
+		}
 
-    let namespace = override?.namespace ?? yaml?.namespace ?? this.env('HATCHET_CLIENT_NAMESPACE');
+		let namespace =
+			override?.namespace ??
+			yaml?.namespace ??
+			this.env("HATCHET_CLIENT_NAMESPACE");
 
-    if (namespace && !namespace?.endsWith('_')) {
-      namespace = `${namespace}_`;
-    }
+		if (namespace && !namespace?.endsWith("_")) {
+			namespace = `${namespace}_`;
+		}
 
-    return {
-      token: override?.token ?? yaml?.token ?? this.env('HATCHET_CLIENT_TOKEN'),
-      host_port: grpcBroadcastAddress,
-      api_url: apiUrl,
-      tls_config: tlsConfig,
-      log_level:
-        override?.log_level ??
-        yaml?.log_level ??
-        (this.env('HATCHET_CLIENT_LOG_LEVEL') as LogLevel) ??
-        'INFO',
-      tenant_id: tenantId,
-      namespace: namespace ? `${namespace}`.toLowerCase() : '',
-    };
-  }
+		// Determine gRPC max message sizes (defaults to 4MB if unset)
+		const grpcMaxRecv =
+			override?.grpc_max_recv_message_length ??
+			yaml?.grpc_max_recv_message_length ??
+			(this.env("HATCHET_CLIENT_GRPC_MAX_RECV_MESSAGE_LENGTH")
+				? Number(this.env("HATCHET_CLIENT_GRPC_MAX_RECV_MESSAGE_LENGTH"))
+				: undefined) ??
+			4 * 1024 * 1024;
 
-  static get default_yaml_config_path() {
-    return p.join(process.cwd(), DEFAULT_CONFIG_FILE);
-  }
+		const grpcMaxSend =
+			override?.grpc_max_send_message_length ??
+			yaml?.grpc_max_send_message_length ??
+			(this.env("HATCHET_CLIENT_GRPC_MAX_SEND_MESSAGE_LENGTH")
+				? Number(this.env("HATCHET_CLIENT_GRPC_MAX_SEND_MESSAGE_LENGTH"))
+				: undefined) ??
+			4 * 1024 * 1024;
 
-  static createCredentials(config: ClientConfig['tls_config']): ChannelCredentials {
-    // if none, create insecure credentials
-    if (config.tls_strategy === 'none') {
-      return ChannelCredentials.createInsecure();
-    }
+		return {
+			token: override?.token ?? yaml?.token ?? this.env("HATCHET_CLIENT_TOKEN"),
+			host_port: grpcBroadcastAddress,
+			api_url: apiUrl,
+			tls_config: tlsConfig,
+			log_level:
+				override?.log_level ??
+				yaml?.log_level ??
+				(this.env("HATCHET_CLIENT_LOG_LEVEL") as LogLevel) ??
+				"INFO",
+			tenant_id: tenantId,
+			namespace: namespace ? `${namespace}`.toLowerCase() : "",
+			grpc_max_recv_message_length: grpcMaxRecv,
+			grpc_max_send_message_length: grpcMaxSend,
+		};
+	}
 
-    if (config.tls_strategy === 'tls') {
-      const rootCerts = config.ca_file ? readFileSync(config.ca_file) : undefined;
-      return ChannelCredentials.createSsl(rootCerts);
-    }
+	static get default_yaml_config_path() {
+		return p.join(process.cwd(), DEFAULT_CONFIG_FILE);
+	}
 
-    const rootCerts = config.ca_file ? readFileSync(config.ca_file) : null;
-    const privateKey = config.key_file ? readFileSync(config.key_file) : null;
-    const certChain = config.cert_file ? readFileSync(config.cert_file) : null;
-    return ChannelCredentials.createSsl(rootCerts, privateKey, certChain);
-  }
+	static createCredentials(
+		config: ClientConfig["tls_config"],
+	): ChannelCredentials {
+		// if none, create insecure credentials
+		if (config.tls_strategy === "none") {
+			return ChannelCredentials.createInsecure();
+		}
 
-  static loadYamlConfig(path?: string): ClientConfig | undefined {
-    try {
-      const configFile = readFileSync(
-        p.join(__dirname, path ?? this.default_yaml_config_path),
-        'utf8'
-      );
+		if (config.tls_strategy === "tls") {
+			const rootCerts = config.ca_file
+				? readFileSync(config.ca_file)
+				: undefined;
+			return ChannelCredentials.createSsl(rootCerts);
+		}
 
-      const config = parse(configFile);
+		const rootCerts = config.ca_file ? readFileSync(config.ca_file) : null;
+		const privateKey = config.key_file ? readFileSync(config.key_file) : null;
+		const certChain = config.cert_file ? readFileSync(config.cert_file) : null;
+		return ChannelCredentials.createSsl(rootCerts, privateKey, certChain);
+	}
 
-      ClientConfigSchema.partial().parse(config);
+	static loadYamlConfig(path?: string): ClientConfig | undefined {
+		try {
+			const configFile = readFileSync(
+				p.join(__dirname, path ?? this.default_yaml_config_path),
+				"utf8",
+			);
 
-      return config as ClientConfig;
-    } catch (e) {
-      if (!path) return undefined;
+			const config = parse(configFile);
 
-      if (e instanceof z.ZodError) {
-        throw new Error(`Invalid yaml config: ${e.message}`);
-      }
+			ClientConfigSchema.partial().parse(config);
 
-      throw e;
-    }
-  }
+			return config as ClientConfig;
+		} catch (e) {
+			if (!path) return undefined;
 
-  private static env(name: EnvVars): string | undefined {
-    return process.env[name];
-  }
+			if (e instanceof z.ZodError) {
+				throw new Error(`Invalid yaml config: ${e.message}`);
+			}
+
+			throw e;
+		}
+	}
+
+	private static env(name: EnvVars): string | undefined {
+		return process.env[name];
+	}
 }

--- a/sdks/typescript/src/util/config-loader/config-loader.ts
+++ b/sdks/typescript/src/util/config-loader/config-loader.ts
@@ -1,192 +1,172 @@
-import { parse } from "yaml";
-import { readFileSync } from "fs";
-import * as p from "path";
-import { z } from "zod";
-import { ClientConfig, ClientConfigSchema } from "@clients/hatchet-client";
-import { ChannelCredentials } from "nice-grpc";
-import { LogLevel } from "@util/logger";
-import { getAddressesFromJWT, getTenantIdFromJWT } from "./token";
+import { parse } from 'yaml';
+import { readFileSync } from 'fs';
+import * as p from 'path';
+import { z } from 'zod';
+import { ClientConfig, ClientConfigSchema } from '@clients/hatchet-client';
+import { ChannelCredentials } from 'nice-grpc';
+import { LogLevel } from '@util/logger';
+import { getAddressesFromJWT, getTenantIdFromJWT } from './token';
 
 type EnvVars =
-	| "HATCHET_CLIENT_TOKEN"
-	| "HATCHET_CLIENT_TLS_STRATEGY"
-	| "HATCHET_CLIENT_HOST_PORT"
-	| "HATCHET_CLIENT_API_URL"
-	| "HATCHET_CLIENT_TLS_CERT_FILE"
-	| "HATCHET_CLIENT_TLS_KEY_FILE"
-	| "HATCHET_CLIENT_TLS_ROOT_CA_FILE"
-	| "HATCHET_CLIENT_TLS_SERVER_NAME"
-	| "HATCHET_CLIENT_LOG_LEVEL"
-	| "HATCHET_CLIENT_NAMESPACE"
-	| "HATCHET_CLIENT_GRPC_MAX_RECV_MESSAGE_LENGTH"
-	| "HATCHET_CLIENT_GRPC_MAX_SEND_MESSAGE_LENGTH";
+  | 'HATCHET_CLIENT_TOKEN'
+  | 'HATCHET_CLIENT_TLS_STRATEGY'
+  | 'HATCHET_CLIENT_HOST_PORT'
+  | 'HATCHET_CLIENT_API_URL'
+  | 'HATCHET_CLIENT_TLS_CERT_FILE'
+  | 'HATCHET_CLIENT_TLS_KEY_FILE'
+  | 'HATCHET_CLIENT_TLS_ROOT_CA_FILE'
+  | 'HATCHET_CLIENT_TLS_SERVER_NAME'
+  | 'HATCHET_CLIENT_LOG_LEVEL'
+  | 'HATCHET_CLIENT_NAMESPACE'
+  | 'HATCHET_CLIENT_GRPC_MAX_RECV_MESSAGE_LENGTH'
+  | 'HATCHET_CLIENT_GRPC_MAX_SEND_MESSAGE_LENGTH';
 
-type TLSStrategy = "tls" | "mtls";
+type TLSStrategy = 'tls' | 'mtls';
 
 interface LoadClientConfigOptions {
-	path?: string;
+  path?: string;
 }
 
-const DEFAULT_CONFIG_FILE = ".hatchet.yaml";
+const DEFAULT_CONFIG_FILE = '.hatchet.yaml';
 
 export class ConfigLoader {
-	static loadClientConfig(
-		override?: Partial<ClientConfig>,
-		config?: LoadClientConfigOptions,
-	): Partial<ClientConfig> {
-		const yaml = this.loadYamlConfig(config?.path);
-		const tlsConfig = override?.tls_config ?? {
-			tls_strategy:
-				yaml?.tls_config?.tls_strategy ??
-				(this.env("HATCHET_CLIENT_TLS_STRATEGY") as TLSStrategy | undefined) ??
-				"tls",
-			cert_file:
-				yaml?.tls_config?.cert_file ??
-				this.env("HATCHET_CLIENT_TLS_CERT_FILE")!,
-			key_file:
-				yaml?.tls_config?.key_file ?? this.env("HATCHET_CLIENT_TLS_KEY_FILE")!,
-			ca_file:
-				yaml?.tls_config?.ca_file ??
-				this.env("HATCHET_CLIENT_TLS_ROOT_CA_FILE")!,
-			server_name:
-				yaml?.tls_config?.server_name ??
-				this.env("HATCHET_CLIENT_TLS_SERVER_NAME")!,
-		};
+  static loadClientConfig(
+    override?: Partial<ClientConfig>,
+    config?: LoadClientConfigOptions
+  ): Partial<ClientConfig> {
+    const yaml = this.loadYamlConfig(config?.path);
+    const tlsConfig = override?.tls_config ?? {
+      tls_strategy:
+        yaml?.tls_config?.tls_strategy ??
+        (this.env('HATCHET_CLIENT_TLS_STRATEGY') as TLSStrategy | undefined) ??
+        'tls',
+      cert_file: yaml?.tls_config?.cert_file ?? this.env('HATCHET_CLIENT_TLS_CERT_FILE')!,
+      key_file: yaml?.tls_config?.key_file ?? this.env('HATCHET_CLIENT_TLS_KEY_FILE')!,
+      ca_file: yaml?.tls_config?.ca_file ?? this.env('HATCHET_CLIENT_TLS_ROOT_CA_FILE')!,
+      server_name: yaml?.tls_config?.server_name ?? this.env('HATCHET_CLIENT_TLS_SERVER_NAME')!,
+    };
 
-		const token =
-			override?.token ?? yaml?.token ?? this.env("HATCHET_CLIENT_TOKEN");
+    const token = override?.token ?? yaml?.token ?? this.env('HATCHET_CLIENT_TOKEN');
 
-		if (!token) {
-			throw new Error(
-				"No token provided. Provide it by setting the HATCHET_CLIENT_TOKEN environment variable.",
-			);
-		}
+    if (!token) {
+      throw new Error(
+        'No token provided. Provide it by setting the HATCHET_CLIENT_TOKEN environment variable.'
+      );
+    }
 
-		let grpcBroadcastAddress: string | undefined;
-		let apiUrl: string | undefined;
-		const tenantId = getTenantIdFromJWT(token!);
+    let grpcBroadcastAddress: string | undefined;
+    let apiUrl: string | undefined;
+    const tenantId = getTenantIdFromJWT(token!);
 
-		if (!tenantId) {
-			throw new Error("Tenant ID not found in subject claim of token");
-		}
+    if (!tenantId) {
+      throw new Error('Tenant ID not found in subject claim of token');
+    }
 
-		try {
-			const addresses = getAddressesFromJWT(token!);
+    try {
+      const addresses = getAddressesFromJWT(token!);
 
-			grpcBroadcastAddress =
-				override?.host_port ??
-				yaml?.host_port ??
-				this.env("HATCHET_CLIENT_HOST_PORT") ??
-				addresses.grpcBroadcastAddress;
+      grpcBroadcastAddress =
+        override?.host_port ??
+        yaml?.host_port ??
+        this.env('HATCHET_CLIENT_HOST_PORT') ??
+        addresses.grpcBroadcastAddress;
 
-			apiUrl =
-				override?.api_url ??
-				yaml?.api_url ??
-				this.env("HATCHET_CLIENT_API_URL") ??
-				addresses.serverUrl;
-		} catch (e) {
-			grpcBroadcastAddress =
-				override?.host_port ??
-				yaml?.host_port ??
-				this.env("HATCHET_CLIENT_HOST_PORT");
-			apiUrl =
-				override?.api_url ??
-				yaml?.api_url ??
-				this.env("HATCHET_CLIENT_API_URL");
-		}
+      apiUrl =
+        override?.api_url ??
+        yaml?.api_url ??
+        this.env('HATCHET_CLIENT_API_URL') ??
+        addresses.serverUrl;
+    } catch (e) {
+      grpcBroadcastAddress =
+        override?.host_port ?? yaml?.host_port ?? this.env('HATCHET_CLIENT_HOST_PORT');
+      apiUrl = override?.api_url ?? yaml?.api_url ?? this.env('HATCHET_CLIENT_API_URL');
+    }
 
-		let namespace =
-			override?.namespace ??
-			yaml?.namespace ??
-			this.env("HATCHET_CLIENT_NAMESPACE");
+    let namespace = override?.namespace ?? yaml?.namespace ?? this.env('HATCHET_CLIENT_NAMESPACE');
 
-		if (namespace && !namespace?.endsWith("_")) {
-			namespace = `${namespace}_`;
-		}
+    if (namespace && !namespace?.endsWith('_')) {
+      namespace = `${namespace}_`;
+    }
 
-		// Determine gRPC max message sizes (defaults to 4MB if unset)
-		const grpcMaxRecv =
-			override?.grpc_max_recv_message_length ??
-			yaml?.grpc_max_recv_message_length ??
-			(this.env("HATCHET_CLIENT_GRPC_MAX_RECV_MESSAGE_LENGTH")
-				? Number(this.env("HATCHET_CLIENT_GRPC_MAX_RECV_MESSAGE_LENGTH"))
-				: undefined) ??
-			4 * 1024 * 1024;
+    // Determine gRPC max message sizes (defaults to 4MB if unset)
+    const grpcMaxRecv =
+      override?.grpc_max_recv_message_length ??
+      yaml?.grpc_max_recv_message_length ??
+      (this.env('HATCHET_CLIENT_GRPC_MAX_RECV_MESSAGE_LENGTH')
+        ? Number(this.env('HATCHET_CLIENT_GRPC_MAX_RECV_MESSAGE_LENGTH'))
+        : undefined) ??
+      4 * 1024 * 1024;
 
-		const grpcMaxSend =
-			override?.grpc_max_send_message_length ??
-			yaml?.grpc_max_send_message_length ??
-			(this.env("HATCHET_CLIENT_GRPC_MAX_SEND_MESSAGE_LENGTH")
-				? Number(this.env("HATCHET_CLIENT_GRPC_MAX_SEND_MESSAGE_LENGTH"))
-				: undefined) ??
-			4 * 1024 * 1024;
+    const grpcMaxSend =
+      override?.grpc_max_send_message_length ??
+      yaml?.grpc_max_send_message_length ??
+      (this.env('HATCHET_CLIENT_GRPC_MAX_SEND_MESSAGE_LENGTH')
+        ? Number(this.env('HATCHET_CLIENT_GRPC_MAX_SEND_MESSAGE_LENGTH'))
+        : undefined) ??
+      4 * 1024 * 1024;
 
-		return {
-			token: override?.token ?? yaml?.token ?? this.env("HATCHET_CLIENT_TOKEN"),
-			host_port: grpcBroadcastAddress,
-			api_url: apiUrl,
-			tls_config: tlsConfig,
-			log_level:
-				override?.log_level ??
-				yaml?.log_level ??
-				(this.env("HATCHET_CLIENT_LOG_LEVEL") as LogLevel) ??
-				"INFO",
-			tenant_id: tenantId,
-			namespace: namespace ? `${namespace}`.toLowerCase() : "",
-			grpc_max_recv_message_length: grpcMaxRecv,
-			grpc_max_send_message_length: grpcMaxSend,
-		};
-	}
+    return {
+      token: override?.token ?? yaml?.token ?? this.env('HATCHET_CLIENT_TOKEN'),
+      host_port: grpcBroadcastAddress,
+      api_url: apiUrl,
+      tls_config: tlsConfig,
+      log_level:
+        override?.log_level ??
+        yaml?.log_level ??
+        (this.env('HATCHET_CLIENT_LOG_LEVEL') as LogLevel) ??
+        'INFO',
+      tenant_id: tenantId,
+      namespace: namespace ? `${namespace}`.toLowerCase() : '',
+      grpc_max_recv_message_length: grpcMaxRecv,
+      grpc_max_send_message_length: grpcMaxSend,
+    };
+  }
 
-	static get default_yaml_config_path() {
-		return p.join(process.cwd(), DEFAULT_CONFIG_FILE);
-	}
+  static get default_yaml_config_path() {
+    return p.join(process.cwd(), DEFAULT_CONFIG_FILE);
+  }
 
-	static createCredentials(
-		config: ClientConfig["tls_config"],
-	): ChannelCredentials {
-		// if none, create insecure credentials
-		if (config.tls_strategy === "none") {
-			return ChannelCredentials.createInsecure();
-		}
+  static createCredentials(config: ClientConfig['tls_config']): ChannelCredentials {
+    // if none, create insecure credentials
+    if (config.tls_strategy === 'none') {
+      return ChannelCredentials.createInsecure();
+    }
 
-		if (config.tls_strategy === "tls") {
-			const rootCerts = config.ca_file
-				? readFileSync(config.ca_file)
-				: undefined;
-			return ChannelCredentials.createSsl(rootCerts);
-		}
+    if (config.tls_strategy === 'tls') {
+      const rootCerts = config.ca_file ? readFileSync(config.ca_file) : undefined;
+      return ChannelCredentials.createSsl(rootCerts);
+    }
 
-		const rootCerts = config.ca_file ? readFileSync(config.ca_file) : null;
-		const privateKey = config.key_file ? readFileSync(config.key_file) : null;
-		const certChain = config.cert_file ? readFileSync(config.cert_file) : null;
-		return ChannelCredentials.createSsl(rootCerts, privateKey, certChain);
-	}
+    const rootCerts = config.ca_file ? readFileSync(config.ca_file) : null;
+    const privateKey = config.key_file ? readFileSync(config.key_file) : null;
+    const certChain = config.cert_file ? readFileSync(config.cert_file) : null;
+    return ChannelCredentials.createSsl(rootCerts, privateKey, certChain);
+  }
 
-	static loadYamlConfig(path?: string): ClientConfig | undefined {
-		try {
-			const configFile = readFileSync(
-				p.join(__dirname, path ?? this.default_yaml_config_path),
-				"utf8",
-			);
+  static loadYamlConfig(path?: string): ClientConfig | undefined {
+    try {
+      const configFile = readFileSync(
+        p.join(__dirname, path ?? this.default_yaml_config_path),
+        'utf8'
+      );
 
-			const config = parse(configFile);
+      const config = parse(configFile);
 
-			ClientConfigSchema.partial().parse(config);
+      ClientConfigSchema.partial().parse(config);
 
-			return config as ClientConfig;
-		} catch (e) {
-			if (!path) return undefined;
+      return config as ClientConfig;
+    } catch (e) {
+      if (!path) return undefined;
 
-			if (e instanceof z.ZodError) {
-				throw new Error(`Invalid yaml config: ${e.message}`);
-			}
+      if (e instanceof z.ZodError) {
+        throw new Error(`Invalid yaml config: ${e.message}`);
+      }
 
-			throw e;
-		}
-	}
+      throw e;
+    }
+  }
 
-	private static env(name: EnvVars): string | undefined {
-		return process.env[name];
-	}
+  private static env(name: EnvVars): string | undefined {
+    return process.env[name];
+  }
 }

--- a/sdks/typescript/src/util/grpc-helpers.ts
+++ b/sdks/typescript/src/util/grpc-helpers.ts
@@ -1,67 +1,60 @@
-import { ClientConfig } from "@hatchet/clients/hatchet-client";
+import { ClientConfig } from '@hatchet/clients/hatchet-client';
 import {
-	ChannelCredentials,
-	CompatServiceDefinition,
-	createChannel,
-	createClientFactory,
-} from "nice-grpc";
-import { ClientMiddlewareCall, CallOptions, Metadata } from "nice-grpc-common";
-import { ConfigLoader } from "./config-loader";
+  ChannelCredentials,
+  CompatServiceDefinition,
+  createChannel,
+  createClientFactory,
+} from 'nice-grpc';
+import { ClientMiddlewareCall, CallOptions, Metadata } from 'nice-grpc-common';
+import { ConfigLoader } from './config-loader';
 
-export const channelFactory = (
-	config: ClientConfig,
-	credentials: ChannelCredentials,
-) =>
-	createChannel(config.host_port, credentials, {
-		"grpc.ssl_target_name_override": config.tls_config.server_name,
-		"grpc.keepalive_timeout_ms": 60 * 1000,
-		"grpc.client_idle_timeout_ms": 60 * 1000,
-		// Send keepalive pings every 10 seconds, default is 2 hours.
-		"grpc.keepalive_time_ms": 10 * 1000,
-		// Allow keepalive pings when there are no gRPC calls.
-		"grpc.keepalive_permit_without_calls": 1,
-		// Configurable gRPC message size limits
-		"grpc.max_send_message_length":
-			config.grpc_max_send_message_length ?? 4 * 1024 * 1024,
-		"grpc.max_receive_message_length":
-			config.grpc_max_recv_message_length ?? 4 * 1024 * 1024,
-	});
+export const channelFactory = (config: ClientConfig, credentials: ChannelCredentials) =>
+  createChannel(config.host_port, credentials, {
+    'grpc.ssl_target_name_override': config.tls_config.server_name,
+    'grpc.keepalive_timeout_ms': 60 * 1000,
+    'grpc.client_idle_timeout_ms': 60 * 1000,
+    // Send keepalive pings every 10 seconds, default is 2 hours.
+    'grpc.keepalive_time_ms': 10 * 1000,
+    // Allow keepalive pings when there are no gRPC calls.
+    'grpc.keepalive_permit_without_calls': 1,
+    // Configurable gRPC message size limits
+    'grpc.max_send_message_length': config.grpc_max_send_message_length ?? 4 * 1024 * 1024,
+    'grpc.max_receive_message_length': config.grpc_max_recv_message_length ?? 4 * 1024 * 1024,
+  });
 
 export const addTokenMiddleware = (token: string) =>
-	async function* _<Request, Response>(
-		call: ClientMiddlewareCall<Request, Response>,
-		options: CallOptions,
-	) {
-		const optionsWithAuth: CallOptions = {
-			...options,
-			metadata: new Metadata({ authorization: `bearer ${token}` }),
-		};
+  async function* _<Request, Response>(
+    call: ClientMiddlewareCall<Request, Response>,
+    options: CallOptions
+  ) {
+    const optionsWithAuth: CallOptions = {
+      ...options,
+      metadata: new Metadata({ authorization: `bearer ${token}` }),
+    };
 
-		if (!call.responseStream) {
-			const response = yield* call.next(call.request, optionsWithAuth);
+    if (!call.responseStream) {
+      const response = yield* call.next(call.request, optionsWithAuth);
 
-			return response;
-		}
+      return response;
+    }
 
-		for await (const response of call.next(call.request, optionsWithAuth)) {
-			yield response;
-		}
+    for await (const response of call.next(call.request, optionsWithAuth)) {
+      yield response;
+    }
 
-		return undefined;
-	};
+    return undefined;
+  };
 
 export const createGrpcClient = <T extends CompatServiceDefinition>(
-	config: ClientConfig,
-	serviceDefinition: T,
+  config: ClientConfig,
+  serviceDefinition: T
 ) => {
-	const credentials = ConfigLoader.createCredentials(config.tls_config);
-	const clientFactory = createClientFactory().use(
-		addTokenMiddleware(config.token),
-	);
-	const channel = channelFactory(config, credentials);
-	return {
-		factory: clientFactory,
-		channel,
-		client: clientFactory.create<T>(serviceDefinition, channel),
-	};
+  const credentials = ConfigLoader.createCredentials(config.tls_config);
+  const clientFactory = createClientFactory().use(addTokenMiddleware(config.token));
+  const channel = channelFactory(config, credentials);
+  return {
+    factory: clientFactory,
+    channel,
+    client: clientFactory.create<T>(serviceDefinition, channel),
+  };
 };

--- a/sdks/typescript/src/util/grpc-helpers.ts
+++ b/sdks/typescript/src/util/grpc-helpers.ts
@@ -1,57 +1,67 @@
-import { ClientConfig } from '@hatchet/clients/hatchet-client';
+import { ClientConfig } from "@hatchet/clients/hatchet-client";
 import {
-  ChannelCredentials,
-  CompatServiceDefinition,
-  createChannel,
-  createClientFactory,
-} from 'nice-grpc';
-import { ClientMiddlewareCall, CallOptions, Metadata } from 'nice-grpc-common';
-import { ConfigLoader } from './config-loader';
+	ChannelCredentials,
+	CompatServiceDefinition,
+	createChannel,
+	createClientFactory,
+} from "nice-grpc";
+import { ClientMiddlewareCall, CallOptions, Metadata } from "nice-grpc-common";
+import { ConfigLoader } from "./config-loader";
 
-export const channelFactory = (config: ClientConfig, credentials: ChannelCredentials) =>
-  createChannel(config.host_port, credentials, {
-    'grpc.ssl_target_name_override': config.tls_config.server_name,
-    'grpc.keepalive_timeout_ms': 60 * 1000,
-    'grpc.client_idle_timeout_ms': 60 * 1000,
-    // Send keepalive pings every 10 seconds, default is 2 hours.
-    'grpc.keepalive_time_ms': 10 * 1000,
-    // Allow keepalive pings when there are no gRPC calls.
-    'grpc.keepalive_permit_without_calls': 1,
-  });
+export const channelFactory = (
+	config: ClientConfig,
+	credentials: ChannelCredentials,
+) =>
+	createChannel(config.host_port, credentials, {
+		"grpc.ssl_target_name_override": config.tls_config.server_name,
+		"grpc.keepalive_timeout_ms": 60 * 1000,
+		"grpc.client_idle_timeout_ms": 60 * 1000,
+		// Send keepalive pings every 10 seconds, default is 2 hours.
+		"grpc.keepalive_time_ms": 10 * 1000,
+		// Allow keepalive pings when there are no gRPC calls.
+		"grpc.keepalive_permit_without_calls": 1,
+		// Configurable gRPC message size limits
+		"grpc.max_send_message_length":
+			config.grpc_max_send_message_length ?? 4 * 1024 * 1024,
+		"grpc.max_receive_message_length":
+			config.grpc_max_recv_message_length ?? 4 * 1024 * 1024,
+	});
 
 export const addTokenMiddleware = (token: string) =>
-  async function* _<Request, Response>(
-    call: ClientMiddlewareCall<Request, Response>,
-    options: CallOptions
-  ) {
-    const optionsWithAuth: CallOptions = {
-      ...options,
-      metadata: new Metadata({ authorization: `bearer ${token}` }),
-    };
+	async function* _<Request, Response>(
+		call: ClientMiddlewareCall<Request, Response>,
+		options: CallOptions,
+	) {
+		const optionsWithAuth: CallOptions = {
+			...options,
+			metadata: new Metadata({ authorization: `bearer ${token}` }),
+		};
 
-    if (!call.responseStream) {
-      const response = yield* call.next(call.request, optionsWithAuth);
+		if (!call.responseStream) {
+			const response = yield* call.next(call.request, optionsWithAuth);
 
-      return response;
-    }
+			return response;
+		}
 
-    for await (const response of call.next(call.request, optionsWithAuth)) {
-      yield response;
-    }
+		for await (const response of call.next(call.request, optionsWithAuth)) {
+			yield response;
+		}
 
-    return undefined;
-  };
+		return undefined;
+	};
 
 export const createGrpcClient = <T extends CompatServiceDefinition>(
-  config: ClientConfig,
-  serviceDefinition: T
+	config: ClientConfig,
+	serviceDefinition: T,
 ) => {
-  const credentials = ConfigLoader.createCredentials(config.tls_config);
-  const clientFactory = createClientFactory().use(addTokenMiddleware(config.token));
-  const channel = channelFactory(config, credentials);
-  return {
-    factory: clientFactory,
-    channel,
-    client: clientFactory.create<T>(serviceDefinition, channel),
-  };
+	const credentials = ConfigLoader.createCredentials(config.tls_config);
+	const clientFactory = createClientFactory().use(
+		addTokenMiddleware(config.token),
+	);
+	const channel = channelFactory(config, credentials);
+	return {
+		factory: clientFactory,
+		channel,
+		client: clientFactory.create<T>(serviceDefinition, channel),
+	};
 };


### PR DESCRIPTION
# Description

Added `grpc_max_recv_message_length` and `grpc_max_send_message_length` as optional parameters to the ClientConfigSchema.

This allows hatchet users using the typescript SDK to change the max grpc message size for their workers.

If the context for a job grows above 4mb, current behaviour just crashes the worker, which is not ideal if your use case requires bigger messages for certain jobs. `onSuccess` and `onFailure` seems to be especially problematic since all "hanging" tasks are considered parents to those two. 

Fixes:
- https://github.com/hatchet-dev/hatchet-typescript/issues/367
- https://github.com/hatchet-dev/hatchet/issues/768 ( but for typescript SDK )

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

1. gprc params added to the client-config-schema:
```ts
	grpc_max_recv_message_length: z.number().optional(),
	grpc_max_send_message_length: z.number().optional(),
```

2. added the same values as environment variables
```ts
  | 'HATCHET_CLIENT_GRPC_MAX_RECV_MESSAGE_LENGTH'
  | 'HATCHET_CLIENT_GRPC_MAX_SEND_MESSAGE_LENGTH';
```

3. Made sure these values are passed into the channelFactory inside the gprc-helper:
```ts
  createChannel(config.host_port, credentials, {
    'grpc.ssl_target_name_override': config.tls_config.server_name,
    'grpc.keepalive_timeout_ms': 60 * 1000,
    'grpc.client_idle_timeout_ms': 60 * 1000,
    'grpc.keepalive_time_ms': 10 * 1000,
    'grpc.keepalive_permit_without_calls': 1,
    'grpc.max_send_message_length': config.grpc_max_send_message_length ?? 4 * 1024 * 1024,
    'grpc.max_receive_message_length': config.grpc_max_recv_message_length ?? 4 * 1024 * 1024,
  });
```