### PR TITLE
[WIP] Update Failed Slack Message Format

### DIFF
--- a/internal/integrations/alerting/slack.go
+++ b/internal/integrations/alerting/slack.go
@@ -66,7 +66,7 @@ func (t *TenantAlertManager) getSlackWorkflowRunTextAndBlocks(numFailed int, fai
 		res = append(res, slack.NewSectionBlock(
 			slack.NewTextBlockObject(
 				slack.MarkdownType,
-				fmt.Sprintf(":warning: %s failed %s", workflowRun.WorkflowName, workflowRun.RelativeDate),
+				fmt.Sprintf(":warning: %s failed %s\n_%s_", workflowRun.WorkflowName, workflowRun.RelativeDate, workflowRun.AbsoluteDate),
 				false,
 				false,
 			),


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Update the failed slack message to this format: 
```
{
	"blocks": [
		{
			"type": "section",
			"text": {
				"type": "mrkdwn",
				"text": ":warning: deploy-quanta-workflow failed an hour ago\n`01/01/2025 12:45 am UTC`"
			},
			"accessory": {
				"type": "button",
				"text": {
					"type": "plain_text",
					"text": "View"
				},
				"url": "https://app.hatchet.run/workflow-runs/abc123?tenant=xyz",
				"action_id": "button-action"
			}
		}
	]
}
```
<img width="2048" height="1060" alt="image" src="https://github.com/user-attachments/assets/d54ed4b3-362c-4e33-a8e6-eb8e50690dd8" />


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update


