### PR TITLE
Fix: Goroutine to periodically extend lease during reconciliation

### DIFF
--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -3031,7 +3031,7 @@ func (p *OLAPRepositoryImpl) processOLAPPayloadCutoverBatch(ctx context.Context,
 }
 
 func (p *OLAPRepositoryImpl) acquireOrExtendJobLease(ctx context.Context, tx pgx.Tx, processId pgtype.UUID, partitionDate PartitionDate, pagination OLAPPaginationParams) (*OLAPCutoverJobRunMetadata, error) {
-	leaseInterval := 10 * time.Minute
+	leaseInterval := 2 * time.Minute
 	leaseExpiresAt := sqlchelpers.TimestamptzFromTime(time.Now().Add(leaseInterval))
 
 	lease, err := p.queries.AcquireOrExtendOLAPCutoverJobLease(ctx, tx, sqlcv1.AcquireOrExtendOLAPCutoverJobLeaseParams{

--- a/pkg/repository/v1/olap.go
+++ b/pkg/repository/v1/olap.go
@@ -3294,7 +3294,7 @@ func (p *OLAPRepositoryImpl) ProcessOLAPPayloadCutovers(ctx context.Context, ext
 	}
 
 	mostRecentPartitionToOffload := pgtype.Date{
-		Time:  time.Now().Add(-1 * *inlineStoreTTL),
+		Time:  time.Now().Add(-1 * (*inlineStoreTTL + 12*time.Hour)),
 		Valid: true,
 	}
 

--- a/pkg/repository/v1/payloadstore.go
+++ b/pkg/repository/v1/payloadstore.go
@@ -944,7 +944,7 @@ func (p *payloadStoreRepositoryImpl) ProcessPayloadCutovers(ctx context.Context)
 	}
 
 	mostRecentPartitionToOffload := pgtype.Date{
-		Time:  time.Now().Add(-1 * *p.inlineStoreTTL),
+		Time:  time.Now().Add(-1 * (*p.inlineStoreTTL + 12*time.Hour)),
 		Valid: true,
 	}
 

--- a/pkg/repository/v1/payloadstore.go
+++ b/pkg/repository/v1/payloadstore.go
@@ -677,7 +677,7 @@ type CutoverJobRunMetadata struct {
 }
 
 func (p *payloadStoreRepositoryImpl) acquireOrExtendJobLease(ctx context.Context, tx pgx.Tx, processId pgtype.UUID, partitionDate PartitionDate, pagination PaginationParams) (*CutoverJobRunMetadata, error) {
-	leaseInterval := 10 * time.Minute
+	leaseInterval := 2 * time.Minute
 	leaseExpiresAt := sqlchelpers.TimestamptzFromTime(time.Now().Add(leaseInterval))
 
 	lease, err := p.queries.AcquireOrExtendCutoverJobLease(ctx, tx, sqlcv1.AcquireOrExtendCutoverJobLeaseParams{


### PR DESCRIPTION
# Description

Adds a goroutine that runs a ticker that periodically extends the lease while reconciliation is running so that we don't have zombie jobs running expensive queries and snowballing

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

