### PR TITLE
Add vars to tune concurrency poller

### DIFF
--- a/frontend/docs/pages/self-hosting/configuration-options.mdx
+++ b/frontend/docs/pages/self-hosting/configuration-options.mdx
@@ -106,36 +106,38 @@ go run ./cmd/hatchet-admin keyset create-local-keys --key-dir ./keys
 
 Variables marked with ⚠️ are conditionally required when specific features are enabled.
 
-| Variable                                | Description                             | Default Value           |
-| --------------------------------------- | --------------------------------------- | ----------------------- |
-| `SERVER_PORT`                           | Port for the core server                | `8080`                  |
-| `SERVER_URL`                            | Full server URL, including protocol     | `http://localhost:8080` |
-| `SERVER_GRPC_PORT`                      | Port for the GRPC service               | `7070`                  |
-| `SERVER_GRPC_BIND_ADDRESS`              | GRPC server bind address                | `127.0.0.1`             |
-| `SERVER_GRPC_BROADCAST_ADDRESS`         | GRPC server broadcast address           | `127.0.0.1:7070`        |
-| `SERVER_GRPC_INSECURE`                  | Controls if the GRPC server is insecure | `false`                 |
-| `SERVER_SHUTDOWN_WAIT`                  | Shutdown wait duration                  | `20s`                   |
-| `SERVER_ENFORCE_LIMITS`                 | Enforce tenant limits                   | `false`                 |
-| `SERVER_ALLOW_SIGNUP`                   | Allow new tenant signups                | `true`                  |
-| `SERVER_ALLOW_INVITES`                  | Allow new invites                       | `true`                  |
-| `SERVER_ALLOW_CREATE_TENANT`            | Allow tenant creation                   | `true`                  |
-| `SERVER_ALLOW_CHANGE_PASSWORD`          | Allow password changes                  | `true`                  |
-| `SERVER_HEALTHCHECK`                    | Enable healthcheck endpoint             | `true`                  |
-| `SERVER_HEALTHCHECK_PORT`               | Healthcheck port                        | `8733`                  |
-| `SERVER_GRPC_MAX_MSG_SIZE`              | gRPC max message size                   | `4194304`               |
-| `SERVER_GRPC_RATE_LIMIT`                | gRPC rate limit                         | `1000`                  |
-| `SCHEDULER_CONCURRENCY_RATE_LIMIT`      | Scheduler concurrency rate limit        | `20`                    |
-| `SERVER_SERVICES`                       | Services to run                         | `["all"]`               |
-| `SERVER_PAUSED_CONTROLLERS`             | Paused controllers                      |                         |
-| `SERVER_ENABLE_DATA_RETENTION`          | Enable data retention                   | `true`                  |
-| `SERVER_ENABLE_WORKER_RETENTION`        | Enable worker retention                 | `false`                 |
-| `SERVER_MAX_PENDING_INVITES`            | Max pending invites                     | `100`                   |
-| `SERVER_BUFFER_CREATE_WORKFLOW_RUNS`    | Buffer workflow run creation            | `true`                  |
-| `SERVER_DISABLE_TENANT_PUBS`            | Disable tenant pubsub                   |                         |
-| `SERVER_MAX_INTERNAL_RETRY_COUNT`       | Max internal retry count                | `10`                    |
-| `SERVER_PREVENT_TENANT_VERSION_UPGRADE` | Prevent tenant version upgrades         | `false`                 |
-| `SERVER_DEFAULT_ENGINE_VERSION`         | Default engine version                  | `V1`                    |
-| `SERVER_REPLAY_ENABLED`                 | Enable task replay                      | `true`                  |
+| Variable                                     | Description                             | Default Value           |
+| -------------------------------------------- | --------------------------------------- | ----------------------- |
+| `SERVER_PORT`                                | Port for the core server                | `8080`                  |
+| `SERVER_URL`                                 | Full server URL, including protocol     | `http://localhost:8080` |
+| `SERVER_GRPC_PORT`                           | Port for the GRPC service               | `7070`                  |
+| `SERVER_GRPC_BIND_ADDRESS`                   | GRPC server bind address                | `127.0.0.1`             |
+| `SERVER_GRPC_BROADCAST_ADDRESS`              | GRPC server broadcast address           | `127.0.0.1:7070`        |
+| `SERVER_GRPC_INSECURE`                       | Controls if the GRPC server is insecure | `false`                 |
+| `SERVER_SHUTDOWN_WAIT`                       | Shutdown wait duration                  | `20s`                   |
+| `SERVER_ENFORCE_LIMITS`                      | Enforce tenant limits                   | `false`                 |
+| `SERVER_ALLOW_SIGNUP`                        | Allow new tenant signups                | `true`                  |
+| `SERVER_ALLOW_INVITES`                       | Allow new invites                       | `true`                  |
+| `SERVER_ALLOW_CREATE_TENANT`                 | Allow tenant creation                   | `true`                  |
+| `SERVER_ALLOW_CHANGE_PASSWORD`               | Allow password changes                  | `true`                  |
+| `SERVER_HEALTHCHECK`                         | Enable healthcheck endpoint             | `true`                  |
+| `SERVER_HEALTHCHECK_PORT`                    | Healthcheck port                        | `8733`                  |
+| `SERVER_GRPC_MAX_MSG_SIZE`                   | gRPC max message size                   | `4194304`               |
+| `SERVER_GRPC_RATE_LIMIT`                     | gRPC rate limit                         | `1000`                  |
+| `SCHEDULER_CONCURRENCY_RATE_LIMIT`           | Scheduler concurrency rate limit        | `20`                    |
+| `SCHEDULER_CONCURRENCY_POLLING_MIN_INTERVAL` | Minimum concurrency polling interval    | `500ms`                 |
+| `SCHEDULER_CONCURRENCY_POLLING_MAX_INTERVAL` | Maximum concurrency polling interval    | `5s`                    |
+| `SERVER_SERVICES`                            | Services to run                         | `["all"]`               |
+| `SERVER_PAUSED_CONTROLLERS`                  | Paused controllers                      |                         |
+| `SERVER_ENABLE_DATA_RETENTION`               | Enable data retention                   | `true`                  |
+| `SERVER_ENABLE_WORKER_RETENTION`             | Enable worker retention                 | `false`                 |
+| `SERVER_MAX_PENDING_INVITES`                 | Max pending invites                     | `100`                   |
+| `SERVER_BUFFER_CREATE_WORKFLOW_RUNS`         | Buffer workflow run creation            | `true`                  |
+| `SERVER_DISABLE_TENANT_PUBS`                 | Disable tenant pubsub                   |                         |
+| `SERVER_MAX_INTERNAL_RETRY_COUNT`            | Max internal retry count                | `10`                    |
+| `SERVER_PREVENT_TENANT_VERSION_UPGRADE`      | Prevent tenant version upgrades         | `false`                 |
+| `SERVER_DEFAULT_ENGINE_VERSION`              | Default engine version                  | `V1`                    |
+| `SERVER_REPLAY_ENABLED`                      | Enable task replay                      | `true`                  |
 
 ## Database Configuration
 

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -633,6 +633,8 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 		&queueLogger,
 		cf.Runtime.SingleQueueLimit,
 		cf.Runtime.SchedulerConcurrencyRateLimit,
+		cf.Runtime.SchedulerConcurrencyPollingMinInterval,
+		cf.Runtime.SchedulerConcurrencyPollingMaxInterval,
 	)
 
 	if err != nil {

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -259,6 +259,12 @@ type ConfigFileRuntime struct {
 	// SchedulerConcurrencyRateLimit is the rate limit for scheduler concurrency strategy execution (per second)
 	SchedulerConcurrencyRateLimit int `mapstructure:"schedulerConcurrencyRateLimit" json:"schedulerConcurrencyRateLimit,omitempty" default:"20"`
 
+	// SchedulerConcurrencyPollingMinInterval is the minimum interval for concurrency polling
+	SchedulerConcurrencyPollingMinInterval time.Duration `mapstructure:"schedulerConcurrencyPollingMinInterval" json:"schedulerConcurrencyPollingMinInterval,omitempty" default:"500ms"`
+
+	// SchedulerConcurrencyPollingMaxInterval is the maximum interval for concurrency polling
+	SchedulerConcurrencyPollingMaxInterval time.Duration `mapstructure:"schedulerConcurrencyPollingMaxInterval" json:"schedulerConcurrencyPollingMaxInterval,omitempty" default:"5s"`
+
 	// LogIngestionEnabled controls whether the server enables log ingestion for tasks
 	LogIngestionEnabled bool `mapstructure:"logIngestionEnabled" json:"logIngestionEnabled,omitempty" default:"true"`
 
@@ -649,6 +655,8 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("runtime.grpcStaticStreamWindowSize", "SERVER_GRPC_STATIC_STREAM_WINDOW_SIZE")
 	_ = v.BindEnv("runtime.grpcRateLimit", "SERVER_GRPC_RATE_LIMIT")
 	_ = v.BindEnv("runtime.schedulerConcurrencyRateLimit", "SCHEDULER_CONCURRENCY_RATE_LIMIT")
+	_ = v.BindEnv("runtime.schedulerConcurrencyPollingMinInterval", "SCHEDULER_CONCURRENCY_POLLING_MIN_INTERVAL")
+	_ = v.BindEnv("runtime.schedulerConcurrencyPollingMaxInterval", "SCHEDULER_CONCURRENCY_POLLING_MAX_INTERVAL")
 	_ = v.BindEnv("runtime.shutdownWait", "SERVER_SHUTDOWN_WAIT")
 	_ = v.BindEnv("servicesString", "SERVER_SERVICES")
 	_ = v.BindEnv("pausedControllers", "SERVER_PAUSED_CONTROLLERS")

--- a/pkg/scheduling/v1/pool.go
+++ b/pkg/scheduling/v1/pool.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/rs/zerolog"
 
@@ -19,6 +20,10 @@ type sharedConfig struct {
 	singleQueueLimit int
 
 	schedulerConcurrencyRateLimit int
+
+	schedulerConcurrencyPollingMinInterval time.Duration
+
+	schedulerConcurrencyPollingMaxInterval time.Duration
 }
 
 // SchedulingPool is responsible for managing a pool of tenantManagers.
@@ -35,17 +40,19 @@ type SchedulingPool struct {
 	concurrencyResultsCh chan *ConcurrencyResults
 }
 
-func NewSchedulingPool(repo v1.SchedulerRepository, l *zerolog.Logger, singleQueueLimit int, schedulerConcurrencyRateLimit int) (*SchedulingPool, func() error, error) {
+func NewSchedulingPool(repo v1.SchedulerRepository, l *zerolog.Logger, singleQueueLimit int, schedulerConcurrencyRateLimit int, schedulerConcurrencyPollingMinInterval time.Duration, schedulerConcurrencyPollingMaxInterval time.Duration) (*SchedulingPool, func() error, error) {
 	resultsCh := make(chan *QueueResults, 1000)
 	concurrencyResultsCh := make(chan *ConcurrencyResults, 1000)
 
 	s := &SchedulingPool{
 		Extensions: &Extensions{},
 		cf: &sharedConfig{
-			repo:                          repo,
-			l:                             l,
-			singleQueueLimit:              singleQueueLimit,
-			schedulerConcurrencyRateLimit: schedulerConcurrencyRateLimit,
+			repo:                                   repo,
+			l:                                      l,
+			singleQueueLimit:                       singleQueueLimit,
+			schedulerConcurrencyRateLimit:          schedulerConcurrencyRateLimit,
+			schedulerConcurrencyPollingMinInterval: schedulerConcurrencyPollingMinInterval,
+			schedulerConcurrencyPollingMaxInterval: schedulerConcurrencyPollingMaxInterval,
 		},
 		resultsCh:            resultsCh,
 		concurrencyResultsCh: concurrencyResultsCh,


### PR DESCRIPTION
# Description

Adds two new env vars `SCHEDULER_CONCURRENCY_POLLING_MIN_INTERVAL` and `SCHEDULER_CONCURRENCY_POLLING_MAX_INTERVAL` to tune the random ticker for concurrency polling.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Documentation change (pure documentation change)
- [x] New feature (non-breaking change which adds functionality)
