### PR TITLE
Error out when `json.Unmarshal` fails in Go SDK

### DIFF
--- a/sdks/go/workflow.go
+++ b/sdks/go/workflow.go
@@ -72,8 +72,7 @@ func convertInputToType(input any, expectedType reflect.Type) reflect.Value {
 		// Unmarshal JSON into the new instance
 		err = json.Unmarshal(jsonData, result.Interface())
 		if err != nil {
-			// If unmarshaling fails, return the original input value
-			return reflect.ValueOf(input)
+			panic(err)
 		}
 
 		// Return the dereferenced value (not the pointer)


### PR DESCRIPTION
# Description

Right now we simply return the original type (`map[string]any`) when `json.Unmarshal` errors out to convert into expected type which can cause downstream errors.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
