### PR TITLE
fix(ci/vscode): Remove the GH publish step for .vsix

### DIFF
--- a/.github/workflows/vscode-release.yml
+++ b/.github/workflows/vscode-release.yml
@@ -64,25 +64,3 @@ jobs:
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: pnpm run publish
-
-      - name: Upload .vsix as release artifact
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: vscode/v${{ steps.version.outputs.VERSION }}
-          files: frontend/vscode-extension/hatchet-${{ steps.version.outputs.VERSION }}.vsix
-          name: Hatchet VS Code Extension v${{ steps.version.outputs.VERSION }}
-          body: |
-            ## Hatchet VS Code Extension v${{ steps.version.outputs.VERSION }}
-
-            ### Installation
-            **From VS Code Marketplace:** Search for "Hatchet" in the Extensions panel.
-
-            **Manual install:**
-            ```
-            code --install-extension hatchet-${{ steps.version.outputs.VERSION }}.vsix
-            ```
-
-            ### Usage
-            Open any TypeScript file that declares a Hatchet workflow — a
-            "$(graph) Show Hatchet DAG" CodeLens will appear above each
-            `hatchet.workflow(...)` declaration.

--- a/frontend/vscode-extension/RELEASE_INSTRUCTIONS.md
+++ b/frontend/vscode-extension/RELEASE_INSTRUCTIONS.md
@@ -31,7 +31,7 @@ sips -z 128 128 frontend/vscode-extension/assets/icon.png
 
 ### Option A — Automated via git tag (recommended)
 
-Pushing a tag of the form `vscode/vX.Y.Z` triggers `.github/workflows/vscode-release.yml`, which:
+Bumping the version in `package.json` triggers `.github/workflows/vscode-release.yml`, which:
 - installs deps, runs `pnpm build:prod`, packages the `.vsix`, publishes to the Marketplace, and uploads the `.vsix` as a GitHub Release artifact.
 
 ```bash
@@ -42,13 +42,13 @@ vim frontend/vscode-extension/package.json
 # 2. Commit the version bump
 git add frontend/vscode-extension/package.json
 git commit -m "chore(vscode): bump extension version to X.Y.Z"
-
-# 3. Push the tag
-git tag vscode/vX.Y.Z
 git push origin vscode/vX.Y.Z
+
+# 3. Open up a PR targeting main
+gh pr create --web --base main
 ```
 
-The workflow runs automatically. Monitor it at:
+Once merged, the release workflow runs automatically. Monitor it at:
 https://github.com/hatchet-dev/hatchet/actions/workflows/vscode-release.yml
 
 ### Option B — Manual release


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Currently, the VSCode .vsix binary is bundled and released to both the VSCode marketplace and as a GH release. The latter is causing issues since our automation scripts assume only the hatchet-cli artifact is released via GH.

Fixes https://github.com/hatchet-dev/hatchet/issues/3400

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] CI (any automation pipeline changes)


## What's Changed

- Removes GH job step that creates a GH release for the VSCode .vsix bundle.
