### PR TITLE
Increase context timeout for DAG and task status updates to 30 seconds

### DIFF
--- a/internal/services/controllers/v1/olap/process_dag_status_updates.go
+++ b/internal/services/controllers/v1/olap/process_dag_status_updates.go
@@ -17,7 +17,7 @@ import (
 
 func (o *OLAPControllerImpl) runDAGStatusUpdates(ctx context.Context) func() {
 	return func() {
-		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 
 		shouldContinue := true

--- a/internal/services/controllers/v1/olap/process_task_status_updates.go
+++ b/internal/services/controllers/v1/olap/process_task_status_updates.go
@@ -17,7 +17,7 @@ import (
 
 func (o *OLAPControllerImpl) runTaskStatusUpdates(ctx context.Context) func() {
 	return func() {
-		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 
 		shouldContinue := true


### PR DESCRIPTION
# Description

Increase context timeout for DAG and task status updates to 30 seconds.

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] Chore (changes which are not directly related to any business logic)
