### PR TITLE
[FE]: Re-enable refetch queue metrics, fix action button / dropdown state

### DIFF
--- a/frontend/app/src/pages/main/v1/task-runs-v1/actions.tsx
+++ b/frontend/app/src/pages/main/v1/task-runs-v1/actions.tsx
@@ -426,22 +426,25 @@ const BaseActionButton = ({
 export const TaskRunActionButton = ({
   actionType,
   disabled,
+  paramOverrides,
   showModal,
   className,
 }: {
   actionType: ActionType;
   disabled: boolean;
+  paramOverrides?: BaseTaskRunActionParams;
   showModal: boolean;
   className?: string;
 }) => {
   const { actionModalParams } = useRunsContext();
+  const params = paramOverrides || actionModalParams;
 
   switch (actionType) {
     case 'cancel':
       return (
         <BaseActionButton
           disabled={disabled}
-          params={{ ...actionModalParams, actionType: 'cancel' }}
+          params={{ ...params, actionType: 'cancel' }}
           icon={<XCircleIcon className="w-4 h-4" />}
           label={'Cancel'}
           showModal={showModal}
@@ -452,7 +455,7 @@ export const TaskRunActionButton = ({
       return (
         <BaseActionButton
           disabled={disabled}
-          params={{ ...actionModalParams, actionType: 'replay' }}
+          params={{ ...params, actionType: 'replay' }}
           icon={<Repeat1 className="w-4 h-4" />}
           label={'Replay'}
           showModal={showModal}

--- a/frontend/app/src/pages/main/v1/task-runs-v1/actions.tsx
+++ b/frontend/app/src/pages/main/v1/task-runs-v1/actions.tsx
@@ -392,7 +392,11 @@ const BaseActionButton = ({
 }) => {
   const { handleTaskRunAction } = useTaskRunActions();
   const {
-    actions: { setIsActionModalOpen, setSelectedActionType },
+    actions: {
+      setIsActionModalOpen,
+      setSelectedActionType,
+      setIsActionDropdownOpen,
+    },
   } = useRunsContext();
 
   return (
@@ -402,8 +406,10 @@ const BaseActionButton = ({
       variant={'outline'}
       disabled={disabled}
       onClick={() => {
+        setSelectedActionType(params.actionType);
+        setIsActionDropdownOpen(false);
+
         if (!showModal) {
-          setSelectedActionType(params.actionType);
           handleTaskRunAction(params);
           return;
         }
@@ -420,22 +426,22 @@ const BaseActionButton = ({
 export const TaskRunActionButton = ({
   actionType,
   disabled,
-  params,
   showModal,
   className,
 }: {
   actionType: ActionType;
   disabled: boolean;
-  params: BaseTaskRunActionParams;
   showModal: boolean;
   className?: string;
 }) => {
+  const { actionModalParams } = useRunsContext();
+
   switch (actionType) {
     case 'cancel':
       return (
         <BaseActionButton
           disabled={disabled}
-          params={{ ...params, actionType: 'cancel' }}
+          params={{ ...actionModalParams, actionType: 'cancel' }}
           icon={<XCircleIcon className="w-4 h-4" />}
           label={'Cancel'}
           showModal={showModal}
@@ -446,7 +452,7 @@ export const TaskRunActionButton = ({
       return (
         <BaseActionButton
           disabled={disabled}
-          params={{ ...params, actionType: 'replay' }}
+          params={{ ...actionModalParams, actionType: 'replay' }}
           icon={<Repeat1 className="w-4 h-4" />}
           label={'Replay'}
           showModal={showModal}

--- a/frontend/app/src/pages/main/v1/task-runs-v1/actions.tsx
+++ b/frontend/app/src/pages/main/v1/task-runs-v1/actions.tsx
@@ -35,9 +35,9 @@ export const TASK_RUN_TERMINAL_STATUSES = [
   V1TaskStatus.COMPLETED,
 ];
 
-type ActionType = 'cancel' | 'replay';
+export type ActionType = 'cancel' | 'replay';
 
-type BaseTaskRunActionParams =
+export type BaseTaskRunActionParams =
   | {
       filter?: never;
       externalIds:
@@ -51,7 +51,7 @@ type BaseTaskRunActionParams =
       externalIds?: never;
     };
 
-type TaskRunActionsParams =
+export type TaskRunActionsParams =
   | {
       actionType: 'cancel';
       filter?: never;
@@ -167,10 +167,7 @@ export const useTaskRunActions = () => {
 
 type ConfirmActionModalProps = {
   actionType: ActionType;
-  onConfirm: () => void;
-  params: TaskRunActionsParams;
-  isOpen: boolean;
-  setIsOpen: (isOpen: boolean) => void;
+  params: BaseTaskRunActionParams;
 };
 
 const actionTypeToLabel = (actionType: ActionType) => {
@@ -188,7 +185,7 @@ const actionTypeToLabel = (actionType: ActionType) => {
 
 type ModalContentProps = {
   label: string;
-  params: TaskRunActionsParams;
+  params: BaseTaskRunActionParams;
 };
 
 const CancelByExternalIdsContent = ({ label, params }: ModalContentProps) => {
@@ -326,8 +323,11 @@ const ModalContent = ({ label, params }: ModalContentProps) => {
   }
 };
 
-export const ConfirmActionModal = ({ params }: ConfirmActionModalProps) => {
-  const label = actionTypeToLabel(params.actionType);
+export const ConfirmActionModal = ({
+  actionType,
+  params,
+}: ConfirmActionModalProps) => {
+  const label = actionTypeToLabel(actionType);
   const { handleTaskRunAction } = useTaskRunActions();
   const {
     isActionModalOpen,
@@ -359,7 +359,10 @@ export const ConfirmActionModal = ({ params }: ConfirmActionModalProps) => {
             </Button>
             <Button
               onClick={() => {
-                handleTaskRunAction(params);
+                handleTaskRunAction({
+                  ...params,
+                  actionType,
+                });
                 setIsActionModalOpen(false);
               }}
             >
@@ -389,7 +392,7 @@ const BaseActionButton = ({
 }) => {
   const { handleTaskRunAction } = useTaskRunActions();
   const {
-    actions: { setIsActionModalOpen },
+    actions: { setIsActionModalOpen, setSelectedActionType },
   } = useRunsContext();
 
   return (
@@ -400,6 +403,7 @@ const BaseActionButton = ({
       disabled={disabled}
       onClick={() => {
         if (!showModal) {
+          setSelectedActionType(params.actionType);
           handleTaskRunAction(params);
           return;
         }

--- a/frontend/app/src/pages/main/v1/task-runs-v1/actions.tsx
+++ b/frontend/app/src/pages/main/v1/task-runs-v1/actions.tsx
@@ -78,9 +78,6 @@ export const useTaskRunActions = () => {
   const { toast } = useToast();
 
   const { handleApiError } = useApiError({});
-  const {
-    actions: { setIsActionDropdownOpen },
-  } = useRunsContext();
 
   const onActionSubmit = useCallback(
     (actionType: ActionType) => {

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/index.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/index.tsx
@@ -37,6 +37,7 @@ import { useQuery } from '@tanstack/react-query';
 import invariant from 'tiny-invariant';
 import { Spinner } from '@/components/v1/ui/loading';
 import { Waterfall } from './v2components/waterfall';
+import { RunsProvider } from '../hooks/runs-provider';
 
 export const WORKFLOW_RUN_TERMINAL_STATUSES = [
   WorkflowRunStatus.CANCELLED,
@@ -165,11 +166,19 @@ export default function Run() {
   }
 
   if (runData.type === 'task') {
-    return <ExpandedTaskRun id={run} />;
+    return (
+      <RunsProvider tableKey={`task-runs-${run}`}>
+        <ExpandedTaskRun id={run} />
+      </RunsProvider>
+    );
   }
 
   if (runData.type === 'dag') {
-    return <ExpandedWorkflowRun id={run} />;
+    return (
+      <RunsProvider tableKey={`workflow-runs-${run}`}>
+        <ExpandedWorkflowRun id={run} />
+      </RunsProvider>
+    );
   }
 }
 

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/header.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/header.tsx
@@ -18,8 +18,6 @@ import { CopyWorkflowConfigButton } from '@/components/v1/shared/copy-workflow-c
 import { useCurrentTenantId } from '@/hooks/use-tenant';
 import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { useToast } from '@/components/v1/hooks/use-toast';
-import { useCallback } from 'react';
 import { Toaster } from '@/components/v1/ui/toaster';
 
 export const WORKFLOW_RUN_TERMINAL_STATUSES = [
@@ -30,7 +28,6 @@ export const WORKFLOW_RUN_TERMINAL_STATUSES = [
 
 export const V1RunDetailHeader = () => {
   const { tenantId } = useCurrentTenantId();
-  const { toast } = useToast();
   const {
     workflowRun,
     workflowConfig,

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/header.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/header.tsx
@@ -37,22 +37,6 @@ export const V1RunDetailHeader = () => {
     isLoading: loading,
   } = useWorkflowDetails();
 
-  const onActionProcessed = useCallback(
-    (action: 'cancel' | 'replay') => {
-      const prefix = action === 'cancel' ? 'Canceling' : 'Replaying';
-
-      const t = toast({
-        title: `${prefix} task run`,
-        description: `This may take a few seconds. You don't need to hit ${action} again.`,
-      });
-
-      setTimeout(() => {
-        t.dismiss();
-      }, 5000);
-    },
-    [toast],
-  );
-
   if (loading || !workflowRun) {
     return <div>Loading...</div>;
   }
@@ -97,14 +81,12 @@ export const V1RunDetailHeader = () => {
                 !TASK_RUN_TERMINAL_STATUSES.includes(workflowRun.status)
               }
               showModal={false}
-              onActionProcessed={() => onActionProcessed('replay')}
             />
             <TaskRunActionButton
               actionType="cancel"
               params={{ externalIds: [workflowRun.metadata.id] }}
               disabled={TASK_RUN_TERMINAL_STATUSES.includes(workflowRun.status)}
               showModal={false}
-              onActionProcessed={() => onActionProcessed('cancel')}
             />
           </div>
         </div>

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/header.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/header.tsx
@@ -73,7 +73,7 @@ export const V1RunDetailHeader = () => {
             <WorkflowDefinitionLink workflowId={workflowRun.workflowId} />
             <TaskRunActionButton
               actionType="replay"
-              params={{ externalIds: [workflowRun.metadata.id] }}
+              paramOverrides={{ externalIds: [workflowRun.metadata.id] }}
               disabled={
                 !TASK_RUN_TERMINAL_STATUSES.includes(workflowRun.status)
               }
@@ -81,7 +81,7 @@ export const V1RunDetailHeader = () => {
             />
             <TaskRunActionButton
               actionType="cancel"
-              params={{ externalIds: [workflowRun.metadata.id] }}
+              paramOverrides={{ externalIds: [workflowRun.metadata.id] }}
               disabled={TASK_RUN_TERMINAL_STATUSES.includes(workflowRun.status)}
               showModal={false}
             />

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/header.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/header.tsx
@@ -98,12 +98,6 @@ export const V1RunDetailHeader = () => {
               }
               showModal={false}
               onActionProcessed={() => onActionProcessed('replay')}
-              onActionSubmit={() => {
-                toast({
-                  title: 'Replay request submitted',
-                  description: "No need to hit 'Replay' again.",
-                });
-              }}
             />
             <TaskRunActionButton
               actionType="cancel"
@@ -111,12 +105,6 @@ export const V1RunDetailHeader = () => {
               disabled={TASK_RUN_TERMINAL_STATUSES.includes(workflowRun.status)}
               showModal={false}
               onActionProcessed={() => onActionProcessed('cancel')}
-              onActionSubmit={() => {
-                toast({
-                  title: 'Cancel request submitted',
-                  description: "No need to hit 'Cancel' again.",
-                });
-              }}
             />
           </div>
         </div>

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail.tsx
@@ -29,7 +29,6 @@ import { CopyWorkflowConfigButton } from '@/components/v1/shared/copy-workflow-c
 import { useCurrentTenantId } from '@/hooks/use-tenant';
 import { Waterfall } from '../waterfall';
 import { useState, useCallback } from 'react';
-import { useToast } from '@/components/v1/hooks/use-toast';
 import { Toaster } from '@/components/v1/ui/toaster';
 
 export enum TabOption {
@@ -95,7 +94,6 @@ export const TaskRunDetail = ({
 }: TaskRunDetailProps) => {
   const [selectedTaskRunId, setSelectedTaskRunId] = useState<string>();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-  const { toast } = useToast();
 
   const handleTaskRunExpand = useCallback((taskRunId: string) => {
     setSelectedTaskRunId(taskRunId);

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail.tsx
@@ -114,22 +114,6 @@ export const TaskRunDetail = ({
     },
   });
 
-  const onActionProcessed = useCallback(
-    (action: 'cancel' | 'replay') => {
-      const prefix = action === 'cancel' ? 'Canceling' : 'Replaying';
-
-      const t = toast({
-        title: `${prefix} task run`,
-        description: `This may take a few seconds. You don't need to hit ${action} again.`,
-      });
-
-      setTimeout(() => {
-        t.dismiss();
-      }, 5000);
-    },
-    [toast],
-  );
-
   const taskRun = taskRunQuery.data;
 
   if (taskRunQuery.isLoading) {
@@ -170,14 +154,12 @@ export const TaskRunDetail = ({
           params={{ externalIds: [taskRunId] }}
           disabled={!TASK_RUN_TERMINAL_STATUSES.includes(taskRun.status)}
           showModal={false}
-          onActionProcessed={() => onActionProcessed('replay')}
         />
         <TaskRunActionButton
           actionType="cancel"
           params={{ externalIds: [taskRunId] }}
           disabled={TASK_RUN_TERMINAL_STATUSES.includes(taskRun.status)}
           showModal={false}
-          onActionProcessed={() => onActionProcessed('cancel')}
         />
         <TaskRunPermalinkOrBacklink
           taskRun={taskRun}

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail.tsx
@@ -149,13 +149,13 @@ export const TaskRunDetail = ({
       <div className="flex flex-row gap-2 items-center">
         <TaskRunActionButton
           actionType="replay"
-          params={{ externalIds: [taskRunId] }}
+          paramOverrides={{ externalIds: [taskRunId] }}
           disabled={!TASK_RUN_TERMINAL_STATUSES.includes(taskRun.status)}
           showModal={false}
         />
         <TaskRunActionButton
           actionType="cancel"
-          params={{ externalIds: [taskRunId] }}
+          paramOverrides={{ externalIds: [taskRunId] }}
           disabled={TASK_RUN_TERMINAL_STATUSES.includes(taskRun.status)}
           showModal={false}
         />

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail.tsx
@@ -171,12 +171,6 @@ export const TaskRunDetail = ({
           disabled={!TASK_RUN_TERMINAL_STATUSES.includes(taskRun.status)}
           showModal={false}
           onActionProcessed={() => onActionProcessed('replay')}
-          onActionSubmit={() => {
-            toast({
-              title: 'Replay request submitted',
-              description: "No need to hit 'Replay' again.",
-            });
-          }}
         />
         <TaskRunActionButton
           actionType="cancel"
@@ -184,12 +178,6 @@ export const TaskRunDetail = ({
           disabled={TASK_RUN_TERMINAL_STATUSES.includes(taskRun.status)}
           showModal={false}
           onActionProcessed={() => onActionProcessed('cancel')}
-          onActionSubmit={() => {
-            toast({
-              title: 'Cancel request submitted',
-              description: "No need to hit 'Cancel' again.",
-            });
-          }}
         />
         <TaskRunPermalinkOrBacklink
           taskRun={taskRun}

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
@@ -35,6 +35,7 @@ import { useRunsContext } from '../hooks/runs-provider';
 
 import { TableActions } from './task-runs-table/table-actions';
 import { TimeFilter } from './task-runs-table/time-filter';
+import { ConfirmActionModal } from '../../task-runs-v1/actions';
 
 export interface RunsTableProps {
   headerClassName?: string;
@@ -112,6 +113,8 @@ export function RunsTable({ headerClassName }: RunsTableProps) {
     isMetricsFetching,
     metrics,
     tenantMetrics,
+    actionModalParams,
+    selectedActionType,
     display: {
       hideMetrics,
       hideCounts,
@@ -230,6 +233,12 @@ export function RunsTable({ headerClassName }: RunsTableProps) {
   return (
     <div className="flex flex-col h-full overflow-hidden">
       <Toaster />
+      {selectedActionType && (
+        <ConfirmActionModal
+          actionType={selectedActionType}
+          params={actionModalParams}
+        />
+      )}
 
       <TriggerWorkflowForm
         defaultWorkflow={undefined}

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
@@ -24,7 +24,6 @@ import {
 import { IntroDocsEmptyState } from '@/pages/onboarding/intro-docs-empty-state';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
 import { TriggerWorkflowForm } from '../../workflows/$workflow/components/trigger-workflow-form';
-import { useToast } from '@/components/v1/hooks/use-toast';
 import { Toaster } from '@/components/v1/ui/toaster';
 import { useQuery } from '@tanstack/react-query';
 import { queries } from '@/lib/api';
@@ -98,7 +97,6 @@ const GetWorkflowChart = () => {
 
 export function RunsTable({ headerClassName }: RunsTableProps) {
   const { tenantId } = useCurrentTenantId();
-  const { toast } = useToast();
   const [, setSearchParams] = useSearchParams();
 
   const {
@@ -195,23 +193,6 @@ export function RunsTable({ headerClassName }: RunsTableProps) {
     refetchMetrics();
     setRotate(!rotate);
   }, [refetchRuns, refetchMetrics, rotate]);
-
-  const handleActionProcessed = useCallback(
-    (action: 'cancel' | 'replay', ids: string[]) => {
-      const prefix = action === 'cancel' ? 'Canceling' : 'Replaying';
-      const count = ids.length;
-
-      const t = toast({
-        title: `${prefix} ${count} task run${count > 1 ? 's' : ''}`,
-        description: `This may take a few seconds. You don't need to hit ${action} again.`,
-      });
-
-      setTimeout(() => {
-        t.dismiss();
-      }, 5000);
-    },
-    [toast],
-  );
 
   useEffect(() => {
     if (state.isCustomTimeRange) {
@@ -350,10 +331,8 @@ export function RunsTable({ headerClassName }: RunsTableProps) {
             <TableActions
               key="table-actions"
               onRefresh={handleRefresh}
-              onActionProcessed={handleActionProcessed}
               onTriggerWorkflow={() => updateUIState({ triggerWorkflow: true })}
               rotate={rotate}
-              toast={toast}
             />,
           ]}
           columnFilters={state.columnFilters}

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions.tsx
@@ -55,10 +55,7 @@ export const TableActions = ({
             <ChevronDownIcon className="ml-2 h-4 w-4" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent
-          align="end"
-          className="z-[70]"
-        >
+        <DropdownMenuContent align="end" className="z-[70]">
           {!hideCancelAndReplayButtons && (
             <>
               <CancelMenuItem />

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions.tsx
@@ -57,7 +57,7 @@ export const TableActions = ({
         </DropdownMenuTrigger>
         <DropdownMenuContent
           align="end"
-          className="z-[70] data-[is-modal-open=true]:hidden"
+          className="z-[70]"
         >
           {!hideCancelAndReplayButtons && (
             <>

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions.tsx
@@ -170,13 +170,6 @@ const CancelMenuItem = ({
         params={params}
         showModal
         onActionProcessed={(ids) => onActionProcessed('cancel', ids)}
-        onActionSubmit={() => {
-          onDelayedClose();
-          toast({
-            title: 'Cancel request submitted',
-            description: "No need to hit 'Cancel' again.",
-          });
-        }}
         className="w-full justify-start h-8 px-2 py-1.5 font-normal border-0 bg-transparent hover:bg-accent hover:text-accent-foreground rounded-sm"
       />
     </div>
@@ -210,13 +203,6 @@ const ReplayMenuItem = ({
         params={params}
         showModal
         onActionProcessed={(ids) => onActionProcessed('replay', ids)}
-        onActionSubmit={() => {
-          onDelayedClose();
-          toast({
-            title: 'Replay request submitted',
-            description: "No need to hit 'Replay' again.",
-          });
-        }}
         className="w-full justify-start h-8 px-2 py-1.5 font-normal border-0 bg-transparent hover:bg-accent hover:text-accent-foreground rounded-sm"
       />
     </div>

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions.tsx
@@ -67,22 +67,8 @@ export const TableActions = ({
         >
           {!hideCancelAndReplayButtons && (
             <>
-              <CancelMenuItem
-                onActionProcessed={(action, ids) => {
-                  onActionProcessed(action, ids);
-                  setDropdownOpen(false);
-                }}
-                toast={toast}
-                onDelayedClose={() => setShouldDelayClose(true)}
-              />
-              <ReplayMenuItem
-                onActionProcessed={(action, ids) => {
-                  onActionProcessed(action, ids);
-                  setDropdownOpen(false);
-                }}
-                toast={toast}
-                onDelayedClose={() => setShouldDelayClose(true)}
-              />
+              <CancelMenuItem />
+              <ReplayMenuItem />
               <DropdownMenuSeparator />
             </>
           )}
@@ -143,13 +129,7 @@ export const TableActions = ({
   return <>{actions}</>;
 };
 
-const CancelMenuItem = ({
-  onActionProcessed,
-  toast,
-  onDelayedClose,
-}: Pick<TableActionsProps, 'toast' | 'onActionProcessed'> & {
-  onDelayedClose: () => void;
-}) => {
+const CancelMenuItem = () => {
   const { selectedRuns, filters } = useRunsContext();
 
   const params =
@@ -169,20 +149,13 @@ const CancelMenuItem = ({
         disabled={false}
         params={params}
         showModal
-        onActionProcessed={(ids) => onActionProcessed('cancel', ids)}
         className="w-full justify-start h-8 px-2 py-1.5 font-normal border-0 bg-transparent hover:bg-accent hover:text-accent-foreground rounded-sm"
       />
     </div>
   );
 };
 
-const ReplayMenuItem = ({
-  onActionProcessed,
-  toast,
-  onDelayedClose,
-}: Pick<TableActionsProps, 'toast' | 'onActionProcessed'> & {
-  onDelayedClose: () => void;
-}) => {
+const ReplayMenuItem = () => {
   const { selectedRuns, filters } = useRunsContext();
 
   const params =
@@ -202,7 +175,6 @@ const ReplayMenuItem = ({
         disabled={false}
         params={params}
         showModal
-        onActionProcessed={(ids) => onActionProcessed('replay', ids)}
         className="w-full justify-start h-8 px-2 py-1.5 font-normal border-0 bg-transparent hover:bg-accent hover:text-accent-foreground rounded-sm"
       />
     </div>

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions.tsx
@@ -15,18 +15,14 @@ import { ChevronDownIcon } from '@radix-ui/react-icons';
 
 interface TableActionsProps {
   onRefresh: () => void;
-  onActionProcessed: (action: 'cancel' | 'replay', ids: string[]) => void;
   onTriggerWorkflow: () => void;
   rotate: boolean;
-  toast: any;
 }
 
 export const TableActions = ({
   onRefresh,
-  onActionProcessed,
   onTriggerWorkflow,
   rotate,
-  toast,
 }: TableActionsProps) => {
   const [shouldDelayClose, setShouldDelayClose] = useState(false);
   const {
@@ -34,7 +30,6 @@ export const TableActions = ({
     isActionDropdownOpen,
     actions: { setIsFrozen, setIsActionDropdownOpen },
     display: { hideTriggerRunButton, hideCancelAndReplayButtons },
-    isActionModalOpen,
   } = useRunsContext();
 
   const actions = useMemo(() => {
@@ -112,17 +107,15 @@ export const TableActions = ({
     return baseActions;
   }, [
     onRefresh,
-    onActionProcessed,
     onTriggerWorkflow,
     hideTriggerRunButton,
     rotate,
-    toast,
     hideCancelAndReplayButtons,
     isFrozen,
     setIsFrozen,
     setIsActionDropdownOpen,
+    isActionDropdownOpen,
     shouldDelayClose,
-    isActionModalOpen,
   ]);
 
   return <>{actions}</>;

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions.tsx
@@ -28,11 +28,11 @@ export const TableActions = ({
   rotate,
   toast,
 }: TableActionsProps) => {
-  const [dropdownOpen, setDropdownOpen] = useState(false);
   const [shouldDelayClose, setShouldDelayClose] = useState(false);
   const {
     isFrozen,
-    actions: { setIsFrozen },
+    isActionDropdownOpen,
+    actions: { setIsFrozen, setIsActionDropdownOpen },
     display: { hideTriggerRunButton, hideCancelAndReplayButtons },
     isActionModalOpen,
   } = useRunsContext();
@@ -41,16 +41,16 @@ export const TableActions = ({
     let baseActions = [
       <DropdownMenu
         key="actions"
-        open={dropdownOpen}
+        open={isActionDropdownOpen}
         onOpenChange={(open) => {
           if (open) {
-            setDropdownOpen(true);
+            setIsActionDropdownOpen(true);
             setShouldDelayClose(false);
           } else if (shouldDelayClose) {
-            setTimeout(() => setDropdownOpen(false), 150);
+            setTimeout(() => setIsActionDropdownOpen(false), 150);
             setShouldDelayClose(false);
           } else {
-            setDropdownOpen(false);
+            setIsActionDropdownOpen(false);
           }
         }}
       >
@@ -63,7 +63,6 @@ export const TableActions = ({
         <DropdownMenuContent
           align="end"
           className="z-[70] data-[is-modal-open=true]:hidden"
-          data-is-modal-open={isActionModalOpen}
         >
           {!hideCancelAndReplayButtons && (
             <>
@@ -121,7 +120,7 @@ export const TableActions = ({
     hideCancelAndReplayButtons,
     isFrozen,
     setIsFrozen,
-    dropdownOpen,
+    setIsActionDropdownOpen,
     shouldDelayClose,
     isActionModalOpen,
   ]);
@@ -130,24 +129,11 @@ export const TableActions = ({
 };
 
 const CancelMenuItem = () => {
-  const { selectedRuns, filters } = useRunsContext();
-
-  const params =
-    selectedRuns.length > 0
-      ? { externalIds: selectedRuns.map((run) => run?.metadata.id) }
-      : {
-          filter: {
-            ...filters.apiFilters,
-            since: filters.apiFilters.since || '',
-          },
-        };
-
   return (
     <div className="w-full">
       <TaskRunActionButton
         actionType="cancel"
         disabled={false}
-        params={params}
         showModal
         className="w-full justify-start h-8 px-2 py-1.5 font-normal border-0 bg-transparent hover:bg-accent hover:text-accent-foreground rounded-sm"
       />
@@ -156,24 +142,11 @@ const CancelMenuItem = () => {
 };
 
 const ReplayMenuItem = () => {
-  const { selectedRuns, filters } = useRunsContext();
-
-  const params =
-    selectedRuns.length > 0
-      ? { externalIds: selectedRuns.map((run) => run?.metadata.id) }
-      : {
-          filter: {
-            ...filters.apiFilters,
-            since: filters.apiFilters.since || '',
-          },
-        };
-
   return (
     <div className="w-full">
       <TaskRunActionButton
         actionType="replay"
         disabled={false}
-        params={params}
         showModal
         className="w-full justify-start h-8 px-2 py-1.5 font-normal border-0 bg-transparent hover:bg-accent hover:text-accent-foreground rounded-sm"
       />

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
@@ -192,7 +192,7 @@ export const RunsProvider = ({
     parentTaskExternalId: derivedParentTaskExternalId,
     createdAfter: state.createdAfter,
     refetchInterval,
-    pauseRefetch: state.hasOpenUI || isFrozen,
+    pauseRefetch: isFrozen,
   });
 
   const value = useMemo<RunsContextType>(

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
@@ -64,6 +64,7 @@ type RunsContextType = {
     resetState: () => void;
     setIsFrozen: (isFrozen: boolean) => void;
     setIsActionModalOpen: (isOpen: boolean) => void;
+    setIsActionDropdownOpen: (isOpen: boolean) => void;
     refetchRuns: () => void;
     refetchMetrics: () => void;
     getRowId: (row: V1TaskSummary) => string;
@@ -81,6 +82,7 @@ type RunsContextType = {
   tenantMetrics: object;
   isFrozen: boolean;
   isActionModalOpen: boolean;
+  isActionDropdownOpen: boolean;
   display: DisplayProps;
 };
 
@@ -98,6 +100,7 @@ export const RunsProvider = ({
 }: RunsProviderProps) => {
   const [isFrozen, setIsFrozen] = useState(false);
   const [isActionModalOpen, setIsActionModalOpen] = useState(false);
+  const [isActionDropdownOpen, setIsActionDropdownOpen] = useState(false);
 
   const {
     workflowId,
@@ -211,6 +214,7 @@ export const RunsProvider = ({
       tenantMetrics,
       isFrozen,
       isActionModalOpen,
+      isActionDropdownOpen,
       display: {
         hideMetrics,
         hideCounts,
@@ -230,6 +234,7 @@ export const RunsProvider = ({
         resetState,
         setIsFrozen,
         setIsActionModalOpen,
+        setIsActionDropdownOpen,
         refetchRuns,
         refetchMetrics,
         getRowId,
@@ -250,6 +255,7 @@ export const RunsProvider = ({
       tenantMetrics,
       isFrozen,
       isActionModalOpen,
+      isActionDropdownOpen,
       hideMetrics,
       hideCounts,
       hideDateFilter,
@@ -263,6 +269,7 @@ export const RunsProvider = ({
       resetState,
       setIsFrozen,
       setIsActionModalOpen,
+      setIsActionDropdownOpen,
       refetchRuns,
       refetchMetrics,
       getRowId,

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
@@ -12,6 +12,10 @@ import { useMetrics } from './use-metrics';
 import { workflowKey } from '../components/v1/task-runs-columns';
 import { V1TaskRunMetrics, V1TaskSummary } from '@/lib/api';
 import { PaginationState } from '@tanstack/react-table';
+import {
+  ActionType,
+  BaseTaskRunActionParams,
+} from '../../task-runs-v1/actions';
 
 type DisplayProps = {
   hideMetrics?: boolean;
@@ -65,6 +69,7 @@ type RunsContextType = {
     setIsFrozen: (isFrozen: boolean) => void;
     setIsActionModalOpen: (isOpen: boolean) => void;
     setIsActionDropdownOpen: (isOpen: boolean) => void;
+    setSelectedActionType: (actionType: ActionType | null) => void;
     refetchRuns: () => void;
     refetchMetrics: () => void;
     getRowId: (row: V1TaskSummary) => string;
@@ -83,6 +88,8 @@ type RunsContextType = {
   isFrozen: boolean;
   isActionModalOpen: boolean;
   isActionDropdownOpen: boolean;
+  selectedActionType: ActionType | null;
+  actionModalParams: BaseTaskRunActionParams;
   display: DisplayProps;
 };
 
@@ -101,6 +108,8 @@ export const RunsProvider = ({
   const [isFrozen, setIsFrozen] = useState(false);
   const [isActionModalOpen, setIsActionModalOpen] = useState(false);
   const [isActionDropdownOpen, setIsActionDropdownOpen] = useState(false);
+  const [selectedActionType, setSelectedActionType] =
+    useState<ActionType | null>(null);
 
   const {
     workflowId,
@@ -184,6 +193,19 @@ export const RunsProvider = ({
     onlyTasks: !!workerId || flattenDAGs,
   });
 
+  const actionModalParams = useMemo(
+    () =>
+      selectedRuns.length > 0
+        ? { externalIds: selectedRuns.map((run) => run?.metadata.id) }
+        : {
+            filter: {
+              ...filters.apiFilters,
+              since: filters.apiFilters.since || '',
+            },
+          },
+    [selectedRuns, filters.apiFilters],
+  );
+
   const {
     metrics,
     tenantMetrics,
@@ -215,6 +237,8 @@ export const RunsProvider = ({
       isFrozen,
       isActionModalOpen,
       isActionDropdownOpen,
+      actionModalParams,
+      selectedActionType,
       display: {
         hideMetrics,
         hideCounts,
@@ -235,6 +259,7 @@ export const RunsProvider = ({
         setIsFrozen,
         setIsActionModalOpen,
         setIsActionDropdownOpen,
+        setSelectedActionType,
         refetchRuns,
         refetchMetrics,
         getRowId,
@@ -261,6 +286,8 @@ export const RunsProvider = ({
       hideDateFilter,
       hideTriggerRunButton,
       hideFlatten,
+      actionModalParams,
+      selectedActionType,
       refetchInterval,
       updatePagination,
       updateFilters,
@@ -270,6 +297,7 @@ export const RunsProvider = ({
       setIsFrozen,
       setIsActionModalOpen,
       setIsActionDropdownOpen,
+      setSelectedActionType,
       refetchRuns,
       refetchMetrics,
       getRowId,


### PR DESCRIPTION
# Description

Fixing a couple of UI bugs:

* Continue refetching when the queue metrics are open
* Improving state handling in the action buttons (cancel / replay) so that the dropdown doesn't stay open in the background

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

