### PR TITLE
feat(python-sdk): add SwiftAPI integration for execution governance

### DIFF
--- a/sdks/python/hatchet_sdk/__init__.py
+++ b/sdks/python/hatchet_sdk/__init__.py
@@ -156,6 +156,7 @@ from hatchet_sdk.exceptions import (
 from hatchet_sdk.features.cel import CELEvaluationResult, CELFailure, CELSuccess
 from hatchet_sdk.features.runs import BulkCancelReplayOpts, RunFilter
 from hatchet_sdk.hatchet import Hatchet
+from hatchet_sdk.integrations.swiftapi import SwiftAPIConfig
 from hatchet_sdk.runnables.task import Depends, Task
 from hatchet_sdk.runnables.types import (
     ConcurrencyExpression,
@@ -251,6 +252,7 @@ __all__ = [
     "StepRunEventType",
     "StepRunStatus",
     "StickyStrategy",
+    "SwiftAPIConfig",
     "Task",
     "TaskDefaults",
     "TaskRunError",

--- a/sdks/python/hatchet_sdk/hatchet.py
+++ b/sdks/python/hatchet_sdk/hatchet.py
@@ -23,6 +23,7 @@ from hatchet_sdk.features.scheduled import ScheduledClient
 from hatchet_sdk.features.stubs import StubsClient
 from hatchet_sdk.features.workers import WorkersClient
 from hatchet_sdk.features.workflows import WorkflowsClient
+from hatchet_sdk.integrations.swiftapi import SwiftAPIConfig
 from hatchet_sdk.labels import DesiredWorkerLabel
 from hatchet_sdk.logger import logger
 from hatchet_sdk.rate_limit import RateLimit
@@ -183,6 +184,7 @@ class Hatchet:
         labels: dict[str, str | int] | None = None,
         workflows: list[BaseWorkflow[Any]] | None = None,
         lifespan: LifespanFn | None = None,
+        swiftapi: SwiftAPIConfig | None = None,
     ) -> Worker:
         """
         Create a Hatchet worker on which to run workflows.
@@ -198,6 +200,8 @@ class Hatchet:
         :param workflows: A list of workflows to register on the worker, as a shorthand for calling `register_workflow` on each or `register_workflows` on all of them.
 
         :param lifespan: A lifespan function to run on the worker. This function will be called when the worker is started, and can be used to perform any setup or teardown tasks.
+
+        :param swiftapi: Optional SwiftAPI configuration for execution governance. When provided, all task executions will be verified through SwiftAPI before running.
 
         :returns: The created `Worker` object, which exposes an instance method `start` which can be called to start the worker.
         """
@@ -217,6 +221,7 @@ class Hatchet:
             owned_loop=loop is None,
             workflows=workflows,
             lifespan=lifespan,
+            swiftapi=swiftapi,
         )
 
     @overload

--- a/sdks/python/hatchet_sdk/integrations/__init__.py
+++ b/sdks/python/hatchet_sdk/integrations/__init__.py
@@ -1,0 +1,1 @@
+# Hatchet SDK Integrations

--- a/sdks/python/hatchet_sdk/integrations/swiftapi.py
+++ b/sdks/python/hatchet_sdk/integrations/swiftapi.py
@@ -1,0 +1,137 @@
+"""
+SwiftAPI integration for Hatchet SDK.
+
+Provides execution governance for AI agent task execution. When enabled,
+every task execution is verified by SwiftAPI before running, creating
+cryptographic attestations that prove authorization.
+
+Usage:
+    from hatchet_sdk import Hatchet
+    from hatchet_sdk.integrations.swiftapi import SwiftAPIConfig
+
+    hatchet = Hatchet()
+
+    # Enable SwiftAPI for a worker
+    worker = hatchet.worker(
+        "my-worker",
+        slots=10,
+        swiftapi=SwiftAPIConfig(
+            api_key="swiftapi_live_...",
+        ),
+    )
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from hatchet_sdk.logger import logger
+
+try:
+    from swiftapi import Enforcement, PolicyViolation, SwiftAPI
+
+    SWIFTAPI_AVAILABLE = True
+except ImportError:
+    SWIFTAPI_AVAILABLE = False
+    SwiftAPI = None  # type: ignore[assignment, misc]
+    Enforcement = None  # type: ignore[assignment, misc]
+    PolicyViolation = None  # type: ignore[assignment, misc]
+
+
+@dataclass
+class SwiftAPIConfig:
+    """Configuration for SwiftAPI integration.
+
+    :param api_key: SwiftAPI API key (starts with swiftapi_live_ or swiftapi_test_)
+    :param paranoid: If True, always verify attestation revocation online
+    :param verbose: If True, print verification status messages
+    :param action_prefix: Prefix for action types (default: "hatchet")
+    :param on_violation: Callback when policy violation occurs
+    """
+
+    api_key: str
+    paranoid: bool = False
+    verbose: bool = False
+    action_prefix: str = "hatchet"
+    on_violation: Callable[[str, str, Exception], None] | None = None
+    _enforcement: Any = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if not SWIFTAPI_AVAILABLE:
+            raise ImportError(
+                "swiftapi-python is not installed. Install it with: pip install swiftapi-python"
+            )
+
+        if not self.api_key:
+            raise ValueError("SwiftAPI api_key is required")
+
+        if not self.api_key.startswith("swiftapi_"):
+            raise ValueError(
+                "Invalid SwiftAPI key format. Keys should start with 'swiftapi_live_' or 'swiftapi_test_'"
+            )
+
+        client = SwiftAPI(key=self.api_key)
+        self._enforcement = Enforcement(
+            client=client,
+            paranoid=self.paranoid,
+            verbose=self.verbose,
+        )
+
+    def verify_task_execution(
+        self,
+        action_name: str,
+        workflow_name: str,
+        workflow_run_id: str,
+        step_run_id: str,
+        worker_id: str,
+        tenant_id: str,
+        retry_count: int,
+    ) -> dict[str, Any]:
+        """Verify task execution with SwiftAPI.
+
+        :param action_name: The action being executed
+        :param workflow_name: Name of the workflow
+        :param workflow_run_id: Workflow run ID
+        :param step_run_id: Step run ID
+        :param worker_id: Worker ID executing the task
+        :param tenant_id: Tenant ID
+        :param retry_count: Current retry count
+
+        :returns: Attestation data if approved
+
+        :raises PolicyViolation: If the action is denied by policy
+        """
+        action_type = f"{self.action_prefix}.task.execute"
+        intent = f"Execute task '{action_name}' in workflow '{workflow_name}'"
+
+        params = {
+            "action_name": action_name,
+            "workflow_name": workflow_name,
+            "workflow_run_id": workflow_run_id,
+            "step_run_id": step_run_id,
+            "worker_id": worker_id,
+            "tenant_id": tenant_id,
+            "retry_count": retry_count,
+        }
+
+        try:
+            return self._enforcement.client.verify(
+                action_type=action_type,
+                intent=intent,
+                params=params,
+            )
+        except PolicyViolation as e:
+            logger.warning(
+                "SwiftAPI denied task execution: action=%s, workflow=%s, reason=%s",
+                action_name,
+                workflow_name,
+                getattr(e, "denial_reason", str(e)),
+            )
+            if self.on_violation:
+                self.on_violation(action_name, workflow_name, e)
+            raise
+
+
+def is_swiftapi_available() -> bool:
+    """Check if SwiftAPI SDK is installed."""
+    return SWIFTAPI_AVAILABLE

--- a/sdks/python/hatchet_sdk/worker/runner/run_loop_manager.py
+++ b/sdks/python/hatchet_sdk/worker/runner/run_loop_manager.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from multiprocessing import Queue
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from hatchet_sdk.client import Client
 from hatchet_sdk.config import ClientConfig
@@ -12,6 +12,9 @@ from hatchet_sdk.utils.typing import STOP_LOOP, STOP_LOOP_TYPE
 from hatchet_sdk.worker.action_listener_process import ActionEvent
 from hatchet_sdk.worker.runner.runner import Runner
 from hatchet_sdk.worker.runner.utils.capture_logs import AsyncLogSender, capture_logs
+
+if TYPE_CHECKING:
+    from hatchet_sdk.integrations.swiftapi import SwiftAPIConfig
 
 T = TypeVar("T")
 
@@ -30,6 +33,7 @@ class WorkerActionRunLoopManager:
         debug: bool,
         labels: dict[str, str | int] | None,
         lifespan_context: Any | None,
+        swiftapi: "SwiftAPIConfig | None" = None,
     ) -> None:
         self.name = name
         self.action_registry = action_registry
@@ -42,6 +46,7 @@ class WorkerActionRunLoopManager:
         self.debug = debug
         self.labels = labels
         self.lifespan_context = lifespan_context
+        self.swiftapi = swiftapi
 
         if self.debug:
             logger.setLevel(logging.DEBUG)
@@ -96,6 +101,7 @@ class WorkerActionRunLoopManager:
             self.labels,
             self.lifespan_context,
             self.log_sender,
+            self.swiftapi,
         )
 
         logger.debug(f"'{self.name}' waiting for {list(self.action_registry.keys())}")

--- a/sdks/python/hatchet_sdk/worker/worker.py
+++ b/sdks/python/hatchet_sdk/worker/worker.py
@@ -25,6 +25,7 @@ from hatchet_sdk.client import Client
 from hatchet_sdk.config import ClientConfig
 from hatchet_sdk.contracts.v1.workflows_pb2 import CreateWorkflowVersionRequest
 from hatchet_sdk.exceptions import LifespanSetupError, LoopAlreadyRunningError
+from hatchet_sdk.integrations.swiftapi import SwiftAPIConfig
 from hatchet_sdk.logger import logger
 from hatchet_sdk.runnables.action import Action
 from hatchet_sdk.runnables.contextvars import task_count
@@ -89,9 +90,11 @@ class Worker:
         handle_kill: bool = True,
         workflows: list[BaseWorkflow[Any]] | None = None,
         lifespan: LifespanFn | None = None,
+        swiftapi: SwiftAPIConfig | None = None,
     ) -> None:
         self.config = config
         self.name = self.config.apply_namespace(name)
+        self.swiftapi = swiftapi
         self.slots = slots
         self.durable_slots = durable_slots
         self.debug = debug
@@ -324,6 +327,7 @@ class Worker:
                 self.client.debug,
                 self.labels,
                 lifespan_context,
+                self.swiftapi,
             )
 
         raise RuntimeError("event loop not set, cannot start action runner")


### PR DESCRIPTION
## Description

Add optional SwiftAPI integration to the Python SDK worker that enables cryptographic attestation of task executions. When configured, every task execution is verified by SwiftAPI before running.

## Changes

- Add `SwiftAPIConfig` dataclass for configuration
- Pass swiftapi config through worker → run_loop_manager → runner
- Verify task execution in `async_wrapped_action_func` before running
- Export `SwiftAPIConfig` from `hatchet_sdk` package

## Usage

```python
from hatchet_sdk import Hatchet, SwiftAPIConfig

hatchet = Hatchet()

worker = hatchet.worker(
    "my-worker",
    swiftapi=SwiftAPIConfig(api_key="swiftapi_live_..."),
)
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Test plan

- Requires `swiftapi-python` package to be installed
- When enabled, all task executions are verified through SwiftAPI before running
- PolicyViolation exceptions are logged and re-raised