### PR TITLE
fix: select only stable releases for install

### DIFF
--- a/hack/install/install.sh
+++ b/hack/install/install.sh
@@ -206,14 +206,16 @@ get_version() {
         log_info "Using requested version: $VERSION"
     else
         log_info "Fetching latest version..."
+        # Use /releases and select the first stable core tag (vX.Y.Z).
+        # This avoids non-CLI/scoped tags (e.g. vscode/v0.1.2) and prereleases.
         if [ "$DOWNLOADER" = "curl" ]; then
-            VERSION=$(curl -fsSL "${GITHUB_API}/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+            VERSION=$(curl -fsSL "${GITHUB_API}/releases" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
         else
-            VERSION=$(wget -qO- "${GITHUB_API}/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+            VERSION=$(wget -qO- "${GITHUB_API}/releases" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
         fi
 
         if [ -z "$VERSION" ]; then
-            log_error "Failed to fetch latest version"
+            log_error "Failed to fetch latest stable version"
             exit 1
         fi
 


### PR DESCRIPTION
# Description

Fix installer version resolution so it only auto-selects stable Hatchet CLI releases in the format `vX.Y.Z`, and ignores scoped tags (for example `vscode/v0.1.2`) and prereleases (for example `v0.83.1-alpha.0`).

This updates the release lookup logic to use the releases list endpoint and apply strict stable tag filtering before choosing the latest version.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [x] Changed installer latest-version lookup to read from the releases list instead of relying on a single latest-tag response.
- [x] Added strict stable semver filtering (`^v[0-9]+\.[0-9]+\.[0-9]+$`) for auto-selected versions.
- [x] Ensured scoped tags and prerelease tags are excluded from automatic selection.
- [x] Updated failure messaging to indicate stable-version resolution failure when no valid tag is found.