### PR TITLE
test(rest): add typed REST transport exceptions + diagnostics tests

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.2] - 2026-02-11
+
+### Changed
+
+- Improves error handling for REST transport-level failures by raising typed exceptions for timeouts, connection, TLS, and protocol errors while preserving existing diagnostics.
+
+
 ## [1.23.1] - 2026-02-10
 
 ### Changed

--- a/sdks/python/apply_patches.py
+++ b/sdks/python/apply_patches.py
@@ -87,21 +87,202 @@ def patch_grpc_init_signature(content: str) -> str:
     )
 
 
+def patch_rest_transport_exceptions(content: str) -> str:
+    """Insert typed REST transport exception classes into exceptions.py.
+
+    Adds exception classes above render_path function, idempotently.
+    """
+    # Check if already patched
+    if "class RestTransportError" in content:
+        return content
+
+    new_exceptions = '''\
+
+class RestTransportError(ApiException):
+    """Base exception for REST transport-level errors (network, timeout, TLS)."""
+
+    pass
+
+
+class RestTimeoutError(RestTransportError):
+    """Raised when a REST request times out (connect or read timeout)."""
+
+    pass
+
+
+class RestConnectionError(RestTransportError):
+    """Raised when a REST request fails to establish a connection."""
+
+    pass
+
+
+class RestTLSError(RestTransportError):
+    """Raised when a REST request fails due to SSL/TLS errors."""
+
+    pass
+
+
+class RestProtocolError(RestTransportError):
+    """Raised when a REST request fails due to protocol-level errors."""
+
+    pass
+
+
+'''
+
+    # Insert before render_path function (match any arguments)
+    pattern = r"(\ndef render_path\([^)]*\):)"
+    replacement = new_exceptions + r"\1"
+
+    return re.sub(pattern, replacement, content)
+
+
+def patch_rest_imports(content: str) -> str:
+    """Update rest.py imports to include typed transport exceptions.
+
+    Handles both single-line and parenthesized import formats. Idempotent.
+    """
+    # The exceptions we need to ensure are imported
+    required_exceptions = [
+        "RestConnectionError",
+        "RestProtocolError",
+        "RestTimeoutError",
+        "RestTLSError",
+    ]
+
+    # Idempotency check: if RestTLSError is already imported from this module, do nothing.
+    if re.search(
+        r"(?m)^from\s+hatchet_sdk\.clients\.rest\.exceptions\s+import[^\n]*\bRestTLSError\b",
+        content,
+    ):
+        return content
+
+    # Parenthesized import block includes RestTLSError
+    if re.search(
+        r"^from\s+hatchet_sdk\.clients\.rest\.exceptions\s+import\s*\(\s*.*?\bRestTLSError\b.*?\)\s*$",
+        content,
+        flags=re.MULTILINE | re.DOTALL,
+    ):
+        return content
+
+    # The target import statement we want with trailing newline to preserve spacing
+    new_import = (
+        "from hatchet_sdk.clients.rest.exceptions import (\n"
+        "    ApiException,\n"
+        "    ApiValueError,\n"
+        "    RestConnectionError,\n"
+        "    RestProtocolError,\n"
+        "    RestTimeoutError,\n"
+        "    RestTLSError,\n"
+        ")\n"
+    )
+
+    # Single line import
+    # Matches: from hatchet_sdk.clients.rest.exceptions import ApiException, ApiValueError
+    single_line_pattern = (
+        r"^from\s+hatchet_sdk\.clients\.rest\.exceptions\s+import\s+"
+        r"ApiException\s*,\s*ApiValueError\s*$"
+    )
+
+    modified = re.sub(single_line_pattern, new_import, content, flags=re.MULTILINE)
+    if modified != content:
+        return modified
+
+    # More flexible parenthesized import which matches any order, with or without trailing comma
+    # This handles cases where ApiException and ApiValueError might be in different orders
+    flexible_paren_pattern = (
+        r"^from\s+hatchet_sdk\.clients\.rest\.exceptions\s+import\s*\("
+        r"[^)]*?"  # Non-greedy match of contents (only ApiException/ApiValueError expected)
+        r"\)"
+    )
+
+    # Only apply if the block contains just ApiException and/or ApiValueError (no Rest* yet)
+    match = re.search(flexible_paren_pattern, content, flags=re.MULTILINE | re.DOTALL)
+    if match:
+        block = match.group(0)
+        # Verify it only has ApiException/ApiValueError, not our new exceptions
+        if not any(exc in block for exc in required_exceptions):
+            if "ApiException" in block or "ApiValueError" in block:
+                modified = (
+                    content[: match.start()] + new_import + content[match.end() :]
+                )
+                return modified
+
+    return content
+
+
 def patch_rest_error_diagnostics(content: str) -> str:
-    pattern = (
+    """Patch rest.py exception handlers to use typed exceptions.
+
+    Replaces the generic ApiException handler with typed exception handlers.
+    Handler ordering is critical: NewConnectionError must be caught before
+    ConnectTimeoutError because it inherits from ConnectTimeoutError in urllib3.
+    """
+    # This pattern matches either the original SSLError only handler or
+    # the previously patched multi-exception handler raising ApiException
+    pattern_original = (
         r"(?ms)^([ \t]*)except urllib3\.exceptions\.SSLError as e:\s*\n"
         r"^\1[ \t]*msg = \"\\n\"\.join\(\[type\(e\)\.__name__, str\(e\)\]\)\s*\n"
         r"^\1[ \t]*raise ApiException\(status=0, reason=msg\)\s*\n"
     )
 
+    pattern_expanded = (
+        r"(?ms)^([ \t]*)except \(\s*\n"
+        r"^\1[ \t]*urllib3\.exceptions\.SSLError,\s*\n"
+        r"^\1[ \t]*urllib3\.exceptions\.ConnectTimeoutError,\s*\n"
+        r"^\1[ \t]*urllib3\.exceptions\.ReadTimeoutError,\s*\n"
+        r"^\1[ \t]*urllib3\.exceptions\.MaxRetryError,\s*\n"
+        r"^\1[ \t]*urllib3\.exceptions\.NewConnectionError,\s*\n"
+        r"^\1[ \t]*urllib3\.exceptions\.ProtocolError,\s*\n"
+        r"^\1\) as e:\s*\n"
+        r'^\1[ \t]*msg = "\\n"\.join\(\s*\n'
+        r"^\1[ \t]*\[\s*\n"
+        r"^\1[ \t]*type\(e\)\.__name__,\s*\n"
+        r"^\1[ \t]*str\(e\),\s*\n"
+        r'^\1[ \t]*f"method=\{method\}",\s*\n'
+        r'^\1[ \t]*f"url=\{url\}",\s*\n'
+        r'^\1[ \t]*f"timeout=\{_request_timeout\}",\s*\n'
+        r"^\1[ \t]*\]\s*\n"
+        r"^\1[ \t]*\)\s*\n"
+        r"^\1[ \t]*raise ApiException\(status=0, reason=msg\)\s*\n"
+    )
+
+    # Check if already using typed exceptions
+    if "raise RestTLSError" in content:
+        return content
+
+    # Build typed replacement with proper handler ordering
+    # NewConnectionError inherits from ConnectTimeoutError, so must be caught first
     replacement = (
+        r"\1except urllib3.exceptions.SSLError as e:\n"
+        r'\1    msg = "\\n".join(\n'
+        r"\1        [\n"
+        r"\1            type(e).__name__,\n"
+        r"\1            str(e),\n"
+        r'\1            f"method={method}",\n'
+        r'\1            f"url={url}",\n'
+        r'\1            f"timeout={_request_timeout}",\n'
+        r"\1        ]\n"
+        r"\1    )\n"
+        r"\1    raise RestTLSError(status=0, reason=msg) from e\n"
         r"\1except (\n"
-        r"\1    urllib3.exceptions.SSLError,\n"
-        r"\1    urllib3.exceptions.ConnectTimeoutError,\n"
-        r"\1    urllib3.exceptions.ReadTimeoutError,\n"
         r"\1    urllib3.exceptions.MaxRetryError,\n"
         r"\1    urllib3.exceptions.NewConnectionError,\n"
-        r"\1    urllib3.exceptions.ProtocolError,\n"
+        r"\1) as e:\n"
+        r"\1    # NewConnectionError inherits from ConnectTimeoutError, so must be caught first\n"
+        r'\1    msg = "\\n".join(\n'
+        r"\1        [\n"
+        r"\1            type(e).__name__,\n"
+        r"\1            str(e),\n"
+        r'\1            f"method={method}",\n'
+        r'\1            f"url={url}",\n'
+        r'\1            f"timeout={_request_timeout}",\n'
+        r"\1        ]\n"
+        r"\1    )\n"
+        r"\1    raise RestConnectionError(status=0, reason=msg) from e\n"
+        r"\1except (\n"
+        r"\1    urllib3.exceptions.ConnectTimeoutError,\n"
+        r"\1    urllib3.exceptions.ReadTimeoutError,\n"
         r"\1) as e:\n"
         r'\1    msg = "\\n".join(\n'
         r"\1        [\n"
@@ -112,10 +293,27 @@ def patch_rest_error_diagnostics(content: str) -> str:
         r'\1            f"timeout={_request_timeout}",\n'
         r"\1        ]\n"
         r"\1    )\n"
-        r"\1    raise ApiException(status=0, reason=msg)\n"
+        r"\1    raise RestTimeoutError(status=0, reason=msg) from e\n"
+        r"\1except urllib3.exceptions.ProtocolError as e:\n"
+        r'\1    msg = "\\n".join(\n'
+        r"\1        [\n"
+        r"\1            type(e).__name__,\n"
+        r"\1            str(e),\n"
+        r'\1            f"method={method}",\n'
+        r'\1            f"url={url}",\n'
+        r'\1            f"timeout={_request_timeout}",\n'
+        r"\1        ]\n"
+        r"\1    )\n"
+        r"\1    raise RestProtocolError(status=0, reason=msg) from e\n"
     )
 
-    return apply_patch(content, pattern, replacement)
+    # Try expanded pattern first. Relevant if previously patched with ApiException
+    modified = re.sub(pattern_expanded, replacement, content)
+    if modified != content:
+        return modified
+
+    # Otherwise try original pattern
+    return re.sub(pattern_original, replacement, content)
 
 
 def apply_patches_to_matching_files(
@@ -163,8 +361,16 @@ if __name__ == "__main__":
         [patch_workflow_run_metrics_counts_return_type],
     )
 
+    # Patch exceptions.py first to add typed transport exceptions
     atomically_patch_file(
-        "hatchet_sdk/clients/rest/rest.py", [patch_rest_error_diagnostics]
+        "hatchet_sdk/clients/rest/exceptions.py",
+        [patch_rest_transport_exceptions],
+    )
+
+    # Patch rest.py with imports and typed exception handlers
+    atomically_patch_file(
+        "hatchet_sdk/clients/rest/rest.py",
+        [patch_rest_imports, patch_rest_error_diagnostics],
     )
 
     grpc_patches: list[Callable[[str], str]] = [

--- a/sdks/python/apply_patches.py
+++ b/sdks/python/apply_patches.py
@@ -361,13 +361,10 @@ if __name__ == "__main__":
         [patch_workflow_run_metrics_counts_return_type],
     )
 
-    # Patch exceptions.py first to add typed transport exceptions
     atomically_patch_file(
         "hatchet_sdk/clients/rest/exceptions.py",
         [patch_rest_transport_exceptions],
     )
-
-    # Patch rest.py with imports and typed exception handlers
     atomically_patch_file(
         "hatchet_sdk/clients/rest/rest.py",
         [patch_rest_imports, patch_rest_error_diagnostics],

--- a/sdks/python/hatchet_sdk/clients/rest/exceptions.py
+++ b/sdks/python/hatchet_sdk/clients/rest/exceptions.py
@@ -209,6 +209,36 @@ class UnprocessableEntityException(ApiException):
     pass
 
 
+class RestTransportError(ApiException):
+    """Base exception for REST transport-level errors (network, timeout, TLS)."""
+
+    pass
+
+
+class RestTimeoutError(RestTransportError):
+    """Raised when a REST request times out (connect or read timeout)."""
+
+    pass
+
+
+class RestConnectionError(RestTransportError):
+    """Raised when a REST request fails to establish a connection."""
+
+    pass
+
+
+class RestTLSError(RestTransportError):
+    """Raised when a REST request fails due to SSL/TLS errors."""
+
+    pass
+
+
+class RestProtocolError(RestTransportError):
+    """Raised when a REST request fails due to protocol-level errors."""
+
+    pass
+
+
 def render_path(path_to_item):
     """Returns a string representation of a path"""
     result = ""

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.23.1"
+version = "1.23.2"
 description = "This is the official Python SDK for Hatchet, a distributed, fault-tolerant task queue. The SDK allows you to easily integrate Hatchet's task scheduling and workflow orchestration capabilities into your Python applications."
 authors = [
   "Alexander Belanger <alexander@hatchet.run>",

--- a/sdks/python/tests/test_rest_transport_exceptions.py
+++ b/sdks/python/tests/test_rest_transport_exceptions.py
@@ -26,45 +26,34 @@ from hatchet_sdk.clients.rest.rest import RESTClientObject
 
 
 class TestRestTransportExceptionHierarchy:
-    """Test that exception hierarchy is correct for backward compatibility."""
-
     def test_rest_transport_error_inherits_from_api_exception(self) -> None:
-        """RestTransportError should inherit from ApiException."""
         assert issubclass(RestTransportError, ApiException)
 
     def test_rest_timeout_error_inherits_from_transport_error(self) -> None:
-        """RestTimeoutError should inherit from RestTransportError."""
         assert issubclass(RestTimeoutError, RestTransportError)
         assert issubclass(RestTimeoutError, ApiException)
 
     def test_rest_connection_error_inherits_from_transport_error(self) -> None:
-        """RestConnectionError should inherit from RestTransportError."""
         assert issubclass(RestConnectionError, RestTransportError)
         assert issubclass(RestConnectionError, ApiException)
 
     def test_rest_tls_error_inherits_from_transport_error(self) -> None:
-        """RestTLSError should inherit from RestTransportError."""
         assert issubclass(RestTLSError, RestTransportError)
         assert issubclass(RestTLSError, ApiException)
 
     def test_rest_protocol_error_inherits_from_transport_error(self) -> None:
-        """RestProtocolError should inherit from RestTransportError."""
         assert issubclass(RestProtocolError, RestTransportError)
         assert issubclass(RestProtocolError, ApiException)
 
 
 class TestRestTransportExceptionTranslation:
-    """Test that urllib3 exceptions are translated to the correct typed exceptions."""
-
     @pytest.fixture
     def rest_client(self) -> Any:
-        """Create a RESTClientObject with minimal configuration."""
         config = Configuration(host="http://localhost:8080")
         return cast(Any, RESTClientObject(config))
 
     @pytest.fixture
     def request_params(self) -> dict[str, Any]:
-        """Standard request parameters for testing."""
         return {
             "method": "GET",
             "url": "http://localhost:8080/api/test",
@@ -78,7 +67,6 @@ class TestRestTransportExceptionTranslation:
         request_params: dict[str, Any],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """urllib3.exceptions.SSLError should raise RestTLSError."""
         original_exc = urllib3.exceptions.SSLError("SSL certificate verify failed")
 
         def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
@@ -103,7 +91,6 @@ class TestRestTransportExceptionTranslation:
         request_params: dict[str, Any],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """urllib3.exceptions.ConnectTimeoutError should raise RestTimeoutError."""
         original_exc = urllib3.exceptions.ConnectTimeoutError(
             None, "http://localhost:8080", "Connection timed out"
         )
@@ -130,7 +117,6 @@ class TestRestTransportExceptionTranslation:
         request_params: dict[str, Any],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """urllib3.exceptions.ReadTimeoutError should raise RestTimeoutError."""
         original_exc = urllib3.exceptions.ReadTimeoutError(
             cast(Any, None), "http://localhost:8080", "Read timed out"
         )
@@ -157,7 +143,6 @@ class TestRestTransportExceptionTranslation:
         request_params: dict[str, Any],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """urllib3.exceptions.MaxRetryError should raise RestConnectionError."""
         original_exc = urllib3.exceptions.MaxRetryError(
             cast(Any, None), "http://localhost:8080", Exception("Max retries exceeded")
         )
@@ -184,7 +169,6 @@ class TestRestTransportExceptionTranslation:
         request_params: dict[str, Any],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """urllib3.exceptions.NewConnectionError should raise RestConnectionError."""
         original_exc = urllib3.exceptions.NewConnectionError(
             cast(Any, None), "Failed to establish a new connection"
         )
@@ -211,7 +195,6 @@ class TestRestTransportExceptionTranslation:
         request_params: dict[str, Any],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """urllib3.exceptions.ProtocolError should raise RestProtocolError."""
         original_exc = urllib3.exceptions.ProtocolError("Connection aborted")
 
         def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
@@ -232,17 +215,13 @@ class TestRestTransportExceptionTranslation:
 
 
 class TestRestTransportExceptionBackwardCompatibility:
-    """Test that existing code catching ApiException still works."""
-
     @pytest.fixture
     def rest_client(self) -> Any:
-        """Create a RESTClientObject with minimal configuration."""
         config = Configuration(host="http://localhost:8080")
         return cast(Any, RESTClientObject(config))
 
     @pytest.fixture
     def request_params(self) -> dict[str, Any]:
-        """Standard request parameters for testing."""
         return {
             "method": "GET",
             "url": "http://localhost:8080/api/test",
@@ -256,7 +235,6 @@ class TestRestTransportExceptionBackwardCompatibility:
         request_params: dict[str, Any],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Code catching ApiException should also catch RestTLSError."""
 
         def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
             raise urllib3.exceptions.SSLError("SSL failed")
@@ -275,8 +253,6 @@ class TestRestTransportExceptionBackwardCompatibility:
         request_params: dict[str, Any],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Code catching ApiException should also catch RestTimeoutError."""
-
         def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
             raise urllib3.exceptions.ConnectTimeoutError(None, "url", "timeout")
 
@@ -293,8 +269,6 @@ class TestRestTransportExceptionBackwardCompatibility:
         request_params: dict[str, Any],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Code catching ApiException should also catch RestConnectionError."""
-
         def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
             raise urllib3.exceptions.NewConnectionError(
                 cast(Any, None), "connection failed"
@@ -313,8 +287,6 @@ class TestRestTransportExceptionBackwardCompatibility:
         request_params: dict[str, Any],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Code catching ApiException should also catch RestProtocolError."""
-
         def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
             raise urllib3.exceptions.ProtocolError("protocol error")
 
@@ -331,7 +303,6 @@ class TestRestTransportExceptionBackwardCompatibility:
         request_params: dict[str, Any],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Code catching RestTransportError should catch all transport subtypes."""
         exceptions_to_test = [
             (urllib3.exceptions.SSLError("ssl"), RestTLSError),
             (
@@ -373,18 +344,14 @@ class TestRestTransportExceptionBackwardCompatibility:
 
 
 class TestRestTransportExceptionDiagnostics:
-    """Test that diagnostic information is correctly included in exceptions."""
-
     @pytest.fixture
     def rest_client(self) -> Any:
-        """Create a RESTClientObject with minimal configuration."""
         config = Configuration(host="http://localhost:8080")
         return cast(Any, RESTClientObject(config))
 
     def test_reason_includes_all_diagnostic_fields(
         self, rest_client: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Verify that reason includes method, url, and timeout."""
 
         def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
             raise urllib3.exceptions.SSLError("test error message")
@@ -409,8 +376,6 @@ class TestRestTransportExceptionDiagnostics:
     def test_reason_handles_none_timeout(
         self, rest_client: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Verify that reason correctly shows timeout=None when not specified."""
-
         def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
             raise urllib3.exceptions.NewConnectionError(
                 cast(Any, None), "connection refused"

--- a/sdks/python/tests/test_rest_transport_exceptions.py
+++ b/sdks/python/tests/test_rest_transport_exceptions.py
@@ -25,371 +25,362 @@ from hatchet_sdk.clients.rest.exceptions import (
 from hatchet_sdk.clients.rest.rest import RESTClientObject
 
 
-class TestRestTransportExceptionHierarchy:
-    def test_rest_transport_error_inherits_from_api_exception(self) -> None:
-        assert issubclass(RestTransportError, ApiException)
-
-    def test_rest_timeout_error_inherits_from_transport_error(self) -> None:
-        assert issubclass(RestTimeoutError, RestTransportError)
-        assert issubclass(RestTimeoutError, ApiException)
-
-    def test_rest_connection_error_inherits_from_transport_error(self) -> None:
-        assert issubclass(RestConnectionError, RestTransportError)
-        assert issubclass(RestConnectionError, ApiException)
-
-    def test_rest_tls_error_inherits_from_transport_error(self) -> None:
-        assert issubclass(RestTLSError, RestTransportError)
-        assert issubclass(RestTLSError, ApiException)
-
-    def test_rest_protocol_error_inherits_from_transport_error(self) -> None:
-        assert issubclass(RestProtocolError, RestTransportError)
-        assert issubclass(RestProtocolError, ApiException)
+@pytest.fixture
+def rest_client() -> Any:
+    config = Configuration(host="http://localhost:8080")
+    return cast(Any, RESTClientObject(config))
 
 
-class TestRestTransportExceptionTranslation:
-    @pytest.fixture
-    def rest_client(self) -> Any:
-        config = Configuration(host="http://localhost:8080")
-        return cast(Any, RESTClientObject(config))
+@pytest.fixture
+def request_params() -> dict[str, Any]:
+    return {
+        "method": "GET",
+        "url": "http://localhost:8080/api/test",
+        "headers": {"Content-Type": "application/json"},
+        "_request_timeout": 30,
+    }
 
-    @pytest.fixture
-    def request_params(self) -> dict[str, Any]:
-        return {
-            "method": "GET",
-            "url": "http://localhost:8080/api/test",
-            "headers": {"Content-Type": "application/json"},
-            "_request_timeout": 30,
-        }
 
-    def test_ssl_error_raises_rest_tls_error(
-        self,
-        rest_client: Any,
-        request_params: dict[str, Any],
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        original_exc = urllib3.exceptions.SSLError("SSL certificate verify failed")
+# --- Hierarchy tests ---
 
-        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
-            raise original_exc
 
-        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+def test_hierarchy__rest_transport_error_inherits_from_api_exception() -> None:
+    assert issubclass(RestTransportError, ApiException)
 
-        with pytest.raises(RestTLSError) as exc_info:
-            rest_client.request(**request_params)
 
-        exc = exc_info.value
-        assert exc.status == 0
-        assert "SSLError" in exc.reason
-        assert "method=GET" in exc.reason
-        assert "url=http://localhost:8080/api/test" in exc.reason
-        assert "timeout=30" in exc.reason
-        assert exc.__cause__ is original_exc
+def test_hierarchy__rest_timeout_error_inherits_from_transport_error() -> None:
+    assert issubclass(RestTimeoutError, RestTransportError)
+    assert issubclass(RestTimeoutError, ApiException)
 
-    def test_connect_timeout_error_raises_rest_timeout_error(
-        self,
-        rest_client: Any,
-        request_params: dict[str, Any],
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        original_exc = urllib3.exceptions.ConnectTimeoutError(
-            None, "http://localhost:8080", "Connection timed out"
+
+def test_hierarchy__rest_connection_error_inherits_from_transport_error() -> None:
+    assert issubclass(RestConnectionError, RestTransportError)
+    assert issubclass(RestConnectionError, ApiException)
+
+
+def test_hierarchy__rest_tls_error_inherits_from_transport_error() -> None:
+    assert issubclass(RestTLSError, RestTransportError)
+    assert issubclass(RestTLSError, ApiException)
+
+
+def test_hierarchy__rest_protocol_error_inherits_from_transport_error() -> None:
+    assert issubclass(RestProtocolError, RestTransportError)
+    assert issubclass(RestProtocolError, ApiException)
+
+
+# --- Translation tests ---
+
+
+def test_translation__ssl_error_raises_rest_tls_error(
+    rest_client: Any,
+    request_params: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_exc = urllib3.exceptions.SSLError("SSL certificate verify failed")
+
+    def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+        raise original_exc
+
+    monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+    with pytest.raises(RestTLSError) as exc_info:
+        rest_client.request(**request_params)
+
+    exc = exc_info.value
+    assert exc.status == 0
+    assert "SSLError" in exc.reason
+    assert "method=GET" in exc.reason
+    assert "url=http://localhost:8080/api/test" in exc.reason
+    assert "timeout=30" in exc.reason
+    assert exc.__cause__ is original_exc
+
+
+def test_translation__connect_timeout_error_raises_rest_timeout_error(
+    rest_client: Any,
+    request_params: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_exc = urllib3.exceptions.ConnectTimeoutError(
+        None, "http://localhost:8080", "Connection timed out"
+    )
+
+    def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+        raise original_exc
+
+    monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+    with pytest.raises(RestTimeoutError) as exc_info:
+        rest_client.request(**request_params)
+
+    exc = exc_info.value
+    assert exc.status == 0
+    assert "ConnectTimeoutError" in exc.reason
+    assert "method=GET" in exc.reason
+    assert "url=http://localhost:8080/api/test" in exc.reason
+    assert "timeout=30" in exc.reason
+    assert exc.__cause__ is original_exc
+
+
+def test_translation__read_timeout_error_raises_rest_timeout_error(
+    rest_client: Any,
+    request_params: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_exc = urllib3.exceptions.ReadTimeoutError(
+        cast(Any, None), "http://localhost:8080", "Read timed out"
+    )
+
+    def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+        raise original_exc
+
+    monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+    with pytest.raises(RestTimeoutError) as exc_info:
+        rest_client.request(**request_params)
+
+    exc = exc_info.value
+    assert exc.status == 0
+    assert "ReadTimeoutError" in exc.reason
+    assert "method=GET" in exc.reason
+    assert "url=http://localhost:8080/api/test" in exc.reason
+    assert "timeout=30" in exc.reason
+    assert exc.__cause__ is original_exc
+
+
+def test_translation__max_retry_error_raises_rest_connection_error(
+    rest_client: Any,
+    request_params: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_exc = urllib3.exceptions.MaxRetryError(
+        cast(Any, None), "http://localhost:8080", Exception("Max retries exceeded")
+    )
+
+    def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+        raise original_exc
+
+    monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+    with pytest.raises(RestConnectionError) as exc_info:
+        rest_client.request(**request_params)
+
+    exc = exc_info.value
+    assert exc.status == 0
+    assert "MaxRetryError" in exc.reason
+    assert "method=GET" in exc.reason
+    assert "url=http://localhost:8080/api/test" in exc.reason
+    assert "timeout=30" in exc.reason
+    assert exc.__cause__ is original_exc
+
+
+def test_translation__new_connection_error_raises_rest_connection_error(
+    rest_client: Any,
+    request_params: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_exc = urllib3.exceptions.NewConnectionError(
+        cast(Any, None), "Failed to establish a new connection"
+    )
+
+    def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+        raise original_exc
+
+    monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+    with pytest.raises(RestConnectionError) as exc_info:
+        rest_client.request(**request_params)
+
+    exc = exc_info.value
+    assert exc.status == 0
+    assert "NewConnectionError" in exc.reason
+    assert "method=GET" in exc.reason
+    assert "url=http://localhost:8080/api/test" in exc.reason
+    assert "timeout=30" in exc.reason
+    assert exc.__cause__ is original_exc
+
+
+def test_translation__protocol_error_raises_rest_protocol_error(
+    rest_client: Any,
+    request_params: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_exc = urllib3.exceptions.ProtocolError("Connection aborted")
+
+    def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+        raise original_exc
+
+    monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+    with pytest.raises(RestProtocolError) as exc_info:
+        rest_client.request(**request_params)
+
+    exc = exc_info.value
+    assert exc.status == 0
+    assert "ProtocolError" in exc.reason
+    assert "method=GET" in exc.reason
+    assert "url=http://localhost:8080/api/test" in exc.reason
+    assert "timeout=30" in exc.reason
+    assert exc.__cause__ is original_exc
+
+
+# --- Backward compatibility tests ---
+
+
+def test_backward_compat__catching_api_exception_catches_tls_error(
+    rest_client: Any,
+    request_params: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+        raise urllib3.exceptions.SSLError("SSL failed")
+
+    monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+    with pytest.raises(ApiException) as exc_info:
+        rest_client.request(**request_params)
+
+    assert isinstance(exc_info.value, RestTLSError)
+
+
+def test_backward_compat__catching_api_exception_catches_timeout_error(
+    rest_client: Any,
+    request_params: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+        raise urllib3.exceptions.ConnectTimeoutError(None, "url", "timeout")
+
+    monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+    with pytest.raises(ApiException) as exc_info:
+        rest_client.request(**request_params)
+
+    assert isinstance(exc_info.value, RestTimeoutError)
+
+
+def test_backward_compat__catching_api_exception_catches_connection_error(
+    rest_client: Any,
+    request_params: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+        raise urllib3.exceptions.NewConnectionError(
+            cast(Any, None), "connection failed"
         )
 
-        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
-            raise original_exc
+    monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+    with pytest.raises(ApiException) as exc_info:
+        rest_client.request(**request_params)
+
+    assert isinstance(exc_info.value, RestConnectionError)
+
+
+def test_backward_compat__catching_api_exception_catches_protocol_error(
+    rest_client: Any,
+    request_params: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+        raise urllib3.exceptions.ProtocolError("protocol error")
+
+    monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+    with pytest.raises(ApiException) as exc_info:
+        rest_client.request(**request_params)
+
+    assert isinstance(exc_info.value, RestProtocolError)
+
+
+def test_backward_compat__catching_rest_transport_error_catches_all_subtypes(
+    rest_client: Any,
+    request_params: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    exceptions_to_test = [
+        (urllib3.exceptions.SSLError("ssl"), RestTLSError),
+        (
+            urllib3.exceptions.ConnectTimeoutError(None, "url", "msg"),
+            RestTimeoutError,
+        ),
+        (
+            urllib3.exceptions.ReadTimeoutError(cast(Any, None), "url", "msg"),
+            RestTimeoutError,
+        ),
+        (
+            urllib3.exceptions.MaxRetryError(cast(Any, None), "url", Exception("msg")),
+            RestConnectionError,
+        ),
+        (
+            urllib3.exceptions.NewConnectionError(cast(Any, None), "msg"),
+            RestConnectionError,
+        ),
+        (urllib3.exceptions.ProtocolError("msg"), RestProtocolError),
+    ]
+
+    for urllib3_exc, expected_type in exceptions_to_test:
+
+        def mock_request(
+            *args: Any, _exc: Exception = urllib3_exc, **kwargs: Any
+        ) -> NoReturn:
+            raise _exc
 
         monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
 
-        with pytest.raises(RestTimeoutError) as exc_info:
+        with pytest.raises(RestTransportError) as exc_info:
             rest_client.request(**request_params)
 
-        exc = exc_info.value
-        assert exc.status == 0
-        assert "ConnectTimeoutError" in exc.reason
-        assert "method=GET" in exc.reason
-        assert "url=http://localhost:8080/api/test" in exc.reason
-        assert "timeout=30" in exc.reason
-        assert exc.__cause__ is original_exc
+        assert isinstance(
+            exc_info.value, expected_type
+        ), f"Expected {expected_type.__name__} for {type(urllib3_exc).__name__}"
 
-    def test_read_timeout_error_raises_rest_timeout_error(
-        self,
-        rest_client: Any,
-        request_params: dict[str, Any],
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        original_exc = urllib3.exceptions.ReadTimeoutError(
-            cast(Any, None), "http://localhost:8080", "Read timed out"
+
+# --- Diagnostics tests ---
+
+
+def test_diagnostics__reason_includes_all_diagnostic_fields(
+    rest_client: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+        raise urllib3.exceptions.SSLError("test error message")
+
+    monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+    with pytest.raises(RestTLSError) as exc_info:
+        rest_client.request(
+            method="POST",
+            url="https://example.com/api/v1/resource",
+            headers={},
+            _request_timeout=(5, 30),
         )
 
-        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
-            raise original_exc
+    reason = exc_info.value.reason
+    assert "SSLError" in reason
+    assert "test error message" in reason
+    assert "method=POST" in reason
+    assert "url=https://example.com/api/v1/resource" in reason
+    assert "timeout=(5, 30)" in reason
 
-        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
 
-        with pytest.raises(RestTimeoutError) as exc_info:
-            rest_client.request(**request_params)
-
-        exc = exc_info.value
-        assert exc.status == 0
-        assert "ReadTimeoutError" in exc.reason
-        assert "method=GET" in exc.reason
-        assert "url=http://localhost:8080/api/test" in exc.reason
-        assert "timeout=30" in exc.reason
-        assert exc.__cause__ is original_exc
-
-    def test_max_retry_error_raises_rest_connection_error(
-        self,
-        rest_client: Any,
-        request_params: dict[str, Any],
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        original_exc = urllib3.exceptions.MaxRetryError(
-            cast(Any, None), "http://localhost:8080", Exception("Max retries exceeded")
+def test_diagnostics__reason_handles_none_timeout(
+    rest_client: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+        raise urllib3.exceptions.NewConnectionError(
+            cast(Any, None), "connection refused"
         )
 
-        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
-            raise original_exc
+    monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
 
-        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
-
-        with pytest.raises(RestConnectionError) as exc_info:
-            rest_client.request(**request_params)
-
-        exc = exc_info.value
-        assert exc.status == 0
-        assert "MaxRetryError" in exc.reason
-        assert "method=GET" in exc.reason
-        assert "url=http://localhost:8080/api/test" in exc.reason
-        assert "timeout=30" in exc.reason
-        assert exc.__cause__ is original_exc
-
-    def test_new_connection_error_raises_rest_connection_error(
-        self,
-        rest_client: Any,
-        request_params: dict[str, Any],
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        original_exc = urllib3.exceptions.NewConnectionError(
-            cast(Any, None), "Failed to establish a new connection"
+    with pytest.raises(RestConnectionError) as exc_info:
+        rest_client.request(
+            method="GET",
+            url="http://localhost/test",
+            headers={},
+            _request_timeout=None,
         )
 
-        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
-            raise original_exc
-
-        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
-
-        with pytest.raises(RestConnectionError) as exc_info:
-            rest_client.request(**request_params)
-
-        exc = exc_info.value
-        assert exc.status == 0
-        assert "NewConnectionError" in exc.reason
-        assert "method=GET" in exc.reason
-        assert "url=http://localhost:8080/api/test" in exc.reason
-        assert "timeout=30" in exc.reason
-        assert exc.__cause__ is original_exc
-
-    def test_protocol_error_raises_rest_protocol_error(
-        self,
-        rest_client: Any,
-        request_params: dict[str, Any],
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        original_exc = urllib3.exceptions.ProtocolError("Connection aborted")
-
-        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
-            raise original_exc
-
-        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
-
-        with pytest.raises(RestProtocolError) as exc_info:
-            rest_client.request(**request_params)
-
-        exc = exc_info.value
-        assert exc.status == 0
-        assert "ProtocolError" in exc.reason
-        assert "method=GET" in exc.reason
-        assert "url=http://localhost:8080/api/test" in exc.reason
-        assert "timeout=30" in exc.reason
-        assert exc.__cause__ is original_exc
-
-
-class TestRestTransportExceptionBackwardCompatibility:
-    @pytest.fixture
-    def rest_client(self) -> Any:
-        config = Configuration(host="http://localhost:8080")
-        return cast(Any, RESTClientObject(config))
-
-    @pytest.fixture
-    def request_params(self) -> dict[str, Any]:
-        return {
-            "method": "GET",
-            "url": "http://localhost:8080/api/test",
-            "headers": {"Content-Type": "application/json"},
-            "_request_timeout": 30,
-        }
-
-    def test_catching_api_exception_catches_tls_error(
-        self,
-        rest_client: Any,
-        request_params: dict[str, Any],
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-
-        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
-            raise urllib3.exceptions.SSLError("SSL failed")
-
-        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
-
-        with pytest.raises(ApiException) as exc_info:
-            rest_client.request(**request_params)
-
-        # Should be the specific subclass
-        assert isinstance(exc_info.value, RestTLSError)
-
-    def test_catching_api_exception_catches_timeout_error(
-        self,
-        rest_client: Any,
-        request_params: dict[str, Any],
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
-            raise urllib3.exceptions.ConnectTimeoutError(None, "url", "timeout")
-
-        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
-
-        with pytest.raises(ApiException) as exc_info:
-            rest_client.request(**request_params)
-
-        assert isinstance(exc_info.value, RestTimeoutError)
-
-    def test_catching_api_exception_catches_connection_error(
-        self,
-        rest_client: Any,
-        request_params: dict[str, Any],
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
-            raise urllib3.exceptions.NewConnectionError(
-                cast(Any, None), "connection failed"
-            )
-
-        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
-
-        with pytest.raises(ApiException) as exc_info:
-            rest_client.request(**request_params)
-
-        assert isinstance(exc_info.value, RestConnectionError)
-
-    def test_catching_api_exception_catches_protocol_error(
-        self,
-        rest_client: Any,
-        request_params: dict[str, Any],
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
-            raise urllib3.exceptions.ProtocolError("protocol error")
-
-        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
-
-        with pytest.raises(ApiException) as exc_info:
-            rest_client.request(**request_params)
-
-        assert isinstance(exc_info.value, RestProtocolError)
-
-    def test_catching_rest_transport_error_catches_all_subtypes(
-        self,
-        rest_client: Any,
-        request_params: dict[str, Any],
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        exceptions_to_test = [
-            (urllib3.exceptions.SSLError("ssl"), RestTLSError),
-            (
-                urllib3.exceptions.ConnectTimeoutError(None, "url", "msg"),
-                RestTimeoutError,
-            ),
-            (
-                urllib3.exceptions.ReadTimeoutError(cast(Any, None), "url", "msg"),
-                RestTimeoutError,
-            ),
-            (
-                urllib3.exceptions.MaxRetryError(
-                    cast(Any, None), "url", Exception("msg")
-                ),
-                RestConnectionError,
-            ),
-            (
-                urllib3.exceptions.NewConnectionError(cast(Any, None), "msg"),
-                RestConnectionError,
-            ),
-            (urllib3.exceptions.ProtocolError("msg"), RestProtocolError),
-        ]
-
-        for urllib3_exc, expected_type in exceptions_to_test:
-
-            def mock_request(
-                *args: Any, _exc: Exception = urllib3_exc, **kwargs: Any
-            ) -> NoReturn:
-                raise _exc
-
-            monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
-
-            with pytest.raises(RestTransportError) as exc_info:
-                rest_client.request(**request_params)
-
-            assert isinstance(
-                exc_info.value, expected_type
-            ), f"Expected {expected_type.__name__} for {type(urllib3_exc).__name__}"
-
-
-class TestRestTransportExceptionDiagnostics:
-    @pytest.fixture
-    def rest_client(self) -> Any:
-        config = Configuration(host="http://localhost:8080")
-        return cast(Any, RESTClientObject(config))
-
-    def test_reason_includes_all_diagnostic_fields(
-        self, rest_client: Any, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-
-        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
-            raise urllib3.exceptions.SSLError("test error message")
-
-        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
-
-        with pytest.raises(RestTLSError) as exc_info:
-            rest_client.request(
-                method="POST",
-                url="https://example.com/api/v1/resource",
-                headers={},
-                _request_timeout=(5, 30),
-            )
-
-        reason = exc_info.value.reason
-        assert "SSLError" in reason
-        assert "test error message" in reason
-        assert "method=POST" in reason
-        assert "url=https://example.com/api/v1/resource" in reason
-        assert "timeout=(5, 30)" in reason
-
-    def test_reason_handles_none_timeout(
-        self, rest_client: Any, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
-            raise urllib3.exceptions.NewConnectionError(
-                cast(Any, None), "connection refused"
-            )
-
-        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
-
-        with pytest.raises(RestConnectionError) as exc_info:
-            rest_client.request(
-                method="GET",
-                url="http://localhost/test",
-                headers={},
-                _request_timeout=None,
-            )
-
-        reason = exc_info.value.reason
-        assert "timeout=None" in reason
+    reason = exc_info.value.reason
+    assert "timeout=None" in reason

--- a/sdks/python/tests/test_rest_transport_exceptions.py
+++ b/sdks/python/tests/test_rest_transport_exceptions.py
@@ -1,0 +1,430 @@
+"""Unit tests for REST transport exception translation.
+
+These tests verify that urllib3 transport exceptions are correctly translated
+to typed Hatchet REST exceptions while preserving:
+- status=0 (no HTTP status was received)
+- diagnostic information in reason (method, url, timeout)
+- exception chaining via __cause__
+- backward compatibility (all exceptions inherit from ApiException)
+"""
+
+from typing import Any, NoReturn, cast
+
+import pytest
+import urllib3.exceptions
+
+from hatchet_sdk.clients.rest.configuration import Configuration
+from hatchet_sdk.clients.rest.exceptions import (
+    ApiException,
+    RestConnectionError,
+    RestProtocolError,
+    RestTimeoutError,
+    RestTLSError,
+    RestTransportError,
+)
+from hatchet_sdk.clients.rest.rest import RESTClientObject
+
+
+class TestRestTransportExceptionHierarchy:
+    """Test that exception hierarchy is correct for backward compatibility."""
+
+    def test_rest_transport_error_inherits_from_api_exception(self) -> None:
+        """RestTransportError should inherit from ApiException."""
+        assert issubclass(RestTransportError, ApiException)
+
+    def test_rest_timeout_error_inherits_from_transport_error(self) -> None:
+        """RestTimeoutError should inherit from RestTransportError."""
+        assert issubclass(RestTimeoutError, RestTransportError)
+        assert issubclass(RestTimeoutError, ApiException)
+
+    def test_rest_connection_error_inherits_from_transport_error(self) -> None:
+        """RestConnectionError should inherit from RestTransportError."""
+        assert issubclass(RestConnectionError, RestTransportError)
+        assert issubclass(RestConnectionError, ApiException)
+
+    def test_rest_tls_error_inherits_from_transport_error(self) -> None:
+        """RestTLSError should inherit from RestTransportError."""
+        assert issubclass(RestTLSError, RestTransportError)
+        assert issubclass(RestTLSError, ApiException)
+
+    def test_rest_protocol_error_inherits_from_transport_error(self) -> None:
+        """RestProtocolError should inherit from RestTransportError."""
+        assert issubclass(RestProtocolError, RestTransportError)
+        assert issubclass(RestProtocolError, ApiException)
+
+
+class TestRestTransportExceptionTranslation:
+    """Test that urllib3 exceptions are translated to the correct typed exceptions."""
+
+    @pytest.fixture
+    def rest_client(self) -> Any:
+        """Create a RESTClientObject with minimal configuration."""
+        config = Configuration(host="http://localhost:8080")
+        return cast(Any, RESTClientObject(config))
+
+    @pytest.fixture
+    def request_params(self) -> dict[str, Any]:
+        """Standard request parameters for testing."""
+        return {
+            "method": "GET",
+            "url": "http://localhost:8080/api/test",
+            "headers": {"Content-Type": "application/json"},
+            "_request_timeout": 30,
+        }
+
+    def test_ssl_error_raises_rest_tls_error(
+        self,
+        rest_client: Any,
+        request_params: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """urllib3.exceptions.SSLError should raise RestTLSError."""
+        original_exc = urllib3.exceptions.SSLError("SSL certificate verify failed")
+
+        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+            raise original_exc
+
+        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+        with pytest.raises(RestTLSError) as exc_info:
+            rest_client.request(**request_params)
+
+        exc = exc_info.value
+        assert exc.status == 0
+        assert "SSLError" in exc.reason
+        assert "method=GET" in exc.reason
+        assert "url=http://localhost:8080/api/test" in exc.reason
+        assert "timeout=30" in exc.reason
+        assert exc.__cause__ is original_exc
+
+    def test_connect_timeout_error_raises_rest_timeout_error(
+        self,
+        rest_client: Any,
+        request_params: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """urllib3.exceptions.ConnectTimeoutError should raise RestTimeoutError."""
+        original_exc = urllib3.exceptions.ConnectTimeoutError(
+            None, "http://localhost:8080", "Connection timed out"
+        )
+
+        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+            raise original_exc
+
+        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+        with pytest.raises(RestTimeoutError) as exc_info:
+            rest_client.request(**request_params)
+
+        exc = exc_info.value
+        assert exc.status == 0
+        assert "ConnectTimeoutError" in exc.reason
+        assert "method=GET" in exc.reason
+        assert "url=http://localhost:8080/api/test" in exc.reason
+        assert "timeout=30" in exc.reason
+        assert exc.__cause__ is original_exc
+
+    def test_read_timeout_error_raises_rest_timeout_error(
+        self,
+        rest_client: Any,
+        request_params: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """urllib3.exceptions.ReadTimeoutError should raise RestTimeoutError."""
+        original_exc = urllib3.exceptions.ReadTimeoutError(
+            cast(Any, None), "http://localhost:8080", "Read timed out"
+        )
+
+        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+            raise original_exc
+
+        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+        with pytest.raises(RestTimeoutError) as exc_info:
+            rest_client.request(**request_params)
+
+        exc = exc_info.value
+        assert exc.status == 0
+        assert "ReadTimeoutError" in exc.reason
+        assert "method=GET" in exc.reason
+        assert "url=http://localhost:8080/api/test" in exc.reason
+        assert "timeout=30" in exc.reason
+        assert exc.__cause__ is original_exc
+
+    def test_max_retry_error_raises_rest_connection_error(
+        self,
+        rest_client: Any,
+        request_params: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """urllib3.exceptions.MaxRetryError should raise RestConnectionError."""
+        original_exc = urllib3.exceptions.MaxRetryError(
+            cast(Any, None), "http://localhost:8080", Exception("Max retries exceeded")
+        )
+
+        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+            raise original_exc
+
+        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+        with pytest.raises(RestConnectionError) as exc_info:
+            rest_client.request(**request_params)
+
+        exc = exc_info.value
+        assert exc.status == 0
+        assert "MaxRetryError" in exc.reason
+        assert "method=GET" in exc.reason
+        assert "url=http://localhost:8080/api/test" in exc.reason
+        assert "timeout=30" in exc.reason
+        assert exc.__cause__ is original_exc
+
+    def test_new_connection_error_raises_rest_connection_error(
+        self,
+        rest_client: Any,
+        request_params: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """urllib3.exceptions.NewConnectionError should raise RestConnectionError."""
+        original_exc = urllib3.exceptions.NewConnectionError(
+            cast(Any, None), "Failed to establish a new connection"
+        )
+
+        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+            raise original_exc
+
+        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+        with pytest.raises(RestConnectionError) as exc_info:
+            rest_client.request(**request_params)
+
+        exc = exc_info.value
+        assert exc.status == 0
+        assert "NewConnectionError" in exc.reason
+        assert "method=GET" in exc.reason
+        assert "url=http://localhost:8080/api/test" in exc.reason
+        assert "timeout=30" in exc.reason
+        assert exc.__cause__ is original_exc
+
+    def test_protocol_error_raises_rest_protocol_error(
+        self,
+        rest_client: Any,
+        request_params: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """urllib3.exceptions.ProtocolError should raise RestProtocolError."""
+        original_exc = urllib3.exceptions.ProtocolError("Connection aborted")
+
+        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+            raise original_exc
+
+        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+        with pytest.raises(RestProtocolError) as exc_info:
+            rest_client.request(**request_params)
+
+        exc = exc_info.value
+        assert exc.status == 0
+        assert "ProtocolError" in exc.reason
+        assert "method=GET" in exc.reason
+        assert "url=http://localhost:8080/api/test" in exc.reason
+        assert "timeout=30" in exc.reason
+        assert exc.__cause__ is original_exc
+
+
+class TestRestTransportExceptionBackwardCompatibility:
+    """Test that existing code catching ApiException still works."""
+
+    @pytest.fixture
+    def rest_client(self) -> Any:
+        """Create a RESTClientObject with minimal configuration."""
+        config = Configuration(host="http://localhost:8080")
+        return cast(Any, RESTClientObject(config))
+
+    @pytest.fixture
+    def request_params(self) -> dict[str, Any]:
+        """Standard request parameters for testing."""
+        return {
+            "method": "GET",
+            "url": "http://localhost:8080/api/test",
+            "headers": {"Content-Type": "application/json"},
+            "_request_timeout": 30,
+        }
+
+    def test_catching_api_exception_catches_tls_error(
+        self,
+        rest_client: Any,
+        request_params: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Code catching ApiException should also catch RestTLSError."""
+
+        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+            raise urllib3.exceptions.SSLError("SSL failed")
+
+        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+        with pytest.raises(ApiException) as exc_info:
+            rest_client.request(**request_params)
+
+        # Should be the specific subclass
+        assert isinstance(exc_info.value, RestTLSError)
+
+    def test_catching_api_exception_catches_timeout_error(
+        self,
+        rest_client: Any,
+        request_params: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Code catching ApiException should also catch RestTimeoutError."""
+
+        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+            raise urllib3.exceptions.ConnectTimeoutError(None, "url", "timeout")
+
+        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+        with pytest.raises(ApiException) as exc_info:
+            rest_client.request(**request_params)
+
+        assert isinstance(exc_info.value, RestTimeoutError)
+
+    def test_catching_api_exception_catches_connection_error(
+        self,
+        rest_client: Any,
+        request_params: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Code catching ApiException should also catch RestConnectionError."""
+
+        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+            raise urllib3.exceptions.NewConnectionError(
+                cast(Any, None), "connection failed"
+            )
+
+        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+        with pytest.raises(ApiException) as exc_info:
+            rest_client.request(**request_params)
+
+        assert isinstance(exc_info.value, RestConnectionError)
+
+    def test_catching_api_exception_catches_protocol_error(
+        self,
+        rest_client: Any,
+        request_params: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Code catching ApiException should also catch RestProtocolError."""
+
+        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+            raise urllib3.exceptions.ProtocolError("protocol error")
+
+        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+        with pytest.raises(ApiException) as exc_info:
+            rest_client.request(**request_params)
+
+        assert isinstance(exc_info.value, RestProtocolError)
+
+    def test_catching_rest_transport_error_catches_all_subtypes(
+        self,
+        rest_client: Any,
+        request_params: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Code catching RestTransportError should catch all transport subtypes."""
+        exceptions_to_test = [
+            (urllib3.exceptions.SSLError("ssl"), RestTLSError),
+            (
+                urllib3.exceptions.ConnectTimeoutError(None, "url", "msg"),
+                RestTimeoutError,
+            ),
+            (
+                urllib3.exceptions.ReadTimeoutError(cast(Any, None), "url", "msg"),
+                RestTimeoutError,
+            ),
+            (
+                urllib3.exceptions.MaxRetryError(
+                    cast(Any, None), "url", Exception("msg")
+                ),
+                RestConnectionError,
+            ),
+            (
+                urllib3.exceptions.NewConnectionError(cast(Any, None), "msg"),
+                RestConnectionError,
+            ),
+            (urllib3.exceptions.ProtocolError("msg"), RestProtocolError),
+        ]
+
+        for urllib3_exc, expected_type in exceptions_to_test:
+
+            def mock_request(
+                *args: Any, _exc: Exception = urllib3_exc, **kwargs: Any
+            ) -> NoReturn:
+                raise _exc
+
+            monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+            with pytest.raises(RestTransportError) as exc_info:
+                rest_client.request(**request_params)
+
+            assert isinstance(
+                exc_info.value, expected_type
+            ), f"Expected {expected_type.__name__} for {type(urllib3_exc).__name__}"
+
+
+class TestRestTransportExceptionDiagnostics:
+    """Test that diagnostic information is correctly included in exceptions."""
+
+    @pytest.fixture
+    def rest_client(self) -> Any:
+        """Create a RESTClientObject with minimal configuration."""
+        config = Configuration(host="http://localhost:8080")
+        return cast(Any, RESTClientObject(config))
+
+    def test_reason_includes_all_diagnostic_fields(
+        self, rest_client: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify that reason includes method, url, and timeout."""
+
+        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+            raise urllib3.exceptions.SSLError("test error message")
+
+        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+        with pytest.raises(RestTLSError) as exc_info:
+            rest_client.request(
+                method="POST",
+                url="https://example.com/api/v1/resource",
+                headers={},
+                _request_timeout=(5, 30),
+            )
+
+        reason = exc_info.value.reason
+        assert "SSLError" in reason
+        assert "test error message" in reason
+        assert "method=POST" in reason
+        assert "url=https://example.com/api/v1/resource" in reason
+        assert "timeout=(5, 30)" in reason
+
+    def test_reason_handles_none_timeout(
+        self, rest_client: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify that reason correctly shows timeout=None when not specified."""
+
+        def mock_request(*args: Any, **kwargs: Any) -> NoReturn:
+            raise urllib3.exceptions.NewConnectionError(
+                cast(Any, None), "connection refused"
+            )
+
+        monkeypatch.setattr(rest_client.pool_manager, "request", mock_request)
+
+        with pytest.raises(RestConnectionError) as exc_info:
+            rest_client.request(
+                method="GET",
+                url="http://localhost/test",
+                headers={},
+                _request_timeout=None,
+            )
+
+        reason = exc_info.value.reason
+        assert "timeout=None" in reason


### PR DESCRIPTION
Adds typed REST transport exceptions for urllib3/network failures and unit tests verifying translation, diagnostics, and backward compatibility. Updates apply_patches.py to patch generated REST client code and exceptions.

Follow-up to: #2872

# Description

This PR introduces typed REST transport exceptions for the Python SDK to replace the generic `ApiException` previously raised for urllib3/network-level failures.

Specifically:
- Adds a `RestTransportError` base class and concrete subtypes for TLS, timeout, connection, and protocol errors
- Updates the generated REST client error handling to translate urllib3 exceptions into the appropriate typed exception
- Preserves backward compatibility: all new exceptions inherit from `ApiException`
- Improves diagnostic messages by consistently including method, URL, and timeout
- Adds comprehensive unit tests covering translation, diagnostics, and backward compatibility
- Updates `apply_patches.py` so regenerated clients receive the new imports and handlers idempotently

No retry behavior is changed in this PR.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

- Add typed REST transport exception hierarchy (`RestTransportError`, `RestTLSError`, `RestTimeoutError`, `RestConnectionError`, `RestProtocolError`)
- Translate urllib3 exceptions into typed REST exceptions in the generated REST client
- Ensure exception handler ordering is correct for urllib3 inheritance behavior
- Add unit tests covering:
  - Exception translation
  - Diagnostic message contents
  - Backward compatibility with `ApiException`
- Update `apply_patches.py` to patch generated REST clients and exception imports idempotently
