### PR TITLE
Fix: Leasing for payload job

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20251205170304_v1_0_55.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20251205170304_v1_0_55.sql
@@ -2,7 +2,7 @@
 -- +goose StatementBegin
 ALTER TABLE v1_payload_cutover_job_offset
 ADD COLUMN lease_process_id UUID NOT NULL DEFAULT gen_random_uuid(),
-ADD COLUMN lease_expires_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+ADD COLUMN lease_expires_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 
 -- +goose StatementEnd
 

--- a/cmd/hatchet-migrate/migrate/migrations/20251205170304_v1_0_55.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20251205170304_v1_0_55.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE v1_payload_cutover_job_offset
+ADD COLUMN lease_process_id UUID NOT NULL DEFAULT gen_random_uuid(),
+ADD COLUMN lease_expires_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE v1_payload_cutover_job_offset
+DROP COLUMN lease_expires_at,
+DROP COLUMN lease_process_id;
+-- +goose StatementEnd

--- a/pkg/repository/v1/payloadstore.go
+++ b/pkg/repository/v1/payloadstore.go
@@ -497,7 +497,7 @@ func (p *payloadStoreRepositoryImpl) ProcessPayloadCutoverBatch(ctx context.Cont
 	_, err = p.acquireOrExtendJobLease(ctx, tx, processId, partitionDate, offset)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to upsert last offset for cutover job: %w", err)
+		return nil, fmt.Errorf("failed to extend cutover job lease: %w", err)
 	}
 
 	if err := commit(ctx); err != nil {

--- a/pkg/repository/v1/payloadstore.go
+++ b/pkg/repository/v1/payloadstore.go
@@ -536,6 +536,8 @@ func (p *payloadStoreRepositoryImpl) acquireOrExtendJobLease(ctx context.Context
 	})
 
 	if err != nil {
+		// ErrNoRows here means that something else is holding the lease
+		// since we did not insert a new record, and the `UPDATE` returned an empty set
 		if errors.Is(err, pgx.ErrNoRows) {
 			return &CutoverJobRunMetadata{
 				ShouldRun:      false,

--- a/pkg/repository/v1/payloadstore.go
+++ b/pkg/repository/v1/payloadstore.go
@@ -565,7 +565,6 @@ func (p *payloadStoreRepositoryImpl) acquireOrExtendJobLease(ctx context.Context
 }
 
 func (p *payloadStoreRepositoryImpl) prepareCutoverTableJob(ctx context.Context, processId pgtype.UUID) (*CutoverJobRunMetadata, error) {
-	fmt.Println("preparing cutover table job")
 	if p.inlineStoreTTL == nil {
 		return nil, fmt.Errorf("inline store TTL is not set")
 	}
@@ -586,13 +585,9 @@ func (p *payloadStoreRepositoryImpl) prepareCutoverTableJob(ctx context.Context,
 
 	lease, err := p.acquireOrExtendJobLease(ctx, tx, processId, partitionDate, 0)
 
-	fmt.Println("err", err)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to acquire or extend cutover job lease: %w", err)
 	}
-
-	fmt.Printf("lease proc id: %s, should run: %t, date: %s, offset: %d\n", lease.LeaseProcessId.String(), lease.ShouldRun, lease.PartitionDate.String(), lease.LastOffset)
 
 	if !lease.ShouldRun {
 		return lease, nil

--- a/pkg/repository/v1/sqlcv1/models.go
+++ b/pkg/repository/v1/sqlcv1/models.go
@@ -3130,9 +3130,11 @@ type V1Payload struct {
 }
 
 type V1PayloadCutoverJobOffset struct {
-	Key         pgtype.Date `json:"key"`
-	LastOffset  int64       `json:"last_offset"`
-	IsCompleted bool        `json:"is_completed"`
+	Key            pgtype.Date        `json:"key"`
+	LastOffset     int64              `json:"last_offset"`
+	IsCompleted    bool               `json:"is_completed"`
+	LeaseProcessID pgtype.UUID        `json:"lease_process_id"`
+	LeaseExpiresAt pgtype.Timestamptz `json:"lease_expires_at"`
 }
 
 type V1PayloadCutoverQueueItem struct {

--- a/pkg/repository/v1/sqlcv1/payload-store.sql
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql
@@ -249,10 +249,10 @@ INSERT INTO v1_payload_cutover_job_offset (key, last_offset, lease_process_id, l
 VALUES (@key::DATE, @lastOffset::BIGINT, @leaseProcessId::UUID, @leaseExpiresAt::TIMESTAMPTZ)
 ON CONFLICT (key)
 DO UPDATE SET
-    last_offset = EXCLUDED.last_offset,
-    lease_process_id = EXCLUDED.lease_process_id,
-    lease_expires_at = EXCLUDED.lease_expires_at
-WHERE lease_expires_at < NOW() OR lease_process_id = @leaseProcessId::UUID
+    v1_payload_cutover_job_offset.last_offset = EXCLUDED.last_offset,
+    v1_payload_cutover_job_offset.lease_process_id = EXCLUDED.lease_process_id,
+    v1_payload_cutover_job_offset.lease_expires_at = EXCLUDED.lease_expires_at
+WHERE v1_payload_cutover_job_offset.lease_expires_at < NOW() OR v1_payload_cutover_job_offset.lease_process_id = @leaseProcessId::UUID
 RETURNING *
 ;
 

--- a/pkg/repository/v1/sqlcv1/payload-store.sql
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql
@@ -252,7 +252,7 @@ DO UPDATE SET
     last_offset = EXCLUDED.last_offset,
     lease_process_id = EXCLUDED.lease_process_id,
     lease_expires_at = EXCLUDED.lease_expires_at
-WHERE v1_payload_cutover_job_offset.lease_expires_at < NOW() OR lease_process_id = @leaseProcessId::UUID
+WHERE v1_payload_cutover_job_offset.lease_expires_at < NOW() OR v1_payload_cutover_job_offset.lease_process_id = @leaseProcessId::UUID
 RETURNING *
 ;
 

--- a/pkg/repository/v1/sqlcv1/payload-store.sql
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql
@@ -249,10 +249,10 @@ INSERT INTO v1_payload_cutover_job_offset (key, last_offset, lease_process_id, l
 VALUES (@key::DATE, @lastOffset::BIGINT, @leaseProcessId::UUID, @leaseExpiresAt::TIMESTAMPTZ)
 ON CONFLICT (key)
 DO UPDATE SET
-    v1_payload_cutover_job_offset.last_offset = EXCLUDED.last_offset,
-    v1_payload_cutover_job_offset.lease_process_id = EXCLUDED.lease_process_id,
-    v1_payload_cutover_job_offset.lease_expires_at = EXCLUDED.lease_expires_at
-WHERE v1_payload_cutover_job_offset.lease_expires_at < NOW() OR v1_payload_cutover_job_offset.lease_process_id = @leaseProcessId::UUID
+    last_offset = EXCLUDED.last_offset,
+    lease_process_id = EXCLUDED.lease_process_id,
+    lease_expires_at = EXCLUDED.lease_expires_at
+WHERE v1_payload_cutover_job_offset.lease_expires_at < NOW() OR lease_process_id = @leaseProcessId::UUID
 RETURNING *
 ;
 

--- a/pkg/repository/v1/sqlcv1/payload-store.sql.go
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql.go
@@ -16,9 +16,9 @@ INSERT INTO v1_payload_cutover_job_offset (key, last_offset, lease_process_id, l
 VALUES ($1::DATE, $2::BIGINT, $3::UUID, $4::TIMESTAMPTZ)
 ON CONFLICT (key)
 DO UPDATE SET
-    v1_payload_cutover_job_offset.last_offset = EXCLUDED.last_offset,
-    v1_payload_cutover_job_offset.lease_process_id = EXCLUDED.lease_process_id,
-    v1_payload_cutover_job_offset.lease_expires_at = EXCLUDED.lease_expires_at
+    last_offset = EXCLUDED.last_offset,
+    lease_process_id = EXCLUDED.lease_process_id,
+    lease_expires_at = EXCLUDED.lease_expires_at
 WHERE v1_payload_cutover_job_offset.lease_expires_at < NOW() OR v1_payload_cutover_job_offset.lease_process_id = $3::UUID
 RETURNING key, last_offset, is_completed, lease_process_id, lease_expires_at
 `

--- a/pkg/repository/v1/sqlcv1/payload-store.sql.go
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql.go
@@ -16,10 +16,10 @@ INSERT INTO v1_payload_cutover_job_offset (key, last_offset, lease_process_id, l
 VALUES ($1::DATE, $2::BIGINT, $3::UUID, $4::TIMESTAMPTZ)
 ON CONFLICT (key)
 DO UPDATE SET
-    last_offset = EXCLUDED.last_offset,
-    lease_process_id = EXCLUDED.lease_process_id,
-    lease_expires_at = EXCLUDED.lease_expires_at
-WHERE lease_expires_at < NOW() OR lease_process_id = $3::UUID
+    v1_payload_cutover_job_offset.last_offset = EXCLUDED.last_offset,
+    v1_payload_cutover_job_offset.lease_process_id = EXCLUDED.lease_process_id,
+    v1_payload_cutover_job_offset.lease_expires_at = EXCLUDED.lease_expires_at
+WHERE v1_payload_cutover_job_offset.lease_expires_at < NOW() OR v1_payload_cutover_job_offset.lease_process_id = $3::UUID
 RETURNING key, last_offset, is_completed, lease_process_id, lease_expires_at
 `
 

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -1759,7 +1759,9 @@ $$;
 CREATE TABLE v1_payload_cutover_job_offset (
     key DATE PRIMARY KEY,
     last_offset BIGINT NOT NULL,
-    is_completed BOOLEAN NOT NULL DEFAULT FALSE
+    is_completed BOOLEAN NOT NULL DEFAULT FALSE,
+    lease_process_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    lease_expires_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE OR REPLACE FUNCTION copy_v1_payload_partition_structure(


### PR DESCRIPTION
# Description

Making the payload job acquire a lease before continuing as opposed to an advisory lock so that only one controller can run the job at a time

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
