### PR TITLE
Fix: Check `uuid.Nil` when creating or groups too

### DIFF
--- a/internal/services/admin/v1/server.go
+++ b/internal/services/admin/v1/server.go
@@ -932,6 +932,7 @@ func getCreateTaskOpts(tasks []*contracts.CreateTaskOpts, kind string) ([]v1.Cre
 					orGroupIdStr := userEventCondition.Base.OrGroupId
 
 					if orGroupIdStr == "" {
+					if orGroupIdStr == "" || orGroupIdStr == uuid.Nil.String() {
 						orGroupIdStr = uuid.New().String()
 					}
 
@@ -965,7 +966,7 @@ func getCreateTaskOpts(tasks []*contracts.CreateTaskOpts, kind string) ([]v1.Cre
 
 					orGroupIdStr := sleepCondition.Base.OrGroupId
 
-					if orGroupIdStr == "" {
+					if orGroupIdStr == "" || orGroupIdStr == uuid.Nil.String() {
 						orGroupIdStr = uuid.New().String()
 					}
 
@@ -996,7 +997,7 @@ func getCreateTaskOpts(tasks []*contracts.CreateTaskOpts, kind string) ([]v1.Cre
 
 					orGroupIdStr := parentOverrideCondition.Base.OrGroupId
 
-					if orGroupIdStr == "" {
+					if orGroupIdStr == "" || orGroupIdStr == uuid.Nil.String() {
 						orGroupIdStr = uuid.New().String()
 					}
 

--- a/internal/services/admin/v1/server.go
+++ b/internal/services/admin/v1/server.go
@@ -931,7 +931,6 @@ func getCreateTaskOpts(tasks []*contracts.CreateTaskOpts, kind string) ([]v1.Cre
 
 					orGroupIdStr := userEventCondition.Base.OrGroupId
 
-					if orGroupIdStr == "" {
 					if orGroupIdStr == "" || orGroupIdStr == uuid.Nil.String() {
 						orGroupIdStr = uuid.New().String()
 					}


### PR DESCRIPTION
# Description

Forgot the SDK will send `uuid.Nil` by default because it's `uuid.UUID` not `*uuid.UUID` 🤦 

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

