### PR TITLE
step to task

### DIFF
--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improved cancellation log messages: cancellation-related logs now use `debug` level instead of `error` level since cancellation is expected behavior, not a failure.
 - Updated terminology in log messages from "step run" to "task run" for consistency.
+- Added link to cancellation docs (https://docs.hatchet.run/home/cancellation) in error messages when task completion fails.
 
 ## [1.10.7] - 2026-01-27
 

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Hatchet's TypeScript SDK will be documented in this chang
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.8] - 2026-02-02
+
+### Changed
+
+- Improved cancellation log messages: cancellation-related logs now use `debug` level instead of `error` level since cancellation is expected behavior, not a failure.
+- Updated terminology in log messages from "step run" to "task run" for consistency.
+
 ## [1.10.7] - 2026-01-27
 
 ### Added

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "1.10.7",
+  "version": "1.10.8",
   "description": "Background task orchestration & visibility for developers",
   "types": "dist/index.d.ts",
   "files": [

--- a/sdks/typescript/src/clients/worker/worker.ts
+++ b/sdks/typescript/src/clients/worker/worker.ts
@@ -364,7 +364,11 @@ export class V0Worker {
         if (message.includes('Cancelled')) {
           this.logger.debug(`Task run ${action.stepRunId} was cancelled`);
         } else {
-          this.logger.error(`Could not wait for task run ${action.stepRunId} to finish: `, e);
+          this.logger.error(
+            `Could not wait for task run ${action.stepRunId} to finish. ` +
+              `See https://docs.hatchet.run/home/cancellation for best practices on handling cancellation: `,
+            e
+          );
         }
       }
     } catch (e: any) {

--- a/sdks/typescript/src/v1/client/worker/worker-internal.ts
+++ b/sdks/typescript/src/v1/client/worker/worker-internal.ts
@@ -676,7 +676,11 @@ export class V1Worker {
         if (message.includes('Cancelled')) {
           this.logger.debug(`Task run ${action.stepRunId} was cancelled`);
         } else {
-          this.logger.error(`Could not wait for task run ${action.stepRunId} to finish: `, e);
+          this.logger.error(
+            `Could not wait for task run ${action.stepRunId} to finish. ` +
+              `See https://docs.hatchet.run/home/cancellation for best practices on handling cancellation: `,
+            e
+          );
         }
       }
     } catch (e: any) {


### PR DESCRIPTION
# Description

Improves the clarity of cancellation-related log messages in the TypeScript SDK. Previously, when a workflow was cancelled, the SDK would log misleading error messages like "Could not wait for step run to finish: Cancelled by worker" at the `error` level, causing confusion since cancellation is expected behavior, not a failure.

This PR:
1. Changes cancellation-related logs from `error` to `debug` level
2. Updates terminology from "step run" to "task run" for consistency with current naming conventions

## Type of change

- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)

## What's Changed

- Changed `handleStartStepRun` catch block to log cancellations at `debug` level while keeping real failures at `error` level
- Changed `handleCancelStepRun` catch block to use `debug` level since the promise rejection is expected during cancellation
- Updated all log messages to use "task run" instead of "step run"
- Updated CHANGELOG.md for version 1.10.8

**Before:**
```
[ERROR/Worker/analyst-worker] Could not wait for step run to finish: Cancelled by worker
[ERROR/Worker/analyst-worker] Could not cancel step run: Cancelled by worker
```

**After:**
```
[DEBUG/Worker/analyst-worker] Task run XXX-XXX-XXX-XXX-XXX was cancelled
[DEBUG/Worker/analyst-worker] Task run XXX-XXX-XXX-XXX-XXX cancellation completed
```