### PR TITLE
Add whitespace-pre to log

### DIFF
--- a/frontend/app/src/components/cloud/logging/logs.tsx
+++ b/frontend/app/src/components/cloud/logging/logs.tsx
@@ -162,7 +162,7 @@ const LoggingComponent: React.FC<LogProps> = ({
         return (
           <p
             key={logHash}
-            className="pb-2 break-all overflow-x-hidden"
+            className="pb-2 break-all overflow-x-hidden whitespace-pre"
             id={'log' + i}
           >
             {log.badge}

--- a/frontend/app/src/components/cloud/logging/logs.tsx
+++ b/frontend/app/src/components/cloud/logging/logs.tsx
@@ -162,7 +162,7 @@ const LoggingComponent: React.FC<LogProps> = ({
         return (
           <p
             key={logHash}
-            className="pb-2 break-all overflow-x-hidden whitespace-pre"
+            className="pb-2 break-all overflow-x-hidden whitespace-pre-wrap"
             id={'log' + i}
           >
             {log.badge}

--- a/frontend/app/src/components/v1/cloud/logging/logs.tsx
+++ b/frontend/app/src/components/v1/cloud/logging/logs.tsx
@@ -183,7 +183,7 @@ const LoggingComponent: React.FC<LogProps> = ({
         return (
           <p
             key={logHash}
-            className="pb-2 break-all overflow-x-hidden"
+            className="pb-2 break-all overflow-x-hidden whitespace-pre-wrap"
             id={'log' + i}
           >
             {log.badge}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In the current log viewer, when rendering e.g. JSON object, the indentation/format is not visible. This add the while space back, so e.g. JSON, space can display properly

Before
<img width="597" height="158" alt="image" src="https://github.com/user-attachments/assets/b2ba3f64-6004-4376-8aa2-949aab2f8988" />

After
<img width="556" height="157" alt="image" src="https://github.com/user-attachments/assets/b8348579-c79f-4df2-b278-a13cf7c7b534" />


Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- Add style while-space: pre to the log
