### PR TITLE
fix: orphaned inactive queues

### DIFF
--- a/pkg/repository/scheduler_concurrency.go
+++ b/pkg/repository/scheduler_concurrency.go
@@ -762,18 +762,18 @@ WHERE tenant_id = $1::uuid AND strategy_id = $2::bigint;`,
 
 func (c *ConcurrencyRepositoryImpl) upsertQueuesForQueuedTasks(ctx context.Context, tx sqlcv1.DBTX, tenantId string, queuedTasks []TaskWithQueue) error {
 	uniqueQueues := make(map[string]bool, len(queuedTasks))
+	queueList := make([]string, 0, len(queuedTasks))
 	for _, queue := range queuedTasks {
 		if _, ok := uniqueQueues[queue.Queue]; ok {
 			continue
 		}
 		uniqueQueues[queue.Queue] = true
+		queueList = append(queueList, queue.Queue)
 	}
 
-	for queue := range uniqueQueues {
-		_, err := c.upsertQueues(ctx, tx, tenantId, []string{queue})
-		if err != nil {
-			return fmt.Errorf("failed to upsert queue: %w", err)
-		}
+	_, err := c.upsertQueues(ctx, tx, tenantId, queueList)
+	if err != nil {
+		return fmt.Errorf("failed to upsert queues: %w", err)
 	}
 
 	return nil

--- a/pkg/repository/scheduler_concurrency.go
+++ b/pkg/repository/scheduler_concurrency.go
@@ -260,6 +260,17 @@ func (c *ConcurrencyRepositoryImpl) runGroupRoundRobin(
 		}
 	}
 
+	// for each queue, call upsert queues
+	for _, queue := range queued {
+		err = c.queries.UpsertQueues(ctx, tx, sqlcv1.UpsertQueuesParams{
+			TenantID: tenantId,
+			Names:    []string{queue.Queue},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to upsert queue (strategy ID: %d): %w", strategy.ID, err)
+		}
+	}
+
 	if err = commit(ctx); err != nil {
 		return nil, fmt.Errorf("failed to commit transaction (strategy ID: %d): %w", strategy.ID, err)
 	}

--- a/pkg/repository/sqlcv1/queue.sql
+++ b/pkg/repository/sqlcv1/queue.sql
@@ -511,3 +511,26 @@ WHERE (task_id, task_inserted_at) IN (
     SELECT task_id, task_inserted_at
     FROM locked_qis
 );
+
+-- name: ReactivateInactiveQueuesWithItems :execresult
+-- Reactivates queues that have been marked inactive (last_active > 1 day ago)
+-- but still have pending items in v1_queue_item. This is a fallback mechanism
+-- to ensure queues don't get stuck inactive while they have work to do.
+WITH inactive_queues_with_items AS (
+    SELECT q.tenant_id, q.name
+    FROM v1_queue q
+    WHERE q.last_active <= NOW() - INTERVAL '1 day'
+      AND EXISTS (
+        SELECT 1
+        FROM v1_queue_item qi
+        WHERE qi.tenant_id = q.tenant_id
+          AND qi.queue = q.name
+        LIMIT 1
+      )
+    FOR UPDATE SKIP LOCKED
+)
+UPDATE v1_queue q
+SET last_active = NOW()
+FROM inactive_queues_with_items i
+WHERE q.tenant_id = i.tenant_id
+  AND q.name = i.name;

--- a/pkg/repository/sqlcv1/queue.sql.go
+++ b/pkg/repository/sqlcv1/queue.sql.go
@@ -647,6 +647,34 @@ func (q *Queries) MoveRateLimitedQueueItems(ctx context.Context, db DBTX, arg Mo
 	return items, nil
 }
 
+const reactivateInactiveQueuesWithItems = `-- name: ReactivateInactiveQueuesWithItems :execresult
+WITH inactive_queues_with_items AS (
+    SELECT q.tenant_id, q.name
+    FROM v1_queue q
+    WHERE q.last_active <= NOW() - INTERVAL '1 day'
+      AND EXISTS (
+        SELECT 1
+        FROM v1_queue_item qi
+        WHERE qi.tenant_id = q.tenant_id
+          AND qi.queue = q.name
+        LIMIT 1
+      )
+    FOR UPDATE SKIP LOCKED
+)
+UPDATE v1_queue q
+SET last_active = NOW()
+FROM inactive_queues_with_items i
+WHERE q.tenant_id = i.tenant_id
+  AND q.name = i.name
+`
+
+// Reactivates queues that have been marked inactive (last_active > 1 day ago)
+// but still have pending items in v1_queue_item. This is a fallback mechanism
+// to ensure queues don't get stuck inactive while they have work to do.
+func (q *Queries) ReactivateInactiveQueuesWithItems(ctx context.Context, db DBTX) (pgconn.CommandTag, error) {
+	return db.Exec(ctx, reactivateInactiveQueuesWithItems)
+}
+
 const requeueRateLimitedQueueItems = `-- name: RequeueRateLimitedQueueItems :many
 WITH ready_items AS (
     SELECT

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -3789,6 +3789,16 @@ func (r *TaskRepositoryImpl) Cleanup(ctx context.Context) (bool, error) {
 		shouldContinue = true
 	}
 
+	// Reactivate any inactive queues that still have pending items
+	result, err = r.queries.ReactivateInactiveQueuesWithItems(ctx, tx)
+	if err != nil {
+		return false, fmt.Errorf("error reactivating inactive queues: %v", err)
+	}
+
+	if result.RowsAffected() > 0 {
+		r.l.Warn().Msgf("reactivated %d inactive queues with pending items", result.RowsAffected())
+	}
+
 	if err := commit(ctx); err != nil {
 		return false, fmt.Errorf("error committing transaction: %v", err)
 	}

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -3796,7 +3796,8 @@ func (r *TaskRepositoryImpl) Cleanup(ctx context.Context) (bool, error) {
 	}
 
 	if result.RowsAffected() > 0 {
-		r.l.Warn().Msgf("reactivated %d inactive queues with pending items", result.RowsAffected())
+		// FIXME: this is an error because there is an underlying bug that needs to be fixed
+		r.l.Error().Msgf("reactivated %d inactive queues with pending items", result.RowsAffected())
 	}
 
 	if err := commit(ctx); err != nil {

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -14,6 +15,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/hatchet-dev/hatchet/internal/cel"
 	"github.com/hatchet-dev/hatchet/internal/statusutils"
@@ -3712,96 +3714,143 @@ func (r *TaskRepositoryImpl) AnalyzeTaskTables(ctx context.Context) error {
 
 func (r *TaskRepositoryImpl) Cleanup(ctx context.Context) (bool, error) {
 	const timeout = 1000 * 60 // 1 minute timeout
-	tx, commit, rollback, err := sqlchelpers.PrepareTxWithStatementTimeout(ctx, r.pool, r.l, timeout)
-
-	if err != nil {
-		return false, fmt.Errorf("error beginning transaction: %v", err)
-	}
-
-	defer rollback()
-
-	acquired, err := r.queries.TryAdvisoryLock(ctx, tx, hash("cleanup-tables"))
-
-	if err != nil {
-		return false, fmt.Errorf("error acquiring advisory lock: %v", err)
-	}
-
-	if !acquired {
-		return false, nil
-	}
-
 	const batchSize = 1000
-	shouldContinue := false
 
-	result, err := r.queries.CleanupV1QueueItem(ctx, tx, batchSize)
-	if err != nil {
-		return false, fmt.Errorf("error cleaning up v1_queue_item: %v", err)
+	var (
+		mu             sync.Mutex
+		shouldContinue bool
+	)
+	eg, ctx := errgroup.WithContext(ctx)
+
+	// Helper to run a cleanup operation with its own transaction and advisory lock
+	runCleanup := func(lockName string, cleanupFn func(ctx context.Context, tx sqlcv1.DBTX) error) func() error {
+		return func() error {
+			tx, commit, rollback, err := sqlchelpers.PrepareTxWithStatementTimeout(ctx, r.pool, r.l, timeout)
+			if err != nil {
+				return fmt.Errorf("error beginning transaction for %s: %v", lockName, err)
+			}
+			defer rollback()
+
+			acquired, err := r.queries.TryAdvisoryLock(ctx, tx, hash(lockName))
+			if err != nil {
+				return fmt.Errorf("error acquiring advisory lock for %s: %v", lockName, err)
+			}
+			if !acquired {
+				return nil
+			}
+
+			if err := cleanupFn(ctx, tx); err != nil {
+				return err
+			}
+
+			if err := commit(ctx); err != nil {
+				return fmt.Errorf("error committing transaction for %s: %v", lockName, err)
+			}
+
+			return nil
+		}
 	}
 
-	if result.RowsAffected() == batchSize {
-		shouldContinue = true
-	}
+	// CleanupV1QueueItem
+	eg.Go(runCleanup("cleanup-v1-queue-item", func(ctx context.Context, tx sqlcv1.DBTX) error {
+		result, err := r.queries.CleanupV1QueueItem(ctx, tx, batchSize)
+		if err != nil {
+			return fmt.Errorf("error cleaning up v1_queue_item: %v", err)
+		}
+		if result.RowsAffected() == batchSize {
+			mu.Lock()
+			shouldContinue = true
+			mu.Unlock()
+		}
+		return nil
+	}))
 
-	result, err = r.queries.CleanupV1RetryQueueItem(ctx, tx, batchSize)
-	if err != nil {
-		return false, fmt.Errorf("error cleaning up v1_retry_queue_item: %v", err)
-	}
+	// CleanupV1RetryQueueItem
+	eg.Go(runCleanup("cleanup-v1-retry-queue-item", func(ctx context.Context, tx sqlcv1.DBTX) error {
+		result, err := r.queries.CleanupV1RetryQueueItem(ctx, tx, batchSize)
+		if err != nil {
+			return fmt.Errorf("error cleaning up v1_retry_queue_item: %v", err)
+		}
+		if result.RowsAffected() == batchSize {
+			mu.Lock()
+			shouldContinue = true
+			mu.Unlock()
+		}
+		return nil
+	}))
 
-	if result.RowsAffected() == batchSize {
-		shouldContinue = true
-	}
+	// CleanupV1RateLimitedQueueItem
+	eg.Go(runCleanup("cleanup-v1-rate-limited-queue-item", func(ctx context.Context, tx sqlcv1.DBTX) error {
+		result, err := r.queries.CleanupV1RateLimitedQueueItem(ctx, tx, batchSize)
+		if err != nil {
+			return fmt.Errorf("error cleaning up v1_rate_limited_queue_items: %v", err)
+		}
+		if result.RowsAffected() == batchSize {
+			mu.Lock()
+			shouldContinue = true
+			mu.Unlock()
+		}
+		return nil
+	}))
 
-	result, err = r.queries.CleanupV1RateLimitedQueueItem(ctx, tx, batchSize)
-	if err != nil {
-		return false, fmt.Errorf("error cleaning up v1_rate_limited_queue_items: %v", err)
-	}
+	// CleanupMatchWithMatchConditions
+	eg.Go(runCleanup("cleanup-v1-match", func(ctx context.Context, tx sqlcv1.DBTX) error {
+		today := time.Now().UTC()
+		removeBefore := today.Add(-1 * r.taskRetentionPeriod)
 
-	if result.RowsAffected() == batchSize {
-		shouldContinue = true
-	}
+		err := r.queries.CleanupMatchWithMatchConditions(ctx, tx, pgtype.Date{
+			Time:  removeBefore,
+			Valid: true,
+		})
+		if err != nil {
+			return fmt.Errorf("error cleaning up v1_match and v1_match_condition: %v", err)
+		}
+		return nil
+	}))
 
-	today := time.Now().UTC()
-	removeBefore := today.Add(-1 * r.taskRetentionPeriod)
+	// CleanupV1TaskRuntime
+	eg.Go(runCleanup("cleanup-v1-task-runtime", func(ctx context.Context, tx sqlcv1.DBTX) error {
+		result, err := r.queries.CleanupV1TaskRuntime(ctx, tx, batchSize)
+		if err != nil {
+			return fmt.Errorf("error cleaning up v1_task_runtime: %v", err)
+		}
+		if result.RowsAffected() == batchSize {
+			mu.Lock()
+			shouldContinue = true
+			mu.Unlock()
+		}
+		return nil
+	}))
 
-	err = r.queries.CleanupMatchWithMatchConditions(ctx, tx, pgtype.Date{
-		Time:  removeBefore,
-		Valid: true,
-	})
-	if err != nil {
-		return false, fmt.Errorf("error cleaning up v1_match and v1_match_condition: %v", err)
-	}
+	// CleanupV1ConcurrencySlot
+	eg.Go(runCleanup("cleanup-v1-concurrency-slot", func(ctx context.Context, tx sqlcv1.DBTX) error {
+		result, err := r.queries.CleanupV1ConcurrencySlot(ctx, tx, batchSize)
+		if err != nil {
+			return fmt.Errorf("error cleaning up v1_concurrency_slot: %v", err)
+		}
+		if result.RowsAffected() == batchSize {
+			mu.Lock()
+			shouldContinue = true
+			mu.Unlock()
+		}
+		return nil
+	}))
 
-	result, err = r.queries.CleanupV1TaskRuntime(ctx, tx, batchSize)
-	if err != nil {
-		return false, fmt.Errorf("error cleaning up v1_task_runtime: %v", err)
-	}
+	// ReactivateInactiveQueuesWithItems
+	eg.Go(runCleanup("cleanup-reactivate-queues", func(ctx context.Context, tx sqlcv1.DBTX) error {
+		result, err := r.queries.ReactivateInactiveQueuesWithItems(ctx, tx)
+		if err != nil {
+			return fmt.Errorf("error reactivating inactive queues: %v", err)
+		}
+		if result.RowsAffected() > 0 {
+			// FIXME: this is an error because there is an underlying bug that needs to be fixed
+			r.l.Error().Msgf("reactivated %d inactive queues with pending items", result.RowsAffected())
+		}
+		return nil
+	}))
 
-	if result.RowsAffected() == batchSize {
-		shouldContinue = true
-	}
-
-	result, err = r.queries.CleanupV1ConcurrencySlot(ctx, tx, batchSize)
-	if err != nil {
-		return false, fmt.Errorf("error cleaning up v1_concurrency_slot: %v", err)
-	}
-
-	if result.RowsAffected() == batchSize {
-		shouldContinue = true
-	}
-
-	// Reactivate any inactive queues that still have pending items
-	result, err = r.queries.ReactivateInactiveQueuesWithItems(ctx, tx)
-	if err != nil {
-		return false, fmt.Errorf("error reactivating inactive queues: %v", err)
-	}
-
-	if result.RowsAffected() > 0 {
-		// FIXME: this is an error because there is an underlying bug that needs to be fixed
-		r.l.Error().Msgf("reactivated %d inactive queues with pending items", result.RowsAffected())
-	}
-
-	if err := commit(ctx); err != nil {
-		return false, fmt.Errorf("error committing transaction: %v", err)
+	if err := eg.Wait(); err != nil {
+		return false, err
 	}
 
 	return shouldContinue, nil

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -3740,7 +3740,7 @@ func (r *TaskRepositoryImpl) Cleanup(ctx context.Context) (bool, error) {
 			}
 
 			if err := cleanupFn(ctx, tx); err != nil {
-				return err
+				return fmt.Errorf("error cleaning up %s: %w", lockName, err)
 			}
 
 			if err := commit(ctx); err != nil {


### PR DESCRIPTION
# Description

If a task complete event is missed, it is possible for the `v1_queue.last_active` timestamp to not be updated. This means the queue may be incorrectly marked as inactive.

The scheduler uses `last_active > NOW() - INTERVAL '1 day'` to filter active queues via `ListQueues`. Once a queue is marked inactive, any remaining queue items are never processed - they become stuck.

This add a defensive fallback in the existing cleanup job (runs every 1 minute) that finds inactive queues with pending `v1_queue_item` entries and reactivates them by setting `last_active = NOW()`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Add `ReactivateInactiveQueuesWithItems` query which runs on Cron
