### PR TITLE
Add queue to update scheduled cron triggers on-demand

### DIFF
--- a/api/v1/server/handlers/workflows/create_cron.go
+++ b/api/v1/server/handlers/workflows/create_cron.go
@@ -73,7 +73,7 @@ func (t *WorkflowService) CronWorkflowTriggerCreate(ctx echo.Context, request ge
 		return gen.CronWorkflowTriggerCreate400JSONResponse(apierrors.NewAPIErrors("error creating cron trigger")), nil
 	}
 	msg := tasktypes.NewCronUpdateMessage(request.Tenant, msgqueue.MsgIDCronCreate)
-	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.CRON_TRIGGER_UPDATE_QUEUE, msg)
+	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.TICKER_UPDATE_QUEUE, msg)
 	if err != nil {
 		t.config.Logger.Err(err).Msg("could not send cron trigger update message")
 	}

--- a/api/v1/server/handlers/workflows/create_cron.go
+++ b/api/v1/server/handlers/workflows/create_cron.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/transformers"
 	"github.com/hatchet-dev/hatchet/internal/msgqueue"
+	tasktypes "github.com/hatchet-dev/hatchet/internal/services/shared/tasktypes/v1"
 	v1 "github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 )
@@ -71,7 +72,7 @@ func (t *WorkflowService) CronWorkflowTriggerCreate(ctx echo.Context, request ge
 
 		return gen.CronWorkflowTriggerCreate400JSONResponse(apierrors.NewAPIErrors("error creating cron trigger")), nil
 	}
-	msg := msgqueue.NewCronUpdateMessage(request.Tenant, "create-cron")
+	msg := tasktypes.NewCronUpdateMessage(request.Tenant, "create-cron")
 	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.CRON_TRIGGER_UPDATE_QUEUE, msg)
 	if err != nil {
 		t.config.Logger.Err(err).Msg("could not send cron trigger update message")

--- a/api/v1/server/handlers/workflows/create_cron.go
+++ b/api/v1/server/handlers/workflows/create_cron.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/apierrors"
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/transformers"
+	"github.com/hatchet-dev/hatchet/internal/msgqueue"
 	v1 "github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 )
@@ -63,13 +64,17 @@ func (t *WorkflowService) CronWorkflowTriggerCreate(ctx echo.Context, request ge
 			Priority:           &priority,
 		},
 	)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "unique constraint") {
 			return gen.CronWorkflowTriggerCreate400JSONResponse(apierrors.NewAPIErrors("cron trigger with that name-expression pair already exists")), nil
 		}
 
 		return gen.CronWorkflowTriggerCreate400JSONResponse(apierrors.NewAPIErrors("error creating cron trigger")), nil
+	}
+	msg := msgqueue.NewCronUpdateMessage(request.Tenant)
+	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.CRON_UPDATE_QUEUE, msg)
+	if err != nil {
+		t.config.Logger.Err(err).Msg("could not send cron update message")
 	}
 
 	return gen.CronWorkflowTriggerCreate200JSONResponse(

--- a/api/v1/server/handlers/workflows/create_cron.go
+++ b/api/v1/server/handlers/workflows/create_cron.go
@@ -72,9 +72,9 @@ func (t *WorkflowService) CronWorkflowTriggerCreate(ctx echo.Context, request ge
 		return gen.CronWorkflowTriggerCreate400JSONResponse(apierrors.NewAPIErrors("error creating cron trigger")), nil
 	}
 	msg := msgqueue.NewCronUpdateMessage(request.Tenant)
-	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.CRON_UPDATE_QUEUE, msg)
+	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.CRON_TRIGGER_UPDATE_QUEUE, msg)
 	if err != nil {
-		t.config.Logger.Err(err).Msg("could not send cron update message")
+		t.config.Logger.Err(err).Msg("could not send cron trigger update message")
 	}
 
 	return gen.CronWorkflowTriggerCreate200JSONResponse(

--- a/api/v1/server/handlers/workflows/create_cron.go
+++ b/api/v1/server/handlers/workflows/create_cron.go
@@ -72,7 +72,7 @@ func (t *WorkflowService) CronWorkflowTriggerCreate(ctx echo.Context, request ge
 
 		return gen.CronWorkflowTriggerCreate400JSONResponse(apierrors.NewAPIErrors("error creating cron trigger")), nil
 	}
-	msg := tasktypes.NewCronUpdateMessage(request.Tenant, "create-cron")
+	msg := tasktypes.NewCronUpdateMessage(request.Tenant, msgqueue.MsgIDCronCreate)
 	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.CRON_TRIGGER_UPDATE_QUEUE, msg)
 	if err != nil {
 		t.config.Logger.Err(err).Msg("could not send cron trigger update message")

--- a/api/v1/server/handlers/workflows/create_cron.go
+++ b/api/v1/server/handlers/workflows/create_cron.go
@@ -71,7 +71,7 @@ func (t *WorkflowService) CronWorkflowTriggerCreate(ctx echo.Context, request ge
 
 		return gen.CronWorkflowTriggerCreate400JSONResponse(apierrors.NewAPIErrors("error creating cron trigger")), nil
 	}
-	msg := msgqueue.NewCronUpdateMessage(request.Tenant)
+	msg := msgqueue.NewCronUpdateMessage(request.Tenant, "create-cron")
 	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.CRON_TRIGGER_UPDATE_QUEUE, msg)
 	if err != nil {
 		t.config.Logger.Err(err).Msg("could not send cron trigger update message")

--- a/api/v1/server/handlers/workflows/delete_cron.go
+++ b/api/v1/server/handlers/workflows/delete_cron.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
 	"github.com/hatchet-dev/hatchet/internal/msgqueue"
+	tasktypes "github.com/hatchet-dev/hatchet/internal/services/shared/tasktypes/v1"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 )
 
@@ -26,7 +27,7 @@ func (t *WorkflowService) WorkflowCronDelete(ctx echo.Context, request gen.Workf
 		return nil, err
 	}
 
-	msg := msgqueue.NewCronUpdateMessage(request.Tenant, "cron-delete")
+	msg := tasktypes.NewCronUpdateMessage(request.Tenant, "cron-delete")
 	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.CRON_TRIGGER_UPDATE_QUEUE, msg)
 	if err != nil {
 		t.config.Logger.Err(err).Msg("could not send cron trigger update message")

--- a/api/v1/server/handlers/workflows/delete_cron.go
+++ b/api/v1/server/handlers/workflows/delete_cron.go
@@ -27,7 +27,7 @@ func (t *WorkflowService) WorkflowCronDelete(ctx echo.Context, request gen.Workf
 		return nil, err
 	}
 
-	msg := tasktypes.NewCronUpdateMessage(request.Tenant, "cron-delete")
+	msg := tasktypes.NewCronUpdateMessage(request.Tenant, msgqueue.MsgIDCronDelete)
 	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.CRON_TRIGGER_UPDATE_QUEUE, msg)
 	if err != nil {
 		t.config.Logger.Err(err).Msg("could not send cron trigger update message")

--- a/api/v1/server/handlers/workflows/delete_cron.go
+++ b/api/v1/server/handlers/workflows/delete_cron.go
@@ -7,6 +7,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
+	"github.com/hatchet-dev/hatchet/internal/msgqueue"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 )
 
@@ -21,9 +22,14 @@ func (t *WorkflowService) WorkflowCronDelete(ctx echo.Context, request gen.Workf
 		cron.TenantId,
 		cron.CronId,
 	)
-
 	if err != nil {
 		return nil, err
+	}
+
+	msg := msgqueue.NewCronUpdateMessage(request.Tenant)
+	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.CRON_UPDATE_QUEUE, msg)
+	if err != nil {
+		t.config.Logger.Err(err).Msg("could not send cron update message")
 	}
 
 	return gen.WorkflowCronDelete204Response{}, nil

--- a/api/v1/server/handlers/workflows/delete_cron.go
+++ b/api/v1/server/handlers/workflows/delete_cron.go
@@ -28,7 +28,7 @@ func (t *WorkflowService) WorkflowCronDelete(ctx echo.Context, request gen.Workf
 	}
 
 	msg := tasktypes.NewCronUpdateMessage(request.Tenant, msgqueue.MsgIDCronDelete)
-	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.CRON_TRIGGER_UPDATE_QUEUE, msg)
+	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.TICKER_UPDATE_QUEUE, msg)
 	if err != nil {
 		t.config.Logger.Err(err).Msg("could not send cron trigger update message")
 	}

--- a/api/v1/server/handlers/workflows/delete_cron.go
+++ b/api/v1/server/handlers/workflows/delete_cron.go
@@ -26,7 +26,7 @@ func (t *WorkflowService) WorkflowCronDelete(ctx echo.Context, request gen.Workf
 		return nil, err
 	}
 
-	msg := msgqueue.NewCronUpdateMessage(request.Tenant)
+	msg := msgqueue.NewCronUpdateMessage(request.Tenant, "cron-delete")
 	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.CRON_TRIGGER_UPDATE_QUEUE, msg)
 	if err != nil {
 		t.config.Logger.Err(err).Msg("could not send cron trigger update message")

--- a/api/v1/server/handlers/workflows/delete_cron.go
+++ b/api/v1/server/handlers/workflows/delete_cron.go
@@ -27,9 +27,9 @@ func (t *WorkflowService) WorkflowCronDelete(ctx echo.Context, request gen.Workf
 	}
 
 	msg := msgqueue.NewCronUpdateMessage(request.Tenant)
-	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.CRON_UPDATE_QUEUE, msg)
+	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.CRON_TRIGGER_UPDATE_QUEUE, msg)
 	if err != nil {
-		t.config.Logger.Err(err).Msg("could not send cron update message")
+		t.config.Logger.Err(err).Msg("could not send cron trigger update message")
 	}
 
 	return gen.WorkflowCronDelete204Response{}, nil

--- a/api/v1/server/handlers/workflows/update_cron.go
+++ b/api/v1/server/handlers/workflows/update_cron.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
 	"github.com/hatchet-dev/hatchet/internal/msgqueue"
+	tasktypes "github.com/hatchet-dev/hatchet/internal/services/shared/tasktypes/v1"
 	v1 "github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 )
@@ -32,7 +33,7 @@ func (t *WorkflowService) WorkflowCronUpdate(ctx echo.Context, request gen.Workf
 		return nil, err
 	}
 
-	msg := msgqueue.NewCronUpdateMessage(request.Tenant, "update-cron")
+	msg := tasktypes.NewCronUpdateMessage(request.Tenant, "update-cron")
 	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.CRON_TRIGGER_UPDATE_QUEUE, msg)
 	if err != nil {
 		t.config.Logger.Err(err).Msg("could not send cron trigger update message")

--- a/api/v1/server/handlers/workflows/update_cron.go
+++ b/api/v1/server/handlers/workflows/update_cron.go
@@ -7,6 +7,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
+	"github.com/hatchet-dev/hatchet/internal/msgqueue"
 	v1 "github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 )
@@ -29,6 +30,12 @@ func (t *WorkflowService) WorkflowCronUpdate(ctx echo.Context, request gen.Workf
 
 	if err != nil {
 		return nil, err
+	}
+
+	msg := msgqueue.NewCronUpdateMessage(request.Tenant)
+	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.CRON_UPDATE_QUEUE, msg)
+	if err != nil {
+		t.config.Logger.Err(err).Msg("could not send cron update message")
 	}
 
 	return gen.WorkflowCronUpdate204Response{}, nil

--- a/api/v1/server/handlers/workflows/update_cron.go
+++ b/api/v1/server/handlers/workflows/update_cron.go
@@ -32,7 +32,7 @@ func (t *WorkflowService) WorkflowCronUpdate(ctx echo.Context, request gen.Workf
 		return nil, err
 	}
 
-	msg := msgqueue.NewCronUpdateMessage(request.Tenant)
+	msg := msgqueue.NewCronUpdateMessage(request.Tenant, "update-cron")
 	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.CRON_TRIGGER_UPDATE_QUEUE, msg)
 	if err != nil {
 		t.config.Logger.Err(err).Msg("could not send cron trigger update message")

--- a/api/v1/server/handlers/workflows/update_cron.go
+++ b/api/v1/server/handlers/workflows/update_cron.go
@@ -33,7 +33,7 @@ func (t *WorkflowService) WorkflowCronUpdate(ctx echo.Context, request gen.Workf
 		return nil, err
 	}
 
-	msg := tasktypes.NewCronUpdateMessage(request.Tenant, "update-cron")
+	msg := tasktypes.NewCronUpdateMessage(request.Tenant, msgqueue.MsgIDCronUpdate)
 	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.CRON_TRIGGER_UPDATE_QUEUE, msg)
 	if err != nil {
 		t.config.Logger.Err(err).Msg("could not send cron trigger update message")

--- a/api/v1/server/handlers/workflows/update_cron.go
+++ b/api/v1/server/handlers/workflows/update_cron.go
@@ -34,7 +34,7 @@ func (t *WorkflowService) WorkflowCronUpdate(ctx echo.Context, request gen.Workf
 	}
 
 	msg := tasktypes.NewCronUpdateMessage(request.Tenant, msgqueue.MsgIDCronUpdate)
-	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.CRON_TRIGGER_UPDATE_QUEUE, msg)
+	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.TICKER_UPDATE_QUEUE, msg)
 	if err != nil {
 		t.config.Logger.Err(err).Msg("could not send cron trigger update message")
 	}

--- a/api/v1/server/handlers/workflows/update_cron.go
+++ b/api/v1/server/handlers/workflows/update_cron.go
@@ -33,9 +33,9 @@ func (t *WorkflowService) WorkflowCronUpdate(ctx echo.Context, request gen.Workf
 	}
 
 	msg := msgqueue.NewCronUpdateMessage(request.Tenant)
-	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.CRON_UPDATE_QUEUE, msg)
+	err = t.config.MessageQueueV1.SendMessage(ctx.Request().Context(), msgqueue.CRON_TRIGGER_UPDATE_QUEUE, msg)
 	if err != nil {
-		t.config.Logger.Err(err).Msg("could not send cron update message")
+		t.config.Logger.Err(err).Msg("could not send cron trigger update message")
 	}
 
 	return gen.WorkflowCronUpdate204Response{}, nil

--- a/internal/msgqueue/message_ids.go
+++ b/internal/msgqueue/message_ids.go
@@ -25,4 +25,7 @@ const (
 	MsgIDUserEvent                    = "user-event"
 	MsgIDWorkflowRunFinished          = "workflow-run-finished"
 	MsgIDWorkflowRunFinishedCandidate = "workflow-run-finished-candidate"
+	MsgIDCronCreate                   = "cron-create"
+	MsgIDCronUpdate                   = "cron-update"
+	MsgIDCronDelete                   = "cron-delete"
 )

--- a/internal/msgqueue/msg.go
+++ b/internal/msgqueue/msg.go
@@ -59,10 +59,9 @@ func NewTenantMessage[T any](tenantId uuid.UUID, id string, immediatelyExpire, p
 	}, nil
 }
 
-func NewCronUpdateMessage(tenantId uuid.UUID) *Message {
-	uid, _ := uuid.NewUUID()
+func NewCronUpdateMessage(tenantId uuid.UUID, id string) *Message {
 	msg := &Message{
-		ID:                uid.String(),
+		ID:                id,
 		Payloads:          nil,
 		TenantID:          tenantId,
 		ImmediatelyExpire: true,

--- a/internal/msgqueue/msg.go
+++ b/internal/msgqueue/msg.go
@@ -59,18 +59,6 @@ func NewTenantMessage[T any](tenantId uuid.UUID, id string, immediatelyExpire, p
 	}, nil
 }
 
-func NewCronUpdateMessage(tenantId uuid.UUID, id string) *Message {
-	msg := &Message{
-		ID:                id,
-		Payloads:          nil,
-		TenantID:          tenantId,
-		ImmediatelyExpire: true,
-		Persistent:        false,
-		Retries:           5,
-	}
-	return msg
-}
-
 func DecodeAndValidateSingleton(dv datautils.DataDecoderValidator, payloads [][]byte, target interface{}) error {
 	if len(payloads) != 1 {
 		return fmt.Errorf("expected exactly one payload, got %d", len(payloads))

--- a/internal/msgqueue/msg.go
+++ b/internal/msgqueue/msg.go
@@ -59,6 +59,19 @@ func NewTenantMessage[T any](tenantId uuid.UUID, id string, immediatelyExpire, p
 	}, nil
 }
 
+func NewCronUpdateMessage(tenantId uuid.UUID) *Message {
+	uid, _ := uuid.NewUUID()
+	msg := &Message{
+		ID:                uid.String(),
+		Payloads:          nil,
+		TenantID:          tenantId,
+		ImmediatelyExpire: true,
+		Persistent:        false,
+		Retries:           5,
+	}
+	return msg
+}
+
 func DecodeAndValidateSingleton(dv datautils.DataDecoderValidator, payloads [][]byte, target interface{}) error {
 	if len(payloads) != 1 {
 		return fmt.Errorf("expected exactly one payload, got %d", len(payloads))

--- a/internal/msgqueue/msgqueue.go
+++ b/internal/msgqueue/msgqueue.go
@@ -50,7 +50,7 @@ const (
 	TASK_PROCESSING_QUEUE        staticQueue = "task_processing_queue_v2"
 	OLAP_QUEUE                   staticQueue = "olap_queue_v2"
 	DISPATCHER_DEAD_LETTER_QUEUE staticQueue = "dispatcher_dlq_v2"
-	CRON_TRIGGER_UPDATE_QUEUE    staticQueue = "cron_trigger_update_queue"
+	TICKER_UPDATE_QUEUE          staticQueue = "ticker_update_queue_v2"
 )
 
 func (s staticQueue) Name() string {

--- a/internal/msgqueue/msgqueue.go
+++ b/internal/msgqueue/msgqueue.go
@@ -50,7 +50,7 @@ const (
 	TASK_PROCESSING_QUEUE        staticQueue = "task_processing_queue_v2"
 	OLAP_QUEUE                   staticQueue = "olap_queue_v2"
 	DISPATCHER_DEAD_LETTER_QUEUE staticQueue = "dispatcher_dlq_v2"
-	CRON_UPDATE_QUEUE            staticQueue = "cron_update_queue_v2"
+	CRON_TRIGGER_UPDATE_QUEUE    staticQueue = "cron_trigger_update_queue"
 )
 
 func (s staticQueue) Name() string {

--- a/internal/msgqueue/msgqueue.go
+++ b/internal/msgqueue/msgqueue.go
@@ -50,6 +50,7 @@ const (
 	TASK_PROCESSING_QUEUE        staticQueue = "task_processing_queue_v2"
 	OLAP_QUEUE                   staticQueue = "olap_queue_v2"
 	DISPATCHER_DEAD_LETTER_QUEUE staticQueue = "dispatcher_dlq_v2"
+	CRON_UPDATE_QUEUE            staticQueue = "cron_update_queue_v2"
 )
 
 func (s staticQueue) Name() string {

--- a/internal/services/admin/v1/server.go
+++ b/internal/services/admin/v1/server.go
@@ -650,9 +650,9 @@ func (a *AdminServiceImpl) PutWorkflow(ctx context.Context, req *contracts.Creat
 
 	if len(createOpts.CronTriggers) > 0 {
 		msg := msgqueue.NewCronUpdateMessage(tenantId)
-		err = a.mq.SendMessage(ctx, msgqueue.CRON_UPDATE_QUEUE, msg)
+		err = a.mq.SendMessage(ctx, msgqueue.CRON_TRIGGER_UPDATE_QUEUE, msg)
 		if err != nil {
-			a.l.Err(err).Msg("could not send cron update message")
+			a.l.Err(err).Msg("could not send cron trigger update message")
 		}
 	}
 

--- a/internal/services/admin/v1/server.go
+++ b/internal/services/admin/v1/server.go
@@ -649,7 +649,7 @@ func (a *AdminServiceImpl) PutWorkflow(ctx context.Context, req *contracts.Creat
 	}
 
 	if len(createOpts.CronTriggers) > 0 {
-		msg := msgqueue.NewCronUpdateMessage(tenantId, "update-cron")
+		msg := tasktypes.NewCronUpdateMessage(tenantId, "update-cron")
 		err = a.mq.SendMessage(ctx, msgqueue.CRON_TRIGGER_UPDATE_QUEUE, msg)
 		if err != nil {
 			a.l.Err(err).Msg("could not send cron trigger update message")

--- a/internal/services/admin/v1/server.go
+++ b/internal/services/admin/v1/server.go
@@ -649,7 +649,7 @@ func (a *AdminServiceImpl) PutWorkflow(ctx context.Context, req *contracts.Creat
 	}
 
 	if len(createOpts.CronTriggers) > 0 {
-		msg := tasktypes.NewCronUpdateMessage(tenantId, "update-cron")
+		msg := tasktypes.NewCronUpdateMessage(tenantId, msgqueue.MsgIDCronUpdate)
 		err = a.mq.SendMessage(ctx, msgqueue.CRON_TRIGGER_UPDATE_QUEUE, msg)
 		if err != nil {
 			a.l.Err(err).Msg("could not send cron trigger update message")

--- a/internal/services/admin/v1/server.go
+++ b/internal/services/admin/v1/server.go
@@ -648,6 +648,14 @@ func (a *AdminServiceImpl) PutWorkflow(ctx context.Context, req *contracts.Creat
 		return nil, err
 	}
 
+	if len(createOpts.CronTriggers) > 0 {
+		msg := msgqueue.NewCronUpdateMessage(tenantId)
+		err = a.mq.SendMessage(ctx, msgqueue.CRON_UPDATE_QUEUE, msg)
+		if err != nil {
+			a.l.Err(err).Msg("could not send cron update message")
+		}
+	}
+
 	a.analytics.Enqueue(
 		"workflow:create",
 		"grpc",

--- a/internal/services/admin/v1/server.go
+++ b/internal/services/admin/v1/server.go
@@ -649,7 +649,7 @@ func (a *AdminServiceImpl) PutWorkflow(ctx context.Context, req *contracts.Creat
 	}
 
 	if len(createOpts.CronTriggers) > 0 {
-		msg := msgqueue.NewCronUpdateMessage(tenantId)
+		msg := msgqueue.NewCronUpdateMessage(tenantId, "update-cron")
 		err = a.mq.SendMessage(ctx, msgqueue.CRON_TRIGGER_UPDATE_QUEUE, msg)
 		if err != nil {
 			a.l.Err(err).Msg("could not send cron trigger update message")

--- a/internal/services/admin/v1/server.go
+++ b/internal/services/admin/v1/server.go
@@ -650,7 +650,7 @@ func (a *AdminServiceImpl) PutWorkflow(ctx context.Context, req *contracts.Creat
 
 	if len(createOpts.CronTriggers) > 0 {
 		msg := tasktypes.NewCronUpdateMessage(tenantId, msgqueue.MsgIDCronUpdate)
-		err = a.mq.SendMessage(ctx, msgqueue.CRON_TRIGGER_UPDATE_QUEUE, msg)
+		err = a.mq.SendMessage(ctx, msgqueue.TICKER_UPDATE_QUEUE, msg)
 		if err != nil {
 			a.l.Err(err).Msg("could not send cron trigger update message")
 		}

--- a/internal/services/shared/tasktypes/v1/cron.go
+++ b/internal/services/shared/tasktypes/v1/cron.go
@@ -1,0 +1,19 @@
+package v1
+
+import (
+	"github.com/google/uuid"
+
+	"github.com/hatchet-dev/hatchet/internal/msgqueue"
+)
+
+func NewCronUpdateMessage(tenantId uuid.UUID, id string) *msgqueue.Message {
+	msg := &msgqueue.Message{
+		ID:                id,
+		Payloads:          nil,
+		TenantID:          tenantId,
+		ImmediatelyExpire: true,
+		Persistent:        false,
+		Retries:           5,
+	}
+	return msg
+}

--- a/internal/services/ticker/cron.go
+++ b/internal/services/ticker/cron.go
@@ -20,48 +20,54 @@ func (t *TickerImpl) refreshCronSchedules(ctx context.Context) func() {
 	return func() {
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
+		// prevent multiple refreshes from running simultaneously
+		if t.userCronRefreshLock.TryLock() {
+			defer t.userCronRefreshLock.Unlock()
 
-		t.l.Debug().Msgf("ticker: polling cron schedules")
+			t.l.Debug().Msgf("ticker: polling cron schedules")
 
-		crons, err := t.repov1.Ticker().PollCronSchedules(ctx, t.tickerId)
+			crons, err := t.repov1.Ticker().PollCronSchedules(ctx, t.tickerId)
 
-		if err != nil {
-			t.l.Err(err).Msg("could not poll cron schedules")
-			return
-		}
-
-		// guard access to the userCronScheduler and userCronSchedulesToIds
-		t.userCronSchedulerLock.Lock()
-		defer t.userCronSchedulerLock.Unlock()
-
-		newCronKeys := make(map[string]bool)
-
-		for _, cron := range crons {
-			cronKey := getCronKey(cron)
-
-			newCronKeys[cronKey] = true
-
-			t.l.Debug().Msgf("ticker: handling cron %s", cronKey)
-
-			// if the cron is already scheduled, skip
-			if _, ok := t.userCronSchedulesToIds[cronKey]; ok {
-				continue
+			if err != nil {
+				t.l.Err(err).Msg("could not poll cron schedules")
+				return
 			}
 
-			// if the cron is not scheduled, schedule it
-			if err := t.handleScheduleCron(ctx, cron); err != nil {
-				t.l.Err(err).Msg("could not schedule cron")
-			}
-		}
+			// guard access to the userCronScheduler and userCronSchedulesToIds
+			t.userCronSchedulerLock.Lock()
+			defer t.userCronSchedulerLock.Unlock()
 
-		// cancel any crons that are no longer assigned to this ticker
-		for key := range t.userCronSchedulesToIds {
-			if _, ok := newCronKeys[key]; !ok {
-				if err := t.handleCancelCron(ctx, key); err != nil {
-					t.l.Err(err).Msg("could not cancel cron")
+			newCronKeys := make(map[string]bool)
+
+			for _, cron := range crons {
+				cronKey := getCronKey(cron)
+
+				newCronKeys[cronKey] = true
+
+				t.l.Debug().Msgf("ticker: handling cron %s", cronKey)
+
+				// if the cron is already scheduled, skip
+				if _, ok := t.userCronSchedulesToIds[cronKey]; ok {
+					continue
+				}
+
+				// if the cron is not scheduled, schedule it
+				if err := t.handleScheduleCron(ctx, cron); err != nil {
+					t.l.Err(err).Msg("could not schedule cron")
 				}
 			}
+
+			// cancel any crons that are no longer assigned to this ticker
+			for key := range t.userCronSchedulesToIds {
+				if _, ok := newCronKeys[key]; !ok {
+					if err := t.handleCancelCron(ctx, key); err != nil {
+						t.l.Err(err).Msg("could not cancel cron")
+					}
+				}
+			}
+
 		}
+
 	}
 }
 

--- a/internal/services/ticker/cron.go
+++ b/internal/services/ticker/cron.go
@@ -13,10 +13,10 @@ import (
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 )
 
-// runPollCronSchedules acquires a list of cron schedules from the database and schedules any which are not
+// refreshCronSchedules acquires a list of cron schedules from the database and schedules any which are not
 // already scheduled. This job runs in "singleton" mode, meaning that only one instance of this job will run at
 // a time.
-func (t *TickerImpl) runPollCronSchedules(ctx context.Context) func() {
+func (t *TickerImpl) refreshCronSchedules(ctx context.Context) func() {
 	return func() {
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()

--- a/internal/services/ticker/cron.go
+++ b/internal/services/ticker/cron.go
@@ -66,6 +66,8 @@ func (t *TickerImpl) refreshCronSchedules(ctx context.Context) func() {
 				}
 			}
 
+		} else {
+			t.l.Debug().Msgf("ticker: skipping cron refresh")
 		}
 
 	}

--- a/internal/services/ticker/ticker.go
+++ b/internal/services/ticker/ticker.go
@@ -39,6 +39,8 @@ type TickerImpl struct {
 	userCronScheduler     gocron.Scheduler
 	userCronSchedulerLock sync.Mutex
 
+	userCronRefreshLock sync.Mutex
+
 	// maps a unique key for the cron schedule to a UUID, because the gocron library depends on uuids
 	// as unique identifiers for scheduled jobs
 	userCronSchedulesToIds map[string]string
@@ -137,7 +139,7 @@ func (t *TickerImpl) Start() (func() error, error) {
 
 	// initialize the cron schedules, so no need to wait for 15 seconds or
 	// a cron to be created
-	t.refreshCronSchedules(ctx)
+	t.refreshCronSchedules(ctx)()
 
 	// add a handler to update the cron schedule on-demand when crons are created
 	cronUpdateHandler := func(task *msgqueue.Message) error {

--- a/internal/services/ticker/ticker.go
+++ b/internal/services/ticker/ticker.go
@@ -137,16 +137,16 @@ func (t *TickerImpl) Start() (func() error, error) {
 
 	// initialize the cron schedules, so no need to wait for 15 seconds or
 	// a cron to be created
-	t.runPollCronSchedules(ctx)
+	t.refreshCronSchedules(ctx)
 
 	// add a handler to update the cron schedule on-demand when crons are created
 	cronUpdateHandler := func(task *msgqueue.Message) error {
-		t.runPollCronSchedules(ctx)()
+		t.refreshCronSchedules(ctx)()
 		return nil
 	}
-	queueCleanupFunc, err := t.mqv1.Subscribe(msgqueue.CRON_UPDATE_QUEUE, cronUpdateHandler, msgqueue.NoOpHook)
+	queueCleanupFunc, err := t.mqv1.Subscribe(msgqueue.CRON_TRIGGER_UPDATE_QUEUE, cronUpdateHandler, msgqueue.NoOpHook)
 	if err != nil {
-		t.l.Log().Err(err).Msg("Could not subscribe to cron update queue")
+		t.l.Log().Err(err).Msg("Could not subscribe to cron trigger update queue")
 	}
 
 	// register the ticker
@@ -175,7 +175,7 @@ func (t *TickerImpl) Start() (func() error, error) {
 		// crons only have a resolution of 1 minute, so only poll every 15 seconds
 		gocron.DurationJob(time.Second*15),
 		gocron.NewTask(
-			t.runPollCronSchedules(ctx),
+			t.refreshCronSchedules(ctx),
 		),
 		gocron.WithSingletonMode(gocron.LimitModeReschedule),
 	)
@@ -240,13 +240,13 @@ func (t *TickerImpl) Start() (func() error, error) {
 	t.userCronScheduler.Start()
 
 	cleanup := func() error {
-		if queueCleanupFunc() != nil {
-			t.l.Log().Err(err).Msg("Could not cleanup cron update queue")
-		}
-
 		t.l.Debug().Msg("removing ticker")
 
 		cancel()
+
+		if queueCleanupFunc() != nil {
+			t.l.Log().Err(err).Msg("Could not cleanup cron trigger update queue")
+		}
 
 		if err := t.s.Shutdown(); err != nil {
 			return fmt.Errorf("could not shutdown scheduler: %w", err)

--- a/internal/services/ticker/ticker.go
+++ b/internal/services/ticker/ticker.go
@@ -144,14 +144,15 @@ func (t *TickerImpl) Start() (func() error, error) {
 		t.runPollCronSchedules(ctx)()
 		return nil
 	}
-	errFunc, err := t.mqv1.Subscribe(msgqueue.CRON_UPDATE_QUEUE, cronUpdateHandler, msgqueue.NoOpHook)
+	cleanupFunc, err := t.mqv1.Subscribe(msgqueue.CRON_UPDATE_QUEUE, cronUpdateHandler, msgqueue.NoOpHook)
 	if err != nil {
 		t.l.Log().Err(err).Msg("Could not subscribe to cron update queue")
-		err = errFunc()
-		if err != nil {
+	}
+	defer func() {
+		if cleanupFunc() != nil {
 			t.l.Log().Err(err).Msg("Could not cleanup cron update queue")
 		}
-	}
+	}()
 
 	// register the ticker
 	_, err = t.repov1.Ticker().CreateNewTicker(ctx, &v1.CreateTickerOpts{

--- a/internal/services/ticker/ticker.go
+++ b/internal/services/ticker/ticker.go
@@ -146,7 +146,7 @@ func (t *TickerImpl) Start() (func() error, error) {
 	}
 	queueCleanupFunc, err := t.mqv1.Subscribe(msgqueue.CRON_TRIGGER_UPDATE_QUEUE, cronUpdateHandler, msgqueue.NoOpHook)
 	if err != nil {
-		t.l.Log().Err(err).Msg("Could not subscribe to cron trigger update queue")
+		t.l.Err(err).Msg("Could not subscribe to cron trigger update queue")
 	}
 
 	// register the ticker
@@ -245,7 +245,7 @@ func (t *TickerImpl) Start() (func() error, error) {
 		cancel()
 
 		if queueCleanupFunc() != nil {
-			t.l.Log().Err(err).Msg("Could not cleanup cron trigger update queue")
+			t.l.Err(err).Msg("Could not cleanup cron trigger update queue")
 		}
 
 		if err := t.s.Shutdown(); err != nil {

--- a/internal/services/ticker/ticker.go
+++ b/internal/services/ticker/ticker.go
@@ -135,8 +135,26 @@ func (t *TickerImpl) Start() (func() error, error) {
 
 	t.l.Debug().Msgf("starting ticker %s", t.tickerId)
 
+	// initialize the cron schedules, so no need to wait for 15 seconds or
+	// a cron to be created
+	t.runPollCronSchedules(ctx)
+
+	// add a handler to update the cron schedule on-demand when crons are created
+	cronUpdateHandler := func(task *msgqueue.Message) error {
+		t.runPollCronSchedules(ctx)()
+		return nil
+	}
+	errFunc, err := t.mqv1.Subscribe(msgqueue.CRON_UPDATE_QUEUE, cronUpdateHandler, msgqueue.NoOpHook)
+	if err != nil {
+		t.l.Log().Err(err).Msg("Could not subscribe to cron update queue")
+		err = errFunc()
+		if err != nil {
+			t.l.Log().Err(err).Msg("Could not cleanup cron update queue")
+		}
+	}
+
 	// register the ticker
-	_, err := t.repov1.Ticker().CreateNewTicker(ctx, &v1.CreateTickerOpts{
+	_, err = t.repov1.Ticker().CreateNewTicker(ctx, &v1.CreateTickerOpts{
 		ID: t.tickerId,
 	})
 
@@ -173,6 +191,8 @@ func (t *TickerImpl) Start() (func() error, error) {
 
 	_, err = t.s.NewJob(
 		// we look ahead every 5 seconds
+		// FIXME: add another queue similar to cron jobs so that tasks scheduled less than 5 seconds
+		// into the future do not take 5 seconds to be triggered
 		gocron.DurationJob(time.Second*5),
 		gocron.NewTask(
 			t.runPollSchedules(ctx),

--- a/internal/services/ticker/ticker.go
+++ b/internal/services/ticker/ticker.go
@@ -246,7 +246,7 @@ func (t *TickerImpl) Start() (func() error, error) {
 
 		cancel()
 
-		if queueCleanupFunc() != nil {
+		if err = queueCleanupFunc(); err != nil {
 			t.l.Err(err).Msg("Could not cleanup cron trigger update queue")
 		}
 

--- a/internal/services/ticker/ticker.go
+++ b/internal/services/ticker/ticker.go
@@ -144,15 +144,10 @@ func (t *TickerImpl) Start() (func() error, error) {
 		t.runPollCronSchedules(ctx)()
 		return nil
 	}
-	cleanupFunc, err := t.mqv1.Subscribe(msgqueue.CRON_UPDATE_QUEUE, cronUpdateHandler, msgqueue.NoOpHook)
+	queueCleanupFunc, err := t.mqv1.Subscribe(msgqueue.CRON_UPDATE_QUEUE, cronUpdateHandler, msgqueue.NoOpHook)
 	if err != nil {
 		t.l.Log().Err(err).Msg("Could not subscribe to cron update queue")
 	}
-	defer func() {
-		if cleanupFunc() != nil {
-			t.l.Log().Err(err).Msg("Could not cleanup cron update queue")
-		}
-	}()
 
 	// register the ticker
 	_, err = t.repov1.Ticker().CreateNewTicker(ctx, &v1.CreateTickerOpts{
@@ -245,6 +240,10 @@ func (t *TickerImpl) Start() (func() error, error) {
 	t.userCronScheduler.Start()
 
 	cleanup := func() error {
+		if queueCleanupFunc() != nil {
+			t.l.Log().Err(err).Msg("Could not cleanup cron update queue")
+		}
+
 		t.l.Debug().Msg("removing ticker")
 
 		cancel()

--- a/internal/services/ticker/ticker.go
+++ b/internal/services/ticker/ticker.go
@@ -146,7 +146,7 @@ func (t *TickerImpl) Start() (func() error, error) {
 		t.refreshCronSchedules(ctx)()
 		return nil
 	}
-	queueCleanupFunc, err := t.mqv1.Subscribe(msgqueue.CRON_TRIGGER_UPDATE_QUEUE, cronUpdateHandler, msgqueue.NoOpHook)
+	queueCleanupFunc, err := t.mqv1.Subscribe(msgqueue.TICKER_UPDATE_QUEUE, cronUpdateHandler, msgqueue.NoOpHook)
 	if err != nil {
 		t.l.Err(err).Msg("Could not subscribe to cron trigger update queue")
 	}


### PR DESCRIPTION
# Description

A previous [PR](https://github.com/hatchet-dev/hatchet/pull/3136/changes) added crons with seconds granularity. However, the code that updated the active crons only ran every 15 seconds. This PR adds a new queue that is pub'ed to by both the GRPC and REST API whenever a new cron is added so that it will begin triggering instantaneously, rather than after 15 seconds.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...
