### PR TITLE
Chore: Prettier plugin for sorting imports

### DIFF
--- a/frontend/app/.prettierrc
+++ b/frontend/app/.prettierrc
@@ -1,5 +1,5 @@
 {
   "singleQuote": true,
   "trailingComma": "all",
-  "plugins": ["prettier-plugin-tailwindcss"]
+  "plugins": ["prettier-plugin-tailwindcss", "@trivago/prettier-plugin-sort-imports"],
 }

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -79,6 +79,7 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@trivago/prettier-plugin-sort-imports": "^6.0.0",
     "@types/dagre": "^0.7.52",
     "@types/node": "^20.17.28",
     "@types/qs": "^6.9.18",

--- a/frontend/app/pnpm-lock.yaml
+++ b/frontend/app/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
         specifier: ^3.24.2
         version: 3.25.76
     devDependencies:
+      '@trivago/prettier-plugin-sort-imports':
+        specifier: ^6.0.0
+        version: 6.0.0(prettier@3.6.2)
       '@types/dagre':
         specifier: ^0.7.52
         version: 0.7.53
@@ -1555,6 +1558,25 @@ packages:
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
 
+  '@trivago/prettier-plugin-sort-imports@6.0.0':
+    resolution: {integrity: sha512-Xarx55ow0R8oC7ViL5fPmDsg1EBa1dVhyZFVbFXNtPPJyW2w9bJADIla8YFSaNG9N06XfcklA9O9vmw4noNxkQ==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@vue/compiler-sfc': 3.x
+      prettier: 2.x - 3.x
+      prettier-plugin-ember-template-tag: '>= 2.0.0'
+      prettier-plugin-svelte: 3.x
+      svelte: 4.x || 5.x
+    peerDependenciesMeta:
+      '@vue/compiler-sfc':
+        optional: true
+      prettier-plugin-ember-template-tag:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+      svelte:
+        optional: true
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -2768,6 +2790,9 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  javascript-natural-sort@0.7.1:
+    resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
+
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
@@ -2854,6 +2879,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -3033,6 +3061,12 @@ packages:
 
   parse-entities@2.0.0:
     resolution: {integrity: sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==}
+
+  parse-imports-exports@0.2.4:
+    resolution: {integrity: sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==}
+
+  parse-statements@1.0.11:
+    resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -5162,6 +5196,20 @@ snapshots:
 
   '@tanstack/table-core@8.21.3': {}
 
+  '@trivago/prettier-plugin-sort-imports@6.0.0(prettier@3.6.2)':
+    dependencies:
+      '@babel/generator': 7.28.3
+      '@babel/parser': 7.28.3
+      '@babel/traverse': 7.28.3
+      '@babel/types': 7.28.2
+      javascript-natural-sort: 0.7.1
+      lodash-es: 4.17.21
+      minimatch: 9.0.5
+      parse-imports-exports: 0.2.4
+      prettier: 3.6.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.28.3
@@ -6611,6 +6659,8 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  javascript-natural-sort@0.7.1: {}
+
   jiti@1.21.7: {}
 
   jiti@2.5.1:
@@ -6676,6 +6726,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.17.21: {}
 
   lodash.merge@4.6.2: {}
 
@@ -6854,6 +6906,12 @@ snapshots:
       is-alphanumerical: 1.0.4
       is-decimal: 1.0.4
       is-hexadecimal: 1.0.4
+
+  parse-imports-exports@0.2.4:
+    dependencies:
+      parse-statements: 1.0.11
+
+  parse-statements@1.0.11: {}
 
   path-exists@4.0.0: {}
 

--- a/frontend/app/src/components/hooks/use-toast.ts
+++ b/frontend/app/src/components/hooks/use-toast.ts
@@ -1,6 +1,5 @@
-import * as React from 'react';
-
 import type { ToastActionElement, ToastProps } from '@/components/v1/ui/toast';
+import * as React from 'react';
 
 const TOAST_LIMIT = 1;
 const TOAST_REMOVE_DELAY = 1000000;

--- a/frontend/app/src/components/molecules/confirm-dialog.tsx
+++ b/frontend/app/src/components/molecules/confirm-dialog.tsx
@@ -1,11 +1,11 @@
 import { ButtonProps, Button } from '@/components/v1/ui/button';
-import { Spinner } from '@/components/v1/ui/loading.tsx';
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from '@/components/v1/ui/dialog';
+import { Spinner } from '@/components/v1/ui/loading.tsx';
 
 interface ConfirmDialogProps {
   title: string;

--- a/frontend/app/src/components/molecules/nav-bar/nav-bar.tsx
+++ b/frontend/app/src/components/molecules/nav-bar/nav-bar.tsx
@@ -1,4 +1,15 @@
-import React from 'react';
+import hatchet from '@/assets/hatchet_logo.png';
+import hatchetDark from '@/assets/hatchet_logo_dark.png';
+import { useSidebar } from '@/components/sidebar-provider';
+import { useTheme } from '@/components/theme-provider';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/v1/ui/breadcrumb';
 import { Button } from '@/components/v1/ui/button';
 import {
   DropdownMenu,
@@ -9,14 +20,19 @@ import {
   DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from '@/components/v1/ui/dropdown-menu';
-
-import { useNavigate } from '@tanstack/react-router';
+import { useBreadcrumbs } from '@/hooks/use-breadcrumbs';
+import { usePendingInvites } from '@/hooks/use-pending-invites';
+import { useTenantDetails } from '@/hooks/use-tenant';
 import api, { TenantMember, User } from '@/lib/api';
 import { useApiError } from '@/lib/hooks';
+import useApiMeta from '@/pages/auth/hooks/use-api-meta';
+import { VersionInfo } from '@/pages/main/info/components/version-info';
+import { appRoutes } from '@/router';
 import { useMutation } from '@tanstack/react-query';
-import hatchet from '@/assets/hatchet_logo.png';
-import hatchetDark from '@/assets/hatchet_logo_dark.png';
-import { useSidebar } from '@/components/sidebar-provider';
+import { useNavigate } from '@tanstack/react-router';
+import { Menu } from 'lucide-react';
+import React from 'react';
+import { useMemo } from 'react';
 import {
   BiBook,
   BiCalendar,
@@ -27,23 +43,6 @@ import {
   BiUserCircle,
   BiEnvelope,
 } from 'react-icons/bi';
-import { Menu } from 'lucide-react';
-import { useTheme } from '@/components/theme-provider';
-import { useMemo } from 'react';
-import useApiMeta from '@/pages/auth/hooks/use-api-meta';
-import { VersionInfo } from '@/pages/main/info/components/version-info';
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from '@/components/v1/ui/breadcrumb';
-import { useBreadcrumbs } from '@/hooks/use-breadcrumbs';
-import { usePendingInvites } from '@/hooks/use-pending-invites';
-import { useTenantDetails } from '@/hooks/use-tenant';
-import { appRoutes } from '@/router';
 
 function HelpDropdown() {
   const meta = useApiMeta();

--- a/frontend/app/src/components/refetch-interval-dropdown.tsx
+++ b/frontend/app/src/components/refetch-interval-dropdown.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { Button } from './v1/ui/button';
 import {
   Select,
   SelectContent,
@@ -6,13 +6,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/v1/ui/select';
+import { useRefetchInterval } from '@/contexts/refetch-interval-context';
 import {
   RefetchInterval,
   RefetchIntervalOption,
 } from '@/lib/api/refetch-interval';
 import { RefreshCw } from 'lucide-react';
-import { useRefetchInterval } from '@/contexts/refetch-interval-context';
-import { Button } from './v1/ui/button';
+import { useMemo } from 'react';
 
 type RefetchIntervalDropdownProps = {
   isRefetching: boolean;

--- a/frontend/app/src/components/side-panel.tsx
+++ b/frontend/app/src/components/side-panel.tsx
@@ -1,13 +1,13 @@
-import { useSidePanel } from '@/hooks/use-side-panel';
+import { Button } from './v1/ui/button';
 import { useLocalStorageState } from '@/hooks/use-local-storage-state';
+import { useSidePanel } from '@/hooks/use-side-panel';
+import { cn } from '@/lib/utils';
 import {
   Cross2Icon,
   ChevronLeftIcon,
   ChevronRightIcon,
 } from '@radix-ui/react-icons';
-import { Button } from './v1/ui/button';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { cn } from '@/lib/utils';
 
 const DEFAULT_PANEL_WIDTH = 650;
 const MIN_PANEL_WIDTH = 350;

--- a/frontend/app/src/components/v1/cloud/billing/payment-methods.tsx
+++ b/frontend/app/src/components/v1/cloud/billing/payment-methods.tsx
@@ -1,4 +1,10 @@
 import { Button } from '@/components/v1/ui/button';
+import { Spinner } from '@/components/v1/ui/loading';
+import { useCurrentTenantId } from '@/hooks/use-tenant';
+import { cloudApi } from '@/lib/api/api';
+import { TenantPaymentMethod } from '@/lib/api/generated/cloud/data-contracts';
+import { useApiError } from '@/lib/hooks';
+import { useState } from 'react';
 import {
   FaCcAmex,
   FaCcDiscover,
@@ -8,16 +14,8 @@ import {
   FaCcDinersClub,
   FaCcJcb,
 } from 'react-icons/fa';
-
-import { LuBanknote } from 'react-icons/lu';
-
 import { IconType } from 'react-icons/lib';
-import { useApiError } from '@/lib/hooks';
-import { useState } from 'react';
-import { Spinner } from '@/components/v1/ui/loading';
-import { TenantPaymentMethod } from '@/lib/api/generated/cloud/data-contracts';
-import { cloudApi } from '@/lib/api/api';
-import { useCurrentTenantId } from '@/hooks/use-tenant';
+import { LuBanknote } from 'react-icons/lu';
 
 const ccIcons: Record<string, IconType> = {
   visa: FaCcVisa,

--- a/frontend/app/src/components/v1/cloud/logging/logs.tsx
+++ b/frontend/app/src/components/v1/cloud/logging/logs.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef, useState } from 'react';
 import AnsiToHtml from 'ansi-to-html';
 import DOMPurify from 'dompurify';
+import React, { useEffect, useRef, useState } from 'react';
 
 const convert = new AnsiToHtml({
   newline: true,

--- a/frontend/app/src/components/v1/hooks/use-toast.ts
+++ b/frontend/app/src/components/v1/hooks/use-toast.ts
@@ -1,6 +1,5 @@
-import * as React from 'react';
-
 import type { ToastActionElement, ToastProps } from '@/components/v1/ui/toast';
+import * as React from 'react';
 
 const TOAST_LIMIT = 1;
 const TOAST_REMOVE_DELAY = 1000000;

--- a/frontend/app/src/components/v1/molecules/charts/zoomable.tsx
+++ b/frontend/app/src/components/v1/molecules/charts/zoomable.tsx
@@ -1,3 +1,10 @@
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/v1/ui/chart';
+import { capitalize, cn } from '@/lib/utils';
 import { useState, useMemo, useRef } from 'react';
 import {
   CartesianGrid,
@@ -12,13 +19,6 @@ import {
   Area,
   AreaChart,
 } from 'recharts';
-import {
-  ChartConfig,
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-} from '@/components/v1/ui/chart';
-import { capitalize, cn } from '@/lib/utils';
 
 export type DataPoint<T extends string> = Record<T, number> & {
   date: string;

--- a/frontend/app/src/components/v1/molecules/combobox/combobox.tsx
+++ b/frontend/app/src/components/v1/molecules/combobox/combobox.tsx
@@ -1,7 +1,4 @@
-import * as React from 'react';
-import { CheckIcon, PlusCircledIcon } from '@radix-ui/react-icons';
-
-import { cn } from '@/lib/utils';
+import { ToolbarType } from '../data-table/data-table-toolbar';
 import { Badge } from '@/components/v1/ui/badge';
 import { Button } from '@/components/v1/ui/button';
 import {
@@ -13,18 +10,20 @@ import {
   CommandList,
   CommandSeparator,
 } from '@/components/v1/ui/command';
+import { Input } from '@/components/v1/ui/input';
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from '@/components/v1/ui/popover';
 import { Separator } from '@/components/v1/ui/separator';
-import { ToolbarType } from '../data-table/data-table-toolbar';
-import { Input } from '@/components/v1/ui/input';
-import { BiX } from 'react-icons/bi';
-import { useForm } from 'react-hook-form';
-import { z } from 'zod';
+import { cn } from '@/lib/utils';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { CheckIcon, PlusCircledIcon } from '@radix-ui/react-icons';
+import * as React from 'react';
+import { useForm } from 'react-hook-form';
+import { BiX } from 'react-icons/bi';
+import { z } from 'zod';
 
 const keyValuePairSchema = z.object({
   key: z.string().min(1, 'Key is required'),

--- a/frontend/app/src/components/v1/molecules/confirm-dialog.tsx
+++ b/frontend/app/src/components/v1/molecules/confirm-dialog.tsx
@@ -1,11 +1,11 @@
 import { ButtonProps, Button } from '@/components/v1/ui/button';
-import { Spinner } from '@/components/v1/ui/loading.tsx';
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from '@/components/v1/ui/dialog';
+import { Spinner } from '@/components/v1/ui/loading.tsx';
 
 interface ConfirmDialogProps {
   title: string;

--- a/frontend/app/src/components/v1/molecules/data-table/data-table-column-header.tsx
+++ b/frontend/app/src/components/v1/molecules/data-table/data-table-column-header.tsx
@@ -1,12 +1,3 @@
-import {
-  ArrowDownIcon,
-  ArrowUpIcon,
-  CaretSortIcon,
-  EyeNoneIcon,
-} from '@radix-ui/react-icons';
-import { Column } from '@tanstack/react-table';
-
-import { cn } from '@/lib/utils';
 import { Button } from '@/components/v1/ui/button';
 import {
   DropdownMenu,
@@ -15,6 +6,14 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/v1/ui/dropdown-menu';
+import { cn } from '@/lib/utils';
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  CaretSortIcon,
+  EyeNoneIcon,
+} from '@radix-ui/react-icons';
+import { Column } from '@tanstack/react-table';
 
 interface DataTableColumnHeaderProps<TData, TValue>
   extends React.HTMLAttributes<HTMLDivElement> {

--- a/frontend/app/src/components/v1/molecules/data-table/data-table-options.tsx
+++ b/frontend/app/src/components/v1/molecules/data-table/data-table-options.tsx
@@ -1,30 +1,20 @@
-import * as React from 'react';
-import { Cross2Icon, MixerHorizontalIcon } from '@radix-ui/react-icons';
-import { ColumnFiltersState, Table } from '@tanstack/react-table';
-import { Button } from '@/components/v1/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from '@/components/v1/ui/dropdown-menu';
-import { Badge } from '@/components/v1/ui/badge';
-import { ChevronDownIcon } from '@radix-ui/react-icons';
-import {
-  flattenDAGsKey,
-  createdAfterKey,
-  finishedBeforeKey,
-  statusKey,
-  isCustomTimeRangeKey,
-  timeWindowKey,
-} from '@/pages/main/v1/workflow-runs-v1/components/v1/task-runs-columns';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../ui/tabs';
 import { ToolbarFilters } from './data-table-toolbar';
 import {
   ToolbarType,
   FilterOption,
   TimeRangeConfig,
 } from './data-table-toolbar';
-import { Input } from '@/components/v1/ui/input';
+import { DateTimePicker } from '@/components/v1/molecules/time-picker/date-time-picker';
+import { Badge } from '@/components/v1/ui/badge';
+import { Button } from '@/components/v1/ui/button';
 import { Checkbox } from '@/components/v1/ui/checkbox';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/v1/ui/dropdown-menu';
+import { Input } from '@/components/v1/ui/input';
 import { Label } from '@/components/v1/ui/label';
 import {
   Select,
@@ -33,11 +23,21 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/v1/ui/select';
-import { DateTimePicker } from '@/components/v1/molecules/time-picker/date-time-picker';
-import { XCircleIcon } from '@heroicons/react/24/outline';
-import { Column } from '@tanstack/react-table';
 import { V1TaskStatus } from '@/lib/api';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../ui/tabs';
+import {
+  flattenDAGsKey,
+  createdAfterKey,
+  finishedBeforeKey,
+  statusKey,
+  isCustomTimeRangeKey,
+  timeWindowKey,
+} from '@/pages/main/v1/workflow-runs-v1/components/v1/task-runs-columns';
+import { XCircleIcon } from '@heroicons/react/24/outline';
+import { Cross2Icon, MixerHorizontalIcon } from '@radix-ui/react-icons';
+import { ChevronDownIcon } from '@radix-ui/react-icons';
+import { ColumnFiltersState, Table } from '@tanstack/react-table';
+import { Column } from '@tanstack/react-table';
+import * as React from 'react';
 
 interface FilterControlProps<TData> {
   column?: Column<TData, any>;

--- a/frontend/app/src/components/v1/molecules/data-table/data-table-pagination.tsx
+++ b/frontend/app/src/components/v1/molecules/data-table/data-table-pagination.tsx
@@ -1,11 +1,3 @@
-import {
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  DoubleArrowLeftIcon,
-  DoubleArrowRightIcon,
-} from '@radix-ui/react-icons';
-import { Table } from '@tanstack/react-table';
-
 import { Button } from '@/components/v1/ui/button';
 import {
   Select,
@@ -14,7 +6,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/v1/ui/select';
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  DoubleArrowLeftIcon,
+  DoubleArrowRightIcon,
+} from '@radix-ui/react-icons';
 import { Label } from '@radix-ui/react-label';
+import { Table } from '@tanstack/react-table';
 
 interface DataTablePaginationProps<TData> {
   table: Table<TData>;

--- a/frontend/app/src/components/v1/molecules/data-table/data-table-row-actions.tsx
+++ b/frontend/app/src/components/v1/molecules/data-table/data-table-row-actions.tsx
@@ -1,6 +1,4 @@
-import { DotsVerticalIcon } from '@radix-ui/react-icons';
-import { Row } from '@tanstack/react-table';
-
+import { IDGetter } from './data-table';
 import { Button } from '@/components/v1/ui/button';
 import {
   DropdownMenu,
@@ -8,14 +6,14 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/v1/ui/dropdown-menu';
-
-import { IDGetter } from './data-table';
 import {
   Tooltip,
   TooltipProvider,
   TooltipTrigger,
   TooltipContent,
 } from '@/components/v1/ui/tooltip';
+import { DotsVerticalIcon } from '@radix-ui/react-icons';
+import { Row } from '@tanstack/react-table';
 
 interface DataTableRowActionsProps<TData extends IDGetter<TData>> {
   row: Row<TData>;

--- a/frontend/app/src/components/v1/molecules/data-table/data-table-toolbar.tsx
+++ b/frontend/app/src/components/v1/molecules/data-table/data-table-toolbar.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react';
-import { Table } from '@tanstack/react-table';
 import { DataTableOptions } from './data-table-options';
-import { Spinner } from '@/components/v1/ui/loading';
 import { RefetchIntervalDropdown } from '@/components/refetch-interval-dropdown';
-import { TableActions } from '@/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions';
+import { Spinner } from '@/components/v1/ui/loading';
 import {
   ActionType,
   BaseTaskRunActionParams,
 } from '@/pages/main/v1/task-runs-v1/actions';
+import { TableActions } from '@/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions';
+import { Table } from '@tanstack/react-table';
+import * as React from 'react';
 
 export interface FilterOption {
   label: string;

--- a/frontend/app/src/components/v1/molecules/data-table/data-table.tsx
+++ b/frontend/app/src/components/v1/molecules/data-table/data-table.tsx
@@ -1,4 +1,21 @@
-import * as React from 'react';
+import { DataTablePagination } from './data-table-pagination';
+import {
+  DataTableToolbar,
+  ShowTableActionsProps,
+  ToolbarFilters,
+} from './data-table-toolbar';
+import { Skeleton } from '@/components/v1/ui/skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/v1/ui/table';
+import { cn } from '@/lib/utils';
+import { ConfirmActionModal } from '@/pages/main/v1/task-runs-v1/actions';
+import { flattenDAGsKey } from '@/pages/main/v1/workflow-runs-v1/components/v1/task-runs-columns';
 import {
   ColumnDef,
   ColumnFiltersState,
@@ -18,26 +35,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/v1/ui/table';
-
-import { DataTablePagination } from './data-table-pagination';
-import {
-  DataTableToolbar,
-  ShowTableActionsProps,
-  ToolbarFilters,
-} from './data-table-toolbar';
-import { Skeleton } from '@/components/v1/ui/skeleton';
-import { cn } from '@/lib/utils';
-import { ConfirmActionModal } from '@/pages/main/v1/task-runs-v1/actions';
-import { flattenDAGsKey } from '@/pages/main/v1/workflow-runs-v1/components/v1/task-runs-columns';
+import * as React from 'react';
 
 export interface IDGetter<T> {
   metadata: {

--- a/frontend/app/src/components/v1/molecules/nav-bar/organization-selector.tsx
+++ b/frontend/app/src/components/v1/molecules/nav-bar/organization-selector.tsx
@@ -1,13 +1,4 @@
 import { Button } from '@/components/v1/ui/button';
-import { cn } from '@/lib/utils';
-import {
-  BuildingOffice2Icon,
-  Cog6ToothIcon,
-  PlusIcon,
-  CheckIcon,
-  ChevronDownIcon,
-  ChevronRightIcon,
-} from '@heroicons/react/24/outline';
 import {
   Command,
   CommandEmpty,
@@ -15,14 +6,6 @@ import {
   CommandItem,
   CommandList,
 } from '@/components/v1/ui/command';
-import { Tenant, TenantMember } from '@/lib/api';
-import { OrganizationForUser } from '@/lib/api/generated/cloud/data-contracts';
-import { CaretSortIcon } from '@radix-ui/react-icons';
-import {
-  PopoverTrigger,
-  Popover,
-  PopoverContent,
-} from '@radix-ui/react-popover';
 import {
   Dialog,
   DialogContent,
@@ -32,12 +15,29 @@ import {
 } from '@/components/v1/ui/dialog';
 import { Input } from '@/components/v1/ui/input';
 import { TooltipProvider } from '@/components/v1/ui/tooltip';
-import { useState, useMemo } from 'react';
-import { useLocation, useNavigate } from '@tanstack/react-router';
-import { useTenantDetails } from '@/hooks/use-tenant';
 import { useOrganizations } from '@/hooks/use-organizations';
-import invariant from 'tiny-invariant';
+import { useTenantDetails } from '@/hooks/use-tenant';
+import { Tenant, TenantMember } from '@/lib/api';
+import { OrganizationForUser } from '@/lib/api/generated/cloud/data-contracts';
+import { cn } from '@/lib/utils';
 import { appRoutes } from '@/router';
+import {
+  BuildingOffice2Icon,
+  Cog6ToothIcon,
+  PlusIcon,
+  CheckIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
+} from '@heroicons/react/24/outline';
+import { CaretSortIcon } from '@radix-ui/react-icons';
+import {
+  PopoverTrigger,
+  Popover,
+  PopoverContent,
+} from '@radix-ui/react-popover';
+import { useLocation, useNavigate } from '@tanstack/react-router';
+import { useState, useMemo } from 'react';
+import invariant from 'tiny-invariant';
 
 interface OrganizationGroupProps {
   organization: OrganizationForUser;

--- a/frontend/app/src/components/v1/molecules/nav-bar/tenant-switcher.tsx
+++ b/frontend/app/src/components/v1/molecules/nav-bar/tenant-switcher.tsx
@@ -1,11 +1,4 @@
 import { Button } from '@/components/v1/ui/button';
-import { cn } from '@/lib/utils';
-import {
-  BuildingOffice2Icon,
-  // ChartBarSquareIcon,
-  CheckIcon,
-} from '@heroicons/react/24/outline';
-import invariant from 'tiny-invariant';
 import {
   Command,
   CommandEmpty,
@@ -13,20 +6,27 @@ import {
   CommandList,
   CommandSeparator,
 } from '@/components/v1/ui/command';
-import { Link } from '@tanstack/react-router';
+import { Spinner } from '@/components/v1/ui/loading.tsx';
+import { useOrganizations } from '@/hooks/use-organizations';
+import { useTenantDetails } from '@/hooks/use-tenant';
 import { TenantMember } from '@/lib/api';
+import { cn } from '@/lib/utils';
+import useApiMeta from '@/pages/auth/hooks/use-api-meta';
+import { appRoutes } from '@/router';
+import {
+  BuildingOffice2Icon,
+  // ChartBarSquareIcon,
+  CheckIcon,
+} from '@heroicons/react/24/outline';
 import { CaretSortIcon, PlusCircledIcon } from '@radix-ui/react-icons';
 import {
   PopoverTrigger,
   Popover,
   PopoverContent,
 } from '@radix-ui/react-popover';
+import { Link } from '@tanstack/react-router';
 import React from 'react';
-import { Spinner } from '@/components/v1/ui/loading.tsx';
-import useApiMeta from '@/pages/auth/hooks/use-api-meta';
-import { useTenantDetails } from '@/hooks/use-tenant';
-import { useOrganizations } from '@/hooks/use-organizations';
-import { appRoutes } from '@/router';
+import invariant from 'tiny-invariant';
 
 interface TenantSwitcherProps {
   className?: string;

--- a/frontend/app/src/components/v1/molecules/relative-date.tsx
+++ b/frontend/app/src/components/v1/molecules/relative-date.tsx
@@ -1,5 +1,3 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import TimeAgo from 'timeago-react';
 import {
   PortalTooltip,
   PortalTooltipTrigger,
@@ -7,6 +5,8 @@ import {
   PortalTooltipProvider,
 } from '@/components/v1/ui/portal-tooltip';
 import { format, parseISO } from 'date-fns';
+import React, { useEffect, useMemo, useState } from 'react';
+import TimeAgo from 'timeago-react';
 
 interface RelativeDateProps {
   date?: Date | string;

--- a/frontend/app/src/components/v1/molecules/time-picker/date-time-picker.tsx
+++ b/frontend/app/src/components/v1/molecules/time-picker/date-time-picker.tsx
@@ -1,5 +1,4 @@
-import { add, format } from 'date-fns';
-import { cn } from '@/lib/utils';
+import { TimePicker } from './time-picker';
 import { Button } from '@/components/v1/ui/button';
 import { Calendar } from '@/components/v1/ui/calendar';
 import {
@@ -7,8 +6,9 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/v1/ui/popover';
-import { TimePicker } from './time-picker';
+import { cn } from '@/lib/utils';
 import { CalendarIcon } from '@radix-ui/react-icons';
+import { add, format } from 'date-fns';
 
 type DateTimePickerProps = {
   date: Date | undefined;

--- a/frontend/app/src/components/v1/molecules/time-picker/time-picker-input.tsx
+++ b/frontend/app/src/components/v1/molecules/time-picker/time-picker-input.tsx
@@ -1,7 +1,3 @@
-import { Input } from '@/components/v1/ui/input';
-
-import { cn } from '@/lib/utils';
-import React from 'react';
 import {
   Period,
   TimePickerType,
@@ -9,6 +5,9 @@ import {
   getDateByType,
   setDateByType,
 } from './time-picker-utils';
+import { Input } from '@/components/v1/ui/input';
+import { cn } from '@/lib/utils';
+import React from 'react';
 
 interface TimePickerInputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {

--- a/frontend/app/src/components/v1/molecules/time-picker/time-picker.tsx
+++ b/frontend/app/src/components/v1/molecules/time-picker/time-picker.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
-import { Label } from '@/components/v1/ui/label';
 import { TimePickerInput } from './time-picker-input';
+import { Label } from '@/components/v1/ui/label';
+import * as React from 'react';
 
 interface TimePickerProps {
   date: Date | undefined;

--- a/frontend/app/src/components/v1/shared/copy-workflow-config.tsx
+++ b/frontend/app/src/components/v1/shared/copy-workflow-config.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
 import { Button } from '../ui/button';
 import { CheckIcon, CopyIcon } from 'lucide-react';
+import { useState } from 'react';
 
 export function CopyWorkflowConfigButton({
   workflowConfig,

--- a/frontend/app/src/components/v1/shared/duration.tsx
+++ b/frontend/app/src/components/v1/shared/duration.tsx
@@ -1,8 +1,3 @@
-import * as React from 'react';
-import { cva, type VariantProps } from 'class-variance-authority';
-import { cn } from '@/lib/utils';
-import { intervalToDuration } from 'date-fns';
-import { Clock } from 'lucide-react';
 import {
   PortalTooltip,
   PortalTooltipTrigger,
@@ -10,7 +5,12 @@ import {
   PortalTooltipProvider,
 } from '@/components/v1/ui/portal-tooltip';
 import { V1TaskStatus } from '@/lib/api';
+import { cn } from '@/lib/utils';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { intervalToDuration } from 'date-fns';
 import { Duration as DateFnsDuration } from 'date-fns';
+import { Clock } from 'lucide-react';
+import * as React from 'react';
 
 function formatDuration(duration: DateFnsDuration, rawTimeMs: number): string {
   const parts = [];

--- a/frontend/app/src/components/v1/ui/accordion.tsx
+++ b/frontend/app/src/components/v1/ui/accordion.tsx
@@ -1,8 +1,7 @@
-import * as React from 'react';
+import { cn } from '@/lib/utils';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
 import { ChevronDownIcon } from '@radix-ui/react-icons';
-
-import { cn } from '@/lib/utils';
+import * as React from 'react';
 
 const Accordion = AccordionPrimitive.Root;
 

--- a/frontend/app/src/components/v1/ui/alert.tsx
+++ b/frontend/app/src/components/v1/ui/alert.tsx
@@ -1,7 +1,6 @@
-import * as React from 'react';
-import { cva, type VariantProps } from 'class-variance-authority';
-
 import { cn } from '@/lib/utils';
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
 
 const alertVariants = cva(
   'relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7',

--- a/frontend/app/src/components/v1/ui/avatar.tsx
+++ b/frontend/app/src/components/v1/ui/avatar.tsx
@@ -1,7 +1,6 @@
-import * as React from 'react';
-import * as AvatarPrimitive from '@radix-ui/react-avatar';
-
 import { cn } from '@/lib/utils';
+import * as AvatarPrimitive from '@radix-ui/react-avatar';
+import * as React from 'react';
 
 const Avatar = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Root>,

--- a/frontend/app/src/components/v1/ui/badge.tsx
+++ b/frontend/app/src/components/v1/ui/badge.tsx
@@ -1,7 +1,6 @@
-import * as React from 'react';
-import { cva, type VariantProps } from 'class-variance-authority';
-
 import { cn } from '@/lib/utils';
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
 
 const badgeVariants = cva(
   'inline-flex items-center rounded-md border px-3 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',

--- a/frontend/app/src/components/v1/ui/breadcrumb.tsx
+++ b/frontend/app/src/components/v1/ui/breadcrumb.tsx
@@ -1,8 +1,7 @@
-import * as React from 'react';
+import { cn } from '@/lib/utils';
 import { ChevronRightIcon, DotsHorizontalIcon } from '@radix-ui/react-icons';
 import { Slot } from '@radix-ui/react-slot';
-
-import { cn } from '@/lib/utils';
+import * as React from 'react';
 
 const Breadcrumb = React.forwardRef<
   HTMLElement,

--- a/frontend/app/src/components/v1/ui/button.tsx
+++ b/frontend/app/src/components/v1/ui/button.tsx
@@ -1,14 +1,13 @@
-import * as React from 'react';
-import { Slot } from '@radix-ui/react-slot';
-import { cva, type VariantProps } from 'class-variance-authority';
-
-import { cn } from '@/lib/utils';
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from './tooltip';
+import { cn } from '@/lib/utils';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
 
 const buttonVariants = cva(
   'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50',

--- a/frontend/app/src/components/v1/ui/calendar.tsx
+++ b/frontend/app/src/components/v1/ui/calendar.tsx
@@ -1,9 +1,8 @@
-import * as React from 'react';
-import { ChevronLeftIcon, ChevronRightIcon } from '@radix-ui/react-icons';
-import { DayPicker } from 'react-day-picker';
-
-import { cn } from '@/lib/utils';
 import { buttonVariants } from '@/components/v1/ui/button';
+import { cn } from '@/lib/utils';
+import { ChevronLeftIcon, ChevronRightIcon } from '@radix-ui/react-icons';
+import * as React from 'react';
+import { DayPicker } from 'react-day-picker';
 
 type CalendarProps = React.ComponentProps<typeof DayPicker>;
 

--- a/frontend/app/src/components/v1/ui/card.tsx
+++ b/frontend/app/src/components/v1/ui/card.tsx
@@ -1,6 +1,5 @@
-import * as React from 'react';
-
 import { cn } from '@/lib/utils';
+import * as React from 'react';
 
 const Card = React.forwardRef<
   HTMLDivElement,

--- a/frontend/app/src/components/v1/ui/chart.tsx
+++ b/frontend/app/src/components/v1/ui/chart.tsx
@@ -1,7 +1,6 @@
+import { cn } from '@/lib/utils';
 import * as React from 'react';
 import * as RechartsPrimitive from 'recharts';
-
-import { cn } from '@/lib/utils';
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: '', dark: '.dark' } as const;

--- a/frontend/app/src/components/v1/ui/checkbox.tsx
+++ b/frontend/app/src/components/v1/ui/checkbox.tsx
@@ -1,8 +1,7 @@
-import * as React from 'react';
+import { cn } from '@/lib/utils';
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
 import { CheckIcon } from '@radix-ui/react-icons';
-
-import { cn } from '@/lib/utils';
+import * as React from 'react';
 
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,

--- a/frontend/app/src/components/v1/ui/code-editor.tsx
+++ b/frontend/app/src/components/v1/ui/code-editor.tsx
@@ -1,8 +1,8 @@
 import CopyToClipboard from './copy-to-clipboard';
+import { useTheme } from '@/components/theme-provider';
 import { cn } from '@/lib/utils';
 import Editor, { Monaco } from '@monaco-editor/react';
 import 'monaco-themes/themes/Pastels on Dark.json';
-import { useTheme } from '@/components/theme-provider';
 
 interface CodeEditorProps {
   code?: string;

--- a/frontend/app/src/components/v1/ui/code-highlighter.tsx
+++ b/frontend/app/src/components/v1/ui/code-highlighter.tsx
@@ -1,16 +1,14 @@
+import CopyToClipboard from './copy-to-clipboard';
+import { useTheme } from '@/components/theme-provider';
+import { cn } from '@/lib/utils';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
-
+import json from 'react-syntax-highlighter/dist/esm/languages/hljs/json';
 import typescript from 'react-syntax-highlighter/dist/esm/languages/hljs/typescript';
 import yaml from 'react-syntax-highlighter/dist/esm/languages/hljs/yaml';
-import json from 'react-syntax-highlighter/dist/esm/languages/hljs/json';
-
 import {
   anOldHope,
   atomOneLight,
 } from 'react-syntax-highlighter/dist/esm/styles/hljs';
-import CopyToClipboard from './copy-to-clipboard';
-import { cn } from '@/lib/utils';
-import { useTheme } from '@/components/theme-provider';
 
 SyntaxHighlighter.registerLanguage('typescript', typescript);
 SyntaxHighlighter.registerLanguage('yaml', yaml);

--- a/frontend/app/src/components/v1/ui/command.tsx
+++ b/frontend/app/src/components/v1/ui/command.tsx
@@ -1,10 +1,9 @@
-import * as React from 'react';
+import { Dialog, DialogContent } from '@/components/v1/ui/dialog';
+import { cn } from '@/lib/utils';
 import { type DialogProps } from '@radix-ui/react-dialog';
 import { MagnifyingGlassIcon } from '@radix-ui/react-icons';
 import { Command as CommandPrimitive } from 'cmdk';
-
-import { cn } from '@/lib/utils';
-import { Dialog, DialogContent } from '@/components/v1/ui/dialog';
+import * as React from 'react';
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,

--- a/frontend/app/src/components/v1/ui/copy-to-clipboard.tsx
+++ b/frontend/app/src/components/v1/ui/copy-to-clipboard.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
 import { Button } from './button';
-import { CopyIcon } from '@radix-ui/react-icons';
-import { CheckIcon } from '@heroicons/react/24/outline';
 import { cn } from '@/lib/utils';
+import { CheckIcon } from '@heroicons/react/24/outline';
+import { CopyIcon } from '@radix-ui/react-icons';
+import React, { useState } from 'react';
 
 type Props = {
   text: string;

--- a/frontend/app/src/components/v1/ui/dialog.tsx
+++ b/frontend/app/src/components/v1/ui/dialog.tsx
@@ -1,7 +1,6 @@
-import * as React from 'react';
-import * as DialogPrimitive from '@radix-ui/react-dialog';
-
 import { cn } from '@/lib/utils';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import * as React from 'react';
 
 const Dialog = DialogPrimitive.Root;
 

--- a/frontend/app/src/components/v1/ui/dropdown-menu.tsx
+++ b/frontend/app/src/components/v1/ui/dropdown-menu.tsx
@@ -1,12 +1,11 @@
-import * as React from 'react';
+import { cn } from '@/lib/utils';
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import {
   CheckIcon,
   ChevronRightIcon,
   DotFilledIcon,
 } from '@radix-ui/react-icons';
-
-import { cn } from '@/lib/utils';
+import * as React from 'react';
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
 

--- a/frontend/app/src/components/v1/ui/envvar.tsx
+++ b/frontend/app/src/components/v1/ui/envvar.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect } from 'react';
-import { Input } from '@/components/v1/ui/input';
 import { Textarea } from './textarea';
 import { Button } from '@/components/v1/ui/button';
+import { Input } from '@/components/v1/ui/input';
 import { cn } from '@/lib/utils';
 import { TrashIcon } from '@radix-ui/react-icons';
+import React, { useEffect } from 'react';
 
 export type KeyValueType = {
   key: string;

--- a/frontend/app/src/components/v1/ui/hover-card.tsx
+++ b/frontend/app/src/components/v1/ui/hover-card.tsx
@@ -1,7 +1,6 @@
-import * as React from 'react';
-import * as HoverCardPrimitive from '@radix-ui/react-hover-card';
-
 import { cn } from '@/lib/utils';
+import * as HoverCardPrimitive from '@radix-ui/react-hover-card';
+import * as React from 'react';
 
 const HoverCard = HoverCardPrimitive.Root;
 

--- a/frontend/app/src/components/v1/ui/input.tsx
+++ b/frontend/app/src/components/v1/ui/input.tsx
@@ -1,6 +1,5 @@
-import * as React from 'react';
-
 import { cn } from '@/lib/utils';
+import * as React from 'react';
 
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
 

--- a/frontend/app/src/components/v1/ui/label.tsx
+++ b/frontend/app/src/components/v1/ui/label.tsx
@@ -1,8 +1,7 @@
-import * as React from 'react';
+import { cn } from '@/lib/utils';
 import * as LabelPrimitive from '@radix-ui/react-label';
 import { cva, type VariantProps } from 'class-variance-authority';
-
-import { cn } from '@/lib/utils';
+import * as React from 'react';
 
 const labelVariants = cva(
   'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',

--- a/frontend/app/src/components/v1/ui/popover.tsx
+++ b/frontend/app/src/components/v1/ui/popover.tsx
@@ -1,7 +1,6 @@
-import * as React from 'react';
-import * as PopoverPrimitive from '@radix-ui/react-popover';
-
 import { cn } from '@/lib/utils';
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+import * as React from 'react';
 
 const Popover = PopoverPrimitive.Root;
 

--- a/frontend/app/src/components/v1/ui/portal-tooltip.tsx
+++ b/frontend/app/src/components/v1/ui/portal-tooltip.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import { cn } from '@/lib/utils';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import React from 'react';
 
 const PortalTooltipProvider = TooltipPrimitive.Provider;
 

--- a/frontend/app/src/components/v1/ui/radio-group.tsx
+++ b/frontend/app/src/components/v1/ui/radio-group.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
-import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
 import { cn } from '@/lib/utils';
 import { DotFilledIcon } from '@radix-ui/react-icons';
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
+import * as React from 'react';
 
 const RadioGroup = React.forwardRef<
   React.ElementRef<typeof RadioGroupPrimitive.Root>,

--- a/frontend/app/src/components/v1/ui/secret-copier.tsx
+++ b/frontend/app/src/components/v1/ui/secret-copier.tsx
@@ -1,23 +1,23 @@
-import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
-import typescript from 'react-syntax-highlighter/dist/esm/languages/hljs/typescript';
-import yaml from 'react-syntax-highlighter/dist/esm/languages/hljs/yaml';
-import json from 'react-syntax-highlighter/dist/esm/languages/hljs/json';
-import {
-  anOldHope,
-  atomOneLight,
-} from 'react-syntax-highlighter/dist/esm/styles/hljs';
+import { Button } from './button';
 import CopyToClipboard from './copy-to-clipboard';
-import { useRef, useState } from 'react';
-import { cn } from '@/lib/utils';
+import { useTheme } from '@/components/theme-provider';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/v1/ui/dropdown-menu';
-import { Button } from './button';
+import { cn } from '@/lib/utils';
 import { CaretSortIcon } from '@radix-ui/react-icons';
-import { useTheme } from '@/components/theme-provider';
+import { useRef, useState } from 'react';
+import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
+import json from 'react-syntax-highlighter/dist/esm/languages/hljs/json';
+import typescript from 'react-syntax-highlighter/dist/esm/languages/hljs/typescript';
+import yaml from 'react-syntax-highlighter/dist/esm/languages/hljs/yaml';
+import {
+  anOldHope,
+  atomOneLight,
+} from 'react-syntax-highlighter/dist/esm/styles/hljs';
 
 SyntaxHighlighter.registerLanguage('typescript', typescript);
 SyntaxHighlighter.registerLanguage('yaml', yaml);

--- a/frontend/app/src/components/v1/ui/select.tsx
+++ b/frontend/app/src/components/v1/ui/select.tsx
@@ -1,12 +1,11 @@
-import * as React from 'react';
+import { cn } from '@/lib/utils';
 import {
   CheckIcon,
   ChevronDownIcon,
   ChevronUpIcon,
 } from '@radix-ui/react-icons';
 import * as SelectPrimitive from '@radix-ui/react-select';
-
-import { cn } from '@/lib/utils';
+import * as React from 'react';
 
 const Select = SelectPrimitive.Root;
 

--- a/frontend/app/src/components/v1/ui/separator.tsx
+++ b/frontend/app/src/components/v1/ui/separator.tsx
@@ -1,7 +1,6 @@
-import * as React from 'react';
-import * as SeparatorPrimitive from '@radix-ui/react-separator';
-
 import { cn } from '@/lib/utils';
+import * as SeparatorPrimitive from '@radix-ui/react-separator';
+import * as React from 'react';
 
 const Separator = React.forwardRef<
   React.ElementRef<typeof SeparatorPrimitive.Root>,

--- a/frontend/app/src/components/v1/ui/steps.tsx
+++ b/frontend/app/src/components/v1/ui/steps.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react';
-import { cva, type VariantProps } from 'class-variance-authority';
-import { cn } from '@/lib/utils';
 import {
   Accordion,
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
 } from './accordion';
+import { cn } from '@/lib/utils';
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
 
 const stepsVariants = cva(
   'ml-4 mb-12 border-l border-border pl-6 dark:border-border [counter-reset:step] flex flex-col gap-4',

--- a/frontend/app/src/components/v1/ui/switch.tsx
+++ b/frontend/app/src/components/v1/ui/switch.tsx
@@ -1,7 +1,6 @@
-import * as React from 'react';
-import * as SwitchPrimitives from '@radix-ui/react-switch';
-
 import { cn } from '@/lib/utils';
+import * as SwitchPrimitives from '@radix-ui/react-switch';
+import * as React from 'react';
 
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,

--- a/frontend/app/src/components/v1/ui/table.tsx
+++ b/frontend/app/src/components/v1/ui/table.tsx
@@ -1,6 +1,5 @@
-import * as React from 'react';
-
 import { cn } from '@/lib/utils';
+import * as React from 'react';
 
 const Table = React.forwardRef<
   HTMLTableElement,

--- a/frontend/app/src/components/v1/ui/tabs.tsx
+++ b/frontend/app/src/components/v1/ui/tabs.tsx
@@ -1,8 +1,7 @@
-import * as React from 'react';
+import { cn } from '@/lib/utils';
 import * as TabsPrimitive from '@radix-ui/react-tabs';
 import { cva } from 'class-variance-authority';
-
-import { cn } from '@/lib/utils';
+import * as React from 'react';
 
 const Tabs = TabsPrimitive.Root;
 

--- a/frontend/app/src/components/v1/ui/textarea.tsx
+++ b/frontend/app/src/components/v1/ui/textarea.tsx
@@ -1,6 +1,5 @@
-import * as React from 'react';
-
 import { cn } from '@/lib/utils';
+import * as React from 'react';
 
 interface TextareaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}

--- a/frontend/app/src/components/v1/ui/toast.tsx
+++ b/frontend/app/src/components/v1/ui/toast.tsx
@@ -1,9 +1,8 @@
-import * as React from 'react';
+import { cn } from '@/lib/utils';
 import { Cross2Icon } from '@radix-ui/react-icons';
 import * as ToastPrimitives from '@radix-ui/react-toast';
 import { cva, type VariantProps } from 'class-variance-authority';
-
-import { cn } from '@/lib/utils';
+import * as React from 'react';
 
 const ToastProvider = ToastPrimitives.Provider;
 

--- a/frontend/app/src/components/v1/ui/tooltip.tsx
+++ b/frontend/app/src/components/v1/ui/tooltip.tsx
@@ -1,7 +1,6 @@
-import * as React from 'react';
-import * as TooltipPrimitive from '@radix-ui/react-tooltip';
-
 import { cn } from '@/lib/utils';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import * as React from 'react';
 
 const TooltipProvider = TooltipPrimitive.Provider;
 

--- a/frontend/app/src/contexts/refetch-interval-context.tsx
+++ b/frontend/app/src/contexts/refetch-interval-context.tsx
@@ -1,3 +1,9 @@
+import { useLocalStorageState } from '@/hooks/use-local-storage-state';
+import {
+  RefetchInterval,
+  RefetchIntervalOption,
+  LabeledRefetchInterval,
+} from '@/lib/api/refetch-interval';
 import {
   createContext,
   useCallback,
@@ -5,12 +11,6 @@ import {
   useMemo,
   ReactNode,
 } from 'react';
-import {
-  RefetchInterval,
-  RefetchIntervalOption,
-  LabeledRefetchInterval,
-} from '@/lib/api/refetch-interval';
-import { useLocalStorageState } from '@/hooks/use-local-storage-state';
 
 interface RefetchIntervalContextType {
   isFrozen: boolean;

--- a/frontend/app/src/devtools.tsx
+++ b/frontend/app/src/devtools.tsx
@@ -1,5 +1,5 @@
-import type { AnyRouter } from '@tanstack/react-router';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import type { AnyRouter } from '@tanstack/react-router';
 import { TanStackRouterDevtools } from '@tanstack/router-devtools';
 
 export default function Devtools({ router }: { router: AnyRouter }) {

--- a/frontend/app/src/hooks/use-analytics.tsx
+++ b/frontend/app/src/hooks/use-analytics.tsx
@@ -1,6 +1,6 @@
-import { useCallback } from 'react';
-import { usePostHog } from 'posthog-js/react';
 import { useTenantDetails } from './use-tenant';
+import { usePostHog } from 'posthog-js/react';
+import { useCallback } from 'react';
 
 interface AnalyticsEvent {
   [key: string]: unknown;

--- a/frontend/app/src/hooks/use-breadcrumbs.ts
+++ b/frontend/app/src/hooks/use-breadcrumbs.ts
@@ -1,5 +1,5 @@
-import { useLocation, useParams } from '@tanstack/react-router';
 import { generateBreadcrumbs, BreadcrumbItem } from '@/lib/breadcrumbs';
+import { useLocation, useParams } from '@tanstack/react-router';
 
 export function useBreadcrumbs(): BreadcrumbItem[] {
   const location = useLocation();

--- a/frontend/app/src/hooks/use-organizations.ts
+++ b/frontend/app/src/hooks/use-organizations.ts
@@ -1,14 +1,14 @@
-import { useMemo, useCallback } from 'react';
-import { useQuery, useMutation } from '@tanstack/react-query';
 import { cloudApi } from '@/lib/api/api';
-import useCloudApiMeta from '@/pages/auth/hooks/use-cloud-api-meta';
-import { useApiError } from '@/lib/hooks';
 import {
   CreateManagementTokenResponse,
   ManagementTokenDuration,
   OrganizationMember,
   TenantStatusType,
 } from '@/lib/api/generated/cloud/data-contracts';
+import { useApiError } from '@/lib/hooks';
+import useCloudApiMeta from '@/pages/auth/hooks/use-cloud-api-meta';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { useMemo, useCallback } from 'react';
 
 export function useOrganizations() {
   const { isCloudEnabled } = useCloudApiMeta();

--- a/frontend/app/src/hooks/use-pagination.tsx
+++ b/frontend/app/src/hooks/use-pagination.tsx
@@ -1,6 +1,6 @@
+import { useSearchParams } from '@/lib/router-helpers';
 import { PaginationState, Updater } from '@tanstack/react-table';
 import { useCallback, useMemo } from 'react';
-import { useSearchParams } from '@/lib/router-helpers';
 
 type PaginationQueryShape = {
   i: number; // index

--- a/frontend/app/src/hooks/use-pending-invites.ts
+++ b/frontend/app/src/hooks/use-pending-invites.ts
@@ -1,7 +1,7 @@
-import { useQuery } from '@tanstack/react-query';
 import api from '@/lib/api';
 import { cloudApi } from '@/lib/api/api';
 import useCloudApiMeta from '@/pages/auth/hooks/use-cloud-api-meta';
+import { useQuery } from '@tanstack/react-query';
 
 export const usePendingInvites = () => {
   const { data: cloudMeta } = useCloudApiMeta();

--- a/frontend/app/src/hooks/use-side-panel.tsx
+++ b/frontend/app/src/hooks/use-side-panel.tsx
@@ -1,3 +1,14 @@
+import { useTheme } from '@/components/theme-provider';
+import { DocPage } from '@/components/v1/docs/docs-button';
+import { V1Event, V1Filter, ScheduledWorkflows } from '@/lib/api';
+import { ExpandedEventContent } from '@/pages/main/v1/events';
+import { FilterDetailView } from '@/pages/main/v1/filters/components/filter-detail-view';
+import { ExpandedScheduledRunContent } from '@/pages/main/v1/scheduled-runs/components/expanded-scheduled-run-content';
+import {
+  TaskRunDetail,
+  TabOption,
+} from '@/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail';
+import { useLocation } from '@tanstack/react-router';
 import {
   createContext,
   useCallback,
@@ -6,17 +17,6 @@ import {
   useMemo,
   useState,
 } from 'react';
-import { useLocation } from '@tanstack/react-router';
-import {
-  TaskRunDetail,
-  TabOption,
-} from '@/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail';
-import { DocPage } from '@/components/v1/docs/docs-button';
-import { V1Event, V1Filter, ScheduledWorkflows } from '@/lib/api';
-import { FilterDetailView } from '@/pages/main/v1/filters/components/filter-detail-view';
-import { ExpandedEventContent } from '@/pages/main/v1/events';
-import { ExpandedScheduledRunContent } from '@/pages/main/v1/scheduled-runs/components/expanded-scheduled-run-content';
-import { useTheme } from '@/components/theme-provider';
 
 type SidePanelContent =
   | {

--- a/frontend/app/src/hooks/use-tenant.tsx
+++ b/frontend/app/src/hooks/use-tenant.tsx
@@ -1,17 +1,17 @@
-import { useCallback, useMemo, useState } from 'react';
 import api, {
   UpdateTenantRequest,
   Tenant,
   CreateTenantRequest,
   queries,
 } from '@/lib/api';
-import { useMatchRoute, useNavigate, useParams } from '@tanstack/react-router';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { BillingContext, lastTenantAtom } from '@/lib/atoms';
-import useCloudApiMeta from '@/pages/auth/hooks/use-cloud-api-meta';
 import { Evaluate } from '@/lib/can/shared/permission.base';
-import { useAtom } from 'jotai';
+import useCloudApiMeta from '@/pages/auth/hooks/use-cloud-api-meta';
 import { appRoutes } from '@/router';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMatchRoute, useNavigate, useParams } from '@tanstack/react-router';
+import { useAtom } from 'jotai';
+import { useCallback, useMemo, useState } from 'react';
 
 type Plan = 'free' | 'starter' | 'growth';
 

--- a/frontend/app/src/hooks/use-zod-column-filters.ts
+++ b/frontend/app/src/hooks/use-zod-column-filters.ts
@@ -1,7 +1,7 @@
-import { z } from 'zod';
 import { useSearchParams } from '@/lib/router-helpers';
-import { useCallback, useMemo } from 'react';
 import { ColumnFiltersState, Updater } from '@tanstack/react-table';
+import { useCallback, useMemo } from 'react';
+import { z } from 'zod';
 
 type FilterMapping<T> = {
   [K in keyof T]: string;

--- a/frontend/app/src/lib/api/index.ts
+++ b/frontend/app/src/lib/api/index.ts
@@ -1,4 +1,5 @@
 import api from './api';
+
 export * from './generated/data-contracts';
 export { queries } from './queries';
 export default api;

--- a/frontend/app/src/lib/api/queries.ts
+++ b/frontend/app/src/lib/api/queries.ts
@@ -1,9 +1,8 @@
-import { createQueryKeyStore } from '@lukemorales/query-key-factory';
-
-import api, { cloudApi } from './api';
-import invariant from 'tiny-invariant';
 import { WebhookWorkerCreateRequest } from '.';
+import api, { cloudApi } from './api';
 import { TemplateOptions } from './generated/cloud/data-contracts';
+import { createQueryKeyStore } from '@lukemorales/query-key-factory';
+import invariant from 'tiny-invariant';
 
 type ListEventQuery = Parameters<typeof api.eventList>[1];
 type ListRateLimitsQuery = Parameters<typeof api.rateLimitList>[1];

--- a/frontend/app/src/lib/atoms.ts
+++ b/frontend/app/src/lib/atoms.ts
@@ -1,7 +1,6 @@
-import { atom } from 'jotai';
 import { Tenant } from './api';
-
 import { TenantBillingState } from './api/generated/cloud/data-contracts';
+import { atom } from 'jotai';
 
 const getInitialValue = <T>(key: string, defaultValue?: T): T | undefined => {
   const item = localStorage.getItem(key);

--- a/frontend/app/src/lib/hooks.ts
+++ b/frontend/app/src/lib/hooks.ts
@@ -1,9 +1,9 @@
-import { useToast } from '@/components/hooks/use-toast';
-import { AxiosError } from 'axios';
-import { Dispatch, SetStateAction } from 'react';
 import api, { APIErrors } from './api';
 import { getFieldErrors } from './utils';
+import { useToast } from '@/components/hooks/use-toast';
 import { useQuery } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { Dispatch, SetStateAction } from 'react';
 
 export function useApiError(props: {
   setFieldErrors?: Dispatch<SetStateAction<Record<string, string>>>;

--- a/frontend/app/src/lib/outlet.ts
+++ b/frontend/app/src/lib/outlet.ts
@@ -1,5 +1,5 @@
-import { useOutletContext } from '@/lib/router-helpers';
 import { TenantMember, User } from './api';
+import { useOutletContext } from '@/lib/router-helpers';
 
 export type UserContextType = { user: User };
 

--- a/frontend/app/src/lib/router-helpers.tsx
+++ b/frontend/app/src/lib/router-helpers.tsx
@@ -1,4 +1,3 @@
-import { createContext, useContext, useMemo } from 'react';
 import {
   Outlet as TanStackOutlet,
   useLocation,
@@ -6,6 +5,7 @@ import {
   useRouter,
 } from '@tanstack/react-router';
 import type { NavigateOptions } from '@tanstack/react-router';
+import { createContext, useContext, useMemo } from 'react';
 
 type SearchNavigateOptions = Pick<NavigateOptions, 'replace' | 'state'>;
 

--- a/frontend/app/src/lib/utils.ts
+++ b/frontend/app/src/lib/utils.ts
@@ -1,6 +1,6 @@
+import type { APIErrors } from './api/generated/data-contracts';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
-import type { APIErrors } from './api/generated/data-contracts';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));

--- a/frontend/app/src/main.tsx
+++ b/frontend/app/src/main.tsx
@@ -1,10 +1,10 @@
-import ReactDOM from 'react-dom/client';
-import { lazy, Suspense } from 'react';
 import './index.css';
-import { QueryClientProvider } from '@tanstack/react-query';
 import queryClient from './query-client.tsx';
 import Router, { router } from './router.tsx';
 import * as Sentry from '@sentry/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { lazy, Suspense } from 'react';
+import ReactDOM from 'react-dom/client';
 
 const Devtools = import.meta.env.DEV
   ? lazy(() => import('./devtools.tsx'))

--- a/frontend/app/src/pages/auth/hooks/use-error-param.ts
+++ b/frontend/app/src/pages/auth/hooks/use-error-param.ts
@@ -1,6 +1,6 @@
 import { useToast } from '@/components/hooks/use-toast';
-import { useEffect } from 'react';
 import { useSearchParams } from '@/lib/router-helpers';
+import { useEffect } from 'react';
 
 export default function useErrorParam() {
   const [searchParams, setSearchParams] = useSearchParams();

--- a/frontend/app/src/pages/auth/login/components/user-login-form.tsx
+++ b/frontend/app/src/pages/auth/login/components/user-login-form.tsx
@@ -1,11 +1,11 @@
-import { cn } from '@/lib/utils';
 import { Button } from '@/components/v1/ui/button';
 import { Input } from '@/components/v1/ui/input';
 import { Label } from '@/components/v1/ui/label';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
 import { Spinner } from '@/components/v1/ui/loading.tsx';
+import { cn } from '@/lib/utils';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 const schema = z.object({
   email: z.string().email('Invalid email address'),

--- a/frontend/app/src/pages/auth/login/index.tsx
+++ b/frontend/app/src/pages/auth/login/index.tsx
@@ -1,15 +1,15 @@
-import { Link, useNavigate } from '@tanstack/react-router';
-import { appRoutes } from '@/router';
+import useApiMeta from '../hooks/use-api-meta';
+import useErrorParam from '../hooks/use-error-param';
 import { UserLoginForm } from './components/user-login-form';
 import { Button } from '@/components/v1/ui/button';
-import { useMutation } from '@tanstack/react-query';
-import api, { UserLoginRequest } from '@/lib/api';
-import { useState } from 'react';
-import { useApiError } from '@/lib/hooks';
-import useApiMeta from '../hooks/use-api-meta';
-import { Loading } from '@/components/v1/ui/loading';
 import { Icons } from '@/components/v1/ui/icons';
-import useErrorParam from '../hooks/use-error-param';
+import { Loading } from '@/components/v1/ui/loading';
+import api, { UserLoginRequest } from '@/lib/api';
+import { useApiError } from '@/lib/hooks';
+import { appRoutes } from '@/router';
+import { useMutation } from '@tanstack/react-query';
+import { Link, useNavigate } from '@tanstack/react-router';
+import { useState } from 'react';
 import React from 'react';
 
 export default function Login() {

--- a/frontend/app/src/pages/auth/no-auth.tsx
+++ b/frontend/app/src/pages/auth/no-auth.tsx
@@ -1,8 +1,8 @@
-import { redirect } from '@tanstack/react-router';
 import api from '@/lib/api';
 import queryClient from '@/query-client';
-import { AxiosError, isAxiosError } from 'axios';
 import { appRoutes } from '@/router';
+import { redirect } from '@tanstack/react-router';
+import { AxiosError, isAxiosError } from 'axios';
 
 const noAuthMiddleware = async () => {
   try {

--- a/frontend/app/src/pages/auth/register/components/user-register-form.tsx
+++ b/frontend/app/src/pages/auth/register/components/user-register-form.tsx
@@ -1,11 +1,11 @@
-import { cn } from '@/lib/utils';
 import { Button } from '@/components/v1/ui/button';
 import { Input } from '@/components/v1/ui/input';
 import { Label } from '@/components/v1/ui/label';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
 import { Spinner } from '@/components/v1/ui/loading.tsx';
+import { cn } from '@/lib/utils';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 const schema = z.object({
   name: z.string().min(3, 'Name must be at least 3 characters long'),

--- a/frontend/app/src/pages/auth/register/index.tsx
+++ b/frontend/app/src/pages/auth/register/index.tsx
@@ -1,19 +1,19 @@
-import { Link, useNavigate } from '@tanstack/react-router';
-import { appRoutes } from '@/router';
-import { UserRegisterForm } from './components/user-register-form';
-import { useMutation } from '@tanstack/react-query';
-import api, { UserRegisterRequest } from '@/lib/api';
-import { useEffect, useState } from 'react';
-import { useApiError } from '@/lib/hooks';
 import useApiMeta from '../hooks/use-api-meta';
-import { Loading } from '@/components/v1/ui/loading';
-import { GithubLogin, GoogleLogin, OrContinueWith } from '../login';
 import useErrorParam from '../hooks/use-error-param';
-import React from 'react';
+import { GithubLogin, GoogleLogin, OrContinueWith } from '../login';
+import { UserRegisterForm } from './components/user-register-form';
+import { Loading } from '@/components/v1/ui/loading';
 import {
   POSTHOG_DISTINCT_ID_LOCAL_STORAGE_KEY,
   POSTHOG_SESSION_ID_LOCAL_STORAGE_KEY,
 } from '@/hooks/use-analytics';
+import api, { UserRegisterRequest } from '@/lib/api';
+import { useApiError } from '@/lib/hooks';
+import { appRoutes } from '@/router';
+import { useMutation } from '@tanstack/react-query';
+import { Link, useNavigate } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
+import React from 'react';
 
 export default function Register() {
   useErrorParam();

--- a/frontend/app/src/pages/authenticated.tsx
+++ b/frontend/app/src/pages/authenticated.tsx
@@ -1,24 +1,24 @@
 import MainNav from '@/components/molecules/nav-bar/nav-bar';
+import SupportChat from '@/components/molecules/support-chat';
+import { Loading } from '@/components/v1/ui/loading.tsx';
+import { useTenantDetails } from '@/hooks/use-tenant';
+import api, { queries, User } from '@/lib/api';
+import { cloudApi } from '@/lib/api/api';
+import { lastTenantAtom } from '@/lib/atoms';
+import { useContextFromParent } from '@/lib/outlet';
+import { OutletWithContext } from '@/lib/router-helpers';
+import { useInactivityDetection } from '@/pages/auth/hooks/use-inactivity-detection';
+import { PostHogProvider } from '@/providers/posthog';
+import { appRoutes } from '@/router';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import {
   useLocation,
   useMatchRoute,
   useNavigate,
 } from '@tanstack/react-router';
-import api, { queries, User } from '@/lib/api';
-import { Loading } from '@/components/v1/ui/loading.tsx';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import SupportChat from '@/components/molecules/support-chat';
-import { PostHogProvider } from '@/providers/posthog';
-import { useEffect } from 'react';
-import { useContextFromParent } from '@/lib/outlet';
 import { AxiosError } from 'axios';
-import { useInactivityDetection } from '@/pages/auth/hooks/use-inactivity-detection';
-import { cloudApi } from '@/lib/api/api';
-import { useTenantDetails } from '@/hooks/use-tenant';
-import { OutletWithContext } from '@/lib/router-helpers';
-import { appRoutes } from '@/router';
 import { useAtom } from 'jotai';
-import { lastTenantAtom } from '@/lib/atoms';
+import { useEffect } from 'react';
 
 export default function Authenticated() {
   const { tenant } = useTenantDetails();

--- a/frontend/app/src/pages/error/index.tsx
+++ b/frontend/app/src/pages/error/index.tsx
@@ -1,11 +1,11 @@
 import { Button } from '@/components/v1/ui/button';
-import { PropsWithChildren } from 'react';
+import { appRoutes } from '@/router';
 import {
   ErrorComponentProps,
   useLocation,
   useNavigate,
 } from '@tanstack/react-router';
-import { appRoutes } from '@/router';
+import { PropsWithChildren } from 'react';
 
 export default function ErrorBoundary({ error }: ErrorComponentProps) {
   const navigate = useNavigate();

--- a/frontend/app/src/pages/main/info/components/version-info.tsx
+++ b/frontend/app/src/pages/main/info/components/version-info.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
 import { Spinner } from '@/components/v1/ui/loading';
 import { queries } from '@/lib/api';
 import { useQuery } from '@tanstack/react-query';
+import React from 'react';
 
 export const VersionInfo: React.FC = () => {
   const { data, isLoading, isError, error } = useQuery({

--- a/frontend/app/src/pages/main/v1/events/components/event-columns.tsx
+++ b/frontend/app/src/pages/main/v1/events/components/event-columns.tsx
@@ -1,11 +1,10 @@
-import { ColumnDef } from '@tanstack/react-table';
-import { Badge } from '@/components/v1/ui/badge';
-import { V1Event } from '@/lib/api';
-import { Button } from '@/components/v1/ui/button';
-
 import { AdditionalMetadata } from './additional-metadata';
-import RelativeDate from '@/components/v1/molecules/relative-date';
 import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
+import RelativeDate from '@/components/v1/molecules/relative-date';
+import { Badge } from '@/components/v1/ui/badge';
+import { Button } from '@/components/v1/ui/button';
+import { V1Event } from '@/lib/api';
+import { ColumnDef } from '@tanstack/react-table';
 
 export const EventColumn = {
   id: 'Event ID',

--- a/frontend/app/src/pages/main/v1/events/hooks/use-events.tsx
+++ b/frontend/app/src/pages/main/v1/events/hooks/use-events.tsx
@@ -1,9 +1,4 @@
-import { usePagination } from '@/hooks/use-pagination';
-import { useCurrentTenantId } from '@/hooks/use-tenant';
-import { useRefetchInterval } from '@/contexts/refetch-interval-context';
-import api, { queries, V1TaskStatus } from '@/lib/api';
-import { useQuery } from '@tanstack/react-query';
-import { useMemo } from 'react';
+import { workflowRunStatusFilters } from '../../workflow-runs-v1/hooks/use-toolbar-filters';
 import {
   keyKey,
   workflowKey,
@@ -13,9 +8,14 @@ import {
   scopeKey,
 } from '../components/event-columns';
 import { FilterOption } from '@/components/v1/molecules/data-table/data-table-toolbar';
+import { useRefetchInterval } from '@/contexts/refetch-interval-context';
+import { usePagination } from '@/hooks/use-pagination';
+import { useCurrentTenantId } from '@/hooks/use-tenant';
 import { useZodColumnFilters } from '@/hooks/use-zod-column-filters';
+import api, { queries, V1TaskStatus } from '@/lib/api';
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import { z } from 'zod';
-import { workflowRunStatusFilters } from '../../workflow-runs-v1/hooks/use-toolbar-filters';
 
 type UseEventsProps = {
   key: string;

--- a/frontend/app/src/pages/main/v1/events/index.tsx
+++ b/frontend/app/src/pages/main/v1/events/index.tsx
@@ -1,4 +1,11 @@
 import {
+  FilterColumn,
+  filterColumns,
+} from '../filters/components/filter-columns';
+import { useFilters } from '../filters/hooks/use-filters';
+import { RunsTable } from '../workflow-runs-v1/components/runs-table';
+import { RunsProvider } from '../workflow-runs-v1/hooks/runs-provider';
+import {
   columns,
   EventColumn,
   idKey,
@@ -8,26 +15,18 @@ import {
   statusKey,
   workflowKey,
 } from './components/event-columns';
-import { Separator } from '@/components/v1/ui/separator';
-import { useMemo, useState } from 'react';
-import { VisibilityState } from '@tanstack/react-table';
-import { V1Event, V1Filter } from '@/lib/api';
-import { ToolbarType } from '@/components/v1/molecules/data-table/data-table-toolbar';
-import RelativeDate from '@/components/v1/molecules/relative-date';
-import { DataTable } from '@/components/v1/molecules/data-table/data-table';
-import { RunsTable } from '../workflow-runs-v1/components/runs-table';
-import { RunsProvider } from '../workflow-runs-v1/hooks/runs-provider';
-import { CodeHighlighter } from '@/components/v1/ui/code-highlighter';
-
-import {
-  FilterColumn,
-  filterColumns,
-} from '../filters/components/filter-columns';
-import { useFilters } from '../filters/hooks/use-filters';
-import { useSidePanel } from '@/hooks/use-side-panel';
 import { useEvents } from './hooks/use-events';
 import { DocsButton } from '@/components/v1/docs/docs-button';
+import { DataTable } from '@/components/v1/molecules/data-table/data-table';
+import { ToolbarType } from '@/components/v1/molecules/data-table/data-table-toolbar';
+import RelativeDate from '@/components/v1/molecules/relative-date';
+import { CodeHighlighter } from '@/components/v1/ui/code-highlighter';
+import { Separator } from '@/components/v1/ui/separator';
+import { useSidePanel } from '@/hooks/use-side-panel';
+import { V1Event, V1Filter } from '@/lib/api';
 import { docsPages } from '@/lib/generated/docs';
+import { VisibilityState } from '@tanstack/react-table';
+import { useMemo, useState } from 'react';
 
 export default function Events() {
   const [openMetadataPopover, setOpenMetadataPopover] = useState<string | null>(

--- a/frontend/app/src/pages/main/v1/filters/components/filter-columns.tsx
+++ b/frontend/app/src/pages/main/v1/filters/components/filter-columns.tsx
@@ -1,9 +1,9 @@
-import { ColumnDef } from '@tanstack/react-table';
-import { V1Filter } from '@/lib/api';
 import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
-import { CodeHighlighter } from '@/components/v1/ui/code-highlighter';
-import { CheckIcon } from 'lucide-react';
 import { Button } from '@/components/v1/ui/button';
+import { CodeHighlighter } from '@/components/v1/ui/code-highlighter';
+import { V1Filter } from '@/lib/api';
+import { ColumnDef } from '@tanstack/react-table';
+import { CheckIcon } from 'lucide-react';
 
 export const FilterColumn = {
   id: 'ID',

--- a/frontend/app/src/pages/main/v1/filters/components/filter-create-form.tsx
+++ b/frontend/app/src/pages/main/v1/filters/components/filter-create-form.tsx
@@ -1,4 +1,6 @@
-import { useState } from 'react';
+import { createFilterSchema, CreateFilterFormData } from '../schemas';
+import { FilterOption } from '@/components/v1/molecules/data-table/data-table-toolbar';
+import { Button } from '@/components/v1/ui/button';
 import {
   Dialog,
   DialogContent,
@@ -6,10 +8,8 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/v1/ui/dialog';
-import { Button } from '@/components/v1/ui/button';
 import { Input } from '@/components/v1/ui/input';
 import { Label } from '@/components/v1/ui/label';
-import { Textarea } from '@/components/v1/ui/textarea';
 import {
   Select,
   SelectContent,
@@ -17,12 +17,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/v1/ui/select';
-import { Filter } from 'lucide-react';
-import { FilterOption } from '@/components/v1/molecules/data-table/data-table-toolbar';
-import { useForm, Controller } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { createFilterSchema, CreateFilterFormData } from '../schemas';
+import { Textarea } from '@/components/v1/ui/textarea';
 import { V1CreateFilterRequest } from '@/lib/api';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Filter } from 'lucide-react';
+import { useState } from 'react';
+import { useForm, Controller } from 'react-hook-form';
 
 interface FilterCreateFormProps {
   isOpen: boolean;

--- a/frontend/app/src/pages/main/v1/filters/components/filter-detail-view.tsx
+++ b/frontend/app/src/pages/main/v1/filters/components/filter-detail-view.tsx
@@ -1,8 +1,6 @@
-import { useCallback, useState } from 'react';
+import { useFilterDetails, useFilters } from '../hooks/use-filters';
+import { updateFilterSchema, UpdateFilterFormData } from '../schemas';
 import { Button } from '@/components/v1/ui/button';
-import { Input } from '@/components/v1/ui/input';
-import { Label } from '@/components/v1/ui/label';
-import { Textarea } from '@/components/v1/ui/textarea';
 import {
   Dialog,
   DialogContent,
@@ -11,12 +9,14 @@ import {
   DialogDescription,
   DialogFooter,
 } from '@/components/v1/ui/dialog';
-import { Trash2Icon, EditIcon, SaveIcon, XIcon } from 'lucide-react';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { useFilterDetails, useFilters } from '../hooks/use-filters';
-import { updateFilterSchema, UpdateFilterFormData } from '../schemas';
+import { Input } from '@/components/v1/ui/input';
+import { Label } from '@/components/v1/ui/label';
+import { Textarea } from '@/components/v1/ui/textarea';
 import { useSidePanel } from '@/hooks/use-side-panel';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Trash2Icon, EditIcon, SaveIcon, XIcon } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { useForm } from 'react-hook-form';
 
 interface FilterDetailViewProps {
   filterId: string;

--- a/frontend/app/src/pages/main/v1/filters/hooks/use-filters.tsx
+++ b/frontend/app/src/pages/main/v1/filters/hooks/use-filters.tsx
@@ -1,17 +1,17 @@
+import { scopeKey, workflowIdKey } from '../components/filter-columns';
+import { FilterOption } from '@/components/v1/molecules/data-table/data-table-toolbar';
+import { useRefetchInterval } from '@/contexts/refetch-interval-context';
 import { usePagination } from '@/hooks/use-pagination';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
-import { useRefetchInterval } from '@/contexts/refetch-interval-context';
 import api, {
   queries,
   V1CreateFilterRequest,
   V1UpdateFilterRequest,
 } from '@/lib/api';
+import { useSearchParams } from '@/lib/router-helpers';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ColumnFiltersState, Updater } from '@tanstack/react-table';
 import { useCallback, useMemo } from 'react';
-import { useSearchParams } from '@/lib/router-helpers';
-import { scopeKey, workflowIdKey } from '../components/filter-columns';
-import { FilterOption } from '@/components/v1/molecules/data-table/data-table-toolbar';
 
 type UseFiltersProps = {
   key: string;

--- a/frontend/app/src/pages/main/v1/filters/index.tsx
+++ b/frontend/app/src/pages/main/v1/filters/index.tsx
@@ -6,15 +6,15 @@ import {
   workflowIdKey,
 } from './components/filter-columns';
 import { FilterCreateButton } from './components/filter-create-form';
-import { useState } from 'react';
-import { VisibilityState } from '@tanstack/react-table';
-import { ToolbarType } from '@/components/v1/molecules/data-table/data-table-toolbar';
-import { DataTable } from '@/components/v1/molecules/data-table/data-table';
 import { useFilters } from './hooks/use-filters';
-import { V1Filter } from '@/lib/api';
-import { useSidePanel } from '@/hooks/use-side-panel';
 import { DocsButton } from '@/components/v1/docs/docs-button';
+import { DataTable } from '@/components/v1/molecules/data-table/data-table';
+import { ToolbarType } from '@/components/v1/molecules/data-table/data-table-toolbar';
+import { useSidePanel } from '@/hooks/use-side-panel';
+import { V1Filter } from '@/lib/api';
 import { docsPages } from '@/lib/generated/docs';
+import { VisibilityState } from '@tanstack/react-table';
+import { useState } from 'react';
 
 export default function Filters() {
   const sidePanel = useSidePanel();

--- a/frontend/app/src/pages/main/v1/index.tsx
+++ b/frontend/app/src/pages/main/v1/index.tsx
@@ -1,18 +1,8 @@
-import { Button } from '@/components/v1/ui/button';
-import { cn } from '@/lib/utils';
-import {
-  CalendarDaysIcon,
-  CpuChipIcon,
-  PlayIcon,
-  ScaleIcon,
-  ServerStackIcon,
-  Squares2X2Icon,
-} from '@heroicons/react/24/outline';
-
 import { SidePanel } from '@/components/side-panel';
 import { useSidebar } from '@/components/sidebar-provider';
 import { OrganizationSelector } from '@/components/v1/molecules/nav-bar/organization-selector';
 import { TenantSwitcher } from '@/components/v1/molecules/nav-bar/tenant-switcher';
+import { Button } from '@/components/v1/ui/button';
 import {
   Collapsible,
   CollapsibleContent,
@@ -26,14 +16,23 @@ import {
   UserContextType,
   useContextFromParent,
 } from '@/lib/outlet';
+import { OutletWithContext, useOutletContext } from '@/lib/router-helpers';
+import { cn } from '@/lib/utils';
 import useCloudApiMeta from '@/pages/auth/hooks/use-cloud-api-meta';
 import useCloudFeatureFlags from '@/pages/auth/hooks/use-cloud-feature-flags';
+import { appRoutes } from '@/router';
+import {
+  CalendarDaysIcon,
+  CpuChipIcon,
+  PlayIcon,
+  ScaleIcon,
+  ServerStackIcon,
+  Squares2X2Icon,
+} from '@heroicons/react/24/outline';
 import { ClockIcon, GearIcon } from '@radix-ui/react-icons';
+import { Link, useMatchRoute } from '@tanstack/react-router';
 import { Filter, SquareActivityIcon, WebhookIcon } from 'lucide-react';
 import React, { useCallback } from 'react';
-import { Link, useMatchRoute } from '@tanstack/react-router';
-import { OutletWithContext, useOutletContext } from '@/lib/router-helpers';
-import { appRoutes } from '@/router';
 
 function Main() {
   const ctx = useOutletContext<UserContextType & MembershipsContextType>();

--- a/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/components/managed-worker-activity.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/components/managed-worker-activity.tsx
@@ -1,5 +1,8 @@
-import { queries } from '@/lib/api';
-import { useQuery } from '@tanstack/react-query';
+import GithubButton from './github-button';
+import { ManagedWorkerBuild } from './managed-worker-build';
+import { ManagedWorkerIaC } from './managed-worker-iac';
+import RelativeDate from '@/components/v1/molecules/relative-date';
+import { Button } from '@/components/v1/ui/button';
 import {
   Card,
   CardContent,
@@ -9,21 +12,18 @@ import {
   CardTitle,
 } from '@/components/v1/ui/card';
 import { Spinner } from '@/components/v1/ui/loading';
-import RelativeDate from '@/components/v1/molecules/relative-date';
-import { Button } from '@/components/v1/ui/button';
-import { ArrowRightIcon, ChevronLeftIcon } from '@radix-ui/react-icons';
-import { cn } from '@/lib/utils';
-import { useState } from 'react';
+import { Separator } from '@/components/v1/ui/separator';
+import { useRefetchInterval } from '@/contexts/refetch-interval-context';
+import { queries } from '@/lib/api';
 import {
   ManagedWorker,
   ManagedWorkerEvent,
   ManagedWorkerEventStatus,
 } from '@/lib/api/generated/cloud/data-contracts';
-import { Separator } from '@/components/v1/ui/separator';
-import { ManagedWorkerBuild } from './managed-worker-build';
-import GithubButton from './github-button';
-import { ManagedWorkerIaC } from './managed-worker-iac';
-import { useRefetchInterval } from '@/contexts/refetch-interval-context';
+import { cn } from '@/lib/utils';
+import { ArrowRightIcon, ChevronLeftIcon } from '@radix-ui/react-icons';
+import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 
 export function ManagedWorkerActivity({
   managedWorker,

--- a/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/components/managed-worker-build-logs.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/components/managed-worker-build-logs.tsx
@@ -1,7 +1,7 @@
-import { queries } from '@/lib/api';
-import { useQuery } from '@tanstack/react-query';
 import LoggingComponent from '@/components/v1/cloud/logging/logs';
 import { useRefetchInterval } from '@/contexts/refetch-interval-context';
+import { queries } from '@/lib/api';
+import { useQuery } from '@tanstack/react-query';
 
 export function ManagedWorkerBuildLogs({ buildId }: { buildId: string }) {
   const { refetchInterval } = useRefetchInterval();

--- a/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/components/managed-worker-build.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/components/managed-worker-build.tsx
@@ -1,8 +1,8 @@
-import { queries } from '@/lib/api';
-import { useQuery } from '@tanstack/react-query';
-import { Spinner } from '@/components/v1/ui/loading';
 import { ManagedWorkerBuildLogs } from './managed-worker-build-logs';
 import RelativeDate from '@/components/v1/molecules/relative-date';
+import { Spinner } from '@/components/v1/ui/loading';
+import { queries } from '@/lib/api';
+import { useQuery } from '@tanstack/react-query';
 
 export function ManagedWorkerBuild({ buildId }: { buildId: string }) {
   const getBuildQuery = useQuery({

--- a/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/components/managed-worker-iac-logs.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/components/managed-worker-iac-logs.tsx
@@ -1,7 +1,7 @@
-import { queries } from '@/lib/api';
-import { useQuery } from '@tanstack/react-query';
 import LoggingComponent from '@/components/v1/cloud/logging/logs';
 import { useRefetchInterval } from '@/contexts/refetch-interval-context';
+import { queries } from '@/lib/api';
+import { useQuery } from '@tanstack/react-query';
 
 export function ManagedWorkerIaCLogs({
   managedWorkerId,

--- a/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/components/managed-worker-instances-columns.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/components/managed-worker-instances-columns.tsx
@@ -1,6 +1,6 @@
-import { ColumnDef } from '@tanstack/react-table';
 import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
 import { Instance } from '@/lib/api/generated/cloud/data-contracts';
+import { ColumnDef } from '@tanstack/react-table';
 
 type InstanceWithMetadata = Instance & {
   metadata: {

--- a/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/components/managed-worker-instances-table.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/components/managed-worker-instances-table.tsx
@@ -1,9 +1,6 @@
-import { useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { queries } from '@/lib/api';
-import { DataTable } from '@/components/v1/molecules/data-table/data-table.tsx';
 import { columns } from './managed-worker-instances-columns';
-import { Loading } from '@/components/v1/ui/loading.tsx';
+import { DataTable } from '@/components/v1/molecules/data-table/data-table.tsx';
+import { Badge } from '@/components/v1/ui/badge';
 import { Button } from '@/components/v1/ui/button';
 import {
   Card,
@@ -12,13 +9,16 @@ import {
   CardDescription,
   CardFooter,
 } from '@/components/v1/ui/card';
+import { Loading } from '@/components/v1/ui/loading.tsx';
+import { useRefetchInterval } from '@/contexts/refetch-interval-context';
+import { queries } from '@/lib/api';
+import { Instance } from '@/lib/api/generated/cloud/data-contracts';
 import { capitalize } from '@/lib/utils';
 import { ArrowPathIcon } from '@heroicons/react/24/outline';
+import { useQuery } from '@tanstack/react-query';
 import { VisibilityState } from '@tanstack/react-table';
+import { useMemo, useState } from 'react';
 import { BiCard, BiTable } from 'react-icons/bi';
-import { Instance } from '@/lib/api/generated/cloud/data-contracts';
-import { Badge } from '@/components/v1/ui/badge';
-import { useRefetchInterval } from '@/contexts/refetch-interval-context';
 
 export function ManagedWorkerInstancesTable({
   managedWorkerId,

--- a/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/components/managed-worker-logs.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/components/managed-worker-logs.tsx
@@ -1,17 +1,17 @@
+import LoggingComponent from '@/components/v1/cloud/logging/logs';
+import { DateTimePicker } from '@/components/v1/molecules/time-picker/date-time-picker';
+import { Button } from '@/components/v1/ui/button';
+import { Input } from '@/components/v1/ui/input';
+import { useRefetchInterval } from '@/contexts/refetch-interval-context';
 import { queries } from '@/lib/api';
-import { useQuery } from '@tanstack/react-query';
 import {
   LogLine,
   ManagedWorker,
 } from '@/lib/api/generated/cloud/data-contracts';
-import LoggingComponent from '@/components/v1/cloud/logging/logs';
-import { useState, useEffect } from 'react';
-import { Input } from '@/components/v1/ui/input';
-import { DateTimePicker } from '@/components/v1/molecules/time-picker/date-time-picker';
-import { Button } from '@/components/v1/ui/button';
-import { ArrowPathIcon } from '@heroicons/react/24/outline';
 import { ListCloudLogsQuery } from '@/lib/api/queries';
-import { useRefetchInterval } from '@/contexts/refetch-interval-context';
+import { ArrowPathIcon } from '@heroicons/react/24/outline';
+import { useQuery } from '@tanstack/react-query';
+import { useState, useEffect } from 'react';
 
 export function ManagedWorkerLogs({
   managedWorker,

--- a/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/components/managed-worker-metrics.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/components/managed-worker-metrics.tsx
@@ -1,22 +1,10 @@
-import { queries } from '@/lib/api';
-import { useQuery } from '@tanstack/react-query';
-import {
-  ManagedWorker,
-  Matrix,
-} from '@/lib/api/generated/cloud/data-contracts';
-import { Loading } from '@/components/v1/ui/loading';
-import { useEffect, useMemo, useState } from 'react';
-import { Separator } from '@/components/v1/ui/separator';
-import { DateTimePicker } from '@/components/v1/molecules/time-picker/date-time-picker';
-import { Button } from '@/components/v1/ui/button';
-import { XCircleIcon } from '@heroicons/react/24/outline';
 import {
   DataPoint,
   ZoomableChart,
 } from '@/components/v1/molecules/charts/zoomable';
-import { useAtom } from 'jotai';
-import { lastWorkerMetricsTimeRangeAtom } from '@/lib/atoms';
-import { getCreatedAfterFromTimeRange } from '@/pages/main/workflow-runs/components/workflow-runs-table';
+import { DateTimePicker } from '@/components/v1/molecules/time-picker/date-time-picker';
+import { Button } from '@/components/v1/ui/button';
+import { Loading } from '@/components/v1/ui/loading';
 import {
   Select,
   SelectContent,
@@ -24,7 +12,19 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/v1/ui/select';
+import { Separator } from '@/components/v1/ui/separator';
 import { useRefetchInterval } from '@/contexts/refetch-interval-context';
+import { queries } from '@/lib/api';
+import {
+  ManagedWorker,
+  Matrix,
+} from '@/lib/api/generated/cloud/data-contracts';
+import { lastWorkerMetricsTimeRangeAtom } from '@/lib/atoms';
+import { getCreatedAfterFromTimeRange } from '@/pages/main/workflow-runs/components/workflow-runs-table';
+import { XCircleIcon } from '@heroicons/react/24/outline';
+import { useQuery } from '@tanstack/react-query';
+import { useAtom } from 'jotai';
+import { useEffect, useMemo, useState } from 'react';
 
 export function ManagedWorkerMetrics({
   managedWorker,

--- a/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/components/update-form.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/components/update-form.tsx
@@ -1,21 +1,3 @@
-import { queries } from '@/lib/api';
-import { useEffect, useMemo, useState } from 'react';
-import { Button } from '@/components/v1/ui/button';
-import { useQuery } from '@tanstack/react-query';
-import { ExclamationTriangleIcon, PlusIcon } from '@heroicons/react/24/outline';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/v1/ui/select';
-import { z } from 'zod';
-import { Controller, useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { Label } from '@/components/v1/ui/label';
-import { Alert, AlertDescription, AlertTitle } from '@/components/v1/ui/alert';
-import { Input } from '@/components/v1/ui/input';
 import {
   getRepoName,
   getRepoOwner,
@@ -25,30 +7,48 @@ import {
   ScalingType,
   scalingTypes,
 } from '../../create/components/create-worker-form';
-import {
-  ManagedWorker,
-  ManagedWorkerRegion,
-} from '@/lib/api/generated/cloud/data-contracts';
+import { UpgradeMessage } from '../../create/components/create-worker-form';
 import {
   Accordion,
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
 } from '@/components/v1/ui/accordion';
+import { Alert, AlertDescription, AlertTitle } from '@/components/v1/ui/alert';
+import { Button } from '@/components/v1/ui/button';
+import { Checkbox } from '@/components/v1/ui/checkbox';
+import EnvGroupArray, { KeyValueType } from '@/components/v1/ui/envvar';
+import { Input } from '@/components/v1/ui/input';
+import { Label } from '@/components/v1/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/v1/ui/select';
 import {
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
 } from '@/components/v1/ui/tabs';
-import { Checkbox } from '@/components/v1/ui/checkbox';
-import { UpgradeMessage } from '../../create/components/create-worker-form';
+import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
+import { queries } from '@/lib/api';
+import {
+  ManagedWorker,
+  ManagedWorkerRegion,
+} from '@/lib/api/generated/cloud/data-contracts';
 import {
   ComputeType,
   managedCompute,
 } from '@/lib/can/features/managed-compute';
-import EnvGroupArray, { KeyValueType } from '@/components/v1/ui/envvar';
-import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
+import { ExclamationTriangleIcon, PlusIcon } from '@heroicons/react/24/outline';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 interface UpdateWorkerFormProps {
   onSubmit: (opts: z.infer<typeof updateManagedWorkerSchema>) => void;

--- a/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/index.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/index.tsx
@@ -1,31 +1,31 @@
-import { Separator } from '@/components/v1/ui/separator';
-import { queries } from '@/lib/api';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { useNavigate, useParams } from '@tanstack/react-router';
-import { relativeDate } from '@/lib/utils';
-import { CpuChipIcon } from '@heroicons/react/24/outline';
-import { Loading } from '@/components/v1/ui/loading.tsx';
-import { useState } from 'react';
+import GithubButton from './components/github-button';
+import { ManagedWorkerActivity } from './components/managed-worker-activity';
+import { ManagedWorkerInstancesTable } from './components/managed-worker-instances-table';
+import { ManagedWorkerLogs } from './components/managed-worker-logs';
+import { ManagedWorkerMetrics } from './components/managed-worker-metrics';
+import UpdateWorkerForm from './components/update-form';
+import { ConfirmDialog } from '@/components/v1/molecules/confirm-dialog';
 import { Button } from '@/components/v1/ui/button';
+import { Loading } from '@/components/v1/ui/loading.tsx';
+import { Separator } from '@/components/v1/ui/separator';
 import {
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
 } from '@/components/v1/ui/tabs';
-import { ConfirmDialog } from '@/components/v1/molecules/confirm-dialog';
-import { ManagedWorkerLogs } from './components/managed-worker-logs';
-import { ManagedWorkerMetrics } from './components/managed-worker-metrics';
-import { ManagedWorkerActivity } from './components/managed-worker-activity';
-import { UpdateManagedWorkerRequest } from '@/lib/api/generated/cloud/data-contracts';
-import { ManagedWorkerInstancesTable } from './components/managed-worker-instances-table';
-import UpdateWorkerForm from './components/update-form';
-import { cloudApi } from '@/lib/api/api';
-import { useApiError } from '@/lib/hooks';
-import GithubButton from './components/github-button';
-import { useCurrentTenantId } from '@/hooks/use-tenant';
 import { useRefetchInterval } from '@/contexts/refetch-interval-context';
+import { useCurrentTenantId } from '@/hooks/use-tenant';
+import { queries } from '@/lib/api';
+import { cloudApi } from '@/lib/api/api';
+import { UpdateManagedWorkerRequest } from '@/lib/api/generated/cloud/data-contracts';
+import { useApiError } from '@/lib/hooks';
+import { relativeDate } from '@/lib/utils';
 import { appRoutes } from '@/router';
+import { CpuChipIcon } from '@heroicons/react/24/outline';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useNavigate, useParams } from '@tanstack/react-router';
+import { useState } from 'react';
 
 export default function ExpandedWorkflow() {
   const navigate = useNavigate();

--- a/frontend/app/src/pages/main/v1/managed-workers/components/billing-required.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/components/billing-required.tsx
@@ -1,14 +1,14 @@
 import { Button } from '@/components/v1/ui/button';
-import { Link } from '@tanstack/react-router';
+import { useCurrentTenantId } from '@/hooks/use-tenant';
+import { queries } from '@/lib/api/queries';
+import { appRoutes } from '@/router';
 import {
   CalendarIcon,
   CpuChipIcon,
   CurrencyDollarIcon,
 } from '@heroicons/react/24/outline';
 import { useQuery } from '@tanstack/react-query';
-import { queries } from '@/lib/api/queries';
-import { useCurrentTenantId } from '@/hooks/use-tenant';
-import { appRoutes } from '@/router';
+import { Link } from '@tanstack/react-router';
 
 interface BillingRequiredProps {
   tenant: any;

--- a/frontend/app/src/pages/main/v1/managed-workers/components/managed-worker-columns.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/components/managed-worker-columns.tsx
@@ -1,10 +1,10 @@
-import { ColumnDef } from '@tanstack/react-table';
-import { Link } from '@tanstack/react-router';
-import { ChevronRightIcon } from '@radix-ui/react-icons';
-import RelativeDate from '@/components/v1/molecules/relative-date';
 import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
+import RelativeDate from '@/components/v1/molecules/relative-date';
 import { ManagedWorker } from '@/lib/api/generated/cloud/data-contracts';
 import { appRoutes } from '@/router';
+import { ChevronRightIcon } from '@radix-ui/react-icons';
+import { Link } from '@tanstack/react-router';
+import { ColumnDef } from '@tanstack/react-table';
 
 export const columns: (tenantId: string) => ColumnDef<ManagedWorker>[] = (
   tenantId,

--- a/frontend/app/src/pages/main/v1/managed-workers/components/managed-workers-table.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/components/managed-workers-table.tsx
@@ -1,10 +1,7 @@
-import { useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { queries } from '@/lib/api';
-import { Link } from '@tanstack/react-router';
-import { DataTable } from '@/components/v1/molecules/data-table/data-table.tsx';
+import GithubButton from '../$managed-worker/components/github-button';
 import { columns } from './managed-worker-columns';
-import { Loading } from '@/components/v1/ui/loading.tsx';
+import { DataTable } from '@/components/v1/molecules/data-table/data-table.tsx';
+import RelativeDate from '@/components/v1/molecules/relative-date';
 import { Button } from '@/components/v1/ui/button';
 import {
   Card,
@@ -13,15 +10,18 @@ import {
   CardDescription,
   CardFooter,
 } from '@/components/v1/ui/card';
-import { ArrowPathIcon, CpuChipIcon } from '@heroicons/react/24/outline';
-import { SortingState, VisibilityState } from '@tanstack/react-table';
-import { BiCard, BiTable } from 'react-icons/bi';
-import RelativeDate from '@/components/v1/molecules/relative-date';
-import { ManagedWorker } from '@/lib/api/generated/cloud/data-contracts';
-import GithubButton from '../$managed-worker/components/github-button';
-import { useCurrentTenantId } from '@/hooks/use-tenant';
+import { Loading } from '@/components/v1/ui/loading.tsx';
 import { useRefetchInterval } from '@/contexts/refetch-interval-context';
+import { useCurrentTenantId } from '@/hooks/use-tenant';
+import { queries } from '@/lib/api';
+import { ManagedWorker } from '@/lib/api/generated/cloud/data-contracts';
 import { appRoutes } from '@/router';
+import { ArrowPathIcon, CpuChipIcon } from '@heroicons/react/24/outline';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
+import { SortingState, VisibilityState } from '@tanstack/react-table';
+import { useMemo, useState } from 'react';
+import { BiCard, BiTable } from 'react-icons/bi';
 
 export function ManagedWorkersTable() {
   const { tenantId } = useCurrentTenantId();

--- a/frontend/app/src/pages/main/v1/managed-workers/create/components/create-worker-form.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/create/components/create-worker-form.tsx
@@ -1,8 +1,14 @@
-import { queries } from '@/lib/api';
-import { useEffect, useState, useMemo } from 'react';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/v1/ui/accordion';
 import { Button } from '@/components/v1/ui/button';
-import { useQuery } from '@tanstack/react-query';
-import { PlusIcon, ArrowUpIcon } from '@heroicons/react/24/outline';
+import { Checkbox } from '@/components/v1/ui/checkbox';
+import EnvGroupArray, { KeyValueType } from '@/components/v1/ui/envvar';
+import { Input } from '@/components/v1/ui/input';
+import { Label } from '@/components/v1/ui/label';
 import {
   Select,
   SelectContent,
@@ -10,32 +16,26 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/v1/ui/select';
-import { z } from 'zod';
-import { Controller, useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { Label } from '@/components/v1/ui/label';
-import { Input } from '@/components/v1/ui/input';
 import { Step, Steps } from '@/components/v1/ui/steps';
-import EnvGroupArray, { KeyValueType } from '@/components/v1/ui/envvar';
-import { ManagedWorkerRegion } from '@/lib/api/generated/cloud/data-contracts';
 import {
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
 } from '@/components/v1/ui/tabs';
-import { Checkbox } from '@/components/v1/ui/checkbox';
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from '@/components/v1/ui/accordion';
+import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
+import { queries } from '@/lib/api';
+import { ManagedWorkerRegion } from '@/lib/api/generated/cloud/data-contracts';
 import {
   managedCompute,
   ComputeType,
 } from '@/lib/can/features/managed-compute';
-import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
+import { PlusIcon, ArrowUpIcon } from '@heroicons/react/24/outline';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useState, useMemo } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 export const machineTypes = [
   {

--- a/frontend/app/src/pages/main/v1/managed-workers/create/index.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/create/index.tsx
@@ -1,17 +1,17 @@
-import { Separator } from '@/components/v1/ui/separator';
-import { useNavigate } from '@tanstack/react-router';
-import { ServerStackIcon } from '@heroicons/react/24/outline';
+import { BillingRequired } from '../components/billing-required';
 import CreateWorkerForm from './components/create-worker-form';
-import { useMutation } from '@tanstack/react-query';
-import { CreateManagedWorkerRequest } from '@/lib/api/generated/cloud/data-contracts';
+import { Separator } from '@/components/v1/ui/separator';
+import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
 import { cloudApi } from '@/lib/api/api';
-import { useState } from 'react';
-import { useApiError } from '@/lib/hooks';
+import { CreateManagedWorkerRequest } from '@/lib/api/generated/cloud/data-contracts';
 import { managedCompute } from '@/lib/can/features/managed-compute';
 import { RejectReason } from '@/lib/can/shared/permission.base';
-import { BillingRequired } from '../components/billing-required';
-import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
+import { useApiError } from '@/lib/hooks';
 import { appRoutes } from '@/router';
+import { ServerStackIcon } from '@heroicons/react/24/outline';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { useState } from 'react';
 
 export default function CreateWorker() {
   const navigate = useNavigate();

--- a/frontend/app/src/pages/main/v1/managed-workers/demo-template/index.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/demo-template/index.tsx
@@ -1,36 +1,36 @@
 import { Button } from '@/components/v1/ui/button';
-import { Separator } from '@/components/v1/ui/separator';
-import { Link } from '@tanstack/react-router';
-import { useState, useEffect, useCallback } from 'react';
-import { ArrowLeftIcon } from '@radix-ui/react-icons';
-import {
-  PlayIcon,
-  CheckCircleIcon,
-  ArrowPathIcon,
-  KeyIcon,
-} from '@heroicons/react/24/outline';
-import { Step, Steps } from '@/components/v1/ui/steps';
-import { CodeHighlighter } from '@/components/v1/ui/code-highlighter';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { queries } from '@/lib/api/queries';
-import {
-  ManagedWorkerEventStatus,
-  TemplateOptions,
-} from '@/lib/api/generated/cloud/data-contracts';
-import { RadioGroup, RadioGroupItem } from '@/components/v1/ui/radio-group';
-import { Label } from '@/components/v1/ui/label';
 import { Card } from '@/components/v1/ui/card';
-import { cloudApi } from '@/lib/api/api';
-import api from '@/lib/api';
+import { CodeHighlighter } from '@/components/v1/ui/code-highlighter';
+import { Label } from '@/components/v1/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/v1/ui/radio-group';
+import { Separator } from '@/components/v1/ui/separator';
+import { Step, Steps } from '@/components/v1/ui/steps';
 import {
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
 } from '@/components/v1/ui/tabs';
-import { GitHubLogoIcon } from '@radix-ui/react-icons';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
+import api from '@/lib/api';
+import { cloudApi } from '@/lib/api/api';
+import {
+  ManagedWorkerEventStatus,
+  TemplateOptions,
+} from '@/lib/api/generated/cloud/data-contracts';
+import { queries } from '@/lib/api/queries';
 import { appRoutes } from '@/router';
+import {
+  PlayIcon,
+  CheckCircleIcon,
+  ArrowPathIcon,
+  KeyIcon,
+} from '@heroicons/react/24/outline';
+import { ArrowLeftIcon } from '@radix-ui/react-icons';
+import { GitHubLogoIcon } from '@radix-ui/react-icons';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
+import { useState, useEffect, useCallback } from 'react';
 
 export default function DemoTemplate() {
   const { tenantId } = useCurrentTenantId();

--- a/frontend/app/src/pages/main/v1/managed-workers/index.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/index.tsx
@@ -1,19 +1,19 @@
-import { Separator } from '@/components/v1/ui/separator';
-import { Link } from '@tanstack/react-router';
+import { BillingRequired } from './components/billing-required';
 import { ManagedWorkersTable } from './components/managed-workers-table';
+import { MonthlyUsageCard } from './components/monthly-usage-card';
 import { Button } from '@/components/v1/ui/button';
+import { Separator } from '@/components/v1/ui/separator';
+import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
 import { cloudApi } from '@/lib/api/api';
-import { useApiError } from '@/lib/hooks';
-import { useEffect, useState } from 'react';
+import { queries } from '@/lib/api/queries';
 import { managedCompute } from '@/lib/can/features/managed-compute';
 import { RejectReason } from '@/lib/can/shared/permission.base';
-import { BillingRequired } from './components/billing-required';
-import { queries } from '@/lib/api/queries';
-import { useQuery } from '@tanstack/react-query';
-import { PlusIcon, ArrowUpIcon } from '@radix-ui/react-icons';
-import { MonthlyUsageCard } from './components/monthly-usage-card';
-import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
+import { useApiError } from '@/lib/hooks';
 import { appRoutes } from '@/router';
+import { PlusIcon, ArrowUpIcon } from '@radix-ui/react-icons';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
 
 export default function ManagedWorkers() {
   const { tenant, billing, can } = useTenantDetails();

--- a/frontend/app/src/pages/main/v1/rate-limits/components/rate-limit-columns.tsx
+++ b/frontend/app/src/pages/main/v1/rate-limits/components/rate-limit-columns.tsx
@@ -1,9 +1,9 @@
-import { ColumnDef } from '@tanstack/react-table';
-import RelativeDate from '@/components/v1/molecules/relative-date';
 import { LimitIndicator } from '../../tenant-settings/resource-limits/components/resource-limit-columns';
-import { capitalize } from '@/lib/utils';
-import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
 import { RateLimitWithMetadata } from '../hooks/use-rate-limits';
+import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
+import RelativeDate from '@/components/v1/molecules/relative-date';
+import { capitalize } from '@/lib/utils';
+import { ColumnDef } from '@tanstack/react-table';
 
 export const RateLimitColumn = {
   key: 'Key',

--- a/frontend/app/src/pages/main/v1/rate-limits/hooks/use-rate-limits.tsx
+++ b/frontend/app/src/pages/main/v1/rate-limits/hooks/use-rate-limits.tsx
@@ -1,5 +1,8 @@
+import { keyKey } from '../components/rate-limit-columns';
+import { useRefetchInterval } from '@/contexts/refetch-interval-context';
 import { usePagination } from '@/hooks/use-pagination';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
+import { useZodColumnFilters } from '@/hooks/use-zod-column-filters';
 import {
   queries,
   RateLimit,
@@ -8,10 +11,7 @@ import {
 } from '@/lib/api';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import { keyKey } from '../components/rate-limit-columns';
 import { useDebounce } from 'use-debounce';
-import { useRefetchInterval } from '@/contexts/refetch-interval-context';
-import { useZodColumnFilters } from '@/hooks/use-zod-column-filters';
 import { z } from 'zod';
 
 const rateLimitQuerySchema = z

--- a/frontend/app/src/pages/main/v1/rate-limits/index.tsx
+++ b/frontend/app/src/pages/main/v1/rate-limits/index.tsx
@@ -3,11 +3,11 @@ import {
   keyKey,
   RateLimitColumn,
 } from './components/rate-limit-columns';
-import { useState } from 'react';
-import { VisibilityState } from '@tanstack/react-table';
-import { DataTable } from '@/components/v1/molecules/data-table/data-table';
 import { useRateLimits } from './hooks/use-rate-limits';
+import { DataTable } from '@/components/v1/molecules/data-table/data-table';
 import { ToolbarType } from '@/components/v1/molecules/data-table/data-table-toolbar';
+import { VisibilityState } from '@tanstack/react-table';
+import { useState } from 'react';
 
 export default function RateLimits() {
   return <RateLimitsTable />;

--- a/frontend/app/src/pages/main/v1/recurring/components/recurring-columns.tsx
+++ b/frontend/app/src/pages/main/v1/recurring/components/recurring-columns.tsx
@@ -1,15 +1,15 @@
-import { ColumnDef } from '@tanstack/react-table';
-import { CronWorkflows } from '@/lib/api';
-import RelativeDate from '@/components/v1/molecules/relative-date';
-import { Link } from '@tanstack/react-router';
-import { DataTableRowActions } from '@/components/v1/molecules/data-table/data-table-row-actions';
 import { AdditionalMetadata } from '../../events/components/additional-metadata';
-import { Badge } from '@/components/v1/ui/badge';
 import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
-import { extractCronTz, formatCron } from '@/lib/cron';
-import { Check, X } from 'lucide-react';
+import { DataTableRowActions } from '@/components/v1/molecules/data-table/data-table-row-actions';
+import RelativeDate from '@/components/v1/molecules/relative-date';
+import { Badge } from '@/components/v1/ui/badge';
 import { Spinner } from '@/components/v1/ui/loading';
+import { CronWorkflows } from '@/lib/api';
+import { extractCronTz, formatCron } from '@/lib/cron';
 import { appRoutes } from '@/router';
+import { Link } from '@tanstack/react-router';
+import { ColumnDef } from '@tanstack/react-table';
+import { Check, X } from 'lucide-react';
 
 export const CronColumn = {
   expression: 'Expression',

--- a/frontend/app/src/pages/main/v1/recurring/hooks/use-crons.tsx
+++ b/frontend/app/src/pages/main/v1/recurring/hooks/use-crons.tsx
@@ -1,19 +1,19 @@
+import { workflowKey, metadataKey } from '../components/recurring-columns';
+import { FilterOption } from '@/components/v1/molecules/data-table/data-table-toolbar';
+import { useRefetchInterval } from '@/contexts/refetch-interval-context';
 import { usePagination } from '@/hooks/use-pagination';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
-import { useRefetchInterval } from '@/contexts/refetch-interval-context';
+import { useZodColumnFilters } from '@/hooks/use-zod-column-filters';
 import api, {
   queries,
   CronWorkflowsOrderByField,
   WorkflowRunOrderByDirection,
   UpdateCronWorkflowTriggerRequest,
 } from '@/lib/api';
+import queryClient from '@/query-client';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
-import { FilterOption } from '@/components/v1/molecules/data-table/data-table-toolbar';
-import { useZodColumnFilters } from '@/hooks/use-zod-column-filters';
 import { z } from 'zod';
-import { workflowKey, metadataKey } from '../components/recurring-columns';
-import queryClient from '@/query-client';
 
 type UseCronsProps = {
   key: string;

--- a/frontend/app/src/pages/main/v1/recurring/index.tsx
+++ b/frontend/app/src/pages/main/v1/recurring/index.tsx
@@ -1,24 +1,24 @@
-import { useState } from 'react';
-import { VisibilityState } from '@tanstack/react-table';
-import { CronWorkflows } from '@/lib/api';
-import { DataTable } from '@/components/v1/molecules/data-table/data-table';
-import { columns } from './components/recurring-columns';
-import { Button } from '@/components/v1/ui/button';
+import { TriggerWorkflowForm } from '../workflows/$workflow/components/trigger-workflow-form';
 import { DeleteCron } from './components/delete-cron';
-import {
-  ToolbarFilters,
-  ToolbarType,
-} from '@/components/v1/molecules/data-table/data-table-toolbar';
-import { useCurrentTenantId } from '@/hooks/use-tenant';
-import { DocsButton } from '@/components/v1/docs/docs-button';
-import { docsPages } from '@/lib/generated/docs';
-import { useCrons } from './hooks/use-crons';
+import { columns } from './components/recurring-columns';
 import {
   CronColumn,
   workflowKey,
   metadataKey,
 } from './components/recurring-columns';
-import { TriggerWorkflowForm } from '../workflows/$workflow/components/trigger-workflow-form';
+import { useCrons } from './hooks/use-crons';
+import { DocsButton } from '@/components/v1/docs/docs-button';
+import { DataTable } from '@/components/v1/molecules/data-table/data-table';
+import {
+  ToolbarFilters,
+  ToolbarType,
+} from '@/components/v1/molecules/data-table/data-table-toolbar';
+import { Button } from '@/components/v1/ui/button';
+import { useCurrentTenantId } from '@/hooks/use-tenant';
+import { CronWorkflows } from '@/lib/api';
+import { docsPages } from '@/lib/generated/docs';
+import { VisibilityState } from '@tanstack/react-table';
+import { useState } from 'react';
 
 export default function CronsTable() {
   const { tenantId } = useCurrentTenantId();

--- a/frontend/app/src/pages/main/v1/scheduled-runs/components/expanded-scheduled-run-content.tsx
+++ b/frontend/app/src/pages/main/v1/scheduled-runs/components/expanded-scheduled-run-content.tsx
@@ -1,11 +1,11 @@
-import { ScheduledWorkflows } from '@/lib/api';
-import { Separator } from '@/components/v1/ui/separator';
+import { RunStatus } from '../../workflow-runs/components/run-statuses';
 import RelativeDate from '@/components/v1/molecules/relative-date';
 import { CodeHighlighter } from '@/components/v1/ui/code-highlighter';
-import { Link } from '@tanstack/react-router';
+import { Separator } from '@/components/v1/ui/separator';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
-import { RunStatus } from '../../workflow-runs/components/run-statuses';
+import { ScheduledWorkflows } from '@/lib/api';
 import { appRoutes } from '@/router';
+import { Link } from '@tanstack/react-router';
 
 export function ExpandedScheduledRunContent({
   scheduledRun,

--- a/frontend/app/src/pages/main/v1/scheduled-runs/components/scheduled-runs-columns.tsx
+++ b/frontend/app/src/pages/main/v1/scheduled-runs/components/scheduled-runs-columns.tsx
@@ -1,12 +1,12 @@
-import { ColumnDef } from '@tanstack/react-table';
-import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
-import { ScheduledWorkflows } from '@/lib/api';
-import RelativeDate from '@/components/v1/molecules/relative-date';
 import { AdditionalMetadata } from '../../events/components/additional-metadata';
 import { RunStatus } from '../../workflow-runs/components/run-statuses';
+import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
 import { DataTableRowActions } from '@/components/v1/molecules/data-table/data-table-row-actions';
-import { Link } from '@tanstack/react-router';
+import RelativeDate from '@/components/v1/molecules/relative-date';
+import { ScheduledWorkflows } from '@/lib/api';
 import { appRoutes } from '@/router';
+import { Link } from '@tanstack/react-router';
+import { ColumnDef } from '@tanstack/react-table';
 
 export const ScheduledRunColumn = {
   id: 'ID',

--- a/frontend/app/src/pages/main/v1/scheduled-runs/hooks/use-scheduled-runs.tsx
+++ b/frontend/app/src/pages/main/v1/scheduled-runs/hooks/use-scheduled-runs.tsx
@@ -1,6 +1,13 @@
+import {
+  workflowKey,
+  statusKey,
+  metadataKey,
+} from '../components/scheduled-runs-columns';
+import { FilterOption } from '@/components/v1/molecules/data-table/data-table-toolbar';
+import { useRefetchInterval } from '@/contexts/refetch-interval-context';
 import { usePagination } from '@/hooks/use-pagination';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
-import { useRefetchInterval } from '@/contexts/refetch-interval-context';
+import { useZodColumnFilters } from '@/hooks/use-zod-column-filters';
 import {
   queries,
   ScheduledRunStatus,
@@ -9,14 +16,7 @@ import {
 } from '@/lib/api';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import { FilterOption } from '@/components/v1/molecules/data-table/data-table-toolbar';
-import { useZodColumnFilters } from '@/hooks/use-zod-column-filters';
 import { z } from 'zod';
-import {
-  workflowKey,
-  statusKey,
-  metadataKey,
-} from '../components/scheduled-runs-columns';
 
 type UseScheduledRunsProps = {
   key: string;

--- a/frontend/app/src/pages/main/v1/scheduled-runs/index.tsx
+++ b/frontend/app/src/pages/main/v1/scheduled-runs/index.tsx
@@ -1,27 +1,27 @@
-import { DataTable } from '@/components/v1/molecules/data-table/data-table.tsx';
-import { useState } from 'react';
-import { VisibilityState } from '@tanstack/react-table';
-import { ScheduledWorkflows } from '@/lib/api';
-import {
-  ToolbarFilters,
-  ToolbarType,
-} from '@/components/v1/molecules/data-table/data-table-toolbar';
-import { Button } from '@/components/v1/ui/button';
-import { columns } from './components/scheduled-runs-columns';
-import { DeleteScheduledRun } from './components/delete-scheduled-runs';
-import { useCurrentTenantId } from '@/hooks/use-tenant';
+import { workflowRunStatusFilters } from '../workflow-runs-v1/hooks/use-toolbar-filters';
 import { TriggerWorkflowForm } from '../workflows/$workflow/components/trigger-workflow-form';
-import { DocsButton } from '@/components/v1/docs/docs-button';
-import { docsPages } from '@/lib/generated/docs';
-import { useScheduledRuns } from './hooks/use-scheduled-runs';
+import { DeleteScheduledRun } from './components/delete-scheduled-runs';
+import { columns } from './components/scheduled-runs-columns';
 import {
   ScheduledRunColumn,
   workflowKey,
   statusKey,
   metadataKey,
 } from './components/scheduled-runs-columns';
-import { workflowRunStatusFilters } from '../workflow-runs-v1/hooks/use-toolbar-filters';
+import { useScheduledRuns } from './hooks/use-scheduled-runs';
+import { DocsButton } from '@/components/v1/docs/docs-button';
+import {
+  ToolbarFilters,
+  ToolbarType,
+} from '@/components/v1/molecules/data-table/data-table-toolbar';
+import { DataTable } from '@/components/v1/molecules/data-table/data-table.tsx';
+import { Button } from '@/components/v1/ui/button';
 import { useSidePanel } from '@/hooks/use-side-panel';
+import { useCurrentTenantId } from '@/hooks/use-tenant';
+import { ScheduledWorkflows } from '@/lib/api';
+import { docsPages } from '@/lib/generated/docs';
+import { VisibilityState } from '@tanstack/react-table';
+import { useState } from 'react';
 
 interface ScheduledWorkflowRunsTableProps {
   createdAfter?: string;

--- a/frontend/app/src/pages/main/v1/task-runs-v1/actions.tsx
+++ b/frontend/app/src/pages/main/v1/task-runs-v1/actions.tsx
@@ -1,3 +1,10 @@
+import { useRunsContext } from '../workflow-runs-v1/hooks/runs-provider';
+import { useToast } from '@/components/v1/hooks/use-toast';
+import { IDGetter } from '@/components/v1/molecules/data-table/data-table';
+import {
+  DataTableOptionsContent,
+  DataTableOptionsContentProps,
+} from '@/components/v1/molecules/data-table/data-table-options';
 import { Button } from '@/components/v1/ui/button';
 import {
   DialogTitle,
@@ -5,26 +12,19 @@ import {
   DialogContent,
   DialogHeader,
 } from '@/components/v1/ui/dialog';
+import { useCurrentTenantId } from '@/hooks/use-tenant';
 import api, {
   queries,
   V1CancelTaskRequest,
   V1ReplayTaskRequest,
 } from '@/lib/api';
 import { useApiError } from '@/lib/hooks';
+import { cn } from '@/lib/utils';
 import { XCircleIcon } from '@heroicons/react/24/outline';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { useCallback } from 'react';
-import { useCurrentTenantId } from '@/hooks/use-tenant';
-import { useRunsContext } from '../workflow-runs-v1/hooks/runs-provider';
-import { cn } from '@/lib/utils';
-import { Repeat1 } from 'lucide-react';
-import { useToast } from '@/components/v1/hooks/use-toast';
 import { capitalize } from 'lodash';
-import {
-  DataTableOptionsContent,
-  DataTableOptionsContentProps,
-} from '@/components/v1/molecules/data-table/data-table-options';
-import { IDGetter } from '@/components/v1/molecules/data-table/data-table';
+import { Repeat1 } from 'lucide-react';
+import { useCallback } from 'react';
 
 export type ActionType = 'cancel' | 'replay';
 

--- a/frontend/app/src/pages/main/v1/tenant-settings/alerting/components/create-email-group-dialog.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/alerting/components/create-email-group-dialog.tsx
@@ -1,16 +1,16 @@
+import { Button } from '@/components/v1/ui/button';
 import {
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
 } from '@/components/v1/ui/dialog';
-import { Button } from '@/components/v1/ui/button';
-import { z } from 'zod';
-import { Controller, useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { cn } from '@/lib/utils';
 import { Spinner } from '@/components/v1/ui/loading';
 import { Textarea } from '@/components/v1/ui/textarea';
+import { cn } from '@/lib/utils';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Controller, useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 const schema = z.object({
   emails: z.array(z.string().email()).min(1).max(100),

--- a/frontend/app/src/pages/main/v1/tenant-settings/alerting/components/delete-email-group-form.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/alerting/components/delete-email-group-form.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@/components/v1/ui/button';
-import { Spinner } from '@/components/v1/ui/loading.tsx';
 import {
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from '@/components/v1/ui/dialog';
+import { Spinner } from '@/components/v1/ui/loading.tsx';
 import { TenantAlertEmailGroup } from '@/lib/api';
 
 interface DeleteEmailGroupFormProps {

--- a/frontend/app/src/pages/main/v1/tenant-settings/alerting/components/delete-slack-form.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/alerting/components/delete-slack-form.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@/components/v1/ui/button';
-import { Spinner } from '@/components/v1/ui/loading.tsx';
 import {
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from '@/components/v1/ui/dialog';
+import { Spinner } from '@/components/v1/ui/loading.tsx';
 import { SlackWebhook } from '@/lib/api';
 
 interface DeleteSlackFormProps {

--- a/frontend/app/src/pages/main/v1/tenant-settings/alerting/components/email-groups-columns.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/alerting/components/email-groups-columns.tsx
@@ -1,9 +1,9 @@
-import { ColumnDef } from '@tanstack/react-table';
-import { TenantAlertEmailGroup } from '@/lib/api';
-import { DataTableRowActions } from '@/components/v1/molecules/data-table/data-table-row-actions';
-import { Badge } from '@/components/v1/ui/badge';
-import RelativeDate from '@/components/v1/molecules/relative-date';
 import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
+import { DataTableRowActions } from '@/components/v1/molecules/data-table/data-table-row-actions';
+import RelativeDate from '@/components/v1/molecules/relative-date';
+import { Badge } from '@/components/v1/ui/badge';
+import { TenantAlertEmailGroup } from '@/lib/api';
+import { ColumnDef } from '@tanstack/react-table';
 
 export const columns = ({
   alertTenantEmailsSet,

--- a/frontend/app/src/pages/main/v1/tenant-settings/alerting/components/slack-webhooks-columns.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/alerting/components/slack-webhooks-columns.tsx
@@ -1,8 +1,8 @@
-import { ColumnDef } from '@tanstack/react-table';
-import { SlackWebhook } from '@/lib/api';
+import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
 import { DataTableRowActions } from '@/components/v1/molecules/data-table/data-table-row-actions';
 import RelativeDate from '@/components/v1/molecules/relative-date';
-import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
+import { SlackWebhook } from '@/lib/api';
+import { ColumnDef } from '@tanstack/react-table';
 
 export const columns = ({
   onDeleteClick,

--- a/frontend/app/src/pages/main/v1/tenant-settings/alerting/components/update-tenant-alerting-settings-form.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/alerting/components/update-tenant-alerting-settings-form.tsx
@@ -1,9 +1,5 @@
-import { cn } from '@/lib/utils';
 import { Button } from '@/components/v1/ui/button';
 import { Label } from '@/components/v1/ui/label';
-import { Controller, useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
 import { Spinner } from '@/components/v1/ui/loading.tsx';
 import {
   Select,
@@ -12,9 +8,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/v1/ui/select';
-import { TenantAlertingSettings } from '@/lib/api';
-import { useState } from 'react';
 import { Switch } from '@/components/v1/ui/switch';
+import { TenantAlertingSettings } from '@/lib/api';
+import { cn } from '@/lib/utils';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 const schema = z.object({
   maxAlertingFrequency: z.string(),

--- a/frontend/app/src/pages/main/v1/tenant-settings/alerting/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/alerting/index.tsx
@@ -1,7 +1,14 @@
+import { CreateEmailGroupDialog } from './components/create-email-group-dialog';
+import { DeleteEmailGroupForm } from './components/delete-email-group-form';
+import { DeleteSlackForm } from './components/delete-slack-form';
+import { columns as emailGroupsColumns } from './components/email-groups-columns';
+import { columns } from './components/slack-webhooks-columns';
+import { UpdateTenantAlertingSettings } from './components/update-tenant-alerting-settings-form';
+import { DataTable } from '@/components/v1/molecules/data-table/data-table';
+import { Button } from '@/components/v1/ui/button';
+import { Spinner } from '@/components/v1/ui/loading';
 import { Separator } from '@/components/v1/ui/separator';
-import { useMemo, useState } from 'react';
-import { useApiError, useApiMetaIntegrations } from '@/lib/hooks';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
 import api, {
   CreateTenantAlertEmailGroupRequest,
   SlackWebhook,
@@ -9,18 +16,10 @@ import api, {
   UpdateTenantRequest,
   queries,
 } from '@/lib/api';
-import { Spinner } from '@/components/v1/ui/loading';
-import { UpdateTenantAlertingSettings } from './components/update-tenant-alerting-settings-form';
-import { columns } from './components/slack-webhooks-columns';
-import { columns as emailGroupsColumns } from './components/email-groups-columns';
-
-import { DataTable } from '@/components/v1/molecules/data-table/data-table';
-import { DeleteSlackForm } from './components/delete-slack-form';
-import { Button } from '@/components/v1/ui/button';
+import { useApiError, useApiMetaIntegrations } from '@/lib/hooks';
 import { Dialog } from '@radix-ui/react-dialog';
-import { CreateEmailGroupDialog } from './components/create-email-group-dialog';
-import { DeleteEmailGroupForm } from './components/delete-email-group-form';
-import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
 
 export default function Alerting() {
   const integrations = useApiMetaIntegrations();

--- a/frontend/app/src/pages/main/v1/tenant-settings/api-tokens/components/api-tokens-columns.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/api-tokens/components/api-tokens-columns.tsx
@@ -1,8 +1,8 @@
-import { ColumnDef } from '@tanstack/react-table';
-import { APIToken } from '@/lib/api';
+import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
 import { DataTableRowActions } from '@/components/v1/molecules/data-table/data-table-row-actions';
 import RelativeDate from '@/components/v1/molecules/relative-date';
-import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
+import { APIToken } from '@/lib/api';
+import { ColumnDef } from '@tanstack/react-table';
 
 export const columns = ({
   onRevokeClick,

--- a/frontend/app/src/pages/main/v1/tenant-settings/api-tokens/components/create-token-dialog.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/api-tokens/components/create-token-dialog.tsx
@@ -1,16 +1,13 @@
+import { Button } from '@/components/v1/ui/button';
 import {
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from '@/components/v1/ui/dialog';
-import { Button } from '@/components/v1/ui/button';
-import { z } from 'zod';
-import { Controller, useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { Label } from '@/components/v1/ui/label';
 import { Input } from '@/components/v1/ui/input';
-import { cn } from '@/lib/utils';
+import { Label } from '@/components/v1/ui/label';
 import { Spinner } from '@/components/v1/ui/loading';
+import { SecretCopier } from '@/components/v1/ui/secret-copier';
 import {
   Select,
   SelectContent,
@@ -18,7 +15,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/v1/ui/select';
-import { SecretCopier } from '@/components/v1/ui/secret-copier';
+import { cn } from '@/lib/utils';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Controller, useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 const EXPIRES_IN_OPTS = {
   '3 months': `${3 * 30 * 24 * 60 * 60}s`,

--- a/frontend/app/src/pages/main/v1/tenant-settings/api-tokens/components/revoke-token-form.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/api-tokens/components/revoke-token-form.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@/components/v1/ui/button';
-import { Spinner } from '@/components/v1/ui/loading.tsx';
 import {
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from '@/components/v1/ui/dialog';
+import { Spinner } from '@/components/v1/ui/loading.tsx';
 import { APIToken } from '@/lib/api';
 
 interface RevokeTokenFormProps {

--- a/frontend/app/src/pages/main/v1/tenant-settings/api-tokens/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/api-tokens/index.tsx
@@ -1,15 +1,15 @@
-import { Button } from '@/components/v1/ui/button';
-import { Separator } from '@/components/v1/ui/separator';
-import { useState } from 'react';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import api, { APIToken, CreateAPITokenRequest, queries } from '@/lib/api';
-import { DataTable } from '@/components/v1/molecules/data-table/data-table';
 import { columns as apiTokensColumns } from './components/api-tokens-columns';
 import { CreateTokenDialog } from './components/create-token-dialog';
 import { RevokeTokenForm } from './components/revoke-token-form';
+import { DataTable } from '@/components/v1/molecules/data-table/data-table';
+import { Button } from '@/components/v1/ui/button';
 import { Dialog } from '@/components/v1/ui/dialog';
-import { useApiError } from '@/lib/hooks';
+import { Separator } from '@/components/v1/ui/separator';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
+import api, { APIToken, CreateAPITokenRequest, queries } from '@/lib/api';
+import { useApiError } from '@/lib/hooks';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 
 export default function APITokens() {
   const { tenantId } = useCurrentTenantId();

--- a/frontend/app/src/pages/main/v1/tenant-settings/github/components/github-installations-columns.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/github/components/github-installations-columns.tsx
@@ -1,10 +1,10 @@
-import { ColumnDef } from '@tanstack/react-table';
+import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/v1/ui/avatar';
 import { Button } from '@/components/v1/ui/button';
-import { GearIcon } from '@radix-ui/react-icons';
 import { GithubAppInstallation } from '@/lib/api/generated/cloud/data-contracts';
-import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
 import { CheckCircleIcon, PlusCircleIcon } from '@heroicons/react/24/outline';
+import { GearIcon } from '@radix-ui/react-icons';
+import { ColumnDef } from '@tanstack/react-table';
 
 export const columns = (
   linkToTenant: (installationId: string) => void,

--- a/frontend/app/src/pages/main/v1/tenant-settings/github/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/github/index.tsx
@@ -1,17 +1,16 @@
-import { Separator } from '@/components/v1/ui/separator';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { queries } from '@/lib/api';
-
 import { columns as githubInstallationsColumns } from './components/github-installations-columns';
+import { ConfirmDialog } from '@/components/v1/molecules/confirm-dialog';
 import { DataTable } from '@/components/v1/molecules/data-table/data-table';
 import { Button } from '@/components/v1/ui/button';
-import useCloudApiMeta from '@/pages/auth/hooks/use-cloud-api-meta';
-import invariant from 'tiny-invariant';
-import { useState } from 'react';
+import { Separator } from '@/components/v1/ui/separator';
+import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
+import { queries } from '@/lib/api';
 import { cloudApi } from '@/lib/api/api';
 import { useApiError } from '@/lib/hooks';
-import { ConfirmDialog } from '@/components/v1/molecules/confirm-dialog';
-import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
+import useCloudApiMeta from '@/pages/auth/hooks/use-cloud-api-meta';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import invariant from 'tiny-invariant';
 
 export default function Github() {
   const { data: cloudMeta } = useCloudApiMeta();

--- a/frontend/app/src/pages/main/v1/tenant-settings/ingestors/components/create-sns-dialog.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/ingestors/components/create-sns-dialog.tsx
@@ -1,17 +1,17 @@
+import { Button } from '@/components/v1/ui/button';
+import { CodeHighlighter } from '@/components/v1/ui/code-highlighter';
 import {
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from '@/components/v1/ui/dialog';
-import { Button } from '@/components/v1/ui/button';
-import { z } from 'zod';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { Label } from '@/components/v1/ui/label';
 import { Input } from '@/components/v1/ui/input';
-import { cn } from '@/lib/utils';
+import { Label } from '@/components/v1/ui/label';
 import { Spinner } from '@/components/v1/ui/loading';
-import { CodeHighlighter } from '@/components/v1/ui/code-highlighter';
+import { cn } from '@/lib/utils';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 const schema = z.object({
   topicArn: z.string().min(1).max(255),

--- a/frontend/app/src/pages/main/v1/tenant-settings/ingestors/components/delete-sns-form.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/ingestors/components/delete-sns-form.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@/components/v1/ui/button';
-import { Spinner } from '@/components/v1/ui/loading.tsx';
 import {
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from '@/components/v1/ui/dialog';
+import { Spinner } from '@/components/v1/ui/loading.tsx';
 import { SNSIntegration } from '@/lib/api';
 
 interface DeleteSNSFormProps {

--- a/frontend/app/src/pages/main/v1/tenant-settings/ingestors/components/sns-integrations-columns.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/ingestors/components/sns-integrations-columns.tsx
@@ -1,12 +1,12 @@
-import { ColumnDef } from '@tanstack/react-table';
-import { SNSIntegration } from '@/lib/api';
+import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
 import { DataTableRowActions } from '@/components/v1/molecules/data-table/data-table-row-actions';
+import RelativeDate from '@/components/v1/molecules/relative-date';
 import { Button } from '@/components/v1/ui/button';
-import { useState } from 'react';
+import { SNSIntegration } from '@/lib/api';
 import { CheckIcon } from '@heroicons/react/24/outline';
 import { CopyIcon } from '@radix-ui/react-icons';
-import RelativeDate from '@/components/v1/molecules/relative-date';
-import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
+import { ColumnDef } from '@tanstack/react-table';
+import { useState } from 'react';
 
 type Props = {
   ingestUrl: string;

--- a/frontend/app/src/pages/main/v1/tenant-settings/ingestors/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/ingestors/index.tsx
@@ -1,19 +1,19 @@
+import { CreateSNSDialog } from './components/create-sns-dialog';
+import { DeleteSNSForm } from './components/delete-sns-form';
+import { columns as snsIntegrationsColumns } from './components/sns-integrations-columns';
+import { DataTable } from '@/components/v1/molecules/data-table/data-table';
+import { Button } from '@/components/v1/ui/button';
 import { Separator } from '@/components/v1/ui/separator';
-import { useState } from 'react';
-import { useApiError } from '@/lib/hooks';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useCurrentTenantId } from '@/hooks/use-tenant';
 import api, {
   CreateSNSIntegrationRequest,
   SNSIntegration,
   queries,
 } from '@/lib/api';
-import { DataTable } from '@/components/v1/molecules/data-table/data-table';
-import { Button } from '@/components/v1/ui/button';
+import { useApiError } from '@/lib/hooks';
 import { Dialog } from '@radix-ui/react-dialog';
-import { CreateSNSDialog } from './components/create-sns-dialog';
-import { DeleteSNSForm } from './components/delete-sns-form';
-import { columns as snsIntegrationsColumns } from './components/sns-integrations-columns';
-import { useCurrentTenantId } from '@/hooks/use-tenant';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 
 export default function Ingestors() {
   return (

--- a/frontend/app/src/pages/main/v1/tenant-settings/members/components/change-password-dialog.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/members/components/change-password-dialog.tsx
@@ -1,16 +1,16 @@
+import { Button } from '@/components/v1/ui/button';
 import {
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from '@/components/v1/ui/dialog';
-import { Button } from '@/components/v1/ui/button';
-import { z } from 'zod';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { Label } from '@/components/v1/ui/label';
 import { Input } from '@/components/v1/ui/input';
-import { cn } from '@/lib/utils';
+import { Label } from '@/components/v1/ui/label';
 import { Spinner } from '@/components/v1/ui/loading';
+import { cn } from '@/lib/utils';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 const passwordSchema = z
   .string()

--- a/frontend/app/src/pages/main/v1/tenant-settings/members/components/create-invite-form.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/members/components/create-invite-form.tsx
@@ -1,10 +1,11 @@
-import { cn } from '@/lib/utils';
 import { Button } from '@/components/v1/ui/button';
+import {
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/v1/ui/dialog';
 import { Input } from '@/components/v1/ui/input';
 import { Label } from '@/components/v1/ui/label';
-import { Controller, useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
 import { Spinner } from '@/components/v1/ui/loading.tsx';
 import {
   Select,
@@ -13,12 +14,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/v1/ui/select';
-import {
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/v1/ui/dialog';
 import { TenantMemberRole } from '@/lib/api';
+import { cn } from '@/lib/utils';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Controller, useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 interface CreateInviteFormProps {
   className?: string;

--- a/frontend/app/src/pages/main/v1/tenant-settings/members/components/delete-invite-form.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/members/components/delete-invite-form.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@/components/v1/ui/button';
-import { Spinner } from '@/components/v1/ui/loading.tsx';
 import {
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from '@/components/v1/ui/dialog';
+import { Spinner } from '@/components/v1/ui/loading.tsx';
 import { TenantInvite } from '@/lib/api';
 
 interface DeleteInviteFormProps {

--- a/frontend/app/src/pages/main/v1/tenant-settings/members/components/invites-columns.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/members/components/invites-columns.tsx
@@ -1,9 +1,9 @@
-import { ColumnDef } from '@tanstack/react-table';
-import { TenantInvite } from '@/lib/api';
-import { DataTableRowActions } from '@/components/v1/molecules/data-table/data-table-row-actions';
-import { capitalize } from '@/lib/utils';
-import RelativeDate from '@/components/v1/molecules/relative-date';
 import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
+import { DataTableRowActions } from '@/components/v1/molecules/data-table/data-table-row-actions';
+import RelativeDate from '@/components/v1/molecules/relative-date';
+import { TenantInvite } from '@/lib/api';
+import { capitalize } from '@/lib/utils';
+import { ColumnDef } from '@tanstack/react-table';
 
 export const columns = ({
   onEditClick,

--- a/frontend/app/src/pages/main/v1/tenant-settings/members/components/members-columns.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/members/components/members-columns.tsx
@@ -1,19 +1,19 @@
-import { ColumnDef } from '@tanstack/react-table';
-import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
-import api, { TenantMember, queries } from '@/lib/api';
-import { capitalize } from '@/lib/utils';
-import { DataTableRowActions } from '@/components/v1/molecules/data-table/data-table-row-actions';
-import { useOutletContext } from '@/lib/router-helpers';
-import { UserContextType } from '@/lib/outlet';
-import RelativeDate from '@/components/v1/molecules/relative-date';
-import { useMutation } from '@tanstack/react-query';
-import { useApiError } from '@/lib/hooks';
-import queryClient from '@/query-client';
 import { ConfirmDialog } from '@/components/v1/molecules/confirm-dialog';
-import { useState } from 'react';
+import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
+import { DataTableRowActions } from '@/components/v1/molecules/data-table/data-table-row-actions';
+import RelativeDate from '@/components/v1/molecules/relative-date';
+import { useCurrentTenantId } from '@/hooks/use-tenant';
+import api, { TenantMember, queries } from '@/lib/api';
+import { useApiError } from '@/lib/hooks';
+import { UserContextType } from '@/lib/outlet';
+import { useOutletContext } from '@/lib/router-helpers';
+import { capitalize } from '@/lib/utils';
 import useApiMeta from '@/pages/auth/hooks/use-api-meta';
 import useCloudApiMeta from '@/pages/auth/hooks/use-cloud-api-meta';
-import { useCurrentTenantId } from '@/hooks/use-tenant';
+import queryClient from '@/query-client';
+import { useMutation } from '@tanstack/react-query';
+import { ColumnDef } from '@tanstack/react-table';
+import { useState } from 'react';
 
 // Component for handling member actions
 function MemberActions({

--- a/frontend/app/src/pages/main/v1/tenant-settings/members/components/update-invite-form.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/members/components/update-invite-form.tsx
@@ -1,10 +1,11 @@
-import { cn } from '@/lib/utils';
 import { Button } from '@/components/v1/ui/button';
+import {
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/v1/ui/dialog';
 import { Input } from '@/components/v1/ui/input';
 import { Label } from '@/components/v1/ui/label';
-import { Controller, useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
 import { Spinner } from '@/components/v1/ui/loading.tsx';
 import {
   Select,
@@ -13,12 +14,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/v1/ui/select';
-import {
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/v1/ui/dialog';
 import { TenantInvite, TenantMemberRole } from '@/lib/api';
+import { cn } from '@/lib/utils';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Controller, useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 const schema = z.object({
   role: z.enum([

--- a/frontend/app/src/pages/main/v1/tenant-settings/members/components/update-member-form.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/members/components/update-member-form.tsx
@@ -1,10 +1,11 @@
-import { cn } from '@/lib/utils';
 import { Button } from '@/components/v1/ui/button';
+import {
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/v1/ui/dialog';
 import { Input } from '@/components/v1/ui/input';
 import { Label } from '@/components/v1/ui/label';
-import { Controller, useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
 import { Spinner } from '@/components/v1/ui/loading.tsx';
 import {
   Select,
@@ -13,12 +14,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/v1/ui/select';
-import {
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/v1/ui/dialog';
 import { TenantMember, TenantMemberRole } from '@/lib/api';
+import { cn } from '@/lib/utils';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Controller, useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 const schema = z.object({
   role: z.nativeEnum(TenantMemberRole),

--- a/frontend/app/src/pages/main/v1/tenant-settings/members/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/members/index.tsx
@@ -1,9 +1,18 @@
-import { Button } from '@/components/v1/ui/button';
-import { Separator } from '@/components/v1/ui/separator';
-import { useState, useEffect, useMemo } from 'react';
+import { ChangePasswordDialog } from './components/change-password-dialog';
 import { CreateInviteForm } from './components/create-invite-form';
-import { useApiError } from '@/lib/hooks';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { DeleteInviteForm } from './components/delete-invite-form';
+import { columns } from './components/invites-columns';
+import { columns as membersColumns } from './components/members-columns';
+import { UpdateInviteForm } from './components/update-invite-form';
+import { UpdateMemberForm } from './components/update-member-form';
+import { DataTable } from '@/components/v1/molecules/data-table/data-table';
+import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
+import RelativeDate from '@/components/v1/molecules/relative-date';
+import { Button } from '@/components/v1/ui/button';
+import { Dialog } from '@/components/v1/ui/dialog';
+import { Separator } from '@/components/v1/ui/separator';
+import { useOrganizations } from '@/hooks/use-organizations';
+import { useCurrentTenantId } from '@/hooks/use-tenant';
 import api, {
   CreateTenantInviteRequest,
   TenantInvite,
@@ -13,23 +22,14 @@ import api, {
   UserChangePasswordRequest,
   queries,
 } from '@/lib/api';
-import { Dialog } from '@/components/v1/ui/dialog';
-import { DataTable } from '@/components/v1/molecules/data-table/data-table';
-import { columns } from './components/invites-columns';
-import { columns as membersColumns } from './components/members-columns';
-import { ColumnDef } from '@tanstack/react-table';
-import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
-import RelativeDate from '@/components/v1/molecules/relative-date';
-import { UpdateInviteForm } from './components/update-invite-form';
-import { UpdateMemberForm } from './components/update-member-form';
-import { DeleteInviteForm } from './components/delete-invite-form';
-import { ChangePasswordDialog } from './components/change-password-dialog';
-import { AxiosError } from 'axios';
+import { useApiError } from '@/lib/hooks';
 import useApiMeta from '@/pages/auth/hooks/use-api-meta';
-import { useCurrentTenantId } from '@/hooks/use-tenant';
-import { useOrganizations } from '@/hooks/use-organizations';
-import { useNavigate } from '@tanstack/react-router';
 import { appRoutes } from '@/router';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { ColumnDef } from '@tanstack/react-table';
+import { AxiosError } from 'axios';
+import { useState, useEffect, useMemo } from 'react';
 
 // Simplified columns for owners (no role column, no actions)
 const ownersColumns: ColumnDef<TenantMember>[] = [

--- a/frontend/app/src/pages/main/v1/tenant-settings/overview/components/update-tenant-form.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/overview/components/update-tenant-form.tsx
@@ -1,12 +1,12 @@
-import { cn } from '@/lib/utils';
 import { Button } from '@/components/v1/ui/button';
-import { Label } from '@/components/v1/ui/label';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
-import { Spinner } from '@/components/v1/ui/loading.tsx';
 import { Input } from '@/components/v1/ui/input';
+import { Label } from '@/components/v1/ui/label';
+import { Spinner } from '@/components/v1/ui/loading.tsx';
 import { useTenantDetails } from '@/hooks/use-tenant';
+import { cn } from '@/lib/utils';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 const schema = z.object({
   name: z.string().max(255).min(1),

--- a/frontend/app/src/pages/main/v1/tenant-settings/overview/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/overview/index.tsx
@@ -1,18 +1,17 @@
-import { Button } from '@/components/v1/ui/button';
-import { Separator } from '@/components/v1/ui/separator';
-import { useState } from 'react';
-import { useApiError } from '@/lib/hooks';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import api, { UpdateTenantRequest } from '@/lib/api';
-import { Switch } from '@/components/v1/ui/switch';
-import { Label } from '@radix-ui/react-label';
-import { Spinner } from '@/components/v1/ui/loading';
-import { capitalize } from '@/lib/utils';
 import { UpdateTenantForm } from './components/update-tenant-form';
-
 import { Alert, AlertDescription } from '@/components/v1/ui/alert';
+import { Button } from '@/components/v1/ui/button';
+import { Spinner } from '@/components/v1/ui/loading';
+import { Separator } from '@/components/v1/ui/separator';
+import { Switch } from '@/components/v1/ui/switch';
 import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
+import api, { UpdateTenantRequest } from '@/lib/api';
 import { cloudApi } from '@/lib/api/api';
+import { useApiError } from '@/lib/hooks';
+import { capitalize } from '@/lib/utils';
+import { Label } from '@radix-ui/react-label';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 
 export default function TenantSettings() {
   const { tenant } = useTenantDetails();

--- a/frontend/app/src/pages/main/v1/tenant-settings/resource-limits/components/resource-limit-columns.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/resource-limits/components/resource-limit-columns.tsx
@@ -1,8 +1,8 @@
-import { ColumnDef } from '@tanstack/react-table';
 import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
-import { TenantResource, TenantResourceLimit } from '@/lib/api';
 import RelativeDate from '@/components/v1/molecules/relative-date';
+import { TenantResource, TenantResourceLimit } from '@/lib/api';
 import { cn } from '@/lib/utils';
+import { ColumnDef } from '@tanstack/react-table';
 
 const resources: Record<TenantResource, string> = {
   [TenantResource.WORKER]: 'Total Workers',

--- a/frontend/app/src/pages/main/v1/tenant-settings/resource-limits/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/resource-limits/index.tsx
@@ -1,12 +1,12 @@
-import { Separator } from '@/components/v1/ui/separator';
-import { useQuery } from '@tanstack/react-query';
-import { queries } from '@/lib/api';
-import { DataTable } from '@/components/v1/molecules/data-table/data-table';
 import { columns } from './components/resource-limit-columns';
 import { PaymentMethods, Subscription } from '@/components/v1/cloud/billing';
+import { DataTable } from '@/components/v1/molecules/data-table/data-table';
 import { Spinner } from '@/components/v1/ui/loading';
-import useCloudApiMeta from '@/pages/auth/hooks/use-cloud-api-meta';
+import { Separator } from '@/components/v1/ui/separator';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
+import { queries } from '@/lib/api';
+import useCloudApiMeta from '@/pages/auth/hooks/use-cloud-api-meta';
+import { useQuery } from '@tanstack/react-query';
 
 export default function ResourceLimits() {
   const { tenantId } = useCurrentTenantId();

--- a/frontend/app/src/pages/main/v1/webhooks/components/auth-setup.tsx
+++ b/frontend/app/src/pages/main/v1/webhooks/components/auth-setup.tsx
@@ -1,3 +1,4 @@
+import { WebhookFormData } from '../hooks/use-webhooks';
 import { Input } from '@/components/v1/ui/input';
 import { Label } from '@/components/v1/ui/label';
 import {
@@ -14,7 +15,6 @@ import {
   V1WebhookSourceName,
 } from '@/lib/api';
 import { useForm } from 'react-hook-form';
-import { WebhookFormData } from '../hooks/use-webhooks';
 
 type BaseAuthMethodProps = {
   register: ReturnType<typeof useForm<WebhookFormData>>['register'];

--- a/frontend/app/src/pages/main/v1/webhooks/components/source-name.tsx
+++ b/frontend/app/src/pages/main/v1/webhooks/components/source-name.tsx
@@ -1,8 +1,8 @@
 import { V1WebhookSourceName } from '@/lib/api';
 import { GitHubLogoIcon } from '@radix-ui/react-icons';
 import { Webhook } from 'lucide-react';
-import { FaSlack, FaStripeS } from 'react-icons/fa';
 import { CgLinear } from 'react-icons/cg';
+import { FaSlack, FaStripeS } from 'react-icons/fa';
 
 export const SourceName = ({
   sourceName,

--- a/frontend/app/src/pages/main/v1/webhooks/components/webhook-columns.tsx
+++ b/frontend/app/src/pages/main/v1/webhooks/components/webhook-columns.tsx
@@ -1,3 +1,6 @@
+import { useWebhooks } from '../hooks/use-webhooks';
+import { AuthMethod } from './auth-method';
+import { SourceName } from './source-name';
 import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
 import { Button } from '@/components/v1/ui/button';
 import {
@@ -12,9 +15,6 @@ import { DotsVerticalIcon } from '@radix-ui/react-icons';
 import { ColumnDef, Row } from '@tanstack/react-table';
 import { Check, Copy, Loader, Save, Trash2, X } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
-import { useWebhooks } from '../hooks/use-webhooks';
-import { AuthMethod } from './auth-method';
-import { SourceName } from './source-name';
 
 export const WebhookColumn = {
   name: 'Name',

--- a/frontend/app/src/pages/main/v1/webhooks/hooks/use-webhooks.tsx
+++ b/frontend/app/src/pages/main/v1/webhooks/hooks/use-webhooks.tsx
@@ -1,4 +1,3 @@
-import { z } from 'zod';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
 import api, {
   queries,
@@ -10,6 +9,7 @@ import api, {
   V1WebhookSourceName,
 } from '@/lib/api';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { z } from 'zod';
 
 export const useWebhooks = (onDeleteSuccess?: () => void) => {
   const queryClient = useQueryClient();

--- a/frontend/app/src/pages/main/v1/webhooks/index.tsx
+++ b/frontend/app/src/pages/main/v1/webhooks/index.tsx
@@ -1,3 +1,12 @@
+import { AuthMethod } from './components/auth-method';
+import { AuthSetup } from './components/auth-setup';
+import { SourceName } from './components/source-name';
+import { columns, WebhookColumn } from './components/webhook-columns';
+import {
+  useWebhooks,
+  WebhookFormData,
+  webhookFormSchema,
+} from './hooks/use-webhooks';
 import { DocsButton } from '@/components/v1/docs/docs-button';
 import { DataTable } from '@/components/v1/molecules/data-table/data-table';
 import { Button } from '@/components/v1/ui/button';
@@ -31,15 +40,6 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { AlertTriangle, Check, Copy, Lightbulb, Webhook } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { AuthMethod } from './components/auth-method';
-import { AuthSetup } from './components/auth-setup';
-import { SourceName } from './components/source-name';
-import { columns, WebhookColumn } from './components/webhook-columns';
-import {
-  useWebhooks,
-  WebhookFormData,
-  webhookFormSchema,
-} from './hooks/use-webhooks';
 
 export default function Webhooks() {
   const { data, isLoading, error } = useWebhooks();

--- a/frontend/app/src/pages/main/v1/workers/$worker/index.tsx
+++ b/frontend/app/src/pages/main/v1/workers/$worker/index.tsx
@@ -1,35 +1,36 @@
-import { Separator } from '@/components/v1/ui/separator';
-import api, { queries, UpdateWorkerRequest, Worker } from '@/lib/api';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { Link, useParams } from '@tanstack/react-router';
-import { ServerStackIcon } from '@heroicons/react/24/outline';
-import { Button } from '@/components/v1/ui/button';
-import { Loading } from '@/components/v1/ui/loading.tsx';
-import { Badge, BadgeProps } from '@/components/v1/ui/badge';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/v1/ui/tooltip';
+import { RunsTable } from '../../workflow-runs-v1/components/runs-table';
+import { flattenDAGsKey } from '../../workflow-runs-v1/components/v1/task-runs-columns';
+import { RunsProvider } from '../../workflow-runs-v1/hooks/runs-provider';
 import RelativeDate from '@/components/v1/molecules/relative-date';
-import { useApiError } from '@/lib/hooks';
-import queryClient from '@/query-client';
-import { BiDotsVertical } from 'react-icons/bi';
+import { Badge, BadgeProps } from '@/components/v1/ui/badge';
+import { Button } from '@/components/v1/ui/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/v1/ui/dropdown-menu';
-import { RunsTable } from '../../workflow-runs-v1/components/runs-table';
-import { RunsProvider } from '../../workflow-runs-v1/hooks/runs-provider';
-import { useCurrentTenantId } from '@/hooks/use-tenant';
-import { capitalize } from '@/lib/utils';
+import { Loading } from '@/components/v1/ui/loading.tsx';
+import { Separator } from '@/components/v1/ui/separator';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/v1/ui/tooltip';
 import { useRefetchInterval } from '@/contexts/refetch-interval-context';
-import { flattenDAGsKey } from '../../workflow-runs-v1/components/v1/task-runs-columns';
-import { useMemo, useState } from 'react';
+import { useCurrentTenantId } from '@/hooks/use-tenant';
+import api, { queries, UpdateWorkerRequest, Worker } from '@/lib/api';
+import { useApiError } from '@/lib/hooks';
+import { capitalize } from '@/lib/utils';
+import queryClient from '@/query-client';
 import { appRoutes } from '@/router';
+import { ServerStackIcon } from '@heroicons/react/24/outline';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { Link, useParams } from '@tanstack/react-router';
+import { useMemo, useState } from 'react';
+import { BiDotsVertical } from 'react-icons/bi';
+
 const isHealthy = (worker?: Worker) => {
   const reasons = [];
 

--- a/frontend/app/src/pages/main/v1/workers/components/sdk-info.tsx
+++ b/frontend/app/src/pages/main/v1/workers/components/sdk-info.tsx
@@ -1,8 +1,7 @@
 import { WorkerRuntimeSDKs } from '@/lib/api';
-
-import { BiLogoGoLang, BiLogoPython, BiLogoTypescript } from 'react-icons/bi';
-import { IconType } from 'react-icons';
 import React from 'react';
+import { IconType } from 'react-icons';
+import { BiLogoGoLang, BiLogoPython, BiLogoTypescript } from 'react-icons/bi';
 
 export const SdkInfo: React.FC<{
   runtimeInfo?: { language?: WorkerRuntimeSDKs; sdkVersion?: string };

--- a/frontend/app/src/pages/main/v1/workers/components/worker-columns.tsx
+++ b/frontend/app/src/pages/main/v1/workers/components/worker-columns.tsx
@@ -1,13 +1,12 @@
-import { ColumnDef } from '@tanstack/react-table';
-import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
-import { Worker } from '@/lib/api';
-import { Link } from '@tanstack/react-router';
-import RelativeDate from '@/components/v1/molecules/relative-date';
 import { SdkInfo } from './sdk-info';
-
+import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
+import RelativeDate from '@/components/v1/molecules/relative-date';
 import { Badge, BadgeProps } from '@/components/v1/ui/badge';
+import { Worker } from '@/lib/api';
 import { cn } from '@/lib/utils';
 import { appRoutes } from '@/router';
+import { Link } from '@tanstack/react-router';
+import { ColumnDef } from '@tanstack/react-table';
 
 export const WorkerColumn = {
   status: 'Status',

--- a/frontend/app/src/pages/main/v1/workers/index.tsx
+++ b/frontend/app/src/pages/main/v1/workers/index.tsx
@@ -1,18 +1,18 @@
-import { useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { queries } from '@/lib/api';
+import { columns, statusKey, WorkerColumn } from './components/worker-columns';
+import { DocsButton } from '@/components/v1/docs/docs-button';
+import { ToolbarType } from '@/components/v1/molecules/data-table/data-table-toolbar';
 import { DataTable } from '@/components/v1/molecules/data-table/data-table.tsx';
 import { Loading } from '@/components/v1/ui/loading.tsx';
-import { VisibilityState } from '@tanstack/react-table';
-import { useCurrentTenantId } from '@/hooks/use-tenant';
 import { useRefetchInterval } from '@/contexts/refetch-interval-context';
-import { columns, statusKey, WorkerColumn } from './components/worker-columns';
-import { ToolbarType } from '@/components/v1/molecules/data-table/data-table-toolbar';
-import { DocsButton } from '@/components/v1/docs/docs-button';
-import { docsPages } from '@/lib/generated/docs';
-import { useZodColumnFilters } from '@/hooks/use-zod-column-filters';
-import { z } from 'zod';
 import { usePagination } from '@/hooks/use-pagination';
+import { useCurrentTenantId } from '@/hooks/use-tenant';
+import { useZodColumnFilters } from '@/hooks/use-zod-column-filters';
+import { queries } from '@/lib/api';
+import { docsPages } from '@/lib/generated/docs';
+import { useQuery } from '@tanstack/react-query';
+import { VisibilityState } from '@tanstack/react-table';
+import { useMemo, useState } from 'react';
+import { z } from 'zod';
 
 const workersQuerySchema = z
   .object({

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/index.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/index.tsx
@@ -1,42 +1,42 @@
-import api, {
-  V1TaskStatus,
-  V1TaskSummary,
-  V1WorkflowRunDetails,
-  WorkflowRunShapeForWorkflowRunDetails,
-} from '@/lib/api';
-import { useParams } from '@tanstack/react-router';
+import { RunsProvider } from '../hooks/runs-provider';
+import {
+  isTerminalState,
+  useWorkflowDetails,
+} from '../hooks/use-workflow-details';
+import { V1RunDetailHeader } from './v2components/header';
+import { JobMiniMap } from './v2components/mini-map';
+import {
+  TabOption,
+  TaskRunDetail,
+} from './v2components/step-run-detail/step-run-detail';
+import { StepRunEvents } from './v2components/step-run-events-for-workflow-run';
+import { ViewToggle } from './v2components/view-toggle';
+import { Waterfall } from './v2components/waterfall';
 import { WorkflowRunInputDialog } from './v2components/workflow-run-input';
+import WorkflowRunVisualizer from './v2components/workflow-run-visualizer-v2';
+import { Badge } from '@/components/v1/ui/badge';
+import { CodeHighlighter } from '@/components/v1/ui/code-highlighter';
+import { Spinner } from '@/components/v1/ui/loading';
+import { Separator } from '@/components/v1/ui/separator';
 import {
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
 } from '@/components/v1/ui/tabs';
-import { StepRunEvents } from './v2components/step-run-events-for-workflow-run';
-import { useCallback, useRef } from 'react';
-import {
-  TabOption,
-  TaskRunDetail,
-} from './v2components/step-run-detail/step-run-detail';
-import { Separator } from '@/components/v1/ui/separator';
-import { CodeHighlighter } from '@/components/v1/ui/code-highlighter';
 import { useSidePanel } from '@/hooks/use-side-panel';
-import { V1RunDetailHeader } from './v2components/header';
-import { Badge } from '@/components/v1/ui/badge';
-import { ViewToggle } from './v2components/view-toggle';
-import WorkflowRunVisualizer from './v2components/workflow-run-visualizer-v2';
-import { useAtom } from 'jotai';
+import api, {
+  V1TaskStatus,
+  V1TaskSummary,
+  V1WorkflowRunDetails,
+  WorkflowRunShapeForWorkflowRunDetails,
+} from '@/lib/api';
 import { preferredWorkflowRunViewAtom } from '@/lib/atoms';
-import { JobMiniMap } from './v2components/mini-map';
-import {
-  isTerminalState,
-  useWorkflowDetails,
-} from '../hooks/use-workflow-details';
-import { useQuery } from '@tanstack/react-query';
-import { Spinner } from '@/components/v1/ui/loading';
-import { Waterfall } from './v2components/waterfall';
-import { RunsProvider } from '../hooks/runs-provider';
 import { appRoutes } from '@/router';
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from '@tanstack/react-router';
+import { useAtom } from 'jotai';
+import { useCallback, useRef } from 'react';
 
 function statusToBadgeVariant(status: V1TaskStatus) {
   switch (status) {

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/events-columns.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/events-columns.tsx
@@ -1,23 +1,23 @@
-import { createColumnHelper } from '@tanstack/react-table';
-import { V1TaskEventType, V1TaskEvent, StepRunEventSeverity } from '@/lib/api';
+import { EventWithMetadata } from './step-run-events-for-workflow-run';
+import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
 import RelativeDate from '@/components/v1/molecules/relative-date';
 import { Badge } from '@/components/v1/ui/badge';
-import {
-  ArrowLeftEndOnRectangleIcon,
-  ServerStackIcon,
-  XCircleIcon,
-} from '@heroicons/react/24/outline';
-import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
-import { cn, emptyGolangUUID } from '@/lib/utils';
-import { Link } from '@tanstack/react-router';
 import { Button } from '@/components/v1/ui/button';
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from '@/components/v1/ui/popover';
-import { EventWithMetadata } from './step-run-events-for-workflow-run';
+import { V1TaskEventType, V1TaskEvent, StepRunEventSeverity } from '@/lib/api';
+import { cn, emptyGolangUUID } from '@/lib/utils';
 import { appRoutes } from '@/router';
+import {
+  ArrowLeftEndOnRectangleIcon,
+  ServerStackIcon,
+  XCircleIcon,
+} from '@heroicons/react/24/outline';
+import { Link } from '@tanstack/react-router';
+import { createColumnHelper } from '@tanstack/react-table';
 
 function eventTypeToSeverity(
   eventType: V1TaskEventType | undefined,

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/header.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/header.tsx
@@ -1,5 +1,8 @@
-import { V1TaskStatus, queries } from '@/lib/api';
-import { AdjustmentsHorizontalIcon } from '@heroicons/react/24/outline';
+import { TaskRunActionButton } from '../../../task-runs-v1/actions';
+import { useWorkflowDetails } from '../../hooks/use-workflow-details';
+import { TASK_RUN_TERMINAL_STATUSES } from './step-run-detail/step-run-detail';
+import RelativeDate from '@/components/v1/molecules/relative-date';
+import { CopyWorkflowConfigButton } from '@/components/v1/shared/copy-workflow-config';
 import {
   Breadcrumb,
   BreadcrumbList,
@@ -8,18 +11,15 @@ import {
   BreadcrumbSeparator,
   BreadcrumbPage,
 } from '@/components/v1/ui/breadcrumb';
-import { formatDuration } from '@/lib/utils';
-import RelativeDate from '@/components/v1/molecules/relative-date';
-import { useWorkflowDetails } from '../../hooks/use-workflow-details';
-import { TaskRunActionButton } from '../../../task-runs-v1/actions';
-import { TASK_RUN_TERMINAL_STATUSES } from './step-run-detail/step-run-detail';
-import { WorkflowDefinitionLink } from '@/pages/main/workflow-runs/$run/v2components/workflow-definition';
-import { CopyWorkflowConfigButton } from '@/components/v1/shared/copy-workflow-config';
-import { useCurrentTenantId } from '@/hooks/use-tenant';
-import { Link } from '@tanstack/react-router';
-import { useQuery } from '@tanstack/react-query';
 import { Toaster } from '@/components/v1/ui/toaster';
+import { useCurrentTenantId } from '@/hooks/use-tenant';
+import { V1TaskStatus, queries } from '@/lib/api';
+import { formatDuration } from '@/lib/utils';
+import { WorkflowDefinitionLink } from '@/pages/main/workflow-runs/$run/v2components/workflow-definition';
 import { appRoutes } from '@/router';
+import { AdjustmentsHorizontalIcon } from '@heroicons/react/24/outline';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
 
 export const V1RunDetailHeader = () => {
   const { tenantId } = useCurrentTenantId();

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/mini-map.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/mini-map.tsx
@@ -1,10 +1,10 @@
-import { useMemo } from 'react';
-import { queries, WorkflowRunShapeItemForWorkflowRunDetails } from '@/lib/api';
+import { useWorkflowDetails } from '../../hooks/use-workflow-details';
 import { TabOption } from './step-run-detail/step-run-detail';
 import StepRunNode from './step-run-node';
-import { useWorkflowDetails } from '../../hooks/use-workflow-details';
-import { useQuery } from '@tanstack/react-query';
 import { useRefetchInterval } from '@/contexts/refetch-interval-context';
+import { queries, WorkflowRunShapeItemForWorkflowRunDetails } from '@/lib/api';
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 
 interface JobMiniMapProps {
   onClick: (stepRunId?: string, defaultOpenTab?: TabOption) => void;

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail.tsx
@@ -1,6 +1,16 @@
-import { V1TaskStatus, V1TaskSummary, queries } from '@/lib/api';
-import { useQuery } from '@tanstack/react-query';
+import { V1RunIndicator } from '../../../components/run-statuses';
+import { RunsTable } from '../../../components/runs-table';
+import { RunsProvider } from '../../../hooks/runs-provider';
+import { isTerminalState } from '../../../hooks/use-workflow-details';
+import { TaskRunMiniMap } from '../mini-map';
+import { StepRunEvents } from '../step-run-events-for-workflow-run';
+import { Waterfall } from '../waterfall';
+import { StepRunLogs } from './step-run-logs';
+import { V1StepRunOutput } from './step-run-output';
+import RelativeDate from '@/components/v1/molecules/relative-date';
+import { CopyWorkflowConfigButton } from '@/components/v1/shared/copy-workflow-config';
 import { Button } from '@/components/v1/ui/button';
+import { CodeHighlighter } from '@/components/v1/ui/code-highlighter';
 import { Loading } from '@/components/v1/ui/loading';
 import { Separator } from '@/components/v1/ui/separator';
 import {
@@ -10,26 +20,16 @@ import {
   TabsTrigger,
 } from '@/components/v1/ui/tabs';
 import { useSidePanel } from '@/hooks/use-side-panel';
-import { StepRunEvents } from '../step-run-events-for-workflow-run';
-import { Link } from '@tanstack/react-router';
-import { RunsTable } from '../../../components/runs-table';
-import { RunsProvider } from '../../../hooks/runs-provider';
-import { V1RunIndicator } from '../../../components/run-statuses';
-import RelativeDate from '@/components/v1/molecules/relative-date';
-import { emptyGolangUUID, formatDuration } from '@/lib/utils';
-import { V1StepRunOutput } from './step-run-output';
-import { CodeHighlighter } from '@/components/v1/ui/code-highlighter';
-import { TaskRunActionButton } from '@/pages/main/v1/task-runs-v1/actions';
-import { TaskRunMiniMap } from '../mini-map';
-import { WorkflowDefinitionLink } from '@/pages/main/workflow-runs/$run/v2components/workflow-definition';
-import { StepRunLogs } from './step-run-logs';
-import { isTerminalState } from '../../../hooks/use-workflow-details';
-import { CopyWorkflowConfigButton } from '@/components/v1/shared/copy-workflow-config';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
-import { Waterfall } from '../waterfall';
-import { useCallback, useState } from 'react';
-import { FullscreenIcon } from 'lucide-react';
+import { V1TaskStatus, V1TaskSummary, queries } from '@/lib/api';
+import { emptyGolangUUID, formatDuration } from '@/lib/utils';
+import { TaskRunActionButton } from '@/pages/main/v1/task-runs-v1/actions';
+import { WorkflowDefinitionLink } from '@/pages/main/workflow-runs/$run/v2components/workflow-definition';
 import { appRoutes } from '@/router';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
+import { FullscreenIcon } from 'lucide-react';
+import { useCallback, useState } from 'react';
 
 export enum TabOption {
   Output = 'output',

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-logs.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-logs.tsx
@@ -1,12 +1,12 @@
+import LoggingComponent from '@/components/v1/cloud/logging/logs';
 import { V1TaskSummary, V1LogLineList, V1TaskStatus } from '@/lib/api';
-import { V1LogLineListQuery } from '@/lib/api/queries';
 import api from '@/lib/api/api';
+import { V1LogLineListQuery } from '@/lib/api/queries';
 import {
   useInfiniteQuery,
   InfiniteData,
   useQueryClient,
 } from '@tanstack/react-query';
-import LoggingComponent from '@/components/v1/cloud/logging/logs';
 import { useMemo, useCallback, useRef, useEffect } from 'react';
 
 const LOGS_PER_PAGE = 100;

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-events-for-workflow-run.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-events-for-workflow-run.tsx
@@ -1,9 +1,9 @@
+import { columns } from './events-columns';
+import { DataTable } from '@/components/v1/molecules/data-table/data-table';
+import { useRefetchInterval } from '@/contexts/refetch-interval-context';
+import { useCurrentTenantId } from '@/hooks/use-tenant';
 import { queries, V1TaskEvent } from '@/lib/api';
 import { useQuery } from '@tanstack/react-query';
-import { DataTable } from '@/components/v1/molecules/data-table/data-table';
-import { columns } from './events-columns';
-import { useCurrentTenantId } from '@/hooks/use-tenant';
-import { useRefetchInterval } from '@/contexts/refetch-interval-context';
 
 export type EventWithMetadata = V1TaskEvent & {
   metadata: {

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-node.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-node.tsx
@@ -1,7 +1,3 @@
-import { V1TaskStatus, V1TaskSummary } from '@/lib/api';
-import { cn, formatDuration } from '@/lib/utils';
-import { memo } from 'react';
-import { Handle, Position } from 'reactflow';
 import { V1RunIndicator } from '../../components/run-statuses';
 import { TabOption } from './step-run-detail/step-run-detail';
 import {
@@ -10,6 +6,10 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/v1/ui/tooltip';
+import { V1TaskStatus, V1TaskSummary } from '@/lib/api';
+import { cn, formatDuration } from '@/lib/utils';
+import { memo } from 'react';
+import { Handle, Position } from 'reactflow';
 
 export type NodeData = {
   taskRun: V1TaskSummary | undefined;

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/view-toggle.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/view-toggle.tsx
@@ -1,9 +1,9 @@
+import { useWorkflowDetails } from '../../hooks/use-workflow-details';
 import { Button } from '@/components/v1/ui/button';
 import { preferredWorkflowRunViewAtom } from '@/lib/atoms';
 import { type ViewOptions } from '@/lib/atoms';
 import { useAtom } from 'jotai';
 import { BiExitFullscreen, BiExpand } from 'react-icons/bi';
-import { useWorkflowDetails } from '../../hooks/use-workflow-details';
 
 const ToggleIcon = ({ view }: { view: ViewOptions | undefined }) => {
   switch (view) {

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/waterfall.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/waterfall.tsx
@@ -1,3 +1,16 @@
+import { Button } from '@/components/v1/ui/button';
+import { ChartContainer, ChartTooltipContent } from '@/components/v1/ui/chart';
+import { Skeleton } from '@/components/v1/ui/skeleton';
+import {
+  TooltipProvider,
+  Tooltip as BaseTooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/v1/ui/tooltip';
+import { useRefetchInterval } from '@/contexts/refetch-interval-context';
+import { V1TaskStatus, V1TaskTiming, queries } from '@/lib/api';
+import { useQuery } from '@tanstack/react-query';
+import { CirclePlus, CircleMinus, Loader } from 'lucide-react';
 import { useState, useMemo, useCallback } from 'react';
 import {
   Bar,
@@ -9,20 +22,6 @@ import {
   ResponsiveContainer,
   Cell,
 } from 'recharts';
-import { CirclePlus, CircleMinus, Loader } from 'lucide-react';
-
-import { ChartContainer, ChartTooltipContent } from '@/components/v1/ui/chart';
-import { V1TaskStatus, V1TaskTiming, queries } from '@/lib/api';
-import { Button } from '@/components/v1/ui/button';
-import { Skeleton } from '@/components/v1/ui/skeleton';
-import {
-  TooltipProvider,
-  Tooltip as BaseTooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/v1/ui/tooltip';
-import { useQuery } from '@tanstack/react-query';
-import { useRefetchInterval } from '@/contexts/refetch-interval-context';
 
 // Helper function to check if a task is a descendant of another task
 function isDescendantOf(

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/workflow-run-visualizer-v2.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/workflow-run-visualizer-v2.tsx
@@ -1,3 +1,8 @@
+import { useWorkflowDetails } from '../../hooks/use-workflow-details';
+import stepRunNode, { NodeData } from './step-run-node';
+import { useTheme } from '@/components/theme-provider';
+import { V1TaskStatus } from '@/lib/api';
+import dagre from 'dagre';
 import { useMemo } from 'react';
 import ReactFlow, {
   Position,
@@ -7,11 +12,6 @@ import ReactFlow, {
   BezierEdge,
 } from 'reactflow';
 import 'reactflow/dist/style.css';
-import dagre from 'dagre';
-import { useTheme } from '@/components/theme-provider';
-import stepRunNode, { NodeData } from './step-run-node';
-import { V1TaskStatus } from '@/lib/api';
-import { useWorkflowDetails } from '../../hooks/use-workflow-details';
 
 const connectionLineStyleDark = { stroke: '#fff' };
 const connectionLineStyleLight = { stroke: '#000' };

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
@@ -1,35 +1,33 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { DataTable } from '@/components/v1/molecules/data-table/data-table.tsx';
-import { columns, TaskRunColumn } from './v1/task-runs-columns';
+import { TabOption } from '../$run/v2components/step-run-detail/step-run-detail';
+import { TriggerWorkflowForm } from '../../workflows/$workflow/components/trigger-workflow-form';
+import { useRunsContext } from '../hooks/runs-provider';
+import { AdditionalMetadataProp } from '../hooks/use-runs-table-filters';
 import { V1WorkflowRunsMetricsView } from './task-runs-metrics';
-import { Skeleton } from '@/components/v1/ui/skeleton';
+import { columns, TaskRunColumn } from './v1/task-runs-columns';
+import { DocsButton } from '@/components/v1/docs/docs-button';
+import {
+  DataPoint,
+  ZoomableChart,
+} from '@/components/v1/molecules/charts/zoomable';
+import { DataTable } from '@/components/v1/molecules/data-table/data-table.tsx';
+import { CodeHighlighter } from '@/components/v1/ui/code-highlighter';
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from '@/components/v1/ui/dialog';
-import { CodeHighlighter } from '@/components/v1/ui/code-highlighter';
+import { Loading } from '@/components/v1/ui/loading';
 import { Separator } from '@/components/v1/ui/separator';
-import {
-  DataPoint,
-  ZoomableChart,
-} from '@/components/v1/molecules/charts/zoomable';
-import { TabOption } from '../$run/v2components/step-run-detail/step-run-detail';
+import { Skeleton } from '@/components/v1/ui/skeleton';
+import { Toaster } from '@/components/v1/ui/toaster';
+import { useRefetchInterval } from '@/contexts/refetch-interval-context';
 import { useSidePanel } from '@/hooks/use-side-panel';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
-import { TriggerWorkflowForm } from '../../workflows/$workflow/components/trigger-workflow-form';
-import { Toaster } from '@/components/v1/ui/toaster';
-import { useQuery } from '@tanstack/react-query';
 import { queries } from '@/lib/api';
-
-import { AdditionalMetadataProp } from '../hooks/use-runs-table-filters';
-import { useRunsContext } from '../hooks/runs-provider';
-
-import { DocsButton } from '@/components/v1/docs/docs-button';
 import { docsPages } from '@/lib/generated/docs';
-import { useRefetchInterval } from '@/contexts/refetch-interval-context';
-import { Loading } from '@/components/v1/ui/loading';
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 interface RunsTableProps {
   headerClassName?: string;

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-metrics.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-metrics.tsx
@@ -1,9 +1,9 @@
-import { V1TaskStatus } from '@/lib/api';
-import { Badge } from '@/components/v1/ui/badge';
 import { useRunsContext } from '../hooks/runs-provider';
+import { Badge } from '@/components/v1/ui/badge';
+import { V1TaskStatus } from '@/lib/api';
+import { cn } from '@/lib/utils';
 import { CheckCircleIcon, ClockIcon } from '@heroicons/react/24/outline';
 import { PlayIcon, X, Ban, ChartColumn } from 'lucide-react';
-import { cn } from '@/lib/utils';
 import { useCallback, useMemo } from 'react';
 
 function statusToFriendlyName(status: V1TaskStatus) {

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions.tsx
@@ -1,14 +1,14 @@
-import { Button } from '@/components/v1/ui/button';
 import { TaskRunActionButton } from '../../../task-runs-v1/actions';
 import { useRunsContext } from '../../hooks/runs-provider';
+import { Button } from '@/components/v1/ui/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from '@/components/v1/ui/dropdown-menu';
-import { useMemo, useState } from 'react';
-import { Play, Command } from 'lucide-react';
 import { ChevronDownIcon } from '@radix-ui/react-icons';
+import { Play, Command } from 'lucide-react';
+import { useMemo, useState } from 'react';
 
 interface TableActionsProps {
   onTriggerWorkflow: () => void;

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/v1/task-runs-columns.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/v1/task-runs-columns.tsx
@@ -1,20 +1,20 @@
-import { ColumnDef } from '@tanstack/react-table';
-import { Link } from '@tanstack/react-router';
 import {
   AdditionalMetadata,
   AdditionalMetadataClick,
 } from '../../../events/components/additional-metadata';
-import RelativeDate from '@/components/v1/molecules/relative-date';
-import { Checkbox } from '@/components/v1/ui/checkbox';
-import { ChevronDownIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
-import { Button } from '@/components/v1/ui/button';
-import { cn } from '@/lib/utils';
-import { DataTableRowActions } from '@/components/v1/molecules/data-table/data-table-row-actions';
 import { V1RunStatus } from '../../../workflow-runs/components/run-statuses';
 import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
-import { V1TaskStatus, V1TaskSummary } from '@/lib/api';
+import { DataTableRowActions } from '@/components/v1/molecules/data-table/data-table-row-actions';
+import RelativeDate from '@/components/v1/molecules/relative-date';
 import { Duration } from '@/components/v1/shared/duration';
+import { Button } from '@/components/v1/ui/button';
+import { Checkbox } from '@/components/v1/ui/checkbox';
+import { V1TaskStatus, V1TaskSummary } from '@/lib/api';
+import { cn } from '@/lib/utils';
 import { appRoutes } from '@/router';
+import { ChevronDownIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+import { Link } from '@tanstack/react-router';
+import { ColumnDef } from '@tanstack/react-table';
 
 export const TaskRunColumn = {
   taskName: 'Task Name',

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
@@ -1,16 +1,16 @@
-import { createContext, useContext, useMemo, useState } from 'react';
-import { RowSelectionState, VisibilityState } from '@tanstack/react-table';
-import { useRunsTableFilters } from './use-runs-table-filters';
-import { useToolbarFilters } from './use-toolbar-filters';
-import { useRuns } from './use-runs';
-import { useMetrics } from './use-metrics';
-import { V1TaskRunMetrics, V1TaskSummary } from '@/lib/api';
-import { PaginationState, Updater } from '@tanstack/react-table';
 import {
   ActionType,
   BaseTaskRunActionParams,
 } from '../../task-runs-v1/actions';
 import { TaskRunColumnKeys } from '../components/v1/task-runs-columns';
+import { useMetrics } from './use-metrics';
+import { useRuns } from './use-runs';
+import { useRunsTableFilters } from './use-runs-table-filters';
+import { useToolbarFilters } from './use-toolbar-filters';
+import { V1TaskRunMetrics, V1TaskSummary } from '@/lib/api';
+import { RowSelectionState, VisibilityState } from '@tanstack/react-table';
+import { PaginationState, Updater } from '@tanstack/react-table';
+import { createContext, useContext, useMemo, useState } from 'react';
 
 type DisplayProps = {
   hideMetrics?: boolean;

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-metrics.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-metrics.tsx
@@ -1,7 +1,7 @@
+import { useRefetchInterval } from '@/contexts/refetch-interval-context';
+import { useCurrentTenantId } from '@/hooks/use-tenant';
 import { queries } from '@/lib/api';
 import { useQuery } from '@tanstack/react-query';
-import { useCurrentTenantId } from '@/hooks/use-tenant';
-import { useRefetchInterval } from '@/contexts/refetch-interval-context';
 
 export const useMetrics = ({
   workflow,

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-runs-table-filters.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-runs-table-filters.tsx
@@ -1,7 +1,3 @@
-import { useCallback, useMemo } from 'react';
-import { useSearchParams } from '@/lib/router-helpers';
-import { V1TaskStatus } from '@/lib/api';
-import { ColumnFiltersState } from '@tanstack/react-table';
 import {
   statusKey,
   workflowKey,
@@ -12,8 +8,12 @@ import {
   isCustomTimeRangeKey,
   timeWindowKey,
 } from '../components/v1/task-runs-columns';
-import { z } from 'zod';
 import { useZodColumnFilters } from '@/hooks/use-zod-column-filters';
+import { V1TaskStatus } from '@/lib/api';
+import { useSearchParams } from '@/lib/router-helpers';
+import { ColumnFiltersState } from '@tanstack/react-table';
+import { useCallback, useMemo } from 'react';
+import { z } from 'zod';
 
 type TimeWindow = '1h' | '6h' | '1d' | '7d';
 

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-runs.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-runs.tsx
@@ -1,10 +1,10 @@
-import { queries, V1TaskSummary, V1TaskStatus } from '@/lib/api';
-import { useQuery } from '@tanstack/react-query';
-import { useCallback, useMemo, useState } from 'react';
-import { RowSelectionState } from '@tanstack/react-table';
-import { useCurrentTenantId } from '@/hooks/use-tenant';
 import { useRefetchInterval } from '@/contexts/refetch-interval-context';
 import { usePagination } from '@/hooks/use-pagination';
+import { useCurrentTenantId } from '@/hooks/use-tenant';
+import { queries, V1TaskSummary, V1TaskStatus } from '@/lib/api';
+import { useQuery } from '@tanstack/react-query';
+import { RowSelectionState } from '@tanstack/react-table';
+import { useCallback, useMemo, useState } from 'react';
 
 type UseRunsProps = {
   key: string;

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-toolbar-filters.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-toolbar-filters.tsx
@@ -1,11 +1,3 @@
-import { V1TaskStatus } from '@/lib/api';
-import { useMemo } from 'react';
-import {
-  FilterOption,
-  ToolbarFilters,
-  ToolbarType,
-  TimeRangeConfig,
-} from '@/components/v1/molecules/data-table/data-table-toolbar';
 import {
   additionalMetadataKey,
   createdAtKey,
@@ -13,8 +5,16 @@ import {
   statusKey,
   workflowKey,
 } from '../components/v1/task-runs-columns';
-import { useWorkflows } from './use-workflows';
 import { FilterActions } from './use-runs-table-filters';
+import { useWorkflows } from './use-workflows';
+import {
+  FilterOption,
+  ToolbarFilters,
+  ToolbarType,
+  TimeRangeConfig,
+} from '@/components/v1/molecules/data-table/data-table-toolbar';
+import { V1TaskStatus } from '@/lib/api';
+import { useMemo } from 'react';
 
 export const workflowRunStatusFilters = [
   {

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-workflow-details.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-workflow-details.tsx
@@ -1,8 +1,8 @@
 import { queries, V1TaskStatus } from '@/lib/api';
-import { useQuery } from '@tanstack/react-query';
-import { AxiosError, isAxiosError } from 'axios';
-import { useParams } from '@tanstack/react-router';
 import { appRoutes } from '@/router';
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from '@tanstack/react-router';
+import { AxiosError, isAxiosError } from 'axios';
 
 export function isTerminalState(status: V1TaskStatus | undefined) {
   if (!status) {

--- a/frontend/app/src/pages/main/v1/workflows/$workflow/components/trigger-workflow-form.tsx
+++ b/frontend/app/src/pages/main/v1/workflows/$workflow/components/trigger-workflow-form.tsx
@@ -1,3 +1,8 @@
+import { Combobox } from '@/components/v1/molecules/combobox/combobox';
+import { ToolbarType } from '@/components/v1/molecules/data-table/data-table-toolbar';
+import { DateTimePicker } from '@/components/v1/molecules/time-picker/date-time-picker';
+import { Button } from '@/components/v1/ui/button';
+import { CodeEditor } from '@/components/v1/ui/code-editor';
 import {
   Dialog,
   DialogContent,
@@ -5,19 +10,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/v1/ui/dialog';
-import api, {
-  CronWorkflows,
-  ScheduledWorkflows,
-  V1WorkflowRunDetails,
-  Workflow,
-} from '@/lib/api';
-import { useCallback, useMemo, useState, useEffect } from 'react';
-import { Button } from '@/components/v1/ui/button';
-import { debounce } from 'lodash';
-import { useApiError } from '@/lib/hooks';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
-import { CodeEditor } from '@/components/v1/ui/code-editor';
 import { Input } from '@/components/v1/ui/input';
 import {
   Tabs,
@@ -25,13 +17,21 @@ import {
   TabsList,
   TabsTrigger,
 } from '@/components/v1/ui/tabs';
-import { DateTimePicker } from '@/components/v1/molecules/time-picker/date-time-picker';
-import { ToolbarType } from '@/components/v1/molecules/data-table/data-table-toolbar';
-import { BiDownArrowCircle } from 'react-icons/bi';
-import { Combobox } from '@/components/v1/molecules/combobox/combobox';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
+import api, {
+  CronWorkflows,
+  ScheduledWorkflows,
+  V1WorkflowRunDetails,
+  Workflow,
+} from '@/lib/api';
 import { formatCron } from '@/lib/cron';
+import { useApiError } from '@/lib/hooks';
 import { appRoutes } from '@/router';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { debounce } from 'lodash';
+import { useCallback, useMemo, useState, useEffect } from 'react';
+import { BiDownArrowCircle } from 'react-icons/bi';
 
 type TimingOption = 'now' | 'schedule' | 'cron';
 

--- a/frontend/app/src/pages/main/v1/workflows/$workflow/index.tsx
+++ b/frontend/app/src/pages/main/v1/workflows/$workflow/index.tsx
@@ -1,36 +1,36 @@
-import api, { queries, WorkflowUpdateRequest } from '@/lib/api';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { useNavigate, useParams } from '@tanstack/react-router';
-import invariant from 'tiny-invariant';
+import { RunsTable } from '../../workflow-runs-v1/components/runs-table';
+import { workflowKey } from '../../workflow-runs-v1/components/v1/task-runs-columns';
+import { RunsProvider } from '../../workflow-runs-v1/hooks/runs-provider';
 import { WorkflowTags } from '../components/workflow-tags';
-import { Badge } from '@/components/v1/ui/badge';
-import { relativeDate } from '@/lib/utils';
-import { Square3Stack3DIcon } from '@heroicons/react/24/outline';
-import { Loading } from '@/components/v1/ui/loading.tsx';
 import { TriggerWorkflowForm } from './components/trigger-workflow-form';
-import { useState } from 'react';
-import { Button } from '@/components/v1/ui/button';
-import { useApiError } from '@/lib/hooks';
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from '@/components/v1/ui/tabs';
 import WorkflowGeneralSettings from './components/workflow-general-settings';
 import { ConfirmDialog } from '@/components/v1/molecules/confirm-dialog';
+import { Badge } from '@/components/v1/ui/badge';
+import { Button } from '@/components/v1/ui/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/v1/ui/dropdown-menu';
-import { RunsTable } from '../../workflow-runs-v1/components/runs-table';
-import { RunsProvider } from '../../workflow-runs-v1/hooks/runs-provider';
-import { useCurrentTenantId } from '@/hooks/use-tenant';
+import { Loading } from '@/components/v1/ui/loading.tsx';
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/components/v1/ui/tabs';
 import { useRefetchInterval } from '@/contexts/refetch-interval-context';
-import { workflowKey } from '../../workflow-runs-v1/components/v1/task-runs-columns';
+import { useCurrentTenantId } from '@/hooks/use-tenant';
+import api, { queries, WorkflowUpdateRequest } from '@/lib/api';
+import { useApiError } from '@/lib/hooks';
+import { relativeDate } from '@/lib/utils';
 import { appRoutes } from '@/router';
+import { Square3Stack3DIcon } from '@heroicons/react/24/outline';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useNavigate, useParams } from '@tanstack/react-router';
+import { useState } from 'react';
+import invariant from 'tiny-invariant';
 
 export default function ExpandedWorkflow() {
   // TODO list previous versions and make selectable

--- a/frontend/app/src/pages/main/v1/workflows/components/workflow-columns.tsx
+++ b/frontend/app/src/pages/main/v1/workflows/components/workflow-columns.tsx
@@ -1,11 +1,11 @@
-import { ColumnDef } from '@tanstack/react-table';
-import { Workflow } from '@/lib/api';
-import { Link } from '@tanstack/react-router';
-import { ChevronRightIcon } from '@radix-ui/react-icons';
+import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
 import RelativeDate from '@/components/v1/molecules/relative-date';
 import { Badge } from '@/components/v1/ui/badge';
-import { DataTableColumnHeader } from '@/components/v1/molecules/data-table/data-table-column-header';
+import { Workflow } from '@/lib/api';
 import { appRoutes } from '@/router';
+import { ChevronRightIcon } from '@radix-ui/react-icons';
+import { Link } from '@tanstack/react-router';
+import { ColumnDef } from '@tanstack/react-table';
 
 export const WorkflowColumn = {
   status: 'Status',

--- a/frontend/app/src/pages/main/v1/workflows/hooks/use-workflows.tsx
+++ b/frontend/app/src/pages/main/v1/workflows/hooks/use-workflows.tsx
@@ -1,12 +1,12 @@
-import { useQuery } from '@tanstack/react-query';
-import { queries } from '@/lib/api';
+import { nameKey } from '../components/workflow-columns';
+import { useRefetchInterval } from '@/contexts/refetch-interval-context';
 import { usePagination } from '@/hooks/use-pagination';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
-import { useRefetchInterval } from '@/contexts/refetch-interval-context';
-import { z } from 'zod';
 import { useZodColumnFilters } from '@/hooks/use-zod-column-filters';
-import { nameKey } from '../components/workflow-columns';
+import { queries } from '@/lib/api';
+import { useQuery } from '@tanstack/react-query';
 import { useDebounce } from 'use-debounce';
+import { z } from 'zod';
 
 type UseWorkflowsProps = {
   key: string;

--- a/frontend/app/src/pages/main/v1/workflows/index.tsx
+++ b/frontend/app/src/pages/main/v1/workflows/index.tsx
@@ -1,8 +1,3 @@
-import { useState } from 'react';
-import { DataTable } from '@/components/v1/molecules/data-table/data-table.tsx';
-import { Loading } from '@/components/v1/ui/loading.tsx';
-import { VisibilityState } from '@tanstack/react-table';
-import { useCurrentTenantId } from '@/hooks/use-tenant';
 import {
   columns,
   nameKey,
@@ -10,8 +5,13 @@ import {
 } from './components/workflow-columns';
 import { useWorkflows } from './hooks/use-workflows';
 import { DocsButton } from '@/components/v1/docs/docs-button';
-import { docsPages } from '@/lib/generated/docs';
 import { ToolbarType } from '@/components/v1/molecules/data-table/data-table-toolbar';
+import { DataTable } from '@/components/v1/molecules/data-table/data-table.tsx';
+import { Loading } from '@/components/v1/ui/loading.tsx';
+import { useCurrentTenantId } from '@/hooks/use-tenant';
+import { docsPages } from '@/lib/generated/docs';
+import { VisibilityState } from '@tanstack/react-table';
+import { useState } from 'react';
 
 export default function WorkflowTable() {
   const { tenantId } = useCurrentTenantId();

--- a/frontend/app/src/pages/main/workflow-runs/$run/v2components/workflow-definition.tsx
+++ b/frontend/app/src/pages/main/workflow-runs/$run/v2components/workflow-definition.tsx
@@ -1,8 +1,8 @@
 import { Button } from '@/components/v1/ui/button';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
+import { appRoutes } from '@/router';
 import { Squares2X2Icon } from '@heroicons/react/24/outline';
 import { Link } from '@tanstack/react-router';
-import { appRoutes } from '@/router';
 
 export const WorkflowDefinitionLink = ({
   workflowId,

--- a/frontend/app/src/pages/onboarding/create-tenant/components/hear-about-us-form.tsx
+++ b/frontend/app/src/pages/onboarding/create-tenant/components/hear-about-us-form.tsx
@@ -1,7 +1,14 @@
-import { Label } from '@/components/v1/ui/label';
-import { Textarea } from '@/components/v1/ui/textarea';
+import { OnboardingStepProps } from '../types';
+import {
+  extractOtherSelection,
+  toggleOtherOption,
+  toggleRegularOption,
+  updateOtherText,
+} from '../utils/other-selection';
 import { Button } from '@/components/v1/ui/button';
 import { Card, CardContent } from '@/components/v1/ui/card';
+import { Label } from '@/components/v1/ui/label';
+import { Textarea } from '@/components/v1/ui/textarea';
 import {
   Search,
   FileText,
@@ -10,14 +17,7 @@ import {
   Calendar,
   HelpCircle,
 } from 'lucide-react';
-import { OnboardingStepProps } from '../types';
 import { FaHackerNews, FaLinkedin, FaTwitter } from 'react-icons/fa';
-import {
-  extractOtherSelection,
-  toggleOtherOption,
-  toggleRegularOption,
-  updateOtherText,
-} from '../utils/other-selection';
 
 interface HearAboutUsFormProps extends OnboardingStepProps<string | string[]> {}
 

--- a/frontend/app/src/pages/onboarding/create-tenant/components/tenant-create-form.tsx
+++ b/frontend/app/src/pages/onboarding/create-tenant/components/tenant-create-form.tsx
@@ -1,17 +1,7 @@
-import { cn } from '@/lib/utils';
+import { OnboardingStepProps } from '../types';
+import { Card, CardContent } from '@/components/v1/ui/card';
 import { Input } from '@/components/v1/ui/input';
 import { Label } from '@/components/v1/ui/label';
-import { Card, CardContent } from '@/components/v1/ui/card';
-import { Monitor, Settings, Rocket } from 'lucide-react';
-import { CheckIcon } from '@heroicons/react/24/outline';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
-import { useEffect, useMemo, useRef } from 'react';
-import { OnboardingStepProps } from '../types';
-import { useQuery } from '@tanstack/react-query';
-import api, { TenantEnvironment } from '@/lib/api';
-import freeEmailDomains from '@/lib/free-email-domains.json';
 import {
   Select,
   SelectContent,
@@ -19,7 +9,17 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/v1/ui/select';
+import api, { TenantEnvironment } from '@/lib/api';
 import { OrganizationForUserList } from '@/lib/api/generated/cloud/data-contracts';
+import freeEmailDomains from '@/lib/free-email-domains.json';
+import { cn } from '@/lib/utils';
+import { CheckIcon } from '@heroicons/react/24/outline';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useQuery } from '@tanstack/react-query';
+import { Monitor, Settings, Rocket } from 'lucide-react';
+import { useEffect, useMemo, useRef } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 const schema = z.object({
   name: z.string().min(4).max(32),

--- a/frontend/app/src/pages/onboarding/create-tenant/components/what-building-form.tsx
+++ b/frontend/app/src/pages/onboarding/create-tenant/components/what-building-form.tsx
@@ -1,7 +1,14 @@
-import { Label } from '@/components/v1/ui/label';
-import { Textarea } from '@/components/v1/ui/textarea';
+import { OnboardingStepProps } from '../types';
+import {
+  extractOtherSelection,
+  toggleOtherOption,
+  toggleRegularOption,
+  updateOtherText,
+} from '../utils/other-selection';
 import { Button } from '@/components/v1/ui/button';
 import { Card, CardContent } from '@/components/v1/ui/card';
+import { Label } from '@/components/v1/ui/label';
+import { Textarea } from '@/components/v1/ui/textarea';
 import {
   Database,
   Workflow,
@@ -10,13 +17,6 @@ import {
   FileText,
   Webhook,
 } from 'lucide-react';
-import { OnboardingStepProps } from '../types';
-import {
-  extractOtherSelection,
-  toggleOtherOption,
-  toggleRegularOption,
-  updateOtherText,
-} from '../utils/other-selection';
 
 interface WhatBuildingFormProps
   extends OnboardingStepProps<string | string[]> {}

--- a/frontend/app/src/pages/onboarding/create-tenant/index.tsx
+++ b/frontend/app/src/pages/onboarding/create-tenant/index.tsx
@@ -1,26 +1,26 @@
+import useCloudApiMeta from '../../auth/hooks/use-cloud-api-meta';
+import { HearAboutUsForm } from './components/hear-about-us-form';
+import { StepProgress } from './components/step-progress';
+import { TenantCreateForm } from './components/tenant-create-form';
+import { WhatBuildingForm } from './components/what-building-form';
+import { OnboardingStepConfig, OnboardingFormData } from './types';
+import { Button } from '@/components/v1/ui/button';
+import { useAnalytics } from '@/hooks/use-analytics';
+import { useOrganizations } from '@/hooks/use-organizations';
 import api, {
   CreateTenantRequest,
   queries,
   Tenant,
   TenantEnvironment,
 } from '@/lib/api';
-import { useOrganizations } from '@/hooks/use-organizations';
-import { useApiError } from '@/lib/hooks';
 import { cloudApi } from '@/lib/api/api';
-import useCloudApiMeta from '../../auth/hooks/use-cloud-api-meta';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { useState, useEffect } from 'react';
-import { useSearchParams } from '@/lib/router-helpers';
-import { TenantCreateForm } from './components/tenant-create-form';
-import { Button } from '@/components/v1/ui/button';
-import { HearAboutUsForm } from './components/hear-about-us-form';
-import { WhatBuildingForm } from './components/what-building-form';
-import { StepProgress } from './components/step-progress';
-import { OnboardingStepConfig, OnboardingFormData } from './types';
-import { useAnalytics } from '@/hooks/use-analytics';
 import { OrganizationTenant } from '@/lib/api/generated/cloud/data-contracts';
+import { useApiError } from '@/lib/hooks';
+import { useSearchParams } from '@/lib/router-helpers';
 import { appRoutes } from '@/router';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
+import { useState, useEffect } from 'react';
 
 const FINAL_STEP = 2;
 

--- a/frontend/app/src/pages/onboarding/get-started/index.tsx
+++ b/frontend/app/src/pages/onboarding/get-started/index.tsx
@@ -1,20 +1,20 @@
+import { DefaultOnboardingAuth } from './platforms/defaults/default-onboarding-auth';
+import { DefaultOnboardingWorkflow } from './platforms/defaults/default-onboarding-workflow';
+import { WorkerListener } from './platforms/defaults/default-worker-listener';
 import { Button } from '@/components/v1/ui/button';
 import { CodeHighlighter } from '@/components/v1/ui/code-highlighter';
 import { Loading } from '@/components/v1/ui/loading';
+import { Step, Steps } from '@/components/v1/ui/steps';
 import {
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
 } from '@/components/v1/ui/tabs';
-import { Step, Steps } from '@/components/v1/ui/steps';
-import { MembershipsContextType, UserContextType } from '@/lib/outlet';
-import { useState } from 'react';
-import { useOutletContext } from '@/lib/router-helpers';
-import { DefaultOnboardingAuth } from './platforms/defaults/default-onboarding-auth';
-import { DefaultOnboardingWorkflow } from './platforms/defaults/default-onboarding-workflow';
-import { WorkerListener } from './platforms/defaults/default-worker-listener';
 import { useTenantDetails } from '@/hooks/use-tenant';
+import { MembershipsContextType, UserContextType } from '@/lib/outlet';
+import { useOutletContext } from '@/lib/router-helpers';
+import { useState } from 'react';
 
 export default function GetStarted() {
   const ctx = useOutletContext<UserContextType & MembershipsContextType>();

--- a/frontend/app/src/pages/onboarding/get-started/platforms/defaults/default-onboarding-workflow.tsx
+++ b/frontend/app/src/pages/onboarding/get-started/platforms/defaults/default-onboarding-workflow.tsx
@@ -1,11 +1,11 @@
-import { Button } from '@/components/v1/ui/button';
 import { useToast } from '@/components/hooks/use-toast';
+import { Button } from '@/components/v1/ui/button';
 import api, { V1WorkflowRunDetails, queries } from '@/lib/api';
 import { useApiError } from '@/lib/hooks';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { useState } from 'react';
-import { useNavigate } from '@tanstack/react-router';
 import { appRoutes } from '@/router';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { useState } from 'react';
 
 export const DefaultOnboardingWorkflow: React.FC<{
   tenantId: string;

--- a/frontend/app/src/pages/onboarding/get-started/platforms/defaults/default-worker-listener.tsx
+++ b/frontend/app/src/pages/onboarding/get-started/platforms/defaults/default-worker-listener.tsx
@@ -1,8 +1,8 @@
 import { Loading } from '@/components/v1/ui/loading';
 import { queries } from '@/lib/api';
 import { useQuery } from '@tanstack/react-query';
-import { useEffect, useRef } from 'react';
 import JSConfetti from 'js-confetti';
+import { useEffect, useRef } from 'react';
 
 export const WorkerListener: React.FC<{
   tenantId: string;

--- a/frontend/app/src/pages/onboarding/invites/index.tsx
+++ b/frontend/app/src/pages/onboarding/invites/index.tsx
@@ -1,11 +1,11 @@
+import { Button } from '@/components/v1/ui/button';
+import { useOrganizations } from '@/hooks/use-organizations';
 import api from '@/lib/api';
 import { cloudApi } from '@/lib/api/api';
 import { useApiError } from '@/lib/hooks';
+import { appRoutes } from '@/router';
 import { useMutation } from '@tanstack/react-query';
 import { redirect, useLoaderData, useNavigate } from '@tanstack/react-router';
-import { Button } from '@/components/v1/ui/button';
-import { useOrganizations } from '@/hooks/use-organizations';
-import { appRoutes } from '@/router';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function loader(_args: { request: Request }) {

--- a/frontend/app/src/pages/onboarding/verify-email/index.tsx
+++ b/frontend/app/src/pages/onboarding/verify-email/index.tsx
@@ -1,9 +1,9 @@
-import api from '@/lib/api';
-import { redirect, useLoaderData } from '@tanstack/react-router';
-import queryClient from '@/query-client';
 import MainNav from '@/components/molecules/nav-bar/nav-bar';
 import { Loading } from '@/components/v1/ui/loading';
+import api from '@/lib/api';
+import queryClient from '@/query-client';
 import { appRoutes } from '@/router';
+import { redirect, useLoaderData } from '@tanstack/react-router';
 
 export async function loader({ request }: { request: Request }) {
   try {

--- a/frontend/app/src/pages/organizations/$organization/components/cancel-invite-modal.tsx
+++ b/frontend/app/src/pages/organizations/$organization/components/cancel-invite-modal.tsx
@@ -1,6 +1,6 @@
-import { OrganizationInvite } from '@/lib/api/generated/cloud/data-contracts';
 import { ConfirmDialog } from '@/components/molecules/confirm-dialog';
 import { useOrganizations } from '@/hooks/use-organizations';
+import { OrganizationInvite } from '@/lib/api/generated/cloud/data-contracts';
 
 interface CancelInviteModalProps {
   open: boolean;

--- a/frontend/app/src/pages/organizations/$organization/components/create-token-modal.tsx
+++ b/frontend/app/src/pages/organizations/$organization/components/create-token-modal.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/v1/ui/button';
+import CopyToClipboard from '@/components/v1/ui/copy-to-clipboard';
 import {
   Dialog,
   DialogContent,
@@ -15,14 +16,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/v1/ui/select';
+import { useOrganizations } from '@/hooks/use-organizations';
+import { ManagementTokenDuration } from '@/lib/api/generated/cloud/data-contracts';
+import { KeyIcon } from '@heroicons/react/24/outline';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useState, useEffect, useCallback } from 'react';
 import { useForm, Controller } from 'react-hook-form';
-import { useOrganizations } from '@/hooks/use-organizations';
-import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { KeyIcon } from '@heroicons/react/24/outline';
-import { ManagementTokenDuration } from '@/lib/api/generated/cloud/data-contracts';
-import CopyToClipboard from '@/components/v1/ui/copy-to-clipboard';
 
 const schema = z.object({
   name: z.string().min(1, 'Token name is required'),

--- a/frontend/app/src/pages/organizations/$organization/components/delete-member-modal.tsx
+++ b/frontend/app/src/pages/organizations/$organization/components/delete-member-modal.tsx
@@ -1,6 +1,6 @@
-import { OrganizationMember } from '@/lib/api/generated/cloud/data-contracts';
 import { ConfirmDialog } from '@/components/molecules/confirm-dialog';
 import { useOrganizations } from '@/hooks/use-organizations';
+import { OrganizationMember } from '@/lib/api/generated/cloud/data-contracts';
 
 interface DeleteMemberModalProps {
   open: boolean;

--- a/frontend/app/src/pages/organizations/$organization/components/delete-tenant-modal.tsx
+++ b/frontend/app/src/pages/organizations/$organization/components/delete-tenant-modal.tsx
@@ -1,15 +1,15 @@
-import { useState, useEffect } from 'react';
-import { OrganizationTenant } from '@/lib/api/generated/cloud/data-contracts';
-import { useOrganizations } from '@/hooks/use-organizations';
+import { Button } from '@/components/v1/ui/button';
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from '@/components/v1/ui/dialog';
-import { Button } from '@/components/v1/ui/button';
 import { Input } from '@/components/v1/ui/input';
 import { Spinner } from '@/components/v1/ui/loading';
+import { useOrganizations } from '@/hooks/use-organizations';
+import { OrganizationTenant } from '@/lib/api/generated/cloud/data-contracts';
+import { useState, useEffect } from 'react';
 
 interface DeleteTenantModalProps {
   open: boolean;

--- a/frontend/app/src/pages/organizations/$organization/components/delete-token-modal.tsx
+++ b/frontend/app/src/pages/organizations/$organization/components/delete-token-modal.tsx
@@ -1,6 +1,6 @@
-import { ManagementToken } from '@/lib/api/generated/cloud/data-contracts';
 import { ConfirmDialog } from '@/components/molecules/confirm-dialog';
 import { useOrganizations } from '@/hooks/use-organizations';
+import { ManagementToken } from '@/lib/api/generated/cloud/data-contracts';
 
 interface DeleteTokenModalProps {
   open: boolean;

--- a/frontend/app/src/pages/organizations/$organization/components/invite-member-modal.tsx
+++ b/frontend/app/src/pages/organizations/$organization/components/invite-member-modal.tsx
@@ -8,15 +8,15 @@ import {
 } from '@/components/v1/ui/dialog';
 import { Input } from '@/components/v1/ui/input';
 import { Label } from '@/components/v1/ui/label';
-import { useState, useEffect } from 'react';
-import { useApiError } from '@/lib/hooks';
-import { useMutation } from '@tanstack/react-query';
 import { cloudApi } from '@/lib/api/api';
 import { OrganizationMemberRoleType } from '@/lib/api/generated/cloud/data-contracts';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
+import { useApiError } from '@/lib/hooks';
 import { UserPlusIcon } from '@heroicons/react/24/outline';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation } from '@tanstack/react-query';
+import { useState, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 const schema = z.object({
   email: z.string().email('Invalid email address'),

--- a/frontend/app/src/pages/organizations/$organization/index.tsx
+++ b/frontend/app/src/pages/organizations/$organization/index.tsx
@@ -1,12 +1,53 @@
-import { useParams, useNavigate } from '@tanstack/react-router';
-import { useQuery, useQueries, useQueryClient } from '@tanstack/react-query';
-import { cloudApi } from '@/lib/api/api';
-import api from '@/lib/api';
-import { useOrganizations } from '@/hooks/use-organizations';
-import { Loading } from '@/components/v1/ui/loading';
+import { CancelInviteModal } from './components/cancel-invite-modal';
+import { CreateTokenModal } from './components/create-token-modal';
+import { DeleteMemberModal } from './components/delete-member-modal';
+import { DeleteTenantModal } from './components/delete-tenant-modal';
+import { DeleteTokenModal } from './components/delete-token-modal';
+import { InviteMemberModal } from './components/invite-member-modal';
+import { Badge } from '@/components/v1/ui/badge';
 import { Button } from '@/components/v1/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/v1/ui/card';
+import CopyToClipboard from '@/components/v1/ui/copy-to-clipboard';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/v1/ui/dropdown-menu';
 import { Input } from '@/components/v1/ui/input';
-import { formatDistanceToNow } from 'date-fns';
+import { Loading } from '@/components/v1/ui/loading';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/v1/ui/table';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/v1/ui/tooltip';
+import { useOrganizations } from '@/hooks/use-organizations';
+import api from '@/lib/api';
+import { cloudApi } from '@/lib/api/api';
+import {
+  OrganizationMember,
+  ManagementToken,
+  OrganizationInvite,
+  OrganizationInviteStatus,
+  TenantStatusType,
+  OrganizationTenant,
+} from '@/lib/api/generated/cloud/data-contracts';
+import { appRoutes } from '@/router';
 import {
   PlusIcon,
   BuildingOffice2Icon,
@@ -18,52 +59,11 @@ import {
   XMarkIcon,
   ArrowRightIcon,
 } from '@heroicons/react/24/outline';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/v1/ui/card';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/v1/ui/table';
-import { Badge } from '@/components/v1/ui/badge';
-import { useState } from 'react';
-import { InviteMemberModal } from './components/invite-member-modal';
-import { DeleteMemberModal } from './components/delete-member-modal';
-import { CreateTokenModal } from './components/create-token-modal';
-import { DeleteTokenModal } from './components/delete-token-modal';
-import { CancelInviteModal } from './components/cancel-invite-modal';
-import { DeleteTenantModal } from './components/delete-tenant-modal';
-import {
-  OrganizationMember,
-  ManagementToken,
-  OrganizationInvite,
-  OrganizationInviteStatus,
-  TenantStatusType,
-  OrganizationTenant,
-} from '@/lib/api/generated/cloud/data-contracts';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/v1/ui/dropdown-menu';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/v1/ui/tooltip';
 import { EllipsisVerticalIcon, TrashIcon } from '@heroicons/react/24/outline';
-import CopyToClipboard from '@/components/v1/ui/copy-to-clipboard';
-import { appRoutes } from '@/router';
+import { useQuery, useQueries, useQueryClient } from '@tanstack/react-query';
+import { useParams, useNavigate } from '@tanstack/react-router';
+import { formatDistanceToNow } from 'date-fns';
+import { useState } from 'react';
 
 export default function OrganizationPage() {
   const { organization: orgId } = useParams({

--- a/frontend/app/src/pages/root.tsx
+++ b/frontend/app/src/pages/root.tsx
@@ -2,8 +2,8 @@ import { SidebarProvider } from '@/components/sidebar-provider';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Toaster } from '@/components/v1/ui/toaster';
 import { RefetchIntervalProvider } from '@/contexts/refetch-interval-context';
-import { PropsWithChildren } from 'react';
 import { Outlet } from '@tanstack/react-router';
+import { PropsWithChildren } from 'react';
 
 function Root({ children }: PropsWithChildren) {
   return (

--- a/frontend/app/src/providers/posthog.tsx
+++ b/frontend/app/src/providers/posthog.tsx
@@ -1,10 +1,10 @@
+import { useTenantDetails } from '@/hooks/use-tenant';
+import type { User } from '@/lib/api';
 import useApiMeta from '@/pages/auth/hooks/use-api-meta';
+import { useLocation } from '@tanstack/react-router';
 import posthog from 'posthog-js';
 import { PostHogProvider as PhProvider, usePostHog } from 'posthog-js/react';
 import { useEffect, useRef, useMemo, createContext } from 'react';
-import { useLocation } from '@tanstack/react-router';
-import type { User } from '@/lib/api';
-import { useTenantDetails } from '@/hooks/use-tenant';
 
 const CROSS_DOMAIN_SESSION_ID_KEY = 'session_id';
 const CROSS_DOMAIN_DISTINCT_ID_KEY = 'distinct_id';

--- a/frontend/app/src/router.tsx
+++ b/frontend/app/src/router.tsx
@@ -1,4 +1,5 @@
-import { FC } from 'react';
+import ErrorBoundary from './pages/error/index.tsx';
+import Root from './pages/root.tsx';
 import {
   RouterProvider,
   createRootRoute,
@@ -8,8 +9,7 @@ import {
   redirect,
 } from '@tanstack/react-router';
 import { Outlet } from '@tanstack/react-router';
-import ErrorBoundary from './pages/error/index.tsx';
-import Root from './pages/root.tsx';
+import { FC } from 'react';
 
 const rootRoute = createRootRoute({
   component: Root,


### PR DESCRIPTION
# Description

Adds the [Trivago import sorter plugin](https://github.com/trivago/prettier-plugin-sort-imports) to the frontend for consistency / ease

## Type of change

- [x] Chore (changes which are not directly related to any business logic)

