### PR TITLE
fix(sdk): Configure logger for Hatchet client

### DIFF
--- a/frontend/docs/pages/self-hosting/worker-configuration-options.mdx
+++ b/frontend/docs/pages/self-hosting/worker-configuration-options.mdx
@@ -44,6 +44,7 @@ These variables enable a local HTTP server that exposes `/health` and `/metrics`
 
 | Variable                                      | Description                                         | Default Value |
 | --------------------------------------------- | --------------------------------------------------- | ------------- |
-| `HATCHET_CLIENT_LOG_LEVEL`                    | Log level for the worker                            | `INFO`        |
+| `HATCHET_CLIENT_LOG_LEVEL`                    | Log level for the worker client                     | `WARN`        |
+| `HATCHET_CLIENT_LOG_FORMAT`                   | Log format for the worker client                    | `console`     |
 | `HATCHET_CLIENT_GRPC_MAX_RECV_MESSAGE_LENGTH` | Maximum gRPC message receive size (Python SDK only) | `4MB`         |
 | `HATCHET_CLIENT_GRPC_MAX_SEND_MESSAGE_LENGTH` | Maximum gRPC message send size (Python SDK only)    | `4MB`         |

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -130,7 +130,7 @@ func defaultClientOpts(token *string, cf *client.ClientConfigFile) *ClientOpts {
 		}
 	}
 
-	logger := logger.NewDefaultLogger("client")
+	logger := logger.NewStdErr(&clientConfig.Logger, "client")
 
 	return &ClientOpts{
 		tenantId:               clientConfig.TenantId,

--- a/pkg/client/loader/loader.go
+++ b/pkg/client/loader/loader.go
@@ -139,6 +139,7 @@ func GetClientConfigFromConfigFile(tokenOverride *string, cf *client.ClientConfi
 	return &client.ClientConfig{
 		TenantId:               cf.TenantId,
 		TLSConfig:              tlsConf,
+		Logger:                 cf.Logger,
 		Token:                  cf.Token,
 		ServerURL:              serverURL,
 		GRPCBroadcastAddress:   grpcBroadcastAddress,

--- a/pkg/config/client/client.go
+++ b/pkg/config/client/client.go
@@ -21,6 +21,8 @@ type ClientConfigFile struct {
 	// corresponding to the gRPC engine service.
 	ServerURL string `mapstructure:"serverURL" json:"serverURL,omitempty"`
 
+	Logger shared.LoggerConfigFile `mapstructure:"log" json:"log,omitempty"`
+
 	TLS ClientTLSConfigFile `mapstructure:"tls" json:"tls,omitempty"`
 
 	Namespace string `mapstructure:"namespace" json:"namespace,omitempty"`
@@ -50,6 +52,8 @@ type ClientConfig struct {
 	ServerURL            string
 	GRPCBroadcastAddress string
 
+	Logger shared.LoggerConfigFile
+
 	// TLSConfig will be nil if the strategy is "none"
 	TLSConfig *tls.Config
 
@@ -69,6 +73,13 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("hostPort", "HATCHET_CLIENT_HOST_PORT")
 	_ = v.BindEnv("serverURL", "HATCHET_CLIENT_SERVER_URL")
 	_ = v.BindEnv("namespace", "HATCHET_CLIENT_NAMESPACE")
+
+	// logger options
+	_ = v.BindEnv("log.level", "HATCHET_CLIENT_LOG_LEVEL")
+	_ = v.BindEnv("log.format", "HATCHET_CLIENT_LOG_FORMAT")
+	// to ensure backwards compatability with previous log settings
+	v.SetDefault("log.level", "debug")
+	v.SetDefault("log.format", "json")
 
 	_ = v.BindEnv("cloudRegisterID", "HATCHET_CLOUD_REGISTER_ID")
 	_ = v.BindEnv("runnableActions", "HATCHET_CLOUD_ACTIONS")


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Currently, the `HATCHET_CLIENT_LOG_LEVEL` never gets propogated to the client logger. This PR ensures we an init a logger using `HATCHET_CLIENT_LOG_LEVEL` and `HATCHET_CLIENT_LOG_FORMAT` config.

Fixes https://github.com/hatchet-dev/hatchet/issues/3008

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## What's Changed

- Support setting the client log level and type via `HATCHET_CLIENT_LOG_LEVEL` and `HATCHET_CLIENT_LOG_FORMAT` respectively.
- The default log level for the hatchet client changes from `DEBUG` to `WARN` and the format from `JSON` to `CONSOLE`.
