### PR TITLE
Add `SERVER_OTEL_COLLECTOR_AUTH` to selfhosting docs

### DIFF
--- a/frontend/docs/pages/self-hosting/configuration-options.mdx
+++ b/frontend/docs/pages/self-hosting/configuration-options.mdx
@@ -6,7 +6,7 @@ The Hatchet server and engine can be configured via environment variables using 
 
 Hatchet uses the following environment variable prefixes:
 
-- **`SERVER_`** (172 variables) - Main server configuration including runtime, authentication, encryption, monitoring, and integrations
+- **`SERVER_`** (173 variables) - Main server configuration including runtime, authentication, encryption, monitoring, and integrations
 - **`DATABASE_`** (13 variables) - PostgreSQL database connection and configuration
 - **`READ_REPLICA_`** (4 variables) - Read replica database configuration
 - **`ADMIN_`** (3 variables) - Administrator user setup for initial seeding
@@ -306,6 +306,7 @@ Variables marked with ⚠️ are conditionally required when specific features a
 | `SERVER_OTEL_COLLECTOR_URL`         | Collector URL for OpenTelemetry                            |               |
 | `SERVER_OTEL_INSECURE`              | Whether to use an insecure connection to the collector URL |               |
 | `SERVER_OTEL_TRACE_ID_RATIO`        | OpenTelemetry trace ID ratio                               |               |
+| `SERVER_OTEL_COLLECTOR_AUTH`        | OpenTelemetry Collector Authorization header value         |               |
 | `SERVER_PROMETHEUS_ENABLED`         | Enable Prometheus                                          | `false`       |
 | `SERVER_PROMETHEUS_ADDRESS`         | Prometheus address                                         | `:9090`       |
 | `SERVER_PROMETHEUS_PATH`            | Prometheus metrics path                                    | `/metrics`    |


### PR DESCRIPTION
# Description
I couldn't find a way to let the server auth against an OTEL collector, but after searching the code I saw that it was possible, but not documented.

I searched and couldn't find any similar issue, so I'm assuming it's not on purpose that it's not documented.
I took the liberty of not creating an issue first since it's such a small change.
Feel free to change the wording or anything as you'd like

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Documentation change (pure documentation change)

## What's Changed

Added `SERVER_OTEL_COLLECTOR_AUTH` to selfhosting docs

