### PR TITLE
[Python] Fix: Raise on un-serializable task output

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.21.4] - 2025-12-06
+## [1.21.5] - 2025-12-06
+
+### Changed
+
+- Task outputs that fail to serialize to JSON will now raise an `IllegalTaskOutputError` instead of being stringified. This pulls errors from the engine upstream to the SDK, and will allow users to catch and handle these errors more easily.
+
+## [1.21.4] - 2025-12-05
 
 ### Added
 

--- a/sdks/python/hatchet_sdk/worker/runner/runner.py
+++ b/sdks/python/hatchet_sdk/worker/runner/runner.py
@@ -501,9 +501,11 @@ class Runner:
 
         try:
             serialized_output = json.dumps(output, default=str)
-        except Exception:
+        except Exception as e:
             logger.exception("could not serialize output")
-            serialized_output = str(output)
+            raise IllegalTaskOutputError(
+                "Task output could not be serialized to JSON. Please ensure that all task outputs are JSON serializable."
+            ) from e
 
         if "\\u0000" in serialized_output:
             raise IllegalTaskOutputError(

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.21.4"
+version = "1.21.5"
 description = "This is the official Python SDK for Hatchet, a distributed, fault-tolerant task queue. The SDK allows you to easily integrate Hatchet's task scheduling and workflow orchestration capabilities into your Python applications."
 authors = [
     "Alexander Belanger <alexander@hatchet.run>",


### PR DESCRIPTION
# Description

Stringifying outputs results in failing writes to the db / message queue because we try to unmarshal the outputs from JSON, but they're not valid JSON. This prevents that.

It's not really a breaking change, since it'll just shift the failure upstream, but it would've failed anyway

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
