### PR TITLE
Hotfix: Stable ordering for flattened tasks + child tasks

### DIFF
--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"sort"
 	"sync"
 	"time"
 
@@ -1915,6 +1916,14 @@ func (r *OLAPRepositoryImpl) populateTaskRunData(ctx context.Context, tx pgx.Tx,
 	for _, taskData := range idInsertedAtToData {
 		result = append(result, taskData)
 	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].InsertedAt.Time.Unix() == result[j].InsertedAt.Time.Unix() {
+			return result[i].ID < result[j].ID
+		}
+
+		return result[i].InsertedAt.Time.After(result[j].InsertedAt.Time)
+	})
 
 	return result, nil
 

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -1918,7 +1918,7 @@ func (r *OLAPRepositoryImpl) populateTaskRunData(ctx context.Context, tx pgx.Tx,
 	}
 
 	sort.Slice(result, func(i, j int) bool {
-		if result[i].InsertedAt.Time.Unix() == result[j].InsertedAt.Time.Unix() {
+		if result[i].InsertedAt.Time.Equal(result[j].InsertedAt.Time) {
 			return result[i].ID < result[j].ID
 		}
 

--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -566,6 +566,7 @@ WHERE
     t.tenant_id = @tenantId::UUID
     AND t.id = @taskId::BIGINT
     AND t.inserted_at = @taskInsertedAt::TIMESTAMPTZ
+ORDER BY t.inserted_at DESC, t.id
 ;
 
 -- name: FindMinInsertedAtForTaskStatusUpdates :one

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -1900,6 +1900,7 @@ WHERE
     t.tenant_id = $2::UUID
     AND t.id = $3::BIGINT
     AND t.inserted_at = $4::TIMESTAMPTZ
+ORDER BY t.inserted_at DESC, t.id
 `
 
 type PopulateTaskRunDataParams struct {


### PR DESCRIPTION
# Description

What it says on the tin - stable ordering was broken by the N+1 queries

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
