### PR TITLE
[hotfix] Fix Ubicloud runner naming

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   generate:
-    runs-on: ubicloud-standard-6
+    runs-on: ubicloud-standard-4
     env:
       DATABASE_URL: postgresql://hatchet:hatchet@127.0.0.1:5431/hatchet?sslmode=disable
 
@@ -54,7 +54,7 @@ jobs:
         run: docker compose down
 
   unit:
-    runs-on: ubicloud-standard-6
+    runs-on: ubicloud-standard-4
     steps:
       - uses: actions/checkout@v6
       - name: Setup Go
@@ -72,7 +72,7 @@ jobs:
         run: go test $(go list ./... | grep -v "quickstart") -v -failfast
 
   integration:
-    runs-on: ubicloud-standard-6
+    runs-on: ubicloud-standard-4
     env:
       DATABASE_URL: postgresql://hatchet:hatchet@127.0.0.1:5431/hatchet?sslmode=disable
 
@@ -118,7 +118,7 @@ jobs:
         run: docker compose down
 
   e2e:
-    runs-on: ubicloud-standard-6
+    runs-on: ubicloud-standard-4
     timeout-minutes: 30
     env:
       DATABASE_URL: postgresql://hatchet:hatchet@127.0.0.1:5431/hatchet?sslmode=disable
@@ -208,7 +208,7 @@ jobs:
         run: docker compose down
 
   e2e-pgmq:
-    runs-on: ubicloud-standard-6
+    runs-on: ubicloud-standard-4
     timeout-minutes: 30
     env:
       DATABASE_URL: postgresql://hatchet:hatchet@127.0.0.1:5431/hatchet?sslmode=disable
@@ -300,7 +300,7 @@ jobs:
         run: docker compose down
 
   load:
-    runs-on: ubicloud-standard-6
+    runs-on: ubicloud-standard-4
     timeout-minutes: 30
     strategy:
       matrix:
@@ -343,7 +343,7 @@ jobs:
           TESTING_MATRIX_OPTIMISTIC_SCHEDULING: ${{ matrix.optimistic-scheduling }}
 
   rampup:
-    runs-on: ubicloud-standard-6
+    runs-on: ubicloud-standard-4
     timeout-minutes: 30
     strategy:
       matrix:


### PR DESCRIPTION
# Description

`ubicloud-standard-4` is the correct runner name

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)