### PR TITLE
[Python, CI] Fix: `psutil` error from no such process

### DIFF
--- a/sdks/python/tests/worker_fixture.py
+++ b/sdks/python/tests/worker_fixture.py
@@ -67,12 +67,21 @@ def hatchet_worker(
     children = parent.children(recursive=True)
 
     for child in children:
-        child.terminate()
+        try:
+            child.terminate()
+        except psutil.NoSuchProcess:
+            pass
 
-    parent.terminate()
+    try:
+        parent.terminate()
+    except psutil.NoSuchProcess:
+        pass
 
     _, alive = psutil.wait_procs([parent] + children, timeout=5)
 
     for p in alive:
         logging.warning(f"Force killing process {p.pid}")
-        p.kill()
+        try:
+            p.kill()
+        except psutil.NoSuchProcess:
+            pass


### PR DESCRIPTION
# Description

Adds some error handling to handle the psutil no such process error we keep seeing in CI

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI (any automation pipeline changes)

