### PR TITLE
Janky Fix: Extract input payloads for standalone tasks for dashboard

### DIFF
--- a/api/v1/server/oas/transformers/v1/tasks.go
+++ b/api/v1/server/oas/transformers/v1/tasks.go
@@ -258,6 +258,12 @@ func ToTask(taskWithData *v1.TaskWithPayloads, workflowRunExternalId uuid.UUID, 
 
 	input := jsonToMap(taskWithData.InputPayload)
 
+	if taskWithData.IsStandalone {
+		// todo: improve this somehow - it's using this implicit assumption about how
+		// we structure payloads, which it shouldn't
+		input = input["input"].(map[string]interface{})
+	}
+
 	stepId := taskWithData.StepID
 
 	retryCount := int(taskWithData.RetryCount)

--- a/api/v1/server/oas/transformers/v1/tasks.go
+++ b/api/v1/server/oas/transformers/v1/tasks.go
@@ -259,7 +259,7 @@ func ToTask(taskWithData *v1.TaskWithPayloads, workflowRunExternalId uuid.UUID, 
 	input := jsonToMap(taskWithData.InputPayload)
 
 	if taskWithData.IsStandalone {
-		// todo: improve this somehow - it's using this implicit assumption about how
+		// fixme: improve this somehow - it's using this implicit assumption about how
 		// we structure payloads, which it shouldn't
 		input = input["input"].(map[string]interface{})
 	}

--- a/api/v1/server/oas/transformers/v1/tasks.go
+++ b/api/v1/server/oas/transformers/v1/tasks.go
@@ -261,7 +261,11 @@ func ToTask(taskWithData *v1.TaskWithPayloads, workflowRunExternalId uuid.UUID, 
 	if taskWithData.IsStandalone {
 		// fixme: improve this somehow - it's using this implicit assumption about how
 		// we structure payloads, which it shouldn't
-		input = input["input"].(map[string]interface{})
+		if inputWithInternalHatchetData, ok := input["input"]; ok {
+			if actualInput, ok := inputWithInternalHatchetData.(map[string]interface{}); ok {
+				input = actualInput
+			}
+		}
 	}
 
 	stepId := taskWithData.StepID

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -644,6 +644,7 @@ func (r *OLAPRepositoryImpl) ReadTaskRunData(ctx context.Context, tenantId uuid.
 			ErrorMessage:          taskRun.ErrorMessage,
 			RetryCount:            taskRun.RetryCount,
 			OutputEventExternalID: taskRun.OutputEventExternalID,
+			IsStandalone:          taskRun.IsStandalone,
 		},
 		input,
 		output,

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -511,6 +511,7 @@ WITH selected_retry_count AS (
 )
 SELECT
     t.*,
+    (t.dag_id IS NULL)::BOOLEAN AS is_standalone,
     st.readable_status::v1_readable_status_olap as status,
     f.finished_at::timestamptz as finished_at,
     s.started_at::timestamptz as started_at,
@@ -567,7 +568,8 @@ WITH input AS (
         t.readable_status,
         t.parent_task_external_id,
         t.workflow_run_id,
-        t.latest_retry_count
+        t.latest_retry_count,
+        t.dag_id
     FROM
         v1_tasks_olap t
     JOIN
@@ -689,6 +691,7 @@ SELECT
     END::JSONB AS input,
     t.readable_status::v1_readable_status_olap as status,
     t.workflow_run_id,
+    (t.dag_id IS NULL)::BOOLEAN AS is_standalone,
     f.finished_at::timestamptz as finished_at,
     s.started_at::timestamptz as started_at,
     q.queued_at::timestamptz as queued_at,

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -2437,6 +2437,7 @@ WITH selected_retry_count AS (
 )
 SELECT
     t.tenant_id, t.id, t.inserted_at, t.external_id, t.queue, t.action_id, t.step_id, t.workflow_id, t.workflow_version_id, t.workflow_run_id, t.schedule_timeout, t.step_timeout, t.priority, t.sticky, t.desired_worker_id, t.display_name, t.input, t.additional_metadata, t.readable_status, t.latest_retry_count, t.latest_worker_id, t.dag_id, t.dag_inserted_at, t.parent_task_external_id,
+    (t.dag_id IS NULL)::BOOLEAN AS is_standalone,
     st.readable_status::v1_readable_status_olap as status,
     f.finished_at::timestamptz as finished_at,
     s.started_at::timestamptz as started_at,
@@ -2498,6 +2499,7 @@ type PopulateSingleTaskRunDataRow struct {
 	DagID                 pgtype.Int8          `json:"dag_id"`
 	DagInsertedAt         pgtype.Timestamptz   `json:"dag_inserted_at"`
 	ParentTaskExternalID  *uuid.UUID           `json:"parent_task_external_id"`
+	IsStandalone          bool                 `json:"is_standalone"`
 	Status                V1ReadableStatusOlap `json:"status"`
 	FinishedAt            pgtype.Timestamptz   `json:"finished_at"`
 	StartedAt             pgtype.Timestamptz   `json:"started_at"`
@@ -2542,6 +2544,7 @@ func (q *Queries) PopulateSingleTaskRunData(ctx context.Context, db DBTX, arg Po
 		&i.DagID,
 		&i.DagInsertedAt,
 		&i.ParentTaskExternalID,
+		&i.IsStandalone,
 		&i.Status,
 		&i.FinishedAt,
 		&i.StartedAt,
@@ -2583,7 +2586,8 @@ WITH input AS (
         t.readable_status,
         t.parent_task_external_id,
         t.workflow_run_id,
-        t.latest_retry_count
+        t.latest_retry_count,
+        t.dag_id
     FROM
         v1_tasks_olap t
     JOIN
@@ -2705,6 +2709,7 @@ SELECT
     END::JSONB AS input,
     t.readable_status::v1_readable_status_olap as status,
     t.workflow_run_id,
+    (t.dag_id IS NULL)::BOOLEAN AS is_standalone,
     f.finished_at::timestamptz as finished_at,
     s.started_at::timestamptz as started_at,
     q.queued_at::timestamptz as queued_at,
@@ -2757,6 +2762,7 @@ type PopulateTaskRunDataRow struct {
 	Input                 []byte               `json:"input"`
 	Status                V1ReadableStatusOlap `json:"status"`
 	WorkflowRunID         uuid.UUID            `json:"workflow_run_id"`
+	IsStandalone          bool                 `json:"is_standalone"`
 	FinishedAt            pgtype.Timestamptz   `json:"finished_at"`
 	StartedAt             pgtype.Timestamptz   `json:"started_at"`
 	QueuedAt              pgtype.Timestamptz   `json:"queued_at"`
@@ -2800,6 +2806,7 @@ func (q *Queries) PopulateTaskRunData(ctx context.Context, db DBTX, arg Populate
 			&i.Input,
 			&i.Status,
 			&i.WorkflowRunID,
+			&i.IsStandalone,
 			&i.FinishedAt,
 			&i.StartedAt,
 			&i.QueuedAt,


### PR DESCRIPTION
# Description

Extracts input payloads correctly over the API so that we get something like this:

```json
{
  "n": 2
}
```

instead of this:

```json
{
  "input": {
    "n": 2
  },
  "overrides": null,
  "parents": {},
  "triggered_by": "manual",
  "triggers": {
    "filter_payload": null
  },
  "user_data": null
}
```

This is technically a breaking change I think, since some people might be retrieving these payloads over the API in some cases, and the removal of the internal stuff could cause breakages? If we don't want to merge because of that that's fine, but this also makes standalone tasks and tasks in DAGs consistent, which I think is a good thing, and removes the hatchet internal stuff from the dashboard

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
