### PR TITLE
Separate out partition cleanup helpers for visibility

### DIFF
--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -152,8 +152,6 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 		return fmt.Errorf("could not create partitioner: %w", err)
 	}
 
-	p.Shutdown(cleanup)
-
 	var h *health.Health
 	healthProbes := sc.HasService("health")
 	if healthProbes {
@@ -513,6 +511,8 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 		"telemetry",
 	)
 
+	p.AddCleanupMethods(cleanup)
+
 	l.Debug().Msgf("engine has started")
 
 	<-ctx.Done()
@@ -547,8 +547,6 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 	if err != nil {
 		return fmt.Errorf("could not create partitioner: %w", err)
 	}
-
-	p.Shutdown(cleanup)
 
 	healthProbes := sc.Runtime.Healthcheck
 	var h *health.Health
@@ -940,6 +938,7 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 		},
 		"telemetry",
 	)
+	p.AddCleanupMethods(cleanup)
 
 	l.Debug().Msgf("engine has started")
 

--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -152,10 +152,7 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 		return fmt.Errorf("could not create partitioner: %w", err)
 	}
 
-	cleanup.Add(
-		p.Shutdown,
-		"partitioner",
-	)
+	p.Shutdown(cleanup)
 
 	var h *health.Health
 	healthProbes := sc.HasService("health")
@@ -550,7 +547,8 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 	if err != nil {
 		return fmt.Errorf("could not create partitioner: %w", err)
 	}
-	cleanup.Add(p.Shutdown, "partitioner")
+
+	p.Shutdown(cleanup)
 
 	healthProbes := sc.Runtime.Healthcheck
 	var h *health.Health

--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -152,6 +152,8 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 		return fmt.Errorf("could not create partitioner: %w", err)
 	}
 
+	p.AddCleanupMethods(cleanup)
+
 	var h *health.Health
 	healthProbes := sc.HasService("health")
 	if healthProbes {
@@ -511,8 +513,6 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 		"telemetry",
 	)
 
-	p.AddCleanupMethods(cleanup)
-
 	l.Debug().Msgf("engine has started")
 
 	<-ctx.Done()
@@ -547,6 +547,8 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 	if err != nil {
 		return fmt.Errorf("could not create partitioner: %w", err)
 	}
+
+	p.AddCleanupMethods(cleanup)
 
 	healthProbes := sc.Runtime.Healthcheck
 	var h *health.Health
@@ -938,7 +940,6 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 		},
 		"telemetry",
 	)
-	p.AddCleanupMethods(cleanup)
 
 	l.Debug().Msgf("engine has started")
 

--- a/internal/services/partition/partition.go
+++ b/internal/services/partition/partition.go
@@ -9,6 +9,8 @@ import (
 	"github.com/go-co-op/gocron/v2"
 	"github.com/rs/zerolog"
 
+	"github.com/hatchet-dev/hatchet/pkg/cleanup"
+
 	v1 "github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 	"github.com/hatchet-dev/hatchet/pkg/telemetry"
@@ -75,29 +77,27 @@ func (p *Partition) GetSchedulerPartitionId() string {
 	return p.schedulerPartitionId
 }
 
-func (p *Partition) Shutdown() error {
-	err := p.controllerCron.Shutdown()
+func (p *Partition) Shutdown(cleanup *cleanup.Cleanup) {
+	cleanup.Add(
+		p.controllerCron.Shutdown,
+		"partitioner controller cron",
+	)
+	cleanup.Add(
+		p.workerCron.Shutdown,
+		"partitioner worker cron",
+	)
+	cleanup.Add(
+		p.schedulerCron.Shutdown,
+		"partitioner scheduler cron",
+	)
 
-	if err != nil {
-		return fmt.Errorf("could not shutdown controller cron: %w", err)
-	}
-
-	err = p.workerCron.Shutdown()
-
-	if err != nil {
-		return fmt.Errorf("could not shutdown worker cron: %w", err)
-	}
-
-	err = p.schedulerCron.Shutdown()
-
-	if err != nil {
-		return fmt.Errorf("could not shutdown scheduler cron: %w", err)
-	}
-
-	// wait for heartbeat timeout duration
-	time.Sleep(heartbeatTimeout)
-
-	return nil
+	cleanup.Add(
+		func() error {
+			time.Sleep(heartbeatTimeout)
+			return nil
+		},
+		"partitioner heartbeat timeout",
+	)
 }
 
 func (p *Partition) StartControllerPartition(ctx context.Context) (func() error, error) {

--- a/internal/services/partition/partition.go
+++ b/internal/services/partition/partition.go
@@ -77,7 +77,7 @@ func (p *Partition) GetSchedulerPartitionId() string {
 	return p.schedulerPartitionId
 }
 
-func (p *Partition) Shutdown(cleanup *cleanup.Cleanup) {
+func (p *Partition) AddCleanupMethods(cleanup *cleanup.Cleanup) {
 	cleanup.Add(
 		p.controllerCron.Shutdown,
 		"partitioner controller cron",


### PR DESCRIPTION
# Description

Partition cleanup also cleans up a few cron jobs, which can block if there are in-flight tasks. Separating these out into separate cleanup functions provides more visibility in logs as to what is actually taking significant time.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...
