### PR TITLE
Fix: bump local dev engine ver

### DIFF
--- a/cmd/hatchet-engine/main.go
+++ b/cmd/hatchet-engine/main.go
@@ -47,7 +47,7 @@ var rootCmd = &cobra.Command{
 
 // Version will be linked by an ldflag during build
 // FIXME: automate this version update on tag, we use it to version the engine for sdks
-var Version = "v0.80.0"
+var Version = "v0.82.2"
 
 func main() {
 	rootCmd.PersistentFlags().BoolVar(


### PR DESCRIPTION
# Description

Bumping the engine version for sdk compat

## Type of change

- [x] Chore (changes which are not directly related to any business logic)
