### PR TITLE
fix(ci/generate): Run format-friendly generate task

### DIFF
--- a/.github/workflows/gen-examples.yml
+++ b/.github/workflows/gen-examples.yml
@@ -11,12 +11,27 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v6
 
+    - name: Install Task
+      uses: arduino/setup-task@v2
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Setup Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: "1.25"
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 10.16.1
+        run_install: false
+
     - uses: actions/setup-python@v6
       with:
         python-version: '3.14'
     - name: Generate snippets
-      working-directory: frontend/snippets
-      run: python3 generate.py
+      run: task install-dependencies pre-commit-install generate-docs -v
 
     - name: Check for changes in examples directory
       id: verify-changed-files


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The newly introduced Taskfile changes automatically format generated files. This PR ensures that the (currently broken)  `gen-examples.yml::generate` CI job uses this task approach, similarly to `test.yml::generate` i.e

https://github.com/hatchet-dev/hatchet/blob/06e0da50fa81b48004135d908a5e1d0b14eb3c73/.github/workflows/test.yml#L25-L39

Once the examples are regenerated, this should fixe the broken `generate` job: https://github.com/hatchet-dev/hatchet/actions/runs/21994591182/job/63550922252

Depends on revert PR https://github.com/hatchet-dev/hatchet/pull/3024

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] CI (any automation pipeline changes)

## What's Changed

- Aligns the `gen-examples.yml::generate` job to use the same taskfile approach as `test.yml:::generate`
