### PR TITLE
[hotfix] `hatchet-admin seed` command should respect default tenant slug

### DIFF
--- a/cmd/hatchet-admin/cli/seed/seed.go
+++ b/cmd/hatchet-admin/cli/seed/seed.go
@@ -46,7 +46,7 @@ func SeedDatabase(dc *database.Layer) error {
 		userID = sqlchelpers.UUIDToStr(user.ID)
 	}
 
-	_, err := dc.APIRepository.Tenant().GetTenantBySlug(context.Background(), "default")
+	_, err := dc.APIRepository.Tenant().GetTenantBySlug(context.Background(), dc.Seed.DefaultTenantSlug)
 
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {


### PR DESCRIPTION
# Description

Right now the seed command will always settle for the "default" tenant slug instead of correctly casing on the config var.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
