### PR TITLE
[Python] Fix: Allow ContextVars to be used in lifespans

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.22.15] - 2026-02-02
 
+### Added
+
+- Adds `task_name` and `workflow_name` properties to the `Context` and `DurableContext` classes to allow tasks and lifespans to access their own names.
+
 ### Changed
 
 - Fixes a bug to allow `ContextVars` to be used in lifespans

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.15] - 2026-02-02
+
+### Changed
+
+- Fixes a bug to allow `ContextVars` to be used in lifespans
+- Improves worker shutdown + cleanup logic to avoid leaking semaphores in the action listener process.
+
 ## [1.22.14] - 2026-01-31
 
 ### Changed

--- a/sdks/python/hatchet_sdk/context/context.py
+++ b/sdks/python/hatchet_sdk/context/context.py
@@ -46,6 +46,8 @@ class Context:
         lifespan_context: Any | None,
         log_sender: AsyncLogSender,
         max_attempts: int,
+        task_name: str,
+        workflow_name: str,
     ):
         self.worker = worker
 
@@ -69,6 +71,8 @@ class Context:
 
         self.stream_index = 0
         self._max_attempts = max_attempts
+        self._workflow_name = workflow_name
+        self._task_name = task_name
 
     def _increment_stream_index(self) -> int:
         index = self.stream_index
@@ -378,6 +382,14 @@ class Context:
 
         return errors
 
+    @property
+    def workflow_name(self) -> str:
+        return self._workflow_name
+
+    @property
+    def task_name(self) -> str:
+        return self._task_name
+
     def fetch_task_run_error(
         self,
         task: "Task[TWorkflowInput, R]",
@@ -432,6 +444,8 @@ class DurableContext(Context):
         lifespan_context: Any | None,
         log_sender: AsyncLogSender,
         max_attempts: int,
+        task_name: str,
+        workflow_name: str,
     ):
         super().__init__(
             action,
@@ -444,6 +458,8 @@ class DurableContext(Context):
             lifespan_context,
             log_sender,
             max_attempts,
+            task_name,
+            workflow_name,
         )
 
         self._wait_index = 0

--- a/sdks/python/hatchet_sdk/runnables/task.py
+++ b/sdks/python/hatchet_sdk/runnables/task.py
@@ -495,6 +495,8 @@ class Task(Generic[TWorkflowInput, R]):
             lifespan_context=lifespan_context,
             log_sender=AsyncLogSender(self.workflow.client._client.event),
             max_attempts=self.retries + 1,
+            task_name=self.name,
+            workflow_name=self.workflow.name,
         )
 
     def mock_run(

--- a/sdks/python/hatchet_sdk/worker/action_listener_process.py
+++ b/sdks/python/hatchet_sdk/worker/action_listener_process.py
@@ -544,11 +544,4 @@ def worker_action_listener_process(
         while not process.killing:  # noqa: ASYNC110
             await asyncio.sleep(0.1)
 
-    try:
-        asyncio.run(run())
-    finally:
-        try:
-            action_queue.close()
-            event_queue.close()
-        except Exception:
-            pass
+    asyncio.run(run())

--- a/sdks/python/hatchet_sdk/worker/action_listener_process.py
+++ b/sdks/python/hatchet_sdk/worker/action_listener_process.py
@@ -544,4 +544,11 @@ def worker_action_listener_process(
         while not process.killing:  # noqa: ASYNC110
             await asyncio.sleep(0.1)
 
-    asyncio.run(run())
+    try:
+        asyncio.run(run())
+    finally:
+        try:
+            action_queue.close()
+            event_queue.close()
+        except Exception:
+            pass

--- a/sdks/python/hatchet_sdk/worker/worker.py
+++ b/sdks/python/hatchet_sdk/worker/worker.py
@@ -498,5 +498,13 @@ class Worker:
 
         await self._close()
 
+        if self._lifespan_cleanup_complete is not None:
+            try:
+                await asyncio.wait_for(
+                    self._lifespan_cleanup_complete.wait(), timeout=5.0
+                )
+            except asyncio.TimeoutError:
+                logger.warning("lifespan cleanup timed out during forceful shutdown")
+
         logger.info("👋")
         sys.exit(1)

--- a/sdks/python/hatchet_sdk/worker/worker.py
+++ b/sdks/python/hatchet_sdk/worker/worker.py
@@ -116,6 +116,7 @@ class Worker:
 
         self.lifespan = lifespan
         self.lifespan_stack: AsyncExitStack | None = None
+        self._lifespan_cleanup_complete: asyncio.Event | None = None
 
         self.register_workflows(workflows or [])
 
@@ -256,11 +257,19 @@ class Worker:
             )
 
         if self.loop:
+            self._lifespan_cleanup_complete = asyncio.Event()
             self.action_listener_health_check = self.loop.create_task(
                 self._check_listener_health()
             )
 
             await self.action_listener_health_check
+
+            try:
+                await self._cleanup_lifespan()
+            except LifespanSetupError:
+                logger.exception("lifespan cleanup failed")
+            finally:
+                self._lifespan_cleanup_complete.set()
 
     def _run_action_runner(
         self, is_durable: bool, lifespan_context: Any | None
@@ -406,6 +415,39 @@ class Worker:
         if self.loop:
             self.loop.create_task(self._exit_forcefully())
 
+    def _close_queues(self) -> None:
+        queues: list[Queue[Any]] = [
+            self.action_queue,
+            self.event_queue,
+            self.durable_action_queue,
+            self.durable_event_queue,
+        ]
+
+        for queue in queues:
+            try:
+                queue.cancel_join_thread()
+                queue.close()
+            except Exception:  # noqa: PERF203
+                continue
+
+    def _terminate_processes(self) -> None:
+        for process in [
+            self.action_listener_process,
+            self.durable_action_listener_process,
+        ]:
+            if process is not None and process.pid is not None:
+                try:
+                    if process.is_alive():
+                        os.kill(process.pid, signal.SIGQUIT)
+
+                    process.join(timeout=5)
+
+                    if process.is_alive():
+                        process.kill()
+                        process.join(timeout=1)
+                except Exception:
+                    pass
+
     async def _close(self) -> None:
         logger.info(f"closing worker '{self.name}'...")
         self.killing = True
@@ -417,6 +459,8 @@ class Worker:
             self.durable_action_runner.cleanup()
 
         await self.action_listener_health_check
+
+        self._close_queues()
 
     async def exit_gracefully(self) -> None:
         logger.debug(f"gracefully stopping worker: {self.name}")
@@ -434,21 +478,12 @@ class Worker:
             await self.durable_action_runner.wait_for_tasks()
             await self.durable_action_runner.exit_gracefully()
 
-        if self.action_listener_process and self.action_listener_process.is_alive():
-            self.action_listener_process.kill()
-
-        if (
-            self.durable_action_listener_process
-            and self.durable_action_listener_process.is_alive()
-        ):
-            self.durable_action_listener_process.kill()
-
-        try:
-            await self._cleanup_lifespan()
-        except LifespanSetupError:
-            logger.exception("lifespan cleanup failed")
+        self._terminate_processes()
 
         await self._close()
+
+        if self._lifespan_cleanup_complete is not None:
+            await self._lifespan_cleanup_complete.wait()
         if self.loop and self.owned_loop:
             self.loop.stop()
 
@@ -459,13 +494,9 @@ class Worker:
 
         logger.debug(f"forcefully stopping worker: {self.name}")
 
+        self._terminate_processes()
+
         await self._close()
-
-        if self.action_listener_process:
-            self.action_listener_process.kill()
-
-        if self.durable_action_listener_process:
-            self.durable_action_listener_process.kill()
 
         logger.info("👋")
         sys.exit(1)

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.22.14"
+version = "1.22.15"
 description = "This is the official Python SDK for Hatchet, a distributed, fault-tolerant task queue. The SDK allows you to easily integrate Hatchet's task scheduling and workflow orchestration capabilities into your Python applications."
 authors = [
   "Alexander Belanger <alexander@hatchet.run>",


### PR DESCRIPTION
# Description

Fixes an issue with contextvars in lifespans not being cleaned up because of some asyncio.task issues in the internal logic. Also improves cleanup logic on worker shutdown to handle closing queues correctly and clean up semaphores to prevent leaks

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
