### PR TITLE
fix: Validate the presence of null unicode in output

### DIFF
--- a/examples/python/guides/pyproject.toml
+++ b/examples/python/guides/pyproject.toml
@@ -6,7 +6,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.10"
-hatchet-sdk = "^1.28.1"
+hatchet-sdk = "^1.28.2"
 # LLM integrations
 openai = "^1.0.0"
 anthropic = "^0.39.0"

--- a/pkg/repository/jsonb.go
+++ b/pkg/repository/jsonb.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -11,7 +12,7 @@ func ValidateJSONB(jsonb []byte, fieldName string) error {
 		return nil
 	}
 
-	if strings.Contains(string(jsonb), "\\u0000") {
+	if !isUnicodeValid(jsonb) {
 		return fmt.Errorf("encoded jsonb contains invalid null character \\u0000 in field `%s`", fieldName)
 	}
 
@@ -20,4 +21,21 @@ func ValidateJSONB(jsonb []byte, fieldName string) error {
 	}
 
 	return nil
+}
+
+func isUnicodeValid(jsonb []byte) bool {
+	dec := json.NewDecoder(bytes.NewReader(jsonb))
+	for {
+		token, err := dec.Token()
+		if err != nil {
+			// NOTE(gregfurman): regardless of whether io.EOF or actual parsing error,
+			// just return early as json.Valid should catch invalid payload.
+			return true
+		}
+		if s, ok := token.(string); ok {
+			if strings.ContainsRune(s, '\u0000') {
+				return false
+			}
+		}
+	}
 }

--- a/pkg/repository/jsonb_test.go
+++ b/pkg/repository/jsonb_test.go
@@ -16,6 +16,8 @@ func TestValidateJSONB_ValidJSON(t *testing.T) {
 		[]byte(`true`),
 		[]byte(`null`),
 		[]byte(`[]`),
+		[]byte(`{"a":"\\u0000"}`),
+		[]byte(`{"a":"\\\\u0000"}`),
 	}
 
 	for _, c := range cases {
@@ -27,9 +29,17 @@ func TestValidateJSONB_ValidJSON(t *testing.T) {
 
 func TestValidateJSONB_RejectsEncodedNull(t *testing.T) {
 	// This byte slice contains the literal substring `\u0000`.
-	b := []byte("{\"a\":\"\\u0000\"}")
-
-	if err := ValidateJSONB(b, "field"); err == nil {
-		t.Fatalf("expected error for encoded null, got nil")
+	cases := [][]byte{
+		[]byte(`{"a":"\u0000"}`),
+		[]byte(`{"a":"\\\u0000"}`),
+		[]byte(`{"foo\u0000":"bar"}`),
+		[]byte(`{"f\u0000oo":"bar"}`),
+		[]byte(`[{"f\u0000oo":"bar"}]`),
+		[]byte(`[{"a":"A","b":"B","c":"C\u0000"}]`),
+	}
+	for _, c := range cases {
+		if isValid := isUnicodeValid(c); isValid {
+			t.Fatalf("expected invalid unicode for json %q, got valid", string(c))
+		}
 	}
 }

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.28.2] - 2026-03-12
+
+### Changed
+
+- Fixes a bug where the literal string (`\u0000`) in task output was incorrectly rejected as null unicode.
+
 ## [1.28.1] - 2026-03-05
 
 ### Changed

--- a/sdks/python/hatchet_sdk/utils/serde.py
+++ b/sdks/python/hatchet_sdk/utils/serde.py
@@ -43,7 +43,9 @@ def remove_null_unicode_character(
 
     if isinstance(data, dict):
         return {
-            key: remove_null_unicode_character(cast(Any, value), replacement)
+            remove_null_unicode_character(
+                cast(Any, key), replacement
+            ): remove_null_unicode_character(cast(Any, value), replacement)
             for key, value in data.items()
         }
 

--- a/sdks/python/hatchet_sdk/worker/runner/runner.py
+++ b/sdks/python/hatchet_sdk/worker/runner/runner.py
@@ -1,6 +1,7 @@
 import asyncio
 import ctypes
 import functools
+import re
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import is_dataclass
@@ -537,7 +538,10 @@ class Runner:
         if not serialized_output:
             return None
 
-        if "\\u0000" in serialized_output:
+        # Checks whether a JSON-encoded null character (\u0000) is present in serialized output.
+        # This matches the literal "\u0000" preceded by an odd number of backslashes, rejecting payloads
+        # that will decode to the null char.
+        if re.search(r"(?<!\\)(\\\\)*\\u0000", serialized_output):
             raise IllegalTaskOutputError(dedent(f"""
                 Task outputs cannot contain the unicode null character \\u0000
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.28.1"
+version = "1.28.2"
 description = "This is the official Python SDK for Hatchet, a distributed, fault-tolerant task queue. The SDK allows you to easily integrate Hatchet's task scheduling and workflow orchestration capabilities into your Python applications."
 authors = [
   "Alexander Belanger <alexander@hatchet.run>",


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR addresses the hatchet server and python SDK incorrectly interpreting escaped unicode as invalid. 

For example, validations would interpret `"\\u0000"` (which is actually `[\, u, 0, 0, 0, 0]`)  as the unicode for`\u0000`.

Fixes #3153

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- Fixes `ValidateJSONB` to account for properly escaped unicode (i.e `"\\u0000"`).
- Updates python SDK to check for null unicode before serialization using new `contains_null_unicode_character` util.
