### PR TITLE
chore(deps): update protobuf dependency to version 6.0.0 or higher in…

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -17,7 +17,7 @@ grpcio-tools = [
     { version = ">=1.64.1, !=1.68.*", markers = "python_version < '3.13'" },
     { version = ">=1.69.0", markers = "python_version >= '3.13'" },
 ]
-protobuf = "^5.29.5"
+protobuf = ">=6.0.0"
 pydantic = "^2.6.3"
 python-dateutil = "^2.9.0.post0"
 urllib3 = ">=1.26.20"


### PR DESCRIPTION
### Description
Fixes protobuf version mismatch with other packages by updating the protobuf dependency to version 6.0.0+.
Changes ( Python SDK )

Updated protobuf dependency in pyproject.toml to >=6.0.0

### Type of Change

 Dependency update

Fixes: #2178