### PR TITLE
Fix: Global Lease for OLAP

### DIFF
--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -1883,7 +1883,8 @@ WITH inputs AS (
         @lastExternalId::UUID AS last_external_id,
         @lastInsertedAt::TIMESTAMPTZ AS last_inserted_at
 ), any_lease_held_by_other_process AS (
-    SELECT BOOL_OR(lease_expires_at > NOW()) AS lease_exists
+    -- need coalesce here in case there are no rows that don't belong to this process
+    SELECT COALESCE(BOOL_OR(lease_expires_at > NOW()), FALSE) AS lease_exists
     FROM v1_payloads_olap_cutover_job_offset
     WHERE lease_process_id != @leaseProcessId::UUID
 ), to_insert AS (

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -12,8 +12,35 @@ import (
 )
 
 const acquireOrExtendOLAPCutoverJobLease = `-- name: AcquireOrExtendOLAPCutoverJobLease :one
+WITH inputs AS (
+    SELECT
+        $2::DATE AS key,
+        $1::UUID AS lease_process_id,
+        $3::TIMESTAMPTZ AS lease_expires_at,
+        $4::UUID AS last_tenant_id,
+        $5::UUID AS last_external_id,
+        $6::TIMESTAMPTZ AS last_inserted_at
+), any_lease_held_by_other_process AS (
+    SELECT BOOL_OR(lease_expires_at > NOW()) AS lease_exists
+    FROM v1_payloads_olap_cutover_job_offset
+    WHERE lease_process_id != $1::UUID
+), to_insert AS (
+    SELECT key, lease_process_id, lease_expires_at, last_tenant_id, last_external_id, last_inserted_at
+    FROM inputs
+    -- if a lease is held by another process, we shouldn't try to insert a new row regardless
+    -- of which key we're trying to acquire a lease on
+    WHERE NOT (SELECT lease_exists FROM any_lease_held_by_other_process)
+)
+
 INSERT INTO v1_payloads_olap_cutover_job_offset (key, lease_process_id, lease_expires_at, last_tenant_id, last_external_id, last_inserted_at)
-VALUES ($1::DATE, $2::UUID, $3::TIMESTAMPTZ, $4::UUID, $5::UUID, $6::TIMESTAMPTZ)
+SELECT
+    ti.key,
+    ti.lease_process_id,
+    ti.lease_expires_at,
+    ti.last_tenant_id,
+    ti.last_external_id,
+    ti.last_inserted_at
+FROM to_insert ti
 ON CONFLICT (key)
 DO UPDATE SET
     -- if the lease is held by this process, then we extend the offset to the new value
@@ -33,13 +60,13 @@ DO UPDATE SET
 
     lease_process_id = EXCLUDED.lease_process_id,
     lease_expires_at = EXCLUDED.lease_expires_at
-WHERE v1_payloads_olap_cutover_job_offset.lease_expires_at < NOW() OR v1_payloads_olap_cutover_job_offset.lease_process_id = $2::UUID
+WHERE v1_payloads_olap_cutover_job_offset.lease_expires_at < NOW() OR v1_payloads_olap_cutover_job_offset.lease_process_id = $1::UUID
 RETURNING key, is_completed, lease_process_id, lease_expires_at, last_tenant_id, last_external_id, last_inserted_at
 `
 
 type AcquireOrExtendOLAPCutoverJobLeaseParams struct {
-	Key            pgtype.Date        `json:"key"`
 	Leaseprocessid pgtype.UUID        `json:"leaseprocessid"`
+	Key            pgtype.Date        `json:"key"`
 	Leaseexpiresat pgtype.Timestamptz `json:"leaseexpiresat"`
 	Lasttenantid   pgtype.UUID        `json:"lasttenantid"`
 	Lastexternalid pgtype.UUID        `json:"lastexternalid"`
@@ -48,8 +75,8 @@ type AcquireOrExtendOLAPCutoverJobLeaseParams struct {
 
 func (q *Queries) AcquireOrExtendOLAPCutoverJobLease(ctx context.Context, db DBTX, arg AcquireOrExtendOLAPCutoverJobLeaseParams) (*V1PayloadsOlapCutoverJobOffset, error) {
 	row := db.QueryRow(ctx, acquireOrExtendOLAPCutoverJobLease,
-		arg.Key,
 		arg.Leaseprocessid,
+		arg.Key,
 		arg.Leaseexpiresat,
 		arg.Lasttenantid,
 		arg.Lastexternalid,

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -21,7 +21,8 @@ WITH inputs AS (
         $5::UUID AS last_external_id,
         $6::TIMESTAMPTZ AS last_inserted_at
 ), any_lease_held_by_other_process AS (
-    SELECT BOOL_OR(lease_expires_at > NOW()) AS lease_exists
+    -- need coalesce here in case there are no rows that don't belong to this process
+    SELECT COALESCE(BOOL_OR(lease_expires_at > NOW()), FALSE) AS lease_exists
     FROM v1_payloads_olap_cutover_job_offset
     WHERE lease_process_id != $1::UUID
 ), to_insert AS (

--- a/pkg/repository/v1/sqlcv1/payload-store.sql
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql
@@ -248,8 +248,31 @@ SELECT copy_v1_payload_partition_structure(@date::DATE);
 SELECT swap_v1_payload_partition_with_temp(@date::DATE);
 
 -- name: AcquireOrExtendCutoverJobLease :one
+WITH inputs AS (
+    SELECT
+        @key::DATE AS key,
+        @leaseProcessId::UUID AS lease_process_id,
+        @leaseExpiresAt::TIMESTAMPTZ AS lease_expires_at,
+        @lastTenantId::UUID AS last_tenant_id,
+        @lastInsertedAt::TIMESTAMPTZ AS last_inserted_at,
+        @lastId::BIGINT AS last_id,
+        @lastType::v1_payload_type AS last_type
+), any_lease_held_by_other_process AS (
+    -- need coalesce here in case there are no rows that don't belong to this process
+    SELECT COALESCE(BOOL_OR(lease_expires_at > NOW()), FALSE) AS lease_exists
+    FROM v1_payload_cutover_job_offset
+    WHERE lease_process_id != @leaseProcessId::UUID
+), to_insert AS (
+    SELECT *
+    FROM inputs
+    -- if a lease is held by another process, we shouldn't try to insert a new row regardless
+    -- of which key we're trying to acquire a lease on
+    WHERE NOT (SELECT lease_exists FROM any_lease_held_by_other_process)
+)
+
 INSERT INTO v1_payload_cutover_job_offset (key, lease_process_id, lease_expires_at, last_tenant_id, last_inserted_at, last_id, last_type)
-VALUES (@key::DATE, @leaseProcessId::UUID, @leaseExpiresAt::TIMESTAMPTZ, @lastTenantId::UUID, @lastInsertedAt::TIMESTAMPTZ, @lastId::BIGINT, @lastType::v1_payload_type)
+SELECT ti.key, ti.lease_process_id, ti.lease_expires_at, ti.last_tenant_id, ti.last_inserted_at, ti.last_id, ti.last_type
+FROM to_insert ti
 ON CONFLICT (key)
 DO UPDATE SET
     -- if the lease is held by this process, then we extend the offset to the new tuple of (last_tenant_id, last_inserted_at, last_id, last_type)


### PR DESCRIPTION
# Description

Global lease for the OLAP side so only one process runs at a time so we don't max out IOPS on our dbs

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
