### PR TITLE
Fix: Payload location handling in reconciliation logic

### DIFF
--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -2998,6 +2998,7 @@ func (p *OLAPRepositoryImpl) processOLAPPayloadCutoverBatch(ctx context.Context,
 			InsertedAt:          payload.InsertedAt,
 			ExternalID:          sqlchelpers.UUIDFromStr(string(externalId)),
 			ExternalLocationKey: string(key),
+			Location:            sqlcv1.V1PayloadLocationOlapEXTERNAL,
 		})
 	}
 
@@ -3243,16 +3244,17 @@ func (p *OLAPRepositoryImpl) processSinglePartition(ctx context.Context, process
 			return fmt.Errorf("failed to diff source and target partitions: %w", err)
 		}
 
-		missingPayloadsToInsert := make([]sqlcv1.CutoverOLAPPayloadToInsert, len(missingRows))
+		missingPayloadsToInsert := make([]sqlcv1.CutoverOLAPPayloadToInsert, 0, len(missingRows))
 
-		for i, p := range missingRows {
-			missingPayloadsToInsert[i] = sqlcv1.CutoverOLAPPayloadToInsert{
+		for _, p := range missingRows {
+			missingPayloadsToInsert = append(missingPayloadsToInsert, sqlcv1.CutoverOLAPPayloadToInsert{
 				TenantID:            p.TenantID,
 				InsertedAt:          p.InsertedAt,
 				ExternalID:          p.ExternalID,
 				ExternalLocationKey: p.ExternalLocationKey,
 				InlineContent:       p.InlineContent,
-			}
+				Location:            p.Location,
+			})
 		}
 
 		_, err = sqlcv1.InsertCutOverOLAPPayloadsIntoTempTable(ctx, p.pool, tempPartitionName, missingPayloadsToInsert)

--- a/pkg/repository/sqlcv1/olap-overwrite.sql.go
+++ b/pkg/repository/sqlcv1/olap-overwrite.sql.go
@@ -460,6 +460,7 @@ type CutoverOLAPPayloadToInsert struct {
 	ExternalID          pgtype.UUID
 	ExternalLocationKey string
 	InlineContent       []byte
+	Location            V1PayloadLocationOlap
 }
 
 type InsertCutOverOLAPPayloadsIntoTempTableRow struct {
@@ -480,7 +481,7 @@ func InsertCutOverOLAPPayloadsIntoTempTable(ctx context.Context, tx DBTX, tableN
 		externalIds = append(externalIds, payload.ExternalID)
 		tenantIds = append(tenantIds, payload.TenantID)
 		insertedAts = append(insertedAts, payload.InsertedAt)
-		locations = append(locations, string(V1PayloadLocationOlapEXTERNAL))
+		locations = append(locations, string(payload.Location))
 		externalLocationKeys = append(externalLocationKeys, string(payload.ExternalLocationKey))
 		inlineContents = append(inlineContents, payload.InlineContent)
 	}

--- a/pkg/repository/sqlcv1/payload-store-overwrite.sql.go
+++ b/pkg/repository/sqlcv1/payload-store-overwrite.sql.go
@@ -15,6 +15,7 @@ type CutoverPayloadToInsert struct {
 	Type                V1PayloadType
 	ExternalLocationKey string
 	InlineContent       []byte
+	Location            V1PayloadLocation
 }
 
 type InsertCutOverPayloadsIntoTempTableRow struct {


### PR DESCRIPTION
# Description

Fixes a bug in reconciliation logic with inline payloads being treated as external

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
