### PR TITLE
feat(sdk): add REST 429 retry support

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.27.0] - 2026-02-25
+
+### Added
+
+- Adds `retry_429` to `TenacityConfig` (default: `False`) to optionally retry REST HTTP 429 responses.
+- Adds `TooManyRequestsException` and maps REST HTTP 429 responses to it.
+
 ## [1.26.0] - 2026-02-25
 
 ### Fixed

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.27.0] - 2026-02-25
+## [1.26.1] - 2026-02-25
 
 ### Added
 

--- a/sdks/python/hatchet_sdk/clients/rest/exceptions.py
+++ b/sdks/python/hatchet_sdk/clients/rest/exceptions.py
@@ -161,6 +161,9 @@ class ApiException(OpenApiException):
                 http_resp=http_resp, body=body, data=data
             )
 
+        if http_resp.status == 429:
+            raise TooManyRequestsException(http_resp=http_resp, body=body, data=data)
+
         if 500 <= http_resp.status <= 599:
             raise ServiceException(http_resp=http_resp, body=body, data=data)
         raise ApiException(http_resp=http_resp, body=body, data=data)
@@ -205,6 +208,12 @@ class ConflictException(ApiException):
 
 class UnprocessableEntityException(ApiException):
     """Exception for HTTP 422 Unprocessable Entity."""
+
+    pass
+
+
+class TooManyRequestsException(ApiException):
+    """Exception for HTTP 429 Too Many Requests."""
 
     pass
 

--- a/sdks/python/hatchet_sdk/clients/rest/tenacity_utils.py
+++ b/sdks/python/hatchet_sdk/clients/rest/tenacity_utils.py
@@ -1,12 +1,20 @@
+from __future__ import annotations
+
 from collections.abc import Callable
-from typing import ParamSpec, TypeVar
+from typing import TYPE_CHECKING, ParamSpec, TypeVar
 
 import grpc
 import tenacity
 
-from hatchet_sdk.clients.rest.exceptions import NotFoundException, ServiceException
-from hatchet_sdk.config import TenacityConfig
+from hatchet_sdk.clients.rest.exceptions import (
+    NotFoundException,
+    ServiceException,
+    TooManyRequestsException,
+)
 from hatchet_sdk.logger import logger
+
+if TYPE_CHECKING:
+    from hatchet_sdk.config import TenacityConfig
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -16,12 +24,15 @@ def tenacity_retry(func: Callable[P, R], config: TenacityConfig) -> Callable[P, 
     if config.max_attempts <= 0:
         return func
 
+    def should_retry(ex: BaseException) -> bool:
+        return tenacity_should_retry(ex, config)
+
     return tenacity.retry(
         reraise=True,
         wait=tenacity.wait_exponential_jitter(),
         stop=tenacity.stop_after_attempt(config.max_attempts),
         before_sleep=tenacity_alert_retry,
-        retry=tenacity.retry_if_exception(tenacity_should_retry),
+        retry=tenacity.retry_if_exception(should_retry),
     )(func)
 
 
@@ -33,9 +44,15 @@ def tenacity_alert_retry(retry_state: tenacity.RetryCallState) -> None:
     )
 
 
-def tenacity_should_retry(ex: BaseException) -> bool:
+def tenacity_should_retry(
+    ex: BaseException, config: TenacityConfig | None = None
+) -> bool:
+    """Return True when the exception should be retried."""
     if isinstance(ex, ServiceException | NotFoundException):
         return True
+
+    if isinstance(ex, TooManyRequestsException):
+        return bool(config and config.retry_429)
 
     if isinstance(ex, grpc.aio.AioRpcError | grpc.RpcError):
         return ex.code() not in [

--- a/sdks/python/hatchet_sdk/config.py
+++ b/sdks/python/hatchet_sdk/config.py
@@ -94,6 +94,11 @@ class TenacityConfig(BaseSettings):
 
     max_attempts: int = 5
 
+    retry_429: bool = Field(
+        default=False,
+        description="Enable retries for HTTP 429 Too Many Requests responses. Default: off.",
+    )
+
 
 DEFAULT_HOST_PORT = "localhost:7070"
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.27.0"
+version = "1.26.1"
 description = "This is the official Python SDK for Hatchet, a distributed, fault-tolerant task queue. The SDK allows you to easily integrate Hatchet's task scheduling and workflow orchestration capabilities into your Python applications."
 authors = [
   "Alexander Belanger <alexander@hatchet.run>",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.26.0"
+version = "1.27.0"
 description = "This is the official Python SDK for Hatchet, a distributed, fault-tolerant task queue. The SDK allows you to easily integrate Hatchet's task scheduling and workflow orchestration capabilities into your Python applications."
 authors = [
   "Alexander Belanger <alexander@hatchet.run>",

--- a/sdks/python/tests/test_429_retry.py
+++ b/sdks/python/tests/test_429_retry.py
@@ -11,8 +11,6 @@ from hatchet_sdk.clients.rest.exceptions import (
 from hatchet_sdk.clients.rest.tenacity_utils import tenacity_should_retry
 from hatchet_sdk.config import TenacityConfig
 
-# --- Fake HTTP response for testing from_response() ---
-
 
 class FakeHttpResponse:
     """Minimal fake HTTP response for testing ApiException.from_response()."""
@@ -24,9 +22,6 @@ class FakeHttpResponse:
 
     def getheaders(self) -> dict[str, str]:
         return {}
-
-
-# --- TooManyRequestsException mapping tests ---
 
 
 def test_from_response__429_raises_too_many_requests_exception() -> None:
@@ -41,16 +36,10 @@ def test_from_response__429_raises_too_many_requests_exception() -> None:
     assert exc.reason == "Too Many Requests"
 
 
-# --- Default behavior: 429 NOT retried ---
-
-
 def test_default__429_not_retried() -> None:
     """By default (no config), TooManyRequestsException should NOT be retried."""
     exc = TooManyRequestsException(status=429, reason="Too Many Requests")
     assert tenacity_should_retry(exc) is False
-
-
-# --- Opt-in behavior: 429 retried when enabled ---
 
 
 def test_optin__429_retried_when_enabled() -> None:
@@ -58,9 +47,6 @@ def test_optin__429_retried_when_enabled() -> None:
     exc = TooManyRequestsException(status=429, reason="Too Many Requests")
     config = TenacityConfig(retry_429=True)
     assert tenacity_should_retry(exc, config) is True
-
-
-# --- Regression tests: existing behavior unchanged ---
 
 
 def test_regression__service_exception_still_retried() -> None:
@@ -73,9 +59,6 @@ def test_regression__not_found_exception_still_retried() -> None:
     """NotFoundException (404) should still be retried."""
     exc = NotFoundException(status=404, reason="Not Found")
     assert tenacity_should_retry(exc) is True
-
-
-# --- Config defaults tests ---
 
 
 def test_config__default_retry_429_is_false() -> None:

--- a/sdks/python/tests/test_429_retry.py
+++ b/sdks/python/tests/test_429_retry.py
@@ -1,0 +1,84 @@
+"""Unit tests for HTTP 429 Too Many Requests retry behavior."""
+
+import pytest
+
+from hatchet_sdk.clients.rest.exceptions import (
+    ApiException,
+    NotFoundException,
+    ServiceException,
+    TooManyRequestsException,
+)
+from hatchet_sdk.clients.rest.tenacity_utils import tenacity_should_retry
+from hatchet_sdk.config import TenacityConfig
+
+# --- Fake HTTP response for testing from_response() ---
+
+
+class FakeHttpResponse:
+    """Minimal fake HTTP response for testing ApiException.from_response()."""
+
+    def __init__(self, status: int, reason: str = "", data: bytes = b"") -> None:
+        self.status = status
+        self.reason = reason
+        self.data = data
+
+    def getheaders(self) -> dict[str, str]:
+        return {}
+
+
+# --- TooManyRequestsException mapping tests ---
+
+
+def test_from_response__429_raises_too_many_requests_exception() -> None:
+    """ApiException.from_response() should raise TooManyRequestsException for status 429."""
+    http_resp = FakeHttpResponse(status=429, reason="Too Many Requests")
+
+    with pytest.raises(TooManyRequestsException) as exc_info:
+        ApiException.from_response(http_resp=http_resp, body=None, data=None)
+
+    exc = exc_info.value
+    assert exc.status == 429
+    assert exc.reason == "Too Many Requests"
+
+
+# --- Default behavior: 429 NOT retried ---
+
+
+def test_default__429_not_retried() -> None:
+    """By default (no config), TooManyRequestsException should NOT be retried."""
+    exc = TooManyRequestsException(status=429, reason="Too Many Requests")
+    assert tenacity_should_retry(exc) is False
+
+
+# --- Opt-in behavior: 429 retried when enabled ---
+
+
+def test_optin__429_retried_when_enabled() -> None:
+    """TooManyRequestsException should be retried when retry_429=True."""
+    exc = TooManyRequestsException(status=429, reason="Too Many Requests")
+    config = TenacityConfig(retry_429=True)
+    assert tenacity_should_retry(exc, config) is True
+
+
+# --- Regression tests: existing behavior unchanged ---
+
+
+def test_regression__service_exception_still_retried() -> None:
+    """ServiceException (5xx) should still be retried."""
+    exc = ServiceException(status=500, reason="Internal Server Error")
+    assert tenacity_should_retry(exc) is True
+
+
+def test_regression__not_found_exception_still_retried() -> None:
+    """NotFoundException (404) should still be retried."""
+    exc = NotFoundException(status=404, reason="Not Found")
+    assert tenacity_should_retry(exc) is True
+
+
+# --- Config defaults tests ---
+
+
+def test_config__default_retry_429_is_false() -> None:
+    """retry_429 should default to False."""
+    config = TenacityConfig()
+    assert config.retry_429 is False

--- a/sdks/python/tests/test_tenacity_utils.py
+++ b/sdks/python/tests/test_tenacity_utils.py
@@ -1,14 +1,6 @@
-"""Unit tests for the tenacity retry predicate.
+"""Unit tests for the tenacity retry predicate (tenacity_should_retry).
 
-These tests verify which exceptions trigger retries and which do not.
-The retry predicate is used by the SDK to determine whether to retry
-failed API calls.
-
-Current retry behavior (as of this PR):
-- REST: ServiceException (5xx) and NotFoundException (404) are retried
-- REST: Transport errors (RestTimeoutError, etc.) are not retried
-- REST: Other 4xx errors are not retried
-- gRPC: Most errors are retried except specific status codes
+These tests verify which REST exceptions and gRPC status codes are treated as retryable.
 """
 
 import grpc
@@ -28,8 +20,6 @@ from hatchet_sdk.clients.rest.exceptions import (
     UnauthorizedException,
 )
 from hatchet_sdk.clients.rest.tenacity_utils import tenacity_should_retry
-
-# --- REST exception retry predicate tests ---
 
 
 @pytest.mark.parametrize(
@@ -72,9 +62,6 @@ def test_rest__exception_retry_behavior(exc: BaseException, expected: bool) -> N
     assert tenacity_should_retry(exc) is expected
 
 
-# --- REST transport error retry predicate tests ---
-
-
 @pytest.mark.parametrize(
     ("exc", "expected"),
     [
@@ -110,9 +97,6 @@ def test_transport__error_retry_behavior(exc: BaseException, expected: bool) -> 
     assert tenacity_should_retry(exc) is expected
 
 
-# --- Generic exception retry predicate tests ---
-
-
 @pytest.mark.parametrize(
     ("exc", "expected"),
     [
@@ -136,9 +120,6 @@ def test_transport__error_retry_behavior(exc: BaseException, expected: bool) -> 
 def test_generic__exception_retry_behavior(exc: BaseException, expected: bool) -> None:
     """Test that generic exceptions have the expected retry behavior."""
     assert tenacity_should_retry(exc) is expected
-
-
-# --- gRPC exception retry predicate tests ---
 
 
 class FakeRpcError(grpc.RpcError):

--- a/sdks/python/tests/test_tenacity_utils.py
+++ b/sdks/python/tests/test_tenacity_utils.py
@@ -24,6 +24,7 @@ from hatchet_sdk.clients.rest.exceptions import (
     RestTLSError,
     RestTransportError,
     ServiceException,
+    TooManyRequestsException,
     UnauthorizedException,
 )
 from hatchet_sdk.clients.rest.tenacity_utils import tenacity_should_retry
@@ -58,6 +59,11 @@ from hatchet_sdk.clients.rest.tenacity_utils import tenacity_should_retry
             ForbiddenException(status=403, reason="Forbidden"),
             False,
             id="ForbiddenException (HTTP 403) should not be retried",
+        ),
+        pytest.param(
+            TooManyRequestsException(status=429, reason="Too Many Requests"),
+            False,
+            id="TooManyRequestsException (HTTP 429) should not be retried by default",
         ),
     ],
 )


### PR DESCRIPTION
Related: #3003 

# Description

This PR adds support for retrying REST HTTP 429 "Too Many Requests" responses via an opt-in Tenacity setting.

Currently:

* REST retries 5xx and 404 by default.
* gRPC retries `RESOURCE_EXHAUSTED` (rate limiting).
* REST 429 responses are not retried.

Per #2872 discussion, REST 429 responses should be retryable to better align with gRPC retry semantics and to handle rate limiting / backpressure scenarios.

This change:

* Introduces `TooManyRequestsException` and maps HTTP 429 to it.
* Extends the Tenacity retry predicate to optionally retry 429 responses when enabled via configuration.
* Keeps default behavior unchanged, i.e. 429 is **not retried** unless explicitly enabled.

No breaking changes are introduced.

Ref: #2872

---

## Type of change

* [x] New feature (non-breaking change which adds functionality)
* [x] Test changes (add, refactor, improve or change a test)

---

## What's Changed

* Map HTTP 429 to `TooManyRequestsException` in REST client.
* Add `retry_429: bool` to `TenacityConfig` (default: `False`).
* Extend `tenacity_should_retry` to conditionally retry 429 when `retry_429=True`.

Add unit tests covering:
* 429 exception mapping
* Default behavior (not retried)
* Opt-in behavior (retried)
* Regression validation for existing retry behavior (5xx, 404, gRPC).

