### PR TITLE
Initialize concurrency keys slice for replayed tasks

### DIFF
--- a/pkg/repository/v1/task.go
+++ b/pkg/repository/v1/task.go
@@ -1826,13 +1826,13 @@ func (r *sharedRepository) insertTasks(
 
 		concurrencyKeys[i] = make([]string, 0)
 
-		if strats, ok := concurrencyStrats[task.StepId]; ok {
-			// we write any parent strategy ids to the task regardless of initial state, as we need to know
-			// when to release the parent concurrency slot
-			taskParentStrategyIds := make([]pgtype.Int8, 0)
-			taskStrategyIds := make([]int64, 0)
-			emptyConcurrencyKeys := make([]string, 0)
+		// we write any parent strategy ids to the task regardless of initial state, as we need to know
+		// when to release the parent concurrency slot
+		taskParentStrategyIds := make([]pgtype.Int8, 0)
+		taskStrategyIds := make([]int64, 0)
+		emptyConcurrencyKeys := make([]string, 0)
 
+		if strats, ok := concurrencyStrats[task.StepId]; ok {
 			for _, strat := range strats {
 				taskStrategyIds = append(taskStrategyIds, strat.ID)
 				taskParentStrategyIds = append(taskParentStrategyIds, strat.ParentStrategyID)
@@ -1846,11 +1846,11 @@ func (r *sharedRepository) insertTasks(
 					cleanupWorkflowVersionIds = append(cleanupWorkflowVersionIds, stepConfig.WorkflowVersionId)
 				}
 			}
-
-			parentStrategyIds[i] = taskParentStrategyIds
-			strategyIds[i] = taskStrategyIds
-			concurrencyKeys[i] = emptyConcurrencyKeys
 		}
+
+		parentStrategyIds[i] = taskParentStrategyIds
+		strategyIds[i] = taskStrategyIds
+		concurrencyKeys[i] = emptyConcurrencyKeys
 
 		// only check for concurrency if the task is in a queued state, otherwise we don't need to
 		// evaluate the expression (and it will likely fail if we do)

--- a/pkg/repository/v1/task.go
+++ b/pkg/repository/v1/task.go
@@ -1826,13 +1826,13 @@ func (r *sharedRepository) insertTasks(
 
 		concurrencyKeys[i] = make([]string, 0)
 
-		// we write any parent strategy ids to the task regardless of initial state, as we need to know
-		// when to release the parent concurrency slot
-		taskParentStrategyIds := make([]pgtype.Int8, 0)
-		taskStrategyIds := make([]int64, 0)
-		emptyConcurrencyKeys := make([]string, 0)
-
 		if strats, ok := concurrencyStrats[task.StepId]; ok {
+			// we write any parent strategy ids to the task regardless of initial state, as we need to know
+			// when to release the parent concurrency slot
+			taskParentStrategyIds := make([]pgtype.Int8, 0)
+			taskStrategyIds := make([]int64, 0)
+			emptyConcurrencyKeys := make([]string, 0)
+
 			for _, strat := range strats {
 				taskStrategyIds = append(taskStrategyIds, strat.ID)
 				taskParentStrategyIds = append(taskParentStrategyIds, strat.ParentStrategyID)
@@ -1846,11 +1846,11 @@ func (r *sharedRepository) insertTasks(
 					cleanupWorkflowVersionIds = append(cleanupWorkflowVersionIds, stepConfig.WorkflowVersionId)
 				}
 			}
-		}
 
-		parentStrategyIds[i] = taskParentStrategyIds
-		strategyIds[i] = taskStrategyIds
-		concurrencyKeys[i] = emptyConcurrencyKeys
+			parentStrategyIds[i] = taskParentStrategyIds
+			strategyIds[i] = taskStrategyIds
+			concurrencyKeys[i] = emptyConcurrencyKeys
+		}
 
 		// only check for concurrency if the task is in a queued state, otherwise we don't need to
 		// evaluate the expression (and it will likely fail if we do)
@@ -2260,17 +2260,17 @@ func (r *sharedRepository) replayTasks(
 			additionalMetadatas[i] = task.AdditionalMetadata
 		}
 
-		concurrencyKeys[i] = make([]string, 0)
-
-		emptyConcurrencyKeys := make([]string, 0)
-
 		if strats, ok := concurrencyStrats[task.StepId]; ok {
+			emptyConcurrencyKeys := make([]string, 0)
+
 			for range strats {
 				emptyConcurrencyKeys = append(emptyConcurrencyKeys, "")
 			}
-		}
 
-		concurrencyKeys[i] = emptyConcurrencyKeys
+			concurrencyKeys[i] = emptyConcurrencyKeys
+		} else {
+			concurrencyKeys[i] = make([]string, 0)
+		}
 
 		// only check for concurrency if the task is in a queued state, otherwise we don't need to
 		// evaluate the expression (and it will likely fail if we do)

--- a/pkg/repository/v1/task.go
+++ b/pkg/repository/v1/task.go
@@ -2094,7 +2094,26 @@ func (r *sharedRepository) insertTasks(
 	eventTypes := make([]sqlcv1.V1TaskEventType, 0)
 
 	for stepId, params := range stepIdsToParams {
-		createdTasks, err := r.queries.CreateTasks(ctx, tx, params)
+		var createdTasks []*sqlcv1.V1Task
+		var err error
+
+		func() {
+			defer func() {
+				if panicErr := recover(); panicErr != nil {
+					r.l.Error().
+						Str("step_id", stepId).
+						Int("num_tasks", len(params.Externalids)).
+						Int("num_concurrency_keys", len(params.ConcurrencyKeys)).
+						Interface("concurrency_keys", params.ConcurrencyKeys).
+						Interface("initial_states", params.InitialStates).
+						Interface("panic", panicErr).
+						Msg("panic during create tasks")
+					panic(panicErr)
+				}
+			}()
+
+			createdTasks, err = r.queries.CreateTasks(ctx, tx, params)
+		}()
 
 		if err != nil {
 			return nil, fmt.Errorf("failed to create tasks for step id %s: %w", stepId, err)
@@ -2260,17 +2279,17 @@ func (r *sharedRepository) replayTasks(
 			additionalMetadatas[i] = task.AdditionalMetadata
 		}
 
-		if strats, ok := concurrencyStrats[task.StepId]; ok {
-			emptyConcurrencyKeys := make([]string, 0)
+		// if strats, ok := concurrencyStrats[task.StepId]; ok {
+		// 	emptyConcurrencyKeys := make([]string, 0)
 
-			for range strats {
-				emptyConcurrencyKeys = append(emptyConcurrencyKeys, "")
-			}
+		// 	for range strats {
+		// 		emptyConcurrencyKeys = append(emptyConcurrencyKeys, "")
+		// 	}
 
-			concurrencyKeys[i] = emptyConcurrencyKeys
-		} else {
-			concurrencyKeys[i] = make([]string, 0)
-		}
+		// 	concurrencyKeys[i] = emptyConcurrencyKeys
+		// } else {
+		// 	concurrencyKeys[i] = make([]string, 0)
+		// }
 
 		// only check for concurrency if the task is in a queued state, otherwise we don't need to
 		// evaluate the expression (and it will likely fail if we do)
@@ -2401,7 +2420,26 @@ func (r *sharedRepository) replayTasks(
 	eventTypes := make([]sqlcv1.V1TaskEventType, 0)
 
 	for stepId, params := range stepIdsToParams {
-		replayRes, err := r.queries.ReplayTasks(ctx, tx, params)
+		var replayRes []*sqlcv1.V1Task
+		var err error
+
+		func() {
+			defer func() {
+				if panicErr := recover(); panicErr != nil {
+					r.l.Error().
+						Str("step_id", stepId).
+						Int("num_tasks", len(params.Taskids)).
+						Int("num_concurrency_keys", len(params.Concurrencykeys)).
+						Interface("concurrency_keys", params.Concurrencykeys).
+						Interface("initial_states", params.InitialStates).
+						Interface("panic", panicErr).
+						Msg("panic during replay tasks")
+					panic(panicErr)
+				}
+			}()
+
+			replayRes, err = r.queries.ReplayTasks(ctx, tx, params)
+		}()
 
 		if err != nil {
 			return nil, fmt.Errorf("failed to replay tasks for step id %s: %w", stepId, err)

--- a/pkg/repository/v1/task.go
+++ b/pkg/repository/v1/task.go
@@ -2260,6 +2260,18 @@ func (r *sharedRepository) replayTasks(
 			additionalMetadatas[i] = task.AdditionalMetadata
 		}
 
+		concurrencyKeys[i] = make([]string, 0)
+
+		emptyConcurrencyKeys := make([]string, 0)
+
+		if strats, ok := concurrencyStrats[task.StepId]; ok {
+			for range strats {
+				emptyConcurrencyKeys = append(emptyConcurrencyKeys, "")
+			}
+		}
+
+		concurrencyKeys[i] = emptyConcurrencyKeys
+
 		// only check for concurrency if the task is in a queued state, otherwise we don't need to
 		// evaluate the expression (and it will likely fail if we do)
 		if task.InitialState == sqlcv1.V1TaskInitialStateQUEUED {


### PR DESCRIPTION
# Description

We initialize concurrency keys in a certain fashion in `insertTasks` but fail to do so in `replayTasks` which can lead to the multi-dimensional slice being nil or with a different cardinality as expected.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)