### PR TITLE
Fix: Dynamically-sized chunks on payload read

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20251222220531_v1_0_64.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20251222220531_v1_0_64.sql
@@ -1,0 +1,90 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION compute_payload_batch_size(
+    partition_date DATE
+) RETURNS BIGINT
+    LANGUAGE plpgsql AS
+$$
+DECLARE
+    partition_date_str TEXT;
+    source_partition_name TEXT;
+    query TEXT;
+    result_size BIGINT;
+BEGIN
+    IF partition_date IS NULL THEN
+        RAISE EXCEPTION 'partition_date parameter cannot be NULL';
+    END IF;
+
+    SELECT to_char(partition_date, 'YYYYMMDD') INTO partition_date_str;
+    SELECT format('v1_payload_%s', partition_date_str) INTO source_partition_name;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_tables WHERE tablename = source_partition_name) THEN
+        RAISE EXCEPTION 'Partition % does not exist', source_partition_name;
+    END IF;
+
+    query := format('
+        WITH candidates AS (
+            SELECT *
+            FROM %I
+            WHERE (tenant_id, inserted_at, id, type) >= ($1::UUID, $2::TIMESTAMPTZ, $3::BIGINT, $4::v1_payload_type)
+            ORDER BY tenant_id, inserted_at, id, type
+            LIMIT $5::INT
+        )
+
+        SELECT SUM(pg_column_size(inline_content)) AS total_size_bytes
+        FROM candidates
+    ', source_partition_name);
+
+    EXECUTE query INTO result_size;
+
+    RETURN result_size;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION compute_olap_payload_batch_size(
+    partition_date DATE
+) RETURNS BIGINT
+    LANGUAGE plpgsql AS
+$$
+DECLARE
+    partition_date_str TEXT;
+    source_partition_name TEXT;
+    query TEXT;
+    result_size BIGINT;
+BEGIN
+    IF partition_date IS NULL THEN
+        RAISE EXCEPTION 'partition_date parameter cannot be NULL';
+    END IF;
+
+    SELECT to_char(partition_date, 'YYYYMMDD') INTO partition_date_str;
+    SELECT format('v1_payloads_olap_%s', partition_date_str) INTO source_partition_name;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_tables WHERE tablename = source_partition_name) THEN
+        RAISE EXCEPTION 'Partition % does not exist', source_partition_name;
+    END IF;
+
+    query := format('
+        WITH candidates AS (
+            SELECT *
+            FROM %I
+            WHERE (tenant_id, external_id, inserted_at) >= ($1::UUID, $2::UUID, $3::TIMESTAMPTZ)
+            ORDER BY tenant_id, external_id, inserted_at
+            LIMIT $4::INT
+        )
+
+        SELECT SUM(pg_column_size(inline_content)) AS total_size_bytes
+        FROM candidates
+    ', source_partition_name);
+
+    EXECUTE query INTO result_size;
+
+    RETURN result_size;
+END;
+$$;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP FUNCTION compute_payload_batch_size(DATE);
+DROP FUNCTION compute_olap_payload_batch_size(DATE);
+-- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20251222220531_v1_0_64.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20251222220531_v1_0_64.sql
@@ -36,7 +36,7 @@ BEGIN
             LIMIT $5::INTEGER
         )
 
-        SELECT SUM(pg_column_size(inline_content)) AS total_size_bytes
+        SELECT COALESCE(SUM(pg_column_size(inline_content)), 0) AS total_size_bytes
         FROM candidates
     ', source_partition_name);
 
@@ -81,7 +81,7 @@ BEGIN
             LIMIT $4::INT
         )
 
-        SELECT SUM(pg_column_size(inline_content)) AS total_size_bytes
+        SELECT COALESCE(SUM(pg_column_size(inline_content)), 0) AS total_size_bytes
         FROM candidates
     ', source_partition_name);
 

--- a/pkg/repository/v1/payloadstore.go
+++ b/pkg/repository/v1/payloadstore.go
@@ -653,7 +653,7 @@ func (p *payloadStoreRepositoryImpl) ProcessPayloadCutoverBatch(ctx context.Cont
 		return nil, fmt.Errorf("failed to commit copy offloaded payloads transaction: %w", err)
 	}
 
-	if numPayloads < int(windowSize) {
+	if numPayloads < int(*windowSize) {
 		return &CutoverBatchOutcome{
 			ShouldContinue: false,
 			NextPagination: extendedLease.Pagination,

--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -2127,3 +2127,6 @@ SELECT
     updated_at::TIMESTAMPTZ
 FROM payloads
 ;
+
+-- name: ComputeOLAPPayloadBatchSize :one
+SELECT compute_olap_payload_batch_size(@partitionDate::DATE) AS total_size_bytes;

--- a/pkg/repository/v1/sqlcv1/olap.sql
+++ b/pkg/repository/v1/sqlcv1/olap.sql
@@ -2129,4 +2129,10 @@ FROM payloads
 ;
 
 -- name: ComputeOLAPPayloadBatchSize :one
-SELECT compute_olap_payload_batch_size(@partitionDate::DATE) AS total_size_bytes;
+SELECT compute_olap_payload_batch_size(
+    @partitionDate::DATE,
+    @lastTenantId::UUID,
+    @lastExternalId::UUID,
+    @lastInsertedAt::TIMESTAMPTZ,
+    @batchSize::INTEGER
+) AS total_size_bytes;

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -168,6 +168,17 @@ func (q *Queries) CleanUpOLAPCutoverJobOffsets(ctx context.Context, db DBTX, key
 	return err
 }
 
+const computeOLAPPayloadBatchSize = `-- name: ComputeOLAPPayloadBatchSize :one
+SELECT compute_olap_payload_batch_size($1::DATE) AS total_size_bytes
+`
+
+func (q *Queries) ComputeOLAPPayloadBatchSize(ctx context.Context, db DBTX, partitiondate pgtype.Date) (int64, error) {
+	row := db.QueryRow(ctx, computeOLAPPayloadBatchSize, partitiondate)
+	var total_size_bytes int64
+	err := row.Scan(&total_size_bytes)
+	return total_size_bytes, err
+}
+
 const countEvents = `-- name: CountEvents :one
 WITH included_events AS (
     SELECT e.tenant_id, e.id, e.external_id, e.seen_at, e.key, e.payload, e.additional_metadata, e.scope, e.triggering_webhook_name

--- a/pkg/repository/v1/sqlcv1/olap.sql.go
+++ b/pkg/repository/v1/sqlcv1/olap.sql.go
@@ -169,11 +169,31 @@ func (q *Queries) CleanUpOLAPCutoverJobOffsets(ctx context.Context, db DBTX, key
 }
 
 const computeOLAPPayloadBatchSize = `-- name: ComputeOLAPPayloadBatchSize :one
-SELECT compute_olap_payload_batch_size($1::DATE) AS total_size_bytes
+SELECT compute_olap_payload_batch_size(
+    $1::DATE,
+    $2::UUID,
+    $3::UUID,
+    $4::TIMESTAMPTZ,
+    $5::INTEGER
+) AS total_size_bytes
 `
 
-func (q *Queries) ComputeOLAPPayloadBatchSize(ctx context.Context, db DBTX, partitiondate pgtype.Date) (int64, error) {
-	row := db.QueryRow(ctx, computeOLAPPayloadBatchSize, partitiondate)
+type ComputeOLAPPayloadBatchSizeParams struct {
+	Partitiondate  pgtype.Date        `json:"partitiondate"`
+	Lasttenantid   pgtype.UUID        `json:"lasttenantid"`
+	Lastexternalid pgtype.UUID        `json:"lastexternalid"`
+	Lastinsertedat pgtype.Timestamptz `json:"lastinsertedat"`
+	Batchsize      int32              `json:"batchsize"`
+}
+
+func (q *Queries) ComputeOLAPPayloadBatchSize(ctx context.Context, db DBTX, arg ComputeOLAPPayloadBatchSizeParams) (int64, error) {
+	row := db.QueryRow(ctx, computeOLAPPayloadBatchSize,
+		arg.Partitiondate,
+		arg.Lasttenantid,
+		arg.Lastexternalid,
+		arg.Lastinsertedat,
+		arg.Batchsize,
+	)
 	var total_size_bytes int64
 	err := row.Scan(&total_size_bytes)
 	return total_size_bytes, err

--- a/pkg/repository/v1/sqlcv1/payload-store.sql
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql
@@ -208,4 +208,11 @@ FROM payloads
 ;
 
 -- name: ComputePayloadBatchSize :one
-SELECT compute_payload_batch_size(@partitionDate::DATE) AS total_size_bytes;
+SELECT compute_payload_batch_size(
+    @partitionDate::DATE,
+    @lastTenantId::UUID,
+    @lastInsertedAt::TIMESTAMPTZ,
+    @lastId::BIGINT,
+    @lastType::v1_payload_type,
+    @batchSize::INTEGER
+) AS total_size_bytes;

--- a/pkg/repository/v1/sqlcv1/payload-store.sql
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql
@@ -206,3 +206,6 @@ SELECT
     updated_at::TIMESTAMPTZ
 FROM payloads
 ;
+
+-- name: ComputePayloadBatchSize :one
+SELECT compute_payload_batch_size(@partitionDate::DATE) AS total_size_bytes;

--- a/pkg/repository/v1/sqlcv1/payload-store.sql.go
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql.go
@@ -118,11 +118,34 @@ func (q *Queries) CleanUpCutoverJobOffsets(ctx context.Context, db DBTX, keystok
 }
 
 const computePayloadBatchSize = `-- name: ComputePayloadBatchSize :one
-SELECT compute_payload_batch_size($1::DATE) AS total_size_bytes
+SELECT compute_payload_batch_size(
+    $1::DATE,
+    $2::UUID,
+    $3::TIMESTAMPTZ,
+    $4::BIGINT,
+    $5::v1_payload_type,
+    $6::INTEGER
+) AS total_size_bytes
 `
 
-func (q *Queries) ComputePayloadBatchSize(ctx context.Context, db DBTX, partitiondate pgtype.Date) (int64, error) {
-	row := db.QueryRow(ctx, computePayloadBatchSize, partitiondate)
+type ComputePayloadBatchSizeParams struct {
+	Partitiondate  pgtype.Date        `json:"partitiondate"`
+	Lasttenantid   pgtype.UUID        `json:"lasttenantid"`
+	Lastinsertedat pgtype.Timestamptz `json:"lastinsertedat"`
+	Lastid         int64              `json:"lastid"`
+	Lasttype       V1PayloadType      `json:"lasttype"`
+	Batchsize      int32              `json:"batchsize"`
+}
+
+func (q *Queries) ComputePayloadBatchSize(ctx context.Context, db DBTX, arg ComputePayloadBatchSizeParams) (int64, error) {
+	row := db.QueryRow(ctx, computePayloadBatchSize,
+		arg.Partitiondate,
+		arg.Lasttenantid,
+		arg.Lastinsertedat,
+		arg.Lastid,
+		arg.Lasttype,
+		arg.Batchsize,
+	)
 	var total_size_bytes int64
 	err := row.Scan(&total_size_bytes)
 	return total_size_bytes, err

--- a/pkg/repository/v1/sqlcv1/payload-store.sql.go
+++ b/pkg/repository/v1/sqlcv1/payload-store.sql.go
@@ -117,6 +117,17 @@ func (q *Queries) CleanUpCutoverJobOffsets(ctx context.Context, db DBTX, keystok
 	return err
 }
 
+const computePayloadBatchSize = `-- name: ComputePayloadBatchSize :one
+SELECT compute_payload_batch_size($1::DATE) AS total_size_bytes
+`
+
+func (q *Queries) ComputePayloadBatchSize(ctx context.Context, db DBTX, partitiondate pgtype.Date) (int64, error) {
+	row := db.QueryRow(ctx, computePayloadBatchSize, partitiondate)
+	var total_size_bytes int64
+	err := row.Scan(&total_size_bytes)
+	return total_size_bytes, err
+}
+
 const createPayloadRangeChunks = `-- name: CreatePayloadRangeChunks :many
 WITH chunks AS (
     SELECT

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -1890,7 +1890,7 @@ BEGIN
             LIMIT $5::INTEGER
         )
 
-        SELECT SUM(pg_column_size(inline_content)) AS total_size_bytes
+        SELECT COALESCE(SUM(pg_column_size(inline_content)), 0) AS total_size_bytes
         FROM candidates
     ', source_partition_name);
 

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -1854,6 +1854,47 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION compute_payload_batch_size(
+    partition_date DATE
+) RETURNS BIGINT
+    LANGUAGE plpgsql AS
+$$
+DECLARE
+    partition_date_str TEXT;
+    source_partition_name TEXT;
+    query TEXT;
+    result_size BIGINT;
+BEGIN
+    IF partition_date IS NULL THEN
+        RAISE EXCEPTION 'partition_date parameter cannot be NULL';
+    END IF;
+
+    SELECT to_char(partition_date, 'YYYYMMDD') INTO partition_date_str;
+    SELECT format('v1_payload_%s', partition_date_str) INTO source_partition_name;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_tables WHERE tablename = source_partition_name) THEN
+        RAISE EXCEPTION 'Partition % does not exist', source_partition_name;
+    END IF;
+
+    query := format('
+        WITH candidates AS (
+            SELECT *
+            FROM %I
+            WHERE (tenant_id, inserted_at, id, type) >= ($1::UUID, $2::TIMESTAMPTZ, $3::BIGINT, $4::v1_payload_type)
+            ORDER BY tenant_id, inserted_at, id, type
+            LIMIT $5::INT
+        )
+
+        SELECT SUM(pg_column_size(inline_content)) AS total_size_bytes
+        FROM candidates
+    ', source_partition_name);
+
+    EXECUTE query INTO result_size;
+
+    RETURN result_size;
+END;
+$$;
+
 CREATE OR REPLACE FUNCTION create_payload_offload_range_chunks(
     partition_date date,
     window_size int,

--- a/sql/schema/v1-olap.sql
+++ b/sql/schema/v1-olap.sql
@@ -1153,6 +1153,47 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION compute_olap_payload_batch_size(
+    partition_date DATE
+) RETURNS BIGINT
+    LANGUAGE plpgsql AS
+$$
+DECLARE
+    partition_date_str TEXT;
+    source_partition_name TEXT;
+    query TEXT;
+    result_size BIGINT;
+BEGIN
+    IF partition_date IS NULL THEN
+        RAISE EXCEPTION 'partition_date parameter cannot be NULL';
+    END IF;
+
+    SELECT to_char(partition_date, 'YYYYMMDD') INTO partition_date_str;
+    SELECT format('v1_payloads_olap_%s', partition_date_str) INTO source_partition_name;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_tables WHERE tablename = source_partition_name) THEN
+        RAISE EXCEPTION 'Partition % does not exist', source_partition_name;
+    END IF;
+
+    query := format('
+        WITH candidates AS (
+            SELECT *
+            FROM %I
+            WHERE (tenant_id, external_id, inserted_at) >= ($1::UUID, $2::UUID, $3::TIMESTAMPTZ)
+            ORDER BY tenant_id, external_id, inserted_at
+            LIMIT $4::INT
+        )
+
+        SELECT SUM(pg_column_size(inline_content)) AS total_size_bytes
+        FROM candidates
+    ', source_partition_name);
+
+    EXECUTE query INTO result_size;
+
+    RETURN result_size;
+END;
+$$;
+
 CREATE OR REPLACE FUNCTION swap_v1_payloads_olap_partition_with_temp(
     partition_date date
 ) RETURNS text

--- a/sql/schema/v1-olap.sql
+++ b/sql/schema/v1-olap.sql
@@ -1188,7 +1188,7 @@ BEGIN
             LIMIT $4::INT
         )
 
-        SELECT SUM(pg_column_size(inline_content)) AS total_size_bytes
+        SELECT COALESCE(SUM(pg_column_size(inline_content)), 0) AS total_size_bytes
         FROM candidates
     ', source_partition_name);
 

--- a/sql/schema/v1-olap.sql
+++ b/sql/schema/v1-olap.sql
@@ -1154,7 +1154,11 @@ END;
 $$;
 
 CREATE OR REPLACE FUNCTION compute_olap_payload_batch_size(
-    partition_date DATE
+    partition_date DATE,
+    last_tenant_id UUID,
+    last_external_id UUID,
+    last_inserted_at TIMESTAMPTZ,
+    batch_size INTEGER
 ) RETURNS BIGINT
     LANGUAGE plpgsql AS
 $$
@@ -1188,7 +1192,7 @@ BEGIN
         FROM candidates
     ', source_partition_name);
 
-    EXECUTE query INTO result_size;
+    EXECUTE query INTO result_size USING last_tenant_id, last_external_id, last_inserted_at, batch_size;
 
     RETURN result_size;
 END;


### PR DESCRIPTION
# Description

Limiting OOMs by binary searching for chunks that are small enough

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
