### PR TITLE
fix input validator type

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.1] - 2026-02-10
+
+### Changed
+
+- Fixes a bug introduced in v1.21.0 where the `BaseWorkflow.input_validator` class property became incorrectly typed. Now separate properties are available for the type adapter and the underlying type.
+
+
 ## [1.23.0] - 2026-02-05
 
 ### Internal Only

--- a/sdks/python/hatchet_sdk/runnables/workflow.py
+++ b/sdks/python/hatchet_sdk/runnables/workflow.py
@@ -263,8 +263,12 @@ class BaseWorkflow(Generic[TWorkflowInput]):
         return options_copy
 
     @property
-    def input_validator(self) -> type[TWorkflowInput]:
-        return cast(type[TWorkflowInput], self.config.input_validator)
+    def input_validator(self) -> TypeAdapter[TWorkflowInput]:
+        return cast(TypeAdapter[TWorkflowInput], self.config.input_validator)
+
+    @property
+    def input_validator_type(self) -> type[TWorkflowInput]:
+        return cast(type[TWorkflowInput], self.config.input_validator._type)
 
     @property
     def tasks(self) -> list[Task[TWorkflowInput, Any]]:

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.23.0"
+version = "1.23.1"
 description = "This is the official Python SDK for Hatchet, a distributed, fault-tolerant task queue. The SDK allows you to easily integrate Hatchet's task scheduling and workflow orchestration capabilities into your Python applications."
 authors = [
   "Alexander Belanger <alexander@hatchet.run>",


### PR DESCRIPTION
# Description

Fixes an issue introduced in v1.21.0 where the move to using type adapters broke the return type of the `BaseWorkflow.input_validator` class property method; this method was provided to allow a type checker-friendly way of accessing the input type of a workflow.  

Solution is to allow a type friendly version of both the type adapter and the type to be provided.

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## What's Changed

- [ ] Adds typed class property for input type
- [ ] Fixes typed class property for input validator