### PR TITLE
Fix: Payloads OLAP backwards compat

### DIFF
--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -1302,7 +1302,7 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId string
 
 		// fall back to input if payload is empty
 		// for backwards compatibility
-		if payload == nil || len(payload) == 0 {
+		if len(payload) == 0 {
 			payload = task.Input
 		}
 

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -1298,6 +1298,14 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId string
 	params := make([]sqlcv1.CreateTasksOLAPParams, 0)
 
 	for _, task := range tasks {
+		payload := task.Payload
+
+		// fall back to input if payload is empty
+		// for backwards compatibility
+		if len(payload) == 0 {
+			payload = task.Input
+		}
+
 		params = append(params, sqlcv1.CreateTasksOLAPParams{
 			TenantID:             task.TenantID,
 			ID:                   task.ID,
@@ -1319,7 +1327,7 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId string
 			DagInsertedAt:        task.DagInsertedAt,
 			ParentTaskExternalID: task.ParentTaskExternalID,
 			WorkflowRunID:        task.WorkflowRunID,
-			Input:                task.Payload,
+			Input:                payload,
 		})
 	}
 

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -1302,7 +1302,7 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId string
 
 		// fall back to input if payload is empty
 		// for backwards compatibility
-		if len(payload) == 0 {
+		if payload == nil || len(payload) == 0 {
 			payload = task.Input
 		}
 


### PR DESCRIPTION
# Description

Fixing a backwards compatibility issue by falling back to the `input` on the OLAP side if the `payload` is null

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

