### PR TITLE
fix: silence tenant alert error

### DIFF
--- a/pkg/repository/ticker.go
+++ b/pkg/repository/ticker.go
@@ -2,9 +2,11 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlchelpers"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
@@ -66,6 +68,10 @@ func (t *tickerRepository) IsTenantAlertActive(ctx context.Context, tenantId uui
 	res, err := t.queries.IsTenantAlertActive(ctx, t.pool, tenantId)
 
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, time.Time{}, nil
+		}
+
 		return false, time.Now(), err
 	}
 


### PR DESCRIPTION
# Description

Treats no row as inactive alert group.

```
2026-03-17T12:36:43.549Z ERR could not process tenant alerts error="could not check if tenant is active: no rows in result set" service=olap-controller
```

Fixes # (issue)

## Type of change

- [x] Chore (changes which are not directly related to 
