### PR TITLE
Fix `GetDetails` in `Runs` feature client of Go SDK v1

### DIFF
--- a/pkg/v1/features/runs.go
+++ b/pkg/v1/features/runs.go
@@ -22,6 +22,7 @@ type RunsClient interface {
 	GetStatus(ctx context.Context, runId string) (*rest.V1WorkflowRunGetStatusResponse, error)
 
 	// GetDetails retrieves detailed information about a workflow run by its ID.
+	// Deprecated: Use Get instead.
 	GetDetails(ctx context.Context, runId string) (*rest.V1WorkflowRunGetResponse, error)
 
 	// List retrieves a collection of workflow runs based on the provided parameters.
@@ -79,6 +80,7 @@ func (r *runsClientImpl) GetStatus(ctx context.Context, runId string) (*rest.V1W
 }
 
 // GetDetails retrieves detailed information about a workflow run by its ID.
+// Deprecated: Use Get instead.
 func (r *runsClientImpl) GetDetails(ctx context.Context, runId string) (*rest.V1WorkflowRunGetResponse, error) {
 	return r.api.V1WorkflowRunGetWithResponse(
 		ctx,

--- a/pkg/v1/features/runs.go
+++ b/pkg/v1/features/runs.go
@@ -22,7 +22,7 @@ type RunsClient interface {
 	GetStatus(ctx context.Context, runId string) (*rest.V1WorkflowRunGetStatusResponse, error)
 
 	// GetDetails retrieves detailed information about a workflow run by its ID.
-	GetDetails(ctx context.Context, runId string) (*rest.WorkflowRunGetShapeResponse, error)
+	GetDetails(ctx context.Context, runId string) (*rest.V1WorkflowRunGetResponse, error)
 
 	// List retrieves a collection of workflow runs based on the provided parameters.
 	List(ctx context.Context, opts rest.V1WorkflowRunListParams) (*rest.V1WorkflowRunListResponse, error)
@@ -79,10 +79,9 @@ func (r *runsClientImpl) GetStatus(ctx context.Context, runId string) (*rest.V1W
 }
 
 // GetDetails retrieves detailed information about a workflow run by its ID.
-func (r *runsClientImpl) GetDetails(ctx context.Context, runId string) (*rest.WorkflowRunGetShapeResponse, error) {
-	return r.api.WorkflowRunGetShapeWithResponse(
+func (r *runsClientImpl) GetDetails(ctx context.Context, runId string) (*rest.V1WorkflowRunGetResponse, error) {
+	return r.api.V1WorkflowRunGetWithResponse(
 		ctx,
-		r.tenantId,
 		uuid.MustParse(runId),
 	)
 }

--- a/sdks/go/features/runs.go
+++ b/sdks/go/features/runs.go
@@ -72,23 +72,6 @@ func (r *RunsClient) GetStatus(ctx context.Context, runId string) (*rest.V1TaskS
 	return resp.JSON200, nil
 }
 
-// GetDetails retrieves detailed information about a workflow run by its ID.
-func (r *RunsClient) GetDetails(ctx context.Context, runId string) (*rest.V1WorkflowRunDetails, error) {
-	resp, err := r.api.V1WorkflowRunGetWithResponse(
-		ctx,
-		uuid.MustParse(runId),
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get workflow run details")
-	}
-
-	if err := validateJSON200Response(resp.StatusCode(), resp.Body, resp.JSON200); err != nil {
-		return nil, err
-	}
-
-	return resp.JSON200, nil
-}
-
 // List retrieves a collection of workflow runs based on the provided parameters.
 func (r *RunsClient) List(ctx context.Context, opts rest.V1WorkflowRunListParams) (*rest.V1TaskSummaryList, error) {
 	resp, err := r.api.V1WorkflowRunListWithResponse(

--- a/sdks/go/features/runs.go
+++ b/sdks/go/features/runs.go
@@ -73,10 +73,9 @@ func (r *RunsClient) GetStatus(ctx context.Context, runId string) (*rest.V1TaskS
 }
 
 // GetDetails retrieves detailed information about a workflow run by its ID.
-func (r *RunsClient) GetDetails(ctx context.Context, runId string) (*rest.WorkflowRunShape, error) {
-	resp, err := r.api.WorkflowRunGetShapeWithResponse(
+func (r *RunsClient) GetDetails(ctx context.Context, runId string) (*rest.V1WorkflowRunDetails, error) {
+	resp, err := r.api.V1WorkflowRunGetWithResponse(
 		ctx,
-		r.tenantId,
 		uuid.MustParse(runId),
 	)
 	if err != nil {


### PR DESCRIPTION
# Description

`GetDetails` in Go SDK v1 always returned a 404 since it called an older endpoint that no longer works for v1. For the older v1 SDK, change the signature and deprecate it. For the newer one, just get rid of the method.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
