### PR TITLE
[TS]: Fix durable task on failure registration, fix dependabot alert

### DIFF
--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -67,7 +67,7 @@
     "grpc-tools": "^1.13.0",
     "jest": "^29.7.0",
     "jest-tsd": "^0.2.2",
-    "pino": "^9.8.0",
+    "pino": "^9.12.0",
     "prettier": "^3.5.3",
     "resolve-tspaths": "^0.8.23",
     "ts-jest": "^29.3.1",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "description": "Background task orchestration & visibility for developers",
   "types": "dist/index.d.ts",
   "files": [

--- a/sdks/typescript/pnpm-lock.yaml
+++ b/sdks/typescript/pnpm-lock.yaml
@@ -118,8 +118,8 @@ importers:
         specifier: ^0.2.2
         version: 0.2.2(@tsd/typescript@5.9.2)
       pino:
-        specifier: ^9.8.0
-        version: 9.8.0
+        specifier: ^9.12.0
+        version: 9.12.0
       prettier:
         specifier: ^3.5.3
         version: 3.6.2
@@ -1515,10 +1515,6 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-redact@3.5.0:
-    resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
-    engines: {node: '>=6'}
-
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -2387,8 +2383,8 @@ packages:
   pino-std-serializers@7.0.0:
     resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
 
-  pino@9.8.0:
-    resolution: {integrity: sha512-L5+rV1wL7vGAcxXP7sPpN5lrJ07Piruka6ArXr7EWBXxdVWjJshGVX8suFsiusJVcGKDGUFfbgbnKdg+VAC+0g==}
+  pino@9.12.0:
+    resolution: {integrity: sha512-0Gd0OezGvqtqMwgYxpL7P0pSHHzTJ0Lx992h+mNlMtRVfNnqweWmf0JmRWk5gJzHalyd2mxTzKjhiNbGS2Ztfw==}
     hasBin: true
 
   pirates@4.0.7:
@@ -2613,6 +2609,9 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  slow-redact@0.3.0:
+    resolution: {integrity: sha512-cf723wn9JeRIYP9tdtd86GuqoR5937u64Io+CYjlm2i7jvu7g0H+Cp0l0ShAf/4ZL+ISUTVT+8Qzz7RZmp9FjA==}
 
   sonic-boom@4.2.0:
     resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
@@ -4686,8 +4685,6 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-redact@3.5.0: {}
-
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -5741,10 +5738,9 @@ snapshots:
 
   pino-std-serializers@7.0.0: {}
 
-  pino@9.8.0:
+  pino@9.12.0:
     dependencies:
       atomic-sleep: 1.0.0
-      fast-redact: 3.5.0
       on-exit-leak-free: 2.1.2
       pino-abstract-transport: 2.0.0
       pino-std-serializers: 7.0.0
@@ -5752,6 +5748,7 @@ snapshots:
       quick-format-unescaped: 4.0.4
       real-require: 0.2.0
       safe-stable-stringify: 2.5.0
+      slow-redact: 0.3.0
       sonic-boom: 4.2.0
       thread-stream: 3.1.0
 
@@ -5994,6 +5991,8 @@ snapshots:
   sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
+
+  slow-redact@0.3.0: {}
 
   sonic-boom@4.2.0:
     dependencies:

--- a/sdks/typescript/src/v1/client/worker/worker-internal.ts
+++ b/sdks/typescript/src/v1/client/worker/worker-internal.ts
@@ -212,7 +212,7 @@ export class V1Worker {
 
       let onFailureTask: CreateTaskOpts | undefined;
 
-      if (!durable && workflow.onFailure && typeof workflow.onFailure === 'function') {
+      if (workflow.onFailure && typeof workflow.onFailure === 'function') {
         onFailureTask = {
           readableId: 'on-failure-task',
           action: onFailureTaskName(workflow),
@@ -226,7 +226,7 @@ export class V1Worker {
         };
       }
 
-      if (!durable && workflow.onFailure && typeof workflow.onFailure === 'object') {
+      if (workflow.onFailure && typeof workflow.onFailure === 'object') {
         const onFailure = workflow.onFailure as CreateOnFailureTaskOpts<any, any>;
 
         onFailureTask = {


### PR DESCRIPTION
# Description

Fixes an issue where if there's a durable task, then an on-failure task fails to register because of an ordering condition

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

