### PR TITLE
[hotfix] Properly handle auth strategies

### DIFF
--- a/api/v1/server/authn/middleware.go
+++ b/api/v1/server/authn/middleware.go
@@ -67,7 +67,7 @@ func (a *AuthN) authenticate(c echo.Context, r *middleware.RouteInfo) error {
 		}
 	}
 
-	if cookieErr != nil && !r.Security.BearerAuth() {
+	if cookieErr != nil && !r.Security.BearerAuth() && !r.Security.CustomAuth() {
 		return cookieErr
 	}
 
@@ -99,7 +99,11 @@ func (a *AuthN) authenticate(c echo.Context, r *middleware.RouteInfo) error {
 		}
 	}
 
-	return customErr
+	if customErr != nil {
+		return customErr
+	}
+
+	return fmt.Errorf("no auth strategy found")
 }
 
 func (a *AuthN) handleNoAuth(c echo.Context) error {


### PR DESCRIPTION
# Description

Right now `customAuth` strategy won't work if bundled with other strategies in the same endpoint. This PR fixes it.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
