### PR TITLE
Fix: Improve performance of `UpdateTasksToAssigned`

### DIFF
--- a/pkg/repository/v1/scheduler_queue.go
+++ b/pkg/repository/v1/scheduler_queue.go
@@ -244,7 +244,7 @@ func (d *queueRepository) MarkQueueItemsProcessed(ctx context.Context, r *Assign
 			taskInsertedAts = append(taskInsertedAts, assignedItem.QueueItem.TaskInsertedAt)
 			workerIds = append(workerIds, assignedItem.WorkerId)
 
-			if !minTaskInsertedAt.Valid || assignedItem.QueueItem.TaskInsertedAt.Time.Before(minTaskInsertedAt.Time) {
+			if assignedItem.QueueItem.TaskInsertedAt.Valid && (!minTaskInsertedAt.Valid || assignedItem.QueueItem.TaskInsertedAt.Time.Before(minTaskInsertedAt.Time)) {
 				minTaskInsertedAt = assignedItem.QueueItem.TaskInsertedAt
 			}
 		}

--- a/pkg/repository/v1/sqlcv1/queue.sql
+++ b/pkg/repository/v1/sqlcv1/queue.sql
@@ -184,6 +184,7 @@ RETURNING
 WITH input AS (
     SELECT
         id,
+        inserted_at,
         worker_id
     FROM
         (

--- a/pkg/repository/v1/sqlcv1/queue.sql
+++ b/pkg/repository/v1/sqlcv1/queue.sql
@@ -188,8 +188,9 @@ WITH input AS (
     FROM
         (
             SELECT
-                unnest(@taskIds::bigint[]) AS id,
-                unnest(@workerIds::uuid[]) AS worker_id
+                UNNEST(@taskIds::bigint[]) AS id,
+                UNNEST(@taskInsertedAts::timestamptz[]) AS inserted_at,
+                UNNEST(@workerIds::uuid[]) AS worker_id
         ) AS subquery
     ORDER BY id
 ), updated_tasks AS (
@@ -197,13 +198,15 @@ WITH input AS (
         t.id,
         t.inserted_at,
         t.retry_count,
-        input.worker_id,
+        i.worker_id,
         t.tenant_id,
         CURRENT_TIMESTAMP + convert_duration_to_interval(t.step_timeout) AS timeout_at
     FROM
-        input
+        v1_task t
     JOIN
-        v1_task t ON t.id = input.id
+        input i ON (t.id, t.inserted_at) = (i.id, i.inserted_at)
+    WHERE
+        t.inserted_at >= @minTaskInsertedAt::timestamptz
     ORDER BY t.id
 ), assigned_tasks AS (
     INSERT INTO v1_task_runtime (

--- a/pkg/repository/v1/sqlcv1/queue.sql.go
+++ b/pkg/repository/v1/sqlcv1/queue.sql.go
@@ -471,6 +471,7 @@ const updateTasksToAssigned = `-- name: UpdateTasksToAssigned :many
 WITH input AS (
     SELECT
         id,
+        inserted_at,
         worker_id
     FROM
         (


### PR DESCRIPTION
# Description

Couple small tweaks:

1. Partition pruning by passing in a `minInsertedAt`
2. Joining using the full PK (including the `insertedAt`)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

