### PR TITLE
Increase duration of stale issues to 90 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
-          stale-issue-message: 'This issue has been stale for 30 days. Please update the issue or comment to keep it active. Otherwise, it will be closed in 5 days.'
-          days-before-stale: 30
+          stale-issue-message: 'This issue has been stale for 90 days. Please update the issue or comment to keep it active. Otherwise, it will be closed in 5 days.'
+          days-before-stale: 90
           days-before-close: 5
           stale-issue-label: 'stale'


### PR DESCRIPTION
# Description

Simply increases the duration from 30 to 90 days.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] CI (any automation pipeline changes)
- [x] Chore (changes which are not directly related to any business logic)
