### PR TITLE
fix: don't send expiry alert on internal proxy tokens

### DIFF
--- a/pkg/repository/postgres/dbsqlc/tickers.sql
+++ b/pkg/repository/postgres/dbsqlc/tickers.sql
@@ -261,6 +261,7 @@ WITH expiring_tokens AS (
             t0."nextAlertAt" IS NULL OR
             t0."nextAlertAt" <= NOW()
         )
+        AND t0."internal" = false
     FOR UPDATE SKIP LOCKED
     LIMIT 100
 )

--- a/pkg/repository/postgres/dbsqlc/tickers.sql.go
+++ b/pkg/repository/postgres/dbsqlc/tickers.sql.go
@@ -300,6 +300,7 @@ WITH expiring_tokens AS (
             t0."nextAlertAt" IS NULL OR
             t0."nextAlertAt" <= NOW()
         )
+        AND t0."internal" = false
     FOR UPDATE SKIP LOCKED
     LIMIT 100
 )


### PR DESCRIPTION
# Description

Don't poll or send internal API token proxy alerts for expiration. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)