### PR TITLE
Fix: Correctly create log files, reject events from non-current invocations

### DIFF
--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -437,7 +437,7 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 	}
 
 	if logFile.LatestInvocationCount != opts.InvocationCount {
-		// todo: should evict this invocation if this happens
+		// TODO-DURABLE: should evict this invocation if this happens
 		return nil, fmt.Errorf("invocation count mismatch: expected %d, got %d. rejecting event write.", logFile.LatestInvocationCount, opts.InvocationCount)
 	}
 

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -446,6 +446,11 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 		return nil, fmt.Errorf("failed to lock log file: %w", err)
 	}
 
+	if logFile.LatestInvocationCount != opts.InvocationCount {
+		// todo: should evict this invocation if this happens
+		return nil, fmt.Errorf("invocation count mismatch: expected %d, got %d. rejecting event write.", logFile.LatestInvocationCount, opts.InvocationCount)
+	}
+
 	// TODO-DURABLE probably need to grab the previous entry here, if it exists, to determine how to increment?
 	// basically need some way to figure out that we've reached a branching point
 	// maybe we need to use `latest_branch_first_parent_node_id` for this?

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -408,18 +408,8 @@ func (r *durableEventsRepository) getAndLockLogFile(ctx context.Context, tx sqlc
 		Tenantid:              tenantId,
 	})
 
-	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+	if err != nil {
 		return nil, fmt.Errorf("failed to lock log file: %w", err)
-	} else if errors.Is(err, pgx.ErrNoRows) {
-		logFile, err = r.queries.CreateEventLogFile(ctx, tx, sqlcv1.CreateEventLogFileParams{
-			Durabletaskid:         durableTaskId,
-			Durabletaskinsertedat: durableTaskInsertedAt,
-			Tenantid:              tenantId,
-		})
-
-		if err != nil {
-			return nil, fmt.Errorf("failed to create log file: %w", err)
-		}
 	}
 
 	return logFile, nil

--- a/pkg/repository/sqlcv1/durable_event_log.sql
+++ b/pkg/repository/sqlcv1/durable_event_log.sql
@@ -33,7 +33,7 @@ SELECT
     1,
     NOW(),
     0,
-    0,
+    1,
     0
 FROM inputs
 ON CONFLICT (durable_task_id, durable_task_inserted_at) DO UPDATE

--- a/pkg/repository/sqlcv1/durable_event_log.sql
+++ b/pkg/repository/sqlcv1/durable_event_log.sql
@@ -38,7 +38,7 @@ SELECT
 FROM inputs
 ON CONFLICT (durable_task_id, durable_task_inserted_at) DO UPDATE
 SET
-    latest_invocation_count = latest_invocation_count + 1,
+    latest_invocation_count = EXCLUDED.latest_invocation_count + 1,
     latest_node_id = 0
 RETURNING v1_durable_event_log_file.*
 ;

--- a/pkg/repository/sqlcv1/durable_event_log.sql
+++ b/pkg/repository/sqlcv1/durable_event_log.sql
@@ -38,7 +38,7 @@ SELECT
 FROM inputs
 ON CONFLICT (durable_task_id, durable_task_inserted_at) DO UPDATE
 SET
-    latest_invocation_count = EXCLUDED.latest_invocation_count + 1,
+    latest_invocation_count = v1_durable_event_log_file.latest_invocation_count + 1,
     latest_node_id = 0
 RETURNING v1_durable_event_log_file.*
 ;

--- a/pkg/repository/sqlcv1/durable_event_log.sql.go
+++ b/pkg/repository/sqlcv1/durable_event_log.sql.go
@@ -253,7 +253,7 @@ SELECT
 FROM inputs
 ON CONFLICT (durable_task_id, durable_task_inserted_at) DO UPDATE
 SET
-    latest_invocation_count = EXCLUDED.latest_invocation_count + 1,
+    latest_invocation_count = v1_durable_event_log_file.latest_invocation_count + 1,
     latest_node_id = 0
 RETURNING v1_durable_event_log_file.tenant_id, v1_durable_event_log_file.durable_task_id, v1_durable_event_log_file.durable_task_inserted_at, v1_durable_event_log_file.latest_invocation_count, v1_durable_event_log_file.latest_inserted_at, v1_durable_event_log_file.latest_node_id, v1_durable_event_log_file.latest_branch_id, v1_durable_event_log_file.latest_branch_first_parent_node_id
 `

--- a/pkg/repository/sqlcv1/durable_event_log.sql.go
+++ b/pkg/repository/sqlcv1/durable_event_log.sql.go
@@ -253,7 +253,7 @@ SELECT
 FROM inputs
 ON CONFLICT (durable_task_id, durable_task_inserted_at) DO UPDATE
 SET
-    latest_invocation_count = latest_invocation_count + 1,
+    latest_invocation_count = EXCLUDED.latest_invocation_count + 1,
     latest_node_id = 0
 RETURNING v1_durable_event_log_file.tenant_id, v1_durable_event_log_file.durable_task_id, v1_durable_event_log_file.durable_task_inserted_at, v1_durable_event_log_file.latest_invocation_count, v1_durable_event_log_file.latest_inserted_at, v1_durable_event_log_file.latest_node_id, v1_durable_event_log_file.latest_branch_id, v1_durable_event_log_file.latest_branch_first_parent_node_id
 `

--- a/pkg/repository/sqlcv1/durable_event_log.sql.go
+++ b/pkg/repository/sqlcv1/durable_event_log.sql.go
@@ -248,7 +248,7 @@ SELECT
     1,
     NOW(),
     0,
-    0,
+    1,
     0
 FROM inputs
 ON CONFLICT (durable_task_id, durable_task_inserted_at) DO UPDATE


### PR DESCRIPTION
# Description

Couple things here:

1. Refactors log file creation to do that correctly - basically, we were implicitly creating the log file when we received the first event, but it should be created by the scheduler right after we insert the running tasks. If there's a conflict, we atomically increment the count.
2. Rejects any incoming durable event requests that are from an invocation that's not the current one, since those invocations should be immediately evicted and should not be able to write to the log

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
