### PR TITLE
fix: consistent expand-only affordances for span interactions

### DIFF
--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/observability.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/observability.tsx
@@ -1,7 +1,7 @@
 import { TaskRunTrace } from './task-run-trace';
-import { TraceSearchInput } from './trace-search/trace-search-input';
 import { filterSpanTrees } from './trace-search/filter';
 import { parseTraceQuery } from './trace-search/parser';
+import { TraceSearchInput } from './trace-search/trace-search-input';
 import type { TraceAutocompleteContext } from './trace-search/types';
 import {
   convertOtelSpansToOtelSpanTree,
@@ -92,7 +92,9 @@ function buildAutocompleteContext(
   const valuesByKey = new Map<string, Set<string>>();
 
   for (const span of spans) {
-    if (!span.spanAttributes) continue;
+    if (!span.spanAttributes) {
+      continue;
+    }
     for (const [key, value] of Object.entries(span.spanAttributes)) {
       keySet.add(key);
       let vals = valuesByKey.get(key);
@@ -167,34 +169,33 @@ export const Observability = (props: ObservabilityProps) => {
     return null;
   }, [traces, tasks]);
 
-  const parsedQuery = useMemo(() => parseTraceQuery(queryString), [queryString]);
+  const parsedQuery = useMemo(
+    () => parseTraceQuery(queryString),
+    [queryString],
+  );
 
   const filteredTrees = useMemo(() => {
-    if (!spanTrees) return null;
+    if (!spanTrees) {
+      return null;
+    }
     return filterSpanTrees(spanTrees, parsedQuery);
   }, [spanTrees, parsedQuery]);
 
-  const handleAddFilter = useCallback(
-    (key: string, value: string) => {
-      const token = `${key}:${value}`;
-      setQueryString((prev) => {
-        const trimmed = prev.trim();
-        return trimmed ? `${trimmed} ${token}` : token;
-      });
-    },
-    [],
-  );
+  const handleAddFilter = useCallback((key: string, value: string) => {
+    const token = `${key}:${value}`;
+    setQueryString((prev) => {
+      const trimmed = prev.trim();
+      return trimmed ? `${trimmed} ${token}` : token;
+    });
+  }, []);
 
-  const handleRemoveFilter = useCallback(
-    (key: string, value: string) => {
-      const token = `${key}:${value}`;
-      setQueryString((prev) => {
-        const parts = prev.split(/\s+/).filter((p) => p !== token);
-        return parts.join(' ');
-      });
-    },
-    [],
-  );
+  const handleRemoveFilter = useCallback((key: string, value: string) => {
+    const token = `${key}:${value}`;
+    setQueryString((prev) => {
+      const parts = prev.split(/\s+/).filter((p) => p !== token);
+      return parts.join(' ');
+    });
+  }, []);
 
   if (!tracesQuery.isFetched) {
     return <Loading />;
@@ -211,17 +212,17 @@ export const Observability = (props: ObservabilityProps) => {
           />
         )}
         <div className="py-4 text-sm text-muted-foreground">
-          {spanTrees
-            ? 'No spans match the current filter.'
-            : (
-                <>
-                  No traces found. To collect traces, use the{' '}
-                  <code className="rounded bg-muted px-1 py-0.5 text-xs">
-                    HatchetInstrumentor
-                  </code>{' '}
-                  in your SDK.
-                </>
-              )}
+          {spanTrees ? (
+            'No spans match the current filter.'
+          ) : (
+            <>
+              No traces found. To collect traces, use the{' '}
+              <code className="rounded bg-muted px-1 py-0.5 text-xs">
+                HatchetInstrumentor
+              </code>{' '}
+              in your SDK.
+            </>
+          )}
         </div>
       </div>
     );

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/span-detail.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/span-detail.tsx
@@ -269,7 +269,12 @@ export function SpanDetail({
         </div>
       </div>
 
-      <div className={cn('grid gap-4', span.queuedPhase ? 'grid-cols-4' : 'grid-cols-3')}>
+      <div
+        className={cn(
+          'grid gap-4',
+          span.queuedPhase ? 'grid-cols-4' : 'grid-cols-3',
+        )}
+      >
         {span.queuedPhase && (
           <div>
             <span className="text-xs text-muted-foreground">Queue Time</span>
@@ -319,7 +324,6 @@ export function SpanDetail({
           />
         </div>
       )}
-
     </div>
   );
 }

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/task-run-trace.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/task-run-trace.tsx
@@ -12,6 +12,33 @@ import { findTimeRange } from '@/components/v1/agent-prism/agent-prism-data';
 import type { OtelSpanTree } from '@/components/v1/agent-prism/span-tree-type';
 import { useCallback, useMemo, useState } from 'react';
 
+function collectAncestorIds(
+  trees: OtelSpanTree[],
+  targetSpanId: string,
+): string[] {
+  const path: string[] = [];
+
+  function walk(node: OtelSpanTree, ancestors: string[]): boolean {
+    if (node.spanId === targetSpanId) {
+      path.push(...ancestors);
+      return true;
+    }
+    for (const child of node.children) {
+      if (walk(child, [...ancestors, node.spanId])) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  for (const tree of trees) {
+    if (walk(tree, [])) {
+      break;
+    }
+  }
+  return path;
+}
+
 type Selection =
   | { kind: 'span'; span: OtelSpanTree }
   | { kind: 'group'; group: SpanGroupInfo };
@@ -78,6 +105,22 @@ export function TaskRunTrace({
     [],
   );
 
+  const handleMinimapSpanClick = useCallback(
+    (span: OtelSpanTree) => {
+      const ancestorIds = collectAncestorIds(spanTrees, span.spanId);
+      const idsToExpand = [...ancestorIds, span.spanId];
+      setExpandedSpansIds((prev) => {
+        const set = new Set(prev);
+        for (const id of idsToExpand) {
+          set.add(id);
+        }
+        return Array.from(set);
+      });
+      setSelection({ kind: 'span', span });
+    },
+    [spanTrees],
+  );
+
   return (
     <div className="my-4 flex min-w-0 flex-col gap-4 overflow-hidden">
       <div className="flex min-w-0">
@@ -90,6 +133,7 @@ export function TaskRunTrace({
             visibleRange={visibleRange}
             onRangeChange={setVisibleRange}
             expandedSpanIds={expandedSpansIds}
+            onSpanClick={handleMinimapSpanClick}
           />
         </div>
       </div>

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/trace-minimap.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/trace-minimap.tsx
@@ -17,6 +17,7 @@ type SpanMarker = {
   spanName: string;
   durationMs: number;
   visible: boolean;
+  span: OtelSpanTree;
 };
 
 type DragState = {
@@ -114,6 +115,7 @@ function collectSpanMarkers(
       spanName: getHatchetDisplayName(node),
       durationMs: node.durationNs / 1_000_000,
       visible: parentVisible,
+      span: node,
     });
     const childrenVisible =
       parentVisible && (!expandedIds || expandedIds.has(node.spanId));
@@ -136,6 +138,7 @@ interface TraceMinimapProps {
   visibleRange: TimeRange;
   onRangeChange: (range: TimeRange) => void;
   expandedSpanIds?: string[];
+  onSpanClick?: (span: OtelSpanTree) => void;
 }
 
 export function TraceMinimap({
@@ -145,6 +148,7 @@ export function TraceMinimap({
   visibleRange,
   onRangeChange,
   expandedSpanIds,
+  onSpanClick,
 }: TraceMinimapProps) {
   const trackRef = useRef<HTMLDivElement>(null);
   const [dragging, setDragging] = useState<DragMode>(null);
@@ -290,7 +294,7 @@ export function TraceMinimap({
         <div
           key={i}
           className={cn(
-            'absolute inset-y-[6px] flex flex-col justify-center transition-[transform,opacity]',
+            'absolute inset-y-[6px] flex cursor-pointer flex-col justify-center transition-[transform,opacity]',
             m.hasErrorInTree ? 'z-[3]' : 'z-[2]',
             hoveredIdx === i && 'z-[5] scale-x-150',
             !m.visible && 'opacity-[0.01]',
@@ -306,6 +310,10 @@ export function TraceMinimap({
           onMouseLeave={() => {
             setHoveredIdx(null);
             setTooltipPos(null);
+          }}
+          onClick={(e) => {
+            e.stopPropagation();
+            onSpanClick?.(m.span);
           }}
         >
           <div className={cn('flex-1 rounded-full', getMarkerColor(m))} />

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/trace-search/autocomplete.ts
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/trace-search/autocomplete.ts
@@ -59,15 +59,15 @@ export function getTraceAutocomplete(
 
   if (lastWord.startsWith('status:')) {
     const partial = lastWord.slice(7).toLowerCase();
-    const suggestions = SPAN_STATUSES.filter((s) =>
-      s.startsWith(partial),
-    ).map((s) => ({
-      type: 'value' as const,
-      label: s,
-      value: s,
-      description: STATUS_DESCRIPTIONS[s],
-      color: SPAN_STATUS_COLORS[s],
-    }));
+    const suggestions = SPAN_STATUSES.filter((s) => s.startsWith(partial)).map(
+      (s) => ({
+        type: 'value' as const,
+        label: s,
+        value: s,
+        description: STATUS_DESCRIPTIONS[s],
+        color: SPAN_STATUS_COLORS[s],
+      }),
+    );
     return { mode: 'value', suggestions };
   }
 

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/trace-search/filter.ts
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/trace-search/filter.ts
@@ -1,6 +1,6 @@
+import type { ParsedTraceQuery } from './types';
 import type { OtelSpanTree } from '@/components/v1/agent-prism/span-tree-type';
 import { OtelStatusCode } from '@/lib/api/generated/data-contracts';
-import type { ParsedTraceQuery } from './types';
 
 export type FilteredSpanTree = OtelSpanTree & {
   matchesFilter: boolean;

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/trace-search/parser.ts
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/trace-search/parser.ts
@@ -1,8 +1,4 @@
-import {
-  SPAN_STATUSES,
-  type ParsedTraceQuery,
-  type SpanStatus,
-} from './types';
+import { SPAN_STATUSES, type ParsedTraceQuery, type SpanStatus } from './types';
 
 export function parseTraceQuery(query: string): ParsedTraceQuery {
   const errors: string[] = [];

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/trace-timeline.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/trace-timeline.tsx
@@ -696,6 +696,15 @@ export function TraceTimeline({
     [expandedSpanIds, onExpandChange],
   );
 
+  const expandOnly = useCallback(
+    (id: string) => {
+      if (!expandedSpanIds.includes(id)) {
+        onExpandChange([...expandedSpanIds, id]);
+      }
+    },
+    [expandedSpanIds, onExpandChange],
+  );
+
   const handleBarHover = useCallback(
     (rowKey: string | null, event?: MouseEvent) => {
       setHoveredRowKey(rowKey);
@@ -858,7 +867,7 @@ export function TraceTimeline({
                 )}
                 style={{ height: ROW_HEIGHT }}
                 onClick={() => {
-                  toggleExpand(row.group.groupId);
+                  expandOnly(row.group.groupId);
                   onGroupSelect?.(row.group);
                 }}
               >
@@ -931,7 +940,7 @@ export function TraceTimeline({
               style={{ height: ROW_HEIGHT }}
               onClick={() => {
                 if (row.hasChildren) {
-                  toggleExpand(row.span.spanId);
+                  expandOnly(row.span.spanId);
                 }
                 onSpanSelect?.(row.span);
               }}
@@ -1143,7 +1152,10 @@ export function TraceTimeline({
                     onMouseEnter={(e) => handleBarHover(row.rowKey, e)}
                     onMouseMove={handleBarMouseMove}
                     onMouseLeave={() => handleBarHover(null)}
-                    onClick={() => onGroupSelect?.(row.group)}
+                    onClick={() => {
+                      expandOnly(row.group.groupId);
+                      onGroupSelect?.(row.group);
+                    }}
                   />
                 </div>
               );
@@ -1208,7 +1220,12 @@ export function TraceTimeline({
                     onMouseEnter={(e) => handleBarHover(row.rowKey, e)}
                     onMouseMove={handleBarMouseMove}
                     onMouseLeave={() => handleBarHover(null)}
-                    onClick={() => onSpanSelect?.(row.span)}
+                    onClick={() => {
+                      if (row.hasChildren) {
+                        expandOnly(row.span.spanId);
+                      }
+                      onSpanSelect?.(row.span);
+                    }}
                   >
                     <div
                       className="absolute inset-0 opacity-40"
@@ -1238,7 +1255,12 @@ export function TraceTimeline({
                   onMouseEnter={(e) => handleBarHover(row.rowKey, e)}
                   onMouseMove={handleBarMouseMove}
                   onMouseLeave={() => handleBarHover(null)}
-                  onClick={() => onSpanSelect?.(row.span)}
+                  onClick={() => {
+                    if (row.hasChildren) {
+                      expandOnly(row.span.spanId);
+                    }
+                    onSpanSelect?.(row.span);
+                  }}
                 />
               </div>
             );

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/trace-timeline.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/trace-timeline.tsx
@@ -633,57 +633,57 @@ export function TraceTimeline({
 
   const { visMinStart, ticks, timelineMaxMs, traceMinStart, traceTotalMs } =
     useMemo(() => {
-    let minStart = Infinity;
-    let maxEnd = -Infinity;
-    const traverse = (node: OtelSpanTree) => {
-      const start = new Date(node.createdAt).getTime();
-      const end = node.inProgress ? now : start + node.durationNs / 1e6;
-      minStart = Math.min(minStart, start);
-      maxEnd = Math.max(maxEnd, end);
-      if (node.queuedPhase) {
-        const qStart = new Date(node.queuedPhase.createdAt).getTime();
-        const qEnd = qStart + node.queuedPhase.durationNs / 1e6;
-        minStart = Math.min(minStart, qStart);
-        maxEnd = Math.max(maxEnd, qEnd);
+      let minStart = Infinity;
+      let maxEnd = -Infinity;
+      const traverse = (node: OtelSpanTree) => {
+        const start = new Date(node.createdAt).getTime();
+        const end = node.inProgress ? now : start + node.durationNs / 1e6;
+        minStart = Math.min(minStart, start);
+        maxEnd = Math.max(maxEnd, end);
+        if (node.queuedPhase) {
+          const qStart = new Date(node.queuedPhase.createdAt).getTime();
+          const qEnd = qStart + node.queuedPhase.durationNs / 1e6;
+          minStart = Math.min(minStart, qStart);
+          maxEnd = Math.max(maxEnd, qEnd);
+        }
+        node.children?.forEach(traverse);
+      };
+      spanTrees.forEach(traverse);
+
+      const totalDurationMs = maxEnd - minStart;
+
+      const isZoomed =
+        visibleRange &&
+        (visibleRange.startPct > 0.001 || visibleRange.endPct < 0.999);
+
+      if (isZoomed) {
+        const visStartMs = minStart + totalDurationMs * visibleRange.startPct;
+        const visEndMs = minStart + totalDurationMs * visibleRange.endPct;
+        const visDurationMs = visEndMs - visStartMs;
+        const { ticks, maxTick } = computeTimeTicks(visDurationMs);
+        return {
+          visMinStart: visStartMs,
+          ticks,
+          timelineMaxMs: hasAnyInProgress
+            ? visDurationMs
+            : Math.max(maxTick, visDurationMs),
+          traceMinStart: minStart,
+          traceTotalMs: totalDurationMs,
+        };
       }
-      node.children?.forEach(traverse);
-    };
-    spanTrees.forEach(traverse);
 
-    const totalDurationMs = maxEnd - minStart;
-
-    const isZoomed =
-      visibleRange &&
-      (visibleRange.startPct > 0.001 || visibleRange.endPct < 0.999);
-
-    if (isZoomed) {
-      const visStartMs = minStart + totalDurationMs * visibleRange.startPct;
-      const visEndMs = minStart + totalDurationMs * visibleRange.endPct;
-      const visDurationMs = visEndMs - visStartMs;
-      const { ticks, maxTick } = computeTimeTicks(visDurationMs);
+      const { ticks, maxTick } = computeTimeTicks(totalDurationMs);
+      const timelineMaxMs = hasAnyInProgress
+        ? totalDurationMs
+        : Math.max(maxTick, totalDurationMs);
       return {
-        visMinStart: visStartMs,
+        visMinStart: minStart,
         ticks,
-        timelineMaxMs: hasAnyInProgress
-          ? visDurationMs
-          : Math.max(maxTick, visDurationMs),
+        timelineMaxMs,
         traceMinStart: minStart,
         traceTotalMs: totalDurationMs,
       };
-    }
-
-    const { ticks, maxTick } = computeTimeTicks(totalDurationMs);
-    const timelineMaxMs = hasAnyInProgress
-      ? totalDurationMs
-      : Math.max(maxTick, totalDurationMs);
-    return {
-      visMinStart: minStart,
-      ticks,
-      timelineMaxMs,
-      traceMinStart: minStart,
-      traceTotalMs: totalDurationMs,
-    };
-  }, [spanTrees, visibleRange, now, hasAnyInProgress]);
+    }, [spanTrees, visibleRange, now, hasAnyInProgress]);
 
   const toggleExpand = useCallback(
     (id: string) => {
@@ -751,10 +751,7 @@ export function TraceTimeline({
           return;
         }
         const r = barsRef.current.getBoundingClientRect();
-        const pct = Math.max(
-          0,
-          Math.min(1, (ev.clientX - r.left) / r.width),
-        );
+        const pct = Math.max(0, Math.min(1, (ev.clientX - r.left) / r.width));
         const lo = Math.min(startPct, pct);
         const hi = Math.max(startPct, pct);
         if (hi - lo > 0.005) {
@@ -771,10 +768,7 @@ export function TraceTimeline({
           return;
         }
         const r = barsRef.current.getBoundingClientRect();
-        const pct = Math.max(
-          0,
-          Math.min(1, (ev.clientX - r.left) / r.width),
-        );
+        const pct = Math.max(0, Math.min(1, (ev.clientX - r.left) / r.width));
         const lo = Math.min(startPct, pct);
         const hi = Math.max(startPct, pct);
 
@@ -789,10 +783,7 @@ export function TraceTimeline({
               0,
               (newStartMs - v.traceMinStart) / v.traceTotalMs,
             ),
-            endPct: Math.min(
-              1,
-              (newEndMs - v.traceMinStart) / v.traceTotalMs,
-            ),
+            endPct: Math.min(1, (newEndMs - v.traceMinStart) / v.traceTotalMs),
           });
         }
       };
@@ -1046,8 +1037,7 @@ export function TraceTimeline({
                 className="pointer-events-none absolute z-10 flex h-full items-center whitespace-nowrap rounded bg-foreground/90 px-1 py-px font-mono text-[10px] leading-tight text-background"
                 style={{
                   left: `${brushRange.lo * 100}%`,
-                  transform:
-                    brushRange.lo < 0.05 ? 'none' : 'translateX(-50%)',
+                  transform: brushRange.lo < 0.05 ? 'none' : 'translateX(-50%)',
                 }}
               >
                 {formatTimeLabel(timelineMaxMs * brushRange.lo)}
@@ -1078,10 +1068,7 @@ export function TraceTimeline({
             }
             const rect = barsRef.current.getBoundingClientRect();
             setCursorPct(
-              Math.max(
-                0,
-                Math.min(1, (e.clientX - rect.left) / rect.width),
-              ),
+              Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width)),
             );
           }}
           onMouseLeave={() => setCursorPct(null)}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description

Makes click affordances consistent across the trace timeline and minimap. Clicking a span, its title, or a bar now always **expands** (never collapses). The chevron/caret remains the only control for toggling (collapsing). Minimap marker clicks expand all ancestor spans so the selected span becomes visible.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Span row clicks, title clicks, and bar clicks now expand-only (not toggle)
- [x] Group row clicks and group bar clicks now expand-only (not toggle)
- [x] Chevron/caret preserves toggle behavior (only way to collapse)
- [x] Minimap marker clicks select the span and expand all ancestors to make it visible
- [x] Added `collectAncestorIds` helper for tree traversal
- [x] Added `onSpanClick` prop to `TraceMinimap` with span reference on markers

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccef7cad-aa27-47c0-a6a9-46db861cd27a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccef7cad-aa27-47c0-a6a9-46db861cd27a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

