### PR TITLE
Only run python 3.13 on PRs for tests

### DIFF
--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubicloud-standard-4
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.13"]') || fromJSON('["3.10", "3.11", "3.12", "3.13"]') }}
         optimistic-scheduling: ["true", "false"]
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Simplify CI to only run python 3.13 if we are in a PR

<img width="2048" height="1636" alt="image" src="https://github.com/user-attachments/assets/b1ff8432-ccd4-4aed-8c76-8d91c535b9e6" />

See run here: https://github.com/hatchet-dev/hatchet/actions/runs/21638793278/job/62372027662?pr=2922


<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [x] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- Ensure only python 3.13 runs on PRs
