### PR TITLE
Modals should appear above the mobile sidebar

### DIFF
--- a/frontend/app/src/components/v1/molecules/nav-bar/tenant-switcher.tsx
+++ b/frontend/app/src/components/v1/molecules/nav-bar/tenant-switcher.tsx
@@ -103,7 +103,7 @@ export function TenantSwitcher({
           align="start"
           sideOffset={8}
           // Must render above the mobile sidebar overlay (`side-nav` uses z-[100]).
-          className="z-[300] w-56 p-0"
+          className="z-[200] w-56 p-0"
         >
           <Command className="">
             <CommandList data-cy="tenant-switcher-list">

--- a/frontend/app/src/components/v1/ui/dialog.tsx
+++ b/frontend/app/src/components/v1/ui/dialog.tsx
@@ -17,7 +17,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-[200] bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className,
     )}
     {...props}
@@ -34,7 +34,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-[200] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
         className,
       )}
       {...props}


### PR DESCRIPTION
# Description

Fixes this issue:
<img width="692" height="502" alt="image" src="https://github.com/user-attachments/assets/320ef543-131b-4592-8913-2afe3c9876fd" />

I changed the tenant-switcher because it didn't seem to make sense for it to be above modals, at least.  Maybe it should be lower?

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [ ] Add a list of tasks or features here...
