### PR TITLE
Hotfix: Swallow idempotency key error for scheduled runs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,6 +101,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
 github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
+github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6 h1:D/V0gu4zQ3cL2WKeVNVM4r2gLxGGf6McLwgXzRTo2RQ=
+github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/internal/services/ticker/schedule_workflow_v1.go
+++ b/internal/services/ticker/schedule_workflow_v1.go
@@ -22,6 +22,8 @@ func (t *TickerImpl) runScheduledWorkflowV1(ctx context.Context, tenantId string
 
 	var pgErr *pgconn.PgError
 	// 23505 is unique violation - https://www.postgresql.org/docs/current/errcodes-appendix.html
+	// if we get this, it means we tried to create a duplicate idempotency key, which means this
+	// run has already been processed, so we should just return
 	if err != nil && errors.As(err, &pgErr) && pgErr.Code == "23505" {
 		t.l.Warn().Msgf("idempotency key for scheduled workflow %s already exists, skipping", scheduledWorkflowId)
 		return nil

--- a/internal/services/ticker/schedule_workflow_v1.go
+++ b/internal/services/ticker/schedule_workflow_v1.go
@@ -21,10 +21,8 @@ func (t *TickerImpl) runScheduledWorkflowV1(ctx context.Context, tenantId string
 	err := t.repov1.Idempotency().CreateIdempotencyKey(ctx, tenantId, scheduledWorkflowId, sqlchelpers.TimestamptzFromTime(expiresAt))
 
 	var pgErr *pgconn.PgError
-	if err != nil && errors.As(err, &pgErr) {
-		if pgErr.Code == "23505" {
-			t.l.Warn().Msgf("idempotency key for scheduled workflow %s already exists, skipping", scheduledWorkflowId)
-		}
+	if err != nil && errors.As(err, &pgErr) && pgErr.Code == "23505" {
+		t.l.Warn().Msgf("idempotency key for scheduled workflow %s already exists, skipping", scheduledWorkflowId)
 	} else if err != nil {
 		return fmt.Errorf("could not create idempotency key: %w", err)
 	}

--- a/internal/services/ticker/schedule_workflow_v1.go
+++ b/internal/services/ticker/schedule_workflow_v1.go
@@ -24,6 +24,7 @@ func (t *TickerImpl) runScheduledWorkflowV1(ctx context.Context, tenantId string
 	// 23505 is unique violation - https://www.postgresql.org/docs/current/errcodes-appendix.html
 	if err != nil && errors.As(err, &pgErr) && pgErr.Code == "23505" {
 		t.l.Warn().Msgf("idempotency key for scheduled workflow %s already exists, skipping", scheduledWorkflowId)
+		return nil
 	} else if err != nil {
 		return fmt.Errorf("could not create idempotency key: %w", err)
 	}

--- a/internal/services/ticker/schedule_workflow_v1.go
+++ b/internal/services/ticker/schedule_workflow_v1.go
@@ -22,8 +22,7 @@ func (t *TickerImpl) runScheduledWorkflowV1(ctx context.Context, tenantId string
 	err := t.repov1.Idempotency().CreateIdempotencyKey(ctx, tenantId, scheduledWorkflowId, sqlchelpers.TimestamptzFromTime(expiresAt))
 
 	var pgErr *pgconn.PgError
-	// 23505 is unique violation - https://www.postgresql.org/docs/current/errcodes-appendix.html
-	// if we get this, it means we tried to create a duplicate idempotency key, which means this
+	// if we get a unique violation, it means we tried to create a duplicate idempotency key, which means this
 	// run has already been processed, so we should just return
 	if err != nil && errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
 		t.l.Info().Msgf("idempotency key for scheduled workflow %s already exists, skipping", scheduledWorkflowId)

--- a/internal/services/ticker/schedule_workflow_v1.go
+++ b/internal/services/ticker/schedule_workflow_v1.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
 
 	msgqueuev1 "github.com/hatchet-dev/hatchet/internal/msgqueue/v1"
@@ -24,7 +25,7 @@ func (t *TickerImpl) runScheduledWorkflowV1(ctx context.Context, tenantId string
 	// 23505 is unique violation - https://www.postgresql.org/docs/current/errcodes-appendix.html
 	// if we get this, it means we tried to create a duplicate idempotency key, which means this
 	// run has already been processed, so we should just return
-	if err != nil && errors.As(err, &pgErr) && pgErr.Code == "23505" {
+	if err != nil && errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
 		t.l.Warn().Msgf("idempotency key for scheduled workflow %s already exists, skipping", scheduledWorkflowId)
 		return nil
 	} else if err != nil {

--- a/internal/services/ticker/schedule_workflow_v1.go
+++ b/internal/services/ticker/schedule_workflow_v1.go
@@ -21,6 +21,7 @@ func (t *TickerImpl) runScheduledWorkflowV1(ctx context.Context, tenantId string
 	err := t.repov1.Idempotency().CreateIdempotencyKey(ctx, tenantId, scheduledWorkflowId, sqlchelpers.TimestamptzFromTime(expiresAt))
 
 	var pgErr *pgconn.PgError
+	// 23505 is unique violation - https://www.postgresql.org/docs/current/errcodes-appendix.html
 	if err != nil && errors.As(err, &pgErr) && pgErr.Code == "23505" {
 		t.l.Warn().Msgf("idempotency key for scheduled workflow %s already exists, skipping", scheduledWorkflowId)
 	} else if err != nil {

--- a/internal/services/ticker/schedule_workflow_v1.go
+++ b/internal/services/ticker/schedule_workflow_v1.go
@@ -26,7 +26,7 @@ func (t *TickerImpl) runScheduledWorkflowV1(ctx context.Context, tenantId string
 	// if we get this, it means we tried to create a duplicate idempotency key, which means this
 	// run has already been processed, so we should just return
 	if err != nil && errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
-		t.l.Warn().Msgf("idempotency key for scheduled workflow %s already exists, skipping", scheduledWorkflowId)
+		t.l.Info().Msgf("idempotency key for scheduled workflow %s already exists, skipping", scheduledWorkflowId)
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("could not create idempotency key: %w", err)


### PR DESCRIPTION
# Description

Swallow idempotency key error on unique violation since it's just indicating that we should not be running the job twice (which is correct, not an error)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


