### PR TITLE
Do not show archived tenants anywhere

### DIFF
--- a/frontend/app/src/components/v1/molecules/nav-bar/organization-selector.tsx
+++ b/frontend/app/src/components/v1/molecules/nav-bar/organization-selector.tsx
@@ -198,7 +198,6 @@ export function OrganizationSelector({
 
     memberships.forEach((membership) => {
       const tenantId = membership.tenant?.metadata.id || '';
-      // Skip archived tenants
       if (isTenantArchivedInOrg(tenantId)) {
         return;
       }

--- a/frontend/app/src/components/v1/molecules/nav-bar/organization-selector.tsx
+++ b/frontend/app/src/components/v1/molecules/nav-bar/organization-selector.tsx
@@ -162,7 +162,8 @@ export function OrganizationSelector({
   const { tenant: currTenant, setTenant: setCurrTenant } = useTenantDetails();
   const [open, setOpen] = useState(false);
   const [expandedOrgs, setExpandedOrgs] = useState<string[]>([]);
-  const { organizations, getOrganizationForTenant } = useOrganizations();
+  const { organizations, getOrganizationForTenant, isTenantArchivedInOrg } =
+    useOrganizations();
 
   const handleClose = () => setOpen(false);
   const handleNavigate = (path: string) => {
@@ -196,9 +197,13 @@ export function OrganizationSelector({
     const standalone: TenantMember[] = [];
 
     memberships.forEach((membership) => {
-      const org = getOrganizationForTenant(
-        membership.tenant?.metadata.id || '',
-      );
+      const tenantId = membership.tenant?.metadata.id || '';
+      // Skip archived tenants
+      if (isTenantArchivedInOrg(tenantId)) {
+        return;
+      }
+
+      const org = getOrganizationForTenant(tenantId);
       if (org) {
         const orgId = org.metadata.id;
         if (!orgMap.has(orgId)) {
@@ -231,7 +236,13 @@ export function OrganizationSelector({
       otherOrgsData: otherOrgs,
       standaloneTenants: standalone,
     };
-  }, [memberships, organizations, getOrganizationForTenant, currTenant]);
+  }, [
+    memberships,
+    organizations,
+    getOrganizationForTenant,
+    isTenantArchivedInOrg,
+    currTenant,
+  ]);
 
   if (!currTenant) {
     return null;

--- a/frontend/app/src/hooks/use-organizations.ts
+++ b/frontend/app/src/hooks/use-organizations.ts
@@ -8,6 +8,8 @@ import {
   ManagementTokenDuration,
   OrganizationMember,
   OrganizationForUser,
+  Organization,
+  TenantStatusType,
 } from '@/lib/api/generated/cloud/data-contracts';
 
 export function useOrganizations() {
@@ -28,6 +30,36 @@ export function useOrganizations() {
     [organizationListQuery.data?.rows],
   );
 
+  // Fetch detailed organization data for each organization to get tenant status info
+  const detailedOrgQueries = useQuery({
+    queryKey: [
+      'organizations:detailed',
+      organizations.map((org) => org.metadata.id).sort(),
+    ],
+    queryFn: async () => {
+      const orgPromises = organizations.map(async (org) => {
+        try {
+          const result = await cloudApi.organizationGet(org.metadata.id);
+          return result.data;
+        } catch (error) {
+          console.warn(
+            `Failed to fetch detailed org data for ${org.metadata.id}:`,
+            error,
+          );
+          return null;
+        }
+      });
+      const results = await Promise.all(orgPromises);
+      return results.filter((org): org is Organization => org !== null);
+    },
+    enabled: isCloudEnabled && organizations.length > 0,
+  });
+
+  const detailedOrganizations = useMemo(
+    () => detailedOrgQueries.data || [],
+    [detailedOrgQueries.data],
+  );
+
   const getOrganizationForTenant = useCallback(
     (tenantId: string) => {
       return organizations.find((org: OrganizationForUser) =>
@@ -43,6 +75,29 @@ export function useOrganizations() {
       return org?.metadata.id || null;
     },
     [getOrganizationForTenant],
+  );
+
+  const isTenantArchivedInOrg = useCallback(
+    (tenantId: string) => {
+      const orgForTenant = getOrganizationForTenant(tenantId);
+      if (!orgForTenant) {
+        return false; // Not part of any org, so not archived
+      }
+
+      const detailedOrg = detailedOrganizations.find(
+        (org) => org.metadata.id === orgForTenant.metadata.id,
+      );
+
+      if (!detailedOrg?.tenants) {
+        return false; // No tenant data available, assume not archived
+      }
+
+      const orgTenant = detailedOrg.tenants.find(
+        (tenant) => tenant.id === tenantId,
+      );
+      return orgTenant?.status === TenantStatusType.ARCHIVED;
+    },
+    [getOrganizationForTenant, detailedOrganizations],
   );
 
   const hasOrganizations = useMemo(() => {
@@ -248,6 +303,7 @@ export function useOrganizations() {
     isCloudEnabled,
     getOrganizationForTenant,
     getOrganizationIdForTenant,
+    isTenantArchivedInOrg,
     hasOrganizations,
     acceptOrgInviteMutation,
     rejectOrgInviteMutation,

--- a/frontend/app/src/lib/api/generated/cloud/data-contracts.ts
+++ b/frontend/app/src/lib/api/generated/cloud/data-contracts.ts
@@ -625,7 +625,7 @@ export interface OrganizationForUser {
   metadata: APIResourceMeta;
   /** Name of the organization */
   name: string;
-  tenants: string[];
+  tenants: OrganizationTenant[];
   /** Whether the user is the owner of the organization */
   isOwner: boolean;
 }

--- a/frontend/app/src/lib/api/generated/cloud/data-contracts.ts
+++ b/frontend/app/src/lib/api/generated/cloud/data-contracts.ts
@@ -23,9 +23,9 @@ export enum ManagementTokenDuration {
   Value90D = "90d",
 }
 
-export enum TenantStatus {
-  Active = "active",
-  Archived = "archived",
+export enum TenantStatusType {
+  ACTIVE = "ACTIVE",
+  ARCHIVED = "ARCHIVED",
 }
 
 export enum OrganizationMemberRoleType {
@@ -692,7 +692,7 @@ export interface OrganizationTenant {
    */
   id: string;
   /** Status of the tenant */
-  status: TenantStatus;
+  status: TenantStatusType;
   /**
    * The timestamp at which the tenant was archived
    * @format date-time


### PR DESCRIPTION
# Description

The server will return 403s for all archived tenants so no need to show them in the UI at all.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
