### PR TITLE
Fix: read payloads from payload store for event API

### DIFF
--- a/api/v1/server/run/run.go
+++ b/api/v1/server/run/run.go
@@ -2,7 +2,6 @@ package run
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -403,9 +402,6 @@ func (t *APIServer) registerSpec(g *echo.Group, spec *openapi3.T) (*populator.Po
 			}
 
 			payload, err := t.config.V1.OLAP().ReadPayload(timeoutCtx, v1Event.TenantID.String(), v1Event.ExternalID)
-
-			pj, _ := json.MarshalIndent(payload, "", "  ")
-			fmt.Printf("event payload: %s\n", string(pj))
 
 			if err != nil {
 				return nil, "", err

--- a/api/v1/server/run/run.go
+++ b/api/v1/server/run/run.go
@@ -401,10 +401,16 @@ func (t *APIServer) registerSpec(g *echo.Group, spec *openapi3.T) (*populator.Po
 				return nil, "", err
 			}
 
+			payload, err := t.config.V1.OLAP().ReadPayload(timeoutCtx, v1Event.TenantID.String(), v1Event.ExternalID)
+
+			if err != nil {
+				return nil, "", err
+			}
+
 			event = &dbsqlc.Event{
 				ID:                 v1Event.ExternalID,
 				TenantId:           v1Event.TenantID,
-				Data:               v1Event.Payload,
+				Data:               payload,
 				CreatedAt:          pgtype.Timestamp(v1Event.SeenAt),
 				AdditionalMetadata: v1Event.AdditionalMetadata,
 				Key:                v1Event.Key,

--- a/api/v1/server/run/run.go
+++ b/api/v1/server/run/run.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -402,6 +403,9 @@ func (t *APIServer) registerSpec(g *echo.Group, spec *openapi3.T) (*populator.Po
 			}
 
 			payload, err := t.config.V1.OLAP().ReadPayload(timeoutCtx, v1Event.TenantID.String(), v1Event.ExternalID)
+
+			pj, _ := json.MarshalIndent(payload, "", "  ")
+			fmt.Printf("event payload: %s\n", string(pj))
 
 			if err != nil {
 				return nil, "", err

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -2073,8 +2073,6 @@ func (r *OLAPRepositoryImpl) BulkCreateEventsAndTriggers(ctx context.Context, ev
 		}] = event.ExternalID
 		payload := eventExternalIdToPayload[event.ExternalID]
 
-		fmt.Println("preparing to offload event:", id, sqlchelpers.UUIDToStr(event.ExternalID), "with payload", string(payload))
-
 		offloadToExternalOpts = append(offloadToExternalOpts, OffloadToExternalStoreOpts{
 			StorePayloadOpts: &StorePayloadOpts{
 				Id:         event.ID,
@@ -2087,8 +2085,6 @@ func (r *OLAPRepositoryImpl) BulkCreateEventsAndTriggers(ctx context.Context, ev
 			OffloadAt: time.Now(),
 		})
 	}
-
-	fmt.Println("num offload opts:", len(offloadToExternalOpts))
 
 	if len(offloadToExternalOpts) == 0 {
 		return nil

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -2067,6 +2067,8 @@ func (r *OLAPRepositoryImpl) BulkCreateEventsAndTriggers(ctx context.Context, ev
 			InsertedAt: insertedAt,
 		}] = event.ExternalID
 
+		fmt.Println("preparing to offload event:", id, sqlchelpers.UUIDToStr(event.ExternalID), "with payload", string(event.Payload))
+
 		offloadToExternalOpts = append(offloadToExternalOpts, OffloadToExternalStoreOpts{
 			StorePayloadOpts: &StorePayloadOpts{
 				Id:         event.ID,
@@ -2079,6 +2081,8 @@ func (r *OLAPRepositoryImpl) BulkCreateEventsAndTriggers(ctx context.Context, ev
 			OffloadAt: time.Now(),
 		})
 	}
+
+	fmt.Println("num offload opts:", len(offloadToExternalOpts))
 
 	if len(offloadToExternalOpts) == 0 {
 		return nil

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -1976,7 +1976,6 @@ func (r *OLAPRepositoryImpl) BulkCreateEventsAndTriggers(ctx context.Context, ev
 
 	defer rollback()
 
-	// todo: remove this when we remove dual writes
 	eventsToInsert := events
 	eventExternalIdToPayload := make(map[pgtype.UUID][]byte)
 
@@ -1984,6 +1983,7 @@ func (r *OLAPRepositoryImpl) BulkCreateEventsAndTriggers(ctx context.Context, ev
 		eventExternalIdToPayload[eventsToInsert.Externalids[i]] = payload
 	}
 
+	// todo: remove this when we remove dual writes
 	if !r.payloadStore.OLAPDualWritesEnabled() {
 		payloads := make([][]byte, len(eventsToInsert.Payloads))
 


### PR DESCRIPTION
# Description

Fixes two more things:

1. Event payloads not writing when dual writes are disabled
2. The event data getter not calling the payload store

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
