### PR TITLE
Feat: New event getter + janky v0 fix

### DIFF
--- a/api-contracts/openapi/components/schemas/_index.yaml
+++ b/api-contracts/openapi/components/schemas/_index.yaml
@@ -114,6 +114,8 @@ WorkflowID:
   $ref: "./event.yaml#/WorkflowID"
 EventList:
   $ref: "./event.yaml#/EventList"
+V1Event:
+  $ref: "./v1/event.yaml#/V1Event"
 V1EventList:
   $ref: "./v1/event.yaml#/V1EventList"
 V1FilterList:

--- a/api-contracts/openapi/openapi.yaml
+++ b/api-contracts/openapi/openapi.yaml
@@ -163,6 +163,8 @@ paths:
     $ref: "./paths/event/event.yaml#/withEvent"
   /api/v1/events/{event}/data:
     $ref: "./paths/event/event.yaml#/eventData"
+  /api/v1/tenants/{tenant}/events/{event}/data:
+    $ref: "./paths/event/event.yaml#/eventDataWithTenant"
   /api/v1/tenants/{tenant}/events/keys:
     $ref: "./paths/event/event.yaml#/keys"
   /api/v1/tenants/{tenant}/workflows:

--- a/api-contracts/openapi/openapi.yaml
+++ b/api-contracts/openapi/openapi.yaml
@@ -57,6 +57,8 @@ paths:
     $ref: "./paths/v1/tasks/tasks.yaml#/getTaskPointMetrics"
   /api/v1/stable/tenants/{tenant}/events:
     $ref: "./paths/v1/events/event.yaml#/V1EventList"
+  /api/v1/stable/tenants/{tenant}/events/{v1-event}:
+    $ref: "./paths/v1/events/event.yaml#/V1EventGet"
   /api/v1/stable/tenants/{tenant}/events/keys:
     $ref: "./paths/v1/events/event.yaml#/keys"
   /api/v1/stable/tenants/{tenant}/filters:

--- a/api-contracts/openapi/openapi.yaml
+++ b/api-contracts/openapi/openapi.yaml
@@ -163,7 +163,7 @@ paths:
     $ref: "./paths/event/event.yaml#/withEvent"
   /api/v1/events/{event}/data:
     $ref: "./paths/event/event.yaml#/eventData"
-  /api/v1/tenants/{tenant}/events/{event}/data:
+  /api/v1/tenants/{tenant}/events/{event-with-tenant}/data:
     $ref: "./paths/event/event.yaml#/eventDataWithTenant"
   /api/v1/tenants/{tenant}/events/keys:
     $ref: "./paths/event/event.yaml#/keys"

--- a/api-contracts/openapi/paths/event/event.yaml
+++ b/api-contracts/openapi/paths/event/event.yaml
@@ -290,13 +290,13 @@ eventData:
 
 eventDataWithTenant:
   get:
-    x-resources: ["tenant", "event"]
+    x-resources: ["tenant", "event-with-tenant"]
     description: Get the data for an event.
     operationId: event-data:get-with-tenant
     parameters:
       - description: The event id
         in: path
-        name: event
+        name: event-with-tenant
         required: true
         schema:
           type: string

--- a/api-contracts/openapi/paths/event/event.yaml
+++ b/api-contracts/openapi/paths/event/event.yaml
@@ -288,6 +288,53 @@ eventData:
     tags:
       - Event
 
+eventDataWithTenant:
+  get:
+    x-resources: ["tenant", "event"]
+    description: Get the data for an event.
+    operationId: event-data:get-with-tenant
+    parameters:
+      - description: The event id
+        in: path
+        name: event
+        required: true
+        schema:
+          type: string
+          format: uuid
+          minLength: 36
+          maxLength: 36
+      - description: The tenant id
+        in: path
+        name: tenant
+        required: true
+        schema:
+          type: string
+          format: uuid
+          minLength: 36
+          maxLength: 36
+    responses:
+      "200":
+        content:
+          application/json:
+            schema:
+              $ref: "../../components/schemas/_index.yaml#/EventData"
+        description: Successfully retrieved the event data
+      "400":
+        content:
+          application/json:
+            schema:
+              $ref: "../../components/schemas/_index.yaml#/APIErrors"
+        description: A malformed or bad request
+      "403":
+        content:
+          application/json:
+            schema:
+              $ref: "../../components/schemas/_index.yaml#/APIErrors"
+        description: Forbidden
+    summary: Get event data
+    tags:
+      - Event
+
 keys:
   get:
     x-resources: ["tenant"]

--- a/api-contracts/openapi/paths/v1/events/event.yaml
+++ b/api-contracts/openapi/paths/v1/events/event.yaml
@@ -1,3 +1,50 @@
+V1EventGet:
+  get:
+    x-resources: ["tenant", "v1-event"]
+    description: Get an event by its id
+    operationId: v1-event:get
+    parameters:
+      - description: The tenant id
+        in: path
+        name: tenant
+        required: true
+        schema:
+          type: string
+          format: uuid
+          minLength: 36
+          maxLength: 36
+      - description: The event id
+        in: path
+        name: v1-event
+        required: true
+        schema:
+          type: string
+          format: uuid
+          minLength: 36
+          maxLength: 36
+    responses:
+      "200":
+        content:
+          application/json:
+            schema:
+              $ref: "../../../components/schemas/_index.yaml#/V1Event"
+        description: Successfully listed the events
+      "400":
+        content:
+          application/json:
+            schema:
+              $ref: "../../../components/schemas/_index.yaml#/APIErrors"
+        description: A malformed or bad request
+      "403":
+        content:
+          application/json:
+            schema:
+              $ref: "../../../components/schemas/_index.yaml#/APIErrors"
+        description: Forbidden
+    summary: Get events
+    tags:
+      - Event
+
 V1EventList:
   get:
     x-resources: ["tenant"]

--- a/api/v1/server/handlers/events/get_data.go
+++ b/api/v1/server/handlers/events/get_data.go
@@ -22,3 +22,20 @@ func (t *EventService) EventDataGet(ctx echo.Context, request gen.EventDataGetRe
 		},
 	), nil
 }
+
+func (t *EventService) EventDataGetWithTenant(ctx echo.Context, request gen.EventDataGetWithTenantRequestObject) (gen.EventDataGetWithTenantResponseObject, error) {
+	// hack to use the tenant id to populate the event in the v1 case
+	event := ctx.Get("event-with-tenant").(*dbsqlc.Event)
+
+	var dataStr string
+
+	if len(event.Data) > 0 {
+		dataStr = string(event.Data)
+	}
+
+	return gen.EventDataGetWithTenant200JSONResponse(
+		gen.EventData{
+			Data: dataStr,
+		},
+	), nil
+}

--- a/api/v1/server/handlers/events/get_data.go
+++ b/api/v1/server/handlers/events/get_data.go
@@ -8,7 +8,15 @@ import (
 )
 
 func (t *EventService) EventDataGet(ctx echo.Context, request gen.EventDataGetRequestObject) (gen.EventDataGetResponseObject, error) {
-	event := ctx.Get("event").(*dbsqlc.Event)
+	eventInterface := ctx.Get("event")
+	if eventInterface == nil {
+		return nil, echo.NewHTTPError(404, "event not found")
+	}
+
+	event, ok := eventInterface.(*dbsqlc.Event)
+	if !ok {
+		return nil, echo.NewHTTPError(500, "invalid event type in context")
+	}
 
 	var dataStr string
 
@@ -25,7 +33,16 @@ func (t *EventService) EventDataGet(ctx echo.Context, request gen.EventDataGetRe
 
 func (t *EventService) EventDataGetWithTenant(ctx echo.Context, request gen.EventDataGetWithTenantRequestObject) (gen.EventDataGetWithTenantResponseObject, error) {
 	// hack to use the tenant id to populate the event in the v1 case
-	event := ctx.Get("event-with-tenant").(*dbsqlc.Event)
+	eventInterface := ctx.Get("event-with-tenant")
+
+	if eventInterface == nil {
+		return nil, echo.NewHTTPError(404, "event not found")
+	}
+
+	event, ok := eventInterface.(*dbsqlc.Event)
+	if !ok {
+		return nil, echo.NewHTTPError(500, "invalid event type in context")
+	}
 
 	var dataStr string
 

--- a/api/v1/server/handlers/v1/events/get.go
+++ b/api/v1/server/handlers/v1/events/get.go
@@ -1,0 +1,17 @@
+package eventsv1
+
+import (
+	"github.com/labstack/echo/v4"
+
+	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
+	"github.com/hatchet-dev/hatchet/api/v1/server/oas/transformers/v1"
+	v1 "github.com/hatchet-dev/hatchet/pkg/repository/v1"
+)
+
+func (t *V1EventsService) V1EventGet(ctx echo.Context, request gen.V1EventGetRequestObject) (gen.V1EventGetResponseObject, error) {
+	event := ctx.Get("v1-event").(*v1.EventWithPayload)
+
+	return gen.V1EventGet200JSONResponse(
+		transformers.ToV1Event(event),
+	), nil
+}

--- a/api/v1/server/oas/gen/openapi.gen.go
+++ b/api/v1/server/oas/gen/openapi.gen.go
@@ -3176,8 +3176,8 @@ type ServerInterface interface {
 	// (POST /api/v1/tenants/{tenant}/events/replay)
 	EventUpdateReplay(ctx echo.Context, tenant openapi_types.UUID) error
 	// Get event data
-	// (GET /api/v1/tenants/{tenant}/events/{event}/data)
-	EventDataGetWithTenant(ctx echo.Context, tenant openapi_types.UUID, event openapi_types.UUID) error
+	// (GET /api/v1/tenants/{tenant}/events/{event-with-tenant}/data)
+	EventDataGetWithTenant(ctx echo.Context, tenant openapi_types.UUID, eventWithTenant openapi_types.UUID) error
 	// List tenant invites
 	// (GET /api/v1/tenants/{tenant}/invites)
 	TenantInviteList(ctx echo.Context, tenant openapi_types.UUID) error
@@ -5200,12 +5200,12 @@ func (w *ServerInterfaceWrapper) EventDataGetWithTenant(ctx echo.Context) error 
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter tenant: %s", err))
 	}
 
-	// ------------- Path parameter "event" -------------
-	var event openapi_types.UUID
+	// ------------- Path parameter "event-with-tenant" -------------
+	var eventWithTenant openapi_types.UUID
 
-	err = runtime.BindStyledParameterWithLocation("simple", false, "event", runtime.ParamLocationPath, ctx.Param("event"), &event)
+	err = runtime.BindStyledParameterWithLocation("simple", false, "event-with-tenant", runtime.ParamLocationPath, ctx.Param("event-with-tenant"), &eventWithTenant)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter event: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter event-with-tenant: %s", err))
 	}
 
 	ctx.Set(BearerAuthScopes, []string{})
@@ -5213,7 +5213,7 @@ func (w *ServerInterfaceWrapper) EventDataGetWithTenant(ctx echo.Context) error 
 	ctx.Set(CookieAuthScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.EventDataGetWithTenant(ctx, tenant, event)
+	err = w.Handler.EventDataGetWithTenant(ctx, tenant, eventWithTenant)
 	return err
 }
 
@@ -7080,7 +7080,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.POST(baseURL+"/api/v1/tenants/:tenant/events/cancel", wrapper.EventUpdateCancel)
 	router.GET(baseURL+"/api/v1/tenants/:tenant/events/keys", wrapper.EventKeyList)
 	router.POST(baseURL+"/api/v1/tenants/:tenant/events/replay", wrapper.EventUpdateReplay)
-	router.GET(baseURL+"/api/v1/tenants/:tenant/events/:event/data", wrapper.EventDataGetWithTenant)
+	router.GET(baseURL+"/api/v1/tenants/:tenant/events/:event-with-tenant/data", wrapper.EventDataGetWithTenant)
 	router.GET(baseURL+"/api/v1/tenants/:tenant/invites", wrapper.TenantInviteList)
 	router.POST(baseURL+"/api/v1/tenants/:tenant/invites", wrapper.TenantInviteCreate)
 	router.DELETE(baseURL+"/api/v1/tenants/:tenant/invites/:tenant-invite", wrapper.TenantInviteDelete)
@@ -9615,8 +9615,8 @@ func (response EventUpdateReplay429JSONResponse) VisitEventUpdateReplayResponse(
 }
 
 type EventDataGetWithTenantRequestObject struct {
-	Tenant openapi_types.UUID `json:"tenant"`
-	Event  openapi_types.UUID `json:"event"`
+	Tenant          openapi_types.UUID `json:"tenant"`
+	EventWithTenant openapi_types.UUID `json:"event-with-tenant"`
 }
 
 type EventDataGetWithTenantResponseObject interface {
@@ -14054,11 +14054,11 @@ func (sh *strictHandler) EventUpdateReplay(ctx echo.Context, tenant openapi_type
 }
 
 // EventDataGetWithTenant operation
-func (sh *strictHandler) EventDataGetWithTenant(ctx echo.Context, tenant openapi_types.UUID, event openapi_types.UUID) error {
+func (sh *strictHandler) EventDataGetWithTenant(ctx echo.Context, tenant openapi_types.UUID, eventWithTenant openapi_types.UUID) error {
 	var request EventDataGetWithTenantRequestObject
 
 	request.Tenant = tenant
-	request.Event = event
+	request.EventWithTenant = eventWithTenant
 
 	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.EventDataGetWithTenant(ctx, request.(EventDataGetWithTenantRequestObject))
@@ -15928,72 +15928,72 @@ var swaggerSpec = []string{
 	"hhHEmUzAlUKB9vmJBQNdfkPhgF9SOuDm4qGNvtgx+cDYVBcSeM1SwgeRD8MKt1v2nRsytMTZORXXJjW4",
 	"Wwkf4WdWKBgC3BUKcWFI4DwEi7WLjblWEOq7sgQM02jAkxNvqoiHc90pIZoY0mCWo6QVUjsrpIaMUjcj",
 	"n5gZzdHGym1zDnbWj3DRPutlxsalbusM2e2N3XRj94Ttd518IE4D6znNeRA3O5qH8oj5WY9mjoBdOZrX",
-	"Y1bjwLVa/U96YH5n/30+ZBbt2pAjQAA/MKNKo+A5IOA9JF8Qmd5IVq+VGZJlzCJDmjy2+kb5w5/mdKOW",
-	"SbvAKKE9zfM+axpmnHm0Kwi7mldR9IgIbBoMIXuZHTwH7Gur10q/Tg0fS3l0Smy3fpymUIeMFjcU38An",
-	"qKT19qlKi2jgKHELZOC4fdHoBQ7uMkELgjB+9rjdk5MtabSAuL1hFfnWJBdgBMYh7CWAwB4bk7KH4LVl",
-	"dF4hheQPPf7vZy5iQkhgWdics9+xMhG5CBreZ2898/JcXw1bT6Fj30/+WtnCKWSXZUuOzTgRZuRq0z/z",
-	"+1gbHd+ME/YnQn5fOGGzQfzLaQUvFsbvyLkcvr3hXBFe35hzq06+GZyNGfM1ukHKXmYW/8S+tjdISY0a",
-	"Ppa6QUpstzdI0w0yo8X1BACK8Q6/8z8clEAPCCC8+ySe1QXQcmr4MVRBsWwbbPzzVnn3t43w7jI64M/B",
-	"tTuUh/bSknZWMWluYxrIi64kZIcUUaVJ7CLgx9CBd0IEbFb55dvlpvwKdOxIOitH6WXQg8W+tcLrhYWX",
-	"Va4sIbyqtJ55Es8gmcIU92ZUB/XrSxNlXTzRRfnX1WWdvFZdP4nJfoiLAoHfyOE8BKhAFcWRmtwBylhu",
-	"mfKlmZJygGFf1nUD+VcKU+jMhqx1Yw78O+21R8y331HL+xSIunl7SI72lstO4T3CBKM4amXiLslEtTtl",
-	"iSg5Z1mZmD31ubhxJ+qxsc6PewgIvKAN25wZu1x5dh35FWoxucksCorOdiCTQhGWbZXMyPNag0ABjZ1b",
-	"38KCFVzHTSZumbfFBf91WYkrevTmcYj8RX06SdnB4x1ckklKN+dr1qNNJXloQstyj0aF3Wgfj7aekRWH",
-	"wH+oTiI5ok28JziexvFD+TmVff7Cv7bPqTx/pI6TJreHAqp3iR22VM34NgIpmcYJ+jcM+MSvtzPxJ0im",
-	"ccCqdYAwjJ/MlZT5BjE9kLOAfp6xjysx4iEmICFWdhzRr/wcuzpNydRjl5UiQ95i+WzDALqiCGU995Ez",
-	"Xx2dGPCgcw9DmThWcliZQhAIr5Ew5gRTY/FkGw79NEFkwfDjx/EDgnRQVvDoq04PDKX5GSUh0B1Ymg7q",
-	"cvqOLkdFAiwI5Ai3cljI4cvRQEdVA0lcxHIri3dOFpcZQUniy9EKqYQLA5sYrI3GYAjI81dlBuH10Wx+",
-	"UueoiuKutgy9Qwxt5TxHjq48UUUNzt42nqxEWfB9e7navLnAhJhmNgNVqzq3M+2jyi48qqi9Wfczs6li",
-	"eiXrZsXRvfGCM1Th9OaEuCd2vO6uVm3fpMQQW7SkfGglwtbKnOq0+AR4rdM6EaEf6vQnutHLVtCulhO1",
-	"+f5OCYGzuUhcydpq4sMmOPYt0V8rQapc4hFmvtJChHAiCHfvgvDCj3h1jLIthk4g7ViRF4wlUHTlYda8",
-	"ZeFdzFSWpJHYqhqPdhTNU+YPwR93Tct93glNpc1TViFf2Ia/hEDJ1lRpC+DNhLNAnXB5D8mID9uKlpfT",
-	"Dppl4LVYGsRw7YVily8Ucpc2IjUIwA89TACpMRgC/MAqPQlLYY2V8AbghxEb1F1EDM5/RNugQkQDDjXi",
-	"uuXRHTAD2thgG+mRhNdM7ylOHqqSRWQO2FaXptabKQsm4aj4wpBKEVJVsZMiQwW88I6e3I72uW3X3s81",
-	"8l8+iaEYxMZCP/07eY5/ODa2VGjXMHPQKAWh3NqWc3fvoVxnvKUOS0YV1Q9p9ITkwrvaSz47G376wzLD",
-	"RFvPei1ZqaX2kI/RW967UiKaG4Ka15nQK/sayk1o5XjbohNa0QkNL7jGoJurnfxyJShMcDuXqtdsvTmC",
-	"aS+pO1maIr9H5XDgalNSE4HzXf9nnR9LjhNqT2BBpvvs1lJgfTNoOgb3WE0Q27VsZoHWzcUe159/QaqP",
-	"6e/maWp5fj5kj5G1j0n8yZIztA70QQ1fD9joLXO/PHNnWUyutQKTHMZV3p3yOGLb3Zq1t2TW/qLjPnLJ",
-	"H5JtUlOVYX0SB0/BHG5IjxixsVt5szfKBN+wVqP4gTQKFbsifIYqI0NFFXbG4mGo3sexQdeoYn0WOMld",
-	"WfqyaF8rA9YO4AXAxBucs4T1U+iFQO6gLU0RwGQQWPMUvTox5Snago9tk2KdpVJ8rUlk93xrlpAl7o43",
-	"brIQO71MsJZuGs1PmTgtgPcgDUnnzVE3Jyq2kUJNzf16mclHPJPaeOGxCcyTik/2fA7bULvax57161vr",
-	"TMmoxqwNBjqTcQ1jQPxp6bGnSmPan2CgTXk5aO8kHBmubvsimqT8VLLux565Zqn5rpS+YRoNApxLPbsS",
-	"gsv5dhsahEQEUvt6VJMejZPNNl5u8KGfxFG9RkJbeX/F4wwokqDJpNZ94iyJo59aTdmb/K5qY1FAp51A",
-	"olTig5o03raL2wbuunTmpuBd1qlSxikZxTeZjnZoPtV+ZiivyJk7Xnj3Ii/v2lL36lIEu6fvHS82l8FX",
-	"Uwq2nMM3h4wVNPT22DVo6aVzbkPqOj10D7/T//Tkr25l7soHsfPDByWcPS96p1ZvAyuH0e2XvXOsT2fc",
-	"xDY/cLFenBlNzd4q8gTx9blb9Zi4InPts3vSDnPWho7O9tjcB8N+o8N6LfKhrrwkm1XN6Cwc9rzW5G7J",
-	"h01Vm9QFxA03cDjZ+igV8BKOLra9OlVBLwbZqgrVckCw5SZEgZsqz44D1wc9/ZWx3k2pNZjtssGMPSI3",
-	"sJax9ls0le2iHW8OEoo0i+tKASze+Iv+mLEl+AwpYoywCSeRzcJ1aozPYokIUgyd6i3KtstYt0asr7Az",
-	"uQD3gKLACSrWsDFIH1EU1EOz98ZUgmbQA/cU0JLz9BPAMpZZX0Ln5OjkuHdE/3dzdPSG/e9/rMZq1v2U",
-	"TmAmXnqs9igUHddq5BTiMbyPE7hJkN+yGdYJcwWW71GE8HR5mGX/reJ5XUCvFdObexwoW+J/2qeBou7Y",
-	"Wjg24i69mTcB5iHtkr8feAI0etDl2V9P6O8YCLHPFahbNbxVw7evhre6ZatbvkgIFF6xYjsTQG1lkfrz",
-	"fQPV07NznoIapCE9HmushqrlMvbDkezcWhF32Yq4uXuRIoC98pxqlalWmdobZSpbRiaq12KbVSA5Mbiy",
-	"0hpg3miMZEnCtFaH9WolFg1gs3rJ4Xf1Z6+U0qnWQdEMckOdZc/dFA04sBYbMKJ6Zz0Xzbvb+iMUXRct",
-	"eGrmkGChjRonxrUw4F4XENwr7tvkcdwexfvu4rhZOeKmGKisLc9ZsGBliXHgRfDJHjLoHjEoXPD2J896",
-	"ffBadZqWStC2Wvx8WU9IUazMuvlbzXPbzN9bTw9vh78Vi9svxbJzuXWFoKui8s1Ea2uyOGdHNstjqREI",
-	"ieyuD5ZUiWEatVJ4m1JY7oC2AU3kr1Vv2GL1yObqqC6Bf8qbZit+ncSvUEjqdOK1i1xesKHnx2lEalx0",
-	"WBuZ/k5WGgGPAIVgHEImfTVxY76Nv4eEF4TAZ2zGvRe9dVkK9zxLaW6zlrx6c1Lh5NNawy1v9DkkLZe7",
-	"NM/+KYYJPvTTJIHVnI357YA39Gi3EvfeYpi8h+RMDLZBuqMzNaQzBnFb8+rla15BP00QWTAx7sfxA4Kn",
-	"KZVdf36loqoQ55onN0nubPsNZDxBZJqOD30QhmPgP1jJ+SyezUNIIKfpKzq/ZzyP6EQ8zu49G/qK4vJM",
-	"Dl8g8FdHJzXvCb6YNyjPO4UgEOUtw5hvhrHwsRLrzwVk5nAnF5ifwxF9mIDELgpG9OtyiGNdm2ONwbN5",
-	"nDHoGiIsjich3Ay9saF/cHrj6FszvWWI++HoDUWPiECXGrhSG+YdeNVel+ObjsCr+Q7EXJusEq1N5OQ/",
-	"ESIsNya/wFZfdD5WWRroAvbKlZyttHcIfB/Oid3ydsq+Y2VhE5NYiqbzzed9OpuxJ/HB+UT1NVorqI+v",
-	"3ER/rReAIi+O7dLeu9NXAllC1YrijfR7M/rifTqbKoVIB18DffGVt/RVSV8c20vQVxhPUGQnq4t4gj0U",
-	"eYCdjQcVCsYFG2hDuVjoEUzH31Ixaad7dBhPJjDwUNRen1/4+tzt/HZysq11z5OY0gAz2vYjgsjC63mP",
-	"IEQBm4xuimiCookH5Uh2hZcRtvkq3+1868GITtVLAIE9ZgOnOjR/qzExc5ySGm6OU+LGznH68sYqwWTx",
-	"jtWGa41UNdo0ox5X+9QMzsYwwVM0b3CH0zq53eP4Gfgp6ybioDZK4OZJm1/odBS1l7plLnU6ButJcg4w",
-	"foqTClcKlf6PdvBk+yqRei3H3JySdDYF0URNtEvaks8gCxSiWnHeKk3NlKZqVueUn2fGlfWpBE6oJE6q",
-	"rt28Ba5UqZSn1Kb4XoKxSxwvkdc+NLZMv56bkqTy9VyWcAj8h408Uo3oyDv8RlUjSRs+Wj3CBAsQKgvB",
-	"i3bSBQrD5NGgpQ+i+/g9JJ/FoGstg6VBmiUFOT44OjgypR3RPI/+VF2/OlS4uqlYbMHbsoLYv0AvgSRN",
-	"ohzyCjcdKmbTKKL8o6b41pND9uI5j3Ius8ATHE/j+KEnHNEOv4sfHEI66VEnWpcd1fjv7tGaYiC7I5ia",
-	"aMt+YI7hjxK+9mB7eeNEMeRSJ1Or95do8dWJOQ4Fnl3MFLKpLCFbzTFCccOuuVl2lm/W4z/JoefukwI1",
-	"FDNDMaFN6qrUswI7arta9twh9mRWmdIWNeVRxZvsj+ca72veyuhYzZwznXiOO5lW+Swbzvj98Vhu7Dsq",
-	"VtzaI0tOyaWAL3lBsfsgM7W6vthIJSG7lxTZCVreVNGO3LlhOysEBlKJsu3FQTnyml70o+U0S5mPVZit",
-	"cJoUg3uckts0K/vT4F60kxEyTRLDKADbAL3tB+iZrkMaxSwZH9Ot07DcOaGByvUzBIotGRzW8tZL85Ye",
-	"hbYKY7mofe7c1UwP3AkGW78umEeGa6w817ryXLZt5dBJIhTVw1YeWBXE1ZizRk10qtBANylfikEx3qN6",
-	"6bCelA0qMuwCPxuyovKcpmsoWbV8wSozYJMkTucs1WwGgtwoKyis00e46NSmAdmwkFgx/bt8VGozwO+g",
-	"NrFUyvlGgkumJrI6t8isGk2TBS2VI2gnJdeNgV0OvME9s27jlFIHDLqMq0JAICaKpxD27iHxpzCwJSTP",
-	"BP+OK1KCDJZMPPRi6YY0eBvlGWqzC7XZhTaQXaiRaBayATu8auVOciexLHxr9sgE8yPI5Q1LOekwtZoq",
-	"2Mq7nVIBM1JcVgUsOv6NIUhgohz/ukZXQOZJxuVBmoSdN53O89fn/x8AAP//ZF4cL9QWAwA=",
+	"Y1bjwLVa/U96YH5n/+09ITLtyU/Mul0bfgQI4IdnVGkgPAcEvIfkCyLTG8n2tfJDso9ZfJRA3vbb5Q9/",
+	"ytNNWyYdA6OK9pTP+7JpmHHm3a6ByKv5GUWPiMCmAROyl9kJdMC+trqv9P3U8LGU16fEduvraQqHyGhx",
+	"QzEQfIJKWm+fs7SoB44St2AHjtsXjXDg4C4T2CAI42eP7T052ZLWC4jbO1eRb01yAUZgHMJeAgjssTEp",
+	"ewheW0YvFlJI/tDj/37mIiaEBJaFzTn7HSszkoug4X321nsvz/XVsPUUOvb95K+VLZxCdlm25NiME2FG",
+	"rjZdNL+PtRH0zThhf6Lo94UTNhvov5xW8GKh/o6cy+HbG84VIfiNObfq5JvB2ZgxX6MbpOxlZvFP7Gt7",
+	"g5TUqOFjqRukxHZ7gzTdIDNaXE+QoBjv8Dv/w0EJ9IAAwrtP4lldkC2nhh9DFRTLtsHGP2+Vd3/bCO8u",
+	"owP+HFy7Q7lqLy2paRWT5jamgbzoSkJ2SCNVmsQuAn4MHXgnRMBmlV++XW7Kr0DHjqS8cpReBj1Y7Fsr",
+	"vF5YeFnlyhLCq0rrmSfxDJIpTHFvRnVQv758UdbFE12UD15dZspr1fWTmOyHuCgQ+I0czkOAClRRHKnJ",
+	"HaCM5ZYpX5opKQcY9mVdN5B/pTCFzmzIWjfmwL/TXnvEfPsd2bxPwaqbt4fkaG+5DBbeI0wwiqNWJu6S",
+	"TFS7U5aIknOWlYnZU5+Lq3eiHhvrfL2HgMAL2rDNq7HL1WnXkYOhFpObzLSg6GwHsi0UYdlWWY08rzUI",
+	"JtDYufUzLFjBddxk4pZ5W1zwX5eVuKJHbx6HyF/Up5yUHTzewSXhpHSFvmY92nSThya0LPdoVNiN9vFo",
+	"61lbcQj8h+pEkyPaxHuC42kcP5SfU9nnL/xr+5zKc0zqOGlyeyigepfYYUsVj28jkJJpnKB/w4BP/Ho7",
+	"E3+CZBoHrKIHCMP4yVxtmW8Q0wM5C+jnGfu4EiMeYgISYmXHEf3Kz7Gr05RMPXZZKTLkLZbPNgygK4pQ",
+	"1nMfOfPV0YkBDzr3MJSJYyWHlSkEgfAaCWNOMDUWT7bh0E8TRBYMP34cPyBIB2VFkb7q9MBQmp9REgLd",
+	"gaXpoC7v7+hyVCTAgkCOcCuHhRy+HA10VDWQxEUst7J452RxmRGUJL4crZBuuDCwicHaaAyGgDx/VWYZ",
+	"Xh/N5id1jqoo7mrL0DvE0FbOc+ToyhNV1OnsbePJSpQO37eXq82bC0yIaWYzUPWsczvTPqrswqOK2pt1",
+	"PzObqqpXsm5WQN0bLzhDFU5vToh7Ysfr7mpl901KDLFFS8qHViJsrRSqTotPgNdDrRMR+qFOf6IbvWyV",
+	"7Wo5UZsT8JQQOJuL5JasrSY+bIJj35IBthKkyiUeYeYrLUQIJ4Jw9y4IL/yIV8co22LoBNKOFbnDWJJF",
+	"Vx5mzVsW3sVsZkkaia2q8WhH0Txl/hD8cde03Oed0FTaXGYV8oVt+EsIlGxNlbYA3kw4C9QJl/eQjPiw",
+	"rWh5Oe2gWZZei6VBDNdeKHb5QiF3aSNSgwD80MMEkBqDIcAPrBqUsBTWWAlvAH4YsUHdRcTg/Ee0DSpE",
+	"NOBQI65bHt0BM6CNDbaRHkl4zfSe4uShKllE5oBtdWlqvZmyYBKOii8MqRQhVVU9KTJUwAvv6MntaJ/b",
+	"du39XCP/5ZMYikFsLPTTv5Pn+IdjY0vFeA0zB41SEMqtbTl39x7KdcZb6rBkVFH9kEZPSC68q73ks7Ph",
+	"pz8sM0y0Na/XkqFaag/5GL3lvSslorkhqHktCr36r6EkhVayty1MoRWm0PCCawy6ufrKL1emwgS3czl7",
+	"zdabI5j2krqT5Svye1QOB642JTURON/1f9b5seQ4ofYEFmS6z24tBdY3g6ZjcI/VBLFdy2YWaN1c7HH9",
+	"+Rek+pj+bp6mlufnQ/YYWfuYxJ8sOUPrQB/U8PWAjd4y98szd5bF5ForQslhXOXdKY8jtt2tWXtLZu0v",
+	"Ou4jl/wh2SY1VRnWJ3HwFMzhhvSIERu7lTd7o0zwDWs1ih9Io1CxK8JnqDIyVFRqZywehup9HBt0jSrW",
+	"Z4GT3JWlLwv7tTJg7QBeAEy8wTlLWD+FXgjkDtrSFAFMBoE1T9GrE1Oeoi342DYp6Fkqy9eaRHbPt2YJ",
+	"WeLueOMmC7HTywRr6abR/JSJ0wJ4D9KQdN4cdXOiYhsp1NTcr5eZfMQzqY0XHpvAPKn4ZM/nsA21q33s",
+	"Wb++tc6UjGrM2mCgMxnXMAbEn5Yee6o0pv0JBtqUl4P2TsKR4eq2L6JJyk8l637smWuWmu9K6Rum0SDA",
+	"udSzKyG4nG+3oUFIRCC1r0c16dE42Wzj5QYf+kkc1WsktJX3VzzOgCIJmkxq3SfOkjj6qdWUvcnvqjYW",
+	"BXTaCSRKJT6oSeNtu7ht4K5LZ24K3mWdKmWcklF8k+loh+ZT7WeG8oqcueOFdy/y8q4tda8uRbB7+t7x",
+	"YnMZfDWlYMs5fHPIWEFDb49dg5ZeOuc2pK7TQ/fwO/1PT/7qVuaufBA7P3xQwtnzondq9Tawchjdftk7",
+	"x/p0xk1s8wMX68WZ0dTsrSJPEF+fu1WPiSsy1z67J+0wZ23o6GyPzX0w7Dc6rNciH+rKS7JZ1YzOwmHP",
+	"a03ulnzYVLVJXUDccAOHk62PUgEv4ehi26tTFfRikK2qUC0HBFtuQhS4qfLsOHB90NNfGevdlFqD2S4b",
+	"zNgjcgNrGWu/RVPZLtrx5iChSLO4rhTA4o2/6I8ZW4LPkCLGCJtwEtksXKfG+CyWiCDF0Kneomy7jHVr",
+	"xPoKO5MLcA8oCpygYg0bg/QRRUE9NHtvTCVoBj1wTwEtOU8/ASxjmfUldE6OTo57R/R/N0dHb9j//sdq",
+	"rGbdT+kEZuKlx2qPQtFxrUZOIR7D+ziBmwT5LZthnTBXYPkeRQhPl4dZ9t8qntcF9FoxvbnHgbIl/qd9",
+	"Gijqjq2FYyPu0pt5E2Ae0i75+4EnQKMHXZ799YT+joEQ+1yBulXDWzV8+2p4q1u2uuWLhEDhFSu2MwHU",
+	"VhapP983UD09O+cpqEEa0uOxxmqoWi5jPxzJzq0VcZetiJu7FykC2CvPqVaZapWpvVGmsmVkonottlkF",
+	"khODKyutAeaNxkiWJExrdVivVmLRADarlxx+V3/2Simdah0UzSA31Fn23E3RgANrsQEjqnfWc9G8u60/",
+	"QtF10YKnZg4JFtqocWJcCwPudQHBveK+TR7H7VG87y6Om5UjboqBytrynAULVpYYB14En+whg+4Rg8IF",
+	"b3/yrNcHr1WnaakEbavFz5f1hBTFyqybv9U8t838vfX08Hb4W7G4/VIsO5dbVwi6KirfTLS2JotzdmSz",
+	"PJYagZDI7vpgSZUYplErhbcpheUOaBvQRP5a9YYtVo9sro7qEvinvGm24tdJ/AqFpE4nXrvI5QUben6c",
+	"RqTGRYe1kenvZKUR8AhQCMYhZNJXEzfm2/h7SHhBCHzGZtx70VuXpXDPs5TmNmvJqzcnFU4+rTXc8kaf",
+	"Q9JyuUvz7J9imOBDP00SWM3ZmN8OeEOPditx7y2GyXtIzsRgG6Q7OlNDOmMQtzWvXr7mFfTTBJEFE+N+",
+	"HD8geJpS2fXnVyqqCnGueXKT5M6230DGE0Sm6fjQB2E4Bv6DlZzP4tk8hARymr6i83vG84hOxOPs3rOh",
+	"ryguz+TwBQJ/dXRS857gi3mD8rxTCAJR3jKM+WYYCx8rsf5cQGYOd3KB+Tkc0YcJSOyiYES/Loc41rU5",
+	"1hg8m8cZg64hwuJ4EsLN0Bsb+genN46+NdNbhrgfjt5Q9IgIdKmBK7Vh3oFX7XU5vukIvJrvQMy1ySrR",
+	"2kRO/hMhwnJj8gts9UXnY5WlgS5gr1zJ2Up7h8D34ZzYLW+n7DtWFjYxiaVoOt983qezGXsSH5xPVF+j",
+	"tYL6+MpN9Nd6ASjy4tgu7b07fSWQJVStKN5IvzejL96ns6lSiHTwNdAXX3lLX5X0xbG9BH2F8QRFdrK6",
+	"iCfYQ5EH2Nl4UKFgXLCBNpSLhR7BdPwtFZN2ukeH8WQCAw9F7fX5ha/P3c5vJyfbWvc8iSkNMKNtPyKI",
+	"LLye9whCFLDJ6KaIJiiaeFCOZFd4GWGbr/LdzrcejOhUvQQQ2GM2cKpD87caEzPHKanh5jglbuwcpy9v",
+	"rBJMFu9YbbjWSFWjTTPqcbVPzeBsDBM8RfMGdzitk9s9jp+Bn7JuIg5qowRunrT5hU5HUXupW+ZSp2Ow",
+	"niTnAOOnOKlwpVDp/2gHT7avEqnXcszNKUlnUxBN1ES7pC35DLJAIaoV563S1ExpqmZ1Tvl5ZlxZn0rg",
+	"hEripOrazVvgSpVKeUptiu8lGLvE8RJ57UNjy/TruSlJKl/PZQmHwH/YyCPViI68w29UNZK04aPVI0yw",
+	"AKGyELxoJ12gMEweDVr6ILqP30PyWQy61jJYGqRZUpDjg6ODI1PaEc3z6E/V9atDhaubisUWvC0riP0L",
+	"9BJI0iTKIa9w06FiNo0iyj9qim89OWQvnvMo5zILPMHxNI4fesIR7fC7+MEhpJMedaJ12VGN/+4erSkG",
+	"sjuCqYm27AfmGP4o4WsPtpc3ThRDLnUytXp/iRZfnZjjUODZxUwhm8oSstUcIxQ37JqbZWf5Zj3+kxx6",
+	"7j4pUEMxMxQT2qSuSj0rsKO2q2XPHWJPZpUpbVFTHlW8yf54rvG+5q2MjtXMOdOJ57iTaZXPsuGM3x+P",
+	"5ca+o2LFrT2y5JRcCviSFxS7DzJTq+uLjVQSsntJkZ2g5U0V7cidG7azQmAglSjbXhyUI6/pRT9aTrOU",
+	"+ViF2QqnSTG4xym5TbOyPw3uRTsZIdMkMYwCsA3Q236Anuk6pFHMkvEx3ToNy50TGqhcP0Og2JLBYS1v",
+	"vTRv6VFoqzCWi9rnzl3N9MCdYLD164J5ZLjGynOtK89l21YOnSRCUT1s5YFVQVyNOWvURKcKDXST8qUY",
+	"FOM9qpcO60nZoCLDLvCzISsqz2m6hpJVyxesMgM2SeJ0zlLNZiDIjbKCwjp9hItObRqQDQuJFdO/y0el",
+	"NgP8DmoTS6WcbyS4ZGoiq3OLzKrRNFnQUjmCdlJy3RjY5cAb3DPrNk4pdcCgy7gqBARiongKYe8eEn8K",
+	"A1tC8kzw77giJchgycRDL5ZuSIO3UZ6hNrtQm11oA9mFGolmIRuww6tW7iR3EsvCt2aPTDA/glzesJST",
+	"DlOrqYKtvNspFTAjxWVVwKLj3xiCBCbK8a9rdAVknmRcHqRJ2HnT6Tx/ff7/AQAA///WEyU7+BYDAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/api/v1/server/oas/gen/openapi.gen.go
+++ b/api/v1/server/oas/gen/openapi.gen.go
@@ -3052,6 +3052,9 @@ type ServerInterface interface {
 	// List event keys
 	// (GET /api/v1/stable/tenants/{tenant}/events/keys)
 	V1EventKeyList(ctx echo.Context, tenant openapi_types.UUID) error
+	// Get events
+	// (GET /api/v1/stable/tenants/{tenant}/events/{v1-event})
+	V1EventGet(ctx echo.Context, tenant openapi_types.UUID, v1Event openapi_types.UUID) error
 	// List filters
 	// (GET /api/v1/stable/tenants/{tenant}/filters)
 	V1FilterList(ctx echo.Context, tenant openapi_types.UUID, params V1FilterListParams) error
@@ -3882,6 +3885,34 @@ func (w *ServerInterfaceWrapper) V1EventKeyList(ctx echo.Context) error {
 
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.V1EventKeyList(ctx, tenant)
+	return err
+}
+
+// V1EventGet converts echo context to params.
+func (w *ServerInterfaceWrapper) V1EventGet(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "tenant" -------------
+	var tenant openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "tenant", runtime.ParamLocationPath, ctx.Param("tenant"), &tenant)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter tenant: %s", err))
+	}
+
+	// ------------- Path parameter "v1-event" -------------
+	var v1Event openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "v1-event", runtime.ParamLocationPath, ctx.Param("v1-event"), &v1Event)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter v1-event: %s", err))
+	}
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	ctx.Set(CookieAuthScopes, []string{})
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.V1EventGet(ctx, tenant, v1Event)
 	return err
 }
 
@@ -6977,6 +7008,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.POST(baseURL+"/api/v1/stable/tenants/:tenant/cel/debug", wrapper.V1CelDebug)
 	router.GET(baseURL+"/api/v1/stable/tenants/:tenant/events", wrapper.V1EventList)
 	router.GET(baseURL+"/api/v1/stable/tenants/:tenant/events/keys", wrapper.V1EventKeyList)
+	router.GET(baseURL+"/api/v1/stable/tenants/:tenant/events/:v1-event", wrapper.V1EventGet)
 	router.GET(baseURL+"/api/v1/stable/tenants/:tenant/filters", wrapper.V1FilterList)
 	router.POST(baseURL+"/api/v1/stable/tenants/:tenant/filters", wrapper.V1FilterCreate)
 	router.DELETE(baseURL+"/api/v1/stable/tenants/:tenant/filters/:v1-filter", wrapper.V1FilterDelete)
@@ -7829,6 +7861,42 @@ func (response V1EventKeyList400JSONResponse) VisitV1EventKeyListResponse(w http
 type V1EventKeyList403JSONResponse APIErrors
 
 func (response V1EventKeyList403JSONResponse) VisitV1EventKeyListResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type V1EventGetRequestObject struct {
+	Tenant  openapi_types.UUID `json:"tenant"`
+	V1Event openapi_types.UUID `json:"v1-event"`
+}
+
+type V1EventGetResponseObject interface {
+	VisitV1EventGetResponse(w http.ResponseWriter) error
+}
+
+type V1EventGet200JSONResponse V1Event
+
+func (response V1EventGet200JSONResponse) VisitV1EventGetResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type V1EventGet400JSONResponse APIErrors
+
+func (response V1EventGet400JSONResponse) VisitV1EventGetResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type V1EventGet403JSONResponse APIErrors
+
+func (response V1EventGet403JSONResponse) VisitV1EventGetResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(403)
 
@@ -12207,6 +12275,8 @@ type StrictServerInterface interface {
 
 	V1EventKeyList(ctx echo.Context, request V1EventKeyListRequestObject) (V1EventKeyListResponseObject, error)
 
+	V1EventGet(ctx echo.Context, request V1EventGetRequestObject) (V1EventGetResponseObject, error)
+
 	V1FilterList(ctx echo.Context, request V1FilterListRequestObject) (V1FilterListResponseObject, error)
 
 	V1FilterCreate(ctx echo.Context, request V1FilterCreateRequestObject) (V1FilterCreateResponseObject, error)
@@ -12896,6 +12966,29 @@ func (sh *strictHandler) V1EventKeyList(ctx echo.Context, tenant openapi_types.U
 		return err
 	} else if validResponse, ok := response.(V1EventKeyListResponseObject); ok {
 		return validResponse.VisitV1EventKeyListResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("Unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// V1EventGet operation
+func (sh *strictHandler) V1EventGet(ctx echo.Context, tenant openapi_types.UUID, v1Event openapi_types.UUID) error {
+	var request V1EventGetRequestObject
+
+	request.Tenant = tenant
+	request.V1Event = v1Event
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.V1EventGet(ctx, request.(V1EventGetRequestObject))
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(V1EventGetResponseObject); ok {
+		return validResponse.VisitV1EventGetResponse(ctx.Response())
 	} else if response != nil {
 		return fmt.Errorf("Unexpected response type: %T", response)
 	}
@@ -15693,119 +15786,120 @@ var swaggerSpec = []string{
 	"vjUkzkEDElYXKvYRk6BPiEz1l5diWVgDfFkSAcvObvhRxH1dueTn3gwQf4rYQ5MPEwJQlAVqV61T5TCD",
 	"S1ByqeCz8+LUlohVjhf0uEOJxx+nTBCLNGcvui3jhZflFc08glmpIXUvsRity2lXjQsxpMCX0zzARY9X",
 	"X5kDlGDvlwAywUe5b+EB759v/vlrUWxVPnm7vdFhP55DJ3nIW7qui7VeDd7N3lHd76etBarOAqV4w9FJ",
-	"v4GCdsiOYUctjZ/tTpraR7jYF2Vt40ErEhdNGYGhu2UGEzN4QntcJ0NwSerCDKJlLSfwg6+9tOzqpaVU",
-	"AdHhmK7VcSunKCmiTOXncx6snga8mUaC0zGGxPNBFCCWu0DS9Vp1lKoVe7cYBoyNOCyEKuFleACRlh1E",
-	"tUVLQvOtqjcaazcQ61LEtDI9L9MlXjKBzvFbJdG7FgsyL0vvAS+CT2Jgq2jmbX9uEzFDAUeHi5mYWYkV",
-	"KfOq69x2uE3LsCCPOtYTJUE0gNuHr209fF1mb105hlf8qXjTnefdtbjD74/HPf63S8gMqJMUjZPB7ZYa",
-	"J7gVsVi/QK7FAJ7C2p5euJxFg4wPasXCS4oFV9bvaoRJj/4K916lwHuIYLOTL5/N1c13p/n5J+fiSUza",
-	"w92a4GOJM7bIaJWpJ+uPzT0Possdmypx40sy3CauAHyTlr4CvEBCS2f5IHNYtvJh/055B2WfedDOskJC",
-	"FWqBkIwyuMxL0sgTPatzYfJ32guECX+rlXWL9lWmlb3rNTTUeEE4ALqyw309NOtygyjaZpn1NwpUVega",
-	"C7CIBX2Z2E9eUYiR8n9gPYzVArSoQETb38nWd6z1RoktC6vlzzbMIUNVRcxiuiwBrLwhiiZ3vL7SliA/",
-	"NbgpPPQeheeAwyNB5q9wN6t0WHhZIzYVbMM0khKteSyeLkXbuNndCYpjezNTB5WbJ7f7iTuPUUQcz90Z",
-	"ilIC6XVc/pVA8BDET5E6ihscw+8huaaT7/shzA486YGoBQgIg3Wnq1UQPjk6Oe4d0f/dHB29Yf/7H4vc",
-	"kSWw7/lNZB0HJINU+SfqoMYUvhWAlRWq37LBdy2GjlJbjtSWkI6MT1r5uKPyMb87a5eS+NBnZVrtsS68",
-	"jKvKcWCSd7zJz/1AyVDAVJWaohs8b0zs+RJpW41VYZOGMOC5Z2pfJmXzNvFIG5NXklEFybB2yZTAeQgW",
-	"VQVD6PdKycSb/NSSiaOgiWRKJNK2KZk4mK6CKRGtW7nUyqWSXCrIhTXKJZFOzsX7VqbsrfO+FRmBW/fb",
-	"XXa/5eTC6sW7Rcmw9pe0+TIhV4ImRmoUV3urJDpnQEWHCkirJ3lxD1edfRq4uCpGbt/i8z6uCjGZ3BQo",
-	"XtnL1ZYYXW1i6+cq/FwFPpq8ckumfCFPV0kjTVxddzGh7s/t61rOluvA+w3UJubuKv7h5u9aKzP23OOV",
-	"Tq7K7gsWrvd9zbBiB3a7dmhX/pf+rC3v74SrSy17d3Vyq3FplfQrfFqFemjh2312ay0owD8aj0pv1ZZH",
-	"Le6qNcckjOgp2EsAgT12A6WbK3WwOk/V2gNvz31VN8s7m/M7/XFVcr2AesvyO6KSG+TB8me2+W5+HWNW",
-	"xhhFfjxD0UTR6wxiDCYVZ/cQ+hA9tjKoiQyK0jAsUX608OZgEcYg8FDkgWjhidV2OwR+I4fzEKACpRWn",
-	"XFWGZD6A1wndboLoOHyhYq54/Bf0q6xrORzdgxDDVmWwVKjhTGdgtWW52+X2LTyBe0ka1b1c5DOO1b5d",
-	"ZBnG2veL3c95iEUWOKcXjK1ljGPe9SAJEcQsTy50Am+Drv4hIE1AWZef/+64cztmoNmTGAQKhIqOc8mb",
-	"A5MNO+5/mUIy5QIARX6YBqycF6anVxyFC/13VWHKJJCicHEnG9QqKeM4DiGIHCI1cuXGHHD2QkEbhqJo",
-	"1ugNh6ygLxbF4d2HYMKO2idBF3HC3Cp0MlB3SxAFXpwS+qdQHTHVHWkDqQceeOfwHqQhz5X9T0oP//TQ",
-	"vZdGGLJj3LR8MdOdHLRTSUJbq7zU9F23dQXatZz9OY1SV3Tl70P6+4rvS7qGexggPA/BosecIGr0XdGW",
-	"DiucJuL7CiW4Wgc+54MxZ4q91oc10aoq4ueRIqIgBfoE6uyKgCZLX6Qw5YYN60YSaEVXK7qaii7JJz3K",
-	"J9WSK8ejTHswJwvPktZVSK6+GGwQ7K/gau+57T33J7nnbu04y+RCe5r9SKdZ7vTYyskmrtf2YJ4b3kD6",
-	"iuYv7BVHV+s0eixQpyGl5pk6RwokFl6Z236f1rRmSAAKcTPvUZ1C2vemojNngYHWwOB5fmaenNovdeXM",
-	"cyQHooC5iKnzn8TqKikKrfxvJ2BE8b8db255jM7ox9GZLAcDt21OWE/LC7C2vL3NULgEl7Wn+A6f4sWg",
-	"NkeG7pYIegkWPxTlpqo4nfDcXSRlhqM83x/UcvFI1rNakpf16TV1/cdkbf362bL0jjp4ncVpGPAoWXqR",
-	"NGkuO5RxJMdVqrjci8ga57LjIBQpCISl3v3qoApUOxu9fp46M5lYNRpAflyJulRFuFaotnpSUXYRNEPR",
-	"pF5bEu0aS6/3kNyIKfb27mOUQQGckynPQ8JzlXn+FIVBAm2uG6xDQ+m3eUHCN6eVJHsvSar4c93iBc6F",
-	"TJF/Ph+CxJ+iR1inBYlWAkza3ShCRgTOhbvuqRzYQXzI8azWUwlv67q7vEa2SZkk9l3suZNUyqeKbIve",
-	"bj/LkuK6QqalspDKsb/G/FI+0e2nsqlKNCkWrpdJLvcyUfbbXR71Zf3gVhr9JNLI/a7VyqL9kUUa429e",
-	"EoXxpM5TKownXoiikm5UNkdfxJMLFEFXa1Arhl42nimEjzB0chniLXMzVzGDpAPa6x2CYWDNCwfpweux",
-	"2TQ4KkqUsA5NARnxXsZQEsACBeIkqFo/+/x2wdfScPIrva8FD3z6ACXQF5HuFVCca82WgSTrv9lDSpcG",
-	"TYvit4nliqeCksLaWXART5ofA8LRqCJhOfOAwMKTyOK4f8N+PtMdX9btmMMH5xPVpd7lrkkv44rDIWzk",
-	"fCOQ+mPT+BJeN4rYVM5Z4U9TJHITRSvXuVqTMXeNES/slQTeNM2SCuwQM1iffLbjLfeyFC8TIbXUvt3b",
-	"BifGIIb8ogG/8RO4VB7DldlyeUqr8y9FfDYUTar5an+yMG3I65QjoMnhNlf5RXJlSttzbp/OOcEnS7Be",
-	"xXl3CEJKGNGkB2cAhb1JEqfzyodTqtzJW6AgLzaGxwbwxABF1j2lTfq0xXvaYF8inTZ/EpoQ07CQlHUT",
-	"Wt7JvyZWUGujc8z56lOeq44xfvqQCv3mVsCN21lXQnmjq93xZtl7iRPQQEMtXxvvfkZuW+8peYghIXWu",
-	"RZjtnuziyS7V2Qw0ckHRZCT67Emq3i0dkxpiVjgj9T1pWclwrTOgaW18NEc9Ej/AmmR43un1wOPtqrnm",
-	"dI5uaLNWn8SHzK/oesDwgYdiloZ8Iv2jWht6UXmkFMlRqzGD+nGVAi1RRu1uxN7qiAwBktY1tXCTJozi",
-	"pC1/rTlsNmOmhgxWdeA4eEvxmnE5lylb2tXMaaZNt7rT7gkPcOHknEDbNU8/w8jgI1y45DXJYFLuy4Nz",
-	"7JoPk8uKxgBKl+jB+ZIgZjFoK6TycYFwmEY8jlIYvl7E1YPt58s4erCpd8DNQ4dDd/KoIJYsgxBceI8g",
-	"TKE5j5Aq/f8nZbfjN6zpcadL/3XC/3VCxXt1vqFP6003lC2DJy5VGYeq6Zw1Hux/pqGlIu1a75rI7nOp",
-	"KS0MuaubkNm4Fh2kvQIwBDBc1JiFRWLiF3Hv4ZTQxOYLeY+f3bv65L+2M+tQ8KdQT+E3H8IAWoo08r1p",
-	"wOf1F5PDcRo+2N3p3qahqGEEcSYTcKVQoH1+YsFAl99QOOCXlA64uXhooy92TD4wNtWFBF6zlPBB5MOw",
-	"wu2WfeeGDC1xdk7FtUkN7lbCR/iZFQqGAHeFQlwYEjgPwWLtYmOuFYT6riwBwzQa8OTEmyri4Vx3Sogm",
-	"hjSY5ShphdTOCqkho9TNyCdmRnO0sXLbnIOd9SNctM96mbFxqds6Q3Z7Yzfd2D1h+10nH4jTwHpOcx7E",
-	"zY7moTxiftajmSNgV47m9ZjVOHCtVv+zHZgoekQENnWwlr3MTmMD9rU9K6WvmIaPpbzEJLZb3zCT+3RG",
-	"ixvymeYTVNJ6a/7WvKQ5StycozluX9QjmoO7jCO0IIyfPRbw5GRLpyQgbnbxIt+a5AKMwDiEvQQQ2GNj",
-	"UvYQvLbCOSp/6PF/P3MRE0ICy8LmnP2O1bXTRdDwPnvr7ZPn+mrYegod+37y18oWTiG7LFtybMaJMCNX",
-	"W86G/D7WRtw244T9ibrdF07YbGDwclrBi4UGO3Iuh29vOFeE7Dbm3KqTbwZnY8Z8jW6QspeZxT+xr+0N",
-	"UlKjho+lbpAS2+0N0nSDzGhxPUFFYrzD7/wPByXQAwII7z6JZ3VBeZwafgxVUCzbBhv/vFXe/W0jvLuM",
-	"DvhzcO0O5ba8tKSyVEya25gG8qIrCdkh7UxpErsI+DF04J0QAZtVfvl2uSm/Ah07kiLHUXoZ9GCxb63w",
-	"emHhZZUrSwivKq1nnsQzSKYwxb0Z1UH9+nInWRdPdFE+O3WZ7K5V109ish/iokDgN3I4DwEqUEVxpCZ3",
-	"gDKWW6Z8aaakHGDYl3XdQP6VwhQ6syFr3ZgD/0577RHz7Xck5D4Ft23eHpKjveUi3r1HmGAUR61M3CWZ",
-	"qHanLBEl5ywrE7OnPhfX0EQ9Ntb5hg4BgRe0YRuHv8vVLNcRs12LyU1GZis624Ho7CIs20rDn+e1Bs7H",
-	"Gju33scFK7iOm0zcMm+LC/7rshJX9OjN4xD5i/oUdbKDxzu4JKiTrpPXrEebnu7QhJblHo0Ku9E+Hm09",
-	"yyMOgf9QnZhuRJt4T3A8jeOH8nMq+/yFf22fU3lOOh0nTW4PBVTvEjtsqULqbQRSMo0T9G8Y8Ilfb2fi",
-	"T5BMY146H4Rh/GSuzso3iOmBnAX084x9XIkRDzEBCbGy44h+5efY1WlKph67rBQZ8hbLZxsG0BVFKOu5",
-	"j5z56ujEgAedexjKxLGSw8oUgkB4jYQxJ5gaiyfbcOinCSILhh8/jh8QpIOyIipfdXpgKM3PKAmB7sDS",
-	"dFCXJ3R0OSoSYEEgR7iVw0IOX44GOqoaSOIilltZvHOyuMwIShJfjlZIT1oY2MRgbTQGQ0Cevyqzkq6P",
-	"ZvOTOkdVFHe1ZegdYmgr5zlydOWJKur69bbxZCVKDe/by9XmzQUmxDSzGaj6t7mdaR9VduFRRe3Nup+Z",
-	"TVWYK1k3K7jsjRecoYwl4PfEjtfd1UrQW6jXvqR8aCXCzhVq10XEWoqzO8mJ2hxip4TA2Vwkw2NtNfFh",
-	"Exz7ljyslSBVLvEIM19pIUI4EYS7d0F44Ue8OkbZFkMnkHasyDXEkrK58jBr3rLwLmY/StJIbFWNRzuK",
-	"5inzh+CPu6blPu+EptLmPqqQL2zDX0KgZGuqtAXwZsJZoE64vIdkxIdtRcvLaQfNsnpaLA1iuPZCscsX",
-	"CrlLG5EaBOCHHiaA1BgMAX5g1WOEpbDGSngD8MOIDeouIgbnP6JtUCGiAYcacd3y6A6YAW1ssI30SMJr",
-	"pvcUJw9VySIyB2yrS1PrzZQFk3BUfGFIpQipqgJIkaECXnhHT25H+9y2a+/nGvkvn8RQDGJjoZ/+nTzH",
-	"PxwbWyreaZg5aJSCUG5ty7m791CuM95ShyWjiuqHNHpCcuFd7SWfnQ0//WGZYaKtkbuyUUgG6+XzJnEc",
-	"L/ucLBHNDUHNc9fr1UINKey1Ep9tInstkb2GF1xj0M3VY325tPYmuJ3LX2u23hzBtJfUnUx3n9+jcjhw",
-	"tSmpicD5rv+zzo8lxwm1J7Ag0312aymwvhk0HYN7rCaI7Vo2s0Dr5mKP68+/INXH9HfzNLU8Px+yx8ja",
-	"xyT+ZMkZWgf6oIavB2z0lrlfnrmzLCbXWtE6DuMq7055HLHtbs3aWzJrf9FxH7nkD8k2qanKsD6Jg6dg",
-	"DjekR4zY2K282Rtlgm9Yq1H8QBqFil0RPkOVkaGisjNj8TBU7+PYoGtUsT4LnOSuLH1ZCKyVAWsH8AJg",
-	"4g3OWcL6KfRCIHfQlqYIYDIIrHmKXp2Y8hRtwce2SQFAXfK0XnA76luzhCxxd7xxk4XY6WWCtXTTaH7K",
-	"xGkBvAdpSDpvjro5UbGNFGpq7tfLTD7imdTGC49NYJ5UfLLnc9iG2tU+9qxf31pnSkY1Zm0w0JmMaxgD",
-	"4k9Ljz1VGtP+BANtystBeyfhyHB12xfRJOWnknU/9sw1S813pfQN02gQ4Fzq2ZUQXM6329AgJCKQ2tej",
-	"mvRonGy28XKDD/0kjuo1EtrK+yseZ0CRBE0mte4TZ0kc/dRqyt7kd1UbiwI67QQSpRIf1KTxtl3cNnDX",
-	"pTM3Be+yTpUyTskovsl0tEPzqfYzQ3lFztzxwrsXeXnXlrpXlyLYPX3veLG5DL6aUrDlHL45ZKygobfH",
-	"rkFLL51zG1LX6aF7+J3+pyd/dStzVz6InR8+KOHsedE7tXobWDmMbr/snWN9OuMmtvmBi/XizGhq9laR",
-	"J4ivz92qx8QVmWuf3ZN2mLM2dHS2x+Y+GPYbHdZrkQ915SXZrGpGZ+Gw57Umd0s+bKrapC4gbriBw8nW",
-	"R6mAl3B0se3VqQp6MchWVaiWA4ItNyEK3FR5dhy4Pujpr4z1bkqtwWyXDWbsEbmBtYy136KpbBfteHOQ",
-	"UKRZXFcKYPHGX/THjC3BZ0gRY4RNOIlsFq5TY3wWS0SQYuhUb1G2Xca6NWJ9hZ3JBbgHFAVOULGGjUH6",
-	"iKKgHpq9N6YSNIMeuKeAlpynnwCWscz6EjonRyfHvSP6v5ujozfsf/9jNVaz7qd0AjPx0mO1R6HouFYj",
-	"pxCP4X2cwE2C/JbNsE6YK7B8jyKEp8vDLPtvFc/rAnqtmN7c40DZEv/TPg0UdcfWwrERd+nNvAkwD2mX",
-	"/P3AE6DRgy7P/npCf8dAiH2uQN2q4a0avn01vNUtW93yRUKg8IoV25kAaiuL1J/vG6ienp3zFNQgDenx",
-	"WGM1VC2XsR+OZOfWirjLVsTN3YsUAeyV51SrTLXK1N4oU9kyMlG9FtusAsmJwZWV1gDzRmMkSxKmtTqs",
-	"VyuxaACb1UsOv6s/e6WUTrUOimaQG+ose+6maMCBtdiAEdU767lo3t3WH6HoumjBUzOHBAtt1DgxroUB",
-	"97qA4F5x3yaP4/Yo3ncXx83KETfFQGVtec6CBStLjAMvgk/2kEH3iEHhgrc/edbrg9eq07RUgrbV4ufL",
-	"ekKKYmXWzd9qnttm/t56eng7/K1Y3H4plp3LrSsEXRWVbyZaW5PFOTuyWR5LjUBIZHd9sKRKDNOolcLb",
-	"lMJyB7QNaCJ/rXrDFqtHNldHdQn8U940W/HrJH6FQlKnE69d5PKCDT0/TiNS46LD2sj0d7LSCHgEKATj",
-	"EDLpq4kb8238PSS8IAQ+YzPuveity1K451lKc5u15NWbkwonn9YabnmjzyFpudylefZPMUzwoZ8mCazm",
-	"bMxvB7yhR7uVuPcWw+Q9JGdisA3SHZ2pIZ0xiNuaVy9f8wr6aYLIgolxP44fEDxNqez68ysVVYU41zy5",
-	"SXJn228g4wki03R86IMwHAP/wUrOZ/FsHkICOU1f0fk943lEJ+Jxdu/Z0FcUl2dy+AKBvzo6qXlP8MW8",
-	"QXneKQSBKG8ZxnwzjIWPlVh/LiAzhzu5wPwcjujDBCR2UTCiX5dDHOvaHGsMns3jjEHXEGFxPAnhZuiN",
-	"Df2D0xtH35rpLUPcD0dvKHpEBLrUwJXaMO/Aq/a6HN90BF7NdyDm2mSVaG0iJ/+JEGG5MfkFtvqi87HK",
-	"0kAXsFeu5GylvUPg+3BO7Ja3U/YdKwubmMRSNJ1vPu/T2Yw9iQ/OJ6qv0VpBfXzlJvprvQAUeXFsl/be",
-	"nb4SyBKqVhRvpN+b0Rfv09lUKUQ6+Broi6+8pa9K+uLYXoK+wniCIjtZXcQT7KHIA+xsPKhQMC7YQBvK",
-	"xUKPYDr+lopJO92jw3gygYGHovb6/MLX527nt5OTba17nsSUBpjRth8RRBZez3sEIQrYZHRTRBMUTTwo",
-	"R7IrvIywzVf5budbD0Z0ql4CCOwxGzjVoflbjYmZ45TUcHOcEjd2jtOXN1YJJot3rDZca6Sq0aYZ9bja",
-	"p2ZwNoYJnqJ5gzuc1sntHsfPwE9ZNxEHtVECN0/a/EKno6i91C1zqdMxWE+Sc4DxU5xUuFKo9H+0gyfb",
-	"V4nUaznm5pSksymIJmqiXdKWfAZZoBDVivNWaWqmNFWzOqf8PDOurE8lcEIlcVJ17eYtcKVKpTylNsX3",
-	"Eoxd4niJvPahsWX69dyUJJWv57KEQ+A/bOSRakRH3uE3qhpJ2vDR6hEmWIBQWQhetJMuUBgmjwYtfRDd",
-	"x+8h+SwGXWsZLA3SLCnI8cHRwZEp7YjmefSn6vrVocLVTcViC96WFcT+BXoJJGkS5ZBXuOlQMZtGEeUf",
-	"NcW3nhyyF895lHOZBZ7geBrHDz3hiHb4XfzgENJJjzrRuuyoxn93j9YUA9kdwdREW/YDcwx/lPC1B9vL",
-	"GyeKIZc6mVq9v0SLr07McSjw7GKmkE1lCdlqjhGKG3bNzbKzfLMe/0kOPXefFKihmBmKCW1SV6WeFdhR",
-	"29Wy5w6xJ7PKlLaoKY8q3mR/PNd4X/NWRsdq5pzpxHPcybTKZ9lwxu+Px3Jj31Gx4tYeWXJKLgV8yQuK",
-	"3QeZqdX1xUYqCdm9pMhO0PKminbkzg3bWSEwkEqUbS8OypHX9KIfLadZynyswmyF06QY3OOU3KZZ2Z8G",
-	"96KdjJBpkhhGAdgG6G0/QM90HdIoZsn4mG6dhuXOCQ1Urp8hUGzJ4LCWt16at/QotFUYy0Xtc+euZnrg",
-	"TjDY+nXBPDJcY+W51pXnsm0rh04SoagetvLAqiCuxpw1aqJThQa6SflSDIrxHtVLh/WkbFCRYRf42ZAV",
-	"lec0XUPJquULVpkBmyRxOmepZjMQ5EZZQWGdPsJFpzYNyIaFxIrp3+WjUpsBfge1iaVSzjcSXDI1kdW5",
-	"RWbVaJosaKkcQTspuW4M7HLgDe6ZdRunlDpg0GVcFQICMVE8hbB3D4k/hYEtIXkm+HdckRJksGTioRdL",
-	"N6TB2yjPUJtdqM0utIHsQo1Es5AN2OFVK3eSO4ll4VuzRyaYH0Eub1jKSYep1VTBVt7tlAqYkeKyKmDR",
-	"8W8MQQIT5fjXNboCMk8yLg/SJOy86XSevz7//wAAAP//8hib5o4PAwA=",
+	"v4GCdsiOYUctjZ/tTpraR7jYF2Vt40ErEhdNGYGhu2UGEzN4QnvcAEN8fzzuNQhTZC/JBJtfk5tELO6w",
+	"F5kNJompPWVOsT/tAbWWQDLcJIhMUY4TZ3Idx+WYEi1rzyiukrbmhF01J5Rqkzoo0LW3z8opSldEdhnn",
+	"cx6snqC/2V0Bp2MMieeDKEAsq4ik67XeHqpW7N1iGDA24rAQej0uwwOItLkieo+zlBrY6sVDY+0Ggl2K",
+	"mFay57UtiZdMtnP8VulaXcvbzhkr0OIBL4JPYmCraOZtf+7HG4YCjg6XBxz2fqNI2WPlcLhVf5tvNoI8",
+	"6lhPFOvRAG6fpLf1JH2ZvULnGF7xp+JNd5531+LYBYv/7RLMBuokReM0jbulxgluRSwKN5BrMV+2FCb2",
+	"87blKBpk5F4rFl5SLLiyflcjTHr0VzjeKwXebjDhs+2zxUTx80/OxZOYtIe71WKyxBlbZLTKpLD1x+ae",
+	"h7fmjk2VUvUlGW4TVwC+SUtfAV4g1ayzfJDZZVv5sH+nvIOyz3zbZ1mJrwq1QEhGGfbpJWnkiZ7VWWq5",
+	"B8UFwoR7UciKYvsq08pxLxoaavyTHABdORSmHpp1OSgVbbPM+hsFql57jQVYRGm/TFQ2r/XFSPk/sB5g",
+	"bgFa1Aaj7e9k6zvWeqPElgW88zc+5iql6pVm0ZaW0HLeEEWTO175bEuQnxociB56j8Knx+GRIPMkuptV",
+	"uhK9rBGbCrZhGkmJ1jxKVpeibUT77oSrsr2ZqYPKLcbC/cSdxygijufuDEUpgfQ6Lv9KIHgI4qdIHcUN",
+	"juH3kFzTyff9EGYHnvQN1kJ3hMG609Vqe58cnRz3juj/bo6O3rD//Y9F7sji9Pf8JrKOA5JBqjyHdVBj",
+	"Ct8KwMra8W/Z4LsW3UqpLUdqS0hHxietfNxR+ZjfnbVLSXzoswLK9ig0XmBZZR8xyTve5Od+oGQoYKpK",
+	"TTkcntEp9nyJtK1GkbFJQxjwrFC1L5OyeZsSqI2WLcmogmRYu2RK4DwEi6pSPvR7pWTiTX5qycRR0EQy",
+	"JRJp25RMHExXwZSI1q1cauVSSS4V5MIa5ZJI9OjifSuTadd534pc3a377S6733Jy8eiwbvFrrP0lbb5M",
+	"MKSgiZEaxdXeKonOGVDRoQLS6kle3MNVZ58GLq6Kkdu3+LyPq0JMJjcFilf2crWVLFCb2Pq5Cj9XgY8m",
+	"r9ySKV/I01XSSBNX111Mdf1z+7qW81g78H4DtYm5u4p/uPm71sqMPfd4pZPLt0fJwvW+rxlW7MBu1w7t",
+	"yv/Sn7Xl/Z1wdall765ObjUurZJ+hU+rUA8tfLvPbq0FBfhH41HprdryqMVdteaYhBE9BXsJILDHbqB0",
+	"c6UOVuepWnvg7bmv6mZ5Z3N+pz+uSi6dT1uW3yGV3CAPlj+zzXfz6xizzB0o8uMZiiaKXmcQYzCpOLuH",
+	"0IfosZVBTWRQlIZhifKjhTcHizAGgYciD0QLT6y22yHwGzmchwAVKK045aoyJPMBvE7odhNEx+ELFXPF",
+	"47+gX2Vdy+HoHoQYtiqDpXYUZzoDqy3L3S63b+EJ3EvSqO7lIp8LsPbtIsv9175f7H42UizyMzq9YGwt",
+	"lyPzrgdJiCBmGayhE3gbdPUPAWkCyrr8/HfHndsxA82exCBQIFR0nEveHJhs2HH/yxSSKRcAKPLDNGCF",
+	"9jA9veIoXOi/q9pvJoEUhYs72aBWSRnHcQhB5BCpkSsE6ICzFwraMJQrtEZvOOTrfbEoDu8+BBN21D4J",
+	"uogT5lahk4G6W4Io8OKU0D+F6oip7kgbSD3wwDuH9yANeRb7f1J6+KeH7r00wpAd46bli5nu5KCdShLa",
+	"Wk20pu+6rSvQrlXTyGmUuqIrfx/S31d8X9I13MMA4XkIFj3mBFGj74q2dFjhNBHfVyjB1TrwOR+MOVPs",
+	"tT6siVasXqdySBFRkAJ9AnV2RUCTpS9SMnbDhnUjCbSiqxVdTUWX5JMe5ZNqyZXjUaY9mNP4Z0nrKiRX",
+	"Xww2CPZXcLX33Pae+5Pcc7d2nGVyoT3NfqTTLHd6bOVkE9drezDPDW8gfUXzF/aKo6t1Gj0WqNOQUvNM",
+	"nSMFEguvzG2/T2taMyQAhbiZ96hOIe17U9GZs8BAa2DwPD8zT07tl5oCEXmSA1HAXMTU+U9idZUUJZD+",
+	"txMwovjfjje3PEZn9OPoTJaDgds2J6yn5QVYW97eZihcgsvaU3yHT/FiUJsjQ3dLBL0Eix+KQnBVnE54",
+	"7i6SMsNRnu8Parl4JCvNLcnL+vSauv5jsrZ+/WxZekcdvM7iNAx4lCy9SJo0lx3KOJLjKlX28UVkDUvh",
+	"5FA4lwXb8tB1bql3vzqo0vHORq+fp85MJlaNBpAfV6IuVauxFaqtnlSUXQTNUDSp15ZEu8bS6z0kN2KK",
+	"vb37GGVQAOdkyvOQ8Fxlnj9FYZBAm+sG69BQ+m1ekPDNaSXJ3kuSKv5ct3iBcyFT5J/PhyDxp+gR1mlB",
+	"opUAk3Y3ipARgXPhrnsqB3YQH3I8q/VUwtu67i6vkW1SJol9F3vuJJXyqSLbap/bz7KkuK6QaakspHLs",
+	"rzG/lE90+6lsqhJNioXrZZLLvUwU5HeXR31ZObWVRj+JNHK/a7WyaH9kkcb4m5dEYTyp85QK44kXoqik",
+	"G5XN0Rfx5AJF0NUa1Iqhl41nCuEjDJ1chnjL3MxVzCDpgPZ6h2AYWPPCQXrwemw2DY6KEiWsQ1NARryX",
+	"MZQEsECBOAmq1s8+v13wtTSc/Erva8EDnz5ACfRFpHsFFOdas2Ugyfpv9pDSpUFbFn/VxHJKCmtnwUU8",
+	"aX4MCEejioTlzAMCC08ii+P+Dfv5THd8WbdjDh+cT1SXepe7Jr2MKw6HsJHzjUDqj03jS3jdKGJTOWeF",
+	"P02RyE0UrVznak3G3DVGvLBXEnjTNEsqsEPMYH3y2Y633MtSvEyE1FL7dm8bnBiDGPKLBvzGT+BSeQxX",
+	"ZsvlKa3OvxTx2VA0qear/cnCtCGvU46AJofbXOUXyZUpbc+5fTrnBJ8swXoV590hCClhRJMenAEU9iZJ",
+	"nM4rH06pcidvgYK82BgeG8ATAxRZ95Q26dMW72mDfYl02vxJaEJMw0JS1k1oeSf/mlhBrY3OMeerT3mu",
+	"Osb46UMq9JtbATduZ10J5Y2udsebZe8lTkADDbV8bbz7GbltvafkIYaE1LkWYbZ7sosnu1RnM9DIBUWT",
+	"keizJ6l6t3RMaohZ4YzU96RlJcO1zoCmtfHRHPVI/ABrkuF5p9cDj7er5prTObqhzVp9Eh8yv6LrAcMH",
+	"HopZGvKJ9I9qbehF5ZFSJEetxgzqx1UKtEQZtbsRe6sjMgRIWtfUwk2aMIqTtvy15rDZjJkaMljVgePg",
+	"LcVrxuVcpmxpVzOnmTbd6k67JzzAhZNzAm3XPP0MI4OPcOGS1ySDSbkvD86xaz5MLisaAyhdogfnS4KY",
+	"xaCtkMrHBcJhGvE4SmH4ehFXD7afL+PowabeATcPHQ7dyaOCWLIMQnDhPYIwheY8Qqr0/5+U3Y7fsKbH",
+	"nS791wn/1wkV79X5hj6tN91QtgyeuFRlHKqmc9Z4sP+ZhpaKtGu9ayK7z6WmtDDkrm5CZuNadJD2CsAQ",
+	"wHBRYxYWiYlfxL2HU0ITmy/kPX527+qT/9rOrEPBn0I9hd98CANoKdLI96YBn9dfTA7Hafhgd6d7m4ai",
+	"hhHEmUzAlUKB9vmJBQNdfkPhgF9SOuDm4qGNvtgx+cDYVBcSeM1SwgeRD8MKt1v2nRsytMTZORXXJjW4",
+	"Wwkf4WdWKBgC3BUKcWFI4DwEi7WLjblWEOq7sgQM02jAkxNvqoiHc90pIZoY0mCWo6QVUjsrpIaMUjcj",
+	"n5gZzdHGym1zDnbWj3DRPutlxsalbusM2e2N3XRj94Ttd518IE4D6znNeRA3O5qH8oj5WY9mjoBdOZrX",
+	"Y1bjwLVa/c92YKLoERHY1MFa9jI7jQ3Y1/aslL5iGj6W8hKT2G59w0zu0xktbshnmk9QSeut+VvzkuYo",
+	"cXOO5rh9UY9oDu4yjtCCMH72WMCTky2dkoC42cWLfGuSCzAC4xD2EkBgj41J2UPw2grnqPyhx//9zEVM",
+	"CAksC5tz9jtW104XQcP77K23T57rq2HrKXTs+8lfK1s4heyybMmxGSfCjFxtORvy+1gbcduME/Yn6nZf",
+	"OGGzgcHLaQUvFhrsyLkcvr3hXBGy25hzq06+GZyNGfM1ukHKXmYW/8S+tjdISY0aPpa6QUpstzdI0w0y",
+	"o8X1BBWJ8Q6/8z8clEAPCCC8+ySe1QXlcWr4MVRBsWwbbPzzVnn3t43w7jI64M/BtTuU2/LSkspSMWlu",
+	"YxrIi64kZIe0M6VJ7CLgx9CBd0IEbFb55dvlpvwKdOxIihxH6WXQg8W+tcLrhYWXVa4sIbyqtJ55Es8g",
+	"mcIU92ZUB/Xry51kXTzRRfns1GWyu1ZdP4nJfoiLAoHfyOE8BKhAFcWRmtwBylhumfKlmZJygGFf1nUD",
+	"+VcKU+jMhqx1Yw78O+21R8y335GQ+xTctnl7SI72lot49x5hglEctTJxl2Si2p2yRJScs6xMzJ76XFxD",
+	"E/XYWOcbOgQEXtCGbRz+LlezXEfMdi0mNxmZrehsB6Kzi7BsKw1/ntcaOB9r7Nx6Hxes4DpuMnHLvC0u",
+	"+K/LSlzRozePQ+Qv6lPUyQ4e7+CSoE66Tl6zHm16ukMTWpZ7NCrsRvt4tPUsjzgE/kN1YroRbeI9wfE0",
+	"jh/Kz6ns8xf+tX1O5TnpdJw0uT0UUL1L7LClCqm3EUjJNE7Qv2HAJ369nYk/QTKNeel8EIbxk7k6K98g",
+	"pgdyFtDPM/ZxJUY8xAQkxMqOI/qVn2NXpymZeuyyUmTIWyyfbRhAVxShrOc+cuaroxMDHnTuYSgTx0oO",
+	"K1MIAuE1EsacYGosnmzDoZ8miCwYfvw4fkCQDsqKqHzV6YGhND+jJAS6A0vTQV2e0NHlqEiABYEc4VYO",
+	"Czl8ORroqGogiYtYbmXxzsniMiMoSXw5WiE9aWFgE4O10RgMAXn+qsxKuj6azU/qHFVR3NWWoXeIoa2c",
+	"58jRlSeqqOvX28aTlSg1vG8vV5s3F5gQ08xmoOrf5namfVTZhUcVtTfrfmY2VWGuZN2s4LI3XnCGMpaA",
+	"3xM7XndXK0FvoV77kvKhlQg7V6hdFxFrKc7uJCdqc4idEgJnc5EMj7XVxIdNcOxb8rBWglS5xCPMfKWF",
+	"COFEEO7eBeGFH/HqGGVbDJ1A2rEi1xBLyubKw6x5y8K7mP0oSSOxVTUe7Siap8wfgj/umpb7vBOaSpv7",
+	"qEK+sA1/CYGSranSFsCbCWeBOuHyHpIRH7YVLS+nHTTL6mmxNIjh2gvFLl8o5C5tRGoQgB96mABSYzAE",
+	"+IFVjxGWwhor4Q3ADyM2qLuIGJz/iLZBhYgGHGrEdcujO2AGtLHBNtIjCa+Z3lOcPFQli8gcsK0uTa03",
+	"UxZMwlHxhSGVIqSqCiBFhgp44R09uR3tc9uuvZ9r5L98EkMxiI2Ffvp38hz/cGxsqXinYeagUQpCubUt",
+	"5+7eQ7nOeEsdlowqqh/S6AnJhXe1l3x2Nvz0h2WGibZG7spGIRmsl8+bxHG87HOyRDQ3BDXPXa9XCzWk",
+	"sNdKfLaJ7LVE9hpecI1BN1eP9eXS2pvgdi5/rdl6cwTTXlJ3Mt19fo/K4cDVpqQmAue7/s86P5YcJ9Se",
+	"wIJM99mtpcD6ZtB0DO6xmiC2a9nMAq2biz2uP/+CVB/T383T1PL8fMgeI2sfk/iTJWdoHeiDGr4esNFb",
+	"5n555s6ymFxrRes4jKu8O+VxxLa7NWtvyaz9Rcd95JI/JNukpirD+iQOnoI53JAeMWJjt/Jmb5QJvmGt",
+	"RvEDaRQqdkX4DFVGhorKzozFw1C9j2ODrlHF+ixwkruy9GUhsFYGrB3AC4CJNzhnCeun0AuB3EFbmiKA",
+	"ySCw5il6dWLKU7QFH9smBQB1ydN6we2ob80SssTd8cZNFmKnlwnW0k2j+SkTpwXwHqQh6bw56uZExTZS",
+	"qKm5Xy8z+YhnUhsvPDaBeVLxyZ7PYRtqV/vYs359a50pGdWYtcFAZzKuYQyIPy099lRpTPsTDLQpLwft",
+	"nYQjw9VtX0STlJ9K1v3YM9csNd+V0jdMo0GAc6lnV0JwOd9uQ4OQiEBqX49q0qNxstnGyw0+9JM4qtdI",
+	"aCvvr3icAUUSNJnUuk+cJXH0U6spe5PfVW0sCui0E0iUSnxQk8bbdnHbwF2XztwUvMs6Vco4JaP4JtPR",
+	"Ds2n2s8M5RU5c8cL717k5V1b6l5dimD39L3jxeYy+GpKwZZz+OaQsYKG3h67Bi29dM5tSF2nh+7hd/qf",
+	"nvzVrcxd+SB2fvighLPnRe/U6m1g5TC6/bJ3jvXpjJvY5gcu1oszo6nZW0WeIL4+d6seE1dkrn12T9ph",
+	"ztrQ0dkem/tg2G90WK9FPtSVl2SzqhmdhcOe15rcLfmwqWqTuoC44QYOJ1sfpQJewtHFtlenKujFIFtV",
+	"oVoOCLbchChwU+XZceD6oKe/Mta7KbUGs102mLFH5AbWMtZ+i6ayXbTjzUFCkWZxXSmAxRt/0R8ztgSf",
+	"IUWMETbhJLJZuE6N8VksEUGKoVO9Rdl2GevWiPUVdiYX4B5QFDhBxRo2BukjioJ6aPbemErQDHrgngJa",
+	"cp5+AljGMutL6JwcnRz3juj/bo6O3rD//Y/VWM26n9IJzMRLj9UehaLjWo2cQjyG93ECNwnyWzbDOmGu",
+	"wPI9ihCeLg+z7L9VPK8L6LVienOPA2VL/E/7NFDUHVsLx0bcpTfzJsA8pF3y9wNPgEYPujz76wn9HQMh",
+	"9rkCdauGt2r49tXwVrdsdcsXCYHCK1ZsZwKorSxSf75voHp6ds5TUIM0pMdjjdVQtVzGfjiSnVsr4i5b",
+	"ETd3L1IEsFeeU60y1SpTe6NMZcvIRPVabLMKJCcGV1ZaA8wbjZEsSZjW6rBercSiAWxWLzn8rv7slVI6",
+	"1ToomkFuqLPsuZuiAQfWYgNGVO+s56J5d1t/hKLrogVPzRwSLLRR48S4Fgbc6wKCe8V9mzyO26N4310c",
+	"NytH3BQDlbXlOQsWrCwxDrwIPtlDBt0jBoUL3v7kWa8PXqtO01IJ2laLny/rCSmKlVk3f6t5bpv5e+vp",
+	"4e3wt2Jx+6VYdi63rhB0VVS+mWhtTRbn7MhmeSw1AiGR3fXBkioxTKNWCm9TCssd0Dagify16g1brB7Z",
+	"XB3VJfBPedNsxa+T+BUKSZ1OvHaRyws29Pw4jUiNiw5rI9PfyUoj4BGgEIxDyKSvJm7Mt/H3kPCCEPiM",
+	"zbj3orcuS+GeZynNbdaSV29OKpx8Wmu45Y0+h6Tlcpfm2T/FMMGHfpoksJqzMb8d8IYe7Vbi3lsMk/eQ",
+	"nInBNkh3dKaGdMYgbmtevXzNK+inCSILJsb9OH5A8DSlsuvPr1RUFeJc8+QmyZ1tv4GMJ4hM0/GhD8Jw",
+	"DPwHKzmfxbN5CAnkNH1F5/eM5xGdiMfZvWdDX1FcnsnhCwT+6uik5j3BF/MG5XmnEASivGUY880wFj5W",
+	"Yv25gMwc7uQC83M4og8TkNhFwYh+XQ5xrGtzrDF4No8zBl1DhMXxJISboTc29A9Obxx9a6a3DHE/HL2h",
+	"6BER6FIDV2rDvAOv2utyfNMReDXfgZhrk1WitYmc/CdChOXG5BfY6ovOxypLA13AXrmSs5X2DoHvwzmx",
+	"W95O2XesLGxiEkvRdL75vE9nM/YkPjifqL5GawX18ZWb6K/1AlDkxbFd2nt3+kogS6haUbyRfm9GX7xP",
+	"Z1OlEOnga6AvvvKWvirpi2N7CfoK4wmK7GR1EU+whyIPsLPxoELBuGADbSgXCz2C6fhbKibtdI8O48kE",
+	"Bh6K2uvzC1+fu53fTk62te55ElMaYEbbfkQQWXg97xGEKGCT0U0RTVA08aAcya7wMsI2X+W7nW89GNGp",
+	"egkgsMds4FSH5m81JmaOU1LDzXFK3Ng5Tl/eWCWYLN6x2nCtkapGm2bU42qfmsHZGCZ4iuYN7nBaJ7d7",
+	"HD8DP2XdRBzURgncPGnzC52OovZSt8ylTsdgPUnOAcZPcVLhSqHS/9EOnmxfJVKv5ZibU5LOpiCaqIl2",
+	"SVvyGWSBQlQrzlulqZnSVM3qnPLzzLiyPpXACZXESdW1m7fAlSqV8pTaFN9LMHaJ4yXy2ofGlunXc1OS",
+	"VL6eyxIOgf+wkUeqER15h9+oaiRpw0erR5hgAUJlIXjRTrpAYZg8GrT0QXQfv4fksxh0rWWwNEizpCDH",
+	"B0cHR6a0I5rn0Z+q61eHClc3FYsteFtWEPsX6CWQpEmUQ17hpkPFbBpFlH/UFN96cshePOdRzmUWeILj",
+	"aRw/9IQj2uF38YNDSCc96kTrsqMa/909WlMMZHcEUxNt2Q/MMfxRwtcebC9vnCiGXOpkavX+Ei2+OjHH",
+	"ocCzi5lCNpUlZKs5Rihu2DU3y87yzXr8Jzn03H1SoIZiZigmtEldlXpWYEdtV8ueO8SezCpT2qKmPKp4",
+	"k/3xXON9zVsZHauZc6YTz3En0yqfZcMZvz8ey419R8WKW3tkySm5FPAlLyh2H2SmVtcXG6kkZPeSIjtB",
+	"y5sq2pE7N2xnhcBAKlG2vTgoR17Ti360nGYp87EKsxVOk2Jwj1Nym2Zlfxrci3YyQqZJYhgFYBugt/0A",
+	"PdN1SKOYJeNjunUaljsnNFC5foZAsSWDw1reemne0qPQVmEsF7XPnbua6YE7wWDr1wXzyHCNledaV57L",
+	"tq0cOkmEonrYygOrgrgac9aoiU4VGugm5UsxKMZ7VC8d1pOyQUWGXeBnQ1ZUntN0DSWrli9YZQZsksTp",
+	"nKWazUCQG2UFhXX6CBed2jQgGxYSK6Z/l49KbQb4HdQmlko530hwydREVucWmVWjabKgpXIE7aTkujGw",
+	"y4E3uGfWbZxS6oBBl3FVCAjERPEUwt49JP4UBraE5Jng33FFSpDBkomHXizdkAZvozxDbXahNrvQBrIL",
+	"NRLNQjZgh1et3EnuJJaFb80emWB+BLm8YSknHaZWUwVbebdTKmBGisuqgEXHvzEECUyU41/X6ArIPMm4",
+	"PEiTsPOm03n++vz/AwAA//9eQb7dKBMDAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/api/v1/server/oas/transformers/v1/events.go
+++ b/api/v1/server/oas/transformers/v1/events.go
@@ -49,6 +49,40 @@ func parseTriggeredRuns(triggeredRuns []byte) ([]gen.V1EventTriggeredRun, error)
 	return result, nil
 }
 
+func ToV1Event(event *v1.EventWithPayload) gen.V1Event {
+	additionalMetadata := jsonToMap(event.EventAdditionalMetadata)
+
+	payload := jsonToMap(event.Payload)
+
+	triggeredRuns, err := parseTriggeredRuns(event.TriggeredRuns)
+
+	if err != nil {
+		triggeredRuns = []gen.V1EventTriggeredRun{}
+	}
+
+	return gen.V1Event{
+		AdditionalMetadata: &additionalMetadata,
+		Key:                event.EventKey,
+		Metadata: gen.APIResourceMeta{
+			CreatedAt: event.EventSeenAt.Time,
+			UpdatedAt: event.EventSeenAt.Time,
+			Id:        event.EventExternalID.String(),
+		},
+		WorkflowRunSummary: gen.V1EventWorkflowRunSummary{
+			Cancelled: event.CancelledCount,
+			Succeeded: event.CompletedCount,
+			Queued:    event.QueuedCount,
+			Failed:    event.FailedCount,
+			Running:   event.RunningCount,
+		},
+		Payload:               &payload,
+		SeenAt:                &event.EventSeenAt.Time,
+		Scope:                 &event.EventScope,
+		TriggeredRuns:         &triggeredRuns,
+		TriggeringWebhookName: event.TriggeringWebhookName,
+	}
+}
+
 func ToV1EventList(events []*v1.EventWithPayload, limit, offset, total int64) gen.V1EventList {
 	rows := make([]gen.V1Event, len(events))
 
@@ -69,37 +103,7 @@ func ToV1EventList(events []*v1.EventWithPayload, limit, offset, total int64) ge
 	}
 
 	for i, row := range events {
-		additionalMetadata := jsonToMap(row.EventAdditionalMetadata)
-
-		payload := jsonToMap(row.Payload)
-
-		triggeredRuns, err := parseTriggeredRuns(row.TriggeredRuns)
-
-		if err != nil {
-			triggeredRuns = []gen.V1EventTriggeredRun{}
-		}
-
-		rows[i] = gen.V1Event{
-			AdditionalMetadata: &additionalMetadata,
-			Key:                row.EventKey,
-			Metadata: gen.APIResourceMeta{
-				CreatedAt: row.EventSeenAt.Time,
-				UpdatedAt: row.EventSeenAt.Time,
-				Id:        row.EventExternalID.String(),
-			},
-			WorkflowRunSummary: gen.V1EventWorkflowRunSummary{
-				Cancelled: row.CancelledCount,
-				Succeeded: row.CompletedCount,
-				Queued:    row.QueuedCount,
-				Failed:    row.FailedCount,
-				Running:   row.RunningCount,
-			},
-			Payload:               &payload,
-			SeenAt:                &row.EventSeenAt.Time,
-			Scope:                 &row.EventScope,
-			TriggeredRuns:         &triggeredRuns,
-			TriggeringWebhookName: row.TriggeringWebhookName,
-		}
+		rows[i] = ToV1Event(row)
 	}
 
 	return gen.V1EventList{

--- a/api/v1/server/run/run.go
+++ b/api/v1/server/run/run.go
@@ -447,6 +447,10 @@ func (t *APIServer) registerSpec(g *echo.Group, spec *openapi3.T) (*populator.Po
 			}
 		}
 
+		if event == nil {
+			return nil, "", fmt.Errorf("event not found")
+		}
+
 		return event, sqlchelpers.UUIDToStr(event.TenantId), nil
 	})
 

--- a/api/v1/server/run/run.go
+++ b/api/v1/server/run/run.go
@@ -487,8 +487,8 @@ func (t *APIServer) registerSpec(g *echo.Group, spec *openapi3.T) (*populator.Po
 	populatorMW.RegisterGetter("v1-event", func(config *server.ServerConfig, parentId, id string) (result interface{}, uniqueParentId string, err error) {
 		event, err := t.config.V1.OLAP().GetEventWithPayload(
 			context.Background(),
-			parentId,
 			id,
+			parentId,
 		)
 
 		if err != nil {

--- a/api/v1/server/run/run.go
+++ b/api/v1/server/run/run.go
@@ -469,6 +469,7 @@ func (t *APIServer) registerSpec(g *echo.Group, spec *openapi3.T) (*populator.Po
 
 		return workflowRun, sqlchelpers.UUIDToStr(workflowRun.WorkflowRun.TenantID), nil
 	})
+
 	populatorMW.RegisterGetter("v1-filter", func(config *server.ServerConfig, parentId, id string) (result interface{}, uniqueParentId string, err error) {
 		filter, err := t.config.V1.Filters().GetFilter(
 			context.Background(),
@@ -481,6 +482,20 @@ func (t *APIServer) registerSpec(g *echo.Group, spec *openapi3.T) (*populator.Po
 		}
 
 		return filter, sqlchelpers.UUIDToStr(filter.TenantID), nil
+	})
+
+	populatorMW.RegisterGetter("v1-event", func(config *server.ServerConfig, parentId, id string) (result interface{}, uniqueParentId string, err error) {
+		event, err := t.config.V1.OLAP().GetEventUsingTenantId(
+			context.Background(),
+			parentId,
+			id,
+		)
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return event, sqlchelpers.UUIDToStr(event.TenantID), nil
 	})
 
 	populatorMW.RegisterGetter("v1-webhook", func(config *server.ServerConfig, parentId, id string) (result interface{}, uniqueParentId string, err error) {

--- a/api/v1/server/run/run.go
+++ b/api/v1/server/run/run.go
@@ -485,7 +485,7 @@ func (t *APIServer) registerSpec(g *echo.Group, spec *openapi3.T) (*populator.Po
 	})
 
 	populatorMW.RegisterGetter("v1-event", func(config *server.ServerConfig, parentId, id string) (result interface{}, uniqueParentId string, err error) {
-		event, err := t.config.V1.OLAP().GetEventUsingTenantId(
+		event, err := t.config.V1.OLAP().GetEventWithPayload(
 			context.Background(),
 			parentId,
 			id,

--- a/frontend/app/src/lib/api/generated/Api.ts
+++ b/frontend/app/src/lib/api/generated/Api.ts
@@ -94,6 +94,7 @@ import {
   V1CreateFilterRequest,
   V1CreateWebhookRequest,
   V1DagChildren,
+  V1Event,
   V1EventList,
   V1Filter,
   V1FilterList,
@@ -714,6 +715,23 @@ export class Api<
       path: `/api/v1/stable/tenants/${tenant}/events`,
       method: "GET",
       query: query,
+      secure: true,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get an event by its id
+   *
+   * @tags Event
+   * @name V1EventGet
+   * @summary Get events
+   * @request GET:/api/v1/stable/tenants/{tenant}/events/{v1-event}
+   * @secure
+   */
+  v1EventGet = (tenant: string, v1Event: string, params: RequestParams = {}) =>
+    this.request<V1Event, APIErrors>({
+      path: `/api/v1/stable/tenants/${tenant}/events/${v1Event}`,
+      method: "GET",
       secure: true,
       format: "json",
       ...params,

--- a/frontend/app/src/lib/api/generated/Api.ts
+++ b/frontend/app/src/lib/api/generated/Api.ts
@@ -2129,16 +2129,16 @@ export class Api<
    * @tags Event
    * @name EventDataGetWithTenant
    * @summary Get event data
-   * @request GET:/api/v1/tenants/{tenant}/events/{event}/data
+   * @request GET:/api/v1/tenants/{tenant}/events/{event-with-tenant}/data
    * @secure
    */
   eventDataGetWithTenant = (
-    event: string,
+    eventWithTenant: string,
     tenant: string,
     params: RequestParams = {},
   ) =>
     this.request<EventData, APIErrors>({
-      path: `/api/v1/tenants/${tenant}/events/${event}/data`,
+      path: `/api/v1/tenants/${tenant}/events/${eventWithTenant}/data`,
       method: "GET",
       secure: true,
       format: "json",

--- a/frontend/app/src/lib/api/generated/Api.ts
+++ b/frontend/app/src/lib/api/generated/Api.ts
@@ -2124,6 +2124,27 @@ export class Api<
       ...params,
     });
   /**
+   * @description Get the data for an event.
+   *
+   * @tags Event
+   * @name EventDataGetWithTenant
+   * @summary Get event data
+   * @request GET:/api/v1/tenants/{tenant}/events/{event}/data
+   * @secure
+   */
+  eventDataGetWithTenant = (
+    event: string,
+    tenant: string,
+    params: RequestParams = {},
+  ) =>
+    this.request<EventData, APIErrors>({
+      path: `/api/v1/tenants/${tenant}/events/${event}/data`,
+      method: "GET",
+      secure: true,
+      format: "json",
+      ...params,
+    });
+  /**
    * @description Lists all event keys for a tenant.
    *
    * @tags Event

--- a/pkg/client/rest/gen.go
+++ b/pkg/client/rest/gen.go
@@ -3124,6 +3124,9 @@ type ClientInterface interface {
 	// V1EventKeyList request
 	V1EventKeyList(ctx context.Context, tenant openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// V1EventGet request
+	V1EventGet(ctx context.Context, tenant openapi_types.UUID, v1Event openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// V1FilterList request
 	V1FilterList(ctx context.Context, tenant openapi_types.UUID, params *V1FilterListParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -3783,6 +3786,18 @@ func (c *Client) V1EventList(ctx context.Context, tenant openapi_types.UUID, par
 
 func (c *Client) V1EventKeyList(ctx context.Context, tenant openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewV1EventKeyListRequest(c.Server, tenant)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) V1EventGet(ctx context.Context, tenant openapi_types.UUID, v1Event openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewV1EventGetRequest(c.Server, tenant, v1Event)
 	if err != nil {
 		return nil, err
 	}
@@ -6495,6 +6510,47 @@ func NewV1EventKeyListRequest(server string, tenant openapi_types.UUID) (*http.R
 	}
 
 	operationPath := fmt.Sprintf("/api/v1/stable/tenants/%s/events/keys", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewV1EventGetRequest generates requests for V1EventGet
+func NewV1EventGetRequest(server string, tenant openapi_types.UUID, v1Event openapi_types.UUID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "tenant", runtime.ParamLocationPath, tenant)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "v1-event", runtime.ParamLocationPath, v1Event)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/stable/tenants/%s/events/%s", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -12715,6 +12771,9 @@ type ClientWithResponsesInterface interface {
 	// V1EventKeyListWithResponse request
 	V1EventKeyListWithResponse(ctx context.Context, tenant openapi_types.UUID, reqEditors ...RequestEditorFn) (*V1EventKeyListResponse, error)
 
+	// V1EventGetWithResponse request
+	V1EventGetWithResponse(ctx context.Context, tenant openapi_types.UUID, v1Event openapi_types.UUID, reqEditors ...RequestEditorFn) (*V1EventGetResponse, error)
+
 	// V1FilterListWithResponse request
 	V1FilterListWithResponse(ctx context.Context, tenant openapi_types.UUID, params *V1FilterListParams, reqEditors ...RequestEditorFn) (*V1FilterListResponse, error)
 
@@ -13600,6 +13659,30 @@ func (r V1EventKeyListResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r V1EventKeyListResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type V1EventGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *V1Event
+	JSON400      *APIErrors
+	JSON403      *APIErrors
+}
+
+// Status returns HTTPResponse.Status
+func (r V1EventGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r V1EventGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -16445,6 +16528,15 @@ func (c *ClientWithResponses) V1EventKeyListWithResponse(ctx context.Context, te
 	return ParseV1EventKeyListResponse(rsp)
 }
 
+// V1EventGetWithResponse request returning *V1EventGetResponse
+func (c *ClientWithResponses) V1EventGetWithResponse(ctx context.Context, tenant openapi_types.UUID, v1Event openapi_types.UUID, reqEditors ...RequestEditorFn) (*V1EventGetResponse, error) {
+	rsp, err := c.V1EventGet(ctx, tenant, v1Event, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseV1EventGetResponse(rsp)
+}
+
 // V1FilterListWithResponse request returning *V1FilterListResponse
 func (c *ClientWithResponses) V1FilterListWithResponse(ctx context.Context, tenant openapi_types.UUID, params *V1FilterListParams, reqEditors ...RequestEditorFn) (*V1FilterListResponse, error) {
 	rsp, err := c.V1FilterList(ctx, tenant, params, reqEditors...)
@@ -18463,6 +18555,46 @@ func ParseV1EventKeyListResponse(rsp *http.Response) (*V1EventKeyListResponse, e
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest EventKeyList
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest APIErrors
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest APIErrors
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseV1EventGetResponse parses an HTTP response from a V1EventGetWithResponse call
+func ParseV1EventGetResponse(rsp *http.Response) (*V1EventGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &V1EventGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest V1Event
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/pkg/client/rest/gen.go
+++ b/pkg/client/rest/gen.go
@@ -3278,7 +3278,7 @@ type ClientInterface interface {
 	EventUpdateReplay(ctx context.Context, tenant openapi_types.UUID, body EventUpdateReplayJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// EventDataGetWithTenant request
-	EventDataGetWithTenant(ctx context.Context, tenant openapi_types.UUID, event openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+	EventDataGetWithTenant(ctx context.Context, tenant openapi_types.UUID, eventWithTenant openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// TenantInviteList request
 	TenantInviteList(ctx context.Context, tenant openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -4471,8 +4471,8 @@ func (c *Client) EventUpdateReplay(ctx context.Context, tenant openapi_types.UUI
 	return c.Client.Do(req)
 }
 
-func (c *Client) EventDataGetWithTenant(ctx context.Context, tenant openapi_types.UUID, event openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewEventDataGetWithTenantRequest(c.Server, tenant, event)
+func (c *Client) EventDataGetWithTenant(ctx context.Context, tenant openapi_types.UUID, eventWithTenant openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEventDataGetWithTenantRequest(c.Server, tenant, eventWithTenant)
 	if err != nil {
 		return nil, err
 	}
@@ -9153,7 +9153,7 @@ func NewEventUpdateReplayRequestWithBody(server string, tenant openapi_types.UUI
 }
 
 // NewEventDataGetWithTenantRequest generates requests for EventDataGetWithTenant
-func NewEventDataGetWithTenantRequest(server string, tenant openapi_types.UUID, event openapi_types.UUID) (*http.Request, error) {
+func NewEventDataGetWithTenantRequest(server string, tenant openapi_types.UUID, eventWithTenant openapi_types.UUID) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -9165,7 +9165,7 @@ func NewEventDataGetWithTenantRequest(server string, tenant openapi_types.UUID, 
 
 	var pathParam1 string
 
-	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "event", runtime.ParamLocationPath, event)
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "event-with-tenant", runtime.ParamLocationPath, eventWithTenant)
 	if err != nil {
 		return nil, err
 	}
@@ -12981,7 +12981,7 @@ type ClientWithResponsesInterface interface {
 	EventUpdateReplayWithResponse(ctx context.Context, tenant openapi_types.UUID, body EventUpdateReplayJSONRequestBody, reqEditors ...RequestEditorFn) (*EventUpdateReplayResponse, error)
 
 	// EventDataGetWithTenantWithResponse request
-	EventDataGetWithTenantWithResponse(ctx context.Context, tenant openapi_types.UUID, event openapi_types.UUID, reqEditors ...RequestEditorFn) (*EventDataGetWithTenantResponse, error)
+	EventDataGetWithTenantWithResponse(ctx context.Context, tenant openapi_types.UUID, eventWithTenant openapi_types.UUID, reqEditors ...RequestEditorFn) (*EventDataGetWithTenantResponse, error)
 
 	// TenantInviteListWithResponse request
 	TenantInviteListWithResponse(ctx context.Context, tenant openapi_types.UUID, reqEditors ...RequestEditorFn) (*TenantInviteListResponse, error)
@@ -17101,8 +17101,8 @@ func (c *ClientWithResponses) EventUpdateReplayWithResponse(ctx context.Context,
 }
 
 // EventDataGetWithTenantWithResponse request returning *EventDataGetWithTenantResponse
-func (c *ClientWithResponses) EventDataGetWithTenantWithResponse(ctx context.Context, tenant openapi_types.UUID, event openapi_types.UUID, reqEditors ...RequestEditorFn) (*EventDataGetWithTenantResponse, error) {
-	rsp, err := c.EventDataGetWithTenant(ctx, tenant, event, reqEditors...)
+func (c *ClientWithResponses) EventDataGetWithTenantWithResponse(ctx context.Context, tenant openapi_types.UUID, eventWithTenant openapi_types.UUID, reqEditors ...RequestEditorFn) (*EventDataGetWithTenantResponse, error) {
+	rsp, err := c.EventDataGetWithTenant(ctx, tenant, eventWithTenant, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -249,6 +249,7 @@ type OLAPRepository interface {
 	BulkCreateEventsAndTriggers(ctx context.Context, events sqlcv1.BulkCreateEventsParams, triggers []EventTriggersFromExternalId) error
 	ListEvents(ctx context.Context, opts sqlcv1.ListEventsParams) ([]*EventWithPayload, *int64, error)
 	GetEvent(ctx context.Context, externalId string) (*sqlcv1.V1EventsOlap, error)
+	GetEventUsingTenantId(ctx context.Context, externalId, tenantId string) (*sqlcv1.V1EventsOlap, error)
 	ListEventKeys(ctx context.Context, tenantId string) ([]string, error)
 
 	GetDAGDurations(ctx context.Context, tenantId string, externalIds []pgtype.UUID, minInsertedAt pgtype.Timestamptz) (map[string]*sqlcv1.GetDagDurationsRow, error)
@@ -2119,6 +2120,13 @@ func (r *OLAPRepositoryImpl) BulkCreateEventsAndTriggers(ctx context.Context, ev
 
 func (r *OLAPRepositoryImpl) GetEvent(ctx context.Context, externalId string) (*sqlcv1.V1EventsOlap, error) {
 	return r.queries.GetEventByExternalId(ctx, r.readPool, sqlchelpers.UUIDFromStr(externalId))
+}
+
+func (r *OLAPRepositoryImpl) GetEventUsingTenantId(ctx context.Context, externalId, tenantId string) (*sqlcv1.V1EventsOlap, error) {
+	return r.queries.GetEventByExternalIdUsingTenantId(ctx, r.readPool, sqlcv1.GetEventByExternalIdUsingTenantIdParams{
+		Tenantid:        sqlchelpers.UUIDFromStr(tenantId),
+		Eventexternalid: sqlchelpers.UUIDFromStr(externalId),
+	})
 }
 
 type ListEventsRow struct {

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -249,7 +249,7 @@ type OLAPRepository interface {
 	BulkCreateEventsAndTriggers(ctx context.Context, events sqlcv1.BulkCreateEventsParams, triggers []EventTriggersFromExternalId) error
 	ListEvents(ctx context.Context, opts sqlcv1.ListEventsParams) ([]*EventWithPayload, *int64, error)
 	GetEvent(ctx context.Context, externalId string) (*sqlcv1.V1EventsOlap, error)
-	GetEventUsingTenantId(ctx context.Context, externalId, tenantId string) (*sqlcv1.V1EventsOlap, error)
+	GetEventWithPayload(ctx context.Context, externalId, tenantId string) (*EventWithPayload, error)
 	ListEventKeys(ctx context.Context, tenantId string) ([]string, error)
 
 	GetDAGDurations(ctx context.Context, tenantId string, externalIds []pgtype.UUID, minInsertedAt pgtype.Timestamptz) (map[string]*sqlcv1.GetDagDurationsRow, error)
@@ -2122,11 +2122,82 @@ func (r *OLAPRepositoryImpl) GetEvent(ctx context.Context, externalId string) (*
 	return r.queries.GetEventByExternalId(ctx, r.readPool, sqlchelpers.UUIDFromStr(externalId))
 }
 
-func (r *OLAPRepositoryImpl) GetEventUsingTenantId(ctx context.Context, externalId, tenantId string) (*sqlcv1.V1EventsOlap, error) {
-	return r.queries.GetEventByExternalIdUsingTenantId(ctx, r.readPool, sqlcv1.GetEventByExternalIdUsingTenantIdParams{
+func (r *OLAPRepositoryImpl) PopulateEventData(ctx context.Context, tenantId pgtype.UUID, eventExternalIds []pgtype.UUID) (map[pgtype.UUID]sqlcv1.PopulateEventDataRow, error) {
+	eventData, err := r.queries.PopulateEventData(ctx, r.readPool, sqlcv1.PopulateEventDataParams{
+		Eventexternalids: eventExternalIds,
+		Tenantid:         tenantId,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("error populating event data: %v", err)
+	}
+
+	externalIdToEventData := make(map[pgtype.UUID]sqlcv1.PopulateEventDataRow)
+
+	for _, data := range eventData {
+		externalIdToEventData[data.ExternalID] = *data
+	}
+
+	return externalIdToEventData, nil
+}
+
+func (r *OLAPRepositoryImpl) GetEventWithPayload(ctx context.Context, externalId, tenantId string) (*EventWithPayload, error) {
+	event, err := r.queries.GetEventByExternalIdUsingTenantId(ctx, r.readPool, sqlcv1.GetEventByExternalIdUsingTenantIdParams{
 		Tenantid:        sqlchelpers.UUIDFromStr(tenantId),
 		Eventexternalid: sqlchelpers.UUIDFromStr(externalId),
 	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	payload, err := r.ReadPayload(ctx, tenantId, event.ExternalID)
+
+	if err != nil {
+		return nil, fmt.Errorf("error reading event payload: %v", err)
+	}
+
+	eventExternalIds := []pgtype.UUID{event.ExternalID}
+
+	eventExternalIdToData, err := r.PopulateEventData(ctx, event.TenantID, eventExternalIds)
+
+	if err != nil {
+		return nil, fmt.Errorf("error populating event data: %v", err)
+	}
+
+	eventData, exists := eventExternalIdToData[event.ExternalID]
+	var triggeredRuns []byte
+	var queuedCount, runningCount, completedCount, cancelledCount, failedCount int64
+
+	if exists {
+		triggeredRuns = eventData.TriggeredRuns
+		queuedCount = eventData.QueuedCount
+		runningCount = eventData.RunningCount
+		completedCount = eventData.CompletedCount
+		cancelledCount = eventData.CancelledCount
+		failedCount = eventData.FailedCount
+	}
+
+	return &EventWithPayload{
+		ListEventsRow: &ListEventsRow{
+			TenantID:                event.TenantID,
+			EventID:                 event.ID,
+			EventExternalID:         event.ExternalID,
+			EventSeenAt:             event.SeenAt,
+			EventKey:                event.Key,
+			EventPayload:            payload,
+			EventAdditionalMetadata: event.AdditionalMetadata,
+			EventScope:              event.Scope.String,
+			QueuedCount:             queuedCount,
+			RunningCount:            runningCount,
+			CompletedCount:          completedCount,
+			CancelledCount:          cancelledCount,
+			FailedCount:             failedCount,
+			TriggeredRuns:           triggeredRuns,
+			TriggeringWebhookName:   &event.TriggeringWebhookName.String,
+		},
+		Payload: payload,
+	}, nil
 }
 
 type ListEventsRow struct {
@@ -2181,19 +2252,14 @@ func (r *OLAPRepositoryImpl) ListEvents(ctx context.Context, opts sqlcv1.ListEve
 		eventExternalIds[i] = event.ExternalID
 	}
 
-	eventData, err := r.queries.PopulateEventData(ctx, r.readPool, sqlcv1.PopulateEventDataParams{
-		Eventexternalids: eventExternalIds,
-		Tenantid:         opts.Tenantid,
-	})
+	eventExternalIdToData, err := r.PopulateEventData(
+		ctx,
+		opts.Tenantid,
+		eventExternalIds,
+	)
 
 	if err != nil {
 		return nil, nil, fmt.Errorf("error populating event data: %v", err)
-	}
-
-	externalIdToEventData := make(map[pgtype.UUID][]*sqlcv1.PopulateEventDataRow)
-
-	for _, data := range eventData {
-		externalIdToEventData[data.ExternalID] = append(externalIdToEventData[data.ExternalID], data)
 	}
 
 	externalIdToPayload, err := r.ReadPayloads(ctx, opts.Tenantid.String(), eventExternalIds...)
@@ -2218,52 +2284,40 @@ func (r *OLAPRepositoryImpl) ListEvents(ctx context.Context, opts sqlcv1.ListEve
 			triggeringWebhookName = &event.TriggeringWebhookName.String
 		}
 
-		data, exists := externalIdToEventData[event.ExternalID]
+		data, exists := eventExternalIdToData[event.ExternalID]
 
-		if !exists || len(data) == 0 {
-			result = append(result, &EventWithPayload{
-				ListEventsRow: &ListEventsRow{
-					TenantID:                event.TenantID,
-					EventID:                 event.ID,
-					EventExternalID:         event.ExternalID,
-					EventSeenAt:             event.SeenAt,
-					EventKey:                event.Key,
-					EventPayload:            payload,
-					EventAdditionalMetadata: event.AdditionalMetadata,
-					EventScope:              event.Scope.String,
-					QueuedCount:             0,
-					RunningCount:            0,
-					CompletedCount:          0,
-					CancelledCount:          0,
-					FailedCount:             0,
-					TriggeringWebhookName:   triggeringWebhookName,
-				},
-				Payload: payload,
-			})
-		} else {
-			for _, d := range data {
-				result = append(result, &EventWithPayload{
-					ListEventsRow: &ListEventsRow{
-						TenantID:                event.TenantID,
-						EventID:                 event.ID,
-						EventExternalID:         event.ExternalID,
-						EventSeenAt:             event.SeenAt,
-						EventKey:                event.Key,
-						EventPayload:            payload,
-						EventAdditionalMetadata: event.AdditionalMetadata,
-						EventScope:              event.Scope.String,
-						QueuedCount:             d.QueuedCount,
-						RunningCount:            d.RunningCount,
-						CompletedCount:          d.CompletedCount,
-						CancelledCount:          d.CancelledCount,
-						FailedCount:             d.FailedCount,
-						TriggeredRuns:           d.TriggeredRuns,
-						TriggeringWebhookName:   triggeringWebhookName,
-					},
-					Payload: payload,
-				})
-			}
+		var triggeredRuns []byte
+		var queuedCount, runningCount, completedCount, cancelledCount, failedCount int64
+
+		if exists {
+			triggeredRuns = data.TriggeredRuns
+			queuedCount = data.QueuedCount
+			runningCount = data.RunningCount
+			completedCount = data.CompletedCount
+			cancelledCount = data.CancelledCount
+			failedCount = data.FailedCount
 		}
+
+		result = append(result, &EventWithPayload{
+			ListEventsRow: &ListEventsRow{
+				TenantID:                event.TenantID,
+				EventID:                 event.ID,
+				EventExternalID:         event.ExternalID,
+				EventSeenAt:             event.SeenAt,
+				EventKey:                event.Key,
+				EventPayload:            payload,
+				EventAdditionalMetadata: event.AdditionalMetadata,
+				EventScope:              event.Scope.String,
+				QueuedCount:             queuedCount,
+				RunningCount:            runningCount,
+				CompletedCount:          completedCount,
+				CancelledCount:          cancelledCount,
+				FailedCount:             failedCount,
+				TriggeredRuns:           triggeredRuns,
+				TriggeringWebhookName:   triggeringWebhookName,
+			},
+			Payload: payload,
+		})
 	}
 
 	return result, &eventCount, nil

--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -1533,6 +1533,15 @@ JOIN v1_events_olap e ON (elt.event_id, elt.event_seen_at) = (e.id, e.seen_at)
 WHERE elt.external_id = @eventExternalId::uuid
 ;
 
+-- name: GetEventByExternalIdUsingTenantId :one
+SELECT e.*
+FROM v1_event_lookup_table_olap elt
+JOIN v1_events_olap e ON (elt.event_id, elt.event_seen_at) = (e.id, e.seen_at)
+WHERE
+    elt.external_id = @eventExternalId::uuid
+    AND elt.tenant_id = @tenantId::uuid
+;
+
 -- name: ListEvents :many
 SELECT e.*
 FROM v1_event_lookup_table_olap elt

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.7] - 2025-12-15
+
+### Added
+
+- Adds a `get` method to the event client
+
 ## [1.21.6] - 2025-12-11
 
 ### Added

--- a/sdks/python/hatchet_sdk/clients/events.py
+++ b/sdks/python/hatchet_sdk/clients/events.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field
 from hatchet_sdk.clients.rest.api.event_api import EventApi
 from hatchet_sdk.clients.rest.api.workflow_runs_api import WorkflowRunsApi
 from hatchet_sdk.clients.rest.api_client import ApiClient
+from hatchet_sdk.clients.rest.models.v1_event import V1Event
 from hatchet_sdk.clients.rest.models.v1_event_list import V1EventList
 from hatchet_sdk.clients.rest.models.v1_task_status import V1TaskStatus
 from hatchet_sdk.clients.rest.tenacity_utils import tenacity_retry
@@ -271,3 +272,22 @@ class EventClient(BaseRestClient):
                 ),
                 scopes=scopes,
             )
+
+    def get(
+        self,
+        event_id: str,
+    ) -> V1Event:
+        with self.client() as client:
+            return self._ea(client).v1_event_get(
+                tenant=self.client_config.tenant_id,
+                v1_event=event_id,
+            )
+
+    async def aio_get(
+        self,
+        event_id: str,
+    ) -> V1Event:
+        return await asyncio.to_thread(
+            self.get,
+            event_id=event_id,
+        )

--- a/sdks/python/hatchet_sdk/clients/rest/api/event_api.py
+++ b/sdks/python/hatchet_sdk/clients/rest/api/event_api.py
@@ -915,6 +915,299 @@ class EventApi:
         )
 
     @validate_call
+    def event_data_get_with_tenant(
+        self,
+        event_with_tenant: Annotated[
+            str,
+            Field(
+                min_length=36, strict=True, max_length=36, description="The event id"
+            ),
+        ],
+        tenant: Annotated[
+            str,
+            Field(
+                min_length=36, strict=True, max_length=36, description="The tenant id"
+            ),
+        ],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)], Annotated[StrictFloat, Field(gt=0)]
+            ],
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> EventData:
+        """Get event data
+
+        Get the data for an event.
+
+        :param event_with_tenant: The event id (required)
+        :type event_with_tenant: str
+        :param tenant: The tenant id (required)
+        :type tenant: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """  # noqa: E501
+
+        _param = self._event_data_get_with_tenant_serialize(
+            event_with_tenant=event_with_tenant,
+            tenant=tenant,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index,
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            "200": "EventData",
+            "400": "APIErrors",
+            "403": "APIErrors",
+        }
+        response_data = self.api_client.call_api(
+            *_param, _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+    @validate_call
+    def event_data_get_with_tenant_with_http_info(
+        self,
+        event_with_tenant: Annotated[
+            str,
+            Field(
+                min_length=36, strict=True, max_length=36, description="The event id"
+            ),
+        ],
+        tenant: Annotated[
+            str,
+            Field(
+                min_length=36, strict=True, max_length=36, description="The tenant id"
+            ),
+        ],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)], Annotated[StrictFloat, Field(gt=0)]
+            ],
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[EventData]:
+        """Get event data
+
+        Get the data for an event.
+
+        :param event_with_tenant: The event id (required)
+        :type event_with_tenant: str
+        :param tenant: The tenant id (required)
+        :type tenant: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """  # noqa: E501
+
+        _param = self._event_data_get_with_tenant_serialize(
+            event_with_tenant=event_with_tenant,
+            tenant=tenant,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index,
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            "200": "EventData",
+            "400": "APIErrors",
+            "403": "APIErrors",
+        }
+        response_data = self.api_client.call_api(
+            *_param, _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+    @validate_call
+    def event_data_get_with_tenant_without_preload_content(
+        self,
+        event_with_tenant: Annotated[
+            str,
+            Field(
+                min_length=36, strict=True, max_length=36, description="The event id"
+            ),
+        ],
+        tenant: Annotated[
+            str,
+            Field(
+                min_length=36, strict=True, max_length=36, description="The tenant id"
+            ),
+        ],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)], Annotated[StrictFloat, Field(gt=0)]
+            ],
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Get event data
+
+        Get the data for an event.
+
+        :param event_with_tenant: The event id (required)
+        :type event_with_tenant: str
+        :param tenant: The tenant id (required)
+        :type tenant: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """  # noqa: E501
+
+        _param = self._event_data_get_with_tenant_serialize(
+            event_with_tenant=event_with_tenant,
+            tenant=tenant,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index,
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            "200": "EventData",
+            "400": "APIErrors",
+            "403": "APIErrors",
+        }
+        response_data = self.api_client.call_api(
+            *_param, _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+    def _event_data_get_with_tenant_serialize(
+        self,
+        event_with_tenant,
+        tenant,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {}
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        if event_with_tenant is not None:
+            _path_params["event-with-tenant"] = event_with_tenant
+        if tenant is not None:
+            _path_params["tenant"] = tenant
+        # process the query parameters
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+
+        # set the HTTP header `Accept`
+        if "Accept" not in _header_params:
+            _header_params["Accept"] = self.api_client.select_header_accept(
+                ["application/json"]
+            )
+
+        # authentication setting
+        _auth_settings: List[str] = ["cookieAuth", "bearerAuth"]
+
+        return self.api_client.param_serialize(
+            method="GET",
+            resource_path="/api/v1/tenants/{tenant}/events/{event-with-tenant}/data",
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth,
+        )
+
+    @validate_call
     def event_get(
         self,
         event: Annotated[

--- a/sdks/python/hatchet_sdk/clients/rest/api/event_api.py
+++ b/sdks/python/hatchet_sdk/clients/rest/api/event_api.py
@@ -38,6 +38,7 @@ from hatchet_sdk.clients.rest.models.event_update_cancel200_response import (
 )
 from hatchet_sdk.clients.rest.models.events import Events
 from hatchet_sdk.clients.rest.models.replay_event_request import ReplayEventRequest
+from hatchet_sdk.clients.rest.models.v1_event import V1Event
 from hatchet_sdk.clients.rest.models.v1_event_list import V1EventList
 from hatchet_sdk.clients.rest.models.v1_task_status import V1TaskStatus
 from hatchet_sdk.clients.rest.models.workflow_run_status import WorkflowRunStatus
@@ -2538,6 +2539,299 @@ class EventApi:
         return self.api_client.param_serialize(
             method="POST",
             resource_path="/api/v1/tenants/{tenant}/events/replay",
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth,
+        )
+
+    @validate_call
+    def v1_event_get(
+        self,
+        tenant: Annotated[
+            str,
+            Field(
+                min_length=36, strict=True, max_length=36, description="The tenant id"
+            ),
+        ],
+        v1_event: Annotated[
+            str,
+            Field(
+                min_length=36, strict=True, max_length=36, description="The event id"
+            ),
+        ],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)], Annotated[StrictFloat, Field(gt=0)]
+            ],
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> V1Event:
+        """Get events
+
+        Get an event by its id
+
+        :param tenant: The tenant id (required)
+        :type tenant: str
+        :param v1_event: The event id (required)
+        :type v1_event: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """  # noqa: E501
+
+        _param = self._v1_event_get_serialize(
+            tenant=tenant,
+            v1_event=v1_event,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index,
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            "200": "V1Event",
+            "400": "APIErrors",
+            "403": "APIErrors",
+        }
+        response_data = self.api_client.call_api(
+            *_param, _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+    @validate_call
+    def v1_event_get_with_http_info(
+        self,
+        tenant: Annotated[
+            str,
+            Field(
+                min_length=36, strict=True, max_length=36, description="The tenant id"
+            ),
+        ],
+        v1_event: Annotated[
+            str,
+            Field(
+                min_length=36, strict=True, max_length=36, description="The event id"
+            ),
+        ],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)], Annotated[StrictFloat, Field(gt=0)]
+            ],
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[V1Event]:
+        """Get events
+
+        Get an event by its id
+
+        :param tenant: The tenant id (required)
+        :type tenant: str
+        :param v1_event: The event id (required)
+        :type v1_event: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """  # noqa: E501
+
+        _param = self._v1_event_get_serialize(
+            tenant=tenant,
+            v1_event=v1_event,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index,
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            "200": "V1Event",
+            "400": "APIErrors",
+            "403": "APIErrors",
+        }
+        response_data = self.api_client.call_api(
+            *_param, _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+    @validate_call
+    def v1_event_get_without_preload_content(
+        self,
+        tenant: Annotated[
+            str,
+            Field(
+                min_length=36, strict=True, max_length=36, description="The tenant id"
+            ),
+        ],
+        v1_event: Annotated[
+            str,
+            Field(
+                min_length=36, strict=True, max_length=36, description="The event id"
+            ),
+        ],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)], Annotated[StrictFloat, Field(gt=0)]
+            ],
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Get events
+
+        Get an event by its id
+
+        :param tenant: The tenant id (required)
+        :type tenant: str
+        :param v1_event: The event id (required)
+        :type v1_event: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """  # noqa: E501
+
+        _param = self._v1_event_get_serialize(
+            tenant=tenant,
+            v1_event=v1_event,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index,
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            "200": "V1Event",
+            "400": "APIErrors",
+            "403": "APIErrors",
+        }
+        response_data = self.api_client.call_api(
+            *_param, _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+    def _v1_event_get_serialize(
+        self,
+        tenant,
+        v1_event,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {}
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        if tenant is not None:
+            _path_params["tenant"] = tenant
+        if v1_event is not None:
+            _path_params["v1-event"] = v1_event
+        # process the query parameters
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+
+        # set the HTTP header `Accept`
+        if "Accept" not in _header_params:
+            _header_params["Accept"] = self.api_client.select_header_accept(
+                ["application/json"]
+            )
+
+        # authentication setting
+        _auth_settings: List[str] = ["cookieAuth", "bearerAuth"]
+
+        return self.api_client.param_serialize(
+            method="GET",
+            resource_path="/api/v1/stable/tenants/{tenant}/events/{v1-event}",
             path_params=_path_params,
             query_params=_query_params,
             header_params=_header_params,

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.21.6"
+version = "1.21.7"
 description = "This is the official Python SDK for Hatchet, a distributed, fault-tolerant task queue. The SDK allows you to easily integrate Hatchet's task scheduling and workflow orchestration capabilities into your Python applications."
 authors = [
     "Alexander Belanger <alexander@hatchet.run>",


### PR DESCRIPTION
# Description

Couple things here:

1. Adds a `v1-event:get` method on the REST API which uses the PK of the OLAP events table properly to try to limit timeouts.
2. Added a really janky `event-with-tenant` populator to try to improve the V0 backwards compat with only minimal breaking SDK changes needed - migration path here would be to change `EventDataGet` -> `EventDataGetWithTenant`, and add the tenant id, and then nothing else would need to change. just a janky hack fix that we can hopefully remove soon 
3. Refactored a bit

## Type of change

- [x] New feature (non-breaking change which adds functionality)
