### PR TITLE
Improve error message when failing to send task to worker

### DIFF
--- a/internal/services/dispatcher/dispatcher_v1.go
+++ b/internal/services/dispatcher/dispatcher_v1.go
@@ -461,7 +461,9 @@ func (d *DispatcherImpl) handleRetries(
 				task.WorkflowRunID,
 				task.RetryCount,
 				false,
-				"Could not send task to worker",
+				"Could not send task to worker. "+
+					"This likely means that too many slots have been configured for the number of workers"+
+					"or the network latency between engine and worker is unusually high.",
 				false,
 			)
 

--- a/internal/services/dispatcher/dispatcher_v1.go
+++ b/internal/services/dispatcher/dispatcher_v1.go
@@ -462,7 +462,7 @@ func (d *DispatcherImpl) handleRetries(
 				task.RetryCount,
 				false,
 				"Could not send task to worker. "+
-					"This likely means that too many slots have been configured for the number of workers"+
+					"This likely means that too many slots have been configured for the number of workers "+
 					"or the network latency between engine and worker is unusually high.",
 				false,
 			)


### PR DESCRIPTION
# Description

Improves the error message surrounding tasks failing to be dispatched to the worker with helpful advice for the user. This goes along with the recent change from using a fixed backlog of tasks being dispatched, to failing when a task times out attempting to acquire the sender lock #3290.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...
