### PR TITLE
Optimize UUID-related `sqlchelpers`

### DIFF
--- a/pkg/repository/postgres/sqlchelpers/uuid.go
+++ b/pkg/repository/postgres/sqlchelpers/uuid.go
@@ -1,13 +1,11 @@
 package sqlchelpers
 
 import (
-	"fmt"
-
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
 func UUIDToStr(uuid pgtype.UUID) string {
-	return fmt.Sprintf("%x-%x-%x-%x-%x", uuid.Bytes[0:4], uuid.Bytes[4:6], uuid.Bytes[6:8], uuid.Bytes[8:10], uuid.Bytes[10:16])
+	return uuid.String()
 }
 
 func UUIDFromStr(uuid string) pgtype.UUID {
@@ -21,14 +19,12 @@ func UUIDFromStr(uuid string) pgtype.UUID {
 }
 
 func UniqueSet(uuids []pgtype.UUID) []pgtype.UUID {
-	seen := make(map[string]struct{})
+	seen := make(map[[16]byte]struct{})
 	unique := make([]pgtype.UUID, 0, len(uuids))
 
 	for _, uuid := range uuids {
-		uuidStr := UUIDToStr(uuid)
-
-		if _, ok := seen[uuidStr]; !ok {
-			seen[uuidStr] = struct{}{}
+		if _, ok := seen[uuid.Bytes]; !ok {
+			seen[uuid.Bytes] = struct{}{}
 			unique = append(unique, uuid)
 		}
 	}

--- a/pkg/repository/postgres/sqlchelpers/uuid_test.go
+++ b/pkg/repository/postgres/sqlchelpers/uuid_test.go
@@ -1,0 +1,134 @@
+package sqlchelpers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+var benchmarkUUID = pgtype.UUID{
+	Bytes: [16]byte{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0},
+	Valid: true,
+}
+
+var benchmarkResult string
+
+func uuidToStrOriginal(uuid pgtype.UUID) string {
+	return fmt.Sprintf("%x-%x-%x-%x-%x", uuid.Bytes[0:4], uuid.Bytes[4:6], uuid.Bytes[6:8], uuid.Bytes[8:10], uuid.Bytes[10:16])
+}
+
+func BenchmarkUUIDToStr(b *testing.B) {
+	b.Run("Optimized", func(b *testing.B) {
+		b.ReportAllocs()
+		var result string
+		for b.Loop() {
+			result = UUIDToStr(benchmarkUUID)
+		}
+		benchmarkResult = result
+	})
+
+	b.Run("Original", func(b *testing.B) {
+		b.ReportAllocs()
+		var result string
+		for b.Loop() {
+			result = uuidToStrOriginal(benchmarkUUID)
+		}
+		benchmarkResult = result
+	})
+}
+
+func uniqueSetOriginal(uuids []pgtype.UUID) []pgtype.UUID {
+	seen := make(map[string]struct{})
+	unique := make([]pgtype.UUID, 0, len(uuids))
+
+	for _, uuid := range uuids {
+		uuidStr := UUIDToStr(uuid)
+
+		if _, ok := seen[uuidStr]; !ok {
+			seen[uuidStr] = struct{}{}
+			unique = append(unique, uuid)
+		}
+	}
+
+	return unique
+}
+
+func TestUniqueSet(t *testing.T) {
+	testUUIDs := make([]pgtype.UUID, 100)
+	for i := 0; i < 100; i++ {
+		uuid := pgtype.UUID{
+			Bytes: [16]byte{
+				byte(i % 256),
+				byte((i / 256) % 256),
+				byte((i / 65536) % 256),
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			},
+			Valid: true,
+		}
+		testUUIDs[i] = uuid
+	}
+	testUUIDs = append(testUUIDs, testUUIDs[:50]...)
+
+	optimized := UniqueSet(testUUIDs)
+	original := uniqueSetOriginal(testUUIDs)
+
+	if len(optimized) != len(original) {
+		t.Fatalf("length mismatch: optimized=%d, original=%d", len(optimized), len(original))
+	}
+
+	optimizedMap := make(map[[16]byte]struct{})
+	for _, uuid := range optimized {
+		optimizedMap[uuid.Bytes] = struct{}{}
+	}
+
+	originalMap := make(map[[16]byte]struct{})
+	for _, uuid := range original {
+		originalMap[uuid.Bytes] = struct{}{}
+	}
+
+	if len(optimizedMap) != len(originalMap) {
+		t.Fatalf("unique count mismatch: optimized=%d, original=%d", len(optimizedMap), len(originalMap))
+	}
+
+	for k := range optimizedMap {
+		if _, ok := originalMap[k]; !ok {
+			t.Errorf("UUID %v found in optimized but not in original", k)
+		}
+	}
+}
+
+func BenchmarkUniqueSet(b *testing.B) {
+	testUUIDs := make([]pgtype.UUID, 1000)
+	for i := 0; i < 1000; i++ {
+		uuid := pgtype.UUID{
+			Bytes: [16]byte{
+				byte(i % 256),
+				byte((i / 256) % 256),
+				byte((i / 65536) % 256),
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			},
+			Valid: true,
+		}
+		testUUIDs[i] = uuid
+	}
+	testUUIDs = append(testUUIDs, testUUIDs[:500]...)
+
+	b.Run("Optimized", func(b *testing.B) {
+		b.ReportAllocs()
+		var result []pgtype.UUID
+		for b.Loop() {
+			result = UniqueSet(testUUIDs)
+		}
+		_ = result
+	})
+
+	b.Run("Original", func(b *testing.B) {
+		b.ReportAllocs()
+		var result []pgtype.UUID
+		for b.Loop() {
+			result = uniqueSetOriginal(testUUIDs)
+		}
+		_ = result
+	})
+}


### PR DESCRIPTION
# Description

Optimizes UUID related `sqlchelpers`

```bash
$ go test -bench=. -benchmem
goos: darwin
goarch: arm64
pkg: github.com/hatchet-dev/hatchet/pkg/repository/postgres/sqlchelpers
cpu: Apple M4 Max
BenchmarkUUIDToStr/Optimized-16                 62717914                18.81 ns/op           48 B/op            1 allocs/op
BenchmarkUUIDToStr/Original-16                   8207217               142.3 ns/op           192 B/op            7 allocs/op
BenchmarkUniqueSet/Optimized-16                    28984             41319 ns/op          101528 B/op           21 allocs/op
BenchmarkUniqueSet/Original-16                     15351             77998 ns/op          208024 B/op         1521 allocs/op
PASS
ok      github.com/hatchet-dev/hatchet/pkg/repository/postgres/sqlchelpers      5.520s
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (changes which are not directly related to any business logic)