### PR TITLE
feat: add opt-in ListenV2 stream keepalive to prevent L7 proxy idle timeout

### DIFF
--- a/api-contracts/dispatcher/dispatcher.proto
+++ b/api-contracts/dispatcher/dispatcher.proto
@@ -124,6 +124,11 @@ enum ActionType {
     START_STEP_RUN = 0;
     CANCEL_STEP_RUN = 1;
     START_GET_GROUP_KEY = 2;
+    // STREAM_KEEPALIVE is a no-op message sent periodically on the ListenV2
+    // stream to prevent L7 proxies (e.g., Envoy) from killing the stream due
+    // to idle timeout. Clients should ignore this action type. Worker liveness
+    // is still determined by the separate Heartbeat RPC.
+    STREAM_KEEPALIVE = 3;
 }
 
 message AssignedAction {

--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -345,6 +345,7 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 			dispatcher.WithDefaultMaxWorkerLockAcquisitionTime(sc.Runtime.GRPCMaxWorkerLockAcquisitionTime),
 			dispatcher.WithWorkflowRunBufferSize(sc.Runtime.WorkflowRunBufferSize),
 			dispatcher.WithStreamEventBufferTimeout(sc.Runtime.StreamEventBufferTimeout),
+			dispatcher.WithListenV2StreamKeepaliveInterval(sc.Runtime.ListenV2StreamKeepaliveInterval),
 			dispatcher.WithVersion(sc.Version),
 			dispatcher.WithAnalytics(sc.Analytics),
 		)
@@ -772,6 +773,7 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 			dispatcher.WithDefaultMaxWorkerLockAcquisitionTime(sc.Runtime.GRPCMaxWorkerLockAcquisitionTime),
 			dispatcher.WithWorkflowRunBufferSize(sc.Runtime.WorkflowRunBufferSize),
 			dispatcher.WithStreamEventBufferTimeout(sc.Runtime.StreamEventBufferTimeout),
+			dispatcher.WithListenV2StreamKeepaliveInterval(sc.Runtime.ListenV2StreamKeepaliveInterval),
 			dispatcher.WithVersion(sc.Version),
 			dispatcher.WithAnalytics(sc.Analytics),
 		)

--- a/internal/services/dispatcher/contracts/dispatcher.pb.go
+++ b/internal/services/dispatcher/contracts/dispatcher.pb.go
@@ -82,6 +82,7 @@ const (
 	ActionType_START_STEP_RUN      ActionType = 0
 	ActionType_CANCEL_STEP_RUN     ActionType = 1
 	ActionType_START_GET_GROUP_KEY ActionType = 2
+	ActionType_STREAM_KEEPALIVE    ActionType = 3
 )
 
 // Enum value maps for ActionType.
@@ -90,11 +91,13 @@ var (
 		0: "START_STEP_RUN",
 		1: "CANCEL_STEP_RUN",
 		2: "START_GET_GROUP_KEY",
+		3: "STREAM_KEEPALIVE",
 	}
 	ActionType_value = map[string]int32{
 		"START_STEP_RUN":      0,
 		"CANCEL_STEP_RUN":     1,
 		"START_GET_GROUP_KEY": 2,
+		"STREAM_KEEPALIVE":    3,
 	}
 )
 

--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -44,7 +44,7 @@ type DispatcherImpl struct {
 	repov1                               v1.Repository
 	cache                                cache.Cacheable
 	payloadSizeThreshold                 int
-	defaultMaxWorkerBacklogSize          int64
+	defaultMaxWorkerLockAcquisitionTime  time.Duration
 	workflowRunBufferSize                int
 	streamEventBufferTimeout             time.Duration
 	listenV2StreamKeepaliveInterval      time.Duration
@@ -131,7 +131,7 @@ type DispatcherOpts struct {
 	cache                                cache.Cacheable
 	analytics                            analytics.Analytics
 	payloadSizeThreshold                 int
-	defaultMaxWorkerBacklogSize          int64
+	defaultMaxWorkerLockAcquisitionTime  time.Duration
 	workflowRunBufferSize                int
 	streamEventBufferTimeout             time.Duration
 	listenV2StreamKeepaliveInterval      time.Duration
@@ -286,7 +286,7 @@ func New(fs ...DispatcherOpt) (*DispatcherImpl, error) {
 		a:                                   a,
 		cache:                               opts.cache,
 		payloadSizeThreshold:                opts.payloadSizeThreshold,
-		defaultMaxWorkerBacklogSize:         opts.defaultMaxWorkerBacklogSize,
+		defaultMaxWorkerLockAcquisitionTime: opts.defaultMaxWorkerLockAcquisitionTime,
 		workflowRunBufferSize:               opts.workflowRunBufferSize,
 		analytics:                           opts.analytics,
 		streamEventBufferTimeout:            opts.streamEventBufferTimeout,

--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -33,20 +33,21 @@ type Dispatcher interface {
 type DispatcherImpl struct {
 	contracts.UnimplementedDispatcherServer
 
-	s                                   gocron.Scheduler
-	mqv1                                msgqueue.MessageQueue
-	pubBuffer                           *msgqueue.MQPubBuffer
-	sharedNonBufferedReaderv1           *msgqueue.SharedTenantReader
-	sharedBufferedReaderv1              *msgqueue.SharedBufferedTenantReader
-	l                                   *zerolog.Logger
-	dv                                  datautils.DataDecoderValidator
-	v                                   validator.Validator
-	repov1                              v1.Repository
-	cache                               cache.Cacheable
-	payloadSizeThreshold                int
-	defaultMaxWorkerLockAcquisitionTime time.Duration
-	workflowRunBufferSize               int
-	streamEventBufferTimeout            time.Duration
+	s                                    gocron.Scheduler
+	mqv1                                 msgqueue.MessageQueue
+	pubBuffer                            *msgqueue.MQPubBuffer
+	sharedNonBufferedReaderv1            *msgqueue.SharedTenantReader
+	sharedBufferedReaderv1               *msgqueue.SharedBufferedTenantReader
+	l                                    *zerolog.Logger
+	dv                                   datautils.DataDecoderValidator
+	v                                    validator.Validator
+	repov1                               v1.Repository
+	cache                                cache.Cacheable
+	payloadSizeThreshold                 int
+	defaultMaxWorkerBacklogSize          int64
+	workflowRunBufferSize                int
+	streamEventBufferTimeout             time.Duration
+	listenV2StreamKeepaliveInterval      time.Duration
 
 	dispatcherId uuid.UUID
 	workers      *workers
@@ -121,19 +122,20 @@ func (w *workers) Delete(workerId uuid.UUID) {
 type DispatcherOpt func(*DispatcherOpts)
 
 type DispatcherOpts struct {
-	mqv1                                msgqueue.MessageQueue
-	l                                   *zerolog.Logger
-	dv                                  datautils.DataDecoderValidator
-	repov1                              v1.Repository
-	dispatcherId                        uuid.UUID
-	alerter                             hatcheterrors.Alerter
-	cache                               cache.Cacheable
-	analytics                           analytics.Analytics
-	payloadSizeThreshold                int
-	defaultMaxWorkerLockAcquisitionTime time.Duration
-	workflowRunBufferSize               int
-	streamEventBufferTimeout            time.Duration
-	version                             string
+	mqv1                                 msgqueue.MessageQueue
+	l                                    *zerolog.Logger
+	dv                                   datautils.DataDecoderValidator
+	repov1                               v1.Repository
+	dispatcherId                         uuid.UUID
+	alerter                              hatcheterrors.Alerter
+	cache                                cache.Cacheable
+	analytics                            analytics.Analytics
+	payloadSizeThreshold                 int
+	defaultMaxWorkerBacklogSize          int64
+	workflowRunBufferSize                int
+	streamEventBufferTimeout             time.Duration
+	listenV2StreamKeepaliveInterval      time.Duration
+	version                              string
 }
 
 func defaultDispatcherOpts() *DispatcherOpts {
@@ -219,6 +221,12 @@ func WithStreamEventBufferTimeout(timeout time.Duration) DispatcherOpt {
 	}
 }
 
+func WithListenV2StreamKeepaliveInterval(interval time.Duration) DispatcherOpt {
+	return func(opts *DispatcherOpts) {
+		opts.listenV2StreamKeepaliveInterval = interval
+	}
+}
+
 func WithVersion(version string) DispatcherOpt {
 	return func(opts *DispatcherOpts) {
 		opts.version = version
@@ -278,10 +286,11 @@ func New(fs ...DispatcherOpt) (*DispatcherImpl, error) {
 		a:                                   a,
 		cache:                               opts.cache,
 		payloadSizeThreshold:                opts.payloadSizeThreshold,
-		defaultMaxWorkerLockAcquisitionTime: opts.defaultMaxWorkerLockAcquisitionTime,
+		defaultMaxWorkerBacklogSize:         opts.defaultMaxWorkerBacklogSize,
 		workflowRunBufferSize:               opts.workflowRunBufferSize,
 		analytics:                           opts.analytics,
 		streamEventBufferTimeout:            opts.streamEventBufferTimeout,
+		listenV2StreamKeepaliveInterval:     opts.listenV2StreamKeepaliveInterval,
 		version:                             opts.version,
 	}, nil
 }

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -341,7 +341,8 @@ func (s *DispatcherImpl) ListenV2(request *contracts.WorkerListenRequest, stream
 
 	fin := make(chan bool)
 
-	s.workers.Add(workerId, sessionId, newSubscribedWorker(stream, fin, workerId, s.defaultMaxWorkerLockAcquisitionTime, s.pubBuffer))
+	sw := newSubscribedWorker(stream, fin, workerId, s.defaultMaxWorkerBacklogSize, s.pubBuffer)
+	s.workers.Add(workerId, sessionId, sw)
 
 	defer func() {
 		// non-blocking send
@@ -353,10 +354,12 @@ func (s *DispatcherImpl) ListenV2(request *contracts.WorkerListenRequest, stream
 		s.workers.DeleteForSession(workerId, sessionId)
 	}()
 
-	// Optionally send periodic keepalive messages on the stream to prevent
-	// L7 proxies (e.g., Envoy on Azure Container Apps) from killing the stream
-	// due to stream_idle_timeout. This does NOT affect worker liveness detection,
-	// which is handled by the separate Heartbeat RPC.
+	// Optionally send periodic keepalive messages on the ListenV2 stream to
+	// prevent L7 proxies (e.g., Envoy on Azure Container Apps) from killing the
+	// stream due to stream_idle_timeout. Keepalives are sent unconditionally at
+	// the configured interval regardless of other stream activity. This does NOT
+	// affect worker liveness detection, which is handled by the separate
+	// Heartbeat RPC.
 	var keepaliveTicker *time.Ticker
 	var keepaliveC <-chan time.Time
 
@@ -395,9 +398,13 @@ func (s *DispatcherImpl) ListenV2(request *contracts.WorkerListenRequest, stream
 
 			return nil
 		case <-keepaliveC:
-			if err := stream.Send(&contracts.AssignedAction{
+			sw.sendMu.Lock()
+			err := stream.Send(&contracts.AssignedAction{
 				ActionType: contracts.ActionType_STREAM_KEEPALIVE,
-			}); err != nil {
+			})
+			sw.sendMu.Unlock()
+
+			if err != nil {
 				s.l.Debug().Err(err).Msgf("failed to send stream keepalive for worker %s, closing stream", request.WorkerId)
 				return nil
 			}

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -341,7 +341,7 @@ func (s *DispatcherImpl) ListenV2(request *contracts.WorkerListenRequest, stream
 
 	fin := make(chan bool)
 
-	sw := newSubscribedWorker(stream, fin, workerId, s.defaultMaxWorkerBacklogSize, s.pubBuffer)
+	sw := newSubscribedWorker(stream, fin, workerId, s.defaultMaxWorkerLockAcquisitionTime, s.pubBuffer)
 	s.workers.Add(workerId, sessionId, sw)
 
 	defer func() {
@@ -398,11 +398,14 @@ func (s *DispatcherImpl) ListenV2(request *contracts.WorkerListenRequest, stream
 
 			return nil
 		case <-keepaliveC:
-			sw.sendMu.Lock()
+			if !sw.sendLock.Acquire() {
+				s.l.Debug().Msgf("could not acquire send lock for keepalive to worker %s, skipping", request.WorkerId)
+				continue
+			}
 			err := stream.Send(&contracts.AssignedAction{
 				ActionType: contracts.ActionType_STREAM_KEEPALIVE,
 			})
-			sw.sendMu.Unlock()
+			sw.sendLock.Release()
 
 			if err != nil {
 				s.l.Debug().Err(err).Msgf("failed to send stream keepalive for worker %s, closing stream", request.WorkerId)

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -353,6 +353,19 @@ func (s *DispatcherImpl) ListenV2(request *contracts.WorkerListenRequest, stream
 		s.workers.DeleteForSession(workerId, sessionId)
 	}()
 
+	// Optionally send periodic keepalive messages on the stream to prevent
+	// L7 proxies (e.g., Envoy on Azure Container Apps) from killing the stream
+	// due to stream_idle_timeout. This does NOT affect worker liveness detection,
+	// which is handled by the separate Heartbeat RPC.
+	var keepaliveTicker *time.Ticker
+	var keepaliveC <-chan time.Time
+
+	if s.listenV2StreamKeepaliveInterval > 0 {
+		keepaliveTicker = time.NewTicker(s.listenV2StreamKeepaliveInterval)
+		keepaliveC = keepaliveTicker.C
+		defer keepaliveTicker.Stop()
+	}
+
 	// Keep the connection alive for sending messages
 	for {
 		select {
@@ -381,6 +394,13 @@ func (s *DispatcherImpl) ListenV2(request *contracts.WorkerListenRequest, stream
 			}
 
 			return nil
+		case <-keepaliveC:
+			if err := stream.Send(&contracts.AssignedAction{
+				ActionType: contracts.ActionType_STREAM_KEEPALIVE,
+			}); err != nil {
+				s.l.Debug().Err(err).Msgf("failed to send stream keepalive for worker %s, closing stream", request.WorkerId)
+				return nil
+			}
 		}
 	}
 }

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -302,6 +302,13 @@ type ConfigFileRuntime struct {
 	// StreamEventBufferTimeout is the timeout duration for the stream event buffer in the dispatcher.
 	// This controls how long the buffer waits for out-of-order events before flushing them.
 	StreamEventBufferTimeout time.Duration `mapstructure:"streamEventBufferTimeout" json:"streamEventBufferTimeout,omitempty" default:"5s"`
+
+	// ListenV2StreamKeepaliveInterval controls how often a no-op STREAM_KEEPALIVE
+	// message is sent on idle ListenV2 streams. This prevents L7 proxies (e.g., Envoy
+	// on Azure Container Apps) from killing the stream due to stream_idle_timeout.
+	// Set to 0 to disable (default). Recommended: 120s for Azure Container Apps (4-min timeout).
+	// Worker liveness is NOT affected — it is still determined by the separate Heartbeat RPC.
+	ListenV2StreamKeepaliveInterval time.Duration `mapstructure:"listenV2StreamKeepaliveInterval" json:"listenV2StreamKeepaliveInterval,omitempty" default:"0s"`
 }
 
 type InternalClientTLSConfigFile struct {
@@ -923,6 +930,7 @@ func BindAllEnv(v *viper.Viper) {
 	// dispatcher options
 	_ = v.BindEnv("runtime.workflowRunBufferSize", "SERVER_WORKFLOW_RUN_BUFFER_SIZE")
 	_ = v.BindEnv("runtime.streamEventBufferTimeout", "SERVER_STREAM_EVENT_BUFFER_TIMEOUT")
+	_ = v.BindEnv("runtime.listenV2StreamKeepaliveInterval", "SERVER_LISTENV2_STREAM_KEEPALIVE_INTERVAL")
 
 	// payload store options
 	_ = v.BindEnv("payloadStore.enablePayloadDualWrites", "SERVER_PAYLOAD_STORE_ENABLE_PAYLOAD_DUAL_WRITES")

--- a/sdks/python/hatchet_sdk/clients/dispatcher/action_listener.py
+++ b/sdks/python/hatchet_sdk/clients/dispatcher/action_listener.py
@@ -212,6 +212,17 @@ class ActionListener:
 
                     assigned_action = result.data
 
+                    # Skip keepalive messages — they only exist to prevent
+                    # L7 proxies from killing idle streams.
+                    action_type = convert_proto_enum_to_python(
+                        assigned_action.action_type,
+                        ActionType,
+                        ActionTypeProto,
+                    )
+
+                    if action_type is None or action_type == ActionType.STREAM_KEEPALIVE:
+                        continue
+
                     try:
                         action_payload = (
                             ActionPayload()
@@ -236,11 +247,7 @@ class ActionListener:
                         step_run_id=assigned_action.task_run_external_id,
                         action_id=assigned_action.action_id,
                         action_payload=action_payload,
-                        action_type=convert_proto_enum_to_python(
-                            assigned_action.action_type,
-                            ActionType,
-                            ActionTypeProto,
-                        ),
+                        action_type=action_type,
                         retry_count=assigned_action.retry_count,
                         additional_metadata=parse_additional_metadata(
                             assigned_action.additional_metadata

--- a/sdks/python/hatchet_sdk/runnables/action.py
+++ b/sdks/python/hatchet_sdk/runnables/action.py
@@ -47,6 +47,7 @@ class ActionPayload(BaseModel):
 class ActionType(str, Enum):
     START_STEP_RUN = "START_STEP_RUN"
     CANCEL_STEP_RUN = "CANCEL_STEP_RUN"
+    STREAM_KEEPALIVE = "STREAM_KEEPALIVE"
 
 
 class Action(BaseModel):

--- a/sdks/python/hatchet_sdk/utils/proto_enums.py
+++ b/sdks/python/hatchet_sdk/utils/proto_enums.py
@@ -44,4 +44,12 @@ def convert_proto_enum_to_python(
     if value is None:
         return None
 
-    return python_enum_class[proto_enum.Name(value)]
+    name = proto_enum.Name(value)
+
+    try:
+        return python_enum_class[name]
+    except KeyError:
+        # Unknown enum values (e.g., from a newer server) are returned as None
+        # so callers can skip them gracefully. This prevents SDK crashes when the
+        # engine sends new ActionType values like STREAM_KEEPALIVE.
+        return None


### PR DESCRIPTION
## Summary

Adds an opt-in server-side stream keepalive for `ListenV2` to prevent L7 proxies from killing idle gRPC streams. When enabled, the engine sends periodic `STREAM_KEEPALIVE` messages (no-op `AssignedAction`) on idle streams, generating DATA frames that reset the proxy's stream idle timer.

Fixes #3280

## Problem

L7 proxies like Envoy (Azure Container Apps, AWS ALB, etc.) enforce per-stream idle timeouts (~4 minutes on ACA). When no tasks are being dispatched, the `ListenV2` stream has zero DATA frames and gets killed. gRPC keepalive PINGs don't help because they're connection-level and proxies respond to them locally ([envoyproxy/envoy#5142](https://github.com/envoyproxy/envoy/issues/5142), [microsoft/azure-container-apps#113](https://github.com/microsoft/azure-container-apps/issues/113)).

## Why this doesn't reintroduce #308

PR #308 removed server-side heartbeats from the stream because proxies were keeping dead worker connections alive — the server heartbeats flowed through the proxy, masking worker death.

This change is different:
- **Worker liveness is still determined solely by the separate Heartbeat RPC** (unchanged)
- The STREAM_KEEPALIVE message only prevents the proxy from killing the stream
- If a worker dies, the Heartbeat RPC stops and the engine detects it within 30 seconds regardless of stream state
- The engine does NOT use stream write-success as a liveness signal

## Configuration

```bash
SERVER_LISTENV2_STREAM_KEEPALIVE_INTERVAL=120s  # disabled by default (0s)
```

## Client Impact

Old SDKs receive ActionType=3 but don't match any handler — they skip it. No client changes required.

## Note

The dispatcher.pb.go was manually updated. Proper protobuf regeneration should be done before merging.