### PR TITLE
fix(ci): Disable redundant worker startup causing port collision

### DIFF
--- a/.github/workflows/sdk-typescript.yml
+++ b/.github/workflows/sdk-typescript.yml
@@ -264,7 +264,7 @@ jobs:
       - name: Run e2e tests
         env:
           HATCHET_CLIENT_TLS_STRATEGY: none
-          HATCHET_CLIENT_WORKER_HEALTHCHECK_ENABLED: "true"
+          HATCHET_CLIENT_WORKER_HEALTHCHECK_ENABLED: "false"
           NODE_TLS_REJECT_UNAUTHORIZED: "0"
         run: |
           echo "Testing current SDK against engine ${{ env.LATEST_TAG }}"


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR disables the redundant client healthcheck at `HATCHET_CLIENT_WORKER_HEALTHCHECK_ENABLED` since the global jest setup already sets it correctly for the e2e-worker child process.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI (any automation pipeline changes)


## What's Changed

- Explicilty sets the `HATCHET_CLIENT_WORKER_HEALTHCHECK_ENABLED=false` in CI for `old-engine-new-sdk` typescript job.
