### PR TITLE
docs(self-hosting): clarify `DATABASE_URL` behavior and Docker usage

### DIFF
--- a/frontend/docs/pages/self-hosting/configuration-options.mdx
+++ b/frontend/docs/pages/self-hosting/configuration-options.mdx
@@ -70,6 +70,10 @@ DATABASE_POSTGRES_PASSWORD=your-secure-password
 
 ## Minimal Configuration Example
 
+<Callout type="warning">
+  This example is for local development when Hatchet connects to PostgreSQL running on the same host. For Docker Compose deployments, use your database service name, such as `postgres`, instead of `127.0.0.1`. See the [Docker Compose deployment guide](/self-hosting/docker-compose).
+</Callout>
+
 ```bash
 # Database
 DATABASE_URL='postgresql://hatchet:hatchet@127.0.0.1:5431/hatchet'
@@ -140,9 +144,13 @@ Variables marked with ⚠️ are conditionally required when specific features a
 
 ## Database Configuration
 
+<Callout type="info">
+  In Docker Compose deployments, use the database service name in `DATABASE_URL` rather than `127.0.0.1`. Inside a container, `127.0.0.1` refers to the container itself. The localhost defaults shown in this section are intended for local development on the same host.
+</Callout>
+
 | Variable                      | Description                                                                | Default Value       |
 | ----------------------------- | -------------------------------------------------------------------------- | ------------------- |
-| `DATABASE_URL`                | PostgreSQL connection string                                               | `127.0.0.1`         |
+| `DATABASE_URL`                | PostgreSQL connection string constructed from database settings if unset   |                     |
 | `DATABASE_POSTGRES_HOST`      | PostgreSQL host                                                            | `127.0.0.1`         |
 | `DATABASE_POSTGRES_PORT`      | PostgreSQL port                                                            | `5431`              |
 | `DATABASE_POSTGRES_USERNAME`  | PostgreSQL username                                                        | `hatchet`           |

--- a/frontend/docs/pages/self-hosting/configuration-options.mdx
+++ b/frontend/docs/pages/self-hosting/configuration-options.mdx
@@ -1,3 +1,5 @@
+import { Callout } from "nextra/components";
+
 # Configuration Options
 
 The Hatchet server and engine can be configured via environment variables using several prefixes. This document contains a comprehensive list of all 197+ available options organized by component.
@@ -71,7 +73,10 @@ DATABASE_POSTGRES_PASSWORD=your-secure-password
 ## Minimal Configuration Example
 
 <Callout type="warning">
-  This example is for local development when Hatchet connects to PostgreSQL running on the same host. For Docker Compose deployments, use your database service name, such as `postgres`, instead of `127.0.0.1`. See the [Docker Compose deployment guide](/self-hosting/docker-compose).
+  This example is for local development when Hatchet connects to PostgreSQL
+  running on the same host. For Docker Compose deployments, use your database
+  service name, such as `postgres`, instead of `127.0.0.1`. See the [Docker
+  Compose deployment guide](/self-hosting/docker-compose).
 </Callout>
 
 ```bash
@@ -145,7 +150,10 @@ Variables marked with ⚠️ are conditionally required when specific features a
 ## Database Configuration
 
 <Callout type="info">
-  In Docker Compose deployments, use the database service name in `DATABASE_URL` rather than `127.0.0.1`. Inside a container, `127.0.0.1` refers to the container itself. The localhost defaults shown in this section are intended for local development on the same host.
+  In Docker Compose deployments, use the database service name in `DATABASE_URL`
+  rather than `127.0.0.1`. Inside a container, `127.0.0.1` refers to the
+  container itself. The localhost defaults shown in this section are intended
+  for local development on the same host.
 </Callout>
 
 | Variable                      | Description                                                                | Default Value       |


### PR DESCRIPTION
# Description

The configuration options documentation currently shows a localhost-based database example without clarifying that it is intended for local development.

In Docker Compose deployments, `127.0.0.1` inside a container refers to the container itself rather than the PostgreSQL service. This can cause confusion when configuring `DATABASE_URL`.

This PR adds clarification for Docker users and updates the `DATABASE_URL` documentation to explain that the connection string is constructed from database settings when not set explicitly.

Related to #2974.

## Type of change

- [x] Documentation change (pure documentation change)

## What's Changed

- Added a warning callout clarifying that the minimal configuration example is intended for local development on the same host.
- Added an informational callout explaining how `127.0.0.1` behaves inside containers and how to configure `DATABASE_URL` when using Docker Compose.
- Updated the `DATABASE_URL` table entry to clarify that the value is constructed from database settings when not set explicitly.