### PR TITLE
Introduce vars to tune `ANALYZE` job gocron run intervals

### DIFF
--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -353,6 +353,7 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig) ([]Teardown, erro
 			task.WithPartition(p),
 			task.WithQueueLoggerConfig(&sc.AdditionalLoggers.Queue),
 			task.WithPgxStatsLoggerConfig(&sc.AdditionalLoggers.PgxStats),
+			task.WithAnalyzeCronInterval(sc.CronOperations.TaskAnalyzeCronInterval),
 		)
 
 		if err != nil {
@@ -379,6 +380,7 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig) ([]Teardown, erro
 			olap.WithTenantAlertManager(sc.TenantAlerter),
 			olap.WithSamplingConfig(sc.Sampling),
 			olap.WithOperationsConfig(sc.Operations),
+			olap.WithAnalyzeCronInterval(sc.CronOperations.OLAPAnalyzeCronInterval),
 		)
 
 		if err != nil {
@@ -806,6 +808,7 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig) ([]Teardown, erro
 				task.WithPgxStatsLoggerConfig(&sc.AdditionalLoggers.PgxStats),
 				task.WithOpsPoolJitter(sc.Operations),
 				task.WithReplayEnabled(sc.Runtime.ReplayEnabled),
+				task.WithAnalyzeCronInterval(sc.CronOperations.TaskAnalyzeCronInterval),
 			)
 
 			if err != nil {
@@ -835,6 +838,7 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig) ([]Teardown, erro
 				olap.WithSamplingConfig(sc.Sampling),
 				olap.WithOperationsConfig(sc.Operations),
 				olap.WithPrometheusMetricsEnabled(sc.Prometheus.Enabled),
+				olap.WithAnalyzeCronInterval(sc.CronOperations.OLAPAnalyzeCronInterval),
 			)
 
 			if err != nil {

--- a/frontend/docs/pages/self-hosting/configuration-options.mdx
+++ b/frontend/docs/pages/self-hosting/configuration-options.mdx
@@ -1,12 +1,12 @@
 # Configuration Options
 
-The Hatchet server and engine can be configured via environment variables using several prefixes. This document contains a comprehensive list of all 193+ available options organized by component.
+The Hatchet server and engine can be configured via environment variables using several prefixes. This document contains a comprehensive list of all 195+ available options organized by component.
 
 ## Environment Variable Prefixes
 
 Hatchet uses the following environment variable prefixes:
 
-- **`SERVER_`** (170 variables) - Main server configuration including runtime, authentication, encryption, monitoring, and integrations
+- **`SERVER_`** (172 variables) - Main server configuration including runtime, authentication, encryption, monitoring, and integrations
 - **`DATABASE_`** (13 variables) - PostgreSQL database connection and configuration
 - **`READ_REPLICA_`** (4 variables) - Read replica database configuration
 - **`ADMIN_`** (3 variables) - Administrator user setup for initial seeding
@@ -313,48 +313,55 @@ Variables marked with ⚠️ are conditionally required when specific features a
 
 ## Tenant Alerting Configuration
 
-| Variable                                                  | Description                                  | Default Value          |
-| --------------------------------------------------------- | -------------------------------------------- | ---------------------- |
-| `SERVER_TENANT_ALERTING_SLACK_ENABLED`                    | Enable Slack for tenant alerting             |                        |
-| `SERVER_TENANT_ALERTING_SLACK_CLIENT_ID`                  | Slack client ID                              |                        |
-| `SERVER_TENANT_ALERTING_SLACK_CLIENT_SECRET`              | Slack client secret                          |                        |
-| `SERVER_TENANT_ALERTING_SLACK_SCOPES`                     | Slack scopes                                 | `["incoming-webhook"]` |
-| `SERVER_EMAIL_POSTMARK_ENABLED`                           | Enable Postmark                              |                        |
-| `SERVER_EMAIL_POSTMARK_SERVER_KEY`                        | Postmark server key                          |                        |
-| `SERVER_EMAIL_POSTMARK_FROM_EMAIL`                        | Postmark from email                          |                        |
-| `SERVER_EMAIL_POSTMARK_FROM_NAME`                         | Postmark from name                           | `Hatchet Support`      |
-| `SERVER_EMAIL_POSTMARK_SUPPORT_EMAIL`                     | Postmark support email                       |                        |
-| `SERVER_MONITORING_ENABLED`                               | Enable monitoring                            | `true`                 |
-| `SERVER_MONITORING_PERMITTED_TENANTS`                     | Permitted tenants for monitoring             |                        |
-| `SERVER_MONITORING_PROBE_TIMEOUT`                         | Monitoring probe timeout                     | `30s`                  |
-| `SERVER_MONITORING_TLS_ROOT_CA_FILE`                      | Monitoring TLS root CA file                  |                        |
-| `SERVER_SAMPLING_ENABLED`                                 | Enable sampling                              | `false`                |
-| `SERVER_SAMPLING_RATE`                                    | Sampling rate                                | `1.0`                  |
-| `SERVER_OPERATIONS_JITTER`                                | Operations jitter in milliseconds            | `0`                    |
-| `SERVER_OPERATIONS_POLL_INTERVAL`                         | Operations poll interval in seconds          | `2`                    |
-| `SERVER_WAIT_FOR_FLUSH`                                   | Default wait for flush                       | `1ms`                  |
-| `SERVER_MAX_CONCURRENT`                                   | Default max concurrent                       | `50`                   |
-| `SERVER_FLUSH_PERIOD_MILLISECONDS`                        | Default flush period                         | `10ms`                 |
-| `SERVER_FLUSH_ITEMS_THRESHOLD`                            | Default flush threshold                      | `100`                  |
-| `SERVER_FLUSH_STRATEGY`                                   | Default flush strategy                       | `DYNAMIC`              |
-| `SERVER_WORKFLOWRUNBUFFER_WAIT_FOR_FLUSH`                 | Workflow run buffer wait for flush           |                        |
-| `SERVER_WORKFLOWRUNBUFFER_MAX_CONCURRENT`                 | Max concurrent workflow run buffer ops       |                        |
-| `SERVER_WORKFLOWRUNBUFFER_FLUSH_PERIOD_MILLISECONDS`      | Flush period for workflow run buffer         |                        |
-| `SERVER_WORKFLOWRUNBUFFER_FLUSH_ITEMS_THRESHOLD`          | Items threshold for workflow run buffer      |                        |
-| `SERVER_WORKFLOWRUNBUFFER_FLUSH_STRATEGY`                 | Flush strategy for workflow run buffer       |                        |
-| `SERVER_EVENTBUFFER_WAIT_FOR_FLUSH`                       | Event buffer wait for flush                  |                        |
-| `SERVER_EVENTBUFFER_MAX_CONCURRENT`                       | Max concurrent event buffer ops              |                        |
-| `SERVER_EVENTBUFFER_FLUSH_PERIOD_MILLISECONDS`            | Flush period for event buffer                |                        |
-| `SERVER_EVENTBUFFER_FLUSH_ITEMS_THRESHOLD`                | Items threshold for event buffer             |                        |
-| `SERVER_EVENTBUFFER_SERIAL_BUFFER`                        | Event buffer serial mode                     |                        |
-| `SERVER_EVENTBUFFER_FLUSH_STRATEGY`                       | Flush strategy for event buffer              |                        |
-| `SERVER_RELEASESEMAPHOREBUFFER_WAIT_FOR_FLUSH`            | Release semaphore buffer wait for flush      |                        |
-| `SERVER_RELEASESEMAPHOREBUFFER_MAX_CONCURRENT`            | Max concurrent release semaphore buffer ops  |                        |
-| `SERVER_RELEASESEMAPHOREBUFFER_FLUSH_PERIOD_MILLISECONDS` | Flush period for release semaphore buffer    |                        |
-| `SERVER_RELEASESEMAPHOREBUFFER_FLUSH_ITEMS_THRESHOLD`     | Items threshold for release semaphore buffer |                        |
-| `SERVER_RELEASESEMAPHOREBUFFER_FLUSH_STRATEGY`            | Flush strategy for release semaphore buffer  |                        |
-| `SERVER_QUEUESTEPRUNBUFFER_WAIT_FOR_FLUSH`                | Queue step run buffer wait for flush         |                        |
-| `SERVER_QUEUESTEPRUNBUFFER_MAX_CONCURRENT`                | Max concurrent queue step run buffer ops     |                        |
-| `SERVER_QUEUESTEPRUNBUFFER_FLUSH_PERIOD_MILLISECONDS`     | Flush period for queue step run buffer       |                        |
-| `SERVER_QUEUESTEPRUNBUFFER_FLUSH_ITEMS_THRESHOLD`         | Items threshold for queue step run buffer    |                        |
-| `SERVER_QUEUESTEPRUNBUFFER_FLUSH_STRATEGY`                | Flush strategy for queue step run buffer     |                        |
+| Variable                                     | Description                         | Default Value          |
+| -------------------------------------------- | ----------------------------------- | ---------------------- |
+| `SERVER_TENANT_ALERTING_SLACK_ENABLED`       | Enable Slack for tenant alerting    |                        |
+| `SERVER_TENANT_ALERTING_SLACK_CLIENT_ID`     | Slack client ID                     |                        |
+| `SERVER_TENANT_ALERTING_SLACK_CLIENT_SECRET` | Slack client secret                 |                        |
+| `SERVER_TENANT_ALERTING_SLACK_SCOPES`        | Slack scopes                        | `["incoming-webhook"]` |
+| `SERVER_EMAIL_POSTMARK_ENABLED`              | Enable Postmark                     |                        |
+| `SERVER_EMAIL_POSTMARK_SERVER_KEY`           | Postmark server key                 |                        |
+| `SERVER_EMAIL_POSTMARK_FROM_EMAIL`           | Postmark from email                 |                        |
+| `SERVER_EMAIL_POSTMARK_FROM_NAME`            | Postmark from name                  | `Hatchet Support`      |
+| `SERVER_EMAIL_POSTMARK_SUPPORT_EMAIL`        | Postmark support email              |                        |
+| `SERVER_MONITORING_ENABLED`                  | Enable monitoring                   | `true`                 |
+| `SERVER_MONITORING_PERMITTED_TENANTS`        | Permitted tenants for monitoring    |                        |
+| `SERVER_MONITORING_PROBE_TIMEOUT`            | Monitoring probe timeout            | `30s`                  |
+| `SERVER_MONITORING_TLS_ROOT_CA_FILE`         | Monitoring TLS root CA file         |                        |
+| `SERVER_SAMPLING_ENABLED`                    | Enable sampling                     | `false`                |
+| `SERVER_SAMPLING_RATE`                       | Sampling rate                       | `1.0`                  |
+| `SERVER_OPERATIONS_JITTER`                   | Operations jitter in milliseconds   | `0`                    |
+| `SERVER_OPERATIONS_POLL_INTERVAL`            | Operations poll interval in seconds | `2`                    |
+
+## Cron Operations Configuration
+
+| Variable                                                  | Description                                           | Default Value |
+| --------------------------------------------------------- | ----------------------------------------------------- | ------------- |
+| `SERVER_CRON_OPERATIONS_TASK_ANALYZE_CRON_INTERVAL`       | Interval for running ANALYZE on task-related tables   | `3h`          |
+| `SERVER_CRON_OPERATIONS_OLAP_ANALYZE_CRON_INTERVAL`       | Interval for running ANALYZE on OLAP/analytics tables | `3h`          |
+| `SERVER_WAIT_FOR_FLUSH`                                   | Default wait for flush                                | `1ms`         |
+| `SERVER_MAX_CONCURRENT`                                   | Default max concurrent                                | `50`          |
+| `SERVER_FLUSH_PERIOD_MILLISECONDS`                        | Default flush period                                  | `10ms`        |
+| `SERVER_FLUSH_ITEMS_THRESHOLD`                            | Default flush threshold                               | `100`         |
+| `SERVER_FLUSH_STRATEGY`                                   | Default flush strategy                                | `DYNAMIC`     |
+| `SERVER_WORKFLOWRUNBUFFER_WAIT_FOR_FLUSH`                 | Workflow run buffer wait for flush                    |               |
+| `SERVER_WORKFLOWRUNBUFFER_MAX_CONCURRENT`                 | Max concurrent workflow run buffer ops                |               |
+| `SERVER_WORKFLOWRUNBUFFER_FLUSH_PERIOD_MILLISECONDS`      | Flush period for workflow run buffer                  |               |
+| `SERVER_WORKFLOWRUNBUFFER_FLUSH_ITEMS_THRESHOLD`          | Items threshold for workflow run buffer               |               |
+| `SERVER_WORKFLOWRUNBUFFER_FLUSH_STRATEGY`                 | Flush strategy for workflow run buffer                |               |
+| `SERVER_EVENTBUFFER_WAIT_FOR_FLUSH`                       | Event buffer wait for flush                           |               |
+| `SERVER_EVENTBUFFER_MAX_CONCURRENT`                       | Max concurrent event buffer ops                       |               |
+| `SERVER_EVENTBUFFER_FLUSH_PERIOD_MILLISECONDS`            | Flush period for event buffer                         |               |
+| `SERVER_EVENTBUFFER_FLUSH_ITEMS_THRESHOLD`                | Items threshold for event buffer                      |               |
+| `SERVER_EVENTBUFFER_SERIAL_BUFFER`                        | Event buffer serial mode                              |               |
+| `SERVER_EVENTBUFFER_FLUSH_STRATEGY`                       | Flush strategy for event buffer                       |               |
+| `SERVER_RELEASESEMAPHOREBUFFER_WAIT_FOR_FLUSH`            | Release semaphore buffer wait for flush               |               |
+| `SERVER_RELEASESEMAPHOREBUFFER_MAX_CONCURRENT`            | Max concurrent release semaphore buffer ops           |               |
+| `SERVER_RELEASESEMAPHOREBUFFER_FLUSH_PERIOD_MILLISECONDS` | Flush period for release semaphore buffer             |               |
+| `SERVER_RELEASESEMAPHOREBUFFER_FLUSH_ITEMS_THRESHOLD`     | Items threshold for release semaphore buffer          |               |
+| `SERVER_RELEASESEMAPHOREBUFFER_FLUSH_STRATEGY`            | Flush strategy for release semaphore buffer           |               |
+| `SERVER_QUEUESTEPRUNBUFFER_WAIT_FOR_FLUSH`                | Queue step run buffer wait for flush                  |               |
+| `SERVER_QUEUESTEPRUNBUFFER_MAX_CONCURRENT`                | Max concurrent queue step run buffer ops              |               |
+| `SERVER_QUEUESTEPRUNBUFFER_FLUSH_PERIOD_MILLISECONDS`     | Flush period for queue step run buffer                |               |
+| `SERVER_QUEUESTEPRUNBUFFER_FLUSH_ITEMS_THRESHOLD`         | Items threshold for queue step run buffer             |               |
+| `SERVER_QUEUESTEPRUNBUFFER_FLUSH_STRATEGY`                | Flush strategy for queue step run buffer              |               |

--- a/internal/services/controllers/v1/olap/controller.go
+++ b/internal/services/controllers/v1/olap/controller.go
@@ -194,6 +194,7 @@ func New(fs ...OLAPControllerOpt) (*OLAPControllerImpl, error) {
 		samplingHashThreshold:    opts.samplingHashThreshold,
 		olapConfig:               opts.olapConfig,
 		prometheusMetricsEnabled: opts.prometheusMetricsEnabled,
+		analyzeCronInterval:      opts.analyzeCronInterval,
 	}
 
 	// Default jitter value

--- a/internal/services/controllers/v1/task/controller.go
+++ b/internal/services/controllers/v1/task/controller.go
@@ -232,6 +232,7 @@ func New(fs ...TasksControllerOpt) (*TasksControllerImpl, error) {
 		opsPoolJitter:       opts.opsPoolJitter,
 		opsPoolPollInterval: opts.opsPoolPollInterval,
 		replayEnabled:       opts.replayEnabled,
+		analyzeCronInterval: opts.analyzeCronInterval,
 	}
 
 	jitter := t.opsPoolJitter

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -715,6 +715,7 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 		Version:                version,
 		Sampling:               cf.Sampling,
 		Operations:             cf.OLAP,
+		CronOperations:         cf.CronOperations,
 	}, nil
 }
 

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -81,6 +81,8 @@ type ServerConfigFile struct {
 	OLAP ConfigFileOperations `mapstructure:"olap" json:"olap,omitempty"`
 
 	PayloadStore PayloadStoreConfig `mapstructure:"payloadStore" json:"payloadStore,omitempty"`
+
+	CronOperations CronOperationsConfigFile `mapstructure:"cronOperations" json:"cronOperations,omitempty"`
 }
 
 type ConfigFileAdditionalLoggers struct {
@@ -119,6 +121,15 @@ type TaskOperationLimitsConfigFile struct {
 
 	// DurableSleepLimit is the limit for how many durable sleep items to process in a single operation
 	DurableSleepLimit int `mapstructure:"durableSleepLimit" json:"durableSleepLimit,omitempty" default:"1000"`
+}
+
+// CronOperationsConfigFile is the configuration for the cron operations
+type CronOperationsConfigFile struct {
+	// TaskAnalyzeCronInterval is the interval for the task analyze cron operation
+	TaskAnalyzeCronInterval time.Duration `mapstructure:"taskAnalyzeCronInterval" json:"taskAnalyzeCronInterval,omitempty" default:"3h"`
+
+	// OLAPAnalyzeCronInterval is the interval for the olap analyze cron operation
+	OLAPAnalyzeCronInterval time.Duration `mapstructure:"olapAnalyzeCronInterval" json:"olapAnalyzeCronInterval,omitempty" default:"3h"`
 }
 
 // General server runtime options
@@ -597,6 +608,8 @@ type ServerConfig struct {
 	GRPCInterceptors []grpc.UnaryServerInterceptor
 
 	Version string
+
+	CronOperations CronOperationsConfigFile
 }
 
 type PayloadStoreConfig struct {
@@ -877,4 +890,8 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("payloadStore.walPollLimit", "SERVER_PAYLOAD_STORE_WAL_POLL_LIMIT")
 	_ = v.BindEnv("payloadStore.walProcessInterval", "SERVER_PAYLOAD_STORE_WAL_PROCESS_INTERVAL")
 	_ = v.BindEnv("payloadStore.externalCutoverProcessInterval", "SERVER_PAYLOAD_STORE_EXTERNAL_CUTOVER_PROCESS_INTERVAL")
+
+	// cron operations options
+	_ = v.BindEnv("cronOperations.taskAnalyzeCronInterval", "SERVER_CRON_OPERATIONS_TASK_ANALYZE_CRON_INTERVAL")
+	_ = v.BindEnv("cronOperations.olapAnalyzeCronInterval", "SERVER_CRON_OPERATIONS_OLAP_ANALYZE_CRON_INTERVAL")
 }


### PR DESCRIPTION
# Description

Introduce two new vars to set the interval for the gocron jobs that run `ANALYZE` on tables:
- `SERVER_CRON_OPERATIONS_TASK_ANALYZE_CRON_INTERVAL`
- `SERVER_CRON_OPERATIONS_OLAP_ANALYZE_CRON_INTERVAL`
and their corresponding viper YAML counterparts:
- `cronOperations.taskAnalyzeCronInterval`
- `cronOperations.olapAnalyzeCronInterval`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
