### PR TITLE
Hotfix: Add back worker id to count params

### DIFF
--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -704,6 +704,7 @@ func (r *OLAPRepositoryImpl) ListTasks(ctx context.Context, tenantId string, opt
 
 	if workerId != nil {
 		params.WorkerId = sqlchelpers.UUIDFromStr(workerId.String())
+		countParams.WorkerId = sqlchelpers.UUIDFromStr(workerId.String())
 	}
 
 	for key, value := range opts.AdditionalMetadata {


### PR DESCRIPTION
# Description

Think this got lost in some of the query optimization shuffle or something

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
