### PR TITLE
fix: Fix checking value in Golang ValidateJSONB

### DIFF
--- a/internal/services/dispatcher/server_v1.go
+++ b/internal/services/dispatcher/server_v1.go
@@ -554,7 +554,8 @@ func (s *DispatcherImpl) sendStepActionEventV1(ctx context.Context, request *con
 		s.l.Warn().Msg("retry count is nil, using task's current retry count")
 	}
 
-	if request.EventType == contracts.StepActionEventType_STEP_EVENT_TYPE_COMPLETED {
+	if request.EventType == contracts.StepActionEventType_STEP_EVENT_TYPE_COMPLETED ||
+		request.EventType == contracts.StepActionEventType_STEP_EVENT_TYPE_FAILED {
 		if err := repository.ValidateJSONB([]byte(request.EventPayload), "taskOutput"); err != nil {
 			request.EventPayload = err.Error()
 			request.EventType = contracts.StepActionEventType_STEP_EVENT_TYPE_FAILED

--- a/pkg/repository/jsonb.go
+++ b/pkg/repository/jsonb.go
@@ -1,8 +1,8 @@
 package repository
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 )
 
 func ValidateJSONB(jsonb []byte, fieldName string) error {
@@ -10,7 +10,7 @@ func ValidateJSONB(jsonb []byte, fieldName string) error {
 		return nil
 	}
 
-	if bytes.Contains(jsonb, []byte("\u0000")) {
+	if strings.Contains(string(jsonb), "\\u0000") {
 		return fmt.Errorf("encoded jsonb contains invalid null character \\u0000 in field `%s`", fieldName)
 	}
 

--- a/pkg/repository/jsonb.go
+++ b/pkg/repository/jsonb.go
@@ -1,8 +1,8 @@
 package repository
 
 import (
+	"bytes"
 	"fmt"
-	"strings"
 )
 
 func ValidateJSONB(jsonb []byte, fieldName string) error {
@@ -10,7 +10,7 @@ func ValidateJSONB(jsonb []byte, fieldName string) error {
 		return nil
 	}
 
-	if strings.Contains(string(jsonb), "\u0000") {
+	if bytes.Contains(jsonb, []byte("\u0000")) {
 		return fmt.Errorf("encoded jsonb contains invalid null character \\u0000 in field `%s`", fieldName)
 	}
 

--- a/pkg/repository/jsonb.go
+++ b/pkg/repository/jsonb.go
@@ -10,7 +10,7 @@ func ValidateJSONB(jsonb []byte, fieldName string) error {
 		return nil
 	}
 
-	if strings.Contains(string(jsonb), "\\u0000") {
+	if strings.Contains(string(jsonb), "\u0000") {
 		return fmt.Errorf("encoded jsonb contains invalid null character \\u0000 in field `%s`", fieldName)
 	}
 

--- a/pkg/repository/jsonb_test.go
+++ b/pkg/repository/jsonb_test.go
@@ -21,17 +21,17 @@ func TestValidateJSONB(t *testing.T) {
 		},
 		{
 			name:    "valid_jsonb_with_encoded_NUL",
-			jsonb:   []byte(`{"NUL":"\\u0000"}`),
+			jsonb:   []byte("{\"NUL\":\"\\u0000\"}"),
 			wantErr: false,
 		},
 		{
 			name:    "invalid_jsonb_with_unicode_NUL",
-			jsonb:   []byte(`{"NUL":"\u0000"}`),
+			jsonb:   []byte("{\"NUL\":\"\u0000\"}"),
 			wantErr: true,
 		},
 		{
 			name:    "invalid_jsonb_with_utf8_NUL",
-			jsonb:   []byte(`{"NUL":"\x00"}`),
+			jsonb:   []byte("{\"NUL\":\"\x00\"}"),
 			wantErr: true,
 		},
 	}

--- a/pkg/repository/jsonb_test.go
+++ b/pkg/repository/jsonb_test.go
@@ -1,0 +1,49 @@
+//go:build !e2e && !load && !rampup && !integration
+
+package repository
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateJSONB(t *testing.T) {
+	tests := []struct {
+		name    string
+		jsonb   []byte
+		wantErr bool
+	}{
+		{
+			name:    "valid_jsonb",
+			jsonb:   []byte(`{"int_zero":0, "string_zero":"0", "null":null, "null_string":"", "normal_string": "Hello 你好 🙂"}`),
+			wantErr: false,
+		},
+		{
+			name:    "valid_jsonb_with_encoded_NUL",
+			jsonb:   []byte(`{"NUL":"\\u0000"}`),
+			wantErr: false,
+		},
+		{
+			name:    "invalid_jsonb_with_unicode_NUL",
+			jsonb:   []byte(`{"NUL":"\u0000"}`),
+			wantErr: true,
+		},
+		{
+			name:    "invalid_jsonb_with_utf8_NUL",
+			jsonb:   []byte(`{"NUL":"\x00"}`),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateJSONB(tt.jsonb, tt.name)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/repository/jsonb_test.go
+++ b/pkg/repository/jsonb_test.go
@@ -10,39 +10,39 @@ import (
 
 func TestValidateJSONB(t *testing.T) {
 	tests := []struct {
-		name    string
-		jsonb   []byte
-		wantErr bool
+		name  string
+		jsonb []byte
+		valid bool
 	}{
 		{
-			name:    "valid_jsonb",
-			jsonb:   []byte(`{"int_zero":0, "string_zero":"0", "null":null, "null_string":"", "normal_string": "Hello 你好 🙂"}`),
-			wantErr: false,
+			name:  "valid_jsonb",
+			jsonb: []byte(`{"int_zero":0, "string_zero":"0", "null":null, "null_string":"", "normal_string": "Hello 你好 🙂"}`),
+			valid: true,
 		},
 		{
-			name:    "valid_jsonb_with_encoded_NUL",
-			jsonb:   []byte("{\"NUL\":\"\\u0000\"}"),
-			wantErr: false,
+			name:  "valid_jsonb_with_encoded_NUL",
+			jsonb: []byte("{\"NUL\":\"\\u0000\"}"),
+			valid: true,
 		},
 		{
-			name:    "invalid_jsonb_with_unicode_NUL",
-			jsonb:   []byte("{\"NUL\":\"\u0000\"}"),
-			wantErr: true,
+			name:  "invalid_jsonb_with_unicode_NUL",
+			jsonb: []byte("{\"NUL\":\"\u0000\"}"),
+			valid: false,
 		},
 		{
-			name:    "invalid_jsonb_with_utf8_NUL",
-			jsonb:   []byte("{\"NUL\":\"\x00\"}"),
-			wantErr: true,
+			name:  "invalid_jsonb_with_utf8_NUL",
+			jsonb: []byte("{\"NUL\":\"\x00\"}"),
+			valid: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateJSONB(tt.jsonb, tt.name)
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
+			if tt.valid {
 				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
 			}
 		})
 	}

--- a/sdks/python/tests/engine_null_unicode_character/task.py
+++ b/sdks/python/tests/engine_null_unicode_character/task.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+
+from hatchet_sdk import Context, EmptyModel, Hatchet
+
+hatchet = Hatchet(debug=True)
+
+
+class Message(BaseModel):
+    content: str
+
+
+@hatchet.task(input_validator=Message)
+async def engine_null_unicode_rejection(input: Message, ctx: Context) -> dict[str, str]:
+    return {"result": "Hello\x00World", "message": input.content}

--- a/sdks/python/tests/engine_null_unicode_character/test_engine_rejects.py
+++ b/sdks/python/tests/engine_null_unicode_character/test_engine_rejects.py
@@ -1,0 +1,47 @@
+from subprocess import Popen
+from typing import Any
+from uuid import uuid4
+
+import grpc
+import pytest
+
+from hatchet_sdk import FailedTaskRunExceptionGroup, Hatchet, TriggerWorkflowOptions
+from tests.engine_null_unicode_character.task import (
+    Message,
+    engine_null_unicode_rejection,
+)
+
+
+@pytest.mark.parametrize(
+    "on_demand_worker",
+    [(["poetry", "run", "python", "tests/worker.py"], 8099)],
+    indirect=True,
+)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_failure_on_timeout(
+    hatchet: Hatchet,
+    on_demand_worker: Popen[Any],
+) -> None:
+    test_run_id = str(uuid4())
+
+    with pytest.raises(
+        grpc.RpcError,
+        match=r"encoded jsonb contains invalid null character .* in field `payload`",
+    ):
+        await engine_null_unicode_rejection.aio_run(
+            input=Message(content="Hello\x00World"),
+            options=TriggerWorkflowOptions(
+                additional_metadata={"test_run_id": test_run_id}
+            ),
+        )
+
+    with pytest.raises(
+        FailedTaskRunExceptionGroup,
+        match=r"encoded jsonb contains invalid null character .* in field `taskOutput`",
+    ):
+        await engine_null_unicode_rejection.aio_run(
+            input=Message(content="Hello World"),
+            options=TriggerWorkflowOptions(
+                additional_metadata={"test_run_id": test_run_id}
+            ),
+        )

--- a/sdks/python/tests/engine_null_unicode_character/test_engine_rejects.py
+++ b/sdks/python/tests/engine_null_unicode_character/test_engine_rejects.py
@@ -18,7 +18,7 @@ from tests.engine_null_unicode_character.task import (
     indirect=True,
 )
 @pytest.mark.asyncio(loop_scope="session")
-async def test_failure_on_timeout(
+async def test_unicode_rejection(
     hatchet: Hatchet,
     on_demand_worker: Popen[Any],
 ) -> None:

--- a/sdks/python/tests/worker.py
+++ b/sdks/python/tests/worker.py
@@ -9,6 +9,7 @@ from tests.child_spawn_cache_on_retry.worker import (
 from tests.correct_failure_on_timeout_with_multi_concurrency.workflow import (
     multiple_concurrent_cancellations_test_workflow,
 )
+from tests.engine_null_unicode_character.task import engine_null_unicode_rejection
 
 hatchet = Hatchet(debug=True)
 
@@ -21,6 +22,7 @@ def main(slots: int) -> None:
             multiple_concurrent_cancellations_test_workflow,
             spawn_cache_on_retry_parent,
             spawn_cache_on_retry_child,
+            engine_null_unicode_rejection,
         ],
     )
 


### PR DESCRIPTION
# Description

https://github.com/hatchet-dev/hatchet/blob/2a08cbf77b98da6c21c1417ec25dfc42f075208f/sdks/python/hatchet_sdk/worker/runner/runner.py#L501-L506

This comment has explained the significance of this method, but the implementation of this method has problems.
This PR fixes the value of this check.

Fixes # (issue)

When the object returned normally contains "\u0000", the task will be reset to failure.

Source Code: 
https://github.com/hatchet-dev/hatchet/blob/5bf9f97720aba5a8095b69fc69e510ce424db4f1/internal/services/dispatcher/server_v1.go#L557-L562

When the object returned error contains "\u0000", the error content is displayed normally (No check for ValidateJSONB). 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...
