### PR TITLE
Fix panic when additionalMetadata is null

### DIFF
--- a/pkg/client/event.go
+++ b/pkg/client/event.go
@@ -162,7 +162,8 @@ func (a *eventClientImpl) BulkPush(ctx context.Context, payload []EventWithAddit
 		if err != nil {
 			return err
 		}
-		eMetadata, err := json.Marshal(p.AdditionalMetadata)
+		md := p.AdditionalMetadata
+		eMetadata, err := a.getAdditionalMetaBytes(&md)
 		if err != nil {
 			return err
 		}

--- a/pkg/repository/v1/trigger.go
+++ b/pkg/repository/v1/trigger.go
@@ -581,7 +581,7 @@ func cleanAdditionalMetadata(additionalMetadata []byte) map[string]interface{} {
 	} else {
 		err := json.Unmarshal(additionalMetadata, &res)
 
-		if err != nil {
+		if err != nil || res == nil {
 			res = make(map[string]interface{})
 		}
 	}

--- a/pkg/repository/v1/trigger_test.go
+++ b/pkg/repository/v1/trigger_test.go
@@ -1,0 +1,40 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_cleanAdditionalMetadataTableTest(t *testing.T) {
+
+	tests := []struct {
+		name               string
+		additionalMetadata []byte
+		expected           map[string]interface{}
+	}{
+
+		{
+			name:               "empty",
+			additionalMetadata: []byte(""),
+			expected:           map[string]interface{}{},
+		},
+		{
+			name:               "null",
+			additionalMetadata: []byte("null"),
+			expected:           map[string]interface{}{},
+		},
+		{
+			name:               "valid",
+			additionalMetadata: []byte(`{"key":"value"}`),
+			expected:           map[string]interface{}{"key": "value"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := cleanAdditionalMetadata(test.additionalMetadata)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
### Fix panic when additionalMetadata is null
Fix panic when additionalMetadata is null; avoid null AdditionalMetadata in BulkPush; add regression test.

# Description

Fixes a panic caused by `additionalMetadata` being serialized as JSON `null`. When unmarshaled into a `map[string]interface{}`, `"null"` results in a nil map, and `TriggeredByEvent.ToMetadata` subsequently attempts to assign into it, causing a panic.

Reproducing with Go client:

```go
// Before fix: omitting AdditionalMetadata causes JSON "null" to be sent
// which leads to a server panic when unmarshaled into a map.

ctx := context.Background()

events := []client.EventWithAdditionalMetadata{
	{
		Event: map[string]any{"foo": "bar"},
		Key:   "test.event",
		// AdditionalMetadata omitted → pre-fix this marshals to JSON "null"
	},
}

_ = eventClient.BulkPush(ctx, events)

// Server-side (pre-fix) panic stack excerpt:
//
// panic: assignment to entry in nil map
// github.com/hatchet-dev/hatchet/pkg/repository/v1.(*TriggeredByEvent).ToMetadata
//   pkg/repository/v1/trigger.go:601
// github.com/hatchet-dev/hatchet/pkg/repository/v1.(*TriggerRepositoryImpl).TriggerFromEvents
//   pkg/repository/v1/trigger.go:369
```


<details>
<summary>Stacktrace</summary>
hatchet-engine-1     | panic: assignment to entry in nil map
hatchet-engine-1     | 
hatchet-engine-1     | goroutine 507 [running]:
hatchet-engine-1     | github.com/hatchet-dev/hatchet/pkg/repository/v1.(*TriggeredByEvent).ToMetadata(0xc000aa6e50, {0xc000339028?, 0xc000339160?, 0xf?})
hatchet-engine-1     |  /hatchet/pkg/repository/v1/trigger.go:601 +0x67
hatchet-engine-1     | github.com/hatchet-dev/hatchet/pkg/repository/v1.(*TriggerRepositoryImpl).TriggerFromEvents(0xc000688ca0, {0x1e6b2f0, 0x2c6e960}, {0xc0009824e0, 0x24}, {0xc000a9c000, 0x1, 0x1?})
hatchet-engine-1     |  /hatchet/pkg/repository/v1/trigger.go:369 +0x1cab
hatchet-engine-1     | github.com/hatchet-dev/hatchet/internal/services/controllers/v1/task.(*TasksControllerImpl).handleProcessUserEventTrigger(0xc0009323c0, {0x1e6b2f0, 0x2c6e960}, {0xc0009824e0, 0x24}, {0xc0003174e0, 0x1, 0x1?})
hatchet-engine-1     |  /hatchet/internal/services/controllers/v1/task/controller.go:984 +0x3de
hatchet-engine-1     | github.com/hatchet-dev/hatchet/internal/services/controllers/v1/task.(*TasksControllerImpl).handleProcessUserEvents.func1()
hatchet-engine-1     |  /hatchet/internal/services/controllers/v1/task/controller.go:953 +0x33
</details>


This change:
- Hardens server-side metadata cleaning to always return a non-nil map.
- Ensures the Go client never emits `"null"` for `additionalMetadata` in BulkPush, using the existing helper to build `{}` when absent.
- Adds a regression test covering empty, `"null"`, and valid metadata.

## Fixes
- Repro (pre-fix): sending an event with `additionalMetadata` serialized as `"null"` triggers `panic: assignment to entry in nil map` in `trigger.go` within `ToMetadata`.
- Validation (post-fix): focused unit test passes; sending events with omitted metadata no longer panics, and workflows trigger as expected.
- Backwards compatibility: non-breaking; server now tolerates `"null"`, client now standardizes absent metadata to `{}`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [x] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [x] Server: in `pkg/repository/v1/trigger.go`, make `cleanAdditionalMetadata` guard against `res == nil` after `json.Unmarshal`, so it always returns a non-nil map.
- [x] Go client: in `pkg/client/event.go`, `BulkPush` now builds metadata via `getAdditionalMetaBytes`, avoiding `"null"` when per-event metadata is omitted.
- [x] Tests: add `pkg/repository/v1/trigger_test.go` table test for `cleanAdditionalMetadata` covering empty string, `"null"`, and valid JSON.