### PR TITLE
fix: add min height to logs chart

### DIFF
--- a/frontend/app/src/pages/main/v1/logs/components/logs-chart.tsx
+++ b/frontend/app/src/pages/main/v1/logs/components/logs-chart.tsx
@@ -137,12 +137,6 @@ export function LogsChart({ metrics, since, until, onZoom }: LogsChartProps) {
               }
             />
             <Bar
-              dataKey="DEBUG"
-              stackId="normal"
-              fill={CHART_CONFIG.DEBUG.color}
-              isAnimationActive={false}
-            />
-            <Bar
               dataKey="INFO"
               stackId="normal"
               fill={CHART_CONFIG.INFO.color}
@@ -153,12 +147,21 @@ export function LogsChart({ metrics, since, until, onZoom }: LogsChartProps) {
               stackId="normal"
               fill={CHART_CONFIG.WARN.color}
               isAnimationActive={false}
+              minPointSize={(value) => (value != null && value > 0 ? 2 : 0)}
+            />
+            <Bar
+              dataKey="DEBUG"
+              stackId="normal"
+              fill={CHART_CONFIG.DEBUG.color}
+              isAnimationActive={false}
+              minPointSize={(value) => (value != null && value > 0 ? 2 : 0)}
             />
             <Bar
               dataKey="ERROR"
               stackId="error"
               fill={CHART_CONFIG.ERROR.color}
               isAnimationActive={false}
+              minPointSize={(value) => (value != null && value > 0 ? 2 : 0)}
             />
 
             {refAreaLeft && refAreaRight && (


### PR DESCRIPTION
# Description

Allows users to see color in the chart even with a tiny percentage of error/warning log lines.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)