### PR TITLE
fix: self-hosting doc references sqlite incorrectly

### DIFF
--- a/frontend/docs/pages/self-hosting/index.mdx
+++ b/frontend/docs/pages/self-hosting/index.mdx
@@ -6,8 +6,8 @@ Self-hosting Hatchet means running your own instance of the **Hatchet Control Pl
 
 When you self-host Hatchet, you're deploying:
 
-- **API Server** - REST and gRPC APIs for workflow management
-- **Engine** - Core workflow orchestration and task scheduling
+- **API Server** - REST APIs for workflow management
+- **Engine** - gRPC API for core workflow orchestration and task scheduling
 - **Database** - PostgreSQL for storing workflow state and metadata
 - **Message Queue (optional)** - RabbitMQ for inter-service communication and high-throughput real-time updates
 - **Dashboard** - Web UI for monitoring workflows and debugging
@@ -20,7 +20,7 @@ There are currently three supported ways to self-host the Hatchet Control Plane:
 
 Docker:
 
-1. [Hatchet Lite](./self-hosting/hatchet-lite.mdx) - Single docker image with embedded SQLite (development, testing, or low-throughput production)
+1. [Hatchet Lite](./self-hosting/hatchet-lite.mdx) - Single docker image with bundled engine and API (development, testing, or low-throughput production)
 2. [Docker Compose](./self-hosting/docker-compose.mdx) - Multi-container setup with PostgreSQL and RabbitMQ (production)
 
 Kubernetes:


### PR DESCRIPTION
# Description

Incorrect statement that hatchet lite bundles sqlite

Fixes #2422 

## Type of change

- [X] Documentation change (pure documentation change)