### PR TITLE
Fix: filter + pagination state handling hack

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: "1.25"
       - uses: actions/setup-python@v6
       - uses: pre-commit/action@v3.0.1
         name: lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: "1.25"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/sdk-go.yml
+++ b/.github/workflows/sdk-go.yml
@@ -2,17 +2,17 @@ name: go
 on:
   pull_request:
     paths:
-      - '.github/**'
-      - 'api/**'
-      - 'api-contracts/**'
-      - 'internal/**'
-      - 'pkg/**'
-      - 'sdks/go/**'
+      - ".github/**"
+      - "api/**"
+      - "api-contracts/**"
+      - "internal/**"
+      - "pkg/**"
+      - "sdks/go/**"
   push:
     branches:
       - main
     paths:
-      - 'sdks/go/**'
+      - "sdks/go/**"
 
 defaults:
   run:
@@ -26,6 +26,8 @@ jobs:
         uses: actions/checkout@v6
       - name: Setup Go
         uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
       - name: Compile Go SDK examples
         run: |
           # Find all directories with go.mod files

--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -2,17 +2,17 @@ name: python
 on:
   pull_request:
     paths:
-      - '.github/**'
-      - 'api/**'
-      - 'api-contracts/**'
-      - 'internal/**'
-      - 'pkg/**'
-      - 'sdks/python/**'
+      - ".github/**"
+      - "api/**"
+      - "api-contracts/**"
+      - "internal/**"
+      - "pkg/**"
+      - "sdks/python/**"
   push:
     branches:
       - main
     paths:
-      - 'sdks/python/**'
+      - "sdks/python/**"
 
 defaults:
   run:
@@ -70,7 +70,7 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:
-          version: '25.1'
+          version: "25.1"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Task
@@ -81,7 +81,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: "1.25"
 
       - name: Start Docker dependencies
         working-directory: .

--- a/.github/workflows/sdk-typescript.yml
+++ b/.github/workflows/sdk-typescript.yml
@@ -2,17 +2,17 @@ name: typescript
 on:
   pull_request:
     paths:
-      - '.github/**'
-      - 'api/**'
-      - 'api-contracts/**'
-      - 'internal/**'
-      - 'pkg/**'
-      - 'sdks/typescript/**'
+      - ".github/**"
+      - "api/**"
+      - "api-contracts/**"
+      - "internal/**"
+      - "pkg/**"
+      - "sdks/typescript/**"
   push:
     branches:
       - main
     paths:
-      - 'sdks/typescript/**'
+      - "sdks/typescript/**"
 
 defaults:
   run:
@@ -95,7 +95,7 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:
-          version: '25.1'
+          version: "25.1"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Task
@@ -106,7 +106,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: "1.25"
 
       - name: Install pnpm
         run: npm install -g pnpm@10.16.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Go deps
         run: go mod download
@@ -86,7 +86,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -134,7 +134,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -224,7 +224,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -319,7 +319,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -360,7 +360,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/build/package/frontend.dockerfile
+++ b/build/package/frontend.dockerfile
@@ -11,7 +11,7 @@ COPY ./frontend/app ./
 RUN npm run build
 
 # Stage 2: Build the static fileserver
-FROM golang:1.24-alpine3.21 AS staticfileserver
+FROM golang:1.25-alpine AS staticfileserver
 
 WORKDIR /app
 

--- a/build/package/loadtest.dockerfile
+++ b/build/package/loadtest.dockerfile
@@ -1,6 +1,6 @@
 # Base Go environment
 # -------------------
-FROM golang:1.24-alpine as base
+FROM golang:1.25-alpine as base
 WORKDIR /hatchet
 
 COPY go.mod go.sum ./

--- a/build/package/servers.dockerfile
+++ b/build/package/servers.dockerfile
@@ -1,6 +1,6 @@
 # Base Go environment
 # -------------------
-FROM golang:1.24-alpine as base
+FROM golang:1.25-alpine as base
 WORKDIR /hatchet
 
 RUN apk update && apk add --no-cache gcc musl-dev git protoc protobuf-dev

--- a/frontend/app/src/hooks/use-pagination.tsx
+++ b/frontend/app/src/hooks/use-pagination.tsx
@@ -79,10 +79,10 @@ export const usePagination = ({ key }: UsePaginationProps) => {
 
       return {
         ...Object.fromEntries(prev.entries()),
-        [paramKey]: JSON.stringify({
+        [paramKey]: {
           i: nextPagination.pageIndex,
           s: nextPagination.pageSize,
-        }),
+        },
       };
     });
   }, [setSearchParams, paramKey]);
@@ -98,10 +98,10 @@ export const usePagination = ({ key }: UsePaginationProps) => {
 
       return {
         ...Object.fromEntries(prev.entries()),
-        [paramKey]: JSON.stringify({
+        [paramKey]: {
           i: prevPagination.pageIndex,
           s: prevPagination.pageSize,
-        }),
+        },
       };
     });
   }, [setSearchParams, paramKey]);
@@ -118,10 +118,10 @@ export const usePagination = ({ key }: UsePaginationProps) => {
 
         return {
           ...Object.fromEntries(prev.entries()),
-          [paramKey]: JSON.stringify({
+          [paramKey]: {
             i: nextPagination.pageIndex,
             s: nextPagination.pageSize,
-          }),
+          },
         };
       });
     },
@@ -138,10 +138,10 @@ export const usePagination = ({ key }: UsePaginationProps) => {
 
         return {
           ...Object.fromEntries(prev.entries()),
-          [paramKey]: JSON.stringify({
+          [paramKey]: {
             i: newPagination.pageIndex,
             s: newPagination.pageSize,
-          }),
+          },
         };
       });
     },

--- a/frontend/app/src/hooks/use-zod-column-filters.ts
+++ b/frontend/app/src/hooks/use-zod-column-filters.ts
@@ -21,14 +21,17 @@ export function useZodColumnFilters<T extends z.ZodType>(
 
   const state = useMemo((): z.infer<T> => {
     const rawValue = searchParams.get(key);
+
     if (!rawValue) {
       return schema.parse({});
     }
 
     try {
-      const parsed = JSON.parse(rawValue);
-      return schema.parse(parsed);
-    } catch {
+      const parsed =
+        typeof rawValue === 'string' ? JSON.parse(rawValue) : rawValue;
+      const validated = schema.parse(parsed);
+      return validated;
+    } catch (e) {
       return schema.parse({});
     }
   }, [searchParams, key, schema]);
@@ -37,7 +40,7 @@ export function useZodColumnFilters<T extends z.ZodType>(
     (newValue: z.infer<T>) => {
       setSearchParams((prev) => ({
         ...Object.fromEntries(prev.entries()),
-        [key]: JSON.stringify(newValue),
+        [key]: newValue,
       }));
     },
     [key, setSearchParams],

--- a/frontend/app/src/lib/router-helpers.tsx
+++ b/frontend/app/src/lib/router-helpers.tsx
@@ -97,7 +97,7 @@ export function useSearchParams(): [
     }
 
     navigate({
-      to: '.',
+      to: location.pathname,
       search: searchObject,
       replace: options?.replace,
       state: options?.state,

--- a/frontend/app/src/lib/router-helpers.tsx
+++ b/frontend/app/src/lib/router-helpers.tsx
@@ -2,7 +2,6 @@ import {
   Outlet as TanStackOutlet,
   useLocation,
   useNavigate as useTanStackNavigate,
-  useRouter,
 } from '@tanstack/react-router';
 import type { NavigateOptions } from '@tanstack/react-router';
 import { createContext, useContext, useMemo } from 'react';
@@ -32,18 +31,14 @@ export function useSearchParams(): [
     init:
       | URLSearchParams
       | string
-      | Record<string, string | number | boolean | null | undefined>
+      | Record<string, unknown>
       | ((
           prev: URLSearchParams,
-        ) =>
-          | URLSearchParams
-          | string
-          | Record<string, string | number | boolean | null | undefined>),
+        ) => URLSearchParams | string | Record<string, unknown>),
     options?: SearchNavigateOptions,
   ) => void,
 ] {
   const location = useLocation();
-  const router = useRouter();
   const navigate = useTanStackNavigate();
 
   const searchParams = useMemo(
@@ -55,37 +50,55 @@ export function useSearchParams(): [
     init:
       | URLSearchParams
       | string
-      | Record<string, string | number | boolean | null | undefined>
+      | Record<string, unknown>
       | ((
           prev: URLSearchParams,
-        ) =>
-          | URLSearchParams
-          | string
-          | Record<string, string | number | boolean | null | undefined>),
+        ) => URLSearchParams | string | Record<string, unknown>),
     options?: SearchNavigateOptions,
   ) => {
     const prev = new URLSearchParams(location.searchStr ?? '');
     const resolved = typeof init === 'function' ? init(prev) : init;
 
-    let next: URLSearchParams;
+    let searchObject: Record<string, unknown>;
     if (resolved instanceof URLSearchParams) {
-      next = resolved;
-    } else if (typeof resolved === 'string') {
-      next = new URLSearchParams(resolved);
-    } else {
-      next = new URLSearchParams();
-      Object.entries(resolved || {}).forEach(([key, value]) => {
-        if (value === undefined || value === null) {
-          return;
+      searchObject = {};
+      resolved.forEach((value, key) => {
+        try {
+          searchObject[key] = JSON.parse(value);
+        } catch {
+          searchObject[key] = value;
         }
-        next.set(key, String(value));
+      });
+    } else if (typeof resolved === 'string') {
+      const params = new URLSearchParams(resolved);
+      searchObject = {};
+      params.forEach((value, key) => {
+        try {
+          searchObject[key] = JSON.parse(value);
+        } catch {
+          searchObject[key] = value;
+        }
+      });
+    } else {
+      searchObject = {};
+      Object.entries(resolved || {}).forEach(([key, value]) => {
+        if (value !== undefined && value !== null) {
+          if (typeof value === 'string') {
+            try {
+              searchObject[key] = JSON.parse(value);
+            } catch {
+              searchObject[key] = value;
+            }
+          } else {
+            searchObject[key] = value;
+          }
+        }
       });
     }
 
-    const searchStr = next.toString();
     navigate({
-      to: router.state.location.pathname,
-      search: searchStr ? () => Object.fromEntries(next.entries()) : {},
+      to: '.',
+      search: searchObject,
       replace: options?.replace,
       state: options?.state,
     });

--- a/frontend/app/src/pages/main/v1/filters/hooks/use-filters.tsx
+++ b/frontend/app/src/pages/main/v1/filters/hooks/use-filters.tsx
@@ -130,7 +130,7 @@ export const useFilters = ({ key, scopeOverrides }: UseFiltersProps) => {
 
         return {
           ...Object.fromEntries(prev.entries()),
-          [paramKey]: JSON.stringify(filterState),
+          [paramKey]: filterState,
         };
       });
     },

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-runs-table-filters.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-runs-table-filters.tsx
@@ -136,7 +136,7 @@ export const useRunsTableFilters = (
       const updatedState = { ...zodState, ...newState };
       setSearchParams((prev) => ({
         ...Object.fromEntries(prev.entries()),
-        [paramKey]: JSON.stringify(updatedState),
+        [paramKey]: updatedState,
       }));
     },
     [zodState, setSearchParams, paramKey],


### PR DESCRIPTION
# Description

Hack to fix the url search param filter state for now - the issue is that tanstack router seems to auto-serialize and deserialize search params, which broke with our existing serde since things would get serialized twice. also added a hack to not deserialize if the thing is already an object

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
