### PR TITLE
Fix: Event getter backwards compat

### DIFF
--- a/api/v1/server/run/run.go
+++ b/api/v1/server/run/run.go
@@ -379,8 +379,6 @@ func (t *APIServer) registerSpec(g *echo.Group, spec *openapi3.T) (*populator.Po
 
 		event, err := config.APIRepository.Event().GetEventById(timeoutCtx, id)
 
-		fmt.Println(err, errors.Is(err, pgx.ErrNoRows))
-
 		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return nil, "", err
 		} else if errors.Is(err, pgx.ErrNoRows) {

--- a/api/v1/server/run/run.go
+++ b/api/v1/server/run/run.go
@@ -382,7 +382,7 @@ func (t *APIServer) registerSpec(g *echo.Group, spec *openapi3.T) (*populator.Po
 		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return nil, "", err
 		} else if errors.Is(err, pgx.ErrNoRows) {
-			v1Event, err := t.config.V1.OLAP().GetEvent(context.Background(), id)
+			v1Event, err := t.config.V1.OLAP().GetEvent(timeoutCtx, id)
 
 			if err != nil {
 				return nil, "", err

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -234,6 +234,7 @@ type OLAPRepository interface {
 	GetTaskTimings(ctx context.Context, tenantId string, workflowRunId pgtype.UUID, depth int32) ([]*sqlcv1.PopulateTaskRunDataRow, map[string]int32, error)
 	BulkCreateEventsAndTriggers(ctx context.Context, events sqlcv1.BulkCreateEventsParams, triggers []EventTriggersFromExternalId) error
 	ListEvents(ctx context.Context, opts sqlcv1.ListEventsParams) ([]*ListEventsRow, *int64, error)
+	GetEvent(ctx context.Context, externalId string) (*sqlcv1.V1EventsOlap, error)
 	ListEventKeys(ctx context.Context, tenantId string) ([]string, error)
 
 	GetDAGDurations(ctx context.Context, tenantId string, externalIds []pgtype.UUID, minInsertedAt pgtype.Timestamptz) (map[string]*sqlcv1.GetDagDurationsRow, error)
@@ -1596,6 +1597,10 @@ func (r *OLAPRepositoryImpl) BulkCreateEventsAndTriggers(ctx context.Context, ev
 	}
 
 	return nil
+}
+
+func (r *OLAPRepositoryImpl) GetEvent(ctx context.Context, externalId string) (*sqlcv1.V1EventsOlap, error) {
+	return r.queries.GetEventByExternalId(ctx, r.readPool, sqlchelpers.UUIDFromStr(externalId))
 }
 
 type ListEventsRow struct {

--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -1342,6 +1342,13 @@ WHERE
 GROUP BY elt.external_id
 ;
 
+-- name: GetEventByExternalId :one
+SELECT e.*
+FROM v1_event_lookup_table_olap elt
+JOIN v1_events_olap e ON (elt.tenant_id, elt.event_id, elt.event_seen_at) = (e.tenant_id, e.id, e.seen_at)
+WHERE elt.external_id = @eventExternalId::uuid
+;
+
 -- name: ListEvents :many
 SELECT e.*
 FROM v1_event_lookup_table_olap elt

--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -1345,7 +1345,7 @@ GROUP BY elt.external_id
 -- name: GetEventByExternalId :one
 SELECT e.*
 FROM v1_event_lookup_table_olap elt
-JOIN v1_events_olap e ON (elt.tenant_id, elt.event_id, elt.event_seen_at) = (e.tenant_id, e.id, e.seen_at)
+JOIN v1_events_olap e ON (elt.event_id, elt.event_seen_at) = (e.id, e.seen_at)
 WHERE elt.external_id = @eventExternalId::uuid
 ;
 

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -463,6 +463,30 @@ func (q *Queries) GetDagDurations(ctx context.Context, db DBTX, arg GetDagDurati
 	return items, nil
 }
 
+const getEventByExternalId = `-- name: GetEventByExternalId :one
+SELECT e.tenant_id, e.id, e.external_id, e.seen_at, e.key, e.payload, e.additional_metadata, e.scope, e.triggering_webhook_name
+FROM v1_event_lookup_table_olap elt
+JOIN v1_events_olap e ON (elt.tenant_id, elt.event_id, elt.event_seen_at) = (e.tenant_id, e.id, e.seen_at)
+WHERE elt.external_id = $1::uuid
+`
+
+func (q *Queries) GetEventByExternalId(ctx context.Context, db DBTX, eventexternalid pgtype.UUID) (*V1EventsOlap, error) {
+	row := db.QueryRow(ctx, getEventByExternalId, eventexternalid)
+	var i V1EventsOlap
+	err := row.Scan(
+		&i.TenantID,
+		&i.ID,
+		&i.ExternalID,
+		&i.SeenAt,
+		&i.Key,
+		&i.Payload,
+		&i.AdditionalMetadata,
+		&i.Scope,
+		&i.TriggeringWebhookName,
+	)
+	return &i, err
+}
+
 const getRunsListRecursive = `-- name: GetRunsListRecursive :many
 WITH RECURSIVE all_runs AS (
   -- seed term

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -466,7 +466,7 @@ func (q *Queries) GetDagDurations(ctx context.Context, db DBTX, arg GetDagDurati
 const getEventByExternalId = `-- name: GetEventByExternalId :one
 SELECT e.tenant_id, e.id, e.external_id, e.seen_at, e.key, e.payload, e.additional_metadata, e.scope, e.triggering_webhook_name
 FROM v1_event_lookup_table_olap elt
-JOIN v1_events_olap e ON (elt.tenant_id, elt.event_id, elt.event_seen_at) = (e.tenant_id, e.id, e.seen_at)
+JOIN v1_events_olap e ON (elt.event_id, elt.event_seen_at) = (e.id, e.seen_at)
 WHERE elt.external_id = $1::uuid
 `
 


### PR DESCRIPTION
# Description

Adding a v1 getter to the v0 event populator to allow for the get and get data methods to work as expected, using the V1 data under the hood

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

