### PR TITLE
[Python] Fix: Serialization error handling, add worker id to context

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.27.2] - 2026-02-28
+
+### Changed
+
+- Fixes a bug where failed serialization of task outputs causes the task to hang indefinitely.
+
 ## [1.27.1] - 2026-02-27
 
 ### Changed

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.27.2] - 2026-02-28
 
+### Added
+
+- Adds the `worker_id` to the `Context`
+
 ### Changed
 
 - Fixes a bug where failed serialization of task outputs causes the task to hang indefinitely.

--- a/sdks/python/hatchet_sdk/context/context.py
+++ b/sdks/python/hatchet_sdk/context/context.py
@@ -390,6 +390,10 @@ class Context:
     def task_name(self) -> str:
         return self._task_name
 
+    @property
+    def worker_id(self) -> str:
+        return self.action.worker_id
+
     def fetch_task_run_error(
         self,
         task: "Task[TWorkflowInput, R]",

--- a/sdks/python/hatchet_sdk/worker/runner/runner.py
+++ b/sdks/python/hatchet_sdk/worker/runner/runner.py
@@ -526,10 +526,13 @@ class Runner:
                 f"Tasks must return either a dictionary, a Pydantic BaseModel, or a dataclass which can be serialized to a JSON object. Got object of type {type(output)} instead."
             )
 
-        serialized_output = validator.dump_json(
-            output,  # type: ignore[arg-type]
-            context=HATCHET_PYDANTIC_SENTINEL,
-        ).decode("utf-8")
+        try:
+            serialized_output = validator.dump_json(
+                output,  # type: ignore[arg-type]
+                context=HATCHET_PYDANTIC_SENTINEL,
+            ).decode("utf-8")
+        except Exception as e:
+            raise IllegalTaskOutputError(f"Failed to serialize task output: {e}") from e
 
         if not serialized_output:
             return None

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.27.1"
+version = "1.27.2"
 description = "This is the official Python SDK for Hatchet, a distributed, fault-tolerant task queue. The SDK allows you to easily integrate Hatchet's task scheduling and workflow orchestration capabilities into your Python applications."
 authors = [
   "Alexander Belanger <alexander@hatchet.run>",


### PR DESCRIPTION
# Description

## [1.27.2] - 2026-02-28

### Added

- Adds the `worker_id` to the `Context`

### Changed

- Fixes a bug where failed serialization of task outputs causes the task to hang indefinitely.


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
