### PR TITLE
Don't flicker the runs table when refetching

### DIFF
--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
@@ -93,8 +93,8 @@ export function RunsTable({ leftLabel }: { leftLabel?: string }) {
     toolbarFilters,
     tableRows,
     numPages,
-    isRunsFetching,
-    isStatusCountsFetching,
+    isRunsLoading,
+    isStatusCountsLoading,
     isQueueMetricsLoading,
     isRefetching,
     runStatusCounts,
@@ -192,7 +192,7 @@ export function RunsTable({ leftLabel }: { leftLabel?: string }) {
     return () => clearInterval(interval);
   }, [filters, filters.isCustomTimeRange, filters.updateCurrentTimeWindow]);
 
-  const isFetching = isRunsFetching || isStatusCountsFetching;
+  const isRunningFirstLoad = isRunsLoading || isStatusCountsLoading;
 
   const leftActions = [
     ...(!hideCounts
@@ -263,7 +263,7 @@ export function RunsTable({ leftLabel }: { leftLabel?: string }) {
               </div>
             </div>
           }
-          isLoading={isFetching}
+          isLoading={isRunningFirstLoad}
           columns={tableColumns}
           columnVisibility={columnVisibility}
           setColumnVisibility={setColumnVisibility}


### PR DESCRIPTION
# Description

Fixes a side effect of some of the query state tweaks made in #3151 where an empty runs table would flicker every few seconds when runs were reloaded in the background.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...
