### PR TITLE
fix: regression on v0 `PutWorkflow` for scheduling timeout

### DIFF
--- a/internal/services/admin/server.go
+++ b/internal/services/admin/server.go
@@ -210,7 +210,7 @@ func getCreateWorkflowOpts(req *contracts.PutWorkflowRequest) (*v1.CreateWorkflo
 		allSteps = append(allSteps, job.Steps...)
 	}
 
-	tasks, err := getCreateTaskOpts(allSteps, "DEFAULT")
+	tasks, err := getCreateTaskOpts(allSteps, req.Opts.ScheduleTimeout)
 	if err != nil {
 		if errors.Is(err, v1.ErrDagParentNotFound) {
 			return nil, status.Error(
@@ -224,7 +224,7 @@ func getCreateWorkflowOpts(req *contracts.PutWorkflowRequest) (*v1.CreateWorkflo
 	var onFailureTask *v1.CreateStepOpts
 
 	if req.Opts.OnFailureJob != nil {
-		onFailureTasks, err := getCreateTaskOpts(req.Opts.OnFailureJob.Steps, "ON_FAILURE")
+		onFailureTasks, err := getCreateTaskOpts(req.Opts.OnFailureJob.Steps, req.Opts.ScheduleTimeout)
 		if err != nil {
 			return nil, err
 		}
@@ -286,7 +286,7 @@ func getCreateWorkflowOpts(req *contracts.PutWorkflowRequest) (*v1.CreateWorkflo
 	}, nil
 }
 
-func getCreateTaskOpts(steps []*contracts.CreateWorkflowStepOpts, kind string) ([]v1.CreateStepOpts, error) {
+func getCreateTaskOpts(steps []*contracts.CreateWorkflowStepOpts, scheduleTimeout *string) ([]v1.CreateStepOpts, error) {
 	if steps == nil {
 		return nil, fmt.Errorf("steps list cannot be nil")
 	}
@@ -349,6 +349,7 @@ func getCreateTaskOpts(steps []*contracts.CreateWorkflowStepOpts, kind string) (
 			DesiredWorkerLabels: affinity,
 			TriggerConditions:   make([]v1.CreateStepMatchConditionOpt, 0),
 			RateLimits:          make([]v1.CreateWorkflowStepRateLimitOpts, 0),
+			ScheduleTimeout:     scheduleTimeout,
 		}
 
 		if step.Parents == nil {


### PR DESCRIPTION
# Description

Very old SDKs that use the v0 PutWorkflow method see a regression on setting the workflow-level scheduling timeout. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)