### PR TITLE
fix: add back SendTemplateEmail methods, fix postmark emails

### DIFF
--- a/pkg/integrations/email/email.go
+++ b/pkg/integrations/email/email.go
@@ -68,6 +68,10 @@ type EmailService interface {
 	SendWorkflowRunFailedAlerts(ctx context.Context, emails []string, data WorkflowRunsFailedEmailData) error
 	SendExpiringTokenEmail(ctx context.Context, emails []string, data ExpiringTokenEmailData) error
 	SendTenantResourceLimitAlert(ctx context.Context, emails []string, data ResourceLimitAlertData) error
+
+	// Used for extending the email provider for sending additional templated emails
+	SendTemplateEmail(ctx context.Context, to, templateAlias string, templateModelData interface{}, bccSupport bool) error
+	SendTemplateEmailBCC(ctx context.Context, bcc, templateAlias string, templateModelData interface{}, bccSupport bool) error
 }
 
 type NoOpService struct{}
@@ -89,5 +93,13 @@ func (s *NoOpService) SendExpiringTokenEmail(ctx context.Context, emails []strin
 }
 
 func (s *NoOpService) SendTenantResourceLimitAlert(ctx context.Context, emails []string, data ResourceLimitAlertData) error {
+	return nil
+}
+
+func (s *NoOpService) SendTemplateEmail(ctx context.Context, to, templateAlias string, templateModelData interface{}, bccSupport bool) error {
+	return nil
+}
+
+func (s *NoOpService) SendTemplateEmailBCC(ctx context.Context, bcc, templateAlias string, templateModelData interface{}, bccSupport bool) error {
 	return nil
 }

--- a/pkg/integrations/email/smtp/smtp.go
+++ b/pkg/integrations/email/smtp/smtp.go
@@ -104,6 +104,35 @@ func (s *SMTPService) SendTenantResourceLimitAlert(ctx context.Context, emails [
 	})
 }
 
+func (s *SMTPService) SendTemplateEmail(ctx context.Context, to, templateAlias string, templateModelData interface{}, bccSupport bool) error {
+	var bcc string
+
+	if bccSupport {
+		bcc = s.supportEmail
+	}
+
+	return s.sendRequest(ctx, &email.SendEmailFromTemplateRequest{
+		From:          fmt.Sprintf("%s <%s>", s.fromName, s.fromEmail),
+		To:            to,
+		Bcc:           bcc,
+		TemplateAlias: templateAlias,
+		TemplateModel: templateModelData,
+	})
+}
+
+func (s *SMTPService) SendTemplateEmailBCC(ctx context.Context, bcc, templateAlias string, templateModelData interface{}, bccSupport bool) error {
+	if bccSupport {
+		bcc = fmt.Sprintf("%s,%s", bcc, s.supportEmail)
+	}
+
+	return s.sendRequest(ctx, &email.SendEmailFromTemplateRequest{
+		From:          fmt.Sprintf("%s <%s>", s.fromName, s.fromEmail),
+		Bcc:           bcc,
+		TemplateAlias: templateAlias,
+		TemplateModel: templateModelData,
+	})
+}
+
 func (s *SMTPService) sendRequest(ctx context.Context, req *email.SendEmailFromTemplateRequest) error {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()


### PR DESCRIPTION
# Description

In the PR review for #2868 I mistakenly thought that the SendTemplateEmail methods were unused, this adds those back. 

Also fixes the `req.Path` being accidentally set to the Postmark URL.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)