### PR TITLE
Feat: Add error level logs if we fall back to the task input for monitoring

### DIFF
--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/index.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/index.tsx
@@ -50,8 +50,11 @@ function statusToBadgeVariant(status: V1TaskStatus) {
     case V1TaskStatus.COMPLETED:
       return 'successful';
     case V1TaskStatus.FAILED:
-    case V1TaskStatus.CANCELLED:
       return 'failed';
+    case V1TaskStatus.CANCELLED:
+      return 'cancelled';
+    case V1TaskStatus.QUEUED:
+      return 'queued';
     default:
       return 'inProgress';
   }

--- a/frontend/app/src/pages/main/v1/workflow-runs/components/run-statuses.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs/components/run-statuses.tsx
@@ -32,21 +32,21 @@ export function createRunStatusVariant(
     case 'FAILED':
       return { text: 'Failed', variant: 'failed' };
     case 'CANCELLED':
-      return { text: 'Cancelled', variant: 'failed' };
+      return { text: 'Cancelled', variant: 'cancelled' };
     case 'CANCELLING':
-      return { text: 'Cancelling', variant: 'inProgress' };
+      return { text: 'Cancelling', variant: 'cancelled' };
     case 'RUNNING':
       return { text: 'Running', variant: 'inProgress' };
     case 'QUEUED':
-      return { text: 'Queued', variant: 'outline' };
+      return { text: 'Queued', variant: 'queued' };
     case 'PENDING':
-      return { text: 'Pending', variant: 'outline' };
+      return { text: 'Pending', variant: 'queued' };
     case 'PENDING_ASSIGNMENT':
-      return { text: 'Pending', variant: 'outline' };
+      return { text: 'Pending', variant: 'queued' };
     case 'ASSIGNED':
       return { text: 'Assigned', variant: 'inProgress' };
     case 'SCHEDULED':
-      return { text: 'Scheduled', variant: 'outline' };
+      return { text: 'Scheduled', variant: 'queued' };
     default:
       return { text: 'Unknown', variant: 'outline' };
   }

--- a/internal/services/dispatcher/dispatcher_v1.go
+++ b/internal/services/dispatcher/dispatcher_v1.go
@@ -257,6 +257,7 @@ func (d *DispatcherImpl) handleTaskBulkAssignedTask(ctx context.Context, msg *ms
 			if input == nil || !ok {
 				// If the input wasn't found in the payload store,
 				// fall back to the input stored on the task itself.
+				d.l.Error().Msgf("task %s has empty payload, falling back to input", task.ExternalID.String())
 				input = task.Input
 			}
 
@@ -313,6 +314,7 @@ func (d *DispatcherImpl) handleTaskBulkAssignedTask(ctx context.Context, msg *ms
 			if input == nil || !ok {
 				// If the input wasn't found in the payload store,
 				// fall back to the input stored on the task itself.
+				d.l.Error().Msgf("task %s has empty payload, falling back to input", task.ExternalID.String())
 				input = task.Input
 			}
 

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -1303,6 +1303,7 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId string
 		// fall back to input if payload is empty
 		// for backwards compatibility
 		if len(payload) == 0 {
+			r.l.Error().Msgf("task %s has empty payload, falling back to input", task.ExternalID.String())
 			payload = task.Input
 		}
 


### PR DESCRIPTION
# Description

Adding error level logs so we know we didn't miss any uses of the input / any places where we're falling back still. If we don't see any of these for a while, we should be good to remove the dual writes

## Type of change

- [x] New feature (non-breaking change which adds functionality)
