### PR TITLE
Fix: Event lookup table PK

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20251112202112_v1_0_54.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20251112202112_v1_0_54.sql
@@ -94,6 +94,8 @@ BEGIN
         new_name := REPLACE(partition_record.tablename, 'v1_event_lookup_table_olap_new_', 'v1_event_lookup_table_olap_');
         EXECUTE format('ALTER TABLE %I RENAME TO %I', partition_record.tablename, new_name);
         RAISE NOTICE 'Renamed % to %', partition_record.tablename, new_name;
+        EXECUTE format('ALTER INDEX %I RENAME TO %I', partition_record.tablename || '_pkey', new_name || '_pkey');
+        RAISE NOTICE 'Renamed % to % and index to %', partition_record.tablename, new_name, new_name || '_pkey';
     END LOOP;
 END $$;
 
@@ -196,6 +198,8 @@ BEGIN
         new_name := REPLACE(partition_record.tablename, 'v1_event_lookup_table_olap_new_', 'v1_event_lookup_table_olap_');
         EXECUTE format('ALTER TABLE %I RENAME TO %I', partition_record.tablename, new_name);
         RAISE NOTICE 'Renamed % to %', partition_record.tablename, new_name;
+        EXECUTE format('ALTER INDEX %I RENAME TO %I', partition_record.tablename || '_pkey', new_name || '_pkey');
+        RAISE NOTICE 'Renamed % to % and index to %', partition_record.tablename, new_name, new_name || '_pkey';
     END LOOP;
 END $$;
 

--- a/cmd/hatchet-migrate/migrate/migrations/20251112202112_v1_0_54.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20251112202112_v1_0_54.sql
@@ -1,0 +1,173 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+-- +goose StatementBegin
+BEGIN;
+
+CREATE TABLE v1_event_lookup_table_olap_new (
+    tenant_id UUID NOT NULL,
+    external_id UUID NOT NULL,
+    event_id BIGINT NOT NULL,
+    event_seen_at TIMESTAMPTZ NOT NULL,
+
+    PRIMARY KEY (external_id, event_seen_at)
+) PARTITION BY RANGE(event_seen_at);
+
+SELECT create_v1_weekly_range_partition('v1_event_lookup_table_olap_new'::text, (NOW() - INTERVAL '1 week')::DATE);
+SELECT create_v1_weekly_range_partition('v1_event_lookup_table_olap_new'::text, DATE 'today');
+
+CREATE OR REPLACE FUNCTION v1_event_lookup_table_olap_new_insert_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    INSERT INTO v1_event_lookup_table_olap_new (
+        tenant_id,
+        external_id,
+        event_id,
+        event_seen_at
+    )
+    SELECT
+        tenant_id,
+        external_id,
+        event_id,
+        event_seen_at
+    FROM new_rows
+    ON CONFLICT DO NOTHING;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE TRIGGER v1_event_lookup_table_olap_new_insert_trigger
+AFTER INSERT ON v1_event_lookup_table_olap
+REFERENCING NEW TABLE AS new_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION v1_event_lookup_table_olap_new_insert_function();
+
+COMMIT;
+
+-- +goose StatementEnd
+-- +goose StatementBegin
+
+INSERT INTO v1_event_lookup_table_olap_new (tenant_id, external_id, event_id, event_seen_at)
+SELECT tenant_id, external_id, event_id, event_seen_at
+FROM v1_event_lookup_table_olap
+ON CONFLICT DO NOTHING;
+
+-- +goose StatementEnd
+-- +goose StatementBegin
+
+BEGIN;
+
+DROP TRIGGER v1_event_lookup_table_olap_new_insert_trigger ON v1_event_lookup_table_olap;
+DROP FUNCTION v1_event_lookup_table_olap_new_insert_function();
+DROP TABLE v1_event_lookup_table_olap;
+ALTER TABLE v1_event_lookup_table_olap_new RENAME TO v1_event_lookup_table_olap;
+ALTER INDEX v1_event_lookup_table_olap_new_pkey RENAME TO v1_event_lookup_table_olap_pkey;
+
+DO $$
+DECLARE
+    partition_record RECORD;
+    new_name TEXT;
+BEGIN
+    FOR partition_record IN
+        SELECT tablename
+        FROM pg_tables
+        WHERE tablename LIKE 'v1_event_lookup_table_olap_new_%'
+        AND schemaname = 'public'
+    LOOP
+        new_name := REPLACE(partition_record.tablename, 'v1_event_lookup_table_olap_new_', 'v1_event_lookup_table_olap_');
+        EXECUTE format('ALTER TABLE %I RENAME TO %I', partition_record.tablename, new_name);
+        RAISE NOTICE 'Renamed % to %', partition_record.tablename, new_name;
+    END LOOP;
+END $$;
+
+COMMIT;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose NO TRANSACTION
+-- +goose StatementBegin
+BEGIN;
+
+CREATE TABLE v1_event_lookup_table_olap_new (
+    tenant_id UUID NOT NULL,
+    external_id UUID NOT NULL,
+    event_id BIGINT NOT NULL,
+    event_seen_at TIMESTAMPTZ NOT NULL,
+
+    PRIMARY KEY (tenant_id, external_id, event_seen_at)
+) PARTITION BY RANGE(event_seen_at);
+
+SELECT create_v1_weekly_range_partition('v1_event_lookup_table_olap_new'::text, (NOW() - INTERVAL '1 week')::DATE);
+SELECT create_v1_weekly_range_partition('v1_event_lookup_table_olap_new'::text, NOW()::DATE);
+
+CREATE OR REPLACE FUNCTION v1_event_lookup_table_olap_new_insert_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    INSERT INTO v1_event_lookup_table_olap_new (
+        tenant_id,
+        external_id,
+        event_id,
+        event_seen_at
+    )
+    SELECT
+        tenant_id,
+        external_id,
+        event_id,
+        event_seen_at
+    FROM new_rows
+    ON CONFLICT DO NOTHING;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE TRIGGER v1_event_lookup_table_olap_new_insert_trigger
+AFTER INSERT ON v1_event_lookup_table_olap
+REFERENCING NEW TABLE AS new_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION v1_event_lookup_table_olap_new_insert_function();
+
+COMMIT;
+
+-- +goose StatementEnd
+-- +goose StatementBegin
+
+INSERT INTO v1_event_lookup_table_olap_new (tenant_id, external_id, event_id, event_seen_at)
+SELECT tenant_id, external_id, event_id, event_seen_at
+FROM v1_event_lookup_table_olap
+ON CONFLICT DO NOTHING;
+
+-- +goose StatementEnd
+-- +goose StatementBegin
+
+BEGIN;
+
+DROP TRIGGER v1_event_lookup_table_olap_new_insert_trigger ON v1_event_lookup_table_olap;
+DROP FUNCTION v1_event_lookup_table_olap_new_insert_function();
+DROP TABLE v1_event_lookup_table_olap;
+ALTER TABLE v1_event_lookup_table_olap_new RENAME TO v1_event_lookup_table_olap;
+ALTER INDEX v1_event_lookup_table_olap_new_pkey RENAME TO v1_event_lookup_table_olap_pkey;
+
+DO $$
+DECLARE
+    partition_record RECORD;
+    new_name TEXT;
+BEGIN
+    FOR partition_record IN
+        SELECT tablename
+        FROM pg_tables
+        WHERE tablename LIKE 'v1_event_lookup_table_olap_new_%'
+        AND schemaname = 'public'
+    LOOP
+        new_name := REPLACE(partition_record.tablename, 'v1_event_lookup_table_olap_new_', 'v1_event_lookup_table_olap_');
+        EXECUTE format('ALTER TABLE %I RENAME TO %I', partition_record.tablename, new_name);
+        RAISE NOTICE 'Renamed % to %', partition_record.tablename, new_name;
+    END LOOP;
+END $$;
+
+COMMIT;
+-- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20251112202112_v1_0_54.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20251112202112_v1_0_54.sql
@@ -99,6 +99,29 @@ BEGIN
     END LOOP;
 END $$;
 
+CREATE OR REPLACE FUNCTION v1_events_lookup_table_olap_insert_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    INSERT INTO v1_event_lookup_table_olap (
+        tenant_id,
+        external_id,
+        event_id,
+        event_seen_at
+    )
+    SELECT
+        tenant_id,
+        external_id,
+        id,
+        seen_at
+    FROM new_rows
+    ON CONFLICT (external_id, event_seen_at) DO NOTHING;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+
 COMMIT;
 -- +goose StatementEnd
 
@@ -202,6 +225,29 @@ BEGIN
         RAISE NOTICE 'Renamed % to % and index to %', partition_record.tablename, new_name, new_name || '_pkey';
     END LOOP;
 END $$;
+
+CREATE OR REPLACE FUNCTION v1_events_lookup_table_olap_insert_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    INSERT INTO v1_event_lookup_table_olap (
+        tenant_id,
+        external_id,
+        event_id,
+        event_seen_at
+    )
+    SELECT
+        tenant_id,
+        external_id,
+        id,
+        seen_at
+    FROM new_rows
+    ON CONFLICT (tenant_id, external_id, event_seen_at) DO NOTHING;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
 
 COMMIT;
 -- +goose StatementEnd

--- a/sql/schema/v1-olap.sql
+++ b/sql/schema/v1-olap.sql
@@ -782,7 +782,7 @@ BEGIN
         id,
         seen_at
     FROM new_rows
-    ON CONFLICT (tenant_id, external_id, event_seen_at) DO NOTHING;
+    ON CONFLICT (external_id, event_seen_at) DO NOTHING;
 
     RETURN NULL;
 END;


### PR DESCRIPTION
# Description

Removes the tenant id from the PK of the event lookup table so that queries stop timing out. Basically the same as our usual process of creating a new table with a trigger, then backfilling, then cutting over.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
