### PR TITLE
small fixes/improvements to CLI logic

### DIFF
--- a/cmd/hatchet-cli/cli/internal/config/cli/profile.go
+++ b/cmd/hatchet-cli/cli/internal/config/cli/profile.go
@@ -165,23 +165,34 @@ func RemoveProfile(name string) error {
 	allSettings := ProfilesViperConfig.AllSettings()
 
 	// Remove the profile from the profiles map
+	var updatedProfiles map[string]any
 	if profiles, ok := allSettings["profiles"].(map[string]any); ok {
 		delete(profiles, name)
-		allSettings["profiles"] = profiles
+		updatedProfiles = profiles
 	}
 
-	// Clear default profile if this was the default
-	if defaultProfile, ok := allSettings["defaultProfile"].(string); ok && defaultProfile == name {
-		allSettings["defaultProfile"] = ""
+	// Check the default profile (Viper normalizes keys to lowercase)
+	var currentDefault string
+	var hasDefault bool
+	if val, ok := allSettings["defaultprofile"]; ok {
+		if strVal, isString := val.(string); isString && strVal != "" {
+			currentDefault = strVal
+			hasDefault = true
+		}
 	}
 
-	// Create a fresh Viper instance to avoid cached key issues
+	clearDefault := hasDefault && currentDefault == name
+
+	// Create a fresh Viper instance
 	newViper := viper.New()
 	newViper.SetConfigType("yaml")
 
-	// Set the cleaned settings
-	for k, v := range allSettings {
-		newViper.Set(k, v)
+	// Set only the profiles (not the default if it was the removed profile)
+	newViper.Set("profiles", updatedProfiles)
+
+	// Only set defaultProfile if it exists and wasn't the removed profile
+	if hasDefault && !clearDefault {
+		newViper.Set("defaultProfile", currentDefault)
 	}
 
 	// Save the config
@@ -191,8 +202,13 @@ func RemoveProfile(name string) error {
 		return err
 	}
 
-	// Replace the global with the new instance
+	// Reload the config into the new viper instance to ensure consistency
 	newViper.SetConfigFile(profilesFilePath)
+	if err := newViper.ReadInConfig(); err != nil {
+		return fmt.Errorf("failed to reload config after removing profile: %w", err)
+	}
+
+	// Replace the global with the new instance
 	ProfilesViperConfig = newViper
 
 	return nil
@@ -326,8 +342,41 @@ func ClearDefaultProfile() error {
 		return fmt.Errorf("failed to reload config: %w", err)
 	}
 
-	ProfilesViperConfig.Set("defaultProfile", "")
-	return saveConfig()
+	// Only proceed if defaultProfile is actually set
+	if !ProfilesViperConfig.IsSet("defaultProfile") {
+		return nil
+	}
+
+	// Get all profiles (Viper normalizes keys to lowercase)
+	allSettings := ProfilesViperConfig.AllSettings()
+
+	// Create a fresh Viper instance with only profiles (no defaultProfile)
+	newViper := viper.New()
+	newViper.SetConfigType("yaml")
+
+	// Copy only the profiles map, explicitly excluding defaultProfile
+	// Note: Viper stores keys as lowercase in AllSettings()
+	if profiles, ok := allSettings["profiles"]; ok {
+		newViper.Set("profiles", profiles)
+	}
+
+	// Save the config
+	profilesFilePath := getProfilesFilePath()
+	if err := newViper.WriteConfigAs(profilesFilePath); err != nil {
+		return err
+	}
+
+	// Reload the config into the new viper instance to ensure consistency
+	newViper.SetConfigFile(profilesFilePath)
+	if err := newViper.ReadInConfig(); err != nil {
+		return fmt.Errorf("failed to reload config after clearing default: %w", err)
+	}
+
+	// Replace the global with the new instance
+	ProfilesViperConfig = newViper
+
+	return nil
+
 }
 
 // getProfilesFilePath returns the path to the profiles config file

--- a/cmd/hatchet-cli/cli/quickstart.go
+++ b/cmd/hatchet-cli/cli/quickstart.go
@@ -66,6 +66,58 @@ var quickstartCmd = &cobra.Command{
 			dir = selectDirectoryForm(projectName)
 		}
 
+		// Check if directory exists and get user confirmation
+		if _, err := os.Stat(dir); err == nil {
+			// Directory exists - ask for confirmation
+			var confirm bool
+
+			confirmForm := huh.NewForm(
+				huh.NewGroup(
+					huh.NewConfirm().
+						Title(fmt.Sprintf("Directory %s already exists. Are you sure this is the right directory?", dir)).
+						Value(&confirm),
+				),
+			).WithTheme(styles.HatchetTheme())
+
+			err := confirmForm.Run()
+			if err != nil {
+				cli.Logger.Fatalf("could not run confirmation form: %v", err)
+			}
+
+			if !confirm {
+				fmt.Println("Quickstart cancelled")
+				os.Exit(0)
+			}
+
+			// Check if directory is not empty
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				cli.Logger.Fatalf("could not read directory: %v", err)
+			}
+
+			if len(entries) > 0 {
+				var confirmNonEmpty bool
+
+				nonEmptyForm := huh.NewForm(
+					huh.NewGroup(
+						huh.NewConfirm().
+							Title("Directory is not empty. Files will be written but existing files will not be deleted. Continue?").
+							Value(&confirmNonEmpty),
+					),
+				).WithTheme(styles.HatchetTheme())
+
+				err := nonEmptyForm.Run()
+				if err != nil {
+					cli.Logger.Fatalf("could not run confirmation form: %v", err)
+				}
+
+				if !confirmNonEmpty {
+					fmt.Println("Quickstart cancelled")
+					os.Exit(0)
+				}
+			}
+		}
+
 		templateData := templater.Data{
 			Name: projectName,
 		}

--- a/cmd/hatchet-cli/cli/tui.go
+++ b/cmd/hatchet-cli/cli/tui.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -33,11 +34,11 @@ var tuiCmd = &cobra.Command{
 
 		var selectedProfile string
 
-		// Use profile from flag if provided, otherwise show selection form
+		// Use profile from flag if provided, otherwise use default or show selection form
 		if profileFlag != "" {
 			selectedProfile = profileFlag
 		} else {
-			selectedProfile = selectProfileForm()
+			selectedProfile = selectProfileForm(true)
 
 			if selectedProfile == "" {
 				cli.Logger.Fatal("no profile selected")
@@ -131,6 +132,7 @@ func newTUIModel(profileName string, hatchetClient client.Client) tuiModel {
 	for name := range profiles {
 		profileNames = append(profileNames, name)
 	}
+	sort.Strings(profileNames)
 
 	return tuiModel{
 		currentView:          currentView,

--- a/cmd/hatchet-cli/cli/worker.go
+++ b/cmd/hatchet-cli/cli/worker.go
@@ -112,11 +112,11 @@ func init() {
 func startWorker(cmd *cobra.Command, devConfig *worker.WorkerDevConfig, profileFlag string) {
 	var selectedProfile string
 
-	// Use profile from flag if provided, otherwise show selection form
+	// Use profile from flag if provided, otherwise use default or show selection form
 	if profileFlag != "" {
 		selectedProfile = profileFlag
 	} else {
-		selectedProfile = selectProfileForm()
+		selectedProfile = selectProfileForm(true)
 
 		if selectedProfile == "" {
 			// No profiles found - prompt user to either start local server or add a profile
@@ -311,7 +311,7 @@ func runScript(cmd *cobra.Command, scriptFlag string, profileFlag string) {
 	if profileFlag != "" {
 		selectedProfile = profileFlag
 	} else {
-		selectedProfile = selectProfileForm()
+		selectedProfile = selectProfileForm(true)
 
 		if selectedProfile == "" {
 			selectedProfile = handleNoProfiles(cmd)
@@ -382,10 +382,6 @@ func runScript(cmd *cobra.Command, scriptFlag string, profileFlag string) {
 
 // selectScriptForm displays an interactive form to select a script
 func selectScriptForm() *worker.Script {
-	if len(c.Scripts) == 1 {
-		return &c.Scripts[0]
-	}
-
 	// Build options from scripts
 	options := make([]huh.Option[int], 0, len(c.Scripts))
 	for i, script := range c.Scripts {

--- a/frontend/docs/pages/cli/profiles.mdx
+++ b/frontend/docs/pages/cli/profiles.mdx
@@ -24,9 +24,36 @@ You can list all the profiles you have configured using the `hatchet profile lis
 hatchet profile list
 ```
 
+This will display all configured profiles, with the default profile marked with `(default)` if one is set.
+
+## Setting a Default Profile
+
+You can set a profile as the default using the `hatchet profile set-default` command. The default profile will be automatically used when no profile is specified with the `--profile` flag.
+
+```sh
+# Set default profile interactively (prompts for selection)
+hatchet profile set-default
+
+# Set a specific profile as default
+hatchet profile set-default --name [name]
+```
+
+Once a default profile is set, you can run commands without specifying the `--profile` flag:
+
+```sh
+# Uses the default profile
+hatchet worker dev
+```
+
+To unset the default profile:
+
+```sh
+hatchet profile unset-default
+```
+
 ## Using a Profile
 
-To use a specific profile for your Hatchet CLI commands, you can specify the profile name using the `--profile` flag. For example:
+To use a specific profile for your Hatchet CLI commands, you can specify the profile name using the `--profile` flag. This overrides the default profile if one is set.
 
 ```sh
 hatchet worker dev --profile [name]
@@ -42,8 +69,10 @@ hatchet profile update
 
 ## Deleting a Profile
 
-You can delete a profile using the `hatchet profile delete` command:
+You can delete a profile using the `hatchet profile remove` command:
 
 ```sh
-hatchet profile delete
+hatchet profile remove
 ```
+
+If you remove a profile that is set as the default, the default profile setting will be automatically cleared.


### PR DESCRIPTION
# Description

Fixes a bunch of small annoyances in the CLI:
- [X] Install script no longer requires `sudo` for installation by default, uses the `.local` bin if in path
- [X] Prompts the user twice if they're writing quickstart files to an existing dir
- [X] Sets a stable ordering for listing profiles
- [X] Provides a script selector on `hatchet worker run` even when there's a single script, so the description can be viewed
- [X] Adds support for default profiles

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation change
- [X] New feature (non-breaking change which adds functionality)