### PR TITLE
add wsl note for python

### DIFF
--- a/frontend/docs/pages/home/workers.mdx
+++ b/frontend/docs/pages/home/workers.mdx
@@ -29,7 +29,7 @@ Declare a worker by calling the `worker` method on the Hatchet client. The `work
     ```
 
     <Callout type="warning">
-      If you are using Windows, attempting to run a worker will result in an error: 
+      If you are using Windows, attempting to run a worker will result in an error:
 
       ```
       AttributeError: module 'signal' has no attribute 'SIGQUIT'
@@ -41,7 +41,7 @@ Declare a worker by calling the `worker` method on the Hatchet client. The `work
       trigger task runs or query the API) in your native Windows environment, but your
       workers have to be run in WSL.
 
-      Another option is to run workers in Docker containers. 
+      Another option is to run workers in Docker containers.
     </Callout>
 
   </Tabs.Tab>

--- a/frontend/docs/pages/home/workers.mdx
+++ b/frontend/docs/pages/home/workers.mdx
@@ -28,6 +28,22 @@ Declare a worker by calling the `worker` method on the Hatchet client. The `work
         main()
     ```
 
+    <Callout type="warning">
+      If you are using Windows, attempting to run a worker will result in an error: 
+
+      ```
+      AttributeError: module 'signal' has no attribute 'SIGQUIT'
+      ```
+
+      However you can use the [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) to run your workers. After
+      you install your Python environment (e.g. via `uv` or `poetry`) in WSL, you can then
+      run your workers inside that environment.  You can still run client code (e.g. to
+      trigger task runs or query the API) in your native Windows environment, but your
+      workers have to be run in WSL.
+
+      Another option is to run workers in Docker containers. 
+    </Callout>
+
   </Tabs.Tab>
   <Tabs.Tab title="Typescript">
     ### Register the Worker


### PR DESCRIPTION
# Description

Currently, workers on Windows raise an attribute error. This can be confusing for someone following the docs, as I do not think it mentions anywhere else that windows workers are not really supported.  A user might not realize that they are doing nothing wrong and have not misconfigured anything, as the error is somewhat cryptic (it's about signaling).

## Type of change

<!-- Please delete options that are not relevant. -->


- [x] Documentation change (pure documentation change)

## What's Changed

- [x] Added a recommendation to either use WSL or Docker containers when building with Hatchet on windows.