### PR TITLE
Fix for Hatchet Lite to still properly fallback to using the `postgres` message queue kind

### DIFF
--- a/cmd/hatchet-lite/main.go
+++ b/cmd/hatchet-lite/main.go
@@ -93,8 +93,11 @@ func start(cf *loader.ConfigLoader, interruptCh <-chan interface{}, version stri
 
 	_, msgQueueKindSet := os.LookupEnv("SERVER_MSGQUEUE_KIND")
 	_, msgQueueRabbitMQURLSet := os.LookupEnv("SERVER_MSGQUEUE_RABBITMQ_URL")
+	// for legacy reasons let us also check for these two variables
+	_, taskQueueKindSet := os.LookupEnv("SERVER_TASKQUEUE_KIND")
+	_, taskQueueRabbitMQURLSet := os.LookupEnv("SERVER_TASKQUEUE_RABBITMQ_URL")
 
-	if !msgQueueKindSet && !msgQueueRabbitMQURLSet {
+	if !msgQueueKindSet && !msgQueueRabbitMQURLSet && !taskQueueKindSet && !taskQueueRabbitMQURLSet {
 		err := os.Setenv("SERVER_MSGQUEUE_KIND", "postgres")
 
 		if err != nil {


### PR DESCRIPTION
# Description

We want to preserve backwards compatibility with older `hatchet-lite` images which always used to use the `postgres` message queue backend. The current "fix" will not work because the generated `/config/server.yaml` in the Lite container has default values set which means using `rabbitmq` with its `URL` set. 

This PR basically preserves the older behavior by making sure that we keep using the `postgres` backend unless either `SERVER_MSGQUEUE_KIND` or `SERVER_MSGQUEUE_RABBITMQ_URL` are explicitly set.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
