### PR TITLE
Use UTC for all columns with type `TIMESTAMP(3)`

### DIFF
--- a/pkg/repository/postgres/dbsqlc/events.sql
+++ b/pkg/repository/postgres/dbsqlc/events.sql
@@ -224,7 +224,7 @@ FROM
     "Event"
 WHERE
     events."deletedAt" IS NOT NULL AND
-    "createdAt" >= NOW() - INTERVAL '1 week'
+    "createdAt" >= NOW() AT TIME ZONE 'UTC' - INTERVAL '1 week'
 GROUP BY
     event_hour
 ORDER BY

--- a/pkg/repository/postgres/dbsqlc/events.sql.go
+++ b/pkg/repository/postgres/dbsqlc/events.sql.go
@@ -269,7 +269,7 @@ FROM
     "Event"
 WHERE
     events."deletedAt" IS NOT NULL AND
-    "createdAt" >= NOW() - INTERVAL '1 week'
+    "createdAt" >= NOW() AT TIME ZONE 'UTC' - INTERVAL '1 week'
 GROUP BY
     event_hour
 ORDER BY

--- a/pkg/repository/postgres/dbsqlc/get_group_key_runs.sql
+++ b/pkg/repository/postgres/dbsqlc/get_group_key_runs.sql
@@ -56,7 +56,7 @@ WITH valid_workers AS (
         "Worker" w
     WHERE
         w."tenantId" = @tenantId::uuid
-        AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+        AND w."lastHeartbeatAt" > NOW() AT TIME ZONE 'UTC' - INTERVAL '5 seconds'
         AND w."isActive" = true
         AND w."isPaused" = false
     GROUP BY
@@ -85,7 +85,7 @@ group_key_runs AS (
         ggr."tenantId" = @tenantId::uuid
         AND ggr."deletedAt" IS NULL
         AND ggr."status" = ANY(ARRAY['RUNNING', 'ASSIGNED']::"StepRunStatus"[])
-        AND w."lastHeartbeatAt" < NOW() - INTERVAL '30 seconds'
+        AND w."lastHeartbeatAt" < NOW() AT TIME ZONE 'UTC' - INTERVAL '30 seconds'
     ORDER BY
         ggr."createdAt" ASC
     LIMIT
@@ -120,7 +120,7 @@ WITH valid_workers AS (
         "Worker" w
     WHERE
         w."tenantId" = @tenantId::uuid
-        AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+        AND w."lastHeartbeatAt" > NOW() AT TIME ZONE 'UTC' - INTERVAL '5 seconds'
         AND w."isActive" = true
     GROUP BY
         w."id"
@@ -196,7 +196,7 @@ WITH get_group_key_run AS (
         "Worker" w, get_group_key_run
     WHERE
         w."tenantId" = @tenantId::uuid
-        AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+        AND w."lastHeartbeatAt" > NOW() AT TIME ZONE 'UTC' - INTERVAL '5 seconds'
         AND w."id" IN (
             SELECT "_ActionToWorker"."B"
             FROM "_ActionToWorker"
@@ -233,7 +233,7 @@ WITH selected_ticker AS (
     FROM
         "Ticker" t
     WHERE
-        t."lastHeartbeatAt" > NOW() - INTERVAL '6 seconds'
+        t."lastHeartbeatAt" > NOW() AT TIME ZONE 'UTC' - INTERVAL '6 seconds'
         AND t."isActive" = true
     ORDER BY random()
     LIMIT 1

--- a/pkg/repository/postgres/dbsqlc/get_group_key_runs.sql.go
+++ b/pkg/repository/postgres/dbsqlc/get_group_key_runs.sql.go
@@ -18,7 +18,7 @@ WITH selected_ticker AS (
     FROM
         "Ticker" t
     WHERE
-        t."lastHeartbeatAt" > NOW() - INTERVAL '6 seconds'
+        t."lastHeartbeatAt" > NOW() AT TIME ZONE 'UTC' - INTERVAL '6 seconds'
         AND t."isActive" = true
     ORDER BY random()
     LIMIT 1
@@ -84,7 +84,7 @@ WITH get_group_key_run AS (
         "Worker" w, get_group_key_run
     WHERE
         w."tenantId" = $2::uuid
-        AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+        AND w."lastHeartbeatAt" > NOW() AT TIME ZONE 'UTC' - INTERVAL '5 seconds'
         AND w."id" IN (
             SELECT "_ActionToWorker"."B"
             FROM "_ActionToWorker"
@@ -227,7 +227,7 @@ WITH valid_workers AS (
         "Worker" w
     WHERE
         w."tenantId" = $1::uuid
-        AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+        AND w."lastHeartbeatAt" > NOW() AT TIME ZONE 'UTC' - INTERVAL '5 seconds'
         AND w."isActive" = true
         AND w."isPaused" = false
     GROUP BY
@@ -256,7 +256,7 @@ group_key_runs AS (
         ggr."tenantId" = $1::uuid
         AND ggr."deletedAt" IS NULL
         AND ggr."status" = ANY(ARRAY['RUNNING', 'ASSIGNED']::"StepRunStatus"[])
-        AND w."lastHeartbeatAt" < NOW() - INTERVAL '30 seconds'
+        AND w."lastHeartbeatAt" < NOW() AT TIME ZONE 'UTC' - INTERVAL '30 seconds'
     ORDER BY
         ggr."createdAt" ASC
     LIMIT
@@ -332,7 +332,7 @@ WITH valid_workers AS (
         "Worker" w
     WHERE
         w."tenantId" = $1::uuid
-        AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+        AND w."lastHeartbeatAt" > NOW() AT TIME ZONE 'UTC' - INTERVAL '5 seconds'
         AND w."isActive" = true
     GROUP BY
         w."id"

--- a/pkg/repository/postgres/dbsqlc/mq.sql
+++ b/pkg/repository/postgres/dbsqlc/mq.sql
@@ -25,7 +25,7 @@ RETURNING *;
 UPDATE
     "MessageQueue"
 SET
-    "lastActive" = NOW()
+    "lastActive" = NOW() AT TIME ZONE 'UTC'
 WHERE
     "name" = @name::text;
 
@@ -33,7 +33,7 @@ WHERE
 DELETE FROM
     "MessageQueue"
 WHERE
-    "lastActive" < NOW() - INTERVAL '1 hour'
+    "lastActive" < NOW() AT TIME ZONE 'UTC' - INTERVAL '1 hour'
     AND "autoDeleted" = true;
 
 -- name: AddMessage :exec
@@ -48,8 +48,8 @@ VALUES
     (
         @payload::jsonb,
         @queueId::text,
-        NOW(),
-        NOW() + INTERVAL '5 minutes'
+        NOW() AT TIME ZONE 'UTC',
+        NOW() AT TIME ZONE 'UTC' + INTERVAL '5 minutes'
     );
 
 -- name: BulkAddMessage :copyfrom
@@ -74,9 +74,9 @@ WITH messages AS (
     FROM
         "MessageQueueItem"
     WHERE
-        "expiresAt" > NOW()
+        "expiresAt" > NOW() AT TIME ZONE 'UTC'
         AND "queueId" = @queueId::text
-        AND "readAfter" <= NOW()
+        AND "readAfter" <= NOW() AT TIME ZONE 'UTC'
         AND "status" = 'PENDING'
     ORDER BY
         "id" ASC
@@ -105,7 +105,7 @@ WHERE
 DELETE FROM
     "MessageQueueItem"
 WHERE
-    "expiresAt" < NOW();
+    "expiresAt" < NOW() AT TIME ZONE 'UTC';
 
 -- name: GetMinMaxExpiredMessageQueueItems :one
 SELECT
@@ -114,7 +114,7 @@ SELECT
 FROM
     "MessageQueueItem"
 WHERE
-    "expiresAt" < NOW();
+    "expiresAt" < NOW() AT TIME ZONE 'UTC';
 
 -- name: CleanupMessageQueueItems :exec
 DELETE FROM "MessageQueueItem"

--- a/pkg/repository/postgres/dbsqlc/mq.sql.go
+++ b/pkg/repository/postgres/dbsqlc/mq.sql.go
@@ -23,8 +23,8 @@ VALUES
     (
         $1::jsonb,
         $2::text,
-        NOW(),
-        NOW() + INTERVAL '5 minutes'
+        NOW() AT TIME ZONE 'UTC',
+        NOW() AT TIME ZONE 'UTC' + INTERVAL '5 minutes'
     )
 `
 
@@ -62,7 +62,7 @@ const cleanupMessageQueue = `-- name: CleanupMessageQueue :exec
 DELETE FROM
     "MessageQueue"
 WHERE
-    "lastActive" < NOW() - INTERVAL '1 hour'
+    "lastActive" < NOW() AT TIME ZONE 'UTC' - INTERVAL '1 hour'
     AND "autoDeleted" = true
 `
 
@@ -93,7 +93,7 @@ const deleteExpiredMessages = `-- name: DeleteExpiredMessages :exec
 DELETE FROM
     "MessageQueueItem"
 WHERE
-    "expiresAt" < NOW()
+    "expiresAt" < NOW() AT TIME ZONE 'UTC'
 `
 
 func (q *Queries) DeleteExpiredMessages(ctx context.Context, db DBTX) error {
@@ -108,7 +108,7 @@ SELECT
 FROM
     "MessageQueueItem"
 WHERE
-    "expiresAt" < NOW()
+    "expiresAt" < NOW() AT TIME ZONE 'UTC'
 `
 
 type GetMinMaxExpiredMessageQueueItemsRow struct {
@@ -130,9 +130,9 @@ WITH messages AS (
     FROM
         "MessageQueueItem"
     WHERE
-        "expiresAt" > NOW()
+        "expiresAt" > NOW() AT TIME ZONE 'UTC'
         AND "queueId" = $1::text
-        AND "readAfter" <= NOW()
+        AND "readAfter" <= NOW() AT TIME ZONE 'UTC'
         AND "status" = 'PENDING'
     ORDER BY
         "id" ASC
@@ -196,7 +196,7 @@ const updateMessageQueueActive = `-- name: UpdateMessageQueueActive :exec
 UPDATE
     "MessageQueue"
 SET
-    "lastActive" = NOW()
+    "lastActive" = NOW() AT TIME ZONE 'UTC'
 WHERE
     "name" = $1::text
 `

--- a/pkg/repository/postgres/dbsqlc/queue.sql
+++ b/pkg/repository/postgres/dbsqlc/queue.sql
@@ -55,7 +55,7 @@ FROM
     "Queue"
 WHERE
     "tenantId" = @tenantId::uuid
-    AND "lastActive" > NOW() - INTERVAL '1 day';
+    AND "lastActive" > NOW() AT TIME ZONE 'UTC' - INTERVAL '1 day';
 
 -- name: CreateQueueItem :exec
 INSERT INTO
@@ -519,7 +519,7 @@ WHERE
     w."tenantId" = @tenantId::uuid
     AND w."id" = ANY(@workerIds::uuid[])
     AND w."dispatcherId" IS NOT NULL
-    AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+    AND w."lastHeartbeatAt" > NOW() AT TIME ZONE 'UTC' - INTERVAL '5 seconds'
     AND w."isActive" = true
     AND w."isPaused" = false;
 
@@ -536,7 +536,7 @@ JOIN
 WHERE
     w."tenantId" = @tenantId::uuid
     AND w."dispatcherId" IS NOT NULL
-    AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+    AND w."lastHeartbeatAt" > NOW() AT TIME ZONE 'UTC' - INTERVAL '5 seconds'
     AND w."isActive" = true
     AND w."isPaused" = false;
 
@@ -549,7 +549,7 @@ FROM
 WHERE
     w."tenantId" = @tenantId::uuid
     AND w."dispatcherId" IS NOT NULL
-    AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+    AND w."lastHeartbeatAt" > NOW() AT TIME ZONE 'UTC' - INTERVAL '5 seconds'
     AND w."isActive" = true
     AND w."isPaused" = false;
 

--- a/pkg/repository/postgres/dbsqlc/queue.sql.go
+++ b/pkg/repository/postgres/dbsqlc/queue.sql.go
@@ -544,7 +544,7 @@ JOIN
 WHERE
     w."tenantId" = $1::uuid
     AND w."dispatcherId" IS NOT NULL
-    AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+    AND w."lastHeartbeatAt" > NOW() AT TIME ZONE 'UTC' - INTERVAL '5 seconds'
     AND w."isActive" = true
     AND w."isPaused" = false
 `
@@ -588,7 +588,7 @@ WHERE
     w."tenantId" = $1::uuid
     AND w."id" = ANY($2::uuid[])
     AND w."dispatcherId" IS NOT NULL
-    AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+    AND w."lastHeartbeatAt" > NOW() AT TIME ZONE 'UTC' - INTERVAL '5 seconds'
     AND w."isActive" = true
     AND w."isPaused" = false
 `
@@ -632,7 +632,7 @@ FROM
 WHERE
     w."tenantId" = $1::uuid
     AND w."dispatcherId" IS NOT NULL
-    AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+    AND w."lastHeartbeatAt" > NOW() AT TIME ZONE 'UTC' - INTERVAL '5 seconds'
     AND w."isActive" = true
     AND w."isPaused" = false
 `
@@ -961,7 +961,7 @@ FROM
     "Queue"
 WHERE
     "tenantId" = $1::uuid
-    AND "lastActive" > NOW() - INTERVAL '1 day'
+    AND "lastActive" > NOW() AT TIME ZONE 'UTC' - INTERVAL '1 day'
 `
 
 func (q *Queries) ListQueues(ctx context.Context, db DBTX, tenantid pgtype.UUID) ([]*Queue, error) {

--- a/pkg/repository/postgres/dbsqlc/step_runs.sql
+++ b/pkg/repository/postgres/dbsqlc/step_runs.sql
@@ -708,7 +708,7 @@ WITH step_runs_on_inactive_workers AS (
         "Step" s ON sr."stepId" = s."id"
     WHERE
         w."tenantId" = @tenantId::uuid
-        AND w."lastHeartbeatAt" < NOW() - INTERVAL '30 seconds'),
+        AND w."lastHeartbeatAt" < NOW() AT TIME ZONE 'UTC' - INTERVAL '30 seconds'),
 step_runs_to_reassign AS (
     SELECT
         *
@@ -1003,7 +1003,7 @@ WHERE
     AND "dispatcherId" IS NOT NULL
     AND "isActive" = true
     AND "isPaused" = false
-    AND "lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+    AND "lastHeartbeatAt" > NOW() AT TIME ZONE 'UTC' - INTERVAL '5 seconds'
     AND "id" = @workerId::uuid;
 
 -- name: GetWorkerDispatcherActions :many
@@ -1647,7 +1647,7 @@ WHERE
     w."tenantId" = @tenantId::uuid
     AND a."actionId" = @actionId::text
     AND w."isActive" = true
-    AND w."lastHeartbeatAt" > NOW() - INTERVAL '6 seconds';
+    AND w."lastHeartbeatAt" > NOW() AT TIME ZONE 'UTC' - INTERVAL '6 seconds';
 
 -- name: ListChildWorkflowRunIds :many
 SELECT

--- a/pkg/repository/postgres/dbsqlc/step_runs.sql.go
+++ b/pkg/repository/postgres/dbsqlc/step_runs.sql.go
@@ -420,7 +420,7 @@ WHERE
     AND "dispatcherId" IS NOT NULL
     AND "isActive" = true
     AND "isPaused" = false
-    AND "lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+    AND "lastHeartbeatAt" > NOW() AT TIME ZONE 'UTC' - INTERVAL '5 seconds'
     AND "id" = $2::uuid
 `
 
@@ -1532,7 +1532,7 @@ WHERE
     w."tenantId" = $1::uuid
     AND a."actionId" = $2::text
     AND w."isActive" = true
-    AND w."lastHeartbeatAt" > NOW() - INTERVAL '6 seconds'
+    AND w."lastHeartbeatAt" > NOW() AT TIME ZONE 'UTC' - INTERVAL '6 seconds'
 `
 
 type HasActiveWorkersForActionIdParams struct {
@@ -2288,7 +2288,7 @@ WITH step_runs_on_inactive_workers AS (
         "Step" s ON sr."stepId" = s."id"
     WHERE
         w."tenantId" = $1::uuid
-        AND w."lastHeartbeatAt" < NOW() - INTERVAL '30 seconds'),
+        AND w."lastHeartbeatAt" < NOW() AT TIME ZONE 'UTC' - INTERVAL '30 seconds'),
 step_runs_to_reassign AS (
     SELECT
         id, "tenantId", "scheduleTimeoutAt", "retryCount", "internalRetryCount", "workerId", "actionId", "stepId", "stepTimeout", "scheduleTimeout"

--- a/pkg/repository/postgres/dbsqlc/stream_event.sql
+++ b/pkg/repository/postgres/dbsqlc/stream_event.sql
@@ -38,4 +38,4 @@ WHERE
 DELETE FROM "StreamEvent"
 WHERE
   -- older than than 5 minutes ago
-  "createdAt" < NOW() - INTERVAL '5 minutes';
+  "createdAt" < NOW() AT TIME ZONE 'UTC' - INTERVAL '5 minutes';

--- a/pkg/repository/postgres/dbsqlc/stream_event.sql.go
+++ b/pkg/repository/postgres/dbsqlc/stream_event.sql.go
@@ -15,7 +15,7 @@ const cleanupStreamEvents = `-- name: CleanupStreamEvents :exec
 DELETE FROM "StreamEvent"
 WHERE
   -- older than than 5 minutes ago
-  "createdAt" < NOW() - INTERVAL '5 minutes'
+  "createdAt" < NOW() AT TIME ZONE 'UTC' - INTERVAL '5 minutes'
 `
 
 func (q *Queries) CleanupStreamEvents(ctx context.Context, db DBTX) error {

--- a/pkg/repository/postgres/dbsqlc/tenant_limits.sql
+++ b/pkg/repository/postgres/dbsqlc/tenant_limits.sql
@@ -9,7 +9,7 @@ WITH resolved_limits AS (
         "value" = 0, -- Reset value to 0
         "lastRefill" = CURRENT_TIMESTAMP -- Update lastRefill timestamp
     WHERE
-        ("window" IS NOT NULL AND "window" != '' AND NOW() - "lastRefill" >= "window"::INTERVAL)
+        ("window" IS NOT NULL AND "window" != '' AND NOW() AT TIME ZONE 'UTC' - "lastRefill" >= "window"::INTERVAL)
     RETURNING *
 )
 SELECT *
@@ -22,7 +22,7 @@ WITH updated AS (
         "value" = 0, -- Reset to 0 if the window has passed
         "lastRefill" = CURRENT_TIMESTAMP -- Update lastRefill if the window has passed
     WHERE "tenantId" = @tenantId::uuid
-      AND (("window" IS NOT NULL AND "window" != '' AND NOW() - "lastRefill" >= "window"::INTERVAL))
+      AND (("window" IS NOT NULL AND "window" != '' AND NOW() AT TIME ZONE 'UTC' - "lastRefill" >= "window"::INTERVAL))
       AND "resource" = sqlc.narg('resource')::"LimitResource"
       AND "customValueMeter" = false
     RETURNING *
@@ -74,13 +74,13 @@ RETURNING *;
 UPDATE "TenantResourceLimit"
 SET
     "value" = CASE
-        WHEN ("customValueMeter" = true OR ("window" IS NOT NULL AND "window" != '' AND NOW() - "lastRefill" >= "window"::INTERVAL)) THEN
+        WHEN ("customValueMeter" = true OR ("window" IS NOT NULL AND "window" != '' AND NOW() AT TIME ZONE 'UTC' - "lastRefill" >= "window"::INTERVAL)) THEN
             0 -- Refill to 0 since the window has passed
         ELSE
             "value" + @numResources::int -- Increment the current value within the window by the number of resources
     END,
     "lastRefill" = CASE
-        WHEN ("window" IS NOT NULL AND "window" != '' AND NOW() - "lastRefill" >= "window"::INTERVAL) THEN
+        WHEN ("window" IS NOT NULL AND "window" != '' AND NOW() AT TIME ZONE 'UTC' - "lastRefill" >= "window"::INTERVAL) THEN
             CURRENT_TIMESTAMP -- Update lastRefill if the window has passed
         ELSE
             "lastRefill" -- Keep the lastRefill unchanged if within the window
@@ -93,12 +93,12 @@ RETURNING *;
 SELECT COUNT(distinct id) AS "count"
 FROM "Worker"
 WHERE "tenantId" = @tenantId::uuid
-AND "lastHeartbeatAt" >= NOW() - '30 seconds'::INTERVAL
+AND "lastHeartbeatAt" >= NOW() AT TIME ZONE 'UTC' - '30 seconds'::INTERVAL
 AND "isActive" = true;
 
 -- name: CountTenantWorkerSlots :one
 SELECT COALESCE(SUM(w."maxRuns"), 0)::int AS "count"
 FROM "Worker" w
 WHERE "tenantId" = @tenantId::uuid
-AND "lastHeartbeatAt" >= NOW() - '30 seconds'::INTERVAL
+AND "lastHeartbeatAt" >= NOW() AT TIME ZONE 'UTC' - '30 seconds'::INTERVAL
 AND "isActive" = true;

--- a/pkg/repository/postgres/dbsqlc/tenants.sql
+++ b/pkg/repository/postgres/dbsqlc/tenants.sql
@@ -5,7 +5,7 @@ WITH active_controller_partitions AS (
     FROM
         "ControllerPartition"
     WHERE
-        "lastHeartbeat" > NOW() - INTERVAL '1 minute'
+        "lastHeartbeat" > NOW() AT TIME ZONE 'UTC' - INTERVAL '1 minute'
 )
 INSERT INTO "Tenant" ("id", "name", "slug", "controllerPartitionId", "dataRetentionPeriod", "version", "uiVersion", "onboardingData", "environment")
 VALUES (
@@ -59,7 +59,7 @@ WHERE
 UPDATE
     "ControllerPartition" p
 SET
-    "lastHeartbeat" = NOW()
+    "lastHeartbeat" = NOW() AT TIME ZONE 'UTC'
 WHERE
     p."id" = sqlc.arg('controllerPartitionId')::text
 RETURNING *;
@@ -68,7 +68,7 @@ RETURNING *;
 UPDATE
     "TenantWorkerPartition" p
 SET
-    "lastHeartbeat" = NOW()
+    "lastHeartbeat" = NOW() AT TIME ZONE 'UTC'
 WHERE
     p."id" = sqlc.arg('workerPartitionId')::text
 RETURNING *;
@@ -239,7 +239,7 @@ GROUP BY
 
 -- name: CreateControllerPartition :one
 INSERT INTO "ControllerPartition" ("id", "createdAt", "lastHeartbeat", "name")
-VALUES (gen_random_uuid()::text, NOW(), NOW(), sqlc.narg('name')::text)
+VALUES (gen_random_uuid()::text, NOW() AT TIME ZONE 'UTC', NOW() AT TIME ZONE 'UTC', sqlc.narg('name')::text)
 ON CONFLICT DO NOTHING
 RETURNING *;
 
@@ -256,7 +256,7 @@ WITH active_partitions AS (
     FROM
         "ControllerPartition"
     WHERE
-        "lastHeartbeat" > NOW() - INTERVAL '1 minute'
+        "lastHeartbeat" > NOW() AT TIME ZONE 'UTC' - INTERVAL '1 minute'
 ),
 tenants_to_update AS (
     SELECT
@@ -285,14 +285,14 @@ WITH active_partitions AS (
     FROM
         "ControllerPartition"
     WHERE
-        "lastHeartbeat" > NOW() - INTERVAL '1 minute'
+        "lastHeartbeat" > NOW() AT TIME ZONE 'UTC' - INTERVAL '1 minute'
 ), inactive_partitions AS (
     SELECT
         "id"
     FROM
         "ControllerPartition"
     WHERE
-        "lastHeartbeat" <= NOW() - INTERVAL '1 minute'
+        "lastHeartbeat" <= NOW() AT TIME ZONE 'UTC' - INTERVAL '1 minute'
 ), tenants_to_update AS (
     SELECT
         tenants."id" AS "id",
@@ -317,7 +317,7 @@ WHERE "id" IN (SELECT "id" FROM inactive_partitions);
 
 -- name: CreateTenantWorkerPartition :one
 INSERT INTO "TenantWorkerPartition" ("id", "createdAt", "lastHeartbeat", "name")
-VALUES (gen_random_uuid()::text, NOW(), NOW(), sqlc.narg('name')::text)
+VALUES (gen_random_uuid()::text, NOW() AT TIME ZONE 'UTC', NOW() AT TIME ZONE 'UTC', sqlc.narg('name')::text)
 ON CONFLICT DO NOTHING
 RETURNING *;
 
@@ -334,7 +334,7 @@ WITH active_partitions AS (
     FROM
         "TenantWorkerPartition"
     WHERE
-        "lastHeartbeat" > NOW() - INTERVAL '1 minute'
+        "lastHeartbeat" > NOW() AT TIME ZONE 'UTC' - INTERVAL '1 minute'
 ),
 tenants_to_update AS (
     SELECT
@@ -364,14 +364,14 @@ WITH active_partitions AS (
     FROM
         "TenantWorkerPartition"
     WHERE
-        "lastHeartbeat" > NOW() - INTERVAL '1 minute'
+        "lastHeartbeat" > NOW() AT TIME ZONE 'UTC' - INTERVAL '1 minute'
 ), inactive_partitions AS (
     SELECT
         "id"
     FROM
         "TenantWorkerPartition"
     WHERE
-        "lastHeartbeat" <= NOW() - INTERVAL '1 minute'
+        "lastHeartbeat" <= NOW() AT TIME ZONE 'UTC' - INTERVAL '1 minute'
 ), tenants_to_update AS (
     SELECT
         tenants."id" AS "id",
@@ -401,14 +401,14 @@ WHERE "id" IN (SELECT "id" FROM inactive_partitions);
 UPDATE
     "SchedulerPartition" p
 SET
-    "lastHeartbeat" = NOW()
+    "lastHeartbeat" = NOW() AT TIME ZONE 'UTC'
 WHERE
     p."id" = sqlc.arg('schedulerPartitionId')::text
 RETURNING *;
 
 -- name: CreateSchedulerPartition :one
 INSERT INTO "SchedulerPartition" ("id", "createdAt", "lastHeartbeat", "name")
-VALUES (gen_random_uuid()::text, NOW(), NOW(), sqlc.narg('name')::text)
+VALUES (gen_random_uuid()::text, NOW() AT TIME ZONE 'UTC', NOW() AT TIME ZONE 'UTC', sqlc.narg('name')::text)
 ON CONFLICT DO NOTHING
 RETURNING *;
 
@@ -425,7 +425,7 @@ WITH active_partitions AS (
     FROM
         "SchedulerPartition"
     WHERE
-        "lastHeartbeat" > NOW() - INTERVAL '1 minute'
+        "lastHeartbeat" > NOW() AT TIME ZONE 'UTC' - INTERVAL '1 minute'
 ),
 tenants_to_update AS (
     SELECT
@@ -455,14 +455,14 @@ WITH active_partitions AS (
     FROM
         "SchedulerPartition"
     WHERE
-        "lastHeartbeat" > NOW() - INTERVAL '1 minute'
+        "lastHeartbeat" > NOW() AT TIME ZONE 'UTC' - INTERVAL '1 minute'
 ), inactive_partitions AS (
     SELECT
         "id"
     FROM
         "SchedulerPartition"
     WHERE
-        "lastHeartbeat" <= NOW() - INTERVAL '1 minute'
+        "lastHeartbeat" <= NOW() AT TIME ZONE 'UTC' - INTERVAL '1 minute'
 ), tenants_to_update AS (
     SELECT
         tenants."id" AS "id",

--- a/pkg/repository/postgres/dbsqlc/tenants.sql.go
+++ b/pkg/repository/postgres/dbsqlc/tenants.sql.go
@@ -15,7 +15,7 @@ const controllerPartitionHeartbeat = `-- name: ControllerPartitionHeartbeat :one
 UPDATE
     "ControllerPartition" p
 SET
-    "lastHeartbeat" = NOW()
+    "lastHeartbeat" = NOW() AT TIME ZONE 'UTC'
 WHERE
     p."id" = $1::text
 RETURNING id, "createdAt", "updatedAt", "lastHeartbeat", name
@@ -36,7 +36,7 @@ func (q *Queries) ControllerPartitionHeartbeat(ctx context.Context, db DBTX, con
 
 const createControllerPartition = `-- name: CreateControllerPartition :one
 INSERT INTO "ControllerPartition" ("id", "createdAt", "lastHeartbeat", "name")
-VALUES (gen_random_uuid()::text, NOW(), NOW(), $1::text)
+VALUES (gen_random_uuid()::text, NOW() AT TIME ZONE 'UTC', NOW() AT TIME ZONE 'UTC', $1::text)
 ON CONFLICT DO NOTHING
 RETURNING id, "createdAt", "updatedAt", "lastHeartbeat", name
 `
@@ -56,7 +56,7 @@ func (q *Queries) CreateControllerPartition(ctx context.Context, db DBTX, name p
 
 const createSchedulerPartition = `-- name: CreateSchedulerPartition :one
 INSERT INTO "SchedulerPartition" ("id", "createdAt", "lastHeartbeat", "name")
-VALUES (gen_random_uuid()::text, NOW(), NOW(), $1::text)
+VALUES (gen_random_uuid()::text, NOW() AT TIME ZONE 'UTC', NOW() AT TIME ZONE 'UTC', $1::text)
 ON CONFLICT DO NOTHING
 RETURNING id, "createdAt", "updatedAt", "lastHeartbeat", name
 `
@@ -81,7 +81,7 @@ WITH active_controller_partitions AS (
     FROM
         "ControllerPartition"
     WHERE
-        "lastHeartbeat" > NOW() - INTERVAL '1 minute'
+        "lastHeartbeat" > NOW() AT TIME ZONE 'UTC' - INTERVAL '1 minute'
 )
 INSERT INTO "Tenant" ("id", "name", "slug", "controllerPartitionId", "dataRetentionPeriod", "version", "uiVersion", "onboardingData", "environment")
 VALUES (
@@ -245,7 +245,7 @@ func (q *Queries) CreateTenantMember(ctx context.Context, db DBTX, arg CreateTen
 
 const createTenantWorkerPartition = `-- name: CreateTenantWorkerPartition :one
 INSERT INTO "TenantWorkerPartition" ("id", "createdAt", "lastHeartbeat", "name")
-VALUES (gen_random_uuid()::text, NOW(), NOW(), $1::text)
+VALUES (gen_random_uuid()::text, NOW() AT TIME ZONE 'UTC', NOW() AT TIME ZONE 'UTC', $1::text)
 ON CONFLICT DO NOTHING
 RETURNING id, "createdAt", "updatedAt", "lastHeartbeat", name
 `
@@ -1201,7 +1201,7 @@ WITH active_partitions AS (
     FROM
         "ControllerPartition"
     WHERE
-        "lastHeartbeat" > NOW() - INTERVAL '1 minute'
+        "lastHeartbeat" > NOW() AT TIME ZONE 'UTC' - INTERVAL '1 minute'
 ),
 tenants_to_update AS (
     SELECT
@@ -1236,7 +1236,7 @@ WITH active_partitions AS (
     FROM
         "SchedulerPartition"
     WHERE
-        "lastHeartbeat" > NOW() - INTERVAL '1 minute'
+        "lastHeartbeat" > NOW() AT TIME ZONE 'UTC' - INTERVAL '1 minute'
 ),
 tenants_to_update AS (
     SELECT
@@ -1272,7 +1272,7 @@ WITH active_partitions AS (
     FROM
         "TenantWorkerPartition"
     WHERE
-        "lastHeartbeat" > NOW() - INTERVAL '1 minute'
+        "lastHeartbeat" > NOW() AT TIME ZONE 'UTC' - INTERVAL '1 minute'
 ),
 tenants_to_update AS (
     SELECT
@@ -1308,14 +1308,14 @@ WITH active_partitions AS (
     FROM
         "ControllerPartition"
     WHERE
-        "lastHeartbeat" > NOW() - INTERVAL '1 minute'
+        "lastHeartbeat" > NOW() AT TIME ZONE 'UTC' - INTERVAL '1 minute'
 ), inactive_partitions AS (
     SELECT
         "id"
     FROM
         "ControllerPartition"
     WHERE
-        "lastHeartbeat" <= NOW() - INTERVAL '1 minute'
+        "lastHeartbeat" <= NOW() AT TIME ZONE 'UTC' - INTERVAL '1 minute'
 ), tenants_to_update AS (
     SELECT
         tenants."id" AS "id",
@@ -1352,14 +1352,14 @@ WITH active_partitions AS (
     FROM
         "SchedulerPartition"
     WHERE
-        "lastHeartbeat" > NOW() - INTERVAL '1 minute'
+        "lastHeartbeat" > NOW() AT TIME ZONE 'UTC' - INTERVAL '1 minute'
 ), inactive_partitions AS (
     SELECT
         "id"
     FROM
         "SchedulerPartition"
     WHERE
-        "lastHeartbeat" <= NOW() - INTERVAL '1 minute'
+        "lastHeartbeat" <= NOW() AT TIME ZONE 'UTC' - INTERVAL '1 minute'
 ), tenants_to_update AS (
     SELECT
         tenants."id" AS "id",
@@ -1399,14 +1399,14 @@ WITH active_partitions AS (
     FROM
         "TenantWorkerPartition"
     WHERE
-        "lastHeartbeat" > NOW() - INTERVAL '1 minute'
+        "lastHeartbeat" > NOW() AT TIME ZONE 'UTC' - INTERVAL '1 minute'
 ), inactive_partitions AS (
     SELECT
         "id"
     FROM
         "TenantWorkerPartition"
     WHERE
-        "lastHeartbeat" <= NOW() - INTERVAL '1 minute'
+        "lastHeartbeat" <= NOW() AT TIME ZONE 'UTC' - INTERVAL '1 minute'
 ), tenants_to_update AS (
     SELECT
         tenants."id" AS "id",
@@ -1442,7 +1442,7 @@ const schedulerPartitionHeartbeat = `-- name: SchedulerPartitionHeartbeat :one
 UPDATE
     "SchedulerPartition" p
 SET
-    "lastHeartbeat" = NOW()
+    "lastHeartbeat" = NOW() AT TIME ZONE 'UTC'
 WHERE
     p."id" = $1::text
 RETURNING id, "createdAt", "updatedAt", "lastHeartbeat", name
@@ -1663,7 +1663,7 @@ const workerPartitionHeartbeat = `-- name: WorkerPartitionHeartbeat :one
 UPDATE
     "TenantWorkerPartition" p
 SET
-    "lastHeartbeat" = NOW()
+    "lastHeartbeat" = NOW() AT TIME ZONE 'UTC'
 WHERE
     p."id" = $1::text
 RETURNING id, "createdAt", "updatedAt", "lastHeartbeat", name

--- a/pkg/repository/postgres/dbsqlc/tickers.sql
+++ b/pkg/repository/postgres/dbsqlc/tickers.sql
@@ -2,7 +2,7 @@
 INSERT INTO
     "Ticker" ("id", "lastHeartbeatAt", "isActive")
 VALUES
-    (sqlc.arg('id')::uuid, CURRENT_TIMESTAMP, 't')
+    (sqlc.arg('id')::uuid, CURRENT_TIMESTAMP AT TIME ZONE 'UTC', 't')
 RETURNING *;
 
 -- name: ListNewlyStaleTickers :many
@@ -77,11 +77,11 @@ WITH getGroupKeyRunsToTimeout AS (
         "GetGroupKeyRun" as getGroupKeyRun
     WHERE
         "status" = ANY(ARRAY['RUNNING', 'ASSIGNED']::"StepRunStatus"[])
-        AND "timeoutAt" < NOW()
+        AND "timeoutAt" < NOW() AT TIME ZONE 'UTC'
         AND "deletedAt" IS NULL
         AND (
             NOT EXISTS (
-                SELECT 1 FROM "Ticker" WHERE "id" = getGroupKeyRun."tickerId" AND "isActive" = true AND "lastHeartbeatAt" >= NOW() - INTERVAL '10 seconds'
+                SELECT 1 FROM "Ticker" WHERE "id" = getGroupKeyRun."tickerId" AND "isActive" = true AND "lastHeartbeatAt" >= NOW() AT TIME ZONE 'UTC' - INTERVAL '10 seconds'
             )
             OR "tickerId" IS NULL
         )
@@ -127,7 +127,7 @@ active_cron_schedules AS (
         AND (
             "tickerId" IS NULL
             OR NOT EXISTS (
-                SELECT 1 FROM "Ticker" WHERE "id" = cronSchedule."tickerId" AND "isActive" = true AND "lastHeartbeatAt" >= NOW() - INTERVAL '10 seconds'
+                SELECT 1 FROM "Ticker" WHERE "id" = cronSchedule."tickerId" AND "isActive" = true AND "lastHeartbeatAt" >= NOW() AT TIME ZONE 'UTC' - INTERVAL '10 seconds'
             )
             OR "tickerId" = @tickerId::uuid
         )
@@ -173,14 +173,14 @@ WITH latest_workflow_versions AS (
     LEFT JOIN
         "WorkflowRunTriggeredBy" AS runTriggeredBy ON runTriggeredBy."scheduledId" = scheduledWorkflow."id"
     WHERE
-        "triggerAt" <= NOW() + INTERVAL '5 seconds'
+        "triggerAt" <= NOW() AT TIME ZONE 'UTC' + INTERVAL '5 seconds'
         AND runTriggeredBy IS NULL
         AND versions."deletedAt" IS NULL
         AND workflow."deletedAt" IS NULL
         AND (
             "tickerId" IS NULL
             OR NOT EXISTS (
-                SELECT 1 FROM "Ticker" WHERE "id" = scheduledWorkflow."tickerId" AND "isActive" = true AND "lastHeartbeatAt" >= NOW() - INTERVAL '10 seconds'
+                SELECT 1 FROM "Ticker" WHERE "id" = scheduledWorkflow."tickerId" AND "isActive" = true AND "lastHeartbeatAt" >= NOW() AT TIME ZONE 'UTC' - INTERVAL '10 seconds'
             )
             OR "tickerId" = @tickerId::uuid
         )
@@ -211,7 +211,7 @@ WITH active_tenant_alerts AS (
         "TenantAlertingSettings" as alerts
     WHERE
         "lastAlertedAt" IS NULL OR
-        "lastAlertedAt" <= NOW() - convert_duration_to_interval(alerts."maxFrequency")
+        "lastAlertedAt" <= NOW() AT TIME ZONE 'UTC' - convert_duration_to_interval(alerts."maxFrequency")
     FOR UPDATE SKIP LOCKED
 ),
 failed_run_count_by_tenant AS (
@@ -228,7 +228,7 @@ failed_run_count_by_tenant AS (
         AND (
             (
                 "lastAlertedAt" IS NULL AND
-                workflowRun."finishedAt" >= NOW() - convert_duration_to_interval(active_tenant_alerts."maxFrequency")
+                workflowRun."finishedAt" >= NOW() AT TIME ZONE 'UTC' - convert_duration_to_interval(active_tenant_alerts."maxFrequency")
             ) OR
             workflowRun."finishedAt" >= "lastAlertedAt"
         )
@@ -238,7 +238,7 @@ UPDATE
     "TenantAlertingSettings" as alerts
 SET
     "tickerId" = @tickerId::uuid,
-    "lastAlertedAt" = NOW()
+    "lastAlertedAt" = NOW() AT TIME ZONE 'UTC'
 FROM
     active_tenant_alerts
 WHERE
@@ -255,11 +255,11 @@ WITH expiring_tokens AS (
         "APIToken" as t0
     WHERE
         t0."revoked" = false
-        AND t0."expiresAt" <= NOW() + INTERVAL '7 days'
-        AND t0."expiresAt" >= NOW()
+        AND t0."expiresAt" <= NOW() AT TIME ZONE 'UTC' + INTERVAL '7 days'
+        AND t0."expiresAt" >= NOW() AT TIME ZONE 'UTC'
         AND (
             t0."nextAlertAt" IS NULL OR
-            t0."nextAlertAt" <= NOW()
+            t0."nextAlertAt" <= NOW() AT TIME ZONE 'UTC'
         )
     FOR UPDATE SKIP LOCKED
     LIMIT 100
@@ -267,7 +267,7 @@ WITH expiring_tokens AS (
 UPDATE
     "APIToken" as t1
 SET
-    "nextAlertAt" = NOW() + INTERVAL '1 day'
+    "nextAlertAt" = NOW() AT TIME ZONE 'UTC' + INTERVAL '1 day'
 FROM
     expiring_tokens
 WHERE
@@ -320,7 +320,7 @@ new_alerts AS (
             FROM "TenantResourceLimitAlert" AS trla
             WHERE trla."resourceLimitId" = arl."resourceLimitId"
             AND trla."alertType" = arl."alertType"::"TenantResourceLimitAlertType"
-            AND trla."createdAt" >= NOW() - arl."window"::INTERVAL
+            AND trla."createdAt" >= NOW() AT TIME ZONE 'UTC' - arl."window"::INTERVAL
         ) AS "existingAlert"
     FROM
         alerting_resource_limits AS arl
@@ -338,8 +338,8 @@ INSERT INTO "TenantResourceLimitAlert" (
 )
 SELECT
     gen_random_uuid(),
-    NOW(),
-    NOW(),
+    NOW() AT TIME ZONE 'UTC',
+    NOW() AT TIME ZONE 'UTC',
     na."resourceLimitId",
     na."resource",
     na."alertType"::"TenantResourceLimitAlertType",
@@ -364,5 +364,5 @@ WHERE
 	OR
 		(sr."status" = 'CANCELLED' AND jr."status" != 'CANCELLED')
 	)
-	AND sr."updatedAt" < CURRENT_TIMESTAMP - INTERVAL '5 seconds'
+	AND sr."updatedAt" < CURRENT_TIMESTAMP AT TIME ZONE 'UTC' - INTERVAL '5 seconds'
 ;

--- a/pkg/repository/postgres/dbsqlc/webhook_workers.sql
+++ b/pkg/repository/postgres/dbsqlc/webhook_workers.sql
@@ -11,7 +11,7 @@ WITH tenants AS (
     UPDATE
         "TenantWorkerPartition"
     SET
-        "lastHeartbeat" = NOW()
+        "lastHeartbeat" = NOW() AT TIME ZONE 'UTC'
     WHERE
         "id" = sqlc.arg('workerPartitionId')::text
 )
@@ -36,7 +36,7 @@ WITH delete_old AS (
     -- Delete old requests
     DELETE FROM "WebhookWorkerRequest"
     WHERE "webhookWorkerId" = @webhookWorkerId::uuid
-    AND "createdAt" < NOW() - INTERVAL '15 minutes'
+    AND "createdAt" < NOW() AT TIME ZONE 'UTC' - INTERVAL '15 minutes'
 )
 INSERT INTO "WebhookWorkerRequest" (
     "id",
@@ -46,7 +46,7 @@ INSERT INTO "WebhookWorkerRequest" (
     "statusCode"
 ) VALUES (
     gen_random_uuid(),
-    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
     @webhookWorkerId::uuid,
     @method::"WebhookWorkerRequestMethod",
     @statusCode::integer
@@ -55,7 +55,7 @@ INSERT INTO "WebhookWorkerRequest" (
 -- name: UpdateWebhookWorkerToken :one
 UPDATE "WebhookWorker"
 SET
-    "updatedAt" = CURRENT_TIMESTAMP,
+    "updatedAt" = CURRENT_TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE 'UTC',
     "tokenValue" = COALESCE(sqlc.narg('tokenValue')::text, "tokenValue"),
     "tokenId" = COALESCE(sqlc.narg('tokenId')::uuid, "tokenId")
 WHERE
@@ -78,8 +78,8 @@ INSERT INTO "WebhookWorker" (
 )
 VALUES (
     gen_random_uuid(),
-    CURRENT_TIMESTAMP,
-    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
+    CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
     @name::text,
     @secret::text,
     @url::text,
@@ -99,7 +99,7 @@ WHERE "id" = @id::uuid;
 UPDATE "WebhookWorker"
 SET
   "deleted" = true,
-  "updatedAt" = CURRENT_TIMESTAMP
+  "updatedAt" = CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
 WHERE
   "id" = @id::uuid
   AND "tenantId" = @tenantId::uuid;

--- a/pkg/repository/postgres/dbsqlc/webhook_workers.sql.go
+++ b/pkg/repository/postgres/dbsqlc/webhook_workers.sql.go
@@ -26,8 +26,8 @@ INSERT INTO "WebhookWorker" (
 )
 VALUES (
     gen_random_uuid(),
-    CURRENT_TIMESTAMP,
-    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
+    CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
     $1::text,
     $2::text,
     $3::text,
@@ -121,7 +121,7 @@ WITH delete_old AS (
     -- Delete old requests
     DELETE FROM "WebhookWorkerRequest"
     WHERE "webhookWorkerId" = $1::uuid
-    AND "createdAt" < NOW() - INTERVAL '15 minutes'
+    AND "createdAt" < NOW() AT TIME ZONE 'UTC' - INTERVAL '15 minutes'
 )
 INSERT INTO "WebhookWorkerRequest" (
     "id",
@@ -131,7 +131,7 @@ INSERT INTO "WebhookWorkerRequest" (
     "statusCode"
 ) VALUES (
     gen_random_uuid(),
-    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
     $1::uuid,
     $2::"WebhookWorkerRequestMethod",
     $3::integer
@@ -233,7 +233,7 @@ WITH tenants AS (
     UPDATE
         "TenantWorkerPartition"
     SET
-        "lastHeartbeat" = NOW()
+        "lastHeartbeat" = NOW() AT TIME ZONE 'UTC'
     WHERE
         "id" = $1::text
 )
@@ -277,7 +277,7 @@ const softDeleteWebhookWorker = `-- name: SoftDeleteWebhookWorker :exec
 UPDATE "WebhookWorker"
 SET
   "deleted" = true,
-  "updatedAt" = CURRENT_TIMESTAMP
+  "updatedAt" = CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
 WHERE
   "id" = $1::uuid
   AND "tenantId" = $2::uuid
@@ -296,7 +296,7 @@ func (q *Queries) SoftDeleteWebhookWorker(ctx context.Context, db DBTX, arg Soft
 const updateWebhookWorkerToken = `-- name: UpdateWebhookWorkerToken :one
 UPDATE "WebhookWorker"
 SET
-    "updatedAt" = CURRENT_TIMESTAMP,
+    "updatedAt" = CURRENT_TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE 'UTC',
     "tokenValue" = COALESCE($1::text, "tokenValue"),
     "tokenId" = COALESCE($2::uuid, "tokenId")
 WHERE

--- a/pkg/repository/postgres/dbsqlc/workers.sql
+++ b/pkg/repository/postgres/dbsqlc/workers.sql
@@ -159,8 +159,8 @@ INSERT INTO "Worker" (
     "runtimeExtra"
 ) VALUES (
     gen_random_uuid(),
-    CURRENT_TIMESTAMP,
-    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
+    CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
     @tenantId::uuid,
     @name::text,
     @dispatcherId::uuid,
@@ -187,7 +187,7 @@ WHERE
 UPDATE
     "Worker"
 SET
-    "updatedAt" = CURRENT_TIMESTAMP,
+    "updatedAt" = CURRENT_TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE 'UTC',
     "lastHeartbeatAt" = sqlc.narg('lastHeartbeatAt')::timestamp
 WHERE
     "id" = @id::uuid
@@ -197,7 +197,7 @@ RETURNING *;
 UPDATE
     "Worker"
 SET
-    "updatedAt" = CURRENT_TIMESTAMP,
+    "updatedAt" = CURRENT_TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE 'UTC',
     "dispatcherId" = coalesce(sqlc.narg('dispatcherId')::uuid, "dispatcherId"),
     "maxRuns" = coalesce(sqlc.narg('maxRuns')::int, "maxRuns"),
     "lastHeartbeatAt" = coalesce(sqlc.narg('lastHeartbeatAt')::timestamp, "lastHeartbeatAt"),
@@ -226,14 +226,14 @@ INSERT INTO "Service" (
 )
 VALUES (
     gen_random_uuid(),
-    CURRENT_TIMESTAMP,
-    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
+    CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
     @name::text,
     @tenantId::uuid
 )
 ON CONFLICT ("tenantId", "name") DO UPDATE
 SET
-    "updatedAt" = CURRENT_TIMESTAMP
+    "updatedAt" = CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
 WHERE
     "Service"."tenantId" = @tenantId AND "Service"."name" = @name::text
 RETURNING *;
@@ -297,15 +297,15 @@ INSERT INTO "WorkerLabel" (
     "intValue",
     "strValue"
 ) VALUES (
-    CURRENT_TIMESTAMP,
-    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
+    CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
     @workerId::uuid,
     @key::text,
     sqlc.narg('intValue')::int,
     sqlc.narg('strValue')::text
 ) ON CONFLICT ("workerId", "key") DO UPDATE
 SET
-    "updatedAt" = CURRENT_TIMESTAMP,
+    "updatedAt" = CURRENT_TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE 'UTC',
     "intValue" = sqlc.narg('intValue')::int,
     "strValue" = sqlc.narg('strValue')::text
 RETURNING *;

--- a/pkg/repository/postgres/dbsqlc/workers.sql.go
+++ b/pkg/repository/postgres/dbsqlc/workers.sql.go
@@ -29,8 +29,8 @@ INSERT INTO "Worker" (
     "runtimeExtra"
 ) VALUES (
     gen_random_uuid(),
-    CURRENT_TIMESTAMP,
-    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
+    CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
     $1::uuid,
     $2::text,
     $3::uuid,
@@ -853,7 +853,7 @@ const updateWorker = `-- name: UpdateWorker :one
 UPDATE
     "Worker"
 SET
-    "updatedAt" = CURRENT_TIMESTAMP,
+    "updatedAt" = CURRENT_TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE 'UTC',
     "dispatcherId" = coalesce($1::uuid, "dispatcherId"),
     "maxRuns" = coalesce($2::int, "maxRuns"),
     "lastHeartbeatAt" = coalesce($3::timestamp, "lastHeartbeatAt"),
@@ -958,7 +958,7 @@ const updateWorkerHeartbeat = `-- name: UpdateWorkerHeartbeat :one
 UPDATE
     "Worker"
 SET
-    "updatedAt" = CURRENT_TIMESTAMP,
+    "updatedAt" = CURRENT_TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE 'UTC',
     "lastHeartbeatAt" = $1::timestamp
 WHERE
     "id" = $2::uuid
@@ -1062,14 +1062,14 @@ INSERT INTO "Service" (
 )
 VALUES (
     gen_random_uuid(),
-    CURRENT_TIMESTAMP,
-    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
+    CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
     $1::text,
     $2::uuid
 )
 ON CONFLICT ("tenantId", "name") DO UPDATE
 SET
-    "updatedAt" = CURRENT_TIMESTAMP
+    "updatedAt" = CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
 WHERE
     "Service"."tenantId" = $2 AND "Service"."name" = $1::text
 RETURNING id, "createdAt", "updatedAt", "deletedAt", name, description, "tenantId"
@@ -1104,15 +1104,15 @@ INSERT INTO "WorkerLabel" (
     "intValue",
     "strValue"
 ) VALUES (
-    CURRENT_TIMESTAMP,
-    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
+    CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
     $1::uuid,
     $2::text,
     $3::int,
     $4::text
 ) ON CONFLICT ("workerId", "key") DO UPDATE
 SET
-    "updatedAt" = CURRENT_TIMESTAMP,
+    "updatedAt" = CURRENT_TIMESTAMP AT TIME ZONE 'UTC' AT TIME ZONE 'UTC',
     "intValue" = $3::int,
     "strValue" = $4::text
 RETURNING id, "createdAt", "updatedAt", "workerId", key, "strValue", "intValue"

--- a/pkg/repository/postgres/dbsqlc/workflows.sql
+++ b/pkg/repository/postgres/dbsqlc/workflows.sql
@@ -110,8 +110,8 @@ INSERT INTO "Workflow" (
     "description"
 ) VALUES (
     @id::uuid,
-    coalesce(sqlc.narg('createdAt')::timestamp, CURRENT_TIMESTAMP),
-    coalesce(sqlc.narg('updatedAt')::timestamp, CURRENT_TIMESTAMP),
+    coalesce(sqlc.narg('createdAt')::timestamp, CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
+    coalesce(sqlc.narg('updatedAt')::timestamp, CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
     @deletedAt::timestamp,
     @tenantId::uuid,
     @name::text,
@@ -133,8 +133,8 @@ INSERT INTO "WorkflowVersion" (
     "defaultPriority"
 ) VALUES (
     @id::uuid,
-    coalesce(sqlc.narg('createdAt')::timestamp, CURRENT_TIMESTAMP),
-    coalesce(sqlc.narg('updatedAt')::timestamp, CURRENT_TIMESTAMP),
+    coalesce(sqlc.narg('createdAt')::timestamp, CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
+    coalesce(sqlc.narg('updatedAt')::timestamp, CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
     @deletedAt::timestamp,
     @checksum::text,
     sqlc.narg('version')::text,
@@ -179,8 +179,8 @@ INSERT INTO "WorkflowConcurrency" (
     "concurrencyGroupExpression"
 ) VALUES (
     gen_random_uuid(),
-    coalesce(sqlc.narg('createdAt')::timestamp, CURRENT_TIMESTAMP),
-    coalesce(sqlc.narg('updatedAt')::timestamp, CURRENT_TIMESTAMP),
+    coalesce(sqlc.narg('createdAt')::timestamp, CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
+    coalesce(sqlc.narg('updatedAt')::timestamp, CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
     @workflowVersionId::uuid,
     sqlc.narg('getConcurrencyGroupId')::uuid,
     coalesce(sqlc.narg('maxRuns')::integer, 1),
@@ -202,8 +202,8 @@ INSERT INTO "Job" (
     "kind"
 ) VALUES (
     @id::uuid,
-    coalesce(sqlc.narg('createdAt')::timestamp, CURRENT_TIMESTAMP),
-    coalesce(sqlc.narg('updatedAt')::timestamp, CURRENT_TIMESTAMP),
+    coalesce(sqlc.narg('createdAt')::timestamp, CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
+    coalesce(sqlc.narg('updatedAt')::timestamp, CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
     @deletedAt::timestamp,
     @tenantId::uuid,
     @workflowVersionId::uuid,
@@ -237,8 +237,8 @@ INSERT INTO "Step" (
     "retryMaxBackoff"
 ) VALUES (
     @id::uuid,
-    coalesce(sqlc.narg('createdAt')::timestamp, CURRENT_TIMESTAMP),
-    coalesce(sqlc.narg('updatedAt')::timestamp, CURRENT_TIMESTAMP),
+    coalesce(sqlc.narg('createdAt')::timestamp, CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
+    coalesce(sqlc.narg('updatedAt')::timestamp, CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
     @deletedAt::timestamp,
     @readableId::text,
     @tenantId::uuid,
@@ -344,8 +344,8 @@ INSERT INTO "WorkflowTriggers" (
     "tenantId"
 ) VALUES (
     @id::uuid,
-    CURRENT_TIMESTAMP,
-    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
+    CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
     NULL,
     @workflowVersionId::uuid,
     @tenantId::uuid
@@ -631,14 +631,14 @@ WHERE
 -- name: SoftDeleteWorkflow :one
 WITH versions AS (
     UPDATE "WorkflowVersion"
-    SET "deletedAt" = CURRENT_TIMESTAMP
+    SET "deletedAt" = CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
     WHERE "workflowId" = @id::uuid
 )
 UPDATE "Workflow"
 SET
     -- set name to the current name plus a random suffix to avoid conflicts
     "name" = "name" || '-' || gen_random_uuid(),
-    "deletedAt" = CURRENT_TIMESTAMP
+    "deletedAt" = CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
 WHERE "id" = @id::uuid
 RETURNING *;
 
@@ -655,7 +655,7 @@ WHERE
 -- name: UpdateWorkflow :one
 UPDATE "Workflow"
 SET
-    "updatedAt" = CURRENT_TIMESTAMP,
+    "updatedAt" = CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
     "isPaused" = coalesce(sqlc.narg('isPaused')::boolean, "isPaused")
 WHERE "id" = @id::uuid
 RETURNING *;
@@ -699,7 +699,7 @@ WITH UniqueWorkers AS (
         AND workflowVersion."deletedAt" IS NULL
         AND w."deletedAt" IS NULL
         AND w."dispatcherId" IS NOT NULL
-        AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+        AND w."lastHeartbeatAt" > NOW() AT TIME ZONE 'UTC' - INTERVAL '5 seconds'
         AND w."isActive" = true
         AND w."isPaused" = false
         AND workflowVersion."workflowId" = @workflowId::uuid

--- a/pkg/repository/v1/scheduler_queue.go
+++ b/pkg/repository/v1/scheduler_queue.go
@@ -106,8 +106,6 @@ func (d *queueRepository) getMinId() pgtype.Int8 {
 }
 
 func (d *queueRepository) ListQueueItems(ctx context.Context, limit int) ([]*sqlcv1.V1QueueItem, error) {
-	fmt.Printf("ListQueueItems called for queue %s with limit %d\n", d.queueName, limit)
-
 	ctx, span := telemetry.NewSpan(ctx, "list-queue-items")
 	defer span.End()
 
@@ -127,8 +125,6 @@ func (d *queueRepository) ListQueueItems(ctx context.Context, limit int) ([]*sql
 	if err != nil {
 		return nil, err
 	}
-
-	fmt.Printf("getMinId: %v, found %d queue items\n", d.getMinId(), len(qis))
 
 	if len(qis) == 0 {
 		return nil, nil

--- a/pkg/repository/v1/scheduler_queue.go
+++ b/pkg/repository/v1/scheduler_queue.go
@@ -106,6 +106,8 @@ func (d *queueRepository) getMinId() pgtype.Int8 {
 }
 
 func (d *queueRepository) ListQueueItems(ctx context.Context, limit int) ([]*sqlcv1.V1QueueItem, error) {
+	fmt.Printf("ListQueueItems called for queue %s with limit %d\n", d.queueName, limit)
+
 	ctx, span := telemetry.NewSpan(ctx, "list-queue-items")
 	defer span.End()
 
@@ -125,6 +127,8 @@ func (d *queueRepository) ListQueueItems(ctx context.Context, limit int) ([]*sql
 	if err != nil {
 		return nil, err
 	}
+
+	fmt.Printf("getMinId: %v, found %d queue items\n", d.getMinId(), len(qis))
 
 	if len(qis) == 0 {
 		return nil, nil

--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -731,7 +731,7 @@ WITH tenants AS (
     SELECT
         tenant_id,
         -- Exponential backoff, we limit to 10 retries which is 2048 seconds/34 minutes
-        CURRENT_TIMESTAMP + (2 ^ requeue_retries) * INTERVAL '2 seconds',
+        CURRENT_TIMESTAMP AT TIME ZONE 'UTC' + (2 ^ requeue_retries) * INTERVAL '2 seconds',
         requeue_retries + 1,
         task_id,
         task_inserted_at,
@@ -917,7 +917,7 @@ WITH tenants AS (
     SELECT
         tenant_id,
         -- Exponential backoff, we limit to 10 retries which is 2048 seconds/34 minutes
-        CURRENT_TIMESTAMP + (2 ^ requeue_retries) * INTERVAL '2 seconds',
+        CURRENT_TIMESTAMP AT TIME ZONE 'UTC' + (2 ^ requeue_retries) * INTERVAL '2 seconds',
         requeue_retries + 1,
         dag_id,
         dag_inserted_at
@@ -1339,7 +1339,7 @@ FROM
     v1_events_olap
 WHERE
     tenant_id = @tenantId::uuid
-    AND seen_at > NOW() - INTERVAL '1 day'
+    AND seen_at > NOW() AT TIME ZONE 'UTC' - INTERVAL '1 day'
 ;
 
 

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -876,7 +876,7 @@ FROM
     v1_events_olap
 WHERE
     tenant_id = $1::uuid
-    AND seen_at > NOW() - INTERVAL '1 day'
+    AND seen_at > NOW() AT TIME ZONE 'UTC' - INTERVAL '1 day'
 `
 
 func (q *Queries) ListEventKeys(ctx context.Context, db DBTX, tenantid pgtype.UUID) ([]string, error) {
@@ -2451,7 +2451,7 @@ WITH tenants AS (
     SELECT
         tenant_id,
         -- Exponential backoff, we limit to 10 retries which is 2048 seconds/34 minutes
-        CURRENT_TIMESTAMP + (2 ^ requeue_retries) * INTERVAL '2 seconds',
+        CURRENT_TIMESTAMP AT TIME ZONE 'UTC' + (2 ^ requeue_retries) * INTERVAL '2 seconds',
         requeue_retries + 1,
         dag_id,
         dag_inserted_at
@@ -2666,7 +2666,7 @@ WITH tenants AS (
     SELECT
         tenant_id,
         -- Exponential backoff, we limit to 10 retries which is 2048 seconds/34 minutes
-        CURRENT_TIMESTAMP + (2 ^ requeue_retries) * INTERVAL '2 seconds',
+        CURRENT_TIMESTAMP AT TIME ZONE 'UTC' + (2 ^ requeue_retries) * INTERVAL '2 seconds',
         requeue_retries + 1,
         task_id,
         task_inserted_at,

--- a/pkg/scheduling/v1/lease_manager.go
+++ b/pkg/scheduling/v1/lease_manager.go
@@ -52,8 +52,6 @@ func newLeaseManager(conf *sharedConfig, tenantId pgtype.UUID) (*LeaseManager, <
 }
 
 func (l *LeaseManager) sendWorkerIds(workerIds []*v1.ListActiveWorkersResult) {
-	fmt.Printf("sendWorkerIds called with %d workers\n", len(workerIds))
-
 	defer func() {
 		if r := recover(); r != nil {
 			l.conf.l.Error().Interface("recovered", r).Msg("recovered from panic")
@@ -62,15 +60,12 @@ func (l *LeaseManager) sendWorkerIds(workerIds []*v1.ListActiveWorkersResult) {
 
 	// at this point, we have a cleanupMu lock, so it's safe to read
 	if l.cleanedUp {
-		fmt.Printf("LeaseManager is cleaned up, not sending workers\n")
 		return
 	}
 
 	select {
 	case l.workersCh <- workerIds:
-		fmt.Printf("Successfully sent %d workers to channel\n", len(workerIds))
 	default:
-		fmt.Printf("Failed to send workers to channel (channel full)\n")
 	}
 }
 
@@ -111,16 +106,11 @@ func (l *LeaseManager) sendConcurrencyLeases(concurrencyLeases []*sqlcv1.V1StepC
 }
 
 func (l *LeaseManager) acquireWorkerLeases(ctx context.Context) error {
-	fmt.Printf("acquireWorkerLeases called for tenant %s\n", l.tenantId.String())
-
 	activeWorkers, err := l.lr.ListActiveWorkers(ctx, l.tenantId)
 
 	if err != nil {
-		fmt.Printf("Error listing active workers: %v\n", err)
 		return err
 	}
-
-	fmt.Printf("ListActiveWorkers returned %d workers\n", len(activeWorkers))
 
 	currResourceIdsToLease := make(map[string]*sqlcv1.Lease, len(l.workerLeases))
 
@@ -165,7 +155,6 @@ func (l *LeaseManager) acquireWorkerLeases(ctx context.Context) error {
 		}
 	}
 
-	fmt.Printf("Sending %d successfully acquired workers\n", len(successfullyAcquiredWorkerIds))
 	l.sendWorkerIds(successfullyAcquiredWorkerIds)
 
 	if len(leasesToRelease) != 0 {
@@ -178,22 +167,16 @@ func (l *LeaseManager) acquireWorkerLeases(ctx context.Context) error {
 }
 
 func (l *LeaseManager) acquireQueueLeases(ctx context.Context) error {
-	fmt.Printf("acquireQueueLeases called for tenant %s\n", l.tenantId.String())
-
 	queues, err := l.lr.ListQueues(ctx, l.tenantId)
 
 	if err != nil {
-		fmt.Printf("Error listing queues: %v\n", err)
 		return err
 	}
-
-	fmt.Printf("ListQueues returned %d queues\n", len(queues))
 
 	currResourceIdsToLease := make(map[string]*sqlcv1.Lease, len(l.queueLeases))
 
 	for _, lease := range l.queueLeases {
 		currResourceIdsToLease[lease.ResourceId] = lease
-		fmt.Printf("Existing lease: resourceId=%s, expiresAt=%v, id=%d\n", lease.ResourceId, lease.ExpiresAt, lease.ID)
 	}
 
 	queueIdsStr := make([]string, len(queues))
@@ -202,19 +185,12 @@ func (l *LeaseManager) acquireQueueLeases(ctx context.Context) error {
 
 	for i, q := range queues {
 		queueIdsStr[i] = q.Name
-		fmt.Printf("Queue %d: name=%s, last_active=%v\n", i, q.Name, q.LastActive)
 
 		if lease, ok := currResourceIdsToLease[queueIdsStr[i]]; ok {
-			fmt.Printf("Found existing lease for queue %s: id=%d, expiresAt=%v\n", q.Name, lease.ID, lease.ExpiresAt)
 			leasesToExtend = append(leasesToExtend, lease)
 			delete(currResourceIdsToLease, queueIdsStr[i])
-		} else {
-			fmt.Printf("No existing lease for queue %s\n", q.Name)
 		}
 	}
-
-	fmt.Printf("queueIdsStr: %v\n", queueIdsStr)
-	fmt.Printf("leasesToExtend: %d leases\n", len(leasesToExtend))
 
 	for _, lease := range currResourceIdsToLease {
 		leasesToRelease = append(leasesToRelease, lease)
@@ -223,34 +199,19 @@ func (l *LeaseManager) acquireQueueLeases(ctx context.Context) error {
 	successfullyAcquiredQueues := []string{}
 
 	if len(queueIdsStr) != 0 {
-		fmt.Printf("Attempting to acquire leases for %d queues: %v\n", len(queueIdsStr), queueIdsStr)
-		fmt.Printf("leasesToExtend: %d leases, existingLeaseIds: %v\n", len(leasesToExtend), func() []int64 {
-			ids := make([]int64, 0, len(leasesToExtend))
-			for _, lease := range leasesToExtend {
-				ids = append(ids, lease.ID)
-			}
-			return ids
-		}())
-
 		queueLeases, err := l.lr.AcquireOrExtendLeases(ctx, l.tenantId, sqlcv1.LeaseKindQUEUE, queueIdsStr, leasesToExtend)
 
 		if err != nil {
-			fmt.Printf("Error acquiring queue leases: %v\n", err)
 			return err
 		}
-
-		fmt.Printf("AcquireOrExtendLeases returned %d leases\n", len(queueLeases))
 
 		l.queueLeases = queueLeases
 
 		for _, lease := range queueLeases {
 			successfullyAcquiredQueues = append(successfullyAcquiredQueues, lease.ResourceId)
 		}
-	} else {
-		fmt.Printf("No queue IDs to acquire leases for\n")
 	}
 
-	fmt.Printf("Sending %d successfully acquired queues: %v\n", len(successfullyAcquiredQueues), successfullyAcquiredQueues)
 	l.sendQueues(successfullyAcquiredQueues)
 
 	if len(leasesToRelease) != 0 {

--- a/pkg/scheduling/v1/queuer.go
+++ b/pkg/scheduling/v1/queuer.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -157,6 +158,8 @@ func (q *Queuer) loopQueue(ctx context.Context) {
 			q.l.Error().Err(err).Msg("error refilling queue")
 			continue
 		}
+
+		fmt.Printf("refillQueue returned %d queue items for queue %s\n", len(qis), q.queueName)
 
 		// NOTE: we don't terminate early out of this loop because calling `tryAssign` is necessary
 		// for calling the scheduling extensions.

--- a/pkg/scheduling/v1/queuer.go
+++ b/pkg/scheduling/v1/queuer.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -158,8 +157,6 @@ func (q *Queuer) loopQueue(ctx context.Context) {
 			q.l.Error().Err(err).Msg("error refilling queue")
 			continue
 		}
-
-		fmt.Printf("refillQueue returned %d queue items for queue %s\n", len(qis), q.queueName)
 
 		// NOTE: we don't terminate early out of this loop because calling `tryAssign` is necessary
 		// for calling the scheduling extensions.

--- a/pkg/scheduling/v1/scheduler.go
+++ b/pkg/scheduling/v1/scheduler.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"sync"
 	"time"
@@ -90,6 +91,14 @@ func (s *Scheduler) nack(ids []int) {
 }
 
 func (s *Scheduler) setWorkers(workers []*v1.ListActiveWorkersResult) {
+	fmt.Printf("setWorkers called with %d workers: %v\n", len(workers), func() []string {
+		ids := make([]string, 0, len(workers))
+		for _, w := range workers {
+			ids = append(ids, w.ID)
+		}
+		return ids
+	}())
+
 	s.workersMu.Lock()
 	defer s.workersMu.Unlock()
 
@@ -134,9 +143,18 @@ func (s *Scheduler) replenish(ctx context.Context, mustReplenish bool) error {
 
 	defer s.actionsMu.Unlock()
 
+	fmt.Printf("replenishing slots\n")
 	s.l.Debug().Msg("replenishing slots")
 
 	workers := s.getWorkers()
+	fmt.Printf("Found %d workers: %v\n", len(workers), func() []string {
+		keys := make([]string, 0, len(workers))
+		for k := range workers {
+			keys = append(keys, k)
+		}
+		return keys
+	}())
+
 	workerIds := make([]pgtype.UUID, 0)
 
 	for workerIdStr := range workers {
@@ -151,6 +169,8 @@ func (s *Scheduler) replenish(ctx context.Context, mustReplenish bool) error {
 	if err != nil {
 		return err
 	}
+
+	fmt.Printf("Found %d worker-action mappings\n", len(workersToActiveActions))
 
 	if sinceStart := time.Since(start); sinceStart > 100*time.Millisecond {
 		s.l.Warn().Msgf("listing actions for workers took %s for %d workers", time.Since(checkpoint), len(workerIds))
@@ -174,6 +194,8 @@ func (s *Scheduler) replenish(ctx context.Context, mustReplenish bool) error {
 		actionsToWorkerIds[actionId] = append(actionsToWorkerIds[actionId], workerId)
 		workerIdsToActions[workerId] = append(workerIdsToActions[workerId], actionId)
 	}
+
+	fmt.Printf("Actions to worker IDs: %v\n", actionsToWorkerIds)
 
 	// FUNCTION 1: determine which actions should be replenished. Logic is the following:
 	// - zero or one slots for an action: replenish all slots
@@ -334,6 +356,7 @@ func (s *Scheduler) replenish(ctx context.Context, mustReplenish bool) error {
 		s.actions[actionId].lastReplenishedSlotCount = actionsToTotalSlots[actionId]
 		s.actions[actionId].lastReplenishedWorkerCount = len(actionsToWorkerIds[actionId])
 
+		fmt.Printf("Action %s has %d slots after replenish\n", actionId, len(newSlots))
 		s.l.Debug().Msgf("before cleanup, action %s has %d slots", actionId, len(newSlots))
 	}
 
@@ -464,6 +487,7 @@ func (s *Scheduler) tryAssignBatch(
 ) (
 	res []*assignSingleResult, newRingOffset int, err error,
 ) {
+	fmt.Printf("tryAssignBatch called for actionId=%s with %d queue items\n", actionId, len(qis))
 	s.l.Debug().Msgf("trying to assign %d queue items", len(qis))
 
 	newRingOffset = ringOffset
@@ -530,6 +554,12 @@ func (s *Scheduler) tryAssignBatch(
 	if !ok || len(action.slots) == 0 {
 		s.actionsMu.RUnlock()
 
+		fmt.Printf("No slots for actionId=%s (ok=%v, slots=%d)\n", actionId, ok, func() int {
+			if ok {
+				return len(action.slots)
+			}
+			return 0
+		}())
 		s.l.Debug().Msgf("no slots for action %s", actionId)
 
 		// if the action is not in the map, then we have no slots to assign to
@@ -541,6 +571,8 @@ func (s *Scheduler) tryAssignBatch(
 		return res, newRingOffset, nil
 	}
 
+	fmt.Printf("Found actionId=%s with %d slots\n", actionId, len(action.slots))
+
 	s.actionsMu.RUnlock()
 
 	action.mu.Lock()
@@ -550,12 +582,14 @@ func (s *Scheduler) tryAssignBatch(
 
 	for i := range res {
 		if res[i].rateLimitResult != nil {
+			fmt.Printf("Queue item %d skipped due to rate limit\n", qis[i].ID)
 			continue
 		}
 
 		denom := len(candidateSlots)
 
 		if denom == 0 {
+			fmt.Printf("Queue item %d: no candidate slots available\n", qis[i].ID)
 			res[i].noSlots = true
 			rlNacks[i]()
 
@@ -565,6 +599,8 @@ func (s *Scheduler) tryAssignBatch(
 		childRingOffset := newRingOffset % denom
 
 		qi := qis[i]
+
+		fmt.Printf("Trying to assign queue item %d to %d candidate slots (ringOffset=%d)\n", qi.ID, denom, childRingOffset)
 
 		singleRes, err := s.tryAssignSingleton(
 			ctx,
@@ -578,6 +614,12 @@ func (s *Scheduler) tryAssignBatch(
 
 		if err != nil {
 			s.l.Error().Err(err).Msg("error assigning queue item")
+		}
+
+		if singleRes.succeeded {
+			fmt.Printf("Successfully assigned queue item %d to worker %s\n", qi.ID, singleRes.workerId.String())
+		} else {
+			fmt.Printf("Failed to assign queue item %d (noSlots=%v)\n", qi.ID, singleRes.noSlots)
 		}
 
 		if !singleRes.succeeded {
@@ -685,6 +727,8 @@ func (s *Scheduler) tryAssign(
 	stepIdsToLabels map[string][]*sqlcv1.GetDesiredLabelsRow,
 	taskIdsToRateLimits map[int64]map[string]int32,
 ) <-chan *assignResults {
+	fmt.Printf("tryAssign called with %d queue items\n", len(qis))
+
 	ctx, span := telemetry.NewSpan(ctx, "try-assign")
 
 	// split into groups based on action ids, and process each action id in parallel
@@ -694,6 +738,7 @@ func (s *Scheduler) tryAssign(
 		qi := qis[i]
 
 		actionId := qi.ActionID
+		fmt.Printf("Queue item %d: actionId=%s, taskId=%d, queue=%s\n", qi.ID, actionId, qi.TaskID, qi.Queue)
 
 		if _, ok := actionIdToQueueItems[actionId]; !ok {
 			actionIdToQueueItems[actionId] = make([]*sqlcv1.V1QueueItem, 0)
@@ -701,6 +746,14 @@ func (s *Scheduler) tryAssign(
 
 		actionIdToQueueItems[actionId] = append(actionIdToQueueItems[actionId], qi)
 	}
+
+	fmt.Printf("Grouped queue items into %d action IDs: %v\n", len(actionIdToQueueItems), func() []string {
+		keys := make([]string, 0, len(actionIdToQueueItems))
+		for k := range actionIdToQueueItems {
+			keys = append(keys, k)
+		}
+		return keys
+	}())
 
 	resultsCh := make(chan *assignResults, len(actionIdToQueueItems))
 
@@ -718,6 +771,8 @@ func (s *Scheduler) tryAssign(
 			go func(actionId string, qis []*sqlcv1.V1QueueItem) {
 				defer wg.Done()
 
+				fmt.Printf("Processing actionId=%s with %d queue items\n", actionId, len(qis))
+
 				ringOffset := 0
 
 				batched := make([]*sqlcv1.V1QueueItem, 0)
@@ -727,12 +782,15 @@ func (s *Scheduler) tryAssign(
 					qi := qis[i]
 
 					if isTimedOut(qi) {
+						fmt.Printf("Queue item %d is timed out\n", qi.ID)
 						schedulingTimedOut = append(schedulingTimedOut, qi)
 						continue
 					}
 
 					batched = append(batched, qi)
 				}
+
+				fmt.Printf("ActionId=%s: %d batched items, %d timed out items\n", actionId, len(batched), len(schedulingTimedOut))
 
 				resultsCh <- &assignResults{
 					schedulingTimedOut: schedulingTimedOut,

--- a/pkg/scheduling/v1/tenant_manager.go
+++ b/pkg/scheduling/v1/tenant_manager.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -112,6 +113,7 @@ func (t *tenantManager) listenForWorkerLeases(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case workerIds := <-t.workersCh:
+			fmt.Printf("listenForWorkerLeases received %d workers\n", len(workerIds))
 			t.scheduler.setWorkers(workerIds)
 		}
 	}
@@ -123,6 +125,7 @@ func (t *tenantManager) listenForQueueLeases(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case queueNames := <-t.queuesCh:
+			fmt.Printf("listenForQueueLeases received %d queues: %v\n", len(queueNames), queueNames)
 			t.setQueuers(queueNames)
 		}
 	}
@@ -140,6 +143,8 @@ func (t *tenantManager) listenForConcurrencyLeases(ctx context.Context) {
 }
 
 func (t *tenantManager) setQueuers(queueNames []string) {
+	fmt.Printf("setQueuers called with %d queues: %v\n", len(queueNames), queueNames)
+
 	t.queuersMu.Lock()
 	defer t.queuersMu.Unlock()
 
@@ -164,10 +169,12 @@ func (t *tenantManager) setQueuers(queueNames []string) {
 	}
 
 	for queueName := range queueNamesSet {
+		fmt.Printf("Creating new queuer for queue: %s\n", queueName)
 		newQueueArr = append(newQueueArr, newQueuer(t.cf, t.tenantId, queueName, t.scheduler, t.resultsCh))
 	}
 
 	t.queuers = newQueueArr
+	fmt.Printf("Total queuers after setQueuers: %d\n", len(t.queuers))
 }
 
 func (t *tenantManager) setConcurrencyStrategies(strategies []*sqlcv1.V1StepConcurrency) {

--- a/pkg/scheduling/v1/tenant_manager.go
+++ b/pkg/scheduling/v1/tenant_manager.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -113,7 +112,6 @@ func (t *tenantManager) listenForWorkerLeases(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case workerIds := <-t.workersCh:
-			fmt.Printf("listenForWorkerLeases received %d workers\n", len(workerIds))
 			t.scheduler.setWorkers(workerIds)
 		}
 	}
@@ -125,7 +123,6 @@ func (t *tenantManager) listenForQueueLeases(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case queueNames := <-t.queuesCh:
-			fmt.Printf("listenForQueueLeases received %d queues: %v\n", len(queueNames), queueNames)
 			t.setQueuers(queueNames)
 		}
 	}
@@ -143,8 +140,6 @@ func (t *tenantManager) listenForConcurrencyLeases(ctx context.Context) {
 }
 
 func (t *tenantManager) setQueuers(queueNames []string) {
-	fmt.Printf("setQueuers called with %d queues: %v\n", len(queueNames), queueNames)
-
 	t.queuersMu.Lock()
 	defer t.queuersMu.Unlock()
 
@@ -169,12 +164,10 @@ func (t *tenantManager) setQueuers(queueNames []string) {
 	}
 
 	for queueName := range queueNamesSet {
-		fmt.Printf("Creating new queuer for queue: %s\n", queueName)
 		newQueueArr = append(newQueueArr, newQueuer(t.cf, t.tenantId, queueName, t.scheduler, t.resultsCh))
 	}
 
 	t.queuers = newQueueArr
-	fmt.Printf("Total queuers after setQueuers: %d\n", len(t.queuers))
 }
 
 func (t *tenantManager) setConcurrencyStrategies(strategies []*sqlcv1.V1StepConcurrency) {


### PR DESCRIPTION
# Description

We have a bunch of `TIMESTAMP(3)` columns with queries using `NOW()`. This currently breaks the engine components around task scheduling and processing if the PostgreSQL server's timezone is non-UTC since `NOW()` simply strips the timezone portion when being used with a `TIMESTAMP(3)` column which can eventually lead to complete stagnation of task triggers and runs.

To fix this, we make sure to use `AT TIME ZONE 'UTC'` for all columns of type `TIMESTAMP(3)`.

Fixes https://github.com/hatchet-dev/hatchet/issues/2355

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
