### PR TITLE
Add missing options for timeout and workflow task defaults

### DIFF
--- a/sdks/go/examples/cancellations/main.go
+++ b/sdks/go/examples/cancellations/main.go
@@ -58,7 +58,7 @@ func main() {
 			Status:    "completed",
 			Completed: true,
 		}, nil
-	}, hatchet.WithTimeout(30*time.Second))
+	}, hatchet.WithExecutionTimeout(30*time.Second))
 
 	// Create a worker
 	worker, err := client.NewWorker("cancellation-worker",

--- a/sdks/go/examples/on-failure/main.go
+++ b/sdks/go/examples/on-failure/main.go
@@ -65,7 +65,7 @@ func main() {
 			Status:  "success",
 			Message: "Task completed: " + input.Message,
 		}, nil
-	}, hatchet.WithTimeout(5*time.Second))
+	}, hatchet.WithExecutionTimeout(5*time.Second))
 
 	// Add failure handler to the workflow
 	failureWorkflow.OnFailure(func(ctx hatchet.Context, input FailureInput) (FailureHandlerOutput, error) {

--- a/sdks/go/examples/retries-concurrency/main.go
+++ b/sdks/go/examples/retries-concurrency/main.go
@@ -59,7 +59,7 @@ func main() {
 	},
 		hatchet.WithRetries(3),
 		hatchet.WithRetryBackoff(2.0, 60), // Exponential backoff: 2s, 4s, 8s, then cap at 60s
-		hatchet.WithTimeout(30*time.Second),
+		hatchet.WithExecutionTimeout(30*time.Second),
 		hatchet.WithConcurrency(&types.Concurrency{
 			Expression:    "input.category", // Limit concurrency per category
 			MaxRuns:       &maxRuns,         // Max 2 concurrent tasks per category

--- a/sdks/go/examples/timeouts/main.go
+++ b/sdks/go/examples/timeouts/main.go
@@ -45,7 +45,7 @@ func main() {
 				Completed: true,
 			}, nil
 		},
-		hatchet.WithTimeout(3*time.Second), // 3 second timeout
+		hatchet.WithExecutionTimeout(3*time.Second), // 3 second timeout
 	)
 
 	// Create workflow with timeout refresh example
@@ -80,7 +80,7 @@ func main() {
 				Completed: true,
 			}, nil
 		},
-		hatchet.WithTimeout(3*time.Second), // Initial 3 second timeout
+		hatchet.WithExecutionTimeout(3*time.Second), // Initial 3 second timeout
 	)
 
 	// Create workflow with context cancellation handling
@@ -115,7 +115,7 @@ func main() {
 				Completed: true,
 			}, nil
 		},
-		hatchet.WithTimeout(5*time.Second), // 5 second timeout
+		hatchet.WithExecutionTimeout(5*time.Second), // 5 second timeout
 	)
 
 	// Create a worker with all workflows

--- a/sdks/go/workflow.go
+++ b/sdks/go/workflow.go
@@ -131,11 +131,12 @@ func (w *Workflow) GetName() string {
 type WorkflowOption func(*workflowConfig)
 
 type workflowConfig struct {
-	onCron      []string
-	onEvents    []string
-	concurrency []types.Concurrency
-	version     string
-	description string
+	onCron       []string
+	onEvents     []string
+	concurrency  []types.Concurrency
+	version      string
+	description  string
+	taskDefaults *create.TaskDefaults
 }
 
 // WithWorkflowCron configures the workflow to run on a cron schedule.
@@ -174,6 +175,13 @@ func WithWorkflowConcurrency(concurrency ...types.Concurrency) WorkflowOption {
 	}
 }
 
+// WithWorkflowTaskDefaults sets the default configuration for all tasks in the workflow.
+func WithWorkflowTaskDefaults(defaults *create.TaskDefaults) WorkflowOption {
+	return func(config *workflowConfig) {
+		config.taskDefaults = defaults
+	}
+}
+
 // newWorkflow creates a new workflow definition.
 func newWorkflow(name string, v0Client v0Client.Client, options ...WorkflowOption) *Workflow {
 	config := &workflowConfig{}
@@ -184,12 +192,13 @@ func newWorkflow(name string, v0Client v0Client.Client, options ...WorkflowOptio
 
 	declaration := internal.NewWorkflowDeclaration[any, any](
 		create.WorkflowCreateOpts[any]{
-			Name:        name,
-			Version:     config.version,
-			Description: config.description,
-			OnEvents:    config.onEvents,
-			OnCron:      config.onCron,
-			Concurrency: config.concurrency,
+			Name:         name,
+			Version:      config.version,
+			Description:  config.description,
+			OnEvents:     config.onEvents,
+			OnCron:       config.onCron,
+			Concurrency:  config.concurrency,
+			TaskDefaults: config.taskDefaults,
 		},
 		v0Client,
 	)
@@ -208,6 +217,7 @@ type taskConfig struct {
 	retryBackoffFactor     float32
 	retryMaxBackoffSeconds int32
 	executionTimeout       time.Duration
+	scheduleTimeout        time.Duration
 	onCron                 []string
 	onEvents               []string
 	defaultFilters         []types.DefaultFilter
@@ -234,8 +244,15 @@ func WithRetryBackoff(factor float32, maxBackoffSeconds int) TaskOption {
 	}
 }
 
-// WithTimeout sets the maximum execution duration for a task.
-func WithTimeout(timeout time.Duration) TaskOption {
+// WithScheduleTimeout sets the maximum time a task can wait to be scheduled.
+func WithScheduleTimeout(timeout time.Duration) TaskOption {
+	return func(config *taskConfig) {
+		config.scheduleTimeout = timeout
+	}
+}
+
+// WithExecutionTimeout sets the maximum execution duration for a task.
+func WithExecutionTimeout(timeout time.Duration) TaskOption {
 	return func(config *taskConfig) {
 		config.executionTimeout = timeout
 	}
@@ -404,6 +421,7 @@ func (w *Workflow) NewTask(name string, fn any, options ...TaskOption) *Task {
 		RetryBackoffFactor:     config.retryBackoffFactor,
 		RetryMaxBackoffSeconds: config.retryMaxBackoffSeconds,
 		ExecutionTimeout:       config.executionTimeout,
+		ScheduleTimeout:        config.scheduleTimeout,
 		Concurrency:            config.concurrency,
 		RateLimits:             config.rateLimits,
 		Parents:                config.parents,


### PR DESCRIPTION
# Description

Add missing options for task scheduling timeout and workflow task defaults.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
