### PR TITLE
Hotfix: Remove payload cutover offset cleanup logic for now

### DIFF
--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -3260,22 +3260,6 @@ func (p *OLAPRepositoryImpl) ProcessOLAPPayloadCutovers(ctx context.Context, ext
 		return fmt.Errorf("failed to find payload partitions before date %s: %w", mostRecentPartitionToOffload.Time.String(), err)
 	}
 
-	partitionDatesToKeep := make([]pgtype.Date, len(partitions))
-
-	for i, partition := range partitions {
-		partitionDatesToKeep[i] = pgtype.Date{
-			Time:  partition.PartitionDate.Time,
-			Valid: true,
-		}
-	}
-
-	// don't need a tx for this since we're just doing cleanup
-	err = p.queries.CleanUpOLAPCutoverJobOffsets(ctx, p.pool, partitionDatesToKeep)
-
-	if err != nil {
-		return fmt.Errorf("failed to clean up olap cutover job offsets: %w", err)
-	}
-
 	processId := sqlchelpers.UUIDFromStr(uuid.NewString())
 
 	for _, partition := range partitions {

--- a/pkg/repository/v1/payloadstore.go
+++ b/pkg/repository/v1/payloadstore.go
@@ -910,22 +910,6 @@ func (p *payloadStoreRepositoryImpl) ProcessPayloadCutovers(ctx context.Context)
 		return fmt.Errorf("failed to find payload partitions before date %s: %w", mostRecentPartitionToOffload.Time.String(), err)
 	}
 
-	partitionDatesToKeep := make([]pgtype.Date, len(partitions))
-
-	for i, partition := range partitions {
-		partitionDatesToKeep[i] = pgtype.Date{
-			Time:  partition.PartitionDate.Time,
-			Valid: true,
-		}
-	}
-
-	// don't need a tx for this since we're just doing cleanup
-	err = p.queries.CleanUpCutoverJobOffsets(ctx, p.pool, partitionDatesToKeep)
-
-	if err != nil {
-		return fmt.Errorf("failed to clean up cutover job offsets: %w", err)
-	}
-
 	processId := sqlchelpers.UUIDFromStr(uuid.NewString())
 
 	for _, partition := range partitions {


### PR DESCRIPTION
# Description

Somehow rows were getting removed that shouldn't have been - not sure why, but we probably don't need to delete these really, so just getting rid of this for now

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

