### PR TITLE
[Python] Fix: Empty Output Serialization

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.13] - 2026-01-31
+
+### Changed
+
+- Allows `None` to be sent from `send_step_action_event` to help limit an internal error on the engine.
+
 ## [1.22.13] - 2026-01-29
 
 ### Added

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.22.13] - 2026-01-31
+## [1.22.14] - 2026-01-31
 
 ### Changed
 

--- a/sdks/python/hatchet_sdk/clients/dispatcher/dispatcher.py
+++ b/sdks/python/hatchet_sdk/clients/dispatcher/dispatcher.py
@@ -93,7 +93,7 @@ class DispatcherClient:
         self,
         action: Action,
         event_type: StepActionEventType,
-        payload: str,
+        payload: str | None,
         should_not_retry: bool,
     ) -> grpc.aio.UnaryUnaryCall[StepActionEvent, ActionEventResponse] | None:
         try:
@@ -116,7 +116,7 @@ class DispatcherClient:
         self,
         action: Action,
         event_type: StepActionEventType,
-        payload: str,
+        payload: str | None,
         should_not_retry: bool,
     ) -> grpc.aio.UnaryUnaryCall[StepActionEvent, ActionEventResponse]:
         if not self.aio_client:

--- a/sdks/python/hatchet_sdk/worker/action_listener_process.py
+++ b/sdks/python/hatchet_sdk/worker/action_listener_process.py
@@ -55,7 +55,7 @@ class HealthStatus(str, Enum):
 class ActionEvent:
     action: Action
     type: Any  # TODO type
-    payload: str
+    payload: str | None
     should_not_retry: bool
 
 
@@ -450,7 +450,7 @@ class WorkerActionListenerProcess:
                             ActionEvent(
                                 action=action,
                                 type=STEP_EVENT_TYPE_STARTED,  # TODO ack type
-                                payload="",
+                                payload=None,
                                 should_not_retry=False,
                             )
                         )

--- a/sdks/python/hatchet_sdk/worker/runner/runner.py
+++ b/sdks/python/hatchet_sdk/worker/runner/runner.py
@@ -415,7 +415,7 @@ class Runner:
                 ActionEvent(
                     action=action,
                     type=STEP_EVENT_TYPE_STARTED,
-                    payload="",
+                    payload=None,
                     should_not_retry=False,
                 )
             )
@@ -503,9 +503,9 @@ class Runner:
         finally:
             self.cleanup_run_id(key)
 
-    def serialize_output(self, output: Any) -> str:
+    def serialize_output(self, output: Any) -> str | None:
         if not output:
-            return ""
+            return None
 
         if isinstance(output, BaseModel):
             try:
@@ -527,7 +527,7 @@ class Runner:
             )
 
         if output is None:
-            return ""
+            return None
 
         try:
             serialized_output = json.dumps(output, default=str)

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.22.13"
+version = "1.22.14"
 description = "This is the official Python SDK for Hatchet, a distributed, fault-tolerant task queue. The SDK allows you to easily integrate Hatchet's task scheduling and workflow orchestration capabilities into your Python applications."
 authors = [
   "Alexander Belanger <alexander@hatchet.run>",

--- a/sdks/python/tests/worker_fixture.py
+++ b/sdks/python/tests/worker_fixture.py
@@ -30,6 +30,8 @@ def wait_for_worker_health(healthcheck_port: int) -> bool:
             if resp.status_code == 200:
                 return True
 
+            time.sleep(1)
+
         except Exception:
             time.sleep(1)
 


### PR DESCRIPTION
# Description

Fixing one cause of `failed to unmarshal json` from the Python SDK sending an empty string instead of `None` when a task returns nothing

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
