### PR TITLE
Fix: Always generate UUID for OrGroup

### DIFF
--- a/internal/services/admin/v1/server.go
+++ b/internal/services/admin/v1/server.go
@@ -929,7 +929,13 @@ func getCreateTaskOpts(tasks []*contracts.CreateTaskOpts, kind string) ([]v1.Cre
 						continue
 					}
 
-					orGroupId, err := uuid.Parse(userEventCondition.Base.OrGroupId)
+					orGroupIdStr := userEventCondition.Base.OrGroupId
+
+					if orGroupIdStr == "" {
+						orGroupIdStr = uuid.New().String()
+					}
+
+					orGroupId, err := uuid.Parse(orGroupIdStr)
 					if err != nil {
 						return nil, fmt.Errorf("invalid OrGroupId in UserEventCondition for step %s: %w", stepCp.ReadableId, err)
 					}

--- a/internal/services/admin/v1/server.go
+++ b/internal/services/admin/v1/server.go
@@ -962,7 +962,14 @@ func getCreateTaskOpts(tasks []*contracts.CreateTaskOpts, kind string) ([]v1.Cre
 					}
 
 					duration := sleepCondition.SleepFor
-					orGroupId, err := uuid.Parse(sleepCondition.Base.OrGroupId)
+
+					orGroupIdStr := sleepCondition.Base.OrGroupId
+
+					if orGroupIdStr == "" {
+						orGroupIdStr = uuid.New().String()
+					}
+
+					orGroupId, err := uuid.Parse(orGroupIdStr)
 					if err != nil {
 						return nil, fmt.Errorf("invalid OrGroupId in SleepCondition for step %s: %w", stepCp.ReadableId, err)
 					}
@@ -986,7 +993,14 @@ func getCreateTaskOpts(tasks []*contracts.CreateTaskOpts, kind string) ([]v1.Cre
 					}
 
 					parentReadableId := parentOverrideCondition.ParentReadableId
-					orGroupId, err := uuid.Parse(parentOverrideCondition.Base.OrGroupId)
+
+					orGroupIdStr := parentOverrideCondition.Base.OrGroupId
+
+					if orGroupIdStr == "" {
+						orGroupIdStr = uuid.New().String()
+					}
+
+					orGroupId, err := uuid.Parse(orGroupIdStr)
 
 					if err != nil {
 						return nil, fmt.Errorf("invalid OrGroupId in ParentOverrideCondition for step %s: %w", stepCp.ReadableId, err)

--- a/pkg/worker/condition/condition.go
+++ b/pkg/worker/condition/condition.go
@@ -55,6 +55,7 @@ func SleepCondition(duration time.Duration) *sleepCondition {
 	return &sleepCondition{
 		baseCondition: &baseCondition{
 			readableDataKey: "sleep:" + duration.String(),
+			orGroupID:       uuid.New(),
 		},
 		duration: duration,
 	}
@@ -91,6 +92,7 @@ func UserEventCondition(eventKey string, expression string) *userEventCondition 
 	return &userEventCondition{
 		baseCondition: baseCondition{
 			readableDataKey: eventKey,
+			orGroupID:       uuid.New(),
 			expression:      expression,
 		},
 		eventKey: eventKey,
@@ -128,6 +130,7 @@ func ParentCondition(parent NamedTask, expression string) *parentCondition {
 	return &parentCondition{
 		baseCondition: baseCondition{
 			readableDataKey: parent.GetName(),
+			orGroupID:       uuid.New(),
 			expression:      expression,
 		},
 		parentReadableId: parent.GetName(),


### PR DESCRIPTION
# Description

Fixes an issue where we don't send an or group id over the wire even though it's required

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
