### PR TITLE
Use durationNs, remove the last custom property from OtelSpanTree

### DIFF
--- a/frontend/app/src/components/v1/agent-prism/agent-prism-data.ts
+++ b/frontend/app/src/components/v1/agent-prism/agent-prism-data.ts
@@ -8,7 +8,7 @@ export const findTimeRange = (
 
   const traverse = (node: OtelSpanTree) => {
     const start = new Date(node.createdAt).getTime();
-    const end = start + node.durationMs;
+    const end = start + node.durationNs / 1_000_000;
     minStart = Math.min(minStart, start);
     maxEnd = Math.max(maxEnd, end);
     node.children?.forEach(traverse);
@@ -50,7 +50,7 @@ export const getTimelineData = ({
 }): { durationMs: number; startPercent: number; widthPercent: number } => {
   const startMs = new Date(spanCard.createdAt).getTime();
   const totalRange = maxEnd - minStart;
-  const durationMs = spanCard.durationMs;
+  const durationMs = spanCard.durationNs / 1_000_000;
   const startPercent = ((startMs - minStart) / totalRange) * 100;
   const widthPercent = (durationMs / totalRange) * 100;
   return { durationMs, startPercent, widthPercent };

--- a/frontend/app/src/components/v1/agent-prism/convert-otel-spans-to-agent-prism-span-tree.ts
+++ b/frontend/app/src/components/v1/agent-prism/convert-otel-spans-to-agent-prism-span-tree.ts
@@ -2,12 +2,6 @@ import type { OtelSpanTree } from './span-tree-type';
 import type { OtelSpan } from '@/lib/api/generated/data-contracts';
 import invariant from 'tiny-invariant';
 
-const convertOtelSpanToTraceSpan = (span: OtelSpan): OtelSpanTree => ({
-  ...span,
-  durationMs: span.durationNs / 1_000_000,
-  children: [],
-});
-
 export const convertOtelSpansToOtelSpanTree = (
   spans: [OtelSpan, ...OtelSpan[]],
 ): OtelSpanTree => {
@@ -15,8 +9,10 @@ export const convertOtelSpansToOtelSpanTree = (
   let rootSpan: OtelSpanTree | null = null;
 
   spans.forEach((span) => {
-    const converted = convertOtelSpanToTraceSpan(span);
-    spanMap.set(converted.spanId, converted);
+    spanMap.set(span.spanId, {
+      ...span,
+      children: [],
+    });
   });
 
   spans.forEach((span) => {
@@ -30,6 +26,7 @@ export const convertOtelSpansToOtelSpanTree = (
       }
       parent.children.push(converted);
     } else {
+      invariant(rootSpan === null, 'There can be only one (root span)');
       rootSpan = converted;
     }
   });

--- a/frontend/app/src/components/v1/agent-prism/span-tree-type.ts
+++ b/frontend/app/src/components/v1/agent-prism/span-tree-type.ts
@@ -1,6 +1,5 @@
 import type { OtelSpan } from '@/lib/api/generated/data-contracts';
 
 export type OtelSpanTree = OtelSpan & {
-  durationMs: number;
   children: OtelSpanTree[];
 };


### PR DESCRIPTION
# Description

Now that the value in the official schema includes the unit, no reason not to just use that property in the view code

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...
