### PR TITLE
Make sure to use 60 seconds timeout for `PutWorkflowVersion`

### DIFF
--- a/pkg/repository/workflow.go
+++ b/pkg/repository/workflow.go
@@ -284,7 +284,7 @@ func (r *workflowRepository) PutWorkflowVersion(ctx context.Context, tenantId uu
 		return nil, err
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
+	tx, commit, rollback, err := sqlchelpers.PrepareTxWithStatementTimeout(ctx, r.pool, r.l, 60000)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

Use 60 seconds timeout for `PutWorkflowVersion` instead of the default 5 seconds.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
