### PR TITLE
Fix: OLAP Immediate Offloads

### DIFF
--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -2394,7 +2394,7 @@ func (r *OLAPRepositoryImpl) PutPayloads(ctx context.Context, tx sqlcv1.DBTX, te
 
 	externalIdToKey := make(map[PayloadExternalId]ExternalPayloadLocationKey)
 
-	if r.payloadStore.ExternalStoreEnabled() {
+	if r.payloadStore.ExternalStoreEnabled() && r.payloadStore.ImmediateOffloadsEnabled() {
 		storeExternalPayloadOpts := make([]OffloadToExternalStoreOpts, len(putPayloadOpts))
 
 		for i, opt := range putPayloadOpts {

--- a/pkg/repository/v1/payloadstore.go
+++ b/pkg/repository/v1/payloadstore.go
@@ -75,6 +75,7 @@ type PayloadStoreRepository interface {
 	ExternalCutoverNumConcurrentOffloads() int32
 	ExternalStoreEnabled() bool
 	ExternalStore() ExternalStore
+	ImmediateOffloadsEnabled() bool
 	ProcessPayloadCutovers(ctx context.Context) error
 }
 
@@ -399,6 +400,10 @@ func (p *payloadStoreRepositoryImpl) ExternalCutoverNumConcurrentOffloads() int3
 
 func (p *payloadStoreRepositoryImpl) ExternalStoreEnabled() bool {
 	return p.externalStoreEnabled
+}
+
+func (p *payloadStoreRepositoryImpl) ImmediateOffloadsEnabled() bool {
+	return p.enableImmediateOffloads
 }
 
 func (p *payloadStoreRepositoryImpl) ExternalStore() ExternalStore {


### PR DESCRIPTION
# Description

Fixes two bugs:
* Call `ExternalStore().Store()` directly instead of calling `PutPayloads` multiple times, which should be a big performance improvement since `PutPayloads` does an update into the payloads table itself, which defeats the whole purpose of this job 🤦 
* Use a flag for enabling / disabling immediate offloads

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
