### PR TITLE
Fix: Rename metrics queries, always refetch queue metrics, change default refetch interval, configurable WAL poll limit

### DIFF
--- a/frontend/app/src/contexts/refetch-interval-context.tsx
+++ b/frontend/app/src/contexts/refetch-interval-context.tsx
@@ -34,7 +34,7 @@ export const RefetchIntervalProvider = ({
   children,
 }: RefetchIntervalProviderProps) => {
   const [storedInterval, setStoredInterval] =
-    useLocalStorageState<RefetchIntervalOption>(STORAGE_KEY, 'off');
+    useLocalStorageState<RefetchIntervalOption>(STORAGE_KEY, '10s');
   const [isFrozen, setIsFrozen] = useLocalStorageState<boolean>(
     'app-refetch-interval-frozen',
     false,

--- a/frontend/app/src/contexts/refetch-interval-context.tsx
+++ b/frontend/app/src/contexts/refetch-interval-context.tsx
@@ -28,7 +28,7 @@ interface RefetchIntervalProviderProps {
   children: ReactNode;
 }
 
-const STORAGE_KEY = 'app-refetch-interval';
+const STORAGE_KEY = 'app-default-refetch-interval';
 
 export const RefetchIntervalProvider = ({
   children,

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
@@ -102,8 +102,8 @@ export function RunsTable({ headerClassName }: RunsTableProps) {
     isMetricsLoading,
     isMetricsFetching,
     isRefetching,
-    metrics,
-    tenantMetrics,
+    runStatusCounts,
+    queueMetrics,
     actionModalParams,
     selectedActionType,
     pagination,
@@ -223,11 +223,11 @@ export function RunsTable({ headerClassName }: RunsTableProps) {
               <DialogTitle>Queue Metrics</DialogTitle>
             </DialogHeader>
             <Separator />
-            {tenantMetrics && (
+            {queueMetrics && (
               <CodeHighlighter
                 language="json"
                 className="max-h-[400px] overflow-y-auto"
-                code={JSON.stringify(tenantMetrics || '{}', null, 2)}
+                code={JSON.stringify(queueMetrics || '{}', null, 2)}
               />
             )}
             {isMetricsLoading && 'Loading...'}
@@ -262,7 +262,7 @@ export function RunsTable({ headerClassName }: RunsTableProps) {
             ...(!hideCounts
               ? [
                   <div key="metrics" className="flex justify-start mr-auto">
-                    {metrics.length > 0 ? (
+                    {runStatusCounts.length > 0 ? (
                       <V1WorkflowRunsMetricsView />
                     ) : (
                       <Skeleton className="max-w-[800px] w-[40vw] h-8" />

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
@@ -29,6 +29,7 @@ import { useRunsContext } from '../hooks/runs-provider';
 import { DocsButton } from '@/components/v1/docs/docs-button';
 import { docsPages } from '@/lib/generated/docs';
 import { useRefetchInterval } from '@/contexts/refetch-interval-context';
+import { Loading } from '@/components/v1/ui/loading';
 
 export interface RunsTableProps {
   headerClassName?: string;
@@ -99,8 +100,9 @@ export function RunsTable({ headerClassName }: RunsTableProps) {
     numPages,
     isRunsLoading,
     isRunsFetching,
-    isMetricsLoading,
-    isMetricsFetching,
+    isStatusCountsFetching,
+    isStatusCountsLoading,
+    isQueueMetricsLoading,
     isRefetching,
     runStatusCounts,
     queueMetrics,
@@ -203,8 +205,8 @@ export function RunsTable({ headerClassName }: RunsTableProps) {
     return () => clearInterval(interval);
   }, [filters, filters.isCustomTimeRange, filters.updateCurrentTimeWindow]);
 
-  const hasLoaded = !isRunsLoading && !isMetricsLoading;
-  const isFetching = !hasLoaded && (isRunsFetching || isMetricsFetching);
+  const hasLoaded = !isRunsLoading && !isStatusCountsLoading;
+  const isFetching = !hasLoaded && (isRunsFetching || isStatusCountsFetching);
 
   return (
     <div className="flex flex-col h-full overflow-hidden gap-y-2">
@@ -223,14 +225,15 @@ export function RunsTable({ headerClassName }: RunsTableProps) {
               <DialogTitle>Queue Metrics</DialogTitle>
             </DialogHeader>
             <Separator />
-            {queueMetrics && (
+            {!queueMetrics || isQueueMetricsLoading ? (
+              <Loading />
+            ) : (
               <CodeHighlighter
                 language="json"
                 className="max-h-[400px] overflow-y-auto"
                 code={JSON.stringify(queueMetrics || '{}', null, 2)}
               />
             )}
-            {isMetricsLoading && 'Loading...'}
           </DialogContent>
         </Dialog>
       )}

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-metrics.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-metrics.tsx
@@ -49,7 +49,7 @@ function MetricBadge({
   status: V1TaskStatus;
   className?: string;
 }) {
-  const { filters, metrics } = useRunsContext();
+  const { filters, runStatusCounts } = useRunsContext();
   const currentStatuses = useMemo(
     () => filters.apiFilters.statuses || [],
     [filters.apiFilters.statuses],
@@ -86,7 +86,7 @@ function MetricBadge({
     [currentStatuses, setStatuses],
   );
 
-  const metric = metrics.find((m) => m.status === status);
+  const metric = runStatusCounts.find((m) => m.status === status);
 
   if (!metric) {
     return null;

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
@@ -187,6 +187,7 @@ export const RunsProvider = ({
     parentTaskExternalId,
     createdAfter: filters.apiFilters.since,
     additionalMetadata: filters.apiFilters.additionalMetadata,
+    showQueueMetrics,
   });
 
   const isRefetching = isRunsRefetching || isMetricsRefetching;

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
@@ -65,8 +65,8 @@ type RunsContextType = {
   isMetricsLoading: boolean;
   isMetricsFetching: boolean;
   isRefetching: boolean;
-  metrics: V1TaskRunMetrics;
-  tenantMetrics: object;
+  runStatusCounts: V1TaskRunMetrics;
+  queueMetrics: object;
   isActionModalOpen: boolean;
   isActionDropdownOpen: boolean;
   selectedActionType: ActionType | null;
@@ -176,8 +176,8 @@ export const RunsProvider = ({
   );
 
   const {
-    metrics,
-    tenantMetrics,
+    runStatusCounts,
+    queueMetrics,
     isLoading: isMetricsLoading,
     isFetching: isMetricsFetching,
     refetch: refetchMetrics,
@@ -203,8 +203,8 @@ export const RunsProvider = ({
       isMetricsLoading,
       isMetricsFetching,
       isRefetching,
-      metrics,
-      tenantMetrics,
+      runStatusCounts,
+      queueMetrics,
       isActionModalOpen,
       isActionDropdownOpen,
       actionModalParams,
@@ -249,8 +249,8 @@ export const RunsProvider = ({
       isRunsFetching,
       isMetricsLoading,
       isMetricsFetching,
-      metrics,
-      tenantMetrics,
+      runStatusCounts,
+      queueMetrics,
       isActionModalOpen,
       isActionDropdownOpen,
       hideMetrics,

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
@@ -62,8 +62,9 @@ type RunsContextType = {
   numPages: number;
   isRunsLoading: boolean;
   isRunsFetching: boolean;
-  isMetricsLoading: boolean;
-  isMetricsFetching: boolean;
+  isStatusCountsLoading: boolean;
+  isStatusCountsFetching: boolean;
+  isQueueMetricsLoading: boolean;
   isRefetching: boolean;
   runStatusCounts: V1TaskRunMetrics;
   queueMetrics: object;
@@ -178,10 +179,11 @@ export const RunsProvider = ({
   const {
     runStatusCounts,
     queueMetrics,
-    isLoading: isMetricsLoading,
-    isFetching: isMetricsFetching,
+    isStatusCountsLoading,
+    isStatusCountsFetching,
     refetch: refetchMetrics,
-    isRefetching: isMetricsRefetching,
+    isStatusCountsRefetching,
+    isQueueMetricsLoading,
   } = useMetrics({
     workflow,
     parentTaskExternalId,
@@ -190,7 +192,7 @@ export const RunsProvider = ({
     showQueueMetrics,
   });
 
-  const isRefetching = isRunsRefetching || isMetricsRefetching;
+  const isRefetching = isRunsRefetching || isStatusCountsRefetching;
 
   const value = useMemo<RunsContextType>(
     () => ({
@@ -201,8 +203,9 @@ export const RunsProvider = ({
       numPages,
       isRunsLoading,
       isRunsFetching,
-      isMetricsLoading,
-      isMetricsFetching,
+      isStatusCountsFetching,
+      isStatusCountsLoading,
+      isQueueMetricsLoading,
       isRefetching,
       runStatusCounts,
       queueMetrics,
@@ -248,8 +251,9 @@ export const RunsProvider = ({
       numPages,
       isRunsLoading,
       isRunsFetching,
-      isMetricsLoading,
-      isMetricsFetching,
+      isStatusCountsFetching,
+      isStatusCountsLoading,
+      isQueueMetricsLoading,
       runStatusCounts,
       queueMetrics,
       isActionModalOpen,

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-metrics.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-metrics.tsx
@@ -8,11 +8,13 @@ export const useMetrics = ({
   parentTaskExternalId,
   additionalMetadata,
   createdAfter,
+  showQueueMetrics,
 }: {
   workflow: string | undefined;
   parentTaskExternalId: string | undefined;
   additionalMetadata?: string[] | undefined;
   createdAfter?: string;
+  showQueueMetrics: boolean;
 }) => {
   const { tenantId } = useCurrentTenantId();
   const { refetchInterval } = useRefetchInterval();
@@ -41,6 +43,7 @@ export const useMetrics = ({
   const { data: queueMetricsRaw } = useQuery({
     ...queries.metrics.getStepRunQueueMetrics(tenantId),
     refetchInterval: 5000,
+    enabled: showQueueMetrics,
   });
 
   const queueMetrics = queueMetricsRaw?.queues || {};

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-metrics.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-metrics.tsx
@@ -17,7 +17,13 @@ export const useMetrics = ({
   const { tenantId } = useCurrentTenantId();
   const { refetchInterval } = useRefetchInterval();
 
-  const metricsQuery = useQuery({
+  const {
+    data: rawStatusCounts,
+    isLoading,
+    isFetching,
+    isRefetching,
+    refetch,
+  } = useQuery({
     ...queries.v1TaskRuns.metrics(tenantId, {
       since:
         createdAfter ||
@@ -30,24 +36,21 @@ export const useMetrics = ({
     refetchInterval,
   });
 
-  const metrics = metricsQuery.data || [];
+  const runStatusCounts = rawStatusCounts || [];
 
-  const tenantMetricsQuery = useQuery({
+  const { data: queueMetricsRaw } = useQuery({
     ...queries.metrics.getStepRunQueueMetrics(tenantId),
-    refetchInterval,
+    refetchInterval: 5000,
   });
 
-  const tenantMetrics = tenantMetricsQuery.data?.queues || {};
+  const queueMetrics = queueMetricsRaw?.queues || {};
 
   return {
-    isLoading: metricsQuery.isLoading || tenantMetricsQuery.isLoading,
-    isFetching: metricsQuery.isFetching || tenantMetricsQuery.isFetching,
-    isRefetching: metricsQuery.isRefetching || tenantMetricsQuery.isRefetching,
-    tenantMetrics,
-    metrics,
-    refetch: () => {
-      tenantMetricsQuery.refetch();
-      metricsQuery.refetch();
-    },
+    runStatusCounts,
+    isLoading,
+    isFetching,
+    isRefetching,
+    refetch,
+    queueMetrics,
   };
 };

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-metrics.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-metrics.tsx
@@ -21,9 +21,9 @@ export const useMetrics = ({
 
   const {
     data: rawStatusCounts,
-    isLoading,
-    isFetching,
-    isRefetching,
+    isLoading: isStatusCountsLoading,
+    isFetching: isStatusCountsFetching,
+    isRefetching: isStatusCountsRefetching,
     refetch,
   } = useQuery({
     ...queries.v1TaskRuns.metrics(tenantId, {
@@ -40,7 +40,7 @@ export const useMetrics = ({
 
   const runStatusCounts = rawStatusCounts || [];
 
-  const { data: queueMetricsRaw } = useQuery({
+  const { data: queueMetricsRaw, isLoading: isQueueMetricsLoading } = useQuery({
     ...queries.metrics.getStepRunQueueMetrics(tenantId),
     refetchInterval: 5000,
     enabled: showQueueMetrics,
@@ -50,9 +50,10 @@ export const useMetrics = ({
 
   return {
     runStatusCounts,
-    isLoading,
-    isFetching,
-    isRefetching,
+    isStatusCountsRefetching,
+    isStatusCountsLoading,
+    isStatusCountsFetching,
+    isQueueMetricsLoading,
     refetch,
     queueMetrics,
   };

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -263,7 +263,7 @@ func (c *ConfigLoader) InitDataLayer() (res *database.Layer, err error) {
 		DurableSleepLimit: scf.Runtime.TaskOperationLimits.DurableSleepLimit,
 	}
 
-	v1, cleanupV1 := repov1.NewRepository(pool, &l, retentionPeriod, retentionPeriod, scf.Runtime.MaxInternalRetryCount, entitlementRepo, taskLimits, scf.PayloadStore.EnablePayloadDualWrites)
+	v1, cleanupV1 := repov1.NewRepository(pool, &l, retentionPeriod, retentionPeriod, scf.Runtime.MaxInternalRetryCount, entitlementRepo, taskLimits, scf.PayloadStore.EnablePayloadDualWrites, scf.PayloadStore.WALPollLimit)
 
 	apiRepo, cleanupApiRepo, err := postgresdb.NewAPIRepository(pool, &scf.Runtime, opts...)
 

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -597,6 +597,7 @@ type ServerConfig struct {
 
 type PayloadStoreConfig struct {
 	EnablePayloadDualWrites bool `mapstructure:"enablePayloadDualWrites" json:"enablePayloadDualWrites,omitempty" default:"false"`
+	WALPollLimit            int  `mapstructure:"walPollLimit" json:"walPollLimit,omitempty" default:"1000"`
 }
 
 func (c *ServerConfig) HasService(name string) bool {
@@ -859,4 +860,5 @@ func BindAllEnv(v *viper.Viper) {
 
 	// payload store options
 	_ = v.BindEnv("payloadStore.enablePayloadDualWrites", "SERVER_PAYLOAD_STORE_ENABLE_PAYLOAD_DUAL_WRITES")
+	_ = v.BindEnv("payloadStore.walPollLimit", "SERVER_PAYLOAD_STORE_WAL_POLL_LIMIT")
 }

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -258,10 +258,10 @@ type OLAPRepositoryImpl struct {
 	shouldPartitionEventsTables bool
 }
 
-func NewOLAPRepositoryFromPool(pool *pgxpool.Pool, l *zerolog.Logger, olapRetentionPeriod time.Duration, entitlements repository.EntitlementsRepository, shouldPartitionEventsTables, enablePayloadDualWrites bool) (OLAPRepository, func() error) {
+func NewOLAPRepositoryFromPool(pool *pgxpool.Pool, l *zerolog.Logger, olapRetentionPeriod time.Duration, entitlements repository.EntitlementsRepository, shouldPartitionEventsTables, enablePayloadDualWrites bool, payloadStoreWALPollLimit int) (OLAPRepository, func() error) {
 	v := validator.NewDefaultValidator()
 
-	shared, cleanupShared := newSharedRepository(pool, v, l, entitlements, enablePayloadDualWrites)
+	shared, cleanupShared := newSharedRepository(pool, v, l, entitlements, enablePayloadDualWrites, payloadStoreWALPollLimit)
 
 	return newOLAPRepository(shared, olapRetentionPeriod, shouldPartitionEventsTables), cleanupShared
 }

--- a/pkg/repository/v1/payloadstore.go
+++ b/pkg/repository/v1/payloadstore.go
@@ -281,8 +281,6 @@ func (p *payloadStoreRepositoryImpl) ProcessPayloadWAL(ctx context.Context, part
 		return false, nil
 	}
 
-	fmt.Println("WAL Poll Limit", int32(p.walPollLimit))
-
 	walRecords, err := p.queries.PollPayloadWALForRecordsToOffload(ctx, tx, sqlcv1.PollPayloadWALForRecordsToOffloadParams{
 		Polllimit:       int32(p.walPollLimit),
 		Partitionnumber: int32(partitionNumber),

--- a/pkg/repository/v1/payloadstore.go
+++ b/pkg/repository/v1/payloadstore.go
@@ -280,6 +280,8 @@ func (p *payloadStoreRepositoryImpl) ProcessPayloadWAL(ctx context.Context, part
 		return false, nil
 	}
 
+	fmt.Println("WAL Poll Limit", int32(p.walPollLimit))
+
 	walRecords, err := p.queries.PollPayloadWALForRecordsToOffload(ctx, tx, sqlcv1.PollPayloadWALForRecordsToOffloadParams{
 		Polllimit:       int32(p.walPollLimit),
 		Partitionnumber: int32(partitionNumber),

--- a/pkg/repository/v1/payloadstore.go
+++ b/pkg/repository/v1/payloadstore.go
@@ -54,6 +54,7 @@ type PayloadStoreRepository interface {
 	ProcessPayloadWAL(ctx context.Context, partitionNumber int64) (bool, error)
 	OverwriteExternalStore(store ExternalStore, inlineStoreTTL time.Duration)
 	DualWritesEnabled() bool
+	WALPollLimit() int
 }
 
 type payloadStoreRepositoryImpl struct {
@@ -436,6 +437,10 @@ func (p *payloadStoreRepositoryImpl) OverwriteExternalStore(store ExternalStore,
 
 func (p *payloadStoreRepositoryImpl) DualWritesEnabled() bool {
 	return p.enablePayloadDualWrites
+}
+
+func (p *payloadStoreRepositoryImpl) WALPollLimit() int {
+	return p.walPollLimit
 }
 
 type NoOpExternalStore struct{}

--- a/pkg/repository/v1/shared.go
+++ b/pkg/repository/v1/shared.go
@@ -39,14 +39,14 @@ type sharedRepository struct {
 	payloadStore              PayloadStoreRepository
 }
 
-func newSharedRepository(pool *pgxpool.Pool, v validator.Validator, l *zerolog.Logger, entitlements repository.EntitlementsRepository, enablePayloadDualWrites bool) (*sharedRepository, func() error) {
+func newSharedRepository(pool *pgxpool.Pool, v validator.Validator, l *zerolog.Logger, entitlements repository.EntitlementsRepository, enablePayloadDualWrites bool, payloadStoreWALPollLimit int) (*sharedRepository, func() error) {
 	m := metered.NewMetered(entitlements, l)
 
 	queries := sqlcv1.New()
 	queueCache := cache.New(5 * time.Minute)
 	stepExpressionCache := cache.New(5 * time.Minute)
 	tenantIdWorkflowNameCache := cache.New(5 * time.Minute)
-	payloadStore := NewPayloadStoreRepository(pool, l, queries, enablePayloadDualWrites)
+	payloadStore := NewPayloadStoreRepository(pool, l, queries, enablePayloadDualWrites, payloadStoreWALPollLimit)
 
 	celParser := cel.NewCELParser()
 


### PR DESCRIPTION
# Description

* Changes the default refetch interval to 10s
* Changes the names of a couple queries to make them easier to reason about
* Always-on refetching
* Configurable WAL poll limit (default 1000)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

