### PR TITLE
FE Polish, IV: Tooltips, task event scrolling

### DIFF
--- a/frontend/app/src/components/v1/molecules/relative-date.tsx
+++ b/frontend/app/src/components/v1/molecules/relative-date.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import TimeAgo from 'timeago-react';
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/v1/ui/tooltip';
+  PortalTooltip,
+  PortalTooltipTrigger,
+  PortalTooltipContent,
+  PortalTooltipProvider,
+} from '@/components/v1/ui/portal-tooltip';
 
 interface RelativeDateProps {
   date?: Date | string;
@@ -70,24 +70,27 @@ const RelativeDate: React.FC<RelativeDateProps> = ({
   }
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger
+    <PortalTooltipProvider>
+      <PortalTooltip>
+        <PortalTooltipTrigger
+          asChild
           onFocusCapture={(e) => {
             e.stopPropagation();
           }}
         >
-          {future && countdown ? (
-            <>{countdown}</>
-          ) : (
-            <TimeAgo datetime={formattedDate} />
-          )}
-        </TooltipTrigger>
-        <TooltipContent className="z-[80]">
+          <span>
+            {future && countdown ? (
+              <>{countdown}</>
+            ) : (
+              <TimeAgo datetime={formattedDate} />
+            )}
+          </span>
+        </PortalTooltipTrigger>
+        <PortalTooltipContent side="top">
           {formattedDate.toLocaleString()}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+        </PortalTooltipContent>
+      </PortalTooltip>
+    </PortalTooltipProvider>
   );
 };
 

--- a/frontend/app/src/components/v1/molecules/relative-date.tsx
+++ b/frontend/app/src/components/v1/molecules/relative-date.tsx
@@ -80,7 +80,7 @@ const RelativeDate: React.FC<RelativeDateProps> = ({
         >
           <span>
             {future && countdown ? (
-              <>{countdown}</>
+              countdown
             ) : (
               <TimeAgo datetime={formattedDate} />
             )}

--- a/frontend/app/src/components/v1/shared/duration.tsx
+++ b/frontend/app/src/components/v1/shared/duration.tsx
@@ -4,11 +4,11 @@ import { cn } from '@/lib/utils';
 import { intervalToDuration } from 'date-fns';
 import { Clock } from 'lucide-react';
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
+  PortalTooltip,
+  PortalTooltipTrigger,
+  PortalTooltipContent,
+  PortalTooltipProvider,
+} from '@/components/v1/ui/portal-tooltip';
 import { V1TaskStatus } from '@/lib/api';
 import { Duration as DateFnsDuration } from 'date-fns';
 
@@ -137,21 +137,21 @@ export function Duration({
   }
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
+    <PortalTooltipProvider>
+      <PortalTooltip>
+        <PortalTooltipTrigger asChild>
           <span
             className={cn(!asChild && durationVariants({ variant }), className)}
             {...props}
           >
             {content}
           </span>
-        </TooltipTrigger>
-        <TooltipContent>
+        </PortalTooltipTrigger>
+        <PortalTooltipContent>
           {isRunning ? 'Running for ' : ''}
           {formatDuration(duration, rawDuration)}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+        </PortalTooltipContent>
+      </PortalTooltip>
+    </PortalTooltipProvider>
   );
 }

--- a/frontend/app/src/components/v1/ui/portal-tooltip.tsx
+++ b/frontend/app/src/components/v1/ui/portal-tooltip.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import { cn } from '@/lib/utils';
+
+const PortalTooltipProvider = TooltipPrimitive.Provider;
+
+const PortalTooltip = TooltipPrimitive.Root;
+
+const PortalTooltipTrigger = TooltipPrimitive.Trigger;
+
+const PortalTooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className,
+      )}
+      avoidCollisions={true}
+      collisionPadding={8}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+));
+PortalTooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export {
+  PortalTooltip,
+  PortalTooltipTrigger,
+  PortalTooltipContent,
+  PortalTooltipProvider,
+};

--- a/frontend/app/src/pages/main/v1/events/components/event-columns.tsx
+++ b/frontend/app/src/pages/main/v1/events/components/event-columns.tsx
@@ -2,17 +2,10 @@ import { ColumnDef } from '@tanstack/react-table';
 import { Badge } from '@/components/v1/ui/badge';
 import { V1Event } from '@/lib/api';
 import { Button } from '@/components/v1/ui/button';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/v1/ui/popover';
-import { useState } from 'react';
+
 import { AdditionalMetadata } from './additional-metadata';
 import RelativeDate from '@/components/v1/molecules/relative-date';
 import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
-import { RunsTable } from '../../workflow-runs-v1/components/runs-table';
-import { RunsProvider } from '../../workflow-runs-v1/hooks/runs-provider';
 
 export const EventColumn = {
   id: 'Event ID',
@@ -206,170 +199,36 @@ export const columns = ({
   ];
 };
 
-// eslint-disable-next-line react-refresh/only-export-components
-function WorkflowRunSummary({ event }: { event: V1Event }) {
-  const [hoverCardOpen, setPopoverOpen] = useState<
-    'failed' | 'succeeded' | 'running' | 'queued' | 'cancelled'
-  >();
+type BadgeProps = {
+  variant: 'failed' | 'successful' | 'inProgress' | 'cancelled' | 'queued';
+  count: number;
+  label: string;
+};
 
+function WorkflowRunSummary({ event }: { event: V1Event }) {
   const numFailed = event.workflowRunSummary?.failed || 0;
   const numSucceeded = event.workflowRunSummary?.succeeded || 0;
   const numRunning = event.workflowRunSummary?.running || 0;
   const numCancelled = event.workflowRunSummary?.cancelled || 0;
   const numQueued = event.workflowRunSummary?.queued || 0;
 
-  const hoverCardContent = (
-    <div className="min-w-fit z-40 p-4 bg-white/10 rounded">
-      <RunsProvider
-        tableKey={`event-runs-${event.metadata.id}`}
-        display={{
-          hideCounts: true,
-          hideMetrics: true,
-          hideDateFilter: true,
-          hideTriggerRunButton: true,
-          hideCancelAndReplayButtons: true,
-        }}
-        runFilters={{
-          triggeringEventExternalId: event.metadata.id,
-        }}
-      >
-        <RunsTable headerClassName="bg-slate-700" />
-      </RunsProvider>
-    </div>
-  );
+  const badges: BadgeProps[] = [
+    { variant: 'failed', count: numFailed, label: 'Failed' },
+    { variant: 'successful', count: numSucceeded, label: 'Succeeded' },
+    { variant: 'inProgress', count: numRunning, label: 'Running' },
+    { variant: 'cancelled', count: numCancelled, label: 'Cancelled' },
+    { variant: 'queued', count: numQueued, label: 'Queued' },
+  ];
 
   return (
     <div className="flex flex-row gap-2 items-center justify-start">
-      {numFailed > 0 && (
-        <Popover
-          open={hoverCardOpen == 'failed'}
-          // open={true}
-          onOpenChange={(open) => {
-            if (!open) {
-              setPopoverOpen(undefined);
-            }
-          }}
-        >
-          <PopoverTrigger>
-            <Badge
-              variant="failed"
-              className="cursor-pointer"
-              onClick={() => setPopoverOpen('failed')}
-            >
-              {numFailed} Failed
+      {badges.map(
+        ({ variant, count, label }) =>
+          count > 0 && (
+            <Badge variant={variant} key={variant}>
+              {count} {label}
             </Badge>
-          </PopoverTrigger>
-          <PopoverContent
-            className="min-w-fit p-0 bg-background border-none z-40"
-            align="end"
-          >
-            {hoverCardContent}
-          </PopoverContent>
-        </Popover>
-      )}
-      {numSucceeded > 0 && (
-        <Popover
-          open={hoverCardOpen == 'succeeded'}
-          onOpenChange={(open) => {
-            if (!open) {
-              setPopoverOpen(undefined);
-            }
-          }}
-        >
-          <PopoverTrigger>
-            <Badge
-              variant="successful"
-              className="cursor-pointer"
-              onClick={() => setPopoverOpen('succeeded')}
-            >
-              {numSucceeded} Succeeded
-            </Badge>
-          </PopoverTrigger>
-          <PopoverContent
-            className="min-w-fit p-0 bg-background border-none z-40"
-            align="end"
-          >
-            {hoverCardContent}
-          </PopoverContent>
-        </Popover>
-      )}
-      {numRunning > 0 && (
-        <Popover
-          open={hoverCardOpen == 'running'}
-          onOpenChange={(open) => {
-            if (!open) {
-              setPopoverOpen(undefined);
-            }
-          }}
-        >
-          <PopoverTrigger>
-            <Badge
-              variant="inProgress"
-              className="cursor-pointer"
-              onClick={() => setPopoverOpen('running')}
-            >
-              {numRunning} Running
-            </Badge>
-          </PopoverTrigger>
-          <PopoverContent
-            className="min-w-fit p-0 bg-background border-none z-40"
-            align="end"
-          >
-            {hoverCardContent}
-          </PopoverContent>
-        </Popover>
-      )}
-      {numCancelled > 0 && (
-        <Popover
-          open={hoverCardOpen == 'cancelled'}
-          onOpenChange={(open) => {
-            if (!open) {
-              setPopoverOpen(undefined);
-            }
-          }}
-        >
-          <PopoverTrigger>
-            <Badge
-              variant="cancelled"
-              className="cursor-pointer"
-              onClick={() => setPopoverOpen('cancelled')}
-            >
-              {numCancelled} Cancelled
-            </Badge>
-          </PopoverTrigger>
-          <PopoverContent
-            className="min-w-fit p-0 bg-background border-none z-40"
-            align="end"
-          >
-            {hoverCardContent}
-          </PopoverContent>
-        </Popover>
-      )}
-      {numQueued > 0 && (
-        <Popover
-          open={hoverCardOpen == 'queued'}
-          onOpenChange={(open) => {
-            if (!open) {
-              setPopoverOpen(undefined);
-            }
-          }}
-        >
-          <PopoverTrigger>
-            <Badge
-              variant="queued"
-              className="cursor-pointer"
-              onClick={() => setPopoverOpen('queued')}
-            >
-              {numQueued} Queued
-            </Badge>
-          </PopoverTrigger>
-          <PopoverContent
-            className="min-w-fit p-0 bg-background border-none z-40"
-            align="end"
-          >
-            {hoverCardContent}
-          </PopoverContent>
-        </Popover>
+          ),
       )}
     </div>
   );

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/events-columns.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/events-columns.tsx
@@ -17,6 +17,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/v1/ui/popover';
+import { EventWithMetadata } from './step-run-events-for-workflow-run';
 
 function eventTypeToSeverity(
   eventType: V1TaskEventType | undefined,
@@ -39,7 +40,7 @@ function eventTypeToSeverity(
   }
 }
 
-const columnHelper = createColumnHelper<V1TaskEvent>();
+const columnHelper = createColumnHelper<EventWithMetadata>();
 
 export const columns = ({
   tenantId,
@@ -47,7 +48,7 @@ export const columns = ({
   fallbackTaskDisplayName,
 }: {
   tenantId: string;
-  onRowClick: (row: V1TaskEvent) => void;
+  onRowClick: (row: EventWithMetadata) => void;
   fallbackTaskDisplayName: string;
 }) => {
   return [

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-events-for-workflow-run.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-events-for-workflow-run.tsx
@@ -5,6 +5,12 @@ import { columns } from './events-columns';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
 import { useRefetchInterval } from '@/contexts/refetch-interval-context';
 
+export type EventWithMetadata = V1TaskEvent & {
+  metadata: {
+    id: string;
+  };
+};
+
 export function StepRunEvents({
   taskRunId,
   workflowRunId,
@@ -33,12 +39,6 @@ export function StepRunEvents({
     refetchInterval,
   });
 
-  type EventWithMetadata = V1TaskEvent & {
-    metadata: {
-      id: string;
-    };
-  };
-
   const events: EventWithMetadata[] =
     eventsQuery.data?.rows?.map((row) => ({
       ...row,
@@ -54,11 +54,13 @@ export function StepRunEvents({
   });
 
   return (
-    <DataTable
-      emptyState={<>No events found.</>}
-      isLoading={eventsQuery.isLoading}
-      columns={cols as any} // TODO: This is a hack, figure out how to type this properly later
-      data={events}
-    />
+    <div className="flex-1 min-h-0 h-[400px]">
+      <DataTable
+        emptyState={<>No events found.</>}
+        isLoading={eventsQuery.isLoading}
+        columns={cols as any} // TODO: This is a hack, figure out how to type this properly later
+        data={events}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
# Description

Fixes tooltip positioning on the runs table and task event scroll behavior. Also removed the runs table on hover from the events list, cleaned up the event run status badges, and fixed the additional metadata filter splitting incorrectly. Also made the task events scroll similar to the other tables


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

<img width="681" height="465" alt="Screenshot 2025-09-24 at 1 56 58 PM" src="https://github.com/user-attachments/assets/706d4c79-c603-465b-825f-6ccdb6284468" />

<img width="1161" height="787" alt="Screenshot 2025-09-24 at 1 57 15 PM" src="https://github.com/user-attachments/assets/a3081347-edd9-4c86-a500-58cdfe584218" />
