### PR TITLE
feat: add server-side column sorting to task runs table

### DIFF
--- a/api-contracts/openapi/paths/v1/workflow-runs/workflow_run.yaml
+++ b/api-contracts/openapi/paths/v1/workflow-runs/workflow_run.yaml
@@ -113,6 +113,28 @@ listWorkflowRuns:
         required: false
         schema:
           $ref: "../../../components/schemas/_index.yaml#/V1RunningFilter"
+      - description: The field to sort results by
+        in: query
+        name: order_by_field
+        required: false
+        schema:
+          type: string
+          enum:
+            - createdAt
+            - taskName
+            - workflow
+            - startedAt
+            - finishedAt
+            - duration
+      - description: The direction to sort results
+        in: query
+        name: order_by_direction
+        required: false
+        schema:
+          type: string
+          enum:
+            - asc
+            - desc
     responses:
       "200":
         content:

--- a/api/v1/server/handlers/v1/workflow-runs/list.go
+++ b/api/v1/server/handlers/v1/workflow-runs/list.go
@@ -166,6 +166,13 @@ func (t *V1WorkflowRunsService) WithDags(ctx context.Context, request gen.V1Work
 		opts.TriggeringEventExternalId = request.Params.TriggeringEventExternalId
 	}
 
+	if request.Params.OrderByField != nil {
+		opts.OrderBy = string(*request.Params.OrderByField)
+	}
+	if request.Params.OrderByDirection != nil {
+		opts.OrderDirection = string(*request.Params.OrderByDirection)
+	}
+
 	dags, total, err := t.config.V1.OLAP().ListWorkflowRuns(
 		ctx,
 		tenantId,
@@ -308,6 +315,13 @@ func (t *V1WorkflowRunsService) OnlyTasks(ctx context.Context, request gen.V1Wor
 
 	if request.Params.TriggeringEventExternalId != nil {
 		opts.TriggeringEventExternalId = request.Params.TriggeringEventExternalId
+	}
+
+	if request.Params.OrderByField != nil {
+		opts.OrderBy = string(*request.Params.OrderByField)
+	}
+	if request.Params.OrderByDirection != nil {
+		opts.OrderDirection = string(*request.Params.OrderByDirection)
 	}
 
 	tasks, total, err := t.config.V1.OLAP().ListTasks(

--- a/api/v1/server/oas/gen/openapi.gen.go
+++ b/api/v1/server/oas/gen/openapi.gen.go
@@ -626,6 +626,26 @@ type EventOrderByDirection string
 // EventOrderByField defines model for EventOrderByField.
 type EventOrderByField string
 
+// V1TaskOrderByField defines the sortable fields for task runs.
+type V1TaskOrderByField string
+
+const (
+	V1TaskOrderByFieldCreatedAt  V1TaskOrderByField = "createdAt"
+	V1TaskOrderByFieldTaskName   V1TaskOrderByField = "taskName"
+	V1TaskOrderByFieldWorkflow   V1TaskOrderByField = "workflow"
+	V1TaskOrderByFieldStartedAt  V1TaskOrderByField = "startedAt"
+	V1TaskOrderByFieldFinishedAt V1TaskOrderByField = "finishedAt"
+	V1TaskOrderByFieldDuration   V1TaskOrderByField = "duration"
+)
+
+// V1TaskOrderByDirection defines the sort direction.
+type V1TaskOrderByDirection string
+
+const (
+	V1TaskOrderByDirectionAsc  V1TaskOrderByDirection = "asc"
+	V1TaskOrderByDirectionDesc V1TaskOrderByDirection = "desc"
+)
+
 // EventSearch defines model for EventSearch.
 type EventSearch = string
 
@@ -2700,6 +2720,12 @@ type V1WorkflowRunListParams struct {
 
 	// RunningFilter Filter within the RUNNING status bucket. ALL returns both on-worker and evicted tasks, ON_WORKER returns only tasks running on a worker, EVICTED returns only evicted tasks. Defaults to ALL.
 	RunningFilter *V1RunningFilter `form:"running_filter,omitempty" json:"running_filter,omitempty"`
+
+	// OrderByField The field to sort by
+	OrderByField *V1TaskOrderByField `form:"order_by_field,omitempty" json:"order_by_field,omitempty"`
+
+	// OrderByDirection The direction to sort by
+	OrderByDirection *V1TaskOrderByDirection `form:"order_by_direction,omitempty" json:"order_by_direction,omitempty"`
 }
 
 // V1WorkflowRunDisplayNamesListParams defines parameters for V1WorkflowRunDisplayNamesList.
@@ -4929,6 +4955,20 @@ func (w *ServerInterfaceWrapper) V1WorkflowRunList(ctx echo.Context) error {
 	err = runtime.BindQueryParameter("form", true, false, "running_filter", ctx.QueryParams(), &params.RunningFilter)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter running_filter: %s", err))
+	}
+
+	// ------------- Optional query parameter "order_by_field" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "order_by_field", ctx.QueryParams(), &params.OrderByField)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter order_by_field: %s", err))
+	}
+
+	// ------------- Optional query parameter "order_by_direction" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "order_by_direction", ctx.QueryParams(), &params.OrderByDirection)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter order_by_direction: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments

--- a/frontend/app/src/components/v1/molecules/data-table/data-table.tsx
+++ b/frontend/app/src/components/v1/molecules/data-table/data-table.tsx
@@ -182,6 +182,7 @@ export function DataTable<TData extends IDGetter<TData>, TValue>({
     manualSorting,
     manualFiltering,
     manualPagination: true,
+    enableMultiSort: false,
     getRowId,
   });
 

--- a/frontend/app/src/lib/api/generated/Api.ts
+++ b/frontend/app/src/lib/api/generated/Api.ts
@@ -504,6 +504,10 @@ export class Api<
       include_payloads?: boolean;
       /** Filter within the RUNNING status bucket. ALL returns both on-worker and evicted tasks, ON_WORKER returns only tasks running on a worker, EVICTED returns only evicted tasks. Defaults to ALL. */
       running_filter?: V1RunningFilter;
+      /** The field to sort results by */
+      order_by_field?: "createdAt" | "taskName" | "workflow" | "startedAt" | "finishedAt" | "duration";
+      /** The direction to sort results */
+      order_by_direction?: "asc" | "desc";
     },
     params: RequestParams = {},
   ) =>

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
@@ -106,6 +106,7 @@ export function RunsTable({ leftLabel }: { leftLabel?: string }) {
     rowSelection,
     showTriggerWorkflow,
     showQueueMetrics,
+    sorting,
     display: { hideMetrics, hideCounts, hideColumnToggle, hiddenFilters },
     actions: {
       refetchRuns,
@@ -117,6 +118,7 @@ export function RunsTable({ leftLabel }: { leftLabel?: string }) {
       setRowSelection,
       setShowTriggerWorkflow,
       setShowQueueMetrics,
+      setSorting,
     },
   } = useRunsContext();
 
@@ -281,6 +283,8 @@ export function RunsTable({ leftLabel }: { leftLabel?: string }) {
           pagination={pagination}
           setPagination={setPagination}
           onSetPageSize={setPageSize}
+          sorting={sorting}
+          setSorting={setSorting}
           rowSelection={rowSelection}
           setRowSelection={setRowSelection}
           pageCount={numPages}

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/v1/task-runs-columns.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/v1/task-runs-columns.tsx
@@ -134,7 +134,7 @@ export const columns: (
         );
       }
     },
-    enableSorting: false,
+    enableSorting: true,
     enableHiding: false,
   },
   {
@@ -177,7 +177,7 @@ export const columns: (
       );
     },
     show: false,
-    enableSorting: false,
+    enableSorting: true,
     enableHiding: true,
   },
   {
@@ -236,7 +236,7 @@ export const columns: (
         </div>
       );
     },
-    enableSorting: false,
+    enableSorting: true,
     enableHiding: true,
   },
   {
@@ -259,7 +259,7 @@ export const columns: (
         </div>
       );
     },
-    enableSorting: false,
+    enableSorting: true,
     enableHiding: true,
   },
   {
@@ -280,7 +280,7 @@ export const columns: (
 
       return <div className="whitespace-nowrap">{finishedAt}</div>;
     },
-    enableSorting: false,
+    enableSorting: true,
     enableHiding: true,
   },
   {
@@ -302,7 +302,7 @@ export const columns: (
         />
       );
     },
-    enableSorting: false,
+    enableSorting: true,
     enableHiding: true,
   },
   {

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
@@ -8,7 +8,12 @@ import { useRuns } from './use-runs';
 import { useRunsTableFilters } from './use-runs-table-filters';
 import { useToolbarFilters } from './use-toolbar-filters';
 import { V1TaskRunMetrics, V1TaskSummary } from '@/lib/api';
-import { RowSelectionState, VisibilityState } from '@tanstack/react-table';
+import {
+  OnChangeFn,
+  RowSelectionState,
+  SortingState,
+  VisibilityState,
+} from '@tanstack/react-table';
 import { PaginationState, Updater } from '@tanstack/react-table';
 import { createContext, useContext, useMemo, useState } from 'react';
 
@@ -51,6 +56,7 @@ type RunsContextType = {
     setRowSelection: (updater: Updater<RowSelectionState>) => void;
     setShowTriggerWorkflow: (trigger: boolean) => void;
     setShowQueueMetrics: (show: boolean) => void;
+    setSorting: OnChangeFn<SortingState>;
   };
   filters: ReturnType<typeof useRunsTableFilters>;
   toolbarFilters: ReturnType<typeof useToolbarFilters>;
@@ -74,6 +80,7 @@ type RunsContextType = {
   rowSelection: RowSelectionState;
   showTriggerWorkflow: boolean;
   showQueueMetrics: boolean;
+  sorting: SortingState;
 };
 
 const RunsContext = createContext<RunsContextType | null>(null);
@@ -93,6 +100,9 @@ export const RunsProvider = ({
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [showQueueMetrics, setShowQueueMetrics] = useState(false);
   const [showTriggerWorkflow, setShowTriggerWorkflow] = useState(false);
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'createdAt', desc: true },
+  ]);
 
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
     ...initColumnVisibility,
@@ -156,6 +166,7 @@ export const RunsProvider = ({
     parentTaskExternalId,
     triggeringEventExternalId,
     onlyTasks: !!workerId || flattenDAGs,
+    sorting,
   });
 
   const actionModalParams = useMemo(
@@ -212,6 +223,7 @@ export const RunsProvider = ({
       rowSelection,
       showTriggerWorkflow,
       showQueueMetrics,
+      sorting,
       display: {
         hideMetrics,
         hideCounts,
@@ -233,6 +245,7 @@ export const RunsProvider = ({
         setRowSelection,
         setShowQueueMetrics,
         setShowTriggerWorkflow,
+        setSorting,
       },
     }),
     [
@@ -275,6 +288,8 @@ export const RunsProvider = ({
       setColumnVisibility,
       rowSelection,
       showTriggerWorkflow,
+      sorting,
+      setSorting,
     ],
   );
 

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-runs.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-runs.tsx
@@ -8,7 +8,7 @@ import {
   V1TaskStatus,
 } from '@/lib/api';
 import { useQuery } from '@tanstack/react-query';
-import { RowSelectionState } from '@tanstack/react-table';
+import { RowSelectionState, SortingState } from '@tanstack/react-table';
 import { useCallback, useMemo, useState } from 'react';
 
 type UseRunsProps = {
@@ -25,6 +25,7 @@ type UseRunsProps = {
   triggeringEventExternalId?: string | undefined;
   onlyTasks: boolean;
   disablePagination?: boolean;
+  sorting?: SortingState;
 };
 
 export const useRuns = ({
@@ -41,6 +42,7 @@ export const useRuns = ({
   triggeringEventExternalId,
   onlyTasks,
   disablePagination = false,
+  sorting,
 }: UseRunsProps) => {
   const { tenantId } = useCurrentTenantId();
   const { refetchInterval } = useRefetchInterval();
@@ -76,6 +78,20 @@ export const useRuns = ({
       triggering_event_external_id: triggeringEventExternalId,
       include_payloads: false,
       running_filter: runningFilter,
+      order_by_field:
+        sorting && sorting.length > 0
+          ? (sorting[0].id as
+              | 'createdAt'
+              | 'taskName'
+              | 'workflow'
+              | 'startedAt'
+              | 'finishedAt'
+              | 'duration')
+          : undefined,
+      order_by_direction:
+        sorting && sorting.length > 0
+          ? (sorting[0].desc ? 'desc' : 'asc')
+          : undefined,
     }),
     refetchInterval:
       Object.keys(rowSelection).length > 0 ? false : refetchInterval,

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -53,6 +53,10 @@ type ListTaskRunOpts struct {
 	Offset int64
 
 	IncludePayloads bool
+
+	OrderBy        string
+
+	OrderDirection string
 }
 
 type ListWorkflowRunOpts struct {
@@ -77,6 +81,10 @@ type ListWorkflowRunOpts struct {
 	TriggeringEventExternalId *uuid.UUID
 
 	IncludePayloads bool
+
+	OrderBy        string
+
+	OrderDirection string
 }
 
 type ReadTaskRunMetricsOpts struct {
@@ -741,7 +749,7 @@ func (r *OLAPRepositoryImpl) ListTasks(ctx context.Context, tenantId uuid.UUID, 
 
 	g.Go(func() error {
 		var err error
-		rows, err = r.queries.ListTasksOlap(gctx, tx, params)
+		rows, err = r.queries.ListTasksOlapWithSort(gctx, tx, params, opts.OrderBy, opts.OrderDirection)
 		return err
 	})
 
@@ -1086,7 +1094,7 @@ func (r *OLAPRepositoryImpl) ListWorkflowRuns(ctx context.Context, tenantId uuid
 		return nil
 	})
 
-	workflowRunIds, err = r.queries.FetchWorkflowRunIds(ctx, tx, params)
+	workflowRunIds, err = r.queries.FetchWorkflowRunIdsWithSort(ctx, tx, params, opts.OrderBy, opts.OrderDirection)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/pkg/repository/sqlcv1/olap-overwrite.sql.go
+++ b/pkg/repository/sqlcv1/olap-overwrite.sql.go
@@ -3,6 +3,7 @@ package sqlcv1
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -365,6 +366,252 @@ func (q *Queries) ListTasksOlap(ctx context.Context, db DBTX, arg ListTasksOlapP
 	for rows.Next() {
 		var i ListTasksOlapRow
 		if err := rows.Scan(&i.ID, &i.InsertedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+// buildListTasksQuery builds a dynamic SQL query for listing tasks with a configurable ORDER BY clause.
+// The orderBy and orderDir parameters are validated against whitelists to prevent SQL injection.
+// For startedAt/finishedAt/duration, LATERAL joins are used to compute values once per row.
+func buildListTasksQuery(orderBy, orderDir string) string {
+	direction := "DESC"
+	if strings.EqualFold(orderDir, "asc") {
+		direction = "ASC"
+	}
+
+	needsTimes := orderBy == "startedAt" || orderBy == "finishedAt" || orderBy == "duration"
+
+	lateralJoins := ""
+	if needsTimes {
+		lateralJoins = `
+LEFT JOIN LATERAL (
+    SELECT MAX(e.event_timestamp) AS started_at
+    FROM v1_task_events_olap e
+    WHERE e.task_id = t.id AND e.tenant_id = t.tenant_id
+      AND e.task_inserted_at = t.inserted_at AND e.event_type = 'STARTED'
+) _st ON TRUE
+LEFT JOIN LATERAL (
+    SELECT MAX(e.event_timestamp) AS finished_at
+    FROM v1_task_events_olap e
+    WHERE e.task_id = t.id AND e.tenant_id = t.tenant_id
+      AND e.task_inserted_at = t.inserted_at
+      AND e.readable_status = ANY(ARRAY['COMPLETED', 'FAILED', 'CANCELLED']::v1_readable_status_olap[])
+) _fin ON TRUE`
+	}
+
+	orderExpr := "t.inserted_at"
+	nullable := false
+
+	switch orderBy {
+	case "createdAt":
+		orderExpr = "t.inserted_at"
+	case "taskName":
+		orderExpr = "t.display_name"
+	case "workflow":
+		orderExpr = "t.workflow_id"
+	case "startedAt":
+		orderExpr = "_st.started_at"
+		nullable = true
+	case "finishedAt":
+		orderExpr = "_fin.finished_at"
+		nullable = true
+	case "duration":
+		orderExpr = "(_fin.finished_at - _st.started_at)"
+		nullable = true
+	default:
+		orderExpr = "t.inserted_at"
+	}
+
+	nullsClause := ""
+	if nullable {
+		if direction == "DESC" {
+			nullsClause = " NULLS LAST"
+		} else {
+			nullsClause = " NULLS FIRST"
+		}
+	}
+
+	orderClause := fmt.Sprintf("ORDER BY %s %s%s, t.inserted_at %s, t.id %s", orderExpr, direction, nullsClause, direction, direction)
+
+	return fmt.Sprintf(`SELECT
+    t.id,
+    t.inserted_at
+FROM
+    v1_tasks_olap t%s
+WHERE
+    t.tenant_id = $1::uuid
+    AND t.inserted_at >= $2::timestamptz
+    AND t.readable_status = ANY($3::v1_readable_status_olap[])
+    AND (
+        $4::timestamptz IS NULL
+        OR t.inserted_at <= $4::timestamptz
+    )
+    AND (
+        $5::uuid[] IS NULL OR t.workflow_id = ANY($5::uuid[])
+    )
+    AND (
+        $6::uuid IS NULL OR t.latest_worker_id = $6::uuid
+    )
+    AND (
+        $7::text[] IS NULL
+        OR $8::text[] IS NULL
+        OR EXISTS (
+            SELECT 1 FROM jsonb_each_text(t.additional_metadata) kv
+            JOIN LATERAL (
+                SELECT unnest($7::text[]) AS k,
+                    unnest($8::text[]) AS v
+            ) AS u ON kv.key = u.k AND kv.value = u.v
+        )
+    )
+    AND (
+        $11::UUID IS NULL
+		OR (t.id, t.inserted_at) IN (
+			SELECT etr.run_id, etr.run_inserted_at
+			FROM v1_event_lookup_table_olap lt
+			JOIN v1_events_olap e ON (lt.tenant_id, lt.event_id, lt.event_seen_at) = (e.tenant_id, e.id, e.seen_at)
+			JOIN v1_event_to_run_olap etr ON (e.id, e.seen_at) = (etr.event_id, etr.event_seen_at)
+			WHERE
+				lt.tenant_id = $1::uuid
+				AND lt.external_id = $11::UUID
+		)
+    )
+%s
+LIMIT $10::integer
+OFFSET $9::integer`, lateralJoins, orderClause)
+}
+
+// ListTasksOlapWithSort executes a dynamic query for listing tasks with configurable sorting.
+func (q *Queries) ListTasksOlapWithSort(ctx context.Context, db DBTX, arg ListTasksOlapParams, orderBy, orderDir string) ([]*ListTasksOlapRow, error) {
+	query := buildListTasksQuery(orderBy, orderDir)
+	rows, err := db.Query(ctx, query,
+		arg.Tenantid,
+		arg.Since,
+		arg.Statuses,
+		arg.Until,
+		arg.WorkflowIds,
+		arg.WorkerId,
+		arg.Keys,
+		arg.Values,
+		arg.Taskoffset,
+		arg.Tasklimit,
+		arg.TriggeringEventExternalId,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*ListTasksOlapRow
+	for rows.Next() {
+		var i ListTasksOlapRow
+		if err := rows.Scan(&i.ID, &i.InsertedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+// buildFetchWorkflowRunIdsQuery builds a dynamic SQL query for fetching workflow run IDs with a configurable ORDER BY clause.
+// Only "createdAt" is supported as a sort field; all other values fall back to "inserted_at".
+func buildFetchWorkflowRunIdsQuery(orderBy, orderDir string) string {
+	orderByColumn := "inserted_at"
+	// Only createdAt is supported for workflow runs; all others fall back to inserted_at.
+	if orderBy == "createdAt" {
+		orderByColumn = "inserted_at"
+	}
+
+	direction := "DESC"
+	if strings.EqualFold(orderDir, "asc") {
+		direction = "ASC"
+	}
+
+	orderClause := fmt.Sprintf("ORDER BY %s %s, id %s", orderByColumn, direction, direction)
+
+	return fmt.Sprintf(`SELECT id, inserted_at, kind, external_id
+FROM v1_runs_olap
+WHERE
+    tenant_id = $1::uuid
+    AND readable_status = ANY($2::v1_readable_status_olap[])
+    AND (
+        $3::uuid[] IS NULL
+        OR workflow_id = ANY($3::uuid[])
+    )
+    AND inserted_at >= $4::timestamptz
+    AND (
+        $5::timestamptz IS NULL
+        OR inserted_at <= $5::timestamptz
+    )
+    AND (
+        $6::text[] IS NULL
+        OR $7::text[] IS NULL
+        OR EXISTS (
+            SELECT 1 FROM jsonb_each_text(additional_metadata) kv
+            JOIN LATERAL (
+                SELECT unnest($6::text[]) AS k,
+                    unnest($7::text[]) AS v
+            ) AS u ON kv.key = u.k AND kv.value = u.v
+        )
+    )
+    AND (
+        $10::UUID IS NULL
+        OR parent_task_external_id = $10::UUID
+    )
+    AND (
+        $11::UUID IS NULL
+		OR (id, inserted_at) IN (
+			SELECT etr.run_id, etr.run_inserted_at
+			FROM v1_event_lookup_table_olap lt
+			JOIN v1_events_olap e ON (lt.tenant_id, lt.event_id, lt.event_seen_at) = (e.tenant_id, e.id, e.seen_at)
+			JOIN v1_event_to_run_olap etr ON (e.id, e.seen_at) = (etr.event_id, etr.event_seen_at)
+			WHERE
+				lt.tenant_id = $1::uuid
+				AND lt.external_id = $11::UUID
+		)
+    )
+%s
+LIMIT $9::integer
+OFFSET $8::integer`, orderClause)
+}
+
+// FetchWorkflowRunIdsWithSort executes a dynamic query for fetching workflow run IDs with configurable sorting.
+func (q *Queries) FetchWorkflowRunIdsWithSort(ctx context.Context, db DBTX, arg FetchWorkflowRunIdsParams, orderBy, orderDir string) ([]*FetchWorkflowRunIdsRow, error) {
+	query := buildFetchWorkflowRunIdsQuery(orderBy, orderDir)
+	rows, err := db.Query(ctx, query,
+		arg.Tenantid,
+		arg.Statuses,
+		arg.WorkflowIds,
+		arg.Since,
+		arg.Until,
+		arg.Keys,
+		arg.Values,
+		arg.Listworkflowrunsoffset,
+		arg.Listworkflowrunslimit,
+		arg.ParentTaskExternalId,
+		arg.TriggeringEventExternalId,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*FetchWorkflowRunIdsRow
+	for rows.Next() {
+		var i FetchWorkflowRunIdsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.InsertedAt,
+			&i.Kind,
+			&i.ExternalID,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)


### PR DESCRIPTION
## Summary
- Adds server-side sorting for **Task Name**, **Workflow**, **Created At**, **Started At**, **Finished At**, and **Duration** columns in the workflow runs list view
- New `order_by_field` and `order_by_direction` query parameters on the `v1-workflow-run:list` API endpoint
- Dynamic ORDER BY with whitelisted column mappings and LATERAL joins for event-derived fields (started_at, finished_at, duration)
- Frontend wires TanStack React Table sorting state through to the API, with type-safe field mapping and single-column sort only

## Changes across layers
- **OpenAPI spec**: Added `order_by_field` (enum) and `order_by_direction` (asc/desc) params
- **Go handler**: Extracts sort params in both `WithDags` and `OnlyTasks` paths
- **SQL**: Dynamic query builder with LATERAL joins for started_at/finished_at/duration, deterministic tie-breakers for stable pagination
- **Frontend**: Enabled sorting on 6 columns, default sort `createdAt DESC`, disabled multi-sort

## Test plan
- [ ] Verify sorting by each column (asc/desc) produces correct order
- [ ] Verify pagination remains stable across pages when sorting by non-unique columns
- [ ] Verify sorting by Started At / Finished At / Duration correctly handles NULL values (queued/running tasks)
- [ ] Verify default sort (Created At DESC) matches previous behavior
- [ ] Verify WithDags view falls back to createdAt sorting gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)