### PR TITLE
fix: ruby add x86_64-linux to lock file

### DIFF
--- a/.github/workflows/sdk-ruby.yml
+++ b/.github/workflows/sdk-ruby.yml
@@ -181,6 +181,9 @@ jobs:
     runs-on: ubicloud-standard-4
     needs: [lint, test]
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
@@ -194,18 +197,27 @@ jobs:
           bundler-cache: true
           working-directory: ./sdks/ruby/src
 
-      - name: Publish to RubyGems
+      - name: Check if version changed
+        id: version_check
         run: |
           NEW_VERSION=$(ruby -e "require_relative 'lib/hatchet/version'; puts Hatchet::VERSION")
           CURRENT_VERSION=$(gem info hatchet-sdk --remote --exact 2>/dev/null | grep -oP 'hatchet-sdk \(\K[^)]+' || echo "0.0.0")
 
           if [ "$CURRENT_VERSION" == "$NEW_VERSION" ]; then
             echo "Version has not changed ($NEW_VERSION). Skipping publish."
-            exit 0
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Publishing version $NEW_VERSION (current: $CURRENT_VERSION)"
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
           fi
 
-          echo "Publishing version $NEW_VERSION (current: $CURRENT_VERSION)"
+      - name: Configure RubyGems credentials
+        if: steps.version_check.outputs.should_publish == 'true'
+        uses: rubygems/configure-rubygems-credentials@main
+
+      - name: Publish to RubyGems
+        if: steps.version_check.outputs.should_publish == 'true'
+        run: |
           gem build hatchet-sdk.gemspec
+          NEW_VERSION=$(ruby -e "require_relative 'lib/hatchet/version'; puts Hatchet::VERSION")
           gem push hatchet-sdk-${NEW_VERSION}.gem
-        env:
-          GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}

--- a/sdks/ruby/examples/Gemfile.lock
+++ b/sdks/ruby/examples/Gemfile.lock
@@ -30,12 +30,18 @@ GEM
     google-protobuf (4.33.5-arm64-darwin)
       bigdecimal
       rake (>= 13)
+    google-protobuf (4.33.5-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
     googleapis-common-protos-types (1.22.0)
       google-protobuf (~> 4.26)
     grpc (1.78.0)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
     grpc (1.78.0-arm64-darwin)
+      google-protobuf (>= 3.25, < 5.0)
+      googleapis-common-protos-types (~> 1.0)
+    grpc (1.78.0-x86_64-linux-gnu)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
     json (2.13.2)
@@ -63,6 +69,7 @@ GEM
 PLATFORMS
   arm64-darwin-24
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   hatchet-sdk!

--- a/sdks/ruby/src/Gemfile.lock
+++ b/sdks/ruby/src/Gemfile.lock
@@ -34,12 +34,18 @@ GEM
     google-protobuf (4.33.5-arm64-darwin)
       bigdecimal
       rake (>= 13)
+    google-protobuf (4.33.5-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
     googleapis-common-protos-types (1.22.0)
       google-protobuf (~> 4.26)
     grpc (1.78.0)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
     grpc (1.78.0-arm64-darwin)
+      google-protobuf (>= 3.25, < 5.0)
+      googleapis-common-protos-types (~> 1.0)
+    grpc (1.78.0-x86_64-linux-gnu)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
     grpc-tools (1.78.0)
@@ -113,6 +119,7 @@ GEM
 PLATFORMS
   arm64-darwin-24
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   faraday (~> 2.0)


### PR DESCRIPTION
# Description

Adds the x86_64-linux to lockfile to prevent building dependencies from source on CI.

## Type of change

- [x] CI (any automation pipeline changes)

