### PR TITLE
fix: typescript tasks canceled status

### DIFF
--- a/sdks/typescript/src/v1/client/worker/worker-internal.ts
+++ b/sdks/typescript/src/v1/client/worker/worker-internal.ts
@@ -550,10 +550,13 @@ export class V1Worker {
       };
 
       const success = async (result: any) => {
+        if (context.cancelled) {
+          return;
+        }
+
         this.logger.info(`Step run ${action.stepRunId} succeeded`);
 
         try {
-          // Send the action event to the dispatcher
           const event = this.getStepActionEvent(
             action,
             StepActionEventType.STEP_EVENT_TYPE_COMPLETED,
@@ -595,6 +598,10 @@ export class V1Worker {
       };
 
       const failure = async (error: any) => {
+        if (context.cancelled) {
+          return;
+        }
+
         this.logger.error(`Step run ${action.stepRunId} failed: ${error.message}`);
 
         if (error.stack) {
@@ -604,7 +611,6 @@ export class V1Worker {
         const shouldNotRetry = error instanceof NonRetryableError;
 
         try {
-          // Send the action event to the dispatcher
           const event = this.getStepActionEvent(
             action,
             StepActionEventType.STEP_EVENT_TYPE_FAILED,


### PR DESCRIPTION
Add cancellation checks in success/failure callbacks to prevent sending COMPLETED/FAILED events when a task is cancelled. This ensures cancelled tasks are properly marked as CANCELLED and not retried.

# Description

When a TypeScript task is cancelled, the worker was incorrectly sending status updates (COMPLETED or FAILED) to the Hatchet engine. This caused cancelled tasks to be marked as either succeeded or failed (with retries), instead of being properly marked as CANCELLED.

The fix adds cancellation checks in both the `success()` and `failure()` callbacks before sending status events. When a task is cancelled, the worker now suppresses status updates, allowing the engine to properly handle the CANCELLED state. This matches the Python SDK behavior.

Fixes #2655

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed
- Added cancellation check in `success()` callback to suppress COMPLETED events when task is cancelled
- Added cancellation check in `failure()` callback to suppress FAILED events when task is cancelled
- Aligns TypeScript SDK behavior with Python SDK
