### PR TITLE
Update prometheus-client version to >=0.21.1

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -32,7 +32,7 @@ opentelemetry-instrumentation = { version = ">=0.49b0", optional = true }
 opentelemetry-distro = { version = ">=0.49b0", optional = true }
 opentelemetry-exporter-otlp = { version = "^1.28.0", optional = true }
 opentelemetry-exporter-otlp-proto-http = { version = "^1.28.0", optional = true }
-prometheus-client = "^0.21.1"
+prometheus-client = ">=0.21.1"
 pydantic-settings = "^2.7.1"
 
 [tool.poetry.group.lint.dependencies]

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.16.4"
+version = "1.16.5"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
Update prometheus-client version to >=0.21.1 (instead of being pinned to v0.21.1)

# Description

This PR relaxes the version constraint of prometheus-client from ^0.21.1 to >=0.22. The reason for this change is that the previous constraint was too strict and caused dependency conflicts in Poetry when used alongside other packages that require a newer version. Since prometheus-client>=0.22 is backward compatible, this update is safe and avoids unnecessary version resolution issues.

Fixes # (issue)
#2095

## Type of change
- [X] Chore (changes which are not directly related to any business logic)
