### PR TITLE
fix: wrapped types in the Go SDK

### DIFF
--- a/pkg/client/workflow.go
+++ b/pkg/client/workflow.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-
-	dispatchercontracts "github.com/hatchet-dev/hatchet/internal/services/dispatcher/contracts"
 )
 
 // Workflow represents a running workflow instance and provides methods to retrieve its results.
@@ -40,7 +38,7 @@ func (r *Workflow) WorkflowRunId() string {
 }
 
 type WorkflowResult struct {
-	workflowRun *dispatchercontracts.WorkflowRunEvent
+	workflowRun *workflowRunEvent
 }
 
 func (r *WorkflowResult) StepOutput(key string, v interface{}) error {


### PR DESCRIPTION
# Description

Removes a few instances of exposed internal protos in the Go SDK, to try and get #2913 over the line. 

## Type of change

- [X] Refactor (non-breaking changes to code which doesn't change any behaviour)