### PR TITLE
Hotfix: Log dupes

### DIFF
--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-logs.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-logs.tsx
@@ -72,7 +72,9 @@ export function StepRunLogs({
       );
       const rows = response.data.rows;
 
-      if (isTaskRunning) {
+      const maxCreatedAt = rows?.[rows.length - 1]?.createdAt;
+
+      if (isTaskRunning && maxCreatedAt) {
         lastPageTimestampRef.current = rows?.[rows.length - 1]?.createdAt;
         return response.data;
       }

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-logs.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-logs.tsx
@@ -75,7 +75,7 @@ export function StepRunLogs({
       const maxCreatedAt = rows?.[rows.length - 1]?.createdAt;
 
       if (isTaskRunning && maxCreatedAt) {
-        lastPageTimestampRef.current = rows?.[rows.length - 1]?.createdAt;
+        lastPageTimestampRef.current = maxCreatedAt;
         return response.data;
       }
 


### PR DESCRIPTION
# Description

Logs were getting duped in the dashboard because of a race condition causing the max timestamp ref to get unset, causing refetches of the original data

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
