### PR TITLE
Feat: Initial cross-domain identify setup

### DIFF
--- a/frontend/app/src/components/molecules/analytics-provider.tsx
+++ b/frontend/app/src/components/molecules/analytics-provider.tsx
@@ -50,10 +50,10 @@ const AnalyticsProvider: React.FC<
 
     const bootstrapConfig =
       distinctId && sessionId
-        ? `bootstrap: {
-        sessionID: '${sessionId}',
-        distinctID: '${distinctId}'
-      },`
+        ? `bootstrap: ${JSON.stringify({
+            sessionID: sessionId,
+            distinctID: distinctId,
+          })},`
         : '';
 
     const posthogScript = `

--- a/frontend/app/src/components/molecules/analytics-provider.tsx
+++ b/frontend/app/src/components/molecules/analytics-provider.tsx
@@ -13,6 +13,13 @@ const AnalyticsProvider: React.FC<
 > = ({ user, children }) => {
   const meta = useApiMeta();
 
+  // allows for cross-domain tracking with PostHog
+  // see: https://posthog.com/tutorials/cross-domain-tracking
+  // for setup instructions and more details
+  const hashParams = new URLSearchParams(window.location.hash.substring(1));
+  const distinct_id = hashParams.get('distinct_id') ?? undefined;
+  const session_id = hashParams.get('session_id') ?? undefined;
+
   const [loaded, setLoaded] = React.useState(false);
 
   const { tenant } = useTenant();
@@ -47,6 +54,10 @@ posthog.init('${config.apiKey}',{
   session_recording: {
       maskAllInputs: true,
       maskTextSelector: "*"
+  },
+  bootstrap: {
+    sessionID: '${session_id || ''}',
+    distinctID: '${distinct_id || ''}'
   }
 })
 `;

--- a/frontend/app/src/components/molecules/analytics-provider.tsx
+++ b/frontend/app/src/components/molecules/analytics-provider.tsx
@@ -1,7 +1,7 @@
 import { User } from '@/lib/api';
 import { useTenant } from '@/lib/atoms';
 import useApiMeta from '@/pages/auth/hooks/use-api-meta';
-import { useAnalytics } from '@/hooks/use-analytics';
+import { POSTHOG_DISTINCT_ID_LOCAL_STORAGE_KEY, POSTHOG_SESSION_ID_LOCAL_STORAGE_KEY, useAnalytics } from '@/hooks/use-analytics';
 import React, { PropsWithChildren, useEffect, useMemo } from 'react';
 
 interface AnalyticsProviderProps {
@@ -48,8 +48,8 @@ const AnalyticsProvider: React.FC<
     let bootstrapConfig = '';
 
     if (localStorage) {
-      const distinctId = localStorage.getItem('ph__distinct_id');
-      const sessionId = localStorage.getItem('ph__session_id');
+      const distinctId = localStorage.getItem(POSTHOG_DISTINCT_ID_LOCAL_STORAGE_KEY);
+      const sessionId = localStorage.getItem(POSTHOG_SESSION_ID_LOCAL_STORAGE_KEY);
 
       if (distinctId && sessionId) {
         bootstrapConfig = `bootstrap: ${JSON.stringify({

--- a/frontend/app/src/components/molecules/analytics-provider.tsx
+++ b/frontend/app/src/components/molecules/analytics-provider.tsx
@@ -45,7 +45,7 @@ const AnalyticsProvider: React.FC<
       return;
     }
 
-    var bootstrapConfig = '';
+    let bootstrapConfig = '';
 
     if (localStorage) {
       const distinctId = localStorage.getItem('ph__distinct_id');
@@ -75,7 +75,7 @@ posthog.init('${config.apiKey}',{
 `;
     document.head.appendChild(document.createElement('script')).innerHTML =
       posthogScript;
-  }, [config, loaded, tenant, localStorage]);
+  }, [config, loaded, tenant]);
 
   useEffect(() => {
     if (!config) {

--- a/frontend/app/src/components/molecules/analytics-provider.tsx
+++ b/frontend/app/src/components/molecules/analytics-provider.tsx
@@ -17,8 +17,8 @@ const AnalyticsProvider: React.FC<
   // see: https://posthog.com/tutorials/cross-domain-tracking
   // for setup instructions and more details
   const hashParams = new URLSearchParams(window.location.hash.substring(1));
-  const distinct_id = hashParams.get('distinct_id');
-  const session_id = hashParams.get('session_id');
+  const distinctId = hashParams.get('distinct_id');
+  const sessionId = hashParams.get('session_id');
 
   const [loaded, setLoaded] = React.useState(false);
 
@@ -49,10 +49,10 @@ const AnalyticsProvider: React.FC<
     setLoaded(true);
 
     const bootstrapConfig =
-      distinct_id && session_id
+      distinctId && sessionId
         ? `bootstrap: {
-        sessionID: '${session_id}',
-        distinctID: '${distinct_id}'
+        sessionID: '${sessionId}',
+        distinctID: '${distinctId}'
       },`
         : '';
 
@@ -69,7 +69,7 @@ posthog.init('${config.apiKey}',{
 `;
     document.head.appendChild(document.createElement('script')).innerHTML =
       posthogScript;
-  }, [config, loaded, tenant]);
+  }, [config, loaded, tenant, distinctId, sessionId]);
 
   useEffect(() => {
     if (!config) {

--- a/frontend/app/src/components/molecules/analytics-provider.tsx
+++ b/frontend/app/src/components/molecules/analytics-provider.tsx
@@ -17,8 +17,8 @@ const AnalyticsProvider: React.FC<
   // see: https://posthog.com/tutorials/cross-domain-tracking
   // for setup instructions and more details
   const hashParams = new URLSearchParams(window.location.hash.substring(1));
-  const distinct_id = hashParams.get('distinct_id') ?? undefined;
-  const session_id = hashParams.get('session_id') ?? undefined;
+  const distinct_id = hashParams.get('distinct_id');
+  const session_id = hashParams.get('session_id');
 
   const [loaded, setLoaded] = React.useState(false);
 
@@ -47,17 +47,23 @@ const AnalyticsProvider: React.FC<
 
     console.log('Initializing Analytics, opt out in settings.');
     setLoaded(true);
+
+    const bootstrapConfig =
+      distinct_id && session_id
+        ? `bootstrap: {
+        sessionID: '${session_id}',
+        distinctID: '${distinct_id}'
+      },`
+        : '';
+
     const posthogScript = `
 !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
 posthog.init('${config.apiKey}',{
   api_host:'${config.apiHost}',
+  ${bootstrapConfig}
   session_recording: {
       maskAllInputs: true,
       maskTextSelector: "*"
-  },
-  bootstrap: {
-    sessionID: '${session_id || ''}',
-    distinctID: '${distinct_id || ''}'
   }
 })
 `;

--- a/frontend/app/src/components/molecules/analytics-provider.tsx
+++ b/frontend/app/src/components/molecules/analytics-provider.tsx
@@ -1,7 +1,11 @@
 import { User } from '@/lib/api';
 import { useTenant } from '@/lib/atoms';
 import useApiMeta from '@/pages/auth/hooks/use-api-meta';
-import { POSTHOG_DISTINCT_ID_LOCAL_STORAGE_KEY, POSTHOG_SESSION_ID_LOCAL_STORAGE_KEY, useAnalytics } from '@/hooks/use-analytics';
+import {
+  POSTHOG_DISTINCT_ID_LOCAL_STORAGE_KEY,
+  POSTHOG_SESSION_ID_LOCAL_STORAGE_KEY,
+  useAnalytics,
+} from '@/hooks/use-analytics';
 import React, { PropsWithChildren, useEffect, useMemo } from 'react';
 
 interface AnalyticsProviderProps {
@@ -48,8 +52,12 @@ const AnalyticsProvider: React.FC<
     let bootstrapConfig = '';
 
     if (localStorage) {
-      const distinctId = localStorage.getItem(POSTHOG_DISTINCT_ID_LOCAL_STORAGE_KEY);
-      const sessionId = localStorage.getItem(POSTHOG_SESSION_ID_LOCAL_STORAGE_KEY);
+      const distinctId = localStorage.getItem(
+        POSTHOG_DISTINCT_ID_LOCAL_STORAGE_KEY,
+      );
+      const sessionId = localStorage.getItem(
+        POSTHOG_SESSION_ID_LOCAL_STORAGE_KEY,
+      );
 
       if (distinctId && sessionId) {
         bootstrapConfig = `bootstrap: ${JSON.stringify({

--- a/frontend/app/src/hooks/use-analytics.tsx
+++ b/frontend/app/src/hooks/use-analytics.tsx
@@ -64,6 +64,11 @@ export function useAnalytics(): UseAnalyticsReturn {
       } catch (error) {
         console.warn('Analytics identify failed:', error);
       }
+
+      // important: clear out the distinct_id and session_id from local storage
+      // after identifying the user so we don't re-bootstrap over and over
+      localStorage.removeItem(POSTHOG_DISTINCT_ID_LOCAL_STORAGE_KEY);
+      localStorage.removeItem(POSTHOG_SESSION_ID_LOCAL_STORAGE_KEY);
     },
     [isAvailable],
   );

--- a/frontend/app/src/hooks/use-analytics.tsx
+++ b/frontend/app/src/hooks/use-analytics.tsx
@@ -15,6 +15,9 @@ interface UseAnalyticsReturn {
   isAvailable: boolean;
 }
 
+export const POSTHOG_DISTINCT_ID_LOCAL_STORAGE_KEY = 'ph__distinct_id';
+export const POSTHOG_SESSION_ID_LOCAL_STORAGE_KEY = 'ph__session_id';
+
 /**
  * Hook for PostHog analytics integration
  * Provides a clean interface for tracking events and identifying users

--- a/frontend/app/src/pages/auth/register/index.tsx
+++ b/frontend/app/src/pages/auth/register/index.tsx
@@ -9,6 +9,10 @@ import { Loading } from '@/components/ui/loading';
 import { GithubLogin, GoogleLogin, OrContinueWith } from '../login';
 import useErrorParam from '../hooks/use-error-param';
 import React from 'react';
+import {
+  POSTHOG_DISTINCT_ID_LOCAL_STORAGE_KEY,
+  POSTHOG_SESSION_ID_LOCAL_STORAGE_KEY,
+} from '@/hooks/use-analytics';
 
 export default function Register() {
   useErrorParam();
@@ -17,17 +21,19 @@ export default function Register() {
   // allows for cross-domain tracking with PostHog
   // see: https://posthog.com/tutorials/cross-domain-tracking
   // for setup instructions and more details
+  // important: we need to set these in local storage from here,
+  // because once we redirect after the user signs up, we lose the hash params
   const hashParams = new URLSearchParams(window.location.hash.substring(1));
   const distinctId = hashParams.get('distinct_id');
   const sessionId = hashParams.get('session_id');
 
   useEffect(() => {
     if (distinctId) {
-      localStorage.setItem('ph__distinct_id', distinctId);
+      localStorage.setItem(POSTHOG_DISTINCT_ID_LOCAL_STORAGE_KEY, distinctId);
     }
 
     if (sessionId) {
-      localStorage.setItem('ph__session_id', sessionId);
+      localStorage.setItem(POSTHOG_SESSION_ID_LOCAL_STORAGE_KEY, sessionId);
     }
   }, [distinctId, sessionId]);
 

--- a/frontend/app/src/pages/auth/register/index.tsx
+++ b/frontend/app/src/pages/auth/register/index.tsx
@@ -2,7 +2,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { UserRegisterForm } from './components/user-register-form';
 import { useMutation } from '@tanstack/react-query';
 import api, { UserRegisterRequest } from '@/lib/api';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useApiError } from '@/lib/hooks';
 import useApiMeta from '../hooks/use-api-meta';
 import { Loading } from '@/components/ui/loading';
@@ -14,9 +14,26 @@ export default function Register() {
   useErrorParam();
   const meta = useApiMeta();
 
+  // allows for cross-domain tracking with PostHog
+  // see: https://posthog.com/tutorials/cross-domain-tracking
+  // for setup instructions and more details
+  const hashParams = new URLSearchParams(window.location.hash.substring(1));
+  const distinctId = hashParams.get('distinct_id');
+  const sessionId = hashParams.get('session_id');
+
   if (meta.isLoading) {
     return <Loading />;
   }
+
+  useEffect(() => {
+    if (distinctId) {
+      localStorage.setItem('ph__distinct_id', distinctId);
+    }
+
+    if (sessionId) {
+      localStorage.setItem('ph__session_id', sessionId);
+    }
+  }, [distinctId, sessionId]);
 
   const schemes = meta.data?.auth?.schemes || [];
   const basicEnabled = schemes.includes('basic');

--- a/frontend/app/src/pages/auth/register/index.tsx
+++ b/frontend/app/src/pages/auth/register/index.tsx
@@ -21,10 +21,6 @@ export default function Register() {
   const distinctId = hashParams.get('distinct_id');
   const sessionId = hashParams.get('session_id');
 
-  if (meta.isLoading) {
-    return <Loading />;
-  }
-
   useEffect(() => {
     if (distinctId) {
       localStorage.setItem('ph__distinct_id', distinctId);
@@ -34,6 +30,10 @@ export default function Register() {
       localStorage.setItem('ph__session_id', sessionId);
     }
   }, [distinctId, sessionId]);
+
+  if (meta.isLoading) {
+    return <Loading />;
+  }
 
   const schemes = meta.data?.auth?.schemes || [];
   const basicEnabled = schemes.includes('basic');


### PR DESCRIPTION
# Description

Setting up cross-domain identify in PostHog following [this guide](https://posthog.com/tutorials/cross-domain-tracking). Should just need to pass the session id and distinct id as hash params in the URL on redirect now.

One thing I wasn't clear on is if it's possible to get either one or the other, but not both, of the params, but I think it's not based on:

> You need to pass users' distinct_id and session_id between PostHog initializations

## Type of change

- [x] New feature (non-breaking change which adds functionality)

