### PR TITLE
docs(python-sdk): clarify retry and transport error semantics

### DIFF
--- a/sdks/python/docs/retries.md
+++ b/sdks/python/docs/retries.md
@@ -1,0 +1,37 @@
+1️⃣ REST Retry Behavior
+
+Retries:
+
+5xx → ServiceException
+
+404 → NotFoundException (current behavior)
+
+Does NOT retry:
+
+Transport errors (unless TenacityConfig enabled)
+
+Mutating verbs by default
+
+2️⃣ gRPC Retry Behavior
+
+Retries most transient codes
+
+Excludes clearly permanent status codes
+
+Driven by Tenacity retry predicate
+
+3️⃣ Transport Errors
+
+Timeout
+
+Connection errors
+
+TLS/protocol errors
+
+Configurable via TenacityConfig
+
+4️⃣ Idempotency Note
+
+Clear warning:
+
+Retrying mutating operations may duplicate side effects. Ensure idempotency guarantees on backend before enabling aggressive retries.

--- a/sdks/python/hatchet_sdk/connection.py
+++ b/sdks/python/hatchet_sdk/connection.py
@@ -1,11 +1,11 @@
 import os
-from typing import Literal, cast, overload, Callable, TypeVar
+from collections.abc import Callable
+from typing import Literal, TypeVar, cast, overload
 
 import grpc
 
 from hatchet_sdk.config import ClientConfig
 from hatchet_sdk.exceptions import HatchetError
-
 
 T = TypeVar("T")
 


### PR DESCRIPTION
Description

Adds documentation clarifying the current retry behavior and transport error handling for the Python SDK (REST and gRPC).

This PR does not change any retry behavior. It documents the existing semantics to make failure handling clearer for users and reduce ambiguity around transport errors and idempotency.

Fixes # 2872

Type of change

 Documentation change (pure documentation change)

What's Changed

Documented REST retry behavior:

Retries on 5xx errors

Current handling of 404 responses

Transport errors and their behavior

Documented gRPC retry behavior:

Transient vs permanent status codes

How the retry predicate works

Clarified how TenacityConfig affects transport-level retries

Added notes about idempotency considerations for mutating operations