### PR TITLE
Refactor: Simplify External Payload Store Signature

### DIFF
--- a/internal/services/controllers/v1/olap/controller.go
+++ b/internal/services/controllers/v1/olap/controller.go
@@ -762,15 +762,10 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		}] = opt.ExternalID
 
 		offloadToExternalOpts = append(offloadToExternalOpts, v1.OffloadToExternalStoreOpts{
-			StorePayloadOpts: &v1.StorePayloadOpts{
-				Id:         dummyId,
-				InsertedAt: sqlchelpers.TimestamptzFromTime(dummyInsertedAt),
-				ExternalId: opt.ExternalID,
-				Type:       sqlcv1.V1PayloadTypeTASKEVENTDATA,
-				Payload:    opt.Output,
-				TenantId:   tenantId,
-			},
-			OffloadAt: time.Now(),
+			TenantId:   v1.TenantID(tenantId),
+			ExternalID: v1.PayloadExternalId(opt.ExternalID.String()),
+			InsertedAt: sqlchelpers.TimestamptzFromTime(dummyInsertedAt),
+			Payload:    opt.Output,
 		})
 	}
 


### PR DESCRIPTION
# Description

Simplifying the external store signature a bit to make it easier to use, should be safe to do since we just store the key once and then pass it around everywhere

## Type of change

- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)

