### PR TITLE
docs: webhooks out of beta

### DIFF
--- a/frontend/docs/pages/v1/webhooks.mdx
+++ b/frontend/docs/pages/v1/webhooks.mdx
@@ -3,11 +3,6 @@ import UniversalTabs from "@/components/UniversalTabs";
 
 # Webhooks
 
-<Callout type="info" emoji="🪓">
-  This feature is currently in development and might change. Reach out for
-  feedback or if you encounter any problems registering any external webhooks.
-</Callout>
-
 Webhooks allow external systems to trigger Hatchet workflows by sending HTTP requests to dedicated endpoints. This enables real-time integration with third-party services like GitHub, Stripe, Slack, or any system that can send webhook events.
 
 ## Guides


### PR DESCRIPTION
# Description

Remove beta tag from the top of webhooks. 

## Type of change

- [X] Documentation change (pure documentation change)