### PR TITLE
add: email alert support via SMTP

### DIFF
--- a/frontend/docs/pages/self-hosting/_meta.js
+++ b/frontend/docs/pages/self-hosting/_meta.js
@@ -34,4 +34,5 @@ export default {
   "improving-performance": "Improving Performance",
   "read-replicas": "Read Replicas",
   sampling: "Trace Sampling",
+  "smtp-server": "SMTP Server",
 };

--- a/frontend/docs/pages/self-hosting/configuration-options.mdx
+++ b/frontend/docs/pages/self-hosting/configuration-options.mdx
@@ -319,11 +319,19 @@ Variables marked with ⚠️ are conditionally required when specific features a
 | `SERVER_TENANT_ALERTING_SLACK_CLIENT_ID`     | Slack client ID                     |                        |
 | `SERVER_TENANT_ALERTING_SLACK_CLIENT_SECRET` | Slack client secret                 |                        |
 | `SERVER_TENANT_ALERTING_SLACK_SCOPES`        | Slack scopes                        | `["incoming-webhook"]` |
+| `SERVER_EMAIL_KIND`                          | Email integration kind              | `postmark`             |
 | `SERVER_EMAIL_POSTMARK_ENABLED`              | Enable Postmark                     |                        |
 | `SERVER_EMAIL_POSTMARK_SERVER_KEY`           | Postmark server key                 |                        |
 | `SERVER_EMAIL_POSTMARK_FROM_EMAIL`           | Postmark from email                 |                        |
 | `SERVER_EMAIL_POSTMARK_FROM_NAME`            | Postmark from name                  | `Hatchet Support`      |
 | `SERVER_EMAIL_POSTMARK_SUPPORT_EMAIL`        | Postmark support email              |                        |
+| `SERVER_EMAIL_SMTP_ENABLED`                  | Enable SMTP                         |                        |
+| `SERVER_EMAIL_SMTP_SERVER_ADDR`              | SMTP server address                 |                        |
+| `SERVER_EMAIL_SMTP_FROM_EMAIL`               | SMTP from email                     |                        |
+| `SERVER_EMAIL_SMTP_FROM_NAME`                | SMTP from name                      | `Hatchet Support`      |
+| `SERVER_EMAIL_SMTP_SUPPORT_EMAIL`            | SMTP support email                  |                        |
+| `SERVER_EMAIL_SMTP_AUTH_USERNAME`            | SMTP authentication username        |                        |
+| `SERVER_EMAIL_SMTP_AUTH_PASSWORD`            | SMTP authentication password        |                        |
 | `SERVER_MONITORING_ENABLED`                  | Enable monitoring                   | `true`                 |
 | `SERVER_MONITORING_PERMITTED_TENANTS`        | Permitted tenants for monitoring    |                        |
 | `SERVER_MONITORING_PROBE_TIMEOUT`            | Monitoring probe timeout            | `30s`                  |

--- a/frontend/docs/pages/self-hosting/smtp-server.mdx
+++ b/frontend/docs/pages/self-hosting/smtp-server.mdx
@@ -5,11 +5,13 @@ import { Callout } from "nextra/components";
 Configure email delivery for tenant invites and Hatchet alerts using any standard SMTP provider (Gmail, SendGrid, AWS SES, etc).
 
 ## Prerequisites
+
 - An SMTP provider that supports [PLAIN](https://datatracker.ietf.org/doc/html/rfc4616/) authentication with a username and password.
 
 ## Configuration
 
 Set the following environment variables:
+
 ```bash
 # Enable SMTP
 export SERVER_EMAIL_KIND=smtp
@@ -30,13 +32,15 @@ export SERVER_EMAIL_SMTP_FROM_NAME="Hatchet"                       # (Optional) 
 
 Common configuration values for major providers:
 
-| Provider | Server Address | Username | Password |
-| --- | --- | --- | --- |
-| **[Gmail](https://support.google.com/mail/answer/185833?hl=en)** | `smtp.gmail.com:587` | Your Email | [App Password](https://myaccount.google.com/apppasswords) |
-| **[SendGrid](https://docs.sendgrid.com/for-developers/sending-email/integrating-with-the-smtp-api)** | `smtp.sendgrid.net:587` | `apikey` | Your API Key |
-| **[AWS SES](https://docs.aws.amazon.com/ses/latest/dg/send-email-smtp.html)** | `email-smtp.us-east-1.amazonaws.com:587` | IAM Username | IAM Secret |
-| **[Outlook](https://support.microsoft.com/en-us/office/pop-imap-and-smtp-settings-8361e398-8af4-4e97-b147-6c6c4ac95353)** | `smtp.office365.com:587` | Your Email | Your Password |
+| Provider                                                                                                                  | Server Address                           | Username     | Password                                                  |
+| ------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- | ------------ | --------------------------------------------------------- |
+| **[Gmail](https://support.google.com/mail/answer/185833?hl=en)**                                                          | `smtp.gmail.com:587`                     | Your Email   | [App Password](https://myaccount.google.com/apppasswords) |
+| **[SendGrid](https://docs.sendgrid.com/for-developers/sending-email/integrating-with-the-smtp-api)**                      | `smtp.sendgrid.net:587`                  | `apikey`     | Your API Key                                              |
+| **[AWS SES](https://docs.aws.amazon.com/ses/latest/dg/send-email-smtp.html)**                                             | `email-smtp.us-east-1.amazonaws.com:587` | IAM Username | IAM Secret                                                |
+| **[Outlook](https://support.microsoft.com/en-us/office/pop-imap-and-smtp-settings-8361e398-8af4-4e97-b147-6c6c4ac95353)** | `smtp.office365.com:587`                 | Your Email   | Your Password                                             |
 
 <Callout type="info">
-To request another provider or SMTP authentication protocol, open a feature request on [GitHub](https://github.com/hatchet-dev/hatchet/issues/new?template=feature_request.md).
+  To request another provider or SMTP authentication protocol, open a feature
+  request on
+  [GitHub](https://github.com/hatchet-dev/hatchet/issues/new?template=feature_request.md).
 </Callout>

--- a/frontend/docs/pages/self-hosting/smtp-server.mdx
+++ b/frontend/docs/pages/self-hosting/smtp-server.mdx
@@ -1,0 +1,42 @@
+import { Callout } from "nextra/components";
+
+# SMTP Server
+
+Configure email delivery for tenant invites and Hatchet alerts using any standard SMTP provider (Gmail, SendGrid, AWS SES, etc).
+
+## Prerequisites
+- An SMTP provider that supports [PLAIN](https://datatracker.ietf.org/doc/html/rfc4616/) authentication with a username and password.
+
+## Configuration
+
+Set the following environment variables:
+```bash
+# Enable SMTP
+export SERVER_EMAIL_KIND=smtp
+export SERVER_EMAIL_SMTP_ENABLED=true
+
+# Connection Settings
+export SERVER_EMAIL_SMTP_SERVER_ADDR=smtp.gmail.com:587            # Host and port
+export SERVER_EMAIL_SMTP_AUTH_USERNAME=your-email@yourdomain.com   # Username or API Key ID
+export SERVER_EMAIL_SMTP_AUTH_PASSWORD=your-password               # Password or API Secret Key
+
+# Sender Identity
+export SERVER_EMAIL_SMTP_FROM_EMAIL=noreply@yourdomain.com         # Sender email address
+export SERVER_EMAIL_SMTP_SUPPORT_EMAIL=support@yourdomain.com      # Support contact email
+export SERVER_EMAIL_SMTP_FROM_NAME="Hatchet"                       # (Optional) Display name
+```
+
+## Provider Reference
+
+Common configuration values for major providers:
+
+| Provider | Server Address | Username | Password |
+| --- | --- | --- | --- |
+| **[Gmail](https://support.google.com/mail/answer/185833?hl=en)** | `smtp.gmail.com:587` | Your Email | [App Password](https://myaccount.google.com/apppasswords) |
+| **[SendGrid](https://docs.sendgrid.com/for-developers/sending-email/integrating-with-the-smtp-api)** | `smtp.sendgrid.net:587` | `apikey` | Your API Key |
+| **[AWS SES](https://docs.aws.amazon.com/ses/latest/dg/send-email-smtp.html)** | `email-smtp.us-east-1.amazonaws.com:587` | IAM Username | IAM Secret |
+| **[Outlook](https://support.microsoft.com/en-us/office/pop-imap-and-smtp-settings-8361e398-8af4-4e97-b147-6c6c4ac95353)** | `smtp.office365.com:587` | Your Email | Your Password |
+
+<Callout type="info">
+To request another provider or SMTP authentication protocol, open a feature request on [GitHub](https://github.com/hatchet-dev/hatchet/issues/new?template=feature_request.md).
+</Callout>

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/creasty/defaults v1.8.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0
+	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6
+	github.com/emersion/go-smtp v0.24.0
 	github.com/fatih/color v1.18.0
 	github.com/getkin/kin-openapi v0.133.0
 	github.com/go-co-op/gocron/v2 v2.19.0
@@ -44,6 +46,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/rabbitmq v0.40.0
 	github.com/tink-crypto/tink-go v0.0.0-20230613075026-d6de17e3f164
 	github.com/tink-crypto/tink-go-gcpkms v0.0.0-20230602082706-31d0d09ccc8d
+	github.com/wneessen/go-mail v0.7.2
 	go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.64.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.64.0
 	go.opentelemetry.io/otel v1.39.0

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,10 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/ebitengine/purego v0.8.4 h1:CF7LEKg5FFOsASUj0+QwaXf8Ht6TlFxg09+S9wz0omw=
 github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 h1:oP4q0fw+fOSWn3DfFi4EXdT+B+gTtzx8GC9xsc26Znk=
+github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6/go.mod h1:iL2twTeMvZnrg54ZoPDNfJaJaqy0xIQFuBdrLsmspwQ=
+github.com/emersion/go-smtp v0.24.0 h1:g6AfoF140mvW0vLNPD/LuCBLEAdlxOjIXqbIkJIS6Wk=
+github.com/emersion/go-smtp v0.24.0/go.mod h1:ZtRRkbTyp2XTHCA+BmyTFTrj8xY4I+b4McvHxCU2gsQ=
 github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf9B/a0/xU=
 github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
@@ -463,6 +467,8 @@ github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQ
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
+github.com/wneessen/go-mail v0.7.2 h1:xxPnhZ6IZLSgxShebmZ6DPKh1b6OJcoHfzy7UjOkzS8=
+github.com/wneessen/go-mail v0.7.2/go.mod h1:+TkW6QP3EVkgTEqHtVmnAE/1MRhmzb8Y9/W3pweuS+k=
 github.com/woodsbury/decimal128 v1.3.0 h1:8pffMNWIlC0O5vbyHWFZAt5yWvWcrHA+3ovIIjVWss0=
 github.com/woodsbury/decimal128 v1.3.0/go.mod h1:C5UTmyTjW3JftjUFzOVhC20BEQa2a4ZKOB5I6Zjb+ds=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -632,6 +632,8 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create SMTP service: %w", err)
 		}
+	default:
+		return nil, nil, fmt.Errorf("invalid email provider of type %s, must be 'postmark' or 'smtp'", cf.Email.Kind)
 	}
 
 	additionalOAuthConfigs := make(map[string]*oauth2.Config)

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -37,6 +37,7 @@ import (
 	"github.com/hatchet-dev/hatchet/pkg/errors/sentry"
 	"github.com/hatchet-dev/hatchet/pkg/integrations/email"
 	"github.com/hatchet-dev/hatchet/pkg/integrations/email/postmark"
+	"github.com/hatchet-dev/hatchet/pkg/integrations/email/smtp"
 	"github.com/hatchet-dev/hatchet/pkg/logger"
 	"github.com/hatchet-dev/hatchet/pkg/repository/cache"
 	"github.com/hatchet-dev/hatchet/pkg/repository/debugger"
@@ -604,13 +605,33 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 
 	var emailSvc email.EmailService = &email.NoOpService{}
 
-	if cf.Email.Postmark.Enabled {
+	switch strings.ToLower(cf.Email.Kind) {
+	case "postmark":
+		if !cf.Email.Postmark.Enabled {
+			break
+		}
 		emailSvc = postmark.NewPostmarkClient(
 			cf.Email.Postmark.ServerKey,
 			cf.Email.Postmark.FromEmail,
 			cf.Email.Postmark.FromName,
 			cf.Email.Postmark.SupportEmail,
 		)
+
+	case "smtp":
+		if !cf.Email.SMTP.Enabled {
+			break
+		}
+		emailSvc, err = smtp.NewSMTPService(
+			cf.Email.SMTP.ServerAddr,
+			cf.Email.SMTP.BasicAuth.Username,
+			cf.Email.SMTP.BasicAuth.Password,
+			cf.Email.SMTP.FromEmail,
+			cf.Email.SMTP.FromName,
+			cf.Email.SMTP.SupportEmail,
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create SMTP service: %w", err)
+		}
 	}
 
 	additionalOAuthConfigs := make(map[string]*oauth2.Config)

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -473,11 +473,11 @@ type RabbitMQConfigFile struct {
 }
 
 type ConfigFileEmail struct {
-	Kind string `mapstructure:"kind" json:"kind,omitempty" validate:"required,oneof=postmark smtp" default:"postmark"`
+	Kind string `mapstructure:"kind" json:"kind,omitempty"`
 
-	Postmark EmailConfig `mapstructure:"postmark" json:"postmark,omitempty"`
+	Postmark PostmarkConfigFile `mapstructure:"postmark" json:"postmark,omitempty"`
 
-	SMTP EmailConfig `mapstructure:"smtp" json:"smtp,omitempty"`
+	SMTP SMTPEmailConfig `mapstructure:"smtp" json:"smtp,omitempty"`
 }
 
 type ConfigFileMonitoring struct {
@@ -494,7 +494,16 @@ type ConfigFileMonitoring struct {
 	TLSRootCAFile string `mapstructure:"tlsRootCAFile" json:"tlsRootCAFile,omitempty"`
 }
 
-type EmailConfig struct {
+type PostmarkConfigFile struct {
+	Enabled bool `mapstructure:"enabled" json:"enabled,omitempty"`
+
+	ServerKey    string `mapstructure:"serverKey" json:"serverKey,omitempty"`
+	FromEmail    string `mapstructure:"fromEmail" json:"fromEmail,omitempty"`
+	FromName     string `mapstructure:"fromName" json:"fromName,omitempty" default:"Hatchet Support"`
+	SupportEmail string `mapstructure:"supportEmail" json:"supportEmail,omitempty"`
+}
+
+type SMTPEmailConfig struct {
 	Enabled      bool   `mapstructure:"enabled" json:"enabled,omitempty"`
 	ServerKey    string `mapstructure:"serverKey" json:"serverKey,omitempty"`
 	ServerAddr   string `mapstructure:"serverAddr" json:"serverAddr,omitempty"`
@@ -502,10 +511,10 @@ type EmailConfig struct {
 	FromName     string `mapstructure:"fromName" json:"fromName,omitempty" default:"Hatchet Support"`
 	SupportEmail string `mapstructure:"supportEmail" json:"supportEmail,omitempty"`
 
-	BasicAuth EmailConfigAuthBasic `mapstructure:"basicAuth" json:"basicAuth,omitempty"`
+	BasicAuth SMTPEmailConfigAuthBasic `mapstructure:"basicAuth" json:"basicAuth,omitempty"`
 }
 
-type EmailConfigAuthBasic struct {
+type SMTPEmailConfigAuthBasic struct {
 	Username string `mapstructure:"username" json:"username,omitempty"`
 	Password string `mapstructure:"password" json:"password,omitempty"`
 }

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -473,7 +473,7 @@ type RabbitMQConfigFile struct {
 }
 
 type ConfigFileEmail struct {
-	Kind string `mapstructure:"kind" json:"kind,omitempty"`
+	Kind string `mapstructure:"kind" json:"kind,omitempty" default:"postmark"`
 
 	Postmark PostmarkConfigFile `mapstructure:"postmark" json:"postmark,omitempty"`
 

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -473,7 +473,11 @@ type RabbitMQConfigFile struct {
 }
 
 type ConfigFileEmail struct {
-	Postmark PostmarkConfigFile `mapstructure:"postmark" json:"postmark,omitempty"`
+	Kind string `mapstructure:"kind" json:"kind,omitempty" validate:"required,oneof=postmark smtp" default:"postmark"`
+
+	Postmark EmailConfig `mapstructure:"postmark" json:"postmark,omitempty"`
+
+	SMTP EmailConfig `mapstructure:"smtp" json:"smtp,omitempty"`
 }
 
 type ConfigFileMonitoring struct {
@@ -490,15 +494,21 @@ type ConfigFileMonitoring struct {
 	TLSRootCAFile string `mapstructure:"tlsRootCAFile" json:"tlsRootCAFile,omitempty"`
 }
 
-type PostmarkConfigFile struct {
-	Enabled bool `mapstructure:"enabled" json:"enabled,omitempty"`
-
+type EmailConfig struct {
+	Enabled      bool   `mapstructure:"enabled" json:"enabled,omitempty"`
 	ServerKey    string `mapstructure:"serverKey" json:"serverKey,omitempty"`
+	ServerAddr   string `mapstructure:"serverAddr" json:"serverAddr,omitempty"`
 	FromEmail    string `mapstructure:"fromEmail" json:"fromEmail,omitempty"`
 	FromName     string `mapstructure:"fromName" json:"fromName,omitempty" default:"Hatchet Support"`
 	SupportEmail string `mapstructure:"supportEmail" json:"supportEmail,omitempty"`
+
+	BasicAuth EmailConfigAuthBasic `mapstructure:"basicAuth" json:"basicAuth,omitempty"`
 }
 
+type EmailConfigAuthBasic struct {
+	Username string `mapstructure:"username" json:"username,omitempty"`
+	Password string `mapstructure:"password" json:"password,omitempty"`
+}
 type CustomAuthenticator interface {
 	// Authenticate is called to authenticate for endpoints that support the customAuth security scheme
 	Authenticate(c echo.Context) error
@@ -824,11 +834,24 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("tenantAlerting.slack.scopes", "SERVER_TENANT_ALERTING_SLACK_SCOPES")
 
 	// email options
+	_ = v.BindEnv("email.kind", "SERVER_EMAIL_KIND")
+
+	// postmark options
 	_ = v.BindEnv("email.postmark.enabled", "SERVER_EMAIL_POSTMARK_ENABLED")
 	_ = v.BindEnv("email.postmark.serverKey", "SERVER_EMAIL_POSTMARK_SERVER_KEY")
 	_ = v.BindEnv("email.postmark.fromEmail", "SERVER_EMAIL_POSTMARK_FROM_EMAIL")
 	_ = v.BindEnv("email.postmark.fromName", "SERVER_EMAIL_POSTMARK_FROM_NAME")
 	_ = v.BindEnv("email.postmark.supportEmail", "SERVER_EMAIL_POSTMARK_SUPPORT_EMAIL")
+
+	// smtp options
+	_ = v.BindEnv("email.smtp.enabled", "SERVER_EMAIL_SMTP_ENABLED")
+	_ = v.BindEnv("email.smtp.serverAddr", "SERVER_EMAIL_SMTP_SERVER_ADDR")
+	_ = v.BindEnv("email.smtp.fromEmail", "SERVER_EMAIL_SMTP_FROM_EMAIL")
+	_ = v.BindEnv("email.smtp.fromName", "SERVER_EMAIL_SMTP_FROM_NAME")
+	_ = v.BindEnv("email.smtp.supportEmail", "SERVER_EMAIL_SMTP_SUPPORT_EMAIL")
+	// allow basic auth credentials to be set
+	_ = v.BindEnv("email.smtp.basicAuth.username", "SERVER_EMAIL_SMTP_AUTH_USERNAME")
+	_ = v.BindEnv("email.smtp.basicAuth.password", "SERVER_EMAIL_SMTP_AUTH_PASSWORD")
 
 	// monitoring options
 	_ = v.BindEnv("runtime.monitoring.enabled", "SERVER_MONITORING_ENABLED")

--- a/pkg/integrations/email/email.go
+++ b/pkg/integrations/email/email.go
@@ -68,10 +68,6 @@ type EmailService interface {
 	SendWorkflowRunFailedAlerts(ctx context.Context, emails []string, data WorkflowRunsFailedEmailData) error
 	SendExpiringTokenEmail(ctx context.Context, emails []string, data ExpiringTokenEmailData) error
 	SendTenantResourceLimitAlert(ctx context.Context, emails []string, data ResourceLimitAlertData) error
-
-	// For more generalised emails
-	SendTemplateEmail(ctx context.Context, to, templateAlias string, templateModelData interface{}, bccSupport bool) error
-	SendTemplateEmailBCC(ctx context.Context, bcc, templateAlias string, templateModelData interface{}, bccSupport bool) error
 }
 
 type NoOpService struct{}
@@ -93,13 +89,5 @@ func (s *NoOpService) SendExpiringTokenEmail(ctx context.Context, emails []strin
 }
 
 func (s *NoOpService) SendTenantResourceLimitAlert(ctx context.Context, emails []string, data ResourceLimitAlertData) error {
-	return nil
-}
-
-func (s *NoOpService) SendTemplateEmail(ctx context.Context, to, templateAlias string, templateModelData interface{}, bccSupport bool) error {
-	return nil
-}
-
-func (s *NoOpService) SendTemplateEmailBCC(ctx context.Context, bcc, templateAlias string, templateModelData interface{}, bccSupport bool) error {
 	return nil
 }

--- a/pkg/integrations/email/email.go
+++ b/pkg/integrations/email/email.go
@@ -2,7 +2,6 @@ package email
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hatchet-dev/hatchet/internal/integrations/alerting/alerttypes"
 )
@@ -21,21 +20,12 @@ type TenantInviteEmailData struct {
 	ActionURL        string `json:"action_url"`
 }
 
-func (r TenantInviteEmailData) GetSubject() string {
-	return fmt.Sprintf("%s invited you to join %s on Hatchet",
-		r.InviteSenderName, r.TenantName)
-}
-
 type WorkflowRunsFailedEmailData struct {
 	Items        []alerttypes.WorkflowRunFailedItem `json:"items"`
 	Subject      string                             `json:"subject"`
 	Summary      string                             `json:"summary"`
 	TenantName   string                             `json:"tenant_name"`
 	SettingsLink string                             `json:"settings_link"`
-}
-
-func (r ExpiringTokenEmailData) GetSubject() string {
-	return fmt.Sprintf("[%s] %s", r.TenantName, r.Subject)
 }
 
 type ExpiringTokenEmailData struct {
@@ -46,10 +36,6 @@ type ExpiringTokenEmailData struct {
 	TenantName            string `json:"tenant_name"`
 	TokenSettings         string `json:"token_settings"`
 	SettingsLink          string `json:"settings_link"`
-}
-
-func (r WorkflowRunsFailedEmailData) GetSubject() string {
-	return fmt.Sprintf("[%s] %s", r.TenantName, r.Subject)
 }
 
 type ResourceLimitAlertData struct {
@@ -64,10 +50,6 @@ type ResourceLimitAlertData struct {
 	LimitValue   int    `json:"limit_value"`
 	Percentage   int    `json:"percentage"`
 	SettingsLink string `json:"settings_link"`
-}
-
-func (r ResourceLimitAlertData) GetSubject() string {
-	return fmt.Sprintf("[%s] %s", r.TenantName, r.Subject)
 }
 
 type SendEmailFromTemplateRequest struct {

--- a/pkg/integrations/email/email.go
+++ b/pkg/integrations/email/email.go
@@ -6,6 +6,14 @@ import (
 	"github.com/hatchet-dev/hatchet/internal/integrations/alerting/alerttypes"
 )
 
+const (
+	UserInviteTemplate         = "user-invitation"
+	WorkflowRunsFailedTemplate = "workflow-runs-failed"
+	TokenAlertExpiringTemplate = "token-expiring" // nolint: gosec
+	ResourceLimitAlertTemplate = "resource-limit-alert"
+	OrganizationInviteTemplate = "organization-invite"
+)
+
 type TenantInviteEmailData struct {
 	InviteSenderName string `json:"invite_sender_name"`
 	TenantName       string `json:"tenant_name"`
@@ -42,6 +50,14 @@ type ResourceLimitAlertData struct {
 	LimitValue   int    `json:"limit_value"`
 	Percentage   int    `json:"percentage"`
 	SettingsLink string `json:"settings_link"`
+}
+
+type SendEmailFromTemplateRequest struct {
+	From          string      `json:"From"`
+	To            string      `json:"To,omitempty"`
+	Bcc           string      `json:"Bcc,omitempty"`
+	TemplateAlias string      `json:"TemplateAlias"`
+	TemplateModel interface{} `json:"TemplateModel"`
 }
 
 type EmailService interface {

--- a/pkg/integrations/email/email.go
+++ b/pkg/integrations/email/email.go
@@ -2,6 +2,7 @@ package email
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hatchet-dev/hatchet/internal/integrations/alerting/alerttypes"
 )
@@ -20,12 +21,21 @@ type TenantInviteEmailData struct {
 	ActionURL        string `json:"action_url"`
 }
 
+func (r TenantInviteEmailData) GetSubject() string {
+	return fmt.Sprintf("%s invited you to join %s on Hatchet",
+		r.InviteSenderName, r.TenantName)
+}
+
 type WorkflowRunsFailedEmailData struct {
 	Items        []alerttypes.WorkflowRunFailedItem `json:"items"`
 	Subject      string                             `json:"subject"`
 	Summary      string                             `json:"summary"`
 	TenantName   string                             `json:"tenant_name"`
 	SettingsLink string                             `json:"settings_link"`
+}
+
+func (r ExpiringTokenEmailData) GetSubject() string {
+	return fmt.Sprintf("[%s] %s", r.TenantName, r.Subject)
 }
 
 type ExpiringTokenEmailData struct {
@@ -36,6 +46,10 @@ type ExpiringTokenEmailData struct {
 	TenantName            string `json:"tenant_name"`
 	TokenSettings         string `json:"token_settings"`
 	SettingsLink          string `json:"settings_link"`
+}
+
+func (r WorkflowRunsFailedEmailData) GetSubject() string {
+	return fmt.Sprintf("[%s] %s", r.TenantName, r.Subject)
 }
 
 type ResourceLimitAlertData struct {
@@ -50,6 +64,10 @@ type ResourceLimitAlertData struct {
 	LimitValue   int    `json:"limit_value"`
 	Percentage   int    `json:"percentage"`
 	SettingsLink string `json:"settings_link"`
+}
+
+func (r ResourceLimitAlertData) GetSubject() string {
+	return fmt.Sprintf("[%s] %s", r.TenantName, r.Subject)
 }
 
 type SendEmailFromTemplateRequest struct {

--- a/pkg/integrations/email/postmark/postmark.go
+++ b/pkg/integrations/email/postmark/postmark.go
@@ -31,21 +31,7 @@ func NewPostmarkClient(serverKey, fromEmail, fromName, supportEmail string) *Pos
 	return &PostmarkClient{serverKey, fromEmail, fromName, supportEmail, httpClient}
 }
 
-const (
-	postmarkAPIURL             = "https://api.postmarkapp.com"
-	userInviteTemplate         = "user-invitation"
-	workflowRunsFailedTemplate = "workflow-runs-failed"
-	tokenAlertExpiringTemplate = "token-expiring" // nolint: gosec
-	resourceLimitAlertTemplate = "resource-limit-alert"
-)
-
-type sendEmailFromTemplateRequest struct {
-	From          string      `json:"From"`
-	To            string      `json:"To,omitempty"`
-	Bcc           string      `json:"Bcc,omitempty"`
-	TemplateAlias string      `json:"TemplateAlias"`
-	TemplateModel interface{} `json:"TemplateModel"`
-}
+const postmarkAPIURL = "https://api.postmarkapp.com"
 
 type VerifyEmailData struct {
 	ActionURL string `json:"link" mapstructure:"action_url"`
@@ -56,19 +42,19 @@ func (c *PostmarkClient) IsValid() bool {
 }
 
 func (c *PostmarkClient) SendTenantInviteEmail(ctx context.Context, to string, data email.TenantInviteEmailData) error {
-	return c.SendTemplateEmail(ctx, to, userInviteTemplate, data, false)
+	return c.SendTemplateEmail(ctx, to, email.UserInviteTemplate, data, false)
 }
 
 func (c *PostmarkClient) SendWorkflowRunFailedAlerts(ctx context.Context, emails []string, data email.WorkflowRunsFailedEmailData) error {
-	return c.SendTemplateEmailBCC(ctx, strings.Join(emails, ","), workflowRunsFailedTemplate, data, false)
+	return c.SendTemplateEmailBCC(ctx, strings.Join(emails, ","), email.WorkflowRunsFailedTemplate, data, false)
 }
 
 func (c *PostmarkClient) SendExpiringTokenEmail(ctx context.Context, emails []string, data email.ExpiringTokenEmailData) error {
-	return c.SendTemplateEmailBCC(ctx, strings.Join(emails, ","), tokenAlertExpiringTemplate, data, false)
+	return c.SendTemplateEmailBCC(ctx, strings.Join(emails, ","), email.TokenAlertExpiringTemplate, data, false)
 }
 
 func (c *PostmarkClient) SendTenantResourceLimitAlert(ctx context.Context, emails []string, data email.ResourceLimitAlertData) error {
-	return c.SendTemplateEmailBCC(ctx, strings.Join(emails, ","), resourceLimitAlertTemplate, data, true)
+	return c.SendTemplateEmailBCC(ctx, strings.Join(emails, ","), email.ResourceLimitAlertTemplate, data, true)
 }
 
 func (c *PostmarkClient) SendTemplateEmail(ctx context.Context, to, templateAlias string, templateModelData interface{}, bccSupport bool) error {
@@ -78,7 +64,7 @@ func (c *PostmarkClient) SendTemplateEmail(ctx context.Context, to, templateAlia
 		bcc = c.supportEmail
 	}
 
-	return c.sendRequest(ctx, "/email/withTemplate", "POST", &sendEmailFromTemplateRequest{
+	return c.sendRequest(ctx, "/email/withTemplate", "POST", &email.SendEmailFromTemplateRequest{
 		From:          fmt.Sprintf("%s <%s>", c.fromName, c.fromEmail),
 		To:            to,
 		Bcc:           bcc,
@@ -93,7 +79,7 @@ func (c *PostmarkClient) SendTemplateEmailBCC(ctx context.Context, bcc, template
 		bcc = fmt.Sprintf("%s,%s", bcc, c.supportEmail)
 	}
 
-	return c.sendRequest(ctx, "/email/withTemplate", "POST", &sendEmailFromTemplateRequest{
+	return c.sendRequest(ctx, "/email/withTemplate", "POST", &email.SendEmailFromTemplateRequest{
 		From:          fmt.Sprintf("%s <%s>", c.fromName, c.fromEmail),
 		Bcc:           bcc,
 		TemplateAlias: templateAlias,

--- a/pkg/integrations/email/smtp/mock_smtp_test.go
+++ b/pkg/integrations/email/smtp/mock_smtp_test.go
@@ -1,3 +1,5 @@
+//go:build !e2e && !load && !rampup && !integration
+
 package smtp
 
 import (

--- a/pkg/integrations/email/smtp/mock_smtp_test.go
+++ b/pkg/integrations/email/smtp/mock_smtp_test.go
@@ -3,6 +3,7 @@
 package smtp
 
 import (
+	"bytes"
 	"io"
 	"log"
 	"net"
@@ -111,6 +112,13 @@ func (s *mockSession) Data(r io.Reader) error {
 	if err != nil {
 		return err
 	}
+
+	bodyBytes, err := io.ReadAll(msg.Body)
+	if err != nil {
+		return err
+	}
+
+	msg.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
 	s.capture.mu.Lock()
 	defer s.capture.mu.Unlock()

--- a/pkg/integrations/email/smtp/mock_smtp_test.go
+++ b/pkg/integrations/email/smtp/mock_smtp_test.go
@@ -1,0 +1,123 @@
+package smtp
+
+import (
+	"io"
+	"log"
+	"net"
+	"net/mail"
+	"strconv"
+	"sync"
+
+	"github.com/emersion/go-sasl"
+	"github.com/emersion/go-smtp"
+)
+
+func StartMockSMTPServer() (port int, capture *SMTPCapture, cancelFunc func(), err error) {
+	// TODO(gregfurman): This mock SMTP server approach is _good enough_ to test our SMTP client against
+	// and perform introspection on request/responses. However, it's probably a better idea to use an external
+	// container or service (i.e https://github.com/sj26/mailcatcher) since this approach is not easily maintainable.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, nil, nil, err
+	}
+
+	_, portStr, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		return 0, nil, nil, err
+	}
+
+	port, err = strconv.Atoi(portStr)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+
+	capture = &SMTPCapture{}
+	s := smtp.NewServer(&mockBackend{capture: capture})
+	s.Addr = listener.Addr().String()
+	s.Domain = "localhost"
+	s.AllowInsecureAuth = true
+
+	go func() {
+		if err := s.Serve(listener); err != nil && err != net.ErrClosed {
+			log.Printf("SMTP mock server error: %v", err)
+		}
+	}()
+
+	return port, capture, func() { s.Close() }, nil
+}
+
+// ----------------------------------------------------------------------
+
+var (
+	_ smtp.Backend = &mockBackend{}
+	_ smtp.Session = &mockSession{}
+)
+
+// SMTPCapture captures SMTP request and response data that can be used to
+// perform assertions.
+type SMTPCapture struct {
+	mu        sync.Mutex
+	Usernames []string
+	Passwords []string
+	Froms     []string
+	Rcpts     []string
+	Messages  []*mail.Message
+}
+
+type mockBackend struct {
+	capture *SMTPCapture
+}
+
+func (b *mockBackend) NewSession(_ *smtp.Conn) (smtp.Session, error) {
+	return &mockSession{capture: b.capture}, nil
+}
+
+type mockSession struct {
+	capture *SMTPCapture
+}
+
+func (s *mockSession) AuthMechanisms() []string {
+	return []string{sasl.Plain}
+}
+
+func (s *mockSession) Auth(mech string) (sasl.Server, error) {
+	return sasl.NewPlainServer(func(identity, username, password string) error {
+		s.capture.mu.Lock()
+		defer s.capture.mu.Unlock()
+		s.capture.Usernames = append(s.capture.Usernames, username)
+		s.capture.Passwords = append(s.capture.Passwords, password)
+		return nil
+	}), nil
+}
+
+func (s *mockSession) Mail(from string, _ *smtp.MailOptions) error {
+	s.capture.mu.Lock()
+	defer s.capture.mu.Unlock()
+	s.capture.Froms = append(s.capture.Froms, from)
+	return nil
+}
+
+func (s *mockSession) Rcpt(to string, _ *smtp.RcptOptions) error {
+	s.capture.mu.Lock()
+	defer s.capture.mu.Unlock()
+	s.capture.Rcpts = append(s.capture.Rcpts, to)
+	return nil
+}
+
+func (s *mockSession) Data(r io.Reader) error {
+	msg, err := mail.ReadMessage(r)
+	if err != nil {
+		return err
+	}
+
+	s.capture.mu.Lock()
+	defer s.capture.mu.Unlock()
+	s.capture.Messages = append(s.capture.Messages, msg)
+	return nil
+}
+
+func (*mockSession) Reset() {}
+
+func (*mockSession) Logout() error {
+	return nil
+}

--- a/pkg/integrations/email/smtp/smtp.go
+++ b/pkg/integrations/email/smtp/smtp.go
@@ -130,6 +130,11 @@ func (s *SMTPService) sendRequest(ctx context.Context, req *email.SendEmailFromT
 		}
 	}
 
+	switch data := req.TemplateModel.(type) {
+	case interface{ GetSubject() string }:
+		msg.Subject(data.GetSubject())
+	}
+
 	tmpl, err := getTemplate(req.TemplateAlias)
 	if err != nil {
 		return err

--- a/pkg/integrations/email/smtp/smtp.go
+++ b/pkg/integrations/email/smtp/smtp.go
@@ -1,0 +1,143 @@
+package smtp
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/wneessen/go-mail"
+
+	"github.com/hatchet-dev/hatchet/pkg/integrations/email"
+)
+
+var _ email.EmailService = &SMTPService{}
+
+const (
+	defaultSMTPClientPort = 587
+)
+
+type SMTPService struct {
+	fromEmail    string
+	fromName     string
+	supportEmail string
+	client       *mail.Client
+}
+
+// NewSMTPService creates a new service which sends emails
+func NewSMTPService(serverAddr, serverUser, serverKey, fromEmail, fromName, supportEmail string) (*SMTPService, error) {
+	port := defaultSMTPClientPort
+	if host, portStr, err := net.SplitHostPort(serverAddr); err == nil {
+		// if we can split the host by port, then override default
+		serverAddr = host
+		port, _ = strconv.Atoi(portStr)
+	}
+
+	authType := mail.SMTPAuthPlain
+	if serverUser == "" || serverKey == "" {
+		// No username or password is provided, we assume auth is disabled.
+		authType = mail.SMTPAuthNoAuth
+	}
+
+	client, err := mail.NewClient(serverAddr,
+		mail.WithPort(port),
+		mail.WithTLSPortPolicy(mail.TLSOpportunistic),
+		mail.WithSMTPAuth(authType),
+		mail.WithUsername(serverUser),
+		mail.WithPassword(serverKey),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SMTPService{
+		client:       client,
+		fromEmail:    fromEmail,
+		fromName:     fromName,
+		supportEmail: supportEmail,
+	}, nil
+}
+
+func (s *SMTPService) IsValid() bool {
+	return true
+}
+
+func (s *SMTPService) SendTenantInviteEmail(ctx context.Context, to string, data email.TenantInviteEmailData) error {
+	return s.SendTemplateEmail(ctx, to, email.OrganizationInviteTemplate, data, false)
+}
+
+func (s *SMTPService) SendWorkflowRunFailedAlerts(ctx context.Context, emails []string, data email.WorkflowRunsFailedEmailData) error {
+	return s.SendTemplateEmailBCC(ctx, strings.Join(emails, ","), email.WorkflowRunsFailedTemplate, data, false)
+}
+
+func (s *SMTPService) SendExpiringTokenEmail(ctx context.Context, emails []string, data email.ExpiringTokenEmailData) error {
+	return s.SendTemplateEmailBCC(ctx, strings.Join(emails, ","), email.TokenAlertExpiringTemplate, data, false)
+}
+
+func (s *SMTPService) SendTenantResourceLimitAlert(ctx context.Context, emails []string, data email.ResourceLimitAlertData) error {
+	return s.SendTemplateEmailBCC(ctx, strings.Join(emails, ","), email.ResourceLimitAlertTemplate, data, true)
+}
+
+func (s *SMTPService) SendTemplateEmail(ctx context.Context, to, templateAlias string, templateModelData any, bccSupport bool) error {
+	var bcc string
+
+	if bccSupport {
+		bcc = s.supportEmail
+	}
+
+	return s.sendRequest(ctx, &email.SendEmailFromTemplateRequest{
+		From:          fmt.Sprintf("%s <%s>", s.fromName, s.fromEmail),
+		To:            to,
+		Bcc:           bcc,
+		TemplateAlias: templateAlias,
+		TemplateModel: templateModelData,
+	})
+}
+
+func (s *SMTPService) SendTemplateEmailBCC(ctx context.Context, bcc, templateAlias string, templateModelData any, bccSupport bool) error {
+	if bccSupport {
+		bcc = fmt.Sprintf("%s,%s", bcc, s.supportEmail)
+	}
+
+	return s.sendRequest(ctx, &email.SendEmailFromTemplateRequest{
+		From:          fmt.Sprintf("%s <%s>", s.fromName, s.fromEmail),
+		To:            "",
+		Bcc:           bcc,
+		TemplateAlias: templateAlias,
+		TemplateModel: templateModelData,
+	})
+}
+
+func (s *SMTPService) sendRequest(ctx context.Context, req *email.SendEmailFromTemplateRequest) error {
+	msg := mail.NewMsg()
+
+	if req.From != "" {
+		if err := msg.From(req.From); err != nil {
+			return err
+		}
+	}
+
+	if req.Bcc != "" {
+		if err := msg.BccFromString(req.Bcc); err != nil {
+			return err
+		}
+	}
+
+	if req.To != "" {
+		if err := msg.ToFromString(req.To); err != nil {
+			return err
+		}
+	}
+
+	tmpl, err := getTemplate(req.TemplateAlias)
+	if err != nil {
+		return err
+	}
+
+	if err := msg.SetBodyHTMLTemplate(tmpl, req.TemplateModel); err != nil {
+		return err
+	}
+
+	return s.client.DialAndSendWithContext(ctx, msg)
+}

--- a/pkg/integrations/email/smtp/smtp_test.go
+++ b/pkg/integrations/email/smtp/smtp_test.go
@@ -3,8 +3,13 @@
 package smtp
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"html/template"
+	"io"
+	"mime/quotedprintable"
+	"strings"
 	"testing"
 
 	"github.com/hatchet-dev/hatchet/pkg/integrations/email"
@@ -21,67 +26,89 @@ const (
 
 func TestSMTPServiceSendMail(t *testing.T) {
 	tests := []struct {
-		name        string
-		sendFunc    func(*SMTPService) error
-		wantRcpts   []string
-		wantSubject string
+		name string
+
+		expectedTemplate   *template.Template
+		expectedSubject    string
+		expectedRecipients []string
+
+		templateData interface{}
+
+		sendFunc func(s *SMTPService, ctx context.Context, d interface{}) error
 	}{
 		{
-			name: "tenant invite",
-			sendFunc: func(s *SMTPService) error {
-				return s.SendTenantInviteEmail(context.Background(), "user@example.com", email.TenantInviteEmailData{
-					TenantName:       "Acme Corp",
-					InviteSenderName: "Alice",
-					ActionURL:        "https://app.example.com/join/abc123",
-				})
+			name:               "tenant invite",
+			expectedTemplate:   templateRegistry[email.UserInviteTemplate].bodyTmpl,
+			expectedSubject:    "Alice invited you to join Acme Corp on Hatchet",
+			expectedRecipients: []string{"user@example.com"},
+			templateData: email.TenantInviteEmailData{
+				TenantName:       "Acme Corp",
+				InviteSenderName: "Alice",
+				ActionURL:        "https://app.example.com/join/abc123",
 			},
-			wantRcpts:   []string{"user@example.com"},
-			wantSubject: "Alice invited you to join Acme Corp on Hatchet",
+			sendFunc: func(s *SMTPService, ctx context.Context, d interface{}) error {
+				return s.SendTenantInviteEmail(
+					ctx, "user@example.com", d.(email.TenantInviteEmailData),
+				)
+			},
 		},
 		{
-			name: "workflow failed alert",
-			sendFunc: func(s *SMTPService) error {
-				return s.SendWorkflowRunFailedAlerts(context.Background(), []string{"admin1@example.com", "admin2@example.com"}, email.WorkflowRunsFailedEmailData{
-					TenantName:   "Acme Corp",
-					Subject:      "3 workflow runs failed in the last hour",
-					Summary:      "3 workflow runs failed",
-					SettingsLink: "https://app.example.com/settings",
-				})
+			name:               "workflow failed alert",
+			expectedTemplate:   templateRegistry[email.WorkflowRunsFailedTemplate].bodyTmpl,
+			expectedSubject:    "[Acme Corp] 3 workflow runs failed in the last hour",
+			expectedRecipients: []string{"admin1@example.com", "admin2@example.com"},
+			templateData: email.WorkflowRunsFailedEmailData{
+				TenantName:   "Acme Corp",
+				Subject:      "3 workflow runs failed in the last hour",
+				Summary:      "3 workflow runs failed",
+				SettingsLink: "https://app.example.com/settings",
 			},
-			wantRcpts:   []string{"admin1@example.com", "admin2@example.com"},
-			wantSubject: "[Acme Corp] 3 workflow runs failed in the last hour",
+			sendFunc: func(s *SMTPService, ctx context.Context, d interface{}) error {
+				return s.SendWorkflowRunFailedAlerts(
+					ctx, []string{"admin1@example.com", "admin2@example.com"}, d.(email.WorkflowRunsFailedEmailData),
+				)
+			},
 		},
 		{
-			name: "expiring token alert",
-			sendFunc: func(s *SMTPService) error {
-				return s.SendExpiringTokenEmail(context.Background(), []string{"admin@example.com"}, email.ExpiringTokenEmailData{
-					TenantName:            "Acme Corp",
-					Subject:               "API token 'production-api-key' expires soon",
-					TokenName:             "production-api-key",
-					ExpiresAtAbsoluteDate: "2026-02-01",
-					ExpiresAtRelativeDate: "5 days",
-					SettingsLink:          "https://app.example.com/settings/tokens",
-				})
+			name:               "expiring token alert",
+			expectedTemplate:   templateRegistry[email.TokenAlertExpiringTemplate].bodyTmpl,
+			expectedSubject:    "[Acme Corp] API token 'production-api-key' expires soon",
+			expectedRecipients: []string{"admin@example.com"},
+			templateData: email.ExpiringTokenEmailData{
+				TenantName:            "Acme Corp",
+				Subject:               "API token 'production-api-key' expires soon",
+				TokenName:             "production-api-key",
+				ExpiresAtAbsoluteDate: "2026-02-01",
+				ExpiresAtRelativeDate: "5 days",
+				SettingsLink:          "https://app.example.com/settings/tokens",
 			},
-			wantRcpts:   []string{"admin@example.com"},
-			wantSubject: "[Acme Corp] API token 'production-api-key' expires soon",
+			sendFunc: func(s *SMTPService, ctx context.Context, d interface{}) error {
+				return s.SendExpiringTokenEmail(
+					ctx, []string{"admin@example.com"}, d.(email.ExpiringTokenEmailData),
+				)
+			},
 		},
 		{
-			name: "resource limit alert",
-			sendFunc: func(s *SMTPService) error {
-				return s.SendTenantResourceLimitAlert(context.Background(), []string{"admin@example.com"}, email.ResourceLimitAlertData{
-					TenantName:   "Acme Corp",
-					Subject:      "Workflow runs limit reached",
-					Summary:      "Workflow runs at 90%",
-					Resource:     "workflow runs",
-					CurrentValue: 900,
-					LimitValue:   1000,
-					Percentage:   90,
-					Link:         "https://app.example.com/billing",
-				})
+			name:             "resource limit alert",
+			expectedTemplate: templateRegistry[email.ResourceLimitAlertTemplate].bodyTmpl,
+			expectedSubject:  "[Acme Corp] Workflow runs limit reached",
+			// note: a support email is required for ResourceLimitAlert types
+			expectedRecipients: []string{"admin@example.com", testSupportEmail},
+			templateData: email.ResourceLimitAlertData{
+				TenantName:   "Acme Corp",
+				Subject:      "Workflow runs limit reached",
+				Summary:      "Workflow runs at 90%",
+				Resource:     "workflow runs",
+				CurrentValue: 900,
+				LimitValue:   1000,
+				Percentage:   90,
+				Link:         "https://app.example.com/billing",
 			},
-			wantRcpts:   []string{"admin@example.com", testSupportEmail},
-			wantSubject: "[Acme Corp] Workflow runs limit reached",
+			sendFunc: func(s *SMTPService, ctx context.Context, d interface{}) error {
+				return s.SendTenantResourceLimitAlert(
+					ctx, []string{"admin@example.com"}, d.(email.ResourceLimitAlertData),
+				)
+			},
 		},
 	}
 
@@ -89,21 +116,36 @@ func TestSMTPServiceSendMail(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			captured, service := setupTestServer(t)
 
-			err := tt.sendFunc(service)
+			err := tt.sendFunc(service, t.Context(), tt.templateData)
 			require.NoError(t, err)
 
-			require.Len(t, captured.Messages, 1)
+			require.Len(t, captured.Messages, 1, "Expected exactly one email sent")
 			require.Len(t, captured.Froms, 1)
 
-			require.ElementsMatch(t, tt.wantRcpts, captured.Rcpts)
-			require.Contains(t, captured.Froms[0], testFromEmail)
-
 			msg := captured.Messages[0]
+
+			require.ElementsMatch(t, tt.expectedRecipients, captured.Rcpts, "Recipients list mismatch")
+
+			require.Equal(t, tt.expectedSubject, msg.Header.Get("Subject"), "Subject mismatch")
+			require.Contains(t, captured.Froms[0], testFromEmail)
 			require.Contains(t, msg.Header.Get("From"), testFromEmail)
 			require.Contains(t, msg.Header.Get("From"), testFromName)
 			require.Contains(t, msg.Header.Get("Content-Type"), "text/html")
 			require.Empty(t, msg.Header.Get("Bcc"), "Bcc header should not be visible")
-			require.Equal(t, tt.wantSubject, msg.Header.Get("Subject"))
+
+			// HACK: validate that the template renders correctly by directly accessing
+			// from the template registry, reversing the encoding from the actual response,
+			// and checking that the recieved message body equals the expected.
+			var buf bytes.Buffer
+			require.NoError(t, tt.expectedTemplate.Execute(&buf, tt.templateData), "failed to render template")
+			expectedBody := strings.ReplaceAll(buf.String(), "\n", "\r\n")
+
+			qpReader := quotedprintable.NewReader(msg.Body)
+			bodyBytes, err := io.ReadAll(qpReader)
+			require.NoError(t, err)
+			actualBody := string(bodyBytes)
+
+			require.Equal(t, expectedBody, actualBody, "Rendered email body mismatch")
 		})
 	}
 }

--- a/pkg/integrations/email/smtp/smtp_test.go
+++ b/pkg/integrations/email/smtp/smtp_test.go
@@ -1,3 +1,5 @@
+//go:build !e2e && !load && !rampup && !integration
+
 package smtp
 
 import (

--- a/pkg/integrations/email/smtp/smtp_test.go
+++ b/pkg/integrations/email/smtp/smtp_test.go
@@ -1,0 +1,150 @@
+package smtp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hatchet-dev/hatchet/pkg/integrations/email"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testFromEmail    = "from@example.com"
+	testFromName     = "Test"
+	testSupportEmail = "support@example.com"
+	testUsername     = "testuser"
+	testPassword     = "testpass"
+)
+
+func TestSMTPServiceSendMail(t *testing.T) {
+	tests := []struct {
+		name      string
+		sendFunc  func(*SMTPService) error
+		wantRcpts []string
+	}{
+		{
+			name: "tenant invite",
+			sendFunc: func(s *SMTPService) error {
+				return s.SendTenantInviteEmail(context.Background(), "user@example.com", email.TenantInviteEmailData{
+					TenantName:       "Acme Corp",
+					InviteSenderName: "Alice",
+					ActionURL:        "https://app.example.com/join/abc123",
+				})
+			},
+			wantRcpts: []string{"user@example.com"},
+		},
+		{
+			name: "workflow failed alert",
+			sendFunc: func(s *SMTPService) error {
+				return s.SendWorkflowRunFailedAlerts(context.Background(), []string{"admin1@example.com", "admin2@example.com"}, email.WorkflowRunsFailedEmailData{
+					Summary:      "3 workflow runs failed",
+					SettingsLink: "https://app.example.com/settings",
+				})
+			},
+			wantRcpts: []string{"admin1@example.com", "admin2@example.com"},
+		},
+		{
+			name: "expiring token alert",
+			sendFunc: func(s *SMTPService) error {
+				return s.SendExpiringTokenEmail(context.Background(), []string{"admin@example.com"}, email.ExpiringTokenEmailData{
+					TokenName:             "production-api-key",
+					ExpiresAtAbsoluteDate: "2026-02-01",
+					ExpiresAtRelativeDate: "5 days",
+					SettingsLink:          "https://app.example.com/settings/tokens",
+				})
+			},
+			wantRcpts: []string{"admin@example.com"},
+		},
+		{
+			name: "resource limit alert",
+			sendFunc: func(s *SMTPService) error {
+				return s.SendTenantResourceLimitAlert(context.Background(), []string{"admin@example.com"}, email.ResourceLimitAlertData{
+					Summary:      "Workflow runs at 90%",
+					Resource:     "workflow runs",
+					CurrentValue: 900,
+					LimitValue:   1000,
+					Percentage:   90,
+					Link:         "https://app.example.com/billing",
+				})
+			},
+			wantRcpts: []string{"admin@example.com", testSupportEmail},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			captured, service := setupTestServer(t)
+
+			err := tt.sendFunc(service)
+			require.NoError(t, err)
+
+			require.Len(t, captured.Messages, 1)
+			require.Len(t, captured.Froms, 1)
+			require.ElementsMatch(t, tt.wantRcpts, captured.Rcpts)
+
+			require.Contains(t, captured.Froms[0], testFromEmail)
+
+			msg := captured.Messages[0]
+			fromHeader := msg.Header.Get("From")
+			require.Contains(t, fromHeader, testFromEmail)
+			require.Contains(t, fromHeader, testFromName)
+			require.Contains(t, msg.Header.Get("Content-Type"), "text/html")
+			require.Empty(t, msg.Header.Get("Bcc"), "Bcc header should not be visible")
+		})
+	}
+}
+
+func TestSMTPBasicAuth(t *testing.T) {
+	captured, service := setupTestServer(t)
+
+	err := service.SendTenantInviteEmail(context.Background(), "user@example.com", email.TenantInviteEmailData{
+		TenantName: "Test",
+		ActionURL:  "https://example.com",
+	})
+	require.NoError(t, err)
+
+	require.Len(t, captured.Usernames, 1)
+	require.Equal(t, testUsername, captured.Usernames[0])
+
+	require.Len(t, captured.Passwords, 1)
+	require.Equal(t, testPassword, captured.Passwords[0])
+}
+
+func TestSMTPService_MultipleMessages(t *testing.T) {
+	captured, service := setupTestServer(t)
+
+	recipients := []string{"user1@example.com", "user2@example.com", "user3@example.com"}
+
+	for _, rcpt := range recipients {
+		err := service.SendTenantInviteEmail(context.Background(), rcpt, email.TenantInviteEmailData{
+			TenantName: "Test Org",
+			ActionURL:  "https://example.com",
+		})
+		require.NoError(t, err)
+	}
+
+	require.Len(t, captured.Messages, len(recipients))
+	require.Len(t, captured.Rcpts, len(recipients))
+}
+
+func setupTestServer(t *testing.T) (*SMTPCapture, *SMTPService) {
+	t.Helper()
+
+	port, captured, cancel, err := StartMockSMTPServer()
+	require.NoError(t, err)
+	t.Cleanup(cancel)
+
+	serverAddr := fmt.Sprintf("127.0.0.1:%d", port)
+	service, err := NewSMTPService(
+		serverAddr,
+		testUsername,
+		testPassword,
+		testFromEmail,
+		testFromName,
+		testSupportEmail,
+	)
+	require.NoError(t, err)
+
+	return captured, service
+}

--- a/pkg/integrations/email/smtp/templates.go
+++ b/pkg/integrations/email/smtp/templates.go
@@ -1,0 +1,39 @@
+package smtp
+
+import (
+	"embed"
+	"fmt"
+	"html/template"
+
+	"github.com/hatchet-dev/hatchet/pkg/integrations/email"
+)
+
+//go:embed templates/*.html
+var templateFS embed.FS
+
+var templateRegistry = make(map[string]*template.Template)
+
+func init() {
+	templates := map[string]string{
+		email.TokenAlertExpiringTemplate: "templates/expiring_token.html",
+		email.UserInviteTemplate:         "templates/user_invite.html",
+		email.OrganizationInviteTemplate: "templates/organization_invite.html",
+		email.ResourceLimitAlertTemplate: "templates/resource_limit_alert.html",
+		email.WorkflowRunsFailedTemplate: "templates/workflow_runs_failed.html",
+	}
+
+	for alias, fileName := range templates {
+		// We need to ensure that the layout.html is parsed before the HTML template
+		templateRegistry[alias] = template.Must(
+			template.ParseFS(templateFS, "templates/layout.html", fileName),
+		)
+	}
+}
+
+func getTemplate(alias string) (*template.Template, error) {
+	tmpl, ok := templateRegistry[alias]
+	if !ok {
+		return nil, fmt.Errorf("template %s does not exist", alias)
+	}
+	return tmpl, nil
+}

--- a/pkg/integrations/email/smtp/templates/expiring_token.html
+++ b/pkg/integrations/email/smtp/templates/expiring_token.html
@@ -1,0 +1,30 @@
+{{ define "content" }}
+Hi there,
+<br>
+<br>
+We are reaching out to let you know that you have a Hatchet token expiring soon:
+<br>
+<br>
+<table class="attributes" width="100%" cellpadding="0" cellspacing="0">
+  <tr>
+    <td class="attributes_content">
+      <table width="100%" cellpadding="0" cellspacing="0">
+        <tr>
+          <td class="attributes_item"><a href="{{.TokenSettings}}">{{.TokenName}}</a> expires {{.ExpiresAtRelativeDate}}</td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+If you are using this token for a client or worker, please generate a new token and revoke the old one <a href="{{.TokenSettings}}">here.</a>
+
+<br>
+<br>
+Best,
+<br>
+<br>
+The Hatchet Team
+<br>
+<br>
+<small>If you'd like to change your notification settings, you can do so <a href="{{.SettingsLink}}">here.</a></small>
+{{end}}

--- a/pkg/integrations/email/smtp/templates/layout.html
+++ b/pkg/integrations/email/smtp/templates/layout.html
@@ -1,0 +1,477 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="x-apple-disable-message-reformatting" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="color-scheme" content="dark" />
+    <meta name="supported-color-schemes" content="dark" />
+    <title></title>
+    <!--
+    The style block is collapsed on page load to save you some scrolling.
+    Postmark automatically inlines all CSS properties for maximum email client
+    compatibility. You can just update styles here, and Postmark does the rest.
+  -->
+    <style type="text/css" rel="stylesheet" media="all">
+    /* Base ------------------------------ */
+
+    @import url("https://fonts.googleapis.com/css?family=Inter:400,500,700&display=swap");
+    body {
+      width: 100% !important;
+      height: 100%;
+      margin: 0;
+      -webkit-text-size-adjust: none;
+    }
+
+    a {
+      color: #3869D4;
+    }
+
+    a img {
+      border: none;
+    }
+
+    td {
+      word-break: break-word;
+    }
+
+    .preheader {
+      display: none !important;
+      visibility: hidden;
+      mso-hide: all;
+      font-size: 1px;
+      line-height: 1px;
+      max-height: 0;
+      max-width: 0;
+      opacity: 0;
+      overflow: hidden;
+    }
+    /* Type ------------------------------ */
+
+    body,
+    td,
+    th {
+      font-family: "Inter", Helvetica, Arial, sans-serif;
+    }
+
+    h1 {
+      margin-top: 0;
+      color: #333333;
+      font-size: 22px;
+      font-weight: bold;
+      text-align: left;
+    }
+
+    h2 {
+      margin-top: 0;
+      color: #333333;
+      font-size: 16px;
+      font-weight: bold;
+      text-align: left;
+    }
+
+    h3 {
+      margin-top: 0;
+      color: #333333;
+      font-size: 14px;
+      font-weight: bold;
+      text-align: left;
+    }
+
+    td,
+    th {
+      font-size: 16px;
+    }
+
+    p,
+    ul,
+    ol,
+    blockquote {
+      margin: .4em 0 1.1875em;
+      font-size: 16px;
+      line-height: 1.625;
+    }
+
+    p.sub {
+      font-size: 13px;
+    }
+    /* Utilities ------------------------------ */
+
+    .align-right {
+      text-align: right;
+    }
+
+    .align-left {
+      text-align: left;
+    }
+
+    .align-center {
+      text-align: center;
+    }
+    /* Buttons ------------------------------ */
+
+    .button {
+      background-color: #020817;
+      border-top: 10px solid #020817;
+      border-right: 24px solid #020817;
+      border-bottom: 10px solid #020817;
+      border-left: 24px solid #020817;
+      color: #F7FAFC;
+      display: inline-block;
+      font-weight: 500;
+      text-decoration: none;
+      border-radius: 3px;
+      box-shadow: 0 2px 3px rgba(0, 0, 0, 0.16);
+      -webkit-text-size-adjust: none;
+      box-sizing: border-box;
+    }
+
+    .button--green {
+      background-color: #22BC66;
+      border-top: 10px solid #22BC66;
+      border-right: 18px solid #22BC66;
+      border-bottom: 10px solid #22BC66;
+      border-left: 18px solid #22BC66;
+    }
+
+    .button--red {
+      background-color: #FF6136;
+      border-top: 10px solid #FF6136;
+      border-right: 18px solid #FF6136;
+      border-bottom: 10px solid #FF6136;
+      border-left: 18px solid #FF6136;
+    }
+
+    @media only screen and (max-width: 500px) {
+      .button {
+        width: 100% !important;
+        text-align: center !important;
+      }
+    }
+    /* Attribute list ------------------------------ */
+
+    .attributes {
+      margin: 0 0 21px;
+    }
+
+    .attributes_content {
+      background-color: #F4F4F7;
+      padding: 16px;
+    }
+
+    .attributes_item {
+      padding: 0;
+    }
+    /* Related Items ------------------------------ */
+
+    .related {
+      width: 100%;
+      margin: 0;
+      padding: 25px 0 0 0;
+      -premailer-width: 100%;
+      -premailer-cellpadding: 0;
+      -premailer-cellspacing: 0;
+    }
+
+    .related_item {
+      padding: 10px 0;
+      color: #CBCCCF;
+      font-size: 15px;
+      line-height: 18px;
+    }
+
+    .related_item-title {
+      display: block;
+      margin: .5em 0 0;
+    }
+
+    .related_item-thumb {
+      display: block;
+      padding-bottom: 10px;
+    }
+
+    .related_heading {
+      border-top: 1px solid #CBCCCF;
+      text-align: center;
+      padding: 25px 0 10px;
+    }
+    /* Discount Code ------------------------------ */
+
+    .discount {
+      width: 100%;
+      margin: 0;
+      padding: 24px;
+      -premailer-width: 100%;
+      -premailer-cellpadding: 0;
+      -premailer-cellspacing: 0;
+      background-color: #F4F4F7;
+      border: 2px dashed #CBCCCF;
+    }
+
+    .discount_heading {
+      text-align: center;
+    }
+
+    .discount_body {
+      text-align: center;
+      font-size: 15px;
+    }
+    /* Social Icons ------------------------------ */
+
+    .social {
+      width: auto;
+    }
+
+    .social td {
+      padding: 0;
+      width: auto;
+    }
+
+    .social_icon {
+      height: 20px;
+      margin: 0 8px 10px 8px;
+      padding: 0;
+    }
+    /* Data table ------------------------------ */
+
+    .purchase {
+      width: 100%;
+      margin: 0;
+      padding: 35px 0;
+      -premailer-width: 100%;
+      -premailer-cellpadding: 0;
+      -premailer-cellspacing: 0;
+    }
+
+    .purchase_content {
+      width: 100%;
+      margin: 0;
+      padding: 25px 0 0 0;
+      -premailer-width: 100%;
+      -premailer-cellpadding: 0;
+      -premailer-cellspacing: 0;
+    }
+
+    .purchase_item {
+      padding: 10px 0;
+      color: #51545E;
+      font-size: 15px;
+      line-height: 18px;
+    }
+
+    .purchase_heading {
+      padding-bottom: 8px;
+      border-bottom: 1px solid #EAEAEC;
+    }
+
+    .purchase_heading p {
+      margin: 0;
+      color: #85878E;
+      font-size: 12px;
+    }
+
+    .purchase_footer {
+      padding-top: 15px;
+      border-top: 1px solid #EAEAEC;
+    }
+
+    .purchase_total {
+      margin: 0;
+      text-align: right;
+      font-weight: bold;
+      color: #333333;
+    }
+
+    .purchase_total--label {
+      padding: 0 15px 0 0;
+    }
+
+    body {
+      background-color: #F2F4F6;
+      color: #51545E;
+    }
+
+    p {
+      color: #51545E;
+    }
+
+    .email-wrapper {
+      width: 100%;
+      margin: 0;
+      padding: 0;
+      -premailer-width: 100%;
+      -premailer-cellpadding: 0;
+      -premailer-cellspacing: 0;
+      background-color: #F2F4F6;
+    }
+
+    .email-content {
+      width: 100%;
+      margin: 0;
+      padding: 0;
+      -premailer-width: 100%;
+      -premailer-cellpadding: 0;
+      -premailer-cellspacing: 0;
+    }
+    /* Masthead ----------------------- */
+
+    .email-masthead {
+      padding: 25px 0;
+      text-align: center;
+    }
+
+    .email-masthead_logo {
+      width: 94px;
+    }
+
+    .email-masthead_name {
+      font-size: 16px;
+      font-weight: bold;
+      color: #A8AAAF;
+      text-decoration: none;
+      text-shadow: 0 1px 0 white;
+    }
+    /* Body ------------------------------ */
+
+    .email-body {
+      width: 100%;
+      margin: 0;
+      padding: 0;
+      -premailer-width: 100%;
+      -premailer-cellpadding: 0;
+      -premailer-cellspacing: 0;
+    }
+
+    .email-body_inner {
+      width: 570px;
+      margin: 0 auto;
+      padding: 0;
+      -premailer-width: 570px;
+      -premailer-cellpadding: 0;
+      -premailer-cellspacing: 0;
+      background-color: #FFFFFF;
+    }
+
+    .email-footer {
+      width: 570px;
+      margin: 0 auto;
+      padding: 0;
+      -premailer-width: 570px;
+      -premailer-cellpadding: 0;
+      -premailer-cellspacing: 0;
+      text-align: center;
+    }
+
+    .email-footer p {
+      color: #A8AAAF;
+    }
+
+    .body-action {
+      width: 100%;
+      margin: 30px auto;
+      padding: 0;
+      -premailer-width: 100%;
+      -premailer-cellpadding: 0;
+      -premailer-cellspacing: 0;
+      text-align: center;
+    }
+
+    .body-sub {
+      margin-top: 25px;
+      padding-top: 25px;
+      border-top: 1px solid #EAEAEC;
+    }
+
+    .content-cell {
+      padding: 45px;
+    }
+    /*Media Queries ------------------------------ */
+
+    @media only screen and (max-width: 600px) {
+      .email-body_inner,
+      .email-footer {
+        width: 100% !important;
+      }
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body,
+      .email-body,
+      .email-body_inner,
+      .email-content,
+      .email-wrapper,
+      .email-masthead,
+      .email-footer {
+        background-color: #020817 !important;
+        color: #FFF !important;
+      }
+      p,
+      ul,
+      ol,
+      blockquote,
+      h1,
+      h2,
+      h3,
+      span,
+      .purchase_item {
+        color: #FFF !important;
+      }
+      .attributes_content,
+      .discount {
+        background-color: #222 !important;
+      }
+      .email-masthead_name {
+        text-shadow: none !important;
+      }
+    }
+
+    :root {
+      color-scheme: dark;
+      supported-color-schemes: dark;
+    }
+    </style>
+    <!--[if mso]>
+    <style type="text/css">
+      .f-fallback  {
+        font-family: Arial, sans-serif;
+      }
+    </style>
+  <![endif]-->
+  </head>
+  <body>
+    <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+      <tr>
+        <td align="center">
+          <table class="email-content" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+            <tr>
+              <td class="email-masthead">
+                <a href="https://hatchet.run" class="f-fallback email-masthead_name">
+                  <picture>
+                      <source srcset="https://imagedelivery.net/hKvo7fgKu6IoDvMLV830jw/6f16a48b-0d0f-4d8d-b4ab-7412e0355800/large" media="(prefers-color-scheme: dark)">
+                      <img alt="Hatchet" fetchpriority="high" width="200" height="60" decoding="async" data-nimg="1" class="h-9 w-auto" style="color:transparent" src="https://imagedelivery.net/hKvo7fgKu6IoDvMLV830jw/42c129c5-29c7-4f06-adad-37155b3b4c00/large">
+                  </picture>
+                <img src="">
+              </a>
+              </td>
+            </tr>
+            <!-- Email Body -->
+            <tr>
+              <td class="email-body" width="570" cellpadding="0" cellspacing="0">
+                <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0" role="presentation">
+                  <!-- Body content -->
+                  <tr>
+                    <td class="content-cell">
+                      <div class="f-fallback">
+                        {{ block "content" . }}{{ end }}
+                      </div>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/pkg/integrations/email/smtp/templates/organization_invite.html
+++ b/pkg/integrations/email/smtp/templates/organization_invite.html
@@ -1,0 +1,37 @@
+{{ define "content" }}
+<h1>Hi there!</h1>
+<p>You've been invited to join {{.TenantName}} on Hatchet. Use the button below to set up your account and get started:</p>
+<!-- Action -->
+<table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0">
+  <tr>
+    <td align="center">
+      <!-- Border based button https://litmus.com/blog/a-guide-to-bulletproof-buttons-in-email-design -->
+      <table width="100%" border="0" cellspacing="0" cellpadding="0">
+        <tr>
+          <td align="center">
+            <table border="0" cellspacing="0" cellpadding="0">
+              <tr>
+                <td>
+                  <a href="{{.ActionURL}}" class="button" target="_blank">Get started</a>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+<p>Feel free to <a href="mailto:support@hatchet.run">contact us</a> if you run into any issues.</p>
+<p>Welcome aboard,
+  <br>The Hatchet Team</p>
+<!-- Sub copy -->
+<table class="body-sub">
+  <tr>
+    <td>
+      <p class="sub">If you’re having trouble with the button above, copy and paste the URL below into your web browser.</p>
+      <p class="sub">{{.ActionURL}}</p>
+    </td>
+  </tr>
+</table>
+{{ end }}

--- a/pkg/integrations/email/smtp/templates/resource_limit_alert.html
+++ b/pkg/integrations/email/smtp/templates/resource_limit_alert.html
@@ -1,0 +1,36 @@
+{{ define "content" }}
+Hi there,
+<br>
+<br>
+{{.Summary}}
+<br>
+<br>
+<table class="attributes" width="100%" cellpadding="0" cellspacing="0">
+  <tr>
+    <td class="attributes_content">
+      <table width="100%" cellpadding="0" cellspacing="0">
+        <tr>
+          <td class="attributes_item"><a href="{{.Link}}">{{.Resource}}</a> at {{.Percentage}}% ({{.CurrentValue}}/{{.LimitValue}})</td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+
+{{.Summary2}}
+
+<br>
+<br>
+
+Please review your resource usage and consider upgrading your plan <a href="{{.Link}}">here</a> or reply to this email to reach us.
+
+<br>
+<br>
+Best,
+<br>
+<br>
+The Hatchet Team
+<br>
+<br>
+<small>If you'd like to change your notification settings, you can do so <a href="{{.SettingsLink}}">here.</a></small>
+{{ end }}

--- a/pkg/integrations/email/smtp/templates/user_invite.html
+++ b/pkg/integrations/email/smtp/templates/user_invite.html
@@ -1,0 +1,37 @@
+{{ define "content" }}
+<h1>Hi there!</h1>
+<p>{{.InviteSenderName}}  has invited you to join {{.TenantName}} on Hatchet. Use the button below to set up your account and get started:</p>
+<!-- Action -->
+<table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0">
+  <tr>
+    <td align="center">
+      <!-- Border based button https://litmus.com/blog/a-guide-to-bulletproof-buttons-in-email-design -->
+      <table width="100%" border="0" cellspacing="0" cellpadding="0">
+        <tr>
+          <td align="center">
+            <table border="0" cellspacing="0" cellpadding="0">
+              <tr>
+                <td>
+                  <a href="{{.ActionURL}}" class="button" target="_blank">Get started</a>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+<p>Feel free to <a href="mailto:support@hatchet.run">contact us</a> if you run into any issues.</p>
+<p>Welcome aboard,
+  <br>The Hatchet Team</p>
+<!-- Sub copy -->
+<table class="body-sub">
+  <tr>
+    <td>
+      <p class="sub">If you’re having trouble with the button above, copy and paste the URL below into your web browser.</p>
+      <p class="sub">{{.ActionURL}}</p>
+    </td>
+  </tr>
+</table>
+{{end}}

--- a/pkg/integrations/email/smtp/templates/user_invite.html
+++ b/pkg/integrations/email/smtp/templates/user_invite.html
@@ -1,6 +1,6 @@
 {{ define "content" }}
 <h1>Hi there!</h1>
-<p>{{.InviteSenderName}}  has invited you to join {{.TenantName}} on Hatchet. Use the button below to set up your account and get started:</p>
+<p>{{.InviteSenderName}} has invited you to join {{.TenantName}} on Hatchet. Use the button below to set up your account and get started:</p>
 <!-- Action -->
 <table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0">
   <tr>

--- a/pkg/integrations/email/smtp/templates/workflow_runs_failed.html
+++ b/pkg/integrations/email/smtp/templates/workflow_runs_failed.html
@@ -1,0 +1,29 @@
+{{ define "content" }}
+Hi there,
+<br>
+<br>
+We are reaching out to let you know that {{.Summary}}:
+<br>
+<br>
+<table class="attributes" width="100%" cellpadding="0" cellspacing="0">
+  <tr>
+    <td class="attributes_content">
+      <table width="100%" cellpadding="0" cellspacing="0">
+        {{range .Items}}
+        <tr>
+          <td class="attributes_item"><a href="{{.Link}}">{{.WorkflowRunReadableId}}</a> failed {{.RelativeDate}}</td>
+        </tr>
+        {{end}}
+      </table>
+    </td>
+  </tr>
+</table>
+<br>
+If you'd like to change your notification settings, you can do so <a href="{{.SettingsLink}}">here.</a>
+<br>
+<br>
+Best,
+<br>
+<br>
+The Hatchet Team
+{{end}}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Currently, Hatchet only supports sending alert emails via Postmark. This PR adds an additional email provider that supports sending messages to a mail-server using SMTP.

Addresses #2808

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [x] This change requires a documentation update

## What's Changed

- Adds new `smtp.SMTPService` email provider using `github.com/wneessen/go-mail`.
- Adds mock SMTP server for testing using `github.com/emersion/go-smtp` & `github.com/emersion/go-sasl`.
- Embeds HTML email templates in `smtp` package, adapted from `postmark` to use go-template syntax instead of mustache.
- Refactors `sendEmailFromTemplateRequest` and template alias strings to the `email` package.
- Introduces new `SERVER_EMAIL_SMTP_*` config fields and updates corresponding docs.

### TODO
- [x] Add email subject support in the new `SendEmailFromTemplateRequest`

## Testing

E2E tests were run against [sj26/mailcatcher](https://github.com/sj26/mailcatcher) -- which allows us to capture emails and render their templates from the browser.

<details>
<summary><b>See E2E Testing Steps</b></summary>

1. Launch an instance of `mailcatcher` and access the UI at [`localhost:9001`](http://localhost:9001)
   ```sh
   docker run -p 9001:1080 -p 9002:1025 sj26/mailcatcher
   ```

2. Include the following environment variables:

```env
SERVER_EMAIL_KIND=smtp
SERVER_EMAIL_SMTP_ENABLED=true
SERVER_EMAIL_SMTP_SERVER_ADDR=127.0.0.1:9002 # mailcatcher smtp server
SERVER_EMAIL_SMTP_FROM_EMAIL=hatchet@example.com
SERVER_EMAIL_SMTP_FROM_NAME=Hatchet
SERVER_EMAIL_SMTP_SUPPORT_EMAIL=support@example.com
```

3. Run a failing workflow for `WorkflowRunFailed`:
   ```sh
   go run ./examples/go/on-failure/main.go
   ```

4. Create a token that will expire in 6 days (144 hours) for `ExpiringToken`:
   ```sh
   go run ./cmd/hatchet-admin token create --name dummy --tenant-id 707d0855-80ab-4e1f-a156-f1c4546cbf52 --expiresIn 144h
   ```

5. Access the UI, login as admin, and invite a new user for `TenantInvite`.

</details>

#### Screenshots

The following emails were captured, and rendered, as a result of the above e2e tests:

<details>
<summary><b>Workflow Run Failed alert email</b></summary>
<img width="981" height="803" alt="image" src="https://github.com/user-attachments/assets/a007f9e7-4d45-45d3-8be5-2f3581e8b0e1" />
</details>

<details>
<summary><b>Tenant Invite email</b></summary>
<img width="814" height="748" alt="image" src="https://github.com/user-attachments/assets/e9db8635-5e09-4328-a6a9-4eccbb56fa3f" />
</details>

<details>
<summary><b>Expiring Token email</b></summary>
<img width="1638" height="1492" alt="image" src="https://github.com/user-attachments/assets/5725f88a-2191-499b-8162-df60ab8b3058" />
</details>

<details>
<summary><b>Resource Limit alert email</b></summary>

Note: This was not captured with an e2e test but instead by inspecting the body of the `TestSMTPServiceSendMail_resource_limit_alert` case in `smtp_test.go`.

<img width="1612" height="1464" alt="image" src="https://github.com/user-attachments/assets/885be4bd-ece5-4bb4-9311-610f7b769c45" />
</details>