### PR TITLE
fix: change name of publisher

### DIFF
--- a/frontend/vscode-extension/package.json
+++ b/frontend/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Hatchet",
   "description": "Visualize Hatchet workflow DAGs inline in your editor",
   "version": "0.1.0",
-  "publisher": "hatchet-dev",
+  "publisher": "hatchet",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

Changes the name of the vscode extension publisher to `hatchet`. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)