### PR TITLE
Fix: DAG details rendering in side panel, backwards compatible event list API

### DIFF
--- a/api/v1/server/handlers/events/list.go
+++ b/api/v1/server/handlers/events/list.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/labstack/echo/v4"
 
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/apierrors"
@@ -16,115 +17,229 @@ import (
 	"github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/postgres/dbsqlc"
 	"github.com/hatchet-dev/hatchet/pkg/repository/postgres/sqlchelpers"
+	"github.com/hatchet-dev/hatchet/pkg/repository/v1/sqlcv1"
 )
 
 func (t *EventService) EventList(ctx echo.Context, request gen.EventListRequestObject) (gen.EventListResponseObject, error) {
 	tenant := ctx.Get("tenant").(*dbsqlc.Tenant)
 	tenantId := sqlchelpers.UUIDToStr(tenant.ID)
 
-	limit := 50
-	offset := 0
+	total := int64(0)
+	limit := int64(50)
+	offset := int64(0)
+	rows := make([]gen.Event, 0)
 
-	listOpts := &repository.ListEventOpts{
-		Limit:  &limit,
-		Offset: &offset,
-	}
+	switch tenant.Version {
+	case dbsqlc.TenantMajorEngineVersionV0:
+		limitInt := int(limit)
+		offsetInt := int(offset)
 
-	if request.Params.Search != nil {
-		listOpts.Search = request.Params.Search
-	}
-
-	if request.Params.Workflows != nil {
-		listOpts.Workflows = *request.Params.Workflows
-	}
-
-	if request.Params.Keys != nil {
-		listOpts.Keys = *request.Params.Keys
-	}
-
-	if request.Params.OrderByField != nil {
-		listOpts.OrderBy = repository.StringPtr(string(*request.Params.OrderByField))
-	}
-
-	if request.Params.OrderByDirection != nil {
-		listOpts.OrderDirection = repository.StringPtr(strings.ToUpper(string(*request.Params.OrderByDirection)))
-	}
-
-	if request.Params.Limit != nil {
-		limit = int(*request.Params.Limit)
-		listOpts.Limit = &limit
-	}
-
-	if request.Params.Offset != nil {
-		offset = int(*request.Params.Offset)
-		listOpts.Offset = &offset
-	}
-
-	if request.Params.Statuses != nil {
-		statuses := make([]dbsqlc.WorkflowRunStatus, len(*request.Params.Statuses))
-
-		for i, status := range *request.Params.Statuses {
-			statuses[i] = dbsqlc.WorkflowRunStatus(status)
+		listOpts := &repository.ListEventOpts{
+			Limit:  &limitInt,
+			Offset: &offsetInt,
 		}
 
-		listOpts.WorkflowRunStatus = statuses
-	}
+		if request.Params.Search != nil {
+			listOpts.Search = request.Params.Search
+		}
 
-	if request.Params.AdditionalMetadata != nil {
-		additionalMetadata := make(map[string]interface{}, len(*request.Params.AdditionalMetadata))
+		if request.Params.Workflows != nil {
+			listOpts.Workflows = *request.Params.Workflows
+		}
 
-		for _, v := range *request.Params.AdditionalMetadata {
-			splitValue := strings.Split(fmt.Sprintf("%v", v), ":")
+		if request.Params.Keys != nil {
+			listOpts.Keys = *request.Params.Keys
+		}
 
-			if len(splitValue) == 2 {
-				additionalMetadata[splitValue[0]] = splitValue[1]
-			} else {
-				return gen.EventList400JSONResponse(apierrors.NewAPIErrors("Additional metadata filters must be in the format key:value.")), nil
+		if request.Params.OrderByField != nil {
+			listOpts.OrderBy = repository.StringPtr(string(*request.Params.OrderByField))
+		}
 
+		if request.Params.OrderByDirection != nil {
+			listOpts.OrderDirection = repository.StringPtr(strings.ToUpper(string(*request.Params.OrderByDirection)))
+		}
+
+		if request.Params.Limit != nil {
+			limitInt = int(*request.Params.Limit)
+			listOpts.Limit = &limitInt
+		}
+
+		if request.Params.Offset != nil {
+			offsetInt = int(*request.Params.Offset)
+			listOpts.Offset = &offsetInt
+		}
+
+		if request.Params.Statuses != nil {
+			statuses := make([]dbsqlc.WorkflowRunStatus, len(*request.Params.Statuses))
+
+			for i, status := range *request.Params.Statuses {
+				statuses[i] = dbsqlc.WorkflowRunStatus(status)
 			}
+
+			listOpts.WorkflowRunStatus = statuses
 		}
 
-		additionalMetadataBytes, err := json.Marshal(additionalMetadata)
+		if request.Params.AdditionalMetadata != nil {
+			additionalMetadata := make(map[string]interface{}, len(*request.Params.AdditionalMetadata))
+
+			for _, v := range *request.Params.AdditionalMetadata {
+				splitValue := strings.Split(fmt.Sprintf("%v", v), ":")
+
+				if len(splitValue) == 2 {
+					additionalMetadata[splitValue[0]] = splitValue[1]
+				} else {
+					return gen.EventList400JSONResponse(apierrors.NewAPIErrors("Additional metadata filters must be in the format key:value.")), nil
+
+				}
+			}
+
+			additionalMetadataBytes, err := json.Marshal(additionalMetadata)
+
+			if err != nil {
+				return nil, err
+			}
+
+			listOpts.AdditionalMetadata = additionalMetadataBytes
+		}
+
+		if request.Params.EventIds != nil {
+			eventIds := make([]string, len(*request.Params.EventIds))
+
+			for i, id := range *request.Params.EventIds {
+				idCp := id
+				eventIds[i] = idCp.String()
+			}
+
+			listOpts.Ids = eventIds
+		}
+
+		dbCtx, cancel := context.WithTimeout(ctx.Request().Context(), 30*time.Second)
+		defer cancel()
+
+		listRes, err := t.config.APIRepository.Event().ListEvents(dbCtx, tenantId, listOpts)
 
 		if err != nil {
 			return nil, err
 		}
 
-		listOpts.AdditionalMetadata = additionalMetadataBytes
-	}
+		for _, event := range listRes.Rows {
+			eventData, err := transformers.ToEventFromSQLC(event)
 
-	if request.Params.EventIds != nil {
-		eventIds := make([]string, len(*request.Params.EventIds))
+			if err != nil {
+				return nil, err
+			}
 
-		for i, id := range *request.Params.EventIds {
-			idCp := id
-			eventIds[i] = idCp.String()
+			rows = append(rows, *eventData)
+		}
+	case dbsqlc.TenantMajorEngineVersionV1:
+		since := time.Now().Add(-time.Hour * 24)
+
+		if request.Params.Limit != nil {
+			limit = *request.Params.Limit
 		}
 
-		listOpts.Ids = eventIds
-	}
+		if request.Params.Offset != nil {
+			offset = *request.Params.Offset
+		}
 
-	dbCtx, cancel := context.WithTimeout(ctx.Request().Context(), 30*time.Second)
-	defer cancel()
+		opts := sqlcv1.ListEventsParams{
+			Tenantid: sqlchelpers.UUIDFromStr(tenantId),
+			Limit: pgtype.Int8{
+				Int64: limit,
+				Valid: true,
+			},
+			Offset: pgtype.Int8{
+				Int64: offset,
+				Valid: true,
+			},
+			Since: pgtype.Timestamptz{
+				Time:  since,
+				Valid: true,
+			},
+		}
 
-	listRes, err := t.config.APIRepository.Event().ListEvents(dbCtx, tenantId, listOpts)
+		if request.Params.Keys != nil {
+			opts.Keys = *request.Params.Keys
+		}
 
-	if err != nil {
-		return nil, err
-	}
+		if request.Params.Workflows != nil {
+			workflowIds := make([]pgtype.UUID, len(*request.Params.Workflows))
 
-	rows := make([]gen.Event, len(listRes.Rows))
+			for i, workflowId := range *request.Params.Workflows {
+				workflowIds[i] = sqlchelpers.UUIDFromStr(workflowId)
+			}
 
-	for i, event := range listRes.Rows {
-		eventData, err := transformers.ToEventFromSQLC(event)
+			opts.WorkflowIds = workflowIds
+		}
+
+		if request.Params.Statuses != nil {
+			statuses := make([]string, len(*request.Params.Statuses))
+			for i, status := range *request.Params.Statuses {
+				statuses[i] = string(sqlcv1.V1ReadableStatusOlap(status))
+			}
+			opts.Statuses = statuses
+		}
+
+		if request.Params.EventIds != nil {
+			eventIds := make([]pgtype.UUID, len(*request.Params.EventIds))
+			for i, eventId := range *request.Params.EventIds {
+				eventIds[i] = sqlchelpers.UUIDFromStr(eventId.String())
+			}
+			opts.EventIds = eventIds
+		}
+
+		if request.Params.AdditionalMetadata != nil {
+			additionalMeta := make(map[string]interface{})
+
+			for _, m := range *request.Params.AdditionalMetadata {
+				split := strings.Split(m, ":")
+
+				if len(split) != 2 {
+					return nil, fmt.Errorf("invalid additional metadata format: %s, expected key:value", m)
+				}
+
+				key := split[0]
+				value := split[1]
+
+				if key == "" || value == "" {
+					return nil, fmt.Errorf("invalid additional metadata format: %s, key and value must not be empty", m)
+				}
+
+				additionalMeta[key] = value
+			}
+
+			jsonbytes, err := json.Marshal(additionalMeta)
+
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal additional metadata: %w", err)
+			}
+
+			opts.AdditionalMetadata = jsonbytes
+		}
+
+		events, maybeTotal, err := t.config.V1.OLAP().ListEvents(ctx.Request().Context(), opts)
+
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to list events: %w", err)
 		}
-		rows[i] = *eventData
+
+		total = int64(len(events))
+
+		if maybeTotal != nil {
+			total = *maybeTotal
+		}
+
+		for _, event := range events {
+			eventData, err := transformers.ToEventFromSQLCV1(event)
+			if err != nil {
+				return nil, err
+			}
+			rows = append(rows, *eventData)
+		}
 	}
 
 	// use the total rows and limit to calculate the total pages
-	totalPages := int64(math.Ceil(float64(listRes.Count) / float64(limit)))
+	totalPages := int64(math.Ceil(float64(total) / float64(limit)))
 	currPage := 1 + int64(math.Ceil(float64(offset)/float64(limit)))
 	nextPage := currPage + 1
 

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/index.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/index.tsx
@@ -14,7 +14,7 @@ import {
   TabsTrigger,
 } from '@/components/v1/ui/tabs';
 import { StepRunEvents } from './v2components/step-run-events-for-workflow-run';
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import {
   TabOption,
   TaskRunDetail,
@@ -188,9 +188,18 @@ function ExpandedTaskRun({ id }: { id: string }) {
 
 function ExpandedWorkflowRun({ id }: { id: string }) {
   const { open } = useSidePanel();
+  const executingRef = useRef(false);
 
   const handleTaskRunExpand = useCallback(
     (taskRunId: string) => {
+      // hack to prevent click handler from firing multiple times,
+      // causing index offset issues
+      if (executingRef.current) {
+        return;
+      }
+
+      executingRef.current = true;
+
       open({
         type: 'task-run-details',
         content: {
@@ -199,6 +208,10 @@ function ExpandedWorkflowRun({ id }: { id: string }) {
           showViewTaskRunButton: true,
         },
       });
+
+      setTimeout(() => {
+        executingRef.current = false;
+      }, 100);
     },
     [open],
   );


### PR DESCRIPTION
# Description

Couple of small fixes:

1. Making the v0 event list API compatible with the v1 tables by checking the tenant version (basically just copied the v1 implementation for the part, figure we'll delete soon)
2. Fixing an issue with the side panel not rendering properly because of some kind of react state race or rerender race

[Easier to review events changes without whitespace](https://github.com/hatchet-dev/hatchet/pull/2309/files?diff=unified&w=1)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

