### PR TITLE
Retry RMQ messages indefinitely with aggressive logging after 5 retries

### DIFF
--- a/internal/msgqueue/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/rabbitmq/rabbitmq.go
@@ -643,12 +643,13 @@ func (t *MessageQueueImpl) subscribe(
 							// message was rejected before
 							deathCount := xDeath[0].(amqp.Table)["count"].(int64)
 
-							t.l.Error().
-								Int64("death_count", deathCount).
-								Str("message_id", msg.ID).
-								Str("tenant_id", msg.TenantID()).
-								Int("max_death_count", t.maxDeathCount).
-								Msg("message has been rejected")
+							if deathCount > 5 {
+								t.l.Error().
+									Int64("death_count", deathCount).
+									Str("message_id", msg.ID).
+									Str("tenant_id", msg.TenantID()).
+									Msgf("message has been retried for %d times", deathCount)
+							}
 
 							if t.enableMessageRejection && deathCount > int64(t.maxDeathCount) {
 								t.l.Error().

--- a/internal/msgqueue/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/rabbitmq/rabbitmq.go
@@ -64,8 +64,9 @@ type MessageQueueImpl struct {
 
 	disableTenantExchangePubs bool
 
-	// lru cache for tenant ids
-	tenantIdCache *lru.Cache[string, bool]
+	tenantIdCache          *lru.Cache[string, bool]
+	enableMessageRejection bool
+	maxDeathCount          int
 }
 
 func (t *MessageQueueImpl) setNotReady() {
@@ -98,6 +99,8 @@ type MessageQueueImplOpts struct {
 	url                       string
 	qos                       int
 	disableTenantExchangePubs bool
+	enableMessageRejection    bool
+	maxDeathCount             int
 }
 
 func defaultMessageQueueImplOpts() *MessageQueueImplOpts {
@@ -106,6 +109,8 @@ func defaultMessageQueueImplOpts() *MessageQueueImplOpts {
 	return &MessageQueueImplOpts{
 		l:                         &l,
 		disableTenantExchangePubs: false,
+		enableMessageRejection:    false,
+		maxDeathCount:             5,
 	}
 }
 
@@ -133,6 +138,18 @@ func WithDisableTenantExchangePubs(disable bool) MessageQueueImplOpt {
 	}
 }
 
+func WithMessageRejection(enabled bool, maxDeathCount int) MessageQueueImplOpt {
+	return func(opts *MessageQueueImplOpts) {
+		opts.enableMessageRejection = enabled
+
+		if maxDeathCount <= 0 {
+			maxDeathCount = 5
+		}
+
+		opts.maxDeathCount = maxDeathCount
+	}
+}
+
 // New creates a new MessageQueueImpl.
 func New(fs ...MessageQueueImplOpt) (func() error, *MessageQueueImpl) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -153,6 +170,8 @@ func New(fs ...MessageQueueImplOpt) (func() error, *MessageQueueImpl) {
 		qos:                       opts.qos,
 		configFs:                  fs,
 		disableTenantExchangePubs: opts.disableTenantExchangePubs,
+		enableMessageRejection:    opts.enableMessageRejection,
+		maxDeathCount:             opts.maxDeathCount,
 	}
 
 	constructor := func(context.Context) (*amqp.Connection, error) {
@@ -624,14 +643,25 @@ func (t *MessageQueueImpl) subscribe(
 							// message was rejected before
 							deathCount := xDeath[0].(amqp.Table)["count"].(int64)
 
-							t.l.Debug().Msgf("message %s has been rejected %d times", msg.ID, deathCount)
+							t.l.Error().
+								Int64("death_count", deathCount).
+								Str("message_id", msg.ID).
+								Str("tenant_id", msg.TenantID()).
+								Int("max_death_count", t.maxDeathCount).
+								Msg("message has been rejected")
 
-							if deathCount > 5 {
+							if t.enableMessageRejection && deathCount > int64(t.maxDeathCount) {
 								t.l.Error().
 									Int64("death_count", deathCount).
 									Str("message_id", msg.ID).
 									Str("tenant_id", msg.TenantID()).
-									Msg("message has been rejected more than 5 times and is still being retried")
+									Int("max_death_count", t.maxDeathCount).
+									Msg("permanently rejecting message due to exceeding max death count")
+
+								if err := rabbitMsg.Ack(false); err != nil {
+									t.l.Error().Err(err).Msg("error permanently rejecting message")
+								}
+								return
 							}
 						}
 

--- a/internal/msgqueue/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/rabbitmq/rabbitmq.go
@@ -617,9 +617,11 @@ func (t *MessageQueueImpl) subscribe(
 							return
 						}
 
+						// determine if we've hit the max number of retries
 						xDeath, exists := rabbitMsg.Headers["x-death"].([]interface{})
 
 						if exists {
+							// message was rejected before
 							deathCount := xDeath[0].(amqp.Table)["count"].(int64)
 
 							t.l.Debug().Msgf("message %s has been rejected %d times", msg.ID, deathCount)

--- a/internal/msgqueue/rabbitmq/rabbitmq_test.go
+++ b/internal/msgqueue/rabbitmq/rabbitmq_test.go
@@ -113,6 +113,7 @@ func TestDeadLetteringSuccess(t *testing.T) {
 	cleanup, tq := rabbitmq.New(
 		rabbitmq.WithURL(url),
 		rabbitmq.WithQos(100),
+		rabbitmq.WithMessageRejection(false, 10), // Disable message rejection for this test
 	)
 	defer cleanup() // nolint: errcheck
 
@@ -172,6 +173,7 @@ func TestDeadLetteringExceedRetriesFailure(t *testing.T) {
 	cleanup, tq := rabbitmq.New(
 		rabbitmq.WithURL(url),
 		rabbitmq.WithQos(100),
+		rabbitmq.WithMessageRejection(false, 10), // Disable message rejection for this test
 	)
 	defer cleanup() // nolint: errcheck
 

--- a/internal/msgqueue/rabbitmq/rabbitmq_test.go
+++ b/internal/msgqueue/rabbitmq/rabbitmq_test.go
@@ -173,7 +173,7 @@ func TestDeadLetteringExceedRetriesFailure(t *testing.T) {
 	cleanup, tq := rabbitmq.New(
 		rabbitmq.WithURL(url),
 		rabbitmq.WithQos(100),
-		rabbitmq.WithMessageRejection(false, 10), // Disable message rejection for this test
+		rabbitmq.WithMessageRejection(true, 2), // Enable message rejection with max 2 death count
 	)
 	defer cleanup() // nolint: errcheck
 
@@ -200,14 +200,9 @@ func TestDeadLetteringExceedRetriesFailure(t *testing.T) {
 			return nil
 		}
 
-		if attempts > 2 {
-			assert.Fail(t, "message exceeded maximum retry count")
-			cancel()
-			return nil // Stop retrying as it exceeds the limit
-		}
-
 		attempts++
 
+		// Always return an error to trigger retries
 		return fmt.Errorf("intentional error on attempt %d", attempts)
 	}
 
@@ -215,7 +210,13 @@ func TestDeadLetteringExceedRetriesFailure(t *testing.T) {
 	cleanupQueue, err := tq.Subscribe(staticQueue, preAck, msgqueue.NoOpHook)
 	require.NoError(t, err, "subscribing to static queue should not error")
 
+	// Wait for the context to be cancelled or timeout
 	<-ctx.Done()
+
+	// Verify that the message was retried the expected number of times
+	// With message rejection enabled and maxDeathCount=2, the message should be
+	// permanently rejected after 2 death counts (which means 2 processing attempts)
+	assert.GreaterOrEqual(t, attempts, 2, "message should have been retried at least 2 times before being permanently rejected")
 
 	if err := cleanupQueue(); err != nil {
 		t.Fatalf("error cleaning up queue: %v", err)

--- a/internal/msgqueue/v1/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/v1/rabbitmq/rabbitmq.go
@@ -46,10 +46,10 @@ type MessageQueueImpl struct {
 
 	deadLetterBackoff time.Duration
 
-	compressionEnabled bool
-
-	// compressionThreshold is the minimum payload size (in bytes) that will be compressed
-	compressionThreshold int
+	compressionEnabled     bool
+	compressionThreshold   int
+	enableMessageRejection bool
+	maxDeathCount          int
 }
 
 func (t *MessageQueueImpl) IsReady() bool {
@@ -67,9 +67,9 @@ type MessageQueueImplOpts struct {
 	maxPubChannels            int32
 	maxSubChannels            int32
 	compressionEnabled        bool
-
-	// compressionThreshold is the minimum payload size (in bytes) that will be compressed
-	compressionThreshold int
+	compressionThreshold      int
+	enableMessageRejection    bool
+	maxDeathCount             int
 }
 
 func defaultMessageQueueImplOpts() *MessageQueueImplOpts {
@@ -79,6 +79,8 @@ func defaultMessageQueueImplOpts() *MessageQueueImplOpts {
 		l:                         &l,
 		disableTenantExchangePubs: false,
 		deadLetterBackoff:         5 * time.Second,
+		enableMessageRejection:    false,
+		maxDeathCount:             5,
 	}
 }
 
@@ -136,6 +138,18 @@ func WithGzipCompression(enabled bool, threshold int) MessageQueueImplOpt {
 	}
 }
 
+func WithMessageRejection(enabled bool, maxDeathCount int) MessageQueueImplOpt {
+	return func(opts *MessageQueueImplOpts) {
+		opts.enableMessageRejection = enabled
+
+		if maxDeathCount <= 0 {
+			maxDeathCount = 5
+		}
+
+		opts.maxDeathCount = maxDeathCount
+	}
+}
+
 // New creates a new MessageQueueImpl.
 func New(fs ...MessageQueueImplOpt) (func() error, *MessageQueueImpl) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -188,6 +202,8 @@ func New(fs ...MessageQueueImplOpt) (func() error, *MessageQueueImpl) {
 		deadLetterBackoff:         opts.deadLetterBackoff,
 		compressionEnabled:        opts.compressionEnabled,
 		compressionThreshold:      opts.compressionThreshold,
+		enableMessageRejection:    opts.enableMessageRejection,
+		maxDeathCount:             opts.maxDeathCount,
 	}
 
 	// create a new lru cache for tenant ids
@@ -757,15 +773,26 @@ func (t *MessageQueueImpl) subscribe(
 					// message was rejected before
 					deathCount := xDeath[0].(amqp.Table)["count"].(int64)
 
-					t.l.Debug().Msgf("message has been rejected %d times", deathCount)
+					t.l.Error().
+						Int64("death_count", deathCount).
+						Str("message_id", msg.ID).
+						Str("tenant_id", msg.TenantID).
+						Int("num_payloads", len(msg.Payloads)).
+						Int("max_death_count", t.maxDeathCount).
+						Msg("message has been rejected")
 
-					if deathCount > 5 {
+					if t.enableMessageRejection && deathCount > int64(t.maxDeathCount) {
 						t.l.Error().
 							Int64("death_count", deathCount).
 							Str("message_id", msg.ID).
 							Str("tenant_id", msg.TenantID).
-							Int("num_payloads", len(msg.Payloads)).
-							Msg("message has been rejected more than 5 times and is still being retried")
+							Int("max_death_count", t.maxDeathCount).
+							Msg("permanently rejecting message due to exceeding max death count")
+
+						if err := rabbitMsg.Ack(false); err != nil {
+							t.l.Error().Err(err).Msg("error permanently rejecting message")
+						}
+						return
 					}
 				}
 

--- a/internal/msgqueue/v1/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/v1/rabbitmq/rabbitmq.go
@@ -750,9 +750,11 @@ func (t *MessageQueueImpl) subscribe(
 					msg.Payloads = decompressedPayloads
 				}
 
+				// determine if we've hit the max number of retries
 				xDeath, exists := rabbitMsg.Headers["x-death"].([]interface{})
 
 				if exists {
+					// message was rejected before
 					deathCount := xDeath[0].(amqp.Table)["count"].(int64)
 
 					t.l.Debug().Msgf("message has been rejected %d times", deathCount)

--- a/internal/msgqueue/v1/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/v1/rabbitmq/rabbitmq.go
@@ -773,13 +773,14 @@ func (t *MessageQueueImpl) subscribe(
 					// message was rejected before
 					deathCount := xDeath[0].(amqp.Table)["count"].(int64)
 
-					t.l.Error().
-						Int64("death_count", deathCount).
-						Str("message_id", msg.ID).
-						Str("tenant_id", msg.TenantID).
-						Int("num_payloads", len(msg.Payloads)).
-						Int("max_death_count", t.maxDeathCount).
-						Msg("message has been rejected")
+					if deathCount > 5 {
+						t.l.Error().
+							Int64("death_count", deathCount).
+							Str("message_id", msg.ID).
+							Str("tenant_id", msg.TenantID).
+							Int("num_payloads", len(msg.Payloads)).
+							Msgf("message has been retried for %d times", deathCount)
+					}
 
 					if t.enableMessageRejection && deathCount > int64(t.maxDeathCount) {
 						t.l.Error().

--- a/internal/msgqueue/v1/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/v1/rabbitmq/rabbitmq.go
@@ -750,24 +750,20 @@ func (t *MessageQueueImpl) subscribe(
 					msg.Payloads = decompressedPayloads
 				}
 
-				// determine if we've hit the max number of retries
 				xDeath, exists := rabbitMsg.Headers["x-death"].([]interface{})
 
 				if exists {
-					// message was rejected before
 					deathCount := xDeath[0].(amqp.Table)["count"].(int64)
 
 					t.l.Debug().Msgf("message has been rejected %d times", deathCount)
 
-					if deathCount > int64(msg.Retries) {
-						t.l.Debug().Msgf("message has been rejected %d times, not requeuing", deathCount)
-
-						// acknowledge so it's removed from the queue
-						if err := rabbitMsg.Ack(false); err != nil {
-							t.l.Error().Msgf("error acknowledging message: %v", err)
-						}
-
-						return
+					if deathCount > 5 {
+						t.l.Error().
+							Int64("death_count", deathCount).
+							Str("message_id", msg.ID).
+							Str("tenant_id", msg.TenantID).
+							Int("num_payloads", len(msg.Payloads)).
+							Msg("message has been rejected more than 5 times and is still being retried")
 					}
 				}
 

--- a/internal/msgqueue/v1/rabbitmq/rabbitmq_test.go
+++ b/internal/msgqueue/v1/rabbitmq/rabbitmq_test.go
@@ -34,6 +34,7 @@ func TestMessageQueueIntegration(t *testing.T) {
 		WithURL(url),
 		WithQos(100),
 		WithDeadLetterBackoff(5*time.Second),
+		WithMessageRejection(false, 10), // Disable message rejection for this test
 	)
 
 	require.NotNil(t, tq, "task queue implementation should not be nil")
@@ -271,6 +272,7 @@ func TestDeadLetteringSuccess(t *testing.T) {
 		WithURL(url),
 		WithQos(100),
 		WithDeadLetterBackoff(5*time.Second),
+		WithMessageRejection(false, 10), // Disable message rejection for this test
 	)
 
 	require.NotNil(t, tq, "task queue implementation should not be nil")

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -434,6 +434,7 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 				rabbitmq.WithLogger(&l),
 				rabbitmq.WithQos(cf.MessageQueue.RabbitMQ.Qos),
 				rabbitmq.WithDisableTenantExchangePubs(cf.Runtime.DisableTenantPubs),
+				rabbitmq.WithMessageRejection(cf.MessageQueue.RabbitMQ.EnableMessageRejection, cf.MessageQueue.RabbitMQ.MaxDeathCount),
 			)
 
 			cleanupv1, mqv1 = rabbitmqv1.New(
@@ -447,6 +448,7 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 					cf.MessageQueue.RabbitMQ.CompressionEnabled,
 					cf.MessageQueue.RabbitMQ.CompressionThreshold,
 				),
+				rabbitmqv1.WithMessageRejection(cf.MessageQueue.RabbitMQ.EnableMessageRejection, cf.MessageQueue.RabbitMQ.MaxDeathCount),
 			)
 
 			cleanup1 = func() error {

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -479,12 +479,14 @@ type PostgresMQConfigFile struct {
 }
 
 type RabbitMQConfigFile struct {
-	URL                  string `mapstructure:"url" json:"url,omitempty" validate:"required"`
-	Qos                  int    `mapstructure:"qos" json:"qos,omitempty" default:"100"`
-	MaxPubChans          int32  `mapstructure:"maxPubChans" json:"maxPubChans,omitempty" default:"20"`
-	MaxSubChans          int32  `mapstructure:"maxSubChans" json:"maxSubChans,omitempty" default:"100"`
-	CompressionEnabled   bool   `mapstructure:"compressionEnabled" json:"compressionEnabled,omitempty" default:"false"`
-	CompressionThreshold int    `mapstructure:"compressionThreshold" json:"compressionThreshold,omitempty" default:"5120"`
+	URL                    string `mapstructure:"url" json:"url,omitempty" validate:"required"`
+	Qos                    int    `mapstructure:"qos" json:"qos,omitempty" default:"100"`
+	MaxPubChans            int32  `mapstructure:"maxPubChans" json:"maxPubChans,omitempty" default:"20"`
+	MaxSubChans            int32  `mapstructure:"maxSubChans" json:"maxSubChans,omitempty" default:"100"`
+	CompressionEnabled     bool   `mapstructure:"compressionEnabled" json:"compressionEnabled,omitempty" default:"false"`
+	CompressionThreshold   int    `mapstructure:"compressionThreshold" json:"compressionThreshold,omitempty" default:"5120"`
+	EnableMessageRejection bool   `mapstructure:"enableMessageRejection" json:"enableMessageRejection,omitempty" default:"false"`
+	MaxDeathCount          int    `mapstructure:"maxDeathCount" json:"maxDeathCount,omitempty" default:"5"`
 }
 
 type ConfigFileEmail struct {
@@ -803,6 +805,8 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("msgQueue.rabbitmq.maxSubChans", "SERVER_MSGQUEUE_RABBITMQ_MAX_SUB_CHANS")
 	_ = v.BindEnv("msgQueue.rabbitmq.compressionEnabled", "SERVER_MSGQUEUE_RABBITMQ_COMPRESSION_ENABLED")
 	_ = v.BindEnv("msgQueue.rabbitmq.compressionThreshold", "SERVER_MSGQUEUE_RABBITMQ_COMPRESSION_THRESHOLD")
+	_ = v.BindEnv("msgQueue.rabbitmq.enableMessageRejection", "SERVER_MSGQUEUE_RABBITMQ_ENABLE_MESSAGE_REJECTION")
+	_ = v.BindEnv("msgQueue.rabbitmq.maxDeathCount", "SERVER_MSGQUEUE_RABBITMQ_MAX_DEATH_COUNT")
 
 	// throughput options
 	_ = v.BindEnv("msgQueue.rabbitmq.qos", "SERVER_MSGQUEUE_RABBITMQ_QOS")


### PR DESCRIPTION
# Description

Modified RabbitMQ message queue retry behavior to continue retrying failed messages indefinitely instead of dropping them after a configured retry limit. Messages that fail more than 5 times now trigger aggressive error logging with full context.

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
