### PR TITLE
[hotfix] Do not panic when webhook worker listener returns error

### DIFF
--- a/pkg/worker/worker_webhook.go
+++ b/pkg/worker/worker_webhook.go
@@ -79,7 +79,8 @@ func (w *Worker) StartWebhook(ww WebhookWorkerOpts) (func() error, error) {
 			select {
 			case err := <-errCh:
 				// NOTE: this matches the behavior of the old worker, until we change the signature of the webhook workers
-				panic(err)
+				w.l.Error().Err(err).Msgf("error from action channel for webhook worker %s", w.name)
+				return
 			case action := <-actionCh:
 				go func(action *client.Action) {
 					err := w.sendWebhook(context.Background(), action, ww)


### PR DESCRIPTION
# Description

Instead of calling `panic()`, we should log the error and exit from the goroutine when the webhook worker listener returns an error.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
