### PR TITLE
revert: UI version removal

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20251229174938_v1_0_67.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20251229174938_v1_0_67.sql
@@ -10,25 +10,20 @@ ALTER TABLE "Tenant"
 
 ALTER TABLE "Tenant"
     ADD CONSTRAINT "Tenant_version_not_v0" CHECK ("version" != 'V0');
-
--- Step 3: Drop uiVersion column and its type
-ALTER TABLE "Tenant"
-    DROP COLUMN "uiVersion";
-
-DROP TYPE "TenantMajorUIVersion";
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
--- Step 1: Recreate the TenantMajorUIVersion type
-CREATE TYPE "TenantMajorUIVersion" AS ENUM (
-    'V0',
-    'V1'
-);
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'TenantMajorUIVersion') THEN
+        CREATE TYPE "TenantMajorUIVersion" AS ENUM ('V0', 'V1');
+    END IF;
+END
+$$;
 
--- Step 2: Add back the uiVersion column
 ALTER TABLE "Tenant"
-    ADD COLUMN "uiVersion" "TenantMajorUIVersion" NOT NULL DEFAULT 'V0';
+    ADD COLUMN IF NOT EXISTS "uiVersion" "TenantMajorUIVersion" NOT NULL DEFAULT 'V0';
 
 -- Step 3: Remove the version constraint and restore default
 ALTER TABLE "Tenant"

--- a/cmd/hatchet-migrate/migrate/migrations/20260106185235_v1_0_68.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260106185235_v1_0_68.sql
@@ -14,4 +14,9 @@ ALTER TABLE "Tenant"
 
 -- +goose Down
 -- +goose StatementBegin
+-- NOTE: Down migration intentionally left empty.
+-- This migration reintroduces the uiVersion column as part of a revert
+-- strategy for databases that may have already run v1_0_67, which removed it.
+-- We do not drop the column on rollback to avoid data loss and ensure
+-- the column remains available going forward.
 -- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20260106185235_v1_0_68.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260106185235_v1_0_68.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'TenantMajorUIVersion') THEN
+        CREATE TYPE "TenantMajorUIVersion" AS ENUM ('V0', 'V1');
+    END IF;
+END
+$$;
+
+ALTER TABLE "Tenant"
+    ADD COLUMN IF NOT EXISTS "uiVersion" "TenantMajorUIVersion" NOT NULL DEFAULT 'V0';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- +goose StatementEnd

--- a/pkg/repository/sqlcv1/models.go
+++ b/pkg/repository/sqlcv1/models.go
@@ -774,6 +774,48 @@ func (ns NullTenantMajorEngineVersion) Value() (driver.Value, error) {
 	return string(ns.TenantMajorEngineVersion), nil
 }
 
+type TenantMajorUIVersion string
+
+const (
+	TenantMajorUIVersionV0 TenantMajorUIVersion = "V0"
+	TenantMajorUIVersionV1 TenantMajorUIVersion = "V1"
+)
+
+func (e *TenantMajorUIVersion) Scan(src interface{}) error {
+	switch s := src.(type) {
+	case []byte:
+		*e = TenantMajorUIVersion(s)
+	case string:
+		*e = TenantMajorUIVersion(s)
+	default:
+		return fmt.Errorf("unsupported scan type for TenantMajorUIVersion: %T", src)
+	}
+	return nil
+}
+
+type NullTenantMajorUIVersion struct {
+	TenantMajorUIVersion TenantMajorUIVersion `json:"TenantMajorUIVersion"`
+	Valid                bool                 `json:"valid"` // Valid is true if TenantMajorUIVersion is not NULL
+}
+
+// Scan implements the Scanner interface.
+func (ns *NullTenantMajorUIVersion) Scan(value interface{}) error {
+	if value == nil {
+		ns.TenantMajorUIVersion, ns.Valid = "", false
+		return nil
+	}
+	ns.Valid = true
+	return ns.TenantMajorUIVersion.Scan(value)
+}
+
+// Value implements the driver Valuer interface.
+func (ns NullTenantMajorUIVersion) Value() (driver.Value, error) {
+	if !ns.Valid {
+		return nil, nil
+	}
+	return string(ns.TenantMajorUIVersion), nil
+}
+
 type TenantMemberRole string
 
 const (
@@ -2724,6 +2766,7 @@ type Tenant struct {
 	UpdatedAt             pgtype.Timestamp         `json:"updatedAt"`
 	DeletedAt             pgtype.Timestamp         `json:"deletedAt"`
 	Version               TenantMajorEngineVersion `json:"version"`
+	UiVersion             TenantMajorUIVersion     `json:"uiVersion"`
 	Name                  string                   `json:"name"`
 	Slug                  string                   `json:"slug"`
 	AnalyticsOptOut       bool                     `json:"analyticsOptOut"`

--- a/pkg/repository/sqlcv1/tenants.sql.go
+++ b/pkg/repository/sqlcv1/tenants.sql.go
@@ -102,7 +102,7 @@ VALUES (
     $6::jsonb,
     $7::"TenantEnvironment"
 )
-RETURNING id, "createdAt", "updatedAt", "deletedAt", version, name, slug, "analyticsOptOut", "alertMemberEmails", "controllerPartitionId", "workerPartitionId", "dataRetentionPeriod", "schedulerPartitionId", "canUpgradeV1", "onboardingData", environment
+RETURNING id, "createdAt", "updatedAt", "deletedAt", version, "uiVersion", name, slug, "analyticsOptOut", "alertMemberEmails", "controllerPartitionId", "workerPartitionId", "dataRetentionPeriod", "schedulerPartitionId", "canUpgradeV1", "onboardingData", environment
 `
 
 type CreateTenantParams struct {
@@ -132,6 +132,7 @@ func (q *Queries) CreateTenant(ctx context.Context, db DBTX, arg CreateTenantPar
 		&i.UpdatedAt,
 		&i.DeletedAt,
 		&i.Version,
+		&i.UiVersion,
 		&i.Name,
 		&i.Slug,
 		&i.AnalyticsOptOut,
@@ -382,7 +383,7 @@ func (q *Queries) GetEmailGroups(ctx context.Context, db DBTX, tenantid pgtype.U
 
 const getInternalTenantForController = `-- name: GetInternalTenantForController :one
 SELECT
-    id, "createdAt", "updatedAt", "deletedAt", version, name, slug, "analyticsOptOut", "alertMemberEmails", "controllerPartitionId", "workerPartitionId", "dataRetentionPeriod", "schedulerPartitionId", "canUpgradeV1", "onboardingData", environment
+    id, "createdAt", "updatedAt", "deletedAt", version, "uiVersion", name, slug, "analyticsOptOut", "alertMemberEmails", "controllerPartitionId", "workerPartitionId", "dataRetentionPeriod", "schedulerPartitionId", "canUpgradeV1", "onboardingData", environment
 FROM
     "Tenant" as tenants
 WHERE
@@ -399,6 +400,7 @@ func (q *Queries) GetInternalTenantForController(ctx context.Context, db DBTX, c
 		&i.UpdatedAt,
 		&i.DeletedAt,
 		&i.Version,
+		&i.UiVersion,
 		&i.Name,
 		&i.Slug,
 		&i.AnalyticsOptOut,
@@ -535,7 +537,7 @@ func (q *Queries) GetTenantAlertingSettings(ctx context.Context, db DBTX, tenant
 
 const getTenantByID = `-- name: GetTenantByID :one
 SELECT
-    id, "createdAt", "updatedAt", "deletedAt", version, name, slug, "analyticsOptOut", "alertMemberEmails", "controllerPartitionId", "workerPartitionId", "dataRetentionPeriod", "schedulerPartitionId", "canUpgradeV1", "onboardingData", environment
+    id, "createdAt", "updatedAt", "deletedAt", version, "uiVersion", name, slug, "analyticsOptOut", "alertMemberEmails", "controllerPartitionId", "workerPartitionId", "dataRetentionPeriod", "schedulerPartitionId", "canUpgradeV1", "onboardingData", environment
 FROM
     "Tenant" as tenants
 WHERE
@@ -552,6 +554,7 @@ func (q *Queries) GetTenantByID(ctx context.Context, db DBTX, id pgtype.UUID) (*
 		&i.UpdatedAt,
 		&i.DeletedAt,
 		&i.Version,
+		&i.UiVersion,
 		&i.Name,
 		&i.Slug,
 		&i.AnalyticsOptOut,
@@ -569,7 +572,7 @@ func (q *Queries) GetTenantByID(ctx context.Context, db DBTX, id pgtype.UUID) (*
 
 const getTenantBySlug = `-- name: GetTenantBySlug :one
 SELECT
-    id, "createdAt", "updatedAt", "deletedAt", version, name, slug, "analyticsOptOut", "alertMemberEmails", "controllerPartitionId", "workerPartitionId", "dataRetentionPeriod", "schedulerPartitionId", "canUpgradeV1", "onboardingData", environment
+    id, "createdAt", "updatedAt", "deletedAt", version, "uiVersion", name, slug, "analyticsOptOut", "alertMemberEmails", "controllerPartitionId", "workerPartitionId", "dataRetentionPeriod", "schedulerPartitionId", "canUpgradeV1", "onboardingData", environment
 FROM
     "Tenant" as tenants
 WHERE
@@ -586,6 +589,7 @@ func (q *Queries) GetTenantBySlug(ctx context.Context, db DBTX, slug string) (*T
 		&i.UpdatedAt,
 		&i.DeletedAt,
 		&i.Version,
+		&i.UiVersion,
 		&i.Name,
 		&i.Slug,
 		&i.AnalyticsOptOut,
@@ -894,7 +898,7 @@ func (q *Queries) ListTenantMembers(ctx context.Context, db DBTX, tenantid pgtyp
 
 const listTenants = `-- name: ListTenants :many
 SELECT
-    id, "createdAt", "updatedAt", "deletedAt", version, name, slug, "analyticsOptOut", "alertMemberEmails", "controllerPartitionId", "workerPartitionId", "dataRetentionPeriod", "schedulerPartitionId", "canUpgradeV1", "onboardingData", environment
+    id, "createdAt", "updatedAt", "deletedAt", version, "uiVersion", name, slug, "analyticsOptOut", "alertMemberEmails", "controllerPartitionId", "workerPartitionId", "dataRetentionPeriod", "schedulerPartitionId", "canUpgradeV1", "onboardingData", environment
 FROM
     "Tenant" as tenants
 WHERE
@@ -916,6 +920,7 @@ func (q *Queries) ListTenants(ctx context.Context, db DBTX) ([]*Tenant, error) {
 			&i.UpdatedAt,
 			&i.DeletedAt,
 			&i.Version,
+			&i.UiVersion,
 			&i.Name,
 			&i.Slug,
 			&i.AnalyticsOptOut,
@@ -940,7 +945,7 @@ func (q *Queries) ListTenants(ctx context.Context, db DBTX) ([]*Tenant, error) {
 
 const listTenantsByControllerPartitionId = `-- name: ListTenantsByControllerPartitionId :many
 SELECT
-    id, "createdAt", "updatedAt", "deletedAt", version, name, slug, "analyticsOptOut", "alertMemberEmails", "controllerPartitionId", "workerPartitionId", "dataRetentionPeriod", "schedulerPartitionId", "canUpgradeV1", "onboardingData", environment
+    id, "createdAt", "updatedAt", "deletedAt", version, "uiVersion", name, slug, "analyticsOptOut", "alertMemberEmails", "controllerPartitionId", "workerPartitionId", "dataRetentionPeriod", "schedulerPartitionId", "canUpgradeV1", "onboardingData", environment
 FROM
     "Tenant" as tenants
 WHERE
@@ -969,6 +974,7 @@ func (q *Queries) ListTenantsByControllerPartitionId(ctx context.Context, db DBT
 			&i.UpdatedAt,
 			&i.DeletedAt,
 			&i.Version,
+			&i.UiVersion,
 			&i.Name,
 			&i.Slug,
 			&i.AnalyticsOptOut,
@@ -993,7 +999,7 @@ func (q *Queries) ListTenantsByControllerPartitionId(ctx context.Context, db DBT
 
 const listTenantsBySchedulerPartitionId = `-- name: ListTenantsBySchedulerPartitionId :many
 SELECT
-    id, "createdAt", "updatedAt", "deletedAt", version, name, slug, "analyticsOptOut", "alertMemberEmails", "controllerPartitionId", "workerPartitionId", "dataRetentionPeriod", "schedulerPartitionId", "canUpgradeV1", "onboardingData", environment
+    id, "createdAt", "updatedAt", "deletedAt", version, "uiVersion", name, slug, "analyticsOptOut", "alertMemberEmails", "controllerPartitionId", "workerPartitionId", "dataRetentionPeriod", "schedulerPartitionId", "canUpgradeV1", "onboardingData", environment
 FROM
     "Tenant" as tenants
 WHERE
@@ -1022,6 +1028,7 @@ func (q *Queries) ListTenantsBySchedulerPartitionId(ctx context.Context, db DBTX
 			&i.UpdatedAt,
 			&i.DeletedAt,
 			&i.Version,
+			&i.UiVersion,
 			&i.Name,
 			&i.Slug,
 			&i.AnalyticsOptOut,
@@ -1046,7 +1053,7 @@ func (q *Queries) ListTenantsBySchedulerPartitionId(ctx context.Context, db DBTX
 
 const listTenantsByTenantWorkerPartitionId = `-- name: ListTenantsByTenantWorkerPartitionId :many
 SELECT
-    id, "createdAt", "updatedAt", "deletedAt", version, name, slug, "analyticsOptOut", "alertMemberEmails", "controllerPartitionId", "workerPartitionId", "dataRetentionPeriod", "schedulerPartitionId", "canUpgradeV1", "onboardingData", environment
+    id, "createdAt", "updatedAt", "deletedAt", version, "uiVersion", name, slug, "analyticsOptOut", "alertMemberEmails", "controllerPartitionId", "workerPartitionId", "dataRetentionPeriod", "schedulerPartitionId", "canUpgradeV1", "onboardingData", environment
 FROM
     "Tenant" as tenants
 WHERE
@@ -1075,6 +1082,7 @@ func (q *Queries) ListTenantsByTenantWorkerPartitionId(ctx context.Context, db D
 			&i.UpdatedAt,
 			&i.DeletedAt,
 			&i.Version,
+			&i.UiVersion,
 			&i.Name,
 			&i.Slug,
 			&i.AnalyticsOptOut,
@@ -1457,7 +1465,7 @@ SET
     "version" = COALESCE($4::"TenantMajorEngineVersion", "version")
 WHERE
     "id" = $5::uuid
-RETURNING id, "createdAt", "updatedAt", "deletedAt", version, name, slug, "analyticsOptOut", "alertMemberEmails", "controllerPartitionId", "workerPartitionId", "dataRetentionPeriod", "schedulerPartitionId", "canUpgradeV1", "onboardingData", environment
+RETURNING id, "createdAt", "updatedAt", "deletedAt", version, "uiVersion", name, slug, "analyticsOptOut", "alertMemberEmails", "controllerPartitionId", "workerPartitionId", "dataRetentionPeriod", "schedulerPartitionId", "canUpgradeV1", "onboardingData", environment
 `
 
 type UpdateTenantParams struct {
@@ -1483,6 +1491,7 @@ func (q *Queries) UpdateTenant(ctx context.Context, db DBTX, arg UpdateTenantPar
 		&i.UpdatedAt,
 		&i.DeletedAt,
 		&i.Version,
+		&i.UiVersion,
 		&i.Name,
 		&i.Slug,
 		&i.AnalyticsOptOut,

--- a/sql/schema/v0.sql
+++ b/sql/schema/v0.sql
@@ -596,6 +596,11 @@ CREATE TYPE "TenantMajorEngineVersion" AS ENUM (
     'V1'
 );
 
+CREATE TYPE "TenantMajorUIVersion" AS ENUM (
+    'V0',
+    'V1'
+);
+
 -- CreateTable
 CREATE TABLE "Tenant" (
     "id" UUID NOT NULL,
@@ -603,6 +608,7 @@ CREATE TABLE "Tenant" (
     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "deletedAt" TIMESTAMP(3),
     "version" "TenantMajorEngineVersion" NOT NULL DEFAULT 'V1',
+    "uiVersion" "TenantMajorUIVersion" NOT NULL DEFAULT 'V0',
     "name" TEXT NOT NULL,
     "slug" TEXT NOT NULL,
     "analyticsOptOut" BOOLEAN NOT NULL DEFAULT false,


### PR DESCRIPTION
# Description

Reverts changes for UI version removal as it causes errors `could not list tenants: ERROR: column \"uiVersion\" does not exist` during a rolling deploy, when old engines are polling the tenant tables. We'll need to wait with this change until we rebuild our core tables. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)