### PR TITLE
Case on JWT parsing error in the client

### DIFF
--- a/pkg/client/loader/loader.go
+++ b/pkg/client/loader/loader.go
@@ -65,7 +65,9 @@ func GetClientConfigFromConfigFile(cf *client.ClientConfigFile) (res *client.Cli
 
 	tokenConf, err := getConfFromJWT(cf.Token)
 
-	if err == nil {
+	if err != nil {
+		return nil, err
+	} else {
 		if grpcBroadcastAddress == "" && tokenConf.grpcBroadcastAddress != "" {
 			grpcBroadcastAddress = tokenConf.grpcBroadcastAddress
 		}


### PR DESCRIPTION
# Description

We need to properly case on JWT parsing error in the Go client. Currently if an invalid JWT is passed in, the program panics.

Fixes 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
