### PR TITLE
Feat: Run `ANALYZE` on a few tables once a day

### DIFF
--- a/internal/services/controllers/v1/olap/analyze.go
+++ b/internal/services/controllers/v1/olap/analyze.go
@@ -1,0 +1,28 @@
+package olap
+
+import (
+	"context"
+)
+
+func (oc *OLAPControllerImpl) runAnalyze(ctx context.Context) func() {
+	return func() {
+		oc.l.Debug().Msgf("analyze: running analyze on partitioned tables")
+
+		tenant, err := oc.p.GetInternalTenantForController(ctx)
+
+		if err != nil {
+			oc.l.Error().Err(err).Msg("could not get internal tenant")
+			return
+		}
+
+		if tenant == nil {
+			return
+		}
+
+		err = oc.repo.OLAP().AnalyzeOLAPTables(ctx)
+
+		if err != nil {
+			oc.l.Error().Err(err).Msg("could not analyze OLAP tables")
+		}
+	}
+}

--- a/internal/services/controllers/v1/olap/analyze.go
+++ b/internal/services/controllers/v1/olap/analyze.go
@@ -8,18 +8,7 @@ func (oc *OLAPControllerImpl) runAnalyze(ctx context.Context) func() {
 	return func() {
 		oc.l.Debug().Msgf("analyze: running analyze on partitioned tables")
 
-		tenant, err := oc.p.GetInternalTenantForController(ctx)
-
-		if err != nil {
-			oc.l.Error().Err(err).Msg("could not get internal tenant")
-			return
-		}
-
-		if tenant == nil {
-			return
-		}
-
-		err = oc.repo.OLAP().AnalyzeOLAPTables(ctx)
+		err := oc.repo.OLAP().AnalyzeOLAPTables(ctx)
 
 		if err != nil {
 			oc.l.Error().Err(err).Msg("could not analyze OLAP tables")

--- a/internal/services/controllers/v1/olap/controller.go
+++ b/internal/services/controllers/v1/olap/controller.go
@@ -287,6 +287,22 @@ func (o *OLAPControllerImpl) Start() (func() error, error) {
 		return nil, fmt.Errorf("could not schedule process tenant alerts: %w", err)
 	}
 
+	_, err = o.s.NewJob(
+		gocron.DailyJob(1, gocron.NewAtTimes(
+			gocron.NewAtTime(10, 30, 0),
+			gocron.NewAtTime(14, 0, 0),
+		)),
+		gocron.NewTask(
+			o.runAnalyze(ctx),
+		),
+		gocron.WithSingletonMode(gocron.LimitModeReschedule),
+	)
+
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("could not run analyze: %w", err)
+	}
+
 	cleanupBuffer, err := mqBuffer.Start()
 
 	if err != nil {

--- a/internal/services/controllers/v1/olap/controller.go
+++ b/internal/services/controllers/v1/olap/controller.go
@@ -289,8 +289,8 @@ func (o *OLAPControllerImpl) Start() (func() error, error) {
 
 	_, err = o.s.NewJob(
 		gocron.DailyJob(1, gocron.NewAtTimes(
-			gocron.NewAtTime(10, 30, 0),
-			gocron.NewAtTime(14, 0, 0),
+			// 5AM UTC
+			gocron.NewAtTime(5, 0, 0),
 		)),
 		gocron.NewTask(
 			o.runAnalyze(ctx),

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -1795,22 +1795,46 @@ func (r *OLAPRepositoryImpl) StoreCELEvaluationFailures(ctx context.Context, ten
 }
 
 func (r *OLAPRepositoryImpl) AnalyzeOLAPTables(ctx context.Context) error {
-	err := r.queries.AnalyzeV1RunsOLAP(ctx, r.pool)
+	const timeout = 1000 * 60 * 5 // 5 minute timeout
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, timeout)
+
+	if err != nil {
+		return fmt.Errorf("error beginning transaction: %v", err)
+	}
+
+	defer rollback()
+
+	acquired, err := r.queries.TryAdvisoryLock(ctx, tx, hash("analyze-olap-tables"))
+
+	if err != nil {
+		return fmt.Errorf("error acquiring advisory lock: %v", err)
+	}
+
+	if !acquired {
+		r.l.Info().Msg("advisory lock already held, skipping OLAP table analysis")
+		return nil
+	}
+
+	err = r.queries.AnalyzeV1RunsOLAP(ctx, tx)
 
 	if err != nil {
 		return fmt.Errorf("error analyzing v1_runs_olap: %v", err)
 	}
 
-	err = r.queries.AnalyzeV1TasksOLAP(ctx, r.pool)
+	err = r.queries.AnalyzeV1TasksOLAP(ctx, tx)
 
 	if err != nil {
 		return fmt.Errorf("error analyzing v1_tasks_olap: %v", err)
 	}
 
-	err = r.queries.AnalyzeV1DAGsOLAP(ctx, r.pool)
+	err = r.queries.AnalyzeV1DAGsOLAP(ctx, tx)
 
 	if err != nil {
 		return fmt.Errorf("error analyzing v1_dags_olap: %v", err)
+	}
+
+	if err := commit(ctx); err != nil {
+		return fmt.Errorf("error committing transaction: %v", err)
 	}
 
 	return nil

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -238,6 +238,8 @@ type OLAPRepository interface {
 
 	CreateIncomingWebhookValidationFailureLogs(ctx context.Context, tenantId string, opts []CreateIncomingWebhookFailureLogOpts) error
 	StoreCELEvaluationFailures(ctx context.Context, tenantId string, failures []CELEvaluationFailure) error
+
+	AnalyzeOLAPTables(ctx context.Context) error
 }
 
 type OLAPRepositoryImpl struct {
@@ -1790,6 +1792,28 @@ func (r *OLAPRepositoryImpl) StoreCELEvaluationFailures(ctx context.Context, ten
 		Sources:  sources,
 		Errors:   errorMessages,
 	})
+}
+
+func (r *OLAPRepositoryImpl) AnalyzeOLAPTables(ctx context.Context) error {
+	err := r.queries.AnalyzeV1RunsOLAP(ctx, r.pool)
+
+	if err != nil {
+		return fmt.Errorf("error analyzing v1_runs_olap: %v", err)
+	}
+
+	err = r.queries.AnalyzeV1TasksOLAP(ctx, r.pool)
+
+	if err != nil {
+		return fmt.Errorf("error analyzing v1_tasks_olap: %v", err)
+	}
+
+	err = r.queries.AnalyzeV1DAGsOLAP(ctx, r.pool)
+
+	if err != nil {
+		return fmt.Errorf("error analyzing v1_dags_olap: %v", err)
+	}
+
+	return nil
 }
 
 type IdInsertedAt struct {

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -1795,7 +1795,7 @@ func (r *OLAPRepositoryImpl) StoreCELEvaluationFailures(ctx context.Context, ten
 }
 
 func (r *OLAPRepositoryImpl) AnalyzeOLAPTables(ctx context.Context) error {
-	const timeout = 1000 * 60 * 5 // 5 minute timeout
+	const timeout = 1000 * 60 * 30 // 30 minute timeout
 	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, timeout)
 
 	if err != nil {

--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -16,6 +16,15 @@ SELECT
     create_v1_range_partition('v1_cel_evaluation_failures_olap'::text, @date::date)
 ;
 
+-- name: AnalyzeV1RunsOLAP :exec
+ANALYZE v1_runs_olap;
+
+-- name: AnalyzeV1TasksOLAP :exec
+ANALYZE v1_tasks_olap;
+
+-- name: AnalyzeV1DAGsOLAP :exec
+ANALYZE v1_dags_olap;
+
 -- name: ListOLAPPartitionsBeforeDate :many
 WITH task_partitions AS (
     SELECT 'v1_tasks_olap' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_tasks_olap'::text, @date::date) AS p

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -11,6 +11,33 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const analyzeV1DAGsOLAP = `-- name: AnalyzeV1DAGsOLAP :exec
+ANALYZE v1_dags_olap
+`
+
+func (q *Queries) AnalyzeV1DAGsOLAP(ctx context.Context, db DBTX) error {
+	_, err := db.Exec(ctx, analyzeV1DAGsOLAP)
+	return err
+}
+
+const analyzeV1RunsOLAP = `-- name: AnalyzeV1RunsOLAP :exec
+ANALYZE v1_runs_olap
+`
+
+func (q *Queries) AnalyzeV1RunsOLAP(ctx context.Context, db DBTX) error {
+	_, err := db.Exec(ctx, analyzeV1RunsOLAP)
+	return err
+}
+
+const analyzeV1TasksOLAP = `-- name: AnalyzeV1TasksOLAP :exec
+ANALYZE v1_tasks_olap
+`
+
+func (q *Queries) AnalyzeV1TasksOLAP(ctx context.Context, db DBTX) error {
+	_, err := db.Exec(ctx, analyzeV1TasksOLAP)
+	return err
+}
+
 type BulkCreateEventTriggersParams struct {
 	RunID         int64              `json:"run_id"`
 	RunInsertedAt pgtype.Timestamptz `json:"run_inserted_at"`


### PR DESCRIPTION
# Description

Starting with these, figure we can add whatever other tables we want easily. `ANALYZE` should improve our query performance on the partitioned tables significantly

The reason for this is that, as it turns out, autovacuum does not affect the partitioned table itself, only the partitions. This was resulting in the planner making bad choices for how to plan + execute queries (especially ones involving `UNNEST` with many parameters where we'd need to scan many partitions), ending up significantly mis-estimating how many rows different CTEs would return and similar, causing very poor performance. The idea here is that running an analyze would improve these estimations, leading to much improved query performance

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

