### PR TITLE
fix: only fetch finalized workflow runs

### DIFF
--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -356,6 +356,7 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig) ([]Teardown, erro
 			dispatcher.WithCache(cacheInstance),
 			dispatcher.WithPayloadSizeThreshold(sc.Runtime.GRPCMaxMsgSize),
 			dispatcher.WithDefaultMaxWorkerBacklogSize(int64(sc.Runtime.GRPCWorkerStreamMaxBacklogSize)),
+			dispatcher.WithWorkflowRunBufferSize(sc.Runtime.WorkflowRunBufferSize),
 		)
 
 		if err != nil {
@@ -722,6 +723,7 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig) ([]Teardown, erro
 			dispatcher.WithCache(cacheInstance),
 			dispatcher.WithPayloadSizeThreshold(sc.Runtime.GRPCMaxMsgSize),
 			dispatcher.WithDefaultMaxWorkerBacklogSize(int64(sc.Runtime.GRPCWorkerStreamMaxBacklogSize)),
+			dispatcher.WithWorkflowRunBufferSize(sc.Runtime.WorkflowRunBufferSize),
 		)
 
 		if err != nil {

--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -43,6 +43,7 @@ type DispatcherImpl struct {
 	cache                       cache.Cacheable
 	payloadSizeThreshold        int
 	defaultMaxWorkerBacklogSize int64
+	workflowRunBufferSize       int
 
 	dispatcherId string
 	workers      *workers
@@ -122,6 +123,7 @@ type DispatcherOpts struct {
 	cache                       cache.Cacheable
 	payloadSizeThreshold        int
 	defaultMaxWorkerBacklogSize int64
+	workflowRunBufferSize       int
 }
 
 func defaultDispatcherOpts() *DispatcherOpts {
@@ -135,6 +137,7 @@ func defaultDispatcherOpts() *DispatcherOpts {
 		alerter:                     alerter,
 		payloadSizeThreshold:        3 * 1024 * 1024,
 		defaultMaxWorkerBacklogSize: 20,
+		workflowRunBufferSize:       1000,
 	}
 }
 
@@ -192,6 +195,12 @@ func WithDefaultMaxWorkerBacklogSize(size int64) DispatcherOpt {
 	}
 }
 
+func WithWorkflowRunBufferSize(size int) DispatcherOpt {
+	return func(opts *DispatcherOpts) {
+		opts.workflowRunBufferSize = size
+	}
+}
+
 func New(fs ...DispatcherOpt) (*DispatcherImpl, error) {
 	opts := defaultDispatcherOpts()
 
@@ -240,6 +249,7 @@ func New(fs ...DispatcherOpt) (*DispatcherImpl, error) {
 		cache:                       opts.cache,
 		payloadSizeThreshold:        opts.payloadSizeThreshold,
 		defaultMaxWorkerBacklogSize: opts.defaultMaxWorkerBacklogSize,
+		workflowRunBufferSize:       opts.workflowRunBufferSize,
 	}, nil
 }
 

--- a/internal/services/dispatcher/server_v1.go
+++ b/internal/services/dispatcher/server_v1.go
@@ -400,6 +400,11 @@ func (s *DispatcherImpl) subscribeToWorkflowRunsV1(server contracts.Dispatcher_S
 
 		events, err := s.taskEventsToWorkflowRunEvent(tenantId, finalizedWorkflowRuns)
 
+		// Release the reference to finalizedWorkflowRuns so GC can reclaim the large
+		// payload byte slices while we're sending events (which can be slow due to
+		// sendMu serialization). The event data has already been copied to strings.
+		finalizedWorkflowRuns = nil
+
 		if err != nil {
 			s.l.Error().Err(err).Msg("could not convert task events to workflow run events")
 			return err

--- a/internal/services/dispatcher/server_v1.go
+++ b/internal/services/dispatcher/server_v1.go
@@ -366,7 +366,7 @@ func (s *DispatcherImpl) subscribeToWorkflowRunsV1(server contracts.Dispatcher_S
 		iterCtx, iterSpan := telemetry.NewSpan(ctx, "subscribe_to_workflow_runs_v1.iter")
 		defer iterSpan.End()
 
-		bufferSize := 1000
+		bufferSize := s.workflowRunBufferSize
 
 		if len(workflowRunIds) > bufferSize {
 			ringMu.Lock()

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -284,6 +284,9 @@ type ConfigFileRuntime struct {
 
 	// TaskOperationLimits controls the limits for various task operations
 	TaskOperationLimits TaskOperationLimitsConfigFile `mapstructure:"taskOperationLimits" json:"taskOperationLimits,omitempty"`
+
+	// WorkflowRunBufferSize is the buffer size for workflow run event batching in the dispatcher
+	WorkflowRunBufferSize int `mapstructure:"workflowRunBufferSize" json:"workflowRunBufferSize,omitempty" default:"1000"`
 }
 
 type InternalClientTLSConfigFile struct {
@@ -850,6 +853,9 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("taskOperationLimits.reassignLimit", "SERVER_TASK_OPERATION_LIMITS_REASSIGN_LIMIT")
 	_ = v.BindEnv("taskOperationLimits.retryQueueLimit", "SERVER_TASK_OPERATION_LIMITS_RETRY_QUEUE_LIMIT")
 	_ = v.BindEnv("taskOperationLimits.durableSleepLimit", "SERVER_TASK_OPERATION_LIMITS_DURABLE_SLEEP_LIMIT")
+
+	// dispatcher options
+	_ = v.BindEnv("runtime.workflowRunBufferSize", "SERVER_WORKFLOW_RUN_BUFFER_SIZE")
 
 	// payload store options
 	_ = v.BindEnv("payloadStore.enablePayloadDualWrites", "SERVER_PAYLOAD_STORE_ENABLE_PAYLOAD_DUAL_WRITES")

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -892,12 +892,29 @@ func (r *TaskRepositoryImpl) ListFinalizedWorkflowRuns(ctx context.Context, tena
 	durVerify := time.Since(checkpoint)
 	checkpoint = time.Now()
 
+	finalizedRootIdsSet := make(map[string]bool)
+	for _, rootId := range finalizedRootIds {
+		finalizedRootIdsSet[rootId] = true
+	}
+
 	taskExternalIds := make([]string, 0, len(tasks))
 	taskExternalIdsToRootIds := make(map[string]string)
 
 	for _, task := range tasks {
-		taskExternalIds = append(taskExternalIds, sqlchelpers.UUIDToStr(task.ExternalID))
-		taskExternalIdsToRootIds[sqlchelpers.UUIDToStr(task.ExternalID)] = sqlchelpers.UUIDToStr(task.WorkflowRunExternalID)
+		rootId := sqlchelpers.UUIDToStr(task.WorkflowRunExternalID)
+		taskExternalId := sqlchelpers.UUIDToStr(task.ExternalID)
+
+		if finalizedRootIdsSet[rootId] {
+			taskExternalIds = append(taskExternalIds, taskExternalId)
+			taskExternalIdsToRootIds[taskExternalId] = rootId
+		}
+	}
+
+	if len(taskExternalIds) == 0 {
+		if err := commit(ctx); err != nil {
+			return nil, err
+		}
+		return []*ListFinalizedWorkflowRunsResponse{}, nil
 	}
 
 	outputEvents, err := r.listTaskOutputEvents(ctx, tx, tenantId, taskExternalIds)
@@ -927,14 +944,8 @@ func (r *TaskRepositoryImpl) ListFinalizedWorkflowRuns(ctx context.Context, tena
 		taskExternalIdsHasOutputEvent[outputEvent.TaskExternalId] = true
 	}
 
-	finalizedRootIdsMap := make(map[string]bool)
-
-	for _, rootId := range finalizedRootIds {
-		finalizedRootIdsMap[rootId] = true
-	}
-
 	// if tasks that we read originally don't have a TaskOutputEvent, they're not finalized, so set their root
-	// ids in finalizedRootIdsMap to false
+	// ids in finalizedRootIdsSet to false (safety check for race conditions)
 	for _, taskExternalId := range taskExternalIds {
 		if !taskExternalIdsHasOutputEvent[taskExternalId] {
 			rootId, ok := taskExternalIdsToRootIds[taskExternalId]
@@ -944,7 +955,7 @@ func (r *TaskRepositoryImpl) ListFinalizedWorkflowRuns(ctx context.Context, tena
 				continue
 			}
 
-			finalizedRootIdsMap[rootId] = false
+			finalizedRootIdsSet[rootId] = false
 		}
 	}
 
@@ -952,7 +963,7 @@ func (r *TaskRepositoryImpl) ListFinalizedWorkflowRuns(ctx context.Context, tena
 	eventsForFinalizedRootIds := make(map[string][]*TaskOutputEvent)
 
 	for _, rootId := range finalizedRootIds {
-		if !finalizedRootIdsMap[rootId] {
+		if !finalizedRootIdsSet[rootId] {
 			continue
 		}
 


### PR DESCRIPTION
# Description

In ListFinalizedWorkflowRuns, the code was calling listTaskOutputEvents for ALL tasks passed in, even though verifyAllTasksFinalized had already determined which workflow runs were actually finalized. This meant:
1. If 1000 workflow runs were being tracked but only 10 were finalized
2. The system would fetch large payload data for all 1000 workflow runs' tasks
3. Only the 10 finalized ones would be used; the other 990 were immediately discarded
4. Each polling iteration (every 1 second) would repeat this, causing 349MB+ of memory allocations that were never needed

The fix filters taskExternalIds to only include tasks belonging to finalized workflow runs before calling listTaskOutputEvents

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


