### PR TITLE
Inject `tenant` and `tenant-member` into respective create handlers

### DIFF
--- a/api/v1/server/handlers/tenants/create.go
+++ b/api/v1/server/handlers/tenants/create.go
@@ -124,6 +124,8 @@ func (t *TenantService) TenantCreate(ctx echo.Context, request gen.TenantCreateR
 		},
 	)
 
+	ctx.Set("tenant", tenant)
+
 	return gen.TenantCreate200JSONResponse(
 		*transformers.ToTenant(tenant),
 	), nil

--- a/api/v1/server/handlers/users/accept_invite.go
+++ b/api/v1/server/handlers/users/accept_invite.go
@@ -76,7 +76,7 @@ func (u *UserService) TenantInviteAccept(ctx echo.Context, request gen.TenantInv
 	}
 
 	// add the user to the tenant
-	_, err = u.config.APIRepository.Tenant().CreateTenantMember(ctx.Request().Context(), sqlchelpers.UUIDToStr(invite.TenantId), &repository.CreateTenantMemberOpts{
+	member, err := u.config.APIRepository.Tenant().CreateTenantMember(ctx.Request().Context(), sqlchelpers.UUIDToStr(invite.TenantId), &repository.CreateTenantMemberOpts{
 		UserId: userId,
 		Role:   string(invite.Role),
 	})
@@ -98,6 +98,15 @@ func (u *UserService) TenantInviteAccept(ctx echo.Context, request gen.TenantInv
 			"role":      invite.Role,
 		},
 	)
+
+	ctx.Set("tenant-member", member)
+
+	tenant, err := u.config.APIRepository.Tenant().GetTenantByID(ctx.Request().Context(), tenantId)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx.Set("tenant", tenant)
 
 	ctx.Set(constants.ResourceIdKey.String(), inviteId)
 	ctx.Set(constants.ResourceTypeKey.String(), constants.ResourceTypeTenantInvite.String())


### PR DESCRIPTION
# Description

Inject `tenant` and `tenant-member` in respective create handlers for use by middlewares down the line.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (changes which are not directly related to any business logic)
