### PR TITLE
Propagate `RunId` for all `Run()` variants

### DIFF
--- a/sdks/go/workflow.go
+++ b/sdks/go/workflow.go
@@ -550,7 +550,7 @@ func (w *Workflow) Run(ctx context.Context, input any, opts ...RunOptFunc) (*Wor
 		return nil, err
 	}
 
-	return &WorkflowResult{result: workflowResult}, nil
+	return &WorkflowResult{result: workflowResult, RunId: workflowRunRef.RunId}, nil
 }
 
 // RunNoWait executes the workflow with the provided input without waiting for completion.


### PR DESCRIPTION
# Description

Right now the `RunId` is only available via `WorkflowRef`. This PR propagates the run ID for use even from the `Run()` variants as well as `TaskResult`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
