### PR TITLE
Attempt to fix pgx multi dimensional slice reflection error #1

### DIFF
--- a/pkg/repository/v1/task.go
+++ b/pkg/repository/v1/task.go
@@ -1912,6 +1912,9 @@ func (r *sharedRepository) insertTasks(
 						String: failTaskError.Error(),
 						Valid:  true,
 					}
+
+					// set to empty slice to avoid nil in multi-dimensional array
+					concurrencyKeys[i] = []string{}
 				} else {
 					concurrencyKeys[i] = taskConcurrencyKeys
 				}
@@ -2237,6 +2240,9 @@ func (r *sharedRepository) replayTasks(
 
 		taskIds[i] = task.TaskId
 		taskInsertedAts[i] = task.InsertedAt
+
+		// initialize to empty slice to avoid nil in multi-dimensional array
+		concurrencyKeys[i] = []string{}
 
 		// TODO: case on whether this is a v1 or v2 task by looking at the step data. for now,
 		// we're assuming a v1 task.

--- a/pkg/repository/v1/task.go
+++ b/pkg/repository/v1/task.go
@@ -2245,15 +2245,6 @@ func (r *sharedRepository) replayTasks(
 		taskIds[i] = task.TaskId
 		taskInsertedAts[i] = task.InsertedAt
 
-		// initialize with empty strings (one per concurrency strategy) to maintain cardinality in multi-dimensional array
-		emptyConcurrencyKeys := make([]string, 0)
-		if strats, ok := concurrencyStrats[task.StepId]; ok {
-			for range strats {
-				emptyConcurrencyKeys = append(emptyConcurrencyKeys, "")
-			}
-		}
-		concurrencyKeys[i] = emptyConcurrencyKeys
-
 		// TODO: case on whether this is a v1 or v2 task by looking at the step data. for now,
 		// we're assuming a v1 task.
 		if task.Input != nil {


### PR DESCRIPTION
# Description

Make sure the concurrency key results are set to `FAILED` in case of failures so that the cardinality is maintained which leads to errors from pgx's multi dimensional slice reflection issues.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
