### PR TITLE
Remove server ShutdownWait

### DIFF
--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -102,8 +102,6 @@ func Run(ctx context.Context, cf *loader.ConfigLoader, version string) error {
 		return fmt.Errorf("could not run with config: %w", err)
 	}
 
-	time.Sleep(server.Runtime.ShutdownWait)
-
 	l.Debug().Msgf("interrupt received, shutting down")
 
 	err = cleanup.Run()

--- a/internal/services/partition/partition.go
+++ b/internal/services/partition/partition.go
@@ -90,14 +90,6 @@ func (p *Partition) AddCleanupMethods(cleanup *cleanup.Cleanup) {
 		p.schedulerCron.Shutdown,
 		"partitioner scheduler cron",
 	)
-
-	cleanup.Add(
-		func() error {
-			time.Sleep(heartbeatTimeout)
-			return nil
-		},
-		"partitioner heartbeat timeout",
-	)
 }
 
 func (p *Partition) StartControllerPartition(ctx context.Context) (func() error, error) {

--- a/internal/services/partition/partition.go
+++ b/internal/services/partition/partition.go
@@ -90,6 +90,14 @@ func (p *Partition) AddCleanupMethods(cleanup *cleanup.Cleanup) {
 		p.schedulerCron.Shutdown,
 		"partitioner scheduler cron",
 	)
+
+	cleanup.Add(
+		func() error {
+			time.Sleep(heartbeatTimeout)
+			return nil
+		},
+		"partitioner heartbeat timeout",
+	)
 }
 
 func (p *Partition) StartControllerPartition(ctx context.Context) (func() error, error) {

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -196,9 +196,6 @@ type ConfigFileRuntime struct {
 	// GRPCRateLimit is the rate limit for the grpc server. We count limits separately for the Workflow, Dispatcher and Events services. Workflow and Events service are set to this rate, Dispatcher is 10X this rate. The rate limit is per second, per engine, per api token.
 	GRPCRateLimit float64 `mapstructure:"grpcRateLimit" json:"grpcRateLimit,omitempty" default:"1000"`
 
-	// ShutdownWait is the time between the readiness probe being offline when a shutdown is triggered and the actual start of cleaning up resources.
-	ShutdownWait time.Duration `mapstructure:"shutdownWait" json:"shutdownWait,omitempty" default:"20s"`
-
 	// EnforceLimits controls whether the server enforces tenant limits
 	EnforceLimits bool `mapstructure:"enforceLimits" json:"enforceLimits,omitempty" default:"false"`
 
@@ -690,7 +687,6 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("runtime.schedulerConcurrencyRateLimit", "SCHEDULER_CONCURRENCY_RATE_LIMIT")
 	_ = v.BindEnv("runtime.schedulerConcurrencyPollingMinInterval", "SCHEDULER_CONCURRENCY_POLLING_MIN_INTERVAL")
 	_ = v.BindEnv("runtime.schedulerConcurrencyPollingMaxInterval", "SCHEDULER_CONCURRENCY_POLLING_MAX_INTERVAL")
-	_ = v.BindEnv("runtime.shutdownWait", "SERVER_SHUTDOWN_WAIT")
 	_ = v.BindEnv("servicesString", "SERVER_SERVICES")
 	_ = v.BindEnv("pausedControllers", "SERVER_PAUSED_CONTROLLERS")
 	_ = v.BindEnv("enableDataRetention", "SERVER_ENABLE_DATA_RETENTION")


### PR DESCRIPTION
# Description

Kubernetes automatically marks a pod as not ready when the termination process begins, so we do not need to wait for readiness probes to fail before cleaning up and shutting down. 

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...
