### PR TITLE
fix: load shed on slow worker backlogs

### DIFF
--- a/internal/services/dispatcher/dispatcher_v1.go
+++ b/internal/services/dispatcher/dispatcher_v1.go
@@ -28,6 +28,10 @@ func (worker *subscribedWorker) StartTaskFromBulk(
 	tenantId string,
 	task *v1.V1TaskWithPayload,
 ) error {
+	if ctx.Err() != nil {
+		return fmt.Errorf("context done before starting task: %w", ctx.Err())
+	}
+
 	ctx, span := telemetry.NewSpan(ctx, "start-step-run-from-bulk") // nolint:ineffassign
 	defer span.End()
 
@@ -146,6 +150,10 @@ func (worker *subscribedWorker) CancelTask(
 	task *sqlcv1.V1Task,
 	retryCount int32,
 ) error {
+	if ctx.Err() != nil {
+		return fmt.Errorf("context done before cancelling task: %w", ctx.Err())
+	}
+
 	ctx, span := telemetry.NewSpan(ctx, "cancel-task") // nolint:ineffassign
 	defer span.End()
 


### PR DESCRIPTION
# Description

When we have a large backlog of messages which need to be sent to a worker using `stream.Send`, we attempt to call `.Send` even when the context deadline has already been exceeded. 

This returns with an error rather than sending to the worker when the context deadline is exceeded, allowing us to shed some of the backlog. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)