### PR TITLE
TS SDK: Fix `DurableEventGrpcPooledListener` from misrepresenting task UUID

### DIFF
--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "Background task orchestration & visibility for developers",
   "types": "dist/index.d.ts",
   "files": [

--- a/sdks/typescript/src/clients/listeners/durable-listener/pooled-durable-listener-client.ts
+++ b/sdks/typescript/src/clients/listeners/durable-listener/pooled-durable-listener-client.ts
@@ -190,7 +190,7 @@ export class DurableEventGrpcPooledListener {
     this.client.logger.debug(`Replaying ${subscriptionEntries.length} requests...`);
 
     for (const [key, _] of subscriptionEntries) {
-      const [taskId, signalKey] = key.split('-');
+      const [taskId, signalKey] = key.split('|');
       this.requestEmitter.emit('subscribe', { taskId, signalKey });
     }
   }
@@ -203,7 +203,7 @@ export class DurableEventGrpcPooledListener {
 
     for (const key in this.taskSignalKeyToSubscriptionIds) {
       if (this.taskSignalKeyToSubscriptionIds[key].length > 0) {
-        const [taskId, signalKey] = key.split('-');
+        const [taskId, signalKey] = key.split('|');
         existingSubscriptions.add(key);
         yield { taskId, signalKey };
       }
@@ -225,4 +225,4 @@ export class DurableEventGrpcPooledListener {
   }
 }
 
-const keyHelper = (taskId: string, signalKey: string) => `${taskId}-${signalKey}`;
+const keyHelper = (taskId: string, signalKey: string) => `${taskId}|${signalKey}`;


### PR DESCRIPTION
In `DurableEventGrpcPooledListener` we were wrongfully using the delimiter `-` to create task UUID and sign key combinations. Use `|` instead so that we do not misrepresent the task UUID.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
