### PR TITLE
Observability front-end: a few last fixes

### DIFF
--- a/frontend/app/src/components/v1/agent-prism/SpanCard/SpanCard.tsx
+++ b/frontend/app/src/components/v1/agent-prism/SpanCard/SpanCard.tsx
@@ -69,7 +69,7 @@ const getContentWidth = ({
     width -= LAYOUT_CONSTANTS.CONNECTOR_WIDTH;
   }
 
-  return width - contentPadding;
+  return Math.max(width - contentPadding, 40);
 };
 
 const getGridTemplateColumns = ({
@@ -395,7 +395,6 @@ export const SpanCard: FC<SpanCardProps> = ({
                 )}
                 style={{
                   width: `min(${contentWidth}px, 100%)`,
-                  minWidth: 140,
                 }}
                 onClick={eventHandlers.handleToggleClick}
               >

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/task-run-trace.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/task-run-trace.tsx
@@ -48,7 +48,7 @@ export function TaskRunTrace({ spans }: { spans: [OtelSpan, ...OtelSpan[]] }) {
           </h4>
         </div>
       </div>
-      <div className="max-h-[500px] overflow-y-auto">
+      <div className="overflow-y-auto">
         <TreeView
           spanTree={traceSpanTree}
           expandedSpansIds={expandedSpansIds}


### PR DESCRIPTION
# Description

Two small tweaks: removed a max-height that kept the spans from taking up the full vertical space, and fixed the timelines being bumped to the right at deep nestings.

(I haven't actually added a background to the SpanCardTimeline in this PR, it's only visible in this screenshot to demonstrate the fix)

<img width="864" height="1244" alt="CleanShot 2026-03-12 at 10 36 34@2x" src="https://github.com/user-attachments/assets/92e0e077-5e2d-444c-99bb-fc5cee7a391f" />


Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...
