### PR TITLE
[Python]: Improved exception logging, cron aliases, flaky test fix

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.2] - 2025-12-31
+
+### Added
+
+- Crons can now be provided by alias, e.g. `@daily`
+
+### Changed
+
+- Failed workflow logs are only reported at the `exception` level either on the last retry attempt or if the task is marked as `non_retryable`, to avoid spamming e.g. Sentry with exceptions.
+
 ## [1.22.1] - 2025-12-30
 
 ### Changed

--- a/sdks/python/examples/bulk_operations/test_bulk_replay.py
+++ b/sdks/python/examples/bulk_operations/test_bulk_replay.py
@@ -90,8 +90,8 @@ async def test_bulk_replay(hatchet: Hatchet) -> None:
 
     for run in runs.rows:
         assert run.status == V1TaskStatus.COMPLETED
-        assert run.retry_count >= 1
-        assert run.attempt >= 2
+        assert run.retry_count and run.retry_count >= 1
+        assert run.attempt and run.attempt >= 2
 
     assert (
         len([r for r in runs.rows if r.workflow_id == bulk_replay_test_1.id]) == n + 1

--- a/sdks/python/examples/bulk_operations/test_bulk_replay.py
+++ b/sdks/python/examples/bulk_operations/test_bulk_replay.py
@@ -90,8 +90,8 @@ async def test_bulk_replay(hatchet: Hatchet) -> None:
 
     for run in runs.rows:
         assert run.status == V1TaskStatus.COMPLETED
-        assert run.retry_count == 1
-        assert run.attempt == 2
+        assert run.retry_count >= 1
+        assert run.attempt >= 2
 
     assert (
         len([r for r in runs.rows if r.workflow_id == bulk_replay_test_1.id]) == n + 1

--- a/sdks/python/hatchet_sdk/features/cron.py
+++ b/sdks/python/hatchet_sdk/features/cron.py
@@ -48,6 +48,17 @@ class CreateCronTriggerConfig(BaseModel):
         if not v:
             raise ValueError("Cron expression is required")
 
+        ## allow cron aliases
+        if (alias := v.strip()) in {
+            "@yearly",
+            "@annually",
+            "@monthly",
+            "@weekly",
+            "@daily",
+            "@hourly",
+        }:
+            return alias
+
         parts = v.split()
         if len(parts) != 5:
             raise ValueError(

--- a/sdks/python/hatchet_sdk/worker/runner/runner.py
+++ b/sdks/python/hatchet_sdk/worker/runner/runner.py
@@ -149,7 +149,9 @@ class Runner:
             self.running_tasks.add(t)
             t.add_done_callback(lambda task: self.running_tasks.discard(task))
 
-    def step_run_callback(self, action: Action) -> Callable[[asyncio.Task[Any]], None]:
+    def step_run_callback(
+        self, action: Action, t: Task[TWorkflowInput, R]
+    ) -> Callable[[asyncio.Task[Any]], None]:
         def inner_callback(task: asyncio.Task[Any]) -> None:
             self.cleanup_run_id(action.key)
 
@@ -173,7 +175,11 @@ class Runner:
                     )
                 )
 
-                log_with_level = logger.info if should_not_retry else logger.exception
+                # log as info if we're going to retry or we explicitly should _not_ retry
+                # so that e.g. Sentry does not get reported multiple exceptions from multiple retries of a single task
+                log_as_info = should_not_retry or action.retry_count < t.retries
+
+                log_with_level = logger.info if log_as_info else logger.exception
 
                 log_with_level(
                     f"failed step run: {action.action_id}/{action.step_run_id}\n{exc.serialize(include_metadata=False)}"
@@ -397,7 +403,7 @@ class Runner:
                 self.async_wrapped_action_func(context, action_func, action)
             )
 
-            task.add_done_callback(self.step_run_callback(action))
+            task.add_done_callback(self.step_run_callback(action, action_func))
             self.tasks[action.key] = task
 
             task_count.increment()


### PR DESCRIPTION
# Description

## [1.22.2] - 2025-12-31

### Added

- Crons can now be provided by alias, e.g. `@daily`

### Changed

- Failed workflow logs are only reported at the `exception` level either on the last retry attempt or if the task is marked as `non_retryable`, to avoid spamming e.g. Sentry with exceptions.

<img width="1728" height="358" alt="Screenshot 2025-12-30 at 4 47 39 PM" src="https://github.com/user-attachments/assets/d73ded91-3dd4-4026-a8de-f08e610301bd" />


Closes #2666 

Also fixed a flaky test

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

