### PR TITLE
Periodically run `ANALYZE` on `v1_task` and `v1_task_event`

### DIFF
--- a/internal/services/controllers/v1/task/analyze.go
+++ b/internal/services/controllers/v1/task/analyze.go
@@ -1,0 +1,17 @@
+package task
+
+import (
+	"context"
+)
+
+func (tc *TasksControllerImpl) runAnalyze(ctx context.Context) func() {
+	return func() {
+		tc.l.Debug().Msgf("analyze: running analyze on partitioned tables")
+
+		err := tc.repov1.Tasks().AnalyzeTaskTables(ctx)
+
+		if err != nil {
+			tc.l.Error().Err(err).Msg("could not analyze task tables")
+		}
+	}
+}

--- a/internal/services/controllers/v1/task/controller.go
+++ b/internal/services/controllers/v1/task/controller.go
@@ -347,6 +347,28 @@ func (tc *TasksControllerImpl) Start() (func() error, error) {
 		return nil, wrappedErr
 	}
 
+	_, err = tc.s.NewJob(
+		gocron.DailyJob(1, gocron.NewAtTimes(
+			// 5AM UTC
+			gocron.NewAtTime(5, 0, 0),
+		)),
+		gocron.NewTask(
+			tc.runAnalyze(ctx),
+		),
+		gocron.WithSingletonMode(gocron.LimitModeReschedule),
+	)
+
+	if err != nil {
+		wrappedErr := fmt.Errorf("could not run analyze: %w", err)
+
+		cancel()
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "could not run analyze")
+		span.End()
+
+		return nil, wrappedErr
+	}
+
 	cleanup := func() error {
 		cancel()
 

--- a/pkg/repository/v1/sqlcv1/tasks.sql
+++ b/pkg/repository/v1/sqlcv1/tasks.sql
@@ -897,3 +897,9 @@ FROM
 -- name: RegisterBatch :batchexec
 -- DO NOT USE: dummy query to satisfy sqlc and register Batch calls on DBTX
 SELECT * FROM v1_task WHERE id = $1;
+
+-- name: AnalyzeV1Task :exec
+ANALYZE v1_task;
+
+-- name: AnalyzeV1TaskEvent :exec
+ANALYZE v1_task_event;

--- a/pkg/repository/v1/sqlcv1/tasks.sql.go
+++ b/pkg/repository/v1/sqlcv1/tasks.sql.go
@@ -11,6 +11,24 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const analyzeV1Task = `-- name: AnalyzeV1Task :exec
+ANALYZE v1_task
+`
+
+func (q *Queries) AnalyzeV1Task(ctx context.Context, db DBTX) error {
+	_, err := db.Exec(ctx, analyzeV1Task)
+	return err
+}
+
+const analyzeV1TaskEvent = `-- name: AnalyzeV1TaskEvent :exec
+ANALYZE v1_task_event
+`
+
+func (q *Queries) AnalyzeV1TaskEvent(ctx context.Context, db DBTX) error {
+	_, err := db.Exec(ctx, analyzeV1TaskEvent)
+	return err
+}
+
 const cleanupWorkflowConcurrencySlotsAfterInsert = `-- name: CleanupWorkflowConcurrencySlotsAfterInsert :exec
 WITH input AS (
     SELECT

--- a/pkg/repository/v1/task.go
+++ b/pkg/repository/v1/task.go
@@ -251,6 +251,9 @@ type TaskRepository interface {
 	ReleaseSlot(ctx context.Context, tenantId string, externalId string) (*sqlcv1.V1TaskRuntime, error)
 
 	ListSignalCompletedEvents(ctx context.Context, tenantId string, tasks []TaskIdInsertedAtSignalKey) ([]*sqlcv1.V1TaskEvent, error)
+
+	// AnalyzeTaskTables runs ANALYZE on the task tables
+	AnalyzeTaskTables(ctx context.Context) error
 }
 
 type TaskRepositoryImpl struct {
@@ -3304,4 +3307,44 @@ func (r *TaskRepositoryImpl) ListSignalCompletedEvents(ctx context.Context, tena
 		Taskinsertedats: taskInsertedAts,
 		Eventkeys:       eventKeys,
 	})
+}
+
+func (r *TaskRepositoryImpl) AnalyzeTaskTables(ctx context.Context) error {
+	const timeout = 1000 * 60 * 30 // 30 minute timeout
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, timeout)
+
+	if err != nil {
+		return fmt.Errorf("error beginning transaction: %v", err)
+	}
+
+	defer rollback()
+
+	acquired, err := r.queries.TryAdvisoryLock(ctx, tx, hash("analyze-task-tables"))
+
+	if err != nil {
+		return fmt.Errorf("error acquiring advisory lock: %v", err)
+	}
+
+	if !acquired {
+		r.l.Info().Msg("advisory lock already held, skipping OLAP table analysis")
+		return nil
+	}
+
+	err = r.queries.AnalyzeV1Task(ctx, tx)
+
+	if err != nil {
+		return fmt.Errorf("error analyzing v1_task: %v", err)
+	}
+
+	err = r.queries.AnalyzeV1TaskEvent(ctx, tx)
+
+	if err != nil {
+		return fmt.Errorf("error analyzing v1_task_event: %v", err)
+	}
+
+	if err := commit(ctx); err != nil {
+		return fmt.Errorf("error committing transaction: %v", err)
+	}
+
+	return nil
 }

--- a/pkg/repository/v1/task.go
+++ b/pkg/repository/v1/task.go
@@ -3326,7 +3326,7 @@ func (r *TaskRepositoryImpl) AnalyzeTaskTables(ctx context.Context) error {
 	}
 
 	if !acquired {
-		r.l.Info().Msg("advisory lock already held, skipping OLAP table analysis")
+		r.l.Info().Msg("advisory lock already held, skipping task table analysis")
 		return nil
 	}
 


### PR DESCRIPTION
# Description

Run `ANALYZE` on task partitioned tables just like the OLAP counterparts.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
