### PR TITLE
fix(cli): honor active docker context when DOCKER_HOST is unset

### DIFF
--- a/cmd/hatchet-cli/cli/internal/drivers/docker/context_test.go
+++ b/cmd/hatchet-cli/cli/internal/drivers/docker/context_test.go
@@ -1,172 +1,144 @@
 package docker
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
+
+	dockercontext "github.com/docker/go-sdk/context"
 )
 
-func TestResolveDockerHostFromContext(t *testing.T) {
-	t.Setenv("DOCKER_HOST", "")
-	t.Run("no docker config", func(t *testing.T) {
-		// Use a temp dir with no .docker folder
+func TestDockerContextResolution(t *testing.T) {
+	t.Run("no config returns error", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		t.Setenv("HOME", tmpDir)
+		t.Setenv("USERPROFILE", tmpDir)
+		t.Setenv("DOCKER_HOST", "")
+		t.Setenv("DOCKER_CONTEXT", "")
 
-		result := resolveDockerHostFromContext()
-		if result != "" {
-			t.Errorf("expected empty string, got %q", result)
+		_, err := dockercontext.CurrentDockerHost()
+		if err == nil {
+			t.Error("expected error when no docker config exists")
 		}
 	})
 
-	t.Run("empty currentContext", func(t *testing.T) {
+	t.Run("default context returns default host", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		t.Setenv("HOME", tmpDir)
-
-		// create .docker/config.json with no currentContext
-		dockerDir := filepath.Join(tmpDir, ".docker")
-		if err := os.MkdirAll(dockerDir, 0755); err != nil {
-			t.Fatal(err)
-		}
-		configContent := `{"auths": {}}`
-		if err := os.WriteFile(filepath.Join(dockerDir, "config.json"), []byte(configContent), 0644); err != nil {
-			t.Fatal(err)
-		}
-
-		result := resolveDockerHostFromContext()
-		if result != "" {
-			t.Errorf("expected empty string, got %q", result)
-		}
-	})
-
-	t.Run("default context", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		t.Setenv("HOME", tmpDir)
-
-		// create .docker/config.json with currentContext = "default"
-		dockerDir := filepath.Join(tmpDir, ".docker")
-		if err := os.MkdirAll(dockerDir, 0755); err != nil {
-			t.Fatal(err)
-		}
-		configContent := `{"auths": {}, "currentContext": "default"}`
-		if err := os.WriteFile(filepath.Join(dockerDir, "config.json"), []byte(configContent), 0644); err != nil {
-			t.Fatal(err)
-		}
-
-		result := resolveDockerHostFromContext()
-		if result != "" {
-			t.Errorf("expected empty string for default context, got %q", result)
-		}
-	})
-
-	t.Run("non-default context with valid metadata", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		t.Setenv("HOME", tmpDir)
-
-		contextName := "my-rancher"
-		expectedHost := "unix:///tmp/rancher.sock"
-
-		// create .docker/config.json
-		dockerDir := filepath.Join(tmpDir, ".docker")
-		if err := os.MkdirAll(dockerDir, 0755); err != nil {
-			t.Fatal(err)
-		}
-		configContent := `{"auths": {}, "currentContext": "` + contextName + `"}`
-		if err := os.WriteFile(filepath.Join(dockerDir, "config.json"), []byte(configContent), 0644); err != nil {
-			t.Fatal(err)
-		}
-
-		// create context metadata
-		hash := sha256.Sum256([]byte(contextName))
-		hashStr := hex.EncodeToString(hash[:])
-		metaDir := filepath.Join(dockerDir, "contexts", "meta", hashStr)
-		if err := os.MkdirAll(metaDir, 0755); err != nil {
-			t.Fatal(err)
-		}
-		metaContent := `{"Name":"` + contextName + `","Metadata":{},"Endpoints":{"docker":{"Host":"` + expectedHost + `","SkipTLSVerify":false}}}`
-		if err := os.WriteFile(filepath.Join(metaDir, "meta.json"), []byte(metaContent), 0644); err != nil {
-			t.Fatal(err)
-		}
-
-		result := resolveDockerHostFromContext()
-		if result != expectedHost {
-			t.Errorf("expected %q, got %q", expectedHost, result)
-		}
-	})
-
-	t.Run("non-default context with missing metadata", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		t.Setenv("HOME", tmpDir)
-
-		// create .docker/config.json with non-default context but no metadata
-		dockerDir := filepath.Join(tmpDir, ".docker")
-		if err := os.MkdirAll(dockerDir, 0755); err != nil {
-			t.Fatal(err)
-		}
-		configContent := `{"auths": {}, "currentContext": "missing-context"}`
-		if err := os.WriteFile(filepath.Join(dockerDir, "config.json"), []byte(configContent), 0644); err != nil {
-			t.Fatal(err)
-		}
-
-		result := resolveDockerHostFromContext()
-		if result != "" {
-			t.Errorf("expected empty string for missing metadata, got %q", result)
-		}
-	})
-
-	t.Run("invalid config json", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		t.Setenv("HOME", tmpDir)
+		t.Setenv("USERPROFILE", tmpDir)
+		t.Setenv("DOCKER_HOST", "")
+		t.Setenv("DOCKER_CONTEXT", "")
 
 		dockerDir := filepath.Join(tmpDir, ".docker")
 		if err := os.MkdirAll(dockerDir, 0755); err != nil {
 			t.Fatal(err)
 		}
-		// Invalid JSON
+		if err := os.WriteFile(filepath.Join(dockerDir, "config.json"), []byte(`{}`), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		driver, err := NewDockerDriver(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer driver.apiClient.Close()
+
+		host := driver.apiClient.DaemonHost()
+		if host == "" {
+			t.Error("expected default Docker host, got empty string")
+		}
+	})
+
+	t.Run("non-default context resolves host", func(t *testing.T) {
+		dockercontext.SetupTestDockerContexts(t, 1, 1)
+		t.Setenv("DOCKER_HOST", "")
+		t.Setenv("DOCKER_CONTEXT", "")
+
+		driver, err := NewDockerDriver(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer driver.apiClient.Close()
+
+		host := driver.apiClient.DaemonHost()
+		if host != "tcp://127.0.0.1:1" {
+			t.Errorf("expected tcp://127.0.0.1:1, got %q", host)
+		}
+	})
+
+	t.Run("DOCKER_HOST takes precedence", func(t *testing.T) {
+		dockercontext.SetupTestDockerContexts(t, 1, 1)
+		t.Setenv("DOCKER_HOST", "tcp://192.168.1.100:2375")
+
+		driver, err := NewDockerDriver(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer driver.apiClient.Close()
+
+		host := driver.apiClient.DaemonHost()
+		if host != "tcp://192.168.1.100:2375" {
+			t.Errorf("expected tcp://192.168.1.100:2375, got %q", host)
+		}
+	})
+
+	t.Run("DOCKER_CONTEXT overrides config", func(t *testing.T) {
+		dockercontext.SetupTestDockerContexts(t, 1, 2)
+		t.Setenv("DOCKER_HOST", "")
+		t.Setenv("DOCKER_CONTEXT", "context2")
+
+		driver, err := NewDockerDriver(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer driver.apiClient.Close()
+
+		host := driver.apiClient.DaemonHost()
+		if host != "tcp://127.0.0.1:2" {
+			t.Errorf("expected tcp://127.0.0.1:2, got %q", host)
+		}
+	})
+
+	t.Run("missing context returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("HOME", tmpDir)
+		t.Setenv("USERPROFILE", tmpDir)
+		t.Setenv("DOCKER_HOST", "")
+		t.Setenv("DOCKER_CONTEXT", "")
+
+		dockerDir := filepath.Join(tmpDir, ".docker")
+		if err := os.MkdirAll(dockerDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dockerDir, "config.json"), []byte(`{"currentContext": "nonexistent"}`), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := dockercontext.CurrentDockerHost()
+		if err == nil {
+			t.Error("expected error for missing context")
+		}
+	})
+
+	t.Run("invalid config returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("HOME", tmpDir)
+		t.Setenv("USERPROFILE", tmpDir)
+		t.Setenv("DOCKER_HOST", "")
+		t.Setenv("DOCKER_CONTEXT", "")
+
+		dockerDir := filepath.Join(tmpDir, ".docker")
+		if err := os.MkdirAll(dockerDir, 0755); err != nil {
+			t.Fatal(err)
+		}
 		if err := os.WriteFile(filepath.Join(dockerDir, "config.json"), []byte("{invalid}"), 0644); err != nil {
 			t.Fatal(err)
 		}
 
-		result := resolveDockerHostFromContext()
-		if result != "" {
-			t.Errorf("expected empty string for invalid JSON, got %q", result)
-		}
-	})
-
-	t.Run("tcp host endpoint", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		t.Setenv("HOME", tmpDir)
-
-		contextName := "remote-docker"
-		expectedHost := "tcp://192.168.1.100:2375"
-
-		// create .docker/config.json
-		dockerDir := filepath.Join(tmpDir, ".docker")
-		if err := os.MkdirAll(dockerDir, 0755); err != nil {
-			t.Fatal(err)
-		}
-		configContent := `{"auths": {}, "currentContext": "` + contextName + `"}`
-		if err := os.WriteFile(filepath.Join(dockerDir, "config.json"), []byte(configContent), 0644); err != nil {
-			t.Fatal(err)
-		}
-
-		// create context metadata with TCP endpoint
-		hash := sha256.Sum256([]byte(contextName))
-		hashStr := hex.EncodeToString(hash[:])
-		metaDir := filepath.Join(dockerDir, "contexts", "meta", hashStr)
-		if err := os.MkdirAll(metaDir, 0755); err != nil {
-			t.Fatal(err)
-		}
-		metaContent := `{"Name":"` + contextName + `","Metadata":{},"Endpoints":{"docker":{"Host":"` + expectedHost + `","SkipTLSVerify":false}}}`
-		if err := os.WriteFile(filepath.Join(metaDir, "meta.json"), []byte(metaContent), 0644); err != nil {
-			t.Fatal(err)
-		}
-
-		result := resolveDockerHostFromContext()
-		if result != expectedHost {
-			t.Errorf("expected %q, got %q", expectedHost, result)
+		_, err := dockercontext.CurrentDockerHost()
+		if err == nil {
+			t.Error("expected error for invalid config")
 		}
 	})
 }

--- a/cmd/hatchet-cli/cli/internal/drivers/docker/context_test.go
+++ b/cmd/hatchet-cli/cli/internal/drivers/docker/context_test.go
@@ -9,11 +9,11 @@ import (
 )
 
 func TestResolveDockerHostFromContext(t *testing.T) {
-	t.SetEnv("DOCKER_HOST", "")
+	t.Setenv("DOCKER_HOST", "")
 	t.Run("no docker config", func(t *testing.T) {
 		// Use a temp dir with no .docker folder
 		tmpDir := t.TempDir()
-		t.SetEnv("HOME", tmpDir)
+		t.Setenv("HOME", tmpDir)
 
 		result := resolveDockerHostFromContext()
 		if result != "" {
@@ -23,7 +23,7 @@ func TestResolveDockerHostFromContext(t *testing.T) {
 
 	t.Run("empty currentContext", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		t.SetEnv("HOME", tmpDir)
+		t.Setenv("HOME", tmpDir)
 
 		// create .docker/config.json with no currentContext
 		dockerDir := filepath.Join(tmpDir, ".docker")
@@ -43,7 +43,7 @@ func TestResolveDockerHostFromContext(t *testing.T) {
 
 	t.Run("default context", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		t.SetEnv("HOME", tmpDir)
+		t.Setenv("HOME", tmpDir)
 
 		// create .docker/config.json with currentContext = "default"
 		dockerDir := filepath.Join(tmpDir, ".docker")
@@ -63,7 +63,7 @@ func TestResolveDockerHostFromContext(t *testing.T) {
 
 	t.Run("non-default context with valid metadata", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		t.SetEnv("HOME", tmpDir)
+		t.Setenv("HOME", tmpDir)
 
 		contextName := "my-rancher"
 		expectedHost := "unix:///tmp/rancher.sock"
@@ -98,7 +98,7 @@ func TestResolveDockerHostFromContext(t *testing.T) {
 
 	t.Run("non-default context with missing metadata", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		t.SetEnv("HOME", tmpDir)
+		t.Setenv("HOME", tmpDir)
 
 		// create .docker/config.json with non-default context but no metadata
 		dockerDir := filepath.Join(tmpDir, ".docker")
@@ -118,7 +118,7 @@ func TestResolveDockerHostFromContext(t *testing.T) {
 
 	t.Run("invalid config json", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		t.SetEnv("HOME", tmpDir)
+		t.Setenv("HOME", tmpDir)
 
 		dockerDir := filepath.Join(tmpDir, ".docker")
 		if err := os.MkdirAll(dockerDir, 0755); err != nil {
@@ -137,7 +137,7 @@ func TestResolveDockerHostFromContext(t *testing.T) {
 
 	t.Run("tcp host endpoint", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		t.SetEnv("HOME", tmpDir)
+		t.Setenv("HOME", tmpDir)
 
 		contextName := "remote-docker"
 		expectedHost := "tcp://192.168.1.100:2375"

--- a/cmd/hatchet-cli/cli/internal/drivers/docker/context_test.go
+++ b/cmd/hatchet-cli/cli/internal/drivers/docker/context_test.go
@@ -1,0 +1,186 @@
+package docker
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveDockerHostFromContext(t *testing.T) {
+	// save original HOME and DOCKER_HOST, restore after test
+	origHome := os.Getenv("HOME")
+	origDockerHost := os.Getenv("DOCKER_HOST")
+	defer func() {
+		os.Setenv("HOME", origHome)
+		if origDockerHost != "" {
+			os.Setenv("DOCKER_HOST", origDockerHost)
+		} else {
+			os.Unsetenv("DOCKER_HOST")
+		}
+	}()
+
+	// ensure DOCKER_HOST is not set for these tests
+	os.Unsetenv("DOCKER_HOST")
+
+	t.Run("no docker config", func(t *testing.T) {
+		// Use a temp dir with no .docker folder
+		tmpDir := t.TempDir()
+		os.Setenv("HOME", tmpDir)
+
+		result := resolveDockerHostFromContext()
+		if result != "" {
+			t.Errorf("expected empty string, got %q", result)
+		}
+	})
+
+	t.Run("empty currentContext", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		os.Setenv("HOME", tmpDir)
+
+		// create .docker/config.json with no currentContext
+		dockerDir := filepath.Join(tmpDir, ".docker")
+		if err := os.MkdirAll(dockerDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		configContent := `{"auths": {}}`
+		if err := os.WriteFile(filepath.Join(dockerDir, "config.json"), []byte(configContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result := resolveDockerHostFromContext()
+		if result != "" {
+			t.Errorf("expected empty string, got %q", result)
+		}
+	})
+
+	t.Run("default context", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		os.Setenv("HOME", tmpDir)
+
+		// create .docker/config.json with currentContext = "default"
+		dockerDir := filepath.Join(tmpDir, ".docker")
+		if err := os.MkdirAll(dockerDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		configContent := `{"auths": {}, "currentContext": "default"}`
+		if err := os.WriteFile(filepath.Join(dockerDir, "config.json"), []byte(configContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result := resolveDockerHostFromContext()
+		if result != "" {
+			t.Errorf("expected empty string for default context, got %q", result)
+		}
+	})
+
+	t.Run("non-default context with valid metadata", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		os.Setenv("HOME", tmpDir)
+
+		contextName := "my-rancher"
+		expectedHost := "unix:///tmp/rancher.sock"
+
+		// create .docker/config.json
+		dockerDir := filepath.Join(tmpDir, ".docker")
+		if err := os.MkdirAll(dockerDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		configContent := `{"auths": {}, "currentContext": "` + contextName + `"}`
+		if err := os.WriteFile(filepath.Join(dockerDir, "config.json"), []byte(configContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// create context metadata
+		hash := sha256.Sum256([]byte(contextName))
+		hashStr := hex.EncodeToString(hash[:])
+		metaDir := filepath.Join(dockerDir, "contexts", "meta", hashStr)
+		if err := os.MkdirAll(metaDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		metaContent := `{"Name":"` + contextName + `","Metadata":{},"Endpoints":{"docker":{"Host":"` + expectedHost + `","SkipTLSVerify":false}}}`
+		if err := os.WriteFile(filepath.Join(metaDir, "meta.json"), []byte(metaContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result := resolveDockerHostFromContext()
+		if result != expectedHost {
+			t.Errorf("expected %q, got %q", expectedHost, result)
+		}
+	})
+
+	t.Run("non-default context with missing metadata", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		os.Setenv("HOME", tmpDir)
+
+		// create .docker/config.json with non-default context but no metadata
+		dockerDir := filepath.Join(tmpDir, ".docker")
+		if err := os.MkdirAll(dockerDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		configContent := `{"auths": {}, "currentContext": "missing-context"}`
+		if err := os.WriteFile(filepath.Join(dockerDir, "config.json"), []byte(configContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result := resolveDockerHostFromContext()
+		if result != "" {
+			t.Errorf("expected empty string for missing metadata, got %q", result)
+		}
+	})
+
+	t.Run("invalid config json", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		os.Setenv("HOME", tmpDir)
+
+		dockerDir := filepath.Join(tmpDir, ".docker")
+		if err := os.MkdirAll(dockerDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		// Invalid JSON
+		if err := os.WriteFile(filepath.Join(dockerDir, "config.json"), []byte("{invalid}"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result := resolveDockerHostFromContext()
+		if result != "" {
+			t.Errorf("expected empty string for invalid JSON, got %q", result)
+		}
+	})
+
+	t.Run("tcp host endpoint", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		os.Setenv("HOME", tmpDir)
+
+		contextName := "remote-docker"
+		expectedHost := "tcp://192.168.1.100:2375"
+
+		// create .docker/config.json
+		dockerDir := filepath.Join(tmpDir, ".docker")
+		if err := os.MkdirAll(dockerDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		configContent := `{"auths": {}, "currentContext": "` + contextName + `"}`
+		if err := os.WriteFile(filepath.Join(dockerDir, "config.json"), []byte(configContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// create context metadata with TCP endpoint
+		hash := sha256.Sum256([]byte(contextName))
+		hashStr := hex.EncodeToString(hash[:])
+		metaDir := filepath.Join(dockerDir, "contexts", "meta", hashStr)
+		if err := os.MkdirAll(metaDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		metaContent := `{"Name":"` + contextName + `","Metadata":{},"Endpoints":{"docker":{"Host":"` + expectedHost + `","SkipTLSVerify":false}}}`
+		if err := os.WriteFile(filepath.Join(metaDir, "meta.json"), []byte(metaContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result := resolveDockerHostFromContext()
+		if result != expectedHost {
+			t.Errorf("expected %q, got %q", expectedHost, result)
+		}
+	})
+}

--- a/cmd/hatchet-cli/cli/internal/drivers/docker/context_test.go
+++ b/cmd/hatchet-cli/cli/internal/drivers/docker/context_test.go
@@ -9,25 +9,11 @@ import (
 )
 
 func TestResolveDockerHostFromContext(t *testing.T) {
-	// save original HOME and DOCKER_HOST, restore after test
-	origHome := os.Getenv("HOME")
-	origDockerHost := os.Getenv("DOCKER_HOST")
-	defer func() {
-		os.Setenv("HOME", origHome)
-		if origDockerHost != "" {
-			os.Setenv("DOCKER_HOST", origDockerHost)
-		} else {
-			os.Unsetenv("DOCKER_HOST")
-		}
-	}()
-
-	// ensure DOCKER_HOST is not set for these tests
-	os.Unsetenv("DOCKER_HOST")
-
+	t.SetEnv("DOCKER_HOST", "")
 	t.Run("no docker config", func(t *testing.T) {
 		// Use a temp dir with no .docker folder
 		tmpDir := t.TempDir()
-		os.Setenv("HOME", tmpDir)
+		t.SetEnv("HOME", tmpDir)
 
 		result := resolveDockerHostFromContext()
 		if result != "" {
@@ -37,7 +23,7 @@ func TestResolveDockerHostFromContext(t *testing.T) {
 
 	t.Run("empty currentContext", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		os.Setenv("HOME", tmpDir)
+		t.SetEnv("HOME", tmpDir)
 
 		// create .docker/config.json with no currentContext
 		dockerDir := filepath.Join(tmpDir, ".docker")
@@ -57,7 +43,7 @@ func TestResolveDockerHostFromContext(t *testing.T) {
 
 	t.Run("default context", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		os.Setenv("HOME", tmpDir)
+		t.SetEnv("HOME", tmpDir)
 
 		// create .docker/config.json with currentContext = "default"
 		dockerDir := filepath.Join(tmpDir, ".docker")
@@ -77,7 +63,7 @@ func TestResolveDockerHostFromContext(t *testing.T) {
 
 	t.Run("non-default context with valid metadata", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		os.Setenv("HOME", tmpDir)
+		t.SetEnv("HOME", tmpDir)
 
 		contextName := "my-rancher"
 		expectedHost := "unix:///tmp/rancher.sock"
@@ -112,7 +98,7 @@ func TestResolveDockerHostFromContext(t *testing.T) {
 
 	t.Run("non-default context with missing metadata", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		os.Setenv("HOME", tmpDir)
+		t.SetEnv("HOME", tmpDir)
 
 		// create .docker/config.json with non-default context but no metadata
 		dockerDir := filepath.Join(tmpDir, ".docker")
@@ -132,7 +118,7 @@ func TestResolveDockerHostFromContext(t *testing.T) {
 
 	t.Run("invalid config json", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		os.Setenv("HOME", tmpDir)
+		t.SetEnv("HOME", tmpDir)
 
 		dockerDir := filepath.Join(tmpDir, ".docker")
 		if err := os.MkdirAll(dockerDir, 0755); err != nil {
@@ -151,7 +137,7 @@ func TestResolveDockerHostFromContext(t *testing.T) {
 
 	t.Run("tcp host endpoint", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		os.Setenv("HOME", tmpDir)
+		t.SetEnv("HOME", tmpDir)
 
 		contextName := "remote-docker"
 		expectedHost := "tcp://192.168.1.100:2375"

--- a/cmd/hatchet-cli/cli/internal/drivers/docker/context_test.go
+++ b/cmd/hatchet-cli/cli/internal/drivers/docker/context_test.go
@@ -10,16 +10,22 @@ import (
 )
 
 func TestDockerContextResolution(t *testing.T) {
-	t.Run("no config returns error", func(t *testing.T) {
+	t.Run("no config falls back to default host", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		t.Setenv("HOME", tmpDir)
 		t.Setenv("USERPROFILE", tmpDir)
 		t.Setenv("DOCKER_HOST", "")
 		t.Setenv("DOCKER_CONTEXT", "")
 
-		_, err := dockercontext.CurrentDockerHost()
-		if err == nil {
-			t.Error("expected error when no docker config exists")
+		driver, err := NewDockerDriver(context.Background())
+		if err != nil {
+			t.Fatalf("expected driver to initialize, got error: %v", err)
+		}
+		defer driver.apiClient.Close()
+
+		host := driver.apiClient.DaemonHost()
+		if host == "" {
+			t.Error("expected default Docker host, got empty string")
 		}
 	})
 
@@ -100,7 +106,7 @@ func TestDockerContextResolution(t *testing.T) {
 		}
 	})
 
-	t.Run("missing context returns error", func(t *testing.T) {
+	t.Run("missing context falls back to default host", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		t.Setenv("HOME", tmpDir)
 		t.Setenv("USERPROFILE", tmpDir)
@@ -115,13 +121,19 @@ func TestDockerContextResolution(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err := dockercontext.CurrentDockerHost()
-		if err == nil {
-			t.Error("expected error for missing context")
+		driver, err := NewDockerDriver(context.Background())
+		if err != nil {
+			t.Fatalf("expected driver to initialize, got error: %v", err)
+		}
+		defer driver.apiClient.Close()
+
+		host := driver.apiClient.DaemonHost()
+		if host == "" {
+			t.Error("expected default Docker host, got empty string")
 		}
 	})
 
-	t.Run("invalid config returns error", func(t *testing.T) {
+	t.Run("invalid config falls back to default host", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		t.Setenv("HOME", tmpDir)
 		t.Setenv("USERPROFILE", tmpDir)
@@ -136,9 +148,15 @@ func TestDockerContextResolution(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err := dockercontext.CurrentDockerHost()
-		if err == nil {
-			t.Error("expected error for invalid config")
+		driver, err := NewDockerDriver(context.Background())
+		if err != nil {
+			t.Fatalf("expected driver to initialize, got error: %v", err)
+		}
+		defer driver.apiClient.Close()
+
+		host := driver.apiClient.DaemonHost()
+		if host == "" {
+			t.Error("expected default Docker host, got empty string")
 		}
 	})
 }

--- a/cmd/hatchet-cli/cli/internal/drivers/docker/docker.go
+++ b/cmd/hatchet-cli/cli/internal/drivers/docker/docker.go
@@ -2,7 +2,12 @@ package docker
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/docker/docker/client"
 )
@@ -36,13 +41,86 @@ func NewDockerDriver(ctx context.Context, optFns ...DockerDriverOpt) (*DockerDri
 }
 
 func (d *DockerDriver) init() error {
-	apiClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	clientOpts := []client.Opt{
+		client.FromEnv,
+		client.WithAPIVersionNegotiation(),
+	}
+
+	// If DOCKER_HOST is not set, try to resolve from active Docker context
+	if os.Getenv("DOCKER_HOST") == "" {
+		if host := resolveDockerHostFromContext(); host != "" {
+			clientOpts = append(clientOpts, client.WithHost(host))
+		}
+	}
+
+	apiClient, err := client.NewClientWithOpts(clientOpts...)
 	if err != nil {
 		return fmt.Errorf("could not create docker client: %w", err)
 	}
-	defer apiClient.Close()
 
 	d.apiClient = apiClient
 
 	return nil
+}
+
+// dockerConfig represents the relevant fields from ~/.docker/config.json
+type dockerConfig struct {
+	CurrentContext string `json:"currentContext"`
+}
+
+// contextMetadata represents the relevant fields from Docker context metadata
+type contextMetadata struct {
+	Name      string `json:"Name"`
+	Endpoints struct {
+		Docker struct {
+			Host string `json:"Host"`
+		} `json:"docker"`
+	} `json:"Endpoints"`
+}
+
+// resolveDockerHostFromContext reads the active Docker context and returns
+// the Docker host endpoint. Returns empty string if:
+// - Docker config cannot be read
+// - No context is set or context is "default"
+// - Context metadata cannot be read
+func resolveDockerHostFromContext() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	// Read Docker config
+	configPath := filepath.Join(homeDir, ".docker", "config.json")
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		return ""
+	}
+
+	var config dockerConfig
+	if err := json.Unmarshal(configData, &config); err != nil {
+		return ""
+	}
+
+	// No context or default context - use default behavior
+	if config.CurrentContext == "" || config.CurrentContext == "default" {
+		return ""
+	}
+
+	// Read context metadata
+	// Docker stores non-default context metadata under ~/.docker/contexts/meta/.
+	hash := sha256.Sum256([]byte(config.CurrentContext))
+	hashStr := hex.EncodeToString(hash[:])
+	metaPath := filepath.Join(homeDir, ".docker", "contexts", "meta", hashStr, "meta.json")
+
+	metaData, err := os.ReadFile(metaPath)
+	if err != nil {
+		return ""
+	}
+
+	var meta contextMetadata
+	if err := json.Unmarshal(metaData, &meta); err != nil {
+		return ""
+	}
+
+	return meta.Endpoints.Docker.Host
 }

--- a/cmd/hatchet-cli/cli/internal/drivers/docker/docker.go
+++ b/cmd/hatchet-cli/cli/internal/drivers/docker/docker.go
@@ -2,14 +2,10 @@ package docker
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/docker/docker/client"
+	dockercontext "github.com/docker/go-sdk/context"
 )
 
 type DockerDriverOpt func(*DockerDriverOpts) error
@@ -46,11 +42,10 @@ func (d *DockerDriver) init() error {
 		client.WithAPIVersionNegotiation(),
 	}
 
-	// If DOCKER_HOST is not set, try to resolve from active Docker context
-	if os.Getenv("DOCKER_HOST") == "" {
-		if host := resolveDockerHostFromContext(); host != "" {
-			clientOpts = append(clientOpts, client.WithHost(host))
-		}
+	// Resolve Docker host from the current Docker context.
+	// This respects DOCKER_HOST, DOCKER_CONTEXT, and the active context in ~/.docker/config.json.
+	if host, err := dockercontext.CurrentDockerHost(); err == nil && host != "" {
+		clientOpts = append(clientOpts, client.WithHost(host))
 	}
 
 	apiClient, err := client.NewClientWithOpts(clientOpts...)
@@ -61,66 +56,4 @@ func (d *DockerDriver) init() error {
 	d.apiClient = apiClient
 
 	return nil
-}
-
-// dockerConfig represents the relevant fields from ~/.docker/config.json
-type dockerConfig struct {
-	CurrentContext string `json:"currentContext"`
-}
-
-// contextMetadata represents the relevant fields from Docker context metadata
-type contextMetadata struct {
-	Name      string `json:"Name"`
-	Endpoints struct {
-		Docker struct {
-			Host string `json:"Host"`
-		} `json:"docker"`
-	} `json:"Endpoints"`
-}
-
-// resolveDockerHostFromContext reads the active Docker context and returns
-// the Docker host endpoint. Returns empty string if:
-// - Docker config cannot be read
-// - No context is set or context is "default"
-// - Context metadata cannot be read
-func resolveDockerHostFromContext() string {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-
-	// Read Docker config
-	configPath := filepath.Join(homeDir, ".docker", "config.json")
-	configData, err := os.ReadFile(configPath)
-	if err != nil {
-		return ""
-	}
-
-	var config dockerConfig
-	if err := json.Unmarshal(configData, &config); err != nil {
-		return ""
-	}
-
-	// No context or default context - use default behavior
-	if config.CurrentContext == "" || config.CurrentContext == "default" {
-		return ""
-	}
-
-	// Read context metadata
-	// Docker stores non-default context metadata under ~/.docker/contexts/meta/.
-	hash := sha256.Sum256([]byte(config.CurrentContext))
-	hashStr := hex.EncodeToString(hash[:])
-	metaPath := filepath.Join(homeDir, ".docker", "contexts", "meta", hashStr, "meta.json")
-
-	metaData, err := os.ReadFile(metaPath)
-	if err != nil {
-		return ""
-	}
-
-	var meta contextMetadata
-	if err := json.Unmarshal(metaData, &meta); err != nil {
-		return ""
-	}
-
-	return meta.Endpoints.Docker.Host
 }

--- a/cmd/hatchet-cli/cli/internal/drivers/docker/docker_context_test.go
+++ b/cmd/hatchet-cli/cli/internal/drivers/docker/docker_context_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/docker/docker/client"
 	dockercontext "github.com/docker/go-sdk/context"
 )
 
@@ -24,8 +25,8 @@ func TestDockerContextResolution(t *testing.T) {
 		defer driver.apiClient.Close()
 
 		host := driver.apiClient.DaemonHost()
-		if host == "" {
-			t.Error("expected default Docker host, got empty string")
+		if host != client.DefaultDockerHost {
+			t.Errorf("expected %q, got %q", client.DefaultDockerHost, host)
 		}
 	})
 
@@ -51,8 +52,8 @@ func TestDockerContextResolution(t *testing.T) {
 		defer driver.apiClient.Close()
 
 		host := driver.apiClient.DaemonHost()
-		if host == "" {
-			t.Error("expected default Docker host, got empty string")
+		if host != client.DefaultDockerHost {
+			t.Errorf("expected %q, got %q", client.DefaultDockerHost, host)
 		}
 	})
 
@@ -128,8 +129,8 @@ func TestDockerContextResolution(t *testing.T) {
 		defer driver.apiClient.Close()
 
 		host := driver.apiClient.DaemonHost()
-		if host == "" {
-			t.Error("expected default Docker host, got empty string")
+		if host != client.DefaultDockerHost {
+			t.Errorf("expected %q, got %q", client.DefaultDockerHost, host)
 		}
 	})
 
@@ -155,8 +156,8 @@ func TestDockerContextResolution(t *testing.T) {
 		defer driver.apiClient.Close()
 
 		host := driver.apiClient.DaemonHost()
-		if host == "" {
-			t.Error("expected default Docker host, got empty string")
+		if host != client.DefaultDockerHost {
+			t.Errorf("expected %q, got %q", client.DefaultDockerHost, host)
 		}
 	})
 }

--- a/frontend/docs/pages/reference/cli/running-hatchet-locally.mdx
+++ b/frontend/docs/pages/reference/cli/running-hatchet-locally.mdx
@@ -2,7 +2,7 @@
 
 The Hatchet CLI provides the `hatchet server` commands to run a local instance of Hatchet for development and testing purposes. This local instance relies on Docker to run the necessary services.
 
-When `DOCKER_HOST` is not set, Hatchet uses the active Docker context from your local Docker configuration. If `DOCKER_HOST` is set explicitly, it takes precedence.
+When `DOCKER_HOST` is not set, Hatchet resolves the Docker host from the current Docker context. This respects `DOCKER_CONTEXT` when it is set, and otherwise uses the active context from your local Docker configuration. If `DOCKER_HOST` is set explicitly, it takes precedence.
 
 ## Prerequisites
 

--- a/frontend/docs/pages/reference/cli/running-hatchet-locally.mdx
+++ b/frontend/docs/pages/reference/cli/running-hatchet-locally.mdx
@@ -2,6 +2,8 @@
 
 The Hatchet CLI provides the `hatchet server` commands to run a local instance of Hatchet for development and testing purposes. This local instance relies on Docker to run the necessary services.
 
+When `DOCKER_HOST` is not set, Hatchet uses the active Docker context from your local Docker configuration. If `DOCKER_HOST` is set explicitly, it takes precedence.
+
 ## Prerequisites
 
 Before running Hatchet locally, you must have Docker installed on your machine. You can download Docker from [here](https://www.docker.com/get-started).

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/creasty/defaults v1.8.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0
+	github.com/docker/go-sdk/context v0.1.0-alpha013
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6
 	github.com/emersion/go-smtp v0.24.0
 	github.com/fatih/color v1.18.0
@@ -105,6 +106,7 @@ require (
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
+	github.com/docker/go-sdk/config v0.1.0-alpha013 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
@@ -153,6 +155,7 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.2.0 // indirect
+	github.com/moby/moby/api v1.53.0 // indirect
 	github.com/moby/patternmatcher v0.6.0 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/sys/user v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,10 @@ github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaft
 github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=
 github.com/docker/go-connections v0.6.0/go.mod h1:AahvXYshr6JgfUJGdDCs2b5EZG/vmaMAntpSFH5BFKE=
+github.com/docker/go-sdk/config v0.1.0-alpha013 h1:AbVVhOjtuyzlireZ8kJrzd3Xlrqz6CafsBQjLGKOipA=
+github.com/docker/go-sdk/config v0.1.0-alpha013/go.mod h1:Eq39AVh06RUJ50fLvJHFKM80P9kZWTiog1x7NzrndBg=
+github.com/docker/go-sdk/context v0.1.0-alpha013 h1:he+yf7bEAOvDdeRkkd+vNFHiGhmZV2oSx0j7s9lI7e8=
+github.com/docker/go-sdk/context v0.1.0-alpha013/go.mod h1:a+3Mdx3Tss56tN5bajB3YfW29ZHdm6nenlB6yxIaeF4=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
@@ -318,6 +322,8 @@ github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3N
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/go-archive v0.2.0 h1:zg5QDUM2mi0JIM9fdQZWC7U8+2ZfixfTYoHL7rWUcP8=
 github.com/moby/go-archive v0.2.0/go.mod h1:mNeivT14o8xU+5q1YnNrkQVpK+dnNe/K6fHqnTg4qPU=
+github.com/moby/moby/api v1.53.0 h1:PihqG1ncw4W+8mZs69jlwGXdaYBeb5brF6BL7mPIS/w=
+github.com/moby/moby/api v1.53.0/go.mod h1:8mb+ReTlisw4pS6BRzCMts5M49W5M7bKt1cJy/YbAqc=
 github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=
 github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/sys/atomicwriter v0.1.0 h1:kw5D/EqkBwsBFi0ss9v1VG3wIkVhzGvLklJ+w3A14Sw=


### PR DESCRIPTION
# Description

Fixes #3113.

`hatchet server start` currently initializes the Docker client using `client.FromEnv`, which respects `DOCKER_HOST` but does not honor the active Docker context selected via `docker context use`. As a result, users running Docker through alternative contexts, for example Rancher Desktop, may see the CLI attempt to connect to the default socket (`/var/run/docker.sock`) instead of the configured context endpoint.

This change resolves the active Docker context when `DOCKER_HOST` is not set by reading the Docker CLI configuration (`~/.docker/config.json`) and associated context metadata. The resolved host is then passed to the Docker client via `client.WithHost`.

The precedence remains consistent with Docker CLI expectations:

1. `DOCKER_HOST` environment variable  
2. Active Docker context  
3. Default Docker behavior

Unit tests were added to validate context resolution behavior across several cases: default context, missing metadata, invalid configuration, and TCP endpoints.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

- Resolve active Docker context from Docker CLI configuration when `DOCKER_HOST` is unset
- Use the context-derived Docker host when creating the CLI Docker client
- Add unit tests for Docker context resolution scenarios
- Remove premature Docker client close during initialization