### PR TITLE
Fix: Static rate limits resetting to zero

### DIFF
--- a/pkg/repository/v1/scheduler_queue.go
+++ b/pkg/repository/v1/scheduler_queue.go
@@ -511,9 +511,12 @@ func (d *queueRepository) GetTaskRateLimits(ctx context.Context, queueItems []*s
 			continue
 		}
 
-		upsertRateLimitBulkParams.Keys = append(upsertRateLimitBulkParams.Keys, key)
-		upsertRateLimitBulkParams.Windows = append(upsertRateLimitBulkParams.Windows, getWindowParamFromDurString(duration))
-		upsertRateLimitBulkParams.Limitvalues = append(upsertRateLimitBulkParams.Limitvalues, int32(limitValue)) // nolint: gosec
+		// important: we use -1 as a sentinel value for a placeholder to indicate we don't need to upsert
+		if limitValue >= 0 {
+			upsertRateLimitBulkParams.Keys = append(upsertRateLimitBulkParams.Keys, key)
+			upsertRateLimitBulkParams.Windows = append(upsertRateLimitBulkParams.Windows, getWindowParamFromDurString(duration))
+			upsertRateLimitBulkParams.Limitvalues = append(upsertRateLimitBulkParams.Limitvalues, int32(limitValue))
+		}
 	}
 
 	var stepRateLimits []*sqlcv1.StepRateLimit

--- a/pkg/v1/task/task.go
+++ b/pkg/v1/task/task.go
@@ -130,6 +130,11 @@ func makeContractTaskOpts(t *TaskShared, taskDefaults *create.TaskDefaults) *con
 			LimitValuesExpr: rateLimit.LimitValueExpr,
 		}
 
+		if rateLimit.LimitValueExpr == nil {
+			negOne := "-1"
+			rateLimit.LimitValueExpr = &negOne
+		}
+
 		if rateLimit.Units != nil {
 			units32 := int32(*rateLimit.Units) // nolint: gosec
 			rlContract.Units = &units32

--- a/pkg/v1/task/task.go
+++ b/pkg/v1/task/task.go
@@ -132,7 +132,7 @@ func makeContractTaskOpts(t *TaskShared, taskDefaults *create.TaskDefaults) *con
 
 		if rateLimit.LimitValueExpr == nil {
 			negOne := "-1"
-			rateLimit.LimitValueExpr = &negOne
+			rlContract.LimitValuesExpr = &negOne
 		}
 
 		if rateLimit.Units != nil {

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.8] - 2025-12-26
+
+### Changed
+
+- Fixes a bug where static rate limits reset their own values to zero on task registration.
+
 ## [1.21.7] - 2025-12-15
 
 ### Added

--- a/sdks/python/hatchet_sdk/rate_limit.py
+++ b/sdks/python/hatchet_sdk/rate_limit.py
@@ -68,6 +68,9 @@ class RateLimit(BaseModel):
         if self.dynamic_key and not self.limit:
             raise ValueError("CEL based keys requires limit to be set")
 
+        if self.limit is None:
+            self.limit = -1
+
         return self
 
     def to_proto(self) -> CreateTaskRateLimit:

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.21.7"
+version = "1.21.8"
 description = "This is the official Python SDK for Hatchet, a distributed, fault-tolerant task queue. The SDK allows you to easily integrate Hatchet's task scheduling and workflow orchestration capabilities into your Python applications."
 authors = [
     "Alexander Belanger <alexander@hatchet.run>",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "Background task orchestration & visibility for developers",
   "types": "dist/index.d.ts",
   "files": [

--- a/sdks/typescript/src/step.ts
+++ b/sdks/typescript/src/step.ts
@@ -735,12 +735,14 @@ export function mapRateLimit(limits: CreateStep<any, any>['rate_limits']): Creat
         }
         limitExpression = l.limit;
       }
-    } else {
-      limitExpression = `-1`;
     }
 
     if (keyExpression !== undefined && limitExpression === undefined) {
       throw new Error('CEL based keys requires limit to be set');
+    }
+
+    if (limitExpression === undefined) {
+      limitExpression = `-1`;
     }
 
     return {

--- a/sdks/typescript/src/step.ts
+++ b/sdks/typescript/src/step.ts
@@ -735,6 +735,8 @@ export function mapRateLimit(limits: CreateStep<any, any>['rate_limits']): Creat
         }
         limitExpression = l.limit;
       }
+    } else {
+      limitExpression = `-1`;
     }
 
     if (keyExpression !== undefined && limitExpression === undefined) {


### PR DESCRIPTION
# Description

Fixes an issue where static rate limits reset themselves to zero because we would pass `null` for the `limit` value. Instead, passing a sentinel `-1`, and then checking if the limit value is `>= 0` before upserting

Fixes #1834 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
