### PR TITLE
Feat: Include query params in pgx spans

### DIFF
--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -167,7 +167,10 @@ func (c *ConfigLoader) InitDataLayer() (res *database.Layer, err error) {
 		}
 	}
 
-	config.ConnConfig.Tracer = otelpgx.NewTracer()
+	config.ConnConfig.Tracer = otelpgx.NewTracer(
+		// for options, see: https://github.com/exaring/otelpgx/blob/main/options.go
+		otelpgx.WithIncludeQueryParameters(),
+	)
 
 	if cf.MaxConns != 0 {
 		config.MaxConns = int32(cf.MaxConns) // nolint: gosec
@@ -217,7 +220,10 @@ func (c *ConfigLoader) InitDataLayer() (res *database.Layer, err error) {
 		}
 
 		readReplicaConfig.MaxConnLifetime = 15 * 60 * time.Second
-		readReplicaConfig.ConnConfig.Tracer = otelpgx.NewTracer()
+		readReplicaConfig.ConnConfig.Tracer = otelpgx.NewTracer(
+			// for options, see: https://github.com/exaring/otelpgx/blob/main/options.go
+			otelpgx.WithIncludeQueryParameters(),
+		)
 
 		readReplicaPool, err = pgxpool.NewWithConfig(context.Background(), readReplicaConfig)
 


### PR DESCRIPTION
# Description

Quick QoL change, including query params so we can use them in graphs

result:

<img width="875" height="143" alt="Screenshot 2025-09-18 at 7 55 47 AM" src="https://github.com/user-attachments/assets/f1878b40-c656-4143-aa33-d552c22d1564" />


unfortunately it's not smart enough to use the names of the params or to e.g. serialize them to JSON values (like the timestamps), but alas

## Type of change

- [x] New feature (non-breaking change which adds functionality)

