### PR TITLE
Truncate to first 10k characters of log line in Go SDK

### DIFF
--- a/pkg/worker/context.go
+++ b/pkg/worker/context.go
@@ -300,6 +300,12 @@ func (h *hatchetContext) WorkflowVersionId() *string {
 
 func (h *hatchetContext) Log(message string) {
 	infoLevel := "INFO"
+
+	if len(message) > 10_000 {
+		h.l.Warn().Msg("log message is too long, truncating to the first 10,000 characters")
+		message = message[:10_000]
+	}
+
 	err := h.c.Event().PutLog(h, h.a.StepRunId, message, &infoLevel, &h.a.RetryCount)
 
 	if err != nil {

--- a/pkg/worker/context.go
+++ b/pkg/worker/context.go
@@ -301,9 +301,11 @@ func (h *hatchetContext) WorkflowVersionId() *string {
 func (h *hatchetContext) Log(message string) {
 	infoLevel := "INFO"
 
-	if len(message) > 10_000 {
+	runes := []rune(message)
+
+	if len(runes) > 10_000 {
 		h.l.Warn().Msg("log message is too long, truncating to the first 10,000 characters")
-		message = message[:10_000]
+		message = string(runes[:10_000])
 	}
 
 	err := h.c.Event().PutLog(h, h.a.StepRunId, message, &infoLevel, &h.a.RetryCount)


### PR DESCRIPTION
# Description

Just like the Python and TS SDKs, the `ctx.Log()` method will now truncate very long log messages to the first 10k characters.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)