### PR TITLE
Fix: Chunk and recursively retry too-large message sends

### DIFF
--- a/internal/msgqueue/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/rabbitmq/rabbitmq.go
@@ -361,6 +361,10 @@ func (t *MessageQueueImpl) pubMessage(ctx context.Context, q msgqueue.Queue, msg
 	bodySize := len(body)
 
 	if bodySize > t.maxPayloadSize {
+		if len(msg.Payloads) == 1 {
+			return fmt.Errorf("message payload size %d exceeds maximum allowed size of %d bytes", bodySize, t.maxPayloadSize)
+		}
+
 		// split the payload in half each time
 		// can change this value to configure the number of chunks we split the payload
 		// into. more chunks means more messages published, but a smaller likelihood of needing

--- a/internal/msgqueue/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/rabbitmq/rabbitmq.go
@@ -362,7 +362,10 @@ func (t *MessageQueueImpl) pubMessage(ctx context.Context, q msgqueue.Queue, msg
 
 	if bodySize > t.maxPayloadSize {
 		if len(msg.Payloads) == 1 {
-			return fmt.Errorf("message payload size %d exceeds maximum allowed size of %d bytes", bodySize, t.maxPayloadSize)
+			err := fmt.Errorf("message size %d bytes exceeds maximum allowed size of %d bytes", bodySize, t.maxPayloadSize)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "message size exceeds maximum allowed size")
+			return err
 		}
 
 		// split the payload in half each time


### PR DESCRIPTION
# Description

If we try to send a message over the internal queue that's too large, split it in chunks and retry each chunk sequentially.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
