### PR TITLE
Mark issues as `stale`

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: 'Close stale issues'
+on:
+  schedule:
+    - cron: '0 8 * * *'
+
+permissions:
+  actions: write
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue has been stale for 30 days. Please update the issue or comment to keep it active. Otherwise, it will be closed in 5 days.'
+          days-before-stale: 30
+          days-before-close: 5
+          stale-issue-label: 'stale'


### PR DESCRIPTION
# Description

Introduce GitHub workflow to auto mark issues as `stale` when there is no activity for 30 days and close in 5 days.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (changes which are not directly related to any business logic)
