### PR TITLE
Fix: Scope override state issue

### DIFF
--- a/frontend/app/src/pages/main/v1/events/index.tsx
+++ b/frontend/app/src/pages/main/v1/events/index.tsx
@@ -157,7 +157,11 @@ export default function Events() {
 }
 
 export function ExpandedEventContent({ event }: { event: V1Event }) {
-  const { filters, workflowIdToName } = useFilters({ key: 'events-table' });
+  const hasScope = Boolean(event.scope && event.scope.length > 0);
+  const { filters, workflowIdToName } = useFilters({
+    key: 'events-table',
+    scopeOverrides: event.scope ? [event.scope] : undefined,
+  });
 
   return (
     <div className="w-full">
@@ -188,7 +192,7 @@ export function ExpandedEventContent({ event }: { event: V1Event }) {
             <EventDataSection event={event} />
           </div>
 
-          {filters && filters.length > 0 && (
+          {hasScope && filters && filters.length > 0 && (
             <div>
               <h3 className="text-sm font-semibold text-foreground mb-2">
                 Filters

--- a/frontend/app/src/pages/main/v1/filters/hooks/use-filters.tsx
+++ b/frontend/app/src/pages/main/v1/filters/hooks/use-filters.tsx
@@ -15,6 +15,7 @@ import { FilterOption } from '@/components/v1/molecules/data-table/data-table-to
 
 type UseFiltersProps = {
   key: string;
+  scopeOverrides?: string[];
 };
 
 type FilterQueryShape = {
@@ -54,7 +55,7 @@ const parseFilterParam = (searchParams: URLSearchParams, key: string) => {
   };
 };
 
-export const useFilters = ({ key }: UseFiltersProps) => {
+export const useFilters = ({ key, scopeOverrides }: UseFiltersProps) => {
   const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
   const { tenantId } = useCurrentTenantId();
@@ -73,10 +74,14 @@ export const useFilters = ({ key }: UseFiltersProps) => {
   }, [searchParams, paramKey]);
 
   const selectedScopes = useMemo(() => {
+    if (scopeOverrides && scopeOverrides.length > 0) {
+      return scopeOverrides;
+    }
+
     const { s } = parseFilterParam(searchParams, paramKey);
 
     return s;
-  }, [searchParams, paramKey]);
+  }, [searchParams, paramKey, scopeOverrides]);
 
   const columnFilters = useMemo<ColumnFiltersState>(() => {
     const { w, s } = parseFilterParam(searchParams, paramKey);


### PR DESCRIPTION
# Description

Fixing a state issue where scopes weren't properly being overridden on the event detail panel, so all filters were showing up

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

