### PR TITLE
Hotfix: Use `SplitN` instead of `Split` for additional metadata

### DIFF
--- a/api/v1/server/handlers/events/list.go
+++ b/api/v1/server/handlers/events/list.go
@@ -83,7 +83,7 @@ func (t *EventService) EventList(ctx echo.Context, request gen.EventListRequestO
 			additionalMetadata := make(map[string]interface{}, len(*request.Params.AdditionalMetadata))
 
 			for _, v := range *request.Params.AdditionalMetadata {
-				splitValue := strings.Split(fmt.Sprintf("%v", v), ":")
+				splitValue := strings.SplitN(fmt.Sprintf("%v", v), ":", 2)
 
 				if len(splitValue) == 2 {
 					additionalMetadata[splitValue[0]] = splitValue[1]
@@ -192,7 +192,7 @@ func (t *EventService) EventList(ctx echo.Context, request gen.EventListRequestO
 			additionalMeta := make(map[string]interface{})
 
 			for _, m := range *request.Params.AdditionalMetadata {
-				split := strings.Split(m, ":")
+				split := strings.SplitN(m, ":", 2)
 
 				if len(split) != 2 {
 					return nil, fmt.Errorf("invalid additional metadata format: %s, expected key:value", m)

--- a/api/v1/server/handlers/v1/events/list.go
+++ b/api/v1/server/handlers/v1/events/list.go
@@ -97,7 +97,7 @@ func (t *V1EventsService) V1EventList(ctx echo.Context, request gen.V1EventListR
 		additionalMeta := make(map[string]interface{})
 
 		for _, m := range *request.Params.AdditionalMetadata {
-			split := strings.Split(m, ":")
+			split := strings.SplitN(m, ":", 2)
 
 			if len(split) != 2 {
 				return nil, fmt.Errorf("invalid additional metadata format: %s, expected key:value", m)

--- a/api/v1/server/handlers/v1/tasks/get_metrics.go
+++ b/api/v1/server/handlers/v1/tasks/get_metrics.go
@@ -44,7 +44,7 @@ func (t *TasksService) V1TaskListStatusMetrics(ctx echo.Context, request gen.V1T
 
 	if request.Params.AdditionalMetadata != nil {
 		for _, v := range *request.Params.AdditionalMetadata {
-			kv_pairs := strings.Split(v, ":")
+			kv_pairs := strings.SplitN(v, ":", 2)
 			if len(kv_pairs) == 2 {
 				additionalMetadataFilters[kv_pairs[0]] = kv_pairs[1]
 			}

--- a/api/v1/server/handlers/v1/workflow-runs/list.go
+++ b/api/v1/server/handlers/v1/workflow-runs/list.go
@@ -69,7 +69,7 @@ func (t *V1WorkflowRunsService) WithDags(ctx context.Context, request gen.V1Work
 
 	if request.Params.AdditionalMetadata != nil {
 		for _, v := range *request.Params.AdditionalMetadata {
-			kv_pairs := strings.Split(v, ":")
+			kv_pairs := strings.SplitN(v, ":", 2)
 			if len(kv_pairs) == 2 {
 				additionalMetadataFilters[kv_pairs[0]] = kv_pairs[1]
 			}
@@ -235,7 +235,7 @@ func (t *V1WorkflowRunsService) OnlyTasks(ctx context.Context, request gen.V1Wor
 
 	if request.Params.AdditionalMetadata != nil {
 		for _, v := range *request.Params.AdditionalMetadata {
-			kv_pairs := strings.Split(v, ":")
+			kv_pairs := strings.SplitN(v, ":", 2)
 			if len(kv_pairs) == 2 {
 				additionalMetadataFilters[kv_pairs[0]] = kv_pairs[1]
 			}

--- a/internal/services/admin/v1/server.go
+++ b/internal/services/admin/v1/server.go
@@ -72,7 +72,7 @@ func (a *AdminServiceImpl) CancelTasks(ctx context.Context, req *contracts.Cance
 		if len(req.Filter.AdditionalMetadata) > 0 {
 			additionalMetadataFilters = make(map[string]interface{})
 			for _, v := range req.Filter.AdditionalMetadata {
-				kv_pairs := strings.Split(v, ":")
+				kv_pairs := strings.SplitN(v, ":", 2)
 				if len(kv_pairs) == 2 {
 					additionalMetadataFilters[kv_pairs[0]] = kv_pairs[1]
 				} else {
@@ -200,7 +200,7 @@ func (a *AdminServiceImpl) ReplayTasks(ctx context.Context, req *contracts.Repla
 		if len(req.Filter.AdditionalMetadata) > 0 {
 			additionalMetadataFilters = make(map[string]interface{})
 			for _, v := range req.Filter.AdditionalMetadata {
-				kv_pairs := strings.Split(v, ":")
+				kv_pairs := strings.SplitN(v, ":", 2)
 				if len(kv_pairs) == 2 {
 					additionalMetadataFilters[kv_pairs[0]] = kv_pairs[1]
 				} else {


### PR DESCRIPTION
# Description

Using `strings.SplitN` instead of `strings.Split` to handle the possibility of an additional metadata value containing a `:`. Note that this is still broken if the _key_ contains `:`, but that seems relatively less likely

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
