### PR TITLE
Pass labels to durable worker in old Go SDK v1

### DIFF
--- a/pkg/v1/worker/worker.go
+++ b/pkg/v1/worker/worker.go
@@ -164,6 +164,7 @@ func (w *WorkerImpl) RegisterWorkflows(workflows ...workflow.WorkflowBase) error
 				worker.WithClient(w.v0),
 				worker.WithName(w.name),
 				worker.WithMaxRuns(w.slots),
+				worker.WithLogger(w.logger),
 				worker.WithLogLevel(w.logLevel),
 				worker.WithLabels(w.labels),
 			}
@@ -194,6 +195,8 @@ func (w *WorkerImpl) RegisterWorkflows(workflows ...workflow.WorkflowBase) error
 				worker.WithName(w.name + "-durable"),
 				worker.WithMaxRuns(w.durableSlots),
 				worker.WithLogger(logger),
+				worker.WithLogLevel(w.logLevel),
+				worker.WithLabels(w.labels),
 			}
 
 			durableWorker, err := worker.NewWorker(


### PR DESCRIPTION
# Description

This PR fixes passing of labels to durable worker in old Go SDK v1.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
