### PR TITLE
feat: support DAG view for workflow wrappers in typescript

### DIFF
--- a/.github/instructions/comments.instructions.md
+++ b/.github/instructions/comments.instructions.md
@@ -1,0 +1,21 @@
+---
+applyTo: "**"
+---
+
+# Comment Style
+
+Comments must explain **why** or **how** — not **what**. If a comment only restates
+the function name or describes what the next line of code does, delete it.
+
+## Remove
+
+- Section banners that label blocks of code by name or language
+- Doc comments that paraphrase the function or field name
+- Inline narration of the next line of code
+
+## Keep
+
+- Non-obvious design decisions and the reason behind them
+- Constraints with their cause: why a limit exists, why a fallback is needed
+- "Why something is absent": why a guard is missing, why a default is chosen
+- Algorithmic details that aren't self-evident from the code

--- a/frontend/vscode-extension/README.md
+++ b/frontend/vscode-extension/README.md
@@ -12,6 +12,40 @@ This will then open a webview showing the DAG definition. As you update your def
 
 ![Webview](https://raw.githubusercontent.com/hatchet-dev/hatchet/main/frontend/vscode-extension/assets/vscode_dag.png)
 
+## Custom workflow wrappers
+
+If your codebase wraps the Hatchet workflow builder, annotate your factory function with `@hatchet-workflow` so the extension can detect variables it creates:
+
+```typescript
+/**
+ * @hatchet-workflow
+ * @hatchet-task-method task
+ * @hatchet-task-parents parents
+ */
+export function createWorkflowBuilder(options) { ... }
+```
+
+The extension scans your workspace for annotated functions on startup and places a **Show Hatchet DAG** CodeLens above every variable created by one. Two optional tags let you match your wrapper's API:
+
+| Tag | Default | Purpose |
+|---|---|---|
+| `@hatchet-task-method` | `task` | Method name used to register tasks |
+| `@hatchet-task-parents` | `parents` | Option property that lists parent tasks |
+
+Both `wf.task('name', { parents })` and `wf.task({ name, parents })` call signatures are supported automatically.
+
 ## Reporting issues
 
 You can report issues in our [Github issues](https://github.com/hatchet-dev/hatchet/issues).
+
+## Changelog
+
+### 0.2.0
+
+- **Custom wrapper support** — annotate any factory function with `@hatchet-workflow` to get DAG visualization for variables it creates, with no other config required. Use `@hatchet-task-method` and `@hatchet-task-parents` to match your wrapper's API when it differs from the Hatchet defaults.
+- Both positional-name (`wf.task('name', opts)`) and options-object (`wf.task({ name, parents })`) task call signatures are now supported.
+- Cross-file task resolution via LSP now honours custom method and parents property names.
+
+### 0.1.2
+
+- Initial release with DAG visualization for TypeScript, Python, Go, and Ruby workflows.

--- a/frontend/vscode-extension/examples/custom-task-method.ts
+++ b/frontend/vscode-extension/examples/custom-task-method.ts
@@ -1,0 +1,94 @@
+/**
+ * Example: custom wrapper with non-default task method and parent property names.
+ *
+ * When your wrapper uses a method name other than `task`, or a dependency
+ * property name other than `parents`, declare them with:
+ *   @hatchet-task-method  <methodName>
+ *   @hatchet-task-parents <propName>
+ */
+import Hatchet, { type WorkflowDeclaration } from '@hatchet-dev/typescript-sdk';
+
+type JsonObject = Record<string, unknown>;
+
+interface StepOptions<TInput extends JsonObject, TOutput extends JsonObject> {
+  fn: (input: TInput) => Promise<TOutput>;
+  /** Steps that must complete before this one. */
+  dependsOn?: StepHandle<JsonObject>[];
+}
+
+export interface StepHandle<TOutput extends JsonObject> {
+  readonly name: string;
+  readonly _def: ReturnType<WorkflowDeclaration['task']>;
+}
+
+export interface PipelineBuilder<TInput extends JsonObject> {
+  /** Register a pipeline step. */
+  step<TOutput extends JsonObject>(
+    name: string,
+    options: StepOptions<TInput, TOutput>,
+  ): StepHandle<TOutput>;
+  build(): WorkflowDeclaration;
+}
+
+const hatchet = Hatchet.init();
+
+/**
+ * Create a pipeline builder where steps are registered with `.step()` and
+ * dependencies are expressed via `dependsOn`.
+ *
+ * @hatchet-workflow
+ * @hatchet-task-method step
+ * @hatchet-task-parents dependsOn
+ */
+export function createPipelineBuilder<TInput extends JsonObject>(options: {
+  name: string;
+}): PipelineBuilder<TInput> {
+  const wf = hatchet.workflow<TInput>({ name: options.name });
+
+  return {
+    step<TOutput extends JsonObject>(
+      name: string,
+      stepOpts: StepOptions<TInput, TOutput>,
+    ): StepHandle<TOutput> {
+      const def = wf.task({
+        name,
+        parents: stepOpts.dependsOn?.map((s) => s._def),
+        fn: async (input: TInput) => stepOpts.fn(input),
+      });
+      return { name, _def: def };
+    },
+    build(): WorkflowDeclaration {
+      return wf;
+    },
+  };
+}
+
+// ── Usage ─────────────────────────────────────────────────────────────────────
+// The extension detects `imagePipeline` via the @hatchet-workflow annotation
+// on createPipelineBuilder, using `step` as the task method and `dependsOn`
+// as the parents property.
+
+const imagePipeline = createPipelineBuilder<{ imageUrl: string }>({
+  name: 'image-processing-pipeline',
+});
+
+const download = imagePipeline.step('download', {
+  fn: async (input) => ({ bytes: new Uint8Array() }),
+});
+
+const resize = imagePipeline.step('resize', {
+  dependsOn: [download],
+  fn: async (input) => ({ resized: true }),
+});
+
+const compress = imagePipeline.step('compress', {
+  dependsOn: [resize],
+  fn: async (input) => ({ compressed: true }),
+});
+
+const upload = imagePipeline.step('upload', {
+  dependsOn: [compress],
+  fn: async (input) => ({ url: '' }),
+});
+
+export default imagePipeline.build();

--- a/frontend/vscode-extension/examples/custom-wrapper.ts
+++ b/frontend/vscode-extension/examples/custom-wrapper.ts
@@ -1,0 +1,131 @@
+/**
+ * Example: custom workflow builder wrapper.
+ *
+ * Annotate any factory function that returns a workflow-builder-like object
+ * with `@hatchet-workflow`.  The VS Code extension will then detect variables
+ * created by this function and render their DAGs, just like standard
+ * `hatchet.workflow(...)` calls.
+ *
+ * Optional tags:
+ *   @hatchet-task-method  — name of the method used to register tasks
+ *                           (defaults to "task")
+ *   @hatchet-task-parents — name of the option property that lists parent
+ *                           tasks (defaults to "parents")
+ */
+import Hatchet, {
+  type Context,
+  type WorkflowDeclaration,
+} from '@hatchet-dev/typescript-sdk';
+import type { CreateWorkflowTaskOpts } from '@hatchet-dev/typescript-sdk';
+
+// ── Supporting types ──────────────────────────────────────────────────────────
+
+type JsonObject = Record<string, unknown>;
+
+interface Services {
+  db: unknown; // replace with your actual DB/service client types
+}
+
+interface TaskOptions<TInput extends JsonObject, TOutput extends JsonObject> {
+  /** Business logic to execute for this task. */
+  fn: (args: { input: TInput; services: Services }) => Promise<TOutput>;
+  /** Tasks that must complete before this one runs. */
+  parents?: TaskHandle<JsonObject>[];
+  retries?: number;
+  timeoutSeconds?: number;
+}
+
+/**
+ * A lightweight handle returned by `WorkflowBuilder.task()`.
+ * Pass these as `parents` to express DAG dependencies.
+ */
+export interface TaskHandle<TOutput extends JsonObject> {
+  /** Display name shown in the DAG. */
+  readonly name: string;
+  /** @internal Raw Hatchet task opts — used to wire up parents internally. */
+  readonly _taskDef: CreateWorkflowTaskOpts<any, any>;
+}
+
+interface WorkflowBuilderOptions<TInput extends JsonObject> {
+  /** Workflow display name (shown in the Hatchet UI and the VS Code DAG view). */
+  name: string;
+  version?: string;
+  /** Called once per task invocation to produce scoped service clients. */
+  createServices: (input: TInput) => Promise<Services>;
+}
+
+/**
+ * A fluent builder for Hatchet workflows with injected service context.
+ *
+ * Usage:
+ * ```ts
+ * const wf = createWorkflowBuilder({ name: 'my-workflow', createServices });
+ * const step1 = wf.task('step1', { fn: async ({ input, services }) => ... });
+ * const step2 = wf.task('step2', { parents: [step1], fn: async (...) => ... });
+ * export default wf.build();
+ * ```
+ */
+export interface WorkflowBuilder<TInput extends JsonObject> {
+  /**
+   * Register a task on this workflow.
+   *
+   * @param name    Unique task name shown in the DAG.
+   * @param options Task configuration including the `fn` and optional `parents`.
+   */
+  task<TOutput extends JsonObject>(
+    name: string,
+    options: TaskOptions<TInput, TOutput>,
+  ): TaskHandle<TOutput>;
+
+  /** Finalise the workflow and return the underlying `WorkflowDeclaration`. */
+  build(): WorkflowDeclaration;
+}
+
+// ── Factory function ──────────────────────────────────────────────────────────
+
+const hatchet = Hatchet.init();
+
+/**
+ * Create a workflow builder that automatically injects service context into
+ * every task function.
+ *
+ * Annotated with `@hatchet-workflow` so the VS Code extension can detect
+ * variables created by this function and render their task graphs.
+ *
+ * @hatchet-workflow
+ * @hatchet-task-method task
+ * @hatchet-task-parents parents
+ */
+export function createWorkflowBuilder<TInput extends JsonObject>(
+  options: WorkflowBuilderOptions<TInput>,
+): WorkflowBuilder<TInput> {
+  const wf = hatchet.workflow<TInput>({ name: options.name });
+
+  return {
+    task<TOutput extends JsonObject>(
+      name: string,
+      taskOpts: TaskOptions<TInput, TOutput>,
+    ): TaskHandle<TOutput> {
+      const wrappedFn = async (input: TInput, _ctx: Context<TInput>): Promise<TOutput> => {
+        const services = await options.createServices(input);
+        return taskOpts.fn({ input, services });
+      };
+
+      const taskDef = wf.task({
+        name,
+        retries: taskOpts.retries,
+        ...(taskOpts.timeoutSeconds
+          ? { executionTimeout: `${taskOpts.timeoutSeconds}s` }
+          : {}),
+        parents: taskOpts.parents?.map((p) => p._taskDef),
+        fn: wrappedFn,
+      });
+
+      return { name, _taskDef: taskDef };
+    },
+
+    build(): WorkflowDeclaration {
+      return wf;
+    },
+  };
+}

--- a/frontend/vscode-extension/examples/standard.ts
+++ b/frontend/vscode-extension/examples/standard.ts
@@ -1,0 +1,46 @@
+/**
+ * Standard Hatchet workflow — detected automatically by the VS Code extension.
+ *
+ * The extension looks for `hatchet.workflow(...)` calls and renders a DAG
+ * for each one.  No annotation is needed for this pattern.
+ */
+import Hatchet from '@hatchet-dev/typescript-sdk';
+
+const hatchet = Hatchet.init();
+
+// The extension detects this variable as a workflow and places a CodeLens above it.
+const dataProcessing = hatchet.workflow({
+  name: 'data-processing',
+});
+
+const ingest = dataProcessing.task({
+  name: 'ingest',
+  fn: async (input) => {
+    return { raw: 'data' };
+  },
+});
+
+const validate = dataProcessing.task({
+  name: 'validate',
+  parents: [ingest],
+  fn: async (input, ctx) => {
+    const { raw } = await ctx.parentOutput(ingest);
+    return { valid: true };
+  },
+});
+
+const transform = dataProcessing.task({
+  name: 'transform',
+  parents: [validate],
+  fn: async (input, ctx) => {
+    return { transformed: true };
+  },
+});
+
+const load = dataProcessing.task({
+  name: 'load',
+  parents: [transform],
+  fn: async (input, ctx) => {
+    return { loaded: true };
+  },
+});

--- a/frontend/vscode-extension/examples/usage.ts
+++ b/frontend/vscode-extension/examples/usage.ts
@@ -1,0 +1,51 @@
+/**
+ * Example: using the custom workflow builder.
+ *
+ * Because `createWorkflowBuilder` is annotated with `@hatchet-workflow`,
+ * the VS Code extension detects `reportWorkflow` as a workflow variable and
+ * shows a "Show Hatchet DAG" CodeLens above its declaration — no config needed.
+ */
+import { createWorkflowBuilder } from './custom-wrapper';
+
+interface ReportInput {
+  reportId: string;
+  format: 'pdf' | 'csv';
+}
+
+// The extension detects this as a workflow (via the @hatchet-workflow annotation
+// on createWorkflowBuilder) and places a CodeLens above this line.
+const reportWorkflow = createWorkflowBuilder<ReportInput>({
+  name: 'generate-report',
+  createServices: async (_input) => ({
+    db: null, // replace with real DB client
+  }),
+});
+
+const fetchData = reportWorkflow.task('fetch-data', {
+  fn: async ({ input, services }) => {
+    return { rows: [] as unknown[] };
+  },
+});
+
+const formatData = reportWorkflow.task('format-data', {
+  parents: [fetchData],
+  fn: async ({ input, services }) => {
+    return { formatted: '' };
+  },
+});
+
+const generateFile = reportWorkflow.task('generate-file', {
+  parents: [formatData],
+  fn: async ({ input, services }) => {
+    return { fileUrl: '' };
+  },
+});
+
+const sendNotification = reportWorkflow.task('send-notification', {
+  parents: [generateFile],
+  fn: async ({ input, services }) => {
+    return { sent: true };
+  },
+});
+
+export default reportWorkflow.build();

--- a/frontend/vscode-extension/package.json
+++ b/frontend/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "hatchet",
   "displayName": "Hatchet",
   "description": "Visualize Hatchet workflow DAGs inline in your editor",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "publisher": "hatchet",
   "license": "MIT",
   "repository": {

--- a/frontend/vscode-extension/src/analysis/annotation-cache.ts
+++ b/frontend/vscode-extension/src/analysis/annotation-cache.ts
@@ -4,21 +4,36 @@ import {
   type WorkflowFactoryAnnotation,
 } from '../parser/jsdoc-annotations';
 
+// Paths containing these segments are ignored by the file-system watcher,
+// matching the exclusion applied to the initial findFiles scan.
+const IGNORED_PATH_SEGMENTS = ['node_modules', '.git'];
+
+function isIgnoredUri(uri: vscode.Uri): boolean {
+  const p = uri.fsPath;
+  return IGNORED_PATH_SEGMENTS.some((seg) => p.includes(seg));
+}
+
 /**
  * Workspace-level cache of `@hatchet-workflow`-annotated factory functions.
  *
  * Scans all `.ts` / `.tsx` workspace files on initialization, then stays
  * up-to-date via a file-system watcher.  Fires `onDidChange` whenever the
  * set of known annotations changes so callers can refresh (e.g. CodeLens).
+ *
+ * Internal storage is keyed by (fileKey → functionName) so that:
+ *   • Removing a file only removes that file's annotations in O(k).
+ *   • No `as any` casts are needed to track provenance.
+ *   • Duplicate function names across files are handled deterministically
+ *     (the flat view is rebuilt from scratch after every change).
  */
 export class WorkflowAnnotationCache {
-  private readonly _annotations = new Map<string, WorkflowFactoryAnnotation>();
+  private readonly _byFile = new Map<string, Map<string, WorkflowFactoryAnnotation>>();
+  /** Flat view rebuilt after every mutation — returned by getAll(). */
+  private _flat = new Map<string, WorkflowFactoryAnnotation>();
+
   private readonly _onDidChange = new vscode.EventEmitter<void>();
   readonly onDidChange: vscode.Event<void> = this._onDidChange.event;
 
-  // ── Public API ─────────────────────────────────────────────────────────────
-
-  /** Start the cache: scan workspace and begin watching for changes. */
   async initialize(context: vscode.ExtensionContext): Promise<void> {
     await this._scanWorkspace();
 
@@ -29,12 +44,9 @@ export class WorkflowAnnotationCache {
     context.subscriptions.push(watcher, this._onDidChange);
   }
 
-  /** Return a snapshot of all known annotations, keyed by function name. */
   getAll(): ReadonlyMap<string, WorkflowFactoryAnnotation> {
-    return this._annotations;
+    return this._flat;
   }
-
-  // ── Private helpers ────────────────────────────────────────────────────────
 
   private async _scanWorkspace(): Promise<void> {
     const uris = await vscode.workspace.findFiles(
@@ -45,26 +57,26 @@ export class WorkflowAnnotationCache {
   }
 
   private async _scanUri(uri: vscode.Uri, remove: boolean): Promise<void> {
-    // Build a per-file key to allow removal of stale entries
+    if (isIgnoredUri(uri)) return;
+
     const fileKey = uri.toString();
+    const hadExisting = this._byFile.has(fileKey);
 
-    // Remove any previously-known annotations from this file
-    const toRemove = [...this._annotations.entries()]
-      .filter(([, ann]) => (ann as any)._fileKey === fileKey)
-      .map(([name]) => name);
+    // Remove stale entries for this file in O(k) — no full-map scan needed.
+    this._byFile.delete(fileKey);
 
-    let changed = toRemove.length > 0;
-    for (const name of toRemove) this._annotations.delete(name);
+    let changed = hadExisting;
 
     if (!remove) {
       try {
         const doc = await vscode.workspace.openTextDocument(uri);
         const text = doc.getText();
         const found = scanFileForWorkflowAnnotations(text, uri.fsPath);
-        for (const ann of found) {
-          // Attach a hidden file-key so we can remove stale entries later
-          (ann as any)._fileKey = fileKey;
-          this._annotations.set(ann.functionName, ann);
+        if (found.length > 0) {
+          this._byFile.set(
+            fileKey,
+            new Map(found.map((ann) => [ann.functionName, ann])),
+          );
           changed = true;
         }
       } catch {
@@ -72,6 +84,19 @@ export class WorkflowAnnotationCache {
       }
     }
 
-    if (changed) this._onDidChange.fire();
+    if (changed) {
+      this._rebuildFlat();
+      this._onDidChange.fire();
+    }
+  }
+
+  private _rebuildFlat(): void {
+    const flat = new Map<string, WorkflowFactoryAnnotation>();
+    for (const fileAnnotations of this._byFile.values()) {
+      for (const [name, ann] of fileAnnotations) {
+        flat.set(name, ann);
+      }
+    }
+    this._flat = flat;
   }
 }

--- a/frontend/vscode-extension/src/analysis/annotation-cache.ts
+++ b/frontend/vscode-extension/src/analysis/annotation-cache.ts
@@ -1,0 +1,77 @@
+import * as vscode from 'vscode';
+import {
+  scanFileForWorkflowAnnotations,
+  type WorkflowFactoryAnnotation,
+} from '../parser/jsdoc-annotations';
+
+/**
+ * Workspace-level cache of `@hatchet-workflow`-annotated factory functions.
+ *
+ * Scans all `.ts` / `.tsx` workspace files on initialization, then stays
+ * up-to-date via a file-system watcher.  Fires `onDidChange` whenever the
+ * set of known annotations changes so callers can refresh (e.g. CodeLens).
+ */
+export class WorkflowAnnotationCache {
+  private readonly _annotations = new Map<string, WorkflowFactoryAnnotation>();
+  private readonly _onDidChange = new vscode.EventEmitter<void>();
+  readonly onDidChange: vscode.Event<void> = this._onDidChange.event;
+
+  // ── Public API ─────────────────────────────────────────────────────────────
+
+  /** Start the cache: scan workspace and begin watching for changes. */
+  async initialize(context: vscode.ExtensionContext): Promise<void> {
+    await this._scanWorkspace();
+
+    const watcher = vscode.workspace.createFileSystemWatcher('**/*.{ts,tsx}');
+    watcher.onDidChange((uri) => void this._scanUri(uri, /*remove*/ false));
+    watcher.onDidCreate((uri) => void this._scanUri(uri, /*remove*/ false));
+    watcher.onDidDelete((uri) => void this._scanUri(uri, /*remove*/ true));
+    context.subscriptions.push(watcher, this._onDidChange);
+  }
+
+  /** Return a snapshot of all known annotations, keyed by function name. */
+  getAll(): ReadonlyMap<string, WorkflowFactoryAnnotation> {
+    return this._annotations;
+  }
+
+  // ── Private helpers ────────────────────────────────────────────────────────
+
+  private async _scanWorkspace(): Promise<void> {
+    const uris = await vscode.workspace.findFiles(
+      '**/*.{ts,tsx}',
+      '{**/node_modules/**,**/.git/**}',
+    );
+    await Promise.all(uris.map((uri) => this._scanUri(uri, false)));
+  }
+
+  private async _scanUri(uri: vscode.Uri, remove: boolean): Promise<void> {
+    // Build a per-file key to allow removal of stale entries
+    const fileKey = uri.toString();
+
+    // Remove any previously-known annotations from this file
+    const toRemove = [...this._annotations.entries()]
+      .filter(([, ann]) => (ann as any)._fileKey === fileKey)
+      .map(([name]) => name);
+
+    let changed = toRemove.length > 0;
+    for (const name of toRemove) this._annotations.delete(name);
+
+    if (!remove) {
+      try {
+        const doc = await vscode.workspace.openTextDocument(uri);
+        const text = doc.getText();
+        const found = scanFileForWorkflowAnnotations(text, uri.fsPath);
+        for (const ann of found) {
+          // Attach a hidden file-key so we can remove stale entries later
+          (ann as any)._fileKey = fileKey;
+          this._annotations.set(ann.functionName, ann);
+          changed = true;
+        }
+      } catch {
+        // File unreadable — silently skip
+      }
+    }
+
+    if (changed) this._onDidChange.fire();
+  }
+}

--- a/frontend/vscode-extension/src/analysis/lsp-analyzer.ts
+++ b/frontend/vscode-extension/src/analysis/lsp-analyzer.ts
@@ -108,8 +108,6 @@ export class LspAnalyzer {
   }
 }
 
-// ─── Location-level task extraction ──────────────────────────────────────────
-
 function extractTaskAtLocation(
   lines: string[],
   refLineOffset: number,
@@ -133,8 +131,6 @@ function extractTaskAtLocation(
       return undefined;
   }
 }
-
-// ─── TypeScript ───────────────────────────────────────────────────────────────
 
 function extractTsTask(
   lines: string[],
@@ -168,7 +164,7 @@ function extractTsTask(
   let parentVarIds: string[] = [];
 
   if (trimmedContent.startsWith("'") || trimmedContent.startsWith('"') || trimmedContent.startsWith('`')) {
-    // ── Positional-name form: task('step1', { parents: [...] }) ──────────
+    // positional form: task('name', { parents: [...] })
     const nameM = /^['"`]([^'"`\n]+)['"`]/.exec(trimmedContent);
     displayName = nameM?.[1] ?? taskVarId;
 
@@ -178,7 +174,7 @@ function extractTsTask(
       ? parentsM[1].split(',').map((s) => s.trim()).filter((s) => /^\w+$/.test(s))
       : [];
   } else {
-    // ── Options-object form: task({ name: '...', parents: [...] }) ───────
+    // options-object form: task({ name: '...', parents: [...] })
     const nameM = /name\s*:\s*['"`]([^'"`]+)['"`]/.exec(parenContent);
     displayName = nameM?.[1] ?? taskVarId;
 
@@ -202,8 +198,6 @@ function extractTsTask(
   };
 }
 
-// ─── Python ───────────────────────────────────────────────────────────────────
-
 function extractPyTask(
   lines: string[],
   refLineOffset: number,
@@ -217,13 +211,11 @@ function extractPyTask(
   const decRe = new RegExp(`^@${escapeRegex(varName)}\\.task\\s*\\(`);
   if (!decRe.test(refLine.trimStart())) return undefined;
 
-  // Collect decorator paren content
   const fullText = lines.slice(refLineOffset).join('\n');
   const parenIdx = fullText.indexOf('(');
   if (parenIdx === -1) return undefined;
   const parenContent = collectSimpleContent(fullText, parenIdx);
 
-  // Extract parents=[id1, id2, ...]
   const parentsM = /parents\s*=\s*\[([^\]]*)\]/.exec(parenContent);
   const parentVarIds: string[] = parentsM
     ? parentsM[1]
@@ -232,7 +224,6 @@ function extractPyTask(
         .filter((s) => /^\w+$/.test(s))
     : [];
 
-  // Scan forward for `def` or `async def`
   let funcName: string | undefined;
   let defOffset = refLineOffset;
   for (let j = refLineOffset + 1; j < Math.min(refLineOffset + 10, lines.length); j++) {
@@ -254,8 +245,6 @@ function extractPyTask(
   };
 }
 
-// ─── Go ───────────────────────────────────────────────────────────────────────
-
 function extractGoTask(
   lines: string[],
   refLineOffset: number,
@@ -276,12 +265,10 @@ function extractGoTask(
   const taskName = m[2];
   const varId = assignedVar && assignedVar !== '_' ? assignedVar : sanitizeVarId(taskName);
 
-  // Collect full NewTask(...) args with brace-aware depth
   const fullText = lines.slice(refLineOffset).join('\n');
   const parenIdx = fullText.indexOf('(');
   const taskArgs = parenIdx !== -1 ? collectBraceAwareContent(fullText, parenIdx) : '';
 
-  // Extract WithParents(p1, p2)
   const parentsM = /WithParents\s*\(([^)]*)\)/.exec(taskArgs);
   const parentVarIds: string[] = parentsM
     ? parentsM[1]
@@ -298,8 +285,6 @@ function extractGoTask(
     fileUri,
   };
 }
-
-// ─── Ruby ─────────────────────────────────────────────────────────────────────
 
 function extractRubyTask(
   lines: string[],
@@ -321,13 +306,11 @@ function extractRubyTask(
   const taskSymbolName = m[2];
   const varId = assignedConst ?? taskSymbolName;
 
-  // Collect paren content
   const fullText = lines.slice(refLineOffset).join('\n');
   const parenIdx = fullText.indexOf('(');
   if (parenIdx === -1) return undefined;
   const parenContent = collectSimpleContent(fullText, parenIdx);
 
-  // Extract parents: [STEP1, STEP2, :step3]
   const parentsM = /parents:\s*\[([^\]]*)\]/.exec(parenContent);
   const parentVarIds: string[] = parentsM
     ? parentsM[1]
@@ -348,9 +331,6 @@ function extractRubyTask(
   };
 }
 
-// ─── Utilities ────────────────────────────────────────────────────────────────
-
-/** Escape special regex characters in a literal string. */
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/frontend/vscode-extension/src/analysis/lsp-analyzer.ts
+++ b/frontend/vscode-extension/src/analysis/lsp-analyzer.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import type { ParsedTask, ParsedWorkflow, WorkflowDeclaration } from '../parser/workflow-parser';
+import type { WorkflowFactoryAnnotation } from '../parser/jsdoc-annotations';
 import { isWithinWorkspace } from '../utils/workspace';
 
 /**
@@ -75,6 +76,7 @@ export class LspAnalyzer {
               decl.varName,
               doc.languageId,
               location.uri,
+              decl.annotation,
             ) ?? null;
           } catch {
             return null;
@@ -115,11 +117,12 @@ function extractTaskAtLocation(
   varName: string,
   languageId: string,
   fileUri: vscode.Uri,
+  annotation?: WorkflowFactoryAnnotation,
 ): ParsedTask | undefined {
   switch (languageId) {
     case 'typescript':
     case 'typescriptreact': // .tsx files are valid in TS SDK projects
-      return extractTsTask(lines, refLineOffset, absoluteStartLine, varName, fileUri);
+      return extractTsTask(lines, refLineOffset, absoluteStartLine, varName, fileUri, annotation);
     case 'python':
       return extractPyTask(lines, refLineOffset, absoluteStartLine, varName, fileUri);
     case 'go':
@@ -139,40 +142,56 @@ function extractTsTask(
   absoluteStartLine: number,
   varName: string,
   fileUri: vscode.Uri,
+  annotation?: WorkflowFactoryAnnotation,
 ): ParsedTask | undefined {
+  const taskMethod = annotation?.taskMethod ?? 'task';
+  const taskParentsProp = annotation?.taskParentsProp ?? 'parents';
   const refLine = lines[refLineOffset];
 
-  // Match: [const/let varId = ]varName.task({
+  // Match: [const/let varId = ]varName.<taskMethod>(
   const taskRe = new RegExp(
-    `(?:(?:const|let)\\s+(\\w+)\\s*=\\s*)?${escapeRegex(varName)}\\.task\\s*\\(`,
+    `(?:(?:const|let)\\s+(\\w+)\\s*=\\s*)?${escapeRegex(varName)}\\.${escapeRegex(taskMethod)}\\s*\\(`,
   );
   const m = taskRe.exec(refLine);
   if (!m) return undefined;
 
   const taskVarId = m[1]; // may be undefined (anonymous task)
 
-  // Build text from the reference line onward and locate the opening paren
   const fullText = lines.slice(refLineOffset).join('\n');
   const parenIdx = fullText.indexOf('(');
   if (parenIdx === -1) return undefined;
 
   const parenContent = collectBraceAwareContent(fullText, parenIdx);
+  const trimmedContent = parenContent.trimStart();
 
-  // Extract name: '...' or name: "..."
-  const nameM = /name\s*:\s*['"`]([^'"`]+)['"`]/.exec(parenContent);
-  const displayName = nameM?.[1] ?? taskVarId;
+  let displayName: string | undefined;
+  let parentVarIds: string[] = [];
+
+  if (trimmedContent.startsWith("'") || trimmedContent.startsWith('"') || trimmedContent.startsWith('`')) {
+    // ── Positional-name form: task('step1', { parents: [...] }) ──────────
+    const nameM = /^['"`]([^'"`\n]+)['"`]/.exec(trimmedContent);
+    displayName = nameM?.[1] ?? taskVarId;
+
+    const parentsRe = new RegExp(`${escapeRegex(taskParentsProp)}\\s*:\\s*\\[([^\\]]*)\\]`);
+    const parentsM = parentsRe.exec(parenContent);
+    parentVarIds = parentsM
+      ? parentsM[1].split(',').map((s) => s.trim()).filter((s) => /^\w+$/.test(s))
+      : [];
+  } else {
+    // ── Options-object form: task({ name: '...', parents: [...] }) ───────
+    const nameM = /name\s*:\s*['"`]([^'"`]+)['"`]/.exec(parenContent);
+    displayName = nameM?.[1] ?? taskVarId;
+
+    const parentsRe = new RegExp(`${escapeRegex(taskParentsProp)}\\s*:\\s*\\[([^\\]]*)\\]`);
+    const parentsM = parentsRe.exec(parenContent);
+    parentVarIds = parentsM
+      ? parentsM[1].split(',').map((s) => s.trim()).filter((s) => /^\w+$/.test(s))
+      : [];
+  }
+
   if (!displayName) return undefined;
 
   const varId = taskVarId ?? sanitizeVarId(displayName);
-
-  // Extract parents: [id1, id2]
-  const parentsM = /parents\s*:\s*\[([^\]]*)\]/.exec(parenContent);
-  const parentVarIds: string[] = parentsM
-    ? parentsM[1]
-        .split(',')
-        .map((s) => s.trim())
-        .filter((s) => /^\w+$/.test(s))
-    : [];
 
   return {
     varId,

--- a/frontend/vscode-extension/src/extension.ts
+++ b/frontend/vscode-extension/src/extension.ts
@@ -4,22 +4,36 @@ import {
   HatchetCodeLensProvider,
   detectWorkflowDeclarations,
   computeFallbackWorkflow,
+  setAnnotationCache,
 } from './providers/codelens-provider';
 import type { WorkflowDeclaration, ParsedWorkflow } from './parser/workflow-parser';
+import { WorkflowAnnotationCache } from './analysis/annotation-cache';
 
 const SUPPORTED_LANGUAGES = ['typescript', 'typescriptreact', 'python', 'ruby', 'go'];
 
 let codeLensProvider: HatchetCodeLensProvider | undefined;
 
 export function activate(context: vscode.ExtensionContext): void {
+  // ── Annotation cache (must be set up before CodeLens provider is used) ─
+  const annotationCache = new WorkflowAnnotationCache();
+  setAnnotationCache(annotationCache);
+
   // ── CodeLens provider (registered for each supported language) ────────
-  codeLensProvider = new HatchetCodeLensProvider();
+  codeLensProvider = new HatchetCodeLensProvider(annotationCache);
+
+  // Refresh lenses whenever the annotation cache changes (e.g. after initial
+  // workspace scan or when annotated factory files are edited).
+  annotationCache.onDidChange(() => codeLensProvider?.refresh());
 
   for (const lang of SUPPORTED_LANGUAGES) {
     context.subscriptions.push(
       vscode.languages.registerCodeLensProvider({ language: lang }, codeLensProvider),
     );
   }
+
+  // Initialize asynchronously — when scan completes, cache fires onDidChange
+  // which triggers codeLensProvider.refresh() via the subscription above.
+  void annotationCache.initialize(context);
 
   // ── Command: hatchet.showDag ───────────────────────────────────────────
   context.subscriptions.push(

--- a/frontend/vscode-extension/src/extension.ts
+++ b/frontend/vscode-extension/src/extension.ts
@@ -4,7 +4,6 @@ import {
   HatchetCodeLensProvider,
   detectWorkflowDeclarations,
   computeFallbackWorkflow,
-  setAnnotationCache,
 } from './providers/codelens-provider';
 import type { WorkflowDeclaration, ParsedWorkflow } from './parser/workflow-parser';
 import { WorkflowAnnotationCache } from './analysis/annotation-cache';
@@ -12,18 +11,15 @@ import { WorkflowAnnotationCache } from './analysis/annotation-cache';
 const SUPPORTED_LANGUAGES = ['typescript', 'typescriptreact', 'python', 'ruby', 'go'];
 
 let codeLensProvider: HatchetCodeLensProvider | undefined;
+let annotationCache: WorkflowAnnotationCache | undefined;
 
 export function activate(context: vscode.ExtensionContext): void {
-  // ── Annotation cache (must be set up before CodeLens provider is used) ─
-  const annotationCache = new WorkflowAnnotationCache();
-  setAnnotationCache(annotationCache);
-
-  // ── CodeLens provider (registered for each supported language) ────────
+  annotationCache = new WorkflowAnnotationCache();
   codeLensProvider = new HatchetCodeLensProvider(annotationCache);
 
-  // Refresh lenses whenever the annotation cache changes (e.g. after initial
-  // workspace scan or when annotated factory files are edited).
-  annotationCache.onDidChange(() => codeLensProvider?.refresh());
+  context.subscriptions.push(
+    annotationCache.onDidChange(() => codeLensProvider?.refresh()),
+  );
 
   for (const lang of SUPPORTED_LANGUAGES) {
     context.subscriptions.push(
@@ -35,7 +31,6 @@ export function activate(context: vscode.ExtensionContext): void {
   // which triggers codeLensProvider.refresh() via the subscription above.
   void annotationCache.initialize(context);
 
-  // ── Command: hatchet.showDag ───────────────────────────────────────────
   context.subscriptions.push(
     vscode.commands.registerCommand(
       'hatchet.showDag',
@@ -43,12 +38,8 @@ export function activate(context: vscode.ExtensionContext): void {
         const activeEditor = vscode.window.activeTextEditor;
 
         if (!decl) {
-          // Command invoked from the command palette without arguments — try
-          // to detect a workflow declaration in the active document.
           if (!activeEditor) {
-            vscode.window.showWarningMessage(
-              'Hatchet: Open a workflow file first.',
-            );
+            vscode.window.showWarningMessage('Hatchet: Open a workflow file first.');
             return;
           }
           const doc = activeEditor.document;
@@ -61,7 +52,10 @@ export function activate(context: vscode.ExtensionContext): void {
             return;
           }
           decl = decls[0];
-          fallback = computeFallbackWorkflow(text, doc.languageId, doc.fileName, decl);
+          fallback = computeFallbackWorkflow(
+            text, doc.languageId, doc.fileName, decl,
+            annotationCache?.getAll() ?? new Map(),
+          );
           documentUri = doc.uri;
         }
 
@@ -88,21 +82,21 @@ export function activate(context: vscode.ExtensionContext): void {
     ),
   );
 
-  // ── Re-parse on document changes ──────────────────────────────────────
   context.subscriptions.push(
     vscode.workspace.onDidChangeTextDocument((e) => {
       if (!SUPPORTED_LANGUAGES.includes(e.document.languageId)) return;
       codeLensProvider?.refresh();
 
-      // If a panel is open, schedule a debounced re-analysis.
       const doc = e.document;
       const text = doc.getText();
       const decls = tryDetectDeclarations(doc);
       if (decls.length > 0) {
-        // Prefer the workflow the panel is already showing; fall back to first.
         const decl =
           decls.find((d) => d.varName === DagPanel.currentVarName) ?? decls[0];
-        const fallback = computeFallbackWorkflow(text, doc.languageId, doc.fileName, decl);
+        const fallback = computeFallbackWorkflow(
+          text, doc.languageId, doc.fileName, decl,
+          annotationCache?.getAll() ?? new Map(),
+        );
         DagPanel.scheduleUpdate(decl, fallback, doc.uri);
       }
     }),
@@ -120,14 +114,13 @@ export function deactivate(): void {
   // VS Code will dispose all registered subscriptions automatically.
 }
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
 function tryDetectDeclarations(document: vscode.TextDocument): WorkflowDeclaration[] {
   try {
     return detectWorkflowDeclarations(
       document.getText(),
       document.languageId,
       document.fileName,
+      annotationCache?.getAll() ?? new Map(),
     );
   } catch {
     return [];

--- a/frontend/vscode-extension/src/parser/jsdoc-annotations.ts
+++ b/frontend/vscode-extension/src/parser/jsdoc-annotations.ts
@@ -1,11 +1,6 @@
 import * as ts from 'typescript';
 
-/**
- * Metadata extracted from a `@hatchet-workflow` JSDoc annotation on a
- * factory function.
- */
 export interface WorkflowFactoryAnnotation {
-  /** The factory function name (e.g. 'createWorkflowBuilder') */
   functionName: string;
   /**
    * Method on the returned object used to register tasks.
@@ -36,12 +31,16 @@ export function scanFileForWorkflowAnnotations(
   // Quick bail — avoid full parse cost on files that have no annotation
   if (!sourceText.includes('@hatchet-workflow')) return [];
 
+  const scriptKind = fileName.toLowerCase().endsWith('.tsx')
+    ? ts.ScriptKind.TSX
+    : ts.ScriptKind.TS;
+
   const sourceFile = ts.createSourceFile(
     fileName,
     sourceText,
     ts.ScriptTarget.ESNext,
     /*setParentNodes*/ true,
-    ts.ScriptKind.TS,
+    scriptKind,
   );
 
   const results: WorkflowFactoryAnnotation[] = [];
@@ -65,8 +64,6 @@ export function scanFileForWorkflowAnnotations(
   visit(sourceFile);
   return results;
 }
-
-// ─── Internal helpers ─────────────────────────────────────────────────────────
 
 function tryExtract(node: ts.Node, functionName: string): WorkflowFactoryAnnotation | undefined {
   const tags = ts.getJSDocTags(node);

--- a/frontend/vscode-extension/src/parser/jsdoc-annotations.ts
+++ b/frontend/vscode-extension/src/parser/jsdoc-annotations.ts
@@ -1,0 +1,120 @@
+import * as ts from 'typescript';
+
+/**
+ * Metadata extracted from a `@hatchet-workflow` JSDoc annotation on a
+ * factory function.
+ */
+export interface WorkflowFactoryAnnotation {
+  /** The factory function name (e.g. 'createWorkflowBuilder') */
+  functionName: string;
+  /**
+   * Method on the returned object used to register tasks.
+   * Sourced from `@hatchet-task-method <name>`. Defaults to `'task'`.
+   */
+  taskMethod: string;
+  /**
+   * Property name in the task options object that lists parent tasks.
+   * Sourced from `@hatchet-task-parents <prop>`. Defaults to `'parents'`.
+   */
+  taskParentsProp: string;
+}
+
+/**
+ * Scan a TypeScript source file for functions / arrow-function variables
+ * annotated with `@hatchet-workflow` and return their metadata.
+ *
+ * Handles:
+ *   - `/** @hatchet-workflow *\/ function foo(...) {}`
+ *   - `/** @hatchet-workflow *\/ export function foo(...) {}`
+ *   - `/** @hatchet-workflow *\/ const foo = (...) => {}`
+ *   - `/** @hatchet-workflow *\/ const foo = function(...) {}`
+ */
+export function scanFileForWorkflowAnnotations(
+  sourceText: string,
+  fileName = 'file.ts',
+): WorkflowFactoryAnnotation[] {
+  // Quick bail — avoid full parse cost on files that have no annotation
+  if (!sourceText.includes('@hatchet-workflow')) return [];
+
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    sourceText,
+    ts.ScriptTarget.ESNext,
+    /*setParentNodes*/ true,
+    ts.ScriptKind.TS,
+  );
+
+  const results: WorkflowFactoryAnnotation[] = [];
+
+  function visit(node: ts.Node): void {
+    // function foo(...) {}  /  export function foo(...) {}
+    if (ts.isFunctionDeclaration(node) && node.name) {
+      const ann = tryExtract(node, node.name.text);
+      if (ann) results.push(ann);
+    }
+
+    // const foo = (...) => {}  /  const foo = function(...) {}
+    if (ts.isVariableStatement(node)) {
+      const ann = tryExtractFromVariableStatement(node);
+      if (ann) results.push(ann);
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return results;
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+function tryExtract(node: ts.Node, functionName: string): WorkflowFactoryAnnotation | undefined {
+  const tags = ts.getJSDocTags(node);
+  if (!tags.some((t) => t.tagName.text === 'hatchet-workflow')) return undefined;
+
+  return {
+    functionName,
+    taskMethod: getTagText(tags, 'hatchet-task-method') ?? 'task',
+    taskParentsProp: getTagText(tags, 'hatchet-task-parents') ?? 'parents',
+  };
+}
+
+function tryExtractFromVariableStatement(
+  node: ts.VariableStatement,
+): WorkflowFactoryAnnotation | undefined {
+  // JSDoc attaches to the VariableStatement (before `const`/`let`)
+  const tags = ts.getJSDocTags(node);
+  if (!tags.some((t) => t.tagName.text === 'hatchet-workflow')) return undefined;
+
+  for (const decl of node.declarationList.declarations) {
+    if (!ts.isIdentifier(decl.name)) continue;
+    const init = decl.initializer;
+    if (!init) continue;
+    if (ts.isArrowFunction(init) || ts.isFunctionExpression(init)) {
+      return {
+        functionName: decl.name.text,
+        taskMethod: getTagText(tags, 'hatchet-task-method') ?? 'task',
+        taskParentsProp: getTagText(tags, 'hatchet-task-parents') ?? 'parents',
+      };
+    }
+  }
+  return undefined;
+}
+
+function getTagText(tags: readonly ts.JSDocTag[], tagName: string): string | undefined {
+  const tag = tags.find((t) => t.tagName.text === tagName);
+  if (!tag) return undefined;
+  const { comment } = tag;
+  if (typeof comment === 'string') return comment.trim() || undefined;
+  if (Array.isArray(comment)) {
+    // Each element may be a JSDocText node (with a `.text` property) or a
+    // JSDocLink node — use `.text` when present, otherwise skip.
+    return (
+      (comment as Array<{ text?: string }>)
+        .map((c) => c.text ?? '')
+        .join('')
+        .trim() || undefined
+    );
+  }
+  return undefined;
+}

--- a/frontend/vscode-extension/src/parser/workflow-parser.ts
+++ b/frontend/vscode-extension/src/parser/workflow-parser.ts
@@ -13,24 +13,17 @@ export interface ParsedTask {
 }
 
 export interface ParsedWorkflow {
-  /** The workflow's display name (from `.workflow({ name: '...' })`) */
   name: string;
-  /** Variable name of the workflow object (e.g., `dag`) */
   varName: string;
-  /** 0-based line number of the workflow declaration — used for CodeLens placement */
+  /** 0-based line number — used for CodeLens placement */
   declarationLine: number;
   tasks: ParsedTask[];
 }
 
-/**
- * Minimal workflow entry — enough for CodeLens. Tasks resolved later via LSP.
- */
+/** Minimal workflow entry — enough for CodeLens. Tasks resolved later via LSP. */
 export interface WorkflowDeclaration {
-  /** Workflow display name */
   name: string;
-  /** Source variable name (e.g. "dag", "DAG_WORKFLOW") */
   varName: string;
-  /** 0-based line of the workflow declaration */
   declarationLine: number;
   /** 0-based column of the varName identifier — feeds LSP position query */
   declarationCharacter: number;
@@ -41,8 +34,6 @@ export interface WorkflowDeclaration {
    */
   annotation?: WorkflowFactoryAnnotation;
 }
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function getPropertyValue(
   obj: ts.ObjectLiteralExpression,
@@ -111,7 +102,6 @@ function findNameInObjectLiteral(obj: ts.ObjectLiteralExpression): string | unde
       if (val) return val;
     }
 
-    // Recurse into nested object literals
     if (ts.isObjectLiteralExpression(prop.initializer)) {
       const nested = findNameInObjectLiteral(prop.initializer);
       if (nested) return nested;
@@ -133,8 +123,6 @@ function extractWorkflowNameFromArgs(call: ts.CallExpression): string | undefine
   }
   return undefined;
 }
-
-// ─── Main parser ─────────────────────────────────────────────────────────────
 
 /**
  * Parse a TypeScript source file and return all Hatchet workflow declarations.
@@ -160,7 +148,6 @@ export function parseWorkflows(
     ts.ScriptKind.TS,
   );
 
-  // ── Pass 1: find workflow declarations ──────────────────────────────────
   const workflowVars = new Map<
     string,
     { name: string; declarationLine: number; annotation?: WorkflowFactoryAnnotation }
@@ -174,7 +161,6 @@ export function parseWorkflows(
         const init = decl.initializer;
         if (!init) continue;
 
-        // ── Built-in: something.workflow({...}) or workflow({...})
         if (isWorkflowCall(init)) {
           const workflowName = extractWorkflowName(init);
           if (workflowName) {
@@ -185,7 +171,6 @@ export function parseWorkflows(
           }
         }
 
-        // ── Annotated factory: createWorkflowBuilder({...})
         if (ts.isCallExpression(init)) {
           const calleeName = getCalleeIdentifierName(init);
           if (calleeName) {
@@ -216,7 +201,6 @@ export function parseWorkflows(
     return [];
   }
 
-  // ── Pass 2: find task declarations ──────────────────────────────────────
   const tasksByWorkflow = new Map<string, ParsedTask[]>();
   const anonCounters = new Map<string, number>();
 
@@ -317,7 +301,6 @@ export function parseWorkflows(
 
   visitForTasks(sourceFile);
 
-  // ── Build output ─────────────────────────────────────────────────────────
   const results: ParsedWorkflow[] = [];
 
   for (const [varName, { name, declarationLine }] of workflowVars) {
@@ -327,8 +310,6 @@ export function parseWorkflows(
 
   return results;
 }
-
-// ─── Shape helpers ───────────────────────────────────────────────────────────
 
 /**
  * Determine whether a CallExpression matches the pattern `*.workflow({...})`.
@@ -345,9 +326,6 @@ function isWorkflowCall(expr: ts.Expression): expr is ts.CallExpression {
   return false;
 }
 
-/**
- * Extract the `name` string from a `.workflow({ name: '...' })` call.
- */
 function extractWorkflowName(call: ts.CallExpression): string | undefined {
   const arg = call.arguments[0];
   if (!arg || !ts.isObjectLiteralExpression(arg)) return undefined;
@@ -359,8 +337,6 @@ function extractWorkflowName(call: ts.CallExpression): string | undefined {
 function sanitizeVarId(name: string): string {
   return name.replace(/[^a-zA-Z0-9_$]/g, '_');
 }
-
-// ─── Fast detection (Phase 1 / CodeLens) ─────────────────────────────────────
 
 /**
  * Fast, Pass-1-only scan: return one `WorkflowDeclaration` per workflow
@@ -393,7 +369,6 @@ export function detectTsWorkflowDeclarations(
         const init = decl.initializer;
         if (!init) continue;
 
-        // ── Built-in .workflow() detection ──────────────────────────────
         if (isWorkflowCall(init)) {
           const workflowName = extractWorkflowName(init);
           if (!workflowName) continue;
@@ -410,7 +385,6 @@ export function detectTsWorkflowDeclarations(
           continue;
         }
 
-        // ── Annotated factory detection ──────────────────────────────────
         if (ts.isCallExpression(init)) {
           const calleeName = getCalleeIdentifierName(init);
           if (!calleeName) continue;

--- a/frontend/vscode-extension/src/parser/workflow-parser.ts
+++ b/frontend/vscode-extension/src/parser/workflow-parser.ts
@@ -1,5 +1,6 @@
 import * as ts from 'typescript';
 import type * as vscode from 'vscode';
+import type { WorkflowFactoryAnnotation } from './jsdoc-annotations';
 
 export interface ParsedTask {
   varId: string;
@@ -33,6 +34,12 @@ export interface WorkflowDeclaration {
   declarationLine: number;
   /** 0-based column of the varName identifier — feeds LSP position query */
   declarationCharacter: number;
+  /**
+   * Present when this workflow variable was created by an `@hatchet-workflow`-
+   * annotated factory function.  Carries the task-method and parents-prop names
+   * needed for parsing tasks on the wrapper's returned object.
+   */
+  annotation?: WorkflowFactoryAnnotation;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -77,18 +84,73 @@ function extractParentIds(expr: ts.Expression): string[] {
     .filter((id): id is string => id !== undefined);
 }
 
+/**
+ * Return the identifier name of the outermost callee, ignoring any member-
+ * access chain.  E.g. `foo(...)` → `'foo'`; `foo.bar(...)` → `'bar'`.
+ * Returns `undefined` for more complex expressions.
+ */
+function getCalleeIdentifierName(call: ts.CallExpression): string | undefined {
+  const callee = call.expression;
+  if (ts.isIdentifier(callee)) return callee.text;
+  if (ts.isPropertyAccessExpression(callee)) return callee.name.text;
+  return undefined;
+}
+
+/**
+ * Recursively search an object literal expression (and its nested object
+ * literals) for a string-valued `name:` property.  Returns the first match.
+ * Used to extract workflow names from arbitrarily-nested builder call args.
+ */
+function findNameInObjectLiteral(obj: ts.ObjectLiteralExpression): string | undefined {
+  for (const prop of obj.properties) {
+    if (!ts.isPropertyAssignment(prop)) continue;
+    if (!ts.isIdentifier(prop.name)) continue;
+
+    if (prop.name.text === 'name') {
+      const val = getStringLiteral(prop.initializer);
+      if (val) return val;
+    }
+
+    // Recurse into nested object literals
+    if (ts.isObjectLiteralExpression(prop.initializer)) {
+      const nested = findNameInObjectLiteral(prop.initializer);
+      if (nested) return nested;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Search all object-literal arguments of a call expression, at any depth,
+ * for a string-valued `name:` property.
+ */
+function extractWorkflowNameFromArgs(call: ts.CallExpression): string | undefined {
+  for (const arg of call.arguments) {
+    if (ts.isObjectLiteralExpression(arg)) {
+      const found = findNameInObjectLiteral(arg);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
 // ─── Main parser ─────────────────────────────────────────────────────────────
 
 /**
  * Parse a TypeScript source file and return all Hatchet workflow declarations.
  *
  * Two-pass approach:
- *   Pass 1 – collect workflow variable names (`const X = *.workflow({ name })`)
- *   Pass 2 – collect task declarations on known workflow variables
+ *   Pass 1 – collect workflow variable names:
+ *     • `const X = *.workflow({ name })` (built-in Hatchet pattern)
+ *     • `const X = annotatedFn(...)` where `annotatedFn` appears in
+ *       `annotatedFunctions`
+ *   Pass 2 – collect task declarations on known workflow variables, honouring
+ *     each variable's annotation metadata for method name and parents prop.
  */
 export function parseWorkflows(
   sourceText: string,
   fileName = 'workflow.ts',
+  annotatedFunctions: ReadonlyMap<string, WorkflowFactoryAnnotation> = new Map(),
 ): ParsedWorkflow[] {
   const sourceFile = ts.createSourceFile(
     fileName,
@@ -99,14 +161,12 @@ export function parseWorkflows(
   );
 
   // ── Pass 1: find workflow declarations ──────────────────────────────────
-  // Map: varName → { workflowName, declarationLine }
   const workflowVars = new Map<
     string,
-    { name: string; declarationLine: number }
+    { name: string; declarationLine: number; annotation?: WorkflowFactoryAnnotation }
   >();
 
   function visitForWorkflows(node: ts.Node): void {
-    // Match: const/let/var X = <expr>.workflow({ name: '...' })
     if (ts.isVariableStatement(node)) {
       for (const decl of node.declarationList.declarations) {
         if (!ts.isIdentifier(decl.name)) continue;
@@ -114,7 +174,7 @@ export function parseWorkflows(
         const init = decl.initializer;
         if (!init) continue;
 
-        // Accept: something.workflow({...}) or workflow({...})
+        // ── Built-in: something.workflow({...}) or workflow({...})
         if (isWorkflowCall(init)) {
           const workflowName = extractWorkflowName(init);
           if (workflowName) {
@@ -122,6 +182,26 @@ export function parseWorkflows(
               node.getStart(sourceFile),
             ).line;
             workflowVars.set(varName, { name: workflowName, declarationLine: line });
+          }
+        }
+
+        // ── Annotated factory: createWorkflowBuilder({...})
+        if (ts.isCallExpression(init)) {
+          const calleeName = getCalleeIdentifierName(init);
+          if (calleeName) {
+            const ann = annotatedFunctions.get(calleeName);
+            if (ann) {
+              const workflowName =
+                extractWorkflowNameFromArgs(init) ?? varName;
+              const line = sourceFile.getLineAndCharacterOfPosition(
+                node.getStart(sourceFile),
+              ).line;
+              workflowVars.set(varName, {
+                name: workflowName,
+                declarationLine: line,
+                annotation: ann,
+              });
+            }
           }
         }
       }
@@ -137,15 +217,10 @@ export function parseWorkflows(
   }
 
   // ── Pass 2: find task declarations ──────────────────────────────────────
-  // Map: workflowVarName → ParsedTask[]
   const tasksByWorkflow = new Map<string, ParsedTask[]>();
-  // Deduplication counter per workflow for anonymous tasks
   const anonCounters = new Map<string, number>();
 
   function visitForTasks(node: ts.Node): void {
-    // Match: X.task({ name: '...', parents: [...], fn: ... })
-    // where X is a known workflow variable.
-    // Also match: const taskVar = X.task({...})
     let callExpr: ts.CallExpression | undefined;
     let taskVarId: string | undefined;
     let statementLine = 0;
@@ -191,29 +266,46 @@ export function parseWorkflows(
     taskVarId: string | undefined,
     declarationLine: number,
   ): { workflowVar: string; task: ParsedTask } | undefined {
-    // call.expression must be: <workflowVar>.task
     const expr = call.expression;
     if (!ts.isPropertyAccessExpression(expr)) return undefined;
-    if (expr.name.text !== 'task') return undefined;
 
     const receiver = expr.expression;
     if (!ts.isIdentifier(receiver)) return undefined;
     const workflowVar = receiver.text;
-    if (!workflowVars.has(workflowVar)) return undefined;
+    const wfEntry = workflowVars.get(workflowVar);
+    if (!wfEntry) return undefined;
 
-    // First argument must be an ObjectLiteralExpression
-    const arg = call.arguments[0];
-    if (!arg || !ts.isObjectLiteralExpression(arg)) return undefined;
+    const taskMethod = wfEntry.annotation?.taskMethod ?? 'task';
+    const taskParentsProp = wfEntry.annotation?.taskParentsProp ?? 'parents';
 
-    const displayNameExpr = getPropertyValue(arg, 'name');
-    const displayName =
-      getStringLiteral(displayNameExpr) ?? taskVarId ?? generateAnonId(workflowVar);
+    if (expr.name.text !== taskMethod) return undefined;
 
-    const parentsExpr = getPropertyValue(arg, 'parents');
-    const parentVarIds = parentsExpr ? extractParentIds(parentsExpr) : [];
+    const firstArg = call.arguments[0];
+    if (!firstArg) return undefined;
+
+    let displayName: string | undefined;
+    let parentVarIds: string[] = [];
+
+    if (ts.isStringLiteral(firstArg) || ts.isNoSubstitutionTemplateLiteral(firstArg)) {
+      // Positional-name form: wf.task('step1', { parents: [...] })
+      displayName = firstArg.text;
+      const optsArg = call.arguments[1];
+      if (optsArg && ts.isObjectLiteralExpression(optsArg)) {
+        const parentsExpr = getPropertyValue(optsArg, taskParentsProp);
+        parentVarIds = parentsExpr ? extractParentIds(parentsExpr) : [];
+      }
+    } else if (ts.isObjectLiteralExpression(firstArg)) {
+      // Options-object form: wf.task({ name: 'step1', parents: [...] })
+      const displayNameExpr = getPropertyValue(firstArg, 'name');
+      displayName =
+        getStringLiteral(displayNameExpr) ?? taskVarId ?? generateAnonId(workflowVar);
+      const parentsExpr = getPropertyValue(firstArg, taskParentsProp);
+      parentVarIds = parentsExpr ? extractParentIds(parentsExpr) : [];
+    }
+
+    if (!displayName) return undefined;
 
     const varId = taskVarId ?? sanitizeVarId(displayName);
-
     return { workflowVar, task: { varId, displayName, parentVarIds, declarationLine } };
   }
 
@@ -273,10 +365,15 @@ function sanitizeVarId(name: string): string {
 /**
  * Fast, Pass-1-only scan: return one `WorkflowDeclaration` per workflow
  * variable found in the source.  No task scanning — suitable for CodeLens.
+ *
+ * Detects both the built-in `.workflow({name})` pattern and calls to
+ * `@hatchet-workflow`-annotated factory functions listed in
+ * `annotatedFunctions`.
  */
 export function detectTsWorkflowDeclarations(
   sourceText: string,
   fileName = 'workflow.ts',
+  annotatedFunctions: ReadonlyMap<string, WorkflowFactoryAnnotation> = new Map(),
 ): WorkflowDeclaration[] {
   const sourceFile = ts.createSourceFile(
     fileName,
@@ -294,19 +391,44 @@ export function detectTsWorkflowDeclarations(
         if (!ts.isIdentifier(decl.name)) continue;
         const varName = decl.name.text;
         const init = decl.initializer;
-        if (!init || !isWorkflowCall(init)) continue;
-        const workflowName = extractWorkflowName(init);
-        if (!workflowName) continue;
+        if (!init) continue;
 
-        const namePos = sourceFile.getLineAndCharacterOfPosition(
-          decl.name.getStart(sourceFile),
-        );
-        result.push({
-          name: workflowName,
-          varName,
-          declarationLine: namePos.line,
-          declarationCharacter: namePos.character,
-        });
+        // ── Built-in .workflow() detection ──────────────────────────────
+        if (isWorkflowCall(init)) {
+          const workflowName = extractWorkflowName(init);
+          if (!workflowName) continue;
+
+          const namePos = sourceFile.getLineAndCharacterOfPosition(
+            decl.name.getStart(sourceFile),
+          );
+          result.push({
+            name: workflowName,
+            varName,
+            declarationLine: namePos.line,
+            declarationCharacter: namePos.character,
+          });
+          continue;
+        }
+
+        // ── Annotated factory detection ──────────────────────────────────
+        if (ts.isCallExpression(init)) {
+          const calleeName = getCalleeIdentifierName(init);
+          if (!calleeName) continue;
+          const ann = annotatedFunctions.get(calleeName);
+          if (!ann) continue;
+
+          const workflowName = extractWorkflowNameFromArgs(init) ?? varName;
+          const namePos = sourceFile.getLineAndCharacterOfPosition(
+            decl.name.getStart(sourceFile),
+          );
+          result.push({
+            name: workflowName,
+            varName,
+            declarationLine: namePos.line,
+            declarationCharacter: namePos.character,
+            annotation: ann,
+          });
+        }
       }
     }
     ts.forEachChild(node, visit);

--- a/frontend/vscode-extension/src/providers/codelens-provider.ts
+++ b/frontend/vscode-extension/src/providers/codelens-provider.ts
@@ -8,6 +8,19 @@ import { parsePythonWorkflows, detectPyWorkflowDeclarations } from '../parser/py
 import { parseRubyWorkflows, detectRubyWorkflowDeclarations } from '../parser/ruby-parser';
 import { parseGoWorkflows, detectGoWorkflowDeclarations } from '../parser/go-parser';
 import { detectTsWorkflowDeclarations } from '../parser/workflow-parser';
+import type { WorkflowAnnotationCache } from '../analysis/annotation-cache';
+
+// ─── Module-level annotation cache ───────────────────────────────────────────
+
+let _annotationCache: WorkflowAnnotationCache | undefined;
+
+/**
+ * Register the workspace annotation cache.  Call this once from `activate`
+ * before the CodeLens provider begins serving requests.
+ */
+export function setAnnotationCache(cache: WorkflowAnnotationCache): void {
+  _annotationCache = cache;
+}
 
 // ─── Language dispatchers ─────────────────────────────────────────────────────
 
@@ -23,7 +36,11 @@ export function detectWorkflowDeclarations(
   switch (languageId) {
     case 'typescript':
     case 'typescriptreact':
-      return detectTsWorkflowDeclarations(text, fileName);
+      return detectTsWorkflowDeclarations(
+        text,
+        fileName,
+        _annotationCache?.getAll() ?? new Map(),
+      );
     case 'python':
       return detectPyWorkflowDeclarations(text);
     case 'ruby':
@@ -71,7 +88,7 @@ function parseWorkflowsForDocument(
   switch (languageId) {
     case 'typescript':
     case 'typescriptreact':
-      return parseWorkflows(text, fileName);
+      return parseWorkflows(text, fileName, _annotationCache?.getAll() ?? new Map());
     case 'python':
       return parsePythonWorkflows(text);
     case 'ruby':
@@ -90,12 +107,24 @@ function parseWorkflowsForDocument(
 function looksLikeHatchetDocument(text: string, languageId: string): boolean {
   switch (languageId) {
     case 'typescript':
-    case 'typescriptreact':
-      return (
+    case 'typescriptreact': {
+      if (
         text.includes('@hatchet-dev/typescript-sdk') ||
         // Match .workflow( and .workflow<T>(
-        /\.workflow\s*[<(]/.test(text)
-      );
+        /\.workflow\s*[<(]/.test(text) ||
+        text.includes('@hatchet-workflow')
+      ) {
+        return true;
+      }
+      // Check if the text calls any annotated factory function
+      const annotated = _annotationCache?.getAll();
+      if (annotated) {
+        for (const fnName of annotated.keys()) {
+          if (text.includes(fnName)) return true;
+        }
+      }
+      return false;
+    }
     case 'python':
       return text.includes('hatchet_sdk') || /\.workflow\s*\(/.test(text);
     case 'ruby':
@@ -116,6 +145,12 @@ function looksLikeHatchetDocument(text: string, languageId: string): boolean {
 export class HatchetCodeLensProvider implements vscode.CodeLensProvider {
   private _onDidChangeCodeLenses = new vscode.EventEmitter<void>();
   readonly onDidChangeCodeLenses = this._onDidChangeCodeLenses.event;
+
+  constructor(annotationCache?: WorkflowAnnotationCache) {
+    if (annotationCache) {
+      annotationCache.onDidChange(() => this.refresh());
+    }
+  }
 
   /** Call this when the document changes to refresh lenses. */
   refresh(): void {

--- a/frontend/vscode-extension/src/providers/codelens-provider.ts
+++ b/frontend/vscode-extension/src/providers/codelens-provider.ts
@@ -9,20 +9,7 @@ import { parseRubyWorkflows, detectRubyWorkflowDeclarations } from '../parser/ru
 import { parseGoWorkflows, detectGoWorkflowDeclarations } from '../parser/go-parser';
 import { detectTsWorkflowDeclarations } from '../parser/workflow-parser';
 import type { WorkflowAnnotationCache } from '../analysis/annotation-cache';
-
-// ─── Module-level annotation cache ───────────────────────────────────────────
-
-let _annotationCache: WorkflowAnnotationCache | undefined;
-
-/**
- * Register the workspace annotation cache.  Call this once from `activate`
- * before the CodeLens provider begins serving requests.
- */
-export function setAnnotationCache(cache: WorkflowAnnotationCache): void {
-  _annotationCache = cache;
-}
-
-// ─── Language dispatchers ─────────────────────────────────────────────────────
+import type { WorkflowFactoryAnnotation } from '../parser/jsdoc-annotations';
 
 /**
  * Fast, Pass-1-only scan: return one `WorkflowDeclaration` per workflow
@@ -32,15 +19,12 @@ export function detectWorkflowDeclarations(
   text: string,
   languageId: string,
   fileName: string,
+  annotations: ReadonlyMap<string, WorkflowFactoryAnnotation> = new Map(),
 ): WorkflowDeclaration[] {
   switch (languageId) {
     case 'typescript':
     case 'typescriptreact':
-      return detectTsWorkflowDeclarations(
-        text,
-        fileName,
-        _annotationCache?.getAll() ?? new Map(),
-      );
+      return detectTsWorkflowDeclarations(text, fileName, annotations);
     case 'python':
       return detectPyWorkflowDeclarations(text);
     case 'ruby':
@@ -61,8 +45,9 @@ export function computeFallbackWorkflow(
   languageId: string,
   fileName: string,
   decl: WorkflowDeclaration,
+  annotations: ReadonlyMap<string, WorkflowFactoryAnnotation> = new Map(),
 ): ParsedWorkflow {
-  const workflows = parseWorkflowsForDocument(text, languageId, fileName);
+  const workflows = parseWorkflowsForDocument(text, languageId, fileName, annotations);
   const match = workflows.find((w) => w.varName === decl.varName);
   return (
     match ?? {
@@ -74,21 +59,16 @@ export function computeFallbackWorkflow(
   );
 }
 
-// ─── Internal helpers ─────────────────────────────────────────────────────────
-
-/**
- * Route to the appropriate language-specific full parser.
- * Returns an empty array for unsupported language IDs.
- */
 function parseWorkflowsForDocument(
   text: string,
   languageId: string,
   fileName: string,
+  annotations: ReadonlyMap<string, WorkflowFactoryAnnotation> = new Map(),
 ): ParsedWorkflow[] {
   switch (languageId) {
     case 'typescript':
     case 'typescriptreact':
-      return parseWorkflows(text, fileName, _annotationCache?.getAll() ?? new Map());
+      return parseWorkflows(text, fileName, annotations);
     case 'python':
       return parsePythonWorkflows(text);
     case 'ruby':
@@ -100,28 +80,23 @@ function parseWorkflowsForDocument(
   }
 }
 
-/**
- * Quick heuristic: only run the full parser on files that look like Hatchet
- * workflow files.  Avoids unnecessary work on unrelated source files.
- */
-function looksLikeHatchetDocument(text: string, languageId: string): boolean {
+function looksLikeHatchetDocument(
+  text: string,
+  languageId: string,
+  annotations: ReadonlyMap<string, WorkflowFactoryAnnotation>,
+): boolean {
   switch (languageId) {
     case 'typescript':
     case 'typescriptreact': {
       if (
         text.includes('@hatchet-dev/typescript-sdk') ||
-        // Match .workflow( and .workflow<T>(
         /\.workflow\s*[<(]/.test(text) ||
         text.includes('@hatchet-workflow')
       ) {
         return true;
       }
-      // Check if the text calls any annotated factory function
-      const annotated = _annotationCache?.getAll();
-      if (annotated) {
-        for (const fnName of annotated.keys()) {
-          if (text.includes(fnName)) return true;
-        }
+      for (const fnName of annotations.keys()) {
+        if (text.includes(fnName)) return true;
       }
       return false;
     }
@@ -136,23 +111,18 @@ function looksLikeHatchetDocument(text: string, languageId: string): boolean {
   }
 }
 
-// ─── Provider ─────────────────────────────────────────────────────────────────
-
-/**
- * Provides "$(graph) Show Hatchet DAG" CodeLens actions above each
- * workflow declaration in supported language files.
- */
 export class HatchetCodeLensProvider implements vscode.CodeLensProvider {
   private _onDidChangeCodeLenses = new vscode.EventEmitter<void>();
   readonly onDidChangeCodeLenses = this._onDidChangeCodeLenses.event;
 
+  private readonly _annotationCache: WorkflowAnnotationCache | undefined;
+
   constructor(annotationCache?: WorkflowAnnotationCache) {
-    if (annotationCache) {
-      annotationCache.onDidChange(() => this.refresh());
-    }
+    this._annotationCache = annotationCache;
+    // Refresh subscription is managed by the caller (extension.ts) so the
+    // returned Disposable can be added to context.subscriptions for cleanup.
   }
 
-  /** Call this when the document changes to refresh lenses. */
   refresh(): void {
     this._onDidChangeCodeLenses.fire();
   }
@@ -162,23 +132,22 @@ export class HatchetCodeLensProvider implements vscode.CodeLensProvider {
     _token: vscode.CancellationToken,
   ): vscode.CodeLens[] {
     const text = document.getText();
+    const annotations = this._annotationCache?.getAll() ?? new Map();
 
-    if (!looksLikeHatchetDocument(text, document.languageId)) {
+    if (!looksLikeHatchetDocument(text, document.languageId, annotations)) {
       return [];
     }
 
     let decls: WorkflowDeclaration[];
     try {
-      decls = detectWorkflowDeclarations(text, document.languageId, document.fileName);
+      decls = detectWorkflowDeclarations(text, document.languageId, document.fileName, annotations);
     } catch {
       return [];
     }
 
-    // Parse the full workflow list once and index by varName so we don't
-    // re-run the heavy parser once per declaration inside the map below.
     let allWorkflows: ParsedWorkflow[];
     try {
-      allWorkflows = parseWorkflowsForDocument(text, document.languageId, document.fileName);
+      allWorkflows = parseWorkflowsForDocument(text, document.languageId, document.fileName, annotations);
     } catch {
       allWorkflows = [];
     }
@@ -192,12 +161,7 @@ export class HatchetCodeLensProvider implements vscode.CodeLensProvider {
         tasks: [],
       };
 
-      const range = new vscode.Range(
-        decl.declarationLine,
-        0,
-        decl.declarationLine,
-        0,
-      );
+      const range = new vscode.Range(decl.declarationLine, 0, decl.declarationLine, 0);
 
       const command: vscode.Command = {
         title: `$(graph) Show Hatchet DAG — ${decl.name}`,


### PR DESCRIPTION
# Description

It's a common pattern to wrap Hatchet workflows in a utility to provide shared context to tasks and customize the build method. This provides a way to `Show Hatchet DAG` even in cases where we're going through a wrapper. See examples directory. 
  
## Type of change

- [X] New feature (non-breaking change which adds functionality)