### PR TITLE
Fix slack challenge + interactive webhook 

### DIFF
--- a/api/v1/server/handlers/v1/webhooks/receive.go
+++ b/api/v1/server/handlers/v1/webhooks/receive.go
@@ -183,11 +183,11 @@ func (w *V1WebhooksService) V1WebhookReceive(ctx echo.Context, request gen.V1Web
 					bodyPreview = bodyPreview[:200] + "..."
 				}
 				errorMsg := fmt.Sprintf("failed to unmarshal request body as JSON: %v", err)
-				w.config.Logger.Warn().Err(err).Str("webhook", webhookName).Str("tenant", tenantId).Str("content_type", contentType).Int("body_length", len(rawBody)).Str("body_preview", bodyPreview).Msg(errorMsg)
+				w.config.Logger.Info().Err(err).Str("webhook", webhookName).Str("tenant", tenantId).Str("content_type", contentType).Int("body_length", len(rawBody)).Str("body_preview", bodyPreview).Msg(errorMsg)
 				return gen.V1WebhookReceive400JSONResponse{
 					Errors: []gen.APIError{
 						{
-							Description: fmt.Sprintf("failed to unmarshal request body: %v", err),
+							Description: "failed to unmarshal request body",
 						},
 					},
 				}, nil

--- a/api/v1/server/handlers/v1/webhooks/receive.go
+++ b/api/v1/server/handlers/v1/webhooks/receive.go
@@ -130,13 +130,19 @@ func (w *V1WebhooksService) V1WebhookReceive(ctx echo.Context, request gen.V1Web
 						},
 					}, nil
 				}
-				/* Parse the payload parameter as JSON */
+				/* Parse the payload parameter as JSON
+				 * Note: url.ParseQuery automatically URL-decodes the payload parameter value */
 				err := json.Unmarshal([]byte(payloadValue), &payloadMap)
 				if err != nil {
 					return gen.V1WebhookReceive400JSONResponse{
 						Errors: []gen.APIError{
 							{
-								Description: fmt.Sprintf("failed to unmarshal payload parameter: %v", err),
+								Description: fmt.Sprintf("failed to unmarshal payload parameter as JSON: %v (payload length: %d, first 100 chars: %q)", err, len(payloadValue), func() string {
+									if len(payloadValue) > 100 {
+										return payloadValue[:100]
+									}
+									return payloadValue
+								}()),
 							},
 						},
 					}, nil

--- a/api/v1/server/handlers/v1/webhooks/receive.go
+++ b/api/v1/server/handlers/v1/webhooks/receive.go
@@ -107,8 +107,8 @@ func (w *V1WebhooksService) V1WebhookReceive(ctx echo.Context, request gen.V1Web
 		if strings.Contains(contentType, "application/x-www-form-urlencoded") {
 			formData, err := url.ParseQuery(string(rawBody))
 			if err != nil {
-				errorMsg := fmt.Sprintf("failed to parse form data: %v", err)
-				w.config.Logger.Warn().Err(err).Str("webhook", webhookName).Str("tenant", tenantId).Msg(errorMsg)
+				errorMsg := "Failed to parse form data"
+				w.config.Logger.Info().Err(err).Str("webhook", webhookName).Str("tenant", tenantId).Msg(errorMsg)
 				return gen.V1WebhookReceive400JSONResponse{
 					Errors: []gen.APIError{
 						{
@@ -126,7 +126,7 @@ func (w *V1WebhooksService) V1WebhookReceive(ctx echo.Context, request gen.V1Web
 				payloadValue := formData.Get("payload")
 				if payloadValue == "" {
 					errorMsg := "missing payload parameter in form-encoded request"
-					w.config.Logger.Warn().Str("webhook", webhookName).Str("tenant", tenantId).Str("form_keys", fmt.Sprintf("%v", func() []string {
+					w.config.Logger.Info().Str("webhook", webhookName).Str("tenant", tenantId).Str("form_keys", fmt.Sprintf("%v", func() []string {
 						keys := make([]string, 0, len(formData))
 						for k := range formData {
 							keys = append(keys, k)
@@ -148,12 +148,12 @@ func (w *V1WebhooksService) V1WebhookReceive(ctx echo.Context, request gen.V1Web
 					if len(payloadPreview) > 200 {
 						payloadPreview = payloadPreview[:200] + "..."
 					}
-					errorMsg := fmt.Sprintf("failed to unmarshal payload parameter as JSON: %v", err)
-					w.config.Logger.Warn().Err(err).Str("webhook", webhookName).Str("tenant", tenantId).Int("payload_length", len(payloadValue)).Str("payload_preview", payloadPreview).Msg(errorMsg)
+					errorMsg := "Failed to unmarshal payload parameter as JSON"
+					w.config.Logger.Info().Err(err).Str("webhook", webhookName).Str("tenant", tenantId).Int("payload_length", len(payloadValue)).Str("payload_preview", payloadPreview).Msg(errorMsg)
 					return gen.V1WebhookReceive400JSONResponse{
 						Errors: []gen.APIError{
 							{
-								Description: fmt.Sprintf("failed to unmarshal payload parameter as JSON: %v (payload length: %d)", err, len(payloadValue)),
+								Description: errorMsg,
 							},
 						},
 					}, nil
@@ -182,7 +182,7 @@ func (w *V1WebhooksService) V1WebhookReceive(ctx echo.Context, request gen.V1Web
 				if len(bodyPreview) > 200 {
 					bodyPreview = bodyPreview[:200] + "..."
 				}
-				errorMsg := fmt.Sprintf("failed to unmarshal request body as JSON: %v", err)
+				errorMsg := "Failed to unmarshal request body as JSON"
 				w.config.Logger.Info().Err(err).Str("webhook", webhookName).Str("tenant", tenantId).Str("content_type", contentType).Int("body_length", len(rawBody)).Str("body_preview", bodyPreview).Msg(errorMsg)
 				return gen.V1WebhookReceive400JSONResponse{
 					Errors: []gen.APIError{
@@ -216,11 +216,11 @@ func (w *V1WebhooksService) V1WebhookReceive(ctx echo.Context, request gen.V1Web
 	if err != nil {
 		var errorMsg string
 		if strings.Contains(err.Error(), "did not evaluate to a string") {
-			errorMsg = fmt.Sprintf("event key expression must evaluate to a string, but got a different type. Expression: %s. Error: %v", webhook.EventKeyExpression, err)
+			errorMsg = "Event key expression must evaluate to a string"
 		} else if eventKey == "" {
-			errorMsg = fmt.Sprintf("event key evaluated to an empty string. Expression: %s", webhook.EventKeyExpression)
+			errorMsg = "Event key evaluated to an empty string"
 		} else {
-			errorMsg = fmt.Sprintf("failed to evaluate event key expression: %v", err)
+			errorMsg = "Failed to evaluate event key expression"
 		}
 
 		w.config.Logger.Warn().Err(err).Str("webhook", webhookName).Str("tenant", tenantId).Str("event_key_expression", webhook.EventKeyExpression).Msg(errorMsg)
@@ -250,7 +250,7 @@ func (w *V1WebhooksService) V1WebhookReceive(ctx echo.Context, request gen.V1Web
 		return gen.V1WebhookReceive400JSONResponse{
 			Errors: []gen.APIError{
 				{
-					Description: fmt.Sprintf("failed to marshal request body: %v", err),
+					Description: "Failed to marshal request body",
 				},
 			},
 		}, nil
@@ -394,7 +394,7 @@ func (w *V1WebhooksService) validateWebhook(webhookPayload []byte, webhook sqlcv
 		if err != nil {
 			return false, &ValidationError{
 				Code:      Http403,
-				ErrorText: fmt.Sprintf("invalid timestamp in header: %s", err),
+				ErrorText: "Invalid timestamp in header",
 			}
 		}
 
@@ -496,7 +496,7 @@ func (w *V1WebhooksService) validateWebhook(webhookPayload []byte, webhook sqlcv
 		if err != nil {
 			return false, &ValidationError{
 				Code:      Http400,
-				ErrorText: fmt.Sprintf("invalid timestamp in signature header: %s", err),
+				ErrorText: "Invalid timestamp in signature header",
 			}
 		}
 

--- a/api/v1/server/handlers/v1/webhooks/receive.go
+++ b/api/v1/server/handlers/v1/webhooks/receive.go
@@ -30,6 +30,9 @@ func (w *V1WebhooksService) V1WebhookReceive(ctx echo.Context, request gen.V1Web
 	tenantId := request.Tenant.String()
 	webhookName := request.V1Webhook
 
+	/* Log incoming webhook request for debugging */
+	w.config.Logger.Debug().Str("webhook", webhookName).Str("tenant", tenantId).Str("method", ctx.Request().Method).Str("content_type", ctx.Request().Header.Get("Content-Type")).Msg("received webhook request")
+
 	tenant, err := w.config.APIRepository.Tenant().GetTenantByID(ctx.Request().Context(), tenantId)
 
 	if err != nil || tenant == nil {
@@ -219,6 +222,9 @@ func (w *V1WebhooksService) V1WebhookReceive(ctx echo.Context, request gen.V1Web
 			err = fmt.Errorf("event key evaluted to an empty string")
 		}
 
+		errorMsg := fmt.Sprintf("failed to evaluate event key expression: %v", err)
+		w.config.Logger.Warn().Err(err).Str("webhook", webhookName).Str("tenant", tenantId).Str("event_key_expression", webhook.EventKeyExpression).Msg(errorMsg)
+
 		ingestionErr := w.config.Ingestor.IngestCELEvaluationFailure(
 			ctx.Request().Context(),
 			tenant.ID.String(),
@@ -233,7 +239,7 @@ func (w *V1WebhooksService) V1WebhookReceive(ctx echo.Context, request gen.V1Web
 		return gen.V1WebhookReceive400JSONResponse{
 			Errors: []gen.APIError{
 				{
-					Description: fmt.Sprintf("failed to evaluate event key expression: %v", err),
+					Description: errorMsg,
 				},
 			},
 		}, nil
@@ -345,44 +351,18 @@ type IsChallenge bool
 func (w *V1WebhooksService) performChallenge(webhookPayload []byte, webhook sqlcv1.V1IncomingWebhook, request http.Request) (IsChallenge, map[string]interface{}, error) {
 	switch webhook.SourceName {
 	case sqlcv1.V1IncomingWebhookSourceNameSLACK:
-		/* Slack sends requests in different formats:
-		 * - Events API URL verification: application/json with direct JSON payload
-		 * - Interactive components: application/x-www-form-urlencoded with a payload field containing JSON
-		 * See: https://docs.slack.dev/interactivity/handling-user-interaction/#payloads
+		/* Slack Events API URL verification challenges come as application/json with direct JSON payload
+		 * Interactive components are form-encoded but are NOT challenges - they're regular events
+		 * See: https://docs.slack.dev/apis/events-api/using-http-request-urls/#challenge
 		 */
-		contentType := request.Header.Get("Content-Type")
-
-		var payloadJSON []byte
-
-		if strings.Contains(contentType, "application/x-www-form-urlencoded") {
-			/* Parse form-encoded data */
-			formData, err := url.ParseQuery(string(webhookPayload))
-			if err != nil {
-				/* If we can't parse form data, it's likely not a challenge - let normal processing handle it */
-				return false, nil, nil
-			}
-
-			/* Extract the payload field which contains JSON */
-			payloadValue := formData.Get("payload")
-			if payloadValue == "" {
-				/* If no payload field, this is not a challenge - let normal processing handle it */
-				return false, nil, nil
-			}
-			payloadJSON = []byte(payloadValue)
-		} else {
-			/* If not form-encoded, assume JSON */
-			payloadJSON = webhookPayload
-		}
-
 		payload := make(map[string]interface{})
-		err := json.Unmarshal(payloadJSON, &payload)
+		err := json.Unmarshal(webhookPayload, &payload)
 		if err != nil {
 			/* If we can't parse JSON, it's likely not a challenge - let normal processing handle it */
 			return false, nil, nil
 		}
 
 		/* Check for Events API URL verification challenge
-		 * See: https://docs.slack.dev/apis/events-api/using-http-request-urls/#challenge
 		 * The payload should contain: token, challenge, and type: "url_verification"
 		 */
 		payloadType, hasType := payload["type"].(string)

--- a/api/v1/server/handlers/v1/webhooks/receive.go
+++ b/api/v1/server/handlers/v1/webhooks/receive.go
@@ -342,9 +342,9 @@ func (w *V1WebhooksService) performChallenge(webhookPayload []byte, webhook sqlc
 		payloadType, hasType := payload["type"].(string)
 		challenge, hasChallenge := payload["challenge"].(string)
 		
-		/* Accept if challenge exists and (type is url_verification OR type field is missing for backward compatibility) */
+		/* Accept if challenge exists and type is url_verification
+		 * If type is missing but challenge exists, still accept it (defensive: in case Slack sends malformed challenge) */
 		if hasChallenge && challenge != "" {
-			/* If type is present, verify it's url_verification; if not present, still accept for backward compatibility */
 			if !hasType || payloadType == "url_verification" {
 				return true, map[string]interface{}{
 					"challenge": challenge,


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The logic to handle the challenge was interfering with regular interactive web hooks. We should gracefully handle that, also interactive commands have special format: https://docs.slack.dev/interactivity/handling-user-interaction/#payloads which we should support (`application/x-www-form-urlencoded ` with a payload)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update


## Testing

Tested locally

```
2025-12-05T18:03:55.025-05:00 DBG received webhook request content_type=application/x-www-form-urlencoded method=POST service=server tenant=707d0855-80ab-4e1f-a156-f1c4546cbf52 webhook=test
2025-12-05T18:03:55.026-05:00 DBG publishing msg to queue task_processing_queue_v2 service=rabbitmq
2025-12-05T18:03:55.026-05:00 DBG publishing tenant msg to exchange 707d0855-80ab-4e1f-a156-f1c4546cbf52 service=rabbitmq
2025-12-05T18:03:55.026-05:00 DBG published msg to queue task_processing_queue_v2 service=rabbitmq
2025-12-05T18:03:55.026-05:00 INF API host=a861d79bf0d5.ngrok-free.app latency=26.575458 method=POST remote_ip=34.227.8.94 service=server status=200 uri=/api/v1/stable/tenants/707d0855-80ab-4e1f-a156-f1c4546cbf52/webhooks/test user_agent="Slackbot 1.0 (+https://api.slack.com/robots)"
```
<img width="2048" height="810" alt="image" src="https://github.com/user-attachments/assets/006343f2-c616-4677-8e68-1d75b1ab0afd" />
