### PR TITLE
Don't Trigger PostHog Pageview on Query Param Changes

### DIFF
--- a/frontend/app/src/providers/posthog.tsx
+++ b/frontend/app/src/providers/posthog.tsx
@@ -159,7 +159,8 @@ function PostHogPageView() {
     }
 
     posthogClient.capture('$pageview', { $current_url: url });
-  }, [location.pathname, location.search, posthogClient]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally exclude location.search to avoid firing pageviews on query param changes
+  }, [location.pathname, posthogClient]);
 
   return null;
 }


### PR DESCRIPTION
# Description

Removed triggering posthog page views on query param changes.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- Removed `location.search` from `useEffect` dependency array
