### PR TITLE
Fix: Update payload properly on replay

### DIFF
--- a/internal/services/controllers/v1/task/controller.go
+++ b/internal/services/controllers/v1/task/controller.go
@@ -1156,7 +1156,7 @@ func (tc *TasksControllerImpl) handleProcessTaskTrigger(ctx context.Context, ten
 
 	if err != nil {
 		if err == metered.ErrResourceExhausted {
-			tc.l.Warn().Msg("resource exhausted while triggering workflows from names. Not retrying")
+			tc.l.Warn().Str("tenantId", tenantId).Msg("resource exhausted while triggering workflows from names. Not retrying")
 
 			return nil
 		}

--- a/pkg/repository/v1/sqlcv1/payload-store.sql
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql
@@ -27,7 +27,7 @@ WHERE (tenant_id, id, inserted_at, type) IN (
 
 -- name: WritePayloads :exec
 WITH inputs AS (
-    SELECT
+    SELECT DISTINCT
         UNNEST(@ids::BIGINT[]) AS id,
         UNNEST(@insertedAts::TIMESTAMPTZ[]) AS inserted_at,
         UNNEST(CAST(@types::TEXT[] AS v1_payload_type[])) AS type,

--- a/pkg/repository/v1/sqlcv1/payload-store.sql
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql
@@ -52,14 +52,14 @@ SELECT
     i.inserted_at,
     i.type,
     i.location,
-    CASE WHEN i.external_location_key = '' OR i.location = 'EXTERNAL' THEN NULL ELSE i.external_location_key END,
+    CASE WHEN i.external_location_key = '' OR i.location != 'EXTERNAL' THEN NULL ELSE i.external_location_key END,
     i.inline_content
 FROM
     inputs i
 ON CONFLICT (tenant_id, id, inserted_at, type)
 DO UPDATE SET
     location = EXCLUDED.location,
-    external_location_key = CASE WHEN EXCLUDED.external_location_key = '' OR EXCLUDED.location = 'EXTERNAL' THEN NULL ELSE EXCLUDED.external_location_key END,
+    external_location_key = CASE WHEN EXCLUDED.external_location_key = '' OR EXCLUDED.location != 'EXTERNAL' THEN NULL ELSE EXCLUDED.external_location_key END,
     inline_content = EXCLUDED.inline_content,
     updated_at = NOW()
 ;

--- a/pkg/repository/v1/sqlcv1/payload-store.sql.go
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql.go
@@ -288,14 +288,14 @@ SELECT
     i.inserted_at,
     i.type,
     i.location,
-    CASE WHEN i.external_location_key = '' OR i.location = 'EXTERNAL' THEN NULL ELSE i.external_location_key END,
+    CASE WHEN i.external_location_key = '' OR i.location != 'EXTERNAL' THEN NULL ELSE i.external_location_key END,
     i.inline_content
 FROM
     inputs i
 ON CONFLICT (tenant_id, id, inserted_at, type)
 DO UPDATE SET
     location = EXCLUDED.location,
-    external_location_key = CASE WHEN EXCLUDED.external_location_key = '' OR EXCLUDED.location = 'EXTERNAL' THEN NULL ELSE EXCLUDED.external_location_key END,
+    external_location_key = CASE WHEN EXCLUDED.external_location_key = '' OR EXCLUDED.location != 'EXTERNAL' THEN NULL ELSE EXCLUDED.external_location_key END,
     inline_content = EXCLUDED.inline_content,
     updated_at = NOW()
 `

--- a/pkg/repository/v1/sqlcv1/payload-store.sql.go
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql.go
@@ -263,7 +263,7 @@ func (q *Queries) WritePayloadWAL(ctx context.Context, db DBTX, arg WritePayload
 
 const writePayloads = `-- name: WritePayloads :exec
 WITH inputs AS (
-    SELECT
+    SELECT DISTINCT
         UNNEST($1::BIGINT[]) AS id,
         UNNEST($2::TIMESTAMPTZ[]) AS inserted_at,
         UNNEST(CAST($3::TEXT[] AS v1_payload_type[])) AS type,

--- a/sdks/python/examples/bug_tests/payload_bug_on_replay/test_payload_replay_bug.py
+++ b/sdks/python/examples/bug_tests/payload_bug_on_replay/test_payload_replay_bug.py
@@ -1,0 +1,60 @@
+import pytest
+import asyncio
+
+from examples.bug_tests.payload_bug_on_replay.worker import (
+    payload_initial_cancel_bug_workflow,
+    step1,
+    step2,
+    Input,
+    StepOutput,
+)
+from hatchet_sdk import EmptyModel, Hatchet, TriggerWorkflowOptions, V1TaskStatus
+from uuid import uuid4
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_payload_replay_bug(hatchet: Hatchet) -> None:
+    """
+    Tests the case where a task is initially inserted in a non-queued state (e.g. cancelled),
+    but then is replayed. The task should initially have a null payload, but on replay the payload
+    should be updated.
+    """
+
+    test_run_id = str(uuid4())
+
+    ref = await payload_initial_cancel_bug_workflow.aio_run_no_wait(
+        input=Input(random_number=42),
+        options=TriggerWorkflowOptions(
+            additional_metadata={"test_run_id": test_run_id}
+        ),
+    )
+
+    result = await ref.aio_result()
+
+    step_1_output = StepOutput.model_validate(result[step1.name])
+
+    assert step_1_output.should_cancel is True
+
+    await asyncio.sleep(3)
+
+    run = await hatchet.runs.aio_get(ref.workflow_run_id)
+
+    tasks = sorted(run.tasks, key=lambda t: t.metadata.created_at)
+
+    assert len(tasks) == 2
+
+    assert tasks[0].status == V1TaskStatus.COMPLETED
+    assert tasks[1].status == V1TaskStatus.CANCELLED
+
+    await hatchet.runs.aio_replay(run_id=ref.workflow_run_id)
+    await asyncio.sleep(3)
+
+    result = await ref.aio_result()
+
+    step_1_output = StepOutput.model_validate(result[step1.name])
+    step_2_output = StepOutput.model_validate(result[step2.name])
+
+    assert step_1_output.should_cancel is False
+    assert step_2_output.should_cancel is False
+
+    assert False

--- a/sdks/python/examples/bug_tests/payload_bug_on_replay/worker.py
+++ b/sdks/python/examples/bug_tests/payload_bug_on_replay/worker.py
@@ -1,0 +1,35 @@
+from pydantic import BaseModel
+
+from hatchet_sdk import Context, Hatchet, ParentCondition
+
+
+class Input(BaseModel):
+    random_number: int
+
+
+class StepOutput(BaseModel):
+    should_cancel: bool
+
+
+hatchet = Hatchet(debug=True)
+
+payload_initial_cancel_bug_workflow = hatchet.workflow(
+    name="payload-initial-cancel-test",
+    input_validator=Input,
+)
+
+
+@payload_initial_cancel_bug_workflow.task()
+def step1(input: Input, ctx: Context) -> StepOutput:
+    if ctx.retry_count == 0:
+        return StepOutput(should_cancel=True)
+    else:
+        return StepOutput(should_cancel=False)
+
+
+@payload_initial_cancel_bug_workflow.task(
+    parents=[step1],
+    cancel_if=[ParentCondition(parent=step1, expression="output.should_cancel")],
+)
+async def step2(input: Input, ctx: Context) -> StepOutput:
+    return StepOutput(should_cancel=False)

--- a/sdks/python/examples/bug_tests/payload_bug_on_replay/worker.py
+++ b/sdks/python/examples/bug_tests/payload_bug_on_replay/worker.py
@@ -21,10 +21,7 @@ payload_initial_cancel_bug_workflow = hatchet.workflow(
 
 @payload_initial_cancel_bug_workflow.task()
 def step1(input: Input, ctx: Context) -> StepOutput:
-    if ctx.retry_count == 0:
-        return StepOutput(should_cancel=True)
-    else:
-        return StepOutput(should_cancel=False)
+    return StepOutput(should_cancel=ctx.retry_count == 0)
 
 
 @payload_initial_cancel_bug_workflow.task(

--- a/sdks/python/examples/worker.py
+++ b/sdks/python/examples/worker.py
@@ -37,6 +37,9 @@ from examples.on_failure.worker import on_failure_wf, on_failure_wf_with_details
 from examples.return_exceptions.worker import return_exceptions_task
 from examples.simple.worker import simple, simple_durable
 from examples.timeout.worker import refresh_timeout_wf, timeout_wf
+from examples.bug_tests.payload_bug_on_replay.worker import (
+    payload_initial_cancel_bug_workflow,
+)
 from examples.webhooks.worker import webhook
 from hatchet_sdk import Hatchet
 
@@ -75,6 +78,7 @@ def main() -> None:
             concurrency_cancel_newest_workflow,
             concurrency_cancel_in_progress_workflow,
             di_workflow,
+            payload_initial_cancel_bug_workflow,
             lifespan_task,
             simple,
             simple_durable,

--- a/sdks/python/examples/worker.py
+++ b/sdks/python/examples/worker.py
@@ -1,4 +1,7 @@
 from examples.affinity_workers.worker import affinity_worker_workflow
+from examples.bug_tests.payload_bug_on_replay.worker import (
+    payload_initial_cancel_bug_workflow,
+)
 from examples.bulk_fanout.worker import bulk_child_wf, bulk_parent_wf
 from examples.bulk_operations.worker import (
     bulk_replay_test_1,
@@ -37,9 +40,6 @@ from examples.on_failure.worker import on_failure_wf, on_failure_wf_with_details
 from examples.return_exceptions.worker import return_exceptions_task
 from examples.simple.worker import simple, simple_durable
 from examples.timeout.worker import refresh_timeout_wf, timeout_wf
-from examples.bug_tests.payload_bug_on_replay.worker import (
-    payload_initial_cancel_bug_workflow,
-)
 from examples.webhooks.worker import webhook
 from hatchet_sdk import Hatchet
 


### PR DESCRIPTION
# Description

Puts a new payload in the payloads table when a task is replayed to fix a bug where a task is initially inserted in a non-queued state (e.g. `CANCELLED` in a DAG if there's a parent condition that would cancel it), and is initially written with a `null` input.

Python test failed correctly against main

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

