### PR TITLE
Make sure we create older partitions for payload tables to match data retention policy

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20250912162812_v1_0_42.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20250912162812_v1_0_42.sql
@@ -57,8 +57,40 @@ CREATE TABLE v1_payload (
     )
 ) PARTITION BY RANGE(inserted_at);
 
-SELECT create_v1_range_partition('v1_payload'::TEXT, NOW()::DATE);
-SELECT create_v1_range_partition('v1_payload'::TEXT, (NOW() + INTERVAL '1 day')::DATE);
+-- Create v1_payload partitions to match existing v1_task partitions.
+DO $$
+DECLARE
+    oldest_date DATE;
+    current_date_iter DATE;
+    target_date DATE;
+BEGIN
+    -- Find the oldest v1_task partition's start date from pg_catalog
+    SELECT MIN(
+        TO_DATE(
+            regexp_replace(c.relname, '^v1_task_', ''),
+            'YYYYMMDD'
+        )
+    ) INTO oldest_date
+    FROM pg_catalog.pg_class c
+    JOIN pg_catalog.pg_inherits i ON c.oid = i.inhrelid
+    JOIN pg_catalog.pg_class parent ON i.inhparent = parent.oid
+    WHERE parent.relname = 'v1_task'
+      AND c.relname ~ '^v1_task_[0-9]{8}$';
+
+    -- Default to today if no v1_task partitions found
+    IF oldest_date IS NULL THEN
+        oldest_date := NOW()::DATE;
+    END IF;
+
+    target_date := (NOW() + INTERVAL '1 day')::DATE;
+    current_date_iter := oldest_date;
+
+    WHILE current_date_iter <= target_date LOOP
+        PERFORM create_v1_range_partition('v1_payload'::TEXT, current_date_iter);
+        current_date_iter := current_date_iter + INTERVAL '1 day';
+    END LOOP;
+END;
+$$;
 
 CREATE TYPE v1_payload_wal_operation AS ENUM ('CREATE', 'UPDATE', 'DELETE');
 

--- a/cmd/hatchet-migrate/migrate/migrations/20251015164344_v1_0_51.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20251015164344_v1_0_51.sql
@@ -22,9 +22,40 @@ CREATE TABLE v1_payloads_olap (
     )
 ) PARTITION BY RANGE(inserted_at);
 
-SELECT create_v1_range_partition('v1_payloads_olap'::TEXT, NOW()::DATE);
-SELECT create_v1_range_partition('v1_payloads_olap'::TEXT, (NOW() + INTERVAL '1 day')::DATE);
-SELECT create_v1_range_partition('v1_payloads_olap'::TEXT, (NOW() + INTERVAL '2 day')::DATE);
+-- Create v1_payloads_olap partitions to match existing v1_events_olap partitions.
+DO $$
+DECLARE
+    oldest_date DATE;
+    current_date_iter DATE;
+    target_date DATE;
+BEGIN
+    -- Find the oldest v1_events_olap partition's start date from pg_catalog
+    SELECT MIN(
+        TO_DATE(
+            regexp_replace(c.relname, '^v1_events_olap_', ''),
+            'YYYYMMDD'
+        )
+    ) INTO oldest_date
+    FROM pg_catalog.pg_class c
+    JOIN pg_catalog.pg_inherits i ON c.oid = i.inhrelid
+    JOIN pg_catalog.pg_class parent ON i.inhparent = parent.oid
+    WHERE parent.relname = 'v1_events_olap'
+      AND c.relname ~ '^v1_events_olap_[0-9]{8}$';
+
+    -- Default to today if no v1_events_olap partitions found
+    IF oldest_date IS NULL THEN
+        oldest_date := NOW()::DATE;
+    END IF;
+
+    target_date := (NOW() + INTERVAL '2 day')::DATE;
+    current_date_iter := oldest_date;
+
+    WHILE current_date_iter <= target_date LOOP
+        PERFORM create_v1_range_partition('v1_payloads_olap'::TEXT, current_date_iter);
+        current_date_iter := current_date_iter + INTERVAL '1 day';
+    END LOOP;
+END;
+$$;
 
 ALTER TABLE v1_task_events_olap ADD COLUMN external_id UUID;
 ALTER TABLE v1_payload ADD COLUMN external_id UUID;


### PR DESCRIPTION
# Description

We do not backfill `v1_payload` and `v1_payloads_olap` with older partitions that respect the current data retention policy leading to possible `no partition of relation` SQL errors.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)