### PR TITLE
fix: don't query database when flush is called concurrently

### DIFF
--- a/pkg/scheduling/v1/rate_limit.go
+++ b/pkg/scheduling/v1/rate_limit.go
@@ -283,6 +283,16 @@ func (r *rateLimiter) flushToDatabase(ctx context.Context) error {
 	r.dbRateLimitsMu.Lock()
 	defer r.dbRateLimitsMu.Unlock()
 
+	r.nextRefillAtMu.Lock()
+	defer r.nextRefillAtMu.Unlock()
+
+	// check the refill time to avoid unnecessary database calls
+	if r.nextRefillAt != nil {
+		if r.nextRefillAt.After(time.Now().UTC()) {
+			return nil
+		}
+	}
+
 	// copy the unflushed rate limits to a new map
 	updates := make(map[string]int)
 
@@ -303,10 +313,8 @@ func (r *rateLimiter) flushToDatabase(ctx context.Context) error {
 			nextRefillAt = &minRefillAt
 		}
 
-		// update the next refill time
-		r.nextRefillAtMu.Lock()
+		// update the next refill time; we already have the lock
 		r.nextRefillAt = nextRefillAt
-		r.nextRefillAtMu.Unlock()
 	}
 
 	r.dbRateLimits = make(rateLimitSet)


### PR DESCRIPTION
# Description

When there are many calls to `*RateLimiter.use` concurrently, we can still query the database more than the desired frequency because we call `flushToDatabase` before we've updated the `nextRefillAt`. This properly serializes the flush calls. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)