### PR TITLE
Fix: Relax check constraint to allow null payloads

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20250930153446_v1_0_44.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20250930153446_v1_0_44.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE v1_payload DROP CONSTRAINT v1_payload_check;
+ALTER TABLE v1_payload ADD CONSTRAINT v1_payload_check CHECK (
+    (location = 'INLINE' AND external_location_key IS NULL)
+    OR
+    (location = 'EXTERNAL' AND inline_content IS NULL AND external_location_key IS NOT NULL)
+) NOT VALID;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE v1_payload DROP CONSTRAINT v1_payload_check;
+ALTER TABLE v1_payload ADD CONSTRAINT v1_payload_check CHECK (
+    (location = 'INLINE' AND inline_content IS NOT NULL AND external_location_key IS NULL)
+    OR
+    (location = 'EXTERNAL' AND inline_content IS NULL AND external_location_key IS NOT NULL)
+) NOT VALID;
+-- +goose StatementEnd

--- a/internal/services/dispatcher/dispatcher_v1.go
+++ b/internal/services/dispatcher/dispatcher_v1.go
@@ -257,7 +257,7 @@ func (d *DispatcherImpl) handleTaskBulkAssignedTask(ctx context.Context, msg *ms
 			if input == nil || !ok {
 				// If the input wasn't found in the payload store,
 				// fall back to the input stored on the task itself.
-				d.l.Error().Msgf("task %s has empty payload, falling back to input", task.ExternalID.String())
+				d.l.Error().Msgf("handleTaskBulkAssignedTask-1: task %s has empty payload, falling back to input", task.ExternalID.String())
 				input = task.Input
 			}
 
@@ -314,7 +314,7 @@ func (d *DispatcherImpl) handleTaskBulkAssignedTask(ctx context.Context, msg *ms
 			if input == nil || !ok {
 				// If the input wasn't found in the payload store,
 				// fall back to the input stored on the task itself.
-				d.l.Error().Msgf("task %s has empty payload, falling back to input", task.ExternalID.String())
+				d.l.Error().Msgf("handleTaskBulkAssignedTask-2: task %s has empty payload, falling back to input", task.ExternalID.String())
 				input = task.Input
 			}
 

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -1305,7 +1305,7 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId string
 		// fall back to input if payload is empty
 		// for backwards compatibility
 		if len(payload) == 0 {
-			r.l.Error().Msgf("task %s has empty payload, falling back to input", task.ExternalID.String())
+			r.l.Error().Msgf("writeTaskBatch: task %s has empty payload, falling back to input", task.ExternalID.String())
 			payload = task.Input
 		}
 

--- a/pkg/repository/v1/task.go
+++ b/pkg/repository/v1/task.go
@@ -2857,6 +2857,8 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId string, t
 		if input == nil {
 			// If the input wasn't found in the payload store,
 			// fall back to the input stored on the task itself.
+			r.l.Error().Msgf("ReplayTasks: task %s has empty payload, falling back to input", task.ExternalID.String())
+
 			input = task.Input
 		}
 

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -1644,7 +1644,7 @@ CREATE TABLE v1_payload (
 
     PRIMARY KEY (tenant_id, inserted_at, id, type),
     CHECK (
-        (location = 'INLINE' AND inline_content IS NOT NULL AND external_location_key IS NULL)
+        (location = 'INLINE' AND external_location_key IS NULL)
         OR
         (location = 'EXTERNAL' AND inline_content IS NULL AND external_location_key IS NOT NULL)
     )


### PR DESCRIPTION
# Description

Allow null inline payloads in some cases (mostly helpful for replay situations where a task is initially inserted as cancelled).

also tweaked the logs a bit to improve visibility

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
