### PR TITLE
Fix: Last bits of payload job cleanup

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20251219181211_v1_0_63.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20251219181211_v1_0_63.sql
@@ -57,7 +57,7 @@ CREATE OR REPLACE FUNCTION diff_olap_payload_source_and_target_partitions(
     tenant_id UUID,
     external_id UUID,
     inserted_at TIMESTAMPTZ,
-    location v1_payload_location,
+    location v1_payload_location_olap,
     external_location_key TEXT,
     inline_content JSONB,
     updated_at TIMESTAMPTZ

--- a/cmd/hatchet-migrate/migrate/migrations/20251219181211_v1_0_63.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20251219181211_v1_0_63.sql
@@ -1,8 +1,7 @@
 -- +goose Up
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION diff_payload_source_and_target_partitions(
-    partition_date date,
-    max_rows int
+    partition_date date
 ) RETURNS TABLE (
     tenant_id UUID,
     id BIGINT,
@@ -46,16 +45,14 @@ BEGIN
                 AND source.id = target.id
                 AND source.type = target.type
         )
-        LIMIT $1
     ', source_partition_name, temp_partition_name);
 
-    RETURN QUERY EXECUTE query USING max_rows;
+    RETURN QUERY EXECUTE query;
 END;
 $$;
 
 CREATE OR REPLACE FUNCTION diff_olap_payload_source_and_target_partitions(
-    partition_date date,
-    max_rows int
+    partition_date date
 ) RETURNS TABLE (
     tenant_id UUID,
     external_id UUID,
@@ -96,16 +93,15 @@ BEGIN
                 AND source.external_id = target.external_id
                 AND source.inserted_at = target.inserted_at
         )
-        LIMIT $1
     ', source_partition_name, temp_partition_name);
 
-    RETURN QUERY EXECUTE query USING max_rows;
+    RETURN QUERY EXECUTE query;
 END;
 $$;
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
-DROP FUNCTION diff_payload_source_and_target_partitions(date, int);
-DROP FUNCTION diff_olap_payload_source_and_target_partitions(date, int);
+DROP FUNCTION diff_payload_source_and_target_partitions(date);
+DROP FUNCTION diff_olap_payload_source_and_target_partitions(date);
 -- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20251219181211_v1_0_63.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20251219181211_v1_0_63.sql
@@ -34,7 +34,7 @@ BEGIN
     END IF;
 
     query := format('
-        SELECT *
+        SELECT tenant_id, id, inserted_at, external_id, type, location, external_location_key, inline_content, updated_at
         FROM %I source
         WHERE NOT EXISTS (
             SELECT 1
@@ -83,7 +83,7 @@ BEGIN
     END IF;
 
     query := format('
-        SELECT *
+        SELECT tenant_id, external_id, inserted_at, location, external_location_key, inline_content, updated_at
         FROM %I source
         WHERE NOT EXISTS (
             SELECT 1

--- a/cmd/hatchet-migrate/migrate/migrations/20251219181211_v1_0_63.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20251219181211_v1_0_63.sql
@@ -53,7 +53,7 @@ BEGIN
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION diff_payloads_olap_source_and_target_partitions(
+CREATE OR REPLACE FUNCTION diff_olap_payload_source_and_target_partitions(
     partition_date date,
     max_rows int
 ) RETURNS TABLE (
@@ -107,5 +107,5 @@ $$;
 -- +goose Down
 -- +goose StatementBegin
 DROP FUNCTION diff_payload_source_and_target_partitions(date, int);
-DROP FUNCTION diff_payloads_olap_source_and_target_partitions(date, int);
+DROP FUNCTION diff_olap_payload_source_and_target_partitions(date, int);
 -- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20251219181211_v1_0_63.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20251219181211_v1_0_63.sql
@@ -1,0 +1,111 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION diff_payload_source_and_target_partitions(
+    partition_date date,
+    max_rows int
+) RETURNS TABLE (
+    tenant_id UUID,
+    id BIGINT,
+    inserted_at TIMESTAMPTZ,
+    external_id UUID,
+    type v1_payload_type,
+    location v1_payload_location,
+    external_location_key TEXT,
+    inline_content JSONB,
+    updated_at TIMESTAMPTZ
+)
+    LANGUAGE plpgsql AS
+$$
+DECLARE
+    partition_date_str varchar;
+    source_partition_name varchar;
+    temp_partition_name varchar;
+    query text;
+BEGIN
+    IF partition_date IS NULL THEN
+        RAISE EXCEPTION 'partition_date parameter cannot be NULL';
+    END IF;
+
+    SELECT to_char(partition_date, 'YYYYMMDD') INTO partition_date_str;
+    SELECT format('v1_payload_%s', partition_date_str) INTO source_partition_name;
+    SELECT format('v1_payload_offload_tmp_%s', partition_date_str) INTO temp_partition_name;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_tables WHERE tablename = source_partition_name) THEN
+        RAISE EXCEPTION 'Partition % does not exist', source_partition_name;
+    END IF;
+
+    query := format('
+        SELECT *
+        FROM %I source
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM %I AS target
+            WHERE
+                source.tenant_id = target.tenant_id
+                AND source.inserted_at = target.inserted_at
+                AND source.id = target.id
+                AND source.type = target.type
+        )
+        LIMIT $1
+    ', source_partition_name, temp_partition_name);
+
+    RETURN QUERY EXECUTE query USING max_rows;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION diff_payloads_olap_source_and_target_partitions(
+    partition_date date,
+    max_rows int
+) RETURNS TABLE (
+    tenant_id UUID,
+    external_id UUID,
+    inserted_at TIMESTAMPTZ,
+    location v1_payload_location,
+    external_location_key TEXT,
+    inline_content JSONB,
+    updated_at TIMESTAMPTZ
+)
+    LANGUAGE plpgsql AS
+$$
+DECLARE
+    partition_date_str varchar;
+    source_partition_name varchar;
+    temp_partition_name varchar;
+    query text;
+BEGIN
+    IF partition_date IS NULL THEN
+        RAISE EXCEPTION 'partition_date parameter cannot be NULL';
+    END IF;
+
+    SELECT to_char(partition_date, 'YYYYMMDD') INTO partition_date_str;
+    SELECT format('v1_payloads_olap_%s', partition_date_str) INTO source_partition_name;
+    SELECT format('v1_payloads_olap_offload_tmp_%s', partition_date_str) INTO temp_partition_name;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_tables WHERE tablename = source_partition_name) THEN
+        RAISE EXCEPTION 'Partition % does not exist', source_partition_name;
+    END IF;
+
+    query := format('
+        SELECT *
+        FROM %I source
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM %I AS target
+            WHERE
+                source.tenant_id = target.tenant_id
+                AND source.external_id = target.external_id
+                AND source.inserted_at = target.inserted_at
+        )
+        LIMIT $1
+    ', source_partition_name, temp_partition_name);
+
+    RETURN QUERY EXECUTE query USING max_rows;
+END;
+$$;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP FUNCTION diff_payload_source_and_target_partitions(date, int);
+DROP FUNCTION diff_payloads_olap_source_and_target_partitions(date, int);
+-- +goose StatementEnd

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -3174,6 +3174,10 @@ func (p *OLAPRepositoryImpl) ProcessOLAPPayloadCutovers(ctx context.Context, ext
 	// don't need a tx for this since we're just doing cleanup
 	err = p.queries.CleanUpOLAPCutoverJobOffsets(ctx, p.pool, partitionDatesToKeep)
 
+	if err != nil {
+		return fmt.Errorf("failed to clean up olap cutover job offsets: %w", err)
+	}
+
 	processId := sqlchelpers.UUIDFromStr(uuid.NewString())
 
 	for _, partition := range partitions {

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -2933,7 +2933,7 @@ func (p *OLAPRepositoryImpl) processOLAPPayloadCutoverBatch(ctx context.Context,
 }
 
 func (p *OLAPRepositoryImpl) acquireOrExtendJobLease(ctx context.Context, tx pgx.Tx, processId pgtype.UUID, partitionDate PartitionDate, pagination OLAPPaginationParams) (*OLAPCutoverJobRunMetadata, error) {
-	leaseInterval := 2 * time.Minute
+	leaseInterval := 5 * time.Minute
 	leaseExpiresAt := sqlchelpers.TimestamptzFromTime(time.Now().Add(leaseInterval))
 
 	lease, err := p.queries.AcquireOrExtendOLAPCutoverJobLease(ctx, tx, sqlcv1.AcquireOrExtendOLAPCutoverJobLeaseParams{

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -2933,7 +2933,7 @@ func (p *OLAPRepositoryImpl) processOLAPPayloadCutoverBatch(ctx context.Context,
 }
 
 func (p *OLAPRepositoryImpl) acquireOrExtendJobLease(ctx context.Context, tx pgx.Tx, processId pgtype.UUID, partitionDate PartitionDate, pagination OLAPPaginationParams) (*OLAPCutoverJobRunMetadata, error) {
-	leaseInterval := 5 * time.Minute
+	leaseInterval := 10 * time.Minute
 	leaseExpiresAt := sqlchelpers.TimestamptzFromTime(time.Now().Add(leaseInterval))
 
 	lease, err := p.queries.AcquireOrExtendOLAPCutoverJobLease(ctx, tx, sqlcv1.AcquireOrExtendOLAPCutoverJobLeaseParams{

--- a/pkg/repository/v1/payloadstore.go
+++ b/pkg/repository/v1/payloadstore.go
@@ -813,6 +813,22 @@ func (p *payloadStoreRepositoryImpl) ProcessPayloadCutovers(ctx context.Context)
 		return fmt.Errorf("failed to find payload partitions before date %s: %w", mostRecentPartitionToOffload.Time.String(), err)
 	}
 
+	partitionDatesToKeep := make([]pgtype.Date, len(partitions))
+
+	for i, partition := range partitions {
+		partitionDatesToKeep[i] = pgtype.Date{
+			Time:  partition.PartitionDate.Time,
+			Valid: true,
+		}
+	}
+
+	// don't need a tx for this since we're just doing cleanup
+	err = p.queries.CleanUpCutoverJobOffsets(ctx, p.pool, partitionDatesToKeep)
+
+	if err != nil {
+		return fmt.Errorf("failed to clean up cutover job offsets: %w", err)
+	}
+
 	processId := sqlchelpers.UUIDFromStr(uuid.NewString())
 
 	for _, partition := range partitions {

--- a/pkg/repository/v1/payloadstore.go
+++ b/pkg/repository/v1/payloadstore.go
@@ -753,14 +753,52 @@ func (p *payloadStoreRepositoryImpl) processSinglePartition(ctx context.Context,
 	tempPartitionName := fmt.Sprintf("v1_payload_offload_tmp_%s", partitionDate.String())
 	sourcePartitionName := fmt.Sprintf("v1_payload_%s", partitionDate.String())
 
-	countsEqual, err := sqlcv1.ComparePartitionRowCounts(ctx, p.pool, tempPartitionName, sourcePartitionName)
+	rowCounts, err := sqlcv1.ComparePartitionRowCounts(ctx, p.pool, tempPartitionName, sourcePartitionName)
 
 	if err != nil {
 		return fmt.Errorf("failed to compare partition row counts: %w", err)
 	}
 
-	if !countsEqual {
-		return fmt.Errorf("row counts do not match between temp and source partitions for date %s", partitionDate.String())
+	const maxCountDiff = 5000
+
+	if rowCounts.SourcePartitionCount-rowCounts.TempPartitionCount > maxCountDiff {
+		return fmt.Errorf("row counts do not match between temp and source partitions for date %s. off by more than %d", partitionDate.String(), maxCountDiff)
+	} else if rowCounts.SourcePartitionCount > rowCounts.TempPartitionCount {
+		missingRows, err := p.queries.DiffPayloadSourceAndTargetPartitions(ctx, p.pool, pgtype.Date(partitionDate))
+
+		if err != nil {
+			return fmt.Errorf("failed to diff source and target partitions: %w", err)
+		}
+
+		missingPayloadsToInsert := make([]sqlcv1.CutoverPayloadToInsert, len(missingRows))
+
+		for i, p := range missingRows {
+			missingPayloadsToInsert[i] = sqlcv1.CutoverPayloadToInsert{
+				TenantID:            p.TenantID,
+				ID:                  p.ID,
+				InsertedAt:          p.InsertedAt,
+				ExternalID:          p.ExternalID,
+				Type:                p.Type,
+				ExternalLocationKey: p.ExternalLocationKey,
+				InlineContent:       p.InlineContent,
+			}
+		}
+
+		_, err = sqlcv1.InsertCutOverPayloadsIntoTempTable(ctx, p.pool, tempPartitionName, missingPayloadsToInsert)
+
+		if err != nil {
+			return fmt.Errorf("failed to insert missing payloads into temp partition: %w", err)
+		}
+
+		rowCounts, err := sqlcv1.ComparePartitionRowCounts(ctx, p.pool, tempPartitionName, sourcePartitionName)
+
+		if err != nil {
+			return fmt.Errorf("failed to compare partition row counts: %w", err)
+		}
+
+		if rowCounts.SourcePartitionCount != rowCounts.TempPartitionCount {
+			return fmt.Errorf("row counts still do not match between temp and source partitions for date %s after inserting missing rows", partitionDate.String())
+		}
 	}
 
 	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, p.pool, p.l, 10000)

--- a/pkg/repository/v1/payloadstore.go
+++ b/pkg/repository/v1/payloadstore.go
@@ -618,7 +618,7 @@ type CutoverJobRunMetadata struct {
 }
 
 func (p *payloadStoreRepositoryImpl) acquireOrExtendJobLease(ctx context.Context, tx pgx.Tx, processId pgtype.UUID, partitionDate PartitionDate, pagination PaginationParams) (*CutoverJobRunMetadata, error) {
-	leaseInterval := 2 * time.Minute
+	leaseInterval := 5 * time.Minute
 	leaseExpiresAt := sqlchelpers.TimestamptzFromTime(time.Now().Add(leaseInterval))
 
 	lease, err := p.queries.AcquireOrExtendCutoverJobLease(ctx, tx, sqlcv1.AcquireOrExtendCutoverJobLeaseParams{

--- a/pkg/repository/v1/payloadstore.go
+++ b/pkg/repository/v1/payloadstore.go
@@ -618,7 +618,7 @@ type CutoverJobRunMetadata struct {
 }
 
 func (p *payloadStoreRepositoryImpl) acquireOrExtendJobLease(ctx context.Context, tx pgx.Tx, processId pgtype.UUID, partitionDate PartitionDate, pagination PaginationParams) (*CutoverJobRunMetadata, error) {
-	leaseInterval := 5 * time.Minute
+	leaseInterval := 10 * time.Minute
 	leaseExpiresAt := sqlchelpers.TimestamptzFromTime(time.Now().Add(leaseInterval))
 
 	lease, err := p.queries.AcquireOrExtendCutoverJobLease(ctx, tx, sqlcv1.AcquireOrExtendCutoverJobLeaseParams{

--- a/pkg/repository/v1/sqlcv1/olap-overwrite.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap-overwrite.sql.go
@@ -452,6 +452,7 @@ type CutoverOLAPPayloadToInsert struct {
 	InsertedAt          pgtype.Timestamptz
 	ExternalID          pgtype.UUID
 	ExternalLocationKey string
+	InlineContent       []byte
 }
 
 type InsertCutOverOLAPPayloadsIntoTempTableRow struct {
@@ -466,6 +467,7 @@ func InsertCutOverOLAPPayloadsIntoTempTable(ctx context.Context, tx DBTX, tableN
 	externalIds := make([]pgtype.UUID, 0, len(payloads))
 	locations := make([]string, 0, len(payloads))
 	externalLocationKeys := make([]string, 0, len(payloads))
+	inlineContents := make([][]byte, 0, len(payloads))
 
 	for _, payload := range payloads {
 		externalIds = append(externalIds, payload.ExternalID)
@@ -473,6 +475,7 @@ func InsertCutOverOLAPPayloadsIntoTempTable(ctx context.Context, tx DBTX, tableN
 		insertedAts = append(insertedAts, payload.InsertedAt)
 		locations = append(locations, string(V1PayloadLocationOlapEXTERNAL))
 		externalLocationKeys = append(externalLocationKeys, string(payload.ExternalLocationKey))
+		inlineContents = append(inlineContents, payload.InlineContent)
 	}
 
 	row := tx.QueryRow(
@@ -487,7 +490,8 @@ func InsertCutOverOLAPPayloadsIntoTempTable(ctx context.Context, tx DBTX, tableN
 						UNNEST($2::TIMESTAMPTZ[]) AS inserted_at,
 						UNNEST($3::UUID[]) AS external_id,
 						UNNEST($4::TEXT[]) AS location,
-						UNNEST($5::TEXT[]) AS external_location_key
+						UNNEST($5::TEXT[]) AS external_location_key,
+						UNNEST($6::JSONB[]) AS inline_content
 				), inserts AS (
 					INSERT INTO %s (tenant_id, external_id, location, external_location_key, inline_content, inserted_at, updated_at)
 					SELECT
@@ -495,7 +499,7 @@ func InsertCutOverOLAPPayloadsIntoTempTable(ctx context.Context, tx DBTX, tableN
 						external_id,
 						location::v1_payload_location_olap,
 						external_location_key,
-						NULL,
+						inline_content,
 						inserted_at,
 						NOW()
 					FROM inputs
@@ -515,6 +519,7 @@ func InsertCutOverOLAPPayloadsIntoTempTable(ctx context.Context, tx DBTX, tableN
 		externalIds,
 		locations,
 		externalLocationKeys,
+		inlineContents,
 	)
 
 	var insertRow InsertCutOverOLAPPayloadsIntoTempTableRow

--- a/pkg/repository/v1/sqlcv1/olap-overwrite.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap-overwrite.sql.go
@@ -528,35 +528,6 @@ func InsertCutOverOLAPPayloadsIntoTempTable(ctx context.Context, tx DBTX, tableN
 	return &insertRow, err
 }
 
-func CompareOLAPPartitionRowCounts(ctx context.Context, tx DBTX, tempPartitionName, sourcePartitionName string) (*PartitionRowCounts, error) {
-	row := tx.QueryRow(
-		ctx,
-		fmt.Sprintf(
-			`
-				SELECT
-					(SELECT COUNT(*) FROM %s) AS temp_partition_count,
-					(SELECT COUNT(*) FROM %s) AS source_partition_count
-			`,
-			tempPartitionName,
-			sourcePartitionName,
-		),
-	)
-
-	var tempPartitionCount int64
-	var sourcePartitionCount int64
-
-	err := row.Scan(&tempPartitionCount, &sourcePartitionCount)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return &PartitionRowCounts{
-		SourcePartitionCount: sourcePartitionCount,
-		TempPartitionCount:   tempPartitionCount,
-	}, nil
-}
-
 const findV1OLAPPayloadPartitionsBeforeDate = `-- name: findV1OLAPPayloadPartitionsBeforeDate :many
 WITH partitions AS (
     SELECT

--- a/pkg/repository/v1/sqlcv1/olap-overwrite.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap-overwrite.sql.go
@@ -523,7 +523,7 @@ func InsertCutOverOLAPPayloadsIntoTempTable(ctx context.Context, tx DBTX, tableN
 	return &insertRow, err
 }
 
-func CompareOLAPPartitionRowCounts(ctx context.Context, tx DBTX, tempPartitionName, sourcePartitionName string) (bool, error) {
+func CompareOLAPPartitionRowCounts(ctx context.Context, tx DBTX, tempPartitionName, sourcePartitionName string) (*PartitionRowCounts, error) {
 	row := tx.QueryRow(
 		ctx,
 		fmt.Sprintf(
@@ -543,10 +543,13 @@ func CompareOLAPPartitionRowCounts(ctx context.Context, tx DBTX, tempPartitionNa
 	err := row.Scan(&tempPartitionCount, &sourcePartitionCount)
 
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
-	return tempPartitionCount == sourcePartitionCount, nil
+	return &PartitionRowCounts{
+		SourcePartitionCount: sourcePartitionCount,
+		TempPartitionCount:   tempPartitionCount,
+	}, nil
 }
 
 const findV1OLAPPayloadPartitionsBeforeDate = `-- name: findV1OLAPPayloadPartitionsBeforeDate :many

--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -2122,7 +2122,7 @@ SELECT
     tenant_id::UUID,
     inserted_at::TIMESTAMPTZ,
     external_id::UUID,
-    location::v1_payload_location,
+    location::v1_payload_location_olap,
     COALESCE(external_location_key, '')::TEXT AS external_location_key,
     inline_content::JSONB AS inline_content,
     updated_at::TIMESTAMPTZ

--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -2111,7 +2111,4 @@ WHERE key NOT IN (@keysToKeep::DATE[])
 
 
 -- name: DiffOLAPPayloadSourceAndTargetPartitions :many
-SELECT diff_olap_payload_source_and_target_partitions(
-    @partitionDate::DATE,
-    @maxRows::INTEGER
-);
+SELECT diff_olap_payload_source_and_target_partitions(@partitionDate::DATE);

--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -2111,4 +2111,20 @@ WHERE key NOT IN (@keysToKeep::DATE[])
 
 
 -- name: DiffOLAPPayloadSourceAndTargetPartitions :many
-SELECT diff_olap_payload_source_and_target_partitions(@partitionDate::DATE);
+-- name: DiffPayloadSourceAndTargetPartitions :many
+WITH payloads AS (
+    SELECT
+        (p).*
+    FROM diff_olap_payload_source_and_target_partitions(@partitionDate::DATE) p
+)
+
+SELECT
+    tenant_id::UUID,
+    inserted_at::TIMESTAMPTZ,
+    external_id::UUID,
+    location::v1_payload_location,
+    COALESCE(external_location_key, '')::TEXT AS external_location_key,
+    inline_content::JSONB AS inline_content,
+    updated_at::TIMESTAMPTZ
+FROM payloads
+;

--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -2106,7 +2106,7 @@ WHERE key = @key::DATE
 
 -- name: CleanUpOLAPCutoverJobOffsets :exec
 DELETE FROM v1_payload_cutover_job_offset
-WHERE key NOT IN (@keysToKeep::DATE[])
+WHERE NOT key = ANY(@keysToKeep::DATE[])
 ;
 
 
@@ -2120,8 +2120,8 @@ WITH payloads AS (
 
 SELECT
     tenant_id::UUID,
-    inserted_at::TIMESTAMPTZ,
     external_id::UUID,
+    inserted_at::TIMESTAMPTZ,
     location::v1_payload_location_olap,
     COALESCE(external_location_key, '')::TEXT AS external_location_key,
     inline_content::JSONB AS inline_content,

--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -2108,3 +2108,10 @@ WHERE key = @key::DATE
 DELETE FROM v1_payload_cutover_job_offset
 WHERE key NOT IN (@keysToKeep::DATE[])
 ;
+
+
+-- name: DiffOLAPPayloadSourceAndTargetPartitions :many
+SELECT diff_olap_payload_source_and_target_partitions(
+    @partitionDate::DATE,
+    @maxRows::INTEGER
+);

--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -2106,5 +2106,5 @@ WHERE key = @key::DATE
 
 -- name: CleanUpOLAPCutoverJobOffsets :exec
 DELETE FROM v1_payload_cutover_job_offset
-WHERE key IN (@keys::DATE[])
+WHERE key NOT IN (@keysToKeep::DATE[])
 ;

--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -2111,7 +2111,6 @@ WHERE NOT key = ANY(@keysToKeep::DATE[])
 
 
 -- name: DiffOLAPPayloadSourceAndTargetPartitions :many
--- name: DiffPayloadSourceAndTargetPartitions :many
 WITH payloads AS (
     SELECT
         (p).*

--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -2103,3 +2103,8 @@ UPDATE v1_payloads_olap_cutover_job_offset
 SET is_completed = TRUE
 WHERE key = @key::DATE
 ;
+
+-- name: CleanUpOLAPCutoverJobOffsets :exec
+DELETE FROM v1_payload_cutover_job_offset
+WHERE key IN (@keys::DATE[])
+;

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -158,6 +158,16 @@ type BulkCreateEventTriggersParams struct {
 	FilterID      pgtype.UUID        `json:"filter_id"`
 }
 
+const cleanUpOLAPCutoverJobOffsets = `-- name: CleanUpOLAPCutoverJobOffsets :exec
+DELETE FROM v1_payload_cutover_job_offset
+WHERE key IN ($1::DATE[])
+`
+
+func (q *Queries) CleanUpOLAPCutoverJobOffsets(ctx context.Context, db DBTX, keys []pgtype.Date) error {
+	_, err := db.Exec(ctx, cleanUpOLAPCutoverJobOffsets, keys)
+	return err
+}
+
 const countEvents = `-- name: CountEvents :one
 WITH included_events AS (
     SELECT e.tenant_id, e.id, e.external_id, e.seen_at, e.key, e.payload, e.additional_metadata, e.scope, e.triggering_webhook_name

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -160,11 +160,11 @@ type BulkCreateEventTriggersParams struct {
 
 const cleanUpOLAPCutoverJobOffsets = `-- name: CleanUpOLAPCutoverJobOffsets :exec
 DELETE FROM v1_payload_cutover_job_offset
-WHERE key IN ($1::DATE[])
+WHERE key NOT IN ($1::DATE[])
 `
 
-func (q *Queries) CleanUpOLAPCutoverJobOffsets(ctx context.Context, db DBTX, keys []pgtype.Date) error {
-	_, err := db.Exec(ctx, cleanUpOLAPCutoverJobOffsets, keys)
+func (q *Queries) CleanUpOLAPCutoverJobOffsets(ctx context.Context, db DBTX, keystokeep []pgtype.Date) error {
+	_, err := db.Exec(ctx, cleanUpOLAPCutoverJobOffsets, keystokeep)
 	return err
 }
 

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -160,7 +160,7 @@ type BulkCreateEventTriggersParams struct {
 
 const cleanUpOLAPCutoverJobOffsets = `-- name: CleanUpOLAPCutoverJobOffsets :exec
 DELETE FROM v1_payload_cutover_job_offset
-WHERE key NOT IN ($1::DATE[])
+WHERE NOT key = ANY($1::DATE[])
 `
 
 func (q *Queries) CleanUpOLAPCutoverJobOffsets(ctx context.Context, db DBTX, keystokeep []pgtype.Date) error {
@@ -477,8 +477,8 @@ WITH payloads AS (
 
 SELECT
     tenant_id::UUID,
-    inserted_at::TIMESTAMPTZ,
     external_id::UUID,
+    inserted_at::TIMESTAMPTZ,
     location::v1_payload_location_olap,
     COALESCE(external_location_key, '')::TEXT AS external_location_key,
     inline_content::JSONB AS inline_content,
@@ -488,8 +488,8 @@ FROM payloads
 
 type DiffOLAPPayloadSourceAndTargetPartitionsRow struct {
 	TenantID            pgtype.UUID           `json:"tenant_id"`
-	InsertedAt          pgtype.Timestamptz    `json:"inserted_at"`
 	ExternalID          pgtype.UUID           `json:"external_id"`
+	InsertedAt          pgtype.Timestamptz    `json:"inserted_at"`
 	Location            V1PayloadLocationOlap `json:"location"`
 	ExternalLocationKey string                `json:"external_location_key"`
 	InlineContent       []byte                `json:"inline_content"`
@@ -507,8 +507,8 @@ func (q *Queries) DiffOLAPPayloadSourceAndTargetPartitions(ctx context.Context, 
 		var i DiffOLAPPayloadSourceAndTargetPartitionsRow
 		if err := rows.Scan(
 			&i.TenantID,
-			&i.InsertedAt,
 			&i.ExternalID,
+			&i.InsertedAt,
 			&i.Location,
 			&i.ExternalLocationKey,
 			&i.InlineContent,

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -469,19 +469,11 @@ func (q *Queries) CreateV1PayloadOLAPCutoverTemporaryTable(ctx context.Context, 
 }
 
 const diffOLAPPayloadSourceAndTargetPartitions = `-- name: DiffOLAPPayloadSourceAndTargetPartitions :many
-SELECT diff_olap_payload_source_and_target_partitions(
-    $1::DATE,
-    $2::INTEGER
-)
+SELECT diff_olap_payload_source_and_target_partitions($1::DATE)
 `
 
-type DiffOLAPPayloadSourceAndTargetPartitionsParams struct {
-	Partitiondate pgtype.Date `json:"partitiondate"`
-	Maxrows       int32       `json:"maxrows"`
-}
-
-func (q *Queries) DiffOLAPPayloadSourceAndTargetPartitions(ctx context.Context, db DBTX, arg DiffOLAPPayloadSourceAndTargetPartitionsParams) ([]interface{}, error) {
-	rows, err := db.Query(ctx, diffOLAPPayloadSourceAndTargetPartitions, arg.Partitiondate, arg.Maxrows)
+func (q *Queries) DiffOLAPPayloadSourceAndTargetPartitions(ctx context.Context, db DBTX, partitiondate pgtype.Date) ([]interface{}, error) {
+	rows, err := db.Query(ctx, diffOLAPPayloadSourceAndTargetPartitions, partitiondate)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -479,7 +479,7 @@ SELECT
     tenant_id::UUID,
     inserted_at::TIMESTAMPTZ,
     external_id::UUID,
-    location::v1_payload_location,
+    location::v1_payload_location_olap,
     COALESCE(external_location_key, '')::TEXT AS external_location_key,
     inline_content::JSONB AS inline_content,
     updated_at::TIMESTAMPTZ
@@ -487,13 +487,13 @@ FROM payloads
 `
 
 type DiffOLAPPayloadSourceAndTargetPartitionsRow struct {
-	TenantID            pgtype.UUID        `json:"tenant_id"`
-	InsertedAt          pgtype.Timestamptz `json:"inserted_at"`
-	ExternalID          pgtype.UUID        `json:"external_id"`
-	Location            V1PayloadLocation  `json:"location"`
-	ExternalLocationKey string             `json:"external_location_key"`
-	InlineContent       []byte             `json:"inline_content"`
-	UpdatedAt           pgtype.Timestamptz `json:"updated_at"`
+	TenantID            pgtype.UUID           `json:"tenant_id"`
+	InsertedAt          pgtype.Timestamptz    `json:"inserted_at"`
+	ExternalID          pgtype.UUID           `json:"external_id"`
+	Location            V1PayloadLocationOlap `json:"location"`
+	ExternalLocationKey string                `json:"external_location_key"`
+	InlineContent       []byte                `json:"inline_content"`
+	UpdatedAt           pgtype.Timestamptz    `json:"updated_at"`
 }
 
 func (q *Queries) DiffOLAPPayloadSourceAndTargetPartitions(ctx context.Context, db DBTX, partitiondate pgtype.Date) ([]*DiffOLAPPayloadSourceAndTargetPartitionsRow, error) {

--- a/pkg/repository/v1/sqlcv1/payload-store-overwrite.sql.go
+++ b/pkg/repository/v1/sqlcv1/payload-store-overwrite.sql.go
@@ -14,6 +14,7 @@ type CutoverPayloadToInsert struct {
 	ExternalID          pgtype.UUID
 	Type                V1PayloadType
 	ExternalLocationKey string
+	InlineContent       []byte
 }
 
 type InsertCutOverPayloadsIntoTempTableRow struct {
@@ -31,6 +32,7 @@ func InsertCutOverPayloadsIntoTempTable(ctx context.Context, tx DBTX, tableName 
 	types := make([]string, 0, len(payloads))
 	locations := make([]string, 0, len(payloads))
 	externalLocationKeys := make([]string, 0, len(payloads))
+	inlineContents := make([][]byte, 0, len(payloads))
 
 	for _, payload := range payloads {
 		externalIds = append(externalIds, payload.ExternalID)
@@ -40,6 +42,7 @@ func InsertCutOverPayloadsIntoTempTable(ctx context.Context, tx DBTX, tableName 
 		types = append(types, string(payload.Type))
 		locations = append(locations, string(V1PayloadLocationEXTERNAL))
 		externalLocationKeys = append(externalLocationKeys, string(payload.ExternalLocationKey))
+		inlineContents = append(inlineContents, payload.InlineContent)
 	}
 
 	row := tx.QueryRow(
@@ -56,7 +59,8 @@ func InsertCutOverPayloadsIntoTempTable(ctx context.Context, tx DBTX, tableName 
 						UNNEST($4::UUID[]) AS external_id,
 						UNNEST($5::TEXT[]) AS type,
 						UNNEST($6::TEXT[]) AS location,
-						UNNEST($7::TEXT[]) AS external_location_key
+						UNNEST($7::TEXT[]) AS external_location_key,
+						UNNEST($8::JSONB[]) AS inline_content
 				), inserts AS (
 					INSERT INTO %s (tenant_id, id, inserted_at, external_id, type, location, external_location_key, inline_content, updated_at)
 					SELECT
@@ -67,7 +71,7 @@ func InsertCutOverPayloadsIntoTempTable(ctx context.Context, tx DBTX, tableName 
 						type::v1_payload_type,
 						location::v1_payload_location,
 						external_location_key,
-						NULL,
+						inline_content,
 						NOW()
 					FROM inputs
 					ORDER BY tenant_id, inserted_at, id, type
@@ -88,6 +92,7 @@ func InsertCutOverPayloadsIntoTempTable(ctx context.Context, tx DBTX, tableName 
 		types,
 		locations,
 		externalLocationKeys,
+		inlineContents,
 	)
 
 	var insertRow InsertCutOverPayloadsIntoTempTableRow

--- a/pkg/repository/v1/sqlcv1/payload-store-overwrite.sql.go
+++ b/pkg/repository/v1/sqlcv1/payload-store-overwrite.sql.go
@@ -102,7 +102,12 @@ func InsertCutOverPayloadsIntoTempTable(ctx context.Context, tx DBTX, tableName 
 	return &insertRow, err
 }
 
-func ComparePartitionRowCounts(ctx context.Context, tx DBTX, tempPartitionName, sourcePartitionName string) (bool, error) {
+type PartitionRowCounts struct {
+	SourcePartitionCount int64
+	TempPartitionCount   int64
+}
+
+func ComparePartitionRowCounts(ctx context.Context, tx DBTX, tempPartitionName, sourcePartitionName string) (*PartitionRowCounts, error) {
 	row := tx.QueryRow(
 		ctx,
 		fmt.Sprintf(
@@ -122,10 +127,13 @@ func ComparePartitionRowCounts(ctx context.Context, tx DBTX, tempPartitionName, 
 	err := row.Scan(&tempPartitionCount, &sourcePartitionCount)
 
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
-	return tempPartitionCount == sourcePartitionCount, nil
+	return &PartitionRowCounts{
+		SourcePartitionCount: sourcePartitionCount,
+		TempPartitionCount:   tempPartitionCount,
+	}, nil
 }
 
 const findV1PayloadPartitionsBeforeDate = `-- name: findV1PayloadPartitionsBeforeDate :many

--- a/pkg/repository/v1/sqlcv1/payload-store.sql
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql
@@ -181,3 +181,8 @@ UPDATE v1_payload_cutover_job_offset
 SET is_completed = TRUE
 WHERE key = @key::DATE
 ;
+
+-- name: CleanUpCutoverJobOffsets :exec
+DELETE FROM v1_payload_cutover_job_offset
+WHERE key IN (@keys::DATE[])
+;

--- a/pkg/repository/v1/sqlcv1/payload-store.sql
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql
@@ -184,7 +184,7 @@ WHERE key = @key::DATE
 
 -- name: CleanUpCutoverJobOffsets :exec
 DELETE FROM v1_payload_cutover_job_offset
-WHERE key NOT IN (@keysToKeep::DATE[])
+WHERE NOT key = ANY(@keysToKeep::DATE[])
 ;
 
 -- name: DiffPayloadSourceAndTargetPartitions :many

--- a/pkg/repository/v1/sqlcv1/payload-store.sql
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql
@@ -186,3 +186,9 @@ WHERE key = @key::DATE
 DELETE FROM v1_payload_cutover_job_offset
 WHERE key NOT IN (@keysToKeep::DATE[])
 ;
+
+-- name: DiffPayloadSourceAndTargetPartitions :many
+SELECT diff_payload_source_and_target_partitions(
+    @partitionDate::DATE,
+    @maxRows::INTEGER
+);

--- a/pkg/repository/v1/sqlcv1/payload-store.sql
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql
@@ -188,7 +188,4 @@ WHERE key NOT IN (@keysToKeep::DATE[])
 ;
 
 -- name: DiffPayloadSourceAndTargetPartitions :many
-SELECT diff_payload_source_and_target_partitions(
-    @partitionDate::DATE,
-    @maxRows::INTEGER
-);
+SELECT diff_payload_source_and_target_partitions(@partitionDate::DATE);

--- a/pkg/repository/v1/sqlcv1/payload-store.sql
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql
@@ -184,5 +184,5 @@ WHERE key = @key::DATE
 
 -- name: CleanUpCutoverJobOffsets :exec
 DELETE FROM v1_payload_cutover_job_offset
-WHERE key IN (@keys::DATE[])
+WHERE key NOT IN (@keysToKeep::DATE[])
 ;

--- a/pkg/repository/v1/sqlcv1/payload-store.sql
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql
@@ -188,4 +188,21 @@ WHERE key NOT IN (@keysToKeep::DATE[])
 ;
 
 -- name: DiffPayloadSourceAndTargetPartitions :many
-SELECT diff_payload_source_and_target_partitions(@partitionDate::DATE);
+WITH payloads AS (
+    SELECT
+        (p).*
+    FROM diff_payload_source_and_target_partitions(@partitionDate::DATE) p
+)
+
+SELECT
+    tenant_id::UUID,
+    id::BIGINT,
+    inserted_at::TIMESTAMPTZ,
+    external_id::UUID,
+    type::v1_payload_type,
+    location::v1_payload_location,
+    COALESCE(external_location_key, '')::TEXT AS external_location_key,
+    inline_content::JSONB AS inline_content,
+    updated_at::TIMESTAMPTZ
+FROM payloads
+;

--- a/pkg/repository/v1/sqlcv1/payload-store.sql.go
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql.go
@@ -212,19 +212,11 @@ func (q *Queries) CreateV1PayloadCutoverTemporaryTable(ctx context.Context, db D
 }
 
 const diffPayloadSourceAndTargetPartitions = `-- name: DiffPayloadSourceAndTargetPartitions :many
-SELECT diff_payload_source_and_target_partitions(
-    $1::DATE,
-    $2::INTEGER
-)
+SELECT diff_payload_source_and_target_partitions($1::DATE)
 `
 
-type DiffPayloadSourceAndTargetPartitionsParams struct {
-	Partitiondate pgtype.Date `json:"partitiondate"`
-	Maxrows       int32       `json:"maxrows"`
-}
-
-func (q *Queries) DiffPayloadSourceAndTargetPartitions(ctx context.Context, db DBTX, arg DiffPayloadSourceAndTargetPartitionsParams) ([]interface{}, error) {
-	rows, err := db.Query(ctx, diffPayloadSourceAndTargetPartitions, arg.Partitiondate, arg.Maxrows)
+func (q *Queries) DiffPayloadSourceAndTargetPartitions(ctx context.Context, db DBTX, partitiondate pgtype.Date) ([]interface{}, error) {
+	rows, err := db.Query(ctx, diffPayloadSourceAndTargetPartitions, partitiondate)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repository/v1/sqlcv1/payload-store.sql.go
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql.go
@@ -109,11 +109,11 @@ func (q *Queries) AnalyzeV1Payload(ctx context.Context, db DBTX) error {
 
 const cleanUpCutoverJobOffsets = `-- name: CleanUpCutoverJobOffsets :exec
 DELETE FROM v1_payload_cutover_job_offset
-WHERE key IN ($1::DATE[])
+WHERE key NOT IN ($1::DATE[])
 `
 
-func (q *Queries) CleanUpCutoverJobOffsets(ctx context.Context, db DBTX, keys []pgtype.Date) error {
-	_, err := db.Exec(ctx, cleanUpCutoverJobOffsets, keys)
+func (q *Queries) CleanUpCutoverJobOffsets(ctx context.Context, db DBTX, keystokeep []pgtype.Date) error {
+	_, err := db.Exec(ctx, cleanUpCutoverJobOffsets, keystokeep)
 	return err
 }
 

--- a/pkg/repository/v1/sqlcv1/payload-store.sql.go
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql.go
@@ -107,6 +107,16 @@ func (q *Queries) AnalyzeV1Payload(ctx context.Context, db DBTX) error {
 	return err
 }
 
+const cleanUpCutoverJobOffsets = `-- name: CleanUpCutoverJobOffsets :exec
+DELETE FROM v1_payload_cutover_job_offset
+WHERE key IN ($1::DATE[])
+`
+
+func (q *Queries) CleanUpCutoverJobOffsets(ctx context.Context, db DBTX, keys []pgtype.Date) error {
+	_, err := db.Exec(ctx, cleanUpCutoverJobOffsets, keys)
+	return err
+}
+
 const createPayloadRangeChunks = `-- name: CreatePayloadRangeChunks :many
 WITH chunks AS (
     SELECT

--- a/pkg/repository/v1/sqlcv1/payload-store.sql.go
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql.go
@@ -109,7 +109,7 @@ func (q *Queries) AnalyzeV1Payload(ctx context.Context, db DBTX) error {
 
 const cleanUpCutoverJobOffsets = `-- name: CleanUpCutoverJobOffsets :exec
 DELETE FROM v1_payload_cutover_job_offset
-WHERE key NOT IN ($1::DATE[])
+WHERE NOT key = ANY($1::DATE[])
 `
 
 func (q *Queries) CleanUpCutoverJobOffsets(ctx context.Context, db DBTX, keystokeep []pgtype.Date) error {

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -1937,8 +1937,7 @@ END;
 $$;
 
 CREATE OR REPLACE FUNCTION diff_payload_source_and_target_partitions(
-    partition_date date,
-    max_rows int
+    partition_date date
 ) RETURNS TABLE (
     tenant_id UUID,
     id BIGINT,
@@ -1982,10 +1981,9 @@ BEGIN
                 AND source.id = target.id
                 AND source.type = target.type
         )
-        LIMIT $1
     ', source_partition_name, temp_partition_name);
 
-    RETURN QUERY EXECUTE query USING max_rows;
+    RETURN QUERY EXECUTE query;
 END;
 $$;
 

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -1936,6 +1936,59 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION diff_payload_source_and_target_partitions(
+    partition_date date,
+    max_rows int
+) RETURNS TABLE (
+    tenant_id UUID,
+    id BIGINT,
+    inserted_at TIMESTAMPTZ,
+    external_id UUID,
+    type v1_payload_type,
+    location v1_payload_location,
+    external_location_key TEXT,
+    inline_content JSONB,
+    updated_at TIMESTAMPTZ
+)
+    LANGUAGE plpgsql AS
+$$
+DECLARE
+    partition_date_str varchar;
+    source_partition_name varchar;
+    temp_partition_name varchar;
+    query text;
+BEGIN
+    IF partition_date IS NULL THEN
+        RAISE EXCEPTION 'partition_date parameter cannot be NULL';
+    END IF;
+
+    SELECT to_char(partition_date, 'YYYYMMDD') INTO partition_date_str;
+    SELECT format('v1_payload_%s', partition_date_str) INTO source_partition_name;
+    SELECT format('v1_payload_offload_tmp_%s', partition_date_str) INTO temp_partition_name;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_tables WHERE tablename = source_partition_name) THEN
+        RAISE EXCEPTION 'Partition % does not exist', source_partition_name;
+    END IF;
+
+    query := format('
+        SELECT *
+        FROM %I source
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM %I AS target
+            WHERE
+                source.tenant_id = target.tenant_id
+                AND source.inserted_at = target.inserted_at
+                AND source.id = target.id
+                AND source.type = target.type
+        )
+        LIMIT $1
+    ', source_partition_name, temp_partition_name);
+
+    RETURN QUERY EXECUTE query USING max_rows;
+END;
+$$;
+
 CREATE OR REPLACE FUNCTION swap_v1_payload_partition_with_temp(
     partition_date date
 ) RETURNS text

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -1970,7 +1970,7 @@ BEGIN
     END IF;
 
     query := format('
-        SELECT *
+        SELECT tenant_id, id, inserted_at, external_id, type, location, external_location_key, inline_content, updated_at
         FROM %I source
         WHERE NOT EXISTS (
             SELECT 1

--- a/sql/schema/v1-olap.sql
+++ b/sql/schema/v1-olap.sql
@@ -1111,7 +1111,7 @@ CREATE OR REPLACE FUNCTION diff_olap_payload_source_and_target_partitions(
     tenant_id UUID,
     external_id UUID,
     inserted_at TIMESTAMPTZ,
-    location v1_payload_location,
+    location v1_payload_location_olap,
     external_location_key TEXT,
     inline_content JSONB,
     updated_at TIMESTAMPTZ
@@ -1137,7 +1137,7 @@ BEGIN
     END IF;
 
     query := format('
-        SELECT *
+        SELECT tenant_id, external_id, inserted_at, location, external_location_key, inline_content, updated_at
         FROM %I source
         WHERE NOT EXISTS (
             SELECT 1

--- a/sql/schema/v1-olap.sql
+++ b/sql/schema/v1-olap.sql
@@ -1106,8 +1106,7 @@ END;
 $$;
 
 CREATE OR REPLACE FUNCTION diff_olap_payload_source_and_target_partitions(
-    partition_date date,
-    max_rows int
+    partition_date date
 ) RETURNS TABLE (
     tenant_id UUID,
     external_id UUID,
@@ -1148,10 +1147,9 @@ BEGIN
                 AND source.external_id = target.external_id
                 AND source.inserted_at = target.inserted_at
         )
-        LIMIT $1
     ', source_partition_name, temp_partition_name);
 
-    RETURN QUERY EXECUTE query USING max_rows;
+    RETURN QUERY EXECUTE query;
 END;
 $$;
 

--- a/sql/schema/v1-olap.sql
+++ b/sql/schema/v1-olap.sql
@@ -1105,7 +1105,7 @@ BEGIN
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION diff_payloads_olap_source_and_target_partitions(
+CREATE OR REPLACE FUNCTION diff_olap_payload_source_and_target_partitions(
     partition_date date,
     max_rows int
 ) RETURNS TABLE (


### PR DESCRIPTION
# Description

Couple more bits of cleanup for the payload job:

1. Removing unneeded rows from the offsets table once the partition has been dropped (no reason to keep them around at that point)
2. Adding a reconciliation step, where at the end we look for any payloads in the source partition that don't exist in the target, and we just try to select and insert them. If there are too many (hard-coded as 5000 for now), we fail. The idea here is to try to limit how often we need to do manual reconciliation. One note on this front is that the reconciliation query can take a while, so I extended the job lease timeout to 10 mins to give some headroom there and to limit the likelihood of these queries snowballing and blowing up CPU.
3. Reduced the memory footprint of the job by ~50% by not duplicating the payload contents in the stuff that we keep in memory from the goroutines that read the payloads, which should help a bunch

One other note on this front was I noticed for some reason that doing the SELECT + INSERT in the same query would hang indefinitely when separating them out didn't. Not sure what to make of that, but I figured I'd just go with that was working here

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
