### PR TITLE
fix: ensure that slow worker doesn't interrupt dispatcher, guard large RabbitMQ pubs

### DIFF
--- a/internal/msgqueue/v1/rabbitmq/gzip.go
+++ b/internal/msgqueue/v1/rabbitmq/gzip.go
@@ -17,6 +17,14 @@ type CompressionResult struct {
 	CompressionRatio float64
 }
 
+func getPayloadSize(payloads [][]byte) int {
+	totalSize := 0
+	for _, payload := range payloads {
+		totalSize += len(payload)
+	}
+	return totalSize
+}
+
 // compressPayloads compresses message payloads using gzip if they exceed the minimum size threshold.
 // Returns compression results including the compressed payloads and compression statistics.
 func (t *MessageQueueImpl) compressPayloads(payloads [][]byte) (*CompressionResult, error) {
@@ -30,10 +38,7 @@ func (t *MessageQueueImpl) compressPayloads(payloads [][]byte) (*CompressionResu
 	}
 
 	// Calculate total size to determine if compression is worthwhile
-	totalSize := 0
-	for _, payload := range payloads {
-		totalSize += len(payload)
-	}
+	totalSize := getPayloadSize(payloads)
 	result.OriginalSize = totalSize
 
 	// Only compress if total size exceeds threshold

--- a/internal/services/dispatcher/dispatcher_v1.go
+++ b/internal/services/dispatcher/dispatcher_v1.go
@@ -45,7 +45,9 @@ func (worker *subscribedWorker) StartTaskFromBulk(
 	err := worker.sendToWorker(ctx, action)
 
 	if err != nil {
-		// if the context is done, we return nil, because the worker took too long to receive the message
+		// if the context is done, we return nil, because the worker took too long to receive the message, and we're not
+		// sure if the worker received it or not. this is equivalent to a network drop, and would be resolved by worker-side
+		// acks, which we don't currently have.
 		if errors.Is(err, context.DeadlineExceeded) {
 			return nil
 		}

--- a/internal/services/dispatcher/dispatcher_v1.go
+++ b/internal/services/dispatcher/dispatcher_v1.go
@@ -113,7 +113,7 @@ func (worker *subscribedWorker) sendToWorker(
 
 	sendMsgBegin := time.Now()
 
-	sentCh := make(chan error)
+	sentCh := make(chan error, 1)
 
 	go func() {
 		defer close(sentCh)
@@ -153,7 +153,7 @@ func (worker *subscribedWorker) CancelTask(
 
 	action.ActionType = contracts.ActionType_CANCEL_STEP_RUN
 
-	sentCh := make(chan error)
+	sentCh := make(chan error, 1)
 
 	go func() {
 		defer close(sentCh)


### PR DESCRIPTION
# Description

1. If a slow worker or client is connected and receives a cancellation via `handleTaskCancelled`, there's a small risk that sending the cancellation signal risks a RabbitMQ channel consumer timeout, which results in the dispatcher resetting its connection and potentially dropping messages. 

    This makes the stream sends at least partially context-aware (though since the stream's context is managed elsewhere, so we don't have a great way to prevent the message from sending). 

2. Fixes large payload pubs (larger than 16 MB on RabbitMQ `4.x`). Instead of seeing an async channel exception after a large pub, this returns an error immediately instead of sending to Rabbit. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)