### PR TITLE
Fix: Add sleep to python test to let otel traces propagate

### DIFF
--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -18,6 +18,7 @@ services:
       SERVER_GRPC_INSECURE: "true"
       SERVER_DEFAULT_ENGINE_VERSION: V1
       SERVER_MSGQUEUE_KIND: postgres
+      SERVER_OBSERVABILITY_ENABLED: true
     volumes:
       - ./generated:/hatchet/generated
 
@@ -43,6 +44,7 @@ services:
       SERVER_LOGGER_FORMAT: console
       DATABASE_LOGGER_LEVEL: warn
       DATABASE_LOGGER_FORMAT: console
+      SERVER_OBSERVABILITY_ENABLED: true
     volumes:
       - ./generated:/hatchet/generated
 
@@ -65,5 +67,6 @@ services:
       SERVER_MSGQUEUE_KIND: postgres
       DATABASE_LOGGER_LEVEL: warn
       DATABASE_LOGGER_FORMAT: console
+      SERVER_OBSERVABILITY_ENABLED: true
     volumes:
       - ./generated:/hatchet/generated

--- a/sdks/python/examples/opentelemetry_instrumentation/test_otel_traces.py
+++ b/sdks/python/examples/opentelemetry_instrumentation/test_otel_traces.py
@@ -59,6 +59,18 @@ async def test_otel_spans_created_on_task_run(hatchet: Hatchet) -> None:
     await ref.aio_result()
 
     spans = await asyncio.to_thread(poll_for_trace, hatchet, ref.workflow_run_id)
+
+    assert len(spans) == 5, (
+        "five spans: hatchet.run_workflow, hatchet.engine.queued, 2x hatchet.start_step_run, custom.child.span"
+    )
+
+    assert {s.span_name for s in spans} == {
+        "hatchet.run_workflow",
+        "hatchet.engine.queued",
+        "hatchet.start_step_run",
+        "custom.child.span",
+    }
+
     step_run_spans = [s for s in spans if s.span_name == "hatchet.start_step_run"]
     assert len(step_run_spans) >= 1
 
@@ -109,6 +121,8 @@ async def test_otel_spans_created_on_task_run(hatchet: Hatchet) -> None:
         == otel_simple_task.name
     )
 
+    assert False
+
 
 @requires_observability
 @pytest.mark.asyncio(loop_scope="session")
@@ -135,6 +149,17 @@ async def test_otel_spans_on_event_triggered_run(hatchet: Hatchet) -> None:
     assert run_id is not None, "Event-triggered run did not complete in time."
 
     spans = await asyncio.to_thread(poll_for_trace, hatchet, run_id)
+
+    assert len(spans) == 5, (
+        "five spans: hatchet.push_event, hatchet.engine.queued, 2x hatchet.start_step_run, custom.child.span"
+    )
+
+    assert {s.span_name for s in spans} == {
+        "hatchet.push_event",
+        "hatchet.engine.queued",
+        "hatchet.start_step_run",
+        "custom.child.span",
+    }
 
     push_event_spans = [s for s in spans if s.span_name == "hatchet.push_event"]
 
@@ -180,6 +205,41 @@ async def test_otel_spans_on_dag_run(hatchet: Hatchet) -> None:
     spans = await asyncio.to_thread(
         poll_for_trace, hatchet, ref.workflow_run_id, min_spans=4
     )
+
+    assert len(spans) == 24, """
+        24 spans:
+            - hatchet.run_workflow
+            - 4x hatchet.engine.queued
+            - 2x hatchet.start_step_run for each of the 4 tasks (8 total)
+            - db.query
+            - transform.pipeline
+            - transform.normalize
+            - http.request
+            - schema.validate
+            - transform.enrich
+            - data.clean
+            - transform.aggregate
+            - cache.invalidate
+            - notification.send
+            - json.parse
+        """
+
+    assert {s.span_name for s in spans} == {
+        "hatchet.run_workflow",
+        "hatchet.engine.queued",
+        "hatchet.start_step_run",
+        "db.query",
+        "transform.pipeline",
+        "transform.normalize",
+        "http.request",
+        "schema.validate",
+        "transform.enrich",
+        "data.clean",
+        "transform.aggregate",
+        "cache.invalidate",
+        "notification.send",
+        "json.parse",
+    }
 
     step_run_spans = [s for s in spans if s.span_name == "hatchet.start_step_run"]
     step_names = {
@@ -238,6 +298,23 @@ async def test_otel_spans_on_child_spawn(hatchet: Hatchet) -> None:
     await ref.aio_result()
 
     spans = await asyncio.to_thread(poll_for_trace, hatchet, ref.workflow_run_id)
+
+    assert len(spans) == 10, """
+        10 spans:
+            - 2x hatchet.run_workflow (one for parent, one for child)
+            - 2x hatchet.engine.queued (one for parent, one for child)
+            - 4x hatchet.start_step_run for parent and child (2 each)
+            - spawn.child
+            - custom.child.span
+    """
+
+    assert {s.span_name for s in spans} == {
+        "hatchet.run_workflow",
+        "hatchet.engine.queued",
+        "hatchet.start_step_run",
+        "spawn.child",
+        "custom.child.span",
+    }
 
     step_run_spans = [s for s in spans if s.span_name == "hatchet.start_step_run"]
     assert len(step_run_spans) >= 1

--- a/sdks/python/examples/opentelemetry_instrumentation/test_otel_traces.py
+++ b/sdks/python/examples/opentelemetry_instrumentation/test_otel_traces.py
@@ -122,8 +122,6 @@ async def test_otel_spans_created_on_task_run(hatchet: Hatchet) -> None:
         == otel_simple_task.name
     )
 
-    assert False
-
 
 @requires_observability
 @pytest.mark.asyncio(loop_scope="session")

--- a/sdks/python/examples/opentelemetry_instrumentation/test_otel_traces.py
+++ b/sdks/python/examples/opentelemetry_instrumentation/test_otel_traces.py
@@ -61,13 +61,14 @@ async def test_otel_spans_created_on_task_run(hatchet: Hatchet) -> None:
     spans = await asyncio.to_thread(poll_for_trace, hatchet, ref.workflow_run_id)
 
     assert len(spans) == 5, (
-        "five spans: hatchet.run_workflow, hatchet.engine.queued, 2x hatchet.start_step_run, custom.child.span"
+        "five spans: hatchet.run_workflow, hatchet.engine.queued,hatchet.start_step_run, hatchet.engine.started, custom.child.span"
     )
 
     assert {s.span_name for s in spans} == {
         "hatchet.run_workflow",
         "hatchet.engine.queued",
         "hatchet.start_step_run",
+        "hatchet.engine.started",
         "custom.child.span",
     }
 
@@ -151,7 +152,7 @@ async def test_otel_spans_on_event_triggered_run(hatchet: Hatchet) -> None:
     spans = await asyncio.to_thread(poll_for_trace, hatchet, run_id)
 
     assert len(spans) == 5, (
-        "five spans: hatchet.push_event, hatchet.engine.queued, 2x hatchet.start_step_run, custom.child.span"
+        "five spans: hatchet.push_event, hatchet.engine.queued, hatchet.start_step_run, hatchet.engine.started, custom.child.span"
     )
 
     assert {s.span_name for s in spans} == {
@@ -159,6 +160,7 @@ async def test_otel_spans_on_event_triggered_run(hatchet: Hatchet) -> None:
         "hatchet.engine.queued",
         "hatchet.start_step_run",
         "custom.child.span",
+        "hatchet.engine.started",
     }
 
     push_event_spans = [s for s in spans if s.span_name == "hatchet.push_event"]
@@ -210,7 +212,8 @@ async def test_otel_spans_on_dag_run(hatchet: Hatchet) -> None:
         24 spans:
             - hatchet.run_workflow
             - 4x hatchet.engine.queued
-            - 2x hatchet.start_step_run for each of the 4 tasks (8 total)
+            - hatchet.start_step_run for each of the 4 tasks
+            - hatchet.engine.started for each of the 4 tasks
             - db.query
             - transform.pipeline
             - transform.normalize
@@ -239,6 +242,7 @@ async def test_otel_spans_on_dag_run(hatchet: Hatchet) -> None:
         "cache.invalidate",
         "notification.send",
         "json.parse",
+        "hatchet.engine.started",
     }
 
     step_run_spans = [s for s in spans if s.span_name == "hatchet.start_step_run"]
@@ -303,7 +307,8 @@ async def test_otel_spans_on_child_spawn(hatchet: Hatchet) -> None:
         10 spans:
             - 2x hatchet.run_workflow (one for parent, one for child)
             - 2x hatchet.engine.queued (one for parent, one for child)
-            - 4x hatchet.start_step_run for parent and child (2 each)
+            - 2x hatchet.start_step_run for parent and child
+            - 2x hatchet.engine.started for parent and child
             - spawn.child
             - custom.child.span
     """
@@ -314,6 +319,7 @@ async def test_otel_spans_on_child_spawn(hatchet: Hatchet) -> None:
         "hatchet.start_step_run",
         "spawn.child",
         "custom.child.span",
+        "hatchet.engine.started",
     }
 
     step_run_spans = [s for s in spans if s.span_name == "hatchet.start_step_run"]

--- a/sdks/python/examples/opentelemetry_instrumentation/test_otel_traces.py
+++ b/sdks/python/examples/opentelemetry_instrumentation/test_otel_traces.py
@@ -60,9 +60,9 @@ async def test_otel_spans_created_on_task_run(hatchet: Hatchet) -> None:
 
     spans = await asyncio.to_thread(poll_for_trace, hatchet, ref.workflow_run_id)
 
-    assert len(spans) == 5, (
-        "five spans: hatchet.run_workflow, hatchet.engine.queued,hatchet.start_step_run, hatchet.engine.started, custom.child.span"
-    )
+    assert (
+        len(spans) == 5
+    ), "five spans: hatchet.run_workflow, hatchet.engine.queued,hatchet.start_step_run, hatchet.engine.started, custom.child.span"
 
     assert {s.span_name for s in spans} == {
         "hatchet.run_workflow",
@@ -151,9 +151,9 @@ async def test_otel_spans_on_event_triggered_run(hatchet: Hatchet) -> None:
 
     spans = await asyncio.to_thread(poll_for_trace, hatchet, run_id)
 
-    assert len(spans) == 5, (
-        "five spans: hatchet.push_event, hatchet.engine.queued, hatchet.start_step_run, hatchet.engine.started, custom.child.span"
-    )
+    assert (
+        len(spans) == 5
+    ), "five spans: hatchet.push_event, hatchet.engine.queued, hatchet.start_step_run, hatchet.engine.started, custom.child.span"
 
     assert {s.span_name for s in spans} == {
         "hatchet.push_event",

--- a/sdks/python/examples/opentelemetry_instrumentation/test_otel_traces.py
+++ b/sdks/python/examples/opentelemetry_instrumentation/test_otel_traces.py
@@ -20,6 +20,9 @@ requires_observability = pytest.mark.usefixtures("_skip_unless_observability")
 
 
 def poll_for_trace(hatchet: Hatchet, run_id: str, min_spans: int = 1) -> list[OtelSpan]:
+    # sleep to avoid race conditions with engine spans
+    time.sleep(5)
+
     for _ in range(10):
         with hatchet.runs.client() as client:
             try:


### PR DESCRIPTION
# Description

Adds a sleep before we start polling

## Type of change

- [x] Test changes (add, refactor, improve or change a test)

