### PR TITLE
[hotfix] No zombie processes left behind after a Cypress E2E run

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -124,29 +124,7 @@ tasks:
   e2e-frontend:
     desc: Run Cypress E2E for frontend/app against a locally started API stack (CI-friendly).
     cmds:
-      - |
-        set -euo pipefail
-
-        trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
-
-        task start-db
-        task write-e2e-env
-        task generate-local-encryption-keys
-        task migrate
-        task seed-cypress
-
-        bash ./hack/ci/start-api.sh &
-        bash ./hack/ci/start-engine.sh &
-
-        # API readiness server runs on the healthcheck port (default 8733)
-        bash ./hack/ci/wait-for-http.sh http://127.0.0.1:8733/ready 120
-
-        cd frontend/app
-        # Start Vite bound to app.localtest.me (see vite.config.ts)
-        pnpm run dev -- --host app.localtest.me --port 5173 &
-        bash ../../hack/ci/wait-for-http.sh http://app.localtest.me:5173 120
-
-        CYPRESS_BASE_URL=http://app.localtest.me:5173 pnpm run e2e:run
+      - bash ./hack/ci/e2e-frontend.sh
   start-ngrok:
     cmds:
       - ngrok http 8080

--- a/hack/ci/e2e-frontend.sh
+++ b/hack/ci/e2e-frontend.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+TEST_EXIT=0
+
+cleanup() {
+  set +e
+  kill -9 $(jobs -p) 2>/dev/null
+  wait 2>/dev/null
+  pkill -9 -f hatchet-api
+  pkill -9 -f hatchet-engine
+  exit "$TEST_EXIT"
+}
+trap cleanup EXIT
+
+task start-db
+task write-e2e-env
+task generate-local-encryption-keys
+task migrate
+task seed-cypress
+
+bash ./hack/ci/start-api.sh &
+bash ./hack/ci/start-engine.sh &
+
+bash ./hack/ci/wait-for-http.sh http://127.0.0.1:8733/ready 120
+
+cd frontend/app
+pnpm run dev -- --host app.localtest.me --port 5173 &
+bash ../../hack/ci/wait-for-http.sh http://app.localtest.me:5173 120
+
+set +e
+CYPRESS_BASE_URL=http://app.localtest.me:5173 pnpm run e2e:run
+TEST_EXIT=$?
+set -e


### PR DESCRIPTION
# Description

Makes sure that there are no leftover `hatchet` processes after a Cypress E2E run.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
