### PR TITLE
Some fixes for load test plot generation

### DIFF
--- a/cmd/hatchet-loadtest/slack.go
+++ b/cmd/hatchet-loadtest/slack.go
@@ -54,8 +54,7 @@ func NewSlackSender(s3Bucket string) *SlackSender {
 
 func (s *SlackSender) SendMessage(durationPlotUrl string, schedulingPlotUrl string, avgDuration time.Duration, avgScheduling time.Duration) error {
 	text := fmt.Sprintf(
-		"*(%s)* \n:star:Load test results:star:\nAverage task duration: %s\nAverage task scheduling: %s",
-		time.Now().Format("2006-01-02-15:04:05"),
+		":star:Load test results:star:\nAverage task duration: %s\nAverage task scheduling: %s",
 		avgDuration.String(),
 		avgScheduling.String(),
 	)
@@ -90,9 +89,9 @@ func (s *SlackSender) SendMessage(durationPlotUrl string, schedulingPlotUrl stri
 	return err
 }
 
-func (s *SlackSender) UploadS3(imageBytes []byte) (*string, error) {
-	key := fmt.Sprintf("%s-%s", "loadtest-plot", time.Now().Format("20060102150405"))
-	_, err := s.s3Client.PutObject(context.TODO(), &s3.PutObjectInput{
+func (s *SlackSender) UploadS3(imageBytes []byte, plotKey string) (*string, error) {
+	key := fmt.Sprintf("%s-%s-%s", "loadtest-plot", plotKey, time.Now().Format("20060102150405"))
+	_, err := s.s3Client.PutObject(context.Background(), &s3.PutObjectInput{
 		Bucket: aws.String(s.s3Bucket),
 		Key:    &key,
 		Body:   bytes.NewReader(imageBytes),
@@ -117,11 +116,11 @@ func (s *SlackSender) UploadS3(imageBytes []byte) (*string, error) {
 }
 
 func (s *SlackSender) Send(durationBytes []byte, schedulingBytes []byte, avgDuration time.Duration, avgScheduling time.Duration) error {
-	uploadedDurationFileUrl, err := s.UploadS3(durationBytes)
+	uploadedDurationFileUrl, err := s.UploadS3(durationBytes, "duration")
 	if err != nil {
 		return err
 	}
-	uploadedSchedulingFileUrl, err := s.UploadS3(schedulingBytes)
+	uploadedSchedulingFileUrl, err := s.UploadS3(schedulingBytes, "scheduling")
 	if err != nil {
 		return err
 	}

--- a/cmd/hatchet-loadtest/slack.go
+++ b/cmd/hatchet-loadtest/slack.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/google/uuid"
 	"github.com/slack-go/slack"
 )
 
@@ -89,8 +90,8 @@ func (s *SlackSender) SendMessage(durationPlotUrl string, schedulingPlotUrl stri
 	return err
 }
 
-func (s *SlackSender) UploadS3(imageBytes []byte, plotKey string) (*string, error) {
-	key := fmt.Sprintf("%s-%s-%s", "loadtest-plot", plotKey, time.Now().Format("20060102150405"))
+func (s *SlackSender) UploadS3(imageBytes []byte) (*string, error) {
+	key := fmt.Sprintf("%s-%s-%s", "loadtest-plot", uuid.New(), time.Now().Format("20060102150405"))
 	_, err := s.s3Client.PutObject(context.Background(), &s3.PutObjectInput{
 		Bucket: aws.String(s.s3Bucket),
 		Key:    &key,
@@ -116,11 +117,11 @@ func (s *SlackSender) UploadS3(imageBytes []byte, plotKey string) (*string, erro
 }
 
 func (s *SlackSender) Send(durationBytes []byte, schedulingBytes []byte, avgDuration time.Duration, avgScheduling time.Duration) error {
-	uploadedDurationFileUrl, err := s.UploadS3(durationBytes, "duration")
+	uploadedDurationFileUrl, err := s.UploadS3(durationBytes)
 	if err != nil {
 		return err
 	}
-	uploadedSchedulingFileUrl, err := s.UploadS3(schedulingBytes, "scheduling")
+	uploadedSchedulingFileUrl, err := s.UploadS3(schedulingBytes)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

Fixes load test plots uploading two images to Slack that are the same because the bucket key is based on the current time.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...
