### PR TITLE
test(sdk): cover python REST and gRPC retry predicate behavior

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -6,19 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [1.23.4] - 2026-02-12
-
-### Changed
-
-- Adds parameterized unit tests documenting current retry behavior of the Python SDK’s tenacity retry predicate for REST and gRPC errors.
-
-
 ## [1.23.3] - 2026-02-12
 
 ### Added
 
 - Adds type-hinted `Standalone.output_validator` and `Standalone.output_validator_type` properties to support easier type-safety and match the `input_validator` property pattern on `BaseWorkflow`.
 - Adds type-hinted `Task.output_validator` and `Task.output_validator_type` properties to support easier type-safety and match the patterns on `BaseWorkflow/Standalone`.
+- Adds parameterized unit tests documenting current retry behavior of the Python SDK’s tenacity retry predicate for REST and gRPC errors.
 
 
 ## [1.23.2] - 2026-02-11

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,12 +5,21 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.23.4] - 2026-02-12
+
+### Changed
+
+- Adds parameterized unit tests documenting current retry behavior of the Python SDK’s tenacity retry predicate for REST and gRPC errors.
+
+
 ## [1.23.3] - 2026-02-12
 
 ### Added
 
 - Adds type-hinted `Standalone.output_validator` and `Standalone.output_validator_type` properties to support easier type-safety and match the `input_validator` property pattern on `BaseWorkflow`.
 - Adds type-hinted `Task.output_validator` and `Task.output_validator_type` properties to support easier type-safety and match the patterns on `BaseWorkflow/Standalone`.
+
 
 ## [1.23.2] - 2026-02-11
 

--- a/sdks/python/tests/test_tenacity_utils.py
+++ b/sdks/python/tests/test_tenacity_utils.py
@@ -28,120 +28,111 @@ from hatchet_sdk.clients.rest.exceptions import (
 )
 from hatchet_sdk.clients.rest.tenacity_utils import tenacity_should_retry
 
-
-class TestRestExceptionRetryPredicate:
-    """Test retry predicate behavior for REST exceptions."""
-
-    @pytest.mark.parametrize(
-        ("exc", "expected"),
-        [
-            pytest.param(
-                ServiceException(status=500, reason="Internal Server Error"),
-                True,
-                id="ServiceException (HTTP 5xx) should be retried",
-            ),
-            pytest.param(
-                NotFoundException(status=404, reason="Not Found"),
-                True,
-                id="NotFoundException (HTTP 404) should be retried",
-            ),
-            pytest.param(
-                BadRequestException(status=400, reason="Bad Request"),
-                False,
-                id="BadRequestException (HTTP 400) should not be retried",
-            ),
-            pytest.param(
-                UnauthorizedException(status=401, reason="Unauthorized"),
-                False,
-                id="UnauthorizedException (HTTP 401) should not be retried",
-            ),
-            pytest.param(
-                ForbiddenException(status=403, reason="Forbidden"),
-                False,
-                id="ForbiddenException (HTTP 403) should not be retried",
-            ),
-        ],
-    )
-    def test_rest_exception_retry_behavior(
-        self, exc: BaseException, expected: bool
-    ) -> None:
-        """Test that REST exceptions have the expected retry behavior."""
-        assert tenacity_should_retry(exc) is expected
+# --- REST exception retry predicate tests ---
 
 
-class TestRestTransportErrorRetryPredicate:
-    """Test retry predicate behavior for REST transport errors.
-
-    These tests document the current behavior: transport level errors
-    (timeout, connection refused, TLS errors) are not retried by the
-    tenacity predicate.
-    """
-
-    @pytest.mark.parametrize(
-        ("exc", "expected"),
-        [
-            pytest.param(
-                RestTransportError(status=0, reason="Transport error"),
-                False,
-                id="RestTransportError (base class) should not be retried",
-            ),
-            pytest.param(
-                RestTimeoutError(status=0, reason="Connection timed out"),
-                False,
-                id="RestTimeoutError should not be retried",
-            ),
-            pytest.param(
-                RestConnectionError(status=0, reason="Connection refused"),
-                False,
-                id="RestConnectionError should not be retried",
-            ),
-            pytest.param(
-                RestTLSError(status=0, reason="SSL certificate verify failed"),
-                False,
-                id="RestTLSError should not be retried",
-            ),
-            pytest.param(
-                RestProtocolError(status=0, reason="Connection aborted"),
-                False,
-                id="RestProtocolError should not be retried",
-            ),
-        ],
-    )
-    def test_transport_error_retry_behavior(
-        self, exc: BaseException, expected: bool
-    ) -> None:
-        """Test that REST transport errors have the expected retry behavior."""
-        assert tenacity_should_retry(exc) is expected
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        pytest.param(
+            ServiceException(status=500, reason="Internal Server Error"),
+            True,
+            id="ServiceException (HTTP 5xx) should be retried",
+        ),
+        pytest.param(
+            NotFoundException(status=404, reason="Not Found"),
+            True,
+            id="NotFoundException (HTTP 404) should be retried",
+        ),
+        pytest.param(
+            BadRequestException(status=400, reason="Bad Request"),
+            False,
+            id="BadRequestException (HTTP 400) should not be retried",
+        ),
+        pytest.param(
+            UnauthorizedException(status=401, reason="Unauthorized"),
+            False,
+            id="UnauthorizedException (HTTP 401) should not be retried",
+        ),
+        pytest.param(
+            ForbiddenException(status=403, reason="Forbidden"),
+            False,
+            id="ForbiddenException (HTTP 403) should not be retried",
+        ),
+    ],
+)
+def test_rest__exception_retry_behavior(exc: BaseException, expected: bool) -> None:
+    """Test that REST exceptions have the expected retry behavior."""
+    assert tenacity_should_retry(exc) is expected
 
 
-class TestGenericExceptionRetryPredicate:
-    """Test retry predicate behavior for generic/unhandled exceptions."""
+# --- REST transport error retry predicate tests ---
 
-    @pytest.mark.parametrize(
-        ("exc", "expected"),
-        [
-            pytest.param(
-                RuntimeError("Something went wrong"),
-                False,
-                id="RuntimeError should not be retried",
-            ),
-            pytest.param(
-                ValueError("Invalid value"),
-                False,
-                id="ValueError should not be retried",
-            ),
-            pytest.param(
-                Exception("Generic error"),
-                False,
-                id="Generic Exception should not be retried",
-            ),
-        ],
-    )
-    def test_generic_exception_retry_behavior(
-        self, exc: BaseException, expected: bool
-    ) -> None:
-        """Test that generic exceptions have the expected retry behavior."""
-        assert tenacity_should_retry(exc) is expected
+
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        pytest.param(
+            RestTransportError(status=0, reason="Transport error"),
+            False,
+            id="RestTransportError (base class) should not be retried",
+        ),
+        pytest.param(
+            RestTimeoutError(status=0, reason="Connection timed out"),
+            False,
+            id="RestTimeoutError should not be retried",
+        ),
+        pytest.param(
+            RestConnectionError(status=0, reason="Connection refused"),
+            False,
+            id="RestConnectionError should not be retried",
+        ),
+        pytest.param(
+            RestTLSError(status=0, reason="SSL certificate verify failed"),
+            False,
+            id="RestTLSError should not be retried",
+        ),
+        pytest.param(
+            RestProtocolError(status=0, reason="Connection aborted"),
+            False,
+            id="RestProtocolError should not be retried",
+        ),
+    ],
+)
+def test_transport__error_retry_behavior(exc: BaseException, expected: bool) -> None:
+    """Test that REST transport errors have the expected retry behavior."""
+    assert tenacity_should_retry(exc) is expected
+
+
+# --- Generic exception retry predicate tests ---
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        pytest.param(
+            RuntimeError("Something went wrong"),
+            False,
+            id="RuntimeError should not be retried",
+        ),
+        pytest.param(
+            ValueError("Invalid value"),
+            False,
+            id="ValueError should not be retried",
+        ),
+        pytest.param(
+            Exception("Generic error"),
+            False,
+            id="Generic Exception should not be retried",
+        ),
+    ],
+)
+def test_generic__exception_retry_behavior(exc: BaseException, expected: bool) -> None:
+    """Test that generic exceptions have the expected retry behavior."""
+    assert tenacity_should_retry(exc) is expected
+
+
+# --- gRPC exception retry predicate tests ---
 
 
 class FakeRpcError(grpc.RpcError):
@@ -155,83 +146,76 @@ class FakeRpcError(grpc.RpcError):
         return self._code
 
 
-class TestGrpcExceptionRetryPredicate:
-    """Test retry predicate behavior for gRPC exceptions.
-
-    gRPC errors are retried by default, except for specific status codes
-    that indicate permanent failures (authentication, invalid args, etc.).
-    """
-
-    @pytest.mark.parametrize(
-        ("status_code", "expected"),
-        [
-            # Status codes that should be retried (transient/server errors)
-            pytest.param(
-                grpc.StatusCode.UNAVAILABLE,
-                True,
-                id="UNAVAILABLE should be retried (transient error)",
-            ),
-            pytest.param(
-                grpc.StatusCode.DEADLINE_EXCEEDED,
-                True,
-                id="DEADLINE_EXCEEDED should be retried (transient error)",
-            ),
-            pytest.param(
-                grpc.StatusCode.INTERNAL,
-                True,
-                id="INTERNAL should be retried (server error)",
-            ),
-            pytest.param(
-                grpc.StatusCode.RESOURCE_EXHAUSTED,
-                True,
-                id="RESOURCE_EXHAUSTED should be retried",
-            ),
-            pytest.param(
-                grpc.StatusCode.ABORTED,
-                True,
-                id="ABORTED should be retried",
-            ),
-            pytest.param(
-                grpc.StatusCode.UNKNOWN,
-                True,
-                id="UNKNOWN should be retried",
-            ),
-            # Status codes that should not be retried (permanent/client errors)
-            pytest.param(
-                grpc.StatusCode.UNIMPLEMENTED,
-                False,
-                id="UNIMPLEMENTED should not be retried (permanent error)",
-            ),
-            pytest.param(
-                grpc.StatusCode.NOT_FOUND,
-                False,
-                id="NOT_FOUND should not be retried (permanent error)",
-            ),
-            pytest.param(
-                grpc.StatusCode.INVALID_ARGUMENT,
-                False,
-                id="INVALID_ARGUMENT should not be retried (client error)",
-            ),
-            pytest.param(
-                grpc.StatusCode.ALREADY_EXISTS,
-                False,
-                id="ALREADY_EXISTS should not be retried (permanent error)",
-            ),
-            pytest.param(
-                grpc.StatusCode.UNAUTHENTICATED,
-                False,
-                id="UNAUTHENTICATED should not be retried (auth error)",
-            ),
-            pytest.param(
-                grpc.StatusCode.PERMISSION_DENIED,
-                False,
-                id="PERMISSION_DENIED should not be retried (auth error)",
-            ),
-        ],
-    )
-    def test_grpc_status_code_retry_behavior(
-        self, status_code: grpc.StatusCode, expected: bool
-    ) -> None:
-        """Test that gRPC status codes have the expected retry behavior."""
-        exc = FakeRpcError(status_code)
-        assert tenacity_should_retry(exc) is expected
+@pytest.mark.parametrize(
+    ("status_code", "expected"),
+    [
+        # Status codes that should be retried (transient/server errors)
+        pytest.param(
+            grpc.StatusCode.UNAVAILABLE,
+            True,
+            id="UNAVAILABLE should be retried (transient error)",
+        ),
+        pytest.param(
+            grpc.StatusCode.DEADLINE_EXCEEDED,
+            True,
+            id="DEADLINE_EXCEEDED should be retried (transient error)",
+        ),
+        pytest.param(
+            grpc.StatusCode.INTERNAL,
+            True,
+            id="INTERNAL should be retried (server error)",
+        ),
+        pytest.param(
+            grpc.StatusCode.RESOURCE_EXHAUSTED,
+            True,
+            id="RESOURCE_EXHAUSTED should be retried",
+        ),
+        pytest.param(
+            grpc.StatusCode.ABORTED,
+            True,
+            id="ABORTED should be retried",
+        ),
+        pytest.param(
+            grpc.StatusCode.UNKNOWN,
+            True,
+            id="UNKNOWN should be retried",
+        ),
+        # Status codes that should not be retried (permanent/client errors)
+        pytest.param(
+            grpc.StatusCode.UNIMPLEMENTED,
+            False,
+            id="UNIMPLEMENTED should not be retried (permanent error)",
+        ),
+        pytest.param(
+            grpc.StatusCode.NOT_FOUND,
+            False,
+            id="NOT_FOUND should not be retried (permanent error)",
+        ),
+        pytest.param(
+            grpc.StatusCode.INVALID_ARGUMENT,
+            False,
+            id="INVALID_ARGUMENT should not be retried (client error)",
+        ),
+        pytest.param(
+            grpc.StatusCode.ALREADY_EXISTS,
+            False,
+            id="ALREADY_EXISTS should not be retried (permanent error)",
+        ),
+        pytest.param(
+            grpc.StatusCode.UNAUTHENTICATED,
+            False,
+            id="UNAUTHENTICATED should not be retried (auth error)",
+        ),
+        pytest.param(
+            grpc.StatusCode.PERMISSION_DENIED,
+            False,
+            id="PERMISSION_DENIED should not be retried (auth error)",
+        ),
+    ],
+)
+def test_grpc__status_code_retry_behavior(
+    status_code: grpc.StatusCode, expected: bool
+) -> None:
+    """Test that gRPC status codes have the expected retry behavior."""
+    exc = FakeRpcError(status_code)
+    assert tenacity_should_retry(exc) is expected

--- a/sdks/python/tests/test_tenacity_utils.py
+++ b/sdks/python/tests/test_tenacity_utils.py
@@ -1,0 +1,237 @@
+"""Unit tests for the tenacity retry predicate.
+
+These tests verify which exceptions trigger retries and which do not.
+The retry predicate is used by the SDK to determine whether to retry
+failed API calls.
+
+Current retry behavior (as of this PR):
+- REST: ServiceException (5xx) and NotFoundException (404) are retried
+- REST: Transport errors (RestTimeoutError, etc.) are not retried
+- REST: Other 4xx errors are not retried
+- gRPC: Most errors are retried except specific status codes
+"""
+
+import grpc
+import pytest
+
+from hatchet_sdk.clients.rest.exceptions import (
+    BadRequestException,
+    ForbiddenException,
+    NotFoundException,
+    RestConnectionError,
+    RestProtocolError,
+    RestTimeoutError,
+    RestTLSError,
+    RestTransportError,
+    ServiceException,
+    UnauthorizedException,
+)
+from hatchet_sdk.clients.rest.tenacity_utils import tenacity_should_retry
+
+
+class TestRestExceptionRetryPredicate:
+    """Test retry predicate behavior for REST exceptions."""
+
+    @pytest.mark.parametrize(
+        ("exc", "expected"),
+        [
+            pytest.param(
+                ServiceException(status=500, reason="Internal Server Error"),
+                True,
+                id="ServiceException (HTTP 5xx) should be retried",
+            ),
+            pytest.param(
+                NotFoundException(status=404, reason="Not Found"),
+                True,
+                id="NotFoundException (HTTP 404) should be retried",
+            ),
+            pytest.param(
+                BadRequestException(status=400, reason="Bad Request"),
+                False,
+                id="BadRequestException (HTTP 400) should not be retried",
+            ),
+            pytest.param(
+                UnauthorizedException(status=401, reason="Unauthorized"),
+                False,
+                id="UnauthorizedException (HTTP 401) should not be retried",
+            ),
+            pytest.param(
+                ForbiddenException(status=403, reason="Forbidden"),
+                False,
+                id="ForbiddenException (HTTP 403) should not be retried",
+            ),
+        ],
+    )
+    def test_rest_exception_retry_behavior(
+        self, exc: BaseException, expected: bool
+    ) -> None:
+        """Test that REST exceptions have the expected retry behavior."""
+        assert tenacity_should_retry(exc) is expected
+
+
+class TestRestTransportErrorRetryPredicate:
+    """Test retry predicate behavior for REST transport errors.
+
+    These tests document the current behavior: transport level errors
+    (timeout, connection refused, TLS errors) are not retried by the
+    tenacity predicate.
+    """
+
+    @pytest.mark.parametrize(
+        ("exc", "expected"),
+        [
+            pytest.param(
+                RestTransportError(status=0, reason="Transport error"),
+                False,
+                id="RestTransportError (base class) should not be retried",
+            ),
+            pytest.param(
+                RestTimeoutError(status=0, reason="Connection timed out"),
+                False,
+                id="RestTimeoutError should not be retried",
+            ),
+            pytest.param(
+                RestConnectionError(status=0, reason="Connection refused"),
+                False,
+                id="RestConnectionError should not be retried",
+            ),
+            pytest.param(
+                RestTLSError(status=0, reason="SSL certificate verify failed"),
+                False,
+                id="RestTLSError should not be retried",
+            ),
+            pytest.param(
+                RestProtocolError(status=0, reason="Connection aborted"),
+                False,
+                id="RestProtocolError should not be retried",
+            ),
+        ],
+    )
+    def test_transport_error_retry_behavior(
+        self, exc: BaseException, expected: bool
+    ) -> None:
+        """Test that REST transport errors have the expected retry behavior."""
+        assert tenacity_should_retry(exc) is expected
+
+
+class TestGenericExceptionRetryPredicate:
+    """Test retry predicate behavior for generic/unhandled exceptions."""
+
+    @pytest.mark.parametrize(
+        ("exc", "expected"),
+        [
+            pytest.param(
+                RuntimeError("Something went wrong"),
+                False,
+                id="RuntimeError should not be retried",
+            ),
+            pytest.param(
+                ValueError("Invalid value"),
+                False,
+                id="ValueError should not be retried",
+            ),
+            pytest.param(
+                Exception("Generic error"),
+                False,
+                id="Generic Exception should not be retried",
+            ),
+        ],
+    )
+    def test_generic_exception_retry_behavior(
+        self, exc: BaseException, expected: bool
+    ) -> None:
+        """Test that generic exceptions have the expected retry behavior."""
+        assert tenacity_should_retry(exc) is expected
+
+
+class FakeRpcError(grpc.RpcError):
+    """A fake gRPC RpcError for testing without real gRPC infrastructure."""
+
+    def __init__(self, code: grpc.StatusCode) -> None:
+        self._code = code
+        super().__init__()
+
+    def code(self) -> grpc.StatusCode:
+        return self._code
+
+
+class TestGrpcExceptionRetryPredicate:
+    """Test retry predicate behavior for gRPC exceptions.
+
+    gRPC errors are retried by default, except for specific status codes
+    that indicate permanent failures (authentication, invalid args, etc.).
+    """
+
+    @pytest.mark.parametrize(
+        ("status_code", "expected"),
+        [
+            # Status codes that should be retried (transient/server errors)
+            pytest.param(
+                grpc.StatusCode.UNAVAILABLE,
+                True,
+                id="UNAVAILABLE should be retried (transient error)",
+            ),
+            pytest.param(
+                grpc.StatusCode.DEADLINE_EXCEEDED,
+                True,
+                id="DEADLINE_EXCEEDED should be retried (transient error)",
+            ),
+            pytest.param(
+                grpc.StatusCode.INTERNAL,
+                True,
+                id="INTERNAL should be retried (server error)",
+            ),
+            pytest.param(
+                grpc.StatusCode.RESOURCE_EXHAUSTED,
+                True,
+                id="RESOURCE_EXHAUSTED should be retried",
+            ),
+            pytest.param(
+                grpc.StatusCode.ABORTED,
+                True,
+                id="ABORTED should be retried",
+            ),
+            pytest.param(
+                grpc.StatusCode.UNKNOWN,
+                True,
+                id="UNKNOWN should be retried",
+            ),
+            # Status codes that should not be retried (permanent/client errors)
+            pytest.param(
+                grpc.StatusCode.UNIMPLEMENTED,
+                False,
+                id="UNIMPLEMENTED should not be retried (permanent error)",
+            ),
+            pytest.param(
+                grpc.StatusCode.NOT_FOUND,
+                False,
+                id="NOT_FOUND should not be retried (permanent error)",
+            ),
+            pytest.param(
+                grpc.StatusCode.INVALID_ARGUMENT,
+                False,
+                id="INVALID_ARGUMENT should not be retried (client error)",
+            ),
+            pytest.param(
+                grpc.StatusCode.ALREADY_EXISTS,
+                False,
+                id="ALREADY_EXISTS should not be retried (permanent error)",
+            ),
+            pytest.param(
+                grpc.StatusCode.UNAUTHENTICATED,
+                False,
+                id="UNAUTHENTICATED should not be retried (auth error)",
+            ),
+            pytest.param(
+                grpc.StatusCode.PERMISSION_DENIED,
+                False,
+                id="PERMISSION_DENIED should not be retried (auth error)",
+            ),
+        ],
+    )
+    def test_grpc_status_code_retry_behavior(
+        self, status_code: grpc.StatusCode, expected: bool
+    ) -> None:
+        """Test that gRPC status codes have the expected retry behavior."""
+        exc = FakeRpcError(status_code)
+        assert tenacity_should_retry(exc) is expected


### PR DESCRIPTION
**Follow-up to:** #2872 ( test coverage of current behavior)
**stacked on PR:** #2968 

# Description

This PR adds explicit, parameterized unit tests documenting the current retry behavior of the Python SDK’s tenacity retry predicate for both REST and gRPC calls.

The tests make retry semantics clear and intentional without changing any runtime behavior. In particular, they codify which exception types and gRPC status codes are retried vs not retried today.

This PR strictly adds tests documenting current behavior and does not modify retry logic.

### Context / Motivation

Retry behavior is a sensitive area with implications for idempotency, load amplification, and user expectations. Before changing retry semantics (as discussed in issue #2872), it’s important to have clear test coverage that documents existing behavior.

These tests provide that baseline and make future policy changes deliberate and reviewable.

### Relationship to other work

This PR is stacked on top of the earlier Python SDK PR: #2968 

It is intended to be reviewed either:
- after #2968, or
- independently, as it only adds tests.

It also provides groundwork for follow-up discussion and potential changes related to:
- https://github.com/hatchet-dev/hatchet/issues/2872
---

## Type of change

- [x] Test changes (add, refactor, improve or change a test)

---

## What's Changed

- [x] Added parameterized unit tests for the Python SDK tenacity retry predicate
- [x] Covered REST exception retry behavior (5xx, 404, other 4xx, transport errors)
- [x] Covered generic exception behavior (no retries)
- [x] Covered gRPC retry behavior across retried vs non-retried status codes
- [x] Documented current retry semantics without changing implementation

