### PR TITLE
Fix: Frozen refetch state gets stuck

### DIFF
--- a/frontend/app/src/contexts/refetch-interval-context.tsx
+++ b/frontend/app/src/contexts/refetch-interval-context.tsx
@@ -92,7 +92,9 @@ export const RefetchIntervalProvider = ({
     if (isFrozen) {
       setIsFrozen(false);
     }
-  }, [pathname, setIsFrozen, isFrozen]);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname]);
 
   return (
     <RefetchIntervalContext.Provider value={value}>

--- a/frontend/app/src/contexts/refetch-interval-context.tsx
+++ b/frontend/app/src/contexts/refetch-interval-context.tsx
@@ -67,7 +67,7 @@ export const RefetchIntervalProvider = ({
         setIsFrozen(false);
       }
     },
-    [setStoredInterval],
+    [setStoredInterval, setIsFrozen],
   );
 
   const value = useMemo<RefetchIntervalContextType>(
@@ -88,10 +88,11 @@ export const RefetchIntervalProvider = ({
   );
 
   useEffect(() => {
+    // unfreeze refetches on route change
     if (isFrozen) {
       setIsFrozen(false);
     }
-  }, [pathname]);
+  }, [pathname, setIsFrozen, isFrozen]);
 
   return (
     <RefetchIntervalContext.Provider value={value}>

--- a/frontend/app/src/contexts/refetch-interval-context.tsx
+++ b/frontend/app/src/contexts/refetch-interval-context.tsx
@@ -61,6 +61,7 @@ export const RefetchIntervalProvider = ({
 
       if (key) {
         setStoredInterval(key);
+        setIsFrozen(false);
       }
     },
     [setStoredInterval],

--- a/frontend/app/src/contexts/refetch-interval-context.tsx
+++ b/frontend/app/src/contexts/refetch-interval-context.tsx
@@ -4,12 +4,14 @@ import {
   RefetchIntervalOption,
   LabeledRefetchInterval,
 } from '@/lib/api/refetch-interval';
+import { useLocation } from '@tanstack/react-router';
 import {
   createContext,
   useCallback,
   useContext,
   useMemo,
   ReactNode,
+  useEffect,
 } from 'react';
 
 interface RefetchIntervalContextType {
@@ -33,6 +35,7 @@ const STORAGE_KEY = 'app-default-refetch-interval';
 export const RefetchIntervalProvider = ({
   children,
 }: RefetchIntervalProviderProps) => {
+  const { pathname } = useLocation();
   const [storedInterval, setStoredInterval] =
     useLocalStorageState<RefetchIntervalOption>(STORAGE_KEY, '10s');
   const [isFrozen, setIsFrozen] = useLocalStorageState<boolean>(
@@ -83,6 +86,12 @@ export const RefetchIntervalProvider = ({
       userRefetchIntervalPreference,
     ],
   );
+
+  useEffect(() => {
+    if (isFrozen) {
+      setIsFrozen(false);
+    }
+  }, [pathname]);
 
   return (
     <RefetchIntervalContext.Provider value={value}>


### PR DESCRIPTION
# Description

Fixes a small FE bug where you could get into a state where refetches are stuck in "frozen" and it's hard to get out of because previously the only way to unfreeze was to open and close the additional meta

We should probably just have a button for this tbh but it's fine for now

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
