### PR TITLE
fix: typescript SDK handleKill is ignored

### DIFF
--- a/sdks/typescript/src/v1/client/worker/worker-internal.ts
+++ b/sdks/typescript/src/v1/client/worker/worker-internal.ts
@@ -110,11 +110,11 @@ export class InternalWorker {
     this.enableHealthServer = client.config.healthcheck?.enabled ?? false;
     this.healthPort = client.config.healthcheck?.port ?? 8001;
 
-    process.on('SIGTERM', () => this.exitGracefully(true));
-    process.on('SIGINT', () => this.exitGracefully(true));
-
     this.killing = false;
     this.handle_kill = options.handleKill === undefined ? true : options.handleKill;
+
+    process.on('SIGTERM', () => this.exitGracefully(this.handle_kill));
+    process.on('SIGINT', () => this.exitGracefully(this.handle_kill));
 
     this.logger = client.config.logger(`Worker/${this.name}`, this.client.config.log_level);
 


### PR DESCRIPTION
fixes [issue](https://github.com/hatchet-dev/hatchet/issues/2585#issue-3682286616)

Changed the signal handlers to this.handle_kill instead of hardcoded true

Signal handlers now use this.handle_kill instead of true

Tested locally:
Process correctly stays alive and does not exit