### PR TITLE
[Python] Feat: Log Buffering

### DIFF
--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -145,7 +145,7 @@ jobs:
         run: |
           echo "Using HATCHET_CLIENT_NAMESPACE: $HATCHET_CLIENT_NAMESPACE"
 
-          poetry run pytest -s -vvv --maxfail=5 --capture=no --retries 3 --retry-delay 2
+          poetry run pytest -s -vvv --maxfail=5 --capture=no --retries 3 --retry-delay 2 -n auto
 
       - name: Upload engine logs
         if: always()

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.18.0] - 2025-08-26
+## [1.18.2] - 2025-08-30
+
+### Added
+
+- Internally buffers log messages to reduce the number of requests made to the engine for log capture
+- Adds `HATCHET_CLIENT_LOG_BUFFER_SIZE` and `HATCHET_CLIENT_LOG_FLUSH_INTERVAL_SECONDS` environment variables to configure the log buffer size and flush interval, respectively.
+
+## [1.18.1] - 2025-08-26
 
 ### Added
 

--- a/sdks/python/examples/durable/test_durable.py
+++ b/sdks/python/examples/durable/test_durable.py
@@ -27,7 +27,7 @@ async def test_durable(hatchet: Hatchet) -> None:
 
     active_workers = [w for w in workers.rows if w.status == "ACTIVE"]
 
-    assert len(active_workers) == 2
+    assert len(active_workers) >= 2
     assert any(
         w.name == hatchet.config.apply_namespace("e2e-test-worker")
         for w in active_workers

--- a/sdks/python/examples/logger/test_logger.py
+++ b/sdks/python/examples/logger/test_logger.py
@@ -18,7 +18,7 @@ async def test_log_capture(hatchet: Hatchet) -> None:
 
     subtask_ids = [t.metadata.id for t in run.tasks]
 
-    await asyncio.sleep(hatchet.config.log_flush_interval_seconds * 5)
+    await asyncio.sleep(hatchet.config.log_flush_interval_seconds * 7)
 
     for subtask_id in subtask_ids:
         logs = await hatchet.logs.aio_list(task_run_id=subtask_id)

--- a/sdks/python/examples/logger/test_logger.py
+++ b/sdks/python/examples/logger/test_logger.py
@@ -1,10 +1,27 @@
+import asyncio
+
 import pytest
 
-from examples.logger.workflow import logging_workflow
+from examples.logger.workflow import N, logging_workflow
+from hatchet_sdk import ClientConfig, Hatchet
 
 
 @pytest.mark.asyncio(loop_scope="session")
-async def test_run() -> None:
-    result = await logging_workflow.aio_run()
+async def test_log_capture(hatchet: Hatchet) -> None:
+    ref = await logging_workflow.aio_run_no_wait()
+
+    result = await ref.aio_result()
 
     assert result["root_logger"]["status"] == "success"
+
+    run = await hatchet.runs.aio_get(ref.workflow_run_id)
+
+    subtask_ids = [t.metadata.id for t in run.tasks]
+
+    await asyncio.sleep(hatchet.config.log_flush_interval_seconds * 5)
+
+    for subtask_id in subtask_ids:
+        logs = await hatchet.logs.aio_list(task_run_id=subtask_id)
+
+        assert logs.rows
+        assert len(logs.rows) == N * 2

--- a/sdks/python/examples/logger/workflow.py
+++ b/sdks/python/examples/logger/workflow.py
@@ -12,10 +12,12 @@ logging_workflow = hatchet.workflow(
     name="LoggingWorkflow",
 )
 
+N = 12
+
 
 @logging_workflow.task()
 def root_logger(input: EmptyModel, ctx: Context) -> dict[str, str]:
-    for i in range(12):
+    for i in range(N):
         logger.info(f"executed step1 - {i}")
         logger.info({"step1": "step1"})
 
@@ -31,7 +33,7 @@ def root_logger(input: EmptyModel, ctx: Context) -> dict[str, str]:
 
 @logging_workflow.task()
 def context_logger(input: EmptyModel, ctx: Context) -> dict[str, str]:
-    for i in range(12):
+    for i in range(N):
         ctx.log(f"executed step1 - {i}")
         ctx.log({"step1": "step1"})
 

--- a/sdks/python/hatchet_sdk/clients/rest/__init__.py
+++ b/sdks/python/hatchet_sdk/clients/rest/__init__.py
@@ -196,6 +196,7 @@ from hatchet_sdk.clients.rest.models.tenant_alert_email_group_list import (
 from hatchet_sdk.clients.rest.models.tenant_alerting_settings import (
     TenantAlertingSettings,
 )
+from hatchet_sdk.clients.rest.models.tenant_environment import TenantEnvironment
 from hatchet_sdk.clients.rest.models.tenant_invite import TenantInvite
 from hatchet_sdk.clients.rest.models.tenant_invite_list import TenantInviteList
 from hatchet_sdk.clients.rest.models.tenant_list import TenantList
@@ -219,6 +220,9 @@ from hatchet_sdk.clients.rest.models.update_tenant_alert_email_group_request imp
 )
 from hatchet_sdk.clients.rest.models.update_tenant_invite_request import (
     UpdateTenantInviteRequest,
+)
+from hatchet_sdk.clients.rest.models.update_tenant_member_request import (
+    UpdateTenantMemberRequest,
 )
 from hatchet_sdk.clients.rest.models.update_tenant_request import UpdateTenantRequest
 from hatchet_sdk.clients.rest.models.update_worker_request import UpdateWorkerRequest
@@ -290,6 +294,9 @@ from hatchet_sdk.clients.rest.models.v1_trigger_workflow_run_request import (
 from hatchet_sdk.clients.rest.models.v1_update_filter_request import (
     V1UpdateFilterRequest,
 )
+from hatchet_sdk.clients.rest.models.v1_update_webhook_request import (
+    V1UpdateWebhookRequest,
+)
 from hatchet_sdk.clients.rest.models.v1_webhook import V1Webhook
 from hatchet_sdk.clients.rest.models.v1_webhook_api_key_auth import V1WebhookAPIKeyAuth
 from hatchet_sdk.clients.rest.models.v1_webhook_auth_type import V1WebhookAuthType
@@ -302,9 +309,6 @@ from hatchet_sdk.clients.rest.models.v1_webhook_hmac_encoding import (
     V1WebhookHMACEncoding,
 )
 from hatchet_sdk.clients.rest.models.v1_webhook_list import V1WebhookList
-from hatchet_sdk.clients.rest.models.v1_webhook_receive200_response import (
-    V1WebhookReceive200Response,
-)
 from hatchet_sdk.clients.rest.models.v1_webhook_source_name import V1WebhookSourceName
 from hatchet_sdk.clients.rest.models.v1_workflow_run import V1WorkflowRun
 from hatchet_sdk.clients.rest.models.v1_workflow_run_details import V1WorkflowRunDetails

--- a/sdks/python/hatchet_sdk/clients/rest/api/task_api.py
+++ b/sdks/python/hatchet_sdk/clients/rest/api/task_api.py
@@ -1597,6 +1597,10 @@ class TaskApi:
             Optional[Annotated[str, Field(min_length=36, strict=True, max_length=36)]],
             Field(description="The id of the event that triggered the task"),
         ] = None,
+        additional_metadata: Annotated[
+            Optional[List[StrictStr]],
+            Field(description="Additional metadata k-v pairs to filter by"),
+        ] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1625,6 +1629,8 @@ class TaskApi:
         :type parent_task_external_id: str
         :param triggering_event_external_id: The id of the event that triggered the task
         :type triggering_event_external_id: str
+        :param additional_metadata: Additional metadata k-v pairs to filter by
+        :type additional_metadata: List[str]
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1654,6 +1660,7 @@ class TaskApi:
             workflow_ids=workflow_ids,
             parent_task_external_id=parent_task_external_id,
             triggering_event_external_id=triggering_event_external_id,
+            additional_metadata=additional_metadata,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1704,6 +1711,10 @@ class TaskApi:
             Optional[Annotated[str, Field(min_length=36, strict=True, max_length=36)]],
             Field(description="The id of the event that triggered the task"),
         ] = None,
+        additional_metadata: Annotated[
+            Optional[List[StrictStr]],
+            Field(description="Additional metadata k-v pairs to filter by"),
+        ] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1732,6 +1743,8 @@ class TaskApi:
         :type parent_task_external_id: str
         :param triggering_event_external_id: The id of the event that triggered the task
         :type triggering_event_external_id: str
+        :param additional_metadata: Additional metadata k-v pairs to filter by
+        :type additional_metadata: List[str]
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1761,6 +1774,7 @@ class TaskApi:
             workflow_ids=workflow_ids,
             parent_task_external_id=parent_task_external_id,
             triggering_event_external_id=triggering_event_external_id,
+            additional_metadata=additional_metadata,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1811,6 +1825,10 @@ class TaskApi:
             Optional[Annotated[str, Field(min_length=36, strict=True, max_length=36)]],
             Field(description="The id of the event that triggered the task"),
         ] = None,
+        additional_metadata: Annotated[
+            Optional[List[StrictStr]],
+            Field(description="Additional metadata k-v pairs to filter by"),
+        ] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1839,6 +1857,8 @@ class TaskApi:
         :type parent_task_external_id: str
         :param triggering_event_external_id: The id of the event that triggered the task
         :type triggering_event_external_id: str
+        :param additional_metadata: Additional metadata k-v pairs to filter by
+        :type additional_metadata: List[str]
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1868,6 +1888,7 @@ class TaskApi:
             workflow_ids=workflow_ids,
             parent_task_external_id=parent_task_external_id,
             triggering_event_external_id=triggering_event_external_id,
+            additional_metadata=additional_metadata,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1893,6 +1914,7 @@ class TaskApi:
         workflow_ids,
         parent_task_external_id,
         triggering_event_external_id,
+        additional_metadata,
         _request_auth,
         _content_type,
         _headers,
@@ -1903,6 +1925,7 @@ class TaskApi:
 
         _collection_formats: Dict[str, str] = {
             "workflow_ids": "multi",
+            "additional_metadata": "multi",
         }
 
         _path_params: Dict[str, str] = {}
@@ -1953,6 +1976,10 @@ class TaskApi:
             _query_params.append(
                 ("triggering_event_external_id", triggering_event_external_id)
             )
+
+        if additional_metadata is not None:
+
+            _query_params.append(("additional_metadata", additional_metadata))
 
         # process the header parameters
         # process the form parameters

--- a/sdks/python/hatchet_sdk/clients/rest/api/tenant_api.py
+++ b/sdks/python/hatchet_sdk/clients/rest/api/tenant_api.py
@@ -49,6 +49,9 @@ from hatchet_sdk.clients.rest.models.tenant_step_run_queue_metrics import (
 from hatchet_sdk.clients.rest.models.update_tenant_alert_email_group_request import (
     UpdateTenantAlertEmailGroupRequest,
 )
+from hatchet_sdk.clients.rest.models.update_tenant_member_request import (
+    UpdateTenantMemberRequest,
+)
 from hatchet_sdk.clients.rest.models.update_tenant_request import UpdateTenantRequest
 from hatchet_sdk.clients.rest.rest import RESTResponseType
 
@@ -4166,6 +4169,345 @@ class TenantApi:
         return self.api_client.param_serialize(
             method="GET",
             resource_path="/api/v1/tenants/{tenant}/members",
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth,
+        )
+
+    @validate_call
+    def tenant_member_update(
+        self,
+        tenant: Annotated[
+            str,
+            Field(
+                min_length=36, strict=True, max_length=36, description="The tenant id"
+            ),
+        ],
+        member: Annotated[
+            str,
+            Field(
+                min_length=36,
+                strict=True,
+                max_length=36,
+                description="The tenant member id",
+            ),
+        ],
+        update_tenant_member_request: Annotated[
+            UpdateTenantMemberRequest,
+            Field(description="The tenant member properties to update"),
+        ],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)], Annotated[StrictFloat, Field(gt=0)]
+            ],
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> TenantMember:
+        """Update a tenant member
+
+        Update a tenant member
+
+        :param tenant: The tenant id (required)
+        :type tenant: str
+        :param member: The tenant member id (required)
+        :type member: str
+        :param update_tenant_member_request: The tenant member properties to update (required)
+        :type update_tenant_member_request: UpdateTenantMemberRequest
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """  # noqa: E501
+
+        _param = self._tenant_member_update_serialize(
+            tenant=tenant,
+            member=member,
+            update_tenant_member_request=update_tenant_member_request,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index,
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            "200": "TenantMember",
+            "400": "APIErrors",
+            "403": "APIErrors",
+            "404": "APIErrors",
+        }
+        response_data = self.api_client.call_api(
+            *_param, _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+    @validate_call
+    def tenant_member_update_with_http_info(
+        self,
+        tenant: Annotated[
+            str,
+            Field(
+                min_length=36, strict=True, max_length=36, description="The tenant id"
+            ),
+        ],
+        member: Annotated[
+            str,
+            Field(
+                min_length=36,
+                strict=True,
+                max_length=36,
+                description="The tenant member id",
+            ),
+        ],
+        update_tenant_member_request: Annotated[
+            UpdateTenantMemberRequest,
+            Field(description="The tenant member properties to update"),
+        ],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)], Annotated[StrictFloat, Field(gt=0)]
+            ],
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[TenantMember]:
+        """Update a tenant member
+
+        Update a tenant member
+
+        :param tenant: The tenant id (required)
+        :type tenant: str
+        :param member: The tenant member id (required)
+        :type member: str
+        :param update_tenant_member_request: The tenant member properties to update (required)
+        :type update_tenant_member_request: UpdateTenantMemberRequest
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """  # noqa: E501
+
+        _param = self._tenant_member_update_serialize(
+            tenant=tenant,
+            member=member,
+            update_tenant_member_request=update_tenant_member_request,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index,
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            "200": "TenantMember",
+            "400": "APIErrors",
+            "403": "APIErrors",
+            "404": "APIErrors",
+        }
+        response_data = self.api_client.call_api(
+            *_param, _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+    @validate_call
+    def tenant_member_update_without_preload_content(
+        self,
+        tenant: Annotated[
+            str,
+            Field(
+                min_length=36, strict=True, max_length=36, description="The tenant id"
+            ),
+        ],
+        member: Annotated[
+            str,
+            Field(
+                min_length=36,
+                strict=True,
+                max_length=36,
+                description="The tenant member id",
+            ),
+        ],
+        update_tenant_member_request: Annotated[
+            UpdateTenantMemberRequest,
+            Field(description="The tenant member properties to update"),
+        ],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)], Annotated[StrictFloat, Field(gt=0)]
+            ],
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Update a tenant member
+
+        Update a tenant member
+
+        :param tenant: The tenant id (required)
+        :type tenant: str
+        :param member: The tenant member id (required)
+        :type member: str
+        :param update_tenant_member_request: The tenant member properties to update (required)
+        :type update_tenant_member_request: UpdateTenantMemberRequest
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """  # noqa: E501
+
+        _param = self._tenant_member_update_serialize(
+            tenant=tenant,
+            member=member,
+            update_tenant_member_request=update_tenant_member_request,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index,
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            "200": "TenantMember",
+            "400": "APIErrors",
+            "403": "APIErrors",
+            "404": "APIErrors",
+        }
+        response_data = self.api_client.call_api(
+            *_param, _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+    def _tenant_member_update_serialize(
+        self,
+        tenant,
+        member,
+        update_tenant_member_request,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {}
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        if tenant is not None:
+            _path_params["tenant"] = tenant
+        if member is not None:
+            _path_params["member"] = member
+        # process the query parameters
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+        if update_tenant_member_request is not None:
+            _body_params = update_tenant_member_request
+
+        # set the HTTP header `Accept`
+        if "Accept" not in _header_params:
+            _header_params["Accept"] = self.api_client.select_header_accept(
+                ["application/json"]
+            )
+
+        # set the HTTP header `Content-Type`
+        if _content_type:
+            _header_params["Content-Type"] = _content_type
+        else:
+            _default_content_type = self.api_client.select_header_content_type(
+                ["application/json"]
+            )
+            if _default_content_type is not None:
+                _header_params["Content-Type"] = _default_content_type
+
+        # authentication setting
+        _auth_settings: List[str] = ["cookieAuth", "bearerAuth"]
+
+        return self.api_client.param_serialize(
+            method="PATCH",
+            resource_path="/api/v1/tenants/{tenant}/members/{member}",
             path_params=_path_params,
             query_params=_query_params,
             header_params=_header_params,

--- a/sdks/python/hatchet_sdk/clients/rest/api/webhook_api.py
+++ b/sdks/python/hatchet_sdk/clients/rest/api/webhook_api.py
@@ -22,11 +22,11 @@ from hatchet_sdk.clients.rest.api_response import ApiResponse
 from hatchet_sdk.clients.rest.models.v1_create_webhook_request import (
     V1CreateWebhookRequest,
 )
+from hatchet_sdk.clients.rest.models.v1_update_webhook_request import (
+    V1UpdateWebhookRequest,
+)
 from hatchet_sdk.clients.rest.models.v1_webhook import V1Webhook
 from hatchet_sdk.clients.rest.models.v1_webhook_list import V1WebhookList
-from hatchet_sdk.clients.rest.models.v1_webhook_receive200_response import (
-    V1WebhookReceive200Response,
-)
 from hatchet_sdk.clients.rest.models.v1_webhook_source_name import V1WebhookSourceName
 from hatchet_sdk.clients.rest.rest import RESTResponseType
 
@@ -1293,7 +1293,7 @@ class WebhookApi:
         _content_type: Optional[StrictStr] = None,
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
-    ) -> V1WebhookReceive200Response:
+    ) -> Dict[str, object]:
         """Post a webhook message
 
         Post an incoming webhook message
@@ -1334,7 +1334,7 @@ class WebhookApi:
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
-            "200": "V1WebhookReceive200Response",
+            "200": "Dict[str, object]",
             "400": "APIErrors",
             "403": "APIErrors",
         }
@@ -1368,7 +1368,7 @@ class WebhookApi:
         _content_type: Optional[StrictStr] = None,
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
-    ) -> ApiResponse[V1WebhookReceive200Response]:
+    ) -> ApiResponse[Dict[str, object]]:
         """Post a webhook message
 
         Post an incoming webhook message
@@ -1409,7 +1409,7 @@ class WebhookApi:
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
-            "200": "V1WebhookReceive200Response",
+            "200": "Dict[str, object]",
             "400": "APIErrors",
             "403": "APIErrors",
         }
@@ -1484,7 +1484,7 @@ class WebhookApi:
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
-            "200": "V1WebhookReceive200Response",
+            "200": "Dict[str, object]",
             "400": "APIErrors",
             "403": "APIErrors",
         }
@@ -1537,6 +1537,321 @@ class WebhookApi:
 
         return self.api_client.param_serialize(
             method="POST",
+            resource_path="/api/v1/stable/tenants/{tenant}/webhooks/{v1-webhook}",
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth,
+        )
+
+    @validate_call
+    def v1_webhook_update(
+        self,
+        tenant: Annotated[
+            str,
+            Field(
+                min_length=36, strict=True, max_length=36, description="The tenant id"
+            ),
+        ],
+        v1_webhook: Annotated[StrictStr, Field(description="The webhook name")],
+        v1_update_webhook_request: Annotated[
+            V1UpdateWebhookRequest,
+            Field(description="The input to the webhook creation"),
+        ],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)], Annotated[StrictFloat, Field(gt=0)]
+            ],
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> V1Webhook:
+        """Update a webhook
+
+        Update a webhook
+
+        :param tenant: The tenant id (required)
+        :type tenant: str
+        :param v1_webhook: The webhook name (required)
+        :type v1_webhook: str
+        :param v1_update_webhook_request: The input to the webhook creation (required)
+        :type v1_update_webhook_request: V1UpdateWebhookRequest
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """  # noqa: E501
+
+        _param = self._v1_webhook_update_serialize(
+            tenant=tenant,
+            v1_webhook=v1_webhook,
+            v1_update_webhook_request=v1_update_webhook_request,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index,
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            "200": "V1Webhook",
+            "400": "APIErrors",
+            "403": "APIErrors",
+            "404": "APIErrors",
+        }
+        response_data = self.api_client.call_api(
+            *_param, _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+    @validate_call
+    def v1_webhook_update_with_http_info(
+        self,
+        tenant: Annotated[
+            str,
+            Field(
+                min_length=36, strict=True, max_length=36, description="The tenant id"
+            ),
+        ],
+        v1_webhook: Annotated[StrictStr, Field(description="The webhook name")],
+        v1_update_webhook_request: Annotated[
+            V1UpdateWebhookRequest,
+            Field(description="The input to the webhook creation"),
+        ],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)], Annotated[StrictFloat, Field(gt=0)]
+            ],
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[V1Webhook]:
+        """Update a webhook
+
+        Update a webhook
+
+        :param tenant: The tenant id (required)
+        :type tenant: str
+        :param v1_webhook: The webhook name (required)
+        :type v1_webhook: str
+        :param v1_update_webhook_request: The input to the webhook creation (required)
+        :type v1_update_webhook_request: V1UpdateWebhookRequest
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """  # noqa: E501
+
+        _param = self._v1_webhook_update_serialize(
+            tenant=tenant,
+            v1_webhook=v1_webhook,
+            v1_update_webhook_request=v1_update_webhook_request,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index,
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            "200": "V1Webhook",
+            "400": "APIErrors",
+            "403": "APIErrors",
+            "404": "APIErrors",
+        }
+        response_data = self.api_client.call_api(
+            *_param, _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+    @validate_call
+    def v1_webhook_update_without_preload_content(
+        self,
+        tenant: Annotated[
+            str,
+            Field(
+                min_length=36, strict=True, max_length=36, description="The tenant id"
+            ),
+        ],
+        v1_webhook: Annotated[StrictStr, Field(description="The webhook name")],
+        v1_update_webhook_request: Annotated[
+            V1UpdateWebhookRequest,
+            Field(description="The input to the webhook creation"),
+        ],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)], Annotated[StrictFloat, Field(gt=0)]
+            ],
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Update a webhook
+
+        Update a webhook
+
+        :param tenant: The tenant id (required)
+        :type tenant: str
+        :param v1_webhook: The webhook name (required)
+        :type v1_webhook: str
+        :param v1_update_webhook_request: The input to the webhook creation (required)
+        :type v1_update_webhook_request: V1UpdateWebhookRequest
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """  # noqa: E501
+
+        _param = self._v1_webhook_update_serialize(
+            tenant=tenant,
+            v1_webhook=v1_webhook,
+            v1_update_webhook_request=v1_update_webhook_request,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index,
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            "200": "V1Webhook",
+            "400": "APIErrors",
+            "403": "APIErrors",
+            "404": "APIErrors",
+        }
+        response_data = self.api_client.call_api(
+            *_param, _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+    def _v1_webhook_update_serialize(
+        self,
+        tenant,
+        v1_webhook,
+        v1_update_webhook_request,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {}
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        if tenant is not None:
+            _path_params["tenant"] = tenant
+        if v1_webhook is not None:
+            _path_params["v1-webhook"] = v1_webhook
+        # process the query parameters
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+        if v1_update_webhook_request is not None:
+            _body_params = v1_update_webhook_request
+
+        # set the HTTP header `Accept`
+        if "Accept" not in _header_params:
+            _header_params["Accept"] = self.api_client.select_header_accept(
+                ["application/json"]
+            )
+
+        # set the HTTP header `Content-Type`
+        if _content_type:
+            _header_params["Content-Type"] = _content_type
+        else:
+            _default_content_type = self.api_client.select_header_content_type(
+                ["application/json"]
+            )
+            if _default_content_type is not None:
+                _header_params["Content-Type"] = _default_content_type
+
+        # authentication setting
+        _auth_settings: List[str] = ["cookieAuth", "bearerAuth"]
+
+        return self.api_client.param_serialize(
+            method="PATCH",
             resource_path="/api/v1/stable/tenants/{tenant}/webhooks/{v1-webhook}",
             path_params=_path_params,
             query_params=_query_params,

--- a/sdks/python/hatchet_sdk/clients/rest/configuration.py
+++ b/sdks/python/hatchet_sdk/clients/rest/configuration.py
@@ -121,6 +121,7 @@ AuthSettings = TypedDict(
     {
         "bearerAuth": BearerAuthSetting,
         "cookieAuth": APIKeyAuthSetting,
+        "customAuth": BearerAuthSetting,
     },
     total=False,
 )
@@ -536,6 +537,13 @@ class Configuration:
                 "value": self.get_api_key_with_prefix(
                     "cookieAuth",
                 ),
+            }
+        if self.access_token is not None:
+            auth["customAuth"] = {
+                "type": "bearer",
+                "in": "header",
+                "key": "Authorization",
+                "value": "Bearer " + self.access_token,
             }
         return auth
 

--- a/sdks/python/hatchet_sdk/clients/rest/models/__init__.py
+++ b/sdks/python/hatchet_sdk/clients/rest/models/__init__.py
@@ -158,6 +158,7 @@ from hatchet_sdk.clients.rest.models.tenant_alert_email_group_list import (
 from hatchet_sdk.clients.rest.models.tenant_alerting_settings import (
     TenantAlertingSettings,
 )
+from hatchet_sdk.clients.rest.models.tenant_environment import TenantEnvironment
 from hatchet_sdk.clients.rest.models.tenant_invite import TenantInvite
 from hatchet_sdk.clients.rest.models.tenant_invite_list import TenantInviteList
 from hatchet_sdk.clients.rest.models.tenant_list import TenantList
@@ -181,6 +182,9 @@ from hatchet_sdk.clients.rest.models.update_tenant_alert_email_group_request imp
 )
 from hatchet_sdk.clients.rest.models.update_tenant_invite_request import (
     UpdateTenantInviteRequest,
+)
+from hatchet_sdk.clients.rest.models.update_tenant_member_request import (
+    UpdateTenantMemberRequest,
 )
 from hatchet_sdk.clients.rest.models.update_tenant_request import UpdateTenantRequest
 from hatchet_sdk.clients.rest.models.update_worker_request import UpdateWorkerRequest
@@ -252,6 +256,9 @@ from hatchet_sdk.clients.rest.models.v1_trigger_workflow_run_request import (
 from hatchet_sdk.clients.rest.models.v1_update_filter_request import (
     V1UpdateFilterRequest,
 )
+from hatchet_sdk.clients.rest.models.v1_update_webhook_request import (
+    V1UpdateWebhookRequest,
+)
 from hatchet_sdk.clients.rest.models.v1_webhook import V1Webhook
 from hatchet_sdk.clients.rest.models.v1_webhook_api_key_auth import V1WebhookAPIKeyAuth
 from hatchet_sdk.clients.rest.models.v1_webhook_auth_type import V1WebhookAuthType
@@ -264,9 +271,6 @@ from hatchet_sdk.clients.rest.models.v1_webhook_hmac_encoding import (
     V1WebhookHMACEncoding,
 )
 from hatchet_sdk.clients.rest.models.v1_webhook_list import V1WebhookList
-from hatchet_sdk.clients.rest.models.v1_webhook_receive200_response import (
-    V1WebhookReceive200Response,
-)
 from hatchet_sdk.clients.rest.models.v1_webhook_source_name import V1WebhookSourceName
 from hatchet_sdk.clients.rest.models.v1_workflow_run import V1WorkflowRun
 from hatchet_sdk.clients.rest.models.v1_workflow_run_details import V1WorkflowRunDetails

--- a/sdks/python/hatchet_sdk/clients/rest/models/tenant.py
+++ b/sdks/python/hatchet_sdk/clients/rest/models/tenant.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr
 from typing_extensions import Self
 
 from hatchet_sdk.clients.rest.models.api_resource_meta import APIResourceMeta
+from hatchet_sdk.clients.rest.models.tenant_environment import TenantEnvironment
 from hatchet_sdk.clients.rest.models.tenant_ui_version import TenantUIVersion
 from hatchet_sdk.clients.rest.models.tenant_version import TenantVersion
 
@@ -49,6 +50,9 @@ class Tenant(BaseModel):
     ui_version: Optional[TenantUIVersion] = Field(
         default=None, description="The UI of the tenant.", alias="uiVersion"
     )
+    environment: Optional[TenantEnvironment] = Field(
+        default=None, description="The environment type of the tenant."
+    )
     __properties: ClassVar[List[str]] = [
         "metadata",
         "name",
@@ -57,6 +61,7 @@ class Tenant(BaseModel):
         "alertMemberEmails",
         "version",
         "uiVersion",
+        "environment",
     ]
 
     model_config = ConfigDict(
@@ -123,6 +128,7 @@ class Tenant(BaseModel):
                 "alertMemberEmails": obj.get("alertMemberEmails"),
                 "version": obj.get("version"),
                 "uiVersion": obj.get("uiVersion"),
+                "environment": obj.get("environment"),
             }
         )
         return _obj

--- a/sdks/python/hatchet_sdk/clients/rest/models/tenant_environment.py
+++ b/sdks/python/hatchet_sdk/clients/rest/models/tenant_environment.py
@@ -20,21 +20,19 @@ from enum import Enum
 from typing_extensions import Self
 
 
-class V1WebhookSourceName(str, Enum):
+class TenantEnvironment(str, Enum):
     """
-    V1WebhookSourceName
+    TenantEnvironment
     """
 
     """
     allowed enum values
     """
-    GENERIC = "GENERIC"
-    GITHUB = "GITHUB"
-    STRIPE = "STRIPE"
-    SLACK = "SLACK"
-    LINEAR = "LINEAR"
+    LOCAL = "local"
+    DEVELOPMENT = "development"
+    PRODUCTION = "production"
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:
-        """Create an instance of V1WebhookSourceName from a JSON string"""
+        """Create an instance of TenantEnvironment from a JSON string"""
         return cls(json.loads(json_str))

--- a/sdks/python/hatchet_sdk/clients/rest/models/update_tenant_member_request.py
+++ b/sdks/python/hatchet_sdk/clients/rest/models/update_tenant_member_request.py
@@ -19,47 +19,19 @@ import pprint
 import re  # noqa: F401
 from typing import Any, ClassVar, Dict, List, Optional, Set
 
-from pydantic import BaseModel, ConfigDict, Field, StrictStr
+from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import Self
 
-from hatchet_sdk.clients.rest.models.tenant_environment import TenantEnvironment
-from hatchet_sdk.clients.rest.models.tenant_ui_version import TenantUIVersion
-from hatchet_sdk.clients.rest.models.tenant_version import TenantVersion
+from hatchet_sdk.clients.rest.models.tenant_member_role import TenantMemberRole
 
 
-class CreateTenantRequest(BaseModel):
+class UpdateTenantMemberRequest(BaseModel):
     """
-    CreateTenantRequest
+    UpdateTenantMemberRequest
     """  # noqa: E501
 
-    name: StrictStr = Field(description="The name of the tenant.")
-    slug: StrictStr = Field(description="The slug of the tenant.")
-    ui_version: Optional[TenantUIVersion] = Field(
-        default=None,
-        description="The UI version of the tenant. Defaults to V0.",
-        alias="uiVersion",
-    )
-    engine_version: Optional[TenantVersion] = Field(
-        default=None,
-        description="The engine version of the tenant. Defaults to V0.",
-        alias="engineVersion",
-    )
-    environment: Optional[TenantEnvironment] = Field(
-        default=None, description="The environment type of the tenant."
-    )
-    onboarding_data: Optional[Dict[str, Any]] = Field(
-        default=None,
-        description="Additional onboarding data to store with the tenant.",
-        alias="onboardingData",
-    )
-    __properties: ClassVar[List[str]] = [
-        "name",
-        "slug",
-        "uiVersion",
-        "engineVersion",
-        "environment",
-        "onboardingData",
-    ]
+    role: TenantMemberRole = Field(description="The role of the user in the tenant.")
+    __properties: ClassVar[List[str]] = ["role"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -78,7 +50,7 @@ class CreateTenantRequest(BaseModel):
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:
-        """Create an instance of CreateTenantRequest from a JSON string"""
+        """Create an instance of UpdateTenantMemberRequest from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
     def to_dict(self) -> Dict[str, Any]:
@@ -102,21 +74,12 @@ class CreateTenantRequest(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
-        """Create an instance of CreateTenantRequest from a dict"""
+        """Create an instance of UpdateTenantMemberRequest from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
             return cls.model_validate(obj)
 
-        _obj = cls.model_validate(
-            {
-                "name": obj.get("name"),
-                "slug": obj.get("slug"),
-                "uiVersion": obj.get("uiVersion"),
-                "engineVersion": obj.get("engineVersion"),
-                "environment": obj.get("environment"),
-                "onboardingData": obj.get("onboardingData"),
-            }
-        )
+        _obj = cls.model_validate({"role": obj.get("role")})
         return _obj

--- a/sdks/python/hatchet_sdk/clients/rest/models/v1_update_webhook_request.py
+++ b/sdks/python/hatchet_sdk/clients/rest/models/v1_update_webhook_request.py
@@ -22,44 +22,17 @@ from typing import Any, ClassVar, Dict, List, Optional, Set
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing_extensions import Self
 
-from hatchet_sdk.clients.rest.models.tenant_environment import TenantEnvironment
-from hatchet_sdk.clients.rest.models.tenant_ui_version import TenantUIVersion
-from hatchet_sdk.clients.rest.models.tenant_version import TenantVersion
 
-
-class CreateTenantRequest(BaseModel):
+class V1UpdateWebhookRequest(BaseModel):
     """
-    CreateTenantRequest
+    V1UpdateWebhookRequest
     """  # noqa: E501
 
-    name: StrictStr = Field(description="The name of the tenant.")
-    slug: StrictStr = Field(description="The slug of the tenant.")
-    ui_version: Optional[TenantUIVersion] = Field(
-        default=None,
-        description="The UI version of the tenant. Defaults to V0.",
-        alias="uiVersion",
+    event_key_expression: StrictStr = Field(
+        description="The CEL expression to use for the event key. This is used to create the event key from the webhook payload.",
+        alias="eventKeyExpression",
     )
-    engine_version: Optional[TenantVersion] = Field(
-        default=None,
-        description="The engine version of the tenant. Defaults to V0.",
-        alias="engineVersion",
-    )
-    environment: Optional[TenantEnvironment] = Field(
-        default=None, description="The environment type of the tenant."
-    )
-    onboarding_data: Optional[Dict[str, Any]] = Field(
-        default=None,
-        description="Additional onboarding data to store with the tenant.",
-        alias="onboardingData",
-    )
-    __properties: ClassVar[List[str]] = [
-        "name",
-        "slug",
-        "uiVersion",
-        "engineVersion",
-        "environment",
-        "onboardingData",
-    ]
+    __properties: ClassVar[List[str]] = ["eventKeyExpression"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -78,7 +51,7 @@ class CreateTenantRequest(BaseModel):
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:
-        """Create an instance of CreateTenantRequest from a JSON string"""
+        """Create an instance of V1UpdateWebhookRequest from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
     def to_dict(self) -> Dict[str, Any]:
@@ -102,21 +75,12 @@ class CreateTenantRequest(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
-        """Create an instance of CreateTenantRequest from a dict"""
+        """Create an instance of V1UpdateWebhookRequest from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
             return cls.model_validate(obj)
 
-        _obj = cls.model_validate(
-            {
-                "name": obj.get("name"),
-                "slug": obj.get("slug"),
-                "uiVersion": obj.get("uiVersion"),
-                "engineVersion": obj.get("engineVersion"),
-                "environment": obj.get("environment"),
-                "onboardingData": obj.get("onboardingData"),
-            }
-        )
+        _obj = cls.model_validate({"eventKeyExpression": obj.get("eventKeyExpression")})
         return _obj

--- a/sdks/python/hatchet_sdk/config.py
+++ b/sdks/python/hatchet_sdk/config.py
@@ -85,6 +85,7 @@ class ClientConfig(BaseSettings):
     terminate_worker_after_num_tasks: int | None = None
     disable_log_capture: bool = False
     log_queue_size: int = 1000
+    log_buffer_size: int = 100
     grpc_enable_fork_support: bool = False
     force_shutdown_on_shutdown_signal: bool = False
 

--- a/sdks/python/hatchet_sdk/config.py
+++ b/sdks/python/hatchet_sdk/config.py
@@ -83,9 +83,12 @@ class ClientConfig(BaseSettings):
     enable_thread_pool_monitoring: bool = False
 
     terminate_worker_after_num_tasks: int | None = None
+
     disable_log_capture: bool = False
     log_queue_size: int = 1000
     log_buffer_size: int = 100
+    log_flush_interval_seconds: int = 5
+
     grpc_enable_fork_support: bool = False
     force_shutdown_on_shutdown_signal: bool = False
 

--- a/sdks/python/hatchet_sdk/context/context.py
+++ b/sdks/python/hatchet_sdk/context/context.py
@@ -125,6 +125,15 @@ class Context:
         )
 
     @property
+    def task_run_external_id(self) -> str:
+        """
+        The external id of the current task run.
+
+        :return: The external id of the current task run.
+        """
+        return self.action.step_run_id
+
+    @property
     def was_triggered_by_event(self) -> bool:
         """
         A property that indicates whether the workflow was triggered by an event.
@@ -215,7 +224,7 @@ class Context:
         self.log_sender.publish(
             LogRecord(
                 message=line,
-                step_run_id=self.step_run_id,
+                task_run_external_id=self.step_run_id,
                 level=LogLevel.INFO,
                 timestamp=datetime.now(UTC),
             )

--- a/sdks/python/hatchet_sdk/context/context.py
+++ b/sdks/python/hatchet_sdk/context/context.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, cast
 from warnings import warn
 
@@ -213,7 +213,12 @@ class Context:
 
         logger.info(line)
         self.log_sender.publish(
-            LogRecord(message=line, step_run_id=self.step_run_id, level=LogLevel.INFO)
+            LogRecord(
+                message=line,
+                step_run_id=self.step_run_id,
+                level=LogLevel.INFO,
+                timestamp=datetime.now(UTC),
+            )
         )
 
     def release_slot(self) -> None:

--- a/sdks/python/hatchet_sdk/context/context.py
+++ b/sdks/python/hatchet_sdk/context/context.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, cast
 from warnings import warn
 
@@ -226,7 +226,7 @@ class Context:
                 message=line,
                 task_run_external_id=self.step_run_id,
                 level=LogLevel.INFO,
-                timestamp=datetime.now(UTC),
+                timestamp=datetime.now(timezone.utc),
             )
         )
 

--- a/sdks/python/hatchet_sdk/contracts/events_pb2.py
+++ b/sdks/python/hatchet_sdk/contracts/events_pb2.py
@@ -15,7 +15,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0c\x65vents.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xd2\x01\n\x05\x45vent\x12\x10\n\x08tenantId\x18\x01 \x01(\t\x12\x0f\n\x07\x65ventId\x18\x02 \x01(\t\x12\x0b\n\x03key\x18\x03 \x01(\t\x12\x0f\n\x07payload\x18\x04 \x01(\t\x12\x32\n\x0e\x65ventTimestamp\x18\x05 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x1f\n\x12\x61\x64\x64itionalMetadata\x18\x06 \x01(\tH\x00\x88\x01\x01\x12\x12\n\x05scope\x18\x07 \x01(\tH\x01\x88\x01\x01\x42\x15\n\x13_additionalMetadataB\x08\n\x06_scope\" \n\x06\x45vents\x12\x16\n\x06\x65vents\x18\x01 \x03(\x0b\x32\x06.Event\"\xc2\x01\n\rPutLogRequest\x12\x11\n\tstepRunId\x18\x01 \x01(\t\x12-\n\tcreatedAt\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x0f\n\x07message\x18\x03 \x01(\t\x12\x12\n\x05level\x18\x04 \x01(\tH\x00\x88\x01\x01\x12\x10\n\x08metadata\x18\x05 \x01(\t\x12\x1b\n\x0etaskRetryCount\x18\x06 \x01(\x05H\x01\x88\x01\x01\x42\x08\n\x06_levelB\x11\n\x0f_taskRetryCount\"\x10\n\x0ePutLogResponse\"\xa4\x01\n\x15PutStreamEventRequest\x12\x11\n\tstepRunId\x18\x01 \x01(\t\x12-\n\tcreatedAt\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x0f\n\x07message\x18\x03 \x01(\x0c\x12\x10\n\x08metadata\x18\x05 \x01(\t\x12\x17\n\neventIndex\x18\x06 \x01(\x03H\x00\x88\x01\x01\x42\r\n\x0b_eventIndex\"\x18\n\x16PutStreamEventResponse\"9\n\x14\x42ulkPushEventRequest\x12!\n\x06\x65vents\x18\x01 \x03(\x0b\x32\x11.PushEventRequest\"\xde\x01\n\x10PushEventRequest\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x0f\n\x07payload\x18\x02 \x01(\t\x12\x32\n\x0e\x65ventTimestamp\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x1f\n\x12\x61\x64\x64itionalMetadata\x18\x04 \x01(\tH\x00\x88\x01\x01\x12\x15\n\x08priority\x18\x05 \x01(\x05H\x01\x88\x01\x01\x12\x12\n\x05scope\x18\x06 \x01(\tH\x02\x88\x01\x01\x42\x15\n\x13_additionalMetadataB\x0b\n\t_priorityB\x08\n\x06_scope\"%\n\x12ReplayEventRequest\x12\x0f\n\x07\x65ventId\x18\x01 \x01(\t2\x88\x02\n\rEventsService\x12#\n\x04Push\x12\x11.PushEventRequest\x1a\x06.Event\"\x00\x12,\n\x08\x42ulkPush\x12\x15.BulkPushEventRequest\x1a\x07.Events\"\x00\x12\x32\n\x11ReplaySingleEvent\x12\x13.ReplayEventRequest\x1a\x06.Event\"\x00\x12+\n\x06PutLog\x12\x0e.PutLogRequest\x1a\x0f.PutLogResponse\"\x00\x12\x43\n\x0ePutStreamEvent\x12\x16.PutStreamEventRequest\x1a\x17.PutStreamEventResponse\"\x00\x42\x45ZCgithub.com/hatchet-dev/hatchet/internal/services/ingestor/contractsb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0c\x65vents.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xd2\x01\n\x05\x45vent\x12\x10\n\x08tenantId\x18\x01 \x01(\t\x12\x0f\n\x07\x65ventId\x18\x02 \x01(\t\x12\x0b\n\x03key\x18\x03 \x01(\t\x12\x0f\n\x07payload\x18\x04 \x01(\t\x12\x32\n\x0e\x65ventTimestamp\x18\x05 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x1f\n\x12\x61\x64\x64itionalMetadata\x18\x06 \x01(\tH\x00\x88\x01\x01\x12\x12\n\x05scope\x18\x07 \x01(\tH\x01\x88\x01\x01\x42\x15\n\x13_additionalMetadataB\x08\n\x06_scope\" \n\x06\x45vents\x12\x16\n\x06\x65vents\x18\x01 \x03(\x0b\x32\x06.Event\"\xc2\x01\n\rPutLogRequest\x12\x11\n\tstepRunId\x18\x01 \x01(\t\x12-\n\tcreatedAt\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x0f\n\x07message\x18\x03 \x01(\t\x12\x12\n\x05level\x18\x04 \x01(\tH\x00\x88\x01\x01\x12\x10\n\x08metadata\x18\x05 \x01(\t\x12\x1b\n\x0etaskRetryCount\x18\x06 \x01(\x05H\x01\x88\x01\x01\x42\x08\n\x06_levelB\x11\n\x0f_taskRetryCount\"\x10\n\x0ePutLogResponse\".\n\x0ePutLogsRequest\x12\x1c\n\x04logs\x18\x01 \x03(\x0b\x32\x0e.PutLogRequest\"\x11\n\x0fPutLogsResponse\"\xa4\x01\n\x15PutStreamEventRequest\x12\x11\n\tstepRunId\x18\x01 \x01(\t\x12-\n\tcreatedAt\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x0f\n\x07message\x18\x03 \x01(\x0c\x12\x10\n\x08metadata\x18\x05 \x01(\t\x12\x17\n\neventIndex\x18\x06 \x01(\x03H\x00\x88\x01\x01\x42\r\n\x0b_eventIndex\"\x18\n\x16PutStreamEventResponse\"9\n\x14\x42ulkPushEventRequest\x12!\n\x06\x65vents\x18\x01 \x03(\x0b\x32\x11.PushEventRequest\"\xde\x01\n\x10PushEventRequest\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x0f\n\x07payload\x18\x02 \x01(\t\x12\x32\n\x0e\x65ventTimestamp\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x1f\n\x12\x61\x64\x64itionalMetadata\x18\x04 \x01(\tH\x00\x88\x01\x01\x12\x15\n\x08priority\x18\x05 \x01(\x05H\x01\x88\x01\x01\x12\x12\n\x05scope\x18\x06 \x01(\tH\x02\x88\x01\x01\x42\x15\n\x13_additionalMetadataB\x0b\n\t_priorityB\x08\n\x06_scope\"%\n\x12ReplayEventRequest\x12\x0f\n\x07\x65ventId\x18\x01 \x01(\t2\xb8\x02\n\rEventsService\x12#\n\x04Push\x12\x11.PushEventRequest\x1a\x06.Event\"\x00\x12,\n\x08\x42ulkPush\x12\x15.BulkPushEventRequest\x1a\x07.Events\"\x00\x12\x32\n\x11ReplaySingleEvent\x12\x13.ReplayEventRequest\x1a\x06.Event\"\x00\x12+\n\x06PutLog\x12\x0e.PutLogRequest\x1a\x0f.PutLogResponse\"\x00\x12.\n\x07PutLogs\x12\x0f.PutLogsRequest\x1a\x10.PutLogsResponse\"\x00\x12\x43\n\x0ePutStreamEvent\x12\x16.PutStreamEventRequest\x1a\x17.PutStreamEventResponse\"\x00\x42\x45ZCgithub.com/hatchet-dev/hatchet/internal/services/ingestor/contractsb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -31,16 +31,20 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_PUTLOGREQUEST']._serialized_end=491
   _globals['_PUTLOGRESPONSE']._serialized_start=493
   _globals['_PUTLOGRESPONSE']._serialized_end=509
-  _globals['_PUTSTREAMEVENTREQUEST']._serialized_start=512
-  _globals['_PUTSTREAMEVENTREQUEST']._serialized_end=676
-  _globals['_PUTSTREAMEVENTRESPONSE']._serialized_start=678
-  _globals['_PUTSTREAMEVENTRESPONSE']._serialized_end=702
-  _globals['_BULKPUSHEVENTREQUEST']._serialized_start=704
-  _globals['_BULKPUSHEVENTREQUEST']._serialized_end=761
-  _globals['_PUSHEVENTREQUEST']._serialized_start=764
-  _globals['_PUSHEVENTREQUEST']._serialized_end=986
-  _globals['_REPLAYEVENTREQUEST']._serialized_start=988
-  _globals['_REPLAYEVENTREQUEST']._serialized_end=1025
-  _globals['_EVENTSSERVICE']._serialized_start=1028
-  _globals['_EVENTSSERVICE']._serialized_end=1292
+  _globals['_PUTLOGSREQUEST']._serialized_start=511
+  _globals['_PUTLOGSREQUEST']._serialized_end=557
+  _globals['_PUTLOGSRESPONSE']._serialized_start=559
+  _globals['_PUTLOGSRESPONSE']._serialized_end=576
+  _globals['_PUTSTREAMEVENTREQUEST']._serialized_start=579
+  _globals['_PUTSTREAMEVENTREQUEST']._serialized_end=743
+  _globals['_PUTSTREAMEVENTRESPONSE']._serialized_start=745
+  _globals['_PUTSTREAMEVENTRESPONSE']._serialized_end=769
+  _globals['_BULKPUSHEVENTREQUEST']._serialized_start=771
+  _globals['_BULKPUSHEVENTREQUEST']._serialized_end=828
+  _globals['_PUSHEVENTREQUEST']._serialized_start=831
+  _globals['_PUSHEVENTREQUEST']._serialized_end=1053
+  _globals['_REPLAYEVENTREQUEST']._serialized_start=1055
+  _globals['_REPLAYEVENTREQUEST']._serialized_end=1092
+  _globals['_EVENTSSERVICE']._serialized_start=1095
+  _globals['_EVENTSSERVICE']._serialized_end=1407
 # @@protoc_insertion_point(module_scope)

--- a/sdks/python/hatchet_sdk/contracts/events_pb2.pyi
+++ b/sdks/python/hatchet_sdk/contracts/events_pb2.pyi
@@ -50,6 +50,16 @@ class PutLogResponse(_message.Message):
     __slots__ = ()
     def __init__(self) -> None: ...
 
+class PutLogsRequest(_message.Message):
+    __slots__ = ("logs",)
+    LOGS_FIELD_NUMBER: _ClassVar[int]
+    logs: _containers.RepeatedCompositeFieldContainer[PutLogRequest]
+    def __init__(self, logs: _Optional[_Iterable[_Union[PutLogRequest, _Mapping]]] = ...) -> None: ...
+
+class PutLogsResponse(_message.Message):
+    __slots__ = ()
+    def __init__(self) -> None: ...
+
 class PutStreamEventRequest(_message.Message):
     __slots__ = ("stepRunId", "createdAt", "message", "metadata", "eventIndex")
     STEPRUNID_FIELD_NUMBER: _ClassVar[int]

--- a/sdks/python/hatchet_sdk/contracts/events_pb2_grpc.py
+++ b/sdks/python/hatchet_sdk/contracts/events_pb2_grpc.py
@@ -59,6 +59,11 @@ class EventsServiceStub(object):
                 request_serializer=events__pb2.PutLogRequest.SerializeToString,
                 response_deserializer=events__pb2.PutLogResponse.FromString,
                 _registered_method=True)
+        self.PutLogs = channel.unary_unary(
+                '/EventsService/PutLogs',
+                request_serializer=events__pb2.PutLogsRequest.SerializeToString,
+                response_deserializer=events__pb2.PutLogsResponse.FromString,
+                _registered_method=True)
         self.PutStreamEvent = channel.unary_unary(
                 '/EventsService/PutStreamEvent',
                 request_serializer=events__pb2.PutStreamEventRequest.SerializeToString,
@@ -93,6 +98,12 @@ class EventsServiceServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def PutLogs(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
     def PutStreamEvent(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
@@ -121,6 +132,11 @@ def add_EventsServiceServicer_to_server(servicer, server):
                     servicer.PutLog,
                     request_deserializer=events__pb2.PutLogRequest.FromString,
                     response_serializer=events__pb2.PutLogResponse.SerializeToString,
+            ),
+            'PutLogs': grpc.unary_unary_rpc_method_handler(
+                    servicer.PutLogs,
+                    request_deserializer=events__pb2.PutLogsRequest.FromString,
+                    response_serializer=events__pb2.PutLogsResponse.SerializeToString,
             ),
             'PutStreamEvent': grpc.unary_unary_rpc_method_handler(
                     servicer.PutStreamEvent,
@@ -236,6 +252,33 @@ class EventsService(object):
             '/EventsService/PutLog',
             events__pb2.PutLogRequest.SerializeToString,
             events__pb2.PutLogResponse.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+    @staticmethod
+    def PutLogs(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            '/EventsService/PutLogs',
+            events__pb2.PutLogsRequest.SerializeToString,
+            events__pb2.PutLogsResponse.FromString,
             options,
             channel_credentials,
             insecure,

--- a/sdks/python/hatchet_sdk/worker/runner/utils/capture_logs.py
+++ b/sdks/python/hatchet_sdk/worker/runner/utils/capture_logs.py
@@ -90,7 +90,9 @@ class LogBuffer(BaseModel):
 
         oldest_ts = min(r.timestamp for r in self.records)
 
-        return datetime.now(UTC) - oldest_ts > timedelta(minutes=1)
+        return datetime.now(UTC) - oldest_ts > timedelta(
+            seconds=config.log_flush_interval_seconds
+        )
 
 
 class AsyncLogSender:

--- a/sdks/python/hatchet_sdk/worker/runner/utils/capture_logs.py
+++ b/sdks/python/hatchet_sdk/worker/runner/utils/capture_logs.py
@@ -3,7 +3,7 @@ import copy
 import functools
 import logging
 from collections.abc import Awaitable, Callable
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from io import StringIO
 from typing import Literal, ParamSpec, TypeVar
 from uuid import UUID, uuid4
@@ -97,7 +97,7 @@ class LogBuffer(BaseModel):
 
         oldest_ts = min(r.timestamp for r in self.records)
 
-        return datetime.now(UTC) - oldest_ts > timedelta(
+        return datetime.now(timezone.utc) - oldest_ts > timedelta(
             seconds=config.log_flush_interval_seconds
         )
 
@@ -208,7 +208,7 @@ class LogForwardingHandler(logging.StreamHandler):  # type: ignore[type-arg]
                 message=log_entry,
                 task_run_external_id=step_run_id,
                 level=LogLevel.from_levelname(record.levelname),
-                timestamp=datetime.now(UTC),
+                timestamp=datetime.now(timezone.utc),
             )
         )
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.18.1"
+version = "1.18.2"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
# Description

Follows #2222 

Implements log buffering + bulk log pushes on the Python side so we stop spamming the API with log capture

## Type of change

- [x] New feature (non-breaking change which adds functionality)

To do:

* Automatically chunk log requests based on size
* Implement in TS and try to repro the gRPC issue with large logs