### PR TITLE
Fix seq scan in `PollCronSchedules` query

### DIFF
--- a/pkg/repository/postgres/dbsqlc/tickers.sql
+++ b/pkg/repository/postgres/dbsqlc/tickers.sql
@@ -111,6 +111,8 @@ WITH latest_workflow_versions AS (
 active_cron_schedules AS (
     SELECT
         cronSchedule."parentId",
+        cronSchedule."cron",
+        cronSchedule."name",
         versions."id" AS "workflowVersionId",
         triggers."tenantId" AS "tenantId"
     FROM
@@ -141,6 +143,9 @@ FROM
     active_cron_schedules
 WHERE
     cronSchedules."parentId" = active_cron_schedules."parentId"
+    AND cronSchedules."cron" = active_cron_schedules."cron"
+    AND cronSchedules."name" = active_cron_schedules."name"
+
 RETURNING cronSchedules.*, active_cron_schedules."workflowVersionId", active_cron_schedules."tenantId";
 
 -- name: PollScheduledWorkflows :many

--- a/pkg/repository/postgres/dbsqlc/tickers.sql
+++ b/pkg/repository/postgres/dbsqlc/tickers.sql
@@ -102,8 +102,10 @@ WITH latest_workflow_versions AS (
     SELECT
         "workflowId",
         MAX("order") as max_order
-    FROM "WorkflowVersion"
-    WHERE "deletedAt" IS NULL
+    FROM
+        "WorkflowVersion"
+    WHERE
+        "deletedAt" IS NULL
     GROUP BY "workflowId"
 ),
 eligible_cron_with_versions AS (
@@ -115,9 +117,12 @@ eligible_cron_with_versions AS (
         triggers."tenantId",
         versions."workflowId",
         versions."order"
-    FROM "WorkflowTriggerCronRef" cronSchedule
-    JOIN "WorkflowTriggers" triggers ON triggers."id" = cronSchedule."parentId"
-    JOIN "WorkflowVersion" versions ON versions."id" = triggers."workflowVersionId"
+    FROM
+        "WorkflowTriggerCronRef" as cronSchedule
+    JOIN
+        "WorkflowTriggers" as triggers ON triggers."id" = cronSchedule."parentId"
+    JOIN
+        "WorkflowVersion" as versions ON versions."id" = triggers."workflowVersionId"
     WHERE cronSchedule."enabled" = TRUE
         AND versions."deletedAt" IS NULL
         AND (
@@ -136,8 +141,10 @@ eligible_cron_schedules AS (
         ecv."name",
         ecv."workflowVersionId",
         ecv."tenantId"
-    FROM eligible_cron_with_versions ecv
-    JOIN latest_workflow_versions l ON ecv."workflowId" = l."workflowId" AND ecv."order" = l.max_order
+    FROM
+        eligible_cron_with_versions as ecv
+    JOIN
+        latest_workflow_versions as l ON ecv."workflowId" = l."workflowId" AND ecv."order" = l.max_order
 )
 UPDATE
     "WorkflowTriggerCronRef" as cronSchedules

--- a/pkg/repository/postgres/dbsqlc/tickers.sql.go
+++ b/pkg/repository/postgres/dbsqlc/tickers.sql.go
@@ -190,51 +190,55 @@ WITH latest_workflow_versions AS (
     SELECT
         "workflowId",
         MAX("order") as max_order
-    FROM
-        "WorkflowVersion"
-    WHERE
-        "deletedAt" IS NULL
+    FROM "WorkflowVersion"
+    WHERE "deletedAt" IS NULL
     GROUP BY "workflowId"
 ),
-active_cron_schedules AS (
+eligible_cron_with_versions AS (
     SELECT
         cronSchedule."parentId",
         cronSchedule."cron",
         cronSchedule."name",
-        versions."id" AS "workflowVersionId",
-        triggers."tenantId" AS "tenantId"
-    FROM
-        "WorkflowTriggerCronRef" as cronSchedule
-    JOIN
-        "WorkflowTriggers" as triggers ON triggers."id" = cronSchedule."parentId"
-    JOIN
-        "WorkflowVersion" as versions ON versions."id" = triggers."workflowVersionId"
-    JOIN
-        latest_workflow_versions l ON versions."workflowId" = l."workflowId" AND versions."order" = l.max_order
-    WHERE
-        "enabled" = TRUE
+        triggers."workflowVersionId",
+        triggers."tenantId",
+        versions."workflowId",
+        versions."order"
+    FROM "WorkflowTriggerCronRef" cronSchedule
+    JOIN "WorkflowTriggers" triggers ON triggers."id" = cronSchedule."parentId"
+    JOIN "WorkflowVersion" versions ON versions."id" = triggers."workflowVersionId"
+    WHERE cronSchedule."enabled" = TRUE
         AND versions."deletedAt" IS NULL
         AND (
-            "tickerId" IS NULL
+            cronSchedule."tickerId" IS NULL
             OR NOT EXISTS (
                 SELECT 1 FROM "Ticker" WHERE "id" = cronSchedule."tickerId" AND "isActive" = true AND "lastHeartbeatAt" >= NOW() - INTERVAL '10 seconds'
             )
-            OR "tickerId" = $1::uuid
+            OR cronSchedule."tickerId" = $1::uuid
         )
-    FOR UPDATE SKIP LOCKED
+    FOR UPDATE OF cronSchedule SKIP LOCKED
+),
+eligible_cron_schedules AS (
+    SELECT
+        ecv."parentId",
+        ecv."cron",
+        ecv."name",
+        ecv."workflowVersionId",
+        ecv."tenantId"
+    FROM eligible_cron_with_versions ecv
+    JOIN latest_workflow_versions l ON ecv."workflowId" = l."workflowId" AND ecv."order" = l.max_order
 )
 UPDATE
     "WorkflowTriggerCronRef" as cronSchedules
 SET
     "tickerId" = $1::uuid
 FROM
-    active_cron_schedules
+    eligible_cron_schedules
 WHERE
-    cronSchedules."parentId" = active_cron_schedules."parentId"
-    AND cronSchedules."cron" = active_cron_schedules."cron"
-    AND cronSchedules."name" = active_cron_schedules."name"
+    cronSchedules."parentId" = eligible_cron_schedules."parentId"
+    AND cronSchedules."cron" = eligible_cron_schedules."cron"
+    AND cronSchedules."name" = eligible_cron_schedules."name"
 
-RETURNING cronschedules."parentId", cronschedules.cron, cronschedules."tickerId", cronschedules.input, cronschedules.enabled, cronschedules."additionalMetadata", cronschedules."createdAt", cronschedules."deletedAt", cronschedules."updatedAt", cronschedules.name, cronschedules.id, cronschedules.method, cronschedules.priority, active_cron_schedules."workflowVersionId", active_cron_schedules."tenantId"
+RETURNING cronschedules."parentId", cronschedules.cron, cronschedules."tickerId", cronschedules.input, cronschedules.enabled, cronschedules."additionalMetadata", cronschedules."createdAt", cronschedules."deletedAt", cronschedules."updatedAt", cronschedules.name, cronschedules.id, cronschedules.method, cronschedules.priority, eligible_cron_schedules."workflowVersionId", eligible_cron_schedules."tenantId"
 `
 
 type PollCronSchedulesRow struct {

--- a/pkg/repository/postgres/dbsqlc/tickers.sql.go
+++ b/pkg/repository/postgres/dbsqlc/tickers.sql.go
@@ -199,6 +199,8 @@ WITH latest_workflow_versions AS (
 active_cron_schedules AS (
     SELECT
         cronSchedule."parentId",
+        cronSchedule."cron",
+        cronSchedule."name",
         versions."id" AS "workflowVersionId",
         triggers."tenantId" AS "tenantId"
     FROM
@@ -229,6 +231,9 @@ FROM
     active_cron_schedules
 WHERE
     cronSchedules."parentId" = active_cron_schedules."parentId"
+    AND cronSchedules."cron" = active_cron_schedules."cron"
+    AND cronSchedules."name" = active_cron_schedules."name"
+
 RETURNING cronschedules."parentId", cronschedules.cron, cronschedules."tickerId", cronschedules.input, cronschedules.enabled, cronschedules."additionalMetadata", cronschedules."createdAt", cronschedules."deletedAt", cronschedules."updatedAt", cronschedules.name, cronschedules.id, cronschedules.method, cronschedules.priority, active_cron_schedules."workflowVersionId", active_cron_schedules."tenantId"
 `
 

--- a/pkg/repository/postgres/dbsqlc/tickers.sql.go
+++ b/pkg/repository/postgres/dbsqlc/tickers.sql.go
@@ -190,8 +190,10 @@ WITH latest_workflow_versions AS (
     SELECT
         "workflowId",
         MAX("order") as max_order
-    FROM "WorkflowVersion"
-    WHERE "deletedAt" IS NULL
+    FROM
+        "WorkflowVersion"
+    WHERE
+        "deletedAt" IS NULL
     GROUP BY "workflowId"
 ),
 eligible_cron_with_versions AS (
@@ -203,9 +205,12 @@ eligible_cron_with_versions AS (
         triggers."tenantId",
         versions."workflowId",
         versions."order"
-    FROM "WorkflowTriggerCronRef" cronSchedule
-    JOIN "WorkflowTriggers" triggers ON triggers."id" = cronSchedule."parentId"
-    JOIN "WorkflowVersion" versions ON versions."id" = triggers."workflowVersionId"
+    FROM
+        "WorkflowTriggerCronRef" as cronSchedule
+    JOIN
+        "WorkflowTriggers" as triggers ON triggers."id" = cronSchedule."parentId"
+    JOIN
+        "WorkflowVersion" as versions ON versions."id" = triggers."workflowVersionId"
     WHERE cronSchedule."enabled" = TRUE
         AND versions."deletedAt" IS NULL
         AND (
@@ -224,8 +229,10 @@ eligible_cron_schedules AS (
         ecv."name",
         ecv."workflowVersionId",
         ecv."tenantId"
-    FROM eligible_cron_with_versions ecv
-    JOIN latest_workflow_versions l ON ecv."workflowId" = l."workflowId" AND ecv."order" = l.max_order
+    FROM
+        eligible_cron_with_versions as ecv
+    JOIN
+        latest_workflow_versions as l ON ecv."workflowId" = l."workflowId" AND ecv."order" = l.max_order
 )
 UPDATE
     "WorkflowTriggerCronRef" as cronSchedules


### PR DESCRIPTION
# Description

Fixes a seq scan in the query planner when polling for cron schedules.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
