### PR TITLE
Fix: Propagate parent id through to `V1TaskSummary` properly

### DIFF
--- a/api/v1/server/oas/transformers/v1/tasks.go
+++ b/api/v1/server/oas/transformers/v1/tasks.go
@@ -45,10 +45,11 @@ func ToTaskSummary(task *v1.TaskWithPayloads) gen.V1TaskSummary {
 		durationPtr = &duration
 	}
 
-	var parentTaskExternalId uuid.UUID
+	var parentTaskExternalId *uuid.UUID
 
 	if task.ParentTaskExternalID.Valid {
-		parentTaskExternalId = uuid.MustParse(sqlchelpers.UUIDToStr(task.ParentTaskExternalID))
+		parentTaskExternalIdValue := uuid.MustParse(sqlchelpers.UUIDToStr(task.ParentTaskExternalID))
+		parentTaskExternalId = &parentTaskExternalIdValue
 	}
 
 	taskExternalId := uuid.MustParse(sqlchelpers.UUIDToStr(task.ExternalID))
@@ -83,7 +84,7 @@ func ToTaskSummary(task *v1.TaskWithPayloads) gen.V1TaskSummary {
 		WorkflowVersionId:     &workflowVersionID,
 		RetryCount:            &retryCount,
 		Attempt:               &attempt,
-		ParentTaskExternalId:  &parentTaskExternalId,
+		ParentTaskExternalId:  parentTaskExternalId,
 	}
 }
 

--- a/api/v1/server/oas/transformers/v1/tasks.go
+++ b/api/v1/server/oas/transformers/v1/tasks.go
@@ -45,6 +45,12 @@ func ToTaskSummary(task *v1.TaskWithPayloads) gen.V1TaskSummary {
 		durationPtr = &duration
 	}
 
+	var parentTaskExternalId uuid.UUID
+
+	if task.ParentTaskExternalID.Valid {
+		parentTaskExternalId = uuid.MustParse(sqlchelpers.UUIDToStr(task.ParentTaskExternalID))
+	}
+
 	taskExternalId := uuid.MustParse(sqlchelpers.UUIDToStr(task.ExternalID))
 	stepId := uuid.MustParse(sqlchelpers.UUIDToStr(task.StepID))
 
@@ -77,6 +83,7 @@ func ToTaskSummary(task *v1.TaskWithPayloads) gen.V1TaskSummary {
 		WorkflowVersionId:     &workflowVersionID,
 		RetryCount:            &retryCount,
 		Attempt:               &attempt,
+		ParentTaskExternalId:  &parentTaskExternalId,
 	}
 }
 

--- a/api/v1/server/oas/transformers/v1/workflow_runs.go
+++ b/api/v1/server/oas/transformers/v1/workflow_runs.go
@@ -69,9 +69,10 @@ func WorkflowRunDataToV1TaskSummary(task *v1.WorkflowRunData, workflowIdsToNames
 	}
 	attempt := retryCount + 1
 
-	var parentTaskExternalId uuid.UUID
+	var parentTaskExternalId *uuid.UUID
 	if task.ParentTaskExternalId != nil && task.ParentTaskExternalId.Valid {
-		parentTaskExternalId = uuid.MustParse(sqlchelpers.UUIDToStr(*task.ParentTaskExternalId))
+		parentTaskExternalIdValue := uuid.MustParse(sqlchelpers.UUIDToStr(*task.ParentTaskExternalId))
+		parentTaskExternalId = &parentTaskExternalIdValue
 	}
 
 	return gen.V1TaskSummary{
@@ -103,7 +104,7 @@ func WorkflowRunDataToV1TaskSummary(task *v1.WorkflowRunData, workflowIdsToNames
 		WorkflowRunExternalId: uuid.MustParse(sqlchelpers.UUIDToStr(task.ExternalID)),
 		RetryCount:            &retryCount,
 		Attempt:               &attempt,
-		ParentTaskExternalId:  &parentTaskExternalId,
+		ParentTaskExternalId:  parentTaskExternalId,
 	}
 }
 
@@ -183,9 +184,10 @@ func PopulateTaskRunDataRowToV1TaskSummary(task *v1.TaskWithPayloads, workflowNa
 	retryCount := int(task.RetryCount)
 	attempt := retryCount + 1
 
-	var parentTaskExternalId uuid.UUID
+	var parentTaskExternalId *uuid.UUID
 	if task.ParentTaskExternalID.Valid {
-		parentTaskExternalId = uuid.MustParse(sqlchelpers.UUIDToStr(task.ParentTaskExternalID))
+		parentTaskExternalIdValue := uuid.MustParse(sqlchelpers.UUIDToStr(task.ParentTaskExternalID))
+		parentTaskExternalId = &parentTaskExternalIdValue
 	}
 
 	return gen.V1TaskSummary{
@@ -218,7 +220,7 @@ func PopulateTaskRunDataRowToV1TaskSummary(task *v1.TaskWithPayloads, workflowNa
 		RetryCount:            &retryCount,
 		Attempt:               &attempt,
 		WorkflowRunExternalId: uuid.MustParse(sqlchelpers.UUIDToStr(task.WorkflowRunID)),
-		ParentTaskExternalId:  &parentTaskExternalId,
+		ParentTaskExternalId:  parentTaskExternalId,
 	}
 }
 

--- a/api/v1/server/oas/transformers/v1/workflow_runs.go
+++ b/api/v1/server/oas/transformers/v1/workflow_runs.go
@@ -69,6 +69,11 @@ func WorkflowRunDataToV1TaskSummary(task *v1.WorkflowRunData, workflowIdsToNames
 	}
 	attempt := retryCount + 1
 
+	var parentTaskExternalId uuid.UUID
+	if task.ParentTaskExternalId != nil && task.ParentTaskExternalId.Valid {
+		parentTaskExternalId = uuid.MustParse(sqlchelpers.UUIDToStr(*task.ParentTaskExternalId))
+	}
+
 	return gen.V1TaskSummary{
 		Metadata: gen.APIResourceMeta{
 			Id:        sqlchelpers.UUIDToStr(task.ExternalID),
@@ -98,6 +103,7 @@ func WorkflowRunDataToV1TaskSummary(task *v1.WorkflowRunData, workflowIdsToNames
 		WorkflowRunExternalId: uuid.MustParse(sqlchelpers.UUIDToStr(task.ExternalID)),
 		RetryCount:            &retryCount,
 		Attempt:               &attempt,
+		ParentTaskExternalId:  &parentTaskExternalId,
 	}
 }
 
@@ -176,6 +182,12 @@ func PopulateTaskRunDataRowToV1TaskSummary(task *v1.TaskWithPayloads, workflowNa
 
 	retryCount := int(task.RetryCount)
 	attempt := retryCount + 1
+
+	var parentTaskExternalId uuid.UUID
+	if task.ParentTaskExternalID.Valid {
+		parentTaskExternalId = uuid.MustParse(sqlchelpers.UUIDToStr(task.ParentTaskExternalID))
+	}
+
 	return gen.V1TaskSummary{
 		Metadata: gen.APIResourceMeta{
 			Id:        sqlchelpers.UUIDToStr(task.ExternalID),
@@ -206,6 +218,7 @@ func PopulateTaskRunDataRowToV1TaskSummary(task *v1.TaskWithPayloads, workflowNa
 		RetryCount:            &retryCount,
 		Attempt:               &attempt,
 		WorkflowRunExternalId: uuid.MustParse(sqlchelpers.UUIDToStr(task.WorkflowRunID)),
+		ParentTaskExternalId:  &parentTaskExternalId,
 	}
 }
 


### PR DESCRIPTION
# Description

Fixing a small API QoL bug

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
