### PR TITLE
fix: prevent static rate limits from resetting to 0 

### DIFF
--- a/pkg/repository/v1/scheduler_queue.go
+++ b/pkg/repository/v1/scheduler_queue.go
@@ -511,9 +511,11 @@ func (d *queueRepository) GetTaskRateLimits(ctx context.Context, queueItems []*s
 			continue
 		}
 
-		upsertRateLimitBulkParams.Keys = append(upsertRateLimitBulkParams.Keys, key)
-		upsertRateLimitBulkParams.Windows = append(upsertRateLimitBulkParams.Windows, getWindowParamFromDurString(duration))
-		upsertRateLimitBulkParams.Limitvalues = append(upsertRateLimitBulkParams.Limitvalues, int32(limitValue)) // nolint: gosec
+		if limitValue > 0 {
+			upsertRateLimitBulkParams.Keys = append(upsertRateLimitBulkParams.Keys, key)
+			upsertRateLimitBulkParams.Windows = append(upsertRateLimitBulkParams.Windows, getWindowParamFromDurString(duration))
+			upsertRateLimitBulkParams.Limitvalues = append(upsertRateLimitBulkParams.Limitvalues, int32(limitValue))
+		}
 	}
 
 	var stepRateLimits []*sqlcv1.StepRateLimit


### PR DESCRIPTION
Fixes [1834](https://github.com/hatchet-dev/hatchet/issues/1834#issue-3125874777)

This PR fixes a bug where static rate limits were being reset to 0 when tasks using them were queued

Verified fix locally using the exact reproduction code from issue
Confirmed static rate limits maintain their limitValue after tasks are queued