### PR TITLE
Fix: Payload fallbacks, WAL conflict handling, WAL eviction

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20251001122435_v1_0_45.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20251001122435_v1_0_45.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE v1_payload_wal ALTER COLUMN operation SET DEFAULT 'CREATE';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE v1_payload_wal ALTER COLUMN operation DROP DEFAULT;
+-- +goose StatementEnd

--- a/internal/services/dispatcher/dispatcher_v1.go
+++ b/internal/services/dispatcher/dispatcher_v1.go
@@ -254,7 +254,7 @@ func (d *DispatcherImpl) handleTaskBulkAssignedTask(ctx context.Context, msg *ms
 				TenantId:   task.TenantID,
 			}]
 
-			if input == nil || !ok {
+			if !ok {
 				// If the input wasn't found in the payload store,
 				// fall back to the input stored on the task itself.
 				d.l.Error().Msgf("handleTaskBulkAssignedTask-1: task %s has empty payload, falling back to input", task.ExternalID.String())
@@ -311,7 +311,7 @@ func (d *DispatcherImpl) handleTaskBulkAssignedTask(ctx context.Context, msg *ms
 				TenantId:   task.TenantID,
 			}]
 
-			if input == nil || !ok {
+			if !ok {
 				// If the input wasn't found in the payload store,
 				// fall back to the input stored on the task itself.
 				d.l.Error().Msgf("handleTaskBulkAssignedTask-2: task %s has empty payload, falling back to input", task.ExternalID.String())

--- a/pkg/repository/v1/payloadstore.go
+++ b/pkg/repository/v1/payloadstore.go
@@ -422,7 +422,7 @@ func (p *payloadStoreRepositoryImpl) ProcessPayloadWAL(ctx context.Context, part
 			// this is okay - it can happen if e.g. a payload partition is dropped before the WAL is processed (not a great situation, but not catastrophic)
 			// if this happens, we log an error and set the key to `""` which will allow it to be evicted from the WAL. it'll never cause
 			// an update in the payloads table because there won't be a matching row
-			p.l.Error().Int64("id", opt.Id).Time("insertedAt", opt.InsertedAt.Time).Msgf("external location key not found for opts: %+v", opt)
+			p.l.Error().Int64("id", opt.Id).Time("insertedAt", opt.InsertedAt.Time).Msg("external location key not found for opts")
 			key = ""
 		}
 

--- a/pkg/repository/v1/payloadstore.go
+++ b/pkg/repository/v1/payloadstore.go
@@ -103,7 +103,6 @@ func (p *payloadStoreRepositoryImpl) Store(ctx context.Context, tx sqlcv1.DBTX, 
 	payloadTypes := make([]string, 0, len(payloads))
 	inlineContents := make([][]byte, 0, len(payloads))
 	offloadAts := make([]pgtype.Timestamptz, 0, len(payloads))
-	operations := make([]string, 0, len(payloads))
 	tenantIds := make([]pgtype.UUID, 0, len(payloads))
 	locations := make([]string, 0, len(payloads))
 
@@ -135,7 +134,6 @@ func (p *payloadStoreRepositoryImpl) Store(ctx context.Context, tx sqlcv1.DBTX, 
 		tenantIds = append(tenantIds, tenantId)
 		locations = append(locations, string(sqlcv1.V1PayloadLocationINLINE))
 		inlineContents = append(inlineContents, payload.Payload)
-		operations = append(operations, string(sqlcv1.V1PayloadWalOperationCREATE))
 
 		if p.externalStoreEnabled {
 			offloadAts = append(offloadAts, pgtype.Timestamptz{Time: payload.InsertedAt.Time.Add(*p.inlineStoreTTL), Valid: true})
@@ -165,7 +163,6 @@ func (p *payloadStoreRepositoryImpl) Store(ctx context.Context, tx sqlcv1.DBTX, 
 			Payloadinsertedats: taskInsertedAts,
 			Payloadtypes:       payloadTypes,
 			Offloadats:         offloadAts,
-			Operations:         operations,
 		})
 
 		if err != nil {

--- a/pkg/repository/v1/payloadstore.go
+++ b/pkg/repository/v1/payloadstore.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hatchet-dev/hatchet/internal/telemetry"
 	"github.com/hatchet-dev/hatchet/pkg/repository/postgres/sqlchelpers"
 	"github.com/hatchet-dev/hatchet/pkg/repository/v1/sqlcv1"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog"
@@ -185,7 +186,7 @@ func (p *payloadStoreRepositoryImpl) Retrieve(ctx context.Context, opts Retrieve
 	payload, ok := payloadMap[opts]
 
 	if !ok {
-		return nil, nil
+		return nil, pgx.ErrNoRows
 	}
 
 	return payload, nil

--- a/pkg/repository/v1/sqlcv1/payload-store.sql
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql
@@ -72,7 +72,6 @@ WITH inputs AS (
         UNNEST(@payloadInsertedAts::TIMESTAMPTZ[]) AS payload_inserted_at,
         UNNEST(CAST(@payloadTypes::TEXT[] AS v1_payload_type[])) AS payload_type,
         UNNEST(@offloadAts::TIMESTAMPTZ[]) AS offload_at,
-        UNNEST(CAST(@operations::TEXT[] AS v1_payload_wal_operation[])) AS operation,
         UNNEST(@tenantIds::UUID[]) AS tenant_id
 )
 
@@ -81,20 +80,17 @@ INSERT INTO v1_payload_wal (
     offload_at,
     payload_id,
     payload_inserted_at,
-    payload_type,
-    operation
+    payload_type
 )
 SELECT
     i.tenant_id,
     i.offload_at,
     i.payload_id,
     i.payload_inserted_at,
-    i.payload_type,
-    i.operation
+    i.payload_type
 FROM
     inputs i
-ON CONFLICT (offload_at, tenant_id, payload_id, payload_inserted_at, payload_type) DO UPDATE
-SET operation = EXCLUDED.operation
+ON CONFLICT DO NOTHING
 ;
 
 -- name: PollPayloadWALForRecordsToOffload :many

--- a/pkg/repository/v1/task.go
+++ b/pkg/repository/v1/task.go
@@ -2854,7 +2854,7 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId string, t
 			return nil, fmt.Errorf("failed to retrieve task input: %w", err)
 		}
 
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			// If the input wasn't found in the payload store,
 			// fall back to the input stored on the task itself.
 			r.l.Error().Msgf("ReplayTasks: task %s has empty payload, falling back to input", task.ExternalID.String())

--- a/pkg/repository/v1/task.go
+++ b/pkg/repository/v1/task.go
@@ -2850,11 +2850,11 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId string, t
 			TenantId:   sqlchelpers.UUIDFromStr(tenantId),
 		})
 
-		if err != nil {
+		if err != nil && err != pgx.ErrNoRows {
 			return nil, fmt.Errorf("failed to retrieve task input: %w", err)
 		}
 
-		if input == nil {
+		if err == pgx.ErrNoRows {
 			// If the input wasn't found in the payload store,
 			// fall back to the input stored on the task itself.
 			r.l.Error().Msgf("ReplayTasks: task %s has empty payload, falling back to input", task.ExternalID.String())

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -1658,7 +1658,7 @@ CREATE TABLE v1_payload_wal (
     payload_id BIGINT NOT NULL,
     payload_inserted_at TIMESTAMPTZ NOT NULL,
     payload_type v1_payload_type NOT NULL,
-    operation v1_payload_wal_operation NOT NULL,
+    operation v1_payload_wal_operation NOT NULL DEFAULT 'CREATE',
 
     PRIMARY KEY (offload_at, tenant_id, payload_id, payload_inserted_at, payload_type),
     CONSTRAINT "v1_payload_wal_payload" FOREIGN KEY (payload_id, payload_inserted_at, payload_type, tenant_id) REFERENCES v1_payload (id, inserted_at, type, tenant_id) ON DELETE CASCADE


### PR DESCRIPTION
# Description

A few things here:

1. Improving the error logging on the fallback case to have fewer false positives
2. Adding a default for the `operation` (with the intention of later dropping it) and removing the `ON CONFLICT ... DO UPDATE` in favor of `ON CONFLICT DO NOTHING` in the WAL to handle errors more gracefully
3. Handling an edge case in the offloads where a payload was dropped before the WAL was processed, making it basically get stuck in the WAL. Now, we'll evict that row even if we can't find a payload for it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

