### PR TITLE
fix(go-sdk): WithToken should override environment variable `HATCHET_CLIENT_TOKEN`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: check-yaml
         exclude: ^examples/
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: golangci-lint
         args: ["--config=.golangci.yml"]

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -114,7 +114,7 @@ func defaultClientOpts(token *string, cf *client.ClientConfigFile) *ClientOpts {
 		if token != nil {
 			cf.Token = *token
 		}
-		clientConfig, err = loader.GetClientConfigFromConfigFile(cf)
+		clientConfig, err = loader.GetClientConfigFromConfigFile(token, cf)
 
 		if err != nil {
 			panic(err)

--- a/pkg/client/loader/loader.go
+++ b/pkg/client/loader/loader.go
@@ -33,7 +33,7 @@ func (c *ConfigLoader) LoadClientConfig(token *string) (res *client.ClientConfig
 		cf.Token = *token
 	}
 
-	return GetClientConfigFromConfigFile(cf)
+	return GetClientConfigFromConfigFile(token, cf)
 }
 
 // LoadClientConfigFile loads the worker config file via viper
@@ -46,13 +46,17 @@ func LoadClientConfigFile(files ...[]byte) (*client.ClientConfigFile, error) {
 	return configFile, err
 }
 
-func GetClientConfigFromConfigFile(cf *client.ClientConfigFile) (res *client.ClientConfig, err error) {
+func GetClientConfigFromConfigFile(tokenOverride *string, cf *client.ClientConfigFile) (res *client.ClientConfig, err error) {
 	f := client.BindAllEnv
 
 	_, err = loaderutils.LoadConfigFromViper(f, cf)
 
 	if err != nil {
 		return nil, fmt.Errorf("could not load config from viper: %w", err)
+	}
+
+	if tokenOverride != nil {
+		cf.Token = *tokenOverride
 	}
 
 	// if token is empty, throw an error


### PR DESCRIPTION
# Description

In the case that both `HATCHET_CLIENT_TOKEN` are set and a user is passing in `client.WithToken`, the explicit override should take precedence. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)