### PR TITLE
Add panic handler to Go SDK

### DIFF
--- a/pkg/worker/middleware.go
+++ b/pkg/worker/middleware.go
@@ -60,6 +60,10 @@ func (w *Worker) panicMiddleware(ctx HatchetContext, next func(HatchetContext) e
 					w.l.Error().Err(innerErr).Msg("could not send failure event")
 				}
 
+				if w.panicHandler != nil {
+					w.panicHandler(ctx, r)
+				}
+
 				return
 			}
 		}()

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -107,6 +107,8 @@ type Worker struct {
 	labels map[string]interface{}
 
 	id *string
+
+	panicHandler func(ctx HatchetContext, recovered any)
 }
 
 type WorkerOpt func(*WorkerOpts)
@@ -267,6 +269,10 @@ func NewWorker(fs ...WorkerOpt) (*Worker, error) {
 
 func (w *Worker) Use(mws ...MiddlewareFunc) {
 	w.middlewares.add(mws...)
+}
+
+func (w *Worker) SetPanicHandler(panicHandler func(ctx HatchetContext, recovered any)) {
+	w.panicHandler = panicHandler
 }
 
 func (w *Worker) NewService(name string) *Service {

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -81,6 +81,10 @@ func (c *Client) NewWorker(name string, options ...WorkerOption) (*Worker, error
 		return nil, err
 	}
 
+	if config.panicHandler != nil {
+		nonDurableWorker.SetPanicHandler(config.panicHandler)
+	}
+
 	var durableWorker *worker.Worker
 
 	for _, workflow := range config.workflows {
@@ -96,6 +100,10 @@ func (c *Client) NewWorker(name string, options ...WorkerOption) (*Worker, error
 				durableWorker, err = worker.NewWorker(durableWorkerOpts...)
 				if err != nil {
 					return nil, err
+				}
+
+				if config.panicHandler != nil {
+					durableWorker.SetPanicHandler(config.panicHandler)
 				}
 			}
 

--- a/sdks/go/examples/panic-handler/main.go
+++ b/sdks/go/examples/panic-handler/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
+)
+
+func main() {
+	client, err := hatchet.NewClient()
+	if err != nil {
+		log.Fatalf("failed to create hatchet client: %v", err)
+	}
+
+	task := client.NewStandaloneTask("panic-handler-task", func(ctx hatchet.Context, input any) (any, error) {
+		panic("intentional panic for demonstration")
+	})
+
+	worker, err := client.NewWorker("panic-handler-worker", hatchet.WithPanicHandler(func(ctx hatchet.Context, recovered any) {
+		log.Printf("panic handler: %v", recovered)
+	}), hatchet.WithWorkflows(task))
+	if err != nil {
+		log.Fatalf("failed to create worker: %v", err)
+	}
+
+	if err := worker.StartBlocking(context.Background()); err != nil {
+		log.Fatalf("failed to start worker: %v", err)
+	}
+}

--- a/sdks/go/worker.go
+++ b/sdks/go/worker.go
@@ -55,6 +55,8 @@ func WithDurableSlots(durableSlots int) WorkerOption {
 }
 
 // WithPanicHandler sets a custom panic handler for the worker.
+//
+// recovered is the non-nil value that was obtained after calling recover()
 func WithPanicHandler(panicHandler func(ctx Context, recovered any)) WorkerOption {
 	return func(config *workerConfig) {
 		config.panicHandler = panicHandler

--- a/sdks/go/worker.go
+++ b/sdks/go/worker.go
@@ -15,6 +15,7 @@ type workerConfig struct {
 	durableSlots int
 	labels       map[string]any
 	logger       *zerolog.Logger
+	panicHandler func(ctx Context, recovered any)
 }
 
 // WithWorkflows registers workflows and standalone tasks with the worker.
@@ -50,5 +51,12 @@ func WithLogger(logger *zerolog.Logger) WorkerOption {
 func WithDurableSlots(durableSlots int) WorkerOption {
 	return func(config *workerConfig) {
 		config.durableSlots = durableSlots
+	}
+}
+
+// WithPanicHandler sets a custom panic handler for the worker.
+func WithPanicHandler(panicHandler func(ctx Context, recovered any)) WorkerOption {
+	return func(config *workerConfig) {
+		config.panicHandler = panicHandler
 	}
 }


### PR DESCRIPTION
# Description

Adds the ability to register a custom panic handler for the worker. Useful to send panics to external providers such as Sentry.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
