### PR TITLE
Fix type for `hatchet.WithRunMetadata`

### DIFF
--- a/examples/go/run-with-metadata/main.go
+++ b/examples/go/run-with-metadata/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	v0Client "github.com/hatchet-dev/hatchet/pkg/client"
+	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
+)
+
+type Input struct {
+	Message string `json:"message"`
+}
+
+func main() {
+	client, err := hatchet.NewClient()
+	if err != nil {
+		log.Fatalf("failed to create hatchet client: %v", err)
+	}
+
+	// > Run with metadata
+	_, err = client.Run(
+		context.Background(),
+		"my-workflow",
+		Input{Message: "hello"},
+		hatchet.WithRunMetadata(
+			map[string]string{"version": "1.0.0"},
+		),
+	)
+	if err != nil {
+		log.Fatalf("failed to run workflow: %v", err)
+	}
+
+	// > Push an event with metadata
+	err = client.Events().Push(
+		context.Background(),
+		"user:create",
+		Input{Message: "hello"},
+		v0Client.WithEventMetadata(
+			map[string]string{"version": "1.0.0"},
+		),
+	)
+	if err != nil {
+		log.Fatalf("failed to push event: %v", err)
+	}
+}

--- a/frontend/docs/pages/home/additional-metadata.mdx
+++ b/frontend/docs/pages/home/additional-metadata.mdx
@@ -29,16 +29,9 @@ You can attach additional metadata when pushing events or triggering task runs u
 
   </Tabs.Tab>
   <Tabs.Tab>
-```go
-err := c.Event().Push(
-    context.Background(),
-    "user:create",
-    testEvent,
-    client.WithEventMetadata(map[string]string{
-        "source": "api", // Arbitrary key-value pair
-    }),
-)
-```
+
+<Snippet src={snippets.go.run_with_metadata.main.push_an_event_with_metadata} />
+
   </Tabs.Tab>
 </UniversalTabs>
   </Tabs.Tab>
@@ -58,17 +51,9 @@ err := c.Event().Push(
 
   </Tabs.Tab>
   <Tabs.Tab>
-```go
-taskRunId, err := c.Admin().RunWorkflow(
-    "user-task",
-    &userCreateEvent{
-        UserID: "1234",
-    },
-    client.WithRunMetadata(map[string]interface{}{
-        "source": "api", // Arbitrary key-value pair
-    }),
-)
-```
+
+<Snippet src={snippets.go.run_with_metadata.main.run_with_metadata} />
+
   </Tabs.Tab>
 </UniversalTabs>
   </Tabs.Tab>

--- a/sdks/go/examples/run-with-metadata/main.go
+++ b/sdks/go/examples/run-with-metadata/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	v0Client "github.com/hatchet-dev/hatchet/pkg/client"
+	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
+)
+
+type Input struct {
+	Message string `json:"message"`
+}
+
+func main() {
+	client, err := hatchet.NewClient()
+	if err != nil {
+		log.Fatalf("failed to create hatchet client: %v", err)
+	}
+
+	// > Run with metadata
+	_, err = client.Run(
+		context.Background(),
+		"my-workflow",
+		Input{Message: "hello"},
+		hatchet.WithRunMetadata(
+			map[string]string{"version": "1.0.0"},
+		),
+	)
+	if err != nil {
+		log.Fatalf("failed to run workflow: %v", err)
+	}
+	// !!
+
+	// > Push an event with metadata
+	err = client.Events().Push(
+		context.Background(),
+		"user:create",
+		Input{Message: "hello"},
+		v0Client.WithEventMetadata(
+			map[string]string{"version": "1.0.0"},
+		),
+	)
+	if err != nil {
+		log.Fatalf("failed to push event: %v", err)
+	}
+	// !!
+}


### PR DESCRIPTION
# Description

Fixes type for providing additional metadata for a run from `map[string]any` to `map[string]string`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation change (pure documentation change)
