### PR TITLE
fix: startup for optimistic scheduler

### DIFF
--- a/internal/services/admin/admin.go
+++ b/internal/services/admin/admin.go
@@ -143,8 +143,6 @@ func NewAdminService(fs ...AdminServiceOpt) (AdminService, error) {
 
 	if opts.optimisticSchedulingEnabled && opts.localScheduler != nil {
 		localScheduler = opts.localScheduler
-	} else if opts.optimisticSchedulingEnabled && opts.localScheduler == nil {
-		return nil, fmt.Errorf("optimistic writes enabled but no local scheduler provided")
 	}
 
 	return &AdminServiceImpl{

--- a/internal/services/admin/v1/admin.go
+++ b/internal/services/admin/v1/admin.go
@@ -152,8 +152,6 @@ func NewAdminService(fs ...AdminServiceOpt) (AdminService, error) {
 
 	if opts.optimisticSchedulingEnabled && opts.localScheduler != nil {
 		localScheduler = opts.localScheduler
-	} else if opts.optimisticSchedulingEnabled && opts.localScheduler == nil {
-		return nil, fmt.Errorf("optimistic writes enabled but no local scheduler provided")
 	}
 
 	return &AdminServiceImpl{

--- a/internal/services/ingestor/ingestor.go
+++ b/internal/services/ingestor/ingestor.go
@@ -163,8 +163,6 @@ func NewIngestor(fs ...IngestorOptFunc) (Ingestor, error) {
 
 	if opts.optimisticSchedulingEnabled && opts.localScheduler != nil {
 		localScheduler = opts.localScheduler
-	} else if opts.optimisticSchedulingEnabled && opts.localScheduler == nil {
-		return nil, fmt.Errorf("optimistic writes enabled but no local scheduler provided")
 	}
 
 	return &IngestorImpl{


### PR DESCRIPTION
# Description

Fixes a panic on startup when optimistic scheduling is enabled (true by default) but there's no local scheduler (which isn't present in HA mode).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)