### PR TITLE
`TaskOutput` takes in a string arg

### DIFF
--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -333,7 +333,7 @@ func (st *StandaloneTask) Run(ctx context.Context, input any) (*TaskResult, erro
 	}
 
 	// Extract the task result from the workflow result
-	taskResult := result.TaskOutput(st.task)
+	taskResult := result.TaskOutput(st.task.name)
 	return taskResult, nil
 }
 
@@ -346,11 +346,6 @@ func (st *StandaloneTask) RunNoWait(ctx context.Context, input any) (*WorkflowRe
 // Dump implements the WorkflowBase interface for internal use, delegating to the underlying workflow.
 func (st *StandaloneTask) Dump() (*contracts.CreateWorkflowVersionRequest, []internal.NamedFunction, []internal.NamedFunction, internal.WrappedTaskFn) {
 	return st.workflow.Dump()
-}
-
-// NamedTask represents any task that has a name.
-type NamedTask interface {
-	GetName() string
 }
 
 // WorkflowRef is a type that represents a reference to a workflow run.
@@ -373,10 +368,10 @@ type TaskResult struct {
 //
 // Example usage:
 //
-//	taskResult := workflowResult.TaskOutput(myTask)
+//	taskResult := workflowResult.TaskOutput("myTask")
 //	var output MyOutputType
 //	err := taskResult.Into(&output)
-func (wr *WorkflowResult) TaskOutput(task NamedTask) *TaskResult {
+func (wr *WorkflowResult) TaskOutput(taskName string) *TaskResult {
 	// Handle different result structures that might come from workflow execution
 	resultData := wr.result
 
@@ -393,7 +388,7 @@ func (wr *WorkflowResult) TaskOutput(task NamedTask) *TaskResult {
 
 	// If the result is a map, look for the specific task
 	if resultMap, ok := resultData.(map[string]any); ok {
-		if taskOutput, exists := resultMap[task.GetName()]; exists {
+		if taskOutput, exists := resultMap[taskName]; exists {
 			return &TaskResult{result: taskOutput}
 		}
 	}

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -41,7 +41,7 @@ func TestTaskOutput_WithMapResult(t *testing.T) {
 	task1 := &mockTask{name: "task1"}
 
 	// Test TaskOutput method
-	taskResult := workflowResult.TaskOutput(task1)
+	taskResult := workflowResult.TaskOutput(task1.GetName())
 	if taskResult == nil {
 		t.Fatal("TaskOutput returned nil")
 	}
@@ -86,7 +86,7 @@ func TestTaskOutput_WithJSONStringResult(t *testing.T) {
 	task := &mockTask{name: "json-task"}
 
 	// Test TaskOutput and Into
-	taskResult := workflowResult.TaskOutput(task)
+	taskResult := workflowResult.TaskOutput(task.GetName())
 	var actualOutput TestOutputStruct
 	err = taskResult.Into(&actualOutput)
 	if err != nil {
@@ -113,7 +113,7 @@ func TestTaskOutput_TaskNotFound(t *testing.T) {
 
 	// Request a task that doesn't exist
 	nonExistentTask := &mockTask{name: "non-existent-task"}
-	taskResult := workflowResult.TaskOutput(nonExistentTask)
+	taskResult := workflowResult.TaskOutput(nonExistentTask.GetName())
 
 	// Should return the entire result when task not found
 	var actualOutput map[string]any
@@ -147,7 +147,7 @@ func TestTaskOutput_SingleTaskWorkflow(t *testing.T) {
 	task := &mockTask{name: "only-task"}
 
 	// Test TaskOutput and Into
-	taskResult := workflowResult.TaskOutput(task)
+	taskResult := workflowResult.TaskOutput(task.GetName())
 	var actualOutput TestOutputStruct
 	err := taskResult.Into(&actualOutput)
 	if err != nil {
@@ -202,15 +202,5 @@ func TestTaskResult_Into_WithPointerToInterface(t *testing.T) {
 	}
 	if actualOutput.Number != expectedOutput.Number {
 		t.Errorf("Expected Number %d, got %d", expectedOutput.Number, actualOutput.Number)
-	}
-}
-
-func TestTaskCompliesToNamedTaskInterface(t *testing.T) {
-	// Test that our Task struct correctly implements NamedTask interface
-	var _ NamedTask = &Task{name: "test"}
-
-	task := &Task{name: "interface-test"}
-	if task.GetName() != "interface-test" {
-		t.Errorf("Expected name 'interface-test', got %s", task.GetName())
 	}
 }

--- a/sdks/go/examples/child-workflows/main.go
+++ b/sdks/go/examples/child-workflows/main.go
@@ -72,7 +72,7 @@ func main() {
 			}
 
 			var childOutput ChildOutput
-			taskResult := childResult.TaskOutput(processValueTask)
+			taskResult := childResult.TaskOutput(processValueTask.GetName())
 			err = taskResult.Into(&childOutput)
 			if err != nil {
 				return ParentOutput{}, fmt.Errorf("failed to get child workflow result: %w", err)


### PR DESCRIPTION
# Description

Go SDK `TaskOutput()` takes a string for ease of use when tasks are defined in other places.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
