### PR TITLE
Fix: OLAP Task Event Dual Write Bug

### DIFF
--- a/api/v1/server/oas/transformers/v1/workflow_runs.go
+++ b/api/v1/server/oas/transformers/v1/workflow_runs.go
@@ -176,8 +176,8 @@ func PopulateTaskRunDataRowToV1TaskSummary(task *v1.TaskWithPayloads, workflowNa
 		durationPtr = &duration
 	}
 
-	input := jsonToMap(task.Input)
-	output := jsonToMap(task.Output)
+	input := jsonToMap(task.InputPayload)
+	output := jsonToMap(task.OutputPayload)
 
 	stepId := uuid.MustParse(sqlchelpers.UUIDToStr(task.StepID))
 

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -1440,8 +1440,13 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId s
 
 	for _, event := range events {
 		key := getCacheKey(event)
+		output := event.Output
 
 		if _, ok := r.eventCache.Get(key); !ok {
+			if !r.payloadStore.OLAPDualWritesEnabled() && event.Output != nil {
+				event.Output = []byte("{}")
+			}
+
 			eventsToWrite = append(eventsToWrite, event)
 
 			tmpEventsToWrite = append(tmpEventsToWrite, sqlcv1.CreateTaskEventsOLAPTmpParams{
@@ -1467,12 +1472,8 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId s
 				Id:         dummyId,
 				ExternalId: event.ExternalID,
 				InsertedAt: sqlchelpers.TimestamptzFromTime(dummyInsertedAt),
-				Payload:    event.Output,
+				Payload:    output,
 			})
-		}
-
-		if !r.payloadStore.OLAPDualWritesEnabled() {
-			event.Output = []byte("{}")
 		}
 	}
 

--- a/sdks/python/tests/test_rest_api.py
+++ b/sdks/python/tests/test_rest_api.py
@@ -11,8 +11,10 @@ async def test_list_runs(hatchet: Hatchet) -> None:
     dag_result = await dag_workflow.aio_run()
 
     runs = await hatchet.runs.aio_list(
-        limit=10_000,
         only_tasks=True,
+        workflow_ids=[dag_workflow.id],
+        include_payloads=True,
+        limit=100,
     )
 
     for v in dag_result.values():


### PR DESCRIPTION
# Description

Fixing a bug that made OLAP task event payloads still be written to the task events table even when dual writes were shut off

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

