### PR TITLE
docs: comprehensive durable execution documentation

### DIFF
--- a/frontend/docs/pages/reference/python/client.mdx
+++ b/frontend/docs/pages/reference/python/client.mdx
@@ -174,9 +174,28 @@ Parameters:
 | `backoff_max_seconds`         | `int \| None`                                                         | The maximum number of seconds to allow retries with exponential backoff to continue.                                                                                                                                                                             | `None`                  |
 | `default_filters`             | `list[DefaultFilter] \| None`                                         | A list of filters to create with the task is created. Note that this is a helper to allow you to create filters "declaratively" without needing to make a separate API call once the task is created to create them.                                             | `None`                  |
 | `default_additional_metadata` | `JSONSerializableMapping \| None`                                     | A dictionary of additional metadata to attach to each run of this task by default.                                                                                                                                                                               | `None`                  |
+| `eviction_policy`             | `EvictionPolicy \| None`                                              | Eviction policy for durable tasks. Controls when idle durable tasks can be evicted from the worker. Set to `None` to disable eviction entirely. See [EvictionPolicy](#evictionpolicy) for details.                                                              | `EvictionPolicy(ttl=timedelta(minutes=15), allow_capacity_eviction=True, priority=0)` |
 
 Returns:
 
 | Type                                                                                                                                                                                                                                               | Description                                           |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
 | `Callable[[Callable[Concatenate[EmptyModel, DurableContext, P], R \| CoroutineLike[R]]], Standalone[EmptyModel, R]] \| Callable[[Callable[Concatenate[TWorkflowInput, DurableContext, P], R \| CoroutineLike[R]]], Standalone[TWorkflowInput, R]]` | A decorator which creates a `Standalone` task object. |
+
+## Types
+
+### EvictionPolicy
+
+Eviction policy for durable tasks. Controls when idle durable tasks can be evicted from the worker to free up durable slots.
+
+Durable tasks hold a "durable slot" on the worker while they are waiting (e.g., during `ctx.aio_wait_for(...)` or waiting for a workflow run result). When there are many idle durable tasks, the eviction policy determines which ones can be evicted to make room for new tasks.
+
+| Attribute                  | Type               | Description                                                                                                                        | Default                  |
+| -------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `ttl`                      | `timedelta \| None` | Maximum continuous waiting duration before the task becomes eligible for TTL-based eviction. Set to `None` to disable TTL eviction. | `timedelta(minutes=15)` |
+| `allow_capacity_eviction`  | `bool`             | Whether this task may be evicted when the worker is under durable-slot pressure.                                                   | `True`                   |
+| `priority`                 | `int`              | Eviction priority. Lower values are evicted first when multiple tasks are eligible.                                                | `0`                      |
+
+Import path: `from hatchet_sdk.runnables.eviction import EvictionPolicy`
+
+Pass an `EvictionPolicy` instance to the `eviction_policy` parameter of `@hatchet.durable_task()`. Set `eviction_policy=None` to disable eviction entirely. See [Resource Management](/v1/task-eviction) for a conceptual overview.

--- a/frontend/docs/pages/reference/python/context.mdx
+++ b/frontend/docs/pages/reference/python/context.mdx
@@ -295,10 +295,11 @@ Bases: `Context`
 
 Methods:
 
-| Name            | Description                                                                                                                |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `aio_wait_for`  | Durably wait for either a sleep or an event.                                                                               |
-| `aio_sleep_for` | Lightweight wrapper for durable sleep. Allows for shorthand usage of `ctx.aio_wait_for` when specifying a sleep condition. |
+| Name                 | Description                                                                                                                |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `aio_wait_for`       | Durably wait for either a sleep or an event.                                                                               |
+| `aio_sleep_for`      | Lightweight wrapper for durable sleep. Allows for shorthand usage of `ctx.aio_wait_for` when specifying a sleep condition. |
+| `aio_wait_for_event` | Lightweight wrapper for waiting on user events, returning the event payload directly.                                      |
 
 ### Functions
 
@@ -321,12 +322,67 @@ Returns:
 
 Raises:
 
-| Type         | Description                                     |
-| ------------ | ----------------------------------------------- |
-| `ValueError` | If the durable event listener is not available. |
+| Type                   | Description                                                                                                                                                    |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ValueError`           | If the durable event listener is not available.                                                                                                                |
+| `NonDeterminismError`  | If the task is being replayed and the wait conditions don't match the original execution. See [Determinism Requirements](/v1/patterns/durable-task-execution#determinism-requirements). |
 
 #### `aio_sleep_for`
 
 Lightweight wrapper for durable sleep. Allows for shorthand usage of `ctx.aio_wait_for` when specifying a sleep condition.
 
 For more complicated conditions, use `ctx.aio_wait_for` directly.
+
+Parameters:
+
+| Name       | Type       | Description                                                                                       | Default    |
+| ---------- | ---------- | ------------------------------------------------------------------------------------------------- | ---------- |
+| `duration` | `Duration` | The duration to sleep for. Can be a `timedelta` or a string (e.g. `"5m"`, `"1h"`). | _required_ |
+
+Returns:
+
+| Type          | Description                                         |
+| ------------- | --------------------------------------------------- |
+| `SleepResult` | A model containing the duration that was slept for. |
+
+Raises:
+
+| Type                   | Description                                                                                                                                                    |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NonDeterminismError`  | If the task is being replayed and the sleep duration doesn't match the original execution. See [Determinism Requirements](/v1/patterns/durable-task-execution#determinism-requirements). |
+
+#### `aio_wait_for_event`
+
+Lightweight wrapper for waiting for a user event. Allows for shorthand usage of `ctx.aio_wait_for` when specifying a user event condition.
+
+For more complicated conditions (such as waiting for multiple events or combining with sleep), use `ctx.aio_wait_for` directly.
+
+Parameters:
+
+| Name                | Type              | Description                                                                                                                                                                         | Default    |
+| ------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `key`               | `str`             | The event key to wait for.                                                                                                                                                          | _required_ |
+| `expression`        | `str \| None`     | An optional CEL expression to filter events.                                                                                                                                        | `None`     |
+| `payload_validator` | `type[T] \| None` | An optional type (e.g. a Pydantic model, dataclass, or TypedDict) to validate the event payload against. If provided, the payload will be validated and returned as this type. | `None`     |
+
+Returns:
+
+| Type             | Description                                                                                                                                     |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `T \| dict[str, Any]` | The payload of the event, validated against the provided `payload_validator` if given, or as a raw dictionary if no validator was provided. |
+
+Raises:
+
+| Type                   | Description                                                                                                                                                    |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NonDeterminismError`  | If the task is being replayed and the event conditions don't match the original execution. See [Determinism Requirements](/v1/patterns/durable-task-execution#determinism-requirements). |
+
+## Return Types
+
+### `SleepResult`
+
+A Pydantic model representing the result of `aio_sleep_for`.
+
+| Field      | Type        | Description                      |
+| ---------- | ----------- | -------------------------------- |
+| `duration` | `timedelta` | The duration that was slept for. |

--- a/frontend/docs/pages/reference/python/feature-clients/runs.mdx
+++ b/frontend/docs/pages/reference/python/feature-clients/runs.mdx
@@ -29,6 +29,8 @@ Methods:
 | `get_run_ref`                                | Get a reference to a workflow run.                                   |
 | `get_task_run`                               | Get task run details for a given task run ID.                        |
 | `aio_get_task_run`                           | Get task run details for a given task run ID.                        |
+| `reset_durable_task`                         | Reset a durable task from a specific checkpoint.                     |
+| `aio_reset_durable_task`                     | Reset a durable task from a specific checkpoint.                     |
 | `bulk_cancel_by_filters_with_pagination`     | Cancel runs matching the specified filters in chunks.                |
 | `bulk_replay_by_filters_with_pagination`     | Replay runs matching the specified filters in chunks.                |
 | `aio_bulk_cancel_by_filters_with_pagination` | Cancel runs matching the specified filters in chunks.                |
@@ -404,6 +406,46 @@ Returns:
 | Type            | Description                                     |
 | --------------- | ----------------------------------------------- |
 | `V1TaskSummary` | Task run details for the specified task run ID. |
+
+#### `reset_durable_task`
+
+Reset a durable task from a specific checkpoint, creating a new execution branch from that point.
+
+This method branches a durable task from a specific node in its event log. The task will re-execute from the specified checkpoint, creating a new branch in the durable event log. Use `node_id=1` to restart the entire task from the beginning ("replay as new").
+
+Parameters:
+
+| Name               | Type  | Description                                                                                     | Default    |
+| ------------------ | ----- | ----------------------------------------------------------------------------------------------- | ---------- |
+| `task_external_id` | `str` | The external ID (UUID) of the durable task to reset. This is the workflow run ID for the task. | _required_ |
+| `node_id`          | `int` | The checkpoint node ID to replay from. Use `1` to replay from the beginning.                   | _required_ |
+| `branch_id`        | `int` | The branch ID to replay from.                                                                  | _required_ |
+
+Returns:
+
+| Type                          | Description                                                                  |
+| ----------------------------- | ---------------------------------------------------------------------------- |
+| `V1BranchDurableTaskResponse` | The response containing the `node_id` and `branch_id` of the new execution. |
+
+#### `aio_reset_durable_task`
+
+Reset a durable task from a specific checkpoint, creating a new execution branch from that point.
+
+This is the async version of `reset_durable_task`. It branches a durable task from a specific node in its event log. The task will re-execute from the specified checkpoint, creating a new branch in the durable event log. Use `node_id=1` to restart the entire task from the beginning ("replay as new").
+
+Parameters:
+
+| Name               | Type  | Description                                                                                     | Default    |
+| ------------------ | ----- | ----------------------------------------------------------------------------------------------- | ---------- |
+| `task_external_id` | `str` | The external ID (UUID) of the durable task to reset. This is the workflow run ID for the task. | _required_ |
+| `node_id`          | `int` | The checkpoint node ID to replay from. Use `1` to replay from the beginning.                   | _required_ |
+| `branch_id`        | `int` | The branch ID to replay from.                                                                  | _required_ |
+
+Returns:
+
+| Type                          | Description                                                                  |
+| ----------------------------- | ---------------------------------------------------------------------------- |
+| `V1BranchDurableTaskResponse` | The response containing the `node_id` and `branch_id` of the new execution. |
 
 #### `bulk_cancel_by_filters_with_pagination`
 

--- a/frontend/docs/pages/reference/python/runnables.mdx
+++ b/frontend/docs/pages/reference/python/runnables.mdx
@@ -149,6 +149,7 @@ Parameters:
 | `wait_for`              | `list[Condition \| OrGroup] \| None`         | A list of conditions that must be met before the task can run.                                                                                                                                                                          | `None`                  |
 | `skip_if`               | `list[Condition \| OrGroup] \| None`         | A list of conditions that, if met, will cause the task to be skipped.                                                                                                                                                                   | `None`                  |
 | `cancel_if`             | `list[Condition \| OrGroup] \| None`         | A list of conditions that, if met, will cause the task to be canceled.                                                                                                                                                                  | `None`                  |
+| `eviction_policy`       | `EvictionPolicy \| None`                     | Eviction policy for durable tasks. Controls when idle durable tasks can be evicted from the worker. Set to `None` to disable eviction entirely. See [EvictionPolicy](/reference/python/client#evictionpolicy) for details.             | `EvictionPolicy(ttl=timedelta(minutes=15), allow_capacity_eviction=True, priority=0)` |
 
 Returns:
 

--- a/frontend/docs/pages/reference/typescript/Context.mdx
+++ b/frontend/docs/pages/reference/typescript/Context.mdx
@@ -465,6 +465,16 @@ Extends
 
 #### Methods
 
+<a id="sleepresult"></a>
+
+#### SleepResult
+
+The result returned by `sleepFor()` and `sleepUntil()`.
+
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| `durationMs` | `number` | The sleep duration in milliseconds. |
+
 <a id="sleepfor"></a>
 
 ##### `sleepFor()`
@@ -481,9 +491,63 @@ Parameters
 
 Returns
 
-`Promise`\<`Record`\<`string`, `any`\>\>
+`Promise`\<[`SleepResult`](#sleepresult)\>
 
-A promise that resolves when the sleep duration has elapsed.
+A promise that resolves with a SleepResult when the sleep duration has elapsed.
+
+<a id="sleepuntil"></a>
+
+##### `sleepUntil()`
+
+Pauses execution until a specific timestamp.
+
+Parameters
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| `wakeAt` | `Date` | The timestamp to sleep until. |
+
+Returns
+
+`Promise`\<[`SleepResult`](#sleepresult)\>
+
+A SleepResult containing the actual duration slept.
+
+<a id="waitforevent"></a>
+
+##### `waitForEvent()`
+
+Waits for a user event with the specified key.
+
+Parameters
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| `key` | `string` | The event key to wait for. |
+| `expression?` | `string` | An optional CEL expression to filter events. |
+| `payloadSchema?` | `z.ZodTypeAny` | An optional Zod schema to validate and parse the event payload. |
+
+Returns
+
+`Promise`\<`Record`\<`string`, `any`\>\> or `Promise`\<`z.infer<T>`\> if a schema is provided.
+
+The event payload, validated against the schema if one was provided.
+
+<a id="now"></a>
+
+##### `now()`
+
+Returns the current timestamp, memoized across replays.
+
+Returns
+
+`Promise`\<`Date`\>
+
+The memoized current timestamp.
+
+Throws
+
+[`NonDeterminismError`](#nondeterminismerror) if the checkpoint sequence differs from the original execution during replay.
 
 <a id="waitfor"></a>
 
@@ -503,3 +567,31 @@ Returns
 `Promise`\<`Record`\<`string`, `any`\>\>
 
 A promise that resolves with the event that satisfied the conditions.
+
+Throws
+
+[`NonDeterminismError`](#nondeterminismerror) if the wait conditions differ from the original execution during replay.
+
+---
+
+<a id="nondeterminismerror"></a>
+
+### NonDeterminismError
+
+Thrown when a durable task's execution path during replay differs from the original execution. Import from `@hatchet-dev/typescript-sdk/v1`.
+
+This error occurs when Hatchet detects that checkpoint operations (like `sleepFor`, `waitFor`, or `spawnChild`) are being called with different arguments or in a different order than they were during the original task execution.
+
+#### Properties
+
+| Property          | Type     | Description                                            |
+| ----------------- | -------- | ------------------------------------------------------ |
+| `taskExternalId`  | `string` | The ID of the affected task run.                       |
+| `invocationCount` | `number` | Which invocation of the task detected the error.       |
+| `nodeId`          | `number` | The checkpoint position where the mismatch was found.  |
+
+#### Handling NonDeterminismError
+
+You can catch this error in a try/catch block to implement custom recovery logic. Import `NonDeterminismError` from `@hatchet-dev/typescript-sdk/v1` and use `instanceof` to detect it.
+
+See [Determinism Requirements](/v1/durable-task-execution#determinism-requirements) for best practices on writing deterministic durable tasks.

--- a/frontend/docs/pages/reference/typescript/client.mdx
+++ b/frontend/docs/pages/reference/typescript/client.mdx
@@ -322,6 +322,8 @@ Parameters
 | --------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
 | `options` | `CreateDurableTaskWorkflowOpts`\<`I` & `Resolved`\<`GlobalInput`, `MiddlewareBefore`\>, `MergeIfNonEmpty`\<`O`, `GlobalOutput`\>\> | Durable task configuration options |
 
+The `CreateDurableTaskWorkflowOpts` type includes an optional `evictionPolicy` parameter to control when the task can be evicted from a worker slot while waiting. See [`EvictionPolicy`](#evictionpolicy) for details.
+
 Returns
 
 [`TaskWorkflowDeclaration`](Runnables.mdx#taskworkflowdeclaration)\<`I`, `O`, `GlobalInput`, `GlobalOutput`, `MiddlewareBefore`, `MiddlewareAfter`\>
@@ -341,6 +343,22 @@ Returns
 [`TaskWorkflowDeclaration`](Runnables.mdx#taskworkflowdeclaration)\<`I`, `O`, `GlobalInput`, `GlobalOutput`, `MiddlewareBefore`, `MiddlewareAfter`\>
 
 A TaskWorkflowDeclaration instance with inferred types
+
+<a id="evictionpolicy"></a>
+
+#### `EvictionPolicy`
+
+Controls when a durable task can be evicted from a worker slot while waiting. Import from `@hatchet-dev/typescript-sdk/v1`.
+
+Parameters:
+
+| Name                    | Type                    | Description                                                                                              | Default  |
+| ----------------------- | ----------------------- | -------------------------------------------------------------------------------------------------------- | -------- |
+| `ttl`                   | `Duration \| undefined` | Maximum wait duration before the task becomes eligible for TTL-based eviction. Set to `undefined` to disable. | `'15m'`  |
+| `priority`              | `number`                | Eviction priority. Lower values are evicted first when capacity pressure requires evicting tasks.         | `0`      |
+| `allowCapacityEviction` | `boolean`               | Whether this task can be evicted under slot pressure. Set to `false` to prevent capacity-based eviction.  | `true`   |
+
+See [Configuring Eviction Policies](/v1/task-eviction#configuring-eviction-policies) for usage details.
 
 <a id="run"></a>
 

--- a/frontend/docs/pages/v1/durable-task-execution.mdx
+++ b/frontend/docs/pages/v1/durable-task-execution.mdx
@@ -89,8 +89,10 @@ Now add tasks to the workflow. The first is a regular task; the second is a dura
 
 <Callout type="info">
   The `durable_task` decorator gives the function a `DurableContext` instead of
-  a regular `Context`. This is the only difference in declaration; the task
-  registers and runs on the same worker as regular tasks.
+  a regular `Context`. Durable tasks run on the same worker as regular tasks,
+  but they consume slots from a separate pool. This prevents deadlocks where a
+  durable task waiting for children could starve those children of slots. See
+  [Slot types](/v1/workers#slot-types) for details.
 </Callout>
 
 If this task is interrupted at any time, it will continue from where it left off. If the task calls `ctx.aio_sleep_for` for 24 hours and is interrupted after 23 hours, it will only sleep for 1 more hour on restart.
@@ -116,6 +118,60 @@ Child spawning is the primary way durable tasks build workflows at runtime. A du
 The parent is evicted while children execute, so it consumes no resources. The number and type of children can be determined dynamically based on input, intermediate results, or model outputs.
 
 See [Child Spawning](/v1/child-spawning) for patterns and full examples.
+
+## Determinism Requirements
+
+Because durable tasks can be interrupted and resumed, your task code must be **deterministic**. When Hatchet replays a task after an interruption, it re-executes your code from the beginning while skipping operations that were already checkpointed. If the code path taken during replay differs from the original execution, Hatchet raises a `NonDeterminismError`.
+
+### What Causes Non-Determinism
+
+Non-determinism occurs when the same task code produces different checkpoint operations on replay:
+
+| Anti-Pattern | Problem | Solution |
+| --- | --- | --- |
+| **Random values in wait conditions** | Sleep durations that change on replay (e.g., using `random()` or `Math.random()`) | Use deterministic values or memoize random calls |
+| **Time-based logic** | Branching based on current time changes between original run and replay | Use `ctx.now()` (TS) to get a memoized timestamp, or memoize the timestamp value |
+| **Different child spawn inputs** | Generating new IDs (UUIDs, etc.) on each replay | Derive inputs from workflow input or memoize the ID |
+| **External state that changes** | Fetching data from a database or API that may have changed | Memoize the fetch or pass data through workflow input |
+
+### Handling NonDeterminismError
+
+When Hatchet detects a mismatch between the current execution and the recorded checkpoint, it raises `NonDeterminismError` with information about where the mismatch occurred:
+
+- `taskExternalId` (TypeScript) / `task_external_id` (Python): The ID of the affected task run
+- `invocationCount` (TypeScript) / `invocation_count` (Python): Which invocation of the task detected the error
+- `nodeId` (TypeScript) / `node_id` (Python): The checkpoint position where the mismatch was detected
+
+You can catch this error to implement custom recovery logic, but typically the right fix is to make your code deterministic.
+
+For SDK-specific documentation, see:
+- **TypeScript**: [`NonDeterminismError`](/reference/typescript/Context#nondeterminismerror)
+- **Python**: [`NonDeterminismError`](/reference/python/context#durable-context)
+
+### Best Practices
+
+1. **Keep durable operations deterministic**: The arguments to `sleepFor`/`aio_sleep_for`, `waitFor`/`aio_wait_for`, `spawnChild`/`aio_run`, and similar methods should produce the same values on replay
+2. **Memoize non-deterministic operations**: Results of non-deterministic calls (random numbers, UUIDs, timestamps, external services) should be stable across replays. Pass them as workflow input or store them in the durable event log
+3. **Derive values from workflow input**: When possible, include all necessary data in the workflow input rather than fetching it during execution
+4. **Avoid conditional checkpoints**: Don't wrap durable operations in conditions that might evaluate differently on replay
+
+## Replaying from a Checkpoint
+
+You can programmatically reset a durable task to replay from a specific checkpoint. This creates a new execution branch in the durable event log, re-executing from the specified node while preserving the original execution history.
+
+| Use case                        | How                                                                |
+| ------------------------------- | ------------------------------------------------------------------ |
+| **Replay from the beginning**   | Set `node_id=1` to restart the entire task ("replay as new")       |
+| **Replay from a checkpoint**    | Set `node_id` to the specific checkpoint you want to resume from   |
+| **Debugging**                   | Re-run a task from a point where something went wrong              |
+
+The Python SDK provides [`reset_durable_task`](/reference/python/feature-clients/runs#reset_durable_task) and [`aio_reset_durable_task`](/reference/python/feature-clients/runs#aio_reset_durable_task) methods on the runs client.
+
+<Callout type="warning">
+  When you reset a durable task, a new branch is created in the event log. The
+  original execution history is preserved. Completed operations before the
+  specified `node_id` are skipped during replay.
+</Callout>
 
 <Callout type="info">
   For an in-depth look at how durable execution works internally, see [this blog

--- a/frontend/docs/pages/v1/index.mdx
+++ b/frontend/docs/pages/v1/index.mdx
@@ -24,7 +24,7 @@ There are three primary concepts to understand when getting started with Hatchet
 
 - **[Tasks](/v1/tasks)** — the fundamental unit of work. A task wraps a single function and gives Hatchet everything it needs to schedule, execute, and observe it.
 - **[Workers](/v1/workers)** — long-running processes in your infrastructure that pick up and execute tasks.
-- **[Durable Workflows](/v1/durable-workflows)** — compose multiple tasks into durable pipelines with dependencies, retries, and checkpointing.
+- **[Durable Workflows](/v1/durable-workflows-overview)** — compose multiple tasks into durable pipelines with dependencies, retries, and checkpointing.
 
 All tasks and workflows are **defined as code**, making them easy to version, test, and deploy.
 

--- a/frontend/docs/pages/v1/patterns/durable-task-execution.mdx
+++ b/frontend/docs/pages/v1/patterns/durable-task-execution.mdx
@@ -89,8 +89,10 @@ Now add tasks to the workflow. The first is a regular task; the second is a dura
 
 <Callout type="info">
   The `durable_task` decorator gives the function a `DurableContext` instead of
-  a regular `Context`. This is the only difference in declaration; the task
-  registers and runs on the same worker as regular tasks.
+  a regular `Context`. Durable tasks run on the same worker as regular tasks,
+  but they consume slots from a separate pool. This prevents deadlocks where a
+  durable task waiting for children could starve those children of slots. See
+  [Slot types](/v1/workers#slot-types) for details.
 </Callout>
 
 If this task is interrupted at any time, it will continue from where it left off. If the task calls `ctx.aio_sleep_for` for 24 hours and is interrupted after 23 hours, it will only sleep for 1 more hour on restart.
@@ -116,6 +118,60 @@ Child spawning is the primary way durable tasks build workflows at runtime. A du
 The parent is evicted while children execute, so it consumes no resources. The number and type of children can be determined dynamically based on input, intermediate results, or model outputs.
 
 See [Child Spawning](/v1/child-spawning) for patterns and full examples.
+
+## Determinism Requirements
+
+Because durable tasks can be interrupted and resumed, your task code must be **deterministic**. When Hatchet replays a task after an interruption, it re-executes your code from the beginning while skipping operations that were already checkpointed. If the code path taken during replay differs from the original execution, Hatchet raises a `NonDeterminismError`.
+
+### What Causes Non-Determinism
+
+Non-determinism occurs when the same task code produces different checkpoint operations on replay:
+
+| Anti-Pattern | Problem | Solution |
+| --- | --- | --- |
+| **Random values in wait conditions** | Sleep durations that change on replay (e.g., using `random()` or `Math.random()`) | Use deterministic values or memoize random calls |
+| **Time-based logic** | Branching based on current time changes between original run and replay | Use `ctx.now()` (TS) to get a memoized timestamp, or memoize the timestamp value |
+| **Different child spawn inputs** | Generating new IDs (UUIDs, etc.) on each replay | Derive inputs from workflow input or memoize the ID |
+| **External state that changes** | Fetching data from a database or API that may have changed | Memoize the fetch or pass data through workflow input |
+
+### Handling NonDeterminismError
+
+When Hatchet detects a mismatch between the current execution and the recorded checkpoint, it raises `NonDeterminismError` with information about where the mismatch occurred:
+
+- `taskExternalId` (TypeScript) / `task_external_id` (Python): The ID of the affected task run
+- `invocationCount` (TypeScript) / `invocation_count` (Python): Which invocation of the task detected the error
+- `nodeId` (TypeScript) / `node_id` (Python): The checkpoint position where the mismatch was detected
+
+You can catch this error to implement custom recovery logic, but typically the right fix is to make your code deterministic.
+
+For SDK-specific documentation, see:
+- **TypeScript**: [`NonDeterminismError`](/reference/typescript/Context#nondeterminismerror)
+- **Python**: [`NonDeterminismError`](/reference/python/context#durable-context)
+
+### Best Practices
+
+1. **Keep durable operations deterministic**: The arguments to `sleepFor`/`aio_sleep_for`, `waitFor`/`aio_wait_for`, `spawnChild`/`aio_run`, and similar methods should produce the same values on replay
+2. **Memoize non-deterministic operations**: Results of non-deterministic calls (random numbers, UUIDs, timestamps, external services) should be stable across replays. Pass them as workflow input or store them in the durable event log
+3. **Derive values from workflow input**: When possible, include all necessary data in the workflow input rather than fetching it during execution
+4. **Avoid conditional checkpoints**: Don't wrap durable operations in conditions that might evaluate differently on replay
+
+## Replaying from a Checkpoint
+
+You can programmatically reset a durable task to replay from a specific checkpoint. This creates a new execution branch in the durable event log, re-executing from the specified node while preserving the original execution history.
+
+| Use case                        | How                                                                |
+| ------------------------------- | ------------------------------------------------------------------ |
+| **Replay from the beginning**   | Set `node_id=1` to restart the entire task ("replay as new")       |
+| **Replay from a checkpoint**    | Set `node_id` to the specific checkpoint you want to resume from   |
+| **Debugging**                   | Re-run a task from a point where something went wrong              |
+
+The Python SDK provides [`reset_durable_task`](/reference/python/feature-clients/runs#reset_durable_task) and [`aio_reset_durable_task`](/reference/python/feature-clients/runs#aio_reset_durable_task) methods on the runs client.
+
+<Callout type="warning">
+  When you reset a durable task, a new branch is created in the event log. The
+  original execution history is preserved. Completed operations before the
+  specified `node_id` are skipped during replay.
+</Callout>
 
 <Callout type="info">
   For an in-depth look at how durable execution works internally, see [this blog

--- a/frontend/docs/pages/v1/patterns/index.mdx
+++ b/frontend/docs/pages/v1/patterns/index.mdx
@@ -1,9 +1,12 @@
-import { Callout } from "nextra/components";
+---
+title: Durable Workflow Patterns
+description: Patterns for building durable workflows in Hatchet including durable execution, DAGs, and best practices.
+---
 
 # Durable Workflow Patterns
 
 Hatchet supports several patterns for building durable workflows. Choose the pattern that best fits your use case:
 
-- [**Durable Execution**](./patterns/durable-task-execution) - Run long-lived tasks with automatic checkpointing and recovery.
-- [**DAGs (Directed Acyclic Graphs)**](./patterns/directed-acyclic-graphs) - Orchestrate complex multi-step workflows with dependencies between tasks.
-- [**Best Practices**](./patterns/mixing-patterns) - Guidelines for combining and choosing between patterns.
+- [**Durable Execution**](/v1/patterns/durable-task-execution) — Run long-lived tasks with automatic checkpointing and recovery.
+- [**DAGs (Directed Acyclic Graphs)**](/v1/patterns/directed-acyclic-graphs) — Orchestrate complex multi-step workflows with dependencies between tasks.
+- [**Best Practices**](/v1/patterns/mixing-patterns) — Guidelines for combining and choosing between patterns.

--- a/frontend/docs/pages/v1/running-your-task.mdx
+++ b/frontend/docs/pages/v1/running-your-task.mdx
@@ -215,4 +215,4 @@ Hatchet supports additional trigger patterns for more advanced use cases:
 
 ## Next steps
 
-Now that you can run tasks, explore [Durable Workflows](/v1/durable-workflows) to compose multiple tasks into pipelines with dependencies and checkpointing.
+Now that you can run tasks, explore [Durable Workflows](/v1/durable-workflows-overview) to compose multiple tasks into pipelines with dependencies and checkpointing.

--- a/frontend/docs/pages/v1/task-eviction.mdx
+++ b/frontend/docs/pages/v1/task-eviction.mdx
@@ -19,9 +19,13 @@ This is what makes durable tasks fundamentally different from regular tasks: a r
 ```mermaid
 graph LR
     QUEUED -->|Assigned to worker| RUNNING
-    RUNNING -->|Hits SleepFor / WaitForEvent| EVICTED
+    RUNNING -->|Hits SleepFor / WaitForEvent| EVICTED[RUNNING<br/>evicted]
     EVICTED -->|Wait completes or event arrives| QUEUED
 ```
+
+<Callout type="info">
+  When a task is evicted, its API status remains `RUNNING` but with `isEvicted: true`. You can filter evicted tasks using the `running_filter` parameter set to `EVICTED`, or filter for tasks actively executing on a worker with `ON_WORKER`.
+</Callout>
 
 1. **Task reaches a wait.** The durable task calls `SleepFor`, `WaitForEvent`, or `WaitFor`.
 2. **Checkpoint is written.** Hatchet records the current progress in the durable event log.
@@ -40,6 +44,49 @@ This is especially important for:
 - **Long waits** — Tasks that sleep for hours or days should not hold slots.
 - **Human-in-the-loop** — Waiting for a human to approve or respond could take minutes or weeks. Eviction ensures no resources are held in the meantime.
 - **Large fan-outs** — A parent task that spawns thousands of children and waits for results can release its slot while the children run, preventing deadlocks where the parent holds resources that the children need.
+
+### Configuring eviction policies
+
+Durable tasks are evicted after waiting for a default duration of 15 minutes. You can customize this by passing an eviction policy when defining the task.
+
+There are three levers:
+
+**TTL (Time-To-Live)**: How long a task waits before becoming eligible for eviction. When the TTL expires, Hatchet evicts the task, frees the slot, and automatically resumes when the wait condition is satisfied. Shorter TTLs free slots faster but cause more eviction overhead.
+
+**Capacity-based eviction**: Whether Hatchet can evict this task when worker slots are under pressure. Set `allow_capacity_eviction=False` (Python) or `allowCapacityEviction: false` (TypeScript) for critical tasks that should not be interrupted. These tasks keep their slot until their wait completes normally.
+
+**Priority**: When multiple tasks are candidates for capacity-based eviction, tasks with lower priority values are evicted first. Use this to protect important tasks relative to less critical ones.
+
+<Callout type="info">
+To prevent a task from ever being evicted, set `ttl` to `None` (Python) or `undefined` (TypeScript) and disable capacity eviction. This is useful for tasks holding critical state that cannot be checkpointed, but the task will consume a slot for the entire wait duration.
+</Callout>
+
+### EvictionPolicy reference
+
+<UniversalTabs items={["Python", "TypeScript"]} optionKey="sdk">
+<Tabs.Tab title="Python">
+
+Pass an `eviction_policy` to the `durable_task` decorator:
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `ttl` | `timedelta \| None` | `15 minutes` | Maximum wait duration before TTL-based eviction. Set to `None` to disable. |
+| `priority` | `int` | `0` | Lower values are evicted first under capacity pressure. |
+| `allow_capacity_eviction` | `bool` | `True` | Whether the task can be evicted under slot pressure. |
+
+</Tabs.Tab>
+<Tabs.Tab title="TypeScript">
+
+Pass an `evictionPolicy` to `hatchet.durableTask()`:
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `ttl` | `Duration \| undefined` | `'15m'` | Maximum wait duration before TTL-based eviction. Set to `undefined` to disable. |
+| `priority` | `number` | `0` | Lower values are evicted first under capacity pressure. |
+| `allowCapacityEviction` | `boolean` | `true` | Whether the task can be evicted under slot pressure. |
+
+</Tabs.Tab>
+</UniversalTabs>
 
 ### Separate slot pools
 

--- a/frontend/docs/pages/v1/tasks.mdx
+++ b/frontend/docs/pages/v1/tasks.mdx
@@ -76,7 +76,7 @@ Tasks can be configured to handle common problems in distributed systems. For ex
 
 Every task receives an **input** - a JSON-serializable object passed when the task is triggered. The value you return from the task function becomes the task's **output**, which callers receive when they await the result.
 
-When a task is part of a [workflow](/v1/durable-workflows), its output is also available to downstream tasks through the context object, so data flows naturally from one step to the next. See [Accessing Parent Task Outputs](/v1/patterns/directed-acyclic-graphs#accessing-parent-task-outputs) for details.
+When a task is part of a [workflow](/v1/durable-workflows-overview), its output is also available to downstream tasks through the context object, so data flows naturally from one step to the next. See [Accessing Parent Task Outputs](/v1/patterns/directed-acyclic-graphs#accessing-parent-task-outputs) for details.
 
 ## The context object
 

--- a/frontend/docs/pages/v1/workers.mdx
+++ b/frontend/docs/pages/v1/workers.mdx
@@ -151,6 +151,23 @@ Start with a slot count that matches the degree of parallelism your worker can s
   you have gone too far.
 </Callout>
 
+### Slot types
+
+Workers manage multiple slot pools. By default, there are two:
+
+- **default** - used by regular tasks declared with `@hatchet.task()` or `workflow.task()`
+- **durable** - used by [durable tasks](/v1/patterns/durable-task-execution) declared with `@hatchet.durable_task()` or `workflow.durable_task()`
+
+This separation prevents deadlocks. Durable tasks spawn child tasks and wait for their results. If both shared the same pool, a durable task could consume all slots while waiting for children that can never run - there would be no slots left.
+
+With separate pools, a durable task waiting for children does not block regular tasks. Children execute in the default pool while the parent waits in the durable pool.
+
+Configure slot counts with the `slots` parameter (for the default pool) and `durable_slots` parameter (for the durable pool) when creating a worker. See the [Python SDK reference](/reference/python/client#worker) or [TypeScript SDK reference](/reference/typescript/client) for details.
+
+<Callout type="info">
+  If you don't use durable tasks, only the default pool matters. The durable pool is allocated but stays unused.
+</Callout>
+
 ## Scaling workers
 
 You can increase throughput in two ways: add more slots to a single worker, or run more worker processes. In most workloads, horizontal scaling (more workers) is the simplest path because each worker brings its own pool of slots and its own resources.


### PR DESCRIPTION
Consolidated documentation for durable task execution covering:

- **Memoization** — `memo()` / `aio_memo()` functions for caching expensive operations across task replays, with a new dedicated guide page
- **Eviction policies** — configurable `EvictionPolicy` (TTL, priority, capacity eviction) with code examples, plus evicted task status representation (`isEvicted` / `running_filter`)
- **Task replay/reset** — `reset_durable_task` and `aio_reset_durable_task` methods for replaying durable tasks from specific checkpoints
- **Determinism requirements** — `NonDeterminismError` handling and best practices for writing deterministic durable task code
- **Slot types** for durable task isolation — separate worker slot pools prevent deadlocks between durable parents and their children
- **`aio_wait_for_event()`** — typed wrapper for waiting on user events with `payload_validator`, `Event` model, and `SleepResult` model (Python SDK)
- **TypeScript DurableContext methods** — `sleepUntil()`, `waitForEvent()` with Zod schema validation, `now()`, and `SleepResult` type
- **Duration type variants** — documents string, DurationObject, and millisecond formats for TypeScript `Duration` type
- **Broken link fixes** — updates `/v1/durable-workflows` links to `/v1/durable-workflows-overview` and fixes relative links in Patterns index

📋 **Promptless suggestion**: [View in dashboard](https://app.gopromptless.ai/suggestions/2488198a-7630-4f23-a625-6d85cb5eabfb)

## Files changed

### Conceptual docs
- `v1/memo.mdx` — **new file** — memoization guide (178 lines)
- `v1/durable-task-execution.mdx` — slot types, replay from checkpoint, determinism requirements sections
- `v1/patterns/durable-task-execution.mdx` — mirrors main guide
- `v1/task-eviction.mdx` — configurable eviction policies + evicted status representation
- `v1/workers.mdx` — slot types documentation
- `v1/_meta.js` — adds memo navigation entry
- `v1/patterns/index.mdx` — fixes broken relative links
- `v1/index.mdx` — fixes broken durable-workflows link
- `v1/running-your-task.mdx` — fixes broken durable-workflows link
- `v1/tasks.mdx` — fixes broken durable-workflows link

### SDK reference
- `reference/python/context.mdx` — DurableContext `aio_wait_for_event` (with `payload_validator`), `memo`, `aio_memo`, `NonDeterminismError`
- `reference/python/client.mdx` — `eviction_policy` param + `EvictionPolicy` class with examples
- `reference/python/runnables.mdx` — eviction policy on durable runnables
- `reference/python/feature-clients/runs.mdx` — `reset_durable_task` / `aio_reset_durable_task`
- `reference/typescript/Context.mdx` — `sleepUntil()`, `waitForEvent()`, `now()`, `SleepResult`, `memo()`, `NonDeterminismError`
- `reference/typescript/client.mdx` — eviction policy configuration