### PR TITLE
add type-helped input/output validators to standalone and task

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.3] - 2026-02-12
+
+### Added
+
+- Adds type-hinted `Standalone.output_validator` and `Standalone.output_validator_type` properties to support easier type-safety and match the `input_validator` property pattern on `BaseWorkflow`.
+- Adds type-hinted `Task.output_validator` and `Task.output_validator_type` properties to support easier type-safety and match the patterns on `BaseWorkflow/Standalone`.
+
 ## [1.23.2] - 2026-02-11
 
 ### Changed

--- a/sdks/python/hatchet_sdk/runnables/task.py
+++ b/sdks/python/hatchet_sdk/runnables/task.py
@@ -574,3 +574,11 @@ class Task(Generic[TWorkflowInput, R]):
         )
 
         return await self.aio_call(ctx, dependencies)
+
+    @property
+    def output_validator(self) -> TypeAdapter[R]:
+        return cast(TypeAdapter[R], self.validators.step_output)
+
+    @property
+    def output_validator_type(self) -> type[R]:
+        return cast(type[R], self.validators.step_output._type)

--- a/sdks/python/hatchet_sdk/runnables/workflow.py
+++ b/sdks/python/hatchet_sdk/runnables/workflow.py
@@ -1556,3 +1556,11 @@ class Standalone(BaseWorkflow[TWorkflowInput], Generic[TWorkflowInput, R]):
         run_ref = self.get_run_ref(run_id)
 
         return run_ref.result()
+
+    @property
+    def output_validator(self) -> TypeAdapter[R]:
+        return cast(TypeAdapter[R], self._output_validator)
+
+    @property
+    def output_validator_type(self) -> type[R]:
+        return cast(type[R], self._output_validator._type)

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.23.2"
+version = "1.23.3"
 description = "This is the official Python SDK for Hatchet, a distributed, fault-tolerant task queue. The SDK allows you to easily integrate Hatchet's task scheduling and workflow orchestration capabilities into your Python applications."
 authors = [
   "Alexander Belanger <alexander@hatchet.run>",


### PR DESCRIPTION
# Description

- Adds type-hinted `Standalone.output_validator` and `Standalone.output_validator_type` properties to support easier type-safety and match the `input_validator` property pattern on `BaseWorkflow`.
- Adds type-hinted `Task.output_validator` and `Task.output_validator_type` properties to support easier type-safety and match the patterns on `BaseWorkflow/Standalone`.
- 
## Type of change

- [x] Added features

## What's Changed

(see desc)
