### PR TITLE
Fix: Add tenant id to context on v0 sdk

### DIFF
--- a/pkg/worker/context.go
+++ b/pkg/worker/context.go
@@ -71,6 +71,8 @@ type HatchetContext interface {
 
 	WorkflowVersionId() *string
 
+	TenantId() string
+
 	Log(message string)
 
 	StreamEvent(message []byte)
@@ -348,6 +350,12 @@ func (h *hatchetContext) WorkflowId() *string {
 // Use the new Go SDK at github.com/hatchet-dev/hatchet/sdks/go instead of using this directly. Migration guide: https://docs.hatchet.run/home/migration-guide-go
 func (h *hatchetContext) WorkflowVersionId() *string {
 	return h.a.WorkflowVersionId
+}
+
+// Deprecated: TenantId is an internal method used by the new Go SDK.
+// Use the new Go SDK at github.com/hatchet-dev/hatchet/sdks/go instead of using this directly. Migration guide: https://docs.hatchet.run/home/migration-guide-go
+func (h *hatchetContext) TenantId() string {
+	return h.a.TenantId
 }
 
 // Deprecated: Log is an internal method used by the new Go SDK.

--- a/pkg/worker/middleware_test.go
+++ b/pkg/worker/middleware_test.go
@@ -146,6 +146,10 @@ func (c *testHatchetContext) FilterPayload() map[string]interface{} {
 	panic("not implemented")
 }
 
+func (c *testHatchetContext) TenantId(payload map[string]interface{}) {
+	panic("not implemented")
+}
+
 func TestAddMiddleware(t *testing.T) {
 	m := middlewares{}
 	middlewareFunc := func(ctx HatchetContext, next func(HatchetContext) error) error {

--- a/pkg/worker/middleware_test.go
+++ b/pkg/worker/middleware_test.go
@@ -146,7 +146,7 @@ func (c *testHatchetContext) FilterPayload() map[string]interface{} {
 	panic("not implemented")
 }
 
-func (c *testHatchetContext) TenantId(payload map[string]interface{}) {
+func (c *testHatchetContext) TenantId() string {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
# Description

Adding this so we can use it on the internal worker

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a simple accessor to expose `TenantId` from the existing `client.Action` payload and updates a test stub to satisfy the expanded interface.
> 
> **Overview**
> Adds `TenantId()` to the `HatchetContext` interface and implements it on `hatchetContext` by returning `action.TenantId` (marked deprecated like other v0 SDK internals).
> 
> Updates the middleware tests’ `testHatchetContext` stub to implement the new method so the test suite continues to compile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ec1bea3bf0e620b1550b1b3aa70e6b2e2636d86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->