### PR TITLE
Fix: Run `ANALYZE` over partitioned tables every three hours

### DIFF
--- a/internal/services/controllers/v1/olap/controller.go
+++ b/internal/services/controllers/v1/olap/controller.go
@@ -288,10 +288,7 @@ func (o *OLAPControllerImpl) Start() (func() error, error) {
 	}
 
 	_, err = o.s.NewJob(
-		gocron.DailyJob(1, gocron.NewAtTimes(
-			// 5AM UTC
-			gocron.NewAtTime(5, 0, 0),
-		)),
+		gocron.DurationJob(3*time.Hour),
 		gocron.NewTask(
 			o.runAnalyze(ctx),
 		),

--- a/internal/services/controllers/v1/task/controller.go
+++ b/internal/services/controllers/v1/task/controller.go
@@ -371,10 +371,7 @@ func (tc *TasksControllerImpl) Start() (func() error, error) {
 	}
 
 	_, err = tc.s.NewJob(
-		gocron.DailyJob(1, gocron.NewAtTimes(
-			// 5AM UTC
-			gocron.NewAtTime(5, 0, 0),
-		)),
+		gocron.DurationJob(3*time.Hour),
 		gocron.NewTask(
 			tc.runAnalyze(ctx),
 		),

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -1822,7 +1822,7 @@ func (r *OLAPRepositoryImpl) StoreCELEvaluationFailures(ctx context.Context, ten
 }
 
 func (r *OLAPRepositoryImpl) AnalyzeOLAPTables(ctx context.Context) error {
-	const timeout = 1000 * 60 * 30 // 30 minute timeout
+	const timeout = 1000 * 60 * 60 // 60 minute timeout
 	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, timeout)
 
 	if err != nil {

--- a/pkg/repository/v1/task.go
+++ b/pkg/repository/v1/task.go
@@ -3406,7 +3406,7 @@ func (r *TaskRepositoryImpl) ListSignalCompletedEvents(ctx context.Context, tena
 }
 
 func (r *TaskRepositoryImpl) AnalyzeTaskTables(ctx context.Context) error {
-	const timeout = 1000 * 60 * 30 // 30 minute timeout
+	const timeout = 1000 * 60 * 60 // 60 minute timeout
 	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, timeout)
 
 	if err != nil {


### PR DESCRIPTION
# Description

Run `ANALYZE` to recompute stats more often to speed up queries on the partitioned tables

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)