### PR TITLE
fix: improve DAG status updates

### DIFF
--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -1860,6 +1860,12 @@ func (r *OLAPRepositoryImpl) AnalyzeOLAPTables(ctx context.Context) error {
 		return fmt.Errorf("error analyzing v1_dags_olap: %v", err)
 	}
 
+	err = r.queries.AnalyzeV1DAGToTaskOLAP(ctx, tx)
+
+	if err != nil {
+		return fmt.Errorf("error analyzing v1_dags_olap: %v", err)
+	}
+
 	if err := commit(ctx); err != nil {
 		return fmt.Errorf("error committing transaction: %v", err)
 	}

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -1863,7 +1863,7 @@ func (r *OLAPRepositoryImpl) AnalyzeOLAPTables(ctx context.Context) error {
 	err = r.queries.AnalyzeV1DAGToTaskOLAP(ctx, tx)
 
 	if err != nil {
-		return fmt.Errorf("error analyzing v1_dags_olap: %v", err)
+		return fmt.Errorf("error analyzing v1_dag_to_task_olap: %v", err)
 	}
 
 	if err := commit(ctx); err != nil {

--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -25,6 +25,9 @@ ANALYZE v1_tasks_olap;
 -- name: AnalyzeV1DAGsOLAP :exec
 ANALYZE v1_dags_olap;
 
+-- name: AnalyzeV1DAGToTaskOLAP :exec
+ANALYZE v1_dag_to_task_olap;
+
 -- name: ListOLAPPartitionsBeforeDate :many
 WITH task_partitions AS (
     SELECT 'v1_tasks_olap' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_tasks_olap'::text, @date::date) AS p
@@ -822,6 +825,28 @@ WITH tenants AS (
     ORDER BY
         d.inserted_at, d.id
     FOR UPDATE
+), relevant_tasks AS (
+    SELECT
+        t.tenant_id,
+        t.id,
+        d.id AS dag_id,
+        d.inserted_at AS dag_inserted_at,
+        t.readable_status
+    FROM
+        locked_dags d
+    JOIN
+        v1_dag_to_task_olap dt ON
+            (d.id, d.inserted_at) = (dt.dag_id, dt.dag_inserted_at)
+    JOIN
+        v1_tasks_olap t ON
+            (dt.task_id, dt.task_inserted_at) = (t.id, t.inserted_at)
+    WHERE
+        t.inserted_at >= @minInsertedAt::TIMESTAMPTZ
+    -- Note that the ORDER BY seems to help the query planner by pruning partitions earlier. We
+    -- have previously seen Postgres use an index-only scan on partitions older than the minInsertedAt,
+    -- each of which can take a long time to scan. This can be very pathological since we partition on
+    -- both the status and the date, so 14 days of data with 5 statuses is 70 partitions to index scan.
+    ORDER BY t.inserted_at DESC
 ), dag_task_counts AS (
     SELECT
         d.id,
@@ -836,12 +861,7 @@ WITH tenants AS (
     FROM
         locked_dags d
     LEFT JOIN
-        v1_dag_to_task_olap dt ON
-            (d.id, d.inserted_at) = (dt.dag_id, dt.dag_inserted_at)
-    LEFT JOIN
-        v1_tasks_olap t ON
-            (dt.task_id, dt.task_inserted_at) = (t.id, t.inserted_at)
-    WHERE t.inserted_at >= @minInsertedAt::TIMESTAMPTZ
+        relevant_tasks t ON (d.tenant_id, d.id, d.inserted_at) = (t.tenant_id, t.dag_id, t.dag_inserted_at)
     GROUP BY
         d.id, d.inserted_at, d.total_tasks
 ), updated_dags AS (

--- a/pkg/repository/v1/sqlcv1/queue.sql
+++ b/pkg/repository/v1/sqlcv1/queue.sql
@@ -29,7 +29,8 @@ WITH ordered_names AS (
 -- Insert new queues
 INSERT INTO v1_queue (tenant_id, name, last_active)
 SELECT $1, name, NOW()
-FROM names_to_insert;
+FROM names_to_insert
+ON CONFLICT (tenant_id, name) DO NOTHING;
 
 -- name: ListActionsForWorkers :many
 SELECT

--- a/pkg/repository/v1/sqlcv1/queue.sql.go
+++ b/pkg/repository/v1/sqlcv1/queue.sql.go
@@ -823,6 +823,7 @@ WITH ordered_names AS (
 INSERT INTO v1_queue (tenant_id, name, last_active)
 SELECT $1, name, NOW()
 FROM names_to_insert
+ON CONFLICT (tenant_id, name) DO NOTHING
 `
 
 type UpsertQueuesParams struct {


### PR DESCRIPTION
# Description

Improving DAG status updates:
- Adds `ANALYZE` to the `v1_dag_to_task_olap` table which seems to improve query performance of `UpdateDAGStatuses`
- Small refactor of the `UpdateDAGStatuses` query to use an `ORDER BY` when querying for matching tasks for a given DAG. Also breaks it into a separate CTE to avoid the GROUP BY causing issues with the order by
- Drive-by fix on the UpsertQueues query since we were seeing some errors due to concurrent writes to the queue table

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)