### PR TITLE
[Python] Fix: Lifespan not shutting down properly on worker drain

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.28.1] - 2026-03-05
+
+### Changed
+
+- Fixes a bug where lifespans are shut down eagerly before the worker is drained, causing unexpected behavior in still-running tasks.
+
 ## [1.28.0] - 2026-03-02
 
 ### Added

--- a/sdks/python/examples/lifespans/drain.py
+++ b/sdks/python/examples/lifespans/drain.py
@@ -1,0 +1,68 @@
+import asyncio
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+
+from hatchet_sdk import Context, Hatchet
+
+hatchet = Hatchet()
+
+
+class FakePool:
+    def __init__(self) -> None:
+        self._closed = False
+
+    def acquire(self) -> None:
+        if self._closed:
+            raise RuntimeError("the pool is already closed")
+
+    def close(self) -> None:
+        self._closed = True
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+
+async def drain_lifespan() -> AsyncGenerator[FakePool, None]:
+    pool = FakePool()
+    try:
+        yield pool
+    finally:
+        pool.close()
+
+
+@dataclass
+class DrainResult:
+    status: str
+    iterations: int
+
+
+@dataclass
+class DrainInput:
+    n: int
+
+
+@hatchet.task(name="LifespanDrainTask", input_validator=DrainInput)
+async def lifespan_drain_task(input: DrainInput, ctx: Context) -> DrainResult:
+    pool: FakePool = ctx.lifespan
+    iters = 0
+    for _ in range(input.n):
+        pool.acquire()
+        iters += 1
+        await asyncio.sleep(1)
+
+    return DrainResult(status="ok", iterations=iters)
+
+
+def main() -> None:
+    worker = hatchet.worker(
+        "drain-test-worker",
+        slots=5,
+        workflows=[lifespan_drain_task],
+        lifespan=drain_lifespan,
+    )
+    worker.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/sdks/python/examples/lifespans/test_lifespans.py
+++ b/sdks/python/examples/lifespans/test_lifespans.py
@@ -1,6 +1,15 @@
+import asyncio
+import signal
+from subprocess import Popen
+from typing import Any
+
+import psutil
 import pytest
 
+from examples.lifespans.drain import lifespan_drain_task, DrainInput
 from examples.lifespans.simple import Lifespan, lifespan_task
+from hatchet_sdk import Hatchet
+from hatchet_sdk import RunStatus
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -10,3 +19,47 @@ async def test_lifespans() -> None:
     assert isinstance(result, Lifespan)
     assert result.pi == 3.14
     assert result.foo == "bar"
+
+
+@pytest.mark.parametrize(
+    "on_demand_worker",
+    [
+        (
+            ["poetry", "run", "python", "examples/lifespans/drain.py"],
+            8009,
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_lifespan_drain_on_sigterm(
+    hatchet: Hatchet,
+    on_demand_worker: Popen[Any],
+) -> None:
+    n = 6
+    ref = await lifespan_drain_task.aio_run_no_wait(DrainInput(n=n))
+
+    for _ in range(30):
+        run = await hatchet.runs.aio_get_details(ref.workflow_run_id)
+        if run.status == RunStatus.RUNNING:
+            break
+
+        await asyncio.sleep(1)
+    else:
+        pytest.fail("Task never entered RUNNING state")
+
+    await asyncio.sleep(1)
+
+    parent = psutil.Process(on_demand_worker.pid)
+    children = parent.children(recursive=True)
+
+    for proc in [parent] + children:
+        try:
+            proc.send_signal(signal.SIGTERM)
+        except psutil.NoSuchProcess:
+            pass
+
+    result = await ref.aio_result()
+
+    assert result.status == "ok"
+    assert result.iterations == n

--- a/sdks/python/hatchet_sdk/deprecated/worker.py
+++ b/sdks/python/hatchet_sdk/deprecated/worker.py
@@ -142,8 +142,13 @@ async def legacy_aio_start(worker: Worker) -> None:
             )
         )
 
-        await worker.action_runner.wait_for_tasks()
         await worker.action_listener_health_check
+
+        if worker.action_runner:
+            await worker.action_runner.wait_for_tasks()
+
+        if durable_action_runner:
+            await durable_action_runner.wait_for_tasks()
 
         try:
             await worker._cleanup_lifespan()

--- a/sdks/python/hatchet_sdk/deprecated/worker.py
+++ b/sdks/python/hatchet_sdk/deprecated/worker.py
@@ -142,6 +142,7 @@ async def legacy_aio_start(worker: Worker) -> None:
             )
         )
 
+        await worker.action_runner.wait_for_tasks()
         await worker.action_listener_health_check
 
         try:

--- a/sdks/python/hatchet_sdk/worker/worker.py
+++ b/sdks/python/hatchet_sdk/worker/worker.py
@@ -299,8 +299,7 @@ class Worker:
 
             await self.action_listener_health_check
 
-            if self.action_runner:
-                await self.action_runner.wait_for_tasks()
+            await self.action_runner.wait_for_tasks()
 
             try:
                 await self._cleanup_lifespan()

--- a/sdks/python/hatchet_sdk/worker/worker.py
+++ b/sdks/python/hatchet_sdk/worker/worker.py
@@ -299,6 +299,9 @@ class Worker:
 
             await self.action_listener_health_check
 
+            if self.action_runner:
+                await self.action_runner.wait_for_tasks()
+
             try:
                 await self._cleanup_lifespan()
             except LifespanSetupError:
@@ -348,7 +351,9 @@ class Worker:
     async def _cleanup_lifespan(self) -> None:
         try:
             if self.lifespan_stack is not None:
-                await self.lifespan_stack.aclose()
+                stack = self.lifespan_stack
+                self.lifespan_stack = None
+                await stack.aclose()
         except Exception as e:
             logger.exception("error during lifespan cleanup")
             raise LifespanSetupError("An error occurred during lifespan cleanup") from e

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "1.28.0"
+version = "1.28.1"
 description = "This is the official Python SDK for Hatchet, a distributed, fault-tolerant task queue. The SDK allows you to easily integrate Hatchet's task scheduling and workflow orchestration capabilities into your Python applications."
 authors = [
   "Alexander Belanger <alexander@hatchet.run>",


### PR DESCRIPTION
# Description

Fixes #3166 

## [1.28.1] - 2026-03-05

### Changed

- Fixes a bug where lifespans are shut down eagerly before the worker is drained, causing unexpected behavior in still-running tasks.



## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
