### PR TITLE
feat: Add ApplyNamespace for BulkRunWorkflow

### DIFF
--- a/pkg/client/admin.go
+++ b/pkg/client/admin.go
@@ -294,8 +294,9 @@ func (a *adminClientImpl) BulkRunWorkflow(workflows []*WorkflowRun) ([]string, e
 			return nil, fmt.Errorf("could not marshal input: %w", err)
 		}
 
+		workflowName := client.ApplyNamespace(workflow.Name, &a.namespace)
 		triggerWorkflowRequests[i] = &admincontracts.TriggerWorkflowRequest{
-			Name:  workflow.Name,
+			Name:  workflowName,
 			Input: string(inputBytes),
 		}
 


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Add `ApplyNamespace` for `BulkRunWorkflow`.

In this way, the usage of workflowName can be unified, and users do not need to join namespace separately.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add `ApplyNamespace` for `BulkRunWorkflow`.
