### PR TITLE
Use inserted at for proper indexing in DAG replay queries

### DIFF
--- a/pkg/repository/sqlcv1/tasks.sql
+++ b/pkg/repository/sqlcv1/tasks.sql
@@ -769,8 +769,7 @@ ORDER BY
 -- name: LockDAGsForReplay :many
 -- Locks a list of DAGs for replay. Returns successfully locked DAGs which can be replayed.
 SELECT
-    id,
-    inserted_at
+    id
 FROM
     v1_dag
 WHERE

--- a/pkg/repository/sqlcv1/tasks.sql
+++ b/pkg/repository/sqlcv1/tasks.sql
@@ -769,11 +769,13 @@ ORDER BY
 -- name: LockDAGsForReplay :many
 -- Locks a list of DAGs for replay. Returns successfully locked DAGs which can be replayed.
 SELECT
-    id
+    id,
+    inserted_at
 FROM
     v1_dag
 WHERE
     id = ANY(@dagIds::bigint[])
+    AND inserted_at >= @minInsertedAt::TIMESTAMPTZ
     AND tenant_id = @tenantId::uuid
 ORDER BY id
 -- We skip locked tasks because replays are the only thing that can lock a DAG for updates
@@ -794,7 +796,7 @@ WITH dags_to_step_counts AS (
     FROM
         v1_dag d
     JOIN
-        v1_dag_to_task dt ON dt.dag_id = d.id
+        v1_dag_to_task dt ON dt.dag_id = d.id AND dt.dag_inserted_at = d.inserted_at
     JOIN
         "WorkflowVersion" wv ON wv."id" = d.workflow_version_id
     LEFT JOIN
@@ -803,6 +805,7 @@ WITH dags_to_step_counts AS (
         "Step" s ON s."jobId" = j."id"
     WHERE
         d.id = ANY(@dagIds::bigint[])
+        AND d.inserted_at >= @minInsertedAt::TIMESTAMPTZ
         AND d.tenant_id = @tenantId::uuid
     GROUP BY
         d.id,

--- a/pkg/repository/sqlcv1/tasks.sql
+++ b/pkg/repository/sqlcv1/tasks.sql
@@ -768,15 +768,22 @@ ORDER BY
 
 -- name: LockDAGsForReplay :many
 -- Locks a list of DAGs for replay. Returns successfully locked DAGs which can be replayed.
+WITH input AS (
+    SELECT
+        UNNEST(@dagIds::bigint[]) AS dag_id,
+        UNNEST(@dagInsertedAts::timestamptz[]) AS dag_inserted_at
+)
 SELECT
-    id
+    d.id,
+    d.inserted_at
 FROM
-    v1_dag
+    v1_dag d
+JOIN
+    input i ON i.dag_id = d.id AND i.dag_inserted_at = d.inserted_at
 WHERE
-    id = ANY(@dagIds::bigint[])
-    AND inserted_at >= @minInsertedAt::TIMESTAMPTZ
-    AND tenant_id = @tenantId::uuid
-ORDER BY id
+    d.inserted_at >= @minInsertedAt::TIMESTAMPTZ
+    AND d.tenant_id = @tenantId::uuid
+ORDER BY d.id
 -- We skip locked tasks because replays are the only thing that can lock a DAG for updates
 FOR UPDATE SKIP LOCKED;
 
@@ -785,7 +792,11 @@ FOR UPDATE SKIP LOCKED;
 -- match the length of steps in the DAG. This assumes that we have a lock on DAGs so concurrent replays
 -- don't interfere with each other. It also does not check for whether the tasks are running, as that's
 -- checked in a different query. It returns DAGs which cannot be replayed.
-WITH dags_to_step_counts AS (
+WITH input AS (
+    SELECT
+        UNNEST(@dagIds::bigint[]) AS dag_id,
+        UNNEST(@dagInsertedAts::timestamptz[]) AS dag_inserted_at
+), dags_to_step_counts AS (
     SELECT
         d.id,
         d.external_id,
@@ -795,6 +806,8 @@ WITH dags_to_step_counts AS (
     FROM
         v1_dag d
     JOIN
+        input i ON i.dag_id = d.id AND i.dag_inserted_at = d.inserted_at
+    JOIN
         v1_dag_to_task dt ON dt.dag_id = d.id AND dt.dag_inserted_at = d.inserted_at
     JOIN
         "WorkflowVersion" wv ON wv."id" = d.workflow_version_id
@@ -803,8 +816,7 @@ WITH dags_to_step_counts AS (
     LEFT JOIN
         "Step" s ON s."jobId" = j."id"
     WHERE
-        d.id = ANY(@dagIds::bigint[])
-        AND d.inserted_at >= @minInsertedAt::TIMESTAMPTZ
+        d.inserted_at >= @minInsertedAt::TIMESTAMPTZ
         AND d.tenant_id = @tenantId::uuid
     GROUP BY
         d.id,

--- a/pkg/repository/sqlcv1/tasks.sql
+++ b/pkg/repository/sqlcv1/tasks.sql
@@ -781,8 +781,7 @@ FROM
 JOIN
     input i ON i.dag_id = d.id AND i.dag_inserted_at = d.inserted_at
 WHERE
-    d.inserted_at >= @minInsertedAt::TIMESTAMPTZ
-    AND d.tenant_id = @tenantId::uuid
+    d.tenant_id = @tenantId::uuid
 ORDER BY d.id
 -- We skip locked tasks because replays are the only thing that can lock a DAG for updates
 FOR UPDATE SKIP LOCKED;
@@ -816,8 +815,7 @@ WITH input AS (
     LEFT JOIN
         "Step" s ON s."jobId" = j."id"
     WHERE
-        d.inserted_at >= @minInsertedAt::TIMESTAMPTZ
-        AND d.tenant_id = @tenantId::uuid
+        d.tenant_id = @tenantId::uuid
     GROUP BY
         d.id,
         d.inserted_at

--- a/pkg/repository/sqlcv1/tasks.sql.go
+++ b/pkg/repository/sqlcv1/tasks.sql.go
@@ -2143,39 +2143,57 @@ func (q *Queries) ListTasksToTimeout(ctx context.Context, db DBTX, arg ListTasks
 }
 
 const lockDAGsForReplay = `-- name: LockDAGsForReplay :many
+WITH input AS (
+    SELECT
+        UNNEST($3::bigint[]) AS dag_id,
+        UNNEST($4::timestamptz[]) AS dag_inserted_at
+)
 SELECT
-    id
+    d.id,
+    d.inserted_at
 FROM
-    v1_dag
+    v1_dag d
+JOIN
+    input i ON i.dag_id = d.id AND i.dag_inserted_at = d.inserted_at
 WHERE
-    id = ANY($1::bigint[])
-    AND inserted_at >= $2::TIMESTAMPTZ
-    AND tenant_id = $3::uuid
-ORDER BY id
+    d.inserted_at >= $1::TIMESTAMPTZ
+    AND d.tenant_id = $2::uuid
+ORDER BY d.id
 FOR UPDATE SKIP LOCKED
 `
 
 type LockDAGsForReplayParams struct {
-	Dagids        []int64            `json:"dagids"`
-	Mininsertedat pgtype.Timestamptz `json:"mininsertedat"`
-	Tenantid      uuid.UUID          `json:"tenantid"`
+	Mininsertedat  pgtype.Timestamptz   `json:"mininsertedat"`
+	Tenantid       uuid.UUID            `json:"tenantid"`
+	Dagids         []int64              `json:"dagids"`
+	Daginsertedats []pgtype.Timestamptz `json:"daginsertedats"`
+}
+
+type LockDAGsForReplayRow struct {
+	ID         int64              `json:"id"`
+	InsertedAt pgtype.Timestamptz `json:"inserted_at"`
 }
 
 // Locks a list of DAGs for replay. Returns successfully locked DAGs which can be replayed.
 // We skip locked tasks because replays are the only thing that can lock a DAG for updates
-func (q *Queries) LockDAGsForReplay(ctx context.Context, db DBTX, arg LockDAGsForReplayParams) ([]int64, error) {
-	rows, err := db.Query(ctx, lockDAGsForReplay, arg.Dagids, arg.Mininsertedat, arg.Tenantid)
+func (q *Queries) LockDAGsForReplay(ctx context.Context, db DBTX, arg LockDAGsForReplayParams) ([]*LockDAGsForReplayRow, error) {
+	rows, err := db.Query(ctx, lockDAGsForReplay,
+		arg.Mininsertedat,
+		arg.Tenantid,
+		arg.Dagids,
+		arg.Daginsertedats,
+	)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []int64
+	var items []*LockDAGsForReplayRow
 	for rows.Next() {
-		var id int64
-		if err := rows.Scan(&id); err != nil {
+		var i LockDAGsForReplayRow
+		if err := rows.Scan(&i.ID, &i.InsertedAt); err != nil {
 			return nil, err
 		}
-		items = append(items, id)
+		items = append(items, &i)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -2376,7 +2394,11 @@ func (q *Queries) ManualSlotRelease(ctx context.Context, db DBTX, arg ManualSlot
 }
 
 const preflightCheckDAGsForReplay = `-- name: PreflightCheckDAGsForReplay :many
-WITH dags_to_step_counts AS (
+WITH input AS (
+    SELECT
+        UNNEST($1::bigint[]) AS dag_id,
+        UNNEST($2::timestamptz[]) AS dag_inserted_at
+), dags_to_step_counts AS (
     SELECT
         d.id,
         d.external_id,
@@ -2386,6 +2408,8 @@ WITH dags_to_step_counts AS (
     FROM
         v1_dag d
     JOIN
+        input i ON i.dag_id = d.id AND i.dag_inserted_at = d.inserted_at
+    JOIN
         v1_dag_to_task dt ON dt.dag_id = d.id AND dt.dag_inserted_at = d.inserted_at
     JOIN
         "WorkflowVersion" wv ON wv."id" = d.workflow_version_id
@@ -2394,9 +2418,8 @@ WITH dags_to_step_counts AS (
     LEFT JOIN
         "Step" s ON s."jobId" = j."id"
     WHERE
-        d.id = ANY($1::bigint[])
-        AND d.inserted_at >= $2::TIMESTAMPTZ
-        AND d.tenant_id = $3::uuid
+        d.inserted_at >= $3::TIMESTAMPTZ
+        AND d.tenant_id = $4::uuid
     GROUP BY
         d.id,
         d.inserted_at
@@ -2412,9 +2435,10 @@ FROM
 `
 
 type PreflightCheckDAGsForReplayParams struct {
-	Dagids        []int64            `json:"dagids"`
-	Mininsertedat pgtype.Timestamptz `json:"mininsertedat"`
-	Tenantid      uuid.UUID          `json:"tenantid"`
+	Dagids         []int64              `json:"dagids"`
+	Daginsertedats []pgtype.Timestamptz `json:"daginsertedats"`
+	Mininsertedat  pgtype.Timestamptz   `json:"mininsertedat"`
+	Tenantid       uuid.UUID            `json:"tenantid"`
 }
 
 type PreflightCheckDAGsForReplayRow struct {
@@ -2430,7 +2454,12 @@ type PreflightCheckDAGsForReplayRow struct {
 // don't interfere with each other. It also does not check for whether the tasks are running, as that's
 // checked in a different query. It returns DAGs which cannot be replayed.
 func (q *Queries) PreflightCheckDAGsForReplay(ctx context.Context, db DBTX, arg PreflightCheckDAGsForReplayParams) ([]*PreflightCheckDAGsForReplayRow, error) {
-	rows, err := db.Query(ctx, preflightCheckDAGsForReplay, arg.Dagids, arg.Mininsertedat, arg.Tenantid)
+	rows, err := db.Query(ctx, preflightCheckDAGsForReplay,
+		arg.Dagids,
+		arg.Daginsertedats,
+		arg.Mininsertedat,
+		arg.Tenantid,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repository/sqlcv1/tasks.sql.go
+++ b/pkg/repository/sqlcv1/tasks.sql.go
@@ -2144,36 +2144,44 @@ func (q *Queries) ListTasksToTimeout(ctx context.Context, db DBTX, arg ListTasks
 
 const lockDAGsForReplay = `-- name: LockDAGsForReplay :many
 SELECT
-    id
+    id,
+    inserted_at
 FROM
     v1_dag
 WHERE
     id = ANY($1::bigint[])
-    AND tenant_id = $2::uuid
+    AND inserted_at >= $2::TIMESTAMPTZ
+    AND tenant_id = $3::uuid
 ORDER BY id
 FOR UPDATE SKIP LOCKED
 `
 
 type LockDAGsForReplayParams struct {
-	Dagids   []int64   `json:"dagids"`
-	Tenantid uuid.UUID `json:"tenantid"`
+	Dagids        []int64            `json:"dagids"`
+	Mininsertedat pgtype.Timestamptz `json:"mininsertedat"`
+	Tenantid      uuid.UUID          `json:"tenantid"`
+}
+
+type LockDAGsForReplayRow struct {
+	ID         int64              `json:"id"`
+	InsertedAt pgtype.Timestamptz `json:"inserted_at"`
 }
 
 // Locks a list of DAGs for replay. Returns successfully locked DAGs which can be replayed.
 // We skip locked tasks because replays are the only thing that can lock a DAG for updates
-func (q *Queries) LockDAGsForReplay(ctx context.Context, db DBTX, arg LockDAGsForReplayParams) ([]int64, error) {
-	rows, err := db.Query(ctx, lockDAGsForReplay, arg.Dagids, arg.Tenantid)
+func (q *Queries) LockDAGsForReplay(ctx context.Context, db DBTX, arg LockDAGsForReplayParams) ([]*LockDAGsForReplayRow, error) {
+	rows, err := db.Query(ctx, lockDAGsForReplay, arg.Dagids, arg.Mininsertedat, arg.Tenantid)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []int64
+	var items []*LockDAGsForReplayRow
 	for rows.Next() {
-		var id int64
-		if err := rows.Scan(&id); err != nil {
+		var i LockDAGsForReplayRow
+		if err := rows.Scan(&i.ID, &i.InsertedAt); err != nil {
 			return nil, err
 		}
-		items = append(items, id)
+		items = append(items, &i)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -2384,7 +2392,7 @@ WITH dags_to_step_counts AS (
     FROM
         v1_dag d
     JOIN
-        v1_dag_to_task dt ON dt.dag_id = d.id
+        v1_dag_to_task dt ON dt.dag_id = d.id AND dt.dag_inserted_at = d.inserted_at
     JOIN
         "WorkflowVersion" wv ON wv."id" = d.workflow_version_id
     LEFT JOIN
@@ -2393,7 +2401,8 @@ WITH dags_to_step_counts AS (
         "Step" s ON s."jobId" = j."id"
     WHERE
         d.id = ANY($1::bigint[])
-        AND d.tenant_id = $2::uuid
+        AND d.inserted_at >= $2::TIMESTAMPTZ
+        AND d.tenant_id = $3::uuid
     GROUP BY
         d.id,
         d.inserted_at
@@ -2409,8 +2418,9 @@ FROM
 `
 
 type PreflightCheckDAGsForReplayParams struct {
-	Dagids   []int64   `json:"dagids"`
-	Tenantid uuid.UUID `json:"tenantid"`
+	Dagids        []int64            `json:"dagids"`
+	Mininsertedat pgtype.Timestamptz `json:"mininsertedat"`
+	Tenantid      uuid.UUID          `json:"tenantid"`
 }
 
 type PreflightCheckDAGsForReplayRow struct {
@@ -2426,7 +2436,7 @@ type PreflightCheckDAGsForReplayRow struct {
 // don't interfere with each other. It also does not check for whether the tasks are running, as that's
 // checked in a different query. It returns DAGs which cannot be replayed.
 func (q *Queries) PreflightCheckDAGsForReplay(ctx context.Context, db DBTX, arg PreflightCheckDAGsForReplayParams) ([]*PreflightCheckDAGsForReplayRow, error) {
-	rows, err := db.Query(ctx, preflightCheckDAGsForReplay, arg.Dagids, arg.Tenantid)
+	rows, err := db.Query(ctx, preflightCheckDAGsForReplay, arg.Dagids, arg.Mininsertedat, arg.Tenantid)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repository/sqlcv1/tasks.sql.go
+++ b/pkg/repository/sqlcv1/tasks.sql.go
@@ -2145,8 +2145,8 @@ func (q *Queries) ListTasksToTimeout(ctx context.Context, db DBTX, arg ListTasks
 const lockDAGsForReplay = `-- name: LockDAGsForReplay :many
 WITH input AS (
     SELECT
-        UNNEST($3::bigint[]) AS dag_id,
-        UNNEST($4::timestamptz[]) AS dag_inserted_at
+        UNNEST($2::bigint[]) AS dag_id,
+        UNNEST($3::timestamptz[]) AS dag_inserted_at
 )
 SELECT
     d.id,
@@ -2156,14 +2156,12 @@ FROM
 JOIN
     input i ON i.dag_id = d.id AND i.dag_inserted_at = d.inserted_at
 WHERE
-    d.inserted_at >= $1::TIMESTAMPTZ
-    AND d.tenant_id = $2::uuid
+    d.tenant_id = $1::uuid
 ORDER BY d.id
 FOR UPDATE SKIP LOCKED
 `
 
 type LockDAGsForReplayParams struct {
-	Mininsertedat  pgtype.Timestamptz   `json:"mininsertedat"`
 	Tenantid       uuid.UUID            `json:"tenantid"`
 	Dagids         []int64              `json:"dagids"`
 	Daginsertedats []pgtype.Timestamptz `json:"daginsertedats"`
@@ -2177,12 +2175,7 @@ type LockDAGsForReplayRow struct {
 // Locks a list of DAGs for replay. Returns successfully locked DAGs which can be replayed.
 // We skip locked tasks because replays are the only thing that can lock a DAG for updates
 func (q *Queries) LockDAGsForReplay(ctx context.Context, db DBTX, arg LockDAGsForReplayParams) ([]*LockDAGsForReplayRow, error) {
-	rows, err := db.Query(ctx, lockDAGsForReplay,
-		arg.Mininsertedat,
-		arg.Tenantid,
-		arg.Dagids,
-		arg.Daginsertedats,
-	)
+	rows, err := db.Query(ctx, lockDAGsForReplay, arg.Tenantid, arg.Dagids, arg.Daginsertedats)
 	if err != nil {
 		return nil, err
 	}
@@ -2418,8 +2411,7 @@ WITH input AS (
     LEFT JOIN
         "Step" s ON s."jobId" = j."id"
     WHERE
-        d.inserted_at >= $3::TIMESTAMPTZ
-        AND d.tenant_id = $4::uuid
+        d.tenant_id = $3::uuid
     GROUP BY
         d.id,
         d.inserted_at
@@ -2437,7 +2429,6 @@ FROM
 type PreflightCheckDAGsForReplayParams struct {
 	Dagids         []int64              `json:"dagids"`
 	Daginsertedats []pgtype.Timestamptz `json:"daginsertedats"`
-	Mininsertedat  pgtype.Timestamptz   `json:"mininsertedat"`
 	Tenantid       uuid.UUID            `json:"tenantid"`
 }
 
@@ -2454,12 +2445,7 @@ type PreflightCheckDAGsForReplayRow struct {
 // don't interfere with each other. It also does not check for whether the tasks are running, as that's
 // checked in a different query. It returns DAGs which cannot be replayed.
 func (q *Queries) PreflightCheckDAGsForReplay(ctx context.Context, db DBTX, arg PreflightCheckDAGsForReplayParams) ([]*PreflightCheckDAGsForReplayRow, error) {
-	rows, err := db.Query(ctx, preflightCheckDAGsForReplay,
-		arg.Dagids,
-		arg.Daginsertedats,
-		arg.Mininsertedat,
-		arg.Tenantid,
-	)
+	rows, err := db.Query(ctx, preflightCheckDAGsForReplay, arg.Dagids, arg.Daginsertedats, arg.Tenantid)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repository/sqlcv1/tasks.sql.go
+++ b/pkg/repository/sqlcv1/tasks.sql.go
@@ -2144,8 +2144,7 @@ func (q *Queries) ListTasksToTimeout(ctx context.Context, db DBTX, arg ListTasks
 
 const lockDAGsForReplay = `-- name: LockDAGsForReplay :many
 SELECT
-    id,
-    inserted_at
+    id
 FROM
     v1_dag
 WHERE
@@ -2162,26 +2161,21 @@ type LockDAGsForReplayParams struct {
 	Tenantid      uuid.UUID          `json:"tenantid"`
 }
 
-type LockDAGsForReplayRow struct {
-	ID         int64              `json:"id"`
-	InsertedAt pgtype.Timestamptz `json:"inserted_at"`
-}
-
 // Locks a list of DAGs for replay. Returns successfully locked DAGs which can be replayed.
 // We skip locked tasks because replays are the only thing that can lock a DAG for updates
-func (q *Queries) LockDAGsForReplay(ctx context.Context, db DBTX, arg LockDAGsForReplayParams) ([]*LockDAGsForReplayRow, error) {
+func (q *Queries) LockDAGsForReplay(ctx context.Context, db DBTX, arg LockDAGsForReplayParams) ([]int64, error) {
 	rows, err := db.Query(ctx, lockDAGsForReplay, arg.Dagids, arg.Mininsertedat, arg.Tenantid)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*LockDAGsForReplayRow
+	var items []int64
 	for rows.Next() {
-		var i LockDAGsForReplayRow
-		if err := rows.Scan(&i.ID, &i.InsertedAt); err != nil {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
 			return nil, err
 		}
-		items = append(items, &i)
+		items = append(items, id)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
-	"maps"
-	"slices"
 	"sort"
 	"sync"
 	"time"
@@ -525,7 +523,7 @@ func (r *TaskRepositoryImpl) verifyAllTasksFinalized(ctx context.Context, tx sql
 			minTaskInsertedAt = task.InsertedAt
 		}
 
-		if task.DagInsertedAt.Time.Before(minDagInsertedAt.Time) {
+		if task.DagID.Valid && task.DagInsertedAt.Time.Before(minDagInsertedAt.Time) {
 			minDagInsertedAt = task.DagInsertedAt
 		}
 	}
@@ -2977,7 +2975,7 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 			minTaskInsertedAt = task.InsertedAt
 		}
 
-		if task.DagInsertedAt.Time.Before(minDagInsertedAt.Time) {
+		if task.DagID.Valid && task.DagInsertedAt.Time.Before(minDagInsertedAt.Time) {
 			minDagInsertedAt = task.DagInsertedAt
 		}
 	}
@@ -3012,7 +3010,7 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 	dagIdsFailedPreflight := make(map[int64]bool)
 
 	preflightDAGs, err := r.queries.PreflightCheckDAGsForReplay(ctx, tx, sqlcv1.PreflightCheckDAGsForReplayParams{
-		Dagids:        slices.Collect(maps.Keys(successfullyLockedDAGsMap)),
+		Dagids:        successfullyLockedDAGIds,
 		Tenantid:      tenantId,
 		Mininsertedat: minDagInsertedAt,
 	})

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -511,15 +511,15 @@ func (r *TaskRepositoryImpl) verifyAllTasksFinalized(ctx context.Context, tx sql
 	taskIdsToCheck := make([]int64, len(flattenedTasks))
 	taskInsertedAtsToCheck := make([]pgtype.Timestamptz, len(flattenedTasks))
 	taskIdsToTasks := make(map[int64]*sqlcv1.FlattenExternalIdsRow)
-	minTaskInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now()) // current time as a placeholder - will be overwritten
+	minInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now()) // current time as a placeholder - will be overwritten
 
 	for i, task := range flattenedTasks {
 		taskIdsToCheck[i] = task.ID
 		taskInsertedAtsToCheck[i] = task.InsertedAt
 		taskIdsToTasks[task.ID] = task
 
-		if task.InsertedAt.Time.Before(minTaskInsertedAt.Time) {
-			minTaskInsertedAt = task.InsertedAt
+		if task.InsertedAt.Time.Before(minInsertedAt.Time) {
+			minInsertedAt = task.InsertedAt
 		}
 	}
 
@@ -528,7 +528,7 @@ func (r *TaskRepositoryImpl) verifyAllTasksFinalized(ctx context.Context, tx sql
 		Tenantid:        tenantId,
 		Taskids:         taskIdsToCheck,
 		Taskinsertedats: taskInsertedAtsToCheck,
-		Mininsertedat:   minTaskInsertedAt,
+		Mininsertedat:   minInsertedAt,
 	})
 
 	if err != nil {
@@ -2951,7 +2951,8 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 	subtreeStepIds := make(map[int64]map[uuid.UUID]bool) // dag id -> step id -> true
 	subtreeExternalIds := make(map[uuid.UUID]struct{})
 	dagIdsToLockMap := make(map[int64]pgtype.Timestamptz)
-	minTaskInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now())
+	minInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now())
+
 	for i, task := range lockedTasks {
 		lockedTaskIds[i] = task.ID
 		lockedTaskInsertedAts[i] = task.InsertedAt
@@ -2972,8 +2973,8 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 			subtreeExternalIds[task.ExternalID] = struct{}{}
 		}
 
-		if task.InsertedAt.Time.Before(minTaskInsertedAt.Time) {
-			minTaskInsertedAt = task.InsertedAt
+		if task.InsertedAt.Time.Before(minInsertedAt.Time) {
+			minInsertedAt = task.InsertedAt
 		}
 	}
 
@@ -3034,7 +3035,7 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 		Taskids:         lockedTaskIds,
 		Taskinsertedats: lockedTaskInsertedAts,
 		Tenantid:        tenantId,
-		Mininsertedat:   minTaskInsertedAt,
+		Mininsertedat:   minInsertedAt,
 	})
 
 	if err != nil {

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -555,8 +555,9 @@ func (r *TaskRepositoryImpl) verifyAllTasksFinalized(ctx context.Context, tx sql
 
 	// check DAGs
 	notFinalizedDags, err := r.queries.PreflightCheckDAGsForReplay(ctx, tx, sqlcv1.PreflightCheckDAGsForReplayParams{
-		Dagids:   dagsToCheck,
-		Tenantid: tenantId,
+		Dagids:        dagsToCheck,
+		Tenantid:      tenantId,
+		Mininsertedat: minInsertedAt,
 	})
 
 	if err != nil {

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -2978,7 +2978,7 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 		dagIdsToLock = append(dagIdsToLock, dagId)
 	}
 
-	successfullyLockedDAGs, err := r.queries.LockDAGsForReplay(ctx, tx, sqlcv1.LockDAGsForReplayParams{
+	successfullyLockedDAGIds, err := r.queries.LockDAGsForReplay(ctx, tx, sqlcv1.LockDAGsForReplayParams{
 		Dagids:        dagIdsToLock,
 		Tenantid:      tenantId,
 		Mininsertedat: minInsertedAt,
@@ -2990,8 +2990,8 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 
 	successfullyLockedDAGsMap := make(map[int64]bool)
 
-	for _, dag := range successfullyLockedDAGs {
-		successfullyLockedDAGsMap[dag.ID] = true
+	for _, dagId := range successfullyLockedDAGIds {
+		successfullyLockedDAGsMap[dagId] = true
 	}
 
 	// Discard tasks which can't be replayed. Discard rules are as follows:

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -2962,15 +2962,10 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 				subtreeStepIds[task.DagID.Int64] = make(map[uuid.UUID]bool)
 			}
 
-			if task.DagInsertedAt.Valid {
-				dagIdsToLockMap[task.DagID.Int64] = task.DagInsertedAt
-			} else {
-				r.l.Error().Ctx(ctx).Int64("task_id", task.ID).Msg("could not find dag inserted at for task")
-				continue
-			}
-
 			subtreeStepIds[task.DagID.Int64][task.StepID] = true
 			subtreeExternalIds[task.ExternalID] = struct{}{}
+
+			dagIdsToLockMap[task.DagID.Int64] = task.DagInsertedAt
 		}
 
 		if task.InsertedAt.Time.Before(minInsertedAt.Time) {

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -2953,9 +2953,9 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 	lockedTaskInsertedAts := make([]pgtype.Timestamptz, len(lockedTasks))
 	subtreeStepIds := make(map[int64]map[uuid.UUID]bool) // dag id -> step id -> true
 	subtreeExternalIds := make(map[uuid.UUID]struct{})
-	dagIdsToLockMap := make(map[int64]struct{})
-	minTaskInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now()) // current time as a placeholder - will be overwritten
-	minDagInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now())  // current time as a placeholder - will be overwritten
+	dagIdsToLockMap := make(map[int64]pgtype.Timestamptz)
+	minTaskInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now())
+	minDagInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now())
 
 	for i, task := range lockedTasks {
 		lockedTaskIds[i] = task.ID
@@ -2966,7 +2966,7 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 				subtreeStepIds[task.DagID.Int64] = make(map[uuid.UUID]bool)
 			}
 
-			dagIdsToLockMap[task.DagID.Int64] = struct{}{}
+			dagIdsToLockMap[task.DagID.Int64] = task.DagInsertedAt
 			subtreeStepIds[task.DagID.Int64][task.StepID] = true
 			subtreeExternalIds[task.ExternalID] = struct{}{}
 		}
@@ -2975,22 +2975,25 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 			minTaskInsertedAt = task.InsertedAt
 		}
 
-		if task.DagID.Valid && task.DagInsertedAt.Time.Before(minDagInsertedAt.Time) {
+		if task.DagID.Valid && task.DagInsertedAt.Valid && task.DagInsertedAt.Time.Before(minDagInsertedAt.Time) {
 			minDagInsertedAt = task.DagInsertedAt
 		}
 	}
 
 	// lock all tasks in the DAGs
 	dagIdsToLock := make([]int64, 0, len(dagIdsToLockMap))
+	dagInsertedAtsToLock := make([]pgtype.Timestamptz, 0, len(dagIdsToLockMap))
 
-	for dagId := range dagIdsToLockMap {
+	for dagId, dagInsertedAt := range dagIdsToLockMap {
 		dagIdsToLock = append(dagIdsToLock, dagId)
+		dagInsertedAtsToLock = append(dagInsertedAtsToLock, dagInsertedAt)
 	}
 
-	successfullyLockedDAGIds, err := r.queries.LockDAGsForReplay(ctx, tx, sqlcv1.LockDAGsForReplayParams{
-		Dagids:        dagIdsToLock,
-		Tenantid:      tenantId,
-		Mininsertedat: minDagInsertedAt,
+	successfullyLockedDAGs, err := r.queries.LockDAGsForReplay(ctx, tx, sqlcv1.LockDAGsForReplayParams{
+		Dagids:         dagIdsToLock,
+		Daginsertedats: dagInsertedAtsToLock,
+		Tenantid:       tenantId,
+		Mininsertedat:  minDagInsertedAt,
 	})
 
 	if err != nil {
@@ -2998,9 +3001,13 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 	}
 
 	successfullyLockedDAGsMap := make(map[int64]bool)
+	successfullyLockedDAGIds := make([]int64, 0, len(successfullyLockedDAGs))
+	successfullyLockedDAGInsertedAts := make([]pgtype.Timestamptz, 0, len(successfullyLockedDAGs))
 
-	for _, dagId := range successfullyLockedDAGIds {
-		successfullyLockedDAGsMap[dagId] = true
+	for _, dag := range successfullyLockedDAGs {
+		successfullyLockedDAGsMap[dag.ID] = true
+		successfullyLockedDAGIds = append(successfullyLockedDAGIds, dag.ID)
+		successfullyLockedDAGInsertedAts = append(successfullyLockedDAGInsertedAts, dag.InsertedAt)
 	}
 
 	// Discard tasks which can't be replayed. Discard rules are as follows:
@@ -3010,9 +3017,10 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 	dagIdsFailedPreflight := make(map[int64]bool)
 
 	preflightDAGs, err := r.queries.PreflightCheckDAGsForReplay(ctx, tx, sqlcv1.PreflightCheckDAGsForReplayParams{
-		Dagids:        successfullyLockedDAGIds,
-		Tenantid:      tenantId,
-		Mininsertedat: minDagInsertedAt,
+		Dagids:         successfullyLockedDAGIds,
+		Daginsertedats: successfullyLockedDAGInsertedAts,
+		Tenantid:       tenantId,
+		Mininsertedat:  minDagInsertedAt,
 	})
 
 	if err != nil {

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -513,15 +513,20 @@ func (r *TaskRepositoryImpl) verifyAllTasksFinalized(ctx context.Context, tx sql
 	taskIdsToCheck := make([]int64, len(flattenedTasks))
 	taskInsertedAtsToCheck := make([]pgtype.Timestamptz, len(flattenedTasks))
 	taskIdsToTasks := make(map[int64]*sqlcv1.FlattenExternalIdsRow)
-	minInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now()) // current time as a placeholder - will be overwritten
+	minTaskInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now()) // current time as a placeholder - will be overwritten
+	minDagInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now())  // current time as a placeholder - will be overwritten
 
 	for i, task := range flattenedTasks {
 		taskIdsToCheck[i] = task.ID
 		taskInsertedAtsToCheck[i] = task.InsertedAt
 		taskIdsToTasks[task.ID] = task
 
-		if task.InsertedAt.Time.Before(minInsertedAt.Time) {
-			minInsertedAt = task.InsertedAt
+		if task.InsertedAt.Time.Before(minTaskInsertedAt.Time) {
+			minTaskInsertedAt = task.InsertedAt
+		}
+
+		if task.DagInsertedAt.Time.Before(minDagInsertedAt.Time) {
+			minDagInsertedAt = task.DagInsertedAt
 		}
 	}
 
@@ -530,7 +535,7 @@ func (r *TaskRepositoryImpl) verifyAllTasksFinalized(ctx context.Context, tx sql
 		Tenantid:        tenantId,
 		Taskids:         taskIdsToCheck,
 		Taskinsertedats: taskInsertedAtsToCheck,
-		Mininsertedat:   minInsertedAt,
+		Mininsertedat:   minTaskInsertedAt,
 	})
 
 	if err != nil {
@@ -557,7 +562,7 @@ func (r *TaskRepositoryImpl) verifyAllTasksFinalized(ctx context.Context, tx sql
 	notFinalizedDags, err := r.queries.PreflightCheckDAGsForReplay(ctx, tx, sqlcv1.PreflightCheckDAGsForReplayParams{
 		Dagids:        dagsToCheck,
 		Tenantid:      tenantId,
-		Mininsertedat: minInsertedAt,
+		Mininsertedat: minDagInsertedAt,
 	})
 
 	if err != nil {
@@ -2951,7 +2956,8 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 	subtreeStepIds := make(map[int64]map[uuid.UUID]bool) // dag id -> step id -> true
 	subtreeExternalIds := make(map[uuid.UUID]struct{})
 	dagIdsToLockMap := make(map[int64]struct{})
-	minInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now()) // current time as a placeholder - will be overwritten
+	minTaskInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now()) // current time as a placeholder - will be overwritten
+	minDagInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now())  // current time as a placeholder - will be overwritten
 
 	for i, task := range lockedTasks {
 		lockedTaskIds[i] = task.ID
@@ -2967,8 +2973,12 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 			subtreeExternalIds[task.ExternalID] = struct{}{}
 		}
 
-		if task.InsertedAt.Time.Before(minInsertedAt.Time) {
-			minInsertedAt = task.InsertedAt
+		if task.InsertedAt.Time.Before(minTaskInsertedAt.Time) {
+			minTaskInsertedAt = task.InsertedAt
+		}
+
+		if task.DagInsertedAt.Time.Before(minDagInsertedAt.Time) {
+			minDagInsertedAt = task.DagInsertedAt
 		}
 	}
 
@@ -2982,7 +2992,7 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 	successfullyLockedDAGIds, err := r.queries.LockDAGsForReplay(ctx, tx, sqlcv1.LockDAGsForReplayParams{
 		Dagids:        dagIdsToLock,
 		Tenantid:      tenantId,
-		Mininsertedat: minInsertedAt,
+		Mininsertedat: minDagInsertedAt,
 	})
 
 	if err != nil {
@@ -3004,7 +3014,7 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 	preflightDAGs, err := r.queries.PreflightCheckDAGsForReplay(ctx, tx, sqlcv1.PreflightCheckDAGsForReplayParams{
 		Dagids:        slices.Collect(maps.Keys(successfullyLockedDAGsMap)),
 		Tenantid:      tenantId,
-		Mininsertedat: minInsertedAt,
+		Mininsertedat: minDagInsertedAt,
 	})
 
 	if err != nil {
@@ -3023,7 +3033,7 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 		Taskids:         lockedTaskIds,
 		Taskinsertedats: lockedTaskInsertedAts,
 		Tenantid:        tenantId,
-		Mininsertedat:   minInsertedAt,
+		Mininsertedat:   minTaskInsertedAt,
 	})
 
 	if err != nil {

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"maps"
+	"slices"
 	"sort"
 	"sync"
 	"time"
@@ -2976,9 +2978,10 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 		dagIdsToLock = append(dagIdsToLock, dagId)
 	}
 
-	successfullyLockedDAGIds, err := r.queries.LockDAGsForReplay(ctx, tx, sqlcv1.LockDAGsForReplayParams{
-		Dagids:   dagIdsToLock,
-		Tenantid: tenantId,
+	successfullyLockedDAGs, err := r.queries.LockDAGsForReplay(ctx, tx, sqlcv1.LockDAGsForReplayParams{
+		Dagids:        dagIdsToLock,
+		Tenantid:      tenantId,
+		Mininsertedat: minInsertedAt,
 	})
 
 	if err != nil {
@@ -2987,8 +2990,8 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 
 	successfullyLockedDAGsMap := make(map[int64]bool)
 
-	for _, dagId := range successfullyLockedDAGIds {
-		successfullyLockedDAGsMap[dagId] = true
+	for _, dag := range successfullyLockedDAGs {
+		successfullyLockedDAGsMap[dag.ID] = true
 	}
 
 	// Discard tasks which can't be replayed. Discard rules are as follows:
@@ -2998,8 +3001,9 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 	dagIdsFailedPreflight := make(map[int64]bool)
 
 	preflightDAGs, err := r.queries.PreflightCheckDAGsForReplay(ctx, tx, sqlcv1.PreflightCheckDAGsForReplayParams{
-		Dagids:   successfullyLockedDAGIds,
-		Tenantid: tenantId,
+		Dagids:        slices.Collect(maps.Keys(successfullyLockedDAGsMap)),
+		Tenantid:      tenantId,
+		Mininsertedat: minInsertedAt,
 	})
 
 	if err != nil {

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -512,7 +512,6 @@ func (r *TaskRepositoryImpl) verifyAllTasksFinalized(ctx context.Context, tx sql
 	taskInsertedAtsToCheck := make([]pgtype.Timestamptz, len(flattenedTasks))
 	taskIdsToTasks := make(map[int64]*sqlcv1.FlattenExternalIdsRow)
 	minTaskInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now()) // current time as a placeholder - will be overwritten
-	minDagInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now())  // current time as a placeholder - will be overwritten
 
 	for i, task := range flattenedTasks {
 		taskIdsToCheck[i] = task.ID
@@ -521,10 +520,6 @@ func (r *TaskRepositoryImpl) verifyAllTasksFinalized(ctx context.Context, tx sql
 
 		if task.InsertedAt.Time.Before(minTaskInsertedAt.Time) {
 			minTaskInsertedAt = task.InsertedAt
-		}
-
-		if task.DagID.Valid && task.DagInsertedAt.Time.Before(minDagInsertedAt.Time) {
-			minDagInsertedAt = task.DagInsertedAt
 		}
 	}
 
@@ -546,21 +541,23 @@ func (r *TaskRepositoryImpl) verifyAllTasksFinalized(ctx context.Context, tx sql
 		notFinalizedMap[task.ID] = true
 	}
 
-	dagsToCheck := make([]int64, 0)
+	dagIdsToCheck := make([]int64, 0)
+	dagInsertedAtsToCheck := make([]pgtype.Timestamptz, 0)
 	dagsToTasks := make(map[int64][]*sqlcv1.FlattenExternalIdsRow)
 
 	for _, task := range flattenedTasks {
 		if !notFinalizedMap[task.ID] && task.DagID.Valid {
-			dagsToCheck = append(dagsToCheck, task.DagID.Int64)
+			dagIdsToCheck = append(dagIdsToCheck, task.DagID.Int64)
+			dagInsertedAtsToCheck = append(dagInsertedAtsToCheck, task.DagInsertedAt)
 			dagsToTasks[task.DagID.Int64] = append(dagsToTasks[task.DagID.Int64], task)
 		}
 	}
 
 	// check DAGs
 	notFinalizedDags, err := r.queries.PreflightCheckDAGsForReplay(ctx, tx, sqlcv1.PreflightCheckDAGsForReplayParams{
-		Dagids:        dagsToCheck,
-		Tenantid:      tenantId,
-		Mininsertedat: minDagInsertedAt,
+		Dagids:         dagIdsToCheck,
+		Daginsertedats: dagInsertedAtsToCheck,
+		Tenantid:       tenantId,
 	})
 
 	if err != nil {
@@ -2955,8 +2952,6 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 	subtreeExternalIds := make(map[uuid.UUID]struct{})
 	dagIdsToLockMap := make(map[int64]pgtype.Timestamptz)
 	minTaskInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now())
-	minDagInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now())
-
 	for i, task := range lockedTasks {
 		lockedTaskIds[i] = task.ID
 		lockedTaskInsertedAts[i] = task.InsertedAt
@@ -2966,17 +2961,19 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 				subtreeStepIds[task.DagID.Int64] = make(map[uuid.UUID]bool)
 			}
 
-			dagIdsToLockMap[task.DagID.Int64] = task.DagInsertedAt
+			if task.DagInsertedAt.Valid {
+				dagIdsToLockMap[task.DagID.Int64] = task.DagInsertedAt
+			} else {
+				r.l.Error().Ctx(ctx).Int64("task_id", task.ID).Msg("could not find dag inserted at for task")
+				continue
+			}
+
 			subtreeStepIds[task.DagID.Int64][task.StepID] = true
 			subtreeExternalIds[task.ExternalID] = struct{}{}
 		}
 
 		if task.InsertedAt.Time.Before(minTaskInsertedAt.Time) {
 			minTaskInsertedAt = task.InsertedAt
-		}
-
-		if task.DagID.Valid && task.DagInsertedAt.Valid && task.DagInsertedAt.Time.Before(minDagInsertedAt.Time) {
-			minDagInsertedAt = task.DagInsertedAt
 		}
 	}
 
@@ -2993,7 +2990,6 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 		Dagids:         dagIdsToLock,
 		Daginsertedats: dagInsertedAtsToLock,
 		Tenantid:       tenantId,
-		Mininsertedat:  minDagInsertedAt,
 	})
 
 	if err != nil {
@@ -3020,7 +3016,6 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 		Dagids:         successfullyLockedDAGIds,
 		Daginsertedats: successfullyLockedDAGInsertedAts,
 		Tenantid:       tenantId,
-		Mininsertedat:  minDagInsertedAt,
 	})
 
 	if err != nil {

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -2951,7 +2951,7 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 	subtreeStepIds := make(map[int64]map[uuid.UUID]bool) // dag id -> step id -> true
 	subtreeExternalIds := make(map[uuid.UUID]struct{})
 	dagIdsToLockMap := make(map[int64]pgtype.Timestamptz)
-	minInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now())
+	minInsertedAt := sqlchelpers.TimestamptzFromTime(time.Now()) // current time as a placeholder - will be overwritten
 
 	for i, task := range lockedTasks {
 		lockedTaskIds[i] = task.ID


### PR DESCRIPTION
# Description

Fixes two queries `LockDAGsForReplay` and `PreflightCheckDAGsForReplay` which were both not using the inserted at value thereby not using the index as expected.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)