### PR TITLE
fix(docs): remove /index suffix from search result urls to fix 404 routes

### DIFF
--- a/frontend/docs/components/Search.tsx
+++ b/frontend/docs/components/Search.tsx
@@ -36,7 +36,13 @@ function loadIndex(): Promise<MiniSearch> {
 
 /** Convert a MiniSearch doc id to a Next.js route. */
 function idToRoute(id: string): string {
-  return "/" + id.replace("hatchet://docs/", "");
+  return (
+    "/" +
+    id
+      .replace("hatchet://docs/", "")
+      .replace(/\/index$/, "")
+      .replace(/\/index#/, "#")
+  );
 }
 
 /** Extract the page route (without anchor) from a result. */


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The `MiniSearch` indexer provides paths including the `/index` suffix (`/home/index` or `/home/index#section`). However, the Nextra router expects URLs without it. This caused 404s whenever I clicked on a search result URL or a deep-linked header containing `/index`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- Modified `idToRoute` logic in `Search.tsx` to remove `/index` from result paths, but still keeping urls and anchors resolving correctly