### PR TITLE
refactor: set a connection-level statement timeout

### DIFF
--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -145,7 +145,9 @@ func (c *ConfigLoader) InitDataLayer() (res *database.Layer, err error) {
 
 		conn.TypeMap().RegisterType(t)
 
-		return nil
+		_, err = conn.Exec(ctx, "SET statement_timeout=30000")
+
+		return err
 	}
 
 	config, err := pgxpool.ParseConfig(databaseUrl)

--- a/pkg/repository/api_token.go
+++ b/pkg/repository/api_token.go
@@ -87,7 +87,7 @@ func (a *apiTokenRepository) GetAPITokenById(ctx context.Context, id string) (*s
 }
 
 func (a *apiTokenRepository) DeleteAPIToken(ctx context.Context, tenantId, id string) error {
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, a.pool, a.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, a.pool, a.l)
 
 	if err != nil {
 		return err

--- a/pkg/repository/ids.go
+++ b/pkg/repository/ids.go
@@ -110,7 +110,7 @@ func (s *sharedRepository) PopulateExternalIdsForWorkflow(ctx context.Context, t
 }
 
 func (s *sharedRepository) generateExternalIdsForChildWorkflows(ctx context.Context, tenantId string, opts []*WorkflowNameTriggerOpts) error {
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, s.pool, s.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, s.pool, s.l)
 
 	if err != nil {
 		return err

--- a/pkg/repository/match.go
+++ b/pkg/repository/match.go
@@ -163,7 +163,7 @@ func (m *MatchRepositoryImpl) RegisterSignalMatchConditions(ctx context.Context,
 	// 	return err
 	// }
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, m.pool, m.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, m.pool, m.l)
 
 	if err != nil {
 		return err
@@ -242,7 +242,7 @@ func (m *MatchRepositoryImpl) RegisterSignalMatchConditions(ctx context.Context,
 
 // ProcessInternalEventMatches processes a list of internal events
 func (m *MatchRepositoryImpl) ProcessInternalEventMatches(ctx context.Context, tenantId string, events []CandidateEventMatch) (*EventMatchResults, error) {
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, m.pool, m.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, m.pool, m.l)
 
 	if err != nil {
 		return nil, err
@@ -286,7 +286,7 @@ func (m *MatchRepositoryImpl) ProcessInternalEventMatches(ctx context.Context, t
 
 // ProcessUserEventMatches processes a list of user events
 func (m *MatchRepositoryImpl) ProcessUserEventMatches(ctx context.Context, tenantId string, events []CandidateEventMatch) (*EventMatchResults, error) {
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, m.pool, m.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, m.pool, m.l)
 
 	if err != nil {
 		return nil, err

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -631,7 +631,7 @@ func (r *OLAPRepositoryImpl) ListTasks(ctx context.Context, tenantId string, opt
 	ctx, span := telemetry.NewSpan(ctx, "list-tasks-olap")
 	defer span.End()
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.readPool, r.l, 10000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.readPool, r.l)
 
 	if err != nil {
 		return nil, 0, err
@@ -803,7 +803,7 @@ func (r *OLAPRepositoryImpl) ListTasksByDAGId(ctx context.Context, tenantId stri
 	ctx, span := telemetry.NewSpan(ctx, "list-tasks-by-dag-id-olap")
 	defer span.End()
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.readPool, r.l, 15000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.readPool, r.l)
 	taskIdToDagExternalId := make(map[int64]uuid.UUID)
 
 	if err != nil {
@@ -887,7 +887,7 @@ func (r *OLAPRepositoryImpl) ListTasksByIdAndInsertedAt(ctx context.Context, ten
 	ctx, span := telemetry.NewSpan(ctx, "list-tasks-by-id-and-inserted-at-olap")
 	defer span.End()
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.readPool, r.l, 15000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.readPool, r.l)
 
 	if err != nil {
 		return nil, err
@@ -960,7 +960,7 @@ func (r *OLAPRepositoryImpl) ListWorkflowRuns(ctx context.Context, tenantId stri
 	ctx, span := telemetry.NewSpan(ctx, "list-workflow-runs-olap")
 	defer span.End()
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.readPool, r.l, 30000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.readPool, r.l)
 
 	if err != nil {
 		return nil, 0, err
@@ -1246,7 +1246,7 @@ func (r *OLAPRepositoryImpl) ListWorkflowRunExternalIds(ctx context.Context, ten
 	ctx, span := telemetry.NewSpan(ctx, "list-workflow-run-external-ids-olap")
 	defer span.End()
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.readPool, r.l, 30000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.readPool, r.l)
 
 	if err != nil {
 		return nil, err
@@ -1503,7 +1503,7 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId s
 		return nil
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
 		return err
@@ -1568,7 +1568,7 @@ func (r *OLAPRepositoryImpl) UpdateTaskStatuses(ctx context.Context, tenantIds [
 
 		eg.Go(func() error {
 			ctx := innerCtx
-			tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 15000)
+			tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 			if err != nil {
 				return err
@@ -1678,7 +1678,7 @@ func (r *OLAPRepositoryImpl) UpdateDAGStatuses(ctx context.Context, tenantIds []
 
 		eg.Go(func() error {
 			ctx := innerCtx
-			tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 15000)
+			tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 			if err != nil {
 				return fmt.Errorf("failed to prepare transaction: %w", err)
@@ -1806,7 +1806,7 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId string
 		})
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 	if err != nil {
 		return err
 	}
@@ -1867,7 +1867,7 @@ func (r *OLAPRepositoryImpl) writeDAGBatch(ctx context.Context, tenantId string,
 		})
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 	if err != nil {
 		return err
 	}
@@ -2016,7 +2016,7 @@ func (r *OLAPRepositoryImpl) GetTaskTimings(ctx context.Context, tenantId string
 		})
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.readPool, r.l, 30000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.readPool, r.l)
 	defer rollback()
 
 	if err != nil {
@@ -2045,7 +2045,7 @@ type EventTriggersFromExternalId struct {
 }
 
 func (r *OLAPRepositoryImpl) BulkCreateEventsAndTriggers(ctx context.Context, events sqlcv1.BulkCreateEventsParams, triggers []EventTriggersFromExternalId) error {
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
 		return fmt.Errorf("error beginning transaction: %v", err)
@@ -2483,7 +2483,7 @@ func (r *OLAPRepositoryImpl) PutPayloads(ctx context.Context, tx sqlcv1.DBTX, te
 
 	if tx == nil {
 		localTx = true
-		tx, commit, rollback, err = sqlchelpers.PrepareTx(ctx, r.pool, r.l, 5000)
+		tx, commit, rollback, err = sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 		if err != nil {
 			return nil, fmt.Errorf("error beginning transaction in `PutPayload`: %v", err)
@@ -2621,7 +2621,7 @@ func (r *OLAPRepositoryImpl) ReadPayloads(ctx context.Context, tenantId string, 
 }
 
 func (r *OLAPRepositoryImpl) OffloadPayloads(ctx context.Context, tenantId string, payloads []OffloadPayloadOpts) error {
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
 		return fmt.Errorf("error beginning transaction: %v", err)
@@ -2658,7 +2658,7 @@ func (r *OLAPRepositoryImpl) OffloadPayloads(ctx context.Context, tenantId strin
 
 func (r *OLAPRepositoryImpl) AnalyzeOLAPTables(ctx context.Context) error {
 	const timeout = 1000 * 60 * 60 // 60 minute timeout
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, timeout)
+	tx, commit, rollback, err := sqlchelpers.PrepareTxWithStatementTimeout(ctx, r.pool, r.l, timeout)
 
 	if err != nil {
 		return fmt.Errorf("error beginning transaction: %v", err)
@@ -2990,7 +2990,7 @@ func (p *OLAPRepositoryImpl) processOLAPPayloadCutoverBatch(ctx context.Context,
 		})
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, p.pool, p.l, 10000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, p.pool, p.l)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare transaction for copying offloaded payloads: %w", err)
@@ -3097,7 +3097,7 @@ func (p *OLAPRepositoryImpl) prepareCutoverTableJob(ctx context.Context, process
 		return nil, fmt.Errorf("inline store TTL is not set")
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, p.pool, p.l, 10000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, p.pool, p.l)
 
 	if err != nil {
 		return nil, err
@@ -3188,7 +3188,7 @@ func (p *OLAPRepositoryImpl) processSinglePartition(ctx context.Context, process
 			case <-reconciliationDoneChan:
 				return
 			case <-ticker.C:
-				tx, commit, rollback, err := sqlchelpers.PrepareTx(reconciliationCtx, p.pool, p.l, 10000)
+				tx, commit, rollback, err := sqlchelpers.PrepareTx(reconciliationCtx, p.pool, p.l)
 
 				if err != nil {
 					p.l.Error().Err(err).Msg("failed to prepare transaction for extending cutover job lease during reconciliation")
@@ -3263,7 +3263,7 @@ func (p *OLAPRepositoryImpl) processSinglePartition(ctx context.Context, process
 
 	close(reconciliationDoneChan)
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, p.pool, p.l, 10000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, p.pool, p.l)
 
 	if err != nil {
 		return fmt.Errorf("failed to prepare transaction for swapping payload cutover temp table: %w", err)

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -400,23 +400,33 @@ func (r *OLAPRepositoryImpl) UpdateTablePartitions(ctx context.Context) error {
 	for _, partition := range partitions {
 		r.l.Warn().Msgf("detaching partition %s", partition.PartitionName)
 
-		_, err := r.pool.Exec(
+		conn, release, err := sqlchelpers.AcquireConnectionWithStatementTimeout(ctx, r.pool, r.l, 30*60*1000) // 30 minutes
+
+		if err != nil {
+			return err
+		}
+
+		_, err = conn.Exec(
 			ctx,
 			fmt.Sprintf("ALTER TABLE %s DETACH PARTITION %s CONCURRENTLY", partition.ParentTable, partition.PartitionName),
 		)
 
 		if err != nil {
+			release()
 			return err
 		}
 
-		_, err = r.pool.Exec(
+		_, err = conn.Exec(
 			ctx,
 			fmt.Sprintf("DROP TABLE %s", partition.PartitionName),
 		)
 
 		if err != nil {
+			release()
 			return err
 		}
+
+		release()
 	}
 
 	return nil

--- a/pkg/repository/payloadstore.go
+++ b/pkg/repository/payloadstore.go
@@ -620,7 +620,7 @@ func (p *payloadStoreRepositoryImpl) ProcessPayloadCutoverBatch(ctx context.Cont
 		})
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, p.pool, p.l, 10000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, p.pool, p.l)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare transaction for copying offloaded payloads: %w", err)
@@ -735,7 +735,7 @@ func (p *payloadStoreRepositoryImpl) prepareCutoverTableJob(ctx context.Context,
 		return nil, fmt.Errorf("inline store TTL is not set")
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, p.pool, p.l, 10000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, p.pool, p.l)
 
 	if err != nil {
 		return nil, err
@@ -827,7 +827,7 @@ func (p *payloadStoreRepositoryImpl) processSinglePartition(ctx context.Context,
 			case <-reconciliationDoneChan:
 				return
 			case <-ticker.C:
-				tx, commit, rollback, err := sqlchelpers.PrepareTx(reconciliationCtx, p.pool, p.l, 10000)
+				tx, commit, rollback, err := sqlchelpers.PrepareTx(reconciliationCtx, p.pool, p.l)
 
 				if err != nil {
 					p.l.Error().Err(err).Msg("failed to prepare transaction for extending cutover job lease during reconciliation")
@@ -904,7 +904,7 @@ func (p *payloadStoreRepositoryImpl) processSinglePartition(ctx context.Context,
 
 	close(reconciliationDoneChan)
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, p.pool, p.l, 10000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, p.pool, p.l)
 
 	if err != nil {
 		return fmt.Errorf("failed to prepare transaction for swapping payload cutover temp table: %w", err)

--- a/pkg/repository/rate_limit.go
+++ b/pkg/repository/rate_limit.go
@@ -65,7 +65,7 @@ func newRateLimitRepository(shared *sharedRepository) *rateLimitRepository {
 }
 
 func (r *rateLimitRepository) UpdateRateLimits(ctx context.Context, tenantId pgtype.UUID, updates map[string]int) ([]*sqlcv1.ListRateLimitsForTenantWithMutateRow, *time.Time, error) {
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
 		return nil, nil, err

--- a/pkg/repository/scheduler_concurrency.go
+++ b/pkg/repository/scheduler_concurrency.go
@@ -60,7 +60,7 @@ func (c *ConcurrencyRepositoryImpl) UpdateConcurrencyStrategyIsActive(
 	tenantId pgtype.UUID,
 	strategy *sqlcv1.V1StepConcurrency,
 ) error {
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, c.pool, c.l, 30000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, c.pool, c.l)
 
 	if err != nil {
 		return err
@@ -136,7 +136,7 @@ func (c *ConcurrencyRepositoryImpl) runGroupRoundRobin(
 	strategy *sqlcv1.V1StepConcurrency,
 ) (res *RunConcurrencyResult, err error) {
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, c.pool, c.l, 30000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, c.pool, c.l)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare transaction (strategy ID: %d): %w", strategy.ID, err)
@@ -277,7 +277,7 @@ func (c *ConcurrencyRepositoryImpl) runCancelInProgress(
 	strategy *sqlcv1.V1StepConcurrency,
 ) (res *RunConcurrencyResult, err error) {
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, c.pool, c.l, 30000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, c.pool, c.l)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare transaction (strategy ID: %d): %w", strategy.ID, err)
@@ -496,7 +496,7 @@ func (c *ConcurrencyRepositoryImpl) runCancelNewest(
 	tenantId pgtype.UUID,
 	strategy *sqlcv1.V1StepConcurrency,
 ) (res *RunConcurrencyResult, err error) {
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, c.pool, c.l, 30000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, c.pool, c.l)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare transaction (strategy ID: %d): %w", strategy.ID, err)

--- a/pkg/repository/scheduler_lease.go
+++ b/pkg/repository/scheduler_lease.go
@@ -39,7 +39,7 @@ func (d *leaseRepository) AcquireOrExtendLeases(ctx context.Context, tenantId pg
 		leaseIds[i] = lease.ID
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, d.pool, d.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, d.pool, d.l)
 
 	if err != nil {
 		return nil, err
@@ -85,7 +85,7 @@ func (d *leaseRepository) ReleaseLeases(ctx context.Context, tenantId pgtype.UUI
 		leaseIds[i] = lease.ID
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, d.pool, d.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, d.pool, d.l)
 
 	if err != nil {
 		return err

--- a/pkg/repository/scheduler_queue.go
+++ b/pkg/repository/scheduler_queue.go
@@ -186,7 +186,7 @@ func (d *queueRepository) MarkQueueItemsProcessed(ctx context.Context, r *Assign
 	start := time.Now()
 	checkpoint := start
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, d.pool, d.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, d.pool, d.l)
 
 	if err != nil {
 		return nil, nil, err
@@ -597,7 +597,7 @@ func (d *queueRepository) GetDesiredLabels(ctx context.Context, stepIds []pgtype
 }
 
 func (d *queueRepository) RequeueRateLimitedItems(ctx context.Context, tenantId pgtype.UUID, queueName string) ([]*sqlcv1.RequeueRateLimitedQueueItemsRow, error) {
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, d.pool, d.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, d.pool, d.l)
 
 	if err != nil {
 		return nil, err

--- a/pkg/repository/sqlchelpers/tx.go
+++ b/pkg/repository/sqlchelpers/tx.go
@@ -71,7 +71,7 @@ func PrepareTxWithStatementTimeout(ctx context.Context, pool *pgxpool.Pool, l *z
 
 	commit := func(ctx context.Context) error {
 		// reset statement timeout
-		_, err = tx.Exec(ctx, "SET statement_timeout=0")
+		_, err = tx.Exec(ctx, "SET statement_timeout=30000")
 
 		if err != nil {
 			return err

--- a/pkg/repository/sqlchelpers/tx.go
+++ b/pkg/repository/sqlchelpers/tx.go
@@ -93,6 +93,56 @@ func PrepareTxWithStatementTimeout(ctx context.Context, pool *pgxpool.Pool, l *z
 	return tx, commit, rollback, nil
 }
 
+// AcquireConnectionWithStatementTimeout acquires a connection from the pool and overwrites the default statement timeout on it.
+// It does not support timeout values lower than the default timeout (if called with such a value, it will just use the default timeout).
+func AcquireConnectionWithStatementTimeout(ctx context.Context, pool *pgxpool.Pool, l *zerolog.Logger, timeoutMs int) (*pgx.Conn, func(), error) {
+	start := time.Now()
+
+	conn, err := pool.Acquire(ctx)
+
+	if err != nil {
+		if sinceStart := time.Since(start); sinceStart > 100*time.Millisecond {
+			l.Error().Dur(
+				"duration", sinceStart,
+			).Int(
+				"acquired_connections", int(pool.Stat().AcquiredConns()),
+			).Caller(1).Msgf("long connection acquire with error: %v", err)
+		}
+
+		return nil, nil, err
+	}
+
+	if sinceStart := time.Since(start); sinceStart > 100*time.Millisecond {
+		l.Warn().Dur(
+			"duration", sinceStart,
+		).Int(
+			"acquired_connections", int(pool.Stat().AcquiredConns()),
+		).Caller(1).Msg("long connection acquire")
+	}
+
+	release := func() {
+		// reset statement timeout with a separate ctx; we don't want to use the original ctx here in case it has been cancelled
+		resetCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err = conn.Exec(resetCtx, "SET statement_timeout=30000")
+
+		if err != nil {
+			l.Error().Err(err).Msg("failed to reset statement timeout on released connection")
+		}
+
+		conn.Release()
+	}
+
+	_, err = conn.Exec(ctx, fmt.Sprintf("SET statement_timeout=%d", timeoutMs))
+
+	if err != nil {
+		release()
+		return nil, nil, err
+	}
+
+	return conn.Conn(), release, nil
+}
+
 func DeferRollback(ctx context.Context, l *zerolog.Logger, rollback func(context.Context) error) {
 	if err := rollback(ctx); err != nil {
 		if !errors.Is(err, pgx.ErrTxClosed) {

--- a/pkg/repository/sqlchelpers/tx.go
+++ b/pkg/repository/sqlchelpers/tx.go
@@ -84,7 +84,6 @@ func PrepareTxWithStatementTimeout(ctx context.Context, pool *pgxpool.Pool, l *z
 		DeferRollback(ctx, l, tx.Rollback)
 	}
 
-	// set tx timeout to 5 seconds to avoid deadlocks
 	_, err = tx.Exec(ctx, fmt.Sprintf("SET statement_timeout=%d", timeoutMs))
 
 	if err != nil {

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -298,7 +298,7 @@ func (r *TaskRepositoryImpl) UpdateTablePartitions(ctx context.Context) error {
 	const PARTITION_LOCK_OFFSET = 9000000000000000000
 	const partitionLockKey = PARTITION_LOCK_OFFSET + 1
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 600000) // 10 minutes
+	tx, commit, rollback, err := sqlchelpers.PrepareTxWithStatementTimeout(ctx, r.pool, r.l, 600000) // 10 minutes
 	if err != nil {
 		return fmt.Errorf("failed to prepare transaction: %w", err)
 	}
@@ -595,7 +595,7 @@ func (r *TaskRepositoryImpl) CompleteTasks(ctx context.Context, tenantId string,
 		taskIdRetryCounts[i] = *task.TaskIdInsertedAtRetryCount
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
 		err = fmt.Errorf("failed to prepare tx: %w", err)
@@ -665,7 +665,7 @@ func (r *TaskRepositoryImpl) FailTasks(ctx context.Context, tenantId string, fai
 	ctx, span := telemetry.NewSpan(ctx, "TaskRepositoryImpl.FailTasks")
 	defer span.End()
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
 		err = fmt.Errorf("failed to prepare tx: %w", err)
@@ -847,7 +847,7 @@ func (r *TaskRepositoryImpl) ListFinalizedWorkflowRuns(ctx context.Context, tena
 	start := time.Now()
 	checkpoint := time.Now()
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 30000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
 		return nil, err
@@ -986,7 +986,7 @@ func (r *TaskRepositoryImpl) CancelTasks(ctx context.Context, tenantId string, t
 	// 	return err
 	// }
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
 		err = fmt.Errorf("failed to prepare tx: %w", err)
@@ -1161,7 +1161,7 @@ func (r *TaskRepositoryImpl) DefaultTaskActivityGauge(ctx context.Context, tenan
 }
 
 func (r *TaskRepositoryImpl) ProcessTaskTimeouts(ctx context.Context, tenantId string) (*TimeoutTasksResponse, bool, error) {
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 25000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
 		return nil, false, err
@@ -1232,7 +1232,7 @@ func (r *TaskRepositoryImpl) ProcessTaskTimeouts(ctx context.Context, tenantId s
 }
 
 func (r *TaskRepositoryImpl) ProcessTaskReassignments(ctx context.Context, tenantId string) (*FailTasksResponse, bool, error) {
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 25000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
 		return nil, false, err
@@ -1295,7 +1295,7 @@ func (r *TaskRepositoryImpl) ProcessTaskReassignments(ctx context.Context, tenan
 }
 
 func (r *TaskRepositoryImpl) ProcessTaskRetryQueueItems(ctx context.Context, tenantId string) ([]*sqlcv1.V1RetryQueueItem, bool, error) {
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 25000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
 		return nil, false, err
@@ -1331,7 +1331,7 @@ type durableSleepEventData struct {
 }
 
 func (r *TaskRepositoryImpl) ProcessDurableSleeps(ctx context.Context, tenantId string) (*EventMatchResults, bool, error) {
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 25000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
 		return nil, false, err
@@ -1482,7 +1482,7 @@ func (r *TaskRepositoryImpl) RefreshTimeoutBy(ctx context.Context, tenantId stri
 		return nil, err
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
 		return nil, err
@@ -1508,7 +1508,7 @@ func (r *TaskRepositoryImpl) RefreshTimeoutBy(ctx context.Context, tenantId stri
 }
 
 func (r *TaskRepositoryImpl) ReleaseSlot(ctx context.Context, tenantId, externalId string) (*sqlcv1.V1TaskRuntime, error) {
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
 		return nil, err
@@ -2761,7 +2761,7 @@ func hash(s string) int64 {
 }
 
 func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId string, tasks []TaskIdInsertedAtRetryCount) (*ReplayTasksResult, error) {
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 30000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
 		return nil, err
@@ -3614,7 +3614,7 @@ func (r *TaskRepositoryImpl) ListSignalCompletedEvents(ctx context.Context, tena
 
 func (r *TaskRepositoryImpl) AnalyzeTaskTables(ctx context.Context) error {
 	const timeout = 1000 * 60 * 60 // 60 minute timeout
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, timeout)
+	tx, commit, rollback, err := sqlchelpers.PrepareTxWithStatementTimeout(ctx, r.pool, r.l, timeout)
 
 	if err != nil {
 		return fmt.Errorf("error beginning transaction: %v", err)
@@ -3666,7 +3666,7 @@ func (r *TaskRepositoryImpl) AnalyzeTaskTables(ctx context.Context) error {
 
 func (r *TaskRepositoryImpl) Cleanup(ctx context.Context) (bool, error) {
 	const timeout = 1000 * 60 // 1 minute timeout
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, timeout)
+	tx, commit, rollback, err := sqlchelpers.PrepareTxWithStatementTimeout(ctx, r.pool, r.l, timeout)
 
 	if err != nil {
 		return false, fmt.Errorf("error beginning transaction: %v", err)

--- a/pkg/repository/tenant.go
+++ b/pkg/repository/tenant.go
@@ -495,7 +495,7 @@ func (r *tenantRepository) GetQueueMetrics(ctx context.Context, tenantId string,
 		totalParams.WorkflowIds = uuids
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 60*1000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
 		return nil, err

--- a/pkg/repository/tenant_invite.go
+++ b/pkg/repository/tenant_invite.go
@@ -82,7 +82,7 @@ func (r *tenantInviteRepository) CreateTenantInvite(ctx context.Context, tenantI
 		return nil, err
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
 		return nil, err

--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -832,7 +832,7 @@ func (r *TriggerRepositoryImpl) triggerWorkflows(ctx context.Context, tenantId s
 		}
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
 		return nil, nil, err

--- a/pkg/repository/user.go
+++ b/pkg/repository/user.go
@@ -142,7 +142,7 @@ func (r *userRepository) CreateUser(ctx context.Context, opts *CreateUserOpts) (
 		params.Name = sqlchelpers.TextFromStr(*opts.Name)
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
 		return nil, err
@@ -215,7 +215,7 @@ func (r *userRepository) UpdateUser(ctx context.Context, id string, opts *Update
 		params.Name = sqlchelpers.TextFromStr(*opts.Name)
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 5000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
 		return nil, err

--- a/pkg/repository/workflow.go
+++ b/pkg/repository/workflow.go
@@ -295,7 +295,7 @@ func (r *workflowRepository) PutWorkflowVersion(ctx context.Context, tenantId st
 		return nil, err
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l, 25000)
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

Sets a global statement-level timeout of 30 seconds rather than having each tx individually set a statement timeout, which causes more queries sent to Postgres on each tx. It's still possible to overwrite the connection-level timeout with a statement-level timeout using the new method `PrepareTxWithStatementTimeout`. 

Pretty much all of these tx-level values were chosen magically, either 5, 10, 15, 25, or 30 seconds, except for the intentionally very long-running statements that call `ANALYZE` or handle partitioning. There's not a good reason for the lower values, it's just important that there's some sort of statement-level timeout to avoid a class of edge cases we've seen where queries leak through to Postgres from pgx. 

This should be fairly low-risk; the biggest risk is that a query which was firing on the 5-second timeout is firing on the 30-second timeout as well, but now there might be more queries timing out at the same time which is not great for the DB. 

This was originally part of a set of performance improvements in #2258 and made a minimal impact in some benchmarking. 

## Type of change

- [X] Refactor (non-breaking changes to code which doesn't change any behaviour)