### PR TITLE
Fix: Event filtering edge case

### DIFF
--- a/pkg/repository/v1/trigger.go
+++ b/pkg/repository/v1/trigger.go
@@ -262,7 +262,7 @@ func (r *TriggerRepositoryImpl) TriggerFromEvents(ctx context.Context, tenantId 
 
 	workflowIdScopePairs := make(map[WorkflowAndScope]bool)
 
-	// important: need to include all workflow ids here, regardless or whether or
+	// important: need to include all workflow ids here, regardless of whether or
 	// not the corresponding event was pushed with a scope, so we can correctly
 	// tell if there are any filters for the workflows with these events registered
 	workflowIdsForFilterCounts := make([]pgtype.UUID, 0)

--- a/pkg/repository/v1/trigger.go
+++ b/pkg/repository/v1/trigger.go
@@ -265,7 +265,7 @@ func (r *TriggerRepositoryImpl) TriggerFromEvents(ctx context.Context, tenantId 
 	// important: need to include all workflow ids here, regardless of whether or
 	// not the corresponding event was pushed with a scope, so we can correctly
 	// tell if there are any filters for the workflows with these events registered
-	workflowIdsForFilterCounts := make([]pgtype.UUID, 0)
+	workflowIdsForFilterCounts := make([]pgtype.UUID, 0, len(workflowVersionIdsAndEventKeys))
 
 	for _, workflow := range workflowVersionIdsAndEventKeys {
 		opts, ok := eventKeysToOpts[workflow.IncomingEventKey]

--- a/pkg/repository/v1/trigger.go
+++ b/pkg/repository/v1/trigger.go
@@ -142,7 +142,7 @@ func (r *TriggerRepositoryImpl) makeTriggerDecisions(ctx context.Context, filter
 	// Case 1 - no filters exist for the workflow
 	if !hasAnyFilters {
 		return []TriggerDecision{
-			TriggerDecision{
+			{
 				ShouldTrigger: true,
 				FilterPayload: nil,
 				FilterId:      nil,
@@ -154,7 +154,7 @@ func (r *TriggerRepositoryImpl) makeTriggerDecisions(ctx context.Context, filter
 	// so we should not trigger the workflow
 	if len(filters) == 0 {
 		return []TriggerDecision{
-			TriggerDecision{
+			{
 				ShouldTrigger: false,
 				FilterPayload: nil,
 				FilterId:      nil,
@@ -262,12 +262,19 @@ func (r *TriggerRepositoryImpl) TriggerFromEvents(ctx context.Context, tenantId 
 
 	workflowIdScopePairs := make(map[WorkflowAndScope]bool)
 
+	// important: need to include all workflow ids here, regardless or whether or
+	// not the corresponding event was pushed with a scope, so we can correctly
+	// tell if there are any filters for the workflows with these events registered
+	workflowIdsForFilterCounts := make([]pgtype.UUID, 0)
+
 	for _, workflow := range workflowVersionIdsAndEventKeys {
 		opts, ok := eventKeysToOpts[workflow.IncomingEventKey]
 
 		if !ok {
 			continue
 		}
+
+		workflowIdsForFilterCounts = append(workflowIdsForFilterCounts, workflow.WorkflowId)
 
 		for _, opt := range opts {
 			if opt.Scope == nil {
@@ -281,8 +288,8 @@ func (r *TriggerRepositoryImpl) TriggerFromEvents(ctx context.Context, tenantId 
 		}
 	}
 
-	workflowIds := make([]pgtype.UUID, 0)
-	scopes := make([]string, 0)
+	workflowIds := make([]pgtype.UUID, 0, len(workflowIdScopePairs))
+	scopes := make([]string, 0, len(workflowIdScopePairs))
 
 	for pair := range workflowIdScopePairs {
 		workflowIds = append(workflowIds, pair.WorkflowId)
@@ -312,7 +319,7 @@ func (r *TriggerRepositoryImpl) TriggerFromEvents(ctx context.Context, tenantId 
 
 	filterCounts, err := r.queries.ListFilterCountsForWorkflows(ctx, r.pool, sqlcv1.ListFilterCountsForWorkflowsParams{
 		Tenantid:    sqlchelpers.UUIDFromStr(tenantId),
-		Workflowids: workflowIds,
+		Workflowids: workflowIdsForFilterCounts,
 	})
 
 	if err != nil {

--- a/sdks/python/examples/events/test_event.py
+++ b/sdks/python/examples/events/test_event.py
@@ -115,7 +115,7 @@ async def wait_for_result(
     iters = 0
     while True:
         print("waiting for event runs to complete - iteration", iters)
-        if iters > 30:
+        if iters > 10:
             raise TimeoutError("Timed out waiting for event runs to complete.")
 
         iters += 1
@@ -446,7 +446,7 @@ async def test_filtering_by_event_key(hatchet: Hatchet, test_run_id: str) -> Non
     async with event_filter(
         hatchet,
         test_run_id,
-        f"event_key == '{SECONDARY_KEY}'",
+        f"event_key == '{hatchet.config.apply_namespace(SECONDARY_KEY)}'",
     ):
         event_1 = await hatchet.event.aio_push(
             event_key=SECONDARY_KEY,

--- a/sdks/python/examples/events/test_event.py
+++ b/sdks/python/examples/events/test_event.py
@@ -66,7 +66,7 @@ async def event_filter(
 
 async def fetch_runs_for_event(
     hatchet: Hatchet, event: Event
-) -> tuple[ProcessedEvent, list[V1TaskSummary]]:
+) -> tuple[ProcessedEvent, list[V1TaskSummary], bool]:
     runs = await hatchet.runs.aio_list(triggering_event_external_id=event.eventId)
 
     meta = (
@@ -86,7 +86,13 @@ async def fetch_runs_for_event(
         test_run_id=cast(str, meta["test_run_id"]),
     )
 
-    if not all([r.output for r in runs.rows]):
+    if not all(
+        [
+            r.status
+            in [V1TaskStatus.COMPLETED, V1TaskStatus.FAILED, V1TaskStatus.CANCELLED]
+            for r in runs.rows
+        ]
+    ):
         return (processed_event, [])
 
     return (
@@ -108,25 +114,9 @@ async def wait_for_result(
 
     iters = 0
     while True:
-        print("Waiting for event runs to complete...")
+        print("waiting for event runs to complete - iteration", iters)
         if iters > 15:
-            print("Timed out waiting for event runs to complete.")
-            return {
-                ProcessedEvent(
-                    id=event.eventId,
-                    payload=json.loads(event.payload) if event.payload else {},
-                    meta=(
-                        json.loads(event.additionalMetadata)
-                        if event.additionalMetadata
-                        else {}
-                    ),
-                    should_have_runs=False,
-                    test_run_id=cast(
-                        str, json.loads(event.additionalMetadata).get("test_run_id", "")
-                    ),
-                ): []
-                for event in events
-            }
+            raise TimeoutError("Timed out waiting for event runs to complete.")
 
         iters += 1
 
@@ -134,9 +124,21 @@ async def wait_for_result(
             *[fetch_runs_for_event(hatchet, event) for event in events]
         )
 
-        all_empty = all(not event_run for _, event_run in event_runs)
+        should_keep_waiting = any(
+            (not event_run and e.should_have_runs)
+            or any(
+                e.status
+                not in [
+                    V1TaskStatus.COMPLETED,
+                    V1TaskStatus.FAILED,
+                    V1TaskStatus.CANCELLED,
+                ]
+                for e in event_run
+            )
+            for e, event_run in event_runs
+        )
 
-        if all_empty:
+        if should_keep_waiting:
             await asyncio.sleep(1)
             continue
 
@@ -160,6 +162,18 @@ async def wait_for_result(
 async def wait_for_result_and_assert(hatchet: Hatchet, events: list[Event]) -> None:
     event_to_runs = await wait_for_result(hatchet, events)
 
+    unique_events_with_runs = {
+        event.eventId
+        for event in events
+        if json.loads(event.additionalMetadata).get("should_have_runs", False) is True
+    }
+
+    unique_events_with_runs_in_results = {
+        event.id for event, runs in event_to_runs.items() if len(runs) > 0
+    }
+
+    assert len(unique_events_with_runs) == len(unique_events_with_runs_in_results)
+
     for event, runs in event_to_runs.items():
         await assert_event_runs_processed(event, runs)
 
@@ -179,7 +193,7 @@ async def assert_event_runs_processed(
 
         for run in runs:
             assert run.status == V1TaskStatus.COMPLETED
-            assert run.output.get("test_run_id") == event.test_run_id
+            assert run.additional_metadata.get("test_run_id") == event.test_run_id
     else:
         assert len(runs) == 0
 

--- a/sdks/python/examples/events/test_event.py
+++ b/sdks/python/examples/events/test_event.py
@@ -66,7 +66,7 @@ async def event_filter(
 
 async def fetch_runs_for_event(
     hatchet: Hatchet, event: Event
-) -> tuple[ProcessedEvent, list[V1TaskSummary], bool]:
+) -> tuple[ProcessedEvent, list[V1TaskSummary]]:
     runs = await hatchet.runs.aio_list(triggering_event_external_id=event.eventId)
 
     meta = (
@@ -193,7 +193,9 @@ async def assert_event_runs_processed(
 
         for run in runs:
             assert run.status == V1TaskStatus.COMPLETED
-            assert run.additional_metadata.get("test_run_id") == event.test_run_id
+
+            meta = run.additional_metadata or {}
+            assert meta.get("test_run_id") == event.test_run_id
     else:
         assert len(runs) == 0
 

--- a/sdks/python/examples/events/test_event.py
+++ b/sdks/python/examples/events/test_event.py
@@ -115,7 +115,7 @@ async def wait_for_result(
     iters = 0
     while True:
         print("waiting for event runs to complete - iteration", iters)
-        if iters > 20:
+        if iters > 30:
             raise TimeoutError("Timed out waiting for event runs to complete.")
 
         iters += 1

--- a/sdks/python/examples/events/test_event.py
+++ b/sdks/python/examples/events/test_event.py
@@ -115,7 +115,7 @@ async def wait_for_result(
     iters = 0
     while True:
         print("waiting for event runs to complete - iteration", iters)
-        if iters > 15:
+        if iters > 20:
             raise TimeoutError("Timed out waiting for event runs to complete.")
 
         iters += 1


### PR DESCRIPTION
# Description

Fixes an edge case where an event is pushed with no scope but corresponds to a workflow that _does_ have filters causing the workflow to be triggered (as opposed to not being triggered, which would be the correct handling since there was no scope match, by default)

Also added some assertions and fixed a couple of issues in the Python tests to make sure we're asserting more strictly on how many runs we're expecting to get back, and which events should have runs

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
