### PR TITLE
[FE]: Docs-in-app, Part I

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Install dependencies
         working-directory: frontend/app
         run: pnpm install --frozen-lockfile
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Generate docs snippets and examples
+        working-directory: frontend/snippets
+        run: python3 generate.py
       - name: Build
         working-directory: frontend/app
         run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,12 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Generate docs snippets and examples
+        working-directory: frontend/snippets
+        run: python3 generate.py
       - name: Build frontend
         run: docker build -f ./build/package/frontend.dockerfile .
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,12 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Generate docs snippets and examples
+        working-directory: frontend/snippets
+        run: python3 generate.py
       - name: Build lite
         run: |
           DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
@@ -125,6 +131,12 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Generate docs snippets and examples
+        working-directory: frontend/snippets
+        run: python3 generate.py
       - name: Build lite
         run: |
           DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
@@ -159,6 +171,12 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Generate docs snippets and examples
+        working-directory: frontend/snippets
+        run: python3 generate.py
       - name: Build dashboard
         run: |
           DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
@@ -177,6 +195,12 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Generate docs snippets and examples
+        working-directory: frontend/snippets
+        run: python3 generate.py
       - name: Build dashboard
         run: |
           DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \

--- a/build/package/dashboard.dockerfile
+++ b/build/package/dashboard.dockerfile
@@ -15,6 +15,10 @@ RUN corepack pnpm@9.15.4 --version
 RUN corepack pnpm@9.15.4 install --frozen-lockfile && corepack pnpm@9.15.4 store prune
 
 COPY ./frontend/app ./
+COPY ./frontend/snippets ./../snippets
+
+RUN apt-get update && apt-get install -y python3 && python3 ./../snippets/generate.py
+
 RUN npm run build
 
 # Stage 3: run in nginx alpine image

--- a/build/package/dashboard.dockerfile
+++ b/build/package/dashboard.dockerfile
@@ -15,9 +15,6 @@ RUN corepack pnpm@9.15.4 --version
 RUN corepack pnpm@9.15.4 install --frozen-lockfile && corepack pnpm@9.15.4 store prune
 
 COPY ./frontend/app ./
-COPY ./frontend/snippets ./../snippets
-
-RUN apk add --no-cache python3 && python3 ./../snippets/generate.py
 
 RUN npm run build
 

--- a/build/package/dashboard.dockerfile
+++ b/build/package/dashboard.dockerfile
@@ -17,7 +17,7 @@ RUN corepack pnpm@9.15.4 install --frozen-lockfile && corepack pnpm@9.15.4 store
 COPY ./frontend/app ./
 COPY ./frontend/snippets ./../snippets
 
-RUN apt-get update && apt-get install -y python3 && python3 ./../snippets/generate.py
+RUN apk add --no-cache python3 && python3 ./../snippets/generate.py
 
 RUN npm run build
 

--- a/build/package/frontend.dockerfile
+++ b/build/package/frontend.dockerfile
@@ -7,6 +7,9 @@ RUN corepack pnpm@9.15.4 --version
 RUN corepack pnpm@9.15.4 install --frozen-lockfile && corepack pnpm@9.15.4 store prune
 
 COPY ./frontend/app ./
+COPY ./frontend/snippets ./../snippets
+
+RUN apk add --no-cache python3 && python3 ./../snippets/generate.py
 RUN npm run build
 
 # Stage 2: Serve the built app with NGINX

--- a/build/package/frontend.dockerfile
+++ b/build/package/frontend.dockerfile
@@ -7,9 +7,6 @@ RUN corepack pnpm@9.15.4 --version
 RUN corepack pnpm@9.15.4 install --frozen-lockfile && corepack pnpm@9.15.4 store prune
 
 COPY ./frontend/app ./
-COPY ./frontend/snippets ./../snippets
-
-RUN apk add --no-cache python3 && python3 ./../snippets/generate.py
 RUN npm run build
 
 # Stage 2: Serve the built app with NGINX

--- a/frontend/app/.gitignore
+++ b/frontend/app/.gitignore
@@ -25,3 +25,4 @@ dist-ssr
 
 # Sentry Config File
 .env.sentry-build-plugin
+src/lib/generated

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -13,7 +13,8 @@
     "eslint:fix": "eslint \"{src,apps,libs,test}/**/*.{ts,tsx,js}\" --fix",
     "prettier:check": "prettier \"src/**/*.{ts,tsx}\" --list-different",
     "prettier:fix": "prettier \"src/**/*.{ts,tsx}\" --write",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "docs:gen": "cd ../snippets && python3 generate.py"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/frontend/app/src/components/molecules/nav-bar/nav-bar.tsx
+++ b/frontend/app/src/components/molecules/nav-bar/nav-bar.tsx
@@ -27,6 +27,7 @@ import {
   BiUserCircle,
   BiEnvelope,
 } from 'react-icons/bi';
+import { Menu } from 'lucide-react';
 import { useTheme } from '@/components/theme-provider';
 import { useEffect, useMemo } from 'react';
 import useApiMeta from '@/pages/auth/hooks/use-api-meta';
@@ -272,16 +273,21 @@ export default function MainNav({ user, setHasBanner }: MainNavProps) {
       <div className="h-16 border-b bg-background">
         <div className="flex h-16 items-center pr-4 pl-4">
           <div className="flex flex-row items-center gap-x-8">
-            <button
-              onClick={() => toggleSidebarOpen()}
-              className="flex flex-row gap-4 items-center"
-            >
+            <div className="flex items-center gap-3">
+              <Button
+                variant="ghost"
+                onClick={() => toggleSidebarOpen()}
+                className="size-8 p-0 hover:bg-slate-100 dark:hover:bg-slate-800"
+                aria-label="Toggle sidebar"
+              >
+                <Menu className="size-4" />
+              </Button>
               <img
                 src={theme == 'dark' ? hatchet : hatchetDark}
                 alt="Hatchet"
                 className="h-9 rounded"
               />
-            </button>
+            </div>
             {breadcrumbs.length > 0 && (
               <Breadcrumb className="hidden md:block">
                 <BreadcrumbList>

--- a/frontend/app/src/components/side-panel.tsx
+++ b/frontend/app/src/components/side-panel.tsx
@@ -32,7 +32,9 @@ export function SidePanel() {
 
   const handleMouseMove = useCallback(
     (e: MouseEvent) => {
-      if (!isResizing) return;
+      if (!isResizing) {
+        return;
+      }
 
       const deltaX = startX - e.clientX;
       const newWidth = Math.max(MIN_PANEL_WIDTH, startWidth + deltaX);
@@ -76,7 +78,7 @@ export function SidePanel() {
   return (
     <div
       ref={panelRef}
-      className="flex flex-col h-screen border-l border-border bg-background relative flex-shrink-0"
+      className="flex flex-col border-l border-border bg-background relative flex-shrink-0"
       style={{ width: panelWidth }}
     >
       <div
@@ -104,7 +106,7 @@ export function SidePanel() {
         </div>
       </div>
 
-      <div className="flex-1 overflow-hidden p-4">{maybeContent.component}</div>
+      <div className="flex-1  p-4 overflow-auto">{maybeContent.component}</div>
     </div>
   );
 }

--- a/frontend/app/src/components/side-panel.tsx
+++ b/frontend/app/src/components/side-panel.tsx
@@ -1,0 +1,40 @@
+import { useSidePanel } from '@/hooks/use-side-panel';
+import { Cross2Icon } from '@radix-ui/react-icons';
+import { Button } from './v1/ui/button';
+
+export function SidePanel() {
+  const { content: maybeContent, isOpen, close } = useSidePanel();
+
+  if (!maybeContent) {
+    return null;
+  }
+
+  return (
+    isOpen && (
+      <div className="flex flex-col h-screen">
+        <div
+          className={
+            'flex flex-row w-full justify-between items-center border-b bg-background h-16 px-4 md:px-12'
+          }
+        >
+          <h2 className="text-lg font-semibold truncate pr-2">
+            {maybeContent.title}
+          </h2>
+          <div className="flex items-center gap-2">
+            {!maybeContent.isDocs && maybeContent.actions}
+            <Button
+              variant="ghost"
+              onClick={close}
+              className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 flex-shrink-0"
+            >
+              <Cross2Icon className="h-4 w-4" />
+              <span className="sr-only">Close</span>
+            </Button>
+          </div>
+        </div>
+
+        {maybeContent.component}
+      </div>
+    )
+  );
+}

--- a/frontend/app/src/components/side-panel.tsx
+++ b/frontend/app/src/components/side-panel.tsx
@@ -104,8 +104,13 @@ export function SidePanel() {
             )}
           >
             <div className="flex flex-row w-full justify-between items-center bg-background h-4 pt-2 pb-4">
-              <div className="flex flex-row gap-x-2 w-full justify-between items-center">
-                <p className="text-lg font-semibold">{maybeContent.title}</p>
+              <div
+                data-is-docs={maybeContent.isDocs}
+                className="flex flex-row gap-x-2 w-full justify-between items-center data-[is-docs=true]:justify-end"
+              >
+                {!maybeContent.isDocs && (
+                  <p className="text-lg font-semibold">{maybeContent.title}</p>
+                )}
                 <div className="flex flex-row gap-x-2 items-center">
                   <Button
                     variant="ghost"

--- a/frontend/app/src/components/side-panel.tsx
+++ b/frontend/app/src/components/side-panel.tsx
@@ -89,8 +89,8 @@ export function SidePanel() {
     <div
       ref={panelRef}
       className={cn(
-        "flex flex-col border-l border-border bg-background relative flex-shrink-0 overflow-hidden",
-        !isResizing && "transition-all duration-300 ease-in-out"
+        'flex flex-col border-l border-border bg-background relative flex-shrink-0 overflow-hidden',
+        !isResizing && 'transition-all duration-300 ease-in-out',
       )}
       style={{
         width: panelWidth,
@@ -106,31 +106,30 @@ export function SidePanel() {
             onMouseDown={handleMouseDown}
           />
 
-          <div className="flex flex-row w-full justify-between items-center border-b bg-background h-16 px-4 md:px-6">
-            <h2 className="text-lg font-semibold truncate pr-2">
-              {maybeContent.title}
-            </h2>
-            <div className="flex items-center gap-2">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={goBack}
-                disabled={!canGoBack}
-                className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 flex-shrink-0"
-              >
-                <ChevronLeftIcon className="h-4 w-4" />
-                <span className="sr-only">Go Back</span>
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={goForward}
-                disabled={!canGoForward}
-                className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 flex-shrink-0"
-              >
-                <ChevronRightIcon className="h-4 w-4" />
-                <span className="sr-only">Go Forward</span>
-              </Button>
+          <div className="flex-1 p-4 overflow-auto">
+            <div className="flex flex-row w-full justify-between items-center bg-background h-4 px-2">
+              <div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={goBack}
+                  disabled={!canGoBack}
+                  className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 flex-shrink-0"
+                >
+                  <ChevronLeftIcon className="h-4 w-4" />
+                  <span className="sr-only">Go Back</span>
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={goForward}
+                  disabled={!canGoForward}
+                  className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 flex-shrink-0"
+                >
+                  <ChevronRightIcon className="h-4 w-4" />
+                  <span className="sr-only">Go Forward</span>
+                </Button>
+              </div>
               {!maybeContent.isDocs && maybeContent.actions}
               <Button
                 variant="ghost"
@@ -141,9 +140,6 @@ export function SidePanel() {
                 <span className="sr-only">Close</span>
               </Button>
             </div>
-          </div>
-
-          <div className="flex-1 p-4 overflow-auto">
             {maybeContent.component}
           </div>
         </>

--- a/frontend/app/src/components/side-panel.tsx
+++ b/frontend/app/src/components/side-panel.tsx
@@ -106,7 +106,12 @@ export function SidePanel() {
             onMouseDown={handleMouseDown}
           />
 
-          <div className={cn("flex-1 p-4 overflow-auto", isResizing && "pointer-events-none")}>
+          <div
+            className={cn(
+              'flex-1 p-4 overflow-auto',
+              isResizing && 'pointer-events-none',
+            )}
+          >
             <div className="flex flex-row w-full justify-between items-center bg-background h-4 px-2">
               <div>
                 <Button

--- a/frontend/app/src/components/side-panel.tsx
+++ b/frontend/app/src/components/side-panel.tsx
@@ -76,7 +76,7 @@ export function SidePanel() {
   return (
     <div
       ref={panelRef}
-      className="flex flex-col h-screen border-l border-border bg-background relative"
+      className="flex flex-col h-screen border-l border-border bg-background relative flex-shrink-0"
       style={{ width: panelWidth }}
     >
       <div

--- a/frontend/app/src/components/side-panel.tsx
+++ b/frontend/app/src/components/side-panel.tsx
@@ -106,7 +106,7 @@ export function SidePanel() {
             <div className="flex flex-row w-full justify-between items-center bg-background h-4 pt-2 pb-4">
               <div className="flex flex-row gap-x-2 w-full justify-between items-center">
                 <p className="text-lg font-semibold">{maybeContent.title}</p>
-                <div>
+                <div className="flex flex-row gap-x-2 items-center">
                   <Button
                     variant="ghost"
                     size="sm"

--- a/frontend/app/src/components/side-panel.tsx
+++ b/frontend/app/src/components/side-panel.tsx
@@ -53,15 +53,6 @@ export function SidePanel() {
       const deltaX = startX - e.clientX;
       const newWidth = Math.max(MIN_PANEL_WIDTH, startWidth + deltaX);
 
-      console.log({
-        startX,
-        currentX: e.clientX,
-        deltaX,
-        startWidth,
-        newWidth,
-        actualChange: newWidth - startWidth,
-      });
-
       setStoredPanelWidth(newWidth);
     },
     [isResizing, startX, startWidth, setStoredPanelWidth],
@@ -112,38 +103,40 @@ export function SidePanel() {
               isResizing && 'pointer-events-none',
             )}
           >
-            <div className="flex flex-row w-full justify-between items-center bg-background h-4 px-2">
-              <div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={goBack}
-                  disabled={!canGoBack}
-                  className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 flex-shrink-0"
-                >
-                  <ChevronLeftIcon className="h-4 w-4" />
-                  <span className="sr-only">Go Back</span>
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={goForward}
-                  disabled={!canGoForward}
-                  className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 flex-shrink-0"
-                >
-                  <ChevronRightIcon className="h-4 w-4" />
-                  <span className="sr-only">Go Forward</span>
-                </Button>
+            <div className="flex flex-row w-full justify-between items-center bg-background h-4 pt-2 pb-4">
+              <div className="flex flex-row gap-x-2 w-full justify-between items-center">
+                <p className="text-lg font-semibold">{maybeContent.title}</p>
+                <div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={goBack}
+                    disabled={!canGoBack}
+                    className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 flex-shrink-0 border"
+                  >
+                    <ChevronLeftIcon className="h-4 w-4" />
+                    <span className="sr-only">Go Back</span>
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={goForward}
+                    disabled={!canGoForward}
+                    className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 flex-shrink-0 border"
+                  >
+                    <ChevronRightIcon className="h-4 w-4" />
+                    <span className="sr-only">Go Forward</span>
+                  </Button>{' '}
+                  <Button
+                    variant="ghost"
+                    onClick={close}
+                    className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 flex-shrink-0"
+                  >
+                    <Cross2Icon className="h-4 w-4" />
+                    <span className="sr-only">Close</span>
+                  </Button>
+                </div>
               </div>
-              {!maybeContent.isDocs && maybeContent.actions}
-              <Button
-                variant="ghost"
-                onClick={close}
-                className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 flex-shrink-0"
-              >
-                <Cross2Icon className="h-4 w-4" />
-                <span className="sr-only">Close</span>
-              </Button>
             </div>
             {maybeContent.component}
           </div>

--- a/frontend/app/src/components/side-panel.tsx
+++ b/frontend/app/src/components/side-panel.tsx
@@ -88,7 +88,10 @@ export function SidePanel() {
   return (
     <div
       ref={panelRef}
-      className="flex flex-col border-l border-border bg-background relative flex-shrink-0 transition-all duration-300 ease-in-out overflow-hidden"
+      className={cn(
+        "flex flex-col border-l border-border bg-background relative flex-shrink-0 overflow-hidden",
+        !isResizing && "transition-all duration-300 ease-in-out"
+      )}
       style={{
         width: panelWidth,
       }}

--- a/frontend/app/src/components/side-panel.tsx
+++ b/frontend/app/src/components/side-panel.tsx
@@ -1,40 +1,110 @@
 import { useSidePanel } from '@/hooks/use-side-panel';
+import { useLocalStorageState } from '@/hooks/use-local-storage-state';
 import { Cross2Icon } from '@radix-ui/react-icons';
 import { Button } from './v1/ui/button';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
+
+const DEFAULT_PANEL_WIDTH = 650;
+const MIN_PANEL_WIDTH = 200;
 
 export function SidePanel() {
   const { content: maybeContent, isOpen, close } = useSidePanel();
+  const [panelWidth, setPanelWidth] = useLocalStorageState(
+    'sidePanelWidth',
+    DEFAULT_PANEL_WIDTH,
+  );
 
-  if (!maybeContent) {
+  const [isResizing, setIsResizing] = useState(false);
+  const [startX, setStartX] = useState(0);
+  const [startWidth, setStartWidth] = useState(0);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      setIsResizing(true);
+      setStartX(e.clientX);
+      setStartWidth(panelWidth);
+    },
+    [panelWidth],
+  );
+
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (!isResizing) return;
+
+      const deltaX = startX - e.clientX;
+      const newWidth = Math.max(MIN_PANEL_WIDTH, startWidth + deltaX);
+
+      console.log({
+        startX,
+        currentX: e.clientX,
+        deltaX,
+        startWidth,
+        newWidth,
+        actualChange: newWidth - startWidth,
+      });
+
+      setPanelWidth(newWidth);
+    },
+    [isResizing, startX, startWidth, setPanelWidth],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setIsResizing(false);
+  }, []);
+
+  useEffect(() => {
+    if (isResizing) {
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+      document.body.style.cursor = 'col-resize';
+
+      return () => {
+        document.removeEventListener('mousemove', handleMouseMove);
+        document.removeEventListener('mouseup', handleMouseUp);
+        document.body.style.cursor = '';
+      };
+    }
+  }, [isResizing, handleMouseMove, handleMouseUp]);
+
+  if (!maybeContent || !isOpen) {
     return null;
   }
 
   return (
-    isOpen && (
-      <div className="flex flex-col h-screen">
-        <div
-          className={
-            'flex flex-row w-full justify-between items-center border-b bg-background h-16 px-4 md:px-12'
-          }
-        >
-          <h2 className="text-lg font-semibold truncate pr-2">
-            {maybeContent.title}
-          </h2>
-          <div className="flex items-center gap-2">
-            {!maybeContent.isDocs && maybeContent.actions}
-            <Button
-              variant="ghost"
-              onClick={close}
-              className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 flex-shrink-0"
-            >
-              <Cross2Icon className="h-4 w-4" />
-              <span className="sr-only">Close</span>
-            </Button>
-          </div>
-        </div>
+    <div
+      ref={panelRef}
+      className="flex flex-col h-screen border-l border-border bg-background relative"
+      style={{ width: panelWidth }}
+    >
+      <div
+        className={cn(
+          'absolute left-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-blue-500/20 transition-colors z-10',
+          isResizing && 'bg-blue-500/30',
+        )}
+        onMouseDown={handleMouseDown}
+      />
 
-        {maybeContent.component}
+      <div className="flex flex-row w-full justify-between items-center border-b bg-background h-16 px-4 md:px-6">
+        <h2 className="text-lg font-semibold truncate pr-2">
+          {maybeContent.title}
+        </h2>
+        <div className="flex items-center gap-2">
+          {!maybeContent.isDocs && maybeContent.actions}
+          <Button
+            variant="ghost"
+            onClick={close}
+            className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 flex-shrink-0"
+          >
+            <Cross2Icon className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </Button>
+        </div>
       </div>
-    )
+
+      <div className="flex-1 overflow-hidden p-4">{maybeContent.component}</div>
+    </div>
   );
 }

--- a/frontend/app/src/components/side-panel.tsx
+++ b/frontend/app/src/components/side-panel.tsx
@@ -106,7 +106,7 @@ export function SidePanel() {
             onMouseDown={handleMouseDown}
           />
 
-          <div className="flex-1 p-4 overflow-auto">
+          <div className={cn("flex-1 p-4 overflow-auto", isResizing && "pointer-events-none")}>
             <div className="flex flex-row w-full justify-between items-center bg-background h-4 px-2">
               <div>
                 <Button

--- a/frontend/app/src/components/v1/docs/docs-button.tsx
+++ b/frontend/app/src/components/v1/docs/docs-button.tsx
@@ -1,12 +1,19 @@
 import { Button } from '../ui/button';
 import { useSidePanel } from '@/hooks/use-side-panel';
+import { BookOpen } from 'lucide-react';
 
 export type DocPage = {
   title: string;
   href: string;
 };
 
-export const DocsButton = ({ doc }: { doc: DocPage }) => {
+type DocsButtonProps = {
+  doc: DocPage;
+  variant: 'mini' | 'full';
+  label: string;
+};
+
+export const DocsButton = ({ doc, variant, label }: DocsButtonProps) => {
   const { open } = useSidePanel();
 
   const handleClick = () => {
@@ -16,9 +23,26 @@ export const DocsButton = ({ doc }: { doc: DocPage }) => {
     });
   };
 
-  return (
-    <Button onClick={handleClick}>
-      Learn more about {doc.title.toLocaleLowerCase()}
-    </Button>
-  );
+  switch (variant) {
+    case 'full':
+      return (
+        <Button onClick={handleClick}>
+          {label} {doc.title.toLocaleLowerCase()}
+        </Button>
+      );
+    case 'mini':
+      return (
+        <div className="flex flex-row items-center gap-x-4 w-full justify-center">
+          <span className="text-mono font-semibold">{label}</span>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleClick}
+            className="border"
+          >
+            <BookOpen className="size-4" />
+          </Button>
+        </div>
+      );
+  }
 };

--- a/frontend/app/src/components/v1/docs/docs-button.tsx
+++ b/frontend/app/src/components/v1/docs/docs-button.tsx
@@ -26,8 +26,8 @@ export const DocsButton = ({ doc, variant, label }: DocsButtonProps) => {
   switch (variant) {
     case 'full':
       return (
-        <Button onClick={handleClick}>
-          {label} {doc.title.toLocaleLowerCase()}
+        <Button onClick={handleClick} className="w-auto px-4 py-2">
+          {label}
         </Button>
       );
     case 'mini':

--- a/frontend/app/src/components/v1/docs/docs-button.tsx
+++ b/frontend/app/src/components/v1/docs/docs-button.tsx
@@ -1,0 +1,24 @@
+import { Button } from '../ui/button';
+import { useSidePanel } from '@/hooks/use-side-panel';
+
+export type DocPage = {
+  title: string;
+  href: string;
+};
+
+export const DocsButton = ({ doc }: { doc: DocPage }) => {
+  const { open } = useSidePanel();
+
+  const handleClick = () => {
+    open({
+      type: 'docs',
+      content: doc,
+    });
+  };
+
+  return (
+    <Button onClick={handleClick}>
+      Learn more about {doc.title.toLocaleLowerCase()}
+    </Button>
+  );
+};

--- a/frontend/app/src/components/v1/docs/docs-button.tsx
+++ b/frontend/app/src/components/v1/docs/docs-button.tsx
@@ -1,6 +1,6 @@
 import { Button } from '../ui/button';
 import { useSidePanel } from '@/hooks/use-side-panel';
-import { BookOpen } from 'lucide-react';
+import { BookOpenText } from 'lucide-react';
 
 export type DocPage = {
   title: string;
@@ -26,8 +26,12 @@ export const DocsButton = ({ doc, variant, label }: DocsButtonProps) => {
   switch (variant) {
     case 'full':
       return (
-        <Button onClick={handleClick} className="w-auto px-4 py-2">
-          {label}
+        <Button
+          onClick={handleClick}
+          className="w-auto px-4 py-2 flex flex-row items-center gap-x-2"
+        >
+          <BookOpenText className="size-4" />
+          <span>{label}</span>
         </Button>
       );
     case 'mini':
@@ -40,7 +44,7 @@ export const DocsButton = ({ doc, variant, label }: DocsButtonProps) => {
             onClick={handleClick}
             className="border"
           >
-            <BookOpen className="size-4" />
+            <BookOpenText className="size-4" />
           </Button>
         </div>
       );

--- a/frontend/app/src/components/v1/docs/docs-button.tsx
+++ b/frontend/app/src/components/v1/docs/docs-button.tsx
@@ -1,4 +1,4 @@
-import { Button } from '../ui/button';
+import { Button, ButtonProps } from '../ui/button';
 import { useSidePanel } from '@/hooks/use-side-panel';
 import { BookOpenText } from 'lucide-react';
 
@@ -9,11 +9,12 @@ export type DocPage = {
 
 type DocsButtonProps = {
   doc: DocPage;
-  variant: 'mini' | 'full';
+  size: 'mini' | 'full';
+  variant: ButtonProps['variant'];
   label: string;
 };
 
-export const DocsButton = ({ doc, variant, label }: DocsButtonProps) => {
+export const DocsButton = ({ doc, size, variant, label }: DocsButtonProps) => {
   const { open } = useSidePanel();
 
   const handleClick = () => {
@@ -23,12 +24,13 @@ export const DocsButton = ({ doc, variant, label }: DocsButtonProps) => {
     });
   };
 
-  switch (variant) {
+  switch (size) {
     case 'full':
       return (
         <Button
           onClick={handleClick}
           className="w-auto px-4 py-2 flex flex-row items-center gap-x-2"
+          variant={variant}
         >
           <BookOpenText className="size-4" />
           <span>{label}</span>

--- a/frontend/app/src/components/v1/molecules/data-table/data-table-toolbar.tsx
+++ b/frontend/app/src/components/v1/molecules/data-table/data-table-toolbar.tsx
@@ -57,7 +57,14 @@ export function DataTableToolbar<TData>({
 
   return (
     <div className="flex items-center justify-between">
-      <div className="flex flex-1 items-center space-x-2 overflow-x-auto scrollbar-none pr-4 min-w-0" style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}>
+      <div 
+        className="flex flex-1 items-center space-x-2 overflow-x-auto pr-4 min-w-0 [&::-webkit-scrollbar]:h-1 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-gray-400/50 [&::-webkit-scrollbar-thumb]:rounded-full" 
+        style={{
+          scrollbarWidth: 'thin',
+          scrollbarColor: 'rgba(156, 163, 175, 0.5) transparent',
+          scrollbarGutter: 'stable both-edges'
+        }}
+      >
         {setSearch && (
           <Input
             placeholder="Search..."

--- a/frontend/app/src/components/v1/molecules/data-table/data-table-toolbar.tsx
+++ b/frontend/app/src/components/v1/molecules/data-table/data-table-toolbar.tsx
@@ -57,13 +57,13 @@ export function DataTableToolbar<TData>({
 
   return (
     <div className="flex items-center justify-between">
-      <div className="flex flex-1 items-center space-x-2">
+      <div className="flex flex-1 items-center space-x-2 overflow-x-auto scrollbar-none pr-4 min-w-0" style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}>
         {setSearch && (
           <Input
             placeholder="Search..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="h-8 w-[150px] lg:w-[250px]"
+            className="h-8 w-[150px] lg:w-[250px] flex-shrink-0"
           />
         )}
         {filters
@@ -95,14 +95,14 @@ export function DataTableToolbar<TData>({
                 table.resetColumnFilters();
               }
             }}
-            className="h-8 px-2 lg:px-3"
+            className="h-8 px-2 lg:px-3 flex-shrink-0"
           >
             Reset
             <Cross2Icon className="ml-2 h-4 w-4" />
           </Button>
         )}
       </div>
-      <div className="flex flex-row gap-4 items-center">
+      <div className="flex flex-row gap-4 items-center flex-shrink-0">
         {isLoading && <Spinner />}
         {actions && actions.length > 0 && actions}
         {showColumnToggle && <DataTableViewOptions table={table} />}

--- a/frontend/app/src/components/v1/molecules/data-table/data-table-toolbar.tsx
+++ b/frontend/app/src/components/v1/molecules/data-table/data-table-toolbar.tsx
@@ -57,12 +57,12 @@ export function DataTableToolbar<TData>({
 
   return (
     <div className="flex items-center justify-between">
-      <div 
-        className="flex flex-1 items-center space-x-2 overflow-x-auto pr-4 min-w-0 [&::-webkit-scrollbar]:h-1 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-gray-400/50 [&::-webkit-scrollbar-thumb]:rounded-full" 
+      <div
+        className="flex flex-1 items-center space-x-2 overflow-x-auto pr-4 min-w-0 [&::-webkit-scrollbar]:h-1 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-gray-400/50 [&::-webkit-scrollbar-thumb]:rounded-full"
         style={{
           scrollbarWidth: 'thin',
           scrollbarColor: 'rgba(156, 163, 175, 0.5) transparent',
-          scrollbarGutter: 'stable both-edges'
+          scrollbarGutter: 'stable both-edges',
         }}
       >
         {setSearch && (

--- a/frontend/app/src/components/v1/shared/copy-workflow-config.tsx
+++ b/frontend/app/src/components/v1/shared/copy-workflow-config.tsx
@@ -27,7 +27,7 @@ export function CopyWorkflowConfigButton({
       ) : (
         <>
           <CopyIcon className="w-3 h-3 mr-2" />
-          Copy Workflow Config
+          Copy Config
         </>
       )}
     </Button>

--- a/frontend/app/src/hooks/use-local-storage-state.tsx
+++ b/frontend/app/src/hooks/use-local-storage-state.tsx
@@ -1,0 +1,41 @@
+import { useState, useEffect } from 'react';
+
+export function useLocalStorageState<T>(
+  key: string,
+  defaultValue: T
+): [T, (value: T) => void] {
+  const [state, setState] = useState<T>(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? JSON.parse(item) : defaultValue;
+    } catch (error) {
+      return defaultValue;
+    }
+  });
+
+  const setValue = (value: T) => {
+    try {
+      setState(value);
+      window.localStorage.setItem(key, JSON.stringify(value));
+    } catch (error) {
+      console.warn(`Error setting localStorage key "${key}":`, error);
+    }
+  };
+
+  useEffect(() => {
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key === key && e.newValue) {
+        try {
+          setState(JSON.parse(e.newValue));
+        } catch (error) {
+          console.warn(`Error parsing localStorage change for key "${key}":`, error);
+        }
+      }
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+    return () => window.removeEventListener('storage', handleStorageChange);
+  }, [key]);
+
+  return [state, setValue];
+}

--- a/frontend/app/src/hooks/use-local-storage-state.tsx
+++ b/frontend/app/src/hooks/use-local-storage-state.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 
 export function useLocalStorageState<T>(
   key: string,
-  defaultValue: T
+  defaultValue: T,
 ): [T, (value: T) => void] {
   const [state, setState] = useState<T>(() => {
     try {
@@ -28,7 +28,10 @@ export function useLocalStorageState<T>(
         try {
           setState(JSON.parse(e.newValue));
         } catch (error) {
-          console.warn(`Error parsing localStorage change for key "${key}":`, error);
+          console.warn(
+            `Error parsing localStorage change for key "${key}":`,
+            error,
+          );
         }
       }
     };

--- a/frontend/app/src/hooks/use-side-panel.tsx
+++ b/frontend/app/src/hooks/use-side-panel.tsx
@@ -14,6 +14,7 @@ import {
 import { DocPage } from '@/components/v1/docs/docs-button';
 import { V1Event } from '@/lib/api';
 import { ExpandedEventContent } from '@/pages/main/v1/events';
+import { useTheme } from '@/components/theme-provider';
 
 type SidePanelContent =
   | {
@@ -64,6 +65,8 @@ export function useSidePanelData(): SidePanelData {
   const [history, setHistory] = useState<UseSidePanelProps[]>([]);
   const [currentIndex, setCurrentIndex] = useState(-1);
   const location = useLocation();
+  const { theme: rawTheme } = useTheme();
+  const theme = ['dark', 'light'].includes(rawTheme) ? rawTheme : 'dark';
 
   const props =
     currentIndex >= 0 && currentIndex < history.length
@@ -102,7 +105,7 @@ export function useSidePanelData(): SidePanelData {
           component: (
             <div className="p-4 size-full">
               <iframe
-                src={props.content.href}
+                src={`${props.content.href}?theme=${theme}`}
                 className="inset-0 w-full rounded-md border border-slate-800 size-full"
                 title={`Documentation: ${props.content.title}`}
                 loading="lazy"
@@ -116,7 +119,7 @@ export function useSidePanelData(): SidePanelData {
         const exhaustiveCheck: never = panelType;
         throw new Error(`Unhandled action type: ${exhaustiveCheck}`);
     }
-  }, [props]);
+  }, [props, theme]);
 
   const open = useCallback(
     (newProps: UseSidePanelProps) => {

--- a/frontend/app/src/hooks/use-side-panel.tsx
+++ b/frontend/app/src/hooks/use-side-panel.tsx
@@ -1,0 +1,126 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+
+export const pages = docMetadata;
+
+export type DocRef = {
+  title: string;
+  href: string;
+};
+
+type SidePanelContent =
+  | {
+      isDocs: false;
+      component: React.ReactNode;
+      title: React.ReactNode;
+      actions?: React.ReactNode;
+    }
+  | {
+      isDocs: true;
+      title: string;
+      component: React.ReactNode;
+    };
+
+type SidePanelData = {
+  content: SidePanelContent | null;
+  isOpen: boolean;
+  open: (props: UseSidePanelProps) => void;
+  close: () => void;
+};
+
+type UseSidePanelProps =
+  | {
+      type: 'docs';
+      content: DocRef;
+    }
+  | {
+      type: 'task-run-details';
+      content: RunDetailSheetSerializableProps;
+    };
+
+export function useSidePanelData(): SidePanelData {
+  const [isOpen, setIsOpen] = useState(false);
+  const [props, setProps] = useState<UseSidePanelProps | null>(null);
+
+  const content = useMemo((): SidePanelContent | null => {
+    if (!props) {
+      return null;
+    }
+
+    const panelType = props.type;
+
+    switch (panelType) {
+      case 'run-details':
+        return {
+          isDocs: false,
+          component: <RunDetailSheet {...props.content} />,
+          title: 'Run Detail',
+        };
+      case 'docs':
+        return {
+          isDocs: true,
+          component: (
+            <div className="p-4 size-full">
+              <iframe
+                src={props.content.href}
+                className="inset-0 w-full rounded-md border border-slate-800 size-full"
+                title={`Documentation: ${props.content.title}`}
+                loading="lazy"
+              />
+            </div>
+          ),
+          title: props.content.title,
+        };
+      default:
+        // eslint-disable-next-line no-case-declarations
+        const exhaustiveCheck: never = panelType;
+        throw new Error(`Unhandled action type: ${exhaustiveCheck}`);
+    }
+  }, [props]);
+
+  const open = useCallback(
+    (props: UseSidePanelProps) => {
+      setProps(props);
+      setIsOpen(true);
+    },
+    [setIsOpen],
+  );
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+  }, [setIsOpen]);
+
+  return {
+    isOpen,
+    content,
+    open,
+    close,
+  };
+}
+
+const SidePanelContext = createContext<SidePanelData | null>(null);
+
+export function SidePanelProvider({ children }: { children: React.ReactNode }) {
+  const sidePanelState = useSidePanelData();
+
+  return (
+    <SidePanelContext.Provider value={sidePanelState}>
+      {children}
+    </SidePanelContext.Provider>
+  );
+}
+
+export function useSidePanel(): SidePanelData {
+  const context = useContext(SidePanelContext);
+  if (!context) {
+    throw new Error(
+      'useSidePanelContext must be used within a SidePanelProvider',
+    );
+  }
+  return context;
+}

--- a/frontend/app/src/hooks/use-side-panel.tsx
+++ b/frontend/app/src/hooks/use-side-panel.tsx
@@ -7,9 +7,9 @@ import {
   useState,
 } from 'react';
 import { useLocation } from 'react-router-dom';
-import { 
+import {
   TaskRunDetail,
-  TabOption 
+  TabOption,
 } from '@/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail';
 
 export type DocRef = {

--- a/frontend/app/src/hooks/use-side-panel.tsx
+++ b/frontend/app/src/hooks/use-side-panel.tsx
@@ -119,6 +119,8 @@ export function useSidePanelData(): SidePanelData {
 
   const close = useCallback(() => {
     setIsOpen(false);
+    setHistory([]);
+    setCurrentIndex(-1);
   }, []);
 
   const goBack = useCallback(() => {

--- a/frontend/app/src/hooks/use-side-panel.tsx
+++ b/frontend/app/src/hooks/use-side-panel.tsx
@@ -12,6 +12,8 @@ import {
   TabOption,
 } from '@/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail';
 import { DocPage } from '@/components/v1/docs/docs-button';
+import { V1Event } from '@/lib/api';
+import { ExpandedEventContent } from '@/pages/main/v1/events';
 
 type SidePanelContent =
   | {
@@ -49,6 +51,12 @@ type UseSidePanelProps =
         defaultOpenTab?: TabOption;
         showViewTaskRunButton?: boolean;
       };
+    }
+  | {
+      type: 'event-details';
+      content: {
+        event: V1Event;
+      };
     };
 
 export function useSidePanelData(): SidePanelData {
@@ -81,6 +89,12 @@ export function useSidePanelData(): SidePanelData {
           isDocs: false,
           component: <TaskRunDetail {...props.content} />,
           title: 'Run Detail',
+        };
+      case 'event-details':
+        return {
+          isDocs: false,
+          component: <ExpandedEventContent event={props.content.event} />,
+          title: `Event ${props.content.event.metadata.id}`,
         };
       case 'docs':
         return {

--- a/frontend/app/src/hooks/use-side-panel.tsx
+++ b/frontend/app/src/hooks/use-side-panel.tsx
@@ -88,13 +88,13 @@ export function useSidePanelData(): SidePanelData {
         return {
           isDocs: false,
           component: <TaskRunDetail {...props.content} />,
-          title: 'Run Detail',
+          title: 'Run details',
         };
       case 'event-details':
         return {
           isDocs: false,
           component: <ExpandedEventContent event={props.content.event} />,
-          title: `Event ${props.content.event.metadata.id}`,
+          title: `Event ${props.content.event.key} details`,
         };
       case 'docs':
         return {

--- a/frontend/app/src/hooks/use-side-panel.tsx
+++ b/frontend/app/src/hooks/use-side-panel.tsx
@@ -11,11 +11,7 @@ import {
   TaskRunDetail,
   TabOption,
 } from '@/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail';
-
-export type DocRef = {
-  title: string;
-  href: string;
-};
+import { DocPage } from '@/components/v1/docs/docs-button';
 
 type SidePanelContent =
   | {
@@ -44,7 +40,7 @@ type SidePanelData = {
 type UseSidePanelProps =
   | {
       type: 'docs';
-      content: DocRef;
+      content: DocPage;
     }
   | {
       type: 'task-run-details';

--- a/frontend/app/src/hooks/use-side-panel.tsx
+++ b/frontend/app/src/hooks/use-side-panel.tsx
@@ -2,11 +2,15 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from 'react';
-
-export const pages = docMetadata;
+import { useLocation } from 'react-router-dom';
+import { 
+  TaskRunDetail,
+  TabOption 
+} from '@/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail';
 
 export type DocRef = {
   title: string;
@@ -40,12 +44,22 @@ type UseSidePanelProps =
     }
   | {
       type: 'task-run-details';
-      content: RunDetailSheetSerializableProps;
+      content: {
+        taskRunId: string;
+        defaultOpenTab?: TabOption;
+        showViewTaskRunButton?: boolean;
+      };
     };
 
 export function useSidePanelData(): SidePanelData {
   const [isOpen, setIsOpen] = useState(false);
   const [props, setProps] = useState<UseSidePanelProps | null>(null);
+  const location = useLocation();
+
+  useEffect(() => {
+    setIsOpen(false);
+    setProps(null);
+  }, [location.pathname]);
 
   const content = useMemo((): SidePanelContent | null => {
     if (!props) {
@@ -55,10 +69,10 @@ export function useSidePanelData(): SidePanelData {
     const panelType = props.type;
 
     switch (panelType) {
-      case 'run-details':
+      case 'task-run-details':
         return {
           isDocs: false,
-          component: <RunDetailSheet {...props.content} />,
+          component: <TaskRunDetail {...props.content} />,
           title: 'Run Detail',
         };
       case 'docs':

--- a/frontend/app/src/pages/main/v1/events/index.tsx
+++ b/frontend/app/src/pages/main/v1/events/index.tsx
@@ -384,7 +384,7 @@ export function ExpandedEventContent({ event }: { event: V1Event }) {
   });
 
   return (
-    <div className="w-full h-full overflow-auto">
+    <div className="w-full">
       <div className="space-y-6">
         <div className="space-y-2">
           <p className="text-sm text-muted-foreground">

--- a/frontend/app/src/pages/main/v1/events/index.tsx
+++ b/frontend/app/src/pages/main/v1/events/index.tsx
@@ -14,11 +14,9 @@ import {
   FilterOption,
   ToolbarType,
 } from '@/components/v1/molecules/data-table/data-table-toolbar';
-import { Dialog } from '@/components/v1/ui/dialog';
 import { useSearchParams } from 'react-router-dom';
 import { Button } from '@/components/v1/ui/button';
 import { ArrowPathIcon } from '@heroicons/react/24/outline';
-import { Loading } from '@/components/v1/ui/loading.tsx';
 import RelativeDate from '@/components/v1/molecules/relative-date';
 import { DataTable } from '@/components/v1/molecules/data-table/data-table';
 import { RunsTable } from '../workflow-runs-v1/components/runs-table';

--- a/frontend/app/src/pages/main/v1/events/index.tsx
+++ b/frontend/app/src/pages/main/v1/events/index.tsx
@@ -387,7 +387,6 @@ export function ExpandedEventContent({ event }: { event: V1Event }) {
     <div className="w-full h-full overflow-auto">
       <div className="space-y-6">
         <div className="space-y-2">
-          <p className="text-lg font-semibold">Event {event.key}</p>
           <p className="text-sm text-muted-foreground">
             Seen <RelativeDate date={event.metadata.createdAt} />
           </p>
@@ -413,9 +412,7 @@ export function ExpandedEventContent({ event }: { event: V1Event }) {
           )}
 
           <div>
-            <h3 className="text-sm font-semibold text-foreground mb-2">
-              Runs
-            </h3>
+            <h3 className="text-sm font-semibold text-foreground mb-2">Runs</h3>
             <Separator className="mb-3" />
             <EventWorkflowRunsList event={event} />
           </div>

--- a/frontend/app/src/pages/main/v1/index.tsx
+++ b/frontend/app/src/pages/main/v1/index.tsx
@@ -30,6 +30,8 @@ import useCloudFeatureFlags from '@/pages/auth/hooks/use-cloud-feature-flags';
 import { useSidebar } from '@/components/sidebar-provider';
 import { SquareActivityIcon, WebhookIcon } from 'lucide-react';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
+import { SidePanel } from '@/components/side-panel';
+import { SidePanelProvider } from '@/hooks/use-side-panel';
 
 function Main() {
   const ctx = useOutletContext<UserContextType & MembershipsContextType>();
@@ -45,12 +47,15 @@ function Main() {
   }
 
   return (
-    <div className="flex flex-row flex-1 w-full h-full">
-      <Sidebar memberships={memberships} />
-      <div className="p-8 flex-grow overflow-y-auto overflow-x-hidden">
-        <Outlet context={childCtx} />
+    <SidePanelProvider>
+      <div className="flex flex-row flex-1 w-full h-full">
+        <Sidebar memberships={memberships} />
+        <div className="p-8 flex-grow overflow-y-auto overflow-x-hidden">
+          <Outlet context={childCtx} />
+        </div>
+        <SidePanel />
       </div>
-    </div>
+    </SidePanelProvider>
   );
 }
 

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/index.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/index.tsx
@@ -14,14 +14,14 @@ import {
   TabsTrigger,
 } from '@/components/v1/ui/tabs';
 import { StepRunEvents } from './v2components/step-run-events-for-workflow-run';
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import {
   TabOption,
   TaskRunDetail,
 } from './v2components/step-run-detail/step-run-detail';
 import { Separator } from '@/components/v1/ui/separator';
 import { CodeHighlighter } from '@/components/v1/ui/code-highlighter';
-import { Sheet, SheetContent } from '@/components/v1/ui/sheet';
+import { useSidePanel } from '@/hooks/use-side-panel';
 import { V1RunDetailHeader } from './v2components/header';
 import { Badge } from '@/components/v1/ui/badge';
 import { ViewToggle } from './v2components/view-toggle';
@@ -187,13 +187,18 @@ function ExpandedTaskRun({ id }: { id: string }) {
 }
 
 function ExpandedWorkflowRun({ id }: { id: string }) {
-  const [selectedTaskRunId, setSelectedTaskRunId] = useState<string>();
-  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const { open } = useSidePanel();
 
   const handleTaskRunExpand = useCallback((taskRunId: string) => {
-    setSelectedTaskRunId(taskRunId);
-    setIsSidebarOpen(true);
-  }, []);
+    open({
+      type: 'task-run-details',
+      content: {
+        taskRunId,
+        defaultOpenTab: TabOption.Output,
+        showViewTaskRunButton: true,
+      },
+    });
+  }, [open]);
 
   const { workflowRun, shape, isLoading, isError } = useWorkflowDetails();
 
@@ -270,26 +275,12 @@ function ExpandedWorkflowRun({ id }: { id: string }) {
           <TabsContent value="waterfall" className="flex-1 min-h-0">
             <Waterfall
               workflowRunId={id}
-              selectedTaskId={selectedTaskRunId}
+              selectedTaskId={undefined}
               handleTaskSelect={handleTaskRunExpand}
             />
           </TabsContent>
         </Tabs>
       </div>
-      <Sheet
-        open={isSidebarOpen}
-        onOpenChange={(open) => setIsSidebarOpen(open)}
-      >
-        <SheetContent className="w-fit min-w-[56rem] max-w-4xl sm:max-w-2xl z-[60] h-full overflow-auto">
-          {selectedTaskRunId && (
-            <TaskRunDetail
-              taskRunId={selectedTaskRunId}
-              defaultOpenTab={TabOption.Output}
-              showViewTaskRunButton
-            />
-          )}
-        </SheetContent>
-      </Sheet>
     </div>
   );
 }

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/index.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/index.tsx
@@ -189,16 +189,19 @@ function ExpandedTaskRun({ id }: { id: string }) {
 function ExpandedWorkflowRun({ id }: { id: string }) {
   const { open } = useSidePanel();
 
-  const handleTaskRunExpand = useCallback((taskRunId: string) => {
-    open({
-      type: 'task-run-details',
-      content: {
-        taskRunId,
-        defaultOpenTab: TabOption.Output,
-        showViewTaskRunButton: true,
-      },
-    });
-  }, [open]);
+  const handleTaskRunExpand = useCallback(
+    (taskRunId: string) => {
+      open({
+        type: 'task-run-details',
+        content: {
+          taskRunId,
+          defaultOpenTab: TabOption.Output,
+          showViewTaskRunButton: true,
+        },
+      });
+    },
+    [open],
+  );
 
   const { workflowRun, shape, isLoading, isError } = useWorkflowDetails();
 

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail.tsx
@@ -28,8 +28,7 @@ import { isTerminalState } from '../../../hooks/use-workflow-details';
 import { CopyWorkflowConfigButton } from '@/components/v1/shared/copy-workflow-config';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
 import { Waterfall } from '../waterfall';
-import { useState, useCallback } from 'react';
-import { useToast } from '@/components/v1/hooks/use-toast';
+import { useCallback } from 'react';
 import { Toaster } from '@/components/v1/ui/toaster';
 
 export enum TabOption {
@@ -93,9 +92,6 @@ export const TaskRunDetail = ({
   defaultOpenTab = TabOption.Output,
   showViewTaskRunButton,
 }: TaskRunDetailProps) => {
-  const [selectedTaskRunId, setSelectedTaskRunId] = useState<string>();
-  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-  const { toast } = useToast();
   const { open } = useSidePanel();
 
   const handleTaskRunExpand = useCallback(

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail.tsx
@@ -155,18 +155,20 @@ export const TaskRunDetail = ({
         />
       )}
       <div className="flex flex-row gap-2 items-center">
-        <TaskRunActionButton
-          actionType="replay"
-          paramOverrides={{ externalIds: [taskRunId] }}
-          disabled={!TASK_RUN_TERMINAL_STATUSES.includes(taskRun.status)}
-          showModal={false}
-        />
-        <TaskRunActionButton
-          actionType="cancel"
-          paramOverrides={{ externalIds: [taskRunId] }}
-          disabled={TASK_RUN_TERMINAL_STATUSES.includes(taskRun.status)}
-          showModal={false}
-        />
+        <RunsProvider tableKey="task-run-detail">
+          <TaskRunActionButton
+            actionType="replay"
+            paramOverrides={{ externalIds: [taskRunId] }}
+            disabled={!TASK_RUN_TERMINAL_STATUSES.includes(taskRun.status)}
+            showModal={false}
+          />
+          <TaskRunActionButton
+            actionType="cancel"
+            paramOverrides={{ externalIds: [taskRunId] }}
+            disabled={TASK_RUN_TERMINAL_STATUSES.includes(taskRun.status)}
+            showModal={false}
+          />
+        </RunsProvider>
         <TaskRunPermalinkOrBacklink
           taskRun={taskRun}
           showViewTaskRunButton={showViewTaskRunButton || false}

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail.tsx
@@ -10,7 +10,7 @@ import {
   TabsList,
   TabsTrigger,
 } from '@/components/v1/ui/tabs';
-import { Sheet, SheetContent } from '@/components/v1/ui/sheet';
+import { useSidePanel } from '@/hooks/use-side-panel';
 import { StepRunEvents } from '../step-run-events-for-workflow-run';
 import { Link } from 'react-router-dom';
 import { RunsTable } from '../../../components/runs-table';
@@ -29,6 +29,7 @@ import { CopyWorkflowConfigButton } from '@/components/v1/shared/copy-workflow-c
 import { useCurrentTenantId } from '@/hooks/use-tenant';
 import { Waterfall } from '../waterfall';
 import { useState, useCallback } from 'react';
+import { useToast } from '@/components/v1/hooks/use-toast';
 import { Toaster } from '@/components/v1/ui/toaster';
 
 export enum TabOption {
@@ -94,11 +95,22 @@ export const TaskRunDetail = ({
 }: TaskRunDetailProps) => {
   const [selectedTaskRunId, setSelectedTaskRunId] = useState<string>();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const { toast } = useToast();
+  const { open } = useSidePanel();
 
-  const handleTaskRunExpand = useCallback((taskRunId: string) => {
-    setSelectedTaskRunId(taskRunId);
-    setIsSidebarOpen(true);
-  }, []);
+  const handleTaskRunExpand = useCallback(
+    (taskRunId: string) => {
+      open({
+        type: 'task-run-details',
+        content: {
+          taskRunId,
+          defaultOpenTab: TabOption.Output,
+          showViewTaskRunButton: true,
+        },
+      });
+    },
+    [open],
+  );
   const taskRunQuery = useQuery({
     ...queries.v1Tasks.get(taskRunId),
     refetchInterval: (query) => {
@@ -246,7 +258,7 @@ export const TaskRunDetail = ({
           <TabsContent value="waterfall" className="flex-1 min-h-0">
             <Waterfall
               workflowRunId={taskRunId}
-              selectedTaskId={selectedTaskRunId}
+              selectedTaskId={undefined}
               handleTaskSelect={handleTaskRunExpand}
             />
           </TabsContent>
@@ -264,20 +276,6 @@ export const TaskRunDetail = ({
           fallbackTaskDisplayName={taskRun.displayName}
         />
       </div>
-      <Sheet
-        open={isSidebarOpen}
-        onOpenChange={(open) => setIsSidebarOpen(open)}
-      >
-        <SheetContent className="w-fit min-w-[56rem] max-w-4xl sm:max-w-2xl z-[60] h-full overflow-auto">
-          {selectedTaskRunId && (
-            <TaskRunDetail
-              taskRunId={selectedTaskRunId}
-              defaultOpenTab={TabOption.Output}
-              showViewTaskRunButton
-            />
-          )}
-        </SheetContent>
-      </Sheet>
     </div>
   );
 };

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
@@ -275,7 +275,8 @@ export function RunsTable({ headerClassName }: RunsTableProps) {
                 <DocsButton
                   doc={docsPages.home['your-first-task']}
                   label={'Learn more about tasks'}
-                  variant="full"
+                  size="full"
+                  variant="outline"
                 />
               </div>
             </div>

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
@@ -257,7 +257,7 @@ export function RunsTable({ headerClassName }: RunsTableProps) {
       {!hideMetrics && <GetWorkflowChart />}
 
       {!hideCounts && (
-        <div className="flex flex-row justify-between items-center my-4">
+        <div className="flex flex-row justify-between items-center my-4 overflow-auto">
           {metrics.length > 0 ? (
             <V1WorkflowRunsMetricsView />
           ) : (

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
@@ -31,6 +31,8 @@ import { useRunsContext } from '../hooks/runs-provider';
 import { TableActions } from './task-runs-table/table-actions';
 import { TimeFilter } from './task-runs-table/time-filter';
 import { ConfirmActionModal } from '../../task-runs-v1/actions';
+import { DocsButton } from '@/components/v1/docs/docs-button';
+import { docsPages } from '@/lib/generated/docs';
 
 export interface RunsTableProps {
   headerClassName?: string;
@@ -268,11 +270,10 @@ export function RunsTable({ headerClassName }: RunsTableProps) {
       <div className="flex-1 min-h-0">
         <DataTable
           emptyState={
-            <IntroDocsEmptyState
-              link="/home/your-first-task"
-              title="No Runs Found"
-              linkPreambleText="To learn more about how workflows function in Hatchet,"
-              linkText="check out our documentation."
+            <DocsButton
+              doc={docsPages.home['your-first-task']}
+              label={'Learn more about workflows'}
+              variant="mini"
             />
           }
           isLoading={isFetching}

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
@@ -270,11 +270,11 @@ export function RunsTable({ headerClassName }: RunsTableProps) {
         <DataTable
           emptyState={
             <div className="w-full h-full flex flex-col gap-y-4 text-foreground py-8 justify-center items-center">
-              <p className="text-lg font-bold">No runs found</p>
+              <p className="text-lg font-semibold">No runs found</p>
               <div className="w-fit">
                 <DocsButton
                   doc={docsPages.home['your-first-task']}
-                  label={'Learn how to run your first task'}
+                  label={'Learn more about tasks'}
                   variant="full"
                 />
               </div>

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
@@ -17,7 +17,6 @@ import {
 } from '@/components/v1/molecules/charts/zoomable';
 import { TabOption } from '../$run/v2components/step-run-detail/step-run-detail';
 import { useSidePanel } from '@/hooks/use-side-panel';
-import { IntroDocsEmptyState } from '@/pages/onboarding/intro-docs-empty-state';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
 import { TriggerWorkflowForm } from '../../workflows/$workflow/components/trigger-workflow-form';
 import { Toaster } from '@/components/v1/ui/toaster';

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
@@ -269,11 +269,16 @@ export function RunsTable({ headerClassName }: RunsTableProps) {
       <div className="flex-1 min-h-0">
         <DataTable
           emptyState={
-            <DocsButton
-              doc={docsPages.home['your-first-task']}
-              label={'Learn more about workflows'}
-              variant="mini"
-            />
+            <div className="w-full h-full flex flex-col gap-y-4 text-foreground py-8 justify-center items-center">
+              <p className="text-lg font-bold">No runs found</p>
+              <div className="w-fit">
+                <DocsButton
+                  doc={docsPages.home['your-first-task']}
+                  label={'Learn how to run your first task'}
+                  variant="full"
+                />
+              </div>
+            </div>
           }
           isLoading={isFetching}
           columns={tableColumns}

--- a/frontend/app/src/pages/main/workflow-runs/$run/v2components/workflow-definition.tsx
+++ b/frontend/app/src/pages/main/workflow-runs/$run/v2components/workflow-definition.tsx
@@ -18,7 +18,7 @@ export const WorkflowDefinitionLink = ({
     >
       <Button size={'sm'} className="px-2 py-2 gap-2" variant="outline">
         <ArrowTopRightIcon className="w-4 h-4" />
-        Configuration
+        Workflow
       </Button>
     </Link>
   );

--- a/frontend/docs/theme.config.tsx
+++ b/frontend/docs/theme.config.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Image from "next/image";
-import { useConfig } from "nextra-theme-docs";
+import { useConfig, useTheme } from "nextra-theme-docs";
+import { useRouter } from "next/router";
 
 const config = {
   logo: (
@@ -18,6 +19,20 @@ const config = {
         <link rel="icon" type="image/png" href="/favicon.ico" />
       </>
     );
+  },
+  main: ({ children }) => {
+    const router = useRouter();
+    const { setTheme } = useTheme();
+
+    useEffect(() => {
+      const themeParam = router.query.theme;
+
+      if (themeParam === "dark" || themeParam === "light") {
+        setTheme(themeParam);
+      }
+    }, [router.query.theme, setTheme]);
+
+    return <>{children}</>;
   },
   primaryHue: {
     dark: 210,

--- a/frontend/snippets/generate.py
+++ b/frontend/snippets/generate.py
@@ -274,6 +274,18 @@ def extract_doc_name(value: str | dict[str, Any]) -> str:
     raise ValueError(f"Invalid doc value: {value}")
 
 
+def keys_to_path(keys: list[str]) -> str:
+    keys = [k for k in keys if k]
+
+    if len(keys) == 0:
+        return ""
+
+    if len(keys) == 1:
+        return "/" + keys[0]
+
+    return "/" + "/".join(keys).replace("//", "/").rstrip("/")
+
+
 def write_doc_index_to_app() -> None:
     docs_root = os.path.join(ROOT, "frontend", "docs")
     pages_dir = os.path.join(docs_root, "pages/")
@@ -318,9 +330,7 @@ def write_doc_index_to_app() -> None:
                     current[full_keys[-1]] = asdict(
                         DocumentationPage(
                             title=title,
-                            href=f"https://docs.hatchet.run/{
-                                '/'.join(full_keys[:-1]).replace('//', '/')
-                            }/{key}",
+                            href=f"https://docs.hatchet.run{keys_to_path(full_keys[:-1])}/{key}",
                         )
                     )
 

--- a/frontend/snippets/generate.py
+++ b/frontend/snippets/generate.py
@@ -318,9 +318,9 @@ def write_doc_index_to_app() -> None:
                     current[full_keys[-1]] = asdict(
                         DocumentationPage(
                             title=title,
-                            href=f"https://docs.hatchet.run/{'/'.join(full_keys[:-1])}/{key}".replace(
-                                "//", "/"
-                            ),
+                            href=f"https://docs.hatchet.run/{
+                                '/'.join(full_keys[:-1]).replace('//', '/')
+                            }/{key}",
                         )
                     )
 

--- a/frontend/snippets/generate.py
+++ b/frontend/snippets/generate.py
@@ -7,6 +7,22 @@ from enum import Enum
 from typing import Any, cast
 
 
+ROOT = "../../"
+BASE_SNIPPETS_DIR = os.path.join(ROOT, "frontend", "docs", "lib")
+OUTPUT_DIR = os.path.join(BASE_SNIPPETS_DIR, "generated", "snippets")
+OUTPUT_GITHUB_ORG = "hatchet-dev"
+OUTPUT_GITHUB_REPO = "hatchet"
+IGNORED_FILE_PATTERNS = [
+    r"__init__\.py$",
+    r"test_.*\.py$",
+    r"\.test\.ts$",
+    r"\.test-d\.ts$",
+    r"test_.*\.go$",
+    r"_test\.go$",
+    r"\.e2e\.ts$",
+]
+
+
 @dataclass
 class ParsingContext:
     example_path: str
@@ -46,20 +62,14 @@ class ProcessedExample:
     output_path: str
 
 
-ROOT = "../../"
-BASE_SNIPPETS_DIR = os.path.join(ROOT, "frontend", "docs", "lib")
-OUTPUT_DIR = os.path.join(BASE_SNIPPETS_DIR, "generated", "snippets")
-OUTPUT_GITHUB_ORG = "hatchet-dev"
-OUTPUT_GITHUB_REPO = "hatchet"
-IGNORED_FILE_PATTERNS = [
-    r"__init__\.py$",
-    r"test_.*\.py$",
-    r"\.test\.ts$",
-    r"\.test-d\.ts$",
-    r"test_.*\.go$",
-    r"_test\.go$",
-    r"\.e2e\.ts$",
-]
+@dataclass
+class DocumentationPage:
+    title: str
+    href: str
+
+
+Title = str
+Content = str
 
 
 def to_snake_case(text):
@@ -262,12 +272,6 @@ def extract_doc_name(value: str | dict[str, Any]) -> str:
         return value["title"]
 
     raise ValueError(f"Invalid doc value: {value}")
-
-
-@dataclass
-class DocumentationPage:
-    title: str
-    href: str
 
 
 def write_doc_index_to_app() -> None:


### PR DESCRIPTION
# Description

Bringing back docs-in-app + the in-app side panel. Basically opens the side panel in the places where we'd open the sheet before. The side panel is resizeable (and the size you drag to will save), and it can display (right now) event details, task run details, and docs. 

Once this goes in, we'll need to go through and add docs links to all of the empty states everywhere + anywhere else it's appropriate, and I'll also probably try to replace some more modals with side panels.

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Screenshots

#### Open

<img width="1725" height="956" alt="Screenshot 2025-08-28 at 3 16 46 PM" src="https://github.com/user-attachments/assets/0e76b93e-0007-459f-81a3-b6da168e3338" />

#### Dragged wider, metrics + actions scrolling

<img width="1728" height="958" alt="Screenshot 2025-08-28 at 3 17 02 PM" src="https://github.com/user-attachments/assets/0f574292-dbc4-48aa-9665-910bb8f236be" />

#### Empty State, Docs Button

<img width="1728" height="957" alt="Screenshot 2025-08-28 at 3 17 26 PM" src="https://github.com/user-attachments/assets/bc99897f-8a7a-4bed-a259-9f1e85b19e10" />

#### Docs view

<img width="1728" height="959" alt="Screenshot 2025-08-28 at 3 19 44 PM" src="https://github.com/user-attachments/assets/a4b3985d-0fac-4d90-b243-443810f455b8" />

## Events (will do more other places later)

<img width="1728" height="958" alt="Screenshot 2025-08-28 at 3 23 49 PM" src="https://github.com/user-attachments/assets/c1642b64-2a9c-4f39-822c-19196d71ab24" />

TODO:

- [x] Fix overflow states (scrolling?) on toolbar filters, table widths, side panel header, etc.
- [x] Look for other modals to replace with side panel
