### PR TITLE
fix: restore ctx.taskRunId

### DIFF
--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hatchet's TypeScript SDK will be documented in this chang
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.1] - 2026-02-18
+
+### Fixed
+
+- Restored `ctx.taskRunId()` as a deprecated alias for `ctx.taskRunExternalId()` on both v0 and v1 worker contexts, so existing code calling `ctx.taskRunId()` continues to work after the proto naming changes in 1.11.0.
+
 ## [1.12.0] - 2026-02-13
 
 ### Added

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Background task orchestration & visibility for developers",
   "types": "dist/index.d.ts",
   "files": [

--- a/sdks/typescript/src/step.ts
+++ b/sdks/typescript/src/step.ts
@@ -307,6 +307,15 @@ export class V0Context<T, K = {}> {
   }
 
   /**
+   * Gets the ID of the current task run.
+   * @returns The task run ID.
+   * @deprecated use taskRunExternalId() instead
+   */
+  taskRunId(): string {
+    return this.taskRunExternalId();
+  }
+
+  /**
    * Gets the number of times the current task has been retried.
    * @returns The retry count.
    */

--- a/sdks/typescript/src/v1/client/worker/context.ts
+++ b/sdks/typescript/src/v1/client/worker/context.ts
@@ -230,6 +230,15 @@ export class Context<T, K = {}> {
   }
 
   /**
+   * Gets the ID of the current task run.
+   * @returns The task run ID.
+   * @deprecated use taskRunExternalId() instead
+   */
+  taskRunId(): string {
+    return this.taskRunExternalId();
+  }
+
+  /**
    * Gets the number of times the current task has been retried.
    * @returns The retry count.
    */


### PR DESCRIPTION
# Description

Restored `ctx.taskRunId()` as a deprecated alias for `ctx.taskRunExternalId()` on both v0 and v1 worker contexts, so existing code calling `ctx.taskRunId()` continues to work after the proto naming changes in 1.11.0.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
