### PR TITLE
Hotfix: Panic from missing case in `switch`

### DIFF
--- a/internal/services/controllers/v1/olap/controller.go
+++ b/internal/services/controllers/v1/olap/controller.go
@@ -713,6 +713,8 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapFAILED)
 		case sqlcv1.V1EventTypeOlapSKIPPED:
 			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapCOMPLETED)
+		case sqlcv1.V1EventTypeOlapCOULDNOTSENDTOWORKER:
+			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapFAILED)
 		}
 	}
 


### PR DESCRIPTION
# Description

Fixes a panic caused by a missing switch case, where we didn't append if we got `COULD_NOT_SEND_TO_WORKER`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

