### PR TITLE
Fix: Use `sessionStorage` instead of `localStorage` for PostHog ids

### DIFF
--- a/frontend/app/src/components/molecules/analytics-provider.tsx
+++ b/frontend/app/src/components/molecules/analytics-provider.tsx
@@ -51,11 +51,11 @@ const AnalyticsProvider: React.FC<
 
     let bootstrapConfig = '';
 
-    if (localStorage) {
-      const distinctId = localStorage.getItem(
+    if (sessionStorage) {
+      const distinctId = sessionStorage.getItem(
         POSTHOG_DISTINCT_ID_LOCAL_STORAGE_KEY,
       );
-      const sessionId = localStorage.getItem(
+      const sessionId = sessionStorage.getItem(
         POSTHOG_SESSION_ID_LOCAL_STORAGE_KEY,
       );
 

--- a/frontend/app/src/hooks/use-analytics.tsx
+++ b/frontend/app/src/hooks/use-analytics.tsx
@@ -64,11 +64,6 @@ export function useAnalytics(): UseAnalyticsReturn {
       } catch (error) {
         console.warn('Analytics identify failed:', error);
       }
-
-      // important: clear out the distinct_id and session_id from local storage
-      // after identifying the user so we don't re-bootstrap over and over
-      localStorage.removeItem(POSTHOG_DISTINCT_ID_LOCAL_STORAGE_KEY);
-      localStorage.removeItem(POSTHOG_SESSION_ID_LOCAL_STORAGE_KEY);
     },
     [isAvailable],
   );

--- a/frontend/app/src/pages/auth/register/index.tsx
+++ b/frontend/app/src/pages/auth/register/index.tsx
@@ -29,11 +29,11 @@ export default function Register() {
 
   useEffect(() => {
     if (distinctId) {
-      localStorage.setItem(POSTHOG_DISTINCT_ID_LOCAL_STORAGE_KEY, distinctId);
+      sessionStorage.setItem(POSTHOG_DISTINCT_ID_LOCAL_STORAGE_KEY, distinctId);
     }
 
     if (sessionId) {
-      localStorage.setItem(POSTHOG_SESSION_ID_LOCAL_STORAGE_KEY, sessionId);
+      sessionStorage.setItem(POSTHOG_SESSION_ID_LOCAL_STORAGE_KEY, sessionId);
     }
   }, [distinctId, sessionId]);
 


### PR DESCRIPTION
# Description

Using `sessionStorage` and removing the eviction logic to try to get rid of a race condition between the identify and the localStorage unset

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

