### PR TITLE
Fix: Remove null bytes from error message to prevent db crash

### DIFF
--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"math/rand"
+	"strings"
 	"sync"
 	"time"
 
@@ -748,7 +749,8 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 				event.Output = []byte(eventPayloads[i])
 			}
 		case sqlcv1.V1EventTypeOlapFAILED:
-			event.ErrorMessage = sqlchelpers.TextFromStr(eventPayloads[i])
+			errorMsg := strings.ReplaceAll(eventPayloads[i], "\x00", " ")
+			event.ErrorMessage = sqlchelpers.TextFromStr(errorMsg)
 		case sqlcv1.V1EventTypeOlapCANCELLED:
 			event.AdditionalEventMessage = sqlchelpers.TextFromStr(eventMessages[i])
 		}

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -749,7 +749,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 				event.Output = []byte(eventPayloads[i])
 			}
 		case sqlcv1.V1EventTypeOlapFAILED:
-			errorMsg := strings.ReplaceAll(eventPayloads[i], "\x00", " ")
+			errorMsg := strings.ReplaceAll(eventPayloads[i], "\x00", "")
 			event.ErrorMessage = sqlchelpers.TextFromStr(errorMsg)
 		case sqlcv1.V1EventTypeOlapCANCELLED:
 			event.AdditionalEventMessage = sqlchelpers.TextFromStr(eventMessages[i])


### PR DESCRIPTION
# Description

Removes an illegal byte sequence so we don't crash on the db write

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
