### PR TITLE
fix: don't wait for grpc stream send on rabbitmq loop

### DIFF
--- a/internal/services/dispatcher/dispatcher_v1.go
+++ b/internal/services/dispatcher/dispatcher_v1.go
@@ -260,53 +260,61 @@ func (d *DispatcherImpl) handleTaskBulkAssignedTask(ctx context.Context, msg *ms
 		}
 	}
 
-	outerErr := outerEg.Wait()
+	// we spawn a goroutine to wait for the outer error group to finish and handle retries, because sending over the gRPC stream
+	// can occasionally take a long time and we don't want to block the RabbitMQ queue processing
+	go func() {
+		outerErr := outerEg.Wait()
 
-	if len(toRetry) > 0 {
-		retryCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
+		if len(toRetry) > 0 {
+			retryCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
 
-		retryGroup := errgroup.Group{}
+			retryGroup := errgroup.Group{}
 
-		for _, _task := range toRetry {
-			tenantId := msg.TenantID
-			task := _task
+			for _, _task := range toRetry {
+				tenantId := msg.TenantID
+				task := _task
 
-			retryGroup.Go(func() error {
-				msg, err := tasktypesv1.FailedTaskMessage(
-					tenantId,
-					task.ID,
-					task.InsertedAt,
-					sqlchelpers.UUIDToStr(task.ExternalID),
-					sqlchelpers.UUIDToStr(task.WorkflowRunID),
-					task.RetryCount,
-					false,
-					"Could not send task to worker",
-					false,
-				)
+				retryGroup.Go(func() error {
+					msg, err := tasktypesv1.FailedTaskMessage(
+						tenantId,
+						task.ID,
+						task.InsertedAt,
+						sqlchelpers.UUIDToStr(task.ExternalID),
+						sqlchelpers.UUIDToStr(task.WorkflowRunID),
+						task.RetryCount,
+						false,
+						"Could not send task to worker",
+						false,
+					)
 
-				if err != nil {
-					return fmt.Errorf("could not create failed task message: %w", err)
-				}
+					if err != nil {
+						return fmt.Errorf("could not create failed task message: %w", err)
+					}
 
-				queueutils.SleepWithExponentialBackoff(100*time.Millisecond, 5*time.Second, int(task.InternalRetryCount))
+					queueutils.SleepWithExponentialBackoff(100*time.Millisecond, 5*time.Second, int(task.InternalRetryCount))
 
-				err = d.mqv1.SendMessage(retryCtx, msgqueuev1.TASK_PROCESSING_QUEUE, msg)
+					err = d.mqv1.SendMessage(retryCtx, msgqueuev1.TASK_PROCESSING_QUEUE, msg)
 
-				if err != nil {
-					return fmt.Errorf("could not send failed task message: %w", err)
-				}
+					if err != nil {
+						return fmt.Errorf("could not send failed task message: %w", err)
+					}
 
-				return nil
-			})
+					return nil
+				})
+			}
+
+			if err := retryGroup.Wait(); err != nil {
+				outerErr = multierror.Append(outerErr, fmt.Errorf("could not retry failed tasks: %w", err))
+			}
 		}
 
-		if err := retryGroup.Wait(); err != nil {
-			outerErr = multierror.Append(outerErr, fmt.Errorf("could not retry failed tasks: %w", err))
+		if outerErr != nil {
+			d.l.Error().Err(outerErr).Msg("failed to handle task assigned bulk message")
 		}
-	}
+	}()
 
-	return outerErr
+	return nil
 }
 
 func (d *DispatcherImpl) handleTaskCancelled(ctx context.Context, msg *msgqueuev1.Message) error {


### PR DESCRIPTION
# Description

Alternative to #2113 

Avoids blocking on the RabbitMQ dispatcher queue while still waiting for DB lookups to be successful, allowing for backpressure on RabbitMQ if we're seeing high DB latencies.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)