### PR TITLE
add configurable polling interval for workflow runs

### DIFF
--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -345,6 +345,8 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 			dispatcher.WithStreamEventBufferTimeout(sc.Runtime.StreamEventBufferTimeout),
 			dispatcher.WithVersion(sc.Version),
 			dispatcher.WithAnalytics(sc.Analytics),
+			dispatcher.WithMinWorkflowRunPollingInterval(sc.Runtime.WorkflowRunPollingMinInterval),
+			dispatcher.WithMaxWorkflowRunPollingInterval(sc.Runtime.WorkflowRunPollingMaxInterval),
 		)
 
 		if err != nil {
@@ -776,6 +778,8 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 			dispatcher.WithStreamEventBufferTimeout(sc.Runtime.StreamEventBufferTimeout),
 			dispatcher.WithVersion(sc.Version),
 			dispatcher.WithAnalytics(sc.Analytics),
+			dispatcher.WithMinWorkflowRunPollingInterval(sc.Runtime.WorkflowRunPollingMinInterval),
+			dispatcher.WithMaxWorkflowRunPollingInterval(sc.Runtime.WorkflowRunPollingMaxInterval),
 		)
 
 		if err != nil {

--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -47,6 +47,8 @@ type DispatcherImpl struct {
 	defaultMaxWorkerLockAcquisitionTime time.Duration
 	workflowRunBufferSize               int
 	streamEventBufferTimeout            time.Duration
+	minWorkflowRunPollingInterval       time.Duration
+	maxWorkflowRunPollingInterval       time.Duration
 
 	dispatcherId uuid.UUID
 	workers      *workers
@@ -134,6 +136,8 @@ type DispatcherOpts struct {
 	workflowRunBufferSize               int
 	streamEventBufferTimeout            time.Duration
 	version                             string
+	minWorkflowRunPollingInterval       time.Duration
+	maxWorkflowRunPollingInterval       time.Duration
 }
 
 func defaultDispatcherOpts() *DispatcherOpts {
@@ -150,6 +154,8 @@ func defaultDispatcherOpts() *DispatcherOpts {
 		defaultMaxWorkerLockAcquisitionTime: 250 * time.Millisecond,
 		workflowRunBufferSize:               1000,
 		streamEventBufferTimeout:            5 * time.Second,
+		minWorkflowRunPollingInterval:       1 * time.Second,
+		maxWorkflowRunPollingInterval:       2 * time.Second,
 	}
 }
 
@@ -231,6 +237,18 @@ func WithAnalytics(a analytics.Analytics) DispatcherOpt {
 	}
 }
 
+func WithMinWorkflowRunPollingInterval(interval time.Duration) DispatcherOpt {
+	return func(opts *DispatcherOpts) {
+		opts.minWorkflowRunPollingInterval = interval
+	}
+}
+
+func WithMaxWorkflowRunPollingInterval(interval time.Duration) DispatcherOpt {
+	return func(opts *DispatcherOpts) {
+		opts.maxWorkflowRunPollingInterval = interval
+	}
+}
+
 func New(fs ...DispatcherOpt) (*DispatcherImpl, error) {
 	opts := defaultDispatcherOpts()
 
@@ -283,6 +301,8 @@ func New(fs ...DispatcherOpt) (*DispatcherImpl, error) {
 		analytics:                           opts.analytics,
 		streamEventBufferTimeout:            opts.streamEventBufferTimeout,
 		version:                             opts.version,
+		minWorkflowRunPollingInterval:       opts.minWorkflowRunPollingInterval,
+		maxWorkflowRunPollingInterval:       opts.maxWorkflowRunPollingInterval,
 	}, nil
 }
 

--- a/internal/services/dispatcher/server_v1.go
+++ b/internal/services/dispatcher/server_v1.go
@@ -365,9 +365,18 @@ func (s *DispatcherImpl) subscribeToWorkflowRunsV1(server contracts.Dispatcher_S
 		return nil
 	}
 
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
 	iter := func(workflowRunIds []uuid.UUID) error {
 		if len(workflowRunIds) == 0 {
 			return nil
+		}
+
+		select {
+		case <-time.After(500 * time.Millisecond):
+			return nil
+		case <-ticker.C:
 		}
 
 		iterCtx, iterSpan := telemetry.NewSpan(ctx, "subscribe_to_workflow_runs_v1.iter")

--- a/internal/services/dispatcher/server_v1.go
+++ b/internal/services/dispatcher/server_v1.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/hatchet-dev/hatchet/internal/services/dispatcher/contracts"
+	"github.com/hatchet-dev/hatchet/pkg/randomticker"
 	v1 "github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 	"github.com/hatchet-dev/hatchet/pkg/telemetry"
@@ -479,7 +480,7 @@ func (s *DispatcherImpl) subscribeToWorkflowRunsV1(server contracts.Dispatcher_S
 
 	// new goroutine to poll every second for finished workflow runs which are not ackd
 	go func() {
-		ticker := time.NewTicker(1 * time.Second)
+		ticker := randomticker.NewRandomTicker(s.minWorkflowRunPollingInterval, s.maxWorkflowRunPollingInterval)
 
 		for {
 			select {

--- a/internal/services/dispatcher/server_v1.go
+++ b/internal/services/dispatcher/server_v1.go
@@ -365,7 +365,7 @@ func (s *DispatcherImpl) subscribeToWorkflowRunsV1(server contracts.Dispatcher_S
 		return nil
 	}
 
-	ticker := time.NewTicker(500 * time.Millisecond)
+	ticker := time.NewTicker(250 * time.Millisecond)
 	defer ticker.Stop()
 
 	iter := func(workflowRunIds []uuid.UUID) error {
@@ -374,9 +374,9 @@ func (s *DispatcherImpl) subscribeToWorkflowRunsV1(server contracts.Dispatcher_S
 		}
 
 		select {
-		case <-time.After(500 * time.Millisecond):
-			return nil
 		case <-ticker.C:
+		default:
+			return nil
 		}
 
 		iterCtx, iterSpan := telemetry.NewSpan(ctx, "subscribe_to_workflow_runs_v1.iter")

--- a/internal/services/dispatcher/server_v1.go
+++ b/internal/services/dispatcher/server_v1.go
@@ -365,17 +365,8 @@ func (s *DispatcherImpl) subscribeToWorkflowRunsV1(server contracts.Dispatcher_S
 		return nil
 	}
 
-	ticker := time.NewTicker(250 * time.Millisecond)
-	defer ticker.Stop()
-
 	iter := func(workflowRunIds []uuid.UUID) error {
 		if len(workflowRunIds) == 0 {
-			return nil
-		}
-
-		select {
-		case <-ticker.C:
-		default:
 			return nil
 		}
 
@@ -441,14 +432,23 @@ func (s *DispatcherImpl) subscribeToWorkflowRunsV1(server contracts.Dispatcher_S
 		return nil
 	}
 
-	f := func(msg *msgqueue.Message) error {
-		wg.Add(1)
-		defer wg.Done()
+	iterCh := make(chan []uuid.UUID, 100)
+	notifyCh := make(chan struct{}, 1)
 
-		if matchedWorkflowRunIds, ok := s.isMatchingWorkflowRunV1(msg, acks); ok {
-			if err := iter(matchedWorkflowRunIds); err != nil {
-				s.l.Error().Ctx(ctx).Err(err).Msg("could not iterate over workflow runs")
+	enqueue := func(ids []uuid.UUID) {
+		select {
+		case iterCh <- ids:
+			select {
+			case notifyCh <- struct{}{}:
+			default:
 			}
+		default:
+		}
+	}
+
+	f := func(msg *msgqueue.Message) error {
+		if matchedWorkflowRunIds, ok := s.isMatchingWorkflowRunV1(msg, acks); ok {
+			enqueue(matchedWorkflowRunIds)
 		}
 
 		return nil
@@ -487,6 +487,38 @@ func (s *DispatcherImpl) subscribeToWorkflowRunsV1(server contracts.Dispatcher_S
 		}
 	}()
 
+	// serial worker: drains iterCh whenever notified, ensuring at most one iter in flight
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-notifyCh:
+				var ids []uuid.UUID
+			drain:
+				for {
+					select {
+					case batch := <-iterCh:
+						ids = append(ids, batch...)
+					default:
+						break drain
+					}
+				}
+
+				if len(ids) == 0 {
+					continue
+				}
+
+				if err := iter(ids); err != nil {
+					s.l.Error().Ctx(ctx).Err(err).Msg("could not iterate over workflow runs")
+				}
+			}
+		}
+	}()
+
 	// new goroutine to poll every second for finished workflow runs which are not ackd
 	go func() {
 		ticker := randomticker.NewRandomTicker(s.minWorkflowRunPollingInterval, s.maxWorkflowRunPollingInterval)
@@ -498,12 +530,8 @@ func (s *DispatcherImpl) subscribeToWorkflowRunsV1(server contracts.Dispatcher_S
 			case <-ticker.C:
 				workflowRunIds := acks.getNonAckdWorkflowRuns()
 
-				if len(workflowRunIds) == 0 {
-					continue
-				}
-
-				if err := iter(workflowRunIds); err != nil {
-					s.l.Error().Ctx(ctx).Err(err).Msg("could not iterate over workflow runs")
+				if len(workflowRunIds) > 0 {
+					enqueue(workflowRunIds)
 				}
 			}
 		}

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -285,6 +285,12 @@ type ConfigFileRuntime struct {
 	// SchedulerConcurrencyPollingMaxInterval is the maximum interval for concurrency polling
 	SchedulerConcurrencyPollingMaxInterval time.Duration `mapstructure:"schedulerConcurrencyPollingMaxInterval" json:"schedulerConcurrencyPollingMaxInterval,omitempty" default:"5s"`
 
+	// WorkflowRunPollingMinInterval is the minimum interval for polling workflow runs in the dispatcher
+	WorkflowRunPollingMinInterval time.Duration `mapstructure:"workflowRunPollingMinInterval" json:"workflowRunPollingMinInterval,omitempty" default:"1s"`
+
+	// WorkflowRunPollingMaxInterval is the maximum interval for polling workflow runs in the dispatcher
+	WorkflowRunPollingMaxInterval time.Duration `mapstructure:"workflowRunPollingMaxInterval" json:"workflowRunPollingMaxInterval,omitempty" default:"2s"`
+
 	// LogIngestionEnabled controls whether the server enables log ingestion for tasks
 	LogIngestionEnabled bool `mapstructure:"logIngestionEnabled" json:"logIngestionEnabled,omitempty" default:"true"`
 
@@ -691,6 +697,8 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("runtime.schedulerConcurrencyRateLimit", "SCHEDULER_CONCURRENCY_RATE_LIMIT")
 	_ = v.BindEnv("runtime.schedulerConcurrencyPollingMinInterval", "SCHEDULER_CONCURRENCY_POLLING_MIN_INTERVAL")
 	_ = v.BindEnv("runtime.schedulerConcurrencyPollingMaxInterval", "SCHEDULER_CONCURRENCY_POLLING_MAX_INTERVAL")
+	_ = v.BindEnv("runtime.workflowRunPollingMinInterval", "SERVER_WORKFLOW_RUN_POLLING_MIN_INTERVAL")
+	_ = v.BindEnv("runtime.workflowRunPollingMaxInterval", "SERVER_WORKFLOW_RUN_POLLING_MAX_INTERVAL")
 	_ = v.BindEnv("servicesString", "SERVER_SERVICES")
 	_ = v.BindEnv("pausedControllers", "SERVER_PAUSED_CONTROLLERS")
 	_ = v.BindEnv("enableDataRetention", "SERVER_ENABLE_DATA_RETENTION")


### PR DESCRIPTION
# Description

Adds two environment variables to make polling intervals configurable for workflow run subscriptions.

## Type of change

- [X] New feature (non-breaking change which adds functionality)