### PR TITLE
Proposal: Shrink task metrics chart a bunch

### DIFF
--- a/frontend/app/src/components/v1/molecules/charts/zoomable.tsx
+++ b/frontend/app/src/components/v1/molecules/charts/zoomable.tsx
@@ -397,14 +397,13 @@ function ChildAreaChart<T extends string>({
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
       >
-        <CartesianGrid vertical={false} />
         <XAxis
           dataKey="date"
           tickFormatter={formatXAxis}
           tickLine={false}
           axisLine={false}
           tickMargin={4}
-          minTickGap={16}
+          minTickGap={48}
           style={{ fontSize: '10px', userSelect: 'none' }}
         />
         {showYAxis && (

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
@@ -61,12 +61,12 @@ const GetWorkflowChart = () => {
   });
 
   if (workflowRunEventsMetricsQuery.isLoading) {
-    return <Skeleton className="h-36 w-full" />;
+    return <Skeleton className="h-16 w-full" />;
   }
 
   return (
     <ZoomableChart
-      kind="bar"
+      kind="area"
       data={
         workflowRunEventsMetricsQuery.data?.results?.map(
           (result): DataPoint<'SUCCEEDED' | 'FAILED'> => ({
@@ -82,6 +82,7 @@ const GetWorkflowChart = () => {
       }}
       zoom={zoom}
       showYAxis={false}
+      className="h-16 min-h-16"
     />
   );
 };

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
@@ -66,7 +66,7 @@ const GetWorkflowChart = () => {
 
   return (
     <ZoomableChart
-      kind="area"
+      kind="bar"
       data={
         workflowRunEventsMetricsQuery.data?.results?.map(
           (result): DataPoint<'SUCCEEDED' | 'FAILED'> => ({

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
@@ -61,7 +61,7 @@ const GetWorkflowChart = () => {
   });
 
   if (workflowRunEventsMetricsQuery.isLoading) {
-    return <Skeleton className="h-16 w-full" />;
+    return <Skeleton className="h-24 w-full" />;
   }
 
   return (
@@ -82,7 +82,7 @@ const GetWorkflowChart = () => {
       }}
       zoom={zoom}
       showYAxis={false}
-      className="h-16 min-h-16"
+      className="h-24 min-h-24"
     />
   );
 };


### PR DESCRIPTION
# Description

I think we can reduce the amount of vertical space that the run graph over time takes by doing something like this. Happy to just close it too, but thought it was worth a shot since right now this graph takes up like 1/3 of the vertical space we have

<img width="1728" height="956" alt="Screenshot 2025-12-30 at 9 44 01 PM" src="https://github.com/user-attachments/assets/798e5790-4c8e-46a6-b035-6acf2dd4c6b5" />

<img width="1728" height="957" alt="Screenshot 2025-12-30 at 9 42 41 PM" src="https://github.com/user-attachments/assets/e7b9d99a-0f9e-4fea-bf24-1dfff01095e5" />

## Type of change

- [x] New feature (non-breaking change which adds functionality)
