### PR TITLE
Fix: Call `PopulateTaskRunData` sequentially

### DIFF
--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -1776,7 +1776,7 @@ type TaskIdInsertedAt struct {
 }
 
 func (r *OLAPRepositoryImpl) populateTaskRunData(ctx context.Context, tx pgx.Tx, tenantId string, opts []TaskIdInsertedAt, includePayloads bool) ([]*sqlcv1.PopulateTaskRunDataRow, error) {
-	ctx, span := telemetry.NewSpan(ctx, "populate-task-run-data")
+	ctx, span := telemetry.NewSpan(ctx, "populate-task-run-data-olap")
 	defer span.End()
 
 	uniqueTaskIdInsertedAts := make(map[TaskIdInsertedAt]struct{})

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -1776,7 +1776,7 @@ type TaskIdInsertedAt struct {
 }
 
 func (r *OLAPRepositoryImpl) populateTaskRunData(ctx context.Context, tx pgx.Tx, tenantId string, opts []TaskIdInsertedAt, includePayloads bool) ([]*sqlcv1.PopulateTaskRunDataRow, error) {
-	ctx, span := telemetry.NewSpan(ctx, "populate-task-run-data-olap")
+	ctx, span := telemetry.NewSpan(ctx, "populate-task-run-data")
 	defer span.End()
 
 	uniqueTaskIdInsertedAts := make(map[TaskIdInsertedAt]struct{})

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -609,7 +609,7 @@ func (r *OLAPRepositoryImpl) ListTasks(ctx context.Context, tenantId string, opt
 	tasksWithData := make([]*sqlcv1.PopulateTaskRunDataRow, 0)
 	span.SetAttributes(attribute.KeyValue{
 		Key:   "PopulateTaskRunData.num_tasks_to_populate",
-		Value: attribute.Int64Value(int64(len(rows))),
+		Value: attribute.IntValue(len(rows)),
 	})
 
 	for _, row := range rows {
@@ -674,7 +674,7 @@ func (r *OLAPRepositoryImpl) ListTasksByDAGId(ctx context.Context, tenantId stri
 	tasksWithData := make([]*sqlcv1.PopulateTaskRunDataRow, 0)
 	span.SetAttributes(attribute.KeyValue{
 		Key:   "PopulateTaskRunData.num_tasks_to_populate",
-		Value: attribute.Int64Value(int64(len(tasks))),
+		Value: attribute.IntValue(len(tasks)),
 	})
 
 	for _, row := range tasks {
@@ -719,7 +719,7 @@ func (r *OLAPRepositoryImpl) ListTasksByIdAndInsertedAt(ctx context.Context, ten
 	tasksWithData := make([]*sqlcv1.PopulateTaskRunDataRow, 0)
 	span.SetAttributes(attribute.KeyValue{
 		Key:   "PopulateTaskRunData.num_tasks_to_populate",
-		Value: attribute.Int64Value(int64(len(taskMetadata))),
+		Value: attribute.IntValue(len(taskMetadata)),
 	})
 
 	for _, metadata := range taskMetadata {
@@ -840,7 +840,7 @@ func (r *OLAPRepositoryImpl) ListWorkflowRuns(ctx context.Context, tenantId stri
 
 	span.SetAttributes(attribute.KeyValue{
 		Key:   "PopulateTaskRunData.num_tasks_to_populate",
-		Value: attribute.Int64Value(int64(len(workflowRunIds))),
+		Value: attribute.IntValue(len(workflowRunIds)),
 	})
 	for _, row := range workflowRunIds {
 		if row.Kind == sqlcv1.V1RunKindDAG {
@@ -1525,7 +1525,7 @@ func (r *OLAPRepositoryImpl) GetTaskTimings(ctx context.Context, tenantId string
 	tasksWithData := make([]*sqlcv1.PopulateTaskRunDataRow, 0)
 	span.SetAttributes(attribute.KeyValue{
 		Key:   "PopulateTaskRunData.num_tasks_to_populate",
-		Value: attribute.Int64Value(int64(len(runsList))),
+		Value: attribute.IntValue(len(runsList)),
 	})
 
 	for _, row := range runsList {

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -620,7 +620,7 @@ func (r *OLAPRepositoryImpl) ListTasks(ctx context.Context, tenantId string, opt
 		}
 
 		if errors.Is(err, pgx.ErrNoRows) {
-			r.l.Warn().Msgf("task %d not found with inserted at %s", row.ID, row.InsertedAt)
+			r.l.Warn().Msgf("task %d not found with inserted at %s", row.ID, row.InsertedAt.Time)
 			continue
 		}
 

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -1789,7 +1789,7 @@ func (r *OLAPRepositoryImpl) populateTaskRunData(ctx context.Context, tx pgx.Tx,
 	}
 
 	span.SetAttributes(attribute.KeyValue{
-		Key:   "populateTaskRunData.batchSize",
+		Key:   "populate-task-run-data-olap.batch_size",
 		Value: attribute.IntValue(len(uniqueTaskIdInsertedAts)),
 	})
 


### PR DESCRIPTION
# Description

For some reason the planner (esp. with Timescale) is really bad at figuring out which partitions to scan and how to join results together for this query, but running it for a single task is fast 🤷 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

