### PR TITLE
fix: use separate connections for pub and sub

### DIFF
--- a/internal/msgqueue/v1/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/v1/rabbitmq/rabbitmq.go
@@ -366,7 +366,7 @@ func (t *MessageQueueImpl) Subscribe(
 
 func (t *MessageQueueImpl) RegisterTenant(ctx context.Context, tenantId string) error {
 	// create a new fanout exchange for the tenant
-	poolCh, err := t.subChannels.Acquire(ctx)
+	poolCh, err := t.pubChannels.Acquire(ctx)
 
 	if err != nil {
 		t.l.Error().Msgf("cannot acquire channel: %v", err)


### PR DESCRIPTION
# Description

It's recommended to use separate connections for rabbitmq for pub/sub - for example from [this resource](https://www.cloudamqp.com/blog/the-relationship-between-connections-and-channels-in-rabbitmq.html):

> Use at least one connection for publishing and one for consuming for each app/service/process. RabbitMQ can apply back pressure on the TCP connection when the publisher is sending too many messages for the server to handle. If you consume on the same TCP connection, the server might not receive the message acknowledgments from the client, thus affecting the consumer performance. With a lower consume speed, the server will be overwhelmed.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)