### PR TITLE
feat(cli): runs commands

### DIFF
--- a/.github/workflows/cli-e2e-tests.yml
+++ b/.github/workflows/cli-e2e-tests.yml
@@ -3,6 +3,7 @@ name: cli-e2e-tests
 on:
   pull_request:
     paths:
+      - ".github/workflows/cli-e2e-tests.yml"
       - "cmd/hatchet-cli/cli/templates/**"
       - "cmd/hatchet-cli/cli/quickstart.go"
       - "cmd/hatchet-cli/cli/internal/templater/**"
@@ -16,6 +17,7 @@ on:
     branches:
       - main
     paths:
+      - ".github/workflows/cli-e2e-tests.yml"
       - "cmd/hatchet-cli/cli/templates/**"
       - "cmd/hatchet-cli/cli/quickstart.go"
       - "cmd/hatchet-cli/cli/internal/templater/**"
@@ -42,7 +44,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: "3.13" # pinned because of poetry dependency issue
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/cli-e2e-tests.yml
+++ b/.github/workflows/cli-e2e-tests.yml
@@ -12,7 +12,6 @@ on:
       - "cmd/hatchet-cli/cli/*_e2e_test.go"
       - "cmd/hatchet-cli/cli/tui/**"
       - "cmd/hatchet-cli/cli/testharness/**"
-      - ".github/workflows/cli-e2e-tests.yml"
   push:
     branches:
       - main

--- a/.github/workflows/cli-e2e-tests.yml
+++ b/.github/workflows/cli-e2e-tests.yml
@@ -7,7 +7,11 @@ on:
       - "cmd/hatchet-cli/cli/quickstart.go"
       - "cmd/hatchet-cli/cli/internal/templater/**"
       - "cmd/hatchet-cli/cli/quickstart_e2e_test.go"
-      - ".github/workflows/test-templates.yml"
+      - "cmd/hatchet-cli/cli/*.go"
+      - "cmd/hatchet-cli/cli/*_e2e_test.go"
+      - "cmd/hatchet-cli/cli/tui/**"
+      - "cmd/hatchet-cli/cli/testharness/**"
+      - ".github/workflows/cli-e2e-tests.yml"
   push:
     branches:
       - main
@@ -16,11 +20,15 @@ on:
       - "cmd/hatchet-cli/cli/quickstart.go"
       - "cmd/hatchet-cli/cli/internal/templater/**"
       - "cmd/hatchet-cli/cli/quickstart_e2e_test.go"
+      - "cmd/hatchet-cli/cli/*.go"
+      - "cmd/hatchet-cli/cli/*_e2e_test.go"
+      - "cmd/hatchet-cli/cli/tui/**"
+      - "cmd/hatchet-cli/cli/testharness/**"
 
 jobs:
   test-templates:
     runs-on: ubicloud-standard-4
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
@@ -56,6 +64,9 @@ jobs:
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
 
+      - name: Install tmux
+        run: sudo apt-get install -y tmux
+
       - name: Build CLI
         run: |
           cd cmd/hatchet-cli
@@ -79,8 +90,16 @@ jobs:
           cd cmd/hatchet-cli/cli
           go test -tags e2e_cli -run TestQuickstartTemplates -v -timeout 15m
         env:
-          # Ensure tests don't try to interact with stdin
           CI: true
+
+      - name: Run resource E2E tests
+        run: |
+          cd cmd/hatchet-cli/cli
+          go test -tags e2e_cli \
+            -run 'Test(Runs|Workflows|Worker|RateLimits|Scheduled|Cron|Webhooks)' \
+            -v -timeout 10m
+        env:
+          HATCHET_CLI_PROFILE: local
 
       - name: Show server logs on failure
         if: failure()

--- a/cmd/hatchet-cli/cli/client.go
+++ b/cmd/hatchet-cli/cli/client.go
@@ -1,9 +1,13 @@
 package cli
 
 import (
+	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
 
-	"github.com/hatchet-dev/hatchet/pkg/client"
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/config/cli"
+	"github.com/hatchet-dev/hatchet/pkg/client" //nolint:staticcheck
 	profileconfig "github.com/hatchet-dev/hatchet/pkg/config/cli"
 	clientconfig "github.com/hatchet-dev/hatchet/pkg/config/client"
 	"github.com/hatchet-dev/hatchet/pkg/config/shared"
@@ -11,7 +15,7 @@ import (
 
 // NewClientFromProfile creates a new Hatchet client from a profile configuration.
 // It properly handles TLS settings, host/port, and authentication based on the profile.
-func NewClientFromProfile(profile *profileconfig.Profile, logger *zerolog.Logger) (client.Client, error) {
+func NewClientFromProfile(profile *profileconfig.Profile, logger *zerolog.Logger) (client.Client, error) { //nolint:staticcheck
 	// Construct a ClientConfigFile from the profile
 	configFile := &clientconfig.ClientConfigFile{
 		TenantId:  profile.TenantId,
@@ -26,5 +30,46 @@ func NewClientFromProfile(profile *profileconfig.Profile, logger *zerolog.Logger
 	}
 
 	// Create client with the config file and logger
-	return client.NewFromConfigFile(configFile, client.WithLogger(logger))
+	return client.NewFromConfigFile(configFile, client.WithLogger(logger)) //nolint:staticcheck
+}
+
+// clientFromCmd selects a profile and returns a Hatchet client.
+// The profile is read from the --profile flag if present, otherwise selected interactively.
+func clientFromCmd(cmd *cobra.Command) (string, client.Client) { //nolint:staticcheck
+	profileFlag, _ := cmd.Flags().GetString("profile")
+
+	var selectedProfile string
+	if profileFlag != "" {
+		selectedProfile = profileFlag
+	} else {
+		selectedProfile = selectProfileForm(true)
+		if selectedProfile == "" {
+			selectedProfile = handleNoProfiles(cmd)
+			if selectedProfile == "" {
+				cli.Logger.Fatal("no profile selected or created")
+			}
+		}
+	}
+
+	profile, err := cli.GetProfile(selectedProfile)
+	if err != nil {
+		cli.Logger.Fatalf("could not get profile '%s': %v", selectedProfile, err)
+	}
+
+	nopLogger := zerolog.Nop()
+	hatchetClient, err := NewClientFromProfile(profile, &nopLogger)
+	if err != nil {
+		cli.Logger.Fatalf("could not create Hatchet client: %v", err)
+	}
+
+	return selectedProfile, hatchetClient
+}
+
+// clientTenantUUID parses and returns the tenant UUID from the client configuration.
+func clientTenantUUID(hatchetClient client.Client) openapi_types.UUID { //nolint:staticcheck
+	parsed, err := uuid.Parse(hatchetClient.TenantId())
+	if err != nil {
+		cli.Logger.Fatalf("invalid tenant ID: %v", err)
+	}
+	return parsed
 }

--- a/cmd/hatchet-cli/cli/client.go
+++ b/cmd/hatchet-cli/cli/client.go
@@ -33,14 +33,25 @@ func NewClientFromProfile(profile *profileconfig.Profile, logger *zerolog.Logger
 	return client.NewFromConfigFile(configFile, client.WithLogger(logger)) //nolint:staticcheck
 }
 
+// clientCmdConfig holds CLI flag values used to create a Hatchet client.
+type clientCmdConfig struct {
+	Profile string
+}
+
+// readClientCmdConfig reads client-related flags from a command into a config struct.
+func readClientCmdConfig(cmd *cobra.Command) clientCmdConfig {
+	profile, _ := cmd.Flags().GetString("profile")
+	return clientCmdConfig{Profile: profile}
+}
+
 // clientFromCmd selects a profile and returns a Hatchet client.
 // The profile is read from the --profile flag if present, otherwise selected interactively.
 func clientFromCmd(cmd *cobra.Command) (string, client.Client) { //nolint:staticcheck
-	profileFlag, _ := cmd.Flags().GetString("profile")
+	cfg := readClientCmdConfig(cmd)
 
 	var selectedProfile string
-	if profileFlag != "" {
-		selectedProfile = profileFlag
+	if cfg.Profile != "" {
+		selectedProfile = cfg.Profile
 	} else {
 		selectedProfile = selectProfileForm(true)
 		if selectedProfile == "" {

--- a/cmd/hatchet-cli/cli/crons.go
+++ b/cmd/hatchet-cli/cli/crons.go
@@ -1,0 +1,347 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/huh"
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/config/cli"
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/styles"
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/tui"
+	"github.com/hatchet-dev/hatchet/pkg/client/rest"
+)
+
+var cronCmd = &cobra.Command{
+	Use:     "cron",
+	Aliases: []string{"crons", "cron-job", "cron-jobs"},
+	Short:   "Manage cron jobs",
+	Long:    `Commands for listing, inspecting, creating, enabling, disabling, and deleting cron jobs.`,
+	Run:     func(cmd *cobra.Command, args []string) { _ = cmd.Help() },
+}
+
+var cronListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List cron jobs",
+	Long:  `List cron jobs. Without --output json, launches the interactive TUI. With --output json, outputs raw JSON.`,
+	Example: `  # Launch interactive TUI (default)
+  hatchet cron list --profile local
+
+  # JSON output
+  hatchet cron list -o json`,
+	Run: func(cmd *cobra.Command, args []string) {
+		isJSON := isJSONOutput(cmd)
+		selectedProfile, hatchetClient := clientFromCmd(cmd)
+
+		if !isJSON {
+			tuiM := newTUIModel(selectedProfile, hatchetClient)
+			tuiM.currentViewType = ViewTypeCronJobs
+			tuiM.currentView = tui.NewCronJobsView(tuiM.ctx)
+			p := tea.NewProgram(tuiM, tea.WithAltScreen())
+			if _, err := p.Run(); err != nil {
+				cli.Logger.Fatalf("error running TUI: %v", err)
+			}
+			return
+		}
+
+		ctx := cmd.Context()
+		tenantUUID := clientTenantUUID(hatchetClient)
+		limit, _ := cmd.Flags().GetInt64("limit")
+		offset, _ := cmd.Flags().GetInt64("offset")
+
+		resp, err := hatchetClient.API().CronWorkflowListWithResponse(ctx, tenantUUID, &rest.CronWorkflowListParams{
+			Limit:  &limit,
+			Offset: &offset,
+		})
+		if err != nil {
+			cli.Logger.Fatalf("failed to list cron jobs: %v", err)
+		}
+		if resp.JSON200 == nil {
+			cli.Logger.Fatalf("unexpected response from API (status %d)", resp.StatusCode())
+		}
+
+		printJSON(resp.JSON200)
+	},
+}
+
+var cronGetCmd = &cobra.Command{
+	Use:   "get <cron-id>",
+	Short: "Get cron job details",
+	Long:  `Get details about a cron job. Outputs raw JSON.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		cronID := args[0]
+		_, hatchetClient := clientFromCmd(cmd)
+
+		cronUUID, err := uuid.Parse(cronID)
+		if err != nil {
+			cli.Logger.Fatalf("invalid cron job ID %q: %v", cronID, err)
+		}
+
+		ctx := cmd.Context()
+		tenantUUID := clientTenantUUID(hatchetClient)
+		resp, err := hatchetClient.API().WorkflowCronGetWithResponse(ctx, tenantUUID, cronUUID)
+		if err != nil {
+			cli.Logger.Fatalf("failed to get cron job: %v", err)
+		}
+		if resp.JSON200 == nil {
+			cli.Logger.Fatalf("cron job not found (status %d)", resp.StatusCode())
+		}
+
+		printJSON(resp.JSON200)
+	},
+}
+
+var cronCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a cron job",
+	Long:  `Create a new cron job. In --output json mode, all required flags must be set. Otherwise, launches an interactive form.`,
+	Example: `  # Interactive mode
+  hatchet cron create --profile local
+
+  # JSON mode (required flags)
+  hatchet cron create --workflow my-workflow --cron "0 * * * *" --name my-cron -o json`,
+	Run: func(cmd *cobra.Command, args []string) {
+		isJSON := isJSONOutput(cmd)
+		_, hatchetClient := clientFromCmd(cmd)
+
+		workflowStr, _ := cmd.Flags().GetString("workflow")
+		cronExpr, _ := cmd.Flags().GetString("cron")
+		cronName, _ := cmd.Flags().GetString("name")
+		inputStr, _ := cmd.Flags().GetString("input")
+		inputFile, _ := cmd.Flags().GetString("input-file")
+
+		if !isJSON {
+			// Interactive mode
+			form := huh.NewForm(
+				huh.NewGroup(
+					huh.NewInput().
+						Title("Workflow name or ID").
+						Value(&workflowStr).
+						Placeholder("my-workflow"),
+				),
+				huh.NewGroup(
+					huh.NewInput().
+						Title("Cron expression").
+						Value(&cronExpr).
+						Placeholder("0 * * * *"),
+				),
+				huh.NewGroup(
+					huh.NewInput().
+						Title("Cron job name (optional)").
+						Value(&cronName).
+						Placeholder("my-cron"),
+				),
+				huh.NewGroup(
+					huh.NewInput().
+						Title("Input JSON (optional)").
+						Value(&inputStr).
+						Placeholder("{}"),
+				),
+			).WithTheme(styles.HatchetTheme())
+			if err := form.Run(); err != nil {
+				cli.Logger.Fatalf("form cancelled: %v", err)
+			}
+		}
+
+		if workflowStr == "" {
+			cli.Logger.Fatal("--workflow is required")
+		}
+		if cronExpr == "" {
+			cli.Logger.Fatal("--cron is required")
+		}
+
+		// Build input map
+		inputData := map[string]interface{}{}
+		if inputFile != "" {
+			data, err := os.ReadFile(inputFile)
+			if err != nil {
+				cli.Logger.Fatalf("failed to read --input-file: %v", err)
+			}
+			if err := json.Unmarshal(data, &inputData); err != nil {
+				cli.Logger.Fatalf("failed to parse --input-file as JSON: %v", err)
+			}
+		} else if inputStr != "" {
+			if err := json.Unmarshal([]byte(inputStr), &inputData); err != nil {
+				cli.Logger.Fatalf("failed to parse --input as JSON: %v", err)
+			}
+		}
+
+		ctx := cmd.Context()
+		tenantUUID := clientTenantUUID(hatchetClient)
+
+		// Resolve workflow name (the create endpoint uses name as path param, not UUID)
+		workflowName, err := resolveWorkflowName(ctx, hatchetClient, workflowStr)
+		if err != nil {
+			cli.Logger.Fatalf("could not resolve workflow: %v", err)
+		}
+
+		if cronName == "" {
+			cronName = workflowName + "-cron"
+		}
+
+		resp, err := hatchetClient.API().CronWorkflowTriggerCreateWithResponse(ctx, tenantUUID, workflowName, rest.CronWorkflowTriggerCreateJSONRequestBody{
+			CronExpression:     cronExpr,
+			CronName:           cronName,
+			Input:              inputData,
+			AdditionalMetadata: map[string]interface{}{},
+		})
+		if err != nil {
+			cli.Logger.Fatalf("failed to create cron job: %v", err)
+		}
+		if resp.JSON200 == nil {
+			cli.Logger.Fatalf("unexpected response from API (status %d): %s", resp.StatusCode(), string(resp.Body))
+		}
+
+		if isJSON {
+			printJSON(resp.JSON200)
+		} else {
+			fmt.Println(styles.SuccessMessage(fmt.Sprintf("Created cron job: %s", resp.JSON200.Metadata.Id)))
+		}
+	},
+}
+
+var cronDeleteCmd = &cobra.Command{
+	Use:   "delete <cron-id>",
+	Short: "Delete a cron job",
+	Long:  `Delete a cron job by ID. Use --yes to skip confirmation.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		cronID := args[0]
+		isJSON := isJSONOutput(cmd)
+		yes, _ := cmd.Flags().GetBool("yes")
+		_, hatchetClient := clientFromCmd(cmd)
+
+		cronUUID, err := uuid.Parse(cronID)
+		if err != nil {
+			cli.Logger.Fatalf("invalid cron job ID %q: %v", cronID, err)
+		}
+
+		if !isJSON && !yes {
+			if !confirmAction(fmt.Sprintf("Delete cron job '%s'?", shortID(cronID))) {
+				fmt.Println("Aborted.")
+				return
+			}
+		}
+
+		ctx := cmd.Context()
+		tenantUUID := clientTenantUUID(hatchetClient)
+		resp, err := hatchetClient.API().WorkflowCronDeleteWithResponse(ctx, tenantUUID, cronUUID)
+		if err != nil {
+			cli.Logger.Fatalf("failed to delete cron job: %v", err)
+		}
+		if resp.StatusCode() >= 400 {
+			cli.Logger.Fatalf("failed to delete cron job (status %d)", resp.StatusCode())
+		}
+
+		if isJSON {
+			printJSON(map[string]interface{}{"deleted": true, "id": cronID})
+		} else {
+			fmt.Println(styles.SuccessMessage(fmt.Sprintf("Deleted cron job: %s", cronID)))
+		}
+	},
+}
+
+var cronEnableCmd = &cobra.Command{
+	Use:   "enable <cron-id>",
+	Short: "Enable a cron job",
+	Long:  `Enable a cron job by ID.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		cronID := args[0]
+		isJSON := isJSONOutput(cmd)
+		_, hatchetClient := clientFromCmd(cmd)
+
+		cronUUID, err := uuid.Parse(cronID)
+		if err != nil {
+			cli.Logger.Fatalf("invalid cron job ID %q: %v", cronID, err)
+		}
+
+		ctx := cmd.Context()
+		tenantUUID := clientTenantUUID(hatchetClient)
+		enabled := true
+		resp, err := hatchetClient.API().WorkflowCronUpdateWithResponse(ctx, tenantUUID, cronUUID, rest.WorkflowCronUpdateJSONRequestBody{
+			Enabled: &enabled,
+		})
+		if err != nil {
+			cli.Logger.Fatalf("failed to enable cron job: %v", err)
+		}
+		if resp.StatusCode() >= 400 {
+			cli.Logger.Fatalf("failed to enable cron job (status %d)", resp.StatusCode())
+		}
+
+		if isJSON {
+			printJSON(map[string]interface{}{"enabled": true, "id": cronID})
+		} else {
+			fmt.Println(styles.SuccessMessage(fmt.Sprintf("Enabled cron job: %s", cronID)))
+		}
+	},
+}
+
+var cronDisableCmd = &cobra.Command{
+	Use:   "disable <cron-id>",
+	Short: "Disable a cron job",
+	Long:  `Disable a cron job by ID. Use --yes to skip confirmation.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		cronID := args[0]
+		isJSON := isJSONOutput(cmd)
+		yes, _ := cmd.Flags().GetBool("yes")
+		_, hatchetClient := clientFromCmd(cmd)
+
+		cronUUID, err := uuid.Parse(cronID)
+		if err != nil {
+			cli.Logger.Fatalf("invalid cron job ID %q: %v", cronID, err)
+		}
+
+		if !isJSON && !yes {
+			if !confirmAction(fmt.Sprintf("Disable cron job '%s'?", shortID(cronID))) {
+				fmt.Println("Aborted.")
+				return
+			}
+		}
+
+		ctx := cmd.Context()
+		tenantUUID := clientTenantUUID(hatchetClient)
+		enabled := false
+		resp, err := hatchetClient.API().WorkflowCronUpdateWithResponse(ctx, tenantUUID, cronUUID, rest.WorkflowCronUpdateJSONRequestBody{
+			Enabled: &enabled,
+		})
+		if err != nil {
+			cli.Logger.Fatalf("failed to disable cron job: %v", err)
+		}
+		if resp.StatusCode() >= 400 {
+			cli.Logger.Fatalf("failed to disable cron job (status %d)", resp.StatusCode())
+		}
+
+		if isJSON {
+			printJSON(map[string]interface{}{"enabled": false, "id": cronID})
+		} else {
+			fmt.Println(styles.SuccessMessage(fmt.Sprintf("Disabled cron job: %s", cronID)))
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(cronCmd)
+	cronCmd.AddCommand(cronListCmd, cronGetCmd, cronCreateCmd, cronDeleteCmd, cronEnableCmd, cronDisableCmd)
+
+	cronCmd.PersistentFlags().StringP("profile", "p", "", "Profile to use for connecting to Hatchet (default: prompts for selection)")
+	cronCmd.PersistentFlags().StringP("output", "o", "", "Output format: json (skips interactive TUI)")
+
+	cronListCmd.Flags().Int64("limit", 50, "Number of results to return")
+	cronListCmd.Flags().Int64("offset", 0, "Offset for pagination")
+
+	cronCreateCmd.Flags().StringP("workflow", "w", "", "Workflow name or ID")
+	cronCreateCmd.Flags().StringP("cron", "c", "", "Cron expression (e.g. '0 * * * *')")
+	cronCreateCmd.Flags().StringP("name", "n", "", "Cron job name")
+	cronCreateCmd.Flags().StringP("input", "i", "", "Input JSON string")
+	cronCreateCmd.Flags().String("input-file", "", "Path to a JSON file for input")
+
+	cronDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+	cronDisableCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+}

--- a/cmd/hatchet-cli/cli/crons_e2e_test.go
+++ b/cmd/hatchet-cli/cli/crons_e2e_test.go
@@ -1,0 +1,124 @@
+//go:build e2e_cli
+
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/testharness"
+)
+
+func TestCronListJSON(t *testing.T) {
+	h := testharness.New(t)
+	out := h.RunJSON("cron", "list")
+
+	var result struct {
+		Rows []map[string]interface{} `json:"rows"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("failed to unmarshal cron list output: %v\nOutput: %s", err, out)
+	}
+
+	if result.Rows == nil {
+		t.Errorf("expected 'rows' array in response, got nil")
+	}
+
+	// If rows exist, validate expected fields
+	for i, row := range result.Rows {
+		if row["cron"] == nil && row["cronExpression"] == nil {
+			t.Logf("row[%d]: cron expression field not found; available fields: %v", i, keys(row))
+		}
+	}
+}
+
+func TestCronCreateDisableDeleteJSON(t *testing.T) {
+	workflowID := os.Getenv("HATCHET_TEST_WORKFLOW_ID")
+	if workflowID == "" {
+		t.Skip("HATCHET_TEST_WORKFLOW_ID not set; skipping cron create/disable/delete test")
+	}
+
+	h := testharness.New(t)
+
+	// Create a cron job
+	createOut := h.RunJSON("cron", "create",
+		"--workflow", workflowID,
+		"--cron", "0 * * * *",
+		"--name", "e2e-test-cron",
+	)
+
+	var created struct {
+		Metadata struct {
+			ID string `json:"id"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(createOut, &created); err != nil {
+		t.Fatalf("failed to unmarshal cron create output: %v\nOutput: %s", err, createOut)
+	}
+	if created.Metadata.ID == "" {
+		t.Fatal("expected metadata.id in cron create response")
+	}
+
+	cronID := created.Metadata.ID
+	t.Logf("Created cron job: %s", cronID)
+
+	// Disable the cron job
+	disableOut := h.RunJSON("cron", "disable", "--yes", cronID)
+
+	var disabled struct {
+		Enabled bool   `json:"enabled"`
+		ID      string `json:"id"`
+	}
+	if err := json.Unmarshal(disableOut, &disabled); err != nil {
+		t.Fatalf("failed to unmarshal cron disable output: %v\nOutput: %s", err, disableOut)
+	}
+	if disabled.Enabled {
+		t.Errorf("expected enabled=false after disable, got: %s", disableOut)
+	}
+
+	// Delete the cron job
+	deleteOut := h.RunJSON("cron", "delete", "--yes", cronID)
+
+	var deleted struct {
+		Deleted bool   `json:"deleted"`
+		ID      string `json:"id"`
+	}
+	if err := json.Unmarshal(deleteOut, &deleted); err != nil {
+		t.Fatalf("failed to unmarshal cron delete output: %v\nOutput: %s", err, deleteOut)
+	}
+	if !deleted.Deleted {
+		t.Errorf("expected deleted=true, got: %s", deleteOut)
+	}
+	if deleted.ID != cronID {
+		t.Errorf("expected deleted id %q, got %q", cronID, deleted.ID)
+	}
+
+	t.Logf("Deleted cron job: %s", cronID)
+}
+
+func TestCronTUI(t *testing.T) {
+	h := testharness.New(t)
+	tui := testharness.NewTUI(t, h)
+	t.Cleanup(tui.Stop)
+
+	tui.Start("cron", "list")
+	content := tui.CaptureAfter(3 * time.Second)
+
+	if content == "" {
+		t.Fatal("TUI output was empty")
+	}
+	if !containsAny(content, "Cron Jobs", "Cron", "Expression") {
+		t.Errorf("expected TUI to show 'Cron Jobs' header; got:\n%s", content)
+	}
+}
+
+// keys returns the map keys as a slice for logging purposes.
+func keys(m map[string]interface{}) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}

--- a/cmd/hatchet-cli/cli/profile.go
+++ b/cmd/hatchet-cli/cli/profile.go
@@ -319,6 +319,7 @@ func init() {
 	profileRemoveCmd.Flags().StringP("name", "n", "", "Name of the profile to remove (prompted if not provided)")
 
 	// Add flags to profile show command
+	profileShowCmd.Flags().StringP("name", "n", "", "Name of the profile to show (prompted if not provided)")
 	profileShowCmd.Flags().Bool("show-token", false, "Show the full token (default: masked)")
 
 	// Add flags to profile update command

--- a/cmd/hatchet-cli/cli/rate_limits.go
+++ b/cmd/hatchet-cli/cli/rate_limits.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/spf13/cobra"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/config/cli"
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/tui"
+	"github.com/hatchet-dev/hatchet/pkg/client/rest"
+)
+
+var rateLimitsCmd = &cobra.Command{
+	Use:     "rate-limits",
+	Aliases: []string{"rate-limit", "rl", "rls"},
+	Short:   "Manage rate limits",
+	Long:    `Commands for listing and viewing rate limit usage.`,
+	Run:     func(cmd *cobra.Command, args []string) { _ = cmd.Help() },
+}
+
+var rateLimitsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List rate limits",
+	Long:  `List rate limits. Without --output json, launches the interactive TUI. With --output json, outputs raw JSON.`,
+	Example: `  # Launch interactive TUI (default)
+  hatchet rate-limits list --profile local
+
+  # JSON output
+  hatchet rate-limits list -o json`,
+	Run: func(cmd *cobra.Command, args []string) {
+		isJSON := isJSONOutput(cmd)
+		selectedProfile, hatchetClient := clientFromCmd(cmd)
+
+		if !isJSON {
+			tuiM := newTUIModel(selectedProfile, hatchetClient)
+			tuiM.currentViewType = ViewTypeRateLimits
+			tuiM.currentView = tui.NewRateLimitsView(tuiM.ctx)
+			p := tea.NewProgram(tuiM, tea.WithAltScreen())
+			if _, err := p.Run(); err != nil {
+				cli.Logger.Fatalf("error running TUI: %v", err)
+			}
+			return
+		}
+
+		ctx := cmd.Context()
+		tenantUUID := clientTenantUUID(hatchetClient)
+		searchStr, _ := cmd.Flags().GetString("search")
+		limit, _ := cmd.Flags().GetInt64("limit")
+		offset, _ := cmd.Flags().GetInt64("offset")
+
+		params := &rest.RateLimitListParams{
+			Limit:  &limit,
+			Offset: &offset,
+		}
+		if searchStr != "" {
+			params.Search = &searchStr
+		}
+
+		resp, err := hatchetClient.API().RateLimitListWithResponse(ctx, tenantUUID, params)
+		if err != nil {
+			cli.Logger.Fatalf("failed to list rate limits: %v", err)
+		}
+		if resp.JSON200 == nil {
+			cli.Logger.Fatalf("unexpected response from API (status %d)", resp.StatusCode())
+		}
+
+		printJSON(resp.JSON200)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(rateLimitsCmd)
+	rateLimitsCmd.AddCommand(rateLimitsListCmd)
+
+	rateLimitsCmd.PersistentFlags().StringP("profile", "p", "", "Profile to use for connecting to Hatchet (default: prompts for selection)")
+	rateLimitsCmd.PersistentFlags().StringP("output", "o", "", "Output format: json (skips interactive TUI)")
+
+	rateLimitsListCmd.Flags().StringP("search", "s", "", "Search rate limits by key")
+	rateLimitsListCmd.Flags().Int64("limit", 50, "Number of results to return")
+	rateLimitsListCmd.Flags().Int64("offset", 0, "Offset for pagination")
+}

--- a/cmd/hatchet-cli/cli/rate_limits_e2e_test.go
+++ b/cmd/hatchet-cli/cli/rate_limits_e2e_test.go
@@ -1,0 +1,55 @@
+//go:build e2e_cli
+
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/testharness"
+)
+
+func TestRateLimitsListJSON(t *testing.T) {
+	h := testharness.New(t)
+	out := h.RunJSON("rate-limits", "list")
+
+	var result struct {
+		Rows []struct {
+			Key        string `json:"key"`
+			Value      int    `json:"value"`
+			LimitValue int    `json:"limitValue"`
+		} `json:"rows"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("failed to unmarshal rate-limits list output: %v\nOutput: %s", err, out)
+	}
+
+	// rows may be empty, but the field must exist
+	if result.Rows == nil {
+		t.Errorf("expected 'rows' array in response, got nil")
+	}
+
+	// If there are rows, validate they have the expected fields
+	for i, row := range result.Rows {
+		if row.Key == "" {
+			t.Errorf("row[%d]: expected non-empty 'key' field", i)
+		}
+	}
+}
+
+func TestRateLimitsTUI(t *testing.T) {
+	h := testharness.New(t)
+	tui := testharness.NewTUI(t, h)
+	t.Cleanup(tui.Stop)
+
+	tui.Start("rate-limits", "list")
+	content := tui.CaptureAfter(3 * time.Second)
+
+	if content == "" {
+		t.Fatal("TUI output was empty")
+	}
+	if !containsAny(content, "Rate Limits", "rate-limits", "rate_limits") {
+		t.Errorf("expected TUI to show 'Rate Limits' header; got:\n%s", content)
+	}
+}

--- a/cmd/hatchet-cli/cli/runs.go
+++ b/cmd/hatchet-cli/cli/runs.go
@@ -236,7 +236,7 @@ If no run ID is provided, requires --since flag and cancels runs matching the fi
 				if resp.JSON200.Ids != nil {
 					count = len(*resp.JSON200.Ids)
 				}
-				fmt.Println(styles.SuccessMessage(fmt.Sprintf("Cancelled %d task(s)", count)))
+				fmt.Println(styles.SuccessMessage(fmt.Sprintf("Cancelled %d run(s)", count)))
 			}
 			return
 		}
@@ -281,7 +281,7 @@ If no run ID is provided, requires --since flag and cancels runs matching the fi
 			if resp.JSON200.Ids != nil {
 				count = len(*resp.JSON200.Ids)
 			}
-			fmt.Println(styles.SuccessMessage(fmt.Sprintf("Cancelled %d task(s)", count)))
+			fmt.Println(styles.SuccessMessage(fmt.Sprintf("Cancelled %d run(s)", count)))
 		}
 	},
 }
@@ -348,7 +348,7 @@ If no run ID is provided, requires --since flag and replays runs matching the fi
 				if resp.JSON200.Ids != nil {
 					count = len(*resp.JSON200.Ids)
 				}
-				fmt.Println(styles.SuccessMessage(fmt.Sprintf("Replayed %d task(s)", count)))
+				fmt.Println(styles.SuccessMessage(fmt.Sprintf("Replayed %d run(s)", count)))
 			}
 			return
 		}
@@ -393,7 +393,7 @@ If no run ID is provided, requires --since flag and replays runs matching the fi
 			if resp.JSON200.Ids != nil {
 				count = len(*resp.JSON200.Ids)
 			}
-			fmt.Println(styles.SuccessMessage(fmt.Sprintf("Replayed %d task(s)", count)))
+			fmt.Println(styles.SuccessMessage(fmt.Sprintf("Replayed %d run(s)", count)))
 		}
 	},
 }

--- a/cmd/hatchet-cli/cli/runs.go
+++ b/cmd/hatchet-cli/cli/runs.go
@@ -191,6 +191,7 @@ If no run ID is provided, requires --since flag and cancels runs matching the fi
   hatchet runs cancel --since 24h --workflow my-workflow -o json`,
 	Run: func(cmd *cobra.Command, args []string) {
 		isJSON := isJSONOutput(cmd)
+		yes, _ := cmd.Flags().GetBool("yes")
 		_, hatchetClient := clientFromCmd(cmd)
 
 		ctx := cmd.Context()
@@ -204,7 +205,7 @@ If no run ID is provided, requires --since flag and cancels runs matching the fi
 				cli.Logger.Fatalf("invalid run ID %q: %v", runID, err)
 			}
 
-			if !isJSON {
+			if !isJSON && !yes {
 				// Try to get run name for confirmation
 				runName := shortID(runID)
 				runResp, _ := hatchetClient.API().V1WorkflowRunGetWithResponse(ctx, runUUID)
@@ -251,7 +252,7 @@ If no run ID is provided, requires --since flag and cancels runs matching the fi
 			cli.Logger.Fatalf("%v", err)
 		}
 
-		if !isJSON {
+		if !isJSON && !yes {
 			count := countMatchingRuns(ctx, hatchetClient, tenantUUID, listParams)
 			if count == 0 {
 				fmt.Println(styles.Muted.Render("No runs match your filters."))
@@ -303,6 +304,7 @@ If no run ID is provided, requires --since flag and replays runs matching the fi
   hatchet runs replay --since 24h -o json`,
 	Run: func(cmd *cobra.Command, args []string) {
 		isJSON := isJSONOutput(cmd)
+		yes, _ := cmd.Flags().GetBool("yes")
 		_, hatchetClient := clientFromCmd(cmd)
 
 		ctx := cmd.Context()
@@ -316,7 +318,7 @@ If no run ID is provided, requires --since flag and replays runs matching the fi
 				cli.Logger.Fatalf("invalid run ID %q: %v", runID, err)
 			}
 
-			if !isJSON {
+			if !isJSON && !yes {
 				runName := shortID(runID)
 				runResp, _ := hatchetClient.API().V1WorkflowRunGetWithResponse(ctx, runUUID)
 				if runResp != nil && runResp.JSON200 != nil {
@@ -362,7 +364,7 @@ If no run ID is provided, requires --since flag and replays runs matching the fi
 			cli.Logger.Fatalf("%v", err)
 		}
 
-		if !isJSON {
+		if !isJSON && !yes {
 			count := countMatchingRuns(ctx, hatchetClient, tenantUUID, listParams)
 			if count == 0 {
 				fmt.Println(styles.Muted.Render("No runs match your filters."))
@@ -702,7 +704,7 @@ func init() {
 	runsCmd.PersistentFlags().StringP("output", "o", "", "Output format: json (skips interactive TUI)")
 
 	// runs list flags
-	runsListCmd.Flags().StringP("since", "s", "1h", "Show runs since this duration ago (e.g. 1h, 24h, 7d)")
+	runsListCmd.Flags().StringP("since", "s", "24h", "Show runs since this duration ago (e.g. 1h, 24h, 7d)")
 	runsListCmd.Flags().String("until", "", "Show runs until this duration ago (e.g. 30m)")
 	runsListCmd.Flags().StringP("workflow", "w", "", "Filter by workflow name or ID")
 	runsListCmd.Flags().StringSlice("status", nil, "Filter by status (QUEUED,RUNNING,COMPLETED,FAILED,CANCELLED)")
@@ -715,12 +717,14 @@ func init() {
 	runsCancelCmd.Flags().String("until", "", "Cancel runs until this duration ago")
 	runsCancelCmd.Flags().StringP("workflow", "w", "", "Filter by workflow name or ID")
 	runsCancelCmd.Flags().StringSlice("status", nil, "Filter by status (QUEUED,RUNNING,COMPLETED,FAILED,CANCELLED)")
+	runsCancelCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
 
 	// runs replay flags (same as cancel)
 	runsReplayCmd.Flags().StringP("since", "s", "", "Replay runs since this duration ago (e.g. 1h, 24h) [required for bulk replay]")
 	runsReplayCmd.Flags().String("until", "", "Replay runs until this duration ago")
 	runsReplayCmd.Flags().StringP("workflow", "w", "", "Filter by workflow name or ID")
 	runsReplayCmd.Flags().StringSlice("status", nil, "Filter by status (QUEUED,RUNNING,COMPLETED,FAILED,CANCELLED)")
+	runsReplayCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
 
 	// runs logs flags
 	runsLogsCmd.Flags().Int64("tail", 0, "Number of most recent log lines to show (0 = all)")

--- a/cmd/hatchet-cli/cli/runs.go
+++ b/cmd/hatchet-cli/cli/runs.go
@@ -1,0 +1,901 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+	"github.com/spf13/cobra"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/config/cli"
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/styles"
+	"github.com/hatchet-dev/hatchet/pkg/client" //nolint:staticcheck
+	"github.com/hatchet-dev/hatchet/pkg/client/rest"
+)
+
+var runsCmd = &cobra.Command{
+	Use:     "runs",
+	Aliases: []string{"run"},
+	Short:   "Manage runs",
+	Long:    `Commands for listing, inspecting, cancelling, replaying, and viewing logs/events for runs.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		_ = cmd.Help()
+	},
+}
+
+var runsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List runs",
+	Long:  `List runs. Without --output json, launches the interactive TUI. With --output json, outputs raw JSON to stdout.`,
+	Example: `  # Launch interactive TUI (default)
+  hatchet runs list --profile local
+
+  # JSON output with filters
+  hatchet runs list -o json --since 24h --status FAILED
+  hatchet runs list -o json --since 1h --workflow my-workflow --limit 100`,
+	Run: func(cmd *cobra.Command, args []string) {
+		isJSON := isJSONOutput(cmd)
+		selectedProfile, hatchetClient := clientFromCmd(cmd)
+
+		if !isJSON {
+			model := newTUIModel(selectedProfile, hatchetClient)
+			p := tea.NewProgram(model, tea.WithAltScreen())
+			if _, err := p.Run(); err != nil {
+				cli.Logger.Fatalf("error running TUI: %v", err)
+			}
+			return
+		}
+
+		// JSON mode: parse flags and call API
+		ctx := cmd.Context()
+		tenantUUID := clientTenantUUID(hatchetClient)
+
+		sinceStr, _ := cmd.Flags().GetString("since")
+		sinceTime, err := parseSinceDuration(sinceStr)
+		if err != nil {
+			cli.Logger.Fatalf("invalid --since value: %v", err)
+		}
+
+		untilStr, _ := cmd.Flags().GetString("until")
+		var untilPtr *time.Time
+		if untilStr != "" {
+			var until time.Time
+			until, err = parseSinceDuration(untilStr)
+			if err != nil {
+				cli.Logger.Fatalf("invalid --until value: %v", err)
+			}
+			untilPtr = &until
+		}
+
+		workflowStr, _ := cmd.Flags().GetString("workflow")
+		var workflowUUIDs *[]openapi_types.UUID
+		if workflowStr != "" {
+			var wfUUID openapi_types.UUID
+			wfUUID, err = resolveWorkflowID(ctx, hatchetClient, workflowStr)
+			if err != nil {
+				cli.Logger.Fatalf("could not resolve workflow: %v", err)
+			}
+			workflowUUIDs = &[]openapi_types.UUID{wfUUID}
+		}
+
+		statusStrs, _ := cmd.Flags().GetStringSlice("status")
+		statuses, err := parseStatuses(statusStrs)
+		if err != nil {
+			cli.Logger.Fatalf("%v", err)
+		}
+		var statusesPtr *[]rest.V1TaskStatus
+		if len(statuses) > 0 {
+			statusesPtr = &statuses
+		}
+
+		limit, _ := cmd.Flags().GetInt64("limit")
+		offset, _ := cmd.Flags().GetInt64("offset")
+		onlyTasks, _ := cmd.Flags().GetBool("only-tasks")
+
+		params := &rest.V1WorkflowRunListParams{
+			Since:     sinceTime,
+			Until:     untilPtr,
+			Statuses:  statusesPtr,
+			Limit:     &limit,
+			Offset:    &offset,
+			OnlyTasks: onlyTasks,
+		}
+		if workflowUUIDs != nil {
+			params.WorkflowIds = workflowUUIDs
+		}
+
+		resp, err := hatchetClient.API().V1WorkflowRunListWithResponse(ctx, tenantUUID, params)
+		if err != nil {
+			cli.Logger.Fatalf("failed to list runs: %v", err)
+		}
+		if resp.JSON200 == nil {
+			cli.Logger.Fatalf("unexpected response from API (status %d)", resp.StatusCode())
+		}
+
+		printJSON(resp.JSON200)
+	},
+}
+
+var runsGetCmd = &cobra.Command{
+	Use:   "get <run-id>",
+	Short: "Inspect a run",
+	Long:  `Get details about a run. Without --output json, launches the interactive TUI navigated to the run. With --output json, outputs raw JSON.`,
+	Args:  cobra.ExactArgs(1),
+	Example: `  # Launch TUI for a specific run
+  hatchet runs get 8ff4f149-099e-4c16-a8d1-0535f8c79b83 --profile local
+
+  # JSON output
+  hatchet runs get 8ff4f149-099e-4c16-a8d1-0535f8c79b83 -o json`,
+	Run: func(cmd *cobra.Command, args []string) {
+		runID := args[0]
+		isJSON := isJSONOutput(cmd)
+		selectedProfile, hatchetClient := clientFromCmd(cmd)
+
+		if !isJSON {
+			model := tuiModelWithInitialRun{
+				tuiModel:     newTUIModel(selectedProfile, hatchetClient),
+				initialRunID: runID,
+			}
+			p := tea.NewProgram(model, tea.WithAltScreen())
+			if _, err := p.Run(); err != nil {
+				cli.Logger.Fatalf("error running TUI: %v", err)
+			}
+			return
+		}
+
+		// JSON mode
+		ctx := cmd.Context()
+		runUUID, err := uuid.Parse(runID)
+		if err != nil {
+			cli.Logger.Fatalf("invalid run ID %q: %v", runID, err)
+		}
+
+		resp, err := hatchetClient.API().V1WorkflowRunGetWithResponse(ctx, runUUID)
+		if err != nil {
+			cli.Logger.Fatalf("failed to get run: %v", err)
+		}
+		if resp.JSON200 == nil {
+			cli.Logger.Fatalf("run not found (status %d)", resp.StatusCode())
+		}
+
+		printJSON(resp.JSON200)
+	},
+}
+
+var runsCancelCmd = &cobra.Command{
+	Use:   "cancel [run-id]",
+	Short: "Cancel a run or bulk cancel by filter",
+	Long: `Cancel a specific run by ID, or cancel multiple runs matching filter criteria.
+
+If a run ID is provided, cancels that specific run (task or DAG).
+If no run ID is provided, requires --since flag and cancels runs matching the filter.`,
+	Args: cobra.MaximumNArgs(1),
+	Example: `  # Cancel a specific run
+  hatchet runs cancel 8ff4f149-099e-4c16-a8d1-0535f8c79b83 --profile local
+
+  # Bulk cancel by filter
+  hatchet runs cancel --since 1h --status FAILED --profile local
+
+  # Bulk cancel JSON mode (no confirmation)
+  hatchet runs cancel --since 24h --workflow my-workflow -o json`,
+	Run: func(cmd *cobra.Command, args []string) {
+		isJSON := isJSONOutput(cmd)
+		_, hatchetClient := clientFromCmd(cmd)
+
+		ctx := cmd.Context()
+		tenantUUID := clientTenantUUID(hatchetClient)
+
+		if len(args) > 0 {
+			// Single run cancel
+			runID := args[0]
+			runUUID, err := uuid.Parse(runID)
+			if err != nil {
+				cli.Logger.Fatalf("invalid run ID %q: %v", runID, err)
+			}
+
+			if !isJSON {
+				// Try to get run name for confirmation
+				runName := shortID(runID)
+				runResp, _ := hatchetClient.API().V1WorkflowRunGetWithResponse(ctx, runUUID)
+				if runResp != nil && runResp.JSON200 != nil {
+					runName = runResp.JSON200.Run.DisplayName
+				}
+				if !confirmAction(fmt.Sprintf("Cancel run '%s'?", runName)) {
+					fmt.Println("Aborted.")
+					return
+				}
+			}
+
+			externalID := runUUID
+			resp, err := hatchetClient.API().V1TaskCancelWithResponse(ctx, tenantUUID, rest.V1CancelTaskRequest{
+				ExternalIds: &[]openapi_types.UUID{externalID},
+			})
+			if err != nil {
+				cli.Logger.Fatalf("failed to cancel run: %v", err)
+			}
+			if resp.JSON200 == nil {
+				cli.Logger.Fatalf("unexpected response from API (status %d)", resp.StatusCode())
+			}
+
+			if isJSON {
+				printJSON(resp.JSON200)
+			} else {
+				count := 0
+				if resp.JSON200.Ids != nil {
+					count = len(*resp.JSON200.Ids)
+				}
+				fmt.Println(styles.SuccessMessage(fmt.Sprintf("Cancelled %d task(s)", count)))
+			}
+			return
+		}
+
+		// Bulk cancel via filters
+		sinceStr, _ := cmd.Flags().GetString("since")
+		if sinceStr == "" {
+			cli.Logger.Fatal("--since is required for bulk cancel (or provide a run ID as argument)")
+		}
+
+		filter, listParams, err := buildFilterAndParams(ctx, cmd, hatchetClient)
+		if err != nil {
+			cli.Logger.Fatalf("%v", err)
+		}
+
+		if !isJSON {
+			count := countMatchingRuns(ctx, hatchetClient, tenantUUID, listParams)
+			if count == 0 {
+				fmt.Println(styles.Muted.Render("No runs match your filters."))
+				return
+			}
+			if !confirmAction(fmt.Sprintf("This will cancel %d runs matching your filters. Continue?", count)) {
+				fmt.Println("Aborted.")
+				return
+			}
+		}
+
+		resp, err := hatchetClient.API().V1TaskCancelWithResponse(ctx, tenantUUID, rest.V1CancelTaskRequest{
+			Filter: filter,
+		})
+		if err != nil {
+			cli.Logger.Fatalf("failed to cancel runs: %v", err)
+		}
+		if resp.JSON200 == nil {
+			cli.Logger.Fatalf("unexpected response from API (status %d)", resp.StatusCode())
+		}
+
+		if isJSON {
+			printJSON(resp.JSON200)
+		} else {
+			count := 0
+			if resp.JSON200.Ids != nil {
+				count = len(*resp.JSON200.Ids)
+			}
+			fmt.Println(styles.SuccessMessage(fmt.Sprintf("Cancelled %d task(s)", count)))
+		}
+	},
+}
+
+var runsReplayCmd = &cobra.Command{
+	Use:   "replay [run-id]",
+	Short: "Replay a run or bulk replay by filter",
+	Long: `Replay a specific run by ID, or replay multiple runs matching filter criteria.
+
+If a run ID is provided, replays that specific run (task or DAG).
+If no run ID is provided, requires --since flag and replays runs matching the filter.`,
+	Args: cobra.MaximumNArgs(1),
+	Example: `  # Replay a specific run
+  hatchet runs replay 8ff4f149-099e-4c16-a8d1-0535f8c79b83 --profile local
+
+  # Bulk replay by filter
+  hatchet runs replay --since 1h --status FAILED --profile local
+
+  # Bulk replay JSON mode (no confirmation)
+  hatchet runs replay --since 24h -o json`,
+	Run: func(cmd *cobra.Command, args []string) {
+		isJSON := isJSONOutput(cmd)
+		_, hatchetClient := clientFromCmd(cmd)
+
+		ctx := cmd.Context()
+		tenantUUID := clientTenantUUID(hatchetClient)
+
+		if len(args) > 0 {
+			// Single run replay
+			runID := args[0]
+			runUUID, err := uuid.Parse(runID)
+			if err != nil {
+				cli.Logger.Fatalf("invalid run ID %q: %v", runID, err)
+			}
+
+			if !isJSON {
+				runName := shortID(runID)
+				runResp, _ := hatchetClient.API().V1WorkflowRunGetWithResponse(ctx, runUUID)
+				if runResp != nil && runResp.JSON200 != nil {
+					runName = runResp.JSON200.Run.DisplayName
+				}
+				if !confirmAction(fmt.Sprintf("Replay run '%s'?", runName)) {
+					fmt.Println("Aborted.")
+					return
+				}
+			}
+
+			externalID := runUUID
+			resp, err := hatchetClient.API().V1TaskReplayWithResponse(ctx, tenantUUID, rest.V1ReplayTaskRequest{
+				ExternalIds: &[]openapi_types.UUID{externalID},
+			})
+			if err != nil {
+				cli.Logger.Fatalf("failed to replay run: %v", err)
+			}
+			if resp.JSON200 == nil {
+				cli.Logger.Fatalf("unexpected response from API (status %d)", resp.StatusCode())
+			}
+
+			if isJSON {
+				printJSON(resp.JSON200)
+			} else {
+				count := 0
+				if resp.JSON200.Ids != nil {
+					count = len(*resp.JSON200.Ids)
+				}
+				fmt.Println(styles.SuccessMessage(fmt.Sprintf("Replayed %d task(s)", count)))
+			}
+			return
+		}
+
+		// Bulk replay via filters
+		sinceStr, _ := cmd.Flags().GetString("since")
+		if sinceStr == "" {
+			cli.Logger.Fatal("--since is required for bulk replay (or provide a run ID as argument)")
+		}
+
+		filter, listParams, err := buildFilterAndParams(ctx, cmd, hatchetClient)
+		if err != nil {
+			cli.Logger.Fatalf("%v", err)
+		}
+
+		if !isJSON {
+			count := countMatchingRuns(ctx, hatchetClient, tenantUUID, listParams)
+			if count == 0 {
+				fmt.Println(styles.Muted.Render("No runs match your filters."))
+				return
+			}
+			if !confirmAction(fmt.Sprintf("This will replay %d runs matching your filters. Continue?", count)) {
+				fmt.Println("Aborted.")
+				return
+			}
+		}
+
+		resp, err := hatchetClient.API().V1TaskReplayWithResponse(ctx, tenantUUID, rest.V1ReplayTaskRequest{
+			Filter: filter,
+		})
+		if err != nil {
+			cli.Logger.Fatalf("failed to replay runs: %v", err)
+		}
+		if resp.JSON200 == nil {
+			cli.Logger.Fatalf("unexpected response from API (status %d)", resp.StatusCode())
+		}
+
+		if isJSON {
+			printJSON(resp.JSON200)
+		} else {
+			count := 0
+			if resp.JSON200.Ids != nil {
+				count = len(*resp.JSON200.Ids)
+			}
+			fmt.Println(styles.SuccessMessage(fmt.Sprintf("Replayed %d task(s)", count)))
+		}
+	},
+}
+
+var runsLogsCmd = &cobra.Command{
+	Use:   "logs <run-id>",
+	Short: "Print logs from a run",
+	Long:  `Fetch and print logs from a run to stdout, sorted by timestamp. Works for both task runs and DAG workflow runs.`,
+	Args:  cobra.ExactArgs(1),
+	Example: `  # Print logs to stdout
+  hatchet runs logs 8ff4f149-099e-4c16-a8d1-0535f8c79b83 --profile local
+
+  # Show only the last 50 lines
+  hatchet runs logs 8ff4f149-099e-4c16-a8d1-0535f8c79b83 --tail 50
+
+  # Show logs from the last 5 minutes
+  hatchet runs logs 8ff4f149-099e-4c16-a8d1-0535f8c79b83 --since 5m
+
+  # Follow (poll for new logs)
+  hatchet runs logs 8ff4f149-099e-4c16-a8d1-0535f8c79b83 -f
+
+  # JSON output
+  hatchet runs logs 8ff4f149-099e-4c16-a8d1-0535f8c79b83 -o json | jq .`,
+	Run: func(cmd *cobra.Command, args []string) {
+		runID := args[0]
+		isJSON := isJSONOutput(cmd)
+		_, hatchetClient := clientFromCmd(cmd)
+
+		ctx := cmd.Context()
+		runUUID, err := uuid.Parse(runID)
+		if err != nil {
+			cli.Logger.Fatalf("invalid run ID %q: %v", runID, err)
+		}
+
+		tail, _ := cmd.Flags().GetInt64("tail")
+		sinceStr, _ := cmd.Flags().GetString("since")
+		follow, _ := cmd.Flags().GetBool("follow")
+
+		// Build log params from flags
+		buildLogParams := func(since *time.Time, limit *int64) *rest.V1LogLineListParams {
+			p := &rest.V1LogLineListParams{}
+			if since != nil {
+				p.Since = since
+			}
+			if limit != nil && *limit > 0 {
+				p.Limit = limit
+			}
+			return p
+		}
+
+		var sinceTime *time.Time
+		if sinceStr != "" {
+			var t time.Time
+			t, err = parseSinceDuration(sinceStr)
+			if err != nil {
+				cli.Logger.Fatalf("invalid --since value: %v", err)
+			}
+			sinceTime = &t
+		}
+
+		var tailLimit *int64
+		if tail > 0 {
+			tailLimit = &tail
+		}
+
+		type logEntry struct {
+			Task      string    `json:"task"`
+			Timestamp time.Time `json:"timestamp"`
+			Level     string    `json:"level,omitempty"`
+			Message   string    `json:"message"`
+		}
+
+		// fetchLogs fetches logs for the run, optionally filtering by since time
+		fetchLogs := func(since *time.Time, limit *int64) ([]logEntry, error) {
+			params := buildLogParams(since, limit)
+
+			// Try to fetch as a workflow run (DAG)
+			runResp, fetchErr := hatchetClient.API().V1WorkflowRunGetWithResponse(ctx, runUUID)
+			if fetchErr == nil && runResp.JSON200 != nil {
+				// DAG run: iterate tasks
+				var allLogs []logEntry
+				for _, task := range runResp.JSON200.Tasks {
+					taskUUID, parseErr := uuid.Parse(task.Metadata.Id)
+					if parseErr != nil {
+						continue
+					}
+					logsResp, logsErr := hatchetClient.API().V1LogLineListWithResponse(
+						ctx,
+						taskUUID,
+						params,
+					)
+					if logsErr != nil || logsResp.JSON200 == nil || logsResp.JSON200.Rows == nil {
+						continue
+					}
+					for _, logLine := range *logsResp.JSON200.Rows {
+						level := ""
+						if logLine.Level != nil {
+							level = string(*logLine.Level)
+						}
+						allLogs = append(allLogs, logEntry{
+							Task:      task.DisplayName,
+							Timestamp: logLine.CreatedAt,
+							Level:     level,
+							Message:   logLine.Message,
+						})
+					}
+				}
+				sort.Slice(allLogs, func(i, j int) bool {
+					return allLogs[i].Timestamp.Before(allLogs[j].Timestamp)
+				})
+				return allLogs, nil
+			}
+
+			// Fall back: treat run ID as a task ID directly (single task run)
+			logsResp, logsErr := hatchetClient.API().V1LogLineListWithResponse(
+				ctx,
+				runUUID,
+				params,
+			)
+			if logsErr != nil {
+				return nil, fmt.Errorf("failed to fetch logs: %w", logsErr)
+			}
+			if logsResp.JSON200 == nil || logsResp.JSON200.Rows == nil {
+				return nil, nil
+			}
+			var allLogs []logEntry
+			for _, logLine := range *logsResp.JSON200.Rows {
+				level := ""
+				if logLine.Level != nil {
+					level = string(*logLine.Level)
+				}
+				allLogs = append(allLogs, logEntry{
+					Task:      "",
+					Timestamp: logLine.CreatedAt,
+					Level:     level,
+					Message:   logLine.Message,
+				})
+			}
+			return allLogs, nil
+		}
+
+		printLogEntries := func(logs []logEntry) {
+			for _, l := range logs {
+				ts := l.Timestamp.Format("15:04:05.000")
+				if l.Task != "" {
+					if l.Level != "" {
+						fmt.Printf("[%s] %s %-8s %s\n", l.Task, ts, l.Level, l.Message)
+					} else {
+						fmt.Printf("[%s] %s %s\n", l.Task, ts, l.Message)
+					}
+				} else {
+					if l.Level != "" {
+						fmt.Printf("%s %-8s %s\n", ts, l.Level, l.Message)
+					} else {
+						fmt.Printf("%s %s\n", ts, l.Message)
+					}
+				}
+			}
+		}
+
+		// Initial fetch
+		allLogs, err := fetchLogs(sinceTime, tailLimit)
+		if err != nil {
+			cli.Logger.Fatalf("%v", err)
+		}
+
+		if isJSON {
+			printJSON(allLogs)
+			return
+		}
+
+		if len(allLogs) == 0 && !follow {
+			fmt.Println("No logs found for this run.")
+			return
+		}
+
+		printLogEntries(allLogs)
+
+		if !follow {
+			return
+		}
+
+		// Determine the timestamp to use as the "since" cursor for polling
+		var lastTimestamp time.Time
+		if len(allLogs) > 0 {
+			lastTimestamp = allLogs[len(allLogs)-1].Timestamp
+		} else {
+			lastTimestamp = time.Now()
+		}
+
+		// Poll for new logs
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+		defer signal.Stop(sigCh)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-sigCh:
+				return
+			case <-ticker.C:
+				// Add a small buffer to avoid re-fetching the last line
+				pollSince := lastTimestamp.Add(time.Millisecond)
+				newLogs, err := fetchLogs(&pollSince, nil)
+				if err != nil || len(newLogs) == 0 {
+					continue
+				}
+				printLogEntries(newLogs)
+				lastTimestamp = newLogs[len(newLogs)-1].Timestamp
+			}
+		}
+	},
+}
+
+var runsEventsCmd = &cobra.Command{
+	Use:   "events <run-id>",
+	Short: "Print events from a run",
+	Long:  `Fetch and print lifecycle events from a run to stdout. Works for both task runs and DAG workflow runs.`,
+	Args:  cobra.ExactArgs(1),
+	Example: `  # Print events to stdout
+  hatchet runs events 8ff4f149-099e-4c16-a8d1-0535f8c79b83 --profile local
+
+  # JSON output
+  hatchet runs events 8ff4f149-099e-4c16-a8d1-0535f8c79b83 -o json | jq .`,
+	Run: func(cmd *cobra.Command, args []string) {
+		runID := args[0]
+		isJSON := isJSONOutput(cmd)
+		_, hatchetClient := clientFromCmd(cmd)
+
+		ctx := cmd.Context()
+		runUUID, err := uuid.Parse(runID)
+		if err != nil {
+			cli.Logger.Fatalf("invalid run ID %q: %v", runID, err)
+		}
+
+		var events []rest.V1TaskEvent
+
+		// Try as a workflow run (DAG) first — TaskEvents are embedded in the run details
+		runResp, err := hatchetClient.API().V1WorkflowRunGetWithResponse(ctx, runUUID)
+		if err == nil && runResp.JSON200 != nil && len(runResp.JSON200.TaskEvents) > 0 {
+			events = runResp.JSON200.TaskEvents
+		} else {
+			// Fall back: treat run ID as a task ID and use the task events endpoint
+			limit := int64(1000)
+			offset := int64(0)
+			evtResp, err := hatchetClient.API().V1TaskEventListWithResponse(
+				ctx,
+				runUUID,
+				&rest.V1TaskEventListParams{
+					Limit:  &limit,
+					Offset: &offset,
+				},
+			)
+			if err != nil {
+				cli.Logger.Fatalf("failed to fetch events: %v", err)
+			}
+			if evtResp.JSON200 != nil && evtResp.JSON200.Rows != nil {
+				events = *evtResp.JSON200.Rows
+			}
+		}
+
+		if isJSON {
+			printJSON(events)
+			return
+		}
+
+		if len(events) == 0 {
+			fmt.Println("No events found for this run.")
+			return
+		}
+
+		for _, evt := range events {
+			ts := evt.Timestamp.Format("15:04:05.000")
+			taskName := ""
+			if evt.TaskDisplayName != nil {
+				taskName = *evt.TaskDisplayName
+			}
+			fmt.Printf("%s  %-30s  %-25s  %s\n", ts, string(evt.EventType), taskName, evt.Message)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(runsCmd)
+	runsCmd.AddCommand(runsListCmd, runsGetCmd, runsCancelCmd, runsReplayCmd, runsLogsCmd, runsEventsCmd)
+
+	// Persistent flags on parent (inherited by all subcommands)
+	runsCmd.PersistentFlags().StringP("profile", "p", "", "Profile to use for connecting to Hatchet (default: prompts for selection)")
+	runsCmd.PersistentFlags().StringP("output", "o", "", "Output format: json (skips interactive TUI)")
+
+	// runs list flags
+	runsListCmd.Flags().StringP("since", "s", "1h", "Show runs since this duration ago (e.g. 1h, 24h, 7d)")
+	runsListCmd.Flags().String("until", "", "Show runs until this duration ago (e.g. 30m)")
+	runsListCmd.Flags().StringP("workflow", "w", "", "Filter by workflow name or ID")
+	runsListCmd.Flags().StringSlice("status", nil, "Filter by status (QUEUED,RUNNING,COMPLETED,FAILED,CANCELLED)")
+	runsListCmd.Flags().Int64("limit", 50, "Number of results to return")
+	runsListCmd.Flags().Int64("offset", 0, "Offset for pagination")
+	runsListCmd.Flags().Bool("only-tasks", false, "Show only task runs, not DAG runs")
+
+	// runs cancel flags
+	runsCancelCmd.Flags().StringP("since", "s", "", "Cancel runs since this duration ago (e.g. 1h, 24h) [required for bulk cancel]")
+	runsCancelCmd.Flags().String("until", "", "Cancel runs until this duration ago")
+	runsCancelCmd.Flags().StringP("workflow", "w", "", "Filter by workflow name or ID")
+	runsCancelCmd.Flags().StringSlice("status", nil, "Filter by status (QUEUED,RUNNING,COMPLETED,FAILED,CANCELLED)")
+
+	// runs replay flags (same as cancel)
+	runsReplayCmd.Flags().StringP("since", "s", "", "Replay runs since this duration ago (e.g. 1h, 24h) [required for bulk replay]")
+	runsReplayCmd.Flags().String("until", "", "Replay runs until this duration ago")
+	runsReplayCmd.Flags().StringP("workflow", "w", "", "Filter by workflow name or ID")
+	runsReplayCmd.Flags().StringSlice("status", nil, "Filter by status (QUEUED,RUNNING,COMPLETED,FAILED,CANCELLED)")
+
+	// runs logs flags
+	runsLogsCmd.Flags().Int64("tail", 0, "Number of most recent log lines to show (0 = all)")
+	runsLogsCmd.Flags().String("since", "", "Only show logs newer than this duration ago (e.g. 5m, 1h, 24h)")
+	runsLogsCmd.Flags().BoolP("follow", "f", false, "Poll for new logs and print them as they arrive (Ctrl+C to stop)")
+}
+
+// isJSONOutput returns true if --output json was specified
+func isJSONOutput(cmd *cobra.Command) bool {
+	output, _ := cmd.Flags().GetString("output")
+	return strings.ToLower(output) == "json"
+}
+
+// parseSinceDuration parses a duration string (e.g. "1h", "24h", "7d") into a time.Time
+func parseSinceDuration(s string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, fmt.Errorf("duration cannot be empty")
+	}
+
+	// Try standard Go duration (e.g., "1h", "30m", "2h30m")
+	d, err := time.ParseDuration(s)
+	if err == nil {
+		return time.Now().Add(-d), nil
+	}
+
+	// Try days format (e.g., "7d", "30d")
+	if strings.HasSuffix(s, "d") {
+		daysStr := strings.TrimSuffix(s, "d")
+		days, err := strconv.Atoi(daysStr)
+		if err == nil && days > 0 {
+			return time.Now().Add(-time.Duration(days) * 24 * time.Hour), nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("invalid duration %q (use e.g. 1h, 24h, 7d)", s)
+}
+
+// parseStatuses parses a list of status strings into V1TaskStatus values
+func parseStatuses(strs []string) ([]rest.V1TaskStatus, error) {
+	var statuses []rest.V1TaskStatus
+	for _, s := range strs {
+		switch strings.ToUpper(s) {
+		case "QUEUED":
+			statuses = append(statuses, rest.V1TaskStatusQUEUED)
+		case "RUNNING":
+			statuses = append(statuses, rest.V1TaskStatusRUNNING)
+		case "COMPLETED":
+			statuses = append(statuses, rest.V1TaskStatusCOMPLETED)
+		case "FAILED":
+			statuses = append(statuses, rest.V1TaskStatusFAILED)
+		case "CANCELLED":
+			statuses = append(statuses, rest.V1TaskStatusCANCELLED)
+		default:
+			return nil, fmt.Errorf("invalid status %q (valid: QUEUED,RUNNING,COMPLETED,FAILED,CANCELLED)", s)
+		}
+	}
+	return statuses, nil
+}
+
+// resolveWorkflowID resolves a workflow name or UUID string to an openapi_types.UUID
+func resolveWorkflowID(ctx context.Context, hatchetClient client.Client, nameOrID string) (openapi_types.UUID, error) { //nolint:staticcheck
+	// Try as UUID first
+	parsed, err := uuid.Parse(nameOrID)
+	if err == nil {
+		return parsed, nil
+	}
+
+	// Search by name
+	tenantUUID, err := uuid.Parse(hatchetClient.TenantId())
+	if err != nil {
+		return openapi_types.UUID{}, fmt.Errorf("invalid tenant ID: %w", err)
+	}
+
+	resp, err := hatchetClient.API().WorkflowListWithResponse(ctx, tenantUUID, &rest.WorkflowListParams{})
+	if err != nil {
+		return openapi_types.UUID{}, fmt.Errorf("failed to fetch workflows: %w", err)
+	}
+
+	if resp.JSON200 != nil && resp.JSON200.Rows != nil {
+		for _, wf := range *resp.JSON200.Rows {
+			if wf.Name == nameOrID {
+				wfUUID, err := uuid.Parse(wf.Metadata.Id)
+				if err == nil {
+					return wfUUID, nil
+				}
+			}
+		}
+	}
+
+	return openapi_types.UUID{}, fmt.Errorf("workflow %q not found", nameOrID)
+}
+
+// buildFilterAndParams builds a V1TaskFilter and V1WorkflowRunListParams from command flags
+func buildFilterAndParams(ctx context.Context, cmd *cobra.Command, hatchetClient client.Client) (*rest.V1TaskFilter, *rest.V1WorkflowRunListParams, error) { //nolint:staticcheck
+	sinceStr, _ := cmd.Flags().GetString("since")
+	sinceTime, err := parseSinceDuration(sinceStr)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid --since value: %w", err)
+	}
+
+	untilStr, _ := cmd.Flags().GetString("until")
+	var untilPtr *time.Time
+	if untilStr != "" {
+		var until time.Time
+		until, err = parseSinceDuration(untilStr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid --until value: %w", err)
+		}
+		untilPtr = &until
+	}
+
+	workflowStr, _ := cmd.Flags().GetString("workflow")
+	var workflowUUIDs *[]openapi_types.UUID
+	if workflowStr != "" {
+		var wfUUID openapi_types.UUID
+		wfUUID, err = resolveWorkflowID(ctx, hatchetClient, workflowStr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("could not resolve workflow: %w", err)
+		}
+		workflowUUIDs = &[]openapi_types.UUID{wfUUID}
+	}
+
+	statusStrs, _ := cmd.Flags().GetStringSlice("status")
+	statuses, err := parseStatuses(statusStrs)
+	if err != nil {
+		return nil, nil, err
+	}
+	var statusesPtr *[]rest.V1TaskStatus
+	if len(statuses) > 0 {
+		statusesPtr = &statuses
+	}
+
+	filter := &rest.V1TaskFilter{
+		Since:       sinceTime,
+		Until:       untilPtr,
+		Statuses:    statusesPtr,
+		WorkflowIds: workflowUUIDs,
+	}
+
+	listParams := &rest.V1WorkflowRunListParams{
+		Since:    sinceTime,
+		Until:    untilPtr,
+		Statuses: statusesPtr,
+	}
+	if workflowUUIDs != nil {
+		listParams.WorkflowIds = workflowUUIDs
+	}
+
+	return filter, listParams, nil
+}
+
+// countMatchingRuns counts the total number of runs matching the given params using limit=1
+func countMatchingRuns(ctx context.Context, hatchetClient client.Client, tenantUUID openapi_types.UUID, params *rest.V1WorkflowRunListParams) int64 { //nolint:staticcheck
+	limit := int64(1)
+	countParams := *params
+	countParams.Limit = &limit
+
+	resp, err := hatchetClient.API().V1WorkflowRunListWithResponse(ctx, tenantUUID, &countParams)
+	if err != nil || resp.JSON200 == nil {
+		return 0
+	}
+
+	if resp.JSON200.Pagination.NumPages != nil {
+		return *resp.JSON200.Pagination.NumPages
+	}
+	return 0
+}
+
+// confirmAction prompts the user to confirm an action, returns true if confirmed
+func confirmAction(message string) bool {
+	fmt.Printf("%s [y/N]: ", message)
+	reader := bufio.NewReader(os.Stdin)
+	input, _ := reader.ReadString('\n')
+	input = strings.TrimSpace(strings.ToLower(input))
+	return input == "y" || input == "yes"
+}
+
+// printJSON marshals and prints v as indented JSON to stdout
+func printJSON(v interface{}) {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		cli.Logger.Fatalf("failed to marshal JSON: %v", err)
+	}
+	fmt.Println(string(data))
+}
+
+// shortID returns the first 8 characters of a UUID string followed by "..."
+func shortID(id string) string {
+	if len(id) > 8 {
+		return id[:8] + "..."
+	}
+	return id
+}

--- a/cmd/hatchet-cli/cli/runs_e2e_test.go
+++ b/cmd/hatchet-cli/cli/runs_e2e_test.go
@@ -1,0 +1,67 @@
+//go:build e2e_cli
+
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/testharness"
+)
+
+func TestRunsListJSON(t *testing.T) {
+	h := testharness.New(t)
+	out := h.RunJSON("runs", "list")
+
+	var result struct {
+		Rows []map[string]interface{} `json:"rows"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("failed to unmarshal runs list output: %v\nOutput: %s", err, out)
+	}
+
+	// rows may be empty on a fresh server, but the field must be present
+	if result.Rows == nil {
+		t.Errorf("expected 'rows' array in response, got nil")
+	}
+}
+
+func TestRunsGetJSON(t *testing.T) {
+	runID := os.Getenv("HATCHET_TEST_RUN_ID")
+	if runID == "" {
+		t.Skip("HATCHET_TEST_RUN_ID not set; skipping runs get test")
+	}
+
+	h := testharness.New(t)
+	out := h.RunJSON("runs", "get", runID)
+
+	var result struct {
+		Metadata struct {
+			ID string `json:"id"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("failed to unmarshal runs get output: %v\nOutput: %s", err, out)
+	}
+	if result.Metadata.ID != runID {
+		t.Errorf("expected metadata.id = %q, got %q", runID, result.Metadata.ID)
+	}
+}
+
+func TestRunsTUI(t *testing.T) {
+	h := testharness.New(t)
+	tui := testharness.NewTUI(t, h)
+	t.Cleanup(tui.Stop)
+
+	tui.Start("runs", "list")
+	content := tui.CaptureAfter(3 * time.Second)
+
+	if content == "" {
+		t.Fatal("TUI output was empty")
+	}
+	if !containsAny(content, "Runs", "runs") {
+		t.Errorf("expected TUI to show 'Runs' header; got:\n%s", content)
+	}
+}

--- a/cmd/hatchet-cli/cli/scheduled.go
+++ b/cmd/hatchet-cli/cli/scheduled.go
@@ -1,0 +1,265 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/huh"
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/config/cli"
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/styles"
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/tui"
+	"github.com/hatchet-dev/hatchet/pkg/client/rest"
+)
+
+var scheduledCmd = &cobra.Command{
+	Use:     "scheduled",
+	Aliases: []string{"schedule", "scheduled-runs", "schedules"},
+	Short:   "Manage scheduled runs",
+	Long:    `Commands for listing, inspecting, creating, and deleting scheduled workflow runs.`,
+	Run:     func(cmd *cobra.Command, args []string) { _ = cmd.Help() },
+}
+
+var scheduledListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List scheduled runs",
+	Long:  `List scheduled runs. Without --output json, launches the interactive TUI. With --output json, outputs raw JSON.`,
+	Example: `  # Launch interactive TUI (default)
+  hatchet scheduled list --profile local
+
+  # JSON output
+  hatchet scheduled list -o json`,
+	Run: func(cmd *cobra.Command, args []string) {
+		isJSON := isJSONOutput(cmd)
+		selectedProfile, hatchetClient := clientFromCmd(cmd)
+
+		if !isJSON {
+			tuiM := newTUIModel(selectedProfile, hatchetClient)
+			tuiM.currentViewType = ViewTypeScheduledRuns
+			tuiM.currentView = tui.NewScheduledRunsView(tuiM.ctx)
+			p := tea.NewProgram(tuiM, tea.WithAltScreen())
+			if _, err := p.Run(); err != nil {
+				cli.Logger.Fatalf("error running TUI: %v", err)
+			}
+			return
+		}
+
+		ctx := cmd.Context()
+		tenantUUID := clientTenantUUID(hatchetClient)
+		limit, _ := cmd.Flags().GetInt64("limit")
+		offset, _ := cmd.Flags().GetInt64("offset")
+
+		params := &rest.WorkflowScheduledListParams{
+			Limit:  &limit,
+			Offset: &offset,
+		}
+
+		resp, err := hatchetClient.API().WorkflowScheduledListWithResponse(ctx, tenantUUID, params)
+		if err != nil {
+			cli.Logger.Fatalf("failed to list scheduled runs: %v", err)
+		}
+		if resp.JSON200 == nil {
+			cli.Logger.Fatalf("unexpected response from API (status %d)", resp.StatusCode())
+		}
+
+		printJSON(resp.JSON200)
+	},
+}
+
+var scheduledGetCmd = &cobra.Command{
+	Use:   "get <scheduled-run-id>",
+	Short: "Get scheduled run details",
+	Long:  `Get details about a scheduled run. Outputs raw JSON.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		scheduledID := args[0]
+		_, hatchetClient := clientFromCmd(cmd)
+
+		scheduledUUID, err := uuid.Parse(scheduledID)
+		if err != nil {
+			cli.Logger.Fatalf("invalid scheduled run ID %q: %v", scheduledID, err)
+		}
+
+		ctx := cmd.Context()
+		tenantUUID := clientTenantUUID(hatchetClient)
+		resp, err := hatchetClient.API().WorkflowScheduledGetWithResponse(ctx, tenantUUID, scheduledUUID)
+		if err != nil {
+			cli.Logger.Fatalf("failed to get scheduled run: %v", err)
+		}
+		if resp.JSON200 == nil {
+			cli.Logger.Fatalf("scheduled run not found (status %d)", resp.StatusCode())
+		}
+
+		printJSON(resp.JSON200)
+	},
+}
+
+var scheduledCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a scheduled run",
+	Long:  `Create a new scheduled workflow run. In --output json mode, all flags are required. Otherwise, launches an interactive form.`,
+	Example: `  # Interactive mode
+  hatchet scheduled create --profile local
+
+  # JSON mode (all flags required)
+  hatchet scheduled create --workflow my-workflow --trigger-at 2026-01-01T12:00:00Z --input '{}' -o json`,
+	Run: func(cmd *cobra.Command, args []string) {
+		isJSON := isJSONOutput(cmd)
+		_, hatchetClient := clientFromCmd(cmd)
+
+		workflowStr, _ := cmd.Flags().GetString("workflow")
+		triggerAtStr, _ := cmd.Flags().GetString("trigger-at")
+		inputStr, _ := cmd.Flags().GetString("input")
+		inputFile, _ := cmd.Flags().GetString("input-file")
+
+		if !isJSON {
+			// Interactive mode
+			if workflowStr == "" {
+				var wfChoice string
+				form := huh.NewForm(
+					huh.NewGroup(
+						huh.NewInput().
+							Title("Workflow name or ID").
+							Value(&workflowStr).
+							Placeholder("my-workflow"),
+					),
+					huh.NewGroup(
+						huh.NewInput().
+							Title("Trigger at (RFC3339)").
+							Value(&triggerAtStr).
+							Placeholder("2026-01-01T12:00:00Z"),
+					),
+					huh.NewGroup(
+						huh.NewInput().
+							Title("Input JSON (optional)").
+							Value(&inputStr).
+							Placeholder("{}"),
+					),
+				).WithTheme(styles.HatchetTheme())
+				_ = wfChoice
+				if err := form.Run(); err != nil {
+					cli.Logger.Fatalf("form cancelled: %v", err)
+				}
+			}
+		}
+
+		if workflowStr == "" {
+			cli.Logger.Fatal("--workflow is required")
+		}
+		if triggerAtStr == "" {
+			cli.Logger.Fatal("--trigger-at is required")
+		}
+
+		triggerAt, err := time.Parse(time.RFC3339, triggerAtStr)
+		if err != nil {
+			cli.Logger.Fatalf("invalid --trigger-at value (must be RFC3339): %v", err)
+		}
+
+		// Build input map
+		inputData := map[string]interface{}{}
+		if inputFile != "" {
+			data, readErr := os.ReadFile(inputFile)
+			if readErr != nil {
+				cli.Logger.Fatalf("failed to read --input-file: %v", readErr)
+			}
+			if readErr = json.Unmarshal(data, &inputData); readErr != nil {
+				cli.Logger.Fatalf("failed to parse --input-file as JSON: %v", readErr)
+			}
+		} else if inputStr != "" {
+			if parseErr := json.Unmarshal([]byte(inputStr), &inputData); parseErr != nil {
+				cli.Logger.Fatalf("failed to parse --input as JSON: %v", parseErr)
+			}
+		}
+
+		ctx := cmd.Context()
+		tenantUUID := clientTenantUUID(hatchetClient)
+
+		// Resolve workflow name (the create endpoint uses name as path param, not UUID)
+		workflowName, resolveErr := resolveWorkflowName(ctx, hatchetClient, workflowStr)
+		if resolveErr != nil {
+			cli.Logger.Fatalf("could not resolve workflow: %v", resolveErr)
+		}
+
+		resp, err := hatchetClient.API().ScheduledWorkflowRunCreateWithResponse(ctx, tenantUUID, workflowName, rest.ScheduledWorkflowRunCreateJSONRequestBody{
+			TriggerAt:          triggerAt,
+			Input:              inputData,
+			AdditionalMetadata: map[string]interface{}{},
+		})
+		if err != nil {
+			cli.Logger.Fatalf("failed to create scheduled run: %v", err)
+		}
+		if resp.JSON200 == nil {
+			cli.Logger.Fatalf("unexpected response from API (status %d): %s", resp.StatusCode(), string(resp.Body))
+		}
+
+		if isJSON {
+			printJSON(resp.JSON200)
+		} else {
+			fmt.Println(styles.SuccessMessage(fmt.Sprintf("Created scheduled run: %s", resp.JSON200.Metadata.Id)))
+		}
+	},
+}
+
+var scheduledDeleteCmd = &cobra.Command{
+	Use:   "delete <scheduled-run-id>",
+	Short: "Delete a scheduled run",
+	Long:  `Delete a scheduled run by ID. Use --yes to skip confirmation.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		scheduledID := args[0]
+		isJSON := isJSONOutput(cmd)
+		yes, _ := cmd.Flags().GetBool("yes")
+		_, hatchetClient := clientFromCmd(cmd)
+
+		scheduledUUID, err := uuid.Parse(scheduledID)
+		if err != nil {
+			cli.Logger.Fatalf("invalid scheduled run ID %q: %v", scheduledID, err)
+		}
+
+		if !isJSON && !yes {
+			if !confirmAction(fmt.Sprintf("Delete scheduled run '%s'?", shortID(scheduledID))) {
+				fmt.Println("Aborted.")
+				return
+			}
+		}
+
+		ctx := cmd.Context()
+		tenantUUID := clientTenantUUID(hatchetClient)
+		resp, err := hatchetClient.API().WorkflowScheduledDeleteWithResponse(ctx, tenantUUID, scheduledUUID)
+		if err != nil {
+			cli.Logger.Fatalf("failed to delete scheduled run: %v", err)
+		}
+		if resp.StatusCode() >= 400 {
+			cli.Logger.Fatalf("failed to delete scheduled run (status %d)", resp.StatusCode())
+		}
+
+		if isJSON {
+			printJSON(map[string]interface{}{"deleted": true, "id": scheduledID})
+		} else {
+			fmt.Println(styles.SuccessMessage(fmt.Sprintf("Deleted scheduled run: %s", scheduledID)))
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(scheduledCmd)
+	scheduledCmd.AddCommand(scheduledListCmd, scheduledGetCmd, scheduledCreateCmd, scheduledDeleteCmd)
+
+	scheduledCmd.PersistentFlags().StringP("profile", "p", "", "Profile to use for connecting to Hatchet (default: prompts for selection)")
+	scheduledCmd.PersistentFlags().StringP("output", "o", "", "Output format: json (skips interactive TUI)")
+
+	scheduledListCmd.Flags().Int64("limit", 50, "Number of results to return")
+	scheduledListCmd.Flags().Int64("offset", 0, "Offset for pagination")
+
+	scheduledCreateCmd.Flags().StringP("workflow", "w", "", "Workflow name or ID")
+	scheduledCreateCmd.Flags().StringP("trigger-at", "t", "", "Trigger time in RFC3339 format (e.g. 2026-01-01T12:00:00Z)")
+	scheduledCreateCmd.Flags().StringP("input", "i", "", "Input JSON string")
+	scheduledCreateCmd.Flags().String("input-file", "", "Path to a JSON file for input")
+
+	scheduledDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+}

--- a/cmd/hatchet-cli/cli/scheduled.go
+++ b/cmd/hatchet-cli/cli/scheduled.go
@@ -111,28 +111,32 @@ var scheduledCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		isJSON := isJSONOutput(cmd)
 		_, hatchetClient := clientFromCmd(cmd)
+		ctx := cmd.Context()
+		tenantUUID := clientTenantUUID(hatchetClient)
 
 		workflowStr, _ := cmd.Flags().GetString("workflow")
 		triggerAtStr, _ := cmd.Flags().GetString("trigger-at")
+		inStr, _ := cmd.Flags().GetString("in")
 		inputStr, _ := cmd.Flags().GetString("input")
 		inputFile, _ := cmd.Flags().GetString("input-file")
 
 		if !isJSON {
-			// Interactive mode
+			// Interactive mode: show workflow selector then remaining fields
 			if workflowStr == "" {
-				var wfChoice string
+				workflowStr = promptSelectWorkflow(ctx, hatchetClient)
+				if workflowStr == "" {
+					cli.Logger.Fatal("no workflow selected")
+				}
+			}
+
+			// Prompt for trigger time and input if not already provided via flags
+			if triggerAtStr == "" && inStr == "" {
 				form := huh.NewForm(
 					huh.NewGroup(
 						huh.NewInput().
-							Title("Workflow name or ID").
-							Value(&workflowStr).
-							Placeholder("my-workflow"),
-					),
-					huh.NewGroup(
-						huh.NewInput().
-							Title("Trigger at (RFC3339)").
+							Title("Trigger in (e.g. 5m, 2h, 1d) or at RFC3339 time").
 							Value(&triggerAtStr).
-							Placeholder("2026-01-01T12:00:00Z"),
+							Placeholder("1h"),
 					),
 					huh.NewGroup(
 						huh.NewInput().
@@ -141,9 +145,8 @@ var scheduledCreateCmd = &cobra.Command{
 							Placeholder("{}"),
 					),
 				).WithTheme(styles.HatchetTheme())
-				_ = wfChoice
-				if err := form.Run(); err != nil {
-					cli.Logger.Fatalf("form cancelled: %v", err)
+				if formErr := form.Run(); formErr != nil {
+					cli.Logger.Fatalf("form cancelled: %v", formErr)
 				}
 			}
 		}
@@ -151,13 +154,32 @@ var scheduledCreateCmd = &cobra.Command{
 		if workflowStr == "" {
 			cli.Logger.Fatal("--workflow is required")
 		}
-		if triggerAtStr == "" {
-			cli.Logger.Fatal("--trigger-at is required")
+
+		// Resolve trigger time: --in takes priority over --trigger-at
+		var triggerAt time.Time
+		if inStr != "" {
+			d, err := parseDurationFuture(inStr)
+			if err != nil {
+				cli.Logger.Fatalf("invalid --in value: %v", err)
+			}
+			triggerAt = time.Now().UTC().Add(d)
+		} else if triggerAtStr != "" {
+			// Accept RFC3339 or a Go duration (e.g. "1h")
+			var parseErr error
+			triggerAt, parseErr = time.Parse(time.RFC3339, triggerAtStr)
+			if parseErr != nil {
+				d, dErr := parseDurationFuture(triggerAtStr)
+				if dErr != nil {
+					cli.Logger.Fatalf("invalid --trigger-at value (use RFC3339 or a duration like 1h): %v", parseErr)
+				}
+				triggerAt = time.Now().UTC().Add(d)
+			}
+		} else {
+			cli.Logger.Fatal("--trigger-at or --in is required")
 		}
 
-		triggerAt, err := time.Parse(time.RFC3339, triggerAtStr)
-		if err != nil {
-			cli.Logger.Fatalf("invalid --trigger-at value (must be RFC3339): %v", err)
+		if !triggerAt.After(time.Now()) {
+			cli.Logger.Fatalf("trigger time %s is in the past — use a future time or a duration like --in 1h", triggerAt.Format(time.RFC3339))
 		}
 
 		// Build input map
@@ -175,9 +197,6 @@ var scheduledCreateCmd = &cobra.Command{
 				cli.Logger.Fatalf("failed to parse --input as JSON: %v", parseErr)
 			}
 		}
-
-		ctx := cmd.Context()
-		tenantUUID := clientTenantUUID(hatchetClient)
 
 		// Resolve workflow name (the create endpoint uses name as path param, not UUID)
 		workflowName, resolveErr := resolveWorkflowName(ctx, hatchetClient, workflowStr)
@@ -200,21 +219,67 @@ var scheduledCreateCmd = &cobra.Command{
 		if isJSON {
 			printJSON(resp.JSON200)
 		} else {
-			fmt.Println(styles.SuccessMessage(fmt.Sprintf("Created scheduled run: %s", resp.JSON200.Metadata.Id)))
+			fmt.Println(styles.SuccessMessage(fmt.Sprintf(
+				"Created scheduled run: %s\n  Workflow:   %s\n  Trigger at: %s",
+				resp.JSON200.Metadata.Id,
+				resp.JSON200.WorkflowName,
+				resp.JSON200.TriggerAt.Local().Format("2006-01-02 15:04:05 MST"),
+			)))
 		}
 	},
 }
 
 var scheduledDeleteCmd = &cobra.Command{
-	Use:   "delete <scheduled-run-id>",
+	Use:   "delete [scheduled-run-id]",
 	Short: "Delete a scheduled run",
-	Long:  `Delete a scheduled run by ID. Use --yes to skip confirmation.`,
-	Args:  cobra.ExactArgs(1),
+	Long:  `Delete a scheduled run by ID. Omit the ID to pick from a list interactively. Use --yes to skip confirmation.`,
+	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		scheduledID := args[0]
 		isJSON := isJSONOutput(cmd)
 		yes, _ := cmd.Flags().GetBool("yes")
 		_, hatchetClient := clientFromCmd(cmd)
+		ctx := cmd.Context()
+		tenantUUID := clientTenantUUID(hatchetClient)
+
+		var scheduledID string
+		if len(args) == 1 {
+			scheduledID = args[0]
+		} else if !isJSON {
+			// No ID provided — show an interactive selector
+			limit := int64(100)
+			listResp, listErr := hatchetClient.API().WorkflowScheduledListWithResponse(ctx, tenantUUID, &rest.WorkflowScheduledListParams{
+				Limit: &limit,
+			})
+			if listErr != nil {
+				cli.Logger.Fatalf("failed to list scheduled runs: %v", listErr)
+			}
+			if listResp.JSON200 == nil || listResp.JSON200.Rows == nil || len(*listResp.JSON200.Rows) == 0 {
+				cli.Logger.Fatal("no scheduled runs found")
+			}
+
+			var options []huh.Option[string]
+			for _, s := range *listResp.JSON200.Rows {
+				label := fmt.Sprintf("%s  → %s", s.WorkflowName, s.TriggerAt.Format("2006-01-02 15:04:05"))
+				options = append(options, huh.NewOption(label, s.Metadata.Id))
+			}
+
+			height := len(options)
+			if height > 10 {
+				height = 10
+			}
+			form := huh.NewForm(huh.NewGroup(
+				huh.NewSelect[string]().
+					Title("Select a scheduled run to delete").
+					Options(options...).
+					Height(height).
+					Value(&scheduledID),
+			)).WithTheme(styles.HatchetTheme())
+			if formErr := form.Run(); formErr != nil {
+				cli.Logger.Fatalf("selection cancelled: %v", formErr)
+			}
+		} else {
+			cli.Logger.Fatal("scheduled run ID is required in JSON mode")
+		}
 
 		scheduledUUID, err := uuid.Parse(scheduledID)
 		if err != nil {
@@ -228,8 +293,6 @@ var scheduledDeleteCmd = &cobra.Command{
 			}
 		}
 
-		ctx := cmd.Context()
-		tenantUUID := clientTenantUUID(hatchetClient)
 		resp, err := hatchetClient.API().WorkflowScheduledDeleteWithResponse(ctx, tenantUUID, scheduledUUID)
 		if err != nil {
 			cli.Logger.Fatalf("failed to delete scheduled run: %v", err)
@@ -257,7 +320,8 @@ func init() {
 	scheduledListCmd.Flags().Int64("offset", 0, "Offset for pagination")
 
 	scheduledCreateCmd.Flags().StringP("workflow", "w", "", "Workflow name or ID")
-	scheduledCreateCmd.Flags().StringP("trigger-at", "t", "", "Trigger time in RFC3339 format (e.g. 2026-01-01T12:00:00Z)")
+	scheduledCreateCmd.Flags().StringP("trigger-at", "t", "", "Trigger time in RFC3339 format or duration (e.g. 2026-01-01T12:00:00Z or 1h)")
+	scheduledCreateCmd.Flags().String("in", "", "Trigger after this duration from now (e.g. 5m, 2h, 1d)")
 	scheduledCreateCmd.Flags().StringP("input", "i", "", "Input JSON string")
 	scheduledCreateCmd.Flags().String("input-file", "", "Path to a JSON file for input")
 

--- a/cmd/hatchet-cli/cli/scheduled_e2e_test.go
+++ b/cmd/hatchet-cli/cli/scheduled_e2e_test.go
@@ -1,0 +1,119 @@
+//go:build e2e_cli
+
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/testharness"
+)
+
+func TestScheduledListJSON(t *testing.T) {
+	h := testharness.New(t)
+	out := h.RunJSON("scheduled", "list")
+
+	var result struct {
+		Rows []map[string]interface{} `json:"rows"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("failed to unmarshal scheduled list output: %v\nOutput: %s", err, out)
+	}
+
+	if result.Rows == nil {
+		t.Errorf("expected 'rows' array in response, got nil")
+	}
+}
+
+func TestScheduledCreateDeleteJSON(t *testing.T) {
+	workflowID := os.Getenv("HATCHET_TEST_WORKFLOW_ID")
+	if workflowID == "" {
+		t.Skip("HATCHET_TEST_WORKFLOW_ID not set; skipping scheduled create/delete test")
+	}
+
+	// Use a trigger time 1 hour in the future
+	triggerAt := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+
+	h := testharness.New(t)
+
+	// Create a scheduled run
+	createOut := h.RunJSON("scheduled", "create",
+		"--workflow", workflowID,
+		"--trigger-at", triggerAt,
+		"--input", "{}",
+	)
+
+	var created struct {
+		Metadata struct {
+			ID string `json:"id"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(createOut, &created); err != nil {
+		t.Fatalf("failed to unmarshal scheduled create output: %v\nOutput: %s", err, createOut)
+	}
+	if created.Metadata.ID == "" {
+		t.Fatal("expected metadata.id in scheduled create response")
+	}
+
+	scheduledID := created.Metadata.ID
+	t.Logf("Created scheduled run: %s", scheduledID)
+
+	// Delete the scheduled run
+	deleteOut := h.RunJSON("scheduled", "delete", "--yes", scheduledID)
+
+	var deleted struct {
+		Deleted bool   `json:"deleted"`
+		ID      string `json:"id"`
+	}
+	if err := json.Unmarshal(deleteOut, &deleted); err != nil {
+		t.Fatalf("failed to unmarshal scheduled delete output: %v\nOutput: %s", err, deleteOut)
+	}
+	if !deleted.Deleted {
+		t.Errorf("expected deleted=true, got: %s", deleteOut)
+	}
+	if deleted.ID != scheduledID {
+		t.Errorf("expected deleted id %q, got %q", scheduledID, deleted.ID)
+	}
+
+	t.Logf("Deleted scheduled run: %s", scheduledID)
+}
+
+func TestScheduledGetJSON(t *testing.T) {
+	scheduledID := os.Getenv("HATCHET_TEST_SCHEDULED_ID")
+	if scheduledID == "" {
+		t.Skip("HATCHET_TEST_SCHEDULED_ID not set; skipping scheduled get test")
+	}
+
+	h := testharness.New(t)
+	out := h.RunJSON("scheduled", "get", scheduledID)
+
+	var result struct {
+		Metadata struct {
+			ID string `json:"id"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("failed to unmarshal scheduled get output: %v\nOutput: %s", err, out)
+	}
+	if result.Metadata.ID != scheduledID {
+		t.Errorf("expected metadata.id = %q, got %q", scheduledID, result.Metadata.ID)
+	}
+}
+
+func TestScheduledTUI(t *testing.T) {
+	h := testharness.New(t)
+	tui := testharness.NewTUI(t, h)
+	t.Cleanup(tui.Stop)
+
+	tui.Start("scheduled", "list")
+	content := tui.CaptureAfter(3 * time.Second)
+
+	if content == "" {
+		t.Fatal("TUI output was empty")
+	}
+	if !containsAny(content, "Scheduled Runs", "Scheduled", "Trigger") {
+		t.Errorf("expected TUI to show 'Scheduled Runs' header; got:\n%s", content)
+	}
+}

--- a/cmd/hatchet-cli/cli/testharness/harness.go
+++ b/cmd/hatchet-cli/cli/testharness/harness.go
@@ -1,0 +1,130 @@
+//go:build e2e_cli
+
+package testharness
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// CLIHarness provides helpers for running CLI commands in tests.
+// It builds the hatchet binary once per test run and caches the path.
+type CLIHarness struct {
+	// BinaryPath is the path to the compiled hatchet CLI binary.
+	BinaryPath string
+	// Profile is the --profile flag value to pass to commands.
+	Profile string
+	T       *testing.T
+}
+
+var (
+	binaryOnce sync.Once
+	binaryPath string
+	binaryErr  error
+)
+
+// New builds the CLI binary to a temp dir and returns a CLIHarness.
+// The profile is read from the HATCHET_CLI_PROFILE environment variable.
+// If the env var is not set, it defaults to "local".
+func New(t *testing.T) *CLIHarness {
+	t.Helper()
+
+	profile := os.Getenv("HATCHET_CLI_PROFILE")
+	if profile == "" {
+		profile = "local"
+	}
+
+	// Build binary once per test process.
+	// Use os.MkdirTemp (not t.TempDir) so the directory outlives the first test
+	// that calls New — t.TempDir cleanup runs when that test finishes, which
+	// would delete the binary before subsequent tests can use it.
+	binaryOnce.Do(func() {
+		dir, mkErr := os.MkdirTemp("", "hatchet-cli-e2e-*")
+		if mkErr != nil {
+			binaryErr = fmt.Errorf("failed to create temp dir: %w", mkErr)
+			return
+		}
+		out := filepath.Join(dir, "hatchet")
+
+		cmd := exec.Command("go", "build", "-o", out, "./cmd/hatchet-cli")
+		cmd.Dir = findModuleRoot(t)
+		cmd.Env = os.Environ()
+
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			binaryErr = fmt.Errorf("failed to build hatchet CLI: %w\nOutput: %s", err, output)
+			return
+		}
+
+		binaryPath = out
+	})
+
+	if binaryErr != nil {
+		t.Fatalf("CLIHarness: %v", binaryErr)
+	}
+
+	return &CLIHarness{
+		BinaryPath: binaryPath,
+		Profile:    profile,
+		T:          t,
+	}
+}
+
+// RunJSON runs a CLI command with -o json appended, asserts exit 0, and returns stdout.
+func (h *CLIHarness) RunJSON(args ...string) []byte {
+	h.T.Helper()
+	fullArgs := append(args, "-o", "json", "--profile", h.Profile)
+	return h.run(fullArgs...)
+}
+
+// Run runs a CLI command without -o json and returns stdout.
+func (h *CLIHarness) Run(args ...string) string {
+	h.T.Helper()
+	fullArgs := append(args, "--profile", h.Profile)
+	return string(h.run(fullArgs...))
+}
+
+// run executes the binary with the given args and returns stdout.
+// It fatals the test if the command exits non-zero.
+func (h *CLIHarness) run(args ...string) []byte {
+	h.T.Helper()
+
+	cmd := exec.Command(h.BinaryPath, args...)
+	output, err := cmd.Output()
+	if err != nil {
+		var stderr string
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			stderr = string(exitErr.Stderr)
+		}
+		h.T.Fatalf("hatchet %s failed: %v\nStderr: %s\nStdout: %s",
+			strings.Join(args, " "), err, stderr, output)
+	}
+
+	return output
+}
+
+// findModuleRoot walks up from the test's working directory to find go.mod
+func findModuleRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find go.mod - not in a Go module?")
+		}
+		dir = parent
+	}
+}

--- a/cmd/hatchet-cli/cli/testharness/tui.go
+++ b/cmd/hatchet-cli/cli/testharness/tui.go
@@ -1,0 +1,95 @@
+//go:build e2e_cli
+
+package testharness
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TUIHarness provides helpers for testing the TUI via tmux.
+// It requires tmux to be installed on the test machine.
+type TUIHarness struct {
+	harness     *CLIHarness
+	sessionName string
+	paneID      string
+	T           *testing.T
+}
+
+// NewTUI creates a new TUIHarness using the given CLIHarness.
+func NewTUI(t *testing.T, h *CLIHarness) *TUIHarness {
+	t.Helper()
+	return &TUIHarness{
+		harness:     h,
+		sessionName: fmt.Sprintf("hatchet-tui-test-%d", time.Now().UnixNano()),
+		T:           t,
+	}
+}
+
+// Start launches the TUI command in a new tmux session.
+// args are passed to the hatchet binary (e.g., "tui", "--profile", "local").
+func (th *TUIHarness) Start(args ...string) {
+	th.T.Helper()
+
+	fullArgs := append([]string{th.harness.BinaryPath}, args...)
+	fullArgs = append(fullArgs, "--profile", th.harness.Profile)
+	cmdStr := strings.Join(fullArgs, " ")
+
+	// Create a new tmux session (detached)
+	cmd := exec.Command("tmux", "new-session",
+		"-d",
+		"-s", th.sessionName,
+		"-x", "220",
+		"-y", "50",
+		cmdStr,
+	)
+
+	if output, err := cmd.CombinedOutput(); err != nil {
+		th.T.Fatalf("failed to start tmux session: %v\nOutput: %s", err, output)
+	}
+
+	th.paneID = th.sessionName + ":0"
+}
+
+// CaptureAfter waits for the given duration and then captures the pane contents.
+func (th *TUIHarness) CaptureAfter(d time.Duration) string {
+	th.T.Helper()
+
+	time.Sleep(d)
+
+	cmd := exec.Command("tmux", "capture-pane",
+		"-t", th.paneID,
+		"-p",
+		"-e",
+	)
+
+	output, err := cmd.Output()
+	if err != nil {
+		th.T.Fatalf("failed to capture tmux pane: %v", err)
+	}
+
+	return string(output)
+}
+
+// SendKey sends a key sequence to the tmux pane.
+// key should be a tmux key name (e.g., "q", "Enter", "ctrl+c").
+func (th *TUIHarness) SendKey(key string) {
+	th.T.Helper()
+
+	cmd := exec.Command("tmux", "send-keys", "-t", th.paneID, key, "Enter")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		th.T.Fatalf("failed to send key %q: %v\nOutput: %s", key, err, output)
+	}
+}
+
+// Stop kills the tmux session and cleans up.
+func (th *TUIHarness) Stop() {
+	if th.sessionName == "" {
+		return
+	}
+	// Kill the tmux session, ignore errors (session may already be dead)
+	exec.Command("tmux", "kill-session", "-t", th.sessionName).Run() //nolint:errcheck
+}

--- a/cmd/hatchet-cli/cli/testharness/tui.go
+++ b/cmd/hatchet-cli/cli/testharness/tui.go
@@ -29,6 +29,13 @@ func NewTUI(t *testing.T, h *CLIHarness) *TUIHarness {
 	}
 }
 
+// shellEscape returns a single-quoted POSIX shell-safe version of s.
+// Any single quotes within s are escaped by ending the current single-quoted
+// string, inserting an escaped single quote, and reopening the single-quoted string.
+func shellEscape(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
 // Start launches the TUI command in a new tmux session.
 // args are passed to the hatchet binary (e.g., "tui", "--profile", "local").
 func (th *TUIHarness) Start(args ...string) {
@@ -36,7 +43,11 @@ func (th *TUIHarness) Start(args ...string) {
 
 	fullArgs := append([]string{th.harness.BinaryPath}, args...)
 	fullArgs = append(fullArgs, "--profile", th.harness.Profile)
-	cmdStr := strings.Join(fullArgs, " ")
+	escaped := make([]string, len(fullArgs))
+	for i, a := range fullArgs {
+		escaped[i] = shellEscape(a)
+	}
+	cmdStr := strings.Join(escaped, " ")
 
 	// Create a new tmux session (detached)
 	cmd := exec.Command("tmux", "new-session",

--- a/cmd/hatchet-cli/cli/tui.go
+++ b/cmd/hatchet-cli/cli/tui.go
@@ -117,7 +117,7 @@ var availableViews = []viewOption{
 	{Type: ViewTypeRateLimits, Name: "Rate Limits", Description: "View rate limit usage"},
 	{Type: ViewTypeScheduledRuns, Name: "Scheduled Runs", Description: "View scheduled runs"},
 	{Type: ViewTypeCronJobs, Name: "Cron Jobs", Description: "View cron jobs"},
-	{Type: ViewTypeWebhooks, Name: "Webhooks", Description: "View webhook workers"},
+	{Type: ViewTypeWebhooks, Name: "Webhooks", Description: "View webhooks"},
 }
 
 // tuiModel is the root model that manages different views
@@ -345,16 +345,20 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Navigate to appropriate view based on detected type
 		var newView tui.View
-		if msg.Type == "task" {
+		switch {
+		case msg.Type == "task" && msg.TaskData != nil:
 			// Single task view
 			taskView := tui.NewSingleTaskView(m.ctx, msg.TaskData.Metadata.Id)
 			taskView.SetSize(m.width, m.height)
 			newView = taskView
-		} else {
+		case msg.Type == "dag" && msg.DAGData != nil:
 			// DAG workflow run view
 			dagView := tui.NewRunDetailsView(m.ctx, msg.DAGData.Run.Metadata.Id)
 			dagView.SetSize(m.width, m.height)
 			newView = dagView
+		default:
+			// Unknown type or missing data — stay on current view
+			return m, nil
 		}
 
 		m.currentView = newView
@@ -539,15 +543,20 @@ func (m tuiModel) detectRunType(runID string) tea.Cmd {
 			}
 		}
 
-		// Both failed
+		// Both failed — return the most informative error available
 		if taskResult != nil && taskResult.err != nil {
 			return tui.RunTypeDetectedMsg{
 				Error: taskResult.err,
 			}
 		}
-
+		if dagResult != nil && dagResult.err != nil {
+			return tui.RunTypeDetectedMsg{
+				Error: dagResult.err,
+			}
+		}
+		// Both returned non-200 without a network error (e.g. run not yet started)
 		return tui.RunTypeDetectedMsg{
-			Error: dagResult.err,
+			Error: fmt.Errorf("run %q not found", runID),
 		}
 	}
 }

--- a/cmd/hatchet-cli/cli/tui.go
+++ b/cmd/hatchet-cli/cli/tui.go
@@ -96,6 +96,10 @@ const (
 	ViewTypeRuns ViewType = iota
 	ViewTypeWorkflows
 	ViewTypeWorkers
+	ViewTypeRateLimits
+	ViewTypeScheduledRuns
+	ViewTypeCronJobs
+	ViewTypeWebhooks
 )
 
 // viewOption represents a selectable view in the view selector
@@ -110,6 +114,10 @@ var availableViews = []viewOption{
 	{Type: ViewTypeRuns, Name: "Runs", Description: "View task runs"},
 	{Type: ViewTypeWorkflows, Name: "Workflows", Description: "View workflows"},
 	{Type: ViewTypeWorkers, Name: "Workers", Description: "View workers"},
+	{Type: ViewTypeRateLimits, Name: "Rate Limits", Description: "View rate limit usage"},
+	{Type: ViewTypeScheduledRuns, Name: "Scheduled Runs", Description: "View scheduled runs"},
+	{Type: ViewTypeCronJobs, Name: "Cron Jobs", Description: "View cron jobs"},
+	{Type: ViewTypeWebhooks, Name: "Webhooks", Description: "View webhook workers"},
 }
 
 // tuiModel is the root model that manages different views
@@ -553,6 +561,14 @@ func (m tuiModel) createViewForType(viewType ViewType) tui.View {
 		return tui.NewWorkflowsView(m.ctx)
 	case ViewTypeWorkers:
 		return tui.NewWorkersView(m.ctx)
+	case ViewTypeRateLimits:
+		return tui.NewRateLimitsView(m.ctx)
+	case ViewTypeScheduledRuns:
+		return tui.NewScheduledRunsView(m.ctx)
+	case ViewTypeCronJobs:
+		return tui.NewCronJobsView(m.ctx)
+	case ViewTypeWebhooks:
+		return tui.NewWebhooksView(m.ctx)
 	default:
 		return tui.NewRunsListView(m.ctx)
 	}

--- a/cmd/hatchet-cli/cli/tui/cron_jobs.go
+++ b/cmd/hatchet-cli/cli/tui/cron_jobs.go
@@ -1,0 +1,323 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/google/uuid"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/styles"
+	"github.com/hatchet-dev/hatchet/pkg/client/rest"
+)
+
+// CronJobsView displays a list of cron jobs in a table
+type CronJobsView struct {
+	lastFetch   time.Time
+	table       *TableWithStyleFunc
+	debugLogger *DebugLogger
+	cronJobs    []rest.CronWorkflows
+	BaseModel
+	loading   bool
+	showDebug bool
+}
+
+// cronJobsMsg contains the fetched cron jobs
+type cronJobsMsg struct {
+	err       error
+	debugInfo string
+	cronJobs  []rest.CronWorkflows
+}
+
+// cronJobTickMsg is sent periodically to refresh the data
+type cronJobTickMsg time.Time
+
+// NewCronJobsView creates a new cron jobs list view
+func NewCronJobsView(ctx ViewContext) *CronJobsView {
+	v := &CronJobsView{
+		BaseModel:   BaseModel{Ctx: ctx},
+		loading:     false,
+		debugLogger: NewDebugLogger(5000),
+		showDebug:   false,
+	}
+
+	columns := []table.Column{
+		{Title: "Name", Width: 25},
+		{Title: "Expression", Width: 18},
+		{Title: "Workflow", Width: 25},
+		{Title: "Enabled", Width: 8},
+		{Title: "Created At", Width: 18},
+	}
+
+	t := NewTableWithStyleFunc(
+		table.WithColumns(columns),
+		table.WithFocused(true),
+		table.WithHeight(20),
+	)
+
+	s := table.DefaultStyles()
+	s.Header = s.Header.
+		BorderStyle(lipgloss.NormalBorder()).
+		BorderForeground(styles.AccentColor).
+		BorderBottom(true).
+		Bold(true).
+		Foreground(styles.AccentColor)
+	s.Selected = s.Selected.
+		Foreground(lipgloss.AdaptiveColor{Light: "#ffffff", Dark: "#0A1029"}).
+		Background(styles.Blue).
+		Bold(true)
+	s.Cell = lipgloss.NewStyle()
+	t.SetStyles(s)
+
+	// Style: color the Enabled column (col 3) green for enabled, red for disabled
+	t.SetStyleFunc(func(row, col int) lipgloss.Style {
+		if col == 3 && row < len(v.cronJobs) {
+			if v.cronJobs[row].Enabled {
+				return lipgloss.NewStyle().Foreground(styles.StatusSuccessColor)
+			}
+			return lipgloss.NewStyle().Foreground(styles.StatusFailedColor)
+		}
+		return lipgloss.NewStyle()
+	})
+
+	v.table = t
+	return v
+}
+
+// Init initializes the view
+func (v *CronJobsView) Init() tea.Cmd {
+	return tea.Batch(v.fetchCronJobs(), cronJobTick())
+}
+
+// Update handles messages and updates the view state
+func (v *CronJobsView) Update(msg tea.Msg) (View, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		v.SetSize(msg.Width, msg.Height)
+		v.table.SetHeight(msg.Height - 12)
+		return v, nil
+
+	case tea.KeyMsg:
+		if v.showDebug {
+			if handled, debugCmd := HandleDebugKeyboard(v.debugLogger, msg.String()); handled {
+				return v, debugCmd
+			}
+		}
+
+		switch msg.String() {
+		case "r":
+			v.loading = true
+			return v, v.fetchCronJobs()
+		case "d":
+			v.showDebug = !v.showDebug
+			return v, nil
+		case "c":
+			if v.showDebug && !v.debugLogger.IsPromptingFile() {
+				v.debugLogger.Clear()
+			}
+			return v, nil
+		case "w":
+			if v.showDebug && !v.debugLogger.IsPromptingFile() {
+				v.debugLogger.StartFilePrompt()
+			}
+			return v, nil
+		}
+
+	case cronJobTickMsg:
+		return v, tea.Batch(v.fetchCronJobs(), cronJobTick())
+
+	case cronJobsMsg:
+		v.loading = false
+		if msg.err != nil {
+			v.HandleError(msg.err)
+			v.debugLogger.Log("Error fetching cron jobs: %v", msg.err)
+		} else {
+			v.cronJobs = msg.cronJobs
+			v.updateTableRows()
+			v.lastFetch = time.Now()
+			v.ClearError()
+			v.debugLogger.Log("Fetched %d cron jobs", len(msg.cronJobs))
+		}
+		if msg.debugInfo != "" {
+			v.debugLogger.Log("API: %s", msg.debugInfo)
+		}
+		return v, nil
+	}
+
+	if mouseMsg, ok := msg.(tea.MouseMsg); ok {
+		if mouseMsg.Action == tea.MouseActionPress {
+			switch mouseMsg.Button {
+			case tea.MouseButtonWheelUp:
+				if v.table.Cursor() > 0 {
+					upMsg := tea.KeyMsg{Type: tea.KeyUp}
+					_, cmd = v.table.Update(upMsg)
+					return v, cmd
+				}
+			case tea.MouseButtonWheelDown:
+				if v.table.Cursor() < len(v.cronJobs)-1 {
+					downMsg := tea.KeyMsg{Type: tea.KeyDown}
+					_, cmd = v.table.Update(downMsg)
+					return v, cmd
+				}
+			}
+		}
+	}
+
+	_, cmd = v.table.Update(msg)
+	return v, cmd
+}
+
+// View renders the view to a string
+func (v *CronJobsView) View() string {
+	if v.Width == 0 {
+		return "Initializing..."
+	}
+
+	if v.showDebug {
+		return RenderDebugView(v.debugLogger, v.Width, v.Height, "")
+	}
+
+	header := RenderHeaderWithViewIndicator("Cron Jobs", v.Ctx.ProfileName, v.Width)
+
+	statsStyle := lipgloss.NewStyle().Foreground(styles.MutedColor).Padding(0, 1)
+	enabledCount := 0
+	for _, cj := range v.cronJobs {
+		if cj.Enabled {
+			enabledCount++
+		}
+	}
+	stats := statsStyle.Render(fmt.Sprintf("Total: %d  |  Enabled: %d", len(v.cronJobs), enabledCount))
+
+	loadingText := ""
+	if v.loading {
+		loadingStyle := lipgloss.NewStyle().Foreground(styles.AccentColor).Padding(0, 1)
+		loadingText = loadingStyle.Render("Loading...")
+	}
+
+	controlItems := []string{
+		"↑/↓: Navigate",
+		"r: Refresh",
+		"d: Debug",
+		"h: Help",
+		"shift+tab: Switch View",
+		"q: Quit",
+	}
+	controls := RenderFooter(controlItems, v.Width)
+
+	var b strings.Builder
+	b.WriteString(header)
+	b.WriteString("\n\n")
+	b.WriteString(stats)
+	if loadingText != "" {
+		b.WriteString("  ")
+		b.WriteString(loadingText)
+	}
+	b.WriteString("\n\n")
+	b.WriteString(v.table.View())
+	b.WriteString("\n\n")
+
+	if v.Err != nil {
+		b.WriteString(RenderError(fmt.Sprintf("Error: %v", v.Err), v.Width))
+		b.WriteString("\n")
+	}
+
+	if !v.lastFetch.IsZero() {
+		lastFetchStyle := lipgloss.NewStyle().Foreground(styles.MutedColor).Padding(0, 1)
+		b.WriteString(lastFetchStyle.Render(fmt.Sprintf("Last updated: %s", v.lastFetch.Format("15:04:05"))))
+		b.WriteString("\n")
+	}
+
+	b.WriteString(controls)
+	return b.String()
+}
+
+// SetSize updates the view dimensions
+func (v *CronJobsView) SetSize(width, height int) {
+	v.BaseModel.SetSize(width, height)
+	if height > 12 {
+		v.table.SetHeight(height - 12)
+	}
+}
+
+// fetchCronJobs fetches cron jobs from the API
+func (v *CronJobsView) fetchCronJobs() tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+
+		tenantUUID, err := uuid.Parse(v.Ctx.Client.TenantId())
+		if err != nil {
+			return cronJobsMsg{err: fmt.Errorf("invalid tenant ID: %w", err)}
+		}
+
+		limit := int64(50)
+		offset := int64(0)
+		response, err := v.Ctx.Client.API().CronWorkflowListWithResponse(ctx, tenantUUID, &rest.CronWorkflowListParams{
+			Limit:  &limit,
+			Offset: &offset,
+		})
+		if err != nil {
+			return cronJobsMsg{
+				err:       fmt.Errorf("failed to fetch cron jobs: %w", err),
+				debugInfo: "Error: " + err.Error(),
+			}
+		}
+		if response.JSON200 == nil {
+			return cronJobsMsg{
+				err:       fmt.Errorf("unexpected response from API: status %d", response.StatusCode()),
+				debugInfo: fmt.Sprintf("Status: %d", response.StatusCode()),
+			}
+		}
+
+		cronJobs := []rest.CronWorkflows{}
+		if response.JSON200.Rows != nil {
+			cronJobs = *response.JSON200.Rows
+		}
+
+		return cronJobsMsg{
+			cronJobs:  cronJobs,
+			debugInfo: fmt.Sprintf("Fetched %d cron jobs", len(cronJobs)),
+		}
+	}
+}
+
+// updateTableRows updates the table rows based on current cron jobs
+func (v *CronJobsView) updateTableRows() {
+	rows := make([]table.Row, len(v.cronJobs))
+
+	for i, cj := range v.cronJobs {
+		name := "(no name)"
+		if cj.Name != nil && *cj.Name != "" {
+			name = *cj.Name
+		}
+
+		enabled := "✗"
+		if cj.Enabled {
+			enabled = "✓"
+		}
+
+		createdAt := formatRelativeTime(cj.Metadata.CreatedAt)
+
+		rows[i] = table.Row{
+			name,
+			cj.Cron,
+			cj.WorkflowName,
+			enabled,
+			createdAt,
+		}
+	}
+
+	v.table.SetRows(rows)
+}
+
+// cronJobTick returns a command that sends a tick message after a delay
+func cronJobTick() tea.Cmd {
+	return tea.Tick(5*time.Second, func(t time.Time) tea.Msg {
+		return cronJobTickMsg(t)
+	})
+}

--- a/cmd/hatchet-cli/cli/tui/rate_limits.go
+++ b/cmd/hatchet-cli/cli/tui/rate_limits.go
@@ -1,0 +1,318 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/google/uuid"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/styles"
+	"github.com/hatchet-dev/hatchet/pkg/client/rest"
+)
+
+// RateLimitsView displays a list of rate limits in a table
+type RateLimitsView struct {
+	lastFetch   time.Time
+	table       *TableWithStyleFunc
+	debugLogger *DebugLogger
+	rateLimits  []rest.RateLimit
+	BaseModel
+	loading   bool
+	showDebug bool
+}
+
+// rateLimitsMsg contains the fetched rate limits
+type rateLimitsMsg struct {
+	err        error
+	debugInfo  string
+	rateLimits []rest.RateLimit
+}
+
+// rateLimitTickMsg is sent periodically to refresh the data
+type rateLimitTickMsg time.Time
+
+// NewRateLimitsView creates a new rate limits list view
+func NewRateLimitsView(ctx ViewContext) *RateLimitsView {
+	v := &RateLimitsView{
+		BaseModel:   BaseModel{Ctx: ctx},
+		loading:     false,
+		debugLogger: NewDebugLogger(5000),
+		showDebug:   false,
+	}
+
+	columns := []table.Column{
+		{Title: "Key", Width: 35},
+		{Title: "Value", Width: 10},
+		{Title: "Limit", Width: 10},
+		{Title: "Usage %", Width: 10},
+		{Title: "Window", Width: 12},
+		{Title: "Last Refill", Width: 18},
+	}
+
+	t := NewTableWithStyleFunc(
+		table.WithColumns(columns),
+		table.WithFocused(true),
+		table.WithHeight(20),
+	)
+
+	s := table.DefaultStyles()
+	s.Header = s.Header.
+		BorderStyle(lipgloss.NormalBorder()).
+		BorderForeground(styles.AccentColor).
+		BorderBottom(true).
+		Bold(true).
+		Foreground(styles.AccentColor)
+	s.Selected = s.Selected.
+		Foreground(lipgloss.AdaptiveColor{Light: "#ffffff", Dark: "#0A1029"}).
+		Background(styles.Blue).
+		Bold(true)
+	s.Cell = lipgloss.NewStyle()
+	t.SetStyles(s)
+
+	// Style: highlight rows where usage >= 80% in yellow, >= 90% in red
+	t.SetStyleFunc(func(row, col int) lipgloss.Style {
+		if row < len(v.rateLimits) {
+			rl := v.rateLimits[row]
+			if rl.LimitValue > 0 {
+				usage := float64(rl.Value) / float64(rl.LimitValue)
+				if usage >= 0.9 {
+					return lipgloss.NewStyle().Foreground(styles.StatusFailedColor)
+				} else if usage >= 0.8 {
+					return lipgloss.NewStyle().Foreground(styles.StatusInProgressColor)
+				}
+			}
+		}
+		return lipgloss.NewStyle()
+	})
+
+	v.table = t
+	return v
+}
+
+// Init initializes the view
+func (v *RateLimitsView) Init() tea.Cmd {
+	return tea.Batch(v.fetchRateLimits(), rateLimitTick())
+}
+
+// Update handles messages and updates the view state
+func (v *RateLimitsView) Update(msg tea.Msg) (View, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		v.SetSize(msg.Width, msg.Height)
+		v.table.SetHeight(msg.Height - 12)
+		return v, nil
+
+	case tea.KeyMsg:
+		if v.showDebug {
+			if handled, debugCmd := HandleDebugKeyboard(v.debugLogger, msg.String()); handled {
+				return v, debugCmd
+			}
+		}
+
+		switch msg.String() {
+		case "r":
+			v.loading = true
+			return v, v.fetchRateLimits()
+		case "d":
+			v.showDebug = !v.showDebug
+			return v, nil
+		case "c":
+			if v.showDebug && !v.debugLogger.IsPromptingFile() {
+				v.debugLogger.Clear()
+			}
+			return v, nil
+		case "w":
+			if v.showDebug && !v.debugLogger.IsPromptingFile() {
+				v.debugLogger.StartFilePrompt()
+			}
+			return v, nil
+		}
+
+	case rateLimitTickMsg:
+		return v, tea.Batch(v.fetchRateLimits(), rateLimitTick())
+
+	case rateLimitsMsg:
+		v.loading = false
+		if msg.err != nil {
+			v.HandleError(msg.err)
+			v.debugLogger.Log("Error fetching rate limits: %v", msg.err)
+		} else {
+			v.rateLimits = msg.rateLimits
+			v.updateTableRows()
+			v.lastFetch = time.Now()
+			v.ClearError()
+			v.debugLogger.Log("Fetched %d rate limits", len(msg.rateLimits))
+		}
+		if msg.debugInfo != "" {
+			v.debugLogger.Log("API: %s", msg.debugInfo)
+		}
+		return v, nil
+	}
+
+	if mouseMsg, ok := msg.(tea.MouseMsg); ok {
+		if mouseMsg.Action == tea.MouseActionPress {
+			switch mouseMsg.Button {
+			case tea.MouseButtonWheelUp:
+				if v.table.Cursor() > 0 {
+					upMsg := tea.KeyMsg{Type: tea.KeyUp}
+					_, cmd = v.table.Update(upMsg)
+					return v, cmd
+				}
+			case tea.MouseButtonWheelDown:
+				if v.table.Cursor() < len(v.rateLimits)-1 {
+					downMsg := tea.KeyMsg{Type: tea.KeyDown}
+					_, cmd = v.table.Update(downMsg)
+					return v, cmd
+				}
+			}
+		}
+	}
+
+	_, cmd = v.table.Update(msg)
+	return v, cmd
+}
+
+// View renders the view to a string
+func (v *RateLimitsView) View() string {
+	if v.Width == 0 {
+		return "Initializing..."
+	}
+
+	if v.showDebug {
+		return RenderDebugView(v.debugLogger, v.Width, v.Height, "")
+	}
+
+	header := RenderHeaderWithViewIndicator("Rate Limits", v.Ctx.ProfileName, v.Width)
+
+	statsStyle := lipgloss.NewStyle().Foreground(styles.MutedColor).Padding(0, 1)
+	stats := statsStyle.Render(fmt.Sprintf("Total: %d", len(v.rateLimits)))
+
+	loadingText := ""
+	if v.loading {
+		loadingStyle := lipgloss.NewStyle().Foreground(styles.AccentColor).Padding(0, 1)
+		loadingText = loadingStyle.Render("Loading...")
+	}
+
+	controlItems := []string{
+		"↑/↓: Navigate",
+		"r: Refresh",
+		"d: Debug",
+		"h: Help",
+		"shift+tab: Switch View",
+		"q: Quit",
+	}
+	controls := RenderFooter(controlItems, v.Width)
+
+	var b strings.Builder
+	b.WriteString(header)
+	b.WriteString("\n\n")
+	b.WriteString(stats)
+	if loadingText != "" {
+		b.WriteString("  ")
+		b.WriteString(loadingText)
+	}
+	b.WriteString("\n\n")
+	b.WriteString(v.table.View())
+	b.WriteString("\n\n")
+
+	if v.Err != nil {
+		b.WriteString(RenderError(fmt.Sprintf("Error: %v", v.Err), v.Width))
+		b.WriteString("\n")
+	}
+
+	if !v.lastFetch.IsZero() {
+		lastFetchStyle := lipgloss.NewStyle().Foreground(styles.MutedColor).Padding(0, 1)
+		b.WriteString(lastFetchStyle.Render(fmt.Sprintf("Last updated: %s", v.lastFetch.Format("15:04:05"))))
+		b.WriteString("\n")
+	}
+
+	b.WriteString(controls)
+	return b.String()
+}
+
+// SetSize updates the view dimensions
+func (v *RateLimitsView) SetSize(width, height int) {
+	v.BaseModel.SetSize(width, height)
+	if height > 12 {
+		v.table.SetHeight(height - 12)
+	}
+}
+
+// fetchRateLimits fetches rate limits from the API
+func (v *RateLimitsView) fetchRateLimits() tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+
+		tenantUUID, err := uuid.Parse(v.Ctx.Client.TenantId())
+		if err != nil {
+			return rateLimitsMsg{err: fmt.Errorf("invalid tenant ID: %w", err)}
+		}
+
+		limit := int64(100)
+		response, err := v.Ctx.Client.API().RateLimitListWithResponse(ctx, tenantUUID, &rest.RateLimitListParams{
+			Limit: &limit,
+		})
+		if err != nil {
+			return rateLimitsMsg{
+				err:       fmt.Errorf("failed to fetch rate limits: %w", err),
+				debugInfo: "Error: " + err.Error(),
+			}
+		}
+		if response.JSON200 == nil {
+			return rateLimitsMsg{
+				err:       fmt.Errorf("unexpected response from API: status %d", response.StatusCode()),
+				debugInfo: fmt.Sprintf("Status: %d", response.StatusCode()),
+			}
+		}
+
+		rateLimits := []rest.RateLimit{}
+		if response.JSON200.Rows != nil {
+			rateLimits = *response.JSON200.Rows
+		}
+
+		return rateLimitsMsg{
+			rateLimits: rateLimits,
+			debugInfo:  fmt.Sprintf("Fetched %d rate limits", len(rateLimits)),
+		}
+	}
+}
+
+// updateTableRows updates the table rows based on current rate limits
+func (v *RateLimitsView) updateTableRows() {
+	rows := make([]table.Row, len(v.rateLimits))
+
+	for i, rl := range v.rateLimits {
+		usagePct := "0%"
+		if rl.LimitValue > 0 {
+			pct := float64(rl.Value) / float64(rl.LimitValue) * 100
+			usagePct = fmt.Sprintf("%.0f%%", pct)
+		}
+
+		lastRefill := rl.LastRefill.Format("01/02 15:04:05")
+
+		rows[i] = table.Row{
+			rl.Key,
+			fmt.Sprintf("%d", rl.Value),
+			fmt.Sprintf("%d", rl.LimitValue),
+			usagePct,
+			rl.Window,
+			lastRefill,
+		}
+	}
+
+	v.table.SetRows(rows)
+}
+
+// rateLimitTick returns a command that sends a tick message after a delay
+func rateLimitTick() tea.Cmd {
+	return tea.Tick(5*time.Second, func(t time.Time) tea.Msg {
+		return rateLimitTickMsg(t)
+	})
+}

--- a/cmd/hatchet-cli/cli/tui/rate_limits.go
+++ b/cmd/hatchet-cli/cli/tui/rate_limits.go
@@ -74,15 +74,16 @@ func NewRateLimitsView(ctx ViewContext) *RateLimitsView {
 	s.Cell = lipgloss.NewStyle()
 	t.SetStyles(s)
 
-	// Style: highlight rows where usage >= 80% in yellow, >= 90% in red
+	// Style: Value is remaining capacity. Red when exhausted (0), yellow when <=10% remaining.
 	t.SetStyleFunc(func(row, col int) lipgloss.Style {
 		if row < len(v.rateLimits) {
 			rl := v.rateLimits[row]
 			if rl.LimitValue > 0 {
-				usage := float64(rl.Value) / float64(rl.LimitValue)
-				if usage >= 0.9 {
+				if rl.Value == 0 {
 					return lipgloss.NewStyle().Foreground(styles.StatusFailedColor)
-				} else if usage >= 0.8 {
+				}
+				remaining := float64(rl.Value) / float64(rl.LimitValue)
+				if remaining <= 0.1 {
 					return lipgloss.NewStyle().Foreground(styles.StatusInProgressColor)
 				}
 			}

--- a/cmd/hatchet-cli/cli/tui/scheduled_runs.go
+++ b/cmd/hatchet-cli/cli/tui/scheduled_runs.go
@@ -1,0 +1,347 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/google/uuid"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/styles"
+	"github.com/hatchet-dev/hatchet/pkg/client/rest"
+)
+
+// ScheduledRunsView displays a list of scheduled runs in a table
+type ScheduledRunsView struct {
+	lastFetch     time.Time
+	table         *TableWithStyleFunc
+	debugLogger   *DebugLogger
+	scheduledRuns []rest.ScheduledWorkflows
+	BaseModel
+	loading   bool
+	showDebug bool
+}
+
+// scheduledRunsMsg contains the fetched scheduled runs
+type scheduledRunsMsg struct {
+	err       error
+	debugInfo string
+	runs      []rest.ScheduledWorkflows
+}
+
+// scheduledRunTickMsg is sent periodically to refresh the data
+type scheduledRunTickMsg time.Time
+
+// NewScheduledRunsView creates a new scheduled runs list view
+func NewScheduledRunsView(ctx ViewContext) *ScheduledRunsView {
+	v := &ScheduledRunsView{
+		BaseModel:   BaseModel{Ctx: ctx},
+		loading:     false,
+		debugLogger: NewDebugLogger(5000),
+		showDebug:   false,
+	}
+
+	columns := []table.Column{
+		{Title: "ID", Width: 10},
+		{Title: "Status", Width: 14},
+		{Title: "Trigger At", Width: 20},
+		{Title: "Workflow", Width: 25},
+		{Title: "Created At", Width: 18},
+	}
+
+	t := NewTableWithStyleFunc(
+		table.WithColumns(columns),
+		table.WithFocused(true),
+		table.WithHeight(20),
+	)
+
+	s := table.DefaultStyles()
+	s.Header = s.Header.
+		BorderStyle(lipgloss.NormalBorder()).
+		BorderForeground(styles.AccentColor).
+		BorderBottom(true).
+		Bold(true).
+		Foreground(styles.AccentColor)
+	s.Selected = s.Selected.
+		Foreground(lipgloss.AdaptiveColor{Light: "#ffffff", Dark: "#0A1029"}).
+		Background(styles.Blue).
+		Bold(true)
+	s.Cell = lipgloss.NewStyle()
+	t.SetStyles(s)
+
+	// Style: color status column by run status
+	t.SetStyleFunc(func(row, col int) lipgloss.Style {
+		if col == 1 && row < len(v.scheduledRuns) {
+			run := v.scheduledRuns[row]
+			if run.WorkflowRunStatus != nil {
+				switch string(*run.WorkflowRunStatus) {
+				case "SUCCEEDED":
+					return lipgloss.NewStyle().Foreground(styles.StatusSuccessColor)
+				case "FAILED":
+					return lipgloss.NewStyle().Foreground(styles.StatusFailedColor)
+				case "RUNNING":
+					return lipgloss.NewStyle().Foreground(styles.StatusInProgressColor)
+				case "CANCELLED":
+					return lipgloss.NewStyle().Foreground(styles.StatusCancelledColor)
+				}
+			}
+		}
+		return lipgloss.NewStyle()
+	})
+
+	v.table = t
+	return v
+}
+
+// Init initializes the view
+func (v *ScheduledRunsView) Init() tea.Cmd {
+	return tea.Batch(v.fetchScheduledRuns(), scheduledRunTick())
+}
+
+// Update handles messages and updates the view state
+func (v *ScheduledRunsView) Update(msg tea.Msg) (View, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		v.SetSize(msg.Width, msg.Height)
+		v.table.SetHeight(msg.Height - 12)
+		return v, nil
+
+	case tea.KeyMsg:
+		if v.showDebug {
+			if handled, debugCmd := HandleDebugKeyboard(v.debugLogger, msg.String()); handled {
+				return v, debugCmd
+			}
+		}
+
+		switch msg.String() {
+		case "r":
+			v.loading = true
+			return v, v.fetchScheduledRuns()
+		case "d":
+			v.showDebug = !v.showDebug
+			return v, nil
+		case "c":
+			if v.showDebug && !v.debugLogger.IsPromptingFile() {
+				v.debugLogger.Clear()
+			}
+			return v, nil
+		case "w":
+			if v.showDebug && !v.debugLogger.IsPromptingFile() {
+				v.debugLogger.StartFilePrompt()
+			}
+			return v, nil
+		case "enter":
+			// Navigate to run details if the scheduled run was triggered
+			if len(v.scheduledRuns) > 0 {
+				selectedIdx := v.table.Cursor()
+				if selectedIdx >= 0 && selectedIdx < len(v.scheduledRuns) {
+					run := v.scheduledRuns[selectedIdx]
+					if run.WorkflowRunId != nil {
+						runID := run.WorkflowRunId.String()
+						v.debugLogger.Log("Navigating to run: %s", runID)
+						return v, NewNavigateToRunWithDetectionMsg(runID)
+					}
+				}
+			}
+			return v, nil
+		}
+
+	case scheduledRunTickMsg:
+		return v, tea.Batch(v.fetchScheduledRuns(), scheduledRunTick())
+
+	case scheduledRunsMsg:
+		v.loading = false
+		if msg.err != nil {
+			v.HandleError(msg.err)
+			v.debugLogger.Log("Error fetching scheduled runs: %v", msg.err)
+		} else {
+			v.scheduledRuns = msg.runs
+			v.updateTableRows()
+			v.lastFetch = time.Now()
+			v.ClearError()
+			v.debugLogger.Log("Fetched %d scheduled runs", len(msg.runs))
+		}
+		if msg.debugInfo != "" {
+			v.debugLogger.Log("API: %s", msg.debugInfo)
+		}
+		return v, nil
+	}
+
+	if mouseMsg, ok := msg.(tea.MouseMsg); ok {
+		if mouseMsg.Action == tea.MouseActionPress {
+			switch mouseMsg.Button {
+			case tea.MouseButtonWheelUp:
+				if v.table.Cursor() > 0 {
+					upMsg := tea.KeyMsg{Type: tea.KeyUp}
+					_, cmd = v.table.Update(upMsg)
+					return v, cmd
+				}
+			case tea.MouseButtonWheelDown:
+				if v.table.Cursor() < len(v.scheduledRuns)-1 {
+					downMsg := tea.KeyMsg{Type: tea.KeyDown}
+					_, cmd = v.table.Update(downMsg)
+					return v, cmd
+				}
+			}
+		}
+	}
+
+	_, cmd = v.table.Update(msg)
+	return v, cmd
+}
+
+// View renders the view to a string
+func (v *ScheduledRunsView) View() string {
+	if v.Width == 0 {
+		return "Initializing..."
+	}
+
+	if v.showDebug {
+		return RenderDebugView(v.debugLogger, v.Width, v.Height, "")
+	}
+
+	header := RenderHeaderWithViewIndicator("Scheduled Runs", v.Ctx.ProfileName, v.Width)
+
+	statsStyle := lipgloss.NewStyle().Foreground(styles.MutedColor).Padding(0, 1)
+	stats := statsStyle.Render(fmt.Sprintf("Total: %d", len(v.scheduledRuns)))
+
+	loadingText := ""
+	if v.loading {
+		loadingStyle := lipgloss.NewStyle().Foreground(styles.AccentColor).Padding(0, 1)
+		loadingText = loadingStyle.Render("Loading...")
+	}
+
+	controlItems := []string{
+		"↑/↓: Navigate",
+		"enter: View Run",
+		"r: Refresh",
+		"d: Debug",
+		"h: Help",
+		"shift+tab: Switch View",
+		"q: Quit",
+	}
+	controls := RenderFooter(controlItems, v.Width)
+
+	var b strings.Builder
+	b.WriteString(header)
+	b.WriteString("\n\n")
+	b.WriteString(stats)
+	if loadingText != "" {
+		b.WriteString("  ")
+		b.WriteString(loadingText)
+	}
+	b.WriteString("\n\n")
+	b.WriteString(v.table.View())
+	b.WriteString("\n\n")
+
+	if v.Err != nil {
+		b.WriteString(RenderError(fmt.Sprintf("Error: %v", v.Err), v.Width))
+		b.WriteString("\n")
+	}
+
+	if !v.lastFetch.IsZero() {
+		lastFetchStyle := lipgloss.NewStyle().Foreground(styles.MutedColor).Padding(0, 1)
+		b.WriteString(lastFetchStyle.Render(fmt.Sprintf("Last updated: %s", v.lastFetch.Format("15:04:05"))))
+		b.WriteString("\n")
+	}
+
+	b.WriteString(controls)
+	return b.String()
+}
+
+// SetSize updates the view dimensions
+func (v *ScheduledRunsView) SetSize(width, height int) {
+	v.BaseModel.SetSize(width, height)
+	if height > 12 {
+		v.table.SetHeight(height - 12)
+	}
+}
+
+// fetchScheduledRuns fetches scheduled runs from the API
+func (v *ScheduledRunsView) fetchScheduledRuns() tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+
+		tenantUUID, err := uuid.Parse(v.Ctx.Client.TenantId())
+		if err != nil {
+			return scheduledRunsMsg{err: fmt.Errorf("invalid tenant ID: %w", err)}
+		}
+
+		limit := int64(50)
+		offset := int64(0)
+		response, err := v.Ctx.Client.API().WorkflowScheduledListWithResponse(ctx, tenantUUID, &rest.WorkflowScheduledListParams{
+			Limit:  &limit,
+			Offset: &offset,
+		})
+		if err != nil {
+			return scheduledRunsMsg{
+				err:       fmt.Errorf("failed to fetch scheduled runs: %w", err),
+				debugInfo: "Error: " + err.Error(),
+			}
+		}
+		if response.JSON200 == nil {
+			return scheduledRunsMsg{
+				err:       fmt.Errorf("unexpected response from API: status %d", response.StatusCode()),
+				debugInfo: fmt.Sprintf("Status: %d", response.StatusCode()),
+			}
+		}
+
+		runs := []rest.ScheduledWorkflows{}
+		if response.JSON200.Rows != nil {
+			runs = *response.JSON200.Rows
+		}
+
+		return scheduledRunsMsg{
+			runs:      runs,
+			debugInfo: fmt.Sprintf("Fetched %d scheduled runs", len(runs)),
+		}
+	}
+}
+
+// updateTableRows updates the table rows based on current scheduled runs
+func (v *ScheduledRunsView) updateTableRows() {
+	rows := make([]table.Row, len(v.scheduledRuns))
+
+	for i, run := range v.scheduledRuns {
+		// Short ID (first 8 chars)
+		shortID := run.Metadata.Id
+		if len(shortID) > 8 {
+			shortID = shortID[:8]
+		}
+
+		// Status
+		status := "Scheduled"
+		if run.WorkflowRunStatus != nil {
+			status = string(*run.WorkflowRunStatus)
+		}
+
+		// Trigger At
+		triggerAt := run.TriggerAt.Format("01/02 15:04:05")
+
+		// Created At
+		createdAt := formatRelativeTime(run.Metadata.CreatedAt)
+
+		rows[i] = table.Row{
+			shortID,
+			status,
+			triggerAt,
+			run.WorkflowName,
+			createdAt,
+		}
+	}
+
+	v.table.SetRows(rows)
+}
+
+// scheduledRunTick returns a command that sends a tick message after a delay
+func scheduledRunTick() tea.Cmd {
+	return tea.Tick(5*time.Second, func(t time.Time) tea.Msg {
+		return scheduledRunTickMsg(t)
+	})
+}

--- a/cmd/hatchet-cli/cli/tui/webhooks.go
+++ b/cmd/hatchet-cli/cli/tui/webhooks.go
@@ -1,0 +1,295 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/google/uuid"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/styles"
+	"github.com/hatchet-dev/hatchet/pkg/client/rest"
+)
+
+// WebhooksView displays a list of V1 webhooks in a table
+type WebhooksView struct {
+	lastFetch   time.Time
+	table       *TableWithStyleFunc
+	debugLogger *DebugLogger
+	webhooks    []rest.V1Webhook
+	BaseModel
+	loading   bool
+	showDebug bool
+}
+
+// webhooksMsg contains the fetched webhooks
+type webhooksMsg struct {
+	err       error
+	debugInfo string
+	webhooks  []rest.V1Webhook
+}
+
+// webhookTickMsg is sent periodically to refresh the data
+type webhookTickMsg time.Time
+
+// NewWebhooksView creates a new webhooks list view
+func NewWebhooksView(ctx ViewContext) *WebhooksView {
+	v := &WebhooksView{
+		BaseModel:   BaseModel{Ctx: ctx},
+		loading:     false,
+		debugLogger: NewDebugLogger(5000),
+		showDebug:   false,
+	}
+
+	columns := []table.Column{
+		{Title: "Name", Width: 30},
+		{Title: "Source", Width: 20},
+		{Title: "Created At", Width: 18},
+	}
+
+	t := NewTableWithStyleFunc(
+		table.WithColumns(columns),
+		table.WithFocused(true),
+		table.WithHeight(20),
+	)
+
+	s := table.DefaultStyles()
+	s.Header = s.Header.
+		BorderStyle(lipgloss.NormalBorder()).
+		BorderForeground(styles.AccentColor).
+		BorderBottom(true).
+		Bold(true).
+		Foreground(styles.AccentColor)
+	s.Selected = s.Selected.
+		Foreground(lipgloss.AdaptiveColor{Light: "#ffffff", Dark: "#0A1029"}).
+		Background(styles.Blue).
+		Bold(true)
+	s.Cell = lipgloss.NewStyle()
+	t.SetStyles(s)
+
+	t.SetStyleFunc(func(row, col int) lipgloss.Style {
+		return lipgloss.NewStyle()
+	})
+
+	v.table = t
+	return v
+}
+
+// Init initializes the view
+func (v *WebhooksView) Init() tea.Cmd {
+	return tea.Batch(v.fetchWebhooks(), webhookTick())
+}
+
+// Update handles messages and updates the view state
+func (v *WebhooksView) Update(msg tea.Msg) (View, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		v.SetSize(msg.Width, msg.Height)
+		v.table.SetHeight(msg.Height - 12)
+		return v, nil
+
+	case tea.KeyMsg:
+		if v.showDebug {
+			if handled, debugCmd := HandleDebugKeyboard(v.debugLogger, msg.String()); handled {
+				return v, debugCmd
+			}
+		}
+
+		switch msg.String() {
+		case "r":
+			v.loading = true
+			return v, v.fetchWebhooks()
+		case "d":
+			v.showDebug = !v.showDebug
+			return v, nil
+		case "c":
+			if v.showDebug && !v.debugLogger.IsPromptingFile() {
+				v.debugLogger.Clear()
+			}
+			return v, nil
+		case "w":
+			if v.showDebug && !v.debugLogger.IsPromptingFile() {
+				v.debugLogger.StartFilePrompt()
+			}
+			return v, nil
+		}
+
+	case webhookTickMsg:
+		return v, tea.Batch(v.fetchWebhooks(), webhookTick())
+
+	case webhooksMsg:
+		v.loading = false
+		if msg.err != nil {
+			v.HandleError(msg.err)
+			v.debugLogger.Log("Error fetching webhooks: %v", msg.err)
+		} else {
+			v.webhooks = msg.webhooks
+			v.updateTableRows()
+			v.lastFetch = time.Now()
+			v.ClearError()
+			v.debugLogger.Log("Fetched %d webhooks", len(msg.webhooks))
+		}
+		if msg.debugInfo != "" {
+			v.debugLogger.Log("API: %s", msg.debugInfo)
+		}
+		return v, nil
+	}
+
+	if mouseMsg, ok := msg.(tea.MouseMsg); ok {
+		if mouseMsg.Action == tea.MouseActionPress {
+			switch mouseMsg.Button {
+			case tea.MouseButtonWheelUp:
+				if v.table.Cursor() > 0 {
+					upMsg := tea.KeyMsg{Type: tea.KeyUp}
+					_, cmd = v.table.Update(upMsg)
+					return v, cmd
+				}
+			case tea.MouseButtonWheelDown:
+				if v.table.Cursor() < len(v.webhooks)-1 {
+					downMsg := tea.KeyMsg{Type: tea.KeyDown}
+					_, cmd = v.table.Update(downMsg)
+					return v, cmd
+				}
+			}
+		}
+	}
+
+	_, cmd = v.table.Update(msg)
+	return v, cmd
+}
+
+// View renders the view to a string
+func (v *WebhooksView) View() string {
+	if v.Width == 0 {
+		return "Initializing..."
+	}
+
+	if v.showDebug {
+		return RenderDebugView(v.debugLogger, v.Width, v.Height, "")
+	}
+
+	header := RenderHeaderWithViewIndicator("Webhooks", v.Ctx.ProfileName, v.Width)
+
+	statsStyle := lipgloss.NewStyle().Foreground(styles.MutedColor).Padding(0, 1)
+	stats := statsStyle.Render(fmt.Sprintf("Total: %d", len(v.webhooks)))
+
+	loadingText := ""
+	if v.loading {
+		loadingStyle := lipgloss.NewStyle().Foreground(styles.AccentColor).Padding(0, 1)
+		loadingText = loadingStyle.Render("Loading...")
+	}
+
+	controlItems := []string{
+		"↑/↓: Navigate",
+		"r: Refresh",
+		"d: Debug",
+		"h: Help",
+		"shift+tab: Switch View",
+		"q: Quit",
+	}
+	controls := RenderFooter(controlItems, v.Width)
+
+	var b strings.Builder
+	b.WriteString(header)
+	b.WriteString("\n\n")
+	b.WriteString(stats)
+	if loadingText != "" {
+		b.WriteString("  ")
+		b.WriteString(loadingText)
+	}
+	b.WriteString("\n\n")
+	b.WriteString(v.table.View())
+	b.WriteString("\n\n")
+
+	if v.Err != nil {
+		b.WriteString(RenderError(fmt.Sprintf("Error: %v", v.Err), v.Width))
+		b.WriteString("\n")
+	}
+
+	if !v.lastFetch.IsZero() {
+		lastFetchStyle := lipgloss.NewStyle().Foreground(styles.MutedColor).Padding(0, 1)
+		b.WriteString(lastFetchStyle.Render(fmt.Sprintf("Last updated: %s", v.lastFetch.Format("15:04:05"))))
+		b.WriteString("\n")
+	}
+
+	b.WriteString(controls)
+	return b.String()
+}
+
+// SetSize updates the view dimensions
+func (v *WebhooksView) SetSize(width, height int) {
+	v.BaseModel.SetSize(width, height)
+	if height > 12 {
+		v.table.SetHeight(height - 12)
+	}
+}
+
+// fetchWebhooks fetches webhooks from the API
+func (v *WebhooksView) fetchWebhooks() tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+
+		tenantUUID, err := uuid.Parse(v.Ctx.Client.TenantId())
+		if err != nil {
+			return webhooksMsg{err: fmt.Errorf("invalid tenant ID: %w", err)}
+		}
+
+		limit := int64(200)
+		offset := int64(0)
+		response, err := v.Ctx.Client.API().V1WebhookListWithResponse(ctx, tenantUUID, &rest.V1WebhookListParams{
+			Limit:  &limit,
+			Offset: &offset,
+		})
+		if err != nil {
+			return webhooksMsg{
+				err:       fmt.Errorf("failed to fetch webhooks: %w", err),
+				debugInfo: "Error: " + err.Error(),
+			}
+		}
+		if response.JSON200 == nil {
+			return webhooksMsg{
+				err:       fmt.Errorf("unexpected response from API: status %d", response.StatusCode()),
+				debugInfo: fmt.Sprintf("Status: %d", response.StatusCode()),
+			}
+		}
+
+		webhooks := []rest.V1Webhook{}
+		if response.JSON200.Rows != nil {
+			webhooks = *response.JSON200.Rows
+		}
+
+		return webhooksMsg{
+			webhooks:  webhooks,
+			debugInfo: fmt.Sprintf("Fetched %d webhooks", len(webhooks)),
+		}
+	}
+}
+
+// updateTableRows updates the table rows based on current webhooks
+func (v *WebhooksView) updateTableRows() {
+	rows := make([]table.Row, len(v.webhooks))
+
+	for i, wh := range v.webhooks {
+		createdAt := formatRelativeTime(wh.Metadata.CreatedAt)
+		rows[i] = table.Row{
+			wh.Name,
+			string(wh.SourceName),
+			createdAt,
+		}
+	}
+
+	v.table.SetRows(rows)
+}
+
+// webhookTick returns a command that sends a tick message after a delay
+func webhookTick() tea.Cmd {
+	return tea.Tick(5*time.Second, func(t time.Time) tea.Msg {
+		return webhookTickMsg(t)
+	})
+}

--- a/cmd/hatchet-cli/cli/webhooks.go
+++ b/cmd/hatchet-cli/cli/webhooks.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/spf13/cobra"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/config/cli"
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/tui"
+	"github.com/hatchet-dev/hatchet/pkg/client/rest"
+)
+
+var webhooksCmd = &cobra.Command{
+	Use:     "webhooks",
+	Aliases: []string{"webhook"},
+	Short:   "Manage webhooks",
+	Long:    `Commands for listing and inspecting webhooks.`,
+	Run:     func(cmd *cobra.Command, args []string) { _ = cmd.Help() },
+}
+
+var webhooksListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List webhooks",
+	Long:  `List webhooks. Without --output json, launches the interactive TUI. With --output json, outputs raw JSON.`,
+	Example: `  # Launch interactive TUI (default)
+  hatchet webhooks list --profile local
+
+  # JSON output
+  hatchet webhooks list -o json`,
+	Run: func(cmd *cobra.Command, args []string) {
+		isJSON := isJSONOutput(cmd)
+		selectedProfile, hatchetClient := clientFromCmd(cmd)
+
+		if !isJSON {
+			tuiM := newTUIModel(selectedProfile, hatchetClient)
+			tuiM.currentViewType = ViewTypeWebhooks
+			tuiM.currentView = tui.NewWebhooksView(tuiM.ctx)
+			p := tea.NewProgram(tuiM, tea.WithAltScreen())
+			if _, err := p.Run(); err != nil {
+				cli.Logger.Fatalf("error running TUI: %v", err)
+			}
+			return
+		}
+
+		ctx := cmd.Context()
+		tenantUUID := clientTenantUUID(hatchetClient)
+		limit := int64(50)
+		offset := int64(0)
+		resp, err := hatchetClient.API().V1WebhookListWithResponse(ctx, tenantUUID, &rest.V1WebhookListParams{
+			Limit:  &limit,
+			Offset: &offset,
+		})
+		if err != nil {
+			cli.Logger.Fatalf("failed to list webhooks: %v", err)
+		}
+		if resp.JSON200 == nil {
+			cli.Logger.Fatalf("unexpected response from API (status %d)", resp.StatusCode())
+		}
+
+		printJSON(resp.JSON200)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(webhooksCmd)
+	webhooksCmd.AddCommand(webhooksListCmd)
+
+	webhooksCmd.PersistentFlags().StringP("profile", "p", "", "Profile to use for connecting to Hatchet (default: prompts for selection)")
+	webhooksCmd.PersistentFlags().StringP("output", "o", "", "Output format: json (skips interactive TUI)")
+}

--- a/cmd/hatchet-cli/cli/webhooks_e2e_test.go
+++ b/cmd/hatchet-cli/cli/webhooks_e2e_test.go
@@ -1,0 +1,41 @@
+//go:build e2e_cli
+
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/testharness"
+)
+
+func TestWebhooksListJSON(t *testing.T) {
+	h := testharness.New(t)
+	out := h.RunJSON("webhooks", "list")
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("failed to unmarshal webhooks list output: %v\nOutput: %s", err, out)
+	}
+
+	if result == nil {
+		t.Error("expected non-nil JSON response from webhooks list")
+	}
+}
+
+func TestWebhooksTUI(t *testing.T) {
+	h := testharness.New(t)
+	tui := testharness.NewTUI(t, h)
+	t.Cleanup(tui.Stop)
+
+	tui.Start("webhooks", "list")
+	content := tui.CaptureAfter(3 * time.Second)
+
+	if content == "" {
+		t.Fatal("TUI output was empty")
+	}
+	if !containsAny(content, "Webhooks", "webhooks") {
+		t.Errorf("expected TUI to show 'Webhooks' header; got:\n%s", content)
+	}
+}

--- a/cmd/hatchet-cli/cli/workers_e2e_test.go
+++ b/cmd/hatchet-cli/cli/workers_e2e_test.go
@@ -1,0 +1,66 @@
+//go:build e2e_cli
+
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/testharness"
+)
+
+func TestWorkerListJSON(t *testing.T) {
+	h := testharness.New(t)
+	out := h.RunJSON("worker", "list")
+
+	var result struct {
+		Rows []map[string]interface{} `json:"rows"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("failed to unmarshal worker list output: %v\nOutput: %s", err, out)
+	}
+
+	if result.Rows == nil {
+		t.Errorf("expected 'rows' array in response, got nil")
+	}
+}
+
+func TestWorkerGetJSON(t *testing.T) {
+	workerID := os.Getenv("HATCHET_TEST_WORKER_ID")
+	if workerID == "" {
+		t.Skip("HATCHET_TEST_WORKER_ID not set; skipping worker get test")
+	}
+
+	h := testharness.New(t)
+	out := h.RunJSON("worker", "get", workerID)
+
+	var result struct {
+		Metadata struct {
+			ID string `json:"id"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("failed to unmarshal worker get output: %v\nOutput: %s", err, out)
+	}
+	if result.Metadata.ID != workerID {
+		t.Errorf("expected metadata.id = %q, got %q", workerID, result.Metadata.ID)
+	}
+}
+
+func TestWorkersTUI(t *testing.T) {
+	h := testharness.New(t)
+	tui := testharness.NewTUI(t, h)
+	t.Cleanup(tui.Stop)
+
+	tui.Start("worker", "list")
+	content := tui.CaptureAfter(3 * time.Second)
+
+	if content == "" {
+		t.Fatal("TUI output was empty")
+	}
+	if !containsAny(content, "Workers", "workers") {
+		t.Errorf("expected TUI to show 'Workers' header; got:\n%s", content)
+	}
+}

--- a/cmd/hatchet-cli/cli/workflows.go
+++ b/cmd/hatchet-cli/cli/workflows.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/config/cli"
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/tui"
+	"github.com/hatchet-dev/hatchet/pkg/client/rest"
+)
+
+var workflowsCmd = &cobra.Command{
+	Use:     "workflows",
+	Aliases: []string{"workflow"},
+	Short:   "Manage workflows",
+	Long:    `Commands for listing and inspecting workflows.`,
+	Run:     func(cmd *cobra.Command, args []string) { _ = cmd.Help() },
+}
+
+var workflowsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List workflows",
+	Long:  `List workflows. Without --output json, launches the interactive TUI. With --output json, outputs raw JSON.`,
+	Example: `  # Launch interactive TUI (default)
+  hatchet workflows list --profile local
+
+  # JSON output
+  hatchet workflows list -o json
+  hatchet workflows list -o json --search my-workflow --limit 100`,
+	Run: func(cmd *cobra.Command, args []string) {
+		isJSON := isJSONOutput(cmd)
+		selectedProfile, hatchetClient := clientFromCmd(cmd)
+
+		if !isJSON {
+			tuiM := newTUIModel(selectedProfile, hatchetClient)
+			tuiM.currentViewType = ViewTypeWorkflows
+			tuiM.currentView = tui.NewWorkflowsView(tuiM.ctx)
+			p := tea.NewProgram(tuiM, tea.WithAltScreen())
+			if _, err := p.Run(); err != nil {
+				cli.Logger.Fatalf("error running TUI: %v", err)
+			}
+			return
+		}
+
+		ctx := cmd.Context()
+		tenantUUID := clientTenantUUID(hatchetClient)
+		searchStr, _ := cmd.Flags().GetString("search")
+		limit, _ := cmd.Flags().GetInt("limit")
+		offset, _ := cmd.Flags().GetInt("offset")
+
+		params := &rest.WorkflowListParams{
+			Limit:  &limit,
+			Offset: &offset,
+		}
+		if searchStr != "" {
+			params.Name = &searchStr
+		}
+
+		resp, err := hatchetClient.API().WorkflowListWithResponse(ctx, tenantUUID, params)
+		if err != nil {
+			cli.Logger.Fatalf("failed to list workflows: %v", err)
+		}
+		if resp.JSON200 == nil {
+			cli.Logger.Fatalf("unexpected response from API (status %d)", resp.StatusCode())
+		}
+
+		printJSON(resp.JSON200)
+	},
+}
+
+var workflowsGetCmd = &cobra.Command{
+	Use:   "get <workflow-id>",
+	Short: "Get workflow details",
+	Long:  `Get details about a workflow. Without --output json, launches the TUI navigated to the workflow. With --output json, outputs raw JSON.`,
+	Args:  cobra.ExactArgs(1),
+	Example: `  # Launch TUI for a specific workflow
+  hatchet workflows get <workflow-id> --profile local
+
+  # JSON output
+  hatchet workflows get <workflow-id> -o json`,
+	Run: func(cmd *cobra.Command, args []string) {
+		workflowID := args[0]
+		isJSON := isJSONOutput(cmd)
+		selectedProfile, hatchetClient := clientFromCmd(cmd)
+
+		if !isJSON {
+			base := newTUIModel(selectedProfile, hatchetClient)
+			base.currentViewType = ViewTypeWorkflows
+			base.currentView = tui.NewWorkflowsView(base.ctx)
+			model := tuiModelWithInitialWorkflow{
+				tuiModel:          base,
+				initialWorkflowID: workflowID,
+			}
+			p := tea.NewProgram(model, tea.WithAltScreen())
+			if _, err := p.Run(); err != nil {
+				cli.Logger.Fatalf("error running TUI: %v", err)
+			}
+			return
+		}
+
+		workflowUUID, err := uuid.Parse(workflowID)
+		if err != nil {
+			cli.Logger.Fatalf("invalid workflow ID %q: %v", workflowID, err)
+		}
+
+		ctx := cmd.Context()
+		resp, err := hatchetClient.API().WorkflowGetWithResponse(ctx, workflowUUID)
+		if err != nil {
+			cli.Logger.Fatalf("failed to get workflow: %v", err)
+		}
+		if resp.JSON200 == nil {
+			cli.Logger.Fatalf("workflow not found (status %d)", resp.StatusCode())
+		}
+
+		printJSON(resp.JSON200)
+	},
+}
+
+// tuiModelWithInitialWorkflow wraps tuiModel to navigate to a specific workflow on init
+type tuiModelWithInitialWorkflow struct {
+	initialWorkflowID string
+	tuiModel
+}
+
+func (m tuiModelWithInitialWorkflow) Init() tea.Cmd {
+	return tea.Batch(
+		m.tuiModel.Init(),
+		func() tea.Msg { return tui.NavigateToWorkflowMsg{WorkflowID: m.initialWorkflowID} },
+	)
+}
+
+func init() {
+	rootCmd.AddCommand(workflowsCmd)
+	workflowsCmd.AddCommand(workflowsListCmd, workflowsGetCmd)
+
+	workflowsCmd.PersistentFlags().StringP("profile", "p", "", "Profile to use for connecting to Hatchet (default: prompts for selection)")
+	workflowsCmd.PersistentFlags().StringP("output", "o", "", "Output format: json (skips interactive TUI)")
+
+	workflowsListCmd.Flags().StringP("search", "s", "", "Search workflows by name")
+	workflowsListCmd.Flags().Int("limit", 50, "Number of results to return")
+	workflowsListCmd.Flags().Int("offset", 0, "Offset for pagination")
+}

--- a/cmd/hatchet-cli/cli/workflows_e2e_test.go
+++ b/cmd/hatchet-cli/cli/workflows_e2e_test.go
@@ -1,0 +1,81 @@
+//go:build e2e_cli
+
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/testharness"
+)
+
+func TestWorkflowsListJSON(t *testing.T) {
+	h := testharness.New(t)
+	out := h.RunJSON("workflows", "list")
+
+	var result struct {
+		Rows []map[string]interface{} `json:"rows"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("failed to unmarshal workflows list output: %v\nOutput: %s", err, out)
+	}
+
+	// rows may be empty, but the field must exist
+	if result.Rows == nil {
+		t.Errorf("expected 'rows' array in response, got nil")
+	}
+}
+
+func TestWorkflowsGetJSON(t *testing.T) {
+	workflowID := os.Getenv("HATCHET_TEST_WORKFLOW_ID")
+	if workflowID == "" {
+		t.Skip("HATCHET_TEST_WORKFLOW_ID not set; skipping workflows get test")
+	}
+
+	h := testharness.New(t)
+	out := h.RunJSON("workflows", "get", workflowID)
+
+	var result struct {
+		Metadata struct {
+			ID string `json:"id"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("failed to unmarshal workflows get output: %v\nOutput: %s", err, out)
+	}
+	if result.Metadata.ID != workflowID {
+		t.Errorf("expected metadata.id = %q, got %q", workflowID, result.Metadata.ID)
+	}
+}
+
+func TestWorkflowsTUI(t *testing.T) {
+	h := testharness.New(t)
+	tui := testharness.NewTUI(t, h)
+	t.Cleanup(tui.Stop)
+
+	tui.Start("workflows", "list")
+	content := tui.CaptureAfter(3 * time.Second)
+
+	if content == "" {
+		t.Fatal("TUI output was empty")
+	}
+	if !containsAny(content, "Workflows", "workflows") {
+		t.Errorf("expected TUI to show 'Workflows' header; got:\n%s", content)
+	}
+}
+
+// containsAny reports whether s contains any of the given substrings.
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if len(s) >= len(sub) {
+			for i := 0; i <= len(s)-len(sub); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/cmd/hatchet-cli/cli/workflows_e2e_test.go
+++ b/cmd/hatchet-cli/cli/workflows_e2e_test.go
@@ -5,6 +5,7 @@ package cli
 import (
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -69,12 +70,8 @@ func TestWorkflowsTUI(t *testing.T) {
 // containsAny reports whether s contains any of the given substrings.
 func containsAny(s string, subs ...string) bool {
 	for _, sub := range subs {
-		if len(s) >= len(sub) {
-			for i := 0; i <= len(s)-len(sub); i++ {
-				if s[i:i+len(sub)] == sub {
-					return true
-				}
-			}
+		if strings.Contains(s, sub) {
+			return true
 		}
 	}
 	return false


### PR DESCRIPTION
# Description

Adds a set of runs commands to the Hatchet CLI, useful for debugging and hooking into Claude Code:

```txt
Commands for listing, inspecting, cancelling, replaying, and viewing logs/events for workflow runs.

Usage:
  hatchet runs [flags]
  hatchet runs [command]

Available Commands:
  cancel      Cancel a workflow run or bulk cancel by filter
  events      Print events from a workflow run
  get         Inspect a workflow run
  list        List workflow runs
  logs        Print aggregated logs from a workflow run
  replay      Replay a workflow run or bulk replay by filter

Flags:
  -h, --help             help for runs
  -o, --output string    Output format: json (skips interactive TUI)
  -p, --profile string   Profile to use for connecting to Hatchet (default: prompts for selection)

Global Flags:
  -v, --version   The version of the hatchet cli.

Use "hatchet runs [command] --help" for more information about a command.
```

## Type of change

- [X] New feature (non-breaking change which adds functionality)