### PR TITLE
feat(cli): run hatchet locally

### DIFF
--- a/cmd/hatchet-cli/.goreleaser.yml
+++ b/cmd/hatchet-cli/.goreleaser.yml
@@ -26,8 +26,54 @@ builds:
       - -X github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli.Version={{.Version}}
     mod_timestamp: "{{ .CommitTimestamp }}"
 
+  - id: hatchet-api
+    dir: ../hatchet-api
+    main: ./main.go
+    binary: hatchet-api
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    goamd64:
+      - v1
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
+  - id: hatchet-engine
+    dir: ../hatchet-engine
+    main: ./main.go
+    binary: hatchet-engine
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    goamd64:
+      - v1
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
 archives:
   - id: hatchet
+    builds:
+      - hatchet
     formats:
       - tar.gz
     name_template: >-
@@ -46,6 +92,46 @@ archives:
       - LICENSE*
       - README*
       - CHANGELOG*
+
+  - id: hatchet-api
+    builds:
+      - hatchet-api
+    formats:
+      - tar.gz
+    name_template: >-
+      hatchet-api_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    files:
+      - none*
+
+  - id: hatchet-engine
+    builds:
+      - hatchet-engine
+    formats:
+      - tar.gz
+    name_template: >-
+      hatchet-engine_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    files:
+      - none*
 
 checksum:
   name_template: "checksums.txt"

--- a/cmd/hatchet-cli/.goreleaser.yml
+++ b/cmd/hatchet-cli/.goreleaser.yml
@@ -70,6 +70,50 @@ builds:
       - -s -w
     mod_timestamp: "{{ .CommitTimestamp }}"
 
+  - id: hatchet-admin
+    dir: ../hatchet-admin
+    main: ./main.go
+    binary: hatchet-admin
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    goamd64:
+      - v1
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
+  - id: hatchet-migrate
+    dir: ../hatchet-migrate
+    main: ./main.go
+    binary: hatchet-migrate
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    goamd64:
+      - v1
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
 archives:
   - id: hatchet
     builds:
@@ -118,6 +162,42 @@ archives:
       - tar.gz
     name_template: >-
       hatchet-engine_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+  - id: hatchet-admin
+    builds:
+      - hatchet-admin
+    formats:
+      - tar.gz
+    name_template: >-
+      hatchet-admin_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+  - id: hatchet-migrate
+    builds:
+      - hatchet-migrate
+    formats:
+      - tar.gz
+    name_template: >-
+      hatchet-migrate_
       {{- .Version }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64

--- a/cmd/hatchet-cli/.goreleaser.yml
+++ b/cmd/hatchet-cli/.goreleaser.yml
@@ -110,8 +110,6 @@ archives:
       - goos: windows
         formats:
           - zip
-    files:
-      - none*
 
   - id: hatchet-engine
     builds:
@@ -130,8 +128,6 @@ archives:
       - goos: windows
         formats:
           - zip
-    files:
-      - none*
 
 checksum:
   name_template: "checksums.txt"

--- a/cmd/hatchet-cli/cli/internal/drivers/local/build.go
+++ b/cmd/hatchet-cli/cli/internal/drivers/local/build.go
@@ -1,0 +1,105 @@
+package local
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/styles"
+)
+
+const hatchetModule = "github.com/hatchet-dev/hatchet"
+
+// requiredBinaries are the binaries needed for local mode
+var requiredBinaries = []string{
+	"hatchet-api",
+	"hatchet-engine",
+	"hatchet-migrate",
+	"hatchet-admin",
+}
+
+// DetectRepoRoot walks up from the current directory looking for the hatchet go.mod
+func DetectRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("could not get working directory: %w", err)
+	}
+
+	for {
+		goMod := filepath.Join(dir, "go.mod")
+		if data, err := os.ReadFile(goMod); err == nil {
+			for _, line := range strings.Split(string(data), "\n") {
+				line = strings.TrimSpace(line)
+				if strings.HasPrefix(line, "module ") {
+					mod := strings.TrimSpace(strings.TrimPrefix(line, "module"))
+					if mod == hatchetModule {
+						return dir, nil
+					}
+				}
+			}
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	return "", fmt.Errorf("not inside the hatchet repository (looked for go.mod with module %s)", hatchetModule)
+}
+
+// BuildAllBinaries builds all required hatchet binaries from source into the
+// download cache, keyed by the given version. After this, 'hatchet server start --local'
+// will find them via the normal EnsureBinary cache lookup.
+func BuildAllBinaries(ctx context.Context, repoRoot, version string) error {
+	downloader, err := NewBinaryDownloader()
+	if err != nil {
+		return fmt.Errorf("failed to create binary downloader: %w", err)
+	}
+
+	// Normalize version
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+
+	versionDir := filepath.Join(downloader.cacheDir, version)
+	if err := os.MkdirAll(versionDir, 0755); err != nil {
+		return fmt.Errorf("failed to create version directory: %w", err)
+	}
+
+	fmt.Println(styles.InfoMessage(fmt.Sprintf("Building binaries into cache (%s)...", versionDir)))
+
+	for _, name := range requiredBinaries {
+		if err := buildBinary(ctx, repoRoot, name, versionDir); err != nil {
+			return err
+		}
+	}
+
+	fmt.Println(styles.SuccessMessage("All binaries built successfully"))
+	return nil
+}
+
+// buildBinary builds a single hatchet binary from source
+func buildBinary(ctx context.Context, repoRoot, name, outputDir string) error {
+	outputPath := filepath.Join(outputDir, name)
+	pkg := fmt.Sprintf("./cmd/%s", name)
+
+	fmt.Println(styles.InfoMessage(fmt.Sprintf("Building %s...", name)))
+
+	cmd := exec.CommandContext(ctx, "go", "build", "-o", outputPath, pkg)
+	cmd.Dir = repoRoot
+	cmd.Env = os.Environ()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to build %s: %w", name, err)
+	}
+
+	fmt.Println(styles.SuccessMessage(fmt.Sprintf("Built %s", name)))
+	return nil
+}

--- a/cmd/hatchet-cli/cli/internal/drivers/local/config.go
+++ b/cmd/hatchet-cli/cli/internal/drivers/local/config.go
@@ -1,0 +1,182 @@
+package local
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/hatchet-dev/hatchet/pkg/config/database"
+	"github.com/hatchet-dev/hatchet/pkg/config/server"
+	"github.com/hatchet-dev/hatchet/pkg/encryption"
+	"github.com/hatchet-dev/hatchet/pkg/random"
+)
+
+type StoredKeys struct {
+	MasterKey     string `json:"master_key"`
+	PrivateJWT    string `json:"private_jwt"`
+	PublicJWT     string `json:"public_jwt"`
+	CookieSecrets string `json:"cookie_secrets"`
+}
+
+func (d *LocalDriver) ensureEncryptionKeys() error {
+	keysPath := filepath.Join(d.configDir, KeysFileName)
+
+	if fileExists(keysPath) {
+		return d.loadKeys(keysPath)
+	}
+
+	masterKey, privateJWT, publicJWT, err := encryption.GenerateLocalKeys()
+	if err != nil {
+		return fmt.Errorf("failed to generate encryption keys: %w", err)
+	}
+
+	d.masterKey = string(masterKey)
+	d.privateJWT = string(privateJWT)
+	d.publicJWT = string(publicJWT)
+
+	cookieSecrets, err := generateCookieSecrets()
+	if err != nil {
+		return fmt.Errorf("failed to generate cookie secrets: %w", err)
+	}
+	d.cookieSecrets = cookieSecrets
+
+	return d.saveKeys(keysPath)
+}
+
+func (d *LocalDriver) loadKeys(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	var keys StoredKeys
+	if err := json.Unmarshal(data, &keys); err != nil {
+		return err
+	}
+
+	d.masterKey = keys.MasterKey
+	d.privateJWT = keys.PrivateJWT
+	d.publicJWT = keys.PublicJWT
+	d.cookieSecrets = keys.CookieSecrets
+
+	return nil
+}
+
+func (d *LocalDriver) saveKeys(path string) error {
+	keys := StoredKeys{
+		MasterKey:     d.masterKey,
+		PrivateJWT:    d.privateJWT,
+		PublicJWT:     d.publicJWT,
+		CookieSecrets: d.cookieSecrets,
+	}
+
+	data, err := json.MarshalIndent(keys, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0600)
+}
+
+func generateCookieSecrets() (string, error) {
+	hashKey, err := random.Generate(16)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate cookie hash key: %w", err)
+	}
+
+	blockKey, err := random.Generate(16)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate cookie block key: %w", err)
+	}
+
+	return fmt.Sprintf("%s %s", hashKey, blockKey), nil
+}
+
+func (d *LocalDriver) writeConfigFiles() error {
+	if err := d.writeDatabaseConfig(); err != nil {
+		return fmt.Errorf("failed to write database config: %w", err)
+	}
+	if err := d.writeServerConfig(); err != nil {
+		return fmt.Errorf("failed to write server config: %w", err)
+	}
+	return nil
+}
+
+func (d *LocalDriver) writeDatabaseConfig() error {
+	config := &database.ConfigFile{
+		Seed: database.SeedConfigFile{
+			AdminEmail:        "admin@example.com",
+			AdminPassword:     "Admin123!!",
+			AdminName:         "Admin",
+			DefaultTenantName: "Default",
+			DefaultTenantSlug: "default",
+			DefaultTenantID:   DefaultTenantID,
+		},
+	}
+
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return err
+	}
+
+	configPath := filepath.Join(d.configDir, "database.yaml")
+	return os.WriteFile(configPath, data, 0600)
+}
+
+func (d *LocalDriver) writeServerConfig() error {
+	config := &server.ServerConfigFile{
+		Auth: server.ConfigFileAuth{
+			Cookie: server.ConfigFileAuthCookie{
+				Domain:   "localhost",
+				Insecure: true,
+				Secrets:  d.cookieSecrets,
+				Name:     "hatchet",
+			},
+			SetEmailVerified: true,
+		},
+		Encryption: server.EncryptionConfigFile{
+			MasterKeyset: d.masterKey,
+			JWT: server.EncryptionConfigFileJWT{
+				PrivateJWTKeyset: d.privateJWT,
+				PublicJWTKeyset:  d.publicJWT,
+			},
+		},
+		Runtime: server.ConfigFileRuntime{
+			Port:                 d.apiPort,
+			ServerURL:            fmt.Sprintf("http://localhost:%d", d.apiPort),
+			GRPCPort:             d.grpcPort,
+			GRPCBindAddress:      "0.0.0.0",
+			GRPCBroadcastAddress: fmt.Sprintf("localhost:%d", d.grpcPort),
+			GRPCInsecure:         true,
+			AllowSignup:          true,
+			AllowInvites:         true,
+			AllowCreateTenant:    true,
+			AllowChangePassword:  true,
+		},
+		MessageQueue: server.MessageQueueConfigFile{
+			Enabled: true,
+			Kind:    "postgres",
+		},
+		SecurityCheck: server.SecurityCheckConfigFile{
+			Enabled: false,
+		},
+		EnableDataRetention:   true,
+		EnableWorkerRetention: false,
+	}
+
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return err
+	}
+
+	configPath := filepath.Join(d.configDir, "server.yaml")
+	return os.WriteFile(configPath, data, 0600)
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/cmd/hatchet-cli/cli/internal/drivers/local/download.go
+++ b/cmd/hatchet-cli/cli/internal/drivers/local/download.go
@@ -1,0 +1,259 @@
+package local
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/styles"
+)
+
+const (
+	GitHubReleaseURL = "https://github.com/hatchet-dev/hatchet/releases/download"
+	DownloadTimeout  = 10 * time.Minute
+)
+
+// BinaryDownloader handles downloading and caching Hatchet binaries
+type BinaryDownloader struct {
+	cacheDir string // {cacheDir}/hatchet/bin/
+}
+
+// NewBinaryDownloader creates a new binary downloader
+func NewBinaryDownloader() (*BinaryDownloader, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cache directory: %w", err)
+	}
+
+	binCacheDir := filepath.Join(cacheDir, "hatchet", "bin")
+	if err := os.MkdirAll(binCacheDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create binary cache directory: %w", err)
+	}
+
+	return &BinaryDownloader{
+		cacheDir: binCacheDir,
+	}, nil
+}
+
+// EnsureBinary ensures the specified binary is available, downloading if necessary.
+// Returns the path to the binary.
+func (bd *BinaryDownloader) EnsureBinary(ctx context.Context, name, version string) (string, error) {
+	// Normalize version to include 'v' prefix
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+
+	// Path where the binary will be cached
+	versionDir := filepath.Join(bd.cacheDir, version)
+	binaryPath := filepath.Join(versionDir, name)
+
+	// Check if binary already exists and is executable
+	if info, err := os.Stat(binaryPath); err == nil && !info.IsDir() {
+		fmt.Println(styles.SuccessMessage(fmt.Sprintf("Using cached %s", name)))
+		return binaryPath, nil
+	}
+
+	// Create version directory
+	if err := os.MkdirAll(versionDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create version directory: %w", err)
+	}
+
+	// Download the binary
+	if err := bd.downloadBinary(ctx, name, version, binaryPath); err != nil {
+		return "", err
+	}
+
+	return binaryPath, nil
+}
+
+// downloadBinary downloads a specific binary from GitHub releases
+func (bd *BinaryDownloader) downloadBinary(ctx context.Context, name, version, destPath string) error {
+	archiveName := bd.getArchiveName(name, version)
+	url := fmt.Sprintf("%s/%s/%s", GitHubReleaseURL, version, archiveName)
+
+	fmt.Println(styles.InfoMessage(fmt.Sprintf("Downloading %s %s...", name, version)))
+	fmt.Println(styles.Muted.Render("  " + url))
+
+	// Create HTTP client with timeout
+	client := &http.Client{
+		Timeout: DownloadTimeout,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to download binary: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download binary: HTTP %d", resp.StatusCode)
+	}
+
+	// Create a temporary file for the download
+	tmpDir := filepath.Dir(destPath)
+	tmpFile, err := os.CreateTemp(tmpDir, "download-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath)
+
+	// Download to temp file
+	if _, err := io.Copy(tmpFile, resp.Body); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("failed to download binary: %w", err)
+	}
+	tmpFile.Close()
+
+	// Extract binary from archive
+	if err := bd.extractBinary(tmpPath, name, destPath); err != nil {
+		return fmt.Errorf("failed to extract binary: %w", err)
+	}
+
+	// Make binary executable
+	if err := os.Chmod(destPath, 0755); err != nil {
+		return fmt.Errorf("failed to make binary executable: %w", err)
+	}
+
+	fmt.Println(styles.SuccessMessage(fmt.Sprintf("Downloaded %s", name)))
+	return nil
+}
+
+// extractBinary extracts a binary from a tar.gz archive
+func (bd *BinaryDownloader) extractBinary(archivePath, binaryName, destPath string) error {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	gzReader, err := gzip.NewReader(file)
+	if err != nil {
+		return fmt.Errorf("failed to create gzip reader: %w", err)
+	}
+	defer gzReader.Close()
+
+	tarReader := tar.NewReader(gzReader)
+
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read tar: %w", err)
+		}
+
+		// Look for the binary file (might be at root or in a subdirectory)
+		baseName := filepath.Base(header.Name)
+		if baseName == binaryName && header.Typeflag == tar.TypeReg {
+			outFile, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+			if err != nil {
+				return fmt.Errorf("failed to create output file: %w", err)
+			}
+
+			if _, err := io.Copy(outFile, tarReader); err != nil {
+				outFile.Close()
+				return fmt.Errorf("failed to extract binary: %w", err)
+			}
+			outFile.Close()
+			return nil
+		}
+	}
+
+	return fmt.Errorf("binary %s not found in archive", binaryName)
+}
+
+// getArchiveName returns the archive name for a binary based on OS/arch
+func (bd *BinaryDownloader) getArchiveName(name, version string) string {
+	goos := runtime.GOOS
+	goarch := runtime.GOARCH
+
+	// Map Go arch names to release arch names
+	archName := goarch
+	if goarch == "amd64" {
+		archName = "x86_64"
+	}
+
+	// Map Go OS names to release OS names (capitalize first letter)
+	osName := capitalizeFirst(goos)
+
+	// Format: hatchet-api_v0.73.10_Darwin_arm64.tar.gz
+	return fmt.Sprintf("%s_%s_%s_%s.tar.gz", name, version, osName, archName)
+}
+
+// capitalizeFirst capitalizes the first letter of a string
+func capitalizeFirst(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// VerifyChecksum verifies the SHA256 checksum of a file
+func (bd *BinaryDownloader) VerifyChecksum(path, expected string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, file); err != nil {
+		return err
+	}
+
+	actual := hex.EncodeToString(hasher.Sum(nil))
+	if actual != expected {
+		return fmt.Errorf("checksum mismatch: expected %s, got %s", expected, actual)
+	}
+
+	return nil
+}
+
+// CacheDir returns the binary cache directory
+func (bd *BinaryDownloader) CacheDir() string {
+	return bd.cacheDir
+}
+
+// CleanOldVersions removes cached binaries for versions other than the current one
+func (bd *BinaryDownloader) CleanOldVersions(currentVersion string) error {
+	if !strings.HasPrefix(currentVersion, "v") {
+		currentVersion = "v" + currentVersion
+	}
+
+	entries, err := os.ReadDir(bd.cacheDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() && entry.Name() != currentVersion {
+			oldPath := filepath.Join(bd.cacheDir, entry.Name())
+			fmt.Println(styles.Muted.Render(fmt.Sprintf("Removing old cached binaries: %s", oldPath)))
+			if err := os.RemoveAll(oldPath); err != nil {
+				fmt.Println(styles.Muted.Render(fmt.Sprintf("Warning: failed to remove %s: %v", oldPath, err)))
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/hatchet-cli/cli/internal/drivers/local/local.go
+++ b/cmd/hatchet-cli/cli/internal/drivers/local/local.go
@@ -143,6 +143,7 @@ func WithBinaryVersion(version string) LocalOpt {
 	}
 }
 
+
 // NewLocalDriver creates a new local driver
 func NewLocalDriver() *LocalDriver {
 	homeDir, _ := os.UserHomeDir()
@@ -223,7 +224,7 @@ func (d *LocalDriver) Run(ctx context.Context, opts ...LocalOpt) (*RunResult, er
 		return nil, fmt.Errorf("binary version is required")
 	}
 
-	// Download required binaries
+	// Ensure required binaries (uses cache - populated by download or 'hatchet server build')
 	fmt.Println(styles.InfoMessage(fmt.Sprintf("Ensuring binaries are available for version %s...", version)))
 
 	migrateBinary, err := downloader.EnsureBinary(ctx, "hatchet-migrate", version)
@@ -680,7 +681,7 @@ func (d *LocalDriver) StartServer(ctx context.Context, interruptCh <-chan interf
 		return fmt.Errorf("binary version is required")
 	}
 
-	// Download/ensure binaries are available (api and engine)
+	// Ensure binaries are available (uses cache - populated by download or 'hatchet server build')
 	apiBinaryPath, err := d.binaryDownloader.EnsureBinary(ctx, "hatchet-api", version)
 	if err != nil {
 		return fmt.Errorf("failed to ensure hatchet-api binary: %w", err)

--- a/cmd/hatchet-cli/cli/internal/drivers/local/local.go
+++ b/cmd/hatchet-cli/cli/internal/drivers/local/local.go
@@ -1,0 +1,574 @@
+package local
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-admin/cli/seed"
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-api/api"
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-engine/engine"
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-migrate/migrate"
+	cliconfig "github.com/hatchet-dev/hatchet/pkg/config/cli"
+	"github.com/hatchet-dev/hatchet/pkg/config/loader"
+	"github.com/hatchet-dev/hatchet/pkg/config/server"
+)
+
+const (
+	DefaultAPIPort         = 8080
+	DefaultGRPCPort        = 7077
+	DefaultHealthcheckPort = 8733
+	StateFileName          = "state.json"
+	KeysFileName           = "keys.json"
+)
+
+// LocalDriver manages a local Hatchet server running in-process
+type LocalDriver struct {
+	configDir       string
+	databaseURL     string
+	apiPort         int
+	grpcPort        int
+	healthcheckPort int
+	profileName     string
+
+	// Encryption keys
+	masterKey     string
+	privateJWT    string
+	publicJWT     string
+	cookieSecrets string
+}
+
+// LocalServerState persists the state of a running local server
+type LocalServerState struct {
+	ConfigDir   string    `json:"config_dir"`
+	DatabaseURL string    `json:"database_url"`
+	PID         int       `json:"pid"` // PID of the CLI process running the server
+	ApiPort     int       `json:"api_port"`
+	GrpcPort    int       `json:"grpc_port"`
+	ProfileName string    `json:"profile_name"`
+	StartedAt   time.Time `json:"started_at"`
+}
+
+// LocalOpts configures the local driver
+type LocalOpts struct {
+	DatabaseURL     string
+	APIPort         int
+	GRPCPort        int
+	HealthcheckPort int
+	ProfileName     string
+}
+
+// LocalOpt is a functional option for LocalDriver
+type LocalOpt func(*LocalOpts)
+
+// WithDatabaseURL sets the database URL
+func WithDatabaseURL(url string) LocalOpt {
+	return func(o *LocalOpts) {
+		o.DatabaseURL = url
+	}
+}
+
+// WithAPIPort sets the API port
+func WithAPIPort(port int) LocalOpt {
+	return func(o *LocalOpts) {
+		o.APIPort = port
+	}
+}
+
+// WithGRPCPort sets the gRPC port
+func WithGRPCPort(port int) LocalOpt {
+	return func(o *LocalOpts) {
+		o.GRPCPort = port
+	}
+}
+
+// WithHealthcheckPort sets the healthcheck port
+func WithHealthcheckPort(port int) LocalOpt {
+	return func(o *LocalOpts) {
+		o.HealthcheckPort = port
+	}
+}
+
+// WithProfileName sets the profile name
+func WithProfileName(name string) LocalOpt {
+	return func(o *LocalOpts) {
+		o.ProfileName = name
+	}
+}
+
+// NewLocalDriver creates a new local driver
+func NewLocalDriver() *LocalDriver {
+	homeDir, _ := os.UserHomeDir()
+	configDir := filepath.Join(homeDir, ".hatchet", "local")
+
+	return &LocalDriver{
+		configDir: configDir,
+		apiPort:   DefaultAPIPort,
+		grpcPort:  DefaultGRPCPort,
+	}
+}
+
+// Run starts the local Hatchet server in-process (foreground mode)
+// This method blocks until the server is stopped via interrupt signal
+func (d *LocalDriver) Run(ctx context.Context, opts ...LocalOpt) (*RunResult, error) {
+	// Apply options
+	// Default DB URL works with Mac Homebrew Postgres (current user, no password)
+	options := &LocalOpts{
+		DatabaseURL:     "postgresql://localhost:5432/hatchet?sslmode=disable",
+		APIPort:         DefaultAPIPort,
+		GRPCPort:        DefaultGRPCPort,
+		HealthcheckPort: DefaultHealthcheckPort,
+		ProfileName:     "local",
+	}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	d.databaseURL = options.DatabaseURL
+	d.apiPort = options.APIPort
+	d.grpcPort = options.GRPCPort
+	d.healthcheckPort = options.HealthcheckPort
+	d.profileName = options.ProfileName
+
+	if err := d.ensureDatabase(ctx); err != nil {
+		return nil, fmt.Errorf("database setup failed: %w", err)
+	}
+
+	if err := d.initConfigDir(); err != nil {
+		return nil, fmt.Errorf("failed to initialize config directory: %w", err)
+	}
+
+	if err := d.ensureEncryptionKeys(); err != nil {
+		return nil, fmt.Errorf("failed to setup encryption keys: %w", err)
+	}
+
+	if err := d.writeConfigFiles(); err != nil {
+		return nil, fmt.Errorf("failed to write config files: %w", err)
+	}
+
+	if err := d.runMigrations(ctx); err != nil {
+		return nil, fmt.Errorf("failed to run migrations: %w", err)
+	}
+
+	if err := d.seedDatabase(); err != nil {
+		return nil, fmt.Errorf("failed to seed database: %w", err)
+	}
+
+	token, err := d.generateToken(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate API token: %w", err)
+	}
+
+	if err := d.saveState(); err != nil {
+		return nil, fmt.Errorf("failed to save state: %w", err)
+	}
+
+	return &RunResult{
+		ProfileName: d.profileName,
+		Token:       token,
+		APIPort:     d.apiPort,
+		GRPCPort:    d.grpcPort,
+	}, nil
+}
+
+// StartServer starts the API and engine in-process and blocks until interrupted.
+// This should be called after Run() to actually start the server.
+func (d *LocalDriver) StartServer(ctx context.Context, interruptCh <-chan interface{}, onReady func()) error {
+	d.setEnvVars()
+	cf := loader.NewConfigLoader(d.configDir)
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 2)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := api.Start(cf, interruptCh, "local"); err != nil {
+			log.Printf("API error: %v", err)
+			errCh <- fmt.Errorf("API server error: %w", err)
+		}
+	}()
+
+	engineCtx, engineCancel := context.WithCancel(ctx)
+	defer engineCancel()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := engine.Run(engineCtx, cf, "local"); err != nil {
+			log.Printf("Engine error: %v", err)
+			errCh <- fmt.Errorf("engine error: %w", err)
+		}
+	}()
+
+	if err := d.waitForHealth(ctx); err != nil {
+		return fmt.Errorf("server failed to become healthy: %w", err)
+	}
+
+	if onReady != nil {
+		onReady()
+	}
+
+	select {
+	case <-interruptCh:
+		log.Println("cleaning up server config")
+	case err := <-errCh:
+		return err
+	}
+
+	engineCancel()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		log.Println("shutdown timeout, some goroutines may not have exited cleanly")
+	}
+
+	d.removeState()
+
+	return nil
+}
+
+// RunResult contains the result of starting a local server
+type RunResult struct {
+	ProfileName string
+	Token       string
+	APIPort     int
+	GRPCPort    int
+}
+
+func (d *LocalDriver) Stop() error {
+	state, err := d.loadState()
+	if err != nil {
+		return fmt.Errorf("no local server running or state file not found: %w", err)
+	}
+
+	if state.PID > 0 {
+		if err := killProcessByPID(state.PID); err != nil {
+			return fmt.Errorf("failed to stop server (PID %d): %w", state.PID, err)
+		}
+	}
+
+	d.removeState()
+
+	return nil
+}
+
+func (d *LocalDriver) IsRunning() bool {
+	state, err := d.loadState()
+	if err != nil {
+		return false
+	}
+
+	if state.PID > 0 {
+		if process, err := os.FindProcess(state.PID); err == nil {
+			if err := process.Signal(syscall.Signal(0)); err == nil {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (d *LocalDriver) ensureDatabase(ctx context.Context) error {
+	parsedURL, err := url.Parse(d.databaseURL)
+	if err != nil {
+		return fmt.Errorf("invalid database URL: %w", err)
+	}
+
+	dbName := strings.TrimPrefix(parsedURL.Path, "/")
+	if dbName == "" {
+		dbName = "hatchet"
+	}
+
+	if !isValidIdentifier(dbName) {
+		return fmt.Errorf("invalid database name: %s (only alphanumeric and underscores allowed)", dbName)
+	}
+
+	adminURL := *parsedURL
+	adminURL.Path = "/postgres"
+	adminConnStr := adminURL.String()
+
+	conn, err := pgx.Connect(ctx, d.databaseURL)
+	if err == nil {
+		conn.Close(ctx)
+		return d.ensureTimezone(ctx, dbName, adminConnStr)
+	}
+
+	log.Printf("Creating database '%s'...", dbName)
+
+	adminConn, err := pgx.Connect(ctx, adminConnStr)
+	if err != nil {
+		return fmt.Errorf("could not connect to PostgreSQL: %w\n\nEnsure PostgreSQL is running and accessible", err)
+	}
+	defer adminConn.Close(ctx)
+
+	_, err = adminConn.Exec(ctx, fmt.Sprintf(`CREATE DATABASE "%s"`, dbName))
+	if err != nil {
+		if !strings.Contains(err.Error(), "already exists") {
+			return fmt.Errorf("could not create database: %w", err)
+		}
+	}
+
+	return d.ensureTimezone(ctx, dbName, adminConnStr)
+}
+
+func (d *LocalDriver) ensureTimezone(ctx context.Context, dbName, adminConnStr string) error {
+	adminConn, err := pgx.Connect(ctx, adminConnStr)
+	if err != nil {
+		return fmt.Errorf("could not connect to PostgreSQL: %w", err)
+	}
+	defer adminConn.Close(ctx)
+
+	_, err = adminConn.Exec(ctx, fmt.Sprintf(`ALTER DATABASE "%s" SET TIMEZONE='UTC'`, dbName))
+	if err != nil {
+		return fmt.Errorf("could not set timezone: %w", err)
+	}
+
+	conn, err := pgx.Connect(ctx, d.databaseURL)
+	if err != nil {
+		return fmt.Errorf("could not connect to database: %w", err)
+	}
+	defer conn.Close(ctx)
+
+	return conn.Ping(ctx)
+}
+
+func isValidIdentifier(s string) bool {
+	if len(s) == 0 || len(s) > 63 {
+		return false
+	}
+	for i, c := range s {
+		if i == 0 && c >= '0' && c <= '9' {
+			return false
+		}
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') {
+			return false
+		}
+	}
+	return true
+}
+
+func (d *LocalDriver) initConfigDir() error {
+	return os.MkdirAll(d.configDir, 0700)
+}
+
+func (d *LocalDriver) runMigrations(ctx context.Context) error {
+	os.Setenv("DATABASE_URL", d.databaseURL)
+	migrate.RunMigrations(ctx)
+
+	return nil
+}
+
+func (d *LocalDriver) seedDatabase() error {
+	configLoader := loader.NewConfigLoader(d.configDir)
+
+	dbLayer, err := configLoader.InitDataLayer()
+	if err != nil {
+		return fmt.Errorf("failed to initialize data layer: %w", err)
+	}
+	defer dbLayer.Disconnect() // nolint: errcheck
+
+	return seed.SeedDatabase(dbLayer)
+}
+
+func (d *LocalDriver) generateToken(ctx context.Context) (string, error) {
+	configLoader := loader.NewConfigLoader(d.configDir)
+
+	cleanup, serverConfig, err := configLoader.CreateServerFromConfig("local",
+		func(scf *server.ServerConfigFile) {
+			scf.MessageQueue.Enabled = false
+			scf.SecurityCheck.Enabled = false
+		},
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to create server config: %w", err)
+	}
+	defer cleanup() // nolint: errcheck
+
+	tenantID := DefaultTenantID
+	expiresAt := time.Now().UTC().Add(365 * 24 * time.Hour)
+
+	token, err := serverConfig.Auth.JWTManager.GenerateTenantToken(
+		ctx,
+		tenantID,
+		"local-cli-token",
+		false,
+		&expiresAt,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return token.Token, nil
+}
+
+func (d *LocalDriver) setEnvVars() {
+	os.Setenv("DATABASE_URL", d.databaseURL)
+	os.Setenv("SERVER_AUTH_COOKIE_DOMAIN", "localhost")
+	os.Setenv("SERVER_AUTH_COOKIE_INSECURE", "t")
+	os.Setenv("SERVER_AUTH_COOKIE_SECRETS", d.cookieSecrets)
+	os.Setenv("SERVER_GRPC_BIND_ADDRESS", "0.0.0.0")
+	os.Setenv("SERVER_GRPC_INSECURE", "t")
+	os.Setenv("SERVER_GRPC_PORT", strconv.Itoa(d.grpcPort))
+	os.Setenv("SERVER_GRPC_BROADCAST_ADDRESS", fmt.Sprintf("localhost:%d", d.grpcPort))
+	os.Setenv("SERVER_URL", fmt.Sprintf("http://localhost:%d", d.apiPort))
+	os.Setenv("SERVER_PORT", strconv.Itoa(d.apiPort))
+	os.Setenv("SERVER_HEALTHCHECK_PORT", strconv.Itoa(d.healthcheckPort))
+	os.Setenv("SERVER_AUTH_SET_EMAIL_VERIFIED", "t")
+	os.Setenv("SERVER_ENCRYPTION_MASTER_KEYSET", d.masterKey)
+	os.Setenv("SERVER_ENCRYPTION_JWT_PRIVATE_KEYSET", d.privateJWT)
+	os.Setenv("SERVER_ENCRYPTION_JWT_PUBLIC_KEYSET", d.publicJWT)
+	os.Setenv("SERVER_MSGQUEUE_KIND", "postgres")
+	os.Setenv("SERVER_INTERNAL_CLIENT_INTERNAL_GRPC_BROADCAST_ADDRESS", fmt.Sprintf("localhost:%d", d.grpcPort))
+}
+
+func (d *LocalDriver) waitForHealth(ctx context.Context) error {
+	healthURL := fmt.Sprintf("http://localhost:%d/api/ready", d.apiPort)
+	healthCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	for {
+		select {
+		case <-healthCtx.Done():
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return fmt.Errorf("timeout waiting for server to become healthy")
+		case <-ticker.C:
+			req, err := http.NewRequestWithContext(healthCtx, "GET", healthURL, nil)
+			if err != nil {
+				continue
+			}
+			resp, err := client.Do(req)
+			if err == nil {
+				resp.Body.Close()
+				if resp.StatusCode == http.StatusOK {
+					return nil
+				}
+			}
+		}
+	}
+}
+
+func (d *LocalDriver) saveState() error {
+	state := LocalServerState{
+		ConfigDir:   d.configDir,
+		DatabaseURL: d.databaseURL,
+		PID:         os.Getpid(),
+		ApiPort:     d.apiPort,
+		GrpcPort:    d.grpcPort,
+		ProfileName: d.profileName,
+		StartedAt:   time.Now(),
+	}
+
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	stateFile := filepath.Join(d.configDir, StateFileName)
+	return os.WriteFile(stateFile, data, 0600)
+}
+
+func (d *LocalDriver) loadState() (*LocalServerState, error) {
+	stateFile := filepath.Join(d.configDir, StateFileName)
+
+	data, err := os.ReadFile(stateFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var state LocalServerState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, err
+	}
+
+	return &state, nil
+}
+
+func (d *LocalDriver) removeState() {
+	stateFile := filepath.Join(d.configDir, StateFileName)
+	if err := os.Remove(stateFile); err != nil && !os.IsNotExist(err) {
+		log.Printf("Warning: failed to remove state file: %v", err)
+	}
+}
+
+func killProcessByPID(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+
+	if err := process.Signal(syscall.SIGTERM); err != nil {
+		if err == os.ErrProcessDone {
+			return nil
+		}
+		return err
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := process.Wait()
+		done <- err
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-time.After(5 * time.Second):
+		return process.Kill()
+	}
+}
+
+func (d *LocalDriver) GetConfigDir() string {
+	return d.configDir
+}
+
+func GetStateFilePath() string {
+	homeDir, _ := os.UserHomeDir()
+	return filepath.Join(homeDir, ".hatchet", "local", StateFileName)
+}
+
+func IsLocalServerRunning() bool {
+	driver := NewLocalDriver()
+	return driver.IsRunning()
+}
+
+const DefaultTenantID = "707d0855-80ab-4e1f-a156-f1c4546cbf52"
+
+func CreateProfileFromResult(result *RunResult) (*cliconfig.Profile, error) {
+	return &cliconfig.Profile{
+		Name:         result.ProfileName,
+		Token:        result.Token,
+		TenantId:     DefaultTenantID,
+		ApiServerURL: fmt.Sprintf("http://localhost:%d", result.APIPort),
+		GrpcHostPort: fmt.Sprintf("localhost:%d", result.GRPCPort),
+		TLSStrategy:  "none",
+		ExpiresAt:    time.Now().Add(365 * 24 * time.Hour),
+	}, nil
+}

--- a/cmd/hatchet-cli/cli/internal/drivers/local/local.go
+++ b/cmd/hatchet-cli/cli/internal/drivers/local/local.go
@@ -563,6 +563,24 @@ func (d *LocalDriver) removeState() {
 	}
 }
 
+// Cleanup cleans up orphan processes and state files
+func (d *LocalDriver) Cleanup() error {
+	// Try to stop any running process from saved state
+	state, err := d.loadState()
+	if err == nil && state.PID > 0 {
+		fmt.Println(styles.InfoMessage(fmt.Sprintf("Found saved state with PID %d, attempting to stop...", state.PID)))
+		if err := killProcessByPID(state.PID); err != nil {
+			fmt.Println(styles.Muted.Render(fmt.Sprintf("Could not stop process %d: %v", state.PID, err)))
+		} else {
+			fmt.Println(styles.SuccessMessage(fmt.Sprintf("Stopped process %d", state.PID)))
+		}
+	}
+
+	// Remove state file
+	d.removeState()
+	return nil
+}
+
 func killProcessByPID(pid int) error {
 	process, err := os.FindProcess(pid)
 	if err != nil {

--- a/cmd/hatchet-cli/cli/internal/drivers/local/local_test.go
+++ b/cmd/hatchet-cli/cli/internal/drivers/local/local_test.go
@@ -103,11 +103,6 @@ func TestLocalOpts(t *testing.T) {
 		t.Errorf("PostgresPort = %d, want 5434", opts.PostgresPort)
 	}
 
-	WithExecutionMode(ExecutionModeSubprocess)(opts)
-	if opts.ExecutionMode != ExecutionModeSubprocess {
-		t.Errorf("ExecutionMode = %q, want %q", opts.ExecutionMode, ExecutionModeSubprocess)
-	}
-
 	WithBinaryVersion("v0.73.10")(opts)
 	if opts.BinaryVersion != "v0.73.10" {
 		t.Errorf("BinaryVersion = %q, want v0.73.10", opts.BinaryVersion)

--- a/cmd/hatchet-cli/cli/internal/drivers/local/local_test.go
+++ b/cmd/hatchet-cli/cli/internal/drivers/local/local_test.go
@@ -1,0 +1,94 @@
+package local
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsValidIdentifier(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"valid simple", "hatchet", true},
+		{"valid with underscore", "hatchet_db", true},
+		{"valid with numbers", "hatchet123", true},
+		{"valid mixed", "my_db_123", true},
+		{"valid uppercase", "Hatchet", true},
+		{"valid single char", "a", true},
+		{"empty string", "", false},
+		{"starts with digit", "123hatchet", false},
+		{"contains hyphen", "hatchet-db", false},
+		{"contains space", "hatchet db", false},
+		{"contains semicolon", "hatchet;drop", false},
+		{"contains quotes", "hatchet\"test", false},
+		{"too long", "a" + string(make([]byte, 63)), false},
+		{"max length", string(make([]byte, 63)), false}, // 63 null bytes aren't valid chars
+		{"exactly 63 valid chars", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isValidIdentifier(tt.input)
+			if got != tt.want {
+				t.Errorf("isValidIdentifier(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetStateFilePath(t *testing.T) {
+	path := GetStateFilePath()
+	if path == "" {
+		t.Error("GetStateFilePath() returned empty string")
+	}
+	if !strings.Contains(path, ".hatchet/local/state.json") {
+		t.Errorf("GetStateFilePath() = %q, expected to contain .hatchet/local/state.json", path)
+	}
+}
+
+func TestNewLocalDriver(t *testing.T) {
+	driver := NewLocalDriver()
+	if driver == nil {
+		t.Fatal("NewLocalDriver() returned nil")
+	}
+	if driver.apiPort != DefaultAPIPort {
+		t.Errorf("apiPort = %d, want %d", driver.apiPort, DefaultAPIPort)
+	}
+	if driver.grpcPort != DefaultGRPCPort {
+		t.Errorf("grpcPort = %d, want %d", driver.grpcPort, DefaultGRPCPort)
+	}
+	if driver.configDir == "" {
+		t.Error("configDir is empty")
+	}
+}
+
+func TestLocalOpts(t *testing.T) {
+	opts := &LocalOpts{}
+
+	WithDatabaseURL("postgresql://localhost/test")(opts)
+	if opts.DatabaseURL != "postgresql://localhost/test" {
+		t.Errorf("DatabaseURL = %q, want postgresql://localhost/test", opts.DatabaseURL)
+	}
+
+	WithAPIPort(9000)(opts)
+	if opts.APIPort != 9000 {
+		t.Errorf("APIPort = %d, want 9000", opts.APIPort)
+	}
+
+	WithGRPCPort(9001)(opts)
+	if opts.GRPCPort != 9001 {
+		t.Errorf("GRPCPort = %d, want 9001", opts.GRPCPort)
+	}
+
+	WithHealthcheckPort(9002)(opts)
+	if opts.HealthcheckPort != 9002 {
+		t.Errorf("HealthcheckPort = %d, want 9002", opts.HealthcheckPort)
+	}
+
+	WithProfileName("test-profile")(opts)
+	if opts.ProfileName != "test-profile" {
+		t.Errorf("ProfileName = %q, want test-profile", opts.ProfileName)
+	}
+}

--- a/cmd/hatchet-cli/cli/internal/drivers/local/postgres.go
+++ b/cmd/hatchet-cli/cli/internal/drivers/local/postgres.go
@@ -1,0 +1,167 @@
+package local
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/styles"
+)
+
+const (
+	DefaultPostgresPort = 5433 // Use non-standard port to avoid conflicts with local postgres
+)
+
+// PostgresConfig configures the embedded postgres instance
+type PostgresConfig struct {
+	Port     uint32
+	DataPath string // Persistent data (~/.hatchet/local/postgres-data)
+	BinPath  string // Ephemeral binary cache (os.UserCacheDir()/hatchet/postgres)
+}
+
+// EmbeddedPostgres manages an embedded PostgreSQL instance
+type EmbeddedPostgres struct {
+	db       *embeddedpostgres.EmbeddedPostgres
+	port     uint32
+	dataPath string
+	binPath  string
+	started  bool
+}
+
+// NewEmbeddedPostgres creates a new embedded postgres manager
+func NewEmbeddedPostgres(cfg PostgresConfig) (*EmbeddedPostgres, error) {
+	port := cfg.Port
+	if port == 0 {
+		port = DefaultPostgresPort
+	}
+
+	dataPath := cfg.DataPath
+	if dataPath == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get home directory: %w", err)
+		}
+		dataPath = filepath.Join(homeDir, ".hatchet", "local", "postgres-data")
+	}
+
+	binPath := cfg.BinPath
+	if binPath == "" {
+		cacheDir, err := os.UserCacheDir()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get cache directory: %w", err)
+		}
+		binPath = filepath.Join(cacheDir, "hatchet", "postgres")
+	}
+
+	return &EmbeddedPostgres{
+		port:     port,
+		dataPath: dataPath,
+		binPath:  binPath,
+	}, nil
+}
+
+// Start initializes and starts the embedded postgres instance
+func (ep *EmbeddedPostgres) Start(ctx context.Context) error {
+	if ep.started {
+		return nil
+	}
+
+	// Ensure directories exist
+	if err := os.MkdirAll(ep.dataPath, 0700); err != nil {
+		return fmt.Errorf("failed to create data directory: %w", err)
+	}
+	if err := os.MkdirAll(ep.binPath, 0700); err != nil {
+		return fmt.Errorf("failed to create binary directory: %w", err)
+	}
+
+	// Check if this is a fresh install (no existing data)
+	pgVersionFile := filepath.Join(ep.dataPath, "PG_VERSION")
+	freshInstall := !fileExists(pgVersionFile)
+
+	// Check if PostgreSQL binaries need to be downloaded
+	binariesExist := fileExists(filepath.Join(ep.binPath, "bin", "postgres")) ||
+		fileExists(filepath.Join(ep.binPath, "bin", "pg_ctl"))
+
+	if !binariesExist {
+		fmt.Println(styles.InfoMessage("Downloading PostgreSQL binaries (first run, ~50MB)..."))
+		fmt.Println(styles.Muted.Render("  Cache location: " + ep.binPath))
+	}
+
+	fmt.Println(styles.InfoMessage(fmt.Sprintf("Starting embedded PostgreSQL on port %d...", ep.port)))
+
+	ep.db = embeddedpostgres.NewDatabase(
+		embeddedpostgres.DefaultConfig().
+			Port(ep.port).
+			DataPath(ep.dataPath).
+			BinariesPath(ep.binPath).
+			RuntimePath(ep.binPath).
+			Username("postgres").
+			Password("postgres").
+			Database("postgres").
+			StartTimeout(120 * time.Second),
+	)
+
+	if err := ep.db.Start(); err != nil {
+		return fmt.Errorf("failed to start embedded postgres: %w", err)
+	}
+
+	ep.started = true
+
+	if freshInstall {
+		fmt.Println(styles.SuccessMessage("PostgreSQL started (initialized new database)"))
+	} else {
+		fmt.Println(styles.SuccessMessage("PostgreSQL started (using existing data)"))
+	}
+
+	return nil
+}
+
+// Stop gracefully stops the embedded postgres instance
+func (ep *EmbeddedPostgres) Stop() error {
+	if !ep.started || ep.db == nil {
+		return nil
+	}
+
+	fmt.Println(styles.InfoMessage("Stopping embedded PostgreSQL..."))
+
+	if err := ep.db.Stop(); err != nil {
+		return fmt.Errorf("failed to stop embedded postgres: %w", err)
+	}
+
+	ep.started = false
+	fmt.Println(styles.SuccessMessage("PostgreSQL stopped"))
+
+	return nil
+}
+
+// ConnectionURL returns the connection URL for the specified database
+func (ep *EmbeddedPostgres) ConnectionURL(dbName string) string {
+	if dbName == "" {
+		dbName = "hatchet"
+	}
+	return fmt.Sprintf("postgresql://postgres:postgres@localhost:%d/%s?sslmode=disable", ep.port, dbName)
+}
+
+// Port returns the port the embedded postgres is running on
+func (ep *EmbeddedPostgres) Port() uint32 {
+	return ep.port
+}
+
+// DataPath returns the data directory path
+func (ep *EmbeddedPostgres) DataPath() string {
+	return ep.dataPath
+}
+
+// BinPath returns the binary cache directory path
+func (ep *EmbeddedPostgres) BinPath() string {
+	return ep.binPath
+}
+
+// IsRunning returns whether the embedded postgres is currently running
+func (ep *EmbeddedPostgres) IsRunning() bool {
+	return ep.started
+}

--- a/cmd/hatchet-cli/cli/internal/drivers/local/subprocess.go
+++ b/cmd/hatchet-cli/cli/internal/drivers/local/subprocess.go
@@ -1,0 +1,308 @@
+package local
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/styles"
+)
+
+// SubprocessManager manages API and Engine subprocesses
+type SubprocessManager struct {
+	apiCmd    *exec.Cmd
+	engineCmd *exec.Cmd
+	mu        sync.Mutex
+	started   bool
+}
+
+// NewSubprocessManager creates a new subprocess manager
+func NewSubprocessManager() *SubprocessManager {
+	return &SubprocessManager{}
+}
+
+// StartAPI starts the API server as a subprocess
+func (sm *SubprocessManager) StartAPI(ctx context.Context, binaryPath string, env []string, configDir string) error {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if sm.apiCmd != nil {
+		return fmt.Errorf("API is already running")
+	}
+
+	fmt.Println(styles.InfoMessage("Starting API subprocess..."))
+
+	cmd := exec.CommandContext(ctx, binaryPath)
+	cmd.Env = append(os.Environ(), env...)
+	cmd.Dir = configDir
+
+	// Pipe stdout and stderr to the current process
+	cmd.Stdout = newPrefixWriter(os.Stdout, "[api] ")
+	cmd.Stderr = newPrefixWriter(os.Stderr, "[api] ")
+
+	// Set process group so we can kill all children
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start API: %w", err)
+	}
+
+	sm.apiCmd = cmd
+	fmt.Println(styles.SuccessMessage(fmt.Sprintf("API started (PID: %d)", cmd.Process.Pid)))
+
+	return nil
+}
+
+// StartEngine starts the Engine as a subprocess
+func (sm *SubprocessManager) StartEngine(ctx context.Context, binaryPath string, env []string, configDir string) error {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if sm.engineCmd != nil {
+		return fmt.Errorf("Engine is already running")
+	}
+
+	fmt.Println(styles.InfoMessage("Starting Engine subprocess..."))
+
+	cmd := exec.CommandContext(ctx, binaryPath)
+	cmd.Env = append(os.Environ(), env...)
+	cmd.Dir = configDir
+
+	// Pipe stdout and stderr to the current process
+	cmd.Stdout = newPrefixWriter(os.Stdout, "[engine] ")
+	cmd.Stderr = newPrefixWriter(os.Stderr, "[engine] ")
+
+	// Set process group so we can kill all children
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start Engine: %w", err)
+	}
+
+	sm.engineCmd = cmd
+	sm.started = true
+	fmt.Println(styles.SuccessMessage(fmt.Sprintf("Engine started (PID: %d)", cmd.Process.Pid)))
+
+	return nil
+}
+
+// StopAll gracefully stops all running subprocesses
+func (sm *SubprocessManager) StopAll() error {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	var errs []error
+
+	if sm.apiCmd != nil && sm.apiCmd.Process != nil {
+		fmt.Println(styles.InfoMessage("Stopping API subprocess..."))
+		if err := sm.stopProcess(sm.apiCmd); err != nil {
+			errs = append(errs, fmt.Errorf("failed to stop API: %w", err))
+		}
+		sm.apiCmd = nil
+	}
+
+	if sm.engineCmd != nil && sm.engineCmd.Process != nil {
+		fmt.Println(styles.InfoMessage("Stopping Engine subprocess..."))
+		if err := sm.stopProcess(sm.engineCmd); err != nil {
+			errs = append(errs, fmt.Errorf("failed to stop Engine: %w", err))
+		}
+		sm.engineCmd = nil
+	}
+
+	sm.started = false
+
+	if len(errs) > 0 {
+		return errs[0]
+	}
+
+	return nil
+}
+
+// stopProcess sends SIGTERM and waits for process to exit, then SIGKILL if needed
+func (sm *SubprocessManager) stopProcess(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+
+	// Send SIGTERM to process group
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err == nil {
+		syscall.Kill(-pgid, syscall.SIGTERM)
+	} else {
+		cmd.Process.Signal(syscall.SIGTERM)
+	}
+
+	// Wait for process to exit with timeout
+	done := make(chan error, 1)
+	go func() {
+		_, err := cmd.Process.Wait()
+		done <- err
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-time.After(10 * time.Second):
+		// Force kill if graceful shutdown times out
+		fmt.Println(styles.Muted.Render("Graceful shutdown timed out, force killing..."))
+		if pgid, err := syscall.Getpgid(cmd.Process.Pid); err == nil {
+			syscall.Kill(-pgid, syscall.SIGKILL)
+		} else {
+			cmd.Process.Kill()
+		}
+		return nil
+	}
+}
+
+// WaitForHealth waits for the API to become healthy
+func (sm *SubprocessManager) WaitForHealth(ctx context.Context, apiPort int) error {
+	healthURL := fmt.Sprintf("http://localhost:%d/api/ready", apiPort)
+	healthCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	fmt.Println(styles.InfoMessage("Waiting for API to become healthy..."))
+
+	for {
+		select {
+		case <-healthCtx.Done():
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return fmt.Errorf("timeout waiting for API to become healthy")
+		case <-ticker.C:
+			// Check if processes are still running
+			sm.mu.Lock()
+			apiRunning := sm.apiCmd != nil && sm.apiCmd.ProcessState == nil
+			engineRunning := sm.engineCmd != nil && sm.engineCmd.ProcessState == nil
+			sm.mu.Unlock()
+
+			if !apiRunning || !engineRunning {
+				return fmt.Errorf("subprocess exited unexpectedly")
+			}
+
+			req, err := http.NewRequestWithContext(healthCtx, "GET", healthURL, nil)
+			if err != nil {
+				continue
+			}
+
+			resp, err := client.Do(req)
+			if err == nil {
+				resp.Body.Close()
+				if resp.StatusCode == http.StatusOK {
+					fmt.Println(styles.SuccessMessage("API is healthy"))
+					return nil
+				}
+			}
+		}
+	}
+}
+
+// Wait waits for all subprocesses to exit
+func (sm *SubprocessManager) Wait() error {
+	var wg sync.WaitGroup
+	errCh := make(chan error, 2)
+
+	sm.mu.Lock()
+	apiCmd := sm.apiCmd
+	engineCmd := sm.engineCmd
+	sm.mu.Unlock()
+
+	if apiCmd != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := apiCmd.Wait(); err != nil {
+				errCh <- fmt.Errorf("API exited: %w", err)
+			}
+		}()
+	}
+
+	if engineCmd != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := engineCmd.Wait(); err != nil {
+				errCh <- fmt.Errorf("Engine exited: %w", err)
+			}
+		}()
+	}
+
+	// Wait for first error or all processes to exit
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-done:
+		return nil
+	}
+}
+
+// IsRunning returns whether subprocesses are currently running
+func (sm *SubprocessManager) IsRunning() bool {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	return sm.started
+}
+
+// prefixWriter wraps an io.Writer and adds a prefix to each line
+type prefixWriter struct {
+	w      io.Writer
+	prefix string
+	buf    []byte
+}
+
+func newPrefixWriter(w io.Writer, prefix string) *prefixWriter {
+	return &prefixWriter{
+		w:      w,
+		prefix: prefix,
+		buf:    make([]byte, 0, 1024),
+	}
+}
+
+func (pw *prefixWriter) Write(p []byte) (n int, err error) {
+	n = len(p)
+	pw.buf = append(pw.buf, p...)
+
+	for {
+		idx := -1
+		for i, b := range pw.buf {
+			if b == '\n' {
+				idx = i
+				break
+			}
+		}
+
+		if idx == -1 {
+			break
+		}
+
+		line := pw.buf[:idx+1]
+		pw.buf = pw.buf[idx+1:]
+
+		if _, err := fmt.Fprintf(pw.w, "%s%s", pw.prefix, line); err != nil {
+			return n, err
+		}
+	}
+
+	return n, nil
+}

--- a/cmd/hatchet-cli/cli/internal/drivers/local/subprocess_unix.go
+++ b/cmd/hatchet-cli/cli/internal/drivers/local/subprocess_unix.go
@@ -1,0 +1,57 @@
+//go:build !windows
+
+package local
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/styles"
+)
+
+// setPlatformAttributes sets Unix-specific process attributes
+func setPlatformAttributes(cmd *exec.Cmd) {
+	// Make process its own process group so we can kill it and all children
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}
+
+// stopProcess sends SIGTERM and waits for process to exit, then SIGKILL if needed
+func stopProcess(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+
+	// Send SIGTERM to process group
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err == nil {
+		_ = syscall.Kill(-pgid, syscall.SIGTERM)
+	} else {
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+	}
+
+	// Wait for process to exit with timeout
+	done := make(chan error, 1)
+	go func() {
+		_, err := cmd.Process.Wait()
+		done <- err
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-time.After(10 * time.Second):
+		// Force kill if graceful shutdown times out
+		fmt.Println(styles.Muted.Render("Graceful shutdown timed out, force killing..."))
+		if pgid, err := syscall.Getpgid(cmd.Process.Pid); err == nil {
+			_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		} else {
+			_ = cmd.Process.Kill()
+		}
+		<-done // Wait for the process to be fully gone
+		return nil
+	}
+}

--- a/cmd/hatchet-cli/cli/internal/drivers/local/subprocess_windows.go
+++ b/cmd/hatchet-cli/cli/internal/drivers/local/subprocess_windows.go
@@ -1,0 +1,50 @@
+//go:build windows
+
+package local
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/styles"
+)
+
+// setPlatformAttributes sets Windows-specific process attributes
+func setPlatformAttributes(cmd *exec.Cmd) {
+	// Windows doesn't need special process group handling
+	// The taskkill /T flag handles killing child processes
+}
+
+// stopProcess uses taskkill to stop the process and its children on Windows
+func stopProcess(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+
+	pid := cmd.Process.Pid
+
+	// First try graceful shutdown using taskkill with /T (tree kill)
+	killCmd := exec.Command("taskkill", "/T", "/PID", strconv.Itoa(pid))
+	_ = killCmd.Run() // Ignore error as process might already be dead
+
+	// Wait for process to exit with timeout
+	done := make(chan error, 1)
+	go func() {
+		_, err := cmd.Process.Wait()
+		done <- err
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-time.After(10 * time.Second):
+		// Force kill if graceful shutdown times out
+		fmt.Println(styles.Muted.Render("Graceful shutdown timed out, force killing..."))
+		forceKillCmd := exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(pid))
+		_ = forceKillCmd.Run()
+		<-done // Wait for the process to be fully gone
+		return nil
+	}
+}

--- a/frontend/docs/pages/cli/running-hatchet-locally.mdx
+++ b/frontend/docs/pages/cli/running-hatchet-locally.mdx
@@ -1,25 +1,101 @@
 # Running Hatchet Locally
 
-The Hatchet CLI provides the `hatchet server` commands to run a local instance of Hatchet for development and testing purposes. This local instance relies on Docker to run the necessary services.
+The Hatchet CLI provides the `hatchet server` commands to run a local instance of Hatchet for development and testing. There are two modes:
 
-## Prerequisites
+- **Docker mode** (default) — runs Hatchet in Docker containers
+- **Local mode** (`--local`) — downloads and runs Hatchet binaries directly, with an embedded PostgreSQL database. No Docker required.
 
-Before running Hatchet locally, you must have Docker installed on your machine. You can download Docker from [here](https://www.docker.com/get-started).
+## Docker Mode
 
-## Starting Hatchet Locally
+### Prerequisites
 
-To start a local instance of Hatchet, run the following command in your terminal:
+Docker must be installed. You can download it from [here](https://www.docker.com/get-started).
+
+### Starting
 
 ```sh
 hatchet server start
 ```
 
-## Stopping Hatchet Locally
-
-To stop the local Hatchet instance, run the following command:
+### Stopping
 
 ```sh
 hatchet server stop
+```
+
+## Local Mode (no Docker)
+
+Local mode runs Hatchet directly on your machine without Docker. It automatically downloads the required binaries (`hatchet-api`, `hatchet-engine`, `hatchet-migrate`, `hatchet-admin`) from GitHub releases and starts an embedded PostgreSQL instance.
+
+### Starting
+
+```sh
+hatchet server start --local
+```
+
+This will:
+
+1. Start an embedded PostgreSQL database (port 5433 by default)
+2. Download the required Hatchet binaries (cached for future runs)
+3. Run database migrations
+4. Generate encryption keys and seed the database
+5. Start the API and engine servers
+6. Create a local CLI profile for connecting
+
+The server runs in the foreground — press `Ctrl+C` to stop.
+
+### Custom Ports
+
+```sh
+hatchet server start --local --api-port 9080 --grpc-port 9077 --postgres-port 5434
+```
+
+### External PostgreSQL
+
+If you already have a PostgreSQL instance running, you can use it instead of the embedded one:
+
+```sh
+hatchet server start --local --database-url "postgresql://user:pass@localhost:5432/hatchet"
+```
+
+### Stopping
+
+```sh
+hatchet server stop
+```
+
+The stop command auto-detects whether the server was started in Docker or local mode.
+
+### Cleanup
+
+If the server was interrupted and left orphan processes behind (e.g. port already in use errors), run:
+
+```sh
+hatchet server cleanup
+```
+
+## Building Binaries from Source
+
+By default, `--local` mode downloads pre-built binaries from GitHub releases. If you're developing Hatchet itself or need to test unreleased changes, you can build the binaries from the local repository instead.
+
+From within the hatchet repo:
+
+```sh
+hatchet server build
+```
+
+This builds all four binaries (`hatchet-api`, `hatchet-engine`, `hatchet-migrate`, `hatchet-admin`) from source and places them into the same cache that `--local` mode checks. After building, start the server normally:
+
+```sh
+hatchet server start --local
+```
+
+It will find the locally built binaries and use them instead of downloading.
+
+You can also specify the repo root explicitly:
+
+```sh
+hatchet server build --repo-root /path/to/hatchet
 ```
 
 ## Reference
@@ -27,54 +103,63 @@ hatchet server stop
 #### `hatchet server start`
 
 ```txt
-Start a local Hatchet server environment using Docker containers. This command will start both a PostgreSQL database and a Hatchet server instance, automatically creating a local profile for easy access.
-
 Usage:
   hatchet server start [flags]
 
 Examples:
-  # Start server with default settings (port 8888)
+  # Start server with Docker (default)
   hatchet server start
 
-  # Start server with custom dashboard port
-  hatchet server start --dashboard-port 9000
+  # Start server without Docker (uses embedded PostgreSQL)
+  hatchet server start --local
 
-  # Start server with custom ports and project name
-  hatchet server start --dashboard-port 9000 --grpc-port 8077 --project-name my-hatchet
+  # Start local server with external PostgreSQL
+  hatchet server start --local --database-url "postgresql://user:pass@localhost:5432/hatchet"
 
-  # Start server with custom profile name
-  hatchet server start --profile my-local
+  # Start local server with custom ports
+  hatchet server start --local --api-port 9080 --grpc-port 9077
 
 Flags:
-  -d, --dashboard-port int    Port for the Hatchet dashboard (default: auto-detect starting at 8888)
-  -g, --grpc-port int         Port for the Hatchet gRPC server (default: auto-detect starting at 7077)
-  -h, --help                  help for start
-  -n, --profile string        Name for the local profile (default: local) (default "local")
-  -p, --project-name string   Docker project name for containers (default: hatchet-cli)
-
-Global Flags:
-  -v, --version   The version of the hatchet cli.
+      --api-port int            Port for the API server in --local mode (default: 8080)
+      --binary-version string   Version of hatchet-api/engine binaries to download (default: CLI version)
+  -d, --dashboard-port int      Port for the Hatchet dashboard in Docker mode (default: auto-detect starting at 8888)
+      --database-url string     PostgreSQL connection string (disables embedded PostgreSQL)
+  -g, --grpc-port int           Port for the Hatchet gRPC server (default: auto-detect starting at 7077)
+      --healthcheck-port int    Port for the healthcheck server in --local mode (default: 8733)
+  -l, --local                   Run without Docker (uses embedded PostgreSQL by default)
+      --no-embedded-postgres    Disable embedded PostgreSQL (requires external PostgreSQL)
+      --postgres-port int       Port for embedded PostgreSQL (default: 5433)
+  -n, --profile string          Name for the local profile (default: "local")
+  -p, --project-name string     Docker project name for containers (default: hatchet-cli)
 ```
 
 #### `hatchet server stop`
 
 ```txt
-Stop a local Hatchet server environment that was started using Docker containers with the 'hatchet server start' command.
-
 Usage:
   hatchet server stop [flags]
 
-Examples:
-  # Stop the local Hatchet server
-  hatchet server stop
+Flags:
+  -l, --local                   Explicitly stop a local (non-Docker) server
+  -p, --project-name string     Docker project name for containers (default: hatchet-cli)
+```
 
-  # Stop the local Hatchet server with a custom project name
-  hatchet server stop --project-name my-hatchet
+#### `hatchet server build`
+
+```txt
+Usage:
+  hatchet server build [flags]
 
 Flags:
-  -h, --help                  help for stop
-  -p, --project-name string   Docker project name for containers (default: hatchet-cli)
+      --repo-root string   Path to hatchet repo root (auto-detected if inside repo)
+```
 
-Global Flags:
-  -v, --version   The version of the hatchet cli.
+#### `hatchet server cleanup`
+
+```txt
+Usage:
+  hatchet server cleanup [flags]
+
+Flags:
+      --postgres-port int   Port for embedded PostgreSQL to clean up (default: 5433)
 ```

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6
 	github.com/emersion/go-smtp v0.24.0
 	github.com/fatih/color v1.18.0
+	github.com/fergusstrange/embedded-postgres v1.33.0
 	github.com/getkin/kin-openapi v0.133.0
 	github.com/go-co-op/gocron/v2 v2.19.1
 	github.com/google/go-github/v57 v57.0.0
@@ -142,6 +143,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
+	github.com/lib/pq v1.10.9 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
@@ -187,6 +189,7 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/woodsbury/decimal128 v1.3.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/labstack/echo/v4 v4.15.0
+	github.com/lib/pq v1.10.9
 	github.com/mattn/go-runewidth v0.0.19
 	github.com/oapi-codegen/runtime v1.1.2
 	github.com/opencontainers/go-digest v1.0.0
@@ -143,7 +144,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
-	github.com/lib/pq v1.10.9 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fergusstrange/embedded-postgres v1.33.0 h1:ka8vmRpm4IDsES7NPXQ/NThAp1fc/f+crcXYjCW7wK0=
+github.com/fergusstrange/embedded-postgres v1.33.0/go.mod h1:w0YvnCgf19o6tskInrOOACtnqfVlOvluz3hlNLY7tRk=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
@@ -471,6 +473,8 @@ github.com/woodsbury/decimal128 v1.3.0 h1:8pffMNWIlC0O5vbyHWFZAt5yWvWcrHA+3ovIIj
 github.com/woodsbury/decimal128 v1.3.0/go.mod h1:C5UTmyTjW3JftjUFzOVhC20BEQa2a4ZKOB5I6Zjb+ds=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
# Description

Adds `--local` flag to `hatchet server start` that runs Hatchet without Docker. Runs API and engine in-process as a single binary, auto-creates the database, and runs in headless mode (no web UI).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## What's Changed

- Add `--local` flag to `hatchet server start` - runs server in-process without Docker
- Auto-create database and set timezone to UTC (no manual `createdb`/`psql` needed)
- Add `--database-url`, `--api-port`, `--grpc-port`, `--healthcheck-port` flags for local mode
- Auto-detect local vs Docker mode in `hatchet server stop`
- Persist encryption keys to `~/.hatchet/local/keys.json` for reuse across restarts
- Add unit tests for identifier validation and driver initialization

## Usage

```bash
# Start with local Postgres (requires Postgres running)
hatchet server start --local

# Custom database URL
hatchet server start --local --database-url "postgresql://user:pass@localhost:5432/mydb"

# Custom ports (useful alongside Docker)
hatchet server start --local --api-port 9080 --grpc-port 9077

# Stop (auto-detects mode)
hatchet server stop

Note: Local mode is headless (no web UI). Use TUI or SDK to interact.
```

## Notes

Binary size increases from ~27MB to ~66MB due to embedding API and engine code for in-process execution. This is the tradeoff for single-binary distribution without external dependencies.

