### PR TITLE
Ignore tenants that have been (soft) deleted

### DIFF
--- a/pkg/repository/postgres/dbsqlc/tenants.sql
+++ b/pkg/repository/postgres/dbsqlc/tenants.sql
@@ -51,7 +51,9 @@ RETURNING *;
 SELECT
     *
 FROM
-    "Tenant" as tenants;
+    "Tenant" as tenants
+WHERE
+    "deletedAt" IS NULL;
 
 -- name: ControllerPartitionHeartbeat :one
 UPDATE
@@ -87,7 +89,8 @@ FROM
     "Tenant" as tenants
 WHERE
     "controllerPartitionId" = sqlc.arg('controllerPartitionId')::text
-    AND "version" = @majorVersion::"TenantMajorEngineVersion";
+    AND "version" = @majorVersion::"TenantMajorEngineVersion"
+    AND "deletedAt" IS NULL;
 
 -- name: ListTenantsByTenantWorkerPartitionId :many
 SELECT
@@ -96,7 +99,8 @@ FROM
     "Tenant" as tenants
 WHERE
     "workerPartitionId" = sqlc.arg('workerPartitionId')::text
-    AND "version" = @majorVersion::"TenantMajorEngineVersion";
+    AND "version" = @majorVersion::"TenantMajorEngineVersion"
+    AND "deletedAt" IS NULL;
 
 -- name: GetTenantByID :one
 SELECT
@@ -104,7 +108,8 @@ SELECT
 FROM
     "Tenant" as tenants
 WHERE
-    "id" = sqlc.arg('id')::uuid;
+    "id" = sqlc.arg('id')::uuid
+    AND "deletedAt" IS NULL;
 
 -- name: GetTenantBySlug :one
 SELECT
@@ -112,7 +117,8 @@ SELECT
 FROM
     "Tenant" as tenants
 WHERE
-    "slug" = sqlc.arg('slug')::text;
+    "slug" = sqlc.arg('slug')::text
+    AND "deletedAt" IS NULL;
 
 -- name: GetTenantAlertingSettings :one
 SELECT
@@ -489,7 +495,8 @@ FROM
     "Tenant" as tenants
 WHERE
     "schedulerPartitionId" = sqlc.arg('schedulerPartitionId')::text
-    AND "version" = @majorVersion::"TenantMajorEngineVersion";
+    AND "version" = @majorVersion::"TenantMajorEngineVersion"
+    AND "deletedAt" IS NULL;
 
 -- name: UpsertTenantAlertingSettings :one
 INSERT INTO "TenantAlertingSettings" (

--- a/pkg/repository/postgres/dbsqlc/tenants.sql.go
+++ b/pkg/repository/postgres/dbsqlc/tenants.sql.go
@@ -545,6 +545,7 @@ FROM
     "Tenant" as tenants
 WHERE
     "id" = $1::uuid
+    AND "deletedAt" IS NULL
 `
 
 func (q *Queries) GetTenantByID(ctx context.Context, db DBTX, id pgtype.UUID) (*Tenant, error) {
@@ -579,6 +580,7 @@ FROM
     "Tenant" as tenants
 WHERE
     "slug" = $1::text
+    AND "deletedAt" IS NULL
 `
 
 func (q *Queries) GetTenantBySlug(ctx context.Context, db DBTX, slug string) (*Tenant, error) {
@@ -902,6 +904,8 @@ SELECT
     id, "createdAt", "updatedAt", "deletedAt", version, "uiVersion", name, slug, "analyticsOptOut", "alertMemberEmails", "controllerPartitionId", "workerPartitionId", "dataRetentionPeriod", "schedulerPartitionId", "canUpgradeV1", "onboardingData", environment
 FROM
     "Tenant" as tenants
+WHERE
+    "deletedAt" IS NULL
 `
 
 func (q *Queries) ListTenants(ctx context.Context, db DBTX) ([]*Tenant, error) {
@@ -950,6 +954,7 @@ FROM
 WHERE
     "controllerPartitionId" = $1::text
     AND "version" = $2::"TenantMajorEngineVersion"
+    AND "deletedAt" IS NULL
 `
 
 type ListTenantsByControllerPartitionIdParams struct {
@@ -1003,6 +1008,7 @@ FROM
 WHERE
     "schedulerPartitionId" = $1::text
     AND "version" = $2::"TenantMajorEngineVersion"
+    AND "deletedAt" IS NULL
 `
 
 type ListTenantsBySchedulerPartitionIdParams struct {
@@ -1056,6 +1062,7 @@ FROM
 WHERE
     "workerPartitionId" = $1::text
     AND "version" = $2::"TenantMajorEngineVersion"
+    AND "deletedAt" IS NULL
 `
 
 type ListTenantsByTenantWorkerPartitionIdParams struct {


### PR DESCRIPTION
# Description

We should ignore fetching for `"Tenant"`s that have been (soft) deleted.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (changes which are not directly related to any business logic)
