### PR TITLE
fix(sdk/go): Fallback when tenantID is zero UUID

### DIFF
--- a/pkg/client/loader/loader.go
+++ b/pkg/client/loader/loader.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/google/uuid"
+
 	"github.com/hatchet-dev/hatchet/pkg/config/client"
 	"github.com/hatchet-dev/hatchet/pkg/config/loader/loaderutils"
 )
@@ -91,7 +93,7 @@ func GetClientConfigFromConfigFile(tokenOverride *string, cf *client.ClientConfi
 		return nil, fmt.Errorf("server URL is required. Set it via the HATCHET_CLIENT_SERVER_URL environment variable")
 	}
 
-	if cf.TenantId == "" {
+	if cf.TenantId == "" || cf.TenantId == uuid.Nil.String() {
 		cf.TenantId = tokenConf.TenantId
 	}
 


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR checks if the supplied Tenant ID is either empty `""` or the zero `uuid.UUID` value `00000000-0000-0000-0000-000000000000` -- where the only the former was being checked which causing tenant IDs not to be extracted from supplied tokens with `v1.NewHatchetClient(...)` calls.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## What's Changed

- When a tenant ID is the zero value for a `uuid.UUID`, this triggers a fallback to extract from the passed in token.

## Testing

Using the below `client.yaml`, run the go script both with and without the change.

```yaml
token: "<token>"
log:
  level: debug
tls:
  base:
    tlsStrategy: none

```

```go
package main

import (
	"fmt"
	"os"

	clientloader "github.com/hatchet-dev/hatchet/pkg/client/loader"
	v1 "github.com/hatchet-dev/hatchet/pkg/v1"
)

func main() {
	configBytes, err := os.ReadFile("client.yaml")
	if err != nil {
		panic(err)
	}

	cf, err := clientloader.LoadClientConfigFile(configBytes)
	if err != nil {
		panic(err)
	}

	client, err := v1.NewHatchetClient(v1.Config{
		Token: cf.Token,
		TLS: &v1.TLSConfig{
			Base:          &cf.TLS.Base,
			TLSServerName: cf.TLS.TLSServerName,
		},
	})
	if err != nil {
		panic(err)
	}

	fmt.Printf("TenantID: %s\n", client.V0().TenantId())
}
```

You'll see HEAD of `main` return:

```
TenantID: 00000000-0000-0000-0000-000000000000
```

with these changes added:

```
TenantID: 707d0855-80ab-4e1f-a156-f1c4546cbf52 # or whatever tenant ID was used in your token generation
```