### PR TITLE
Include `tenant_id` in OTel spans wherever possible

### DIFF
--- a/internal/msgqueue/v1/postgres/msgqueue.go
+++ b/internal/msgqueue/v1/postgres/msgqueue.go
@@ -111,6 +111,8 @@ func (p *PostgresMessageQueue) SendMessage(ctx context.Context, queue msgqueue.Q
 	ctx, span := telemetry.NewSpan(ctx, "PostgresMessageQueue.SendMessage")
 	defer span.End()
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: task.TenantID})
+
 	err := p.addMessage(ctx, queue, task)
 
 	if err != nil {
@@ -125,6 +127,8 @@ func (p *PostgresMessageQueue) SendMessage(ctx context.Context, queue msgqueue.Q
 func (p *PostgresMessageQueue) addMessage(ctx context.Context, queue msgqueue.Queue, task *msgqueue.Message) error {
 	ctx, span := telemetry.NewSpan(ctx, "add-message")
 	defer span.End()
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: task.TenantID})
 
 	// inject otel carrier into the message
 	if task.OtelCarrier == nil {

--- a/internal/msgqueue/v1/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/v1/rabbitmq/rabbitmq.go
@@ -258,6 +258,8 @@ func (t *MessageQueueImpl) pubMessage(ctx context.Context, q msgqueue.Queue, msg
 	ctx, span := telemetry.NewSpanWithCarrier(ctx, "publish-message", otelCarrier)
 	defer span.End()
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: msg.TenantID})
+
 	msg.SetOtelCarrier(otelCarrier)
 
 	poolCh, err := t.pubChannels.Acquire(ctx)

--- a/internal/services/controllers/events/controller.go
+++ b/internal/services/controllers/events/controller.go
@@ -164,6 +164,10 @@ func (ec *EventsControllerImpl) handleTask(ctx context.Context, task *msgqueue.M
 
 	err = ec.dv.DecodeAndValidate(task.Metadata, &metadata)
 
+	if err == nil {
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
+	}
+
 	if err != nil {
 		return fmt.Errorf("could not decode task metadata: %w", err)
 	}

--- a/internal/services/controllers/events/controller.go
+++ b/internal/services/controllers/events/controller.go
@@ -166,9 +166,7 @@ func (ec *EventsControllerImpl) handleTask(ctx context.Context, task *msgqueue.M
 
 	if err == nil {
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
-	}
-
-	if err != nil {
+	} else {
 		return fmt.Errorf("could not decode task metadata: %w", err)
 	}
 

--- a/internal/services/controllers/jobs/controller.go
+++ b/internal/services/controllers/jobs/controller.go
@@ -318,6 +318,10 @@ func (ec *JobsControllerImpl) handleJobRunQueued(ctx context.Context, task *msgq
 
 	err = ec.dv.DecodeAndValidate(task.Metadata, &metadata)
 
+	if err == nil {
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
+	}
+
 	if err != nil {
 		return fmt.Errorf("could not decode job task metadata: %w", err)
 	}
@@ -374,6 +378,10 @@ func (ec *JobsControllerImpl) handleJobRunCancelled(ctx context.Context, task *m
 
 	err = ec.dv.DecodeAndValidate(task.Metadata, &metadata)
 
+	if err == nil {
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
+	}
+
 	if err != nil {
 		return fmt.Errorf("could not decode job task metadata: %w", err)
 	}
@@ -428,6 +436,10 @@ func (ec *JobsControllerImpl) handleStepRunRetry(ctx context.Context, task *msgq
 	}
 
 	err = ec.dv.DecodeAndValidate(task.Metadata, &metadata)
+
+	if err == nil {
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
+	}
 
 	if err != nil {
 		return fmt.Errorf("could not decode job task metadata: %w", err)
@@ -496,6 +508,10 @@ func (ec *JobsControllerImpl) handleStepRunReplay(ctx context.Context, task *msg
 	}
 
 	err = ec.dv.DecodeAndValidate(task.Metadata, &metadata)
+
+	if err == nil {
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
+	}
 
 	if err != nil {
 		return fmt.Errorf("could not decode job task metadata: %w", err)
@@ -593,6 +609,10 @@ func (ec *JobsControllerImpl) handleStepRunQueued(ctx context.Context, task *msg
 
 	err = ec.dv.DecodeAndValidate(task.Metadata, &metadata)
 
+	if err == nil {
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
+	}
+
 	if err != nil {
 		return fmt.Errorf("could not decode job task metadata: %w", err)
 	}
@@ -689,6 +709,8 @@ func (ec *JobsControllerImpl) runStepRunReassignTenant(ctx context.Context, tena
 	ctx, span := telemetry.NewSpan(ctx, "handle-step-run-reassign")
 	defer span.End()
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	_, stepRunsToFail, err := ec.repo.StepRun().ListStepRunsToReassign(ctx, tenantId)
 
 	if err != nil {
@@ -719,6 +741,8 @@ func (ec *JobsControllerImpl) runStepRunReassignTenant(ctx context.Context, tena
 func (ec *JobsControllerImpl) queueStepRun(ctx context.Context, tenantId, stepId, stepRunId string, isRetry bool) error {
 	ctx, span := telemetry.NewSpan(ctx, "queue-step-run")
 	defer span.End()
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
 
 	// add the rendered data to the step run
 	stepRun, err := ec.repo.StepRun().GetStepRunForEngine(ctx, tenantId, stepRunId)
@@ -929,6 +953,10 @@ func (ec *JobsControllerImpl) handleStepRunStarted(ctx context.Context, task *ms
 
 	err = ec.dv.DecodeAndValidate(task.Metadata, &metadata)
 
+	if err == nil {
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
+	}
+
 	if err != nil {
 		return fmt.Errorf("could not decode step run started task metadata: %w", err)
 	}
@@ -964,6 +992,10 @@ func (ec *JobsControllerImpl) handleStepRunAcked(ctx context.Context, task *msgq
 
 	err = ec.dv.DecodeAndValidate(task.Metadata, &metadata)
 
+	if err == nil {
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
+	}
+
 	if err != nil {
 		return fmt.Errorf("could not decode step run started task metadata: %w", err)
 	}
@@ -998,6 +1030,10 @@ func (ec *JobsControllerImpl) handleStepRunFinished(ctx context.Context, task *m
 	}
 
 	err = ec.dv.DecodeAndValidate(task.Metadata, &metadata)
+
+	if err == nil {
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
+	}
 
 	if err != nil {
 		return fmt.Errorf("could not decode step run finished task metadata: %w", err)
@@ -1066,6 +1102,10 @@ func (ec *JobsControllerImpl) handleStepRunFailed(ctx context.Context, task *msg
 	}
 
 	err = ec.dv.DecodeAndValidate(task.Metadata, &metadata)
+
+	if err == nil {
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
+	}
 
 	if err != nil {
 		return fmt.Errorf("could not decode step run failed task metadata: %w", err)
@@ -1195,6 +1235,10 @@ func (ec *JobsControllerImpl) handleStepRunTimedOut(ctx context.Context, task *m
 
 	err = ec.dv.DecodeAndValidate(task.Metadata, &metadata)
 
+	if err == nil {
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
+	}
+
 	if err != nil {
 		return fmt.Errorf("could not decode step run timed out task metadata: %w", err)
 	}
@@ -1217,6 +1261,10 @@ func (ec *JobsControllerImpl) handleStepRunCancel(ctx context.Context, task *msg
 
 	err = ec.dv.DecodeAndValidate(task.Metadata, &metadata)
 
+	if err == nil {
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
+	}
+
 	if err != nil {
 		return fmt.Errorf("could not decode step run notify cancel task metadata: %w", err)
 	}
@@ -1227,6 +1275,8 @@ func (ec *JobsControllerImpl) handleStepRunCancel(ctx context.Context, task *msg
 func (ec *JobsControllerImpl) cancelStepRun(ctx context.Context, tenantId, stepRunId, reason string, propagate bool) error {
 	ctx, span := telemetry.NewSpan(ctx, "cancel-step-run")
 	defer span.End()
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
 
 	// cancel current step run
 	now := time.Now().UTC()

--- a/internal/services/controllers/jobs/controller.go
+++ b/internal/services/controllers/jobs/controller.go
@@ -320,9 +320,7 @@ func (ec *JobsControllerImpl) handleJobRunQueued(ctx context.Context, task *msgq
 
 	if err == nil {
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
-	}
-
-	if err != nil {
+	} else {
 		return fmt.Errorf("could not decode job task metadata: %w", err)
 	}
 
@@ -380,9 +378,7 @@ func (ec *JobsControllerImpl) handleJobRunCancelled(ctx context.Context, task *m
 
 	if err == nil {
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
-	}
-
-	if err != nil {
+	} else {
 		return fmt.Errorf("could not decode job task metadata: %w", err)
 	}
 
@@ -439,9 +435,7 @@ func (ec *JobsControllerImpl) handleStepRunRetry(ctx context.Context, task *msgq
 
 	if err == nil {
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
-	}
-
-	if err != nil {
+	} else {
 		return fmt.Errorf("could not decode job task metadata: %w", err)
 	}
 
@@ -511,9 +505,7 @@ func (ec *JobsControllerImpl) handleStepRunReplay(ctx context.Context, task *msg
 
 	if err == nil {
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
-	}
-
-	if err != nil {
+	} else {
 		return fmt.Errorf("could not decode job task metadata: %w", err)
 	}
 
@@ -611,9 +603,7 @@ func (ec *JobsControllerImpl) handleStepRunQueued(ctx context.Context, task *msg
 
 	if err == nil {
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
-	}
-
-	if err != nil {
+	} else {
 		return fmt.Errorf("could not decode job task metadata: %w", err)
 	}
 
@@ -955,9 +945,7 @@ func (ec *JobsControllerImpl) handleStepRunStarted(ctx context.Context, task *ms
 
 	if err == nil {
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
-	}
-
-	if err != nil {
+	} else {
 		return fmt.Errorf("could not decode step run started task metadata: %w", err)
 	}
 
@@ -994,9 +982,7 @@ func (ec *JobsControllerImpl) handleStepRunAcked(ctx context.Context, task *msgq
 
 	if err == nil {
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
-	}
-
-	if err != nil {
+	} else {
 		return fmt.Errorf("could not decode step run started task metadata: %w", err)
 	}
 
@@ -1033,9 +1019,7 @@ func (ec *JobsControllerImpl) handleStepRunFinished(ctx context.Context, task *m
 
 	if err == nil {
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
-	}
-
-	if err != nil {
+	} else {
 		return fmt.Errorf("could not decode step run finished task metadata: %w", err)
 	}
 
@@ -1105,9 +1089,7 @@ func (ec *JobsControllerImpl) handleStepRunFailed(ctx context.Context, task *msg
 
 	if err == nil {
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
-	}
-
-	if err != nil {
+	} else {
 		return fmt.Errorf("could not decode step run failed task metadata: %w", err)
 	}
 
@@ -1237,9 +1219,7 @@ func (ec *JobsControllerImpl) handleStepRunTimedOut(ctx context.Context, task *m
 
 	if err == nil {
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
-	}
-
-	if err != nil {
+	} else {
 		return fmt.Errorf("could not decode step run timed out task metadata: %w", err)
 	}
 
@@ -1263,9 +1243,7 @@ func (ec *JobsControllerImpl) handleStepRunCancel(ctx context.Context, task *msg
 
 	if err == nil {
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
-	}
-
-	if err != nil {
+	} else {
 		return fmt.Errorf("could not decode step run notify cancel task metadata: %w", err)
 	}
 

--- a/internal/services/controllers/jobs/queue.go
+++ b/internal/services/controllers/jobs/queue.go
@@ -192,6 +192,10 @@ func (q *queue) handleCheckQueue(ctx context.Context, task *msgqueue.Message) er
 
 	err := q.dv.DecodeAndValidate(task.Metadata, &metadata)
 
+	if err == nil {
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
+	}
+
 	if err != nil {
 		return fmt.Errorf("could not decode check queue metadata: %w", err)
 	}
@@ -232,6 +236,8 @@ func (q *queue) runTenantUpdateStepRunsV2(ctx context.Context) func() {
 func (q *queue) processStepRunUpdatesV2(ctx context.Context, tenantId string) (bool, error) {
 	ctx, span := telemetry.NewSpan(ctx, "process-step-run-updates-v2")
 	defer span.End()
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
 
 	dbCtx, cancel := context.WithTimeout(ctx, 300*time.Second)
 	defer cancel()
@@ -351,6 +357,8 @@ func (q *queue) processStepRunTimeouts(ctx context.Context, tenantId string) (bo
 	ctx, span := telemetry.NewSpan(ctx, "handle-step-run-timeout")
 	defer span.End()
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	shouldContinue, stepRuns, err := q.repo.StepRun().ListStepRunsToTimeout(ctx, tenantId)
 
 	if err != nil {
@@ -369,6 +377,8 @@ func (q *queue) processStepRunTimeouts(ctx context.Context, tenantId string) (bo
 
 		scheduleCtx, span := telemetry.NewSpan(scheduleCtx, "handle-step-run-timeout-step-run")
 		defer span.End()
+
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
 
 		for i := range group {
 			stepRunCp := group[i]
@@ -399,6 +409,8 @@ func (q *queue) processStepRunTimeouts(ctx context.Context, tenantId string) (bo
 func (q *queue) processStepRunRetries(ctx context.Context, tenantId string) (bool, error) {
 	ctx, span := telemetry.NewSpan(ctx, "handle-step-run-timeout")
 	defer span.End()
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
 
 	shouldContinue, err := q.repo.StepRun().RetryStepRuns(ctx, tenantId)
 

--- a/internal/services/controllers/jobs/queue.go
+++ b/internal/services/controllers/jobs/queue.go
@@ -194,9 +194,7 @@ func (q *queue) handleCheckQueue(ctx context.Context, task *msgqueue.Message) er
 
 	if err == nil {
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
-	}
-
-	if err != nil {
+	} else {
 		return fmt.Errorf("could not decode check queue metadata: %w", err)
 	}
 

--- a/internal/services/controllers/retention/events.go
+++ b/internal/services/controllers/retention/events.go
@@ -45,6 +45,8 @@ func (wc *RetentionControllerImpl) runDeleteExpiredEventsTenant(ctx context.Cont
 
 	tenantId := sqlchelpers.UUIDToStr(tenant.ID)
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	createdBefore, err := GetDataRetentionExpiredTime(tenant.DataRetentionPeriod)
 
 	if err != nil {
@@ -77,6 +79,8 @@ func (wc *RetentionControllerImpl) runClearDeletedEventsPayloadTenant(ctx contex
 	defer span.End()
 
 	tenantId := sqlchelpers.UUIDToStr(tenant.ID)
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
 
 	// keep deleting until the context is done
 	for {

--- a/internal/services/controllers/retention/jobruns.go
+++ b/internal/services/controllers/retention/jobruns.go
@@ -31,6 +31,8 @@ func (wc *RetentionControllerImpl) runDeleteExpireJobRunsTenant(ctx context.Cont
 
 	tenantId := sqlchelpers.UUIDToStr(tenant.ID)
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	// keep deleting until the context is done
 	for {
 		select {

--- a/internal/services/controllers/retention/mq.go
+++ b/internal/services/controllers/retention/mq.go
@@ -38,6 +38,8 @@ func (rc *RetentionControllerImpl) runDeleteMessageQueueItemsQueries(ctx context
 	ctx, span := telemetry.NewSpan(ctx, "delete-queue-items-tenant")
 	defer span.End()
 
+	// Note: This function operates across all tenants, so no single tenant_id attribute
+
 	err := rc.repo.MessageQueue().CleanupQueues(ctx)
 
 	if err != nil {

--- a/internal/services/controllers/retention/mq.go
+++ b/internal/services/controllers/retention/mq.go
@@ -38,8 +38,6 @@ func (rc *RetentionControllerImpl) runDeleteMessageQueueItemsQueries(ctx context
 	ctx, span := telemetry.NewSpan(ctx, "delete-queue-items-tenant")
 	defer span.End()
 
-	// Note: This function operates across all tenants, so no single tenant_id attribute
-
 	err := rc.repo.MessageQueue().CleanupQueues(ctx)
 
 	if err != nil {

--- a/internal/services/controllers/retention/queue.go
+++ b/internal/services/controllers/retention/queue.go
@@ -29,6 +29,9 @@ func (rc *RetentionControllerImpl) runDeleteQueueItemsTenant(ctx context.Context
 	defer span.End()
 
 	tenantId := sqlchelpers.UUIDToStr(tenant.ID)
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	return rc.repo.StepRun().CleanupQueueItems(ctx, tenantId)
 }
 
@@ -52,6 +55,9 @@ func (rc *RetentionControllerImpl) runDeleteInternalQueueItemsTenant(ctx context
 	defer span.End()
 
 	tenantId := sqlchelpers.UUIDToStr(tenant.ID)
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	return rc.repo.StepRun().CleanupInternalQueueItems(ctx, tenantId)
 }
 
@@ -75,5 +81,8 @@ func (rc *RetentionControllerImpl) runDeleteRetryQueueItemsTenant(ctx context.Co
 	defer span.End()
 
 	tenantId := sqlchelpers.UUIDToStr(tenant.ID)
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	return rc.repo.StepRun().CleanupRetryQueueItems(ctx, tenantId)
 }

--- a/internal/services/controllers/retention/stepruns.go
+++ b/internal/services/controllers/retention/stepruns.go
@@ -31,6 +31,8 @@ func (wc *RetentionControllerImpl) runDeleteExpireStepRunsTenant(ctx context.Con
 
 	tenantId := sqlchelpers.UUIDToStr(tenant.ID)
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	// keep deleting until the context is done
 	for {
 		select {

--- a/internal/services/controllers/retention/workers.go
+++ b/internal/services/controllers/retention/workers.go
@@ -48,6 +48,8 @@ func (wc *RetentionControllerImpl) runDeleteOldWorkersTenant(ctx context.Context
 
 	tenantId := sqlchelpers.UUIDToStr(tenant.ID)
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	// hard-coded to last heartbeat before 24 hours
 	lastHeartbeatBefore := time.Now().UTC().Add(-24 * time.Hour)
 
@@ -77,6 +79,8 @@ func (wc *RetentionControllerImpl) runDeleteOldWorkerAssignEventsTenant(ctx cont
 	defer span.End()
 
 	tenantId := sqlchelpers.UUIDToStr(tenant.ID)
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
 
 	// hard-coded to last heartbeat after 24 hours
 	lastHeartbeatAfter := time.Now().UTC().Add(-24 * time.Hour)

--- a/internal/services/controllers/retention/workflowruns.go
+++ b/internal/services/controllers/retention/workflowruns.go
@@ -31,6 +31,8 @@ func (wc *RetentionControllerImpl) runDeleteExpiredWorkflowRunsTenant(ctx contex
 
 	tenantId := sqlchelpers.UUIDToStr(tenant.ID)
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	createdBefore, err := GetDataRetentionExpiredTime(tenant.DataRetentionPeriod)
 
 	if err != nil {

--- a/internal/services/controllers/v1/olap/process_alerts.go
+++ b/internal/services/controllers/v1/olap/process_alerts.go
@@ -41,6 +41,8 @@ func (o *OLAPControllerImpl) processTenantAlerts(ctx context.Context, tenantId s
 	ctx, span := telemetry.NewSpan(ctx, "process-tenant-alerts")
 	defer span.End()
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	isActive, lastAlerted, err := o.repo.Ticker().IsTenantAlertActive(ctx, tenantId)
 
 	if err != nil {

--- a/internal/services/controllers/v1/task/controller.go
+++ b/internal/services/controllers/v1/task/controller.go
@@ -474,6 +474,8 @@ func (tc *TasksControllerImpl) handleTaskCompleted(ctx context.Context, tenantId
 	ctx, span := telemetry.NewSpan(ctx, "TasksControllerImpl.handleTaskCompleted")
 	defer span.End()
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	opts := make([]v1.CompleteTaskOpts, 0)
 	idsToData := make(map[int64][]byte)
 
@@ -515,6 +517,8 @@ func (tc *TasksControllerImpl) handleTaskCompleted(ctx context.Context, tenantId
 func (tc *TasksControllerImpl) handleTaskFailed(ctx context.Context, tenantId string, payloads [][]byte) error {
 	ctx, span := telemetry.NewSpan(ctx, "TasksControllerImpl.handleTaskFailed")
 	defer span.End()
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
 
 	opts := make([]v1.FailTaskOpts, 0)
 
@@ -593,6 +597,8 @@ func (tc *TasksControllerImpl) processFailTasksResponse(ctx context.Context, ten
 	ctx, span := telemetry.NewSpan(ctx, "TasksControllerImpl.processFailTasksResponse")
 	defer span.End()
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	retriedTaskIds := make(map[int64]struct{})
 
 	for _, task := range res.RetriedTasks {
@@ -648,6 +654,8 @@ func (tc *TasksControllerImpl) processFailTasksResponse(ctx context.Context, ten
 func (tc *TasksControllerImpl) handleTaskCancelled(ctx context.Context, tenantId string, payloads [][]byte) error {
 	ctx, span := telemetry.NewSpan(ctx, "TasksControllerImpl.handleTaskCancelled")
 	defer span.End()
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
 
 	opts := make([]v1.TaskIdInsertedAtRetryCount, 0)
 
@@ -1010,6 +1018,8 @@ func (tc *TasksControllerImpl) handleProcessUserEvents(ctx context.Context, tena
 	ctx, span := telemetry.NewSpan(ctx, "TasksControllerImpl.handleProcessUserEvents")
 	defer span.End()
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	msgs := msgqueue.JSONConvert[tasktypes.UserEventTaskPayload](payloads)
 
 	eg := &errgroup.Group{}
@@ -1144,6 +1154,8 @@ func (tc *TasksControllerImpl) handleProcessInternalEvents(ctx context.Context, 
 	ctx, span := telemetry.NewSpan(ctx, "TasksControllerImpl.handleProcessInternalEvents")
 	defer span.End()
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	msgs := msgqueue.JSONConvert[v1.InternalTaskEvent](payloads)
 
 	return tc.processInternalEvents(ctx, tenantId, msgs)
@@ -1180,6 +1192,8 @@ func (tc *TasksControllerImpl) handleProcessTaskTrigger(ctx context.Context, ten
 func (tc *TasksControllerImpl) sendInternalEvents(ctx context.Context, tenantId string, events []v1.InternalTaskEvent) error {
 	ctx, span := telemetry.NewSpan(ctx, "TasksControllerImpl.sendInternalEvents")
 	defer span.End()
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
 
 	if len(events) == 0 {
 		return nil

--- a/internal/services/controllers/v1/task/evict_idempotency_keys.go
+++ b/internal/services/controllers/v1/task/evict_idempotency_keys.go
@@ -35,6 +35,8 @@ func (tc *TasksControllerImpl) evictExpiredIdempotencyKeys(ctx context.Context, 
 	ctx, span := telemetry.NewSpan(ctx, "evict-expired-idempotency-keys")
 	defer span.End()
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	err := tc.repov1.Idempotency().EvictExpiredIdempotencyKeys(ctx, sqlchelpers.UUIDFromStr(tenantId))
 
 	if err != nil {

--- a/internal/services/controllers/v1/task/process_reassignments.go
+++ b/internal/services/controllers/v1/task/process_reassignments.go
@@ -40,6 +40,8 @@ func (tc *TasksControllerImpl) processTaskReassignments(ctx context.Context, ten
 	ctx, span := telemetry.NewSpan(ctx, "process-task-reassignments")
 	defer span.End()
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	res, shouldContinue, err := tc.repov1.Tasks().ProcessTaskReassignments(ctx, tenantId)
 
 	if err != nil {

--- a/internal/services/controllers/v1/task/process_retry_queue_items.go
+++ b/internal/services/controllers/v1/task/process_retry_queue_items.go
@@ -41,6 +41,8 @@ func (tc *TasksControllerImpl) processTaskRetryQueueItems(ctx context.Context, t
 	ctx, span := telemetry.NewSpan(ctx, "process-retry-queue-items")
 	defer span.End()
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	retryQueueItems, shouldContinue, err := tc.repov1.Tasks().ProcessTaskRetryQueueItems(ctx, tenantId)
 
 	if err != nil {

--- a/internal/services/controllers/v1/task/process_sleeps.go
+++ b/internal/services/controllers/v1/task/process_sleeps.go
@@ -35,6 +35,8 @@ func (tc *TasksControllerImpl) processSleeps(ctx context.Context, tenantId strin
 	ctx, span := telemetry.NewSpan(ctx, "process-sleep")
 	defer span.End()
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	matchResult, shouldContinue, err := tc.repov1.Tasks().ProcessDurableSleeps(ctx, tenantId)
 
 	if err != nil {

--- a/internal/services/controllers/v1/task/process_timeouts.go
+++ b/internal/services/controllers/v1/task/process_timeouts.go
@@ -39,6 +39,8 @@ func (tc *TasksControllerImpl) processTaskTimeouts(ctx context.Context, tenantId
 	ctx, span := telemetry.NewSpan(ctx, "process-task-timeout")
 	defer span.End()
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	res, shouldContinue, err := tc.repov1.Tasks().ProcessTaskTimeouts(ctx, tenantId)
 
 	if err != nil {

--- a/internal/services/controllers/workflows/controller.go
+++ b/internal/services/controllers/workflows/controller.go
@@ -369,9 +369,7 @@ func (wc *WorkflowsControllerImpl) handleCheckQueue(ctx context.Context, task *m
 
 	if err == nil {
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
-	}
-
-	if err != nil {
+	} else {
 		return fmt.Errorf("could not decode check queue metadata: %w", err)
 	}
 
@@ -420,9 +418,7 @@ func (wc *WorkflowsControllerImpl) handleReplayWorkflowRun(ctx context.Context, 
 
 	if err == nil {
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
-	}
-
-	if err != nil {
+	} else {
 		return fmt.Errorf("could not decode replay workflow run task metadata: %w", err)
 	}
 
@@ -457,9 +453,7 @@ func (ec *WorkflowsControllerImpl) handleGroupKeyRunStarted(ctx context.Context,
 
 	if err == nil {
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
-	}
-
-	if err != nil {
+	} else {
 		return fmt.Errorf("could not decode group key run started task metadata: %w", err)
 	}
 
@@ -495,9 +489,7 @@ func (wc *WorkflowsControllerImpl) handleGroupKeyRunFinished(ctx context.Context
 
 	if err == nil {
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
-	}
-
-	if err != nil {
+	} else {
 		return fmt.Errorf("could not decode group key run finished task metadata: %w", err)
 	}
 
@@ -625,9 +617,7 @@ func (wc *WorkflowsControllerImpl) handleGroupKeyRunFailed(ctx context.Context, 
 
 	if err == nil {
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
-	}
-
-	if err != nil {
+	} else {
 		return fmt.Errorf("could not decode group key run failed task metadata: %w", err)
 	}
 
@@ -667,9 +657,7 @@ func (wc *WorkflowsControllerImpl) handleGetGroupKeyRunTimedOut(ctx context.Cont
 
 	if err == nil {
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
-	}
-
-	if err != nil {
+	} else {
 		return fmt.Errorf("could not decode get group key run run timed out task metadata: %w", err)
 	}
 

--- a/internal/services/controllers/workflows/controller.go
+++ b/internal/services/controllers/workflows/controller.go
@@ -367,6 +367,10 @@ func (wc *WorkflowsControllerImpl) handleCheckQueue(ctx context.Context, task *m
 
 	err := wc.dv.DecodeAndValidate(task.Metadata, &metadata)
 
+	if err == nil {
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
+	}
+
 	if err != nil {
 		return fmt.Errorf("could not decode check queue metadata: %w", err)
 	}
@@ -414,6 +418,10 @@ func (wc *WorkflowsControllerImpl) handleReplayWorkflowRun(ctx context.Context, 
 
 	err = wc.dv.DecodeAndValidate(task.Metadata, &metadata)
 
+	if err == nil {
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
+	}
+
 	if err != nil {
 		return fmt.Errorf("could not decode replay workflow run task metadata: %w", err)
 	}
@@ -446,6 +454,10 @@ func (ec *WorkflowsControllerImpl) handleGroupKeyRunStarted(ctx context.Context,
 	}
 
 	err = ec.dv.DecodeAndValidate(task.Metadata, &metadata)
+
+	if err == nil {
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
+	}
 
 	if err != nil {
 		return fmt.Errorf("could not decode group key run started task metadata: %w", err)
@@ -480,6 +492,10 @@ func (wc *WorkflowsControllerImpl) handleGroupKeyRunFinished(ctx context.Context
 	}
 
 	err = wc.dv.DecodeAndValidate(task.Metadata, &metadata)
+
+	if err == nil {
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
+	}
 
 	if err != nil {
 		return fmt.Errorf("could not decode group key run finished task metadata: %w", err)
@@ -607,6 +623,10 @@ func (wc *WorkflowsControllerImpl) handleGroupKeyRunFailed(ctx context.Context, 
 
 	err = wc.dv.DecodeAndValidate(task.Metadata, &metadata)
 
+	if err == nil {
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
+	}
+
 	if err != nil {
 		return fmt.Errorf("could not decode group key run failed task metadata: %w", err)
 	}
@@ -645,6 +665,10 @@ func (wc *WorkflowsControllerImpl) handleGetGroupKeyRunTimedOut(ctx context.Cont
 
 	err = wc.dv.DecodeAndValidate(task.Metadata, &metadata)
 
+	if err == nil {
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
+	}
+
 	if err != nil {
 		return fmt.Errorf("could not decode get group key run run timed out task metadata: %w", err)
 	}
@@ -655,6 +679,8 @@ func (wc *WorkflowsControllerImpl) handleGetGroupKeyRunTimedOut(ctx context.Cont
 func (wc *WorkflowsControllerImpl) cancelGetGroupKeyRun(ctx context.Context, tenantId, getGroupKeyRunId, reason string) error {
 	ctx, span := telemetry.NewSpan(ctx, "cancel-get-group-key-run") // nolint: ineffassign
 	defer span.End()
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
 
 	// cancel current step run
 	now := time.Now().UTC()
@@ -752,6 +778,8 @@ func (wc *WorkflowsControllerImpl) processWorkflowEvents(ctx context.Context, te
 	ctx, span := telemetry.NewSpan(ctx, "process-workflow-events")
 	defer span.End()
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	dbCtx, cancel := context.WithTimeout(ctx, 300*time.Second)
 	defer cancel()
 
@@ -767,6 +795,8 @@ func (wc *WorkflowsControllerImpl) processWorkflowEvents(ctx context.Context, te
 func (wc *WorkflowsControllerImpl) unpauseWorkflowRuns(ctx context.Context, tenantId string) (bool, error) {
 	ctx, span := telemetry.NewSpan(ctx, "unpause-workflow-runs")
 	defer span.End()
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
 
 	dbCtx, cancel := context.WithTimeout(ctx, 300*time.Second)
 	defer cancel()

--- a/internal/services/controllers/workflows/queue.go
+++ b/internal/services/controllers/workflows/queue.go
@@ -39,6 +39,10 @@ func (wc *WorkflowsControllerImpl) handleWorkflowRunQueued(ctx context.Context, 
 
 	err = wc.dv.DecodeAndValidate(task.Metadata, &metadata)
 
+	if err == nil {
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
+	}
+
 	if err != nil {
 
 		return fmt.Errorf("could not decode job task metadata: %w", err)
@@ -287,6 +291,10 @@ func (wc *WorkflowsControllerImpl) handleWorkflowRunFinished(ctx context.Context
 
 	err = wc.dv.DecodeAndValidate(task.Metadata, &metadata)
 
+	if err == nil {
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
+	}
+
 	if err != nil {
 		return fmt.Errorf("could not decode job task metadata: %w", err)
 	}
@@ -388,6 +396,8 @@ func (wc *WorkflowsControllerImpl) scheduleGetGroupAction(
 	defer span.End()
 
 	tenantId := sqlchelpers.UUIDToStr(getGroupKeyRun.GetGroupKeyRun.TenantId)
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
 	getGroupKeyRunId := sqlchelpers.UUIDToStr(getGroupKeyRun.GetGroupKeyRun.ID)
 	workflowRunId := sqlchelpers.UUIDToStr(getGroupKeyRun.WorkflowRunId)
 
@@ -469,6 +479,8 @@ func (ec *WorkflowsControllerImpl) runGetGroupKeyRunRequeueTenant(ctx context.Co
 	ctx, span := telemetry.NewSpan(ctx, "handle-get-group-key-run-requeue")
 	defer span.End()
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	getGroupKeyRuns, err := ec.repo.GetGroupKeyRun().ListGetGroupKeyRunsToRequeue(ctx, tenantId)
 
 	if err != nil {
@@ -486,6 +498,8 @@ func (ec *WorkflowsControllerImpl) runGetGroupKeyRunRequeueTenant(ctx context.Co
 
 			ctx, span := telemetry.NewSpan(ctx, "handle-get-group-key-run-requeue-tenant")
 			defer span.End()
+
+			telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
 
 			getGroupKeyRunId := sqlchelpers.UUIDToStr(getGroupKeyRunCp.ID)
 
@@ -556,6 +570,8 @@ func (ec *WorkflowsControllerImpl) runGetGroupKeyRunReassignTenant(ctx context.C
 	ctx, span := telemetry.NewSpan(ctx, "handle-get-group-key-run-reassign")
 	defer span.End()
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	getGroupKeyRuns, err := ec.repo.GetGroupKeyRun().ListGetGroupKeyRunsToReassign(ctx, tenantId)
 
 	if err != nil {
@@ -573,6 +589,8 @@ func (ec *WorkflowsControllerImpl) runGetGroupKeyRunReassignTenant(ctx context.C
 
 			ctx, span := telemetry.NewSpan(ctx, "handle-get-group-key-run-reassign-tenant")
 			defer span.End()
+
+			telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
 
 			getGroupKeyRunId := sqlchelpers.UUIDToStr(getGroupKeyRunCp.ID)
 
@@ -599,6 +617,8 @@ func (ec *WorkflowsControllerImpl) runGetGroupKeyRunReassignTenant(ctx context.C
 func (wc *WorkflowsControllerImpl) queueByCancelInProgress(ctx context.Context, tenantId string, workflowVersion *dbsqlc.GetWorkflowVersionForEngineRow) error {
 	ctx, span := telemetry.NewSpan(ctx, "queue-by-cancel-in-progress")
 	defer span.End()
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
 
 	workflowVersionId := sqlchelpers.UUIDToStr(workflowVersion.WorkflowVersion.ID)
 	maxRuns := int(workflowVersion.ConcurrencyMaxRuns.Int32)
@@ -657,6 +677,8 @@ func (wc *WorkflowsControllerImpl) queueByCancelNewest(ctx context.Context, tena
 	ctx, span := telemetry.NewSpan(ctx, "queue-by-cancel-newest")
 	defer span.End()
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
+
 	workflowVersionId := sqlchelpers.UUIDToStr(workflowVersion.WorkflowVersion.ID)
 	maxRuns := int(workflowVersion.ConcurrencyMaxRuns.Int32)
 
@@ -713,6 +735,8 @@ func (wc *WorkflowsControllerImpl) queueByCancelNewest(ctx context.Context, tena
 func (wc *WorkflowsControllerImpl) queueByGroupRoundRobin(ctx context.Context, tenantId string, workflowVersion *dbsqlc.GetWorkflowVersionForEngineRow) error {
 	ctx, span := telemetry.NewSpan(ctx, "queue-by-group-round-robin")
 	defer span.End()
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: tenantId})
 
 	workflowVersionId := sqlchelpers.UUIDToStr(workflowVersion.WorkflowVersion.ID)
 	maxRuns := int(workflowVersion.ConcurrencyMaxRuns.Int32)

--- a/internal/services/controllers/workflows/queue.go
+++ b/internal/services/controllers/workflows/queue.go
@@ -41,10 +41,7 @@ func (wc *WorkflowsControllerImpl) handleWorkflowRunQueued(ctx context.Context, 
 
 	if err == nil {
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
-	}
-
-	if err != nil {
-
+	} else {
 		return fmt.Errorf("could not decode job task metadata: %w", err)
 	}
 
@@ -293,9 +290,7 @@ func (wc *WorkflowsControllerImpl) handleWorkflowRunFinished(ctx context.Context
 
 	if err == nil {
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: metadata.TenantId})
-	}
-
-	if err != nil {
+	} else {
 		return fmt.Errorf("could not decode job task metadata: %w", err)
 	}
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -174,3 +174,23 @@ func WithAttributes(span trace.Span, attrs ...AttributeKV) {
 func prefixSpanKey(name string) string {
 	return fmt.Sprintf("hatchet.run/%s", name)
 }
+
+// CollectUniqueTenantIDs extracts unique tenant IDs from a slice of items.
+// The extractFn should return the tenant ID string for each item.
+func CollectUniqueTenantIDs[T any](items []T, extractFn func(T) string) []string {
+	if len(items) == 0 {
+		return nil
+	}
+
+	tenantIds := make(map[string]bool)
+	for _, item := range items {
+		tenantIds[extractFn(item)] = true
+	}
+
+	uniqueTenantIds := make([]string, 0, len(tenantIds))
+	for tid := range tenantIds {
+		uniqueTenantIds = append(uniqueTenantIds, tid)
+	}
+
+	return uniqueTenantIds
+}

--- a/pkg/scheduling/v0/queuer.go
+++ b/pkg/scheduling/v0/queuer.go
@@ -109,6 +109,8 @@ func (q *Queuer) queue(ctx context.Context) {
 		ctx, span := telemetry.NewSpan(ctx, "notify-queue")
 		defer span.End()
 
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: q.tenantId})
+
 		q.notifyQueueCh <- telemetry.GetCarrier(ctx)
 	}()
 }
@@ -128,10 +130,10 @@ func (q *Queuer) loopQueue(ctx context.Context) {
 
 		ctx, span := telemetry.NewSpanWithCarrier(ctx, "queue", carrier)
 
-		telemetry.WithAttributes(span, telemetry.AttributeKV{
-			Key:   "queue",
-			Value: q.queueName,
-		})
+		telemetry.WithAttributes(span,
+			telemetry.AttributeKV{Key: "queue", Value: q.queueName},
+			telemetry.AttributeKV{Key: "tenant_id", Value: q.tenantId},
+		)
 
 		start := time.Now()
 		checkpoint := start
@@ -371,6 +373,8 @@ func (q *Queuer) flushToDatabase(ctx context.Context, r *assignResults) int {
 
 	ctx, span := telemetry.NewSpan(ctx, "flush-to-database")
 	defer span.End()
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: q.tenantId})
 
 	q.l.Debug().Int("assigned", len(r.assigned)).Int("unassigned", len(r.unassigned)).Int("scheduling_timed_out", len(r.schedulingTimedOut)).Msg("flushing to database")
 

--- a/pkg/scheduling/v0/scheduler.go
+++ b/pkg/scheduling/v0/scheduler.go
@@ -450,14 +450,9 @@ func (s *Scheduler) tryAssignBatch(
 	defer span.End()
 
 	if len(qis) > 0 {
-		tenantIds := make(map[string]bool)
-		for _, qi := range qis {
-			tenantIds[sqlchelpers.UUIDToStr(qi.TenantId)] = true
-		}
-		uniqueTenantIds := make([]string, 0, len(tenantIds))
-		for tid := range tenantIds {
-			uniqueTenantIds = append(uniqueTenantIds, tid)
-		}
+		uniqueTenantIds := telemetry.CollectUniqueTenantIDs(qis, func(qi *dbsqlc.QueueItem) string {
+			return sqlchelpers.UUIDToStr(qi.TenantId)
+		})
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: uniqueTenantIds})
 	}
 
@@ -676,14 +671,9 @@ func (s *Scheduler) tryAssign(
 	ctx, span := telemetry.NewSpan(ctx, "try-assign")
 
 	if len(qis) > 0 {
-		tenantIds := make(map[string]bool)
-		for _, qi := range qis {
-			tenantIds[sqlchelpers.UUIDToStr(qi.TenantId)] = true
-		}
-		uniqueTenantIds := make([]string, 0, len(tenantIds))
-		for tid := range tenantIds {
-			uniqueTenantIds = append(uniqueTenantIds, tid)
-		}
+		uniqueTenantIds := telemetry.CollectUniqueTenantIDs(qis, func(qi *dbsqlc.QueueItem) string {
+			return sqlchelpers.UUIDToStr(qi.TenantId)
+		})
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: uniqueTenantIds})
 	}
 

--- a/pkg/scheduling/v0/scheduler.go
+++ b/pkg/scheduling/v0/scheduler.go
@@ -449,6 +449,18 @@ func (s *Scheduler) tryAssignBatch(
 	ctx, span := telemetry.NewSpan(ctx, "try-assign-batch")
 	defer span.End()
 
+	if len(qis) > 0 {
+		tenantIds := make(map[string]bool)
+		for _, qi := range qis {
+			tenantIds[sqlchelpers.UUIDToStr(qi.TenantId)] = true
+		}
+		uniqueTenantIds := make([]string, 0, len(tenantIds))
+		for tid := range tenantIds {
+			uniqueTenantIds = append(uniqueTenantIds, tid)
+		}
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: uniqueTenantIds})
+	}
+
 	res = make([]*assignSingleResult, len(qis))
 
 	for i := range qis {
@@ -609,6 +621,8 @@ func (s *Scheduler) tryAssignSingleton(
 	ctx, span := telemetry.NewSpan(ctx, "try-assign-singleton") // nolint: ineffassign
 	defer span.End()
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: sqlchelpers.UUIDToStr(qi.TenantId)})
+
 	if qi.Sticky.Valid || len(labels) > 0 {
 		candidateSlots = getRankedSlots(qi, labels, candidateSlots)
 	}
@@ -660,6 +674,18 @@ func (s *Scheduler) tryAssign(
 	stepRunIdsToRateLimits map[string]map[string]int32,
 ) <-chan *assignResults {
 	ctx, span := telemetry.NewSpan(ctx, "try-assign")
+
+	if len(qis) > 0 {
+		tenantIds := make(map[string]bool)
+		for _, qi := range qis {
+			tenantIds[sqlchelpers.UUIDToStr(qi.TenantId)] = true
+		}
+		uniqueTenantIds := make([]string, 0, len(tenantIds))
+		for tid := range tenantIds {
+			uniqueTenantIds = append(uniqueTenantIds, tid)
+		}
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: uniqueTenantIds})
+	}
 
 	// split into groups based on action ids, and process each action id in parallel
 	actionIdToQueueItems := make(map[string][]*dbsqlc.QueueItem)

--- a/pkg/scheduling/v1/concurrency.go
+++ b/pkg/scheduling/v1/concurrency.go
@@ -86,6 +86,8 @@ func (c *ConcurrencyManager) notify(ctx context.Context) {
 	ctx, span := telemetry.NewSpan(ctx, "notify-concurrency")
 	defer span.End()
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: c.tenantId.String()})
+
 	// non-blocking write
 	select {
 	case c.notifyConcurrencyCh <- telemetry.GetCarrier(ctx):
@@ -109,10 +111,10 @@ func (c *ConcurrencyManager) loopConcurrency(ctx context.Context) {
 
 		ctx, span := telemetry.NewSpanWithCarrier(ctx, "concurrency-manager", carrier)
 
-		telemetry.WithAttributes(span, telemetry.AttributeKV{
-			Key:   "strategy_id",
-			Value: c.strategy.ID,
-		})
+		telemetry.WithAttributes(span,
+			telemetry.AttributeKV{Key: "strategy_id", Value: c.strategy.ID},
+			telemetry.AttributeKV{Key: "tenant_id", Value: c.tenantId.String()},
+		)
 
 		if !c.rateLimiter.Allow() {
 			span.End()
@@ -156,10 +158,10 @@ func (c *ConcurrencyManager) loopCheckActive(ctx context.Context) {
 
 		ctx, span := telemetry.NewSpan(ctx, "concurrency-check-active")
 
-		telemetry.WithAttributes(span, telemetry.AttributeKV{
-			Key:   "strategy_id",
-			Value: c.strategy.ID,
-		})
+		telemetry.WithAttributes(span,
+			telemetry.AttributeKV{Key: "strategy_id", Value: c.strategy.ID},
+			telemetry.AttributeKV{Key: "tenant_id", Value: c.tenantId.String()},
+		)
 
 		start := time.Now()
 

--- a/pkg/scheduling/v1/queuer.go
+++ b/pkg/scheduling/v1/queuer.go
@@ -110,6 +110,8 @@ func (q *Queuer) queue(ctx context.Context) {
 		ctx, span := telemetry.NewSpan(ctx, "notify-queue")
 		defer span.End()
 
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: q.tenantId.String()})
+
 		q.notifyQueueCh <- telemetry.GetCarrier(ctx)
 	}()
 }
@@ -132,10 +134,10 @@ func (q *Queuer) loopQueue(ctx context.Context) {
 
 		ctx, span := telemetry.NewSpanWithCarrier(ctx, "queue", carrier)
 
-		telemetry.WithAttributes(span, telemetry.AttributeKV{
-			Key:   "queue",
-			Value: q.queueName,
-		})
+		telemetry.WithAttributes(span,
+			telemetry.AttributeKV{Key: "queue", Value: q.queueName},
+			telemetry.AttributeKV{Key: "tenant_id", Value: q.tenantId.String()},
+		)
 
 		start := time.Now()
 		checkpoint := start
@@ -437,6 +439,8 @@ func (q *Queuer) flushToDatabase(ctx context.Context, r *assignResults) int {
 
 	ctx, span := telemetry.NewSpan(ctx, "flush-to-database")
 	defer span.End()
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: q.tenantId.String()})
 
 	begin := time.Now()
 

--- a/pkg/scheduling/v1/scheduler.go
+++ b/pkg/scheduling/v1/scheduler.go
@@ -471,6 +471,18 @@ func (s *Scheduler) tryAssignBatch(
 	ctx, span := telemetry.NewSpan(ctx, "try-assign-batch")
 	defer span.End()
 
+	if len(qis) > 0 {
+		tenantIds := make(map[string]bool)
+		for _, qi := range qis {
+			tenantIds[qi.TenantID.String()] = true
+		}
+		uniqueTenantIds := make([]string, 0, len(tenantIds))
+		for tid := range tenantIds {
+			uniqueTenantIds = append(uniqueTenantIds, tid)
+		}
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: uniqueTenantIds})
+	}
+
 	res = make([]*assignSingleResult, len(qis))
 
 	for i := range qis {
@@ -631,6 +643,8 @@ func (s *Scheduler) tryAssignSingleton(
 	ctx, span := telemetry.NewSpan(ctx, "try-assign-singleton") // nolint: ineffassign
 	defer span.End()
 
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: qi.TenantID.String()})
+
 	ringOffset = ringOffset % len(candidateSlots)
 
 	if (qi.Sticky != sqlcv1.V1StickyStrategyNONE) || len(labels) > 0 {
@@ -686,6 +700,18 @@ func (s *Scheduler) tryAssign(
 	taskIdsToRateLimits map[int64]map[string]int32,
 ) <-chan *assignResults {
 	ctx, span := telemetry.NewSpan(ctx, "try-assign")
+
+	if len(qis) > 0 {
+		tenantIds := make(map[string]bool)
+		for _, qi := range qis {
+			tenantIds[qi.TenantID.String()] = true
+		}
+		uniqueTenantIds := make([]string, 0, len(tenantIds))
+		for tid := range tenantIds {
+			uniqueTenantIds = append(uniqueTenantIds, tid)
+		}
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: uniqueTenantIds})
+	}
 
 	// split into groups based on action ids, and process each action id in parallel
 	actionIdToQueueItems := make(map[string][]*sqlcv1.V1QueueItem)

--- a/pkg/scheduling/v1/scheduler.go
+++ b/pkg/scheduling/v1/scheduler.go
@@ -472,14 +472,9 @@ func (s *Scheduler) tryAssignBatch(
 	defer span.End()
 
 	if len(qis) > 0 {
-		tenantIds := make(map[string]bool)
-		for _, qi := range qis {
-			tenantIds[qi.TenantID.String()] = true
-		}
-		uniqueTenantIds := make([]string, 0, len(tenantIds))
-		for tid := range tenantIds {
-			uniqueTenantIds = append(uniqueTenantIds, tid)
-		}
+		uniqueTenantIds := telemetry.CollectUniqueTenantIDs(qis, func(qi *sqlcv1.V1QueueItem) string {
+			return qi.TenantID.String()
+		})
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: uniqueTenantIds})
 	}
 
@@ -702,14 +697,9 @@ func (s *Scheduler) tryAssign(
 	ctx, span := telemetry.NewSpan(ctx, "try-assign")
 
 	if len(qis) > 0 {
-		tenantIds := make(map[string]bool)
-		for _, qi := range qis {
-			tenantIds[qi.TenantID.String()] = true
-		}
-		uniqueTenantIds := make([]string, 0, len(tenantIds))
-		for tid := range tenantIds {
-			uniqueTenantIds = append(uniqueTenantIds, tid)
-		}
+		uniqueTenantIds := telemetry.CollectUniqueTenantIDs(qis, func(qi *sqlcv1.V1QueueItem) string {
+			return qi.TenantID.String()
+		})
 		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant_id", Value: uniqueTenantIds})
 	}
 


### PR DESCRIPTION
# Description

Adds a new `tenant_id` OTel span attribute wherever it is accessible.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
