### PR TITLE
[Go SDK] Fix type of `WithWorkflows`

### DIFF
--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -9,7 +9,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	contracts "github.com/hatchet-dev/hatchet/internal/services/shared/proto/v1"
+	v1 "github.com/hatchet-dev/hatchet/internal/services/shared/proto/v1"
 	v0Client "github.com/hatchet-dev/hatchet/pkg/client"
 	"github.com/hatchet-dev/hatchet/pkg/worker"
 	"github.com/hatchet-dev/hatchet/sdks/go/features"
@@ -252,6 +252,11 @@ func (st *StandaloneTask) GetName() string {
 	return st.workflow.declaration.Name()
 }
 
+// Dump implements the WorkflowBase interface for internal use.
+func (st *StandaloneTask) Dump() (*v1.CreateWorkflowVersionRequest, []internal.NamedFunction, []internal.NamedFunction, internal.WrappedTaskFn) {
+	return st.workflow.declaration.Dump()
+}
+
 // StandaloneTaskOption represents options that can be applied to standalone tasks.
 // This interface allows both WorkflowOption and TaskOption to be used interchangeably.
 type StandaloneTaskOption any
@@ -378,9 +383,10 @@ func (st *StandaloneTask) RunMany(ctx context.Context, inputs []RunManyOpt) ([]W
 	return workflowRefs, nil
 }
 
-// Dump implements the WorkflowBase interface for internal use, delegating to the underlying workflow.
-func (st *StandaloneTask) Dump() (*contracts.CreateWorkflowVersionRequest, []internal.NamedFunction, []internal.NamedFunction, internal.WrappedTaskFn) {
-	return st.workflow.Dump()
+// OnFailure sets a failure handler for the standalone task.
+// The handler will be called when the standalone task fails.
+func (st *StandaloneTask) OnFailure(fn any) {
+	st.workflow.OnFailure(fn)
 }
 
 // WorkflowRunRef is a type that represents a reference to a workflow run.

--- a/sdks/go/examples/with-workflows/main.go
+++ b/sdks/go/examples/with-workflows/main.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"log"
+
+	"github.com/hatchet-dev/hatchet/pkg/cmdutils"
+	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
+)
+
+type Input struct {
+	Value int `json:"value"`
+}
+
+type StepOutput struct {
+	Step   int `json:"step"`
+	Result int `json:"result"`
+}
+
+func main() {
+	client, err := hatchet.NewClient()
+	if err != nil {
+		log.Fatalf("failed to create hatchet client: %v", err)
+	}
+
+	// Create a DAG workflow
+	workflow := client.NewWorkflow("dag-workflow")
+
+	// Step 1: Initial processing
+	step1 := workflow.NewTask("step-1", func(ctx hatchet.Context, input Input) (StepOutput, error) {
+		return StepOutput{
+			Step:   1,
+			Result: input.Value * 2,
+		}, nil
+	})
+
+	// Step 2: Depends on step 1
+	step2 := workflow.NewTask("step-2", func(ctx hatchet.Context, input Input) (StepOutput, error) {
+		// Get output from step 1
+		var step1Output StepOutput
+		if err := ctx.ParentOutput(step1, &step1Output); err != nil {
+			return StepOutput{}, err
+		}
+
+		return StepOutput{
+			Step:   2,
+			Result: step1Output.Result + 10,
+		}, nil
+	}, hatchet.WithParents(step1))
+
+	// Step 3: Also depends on step 1, parallel to step 2
+	step3 := workflow.NewTask("step-3", func(ctx hatchet.Context, input Input) (StepOutput, error) {
+		// Get output from step 1
+		var step1Output StepOutput
+		if err := ctx.ParentOutput(step1, &step1Output); err != nil {
+			return StepOutput{}, err
+		}
+
+		return StepOutput{
+			Step:   3,
+			Result: step1Output.Result * 3,
+		}, nil
+	}, hatchet.WithParents(step1))
+
+	// Final step: Combines outputs from step 2 and step 3
+	_ = workflow.NewTask("final-step", func(ctx hatchet.Context, input Input) (StepOutput, error) {
+		var step2Output, step3Output StepOutput
+
+		if err := ctx.ParentOutput(step2, &step2Output); err != nil {
+			return StepOutput{}, err
+		}
+		if err := ctx.ParentOutput(step3, &step3Output); err != nil {
+			return StepOutput{}, err
+		}
+
+		_ = client.Events().Push(ctx, "dag-workflow", map[string]any{})
+
+		return StepOutput{
+			Step:   4,
+			Result: step2Output.Result + step3Output.Result,
+		}, nil
+	}, hatchet.WithParents(step2, step3))
+
+	eventWorkflow := client.NewWorkflow(
+		"event-workflow",
+		hatchet.WithWorkflowEvents("dag-workflow"),
+	)
+
+	eventWorkflow.NewTask("log-event", func(ctx hatchet.Context, input any) (any, error) {
+		log.Printf("Received event: %v", input)
+		return nil, nil
+	})
+
+	workflowArr := []hatchet.WorkflowBase{workflow, eventWorkflow}
+
+	worker, err := client.NewWorker(
+		"dag-worker",
+		hatchet.WithWorkflows(
+			workflowArr...,
+		))
+	if err != nil {
+		log.Fatalf("failed to create worker: %v", err)
+	}
+
+	interruptCtx, cancel := cmdutils.NewInterruptContext()
+	defer cancel()
+
+	if err := worker.StartBlocking(interruptCtx); err != nil {
+		log.Printf("failed to start worker: %v", err)
+	}
+}

--- a/sdks/go/examples/with-workflows/main.go
+++ b/sdks/go/examples/with-workflows/main.go
@@ -1,3 +1,5 @@
+// Code contributed by @jnfrati as part of https://github.com/hatchet-dev/hatchet/issues/2356
+
 package main
 
 import (

--- a/sdks/go/worker.go
+++ b/sdks/go/worker.go
@@ -3,6 +3,7 @@ package hatchet
 import (
 	"github.com/rs/zerolog"
 
+	v1 "github.com/hatchet-dev/hatchet/internal/services/shared/proto/v1"
 	"github.com/hatchet-dev/hatchet/sdks/go/internal"
 )
 
@@ -10,7 +11,7 @@ import (
 type WorkerOption func(*workerConfig)
 
 type workerConfig struct {
-	workflows    []internal.WorkflowBase
+	workflows    []WorkflowBase
 	slots        int
 	durableSlots int
 	labels       map[string]any
@@ -18,9 +19,17 @@ type workerConfig struct {
 	panicHandler func(ctx Context, recovered any)
 }
 
+type WorkflowBase interface {
+	GetName() string
+	OnFailure(fn any)
+
+	// Internal use only. Will be removed in the future.
+	Dump() (*v1.CreateWorkflowVersionRequest, []internal.NamedFunction, []internal.NamedFunction, internal.WrappedTaskFn)
+}
+
 // WithWorkflows registers workflows and standalone tasks with the worker.
 // Both workflows and standalone tasks implement the WorkflowBase interface.
-func WithWorkflows(workflows ...internal.WorkflowBase) WorkerOption {
+func WithWorkflows(workflows ...WorkflowBase) WorkerOption {
 	return func(config *workerConfig) {
 		config.workflows = workflows
 	}

--- a/sdks/go/workflow.go
+++ b/sdks/go/workflow.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	contracts "github.com/hatchet-dev/hatchet/internal/services/shared/proto/v1"
+	v1 "github.com/hatchet-dev/hatchet/internal/services/shared/proto/v1"
 	v0Client "github.com/hatchet-dev/hatchet/pkg/client"
 	"github.com/hatchet-dev/hatchet/pkg/client/create"
 	"github.com/hatchet-dev/hatchet/pkg/client/types"
@@ -463,9 +463,14 @@ func (w *Workflow) NewDurableTask(name string, fn any, options ...TaskOption) *T
 	return w.NewTask(name, fn, durableOptions...)
 }
 
+// Dump implements the WorkflowBase interface for internal use.
+func (w *Workflow) Dump() (*v1.CreateWorkflowVersionRequest, []internal.NamedFunction, []internal.NamedFunction, internal.WrappedTaskFn) {
+	return w.declaration.Dump()
+}
+
 // OnFailure sets a failure handler for the workflow.
 // The handler will be called when any task in the workflow fails.
-func (w *Workflow) OnFailure(fn any) *Workflow {
+func (w *Workflow) OnFailure(fn any) {
 	fnValue := reflect.ValueOf(fn)
 	fnType := fnValue.Type()
 
@@ -525,13 +530,6 @@ func (w *Workflow) OnFailure(fn any) *Workflow {
 		create.WorkflowOnFailureTask[any, any]{},
 		wrapper,
 	)
-
-	return w
-}
-
-// Dump implements the WorkflowBase interface for internal use.
-func (w *Workflow) Dump() (*contracts.CreateWorkflowVersionRequest, []internal.NamedFunction, []internal.NamedFunction, internal.WrappedTaskFn) {
-	return w.declaration.Dump()
 }
 
 // Workflow execution methods


### PR DESCRIPTION
# Description

This PR adds an interface `WorkflowBase` which `Workflow` and `StandaloneTask` implement. `WithWorkflows()` now takes in this type.

Fixes https://github.com/hatchet-dev/hatchet/issues/2356

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
