### PR TITLE
bugfix: allow python healthcheck server to bind on ipv6 hosts

### DIFF
--- a/sdks/python/.gitignore
+++ b/sdks/python/.gitignore
@@ -163,6 +163,3 @@ cython_debug/
 
 openapitools.json
 .python-version
-
-# Dev-specific poetry overrides - e.g. local venvs (use pyproject.toml for project-level config)
-poetry.toml

--- a/sdks/python/.gitignore
+++ b/sdks/python/.gitignore
@@ -163,3 +163,6 @@ cython_debug/
 
 openapitools.json
 .python-version
+
+# Dev-specific poetry overrides - e.g. local venvs (use pyproject.toml for project-level config)
+poetry.toml

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.9] - 2026-01-26
+
+### Added
+
+- `HATCHET_CLIENT_WORKER_HEALTHCHECK_BIND_ADDRESS` now allows configuring the bind address for the worker healthcheck server (default: `0.0.0.0`)
+
 ## [1.22.8] - 2026-01-20
 
 ### Added

--- a/sdks/python/hatchet_sdk/config.py
+++ b/sdks/python/hatchet_sdk/config.py
@@ -42,6 +42,8 @@ class HealthcheckConfig(BaseSettings):
         default=timedelta(seconds=5),
         description="If the worker listener process event loop appears blocked longer than this threshold, /health returns 503. Value is interpreted as seconds.",
     )
+    # HATCHET_CLIENT_WORKER_HEALTHCHECK_BIND_ADDRESS
+    bind_address: str = "0.0.0.0"
 
     @field_validator("event_loop_block_threshold_seconds", mode="before")
     @classmethod

--- a/sdks/python/hatchet_sdk/config.py
+++ b/sdks/python/hatchet_sdk/config.py
@@ -43,7 +43,7 @@ class HealthcheckConfig(BaseSettings):
         description="If the worker listener process event loop appears blocked longer than this threshold, /health returns 503. Value is interpreted as seconds.",
     )
     # HATCHET_CLIENT_WORKER_HEALTHCHECK_BIND_ADDRESS
-    bind_address: str | None = None
+    bind_address: str | None = "0.0.0.0"
 
     @field_validator("event_loop_block_threshold_seconds", mode="before")
     @classmethod

--- a/sdks/python/hatchet_sdk/config.py
+++ b/sdks/python/hatchet_sdk/config.py
@@ -62,6 +62,17 @@ class HealthcheckConfig(BaseSettings):
 
         return timedelta(seconds=float(v))
 
+    @field_validator("bind_address", mode="after")
+    @classmethod
+    def validate_bind_address(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+
+        if value.lower() == "none" or not value.strip():
+            return None
+
+        return value
+
 
 class OpenTelemetryConfig(BaseSettings):
     model_config = create_settings_config(

--- a/sdks/python/hatchet_sdk/config.py
+++ b/sdks/python/hatchet_sdk/config.py
@@ -43,7 +43,7 @@ class HealthcheckConfig(BaseSettings):
         description="If the worker listener process event loop appears blocked longer than this threshold, /health returns 503. Value is interpreted as seconds.",
     )
     # HATCHET_CLIENT_WORKER_HEALTHCHECK_BIND_ADDRESS
-    bind_address: str = "0.0.0.0"
+    bind_address: str | None = None
 
     @field_validator("event_loop_block_threshold_seconds", mode="before")
     @classmethod

--- a/sdks/python/hatchet_sdk/config.py
+++ b/sdks/python/hatchet_sdk/config.py
@@ -47,9 +47,7 @@ class HealthcheckConfig(BaseSettings):
 
     @field_validator("event_loop_block_threshold_seconds", mode="before")
     @classmethod
-    def validate_event_loop_block_threshold_seconds(
-        cls, value: timedelta | int | float | str
-    ) -> timedelta:
+    def validate_event_loop_block_threshold_seconds(cls, value: timedelta | int | float | str) -> timedelta:
         # Settings env vars are strings; interpret as seconds.
         if isinstance(value, timedelta):
             return value
@@ -107,12 +105,8 @@ class ClientConfig(BaseSettings):
     otel: OpenTelemetryConfig = Field(default_factory=lambda: OpenTelemetryConfig())
 
     listener_v2_timeout: int | None = None
-    grpc_max_recv_message_length: int = Field(
-        default=4 * 1024 * 1024, description="4MB default"
-    )
-    grpc_max_send_message_length: int = Field(
-        default=4 * 1024 * 1024, description="4MB default"
-    )
+    grpc_max_recv_message_length: int = Field(default=4 * 1024 * 1024, description="4MB default")
+    grpc_max_send_message_length: int = Field(default=4 * 1024 * 1024, description="4MB default")
 
     worker_preset_labels: dict[str, str] = Field(default_factory=dict)
 
@@ -145,9 +139,7 @@ class ClientConfig(BaseSettings):
     def validate_addresses(self) -> "ClientConfig":
         ## If nothing is set, read from the token
         ## If either is set, override what's in the JWT
-        server_url_from_jwt, grpc_broadcast_address_from_jwt = get_addresses_from_jwt(
-            self.token
-        )
+        server_url_from_jwt, grpc_broadcast_address_from_jwt = get_addresses_from_jwt(self.token)
 
         if "host_port" not in self.model_fields_set:
             self.host_port = grpc_broadcast_address_from_jwt
@@ -189,18 +181,12 @@ class ClientConfig(BaseSettings):
         return hash(json.dumps(self.model_dump(), default=str))
 
     @overload
-    def apply_namespace(
-        self, resource_name: str, namespace_override: str | None = None
-    ) -> str: ...
+    def apply_namespace(self, resource_name: str, namespace_override: str | None = None) -> str: ...
 
     @overload
-    def apply_namespace(
-        self, resource_name: None, namespace_override: str | None = None
-    ) -> None: ...
+    def apply_namespace(self, resource_name: None, namespace_override: str | None = None) -> None: ...
 
-    def apply_namespace(
-        self, resource_name: str | None, namespace_override: str | None = None
-    ) -> str | None:
+    def apply_namespace(self, resource_name: str | None, namespace_override: str | None = None) -> str | None:
         if resource_name is None:
             return None
 

--- a/sdks/python/hatchet_sdk/config.py
+++ b/sdks/python/hatchet_sdk/config.py
@@ -41,7 +41,7 @@ class HealthcheckConfig(BaseSettings):
         default=timedelta(seconds=5),
         description="If the worker listener process event loop appears blocked longer than this threshold, /health returns 503. Value is interpreted as seconds.",
     )
-    bind_address: str = "0.0.0.0"
+    bind_address: str | None = "0.0.0.0"
 
     @field_validator("event_loop_block_threshold_seconds", mode="before")
     @classmethod

--- a/sdks/python/hatchet_sdk/config.py
+++ b/sdks/python/hatchet_sdk/config.py
@@ -47,7 +47,9 @@ class HealthcheckConfig(BaseSettings):
 
     @field_validator("event_loop_block_threshold_seconds", mode="before")
     @classmethod
-    def validate_event_loop_block_threshold_seconds(cls, value: timedelta | int | float | str) -> timedelta:
+    def validate_event_loop_block_threshold_seconds(
+        cls, value: timedelta | int | float | str
+    ) -> timedelta:
         # Settings env vars are strings; interpret as seconds.
         if isinstance(value, timedelta):
             return value
@@ -105,8 +107,12 @@ class ClientConfig(BaseSettings):
     otel: OpenTelemetryConfig = Field(default_factory=lambda: OpenTelemetryConfig())
 
     listener_v2_timeout: int | None = None
-    grpc_max_recv_message_length: int = Field(default=4 * 1024 * 1024, description="4MB default")
-    grpc_max_send_message_length: int = Field(default=4 * 1024 * 1024, description="4MB default")
+    grpc_max_recv_message_length: int = Field(
+        default=4 * 1024 * 1024, description="4MB default"
+    )
+    grpc_max_send_message_length: int = Field(
+        default=4 * 1024 * 1024, description="4MB default"
+    )
 
     worker_preset_labels: dict[str, str] = Field(default_factory=dict)
 
@@ -139,7 +145,9 @@ class ClientConfig(BaseSettings):
     def validate_addresses(self) -> "ClientConfig":
         ## If nothing is set, read from the token
         ## If either is set, override what's in the JWT
-        server_url_from_jwt, grpc_broadcast_address_from_jwt = get_addresses_from_jwt(self.token)
+        server_url_from_jwt, grpc_broadcast_address_from_jwt = get_addresses_from_jwt(
+            self.token
+        )
 
         if "host_port" not in self.model_fields_set:
             self.host_port = grpc_broadcast_address_from_jwt
@@ -181,12 +189,18 @@ class ClientConfig(BaseSettings):
         return hash(json.dumps(self.model_dump(), default=str))
 
     @overload
-    def apply_namespace(self, resource_name: str, namespace_override: str | None = None) -> str: ...
+    def apply_namespace(
+        self, resource_name: str, namespace_override: str | None = None
+    ) -> str: ...
 
     @overload
-    def apply_namespace(self, resource_name: None, namespace_override: str | None = None) -> None: ...
+    def apply_namespace(
+        self, resource_name: None, namespace_override: str | None = None
+    ) -> None: ...
 
-    def apply_namespace(self, resource_name: str | None, namespace_override: str | None = None) -> str | None:
+    def apply_namespace(
+        self, resource_name: str | None, namespace_override: str | None = None
+    ) -> str | None:
         if resource_name is None:
             return None
 

--- a/sdks/python/hatchet_sdk/config.py
+++ b/sdks/python/hatchet_sdk/config.py
@@ -45,6 +45,13 @@ class HealthcheckConfig(BaseSettings):
     # HATCHET_CLIENT_WORKER_HEALTHCHECK_BIND_ADDRESS
     bind_address: str | None = "0.0.0.0"
 
+    @field_validator("bind_address", mode="after")
+    @classmethod
+    def validate_bind_address(cls, value: str | None) -> str | None:
+        if value is None or value.lower() == "none" or len(value) == 0:
+            return None
+        return value
+
     @field_validator("event_loop_block_threshold_seconds", mode="before")
     @classmethod
     def validate_event_loop_block_threshold_seconds(

--- a/sdks/python/hatchet_sdk/config.py
+++ b/sdks/python/hatchet_sdk/config.py
@@ -37,20 +37,11 @@ class HealthcheckConfig(BaseSettings):
 
     port: int = 8001
     enabled: bool = False
-    # HATCHET_CLIENT_WORKER_HEALTHCHECK_EVENT_LOOP_BLOCK_THRESHOLD_SECONDS
     event_loop_block_threshold_seconds: timedelta = Field(
         default=timedelta(seconds=5),
         description="If the worker listener process event loop appears blocked longer than this threshold, /health returns 503. Value is interpreted as seconds.",
     )
-    # HATCHET_CLIENT_WORKER_HEALTHCHECK_BIND_ADDRESS
-    bind_address: str | None = "0.0.0.0"
-
-    @field_validator("bind_address", mode="after")
-    @classmethod
-    def validate_bind_address(cls, value: str | None) -> str | None:
-        if value is None or value.lower() == "none" or len(value) == 0:
-            return None
-        return value
+    bind_address: str = "0.0.0.0"
 
     @field_validator("event_loop_block_threshold_seconds", mode="before")
     @classmethod

--- a/sdks/python/hatchet_sdk/worker/action_listener_process.py
+++ b/sdks/python/hatchet_sdk/worker/action_listener_process.py
@@ -259,7 +259,9 @@ class WorkerActionListenerProcess:
 
         try:
             await runner.setup()
-            await web.TCPSite(runner, "0.0.0.0", self.healthcheck_port).start()
+            await web.TCPSite(
+                runner, self.config.healthcheck.bind_address, self.healthcheck_port
+            ).start()
         except Exception:
             logger.exception("failed to start healthcheck server (listener process)")
             return

--- a/sdks/python/hatchet_sdk/worker/action_listener_process.py
+++ b/sdks/python/hatchet_sdk/worker/action_listener_process.py
@@ -242,7 +242,7 @@ class WorkerActionListenerProcess:
 
         try:
             await runner.setup()
-            await web.TCPSite(runner, self._healthcheck_bind_address, self.healthcheck_port).start()
+            await web.TCPSite(runner, host=self._healthcheck_bind_address, port=self.healthcheck_port).start()
         except Exception:
             logger.exception("failed to start healthcheck server (listener process)")
             return

--- a/sdks/python/hatchet_sdk/worker/action_listener_process.py
+++ b/sdks/python/hatchet_sdk/worker/action_listener_process.py
@@ -95,7 +95,9 @@ class WorkerActionListenerProcess:
         self._event_loop_monitor_task: asyncio.Task[None] | None = None
         self._event_loop_last_lag_seconds: float = 0.0
         self._event_loop_blocked_since: float | None = None
-        self._event_loop_block_threshold: timedelta = self.config.healthcheck.event_loop_block_threshold_seconds
+        self._event_loop_block_threshold: timedelta = (
+            self.config.healthcheck.event_loop_block_threshold_seconds
+        )
         self._waiting_steps_blocked_since: float | None = None
         self._starting_since: float = time.time()
 
@@ -104,7 +106,9 @@ class WorkerActionListenerProcess:
         self.action_loop_task: asyncio.Task[None] | None = None
         self.event_send_loop_task: asyncio.Task[None] | None = None
         self.running_step_runs: dict[str, float] = {}
-        self.step_action_events: set[asyncio.Task[UnaryUnaryCall[StepActionEvent, ActionEventResponse] | None]] = set()
+        self.step_action_events: set[
+            asyncio.Task[UnaryUnaryCall[StepActionEvent, ActionEventResponse] | None]
+        ] = set()
 
         if self.debug:
             logger.setLevel(logging.DEBUG)
@@ -112,9 +116,15 @@ class WorkerActionListenerProcess:
         self.client = Client(config=self.config, debug=self.debug)
 
         loop = asyncio.get_event_loop()
-        loop.add_signal_handler(signal.SIGINT, lambda: asyncio.create_task(self.pause_task_assignment()))
-        loop.add_signal_handler(signal.SIGTERM, lambda: asyncio.create_task(self.pause_task_assignment()))
-        loop.add_signal_handler(signal.SIGQUIT, lambda: asyncio.create_task(self.exit_gracefully()))
+        loop.add_signal_handler(
+            signal.SIGINT, lambda: asyncio.create_task(self.pause_task_assignment())
+        )
+        loop.add_signal_handler(
+            signal.SIGTERM, lambda: asyncio.create_task(self.pause_task_assignment())
+        )
+        loop.add_signal_handler(
+            signal.SIGQUIT, lambda: asyncio.create_task(self.exit_gracefully())
+        )
 
         if self.enable_health_server:
             self._listener_health_gauge = Gauge(
@@ -141,7 +151,9 @@ class WorkerActionListenerProcess:
             if timedelta(seconds=lag) >= self._event_loop_block_threshold:
                 if self._event_loop_blocked_since is None:
                     self._event_loop_blocked_since = start + interval
-                self._event_loop_last_lag_seconds = max(lag, time.time() - self._event_loop_blocked_since)
+                self._event_loop_last_lag_seconds = max(
+                    lag, time.time() - self._event_loop_blocked_since
+                )
             else:
                 self._event_loop_last_lag_seconds = lag
 
@@ -158,7 +170,8 @@ class WorkerActionListenerProcess:
         # If the event loop has been blocked longer than the configured threshold, report unhealthy.
         if (
             self._event_loop_blocked_since is not None
-            and timedelta(seconds=(time.time() - self._event_loop_blocked_since)) > self._event_loop_block_threshold
+            and timedelta(seconds=(time.time() - self._event_loop_blocked_since))
+            > self._event_loop_block_threshold
         ):
             return HealthStatus.UNHEALTHY
 
@@ -167,7 +180,8 @@ class WorkerActionListenerProcess:
         # "Waiting Steps" blocked-loop warning).
         if (
             self._waiting_steps_blocked_since is not None
-            and timedelta(seconds=(time.time() - self._waiting_steps_blocked_since)) > self._event_loop_block_threshold
+            and timedelta(seconds=(time.time() - self._waiting_steps_blocked_since))
+            > self._event_loop_block_threshold
         ):
             return HealthStatus.UNHEALTHY
 
@@ -194,7 +208,11 @@ class WorkerActionListenerProcess:
             now = time.time()
             time_last_hb = listener.time_last_hb_succeeded or 0.0
             has_hb_success = 0.0 < time_last_hb <= now
-            ok = bool(listener.heartbeat_task is not None and listener.last_heartbeat_succeeded and has_hb_success)
+            ok = bool(
+                listener.heartbeat_task is not None
+                and listener.last_heartbeat_succeeded
+                and has_hb_success
+            )
         else:
             # For v1 listen strategy (no heartbeater), treat "no retries" as healthy.
             ok = bool(listener.retries == 0)
@@ -242,7 +260,9 @@ class WorkerActionListenerProcess:
 
         try:
             await runner.setup()
-            await web.TCPSite(runner, host=self._healthcheck_bind_address, port=self.healthcheck_port).start()
+            await web.TCPSite(
+                runner, host=self._healthcheck_bind_address, port=self.healthcheck_port
+            ).start()
         except Exception:
             logger.exception("failed to start healthcheck server (listener process)")
             return
@@ -253,7 +273,9 @@ class WorkerActionListenerProcess:
         )
 
         if self._event_loop_monitor_task is None:
-            self._event_loop_monitor_task = asyncio.create_task(self._monitor_event_loop())
+            self._event_loop_monitor_task = asyncio.create_task(
+                self._monitor_event_loop()
+            )
 
     async def stop_health_server(self) -> None:
         if self._event_loop_monitor_task is not None:
@@ -343,7 +365,9 @@ class WorkerActionListenerProcess:
                     self._waiting_steps_blocked_since = time.time()
                 blocked_for = time.time() - self._waiting_steps_blocked_since
                 # Continuously increasing "lag length" while we're blocked waiting for steps to start.
-                logger.warning(f"{BLOCKED_THREAD_WARNING} Waiting Steps {count} blocked_for={blocked_for:.1f}s")
+                logger.warning(
+                    f"{BLOCKED_THREAD_WARNING} Waiting Steps {count} blocked_for={blocked_for:.1f}s"
+                )
             else:
                 self._waiting_steps_blocked_since = None
             await asyncio.sleep(1)
@@ -359,14 +383,21 @@ class WorkerActionListenerProcess:
                     # ideally we change the first to an ack to set the time
                     if event.type == STEP_EVENT_TYPE_STARTED:
                         if event.action.step_run_id in self.running_step_runs:
-                            diff = self.now() - self.running_step_runs[event.action.step_run_id]
+                            diff = (
+                                self.now()
+                                - self.running_step_runs[event.action.step_run_id]
+                            )
                             if diff > 0.1:
-                                logger.warning(f"{BLOCKED_THREAD_WARNING} time to start: {diff}s")
+                                logger.warning(
+                                    f"{BLOCKED_THREAD_WARNING} time to start: {diff}s"
+                                )
                             else:
                                 logger.debug(f"start time: {diff}")
                             del self.running_step_runs[event.action.step_run_id]
                         else:
-                            self.running_step_runs[event.action.step_run_id] = self.now()
+                            self.running_step_runs[event.action.step_run_id] = (
+                                self.now()
+                            )
 
                     send_started_event_task = asyncio.create_task(
                         self.dispatcher_client.send_step_action_event(
@@ -378,13 +409,17 @@ class WorkerActionListenerProcess:
                     )
 
                     self.step_action_events.add(send_started_event_task)
-                    send_started_event_task.add_done_callback(lambda t: self.step_action_events.discard(t))
+                    send_started_event_task.add_done_callback(
+                        lambda t: self.step_action_events.discard(t)
+                    )
                 case ActionType.CANCEL_STEP_RUN:
                     logger.debug("unimplemented event send")
                 case _:
                     logger.error("unknown action type for event send")
         except Exception:
-            logger.exception(f"could not send action event ({retry_attempt}/{ACTION_EVENT_RETRY_COUNT})")
+            logger.exception(
+                f"could not send action event ({retry_attempt}/{ACTION_EVENT_RETRY_COUNT})"
+            )
             if retry_attempt <= ACTION_EVENT_RETRY_COUNT:
                 await exp_backoff_sleep(retry_attempt, 1)
                 await self.send_event(event, retry_attempt + 1)
@@ -417,16 +452,22 @@ class WorkerActionListenerProcess:
                                 should_not_retry=False,
                             )
                         )
-                        logger.info(f"rx: start step run: {action.step_run_id}/{action.action_id}")
+                        logger.info(
+                            f"rx: start step run: {action.step_run_id}/{action.action_id}"
+                        )
 
                         # TODO handle this case better...
                         if action.step_run_id in self.running_step_runs:
-                            logger.warning(f"step run already running: {action.step_run_id}")
+                            logger.warning(
+                                f"step run already running: {action.step_run_id}"
+                            )
 
                     case ActionType.CANCEL_STEP_RUN:
                         logger.info(f"rx: cancel step run: {action.step_run_id}")
                     case _:
-                        logger.error(f"rx: unknown action type ({action.action_type}): {action.action_type}")
+                        logger.error(
+                            f"rx: unknown action type ({action.action_type}): {action.action_type}"
+                        )
                 try:
                     self.action_queue.put(action)
                 except Exception:

--- a/sdks/python/hatchet_sdk/worker/worker.py
+++ b/sdks/python/hatchet_sdk/worker/worker.py
@@ -333,8 +333,6 @@ class Worker:
                     self.handle_kill,
                     self.client.debug,
                     self.labels,
-                    enable_health_server,
-                    healthcheck_port,
                 ),
             )
             process.start()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.22.8"
+version = "1.22.9"
 description = "This is the official Python SDK for Hatchet, a distributed, fault-tolerant task queue. The SDK allows you to easily integrate Hatchet's task scheduling and workflow orchestration capabilities into your Python applications."
 authors = [
   "Alexander Belanger <alexander@hatchet.run>",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.22.9"
+version = "1.22.10"
 description = "This is the official Python SDK for Hatchet, a distributed, fault-tolerant task queue. The SDK allows you to easily integrate Hatchet's task scheduling and workflow orchestration capabilities into your Python applications."
 authors = [
   "Alexander Belanger <alexander@hatchet.run>",


### PR DESCRIPTION
# Description

Added a configurable "bind_address" environment variable to the python healthcheck route to allow setting to None, which allows the healthcheck web server to bind to all available hosts (ipv4 & ipv6). To do this, set `HATCHET_CLIENT_WORKER_HEALTHCHECK_BIND_ADDRESS = "None"`, `0.0.0.0` for just ipv4, or `::` for just ipv6.

Intention is to support AAAA dns lookups on Railway to healthcheck each instance of a worker deployment. See below for an example implementation:

```py
# Your railway-deployed API service 

async def get_worker_ips(hostname: str) -> list[str]:
    loop = asyncio.get_event_loop()
    results = await loop.getaddrinfo(
        hostname, None, family=socket.AF_INET6, type=socket.SOCK_STREAM
    )
    return [r[4][0]for r in results]
    
# Then inside your healthcheck:
# 1. collect the ips with the internal railway hostname=xxx.railway.internal
# 2. GET each ip via f"http://[{ip}]:{port}/health"
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## What's Changed

- Added configurable host to python healthcheck endpoint 

## Footnote

You may wish to simplify this to just have a "ip mode" config? Or default to previous behaviour but allow setting all hosts? I've just validated this works on our setup via Railway but may obviously have side-effects on other services that I'm not aware of.
