### PR TITLE
Fix: Remove action dropdown, fix a couple broken tooltips

### DIFF
--- a/frontend/app/src/pages/main/v1/task-runs-v1/actions.tsx
+++ b/frontend/app/src/pages/main/v1/task-runs-v1/actions.tsx
@@ -311,12 +311,14 @@ const BaseActionButton = ({
   icon,
   label,
   showModal,
+  showLabel,
   className,
 }: {
   disabled: boolean;
   params: TaskRunActionsParams;
   icon: JSX.Element;
   label: string;
+  showLabel: boolean;
   showModal: boolean;
   className?: string;
 }) => {
@@ -332,7 +334,7 @@ const BaseActionButton = ({
   return (
     <Button
       size={'sm'}
-      className={cn('text-sm', className)}
+      className={cn('text-sm gap-2', className)}
       variant={'outline'}
       disabled={disabled}
       onClick={() => {
@@ -346,9 +348,9 @@ const BaseActionButton = ({
 
         setIsActionModalOpen(true);
       }}
-      leftIcon={icon}
     >
-      {label}
+      {icon}
+      {showLabel && label}
     </Button>
   );
 };
@@ -358,12 +360,14 @@ export const TaskRunActionButton = ({
   disabled,
   paramOverrides,
   showModal,
+  showLabel,
   className,
 }: {
   actionType: ActionType;
   disabled: boolean;
   paramOverrides?: BaseTaskRunActionParams;
   showModal: boolean;
+  showLabel: boolean;
   className?: string;
 }) => {
   const { actionModalParams } = useRunsContext();
@@ -379,6 +383,7 @@ export const TaskRunActionButton = ({
           label={'Cancel'}
           showModal={showModal}
           className={className}
+          showLabel={showLabel}
         />
       );
     case 'replay':
@@ -390,6 +395,7 @@ export const TaskRunActionButton = ({
           label={'Replay'}
           showModal={showModal}
           className={className}
+          showLabel={showLabel}
         />
       );
     default:

--- a/frontend/app/src/pages/main/v1/task-runs-v1/actions.tsx
+++ b/frontend/app/src/pages/main/v1/task-runs-v1/actions.tsx
@@ -18,12 +18,6 @@ import {
   PortalTooltipProvider,
   PortalTooltipTrigger,
 } from '@/components/v1/ui/portal-tooltip';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/v1/ui/tooltip';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
 import api, {
   queries,
@@ -336,11 +330,7 @@ const BaseActionButton = ({
 }) => {
   const { handleTaskRunAction } = useTaskRunActions();
   const {
-    actions: {
-      setIsActionModalOpen,
-      setSelectedActionType,
-      setIsActionDropdownOpen,
-    },
+    actions: { setIsActionModalOpen, setSelectedActionType },
   } = useRunsContext();
 
   return (
@@ -354,7 +344,6 @@ const BaseActionButton = ({
             disabled={disabled}
             onClick={() => {
               setSelectedActionType(params.actionType);
-              setIsActionDropdownOpen(false);
 
               if (!showModal) {
                 handleTaskRunAction(params);

--- a/frontend/app/src/pages/main/v1/task-runs-v1/actions.tsx
+++ b/frontend/app/src/pages/main/v1/task-runs-v1/actions.tsx
@@ -12,6 +12,18 @@ import {
   DialogContent,
   DialogHeader,
 } from '@/components/v1/ui/dialog';
+import {
+  PortalTooltip,
+  PortalTooltipContent,
+  PortalTooltipProvider,
+  PortalTooltipTrigger,
+} from '@/components/v1/ui/portal-tooltip';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/v1/ui/tooltip';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
 import api, {
   queries,
@@ -332,26 +344,33 @@ const BaseActionButton = ({
   } = useRunsContext();
 
   return (
-    <Button
-      size={'sm'}
-      className={cn('text-sm gap-2', className)}
-      variant={'outline'}
-      disabled={disabled}
-      onClick={() => {
-        setSelectedActionType(params.actionType);
-        setIsActionDropdownOpen(false);
+    <PortalTooltipProvider>
+      <PortalTooltip>
+        <PortalTooltipTrigger>
+          <Button
+            size={'sm'}
+            className={cn('text-sm gap-2', className)}
+            variant={'outline'}
+            disabled={disabled}
+            onClick={() => {
+              setSelectedActionType(params.actionType);
+              setIsActionDropdownOpen(false);
 
-        if (!showModal) {
-          handleTaskRunAction(params);
-          return;
-        }
+              if (!showModal) {
+                handleTaskRunAction(params);
+                return;
+              }
 
-        setIsActionModalOpen(true);
-      }}
-    >
-      {icon}
-      {showLabel && label}
-    </Button>
+              setIsActionModalOpen(true);
+            }}
+          >
+            {icon}
+            {showLabel && label}
+          </Button>
+        </PortalTooltipTrigger>
+        <PortalTooltipContent>{label}</PortalTooltipContent>
+      </PortalTooltip>
+    </PortalTooltipProvider>
   );
 };
 

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/header.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/header.tsx
@@ -46,12 +46,14 @@ export const V1RunDetailHeader = () => {
                 !TASK_RUN_TERMINAL_STATUSES.includes(workflowRun.status)
               }
               showModal={false}
+              showLabel
             />
             <TaskRunActionButton
               actionType="cancel"
               paramOverrides={{ externalIds: [workflowRun.metadata.id] }}
               disabled={TASK_RUN_TERMINAL_STATUSES.includes(workflowRun.status)}
               showModal={false}
+              showLabel
             />
           </div>
         </div>

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/step-run-detail.tsx
@@ -175,12 +175,14 @@ export const TaskRunDetail = ({
                 paramOverrides={{ externalIds: [taskRunId] }}
                 disabled={!TASK_RUN_TERMINAL_STATUSES.includes(taskRun.status)}
                 showModal={false}
+                showLabel
               />
               <TaskRunActionButton
                 actionType="cancel"
                 paramOverrides={{ externalIds: [taskRunId] }}
                 disabled={TASK_RUN_TERMINAL_STATUSES.includes(taskRun.status)}
                 showModal={false}
+                showLabel
               />
             </RunsProvider>
           </div>

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-node.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-node.tsx
@@ -1,11 +1,11 @@
 import { V1RunIndicator } from '../../components/run-statuses';
 import { TabOption } from './step-run-detail/step-run-detail';
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/v1/ui/tooltip';
+  PortalTooltip,
+  PortalTooltipContent,
+  PortalTooltipProvider,
+  PortalTooltipTrigger,
+} from '@/components/v1/ui/portal-tooltip';
 import { V1TaskStatus, V1TaskSummary } from '@/lib/api';
 import { cn, formatDuration } from '@/lib/utils';
 import { memo } from 'react';
@@ -40,9 +40,9 @@ export default memo(({ data }: { data: NodeData }) => {
           isConnectable={false}
         />
       )}
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger>
+      <PortalTooltipProvider>
+        <PortalTooltip>
+          <PortalTooltipTrigger>
             <div
               className={cn(
                 `step-run-card mb-1 w-full rounded-sm px-2 py-3 font-mono text-xs font-semibold text-[#050c1c] shadow-md dark:text-[#ffffff]`,
@@ -82,10 +82,10 @@ export default memo(({ data }: { data: NodeData }) => {
                 />
               )}
             </div>
-          </TooltipTrigger>
-          <TooltipContent>{data.taskName}</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+          </PortalTooltipTrigger>
+          <PortalTooltipContent>{data.taskName}</PortalTooltipContent>
+        </PortalTooltip>
+      </PortalTooltipProvider>
     </div>
   );
 });

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions.tsx
@@ -10,8 +10,6 @@ interface TableActionsProps {
 
 export const TableActions = ({ onTriggerWorkflow }: TableActionsProps) => {
   const {
-    isActionDropdownOpen,
-    actions: { setIsActionDropdownOpen },
     display: { hideTriggerRunButton, hideCancelAndReplayButtons },
   } = useRunsContext();
 
@@ -37,13 +35,7 @@ export const TableActions = ({ onTriggerWorkflow }: TableActionsProps) => {
     }
 
     return baseActions;
-  }, [
-    onTriggerWorkflow,
-    hideTriggerRunButton,
-    hideCancelAndReplayButtons,
-    setIsActionDropdownOpen,
-    isActionDropdownOpen,
-  ]);
+  }, [onTriggerWorkflow, hideTriggerRunButton, hideCancelAndReplayButtons]);
 
   return <>{actions}</>;
 };

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions.tsx
@@ -17,8 +17,18 @@ export const TableActions = ({ onTriggerWorkflow }: TableActionsProps) => {
     let baseActions = [
       !hideCancelAndReplayButtons && (
         <div className="flex flex-row gap-x-1">
-          <CancelMenuItem />
-          <ReplayMenuItem />
+          <TaskRunActionButton
+            actionType="cancel"
+            disabled={false}
+            showModal
+            showLabel={false}
+          />
+          <TaskRunActionButton
+            actionType="replay"
+            disabled={false}
+            showModal
+            showLabel={false}
+          />
         </div>
       ),
     ];
@@ -38,28 +48,4 @@ export const TableActions = ({ onTriggerWorkflow }: TableActionsProps) => {
   }, [onTriggerWorkflow, hideTriggerRunButton, hideCancelAndReplayButtons]);
 
   return <>{actions}</>;
-};
-
-const CancelMenuItem = () => {
-  return (
-    <div className="w-full">
-      <TaskRunActionButton
-        actionType="cancel"
-        disabled={false}
-        showModal
-        showLabel={false}
-      />
-    </div>
-  );
-};
-
-const ReplayMenuItem = () => {
-  return (
-    <TaskRunActionButton
-      actionType="replay"
-      disabled={false}
-      showModal
-      showLabel={false}
-    />
-  );
 };

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/task-runs-table/table-actions.tsx
@@ -1,21 +1,14 @@
 import { TaskRunActionButton } from '../../../task-runs-v1/actions';
 import { useRunsContext } from '../../hooks/runs-provider';
 import { Button } from '@/components/v1/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from '@/components/v1/ui/dropdown-menu';
-import { ChevronDownIcon } from '@radix-ui/react-icons';
-import { Play, Command } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { Play } from 'lucide-react';
+import { useMemo } from 'react';
 
 interface TableActionsProps {
   onTriggerWorkflow: () => void;
 }
 
 export const TableActions = ({ onTriggerWorkflow }: TableActionsProps) => {
-  const [shouldDelayClose, setShouldDelayClose] = useState(false);
   const {
     isActionDropdownOpen,
     actions: { setIsActionDropdownOpen },
@@ -25,33 +18,10 @@ export const TableActions = ({ onTriggerWorkflow }: TableActionsProps) => {
   const actions = useMemo(() => {
     let baseActions = [
       !hideCancelAndReplayButtons && (
-        <DropdownMenu
-          key="actions"
-          open={isActionDropdownOpen}
-          onOpenChange={(open) => {
-            if (open) {
-              setIsActionDropdownOpen(true);
-              setShouldDelayClose(false);
-            } else if (shouldDelayClose) {
-              setTimeout(() => setIsActionDropdownOpen(false), 150);
-              setShouldDelayClose(false);
-            } else {
-              setIsActionDropdownOpen(false);
-            }
-          }}
-        >
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="sm">
-              <Command className="cq-xl:hidden size-4" />
-              <span className="cq-xl:inline hidden text-sm">Actions</span>
-              <ChevronDownIcon className="cq-xl:inline ml-2 hidden size-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="z-[70]">
-            <CancelMenuItem />
-            <ReplayMenuItem />
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <div className="flex flex-row gap-x-1">
+          <CancelMenuItem />
+          <ReplayMenuItem />
+        </div>
       ),
     ];
 
@@ -73,7 +43,6 @@ export const TableActions = ({ onTriggerWorkflow }: TableActionsProps) => {
     hideCancelAndReplayButtons,
     setIsActionDropdownOpen,
     isActionDropdownOpen,
-    shouldDelayClose,
   ]);
 
   return <>{actions}</>;
@@ -86,7 +55,7 @@ const CancelMenuItem = () => {
         actionType="cancel"
         disabled={false}
         showModal
-        className="h-8 w-full justify-start rounded-sm border-0 bg-transparent px-2 py-1.5 font-normal hover:bg-accent hover:text-accent-foreground"
+        showLabel={false}
       />
     </div>
   );
@@ -94,13 +63,11 @@ const CancelMenuItem = () => {
 
 const ReplayMenuItem = () => {
   return (
-    <div className="w-full">
-      <TaskRunActionButton
-        actionType="replay"
-        disabled={false}
-        showModal
-        className="h-8 w-full justify-start rounded-sm border-0 bg-transparent px-2 py-1.5 font-normal hover:bg-accent hover:text-accent-foreground"
-      />
-    </div>
+    <TaskRunActionButton
+      actionType="replay"
+      disabled={false}
+      showModal
+      showLabel={false}
+    />
   );
 };

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
@@ -43,7 +43,6 @@ type RunsProviderProps = {
 type RunsContextType = {
   actions: {
     setIsActionModalOpen: (isOpen: boolean) => void;
-    setIsActionDropdownOpen: (isOpen: boolean) => void;
     setSelectedActionType: (actionType: ActionType | null) => void;
     refetchRuns: () => void;
     refetchMetrics: () => void;
@@ -69,7 +68,6 @@ type RunsContextType = {
   runStatusCounts: V1TaskRunMetrics;
   queueMetrics: object;
   isActionModalOpen: boolean;
-  isActionDropdownOpen: boolean;
   selectedActionType: ActionType | null;
   actionModalParams: BaseTaskRunActionParams;
   display: DisplayProps;
@@ -92,7 +90,6 @@ export const RunsProvider = ({
   runFilters,
 }: RunsProviderProps) => {
   const [isActionModalOpen, setIsActionModalOpen] = useState(false);
-  const [isActionDropdownOpen, setIsActionDropdownOpen] = useState(false);
   const [selectedActionType, setSelectedActionType] =
     useState<ActionType | null>(null);
 
@@ -210,7 +207,6 @@ export const RunsProvider = ({
       runStatusCounts,
       queueMetrics,
       isActionModalOpen,
-      isActionDropdownOpen,
       actionModalParams,
       selectedActionType,
       pagination,
@@ -230,7 +226,6 @@ export const RunsProvider = ({
       },
       actions: {
         setIsActionModalOpen,
-        setIsActionDropdownOpen,
         setSelectedActionType,
         refetchRuns,
         refetchMetrics,
@@ -257,7 +252,6 @@ export const RunsProvider = ({
       runStatusCounts,
       queueMetrics,
       isActionModalOpen,
-      isActionDropdownOpen,
       hideMetrics,
       hideCounts,
       hideDateFilter,
@@ -266,7 +260,6 @@ export const RunsProvider = ({
       actionModalParams,
       selectedActionType,
       setIsActionModalOpen,
-      setIsActionDropdownOpen,
       setSelectedActionType,
       refetchRuns,
       refetchMetrics,


### PR DESCRIPTION
# Description

Removes the "action dropdown" (the dropdown with the cancel + replay buttons) in favor of just making them icon buttons with a tooltip to avoid needing the extra click, and fixes a couple of tooltips.

The buttons still look the same on the other views

<img width="1571" height="508" alt="Screenshot 2025-12-30 at 9 21 57 PM" src="https://github.com/user-attachments/assets/e22a60d9-8a84-47b4-a3df-c087ba6b785a" />

<img width="835" height="330" alt="Screenshot 2025-12-30 at 9 22 11 PM" src="https://github.com/user-attachments/assets/b1e5a790-2f26-43f7-93bd-1796555e26fb" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
