### PR TITLE
Use constants for `msgqueue` tenant message IDs

### DIFF
--- a/internal/msgqueue/v1/message_ids.go
+++ b/internal/msgqueue/v1/message_ids.go
@@ -1,0 +1,25 @@
+package v1
+
+// Message ID constants for tenant messages
+const (
+	MsgIDCancelTasks                  = "cancel-tasks"
+	MsgIDCELEvaluationFailure         = "cel-evaluation-failure"
+	MsgIDCheckTenantQueue             = "check-tenant-queue"
+	MsgIDCreateMonitoringEvent        = "create-monitoring-event"
+	MsgIDCreatedDAG                   = "created-dag"
+	MsgIDCreatedEventTrigger          = "created-event-trigger"
+	MsgIDCreatedTask                  = "created-task"
+	MsgIDFailedWebhookValidation      = "failed-webhook-validation"
+	MsgIDInternalEvent                = "internal-event"
+	MsgIDOffloadPayload               = "offload-payload"
+	MsgIDReplayTasks                  = "replay-tasks"
+	MsgIDTaskAssignedBulk             = "task-assigned-bulk"
+	MsgIDTaskCancelled                = "task-cancelled"
+	MsgIDTaskCompleted                = "task-completed"
+	MsgIDTaskFailed                   = "task-failed"
+	MsgIDTaskStreamEvent              = "task-stream-event"
+	MsgIDTaskTrigger                  = "task-trigger"
+	MsgIDUserEvent                    = "user-event"
+	MsgIDWorkflowRunFinished          = "workflow-run-finished"
+	MsgIDWorkflowRunFinishedCandidate = "workflow-run-finished-candidate"
+)

--- a/internal/services/admin/v1/server.go
+++ b/internal/services/admin/v1/server.go
@@ -130,7 +130,7 @@ func (a *AdminServiceImpl) CancelTasks(ctx context.Context, req *contracts.Cance
 
 	msg, err := msgqueue.NewTenantMessage(
 		sqlchelpers.UUIDToStr(tenant.ID),
-		"cancel-tasks",
+		msgqueue.MsgIDCancelTasks,
 		false,
 		true,
 		toCancel,
@@ -310,7 +310,7 @@ func (a *AdminServiceImpl) ReplayTasks(ctx context.Context, req *contracts.Repla
 
 		msg, err := msgqueue.NewTenantMessage(
 			sqlchelpers.UUIDToStr(tenant.ID),
-			"replay-tasks",
+			msgqueue.MsgIDReplayTasks,
 			false,
 			true,
 			toReplay,

--- a/internal/services/controllers/v1/olap/process_dag_status_updates.go
+++ b/internal/services/controllers/v1/olap/process_dag_status_updates.go
@@ -102,7 +102,7 @@ func (o *OLAPControllerImpl) notifyDAGsUpdated(ctx context.Context, rows []v1.Up
 		for tenantId, payloads := range tenantIdToPayloads {
 			msg, err := msgqueue.NewTenantMessage(
 				tenantId.String(),
-				"workflow-run-finished",
+				msgqueue.MsgIDWorkflowRunFinished,
 				true,
 				false,
 				payloads...,

--- a/internal/services/controllers/v1/olap/process_task_status_updates.go
+++ b/internal/services/controllers/v1/olap/process_task_status_updates.go
@@ -102,7 +102,7 @@ func (o *OLAPControllerImpl) notifyTasksUpdated(ctx context.Context, rows []v1.U
 		for tenantId, payloads := range tenantIdToPayloads {
 			msg, err := msgqueue.NewTenantMessage(
 				tenantId.String(),
-				"workflow-run-finished",
+				msgqueue.MsgIDWorkflowRunFinished,
 				true,
 				false,
 				payloads...,

--- a/internal/services/controllers/v1/task/controller.go
+++ b/internal/services/controllers/v1/task/controller.go
@@ -428,21 +428,21 @@ func (tc *TasksControllerImpl) handleBufferedMsgs(tenantId, msgId string, payloa
 	}()
 
 	switch msgId {
-	case "task-completed":
+	case msgqueue.MsgIDTaskCompleted:
 		return tc.handleTaskCompleted(context.Background(), tenantId, payloads)
-	case "task-failed":
+	case msgqueue.MsgIDTaskFailed:
 		return tc.handleTaskFailed(context.Background(), tenantId, payloads)
-	case "task-cancelled":
+	case msgqueue.MsgIDTaskCancelled:
 		return tc.handleTaskCancelled(context.Background(), tenantId, payloads)
-	case "cancel-tasks":
+	case msgqueue.MsgIDCancelTasks:
 		return tc.handleCancelTasks(context.Background(), tenantId, payloads)
-	case "replay-tasks":
+	case msgqueue.MsgIDReplayTasks:
 		return tc.handleReplayTasks(context.Background(), tenantId, payloads)
-	case "user-event":
+	case msgqueue.MsgIDUserEvent:
 		return tc.handleProcessUserEvents(context.Background(), tenantId, payloads)
-	case "internal-event":
+	case msgqueue.MsgIDInternalEvent:
 		return tc.handleProcessInternalEvents(context.Background(), tenantId, payloads)
-	case "task-trigger":
+	case msgqueue.MsgIDTaskTrigger:
 		return tc.handleProcessTaskTrigger(context.Background(), tenantId, payloads)
 	}
 
@@ -767,7 +767,7 @@ func (tc *TasksControllerImpl) handleCancelTasks(ctx context.Context, tenantId s
 	return queueutils.BatchLinear(BULK_MSG_BATCH_SIZE, pubPayloads, func(pubPayloads []tasktypes.CancelledTaskPayload) error {
 		msg, err := msgqueue.NewTenantMessage(
 			tenantId,
-			"task-cancelled",
+			msgqueue.MsgIDTaskCancelled,
 			false,
 			true,
 			pubPayloads...,
@@ -905,7 +905,7 @@ func (tc *TasksControllerImpl) sendTaskCancellationsToDispatcher(ctx context.Con
 	for dispatcherId, payloads := range dispatcherIdsToPayloads {
 		msg, err := msgqueue.NewTenantMessage(
 			tenantId,
-			"task-cancelled",
+			msgqueue.MsgIDTaskCancelled,
 			false,
 			true,
 			payloads...,
@@ -969,7 +969,7 @@ func (tc *TasksControllerImpl) notifyQueuesOnCompletion(ctx context.Context, ten
 
 	msg, err := msgqueue.NewTenantMessage(
 		tenantId,
-		"workflow-run-finished-candidate",
+		msgqueue.MsgIDWorkflowRunFinishedCandidate,
 		true,
 		false,
 		payloads...,

--- a/internal/services/ingestor/ingestor_v1.go
+++ b/internal/services/ingestor/ingestor_v1.go
@@ -154,7 +154,7 @@ func eventToTaskV1(tenantId, eventExternalId, key string, data, additionalMeta [
 
 	return msgqueue.NewTenantMessage(
 		tenantId,
-		"user-event",
+		msgqueue.MsgIDUserEvent,
 		false,
 		true,
 		payloadTyped,
@@ -169,7 +169,7 @@ func createWebhookValidationFailureMsg(tenantId, webhookName, errorText string) 
 
 	return msgqueue.NewTenantMessage(
 		tenantId,
-		"failed-webhook-validation",
+		msgqueue.MsgIDFailedWebhookValidation,
 		false,
 		true,
 		payloadTyped,

--- a/internal/services/ingestor/server_v1.go
+++ b/internal/services/ingestor/server_v1.go
@@ -30,7 +30,7 @@ func (i *IngestorImpl) putStreamEventV1(ctx context.Context, tenant *dbsqlc.Tena
 
 	msg, err := msgqueue.NewTenantMessage(
 		tenantId,
-		"task-stream-event",
+		msgqueue.MsgIDTaskStreamEvent,
 		true,
 		false,
 		tasktypes.StreamEventPayload{

--- a/internal/services/scheduler/v1/scheduler.go
+++ b/internal/services/scheduler/v1/scheduler.go
@@ -321,7 +321,7 @@ func (s *Scheduler) handleTask(ctx context.Context, task *msgqueue.Message) (err
 		}
 	}()
 
-	if task.ID == "check-tenant-queue" {
+	if task.ID == msgqueue.MsgIDCheckTenantQueue {
 		return s.handleCheckQueue(ctx, task)
 	}
 
@@ -702,7 +702,7 @@ func (s *Scheduler) notifyAfterConcurrency(ctx context.Context, tenantId string,
 func taskBulkAssignedTask(tenantId string, workerIdsToTaskIds map[string][]int64) (*msgqueue.Message, error) {
 	return msgqueue.NewTenantMessage(
 		tenantId,
-		"task-assigned-bulk",
+		msgqueue.MsgIDTaskAssignedBulk,
 		false,
 		true,
 		tasktypes.TaskAssignedBulkTaskPayload{
@@ -726,9 +726,9 @@ func (s *Scheduler) handleDeadLetteredMessages(msg *msgqueue.Message) (err error
 	defer cancel()
 
 	switch msg.ID {
-	case "task-assigned-bulk":
+	case msgqueue.MsgIDTaskAssignedBulk:
 		err = s.handleDeadLetteredTaskBulkAssigned(ctx, msg)
-	case "task-cancelled":
+	case msgqueue.MsgIDTaskCancelled:
 		err = s.handleDeadLetteredTaskCancelled(ctx, msg)
 	default:
 		err = fmt.Errorf("unknown task: %s", msg.ID)
@@ -831,7 +831,7 @@ func (s *Scheduler) handleDeadLetteredTaskCancelled(ctx context.Context, msg *ms
 	for dispatcherId, payloads := range dispatcherIdsToPayloads {
 		msg, err := msgqueue.NewTenantMessage(
 			msg.TenantID,
-			"task-cancelled",
+			msgqueue.MsgIDTaskCancelled,
 			false,
 			true,
 			payloads...,

--- a/internal/services/shared/tasktypes/v1/event.go
+++ b/internal/services/shared/tasktypes/v1/event.go
@@ -20,7 +20,7 @@ type UserEventTaskPayload struct {
 func NewInternalEventMessage(tenantId string, timestamp time.Time, events ...v1.InternalTaskEvent) (*msgqueue.Message, error) {
 	return msgqueue.NewTenantMessage(
 		tenantId,
-		"internal-event",
+		msgqueue.MsgIDInternalEvent,
 		false,
 		true,
 		events...,

--- a/internal/services/shared/tasktypes/v1/olap.go
+++ b/internal/services/shared/tasktypes/v1/olap.go
@@ -19,7 +19,7 @@ type CELEvaluationFailures struct {
 func CELEvaluationFailureMessage(tenantId string, failures []v1.CELEvaluationFailure) (*msgqueue.Message, error) {
 	return msgqueue.NewTenantMessage(
 		tenantId,
-		"cel-evaluation-failure",
+		msgqueue.MsgIDCELEvaluationFailure,
 		false,
 		true,
 		CELEvaluationFailures{
@@ -35,7 +35,7 @@ type CreatedTaskPayload struct {
 func CreatedTaskMessage(tenantId string, task *v1.V1TaskWithPayload) (*msgqueue.Message, error) {
 	return msgqueue.NewTenantMessage(
 		tenantId,
-		"created-task",
+		msgqueue.MsgIDCreatedTask,
 		false,
 		true,
 		CreatedTaskPayload{
@@ -51,7 +51,7 @@ type CreatedDAGPayload struct {
 func CreatedDAGMessage(tenantId string, dag *v1.DAGWithData) (*msgqueue.Message, error) {
 	return msgqueue.NewTenantMessage(
 		tenantId,
-		"created-dag",
+		msgqueue.MsgIDCreatedDAG,
 		false,
 		true,
 		CreatedDAGPayload{
@@ -80,7 +80,7 @@ type CreatedEventTriggerPayload struct {
 func CreatedEventTriggerMessage(tenantId string, eventTriggers CreatedEventTriggerPayload) (*msgqueue.Message, error) {
 	return msgqueue.NewTenantMessage(
 		tenantId,
-		"created-event-trigger",
+		msgqueue.MsgIDCreatedEventTrigger,
 		false,
 		true,
 		eventTriggers,
@@ -129,7 +129,7 @@ func MonitoringEventMessageFromActionEvent(tenantId string, taskId int64, retryC
 
 	return msgqueue.NewTenantMessage(
 		tenantId,
-		"create-monitoring-event",
+		msgqueue.MsgIDCreateMonitoringEvent,
 		false,
 		true,
 		payload,
@@ -139,7 +139,7 @@ func MonitoringEventMessageFromActionEvent(tenantId string, taskId int64, retryC
 func MonitoringEventMessageFromInternal(tenantId string, payload CreateMonitoringEventPayload) (*msgqueue.Message, error) {
 	return msgqueue.NewTenantMessage(
 		tenantId,
-		"create-monitoring-event",
+		msgqueue.MsgIDCreateMonitoringEvent,
 		false,
 		true,
 		payload,

--- a/internal/services/shared/tasktypes/v1/scheduler.go
+++ b/internal/services/shared/tasktypes/v1/scheduler.go
@@ -40,7 +40,7 @@ func NotifyTaskReleased(tenantId string, tasks []*sqlcv1.ReleaseTasksRow) (*msgq
 
 	return msgqueue.NewTenantMessage(
 		tenantId,
-		"check-tenant-queue",
+		msgqueue.MsgIDCheckTenantQueue,
 		true,
 		false,
 		payload,
@@ -74,7 +74,7 @@ func NotifyTaskCreated(tenantId string, tasks []*v1.V1TaskWithPayload) (*msgqueu
 
 	return msgqueue.NewTenantMessage(
 		tenantId,
-		"check-tenant-queue",
+		msgqueue.MsgIDCheckTenantQueue,
 		true,
 		false,
 		payload,

--- a/internal/services/shared/tasktypes/v1/task.go
+++ b/internal/services/shared/tasktypes/v1/task.go
@@ -11,7 +11,7 @@ import (
 func TriggerTaskMessage(tenantId string, payloads ...*v1.WorkflowNameTriggerOpts) (*msgqueue.Message, error) {
 	return msgqueue.NewTenantMessage(
 		tenantId,
-		"task-trigger",
+		msgqueue.MsgIDTaskTrigger,
 		false,
 		true,
 		payloads...,
@@ -49,7 +49,7 @@ func CompletedTaskMessage(
 ) (*msgqueue.Message, error) {
 	return msgqueue.NewTenantMessage(
 		tenantId,
-		"task-completed",
+		msgqueue.MsgIDTaskCompleted,
 		false,
 		true,
 		CompletedTaskPayload{
@@ -102,7 +102,7 @@ func FailedTaskMessage(
 ) (*msgqueue.Message, error) {
 	return msgqueue.NewTenantMessage(
 		tenantId,
-		"task-failed",
+		msgqueue.MsgIDTaskFailed,
 		false,
 		true,
 		FailedTaskPayload{
@@ -157,7 +157,7 @@ func CancelledTaskMessage(
 ) (*msgqueue.Message, error) {
 	return msgqueue.NewTenantMessage(
 		tenantId,
-		"task-cancelled",
+		msgqueue.MsgIDTaskCancelled,
 		false,
 		true,
 		CancelledTaskPayload{

--- a/pkg/repository/v1/olappayload.go
+++ b/pkg/repository/v1/olappayload.go
@@ -17,7 +17,7 @@ type OLAPPayloadsToOffload struct {
 func OLAPPayloadOffloadMessage(tenantId string, payloads []OLAPPayloadToOffload) (*msgqueue.Message, error) {
 	return msgqueue.NewTenantMessage(
 		tenantId,
-		"offload-payload",
+		msgqueue.MsgIDOffloadPayload,
 		false,
 		true,
 		OLAPPayloadsToOffload{


### PR DESCRIPTION
# Description

Use constants for `msgqueue` tenant message IDs for readability and ease of code navigation.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)
