### PR TITLE
refactor: use typed maps

### DIFF
--- a/internal/msgqueue/mq_pub_buffer.go
+++ b/internal/msgqueue/mq_pub_buffer.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"os"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/hatchet-dev/hatchet/internal/syncx"
 )
 
 // nolint: staticcheck
@@ -54,8 +54,8 @@ type PubFunc func(m *Message) error
 type MQPubBuffer struct {
 	mq MessageQueue
 
-	// buffers is keyed on (tenantId, msgId) and contains a buffer of messages for that tenantId and msgId.
-	buffers sync.Map
+	// buffers is keyed on a composite (tenantId, msgId) and contains a buffer of messages for that tenantId and msgId.
+	buffers syncx.Map[string, *msgIdPubBuffer]
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -87,10 +87,10 @@ func (m *MQPubBuffer) Pub(ctx context.Context, queue Queue, msg *Message, wait b
 
 	k := getPubKey(queue, msg.TenantID, msg.ID)
 
-	buf, ok := m.buffers.Load(k)
+	msgBuf, ok := m.buffers.Load(k)
 
 	if !ok {
-		buf, _ = m.buffers.LoadOrStore(k, newMsgIDPubBuffer(m.ctx, msg.TenantID, msg.ID, func(msg *Message) error {
+		msgBuf, _ = m.buffers.LoadOrStore(k, newMsgIDPubBuffer(m.ctx, msg.TenantID, msg.ID, func(msg *Message) error {
 			msgCtx, cancel := context.WithTimeout(context.Background(), PUB_TIMEOUT)
 			defer cancel()
 
@@ -107,7 +107,6 @@ func (m *MQPubBuffer) Pub(ctx context.Context, queue Queue, msg *Message, wait b
 	}
 
 	// this places some backpressure on the consumer if buffers are full
-	msgBuf := buf.(*msgIdPubBuffer)
 	msgBuf.msgIdPubBufferCh <- msgWithErr
 	msgBuf.notifier <- struct{}{}
 

--- a/internal/msgqueue/postgres/msgqueue.go
+++ b/internal/msgqueue/postgres/msgqueue.go
@@ -258,7 +258,7 @@ func (p *PostgresMessageQueue) Subscribe(queue msgqueue.Queue, preAck msgqueue.A
 		return eg.Wait()
 	}
 
-	op := queueutils.NewOperationPool(p.l, 60*time.Second, "postgresmq", queueutils.OpMethod[string](func(ctx context.Context, id string) (bool, error) {
+	op := queueutils.NewOperationPool(p.l, 60*time.Second, "postgresmq", queueutils.OpMethod(func(ctx context.Context, _ string) (bool, error) {
 		messages, err := p.repo.ReadMessages(subscribeCtx, queue.Name(), p.qos)
 
 		if err != nil {

--- a/internal/msgqueue/shared_tenant_reader.go
+++ b/internal/msgqueue/shared_tenant_reader.go
@@ -12,7 +12,7 @@ import (
 )
 
 type sharedTenantSub struct {
-	fs        syncx.Map[int, AckHook]
+	fs        *syncx.Map[int, AckHook]
 	counter   int
 	isRunning bool
 	mu        sync.Mutex
@@ -33,7 +33,7 @@ func NewSharedTenantReader(mq MessageQueue) *SharedTenantReader {
 
 func (s *SharedTenantReader) Subscribe(tenantId uuid.UUID, postAck AckHook) (func() error, error) {
 	t, _ := s.tenants.LoadOrStore(tenantId, &sharedTenantSub{
-		fs: syncx.Map[int, AckHook]{},
+		fs: &syncx.Map[int, AckHook]{},
 	})
 
 	t.mu.Lock()
@@ -100,27 +100,27 @@ func (s *SharedTenantReader) Subscribe(tenantId uuid.UUID, postAck AckHook) (fun
 
 type sharedBufferedTenantSub struct {
 	cleanup   func() error
-	fs        syncx.Map[int, DstFunc]
+	fs        *syncx.Map[int, DstFunc]
 	counter   int
 	mu        sync.Mutex
 	isRunning bool
 }
 
 type SharedBufferedTenantReader struct {
-	tenants syncx.Map[uuid.UUID, *sharedBufferedTenantSub]
+	tenants *syncx.Map[uuid.UUID, *sharedBufferedTenantSub]
 	mq      MessageQueue
 }
 
 func NewSharedBufferedTenantReader(mq MessageQueue) *SharedBufferedTenantReader {
 	return &SharedBufferedTenantReader{
-		tenants: syncx.Map[uuid.UUID, *sharedBufferedTenantSub]{},
+		tenants: &syncx.Map[uuid.UUID, *sharedBufferedTenantSub]{},
 		mq:      mq,
 	}
 }
 
 func (s *SharedBufferedTenantReader) Subscribe(tenantId uuid.UUID, f DstFunc) (func() error, error) {
 	t, _ := s.tenants.LoadOrStore(tenantId, &sharedBufferedTenantSub{
-		fs: syncx.Map[int, DstFunc]{},
+		fs: &syncx.Map[int, DstFunc]{},
 	})
 
 	t.mu.Lock()

--- a/internal/queueutils/operation_test.go
+++ b/internal/queueutils/operation_test.go
@@ -30,7 +30,7 @@ func TestSerialOperation_RunOrContinue_NoConcurrentExecution(t *testing.T) {
 		return false, nil
 	}
 
-	operation := &SerialOperation[string]{
+	operation := &SerialOperation{
 		id:          "1234",
 		description: "Test operation",
 		timeout:     2 * time.Second,
@@ -68,7 +68,7 @@ func TestSerialOperation_RunOrContinue_ShouldRunAfterCompletion(t *testing.T) {
 		return false, nil
 	}
 
-	operation := &SerialOperation[string]{
+	operation := &SerialOperation{
 		id:          "1234",
 		description: "Test operation",
 		timeout:     2 * time.Second,
@@ -101,7 +101,7 @@ func TestSerialOperation_RunOrContinue_ShouldRunOnContinues(t *testing.T) {
 		return runCount < 5, nil
 	}
 
-	operation := &SerialOperation[string]{
+	operation := &SerialOperation{
 		id:          "1234",
 		description: "Test operation",
 		timeout:     2 * time.Second,

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -44,7 +44,7 @@ type OLAPControllerImpl struct {
 	p                            *partition.Partition
 	s                            gocron.Scheduler
 	ta                           *alerting.TenantAlertManager
-	processTenantAlertOperations *queueutils.OperationPool[string]
+	processTenantAlertOperations *queueutils.OperationPool
 	samplingHashThreshold        *int64
 	olapConfig                   *server.ConfigFileOperations
 	prometheusMetricsEnabled     bool

--- a/internal/services/controllers/task/controller.go
+++ b/internal/services/controllers/task/controller.go
@@ -54,11 +54,11 @@ type TasksControllerImpl struct {
 	celParser                             *cel.CELParser
 	opsPoolPollInterval                   time.Duration
 	opsPoolJitter                         time.Duration
-	timeoutTaskOperations                 *operation.OperationPool
-	reassignTaskOperations                *operation.OperationPool
-	retryTaskOperations                   *operation.OperationPool
-	emitSleepOperations                   *operation.OperationPool
-	evictExpiredIdempotencyKeysOperations *operation.OperationPool
+	timeoutTaskOperations                 *operation.TenantOperationPool
+	reassignTaskOperations                *operation.TenantOperationPool
+	retryTaskOperations                   *operation.TenantOperationPool
+	emitSleepOperations                   *operation.TenantOperationPool
+	evictExpiredIdempotencyKeysOperations *operation.TenantOperationPool
 	replayEnabled                         bool
 	analyzeCronInterval                   time.Duration
 	signaler                              *signal.OLAPSignaler
@@ -230,7 +230,7 @@ func New(fs ...TasksControllerOpt) (*TasksControllerImpl, error) {
 	jitter := t.opsPoolJitter
 	timeout := time.Second * 30
 
-	t.timeoutTaskOperations = operation.NewOperationPool(opts.p, opts.l, "timeout-step-runs", timeout, "timeout step runs", t.processTaskTimeouts, operation.WithPoolInterval(
+	t.timeoutTaskOperations = operation.NewTenantOperationPool(opts.p, opts.l, "timeout-step-runs", timeout, "timeout step runs", t.processTaskTimeouts, operation.WithPoolInterval(
 		opts.repov1.IntervalSettings(),
 		jitter,
 		1*time.Second,
@@ -239,7 +239,7 @@ func New(fs ...TasksControllerOpt) (*TasksControllerImpl, error) {
 		opts.repov1.Tasks().DefaultTaskActivityGauge,
 	))
 
-	t.emitSleepOperations = operation.NewOperationPool(opts.p, opts.l, "emit-sleep-step-runs", timeout, "emit sleep step runs", t.processSleeps, operation.WithPoolInterval(
+	t.emitSleepOperations = operation.NewTenantOperationPool(opts.p, opts.l, "emit-sleep-step-runs", timeout, "emit sleep step runs", t.processSleeps, operation.WithPoolInterval(
 		opts.repov1.IntervalSettings(),
 		jitter,
 		1*time.Second,
@@ -248,7 +248,7 @@ func New(fs ...TasksControllerOpt) (*TasksControllerImpl, error) {
 		opts.repov1.Tasks().DefaultTaskActivityGauge,
 	))
 
-	t.reassignTaskOperations = operation.NewOperationPool(opts.p, opts.l, "reassign-step-runs", timeout, "reassign step runs", t.processTaskReassignments, operation.WithPoolInterval(
+	t.reassignTaskOperations = operation.NewTenantOperationPool(opts.p, opts.l, "reassign-step-runs", timeout, "reassign step runs", t.processTaskReassignments, operation.WithPoolInterval(
 		opts.repov1.IntervalSettings(),
 		jitter,
 		1*time.Second,
@@ -257,7 +257,7 @@ func New(fs ...TasksControllerOpt) (*TasksControllerImpl, error) {
 		opts.repov1.Tasks().DefaultTaskActivityGauge,
 	))
 
-	t.retryTaskOperations = operation.NewOperationPool(opts.p, opts.l, "retry-step-runs", timeout, "retry step runs", t.processTaskRetryQueueItems, operation.WithPoolInterval(
+	t.retryTaskOperations = operation.NewTenantOperationPool(opts.p, opts.l, "retry-step-runs", timeout, "retry step runs", t.processTaskRetryQueueItems, operation.WithPoolInterval(
 		opts.repov1.IntervalSettings(),
 		jitter,
 		1*time.Second,
@@ -266,7 +266,7 @@ func New(fs ...TasksControllerOpt) (*TasksControllerImpl, error) {
 		opts.repov1.Tasks().DefaultTaskActivityGauge,
 	))
 
-	t.evictExpiredIdempotencyKeysOperations = operation.NewOperationPool(opts.p, opts.l, "evict-expired-idempotency-keys", timeout, "evict expired idempotency keys", t.evictExpiredIdempotencyKeys, operation.WithPoolInterval(
+	t.evictExpiredIdempotencyKeysOperations = operation.NewTenantOperationPool(opts.p, opts.l, "evict-expired-idempotency-keys", timeout, "evict expired idempotency keys", t.evictExpiredIdempotencyKeys, operation.WithPoolInterval(
 		opts.repov1.IntervalSettings(),
 		jitter,
 		1*time.Second,

--- a/internal/services/dispatcher/dispatcher_v1.go
+++ b/internal/services/dispatcher/dispatcher_v1.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hatchet-dev/hatchet/internal/msgqueue"
 	"github.com/hatchet-dev/hatchet/internal/queueutils"
 	tasktypesv1 "github.com/hatchet-dev/hatchet/internal/services/shared/tasktypes/v1"
+	"github.com/hatchet-dev/hatchet/internal/syncx"
 	v1 "github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 	"github.com/hatchet-dev/hatchet/pkg/telemetry"
@@ -88,9 +89,7 @@ func (d *DispatcherImpl) handleTaskBulkAssignedTask(ctx context.Context, msg *ms
 func (d *DispatcherImpl) GetLocalWorkerIds() map[uuid.UUID]struct{} {
 	workerIds := make(map[uuid.UUID]struct{})
 
-	d.workers.Range(func(key, value interface{}) bool {
-		workerId := key.(uuid.UUID)
-
+	d.workers.Range(func(workerId uuid.UUID, value *syncx.Map[string, *subscribedWorker]) bool {
 		workerIds[workerId] = struct{}{}
 
 		return true

--- a/internal/services/ticker/schedule_workflow.go
+++ b/internal/services/ticker/schedule_workflow.go
@@ -25,8 +25,8 @@ func (t *TickerImpl) runPollSchedules(ctx context.Context) func() {
 
 		existingSchedules := make(map[string]bool)
 
-		t.scheduledWorkflows.Range(func(key, value interface{}) bool {
-			existingSchedules[key.(string)] = false
+		t.scheduledWorkflows.Range(func(key string, _ context.CancelFunc) bool {
+			existingSchedules[key] = false
 			return true
 		})
 
@@ -138,19 +138,13 @@ func (t *TickerImpl) handleCancelWorkflow(ctx context.Context, key string) error
 	t.l.Debug().Msg("ticker: canceling scheduled workflow")
 
 	// get the cancel function
-	cancelVal, ok := t.scheduledWorkflows.Load(key)
+	cancel, ok := t.scheduledWorkflows.Load(key)
 
 	if !ok {
 		return fmt.Errorf("could not find scheduled workflow with key %s", key)
 	}
 
 	defer t.scheduledWorkflows.Delete(key)
-
-	cancel, ok := cancelVal.(context.CancelFunc)
-
-	if !ok {
-		return fmt.Errorf("could not cast cancel function")
-	}
 
 	// cancel the scheduled workflow
 	cancel()

--- a/internal/services/ticker/ticker.go
+++ b/internal/services/ticker/ticker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hatchet-dev/hatchet/internal/datautils"
 	"github.com/hatchet-dev/hatchet/internal/integrations/alerting"
 	"github.com/hatchet-dev/hatchet/internal/msgqueue"
+	"github.com/hatchet-dev/hatchet/internal/syncx"
 	"github.com/hatchet-dev/hatchet/pkg/logger"
 	v1 "github.com/hatchet-dev/hatchet/pkg/repository"
 )
@@ -29,7 +30,7 @@ type TickerImpl struct {
 	s      gocron.Scheduler
 	ta     *alerting.TenantAlertManager
 
-	scheduledWorkflows sync.Map
+	scheduledWorkflows syncx.Map[string, context.CancelFunc]
 
 	dv datautils.DataDecoderValidator
 

--- a/internal/syncx/map.go
+++ b/internal/syncx/map.go
@@ -1,0 +1,54 @@
+package syncx
+
+import (
+	"sync"
+)
+
+// Map is a type-safe concurrent map with comparable keys and any values.
+type Map[K comparable, V any] struct {
+	m sync.Map
+}
+
+// Store sets the value for a key.
+func (m *Map[K, V]) Store(key K, value V) {
+	m.m.Store(key, value)
+}
+
+// Load returns the value for a key if it exists.
+func (m *Map[K, V]) Load(key K) (value V, ok bool) {
+	v, ok := m.m.Load(key)
+	if !ok {
+		return value, ok
+	}
+	// The type assertion is safe because we control the types in Store.
+	return v.(V), ok
+}
+
+// Delete deletes the value for a key.
+func (m *Map[K, V]) Delete(key K) {
+	m.m.Delete(key)
+}
+
+// LoadOrStore loads or stores the value for a key.
+func (m *Map[K, V]) LoadOrStore(key K, value V) (actual V, loaded bool) {
+	a, loaded := m.m.LoadOrStore(key, value)
+	return a.(V), loaded
+}
+
+// Range calls f sequentially for each key and value present in the map.
+// If f returns false, the range stops.
+func (m *Map[K, V]) Range(f func(key K, value V) bool) {
+	m.m.Range(func(key, value any) bool {
+		return f(key.(K), value.(V))
+	})
+}
+
+// Len returns the number of elements in the map.
+func (m *Map[K, V]) Len() int {
+	length := 0
+	m.m.Range(func(key, value any) bool {
+		length++
+		return true
+	})
+	return length
+}


### PR DESCRIPTION
# Description

Uses typed `syncx.Map` instead of `sync.Map` for more safety. This also fixes a regression in the tenant manager which didn't properly clean up tenants. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)