### PR TITLE
fix: confusing error message `could not update DAG statuses`

### DIFF
--- a/internal/services/controllers/v1/olap/process_task_status_updates.go
+++ b/internal/services/controllers/v1/olap/process_task_status_updates.go
@@ -45,7 +45,7 @@ func (o *OLAPControllerImpl) runTaskStatusUpdates(ctx context.Context) func() {
 			shouldContinue, rows, err = o.repo.OLAP().UpdateTaskStatuses(ctx, tenantIds)
 
 			if err != nil {
-				o.l.Error().Err(err).Msg("could not update DAG statuses")
+				o.l.Error().Err(err).Msg("could not update task statuses")
 				return
 			}
 


### PR DESCRIPTION
# Description

Fixes an incorrect copypasta error message. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)