### PR TITLE
Attempt to fix deadlock in `PollScheduledWorkflows` by scoping `FOR UPDATE` lock

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260313020630_v1_0_84.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260313020630_v1_0_84.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+-- +goose StatementBegin
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_WorkflowTriggerScheduledRef_triggerAt_tickerId" ON "WorkflowTriggerScheduledRef" ("triggerAt", "tickerId");
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX CONCURRENTLY IF EXISTS "ix_WorkflowTriggerScheduledRef_triggerAt_tickerId";
+-- +goose StatementEnd

--- a/pkg/repository/sqlcv1/ticker.sql
+++ b/pkg/repository/sqlcv1/ticker.sql
@@ -196,23 +196,17 @@ WITH latest_workflow_versions AS (
             )
             OR "tickerId" = @tickerId::uuid
         )
-),
-active_scheduled_workflows AS (
-    SELECT
-        *
-    FROM
-        not_run_scheduled_workflows
-    FOR UPDATE SKIP LOCKED
+    FOR UPDATE OF scheduledWorkflow SKIP LOCKED
 )
 UPDATE
     "WorkflowTriggerScheduledRef" as scheduledWorkflows
 SET
     "tickerId" = @tickerId::uuid
 FROM
-    active_scheduled_workflows
+    not_run_scheduled_workflows
 WHERE
-    scheduledWorkflows."id" = active_scheduled_workflows."id"
-RETURNING scheduledWorkflows.*, active_scheduled_workflows."workflowVersionId", active_scheduled_workflows."tenantId";
+    scheduledWorkflows."id" = not_run_scheduled_workflows."id"
+RETURNING scheduledWorkflows.*, not_run_scheduled_workflows."workflowVersionId", not_run_scheduled_workflows."tenantId";
 
 -- name: PollTenantAlerts :many
 -- Finds tenant alerts which haven't alerted since their frequency and assigns them to a ticker

--- a/pkg/repository/sqlcv1/ticker.sql
+++ b/pkg/repository/sqlcv1/ticker.sql
@@ -210,10 +210,10 @@ UPDATE
 SET
     "tickerId" = @tickerId::uuid
 FROM
-    not_run_scheduled_workflows
+    active_scheduled_workflows
 WHERE
-    scheduledWorkflows."id" = not_run_scheduled_workflows."id"
-RETURNING scheduledWorkflows.*, not_run_scheduled_workflows."workflowVersionId", not_run_scheduled_workflows."tenantId";
+    scheduledWorkflows."id" = active_scheduled_workflows."id"
+RETURNING scheduledWorkflows.*, active_scheduled_workflows."workflowVersionId", active_scheduled_workflows."tenantId";
 
 -- name: PollTenantAlerts :many
 -- Finds tenant alerts which haven't alerted since their frequency and assigns them to a ticker

--- a/pkg/repository/sqlcv1/ticker.sql
+++ b/pkg/repository/sqlcv1/ticker.sql
@@ -196,8 +196,15 @@ WITH latest_workflow_versions AS (
             )
             OR "tickerId" = @tickerId::uuid
         )
-    FOR UPDATE OF scheduledWorkflow SKIP LOCKED
+), active_scheduled_workflows AS (
+    SELECT
+        *
+    FROM
+        not_run_scheduled_workflows
+    ORDER BY "triggerAt" ASC, "id" ASC
+    FOR UPDATE SKIP LOCKED
 )
+
 UPDATE
     "WorkflowTriggerScheduledRef" as scheduledWorkflows
 SET

--- a/pkg/repository/sqlcv1/ticker.sql
+++ b/pkg/repository/sqlcv1/ticker.sql
@@ -182,11 +182,8 @@ WITH latest_workflow_versions AS (
         "Workflow" AS workflow ON workflow."id" = versions."workflowId"
     JOIN
         latest_workflow_versions AS latestVersions ON latestVersions."workflowId" = workflow."id"
-    LEFT JOIN
-        "WorkflowRunTriggeredBy" AS runTriggeredBy ON runTriggeredBy."scheduledId" = scheduledWorkflow."id"
     WHERE
         "triggerAt" <= NOW() + INTERVAL '5 seconds'
-        AND runTriggeredBy IS NULL
         AND versions."deletedAt" IS NULL
         AND workflow."deletedAt" IS NULL
         AND (
@@ -195,6 +192,11 @@ WITH latest_workflow_versions AS (
                 SELECT 1 FROM "Ticker" WHERE "id" = scheduledWorkflow."tickerId" AND "isActive" = true AND "lastHeartbeatAt" >= NOW() - INTERVAL '10 seconds'
             )
             OR "tickerId" = @tickerId::uuid
+        )
+        AND NOT EXISTS (
+            SELECT 1
+            FROM "WorkflowRunTriggeredBy" AS runTriggeredBy
+            WHERE runTriggeredBy."scheduledId" = scheduledWorkflow."id"
         )
 ),
 active_scheduled_workflows AS (

--- a/pkg/repository/sqlcv1/ticker.sql
+++ b/pkg/repository/sqlcv1/ticker.sql
@@ -198,13 +198,7 @@ WITH latest_workflow_versions AS (
             FROM "WorkflowRunTriggeredBy" AS runTriggeredBy
             WHERE runTriggeredBy."scheduledId" = scheduledWorkflow."id"
         )
-),
-active_scheduled_workflows AS (
-    SELECT
-        *
-    FROM
-        not_run_scheduled_workflows
-    ORDER BY "triggerAt" ASC, "id" ASC
+    ORDER BY scheduledWorkflow."triggerAt" ASC, scheduledWorkflow."id" ASC
     FOR UPDATE SKIP LOCKED
 )
 
@@ -213,10 +207,10 @@ UPDATE
 SET
     "tickerId" = @tickerId::uuid
 FROM
-    active_scheduled_workflows
+    not_run_scheduled_workflows
 WHERE
-    scheduledWorkflows."id" = active_scheduled_workflows."id"
-RETURNING scheduledWorkflows.*, active_scheduled_workflows."workflowVersionId", active_scheduled_workflows."tenantId";
+    scheduledWorkflows."id" = not_run_scheduled_workflows."id"
+RETURNING scheduledWorkflows.*, not_run_scheduled_workflows."workflowVersionId", not_run_scheduled_workflows."tenantId";
 
 -- name: PollTenantAlerts :many
 -- Finds tenant alerts which haven't alerted since their frequency and assigns them to a ticker

--- a/pkg/repository/sqlcv1/ticker.sql
+++ b/pkg/repository/sqlcv1/ticker.sql
@@ -196,7 +196,8 @@ WITH latest_workflow_versions AS (
             )
             OR "tickerId" = @tickerId::uuid
         )
-), active_scheduled_workflows AS (
+),
+active_scheduled_workflows AS (
     SELECT
         *
     FROM

--- a/pkg/repository/sqlcv1/ticker.sql
+++ b/pkg/repository/sqlcv1/ticker.sql
@@ -200,6 +200,14 @@ WITH latest_workflow_versions AS (
         )
     ORDER BY scheduledWorkflow."triggerAt" ASC, scheduledWorkflow."id" ASC
     FOR UPDATE SKIP LOCKED
+),
+active_scheduled_workflows AS (
+    SELECT
+        *
+    FROM
+        "WorkflowTriggerScheduledRef"
+    WHERE "id" IN (SELECT "id" FROM not_run_scheduled_workflows)
+    FOR UPDATE SKIP LOCKED
 )
 
 UPDATE
@@ -207,10 +215,12 @@ UPDATE
 SET
     "tickerId" = @tickerId::uuid
 FROM
-    not_run_scheduled_workflows
+    active_scheduled_workflows
+JOIN "WorkflowVersion" as versions ON versions."id" = active_scheduled_workflows."parentId"
+JOIN "Workflow" as workflow ON workflow."id" = versions."workflowId"
 WHERE
-    scheduledWorkflows."id" = not_run_scheduled_workflows."id"
-RETURNING scheduledWorkflows.*, not_run_scheduled_workflows."workflowVersionId", not_run_scheduled_workflows."tenantId";
+    scheduledWorkflows."id" = active_scheduled_workflows."id"
+RETURNING scheduledWorkflows.*, versions."id" AS "workflowVersionId", workflow."tenantId";
 
 -- name: PollTenantAlerts :many
 -- Finds tenant alerts which haven't alerted since their frequency and assigns them to a ticker

--- a/pkg/repository/sqlcv1/ticker.sql
+++ b/pkg/repository/sqlcv1/ticker.sql
@@ -206,6 +206,7 @@ active_scheduled_workflows AS (
     FROM
         "WorkflowTriggerScheduledRef"
     WHERE "id" IN (SELECT "id" FROM not_run_scheduled_workflows)
+    ORDER BY "triggerAt" ASC, "id" ASC
     FOR UPDATE SKIP LOCKED
 )
 

--- a/pkg/repository/sqlcv1/ticker.sql
+++ b/pkg/repository/sqlcv1/ticker.sql
@@ -199,7 +199,6 @@ WITH latest_workflow_versions AS (
             WHERE runTriggeredBy."scheduledId" = scheduledWorkflow."id"
         )
     ORDER BY scheduledWorkflow."triggerAt" ASC, scheduledWorkflow."id" ASC
-    FOR UPDATE SKIP LOCKED
 ),
 active_scheduled_workflows AS (
     SELECT

--- a/pkg/repository/sqlcv1/ticker.sql.go
+++ b/pkg/repository/sqlcv1/ticker.sql.go
@@ -444,23 +444,17 @@ WITH latest_workflow_versions AS (
             )
             OR "tickerId" = $1::uuid
         )
-),
-active_scheduled_workflows AS (
-    SELECT
-        id, "workflowVersionId", "tenantId", "additionalMetadata"
-    FROM
-        not_run_scheduled_workflows
-    FOR UPDATE SKIP LOCKED
+    FOR UPDATE OF scheduledWorkflow SKIP LOCKED
 )
 UPDATE
     "WorkflowTriggerScheduledRef" as scheduledWorkflows
 SET
     "tickerId" = $1::uuid
 FROM
-    active_scheduled_workflows
+    not_run_scheduled_workflows
 WHERE
-    scheduledWorkflows."id" = active_scheduled_workflows."id"
-RETURNING scheduledworkflows.id, scheduledworkflows."parentId", scheduledworkflows."triggerAt", scheduledworkflows."tickerId", scheduledworkflows.input, scheduledworkflows."childIndex", scheduledworkflows."childKey", scheduledworkflows."parentStepRunId", scheduledworkflows."parentWorkflowRunId", scheduledworkflows."additionalMetadata", scheduledworkflows."createdAt", scheduledworkflows."deletedAt", scheduledworkflows."updatedAt", scheduledworkflows.method, scheduledworkflows.priority, active_scheduled_workflows."workflowVersionId", active_scheduled_workflows."tenantId"
+    scheduledWorkflows."id" = not_run_scheduled_workflows."id"
+RETURNING scheduledworkflows.id, scheduledworkflows."parentId", scheduledworkflows."triggerAt", scheduledworkflows."tickerId", scheduledworkflows.input, scheduledworkflows."childIndex", scheduledworkflows."childKey", scheduledworkflows."parentStepRunId", scheduledworkflows."parentWorkflowRunId", scheduledworkflows."additionalMetadata", scheduledworkflows."createdAt", scheduledworkflows."deletedAt", scheduledworkflows."updatedAt", scheduledworkflows.method, scheduledworkflows.priority, not_run_scheduled_workflows."workflowVersionId", not_run_scheduled_workflows."tenantId"
 `
 
 type PollScheduledWorkflowsRow struct {

--- a/pkg/repository/sqlcv1/ticker.sql.go
+++ b/pkg/repository/sqlcv1/ticker.sql.go
@@ -446,13 +446,7 @@ WITH latest_workflow_versions AS (
             FROM "WorkflowRunTriggeredBy" AS runTriggeredBy
             WHERE runTriggeredBy."scheduledId" = scheduledWorkflow."id"
         )
-),
-active_scheduled_workflows AS (
-    SELECT
-        id, "workflowVersionId", "tenantId", "additionalMetadata"
-    FROM
-        not_run_scheduled_workflows
-    ORDER BY "triggerAt" ASC, "id" ASC
+    ORDER BY scheduledWorkflow."triggerAt" ASC, scheduledWorkflow."id" ASC
     FOR UPDATE SKIP LOCKED
 )
 
@@ -461,10 +455,10 @@ UPDATE
 SET
     "tickerId" = $1::uuid
 FROM
-    active_scheduled_workflows
+    not_run_scheduled_workflows
 WHERE
-    scheduledWorkflows."id" = active_scheduled_workflows."id"
-RETURNING scheduledworkflows.id, scheduledworkflows."parentId", scheduledworkflows."triggerAt", scheduledworkflows."tickerId", scheduledworkflows.input, scheduledworkflows."childIndex", scheduledworkflows."childKey", scheduledworkflows."parentStepRunId", scheduledworkflows."parentWorkflowRunId", scheduledworkflows."additionalMetadata", scheduledworkflows."createdAt", scheduledworkflows."deletedAt", scheduledworkflows."updatedAt", scheduledworkflows.method, scheduledworkflows.priority, active_scheduled_workflows."workflowVersionId", active_scheduled_workflows."tenantId"
+    scheduledWorkflows."id" = not_run_scheduled_workflows."id"
+RETURNING scheduledworkflows.id, scheduledworkflows."parentId", scheduledworkflows."triggerAt", scheduledworkflows."tickerId", scheduledworkflows.input, scheduledworkflows."childIndex", scheduledworkflows."childKey", scheduledworkflows."parentStepRunId", scheduledworkflows."parentWorkflowRunId", scheduledworkflows."additionalMetadata", scheduledworkflows."createdAt", scheduledworkflows."deletedAt", scheduledworkflows."updatedAt", scheduledworkflows.method, scheduledworkflows.priority, not_run_scheduled_workflows."workflowVersionId", not_run_scheduled_workflows."tenantId"
 `
 
 type PollScheduledWorkflowsRow struct {

--- a/pkg/repository/sqlcv1/ticker.sql.go
+++ b/pkg/repository/sqlcv1/ticker.sql.go
@@ -454,6 +454,7 @@ active_scheduled_workflows AS (
     FROM
         "WorkflowTriggerScheduledRef"
     WHERE "id" IN (SELECT "id" FROM not_run_scheduled_workflows)
+    ORDER BY "triggerAt" ASC, "id" ASC
     FOR UPDATE SKIP LOCKED
 )
 

--- a/pkg/repository/sqlcv1/ticker.sql.go
+++ b/pkg/repository/sqlcv1/ticker.sql.go
@@ -444,7 +444,8 @@ WITH latest_workflow_versions AS (
             )
             OR "tickerId" = $1::uuid
         )
-), active_scheduled_workflows AS (
+),
+active_scheduled_workflows AS (
     SELECT
         id, "workflowVersionId", "tenantId", "additionalMetadata"
     FROM

--- a/pkg/repository/sqlcv1/ticker.sql.go
+++ b/pkg/repository/sqlcv1/ticker.sql.go
@@ -447,7 +447,6 @@ WITH latest_workflow_versions AS (
             WHERE runTriggeredBy."scheduledId" = scheduledWorkflow."id"
         )
     ORDER BY scheduledWorkflow."triggerAt" ASC, scheduledWorkflow."id" ASC
-    FOR UPDATE SKIP LOCKED
 ),
 active_scheduled_workflows AS (
     SELECT

--- a/pkg/repository/sqlcv1/ticker.sql.go
+++ b/pkg/repository/sqlcv1/ticker.sql.go
@@ -444,8 +444,15 @@ WITH latest_workflow_versions AS (
             )
             OR "tickerId" = $1::uuid
         )
-    FOR UPDATE OF scheduledWorkflow SKIP LOCKED
+), active_scheduled_workflows AS (
+    SELECT
+        id, "workflowVersionId", "tenantId", "additionalMetadata"
+    FROM
+        not_run_scheduled_workflows
+    ORDER BY "triggerAt" ASC, "id" ASC
+    FOR UPDATE SKIP LOCKED
 )
+
 UPDATE
     "WorkflowTriggerScheduledRef" as scheduledWorkflows
 SET

--- a/pkg/repository/sqlcv1/ticker.sql.go
+++ b/pkg/repository/sqlcv1/ticker.sql.go
@@ -458,10 +458,10 @@ UPDATE
 SET
     "tickerId" = $1::uuid
 FROM
-    not_run_scheduled_workflows
+    active_scheduled_workflows
 WHERE
-    scheduledWorkflows."id" = not_run_scheduled_workflows."id"
-RETURNING scheduledworkflows.id, scheduledworkflows."parentId", scheduledworkflows."triggerAt", scheduledworkflows."tickerId", scheduledworkflows.input, scheduledworkflows."childIndex", scheduledworkflows."childKey", scheduledworkflows."parentStepRunId", scheduledworkflows."parentWorkflowRunId", scheduledworkflows."additionalMetadata", scheduledworkflows."createdAt", scheduledworkflows."deletedAt", scheduledworkflows."updatedAt", scheduledworkflows.method, scheduledworkflows.priority, not_run_scheduled_workflows."workflowVersionId", not_run_scheduled_workflows."tenantId"
+    scheduledWorkflows."id" = active_scheduled_workflows."id"
+RETURNING scheduledworkflows.id, scheduledworkflows."parentId", scheduledworkflows."triggerAt", scheduledworkflows."tickerId", scheduledworkflows.input, scheduledworkflows."childIndex", scheduledworkflows."childKey", scheduledworkflows."parentStepRunId", scheduledworkflows."parentWorkflowRunId", scheduledworkflows."additionalMetadata", scheduledworkflows."createdAt", scheduledworkflows."deletedAt", scheduledworkflows."updatedAt", scheduledworkflows.method, scheduledworkflows.priority, active_scheduled_workflows."workflowVersionId", active_scheduled_workflows."tenantId"
 `
 
 type PollScheduledWorkflowsRow struct {

--- a/pkg/repository/sqlcv1/ticker.sql.go
+++ b/pkg/repository/sqlcv1/ticker.sql.go
@@ -448,6 +448,14 @@ WITH latest_workflow_versions AS (
         )
     ORDER BY scheduledWorkflow."triggerAt" ASC, scheduledWorkflow."id" ASC
     FOR UPDATE SKIP LOCKED
+),
+active_scheduled_workflows AS (
+    SELECT
+        id, "parentId", "triggerAt", "tickerId", input, "childIndex", "childKey", "parentStepRunId", "parentWorkflowRunId", "additionalMetadata", "createdAt", "deletedAt", "updatedAt", method, priority
+    FROM
+        "WorkflowTriggerScheduledRef"
+    WHERE "id" IN (SELECT "id" FROM not_run_scheduled_workflows)
+    FOR UPDATE SKIP LOCKED
 )
 
 UPDATE
@@ -455,10 +463,12 @@ UPDATE
 SET
     "tickerId" = $1::uuid
 FROM
-    not_run_scheduled_workflows
+    active_scheduled_workflows
+JOIN "WorkflowVersion" as versions ON versions."id" = active_scheduled_workflows."parentId"
+JOIN "Workflow" as workflow ON workflow."id" = versions."workflowId"
 WHERE
-    scheduledWorkflows."id" = not_run_scheduled_workflows."id"
-RETURNING scheduledworkflows.id, scheduledworkflows."parentId", scheduledworkflows."triggerAt", scheduledworkflows."tickerId", scheduledworkflows.input, scheduledworkflows."childIndex", scheduledworkflows."childKey", scheduledworkflows."parentStepRunId", scheduledworkflows."parentWorkflowRunId", scheduledworkflows."additionalMetadata", scheduledworkflows."createdAt", scheduledworkflows."deletedAt", scheduledworkflows."updatedAt", scheduledworkflows.method, scheduledworkflows.priority, not_run_scheduled_workflows."workflowVersionId", not_run_scheduled_workflows."tenantId"
+    scheduledWorkflows."id" = active_scheduled_workflows."id"
+RETURNING scheduledworkflows.id, scheduledworkflows."parentId", scheduledworkflows."triggerAt", scheduledworkflows."tickerId", scheduledworkflows.input, scheduledworkflows."childIndex", scheduledworkflows."childKey", scheduledworkflows."parentStepRunId", scheduledworkflows."parentWorkflowRunId", scheduledworkflows."additionalMetadata", scheduledworkflows."createdAt", scheduledworkflows."deletedAt", scheduledworkflows."updatedAt", scheduledworkflows.method, scheduledworkflows.priority, versions."id" AS "workflowVersionId", workflow."tenantId"
 `
 
 type PollScheduledWorkflowsRow struct {

--- a/pkg/repository/sqlcv1/ticker.sql.go
+++ b/pkg/repository/sqlcv1/ticker.sql.go
@@ -430,11 +430,8 @@ WITH latest_workflow_versions AS (
         "Workflow" AS workflow ON workflow."id" = versions."workflowId"
     JOIN
         latest_workflow_versions AS latestVersions ON latestVersions."workflowId" = workflow."id"
-    LEFT JOIN
-        "WorkflowRunTriggeredBy" AS runTriggeredBy ON runTriggeredBy."scheduledId" = scheduledWorkflow."id"
     WHERE
         "triggerAt" <= NOW() + INTERVAL '5 seconds'
-        AND runTriggeredBy IS NULL
         AND versions."deletedAt" IS NULL
         AND workflow."deletedAt" IS NULL
         AND (
@@ -443,6 +440,11 @@ WITH latest_workflow_versions AS (
                 SELECT 1 FROM "Ticker" WHERE "id" = scheduledWorkflow."tickerId" AND "isActive" = true AND "lastHeartbeatAt" >= NOW() - INTERVAL '10 seconds'
             )
             OR "tickerId" = $1::uuid
+        )
+        AND NOT EXISTS (
+            SELECT 1
+            FROM "WorkflowRunTriggeredBy" AS runTriggeredBy
+            WHERE runTriggeredBy."scheduledId" = scheduledWorkflow."id"
         )
 ),
 active_scheduled_workflows AS (

--- a/sql/schema/v0.sql
+++ b/sql/schema/v0.sql
@@ -1538,6 +1538,9 @@ CREATE UNIQUE INDEX "WorkflowTriggerEventRef_parentId_eventKey_key" ON "Workflow
 CREATE UNIQUE INDEX "WorkflowTriggerScheduledRef_id_key" ON "WorkflowTriggerScheduledRef" ("id" ASC);
 
 -- CreateIndex
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_WorkflowTriggerScheduledRef_triggerAt_tickerId" ON "WorkflowTriggerScheduledRef" ("triggerAt", "tickerId");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "WorkflowTriggerScheduledRef_parentId_parentStepRunId_childK_key" ON "WorkflowTriggerScheduledRef" (
     "parentId" ASC,
     "parentStepRunId" ASC,


### PR DESCRIPTION
# Description

Attempts to fix a intermittent deadlock under load in `PollScheduledWorkflows` by adding an `ORDER BY` to the CTE doing the locking, and also adds a missing index to speed up the query a bunch

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)