### PR TITLE
streaming: document ~8KB limit and guard Python put_stream payload size

### DIFF
--- a/frontend/docs/pages/home/streaming.mdx
+++ b/frontend/docs/pages/home/streaming.mdx
@@ -11,6 +11,13 @@ Hatchet tasks can stream data back to a consumer in real-time. This has a number
 
 You can stream data out of a task run by using the `put_stream` (or equivalent) method on the `Context`.
 
+<Callout type="warning" emoji="📏">
+  Stream event payloads are sent via PostgreSQL `NOTIFY`, which has a payload
+  size limit of roughly 8KB (minus envelope overhead). Keep stream payloads
+  small (for example: summaries, deltas, or a capped list) to avoid dropped
+  events or internal errors when publishing oversized messages.
+</Callout>
+
 <UniversalTabs items={["Python", "Typescript", "Go", "Ruby"]}>
   <Tabs.Tab title="Python">
 <Snippet src={snippets.python.streaming.worker.streaming} />

--- a/sdks/python/hatchet_sdk/clients/events.py
+++ b/sdks/python/hatchet_sdk/clients/events.py
@@ -255,6 +255,12 @@ class EventClient(BaseRestClient):
         else:
             raise ValueError("Invalid data type. Expected str, bytes, or file.")
 
+        if len(data_bytes) > 8_000:
+            logger.warning(
+                "truncating stream payload to 8,000 bytes to avoid PostgreSQL NOTIFY payload limits"
+            )
+            data_bytes = data_bytes[:8_000]
+
         request = PutStreamEventRequest(
             task_run_external_id=step_run_id,
             created_at=proto_timestamp_now(),


### PR DESCRIPTION
## Summary
Adds guardrails for oversized stream payloads and documents the practical size constraint.

## Why
`put_stream` payloads flow through PostgreSQL `NOTIFY` (effective ~8KB payload ceiling). Without guardrails, oversized payloads can fail with hard-to-debug internal errors.

## Changes
- **Docs:** add warning callout in `frontend/docs/pages/home/streaming.mdx` about the ~8KB limit
- **Python SDK:** add stream payload guard in `sdks/python/hatchet_sdk/clients/events.py`
  - If payload > 8,000 bytes, log warning and truncate to 8,000 bytes
  - Pattern intentionally mirrors existing `log()` truncation behavior

Closes #3087