### PR TITLE
docs: comprehensive durable execution documentation

### DIFF
--- a/frontend/docs/pages/reference/python/client.mdx
+++ b/frontend/docs/pages/reference/python/client.mdx
@@ -174,9 +174,24 @@ Parameters:
 | `backoff_max_seconds`         | `int \| None`                                                         | The maximum number of seconds to allow retries with exponential backoff to continue.                                                                                                                                                                             | `None`                  |
 | `default_filters`             | `list[DefaultFilter] \| None`                                         | A list of filters to create with the task is created. Note that this is a helper to allow you to create filters "declaratively" without needing to make a separate API call once the task is created to create them.                                             | `None`                  |
 | `default_additional_metadata` | `JSONSerializableMapping \| None`                                     | A dictionary of additional metadata to attach to each run of this task by default.                                                                                                                                                                               | `None`                  |
+| `eviction_policy`             | `EvictionPolicy \| None`                                              | Controls when this durable task can be evicted from a worker slot while waiting. Set to `None` to disable eviction entirely.                                                                                                                                     | `EvictionPolicy(ttl=timedelta(minutes=5), priority=0, allow_capacity_eviction=True)` |
 
 Returns:
 
 | Type                                                                                                                                                                                                                                               | Description                                           |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
 | `Callable[[Callable[Concatenate[EmptyModel, DurableContext, P], R \| CoroutineLike[R]]], Standalone[EmptyModel, R]] \| Callable[[Callable[Concatenate[TWorkflowInput, DurableContext, P], R \| CoroutineLike[R]]], Standalone[TWorkflowInput, R]]` | A decorator which creates a `Standalone` task object. |
+
+#### `EvictionPolicy`
+
+Controls when a durable task can be evicted from a worker slot while waiting. Import from `hatchet_sdk.runnables.eviction`.
+
+Parameters:
+
+| Name                      | Type                  | Description                                                                                                | Default       |
+| ------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------- | ------------- |
+| `ttl`                     | `timedelta \| None`   | Maximum wait duration before the task becomes eligible for TTL-based eviction. Set to `None` to disable.    | `5 minutes`   |
+| `priority`                | `int`                 | Eviction priority. Lower values are evicted first when capacity pressure requires evicting tasks.           | `0`           |
+| `allow_capacity_eviction` | `bool`                | Whether this task can be evicted under slot pressure. Set to `False` to prevent capacity-based eviction.    | `True`        |
+
+See [Configuring Eviction Policies](/v1/task-eviction#configuring-eviction-policies) for usage details.

--- a/frontend/docs/pages/reference/python/context.mdx
+++ b/frontend/docs/pages/reference/python/context.mdx
@@ -295,10 +295,13 @@ Bases: `Context`
 
 Methods:
 
-| Name            | Description                                                                                                                |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `aio_wait_for`  | Durably wait for either a sleep or an event.                                                                               |
-| `aio_sleep_for` | Lightweight wrapper for durable sleep. Allows for shorthand usage of `ctx.aio_wait_for` when specifying a sleep condition. |
+| Name                 | Description                                                                                                                |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `aio_wait_for`       | Durably wait for either a sleep or an event.                                                                               |
+| `aio_sleep_for`      | Lightweight wrapper for durable sleep. Allows for shorthand usage of `ctx.aio_wait_for` when specifying a sleep condition. |
+| `aio_wait_for_event` | Lightweight wrapper for waiting on user events. Pauses until an event arrives, then returns a structured `Event` object.   |
+| `memo`               | Memoize the result of a synchronous function based on dependencies.                                                        |
+| `aio_memo`           | Memoize the result of an async function based on dependencies.                                                             |
 
 ### Functions
 
@@ -321,12 +324,120 @@ Returns:
 
 Raises:
 
-| Type         | Description                                     |
-| ------------ | ----------------------------------------------- |
-| `ValueError` | If the durable event listener is not available. |
+| Type                   | Description                                                                                                                                                    |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ValueError`           | If the durable event listener is not available.                                                                                                                |
+| `NonDeterminismError`  | If the task is being replayed and the wait conditions don't match the original execution. See [Determinism Requirements](/v1/patterns/durable-task-execution#determinism-requirements). |
 
 #### `aio_sleep_for`
 
 Lightweight wrapper for durable sleep. Allows for shorthand usage of `ctx.aio_wait_for` when specifying a sleep condition.
 
 For more complicated conditions, use `ctx.aio_wait_for` directly.
+
+Parameters:
+
+| Name       | Type       | Description                                                                                   | Default    |
+| ---------- | ---------- | --------------------------------------------------------------------------------------------- | ---------- |
+| `duration` | `Duration` | The duration to sleep for. Can be a string (e.g. "5m"), a `timedelta`, or milliseconds as an int. | _required_ |
+
+Returns:
+
+| Type          | Description                                          |
+| ------------- | ---------------------------------------------------- |
+| `SleepResult` | A model containing the duration that was slept for.  |
+
+Raises:
+
+| Type                   | Description                                                                                                                                                    |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NonDeterminismError`  | If the task is being replayed and the sleep duration doesn't match the original execution. See [Determinism Requirements](/v1/patterns/durable-task-execution#determinism-requirements). |
+
+#### `aio_wait_for_event`
+
+Lightweight wrapper for waiting on user events. Pauses the durable task until an event with the specified key arrives (optionally filtered by a CEL expression), then returns a structured `Event` object containing the full event details.
+
+For more complex waiting conditions (like combining events with sleeps, or waiting for multiple events), use `ctx.aio_wait_for` directly.
+
+Parameters:
+
+| Name         | Type           | Description                                                                                             | Default    |
+| ------------ | -------------- | ------------------------------------------------------------------------------------------------------- | ---------- |
+| `key`        | `str`          | The event key to wait for.                                                                              | _required_ |
+| `expression` | `str \| None`  | Optional [CEL](https://github.com/google/cel-spec) expression to filter events based on their payload.  | `None`     |
+
+Returns:
+
+| Type    | Description                                           |
+| ------- | ----------------------------------------------------- |
+| `Event` | A model containing the full event details.            |
+
+#### `memo`
+
+Memoize the result of a synchronous function based on dependencies. If the function has been called before with the same dependencies, the cached result is returned without re-executing the function. This is useful for expensive operations that should only run once, even if the task is replayed after eviction.
+
+Parameters:
+
+| Name   | Type                 | Description                                                                                      | Default    |
+| ------ | -------------------- | ------------------------------------------------------------------------------------------------ | ---------- |
+| `fn`   | `Callable[[], T]`    | A zero-argument callable that returns the value to memoize.                                      | _required_ |
+| `deps` | `list[Any]`          | A list of dependencies used to compute the cache key. If deps change, the function re-executes. | _required_ |
+
+Returns:
+
+| Type | Description                                                                   |
+| ---- | ----------------------------------------------------------------------------- |
+| `T`  | The result of the function, either freshly computed or retrieved from cache.  |
+
+Raises:
+
+| Type         | Description                                     |
+| ------------ | ----------------------------------------------- |
+| `ValueError` | If the durable event listener is not available. |
+
+#### `aio_memo`
+
+Memoize the result of an async function based on dependencies. This is the async version of `memo` for use with async functions.
+
+Parameters:
+
+| Name   | Type                        | Description                                                                                      | Default    |
+| ------ | --------------------------- | ------------------------------------------------------------------------------------------------ | ---------- |
+| `fn`   | `Callable[[], Awaitable[T]]`| A zero-argument async callable that returns the value to memoize.                                | _required_ |
+| `deps` | `list[Any]`                 | A list of dependencies used to compute the cache key. If deps change, the function re-executes. | _required_ |
+
+Returns:
+
+| Type | Description                                                                   |
+| ---- | ----------------------------------------------------------------------------- |
+| `T`  | The result of the function, either freshly computed or retrieved from cache.  |
+
+Raises:
+
+| Type         | Description                                     |
+| ------------ | ----------------------------------------------- |
+| `ValueError` | If the durable event listener is not available. |
+
+## Return Types
+
+### `Event`
+
+A Pydantic model representing an event received from `aio_wait_for_event`.
+
+| Field                 | Type                             | Description                                      |
+| --------------------- | -------------------------------- | ------------------------------------------------ |
+| `id`                  | `str`                            | The unique identifier for the event.             |
+| `tenant_id`           | `str`                            | The tenant ID.                                   |
+| `key`                 | `str`                            | The event key.                                   |
+| `payload`             | `JSONSerializableMapping`        | The event payload data.                          |
+| `seen_at`             | `datetime`                       | When the event was received by Hatchet.          |
+| `additional_metadata` | `JSONSerializableMapping \| None`| Optional additional metadata sent with the event.|
+| `scope`               | `str \| None`                    | Optional event scope.                            |
+
+### `SleepResult`
+
+A Pydantic model representing the result of `aio_sleep_for`.
+
+| Field      | Type        | Description                      |
+| ---------- | ----------- | -------------------------------- |
+| `duration` | `timedelta` | The duration that was slept for. |

--- a/frontend/docs/pages/reference/python/feature-clients/runs.mdx
+++ b/frontend/docs/pages/reference/python/feature-clients/runs.mdx
@@ -29,6 +29,8 @@ Methods:
 | `get_run_ref`                                | Get a reference to a workflow run.                                   |
 | `get_task_run`                               | Get task run details for a given task run ID.                        |
 | `aio_get_task_run`                           | Get task run details for a given task run ID.                        |
+| `reset_durable_task`                         | Reset a durable task from a specific checkpoint.                     |
+| `aio_reset_durable_task`                     | Reset a durable task from a specific checkpoint.                     |
 | `bulk_cancel_by_filters_with_pagination`     | Cancel runs matching the specified filters in chunks.                |
 | `bulk_replay_by_filters_with_pagination`     | Replay runs matching the specified filters in chunks.                |
 | `aio_bulk_cancel_by_filters_with_pagination` | Cancel runs matching the specified filters in chunks.                |
@@ -404,6 +406,44 @@ Returns:
 | Type            | Description                                     |
 | --------------- | ----------------------------------------------- |
 | `V1TaskSummary` | Task run details for the specified task run ID. |
+
+#### `reset_durable_task`
+
+Reset a durable task from a specific checkpoint, creating a new execution branch from that point.
+
+This method forks a durable task from a specific node in its event log. The task will re-execute from the specified checkpoint, creating a new branch in the durable event log. Use `node_id=1` to restart the entire task from the beginning ("replay as new").
+
+Parameters:
+
+| Name               | Type  | Description                                                                                     | Default    |
+| ------------------ | ----- | ----------------------------------------------------------------------------------------------- | ---------- |
+| `task_external_id` | `str` | The external ID (UUID) of the durable task to reset. This is the workflow run ID for the task. | _required_ |
+| `node_id`          | `int` | The checkpoint node ID to replay from. Use `1` to replay from the beginning.                   | _required_ |
+
+Returns:
+
+| Type                        | Description                                                                  |
+| --------------------------- | ---------------------------------------------------------------------------- |
+| `V1ForkDurableTaskResponse` | The response containing the `node_id` and `branch_id` of the new execution. |
+
+#### `aio_reset_durable_task`
+
+Reset a durable task from a specific checkpoint, creating a new execution branch from that point.
+
+This is the async version of `reset_durable_task`. It forks a durable task from a specific node in its event log. The task will re-execute from the specified checkpoint, creating a new branch in the durable event log. Use `node_id=1` to restart the entire task from the beginning ("replay as new").
+
+Parameters:
+
+| Name               | Type  | Description                                                                                     | Default    |
+| ------------------ | ----- | ----------------------------------------------------------------------------------------------- | ---------- |
+| `task_external_id` | `str` | The external ID (UUID) of the durable task to reset. This is the workflow run ID for the task. | _required_ |
+| `node_id`          | `int` | The checkpoint node ID to replay from. Use `1` to replay from the beginning.                   | _required_ |
+
+Returns:
+
+| Type                        | Description                                                                  |
+| --------------------------- | ---------------------------------------------------------------------------- |
+| `V1ForkDurableTaskResponse` | The response containing the `node_id` and `branch_id` of the new execution. |
 
 #### `bulk_cancel_by_filters_with_pagination`
 

--- a/frontend/docs/pages/reference/python/runnables.mdx
+++ b/frontend/docs/pages/reference/python/runnables.mdx
@@ -149,6 +149,7 @@ Parameters:
 | `wait_for`              | `list[Condition \| OrGroup] \| None`         | A list of conditions that must be met before the task can run.                                                                                                                                                                          | `None`                  |
 | `skip_if`               | `list[Condition \| OrGroup] \| None`         | A list of conditions that, if met, will cause the task to be skipped.                                                                                                                                                                   | `None`                  |
 | `cancel_if`             | `list[Condition \| OrGroup] \| None`         | A list of conditions that, if met, will cause the task to be canceled.                                                                                                                                                                  | `None`                  |
+| `eviction_policy`       | `EvictionPolicy \| None`                     | Controls when this durable task can be evicted from a worker slot while waiting. Set to `None` to disable eviction entirely. See [Configuring Eviction Policies](/v1/task-eviction#configuring-eviction-policies) for details.          | `EvictionPolicy(ttl=timedelta(minutes=5), priority=0, allow_capacity_eviction=True)` |
 
 Returns:
 

--- a/frontend/docs/pages/reference/typescript/Context.mdx
+++ b/frontend/docs/pages/reference/typescript/Context.mdx
@@ -179,7 +179,7 @@ Parameters
 
 | Parameter     | Type       | Description                                                                                                                                                   |
 | ------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `incrementBy` | `Duration` | The interval by which to increment the timeout. The interval should be specified in the format of '10s' for 10 seconds, '1m' for 1 minute, or '1d' for 1 day. |
+| `incrementBy` | `Duration` | The interval by which to increment the timeout. Accepts a string (`"10s"`, `"1m"`, `"1d"`), a DurationObject, or milliseconds as a number. |
 
 Returns
 
@@ -479,11 +479,20 @@ Parameters
 | `duration`         | `Duration` | The duration to sleep for. |
 | `readableDataKey?` | `string`   | -                          |
 
+The `Duration` type accepts:
+- A **string** in Go duration format: `"1h30m5s"`, `"10m"`, `"30s"`
+- A **DurationObject**: `{ hours: 1, minutes: 30, seconds: 5 }`
+- A **number** representing milliseconds: `5000` (for 5 seconds)
+
 Returns
 
 `Promise`\<`Record`\<`string`, `any`\>\>
 
 A promise that resolves when the sleep duration has elapsed.
+
+Throws
+
+[`NonDeterminismError`](#nondeterminismerror) if the sleep duration differs from the original execution during replay.
 
 <a id="waitfor"></a>
 
@@ -503,3 +512,71 @@ Returns
 `Promise`\<`Record`\<`string`, `any`\>\>
 
 A promise that resolves with the event that satisfied the conditions.
+
+Throws
+
+[`NonDeterminismError`](#nondeterminismerror) if the wait conditions differ from the original execution during replay.
+
+<a id="memo"></a>
+
+##### `memo()`
+
+Memoize the result of an async function based on dependencies. If the function has been called before with the same dependencies, the cached result is returned without re-executing the function. This is useful for expensive operations that should only run once, even if the task is replayed after eviction.
+
+Parameters
+
+| Parameter | Type            | Description                                                                                      |
+| --------- | --------------- | ------------------------------------------------------------------------------------------------ |
+| `fn`      | `() => Promise<R>` | A zero-argument async function that returns the value to memoize.                             |
+| `deps`    | `any[]`         | An array of dependencies used to compute the cache key. If deps change, the function re-executes. |
+
+Returns
+
+`Promise`\<`R`\>
+
+A promise that resolves with the result of the function, either freshly computed or retrieved from cache.
+
+---
+
+<a id="nondeterminismerror"></a>
+
+### NonDeterminismError
+
+Thrown when a durable task's execution path during replay differs from the original execution. Import from `@hatchet-dev/typescript-sdk/util/errors/non-determinism-error`.
+
+This error occurs when Hatchet detects that checkpoint operations (like `sleepFor`, `waitFor`, or `spawnChild`) are being called with different arguments or in a different order than they were during the original task execution.
+
+#### Properties
+
+| Property          | Type     | Description                                            |
+| ----------------- | -------- | ------------------------------------------------------ |
+| `taskExternalId`  | `string` | The ID of the affected task run.                       |
+| `invocationCount` | `number` | Which invocation of the task detected the error.       |
+| `nodeId`          | `number` | The checkpoint position where the mismatch was found.  |
+
+#### Handling NonDeterminismError
+
+You can catch this error to implement custom recovery logic:
+
+```typescript
+import { NonDeterminismError } from '@hatchet-dev/typescript-sdk/util/errors/non-determinism-error';
+
+const myDurableTask = hatchet.durableTask({
+  name: 'my-durable-task',
+  fn: async (input, ctx) => {
+    try {
+      await ctx.sleepFor('10s');
+    } catch (e) {
+      if (e instanceof NonDeterminismError) {
+        // Handle non-determinism, e.g., log and return early
+        console.error(`Non-determinism at node ${e.nodeId}`);
+        return { error: 'non-determinism detected' };
+      }
+      throw e;
+    }
+    return { success: true };
+  },
+});
+```
+
+See [Determinism Requirements](/v1/durable-task-execution#determinism-requirements) for best practices on writing deterministic durable tasks.

--- a/frontend/docs/pages/reference/typescript/client.mdx
+++ b/frontend/docs/pages/reference/typescript/client.mdx
@@ -278,6 +278,8 @@ Parameters
 | --------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
 | `options` | `CreateDurableTaskWorkflowOpts`\<`I` & `Resolved`\<`GlobalInput`, `MiddlewareBefore`\>, `MergeIfNonEmpty`\<`O`, `GlobalOutput`\>\> | Durable task configuration options |
 
+The `CreateDurableTaskWorkflowOpts` type includes an optional `evictionPolicy` parameter to control when the task can be evicted from a worker slot while waiting. See [`EvictionPolicy`](#evictionpolicy) for details.
+
 Returns
 
 [`TaskWorkflowDeclaration`](Runnables.mdx#taskworkflowdeclaration)\<`I`, `O`, `GlobalInput`, `GlobalOutput`, `MiddlewareBefore`, `MiddlewareAfter`\>
@@ -297,6 +299,22 @@ Returns
 [`TaskWorkflowDeclaration`](Runnables.mdx#taskworkflowdeclaration)\<`I`, `O`, `GlobalInput`, `GlobalOutput`, `MiddlewareBefore`, `MiddlewareAfter`\>
 
 A TaskWorkflowDeclaration instance with inferred types
+
+<a id="evictionpolicy"></a>
+
+#### `EvictionPolicy`
+
+Controls when a durable task can be evicted from a worker slot while waiting. Import from `@hatchet-dev/typescript-sdk/v1`.
+
+Parameters:
+
+| Name                    | Type                    | Description                                                                                              | Default  |
+| ----------------------- | ----------------------- | -------------------------------------------------------------------------------------------------------- | -------- |
+| `ttl`                   | `Duration \| undefined` | Maximum wait duration before the task becomes eligible for TTL-based eviction. Set to `undefined` to disable. | `'15m'`  |
+| `priority`              | `number`                | Eviction priority. Lower values are evicted first when capacity pressure requires evicting tasks.         | `0`      |
+| `allowCapacityEviction` | `boolean`               | Whether this task can be evicted under slot pressure. Set to `false` to prevent capacity-based eviction.  | `true`   |
+
+See [Configuring Eviction Policies](/v1/task-eviction#configuring-eviction-policies) for usage details.
 
 <a id="run"></a>
 

--- a/frontend/docs/pages/v1/_meta.js
+++ b/frontend/docs/pages/v1/_meta.js
@@ -53,6 +53,7 @@ export default {
   "child-spawning": "Child Spawning",
   sleep: "Sleep & Delays",
   events: "Wait For Events",
+  memo: "Memoization",
   conditions: "Conditions & Branching",
   "on-failure": "Error Handling",
   "task-eviction": "Resource Management",

--- a/frontend/docs/pages/v1/bulk-run.mdx
+++ b/frontend/docs/pages/v1/bulk-run.mdx
@@ -31,6 +31,10 @@ And blocking variants:
 
 As with the run methods, you can call bulk methods from within a task and the runs will be associated with the parent task in the dashboard.
 
+<Callout type="info">
+When you call bulk methods from within a [durable task](/v1/patterns/durable-task-execution), they're durable-aware. The parent task is evicted while waiting for child results, freeing up its worker slot. If the parent gets interrupted and resumes, it picks up where it left off—waiting for the same children without re-spawning them.
+</Callout>
+
   </Tabs.Tab>
   <Tabs.Tab title="Typescript">
 

--- a/frontend/docs/pages/v1/durable-task-execution.mdx
+++ b/frontend/docs/pages/v1/durable-task-execution.mdx
@@ -76,7 +76,7 @@ Declare a task as durable (using `durable_task` instead of `task`) and it receiv
 | **`SleepFor(duration)`**      | Pause for a fixed duration. Respects the original sleep time on restart; if interrupted after 23 of 24 hours, only sleeps 1 more hour.                                         |
 | **`WaitForEvent(key, expr)`** | Wait for an external event by key, with optional [CEL filter](https://github.com/google/cel-spec) expression on the payload.                                                   |
 | **`WaitFor(conditions)`**     | General-purpose wait accepting any combination of sleep conditions, event conditions, or or-groups. `SleepFor` and `WaitForEvent` are convenience wrappers around this method. |
-| **`Memo(function)`**          | Run functions whose outputs are memoized based on the input arguments.                                                                                                         |
+| **[`Memo(function)`](/v1/memo)** | Cache expensive operations so they aren't re-executed on task replay. See [Memoization](/v1/memo).                                                                             |
 | **`RunChild(task, input)`**   | Spawn a child task and wait for its result. The parent is evicted during the wait.                                                                                             |
 
 ## Example Task
@@ -89,8 +89,10 @@ Now add tasks to the workflow. The first is a regular task; the second is a dura
 
 <Callout type="info">
   The `durable_task` decorator gives the function a `DurableContext` instead of
-  a regular `Context`. This is the only difference in declaration; the task
-  registers and runs on the same worker as regular tasks.
+  a regular `Context`. Durable tasks run on the same worker as regular tasks,
+  but they consume slots from a separate pool. This prevents deadlocks where a
+  durable task waiting for children could starve those children of slots. See
+  [Slot types](/v1/workers#slot-types) for details.
 </Callout>
 
 If this task is interrupted at any time, it will continue from where it left off. If the task calls `ctx.aio_sleep_for` for 24 hours and is interrupted after 23 hours, it will only sleep for 1 more hour on restart.
@@ -116,6 +118,60 @@ Child spawning is the primary way durable tasks build workflows at runtime. A du
 The parent is evicted while children execute, so it consumes no resources. The number and type of children can be determined dynamically based on input, intermediate results, or model outputs.
 
 See [Child Spawning](/v1/child-spawning) for patterns and full examples.
+
+## Determinism Requirements
+
+Because durable tasks can be interrupted and resumed, your task code must be **deterministic**. When Hatchet replays a task after an interruption, it re-executes your code from the beginning while skipping operations that were already checkpointed. If the code path taken during replay differs from the original execution, Hatchet raises a `NonDeterminismError`.
+
+### What Causes Non-Determinism
+
+Non-determinism occurs when the same task code produces different checkpoint operations on replay:
+
+| Anti-Pattern | Problem | Solution |
+| --- | --- | --- |
+| **Random values in wait conditions** | Sleep durations that change on replay (e.g., using `random()` or `Math.random()`) | Use deterministic values or memoize random calls |
+| **Time-based logic** | Branching based on current time changes between original run and replay | Use `ctx.invocationCount` (TS) / `ctx.attempt_number` (Python) or memoize the timestamp |
+| **Different child spawn inputs** | Generating new IDs (UUIDs, etc.) on each replay | Derive inputs from workflow input or memoize the ID |
+| **External state that changes** | Fetching data from a database or API that may have changed | Memoize the fetch or pass data through workflow input |
+
+### Handling NonDeterminismError
+
+When Hatchet detects a mismatch between the current execution and the recorded checkpoint, it raises `NonDeterminismError` with information about where the mismatch occurred:
+
+- `taskExternalId` (TypeScript) / `task_external_id` (Python): The ID of the affected task run
+- `invocationCount` (TypeScript) / `invocation_count` (Python): Which invocation of the task detected the error
+- `nodeId` (TypeScript) / `node_id` (Python): The checkpoint position where the mismatch was detected
+
+You can catch this error to implement custom recovery logic, but typically the right fix is to make your code deterministic.
+
+For SDK-specific documentation, see:
+- **TypeScript**: [`NonDeterminismError`](/reference/typescript/Context#nondeterminismerror)
+- **Python**: [`NonDeterminismError`](/reference/python/context#durable-context)
+
+### Best Practices
+
+1. **Keep durable operations deterministic**: The arguments to `sleepFor`/`aio_sleep_for`, `waitFor`/`aio_wait_for`, `spawnChild`/`aio_run`, and similar methods should produce the same values on replay
+2. **Use `memo()` for non-deterministic operations**: Wrap calls to random number generators, UUIDs, timestamps, or external services in `ctx.memo()` so the result is cached and reused on replay
+3. **Derive values from workflow input**: When possible, include all necessary data in the workflow input rather than fetching it during execution
+4. **Avoid conditional checkpoints**: Don't wrap durable operations in conditions that might evaluate differently on replay
+
+## Replaying from a Checkpoint
+
+You can programmatically reset a durable task to replay from a specific checkpoint. This creates a new execution branch in the durable event log, re-executing from the specified node while preserving the original execution history.
+
+| Use case                        | How                                                                |
+| ------------------------------- | ------------------------------------------------------------------ |
+| **Replay from the beginning**   | Set `node_id=1` to restart the entire task ("replay as new")       |
+| **Replay from a checkpoint**    | Set `node_id` to the specific checkpoint you want to resume from   |
+| **Debugging**                   | Re-run a task from a point where something went wrong              |
+
+The Python SDK provides [`reset_durable_task`](/reference/python/feature-clients/runs#reset_durable_task) and [`aio_reset_durable_task`](/reference/python/feature-clients/runs#aio_reset_durable_task) methods on the runs client.
+
+<Callout type="warning">
+  When you reset a durable task, a new branch is created in the event log. The
+  original execution history is preserved. Completed operations before the
+  specified `node_id` are skipped during replay.
+</Callout>
 
 <Callout type="info">
   For an in-depth look at how durable execution works internally, see [this blog

--- a/frontend/docs/pages/v1/index.mdx
+++ b/frontend/docs/pages/v1/index.mdx
@@ -17,7 +17,7 @@ The core mental model has three parts:
 
 - **[Tasks](/v1/tasks)** — the fundamental unit of work. A task wraps a single function and gives Hatchet everything it needs to schedule, execute, and observe it.
 - **[Workers](/v1/workers)** — long-running processes in your infrastructure that pick up and execute tasks.
-- **[Durable Workflows](/v1/durable-workflows)** — compose multiple tasks into durable pipelines with dependencies, retries, and checkpointing.
+- **[Durable Workflows](/v1/durable-workflows-overview)** — compose multiple tasks into durable pipelines with dependencies, retries, and checkpointing.
 
 All tasks and workflows are **defined as code**, making them easy to version, test, and deploy.
 

--- a/frontend/docs/pages/v1/memo.mdx
+++ b/frontend/docs/pages/v1/memo.mdx
@@ -1,0 +1,178 @@
+import { Callout, Tabs } from "nextra/components";
+import UniversalTabs from "@/components/UniversalTabs";
+
+# Memoization
+
+Memoization caches the results of expensive operations within a durable task. When a task replays after eviction, memoized operations return their cached results instead of re-executing.
+
+<Callout type="info">
+  Memoization is only available in durable tasks. Regular tasks run to
+  completion without replay, so memoization has no effect.
+</Callout>
+
+## When to Use Memoization
+
+Use memoization when a durable task performs an expensive or non-idempotent operation that should only execute once:
+
+| Scenario                        | Why Memoize?                                                                                       |
+| ------------------------------- | -------------------------------------------------------------------------------------------------- |
+| **API calls**                   | External API calls may be slow, rate-limited, or have side effects. Memoize to avoid duplicates.  |
+| **LLM/AI model calls**          | Model inference is expensive. Memoize to preserve the original response across replays.           |
+| **Database writes**             | Inserts or updates should happen once. Memoize to prevent duplicate records.                      |
+| **File uploads**                | Uploading to S3 or other storage should happen once. Memoize to avoid re-uploading on replay.     |
+| **Random or time-based values** | Values like UUIDs or timestamps should be stable. Memoize to get the same value on replay.        |
+
+## How It Works
+
+The `memo` function takes a callable and a list of dependencies. On the first call, it executes the callable and stores the result in the durable event log. On subsequent calls with the same dependencies, it returns the cached result without re-executing.
+
+```mermaid
+sequenceDiagram
+    participant T as Durable Task
+    participant H as Hatchet
+    participant E as External API
+
+    T->>H: memo(call_api, [user_id])
+    Note over H: First call: no cached result
+    H->>E: Execute call_api()
+    E->>H: API response
+    H->>H: Store result in event log
+    H->>T: Return response
+
+    Note over T: Task evicted, then resumed
+
+    T->>H: memo(call_api, [user_id])
+    Note over H: Replay: result exists
+    H->>T: Return cached response
+    Note over E: API not called
+```
+
+### Dependencies
+
+The `deps` parameter controls when memoized results are reused:
+
+- **Same dependencies**: Return the cached result from the event log.
+- **Different dependencies**: Execute the function again and cache the new result.
+
+For example, if you memoize an API call with `deps=[user_id]`, changing the `user_id` will trigger a fresh API call.
+
+<Callout type="warning">
+  Dependencies must be serializable. Use primitive types (strings, numbers,
+  booleans) or simple data structures. Complex objects may not hash consistently.
+</Callout>
+
+## Usage
+
+<Callout type="warning">
+  Code examples for this page require SDK snippets to be generated. The following
+  snippets need to be created in the SDK example directories:
+
+  **Python** (`sdks/python/examples/durable_memo/`):
+  - `worker.py` with snippets: `basic_memo`, `async_memo`, `memo_with_llm`, `multiple_memos`
+
+  **TypeScript** (`sdks/typescript/src/v1/examples/durable_memo/`):
+  - `workflow.ts` with snippets: `basic_memo`, `memo_with_llm`, `multiple_memos`
+
+  **Go** (`sdks/go/examples/durable_memo/`):
+  - `main.go` with snippets: `basic_memo`, `memo_with_external_call`
+
+  **Ruby** (`sdks/ruby/examples/durable_memo/`):
+  - `worker.rb` with snippets: `basic_memo`, `async_memo`
+</Callout>
+
+### Basic Memoization
+
+Wrap expensive operations in `memo` to cache their results. The function is executed on the first call, and subsequent calls (including after task replay) return the cached result.
+
+{/* TODO: Add snippets once SDK examples are created
+<UniversalTabs items={["Python", "Typescript", "Go", "Ruby"]}>
+  <Tabs.Tab title="Python">
+    <Snippet src={snippets.python.durable_memo.worker.basic_memo} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+    <Snippet src={snippets.typescript.durable_memo.workflow.basic_memo} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Go">
+    <Snippet src={snippets.go.durable_memo.main.basic_memo} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Ruby">
+    <Snippet src={snippets.ruby.durable_memo.worker.basic_memo} />
+  </Tabs.Tab>
+</UniversalTabs>
+*/}
+
+### Memoizing LLM Calls
+
+AI model calls are a common use case for memoization. Without memoization, a task replay would call the model again, potentially returning a different response and incurring additional cost.
+
+{/* TODO: Add snippets once SDK examples are created
+<UniversalTabs items={["Python", "Typescript", "Go", "Ruby"]}>
+  <Tabs.Tab title="Python">
+    <Snippet src={snippets.python.durable_memo.worker.memo_with_llm} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+    <Snippet src={snippets.typescript.durable_memo.workflow.memo_with_llm} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Go">
+    <Snippet src={snippets.go.durable_memo.main.memo_with_external_call} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Ruby">
+    <Snippet src={snippets.ruby.durable_memo.worker.async_memo} />
+  </Tabs.Tab>
+</UniversalTabs>
+*/}
+
+### Multiple Memoized Operations
+
+A single durable task can memoize multiple operations. Each `memo` call is tracked independently based on its position in the code and its dependencies.
+
+{/* TODO: Add snippets once SDK examples are created
+<UniversalTabs items={["Python", "Typescript", "Go", "Ruby"]}>
+  <Tabs.Tab title="Python">
+    <Snippet src={snippets.python.durable_memo.worker.multiple_memos} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+    <Snippet src={snippets.typescript.durable_memo.workflow.multiple_memos} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Go">
+    <Snippet src={snippets.go.durable_memo.main.basic_memo} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Ruby">
+    <Snippet src={snippets.ruby.durable_memo.worker.basic_memo} />
+  </Tabs.Tab>
+</UniversalTabs>
+*/}
+
+## Best Practices
+
+### Do Memoize
+
+- **External API calls** that may be slow or rate-limited
+- **LLM/AI inference** calls where you want deterministic replay
+- **Database operations** with side effects (inserts, updates)
+- **File operations** like uploads or downloads
+- **Random values** that should remain stable (UUIDs, timestamps)
+
+### Don't Memoize
+
+- **Pure computations** on local data (these are fast and deterministic anyway)
+- **Operations that should vary** on each replay (rare, but possible)
+- **Logging or metrics** (side effects that are safe to repeat)
+
+### Keep Dependencies Minimal
+
+Only include values that actually affect the operation's result. Extra dependencies cause unnecessary cache misses. For example, when fetching user data, only include `user_id` in the dependencies, not unrelated values like timestamps.
+
+## API Reference
+
+For detailed API documentation including method signatures and parameters, see:
+
+- [Python DurableContext.memo](/reference/python/context#memo)
+- [TypeScript DurableContext.memo](/reference/typescript/Context#memo)
+
+## Related
+
+- [Durable Tasks](/v1/durable-task-execution) — Overview of durable task execution
+- [Sleep & Delays](/v1/sleep) — Pausing tasks with durable sleep
+- [Events](/v1/events) — Waiting for external events
+- [Child Spawning](/v1/child-spawning) — Spawning child tasks from durable tasks

--- a/frontend/docs/pages/v1/observability/opentelemetry.mdx
+++ b/frontend/docs/pages/v1/observability/opentelemetry.mdx
@@ -42,6 +42,19 @@ By default, Hatchet creates spans at the following points in the lifecycle of a 
 
 In addition, you'll get a handful of attributes set (prefixed by `hatchet.`) on the task run events, such as the task name and the worker ID, as well as success/failure states, and so on.
 
+### Durable Execution Spans
+
+[Durable tasks](/v1/durable-task-execution) create additional spans for durable context operations:
+
+| Span Name | When Created |
+| --------- | ------------ |
+| `hatchet.durable.wait_for` | When calling `aio_wait_for` to wait for external signals |
+| `hatchet.run_workflow` | When spawning a single child workflow from a durable task |
+| `hatchet.run_workflows` | When spawning multiple child workflows from a durable task |
+| `hatchet.durable.memo.{fn_name}` | When calling `aio_memo` to memoize a function result |
+
+These spans include attributes like `signal_key`, `num_conditions`, and `memo_fn_name` to help trace what your durable tasks are doing.
+
 Some other important notes:
 
 1. The instrumentor will automatically propagate the trace context between task runs, so if you spawn a task from another task, the child will correctly show up as a child of its parent in the trace waterfall.

--- a/frontend/docs/pages/v1/opentelemetry.mdx
+++ b/frontend/docs/pages/v1/opentelemetry.mdx
@@ -42,6 +42,19 @@ By default, Hatchet creates spans at the following points in the lifecycle of a 
 
 In addition, you'll get a handful of attributes set (prefixed by `hatchet.`) on the task run events, such as the task name and the worker ID, as well as success/failure states, and so on.
 
+### Durable Execution Spans
+
+[Durable tasks](/v1/durable-task-execution) create additional spans for durable context operations:
+
+| Span Name | When Created |
+| --------- | ------------ |
+| `hatchet.durable.wait_for` | When calling `aio_wait_for` to wait for external signals |
+| `hatchet.run_workflow` | When spawning a single child workflow from a durable task |
+| `hatchet.run_workflows` | When spawning multiple child workflows from a durable task |
+| `hatchet.durable.memo.{fn_name}` | When calling `aio_memo` to memoize a function result |
+
+These spans include attributes like `signal_key`, `num_conditions`, and `memo_fn_name` to help trace what your durable tasks are doing.
+
 Some other important notes:
 
 1. The instrumentor will automatically propagate the trace context between task runs, so if you spawn a task from another task, the child will correctly show up as a child of its parent in the trace waterfall.

--- a/frontend/docs/pages/v1/patterns/durable-task-execution.mdx
+++ b/frontend/docs/pages/v1/patterns/durable-task-execution.mdx
@@ -76,7 +76,7 @@ Declare a task as durable (using `durable_task` instead of `task`) and it receiv
 | **`SleepFor(duration)`**      | Pause for a fixed duration. Respects the original sleep time on restart; if interrupted after 23 of 24 hours, only sleeps 1 more hour.                                         |
 | **`WaitForEvent(key, expr)`** | Wait for an external event by key, with optional [CEL filter](https://github.com/google/cel-spec) expression on the payload.                                                   |
 | **`WaitFor(conditions)`**     | General-purpose wait accepting any combination of sleep conditions, event conditions, or or-groups. `SleepFor` and `WaitForEvent` are convenience wrappers around this method. |
-| **`Memo(function)`**          | Run functions whose outputs are memoized based on the input arguments.                                                                                                         |
+| **[`Memo(function)`](/v1/memo)** | Cache expensive operations so they aren't re-executed on task replay. See [Memoization](/v1/memo).                                                                             |
 | **`RunChild(task, input)`**   | Spawn a child task and wait for its result. The parent is evicted during the wait.                                                                                             |
 
 ## Example Task
@@ -89,8 +89,10 @@ Now add tasks to the workflow. The first is a regular task; the second is a dura
 
 <Callout type="info">
   The `durable_task` decorator gives the function a `DurableContext` instead of
-  a regular `Context`. This is the only difference in declaration; the task
-  registers and runs on the same worker as regular tasks.
+  a regular `Context`. Durable tasks run on the same worker as regular tasks,
+  but they consume slots from a separate pool. This prevents deadlocks where a
+  durable task waiting for children could starve those children of slots. See
+  [Slot types](/v1/workers#slot-types) for details.
 </Callout>
 
 If this task is interrupted at any time, it will continue from where it left off. If the task calls `ctx.aio_sleep_for` for 24 hours and is interrupted after 23 hours, it will only sleep for 1 more hour on restart.
@@ -116,6 +118,60 @@ Child spawning is the primary way durable tasks build workflows at runtime. A du
 The parent is evicted while children execute, so it consumes no resources. The number and type of children can be determined dynamically based on input, intermediate results, or model outputs.
 
 See [Child Spawning](/v1/child-spawning) for patterns and full examples.
+
+## Determinism Requirements
+
+Because durable tasks can be interrupted and resumed, your task code must be **deterministic**. When Hatchet replays a task after an interruption, it re-executes your code from the beginning while skipping operations that were already checkpointed. If the code path taken during replay differs from the original execution, Hatchet raises a `NonDeterminismError`.
+
+### What Causes Non-Determinism
+
+Non-determinism occurs when the same task code produces different checkpoint operations on replay:
+
+| Anti-Pattern | Problem | Solution |
+| --- | --- | --- |
+| **Random values in wait conditions** | Sleep durations that change on replay (e.g., using `random()` or `Math.random()`) | Use deterministic values or memoize random calls |
+| **Time-based logic** | Branching based on current time changes between original run and replay | Use `ctx.invocationCount` (TS) / `ctx.attempt_number` (Python) or memoize the timestamp |
+| **Different child spawn inputs** | Generating new IDs (UUIDs, etc.) on each replay | Derive inputs from workflow input or memoize the ID |
+| **External state that changes** | Fetching data from a database or API that may have changed | Memoize the fetch or pass data through workflow input |
+
+### Handling NonDeterminismError
+
+When Hatchet detects a mismatch between the current execution and the recorded checkpoint, it raises `NonDeterminismError` with information about where the mismatch occurred:
+
+- `taskExternalId` (TypeScript) / `task_external_id` (Python): The ID of the affected task run
+- `invocationCount` (TypeScript) / `invocation_count` (Python): Which invocation of the task detected the error
+- `nodeId` (TypeScript) / `node_id` (Python): The checkpoint position where the mismatch was detected
+
+You can catch this error to implement custom recovery logic, but typically the right fix is to make your code deterministic.
+
+For SDK-specific documentation, see:
+- **TypeScript**: [`NonDeterminismError`](/reference/typescript/Context#nondeterminismerror)
+- **Python**: [`NonDeterminismError`](/reference/python/context#durable-context)
+
+### Best Practices
+
+1. **Keep durable operations deterministic**: The arguments to `sleepFor`/`aio_sleep_for`, `waitFor`/`aio_wait_for`, `spawnChild`/`aio_run`, and similar methods should produce the same values on replay
+2. **Use `memo()` for non-deterministic operations**: Wrap calls to random number generators, UUIDs, timestamps, or external services in `ctx.memo()` so the result is cached and reused on replay
+3. **Derive values from workflow input**: When possible, include all necessary data in the workflow input rather than fetching it during execution
+4. **Avoid conditional checkpoints**: Don't wrap durable operations in conditions that might evaluate differently on replay
+
+## Replaying from a Checkpoint
+
+You can programmatically reset a durable task to replay from a specific checkpoint. This creates a new execution branch in the durable event log, re-executing from the specified node while preserving the original execution history.
+
+| Use case                        | How                                                                |
+| ------------------------------- | ------------------------------------------------------------------ |
+| **Replay from the beginning**   | Set `node_id=1` to restart the entire task ("replay as new")       |
+| **Replay from a checkpoint**    | Set `node_id` to the specific checkpoint you want to resume from   |
+| **Debugging**                   | Re-run a task from a point where something went wrong              |
+
+The Python SDK provides [`reset_durable_task`](/reference/python/feature-clients/runs#reset_durable_task) and [`aio_reset_durable_task`](/reference/python/feature-clients/runs#aio_reset_durable_task) methods on the runs client.
+
+<Callout type="warning">
+  When you reset a durable task, a new branch is created in the event log. The
+  original execution history is preserved. Completed operations before the
+  specified `node_id` are skipped during replay.
+</Callout>
 
 <Callout type="info">
   For an in-depth look at how durable execution works internally, see [this blog

--- a/frontend/docs/pages/v1/patterns/mixing-patterns.mdx
+++ b/frontend/docs/pages/v1/patterns/mixing-patterns.mdx
@@ -88,3 +88,22 @@ Durable tasks must be **deterministic** between checkpoints. The task should alw
 1. **Only call methods available on the `DurableContext`**: a common way to introduce non-determinism is to call methods that produce side effects. If you need to fetch data from a database, call an API, or otherwise interact with external systems, spawn those operations as a **child task** using `RunChild`. Durable tasks are [evicted](/v1/task-eviction) at every wait point and replayed from checkpoint on resume. Any side effect not behind a checkpoint will re-execute.
 
 2. **When updating durable tasks, always guarantee backwards compatibility**: if you change the order of checkpoint operations in a durable task, you may break determinism. For example, if you call `SleepFor` followed by `WaitFor`, and then change the order of those calls, Hatchet will not be able to replay the task correctly. The task may have already been checkpointed at the first call to `SleepFor`, and changing the order makes that checkpoint meaningless.
+
+### Understanding Non-determinism Errors
+
+When a durable task violates determinism rules, Hatchet raises a `NonDeterminismError`. The error shows what operation was expected from checkpoint history versus what your code tried to perform.
+
+Example error:
+```
+non-determinism error in task abc123 at node 3:1
+  expected: waitFor(sleep(2s))
+  received: waitFor(sleep(4s))
+```
+
+This means the task called `sleepFor("2s")` at this checkpoint on a previous run, but on replay it's now calling `sleepFor("4s")`. Common causes:
+
+- **Changed sleep durations**: Changing a sleep from `"2s"` to `"4s"` while a task is in progress breaks replay because the checkpoint expects the original duration.
+- **Reordered operations**: Swapping the order of `sleepFor` and `waitForEvent` calls causes the checkpoint sequence to mismatch.
+- **Conditional logic changes**: Adding or removing branches that affect which checkpoint operations run can break in-flight tasks.
+
+To fix these errors, make sure code changes to durable tasks are backwards-compatible with in-flight runs, or wait for existing runs to complete before deploying.

--- a/frontend/docs/pages/v1/running-your-task.mdx
+++ b/frontend/docs/pages/v1/running-your-task.mdx
@@ -215,4 +215,4 @@ Hatchet supports additional trigger patterns for more advanced use cases:
 
 ## Next steps
 
-Now that you can run tasks, explore [Durable Workflows](/v1/durable-workflows) to compose multiple tasks into pipelines with dependencies and checkpointing.
+Now that you can run tasks, explore [Durable Workflows](/v1/durable-workflows-overview) to compose multiple tasks into pipelines with dependencies and checkpointing.

--- a/frontend/docs/pages/v1/task-eviction.mdx
+++ b/frontend/docs/pages/v1/task-eviction.mdx
@@ -41,6 +41,49 @@ This is especially important for:
 - **Human-in-the-loop** — Waiting for a human to approve or respond could take minutes or weeks. Eviction ensures no resources are held in the meantime.
 - **Large fan-outs** — A parent task that spawns thousands of children and waits for results can release its slot while the children run, preventing deadlocks where the parent holds resources that the children need.
 
+### Configuring eviction policies
+
+Durable tasks are evicted after waiting for a default duration—5 minutes in Python, 15 minutes in TypeScript. You can customize this by passing an eviction policy when defining the task.
+
+There are three levers:
+
+**TTL (Time-To-Live)**: How long a task waits before becoming eligible for eviction. When the TTL expires, Hatchet evicts the task, frees the slot, and automatically resumes when the wait condition is satisfied. Shorter TTLs free slots faster but cause more eviction overhead.
+
+**Capacity-based eviction**: Whether Hatchet can evict this task when worker slots are under pressure. Set `allow_capacity_eviction=False` (Python) or `allowCapacityEviction: false` (TypeScript) for critical tasks that should not be interrupted. These tasks keep their slot until their wait completes normally.
+
+**Priority**: When multiple tasks are candidates for capacity-based eviction, tasks with lower priority values are evicted first. Use this to protect important tasks relative to less critical ones.
+
+<Callout type="info">
+To prevent a task from ever being evicted, set `ttl` to `None` (Python) or `undefined` (TypeScript) and disable capacity eviction. This is useful for tasks holding critical state that cannot be checkpointed, but the task will consume a slot for the entire wait duration.
+</Callout>
+
+### EvictionPolicy reference
+
+<UniversalTabs items={["Python", "TypeScript"]} optionKey="sdk">
+<Tabs.Tab title="Python">
+
+Pass an `eviction_policy` to the `durable_task` decorator:
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `ttl` | `timedelta \| None` | `5 minutes` | Maximum wait duration before TTL-based eviction. Set to `None` to disable. |
+| `priority` | `int` | `0` | Lower values are evicted first under capacity pressure. |
+| `allow_capacity_eviction` | `bool` | `True` | Whether the task can be evicted under slot pressure. |
+
+</Tabs.Tab>
+<Tabs.Tab title="TypeScript">
+
+Pass an `evictionPolicy` to `hatchet.durableTask()`:
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `ttl` | `Duration \| undefined` | `'15m'` | Maximum wait duration before TTL-based eviction. Set to `undefined` to disable. |
+| `priority` | `number` | `0` | Lower values are evicted first under capacity pressure. |
+| `allowCapacityEviction` | `boolean` | `true` | Whether the task can be evicted under slot pressure. |
+
+</Tabs.Tab>
+</UniversalTabs>
+
 ### Separate slot pools
 
 Durable tasks consume slots from a **separate slot pool** than regular tasks. This prevents a common deadlock: if durable and regular tasks shared the same pool, a durable task waiting on child tasks could hold the very slot those children need to execute.
@@ -50,6 +93,31 @@ By isolating slot pools, Hatchet ensures that durable tasks waiting on children 
 ### Eviction and determinism
 
 Because a task may be evicted and resumed on a different worker at any time, the code between checkpoints must be [deterministic](/v1/patterns/mixing-patterns#determinism-in-durable-tasks). On resume, Hatchet replays the event log; it does not re-execute completed operations. If the code has changed between the original run and the replay, the checkpoint sequence may not match, leading to unexpected behavior.
+
+### Server-initiated eviction
+
+The Hatchet engine can also trigger eviction when it detects a **stale invocation**. This happens when a worker loses connectivity (missed heartbeats) and Hatchet re-queues the task to another worker. The original worker might still be running—just disconnected. When it reconnects, the engine notices the invocation is outdated and sends an eviction notification.
+
+#### How stale invocation detection works
+
+Each time a durable task is evicted and resumed, its **invocation count** increments. Workers report their invocation count in status updates. If the engine sees a worker reporting a lower count than current, it knows that worker is running stale code.
+
+1. **Worker A starts the task.** Invocation count is 1.
+2. **Worker A loses connectivity.** Heartbeats stop arriving.
+3. **Hatchet re-queues the task.** Worker B picks it up. Invocation count becomes 2.
+4. **Worker A reconnects.** It reports invocation count 1.
+5. **Engine detects the mismatch.** It sends a server eviction notification to Worker A.
+6. **Worker A cancels the stale task.** Only Worker B continues.
+
+#### Why server-initiated eviction matters
+
+Without this mechanism, two workers could run the same task simultaneously—a "split-brain" scenario. This could cause:
+
+- **Duplicate side effects** — Both workers might call external APIs or write to databases.
+- **Race conditions** — Both might try to complete the same checkpoint, leading to conflicts.
+- **Wasted resources** — The stale worker consumes a slot for work that will be discarded.
+
+Server-initiated eviction ensures only the most recent invocation runs. Stale invocations are cancelled as soon as they're detected.
 
 </Tabs.Tab>
 <Tabs.Tab title="DAGs">

--- a/frontend/docs/pages/v1/tasks.mdx
+++ b/frontend/docs/pages/v1/tasks.mdx
@@ -76,7 +76,7 @@ Tasks can be configured to handle common problems in distributed systems. For ex
 
 Every task receives an **input** - a JSON-serializable object passed when the task is triggered. The value you return from the task function becomes the task's **output**, which callers receive when they await the result.
 
-When a task is part of a [workflow](/v1/durable-workflows), its output is also available to downstream tasks through the context object, so data flows naturally from one step to the next. See [Accessing Parent Task Outputs](/v1/patterns/directed-acyclic-graphs#accessing-parent-task-outputs) for details.
+When a task is part of a [workflow](/v1/durable-workflows-overview), its output is also available to downstream tasks through the context object, so data flows naturally from one step to the next. See [Accessing Parent Task Outputs](/v1/patterns/directed-acyclic-graphs#accessing-parent-task-outputs) for details.
 
 ## The context object
 

--- a/frontend/docs/pages/v1/workers.mdx
+++ b/frontend/docs/pages/v1/workers.mdx
@@ -151,6 +151,23 @@ Start with a slot count that matches the degree of parallelism your worker can s
   you have gone too far.
 </Callout>
 
+### Slot types
+
+Workers manage multiple slot pools. By default, there are two:
+
+- **default** - used by regular tasks declared with `@hatchet.task()` or `workflow.task()`
+- **durable** - used by [durable tasks](/v1/patterns/durable-task-execution) declared with `@hatchet.durable_task()` or `workflow.durable_task()`
+
+This separation prevents deadlocks. Durable tasks spawn child tasks and wait for their results. If both shared the same pool, a durable task could consume all slots while waiting for children that can never run - there would be no slots left.
+
+With separate pools, a durable task waiting for children does not block regular tasks. Children execute in the default pool while the parent waits in the durable pool.
+
+Configure slot counts with the `slots` parameter (for the default pool) and `durable_slots` parameter (for the durable pool) when creating a worker. See the [Python SDK reference](/reference/python/client#worker) or [TypeScript SDK reference](/reference/typescript/client) for details.
+
+<Callout type="info">
+  If you don't use durable tasks, only the default pool matters. The durable pool is allocated but stays unused.
+</Callout>
+
 ## Scaling workers
 
 You can increase throughput in two ways: add more slots to a single worker, or run more worker processes. In most workloads, horizontal scaling (more workers) is the simplest path because each worker brings its own pool of slots and its own resources.


### PR DESCRIPTION
Consolidated documentation for durable task execution covering:

- **Slot types** for durable task isolation — separate worker slot pools prevent deadlocks between durable parents and their children
- **Eviction policies** — configurable policies for how durable tasks are evicted from worker slots during waits, including server-initiated eviction for stale invocation detection and split-brain prevention
- **Task replay/reset** — `reset_durable_task` and `aio_reset_durable_task` methods for replaying durable tasks from specific checkpoints
- **Determinism requirements** — `NonDeterminismError` handling and best practices for writing deterministic durable task code, with examples in the mixing patterns guide
- **Memoization** — `memo()` / `aio_memo()` functions for caching expensive operations across task replays
- **`aio_wait_for_event()`** — typed wrapper for waiting on user events with `Event` and `SleepResult` return models
- **Duration type variants** — documents string, DurationObject, and millisecond formats for TypeScript `Duration` type
- **Durable execution OTel spans** — `wait_for`, `run_workflow`, and `memo` span documentation for OpenTelemetry observability
- **Durable-aware bulk spawning** — callout documenting how bulk child spawn methods are durable-aware
- **Broken link fixes** — updates `/v1/durable-workflows` links to `/v1/durable-workflows-overview` after docs refactor

📋 **Promptless suggestion**: [View in dashboard](https://app.gopromptless.ai/suggestions/2488198a-7630-4f23-a625-6d85cb5eabfb)

## Files changed

### Conceptual docs
- `v1/durable-task-execution.mdx` — main durable tasks guide (slot types, replay, determinism sections)
- `v1/patterns/durable-task-execution.mdx` — patterns guide (mirrors main guide)
- `v1/workers.mdx` — slot types documentation
- `v1/task-eviction.mdx` — eviction policies + server-initiated eviction
- `v1/memo.mdx` — **new file** — memoization guide
- `v1/_meta.js` — adds memo navigation entry
- `v1/patterns/mixing-patterns.mdx` — non-determinism error examples
- `v1/opentelemetry.mdx` — durable execution OTel spans table
- `v1/observability/opentelemetry.mdx` — durable execution OTel spans table
- `v1/bulk-run.mdx` — durable-aware bulk spawning callout
- `v1/index.mdx` — fix broken durable-workflows link
- `v1/running-your-task.mdx` — fix broken durable-workflows link
- `v1/tasks.mdx` — fix broken durable-workflows link

### SDK reference
- `reference/python/context.mdx` — DurableContext `memo`, `aio_memo`, `aio_wait_for_event`, `Event`/`SleepResult` models, `NonDeterminismError`
- `reference/python/client.mdx` — `eviction_policy` param + `EvictionPolicy` class
- `reference/python/runnables.mdx` — eviction policy on durable runnables
- `reference/python/feature-clients/runs.mdx` — `reset_durable_task` / `aio_reset_durable_task`
- `reference/typescript/Context.mdx` — `memo()`, `Duration` type docs, `NonDeterminismError`
- `reference/typescript/client.mdx` — eviction policy configuration