### PR TITLE
(fix): Make sure sqlc generates TotalReads as int64

### DIFF
--- a/pkg/repository/sqlcv1/pg_health.sql
+++ b/pkg/repository/sqlcv1/pg_health.sql
@@ -52,7 +52,7 @@ SELECT
     relname AS tablename,
     heap_blks_read,
     heap_blks_hit,
-    heap_blks_hit + heap_blks_read AS total_reads,
+    (heap_blks_hit + heap_blks_read)::BIGINT AS total_reads,
     ROUND(
         100.0 * heap_blks_hit / NULLIF(heap_blks_hit + heap_blks_read, 0),
         2

--- a/pkg/repository/sqlcv1/pg_health.sql.go
+++ b/pkg/repository/sqlcv1/pg_health.sql.go
@@ -157,7 +157,7 @@ SELECT
     relname AS tablename,
     heap_blks_read,
     heap_blks_hit,
-    heap_blks_hit + heap_blks_read AS total_reads,
+    (heap_blks_hit + heap_blks_read)::BIGINT AS total_reads,
     ROUND(
         100.0 * heap_blks_hit / NULLIF(heap_blks_hit + heap_blks_read, 0),
         2
@@ -177,7 +177,7 @@ type CheckQueryCachesRow struct {
 	Tablename        pgtype.Text `json:"tablename"`
 	HeapBlksRead     pgtype.Int8 `json:"heap_blks_read"`
 	HeapBlksHit      pgtype.Int8 `json:"heap_blks_hit"`
-	TotalReads       int32       `json:"total_reads"`
+	TotalReads       int64       `json:"total_reads"`
 	CacheHitRatioPct float64     `json:"cache_hit_ratio_pct"`
 	TotalSize        string      `json:"total_size"`
 }


### PR DESCRIPTION
# Description

Needs the manual type cast to make sure that it is cast to int64, not int32, as the values `heap_blks_read` and `heap_blks_hit` are `BIGINT` which will overflow int32.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...
