### PR TITLE
Fix: Add `credentialless` header to docs embed

### DIFF
--- a/frontend/docs/middleware.ts
+++ b/frontend/docs/middleware.ts
@@ -35,6 +35,7 @@ export function middleware(request: NextRequest) {
   response.headers.set('Access-Control-Allow-Origin', "*")
   response.headers.set('Access-Control-Allow-Credentials', 'true')
   response.headers.set('Cross-Origin-Resource-Policy', 'cross-origin')
+  response.headers.set('Cross-Origin-Embedder-Policy', 'credentialless')
 
   return response
 }


### PR DESCRIPTION
# Description

Fixing docs embed, attempt 2

## Type of change

- [x] Documentation change (pure documentation change)

