### PR TITLE
Use `len()` for byte slice

### DIFF
--- a/internal/services/dispatcher/dispatcher_v1.go
+++ b/internal/services/dispatcher/dispatcher_v1.go
@@ -278,7 +278,7 @@ func (d *DispatcherImpl) handleTaskBulkAssignedTask(ctx context.Context, msg *ms
 				for _, outputEvent := range parentData {
 					outputMap := make(map[string]interface{})
 
-					if outputEvent.Output != nil {
+					if len(outputEvent.Output) > 0 {
 						err := json.Unmarshal(outputEvent.Output, &outputMap)
 
 						if err != nil {


### PR DESCRIPTION
# Description

Use `len()` to properly case on byte slice in dispatcher's output.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)
