### PR TITLE
Fix cross-strategy slot contamination in chained concurrency gates

### DIFF
--- a/pkg/repository/scheduler_concurrency.go
+++ b/pkg/repository/scheduler_concurrency.go
@@ -545,6 +545,8 @@ func (c *ConcurrencyRepositoryImpl) runCancelNewest(
 		}
 
 		if !parentAcquired {
+			// Log the event when the parent advisory lock is not acquired
+			c.l.Warn().Msgf("Parent advisory lock not acquired (strategy ID: %d, parent: %d)", strategy.ID, strategy.ParentStrategyID.Int64)
 			// Parent lock not available, return empty result
 			return &RunConcurrencyResult{
 				Queued:                    []TaskWithQueue{},

--- a/pkg/repository/scheduler_concurrency.go
+++ b/pkg/repository/scheduler_concurrency.go
@@ -136,7 +136,6 @@ func (c *ConcurrencyRepositoryImpl) runGroupRoundRobin(
 	tenantId uuid.UUID,
 	strategy *sqlcv1.V1StepConcurrency,
 ) (res *RunConcurrencyResult, err error) {
-
 	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, c.pool, c.l)
 
 	if err != nil {
@@ -546,8 +545,6 @@ func (c *ConcurrencyRepositoryImpl) runCancelNewest(
 		}
 
 		if !parentAcquired {
-			// Log the event when the parent advisory lock is not acquired
-			c.l.Warn().Msgf("Parent advisory lock not acquired (strategy ID: %d, parent: %d)", strategy.ID, strategy.ParentStrategyID.Int64)
 			// Parent lock not available, return empty result
 			return &RunConcurrencyResult{
 				Queued:                    []TaskWithQueue{},

--- a/pkg/repository/sqlcv1/concurrency-overwrite.sql.go
+++ b/pkg/repository/sqlcv1/concurrency-overwrite.sql.go
@@ -303,6 +303,8 @@ WITH slots AS (
         v1_concurrency_slot.task_id = s.task_id AND
         v1_concurrency_slot.task_inserted_at = s.task_inserted_at AND
         v1_concurrency_slot.task_retry_count = s.task_retry_count AND
+        v1_concurrency_slot.tenant_id = s.tenant_id AND
+        v1_concurrency_slot.strategy_id = s.strategy_id AND
         v1_concurrency_slot.key = s.key AND
         v1_concurrency_slot.is_filled = FALSE AND
         s.operation = 'run'
@@ -556,6 +558,8 @@ WITH slots AS (
         v1_concurrency_slot.task_id = s.task_id AND
         v1_concurrency_slot.task_inserted_at = s.task_inserted_at AND
         v1_concurrency_slot.task_retry_count = s.task_retry_count AND
+        v1_concurrency_slot.tenant_id = s.tenant_id AND
+        v1_concurrency_slot.strategy_id = s.strategy_id AND
         v1_concurrency_slot.key = s.key AND
         v1_concurrency_slot.is_filled = FALSE AND
         s.operation = 'run'

--- a/pkg/repository/sqlcv1/concurrency.sql
+++ b/pkg/repository/sqlcv1/concurrency.sql
@@ -148,15 +148,7 @@ SELECT pg_advisory_xact_lock(@key::bigint);
 SELECT pg_try_advisory_xact_lock(@key::bigint) AS "locked";
 
 -- name: RunParentGroupRoundRobin :exec
-WITH filled_counts AS (
-    SELECT key, COUNT(*) as cnt
-    FROM v1_workflow_concurrency_slot
-    WHERE
-        tenant_id = @tenantId::uuid
-        AND strategy_id = @strategyId::bigint
-        AND is_filled = TRUE
-    GROUP BY key
-), eligible_slots_per_group AS (
+WITH eligible_slots_per_group AS (
     SELECT wsc.*
     FROM (
         SELECT DISTINCT key
@@ -172,9 +164,8 @@ WITH filled_counts AS (
             wcs_all.key = distinct_keys.key
             AND wcs_all.tenant_id = @tenantId::uuid
             AND wcs_all.strategy_id = @strategyId::bigint
-            AND wcs_all.is_filled = FALSE
         ORDER BY wcs_all.priority DESC, wcs_all.sort_id ASC
-        LIMIT GREATEST(0, @maxRuns::int - COALESCE((SELECT cnt FROM filled_counts fc WHERE fc.key = distinct_keys.key), 0))
+        LIMIT @maxRuns::int
     ) wsc ON true
 ), eligible_slots AS (
     SELECT
@@ -208,15 +199,7 @@ WHERE
 
 -- name: RunGroupRoundRobin :many
 -- Used for round-robin scheduling when a strategy doesn't have a parent strategy
-WITH filled_counts AS (
-    SELECT key, COUNT(*) as cnt
-    FROM v1_concurrency_slot
-    WHERE
-        tenant_id = @tenantId::uuid
-        AND strategy_id = @strategyId::bigint
-        AND is_filled = TRUE
-    GROUP BY key
-), eligible_slots_per_group AS (
+WITH eligible_slots_per_group AS (
     SELECT cs.*
     FROM (
         SELECT DISTINCT key
@@ -232,9 +215,8 @@ WITH filled_counts AS (
             wcs_all.key = distinct_keys.key
             AND wcs_all.tenant_id = @tenantId::uuid
             AND wcs_all.strategy_id = @strategyId::bigint
-            AND wcs_all.is_filled = FALSE
         ORDER BY wcs_all.sort_id ASC
-        LIMIT GREATEST(0, @maxRuns::int - COALESCE((SELECT cnt FROM filled_counts fc WHERE fc.key = distinct_keys.key), 0))
+        LIMIT @maxRuns::int
     ) cs ON true
 ), schedule_timeout_slots AS (
     SELECT

--- a/pkg/repository/sqlcv1/concurrency.sql
+++ b/pkg/repository/sqlcv1/concurrency.sql
@@ -148,7 +148,15 @@ SELECT pg_advisory_xact_lock(@key::bigint);
 SELECT pg_try_advisory_xact_lock(@key::bigint) AS "locked";
 
 -- name: RunParentGroupRoundRobin :exec
-WITH eligible_slots_per_group AS (
+WITH filled_counts AS (
+    SELECT key, COUNT(*) as cnt
+    FROM v1_workflow_concurrency_slot
+    WHERE
+        tenant_id = @tenantId::uuid
+        AND strategy_id = @strategyId::bigint
+        AND is_filled = TRUE
+    GROUP BY key
+), eligible_slots_per_group AS (
     SELECT wsc.*
     FROM (
         SELECT DISTINCT key
@@ -164,8 +172,9 @@ WITH eligible_slots_per_group AS (
             wcs_all.key = distinct_keys.key
             AND wcs_all.tenant_id = @tenantId::uuid
             AND wcs_all.strategy_id = @strategyId::bigint
+            AND wcs_all.is_filled = FALSE
         ORDER BY wcs_all.priority DESC, wcs_all.sort_id ASC
-        LIMIT @maxRuns::int
+        LIMIT GREATEST(0, @maxRuns::int - COALESCE((SELECT cnt FROM filled_counts fc WHERE fc.key = distinct_keys.key), 0))
     ) wsc ON true
 ), eligible_slots AS (
     SELECT
@@ -199,7 +208,15 @@ WHERE
 
 -- name: RunGroupRoundRobin :many
 -- Used for round-robin scheduling when a strategy doesn't have a parent strategy
-WITH eligible_slots_per_group AS (
+WITH filled_counts AS (
+    SELECT key, COUNT(*) as cnt
+    FROM v1_concurrency_slot
+    WHERE
+        tenant_id = @tenantId::uuid
+        AND strategy_id = @strategyId::bigint
+        AND is_filled = TRUE
+    GROUP BY key
+), eligible_slots_per_group AS (
     SELECT cs.*
     FROM (
         SELECT DISTINCT key
@@ -215,8 +232,9 @@ WITH eligible_slots_per_group AS (
             wcs_all.key = distinct_keys.key
             AND wcs_all.tenant_id = @tenantId::uuid
             AND wcs_all.strategy_id = @strategyId::bigint
+            AND wcs_all.is_filled = FALSE
         ORDER BY wcs_all.sort_id ASC
-        LIMIT @maxRuns::int
+        LIMIT GREATEST(0, @maxRuns::int - COALESCE((SELECT cnt FROM filled_counts fc WHERE fc.key = distinct_keys.key), 0))
     ) cs ON true
 ), schedule_timeout_slots AS (
     SELECT
@@ -482,6 +500,8 @@ WITH slots AS (
         v1_concurrency_slot.task_id = slots_to_run.task_id AND
         v1_concurrency_slot.task_inserted_at = slots_to_run.task_inserted_at AND
         v1_concurrency_slot.task_retry_count = slots_to_run.task_retry_count AND
+        v1_concurrency_slot.tenant_id = slots_to_run.tenant_id AND
+        v1_concurrency_slot.strategy_id = slots_to_run.strategy_id AND
         v1_concurrency_slot.key = slots_to_run.key AND
         v1_concurrency_slot.is_filled = FALSE
     RETURNING
@@ -722,6 +742,8 @@ WITH slots AS (
         v1_concurrency_slot.task_id = slots_to_run.task_id AND
         v1_concurrency_slot.task_inserted_at = slots_to_run.task_inserted_at AND
         v1_concurrency_slot.task_retry_count = slots_to_run.task_retry_count AND
+        v1_concurrency_slot.tenant_id = slots_to_run.tenant_id AND
+        v1_concurrency_slot.strategy_id = slots_to_run.strategy_id AND
         v1_concurrency_slot.key = slots_to_run.key AND
         v1_concurrency_slot.is_filled = FALSE
     RETURNING

--- a/pkg/repository/sqlcv1/concurrency.sql.go
+++ b/pkg/repository/sqlcv1/concurrency.sql.go
@@ -443,6 +443,8 @@ WITH slots AS (
         v1_concurrency_slot.task_id = slots_to_run.task_id AND
         v1_concurrency_slot.task_inserted_at = slots_to_run.task_inserted_at AND
         v1_concurrency_slot.task_retry_count = slots_to_run.task_retry_count AND
+        v1_concurrency_slot.tenant_id = slots_to_run.tenant_id AND
+        v1_concurrency_slot.strategy_id = slots_to_run.strategy_id AND
         v1_concurrency_slot.key = slots_to_run.key AND
         v1_concurrency_slot.is_filled = FALSE
     RETURNING
@@ -657,6 +659,8 @@ WITH slots AS (
         v1_concurrency_slot.task_id = slots_to_run.task_id AND
         v1_concurrency_slot.task_inserted_at = slots_to_run.task_inserted_at AND
         v1_concurrency_slot.task_retry_count = slots_to_run.task_retry_count AND
+        v1_concurrency_slot.tenant_id = slots_to_run.tenant_id AND
+        v1_concurrency_slot.strategy_id = slots_to_run.strategy_id AND
         v1_concurrency_slot.key = slots_to_run.key AND
         v1_concurrency_slot.is_filled = FALSE
     RETURNING
@@ -773,7 +777,15 @@ func (q *Queries) RunCancelNewest(ctx context.Context, db DBTX, arg RunCancelNew
 }
 
 const runGroupRoundRobin = `-- name: RunGroupRoundRobin :many
-WITH eligible_slots_per_group AS (
+WITH filled_counts AS (
+    SELECT key, COUNT(*) as cnt
+    FROM v1_concurrency_slot
+    WHERE
+        tenant_id = $1::uuid
+        AND strategy_id = $2::bigint
+        AND is_filled = TRUE
+    GROUP BY key
+), eligible_slots_per_group AS (
     SELECT cs.sort_id, cs.task_id, cs.task_inserted_at, cs.task_retry_count, cs.external_id, cs.tenant_id, cs.workflow_id, cs.workflow_version_id, cs.workflow_run_id, cs.strategy_id, cs.parent_strategy_id, cs.priority, cs.key, cs.is_filled, cs.next_parent_strategy_ids, cs.next_strategy_ids, cs.next_keys, cs.queue_to_notify, cs.schedule_timeout_at
     FROM (
         SELECT DISTINCT key
@@ -789,8 +801,9 @@ WITH eligible_slots_per_group AS (
             wcs_all.key = distinct_keys.key
             AND wcs_all.tenant_id = $1::uuid
             AND wcs_all.strategy_id = $2::bigint
+            AND wcs_all.is_filled = FALSE
         ORDER BY wcs_all.sort_id ASC
-        LIMIT $3::int
+        LIMIT GREATEST(0, $3::int - COALESCE((SELECT cnt FROM filled_counts fc WHERE fc.key = distinct_keys.key), 0))
     ) cs ON true
 ), schedule_timeout_slots AS (
     SELECT
@@ -1102,7 +1115,15 @@ func (q *Queries) RunParentCancelNewest(ctx context.Context, db DBTX, arg RunPar
 }
 
 const runParentGroupRoundRobin = `-- name: RunParentGroupRoundRobin :exec
-WITH eligible_slots_per_group AS (
+WITH filled_counts AS (
+    SELECT key, COUNT(*) as cnt
+    FROM v1_workflow_concurrency_slot
+    WHERE
+        tenant_id = $1::uuid
+        AND strategy_id = $2::bigint
+        AND is_filled = TRUE
+    GROUP BY key
+), eligible_slots_per_group AS (
     SELECT wsc.sort_id, wsc.tenant_id, wsc.workflow_id, wsc.workflow_version_id, wsc.workflow_run_id, wsc.strategy_id, wsc.completed_child_strategy_ids, wsc.child_strategy_ids, wsc.priority, wsc.key, wsc.is_filled
     FROM (
         SELECT DISTINCT key
@@ -1118,8 +1139,9 @@ WITH eligible_slots_per_group AS (
             wcs_all.key = distinct_keys.key
             AND wcs_all.tenant_id = $1::uuid
             AND wcs_all.strategy_id = $2::bigint
+            AND wcs_all.is_filled = FALSE
         ORDER BY wcs_all.priority DESC, wcs_all.sort_id ASC
-        LIMIT $3::int
+        LIMIT GREATEST(0, $3::int - COALESCE((SELECT cnt FROM filled_counts fc WHERE fc.key = distinct_keys.key), 0))
     ) wsc ON true
 ), eligible_slots AS (
     SELECT

--- a/pkg/repository/sqlcv1/concurrency.sql.go
+++ b/pkg/repository/sqlcv1/concurrency.sql.go
@@ -777,15 +777,7 @@ func (q *Queries) RunCancelNewest(ctx context.Context, db DBTX, arg RunCancelNew
 }
 
 const runGroupRoundRobin = `-- name: RunGroupRoundRobin :many
-WITH filled_counts AS (
-    SELECT key, COUNT(*) as cnt
-    FROM v1_concurrency_slot
-    WHERE
-        tenant_id = $1::uuid
-        AND strategy_id = $2::bigint
-        AND is_filled = TRUE
-    GROUP BY key
-), eligible_slots_per_group AS (
+WITH eligible_slots_per_group AS (
     SELECT cs.sort_id, cs.task_id, cs.task_inserted_at, cs.task_retry_count, cs.external_id, cs.tenant_id, cs.workflow_id, cs.workflow_version_id, cs.workflow_run_id, cs.strategy_id, cs.parent_strategy_id, cs.priority, cs.key, cs.is_filled, cs.next_parent_strategy_ids, cs.next_strategy_ids, cs.next_keys, cs.queue_to_notify, cs.schedule_timeout_at
     FROM (
         SELECT DISTINCT key
@@ -801,9 +793,8 @@ WITH filled_counts AS (
             wcs_all.key = distinct_keys.key
             AND wcs_all.tenant_id = $1::uuid
             AND wcs_all.strategy_id = $2::bigint
-            AND wcs_all.is_filled = FALSE
         ORDER BY wcs_all.sort_id ASC
-        LIMIT GREATEST(0, $3::int - COALESCE((SELECT cnt FROM filled_counts fc WHERE fc.key = distinct_keys.key), 0))
+        LIMIT $3::int
     ) cs ON true
 ), schedule_timeout_slots AS (
     SELECT
@@ -1115,15 +1106,7 @@ func (q *Queries) RunParentCancelNewest(ctx context.Context, db DBTX, arg RunPar
 }
 
 const runParentGroupRoundRobin = `-- name: RunParentGroupRoundRobin :exec
-WITH filled_counts AS (
-    SELECT key, COUNT(*) as cnt
-    FROM v1_workflow_concurrency_slot
-    WHERE
-        tenant_id = $1::uuid
-        AND strategy_id = $2::bigint
-        AND is_filled = TRUE
-    GROUP BY key
-), eligible_slots_per_group AS (
+WITH eligible_slots_per_group AS (
     SELECT wsc.sort_id, wsc.tenant_id, wsc.workflow_id, wsc.workflow_version_id, wsc.workflow_run_id, wsc.strategy_id, wsc.completed_child_strategy_ids, wsc.child_strategy_ids, wsc.priority, wsc.key, wsc.is_filled
     FROM (
         SELECT DISTINCT key
@@ -1139,9 +1122,8 @@ WITH filled_counts AS (
             wcs_all.key = distinct_keys.key
             AND wcs_all.tenant_id = $1::uuid
             AND wcs_all.strategy_id = $2::bigint
-            AND wcs_all.is_filled = FALSE
         ORDER BY wcs_all.priority DESC, wcs_all.sort_id ASC
-        LIMIT GREATEST(0, $3::int - COALESCE((SELECT cnt FROM filled_counts fc WHERE fc.key = distinct_keys.key), 0))
+        LIMIT $3::int
     ) wsc ON true
 ), eligible_slots AS (
     SELECT

--- a/pkg/scheduling/v1/concurrency_integration_test.go
+++ b/pkg/scheduling/v1/concurrency_integration_test.go
@@ -1,0 +1,188 @@
+//go:build integration
+
+package v1_test
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hatchet-dev/hatchet/pkg/config/database"
+	repo "github.com/hatchet-dev/hatchet/pkg/repository"
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
+)
+
+func TestConcurrency_ChainedStrategiesDoNotContaminate(t *testing.T) {
+	runWithDatabase(t, func(conf *database.Layer) error {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		requireSchedulerSchema(t, ctx, conf)
+
+		r := conf.V1
+
+		// 1. Create a tenant
+		tenantId := uuid.New()
+		_, err := r.Tenant().CreateTenant(ctx, &repo.CreateTenantOpts{
+			ID:   &tenantId,
+			Name: "concurrency-chain-test",
+			Slug: fmt.Sprintf("concurrency-chain-test-%s", tenantId.String()),
+		})
+		require.NoError(t, err)
+
+		// 2. Create a workflow with two chained workflow-level concurrency strategies:
+		//    Gate 1: CANCEL_NEWEST maxRuns=3
+		//    Gate 2: GROUP_ROUND_ROBIN maxRuns=1
+		desc := "test workflow for chained concurrency"
+		cancelNewest := "CANCEL_NEWEST"
+		groupRR := "GROUP_ROUND_ROBIN"
+		var maxRunsGate1 int32 = 3
+		var maxRunsGate2 int32 = 1
+
+		wfVersion, err := r.Workflows().PutWorkflowVersion(ctx, tenantId, &repo.CreateWorkflowVersionOpts{
+			Name:        "chained-concurrency-test",
+			Description: &desc,
+			Tasks: []repo.CreateStepOpts{
+				{
+					ReadableId: "my-task",
+					Action:     "test:run",
+				},
+			},
+			Concurrency: []repo.CreateConcurrencyOpts{
+				{
+					MaxRuns:       &maxRunsGate1,
+					LimitStrategy: &cancelNewest,
+					Expression:    "input.my_id",
+				},
+				{
+					MaxRuns:       &maxRunsGate2,
+					LimitStrategy: &groupRR,
+					Expression:    "input.my_id",
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		workflowId := wfVersion.WorkflowVersion.WorkflowId
+		workflowVersionId := wfVersion.WorkflowVersion.ID
+
+		// 3. Get the step concurrency strategies created by the trigger
+		queries := sqlcv1.New()
+		strategies, err := queries.ListActiveConcurrencyStrategies(ctx, conf.Pool, tenantId)
+		require.NoError(t, err)
+		require.Len(t, strategies, 2, "expected 2 step concurrency strategies")
+
+		// Sort by ID (lower ID = first strategy created = CANCEL_NEWEST)
+		sort.Slice(strategies, func(i, j int) bool {
+			return strategies[i].ID < strategies[j].ID
+		})
+
+		strat1 := strategies[0] // CANCEL_NEWEST
+		strat2 := strategies[1] // GROUP_ROUND_ROBIN
+
+		require.Equal(t, sqlcv1.V1ConcurrencyStrategyCANCELNEWEST, strat1.Strategy)
+		require.Equal(t, sqlcv1.V1ConcurrencyStrategyGROUPROUNDROBIN, strat2.Strategy)
+		require.Equal(t, int32(3), strat1.MaxConcurrency)
+		require.Equal(t, int32(1), strat2.MaxConcurrency)
+
+		stepId := strat1.StepID
+
+		// 4. Insert 5 tasks with both concurrency strategies
+		numTasks := 5
+		taskParams := sqlcv1.CreateTasksParams{
+			Tenantids:                    make([]uuid.UUID, numTasks),
+			Queues:                       make([]string, numTasks),
+			Actionids:                    make([]string, numTasks),
+			Stepids:                      make([]uuid.UUID, numTasks),
+			Stepreadableids:              make([]string, numTasks),
+			Workflowids:                  make([]uuid.UUID, numTasks),
+			Scheduletimeouts:             make([]string, numTasks),
+			Steptimeouts:                 make([]string, numTasks),
+			Priorities:                   make([]int32, numTasks),
+			Stickies:                     make([]string, numTasks),
+			Desiredworkerids:             make([]*uuid.UUID, numTasks),
+			Externalids:                  make([]uuid.UUID, numTasks),
+			Displaynames:                 make([]string, numTasks),
+			Inputs:                       make([][]byte, numTasks),
+			Retrycounts:                  make([]int32, numTasks),
+			Additionalmetadatas:          make([][]byte, numTasks),
+			InitialStates:                make([]string, numTasks),
+			InitialStateReasons:          make([]pgtype.Text, numTasks),
+			Dagids:                       make([]pgtype.Int8, numTasks),
+			Daginsertedats:               make([]pgtype.Timestamptz, numTasks),
+			Concurrencyparentstrategyids: make([][]pgtype.Int8, numTasks),
+			ConcurrencyStrategyIds:       make([][]int64, numTasks),
+			ConcurrencyKeys:              make([][]string, numTasks),
+			ParentTaskExternalIds:        make([]*uuid.UUID, numTasks),
+			ParentTaskIds:                make([]pgtype.Int8, numTasks),
+			ParentTaskInsertedAts:        make([]pgtype.Timestamptz, numTasks),
+			ChildIndex:                   make([]pgtype.Int8, numTasks),
+			ChildKey:                     make([]pgtype.Text, numTasks),
+			StepIndex:                    make([]int64, numTasks),
+			RetryBackoffFactor:           make([]pgtype.Float8, numTasks),
+			RetryMaxBackoff:              make([]pgtype.Int4, numTasks),
+			WorkflowVersionIds:           make([]uuid.UUID, numTasks),
+			WorkflowRunIds:               make([]uuid.UUID, numTasks),
+		}
+
+		for i := 0; i < numTasks; i++ {
+			taskParams.Tenantids[i] = tenantId
+			taskParams.Queues[i] = "default"
+			taskParams.Actionids[i] = "test:run"
+			taskParams.Stepids[i] = stepId
+			taskParams.Stepreadableids[i] = "my-task"
+			taskParams.Workflowids[i] = workflowId
+			taskParams.Scheduletimeouts[i] = "5m"
+			taskParams.Priorities[i] = 1
+			taskParams.Stickies[i] = string(sqlcv1.V1StickyStrategyNONE)
+			taskParams.Externalids[i] = uuid.New()
+			taskParams.Displaynames[i] = fmt.Sprintf("task-%d", i)
+			taskParams.Inputs[i] = []byte(`{"my_id": "test-key"}`)
+			taskParams.Additionalmetadatas[i] = []byte(`{}`)
+			taskParams.InitialStates[i] = string(sqlcv1.V1TaskInitialStateQUEUED)
+			taskParams.Concurrencyparentstrategyids[i] = []pgtype.Int8{strat1.ParentStrategyID, strat2.ParentStrategyID}
+			taskParams.ConcurrencyStrategyIds[i] = []int64{strat1.ID, strat2.ID}
+			taskParams.ConcurrencyKeys[i] = []string{"test-key", "test-key"}
+			taskParams.WorkflowVersionIds[i] = workflowVersionId
+			taskParams.WorkflowRunIds[i] = uuid.New()
+		}
+
+		tasks, err := queries.CreateTasks(ctx, conf.Pool, taskParams)
+		require.NoError(t, err)
+		require.Len(t, tasks, numTasks)
+
+		concurrencyRepo := r.Scheduler().Concurrency()
+
+		// 5. Run strategy 1 (CANCEL_NEWEST, maxRuns=3):
+		//    - 3 oldest tasks should advance to next strategy (slots filled, triggers slot creation for strategy 2)
+		//    - 2 newest tasks should be cancelled
+		res1, err := concurrencyRepo.RunConcurrencyStrategy(ctx, tenantId, strat1)
+		require.NoError(t, err)
+		require.Len(t, res1.NextConcurrencyStrategies, 3, "expected 3 tasks to advance to next strategy")
+		require.Len(t, res1.Cancelled, 2, "expected 2 tasks cancelled by CANCEL_NEWEST")
+		require.Len(t, res1.Queued, 0, "no tasks should be queued directly")
+
+		// 6. Run strategy 1 AGAIN — this is the key regression check.
+		//    Before the fix, this would fill strategy 2's unfilled slots (same task_id, key, is_filled=FALSE)
+		//    and queue them directly, bypassing strategy 2's round-robin logic.
+		res1Again, err := concurrencyRepo.RunConcurrencyStrategy(ctx, tenantId, strat1)
+		require.NoError(t, err)
+		require.Len(t, res1Again.Queued, 0, "re-running strategy 1 must not queue tasks from strategy 2's slots")
+		require.Len(t, res1Again.Cancelled, 0, "re-running strategy 1 must not cancel anything")
+		require.Len(t, res1Again.NextConcurrencyStrategies, 0, "re-running strategy 1 must not advance anything")
+
+		// 7. Run strategy 2 (GROUP_ROUND_ROBIN, maxRuns=1):
+		//    Only 1 task should be queued per concurrency key.
+		res2, err := concurrencyRepo.RunConcurrencyStrategy(ctx, tenantId, strat2)
+		require.NoError(t, err)
+		require.Len(t, res2.Queued, 1, "GROUP_ROUND_ROBIN with maxRuns=1 should queue exactly 1 task")
+
+		return nil
+	})
+}

--- a/pkg/scheduling/v1/concurrency_integration_test.go
+++ b/pkg/scheduling/v1/concurrency_integration_test.go
@@ -18,6 +18,206 @@ import (
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 )
 
+// concurrencyTestSetup holds the common state for concurrency integration tests.
+type concurrencyTestSetup struct {
+	tenantId        uuid.UUID
+	strategy        *sqlcv1.V1StepConcurrency
+	concurrencyRepo repo.ConcurrencyRepository
+}
+
+// setupStepConcurrencyTest creates a tenant, workflow with a single step-level concurrency
+// strategy, and inserts numTasks tasks. Returns the setup needed to call RunConcurrencyStrategy.
+func setupStepConcurrencyTest(
+	t *testing.T,
+	ctx context.Context,
+	conf *database.Layer,
+	name string,
+	strategyType string,
+	maxRuns int32,
+	numTasks int,
+) *concurrencyTestSetup {
+	t.Helper()
+
+	r := conf.V1
+	queries := sqlcv1.New()
+
+	tenantId := uuid.New()
+	_, err := r.Tenant().CreateTenant(ctx, &repo.CreateTenantOpts{
+		ID:   &tenantId,
+		Name: name,
+		Slug: fmt.Sprintf("%s-%s", name, tenantId.String()),
+	})
+	require.NoError(t, err)
+
+	desc := "test workflow"
+	wfVersion, err := r.Workflows().PutWorkflowVersion(ctx, tenantId, &repo.CreateWorkflowVersionOpts{
+		Name:        name,
+		Description: &desc,
+		Tasks: []repo.CreateStepOpts{
+			{
+				ReadableId: "my-task",
+				Action:     "test:run",
+				Concurrency: []repo.CreateConcurrencyOpts{
+					{
+						MaxRuns:       &maxRuns,
+						LimitStrategy: &strategyType,
+						Expression:    "input.my_id",
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	workflowId := wfVersion.WorkflowVersion.WorkflowId
+	workflowVersionId := wfVersion.WorkflowVersion.ID
+
+	strategies, err := queries.ListActiveConcurrencyStrategies(ctx, conf.Pool, tenantId)
+	require.NoError(t, err)
+	require.Len(t, strategies, 1)
+
+	strat := strategies[0]
+	require.Equal(t, sqlcv1.V1ConcurrencyStrategy(strategyType), strat.Strategy)
+	require.Equal(t, maxRuns, strat.MaxConcurrency)
+	require.False(t, strat.ParentStrategyID.Valid, "step-level concurrency should have no parent")
+
+	taskParams := newCreateTasksParams(numTasks)
+	for i := 0; i < numTasks; i++ {
+		taskParams.Tenantids[i] = tenantId
+		taskParams.Queues[i] = "default"
+		taskParams.Actionids[i] = "test:run"
+		taskParams.Stepids[i] = strat.StepID
+		taskParams.Stepreadableids[i] = "my-task"
+		taskParams.Workflowids[i] = workflowId
+		taskParams.Scheduletimeouts[i] = "5m"
+		taskParams.Priorities[i] = 1
+		taskParams.Stickies[i] = string(sqlcv1.V1StickyStrategyNONE)
+		taskParams.Externalids[i] = uuid.New()
+		taskParams.Displaynames[i] = fmt.Sprintf("task-%d", i)
+		taskParams.Inputs[i] = []byte(`{"my_id": "test-key"}`)
+		taskParams.Additionalmetadatas[i] = []byte(`{}`)
+		taskParams.InitialStates[i] = string(sqlcv1.V1TaskInitialStateQUEUED)
+		taskParams.Concurrencyparentstrategyids[i] = []pgtype.Int8{{}}
+		taskParams.ConcurrencyStrategyIds[i] = []int64{strat.ID}
+		taskParams.ConcurrencyKeys[i] = []string{"test-key"}
+		taskParams.WorkflowVersionIds[i] = workflowVersionId
+		taskParams.WorkflowRunIds[i] = uuid.New()
+	}
+
+	tasks, err := queries.CreateTasks(ctx, conf.Pool, taskParams)
+	require.NoError(t, err)
+	require.Len(t, tasks, numTasks)
+
+	return &concurrencyTestSetup{
+		tenantId:        tenantId,
+		strategy:        strat,
+		concurrencyRepo: r.Scheduler().Concurrency(),
+	}
+}
+
+// newCreateTasksParams allocates a CreateTasksParams with all slices pre-sized to n.
+func newCreateTasksParams(n int) sqlcv1.CreateTasksParams {
+	return sqlcv1.CreateTasksParams{
+		Tenantids:                    make([]uuid.UUID, n),
+		Queues:                       make([]string, n),
+		Actionids:                    make([]string, n),
+		Stepids:                      make([]uuid.UUID, n),
+		Stepreadableids:              make([]string, n),
+		Workflowids:                  make([]uuid.UUID, n),
+		Scheduletimeouts:             make([]string, n),
+		Steptimeouts:                 make([]string, n),
+		Priorities:                   make([]int32, n),
+		Stickies:                     make([]string, n),
+		Desiredworkerids:             make([]*uuid.UUID, n),
+		Externalids:                  make([]uuid.UUID, n),
+		Displaynames:                 make([]string, n),
+		Inputs:                       make([][]byte, n),
+		Retrycounts:                  make([]int32, n),
+		Additionalmetadatas:          make([][]byte, n),
+		InitialStates:                make([]string, n),
+		InitialStateReasons:          make([]pgtype.Text, n),
+		Dagids:                       make([]pgtype.Int8, n),
+		Daginsertedats:               make([]pgtype.Timestamptz, n),
+		Concurrencyparentstrategyids: make([][]pgtype.Int8, n),
+		ConcurrencyStrategyIds:       make([][]int64, n),
+		ConcurrencyKeys:              make([][]string, n),
+		ParentTaskExternalIds:        make([]*uuid.UUID, n),
+		ParentTaskIds:                make([]pgtype.Int8, n),
+		ParentTaskInsertedAts:        make([]pgtype.Timestamptz, n),
+		ChildIndex:                   make([]pgtype.Int8, n),
+		ChildKey:                     make([]pgtype.Text, n),
+		StepIndex:                    make([]int64, n),
+		RetryBackoffFactor:           make([]pgtype.Float8, n),
+		RetryMaxBackoff:              make([]pgtype.Int4, n),
+		WorkflowVersionIds:           make([]uuid.UUID, n),
+		WorkflowRunIds:               make([]uuid.UUID, n),
+	}
+}
+
+// --- Standalone strategy tests (no chaining) ---
+
+func TestConcurrency_GroupRoundRobin(t *testing.T) {
+	runWithDatabase(t, func(conf *database.Layer) error {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		requireSchedulerSchema(t, ctx, conf)
+
+		// GROUP_ROUND_ROBIN with maxRuns=2 and 5 tasks (same key):
+		// Fills 2 oldest slots per key. Remaining 3 stay unfilled (not cancelled).
+		s := setupStepConcurrencyTest(t, ctx, conf, "grr-test", "GROUP_ROUND_ROBIN", 2, 5)
+
+		res, err := s.concurrencyRepo.RunConcurrencyStrategy(ctx, s.tenantId, s.strategy)
+		require.NoError(t, err)
+		require.Len(t, res.Queued, 2, "GROUP_ROUND_ROBIN should queue maxRuns tasks")
+		require.Len(t, res.Cancelled, 0, "GROUP_ROUND_ROBIN should not cancel tasks")
+
+		return nil
+	})
+}
+
+func TestConcurrency_CancelNewest(t *testing.T) {
+	runWithDatabase(t, func(conf *database.Layer) error {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		requireSchedulerSchema(t, ctx, conf)
+
+		// CANCEL_NEWEST with maxRuns=2 and 5 tasks (same key):
+		// Fills 2 oldest slots, cancels 3 newest.
+		s := setupStepConcurrencyTest(t, ctx, conf, "cn-test", "CANCEL_NEWEST", 2, 5)
+
+		res, err := s.concurrencyRepo.RunConcurrencyStrategy(ctx, s.tenantId, s.strategy)
+		require.NoError(t, err)
+		require.Len(t, res.Queued, 2, "CANCEL_NEWEST should queue maxRuns oldest tasks")
+		require.Len(t, res.Cancelled, 3, "CANCEL_NEWEST should cancel excess newest tasks")
+
+		return nil
+	})
+}
+
+func TestConcurrency_CancelInProgress(t *testing.T) {
+	runWithDatabase(t, func(conf *database.Layer) error {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		requireSchedulerSchema(t, ctx, conf)
+
+		// CANCEL_IN_PROGRESS with maxRuns=2 and 5 tasks (same key):
+		// Fills 2 newest slots, cancels 3 oldest.
+		s := setupStepConcurrencyTest(t, ctx, conf, "cip-test", "CANCEL_IN_PROGRESS", 2, 5)
+
+		res, err := s.concurrencyRepo.RunConcurrencyStrategy(ctx, s.tenantId, s.strategy)
+		require.NoError(t, err)
+		require.Len(t, res.Queued, 2, "CANCEL_IN_PROGRESS should queue maxRuns newest tasks")
+		require.Len(t, res.Cancelled, 3, "CANCEL_IN_PROGRESS should cancel excess oldest tasks")
+
+		return nil
+	})
+}
+
+// --- Chained strategy regression test ---
+
+// TestConcurrency_ChainedStrategiesDoNotContaminate verifies that when two concurrency
+// strategies are chained (CANCEL_NEWEST → GROUP_ROUND_ROBIN), re-running the first
+// strategy does not accidentally fill the second strategy's slots.
 func TestConcurrency_ChainedStrategiesDoNotContaminate(t *testing.T) {
 	runWithDatabase(t, func(conf *database.Layer) error {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -26,8 +226,8 @@ func TestConcurrency_ChainedStrategiesDoNotContaminate(t *testing.T) {
 		requireSchedulerSchema(t, ctx, conf)
 
 		r := conf.V1
+		queries := sqlcv1.New()
 
-		// 1. Create a tenant
 		tenantId := uuid.New()
 		_, err := r.Tenant().CreateTenant(ctx, &repo.CreateTenantOpts{
 			ID:   &tenantId,
@@ -36,9 +236,9 @@ func TestConcurrency_ChainedStrategiesDoNotContaminate(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// 2. Create a workflow with two chained workflow-level concurrency strategies:
-		//    Gate 1: CANCEL_NEWEST maxRuns=3
-		//    Gate 2: GROUP_ROUND_ROBIN maxRuns=1
+		// Create a workflow with two chained workflow-level concurrency strategies:
+		//   Gate 1: CANCEL_NEWEST maxRuns=3
+		//   Gate 2: GROUP_ROUND_ROBIN maxRuns=1
 		desc := "test workflow for chained concurrency"
 		cancelNewest := "CANCEL_NEWEST"
 		groupRR := "GROUP_ROUND_ROBIN"
@@ -72,13 +272,10 @@ func TestConcurrency_ChainedStrategiesDoNotContaminate(t *testing.T) {
 		workflowId := wfVersion.WorkflowVersion.WorkflowId
 		workflowVersionId := wfVersion.WorkflowVersion.ID
 
-		// 3. Get the step concurrency strategies created by the trigger
-		queries := sqlcv1.New()
 		strategies, err := queries.ListActiveConcurrencyStrategies(ctx, conf.Pool, tenantId)
 		require.NoError(t, err)
 		require.Len(t, strategies, 2, "expected 2 step concurrency strategies")
 
-		// Sort by ID (lower ID = first strategy created = CANCEL_NEWEST)
 		sort.Slice(strategies, func(i, j int) bool {
 			return strategies[i].ID < strategies[j].ID
 		})
@@ -88,49 +285,12 @@ func TestConcurrency_ChainedStrategiesDoNotContaminate(t *testing.T) {
 
 		require.Equal(t, sqlcv1.V1ConcurrencyStrategyCANCELNEWEST, strat1.Strategy)
 		require.Equal(t, sqlcv1.V1ConcurrencyStrategyGROUPROUNDROBIN, strat2.Strategy)
-		require.Equal(t, int32(3), strat1.MaxConcurrency)
-		require.Equal(t, int32(1), strat2.MaxConcurrency)
 
 		stepId := strat1.StepID
 
-		// 4. Insert 5 tasks with both concurrency strategies
+		// Insert 5 tasks with both concurrency strategies
 		numTasks := 5
-		taskParams := sqlcv1.CreateTasksParams{
-			Tenantids:                    make([]uuid.UUID, numTasks),
-			Queues:                       make([]string, numTasks),
-			Actionids:                    make([]string, numTasks),
-			Stepids:                      make([]uuid.UUID, numTasks),
-			Stepreadableids:              make([]string, numTasks),
-			Workflowids:                  make([]uuid.UUID, numTasks),
-			Scheduletimeouts:             make([]string, numTasks),
-			Steptimeouts:                 make([]string, numTasks),
-			Priorities:                   make([]int32, numTasks),
-			Stickies:                     make([]string, numTasks),
-			Desiredworkerids:             make([]*uuid.UUID, numTasks),
-			Externalids:                  make([]uuid.UUID, numTasks),
-			Displaynames:                 make([]string, numTasks),
-			Inputs:                       make([][]byte, numTasks),
-			Retrycounts:                  make([]int32, numTasks),
-			Additionalmetadatas:          make([][]byte, numTasks),
-			InitialStates:                make([]string, numTasks),
-			InitialStateReasons:          make([]pgtype.Text, numTasks),
-			Dagids:                       make([]pgtype.Int8, numTasks),
-			Daginsertedats:               make([]pgtype.Timestamptz, numTasks),
-			Concurrencyparentstrategyids: make([][]pgtype.Int8, numTasks),
-			ConcurrencyStrategyIds:       make([][]int64, numTasks),
-			ConcurrencyKeys:              make([][]string, numTasks),
-			ParentTaskExternalIds:        make([]*uuid.UUID, numTasks),
-			ParentTaskIds:                make([]pgtype.Int8, numTasks),
-			ParentTaskInsertedAts:        make([]pgtype.Timestamptz, numTasks),
-			ChildIndex:                   make([]pgtype.Int8, numTasks),
-			ChildKey:                     make([]pgtype.Text, numTasks),
-			StepIndex:                    make([]int64, numTasks),
-			RetryBackoffFactor:           make([]pgtype.Float8, numTasks),
-			RetryMaxBackoff:              make([]pgtype.Int4, numTasks),
-			WorkflowVersionIds:           make([]uuid.UUID, numTasks),
-			WorkflowRunIds:               make([]uuid.UUID, numTasks),
-		}
-
+		taskParams := newCreateTasksParams(numTasks)
 		for i := 0; i < numTasks; i++ {
 			taskParams.Tenantids[i] = tenantId
 			taskParams.Queues[i] = "default"
@@ -159,26 +319,24 @@ func TestConcurrency_ChainedStrategiesDoNotContaminate(t *testing.T) {
 
 		concurrencyRepo := r.Scheduler().Concurrency()
 
-		// 5. Run strategy 1 (CANCEL_NEWEST, maxRuns=3):
-		//    - 3 oldest tasks should advance to next strategy (slots filled, triggers slot creation for strategy 2)
-		//    - 2 newest tasks should be cancelled
+		// Run strategy 1 (CANCEL_NEWEST, maxRuns=3):
+		//   3 oldest advance to next strategy, 2 newest cancelled.
 		res1, err := concurrencyRepo.RunConcurrencyStrategy(ctx, tenantId, strat1)
 		require.NoError(t, err)
 		require.Len(t, res1.NextConcurrencyStrategies, 3, "expected 3 tasks to advance to next strategy")
 		require.Len(t, res1.Cancelled, 2, "expected 2 tasks cancelled by CANCEL_NEWEST")
 		require.Len(t, res1.Queued, 0, "no tasks should be queued directly")
 
-		// 6. Run strategy 1 AGAIN — this is the key regression check.
-		//    Before the fix, this would fill strategy 2's unfilled slots (same task_id, key, is_filled=FALSE)
-		//    and queue them directly, bypassing strategy 2's round-robin logic.
+		// Run strategy 1 AGAIN — the key regression check.
+		// Before the fix, this filled strategy 2's unfilled slots and queued them directly.
 		res1Again, err := concurrencyRepo.RunConcurrencyStrategy(ctx, tenantId, strat1)
 		require.NoError(t, err)
 		require.Len(t, res1Again.Queued, 0, "re-running strategy 1 must not queue tasks from strategy 2's slots")
 		require.Len(t, res1Again.Cancelled, 0, "re-running strategy 1 must not cancel anything")
 		require.Len(t, res1Again.NextConcurrencyStrategies, 0, "re-running strategy 1 must not advance anything")
 
-		// 7. Run strategy 2 (GROUP_ROUND_ROBIN, maxRuns=1):
-		//    Only 1 task should be queued per concurrency key.
+		// Run strategy 2 (GROUP_ROUND_ROBIN, maxRuns=1):
+		//   Only 1 task should be queued per concurrency key.
 		res2, err := concurrencyRepo.RunConcurrencyStrategy(ctx, tenantId, strat2)
 		require.NoError(t, err)
 		require.Len(t, res2.Queued, 1, "GROUP_ROUND_ROBIN with maxRuns=1 should queue exactly 1 task")


### PR DESCRIPTION
# Description

Fixes a bug where chained concurrency strategies (e.g., CANCEL_NEWEST -> GROUP_ROUND_ROBIN) bypass the second gate entirely.

The `updated_slots` CTE in `RunChildCancelNewest` and `RunChildCancelInProgress` matched slots by `(task_id, task_inserted_at, task_retry_count, key)` but was missing `strategy_id` in the WHERE clause. When the first strategy's query ran again after its own slots were already filled, it matched the second strategy's unfilled slots - which share the same `(task_id, key)` - and filled them directly, bypassing the second strategy's scheduling logic entirely.

Added `strategy_id` and `tenant_id` to the `updated_slots` WHERE clause so each strategy can only fill its own slots.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)