### PR TITLE
feat: add runMany and runManyNoWait with per-item options

### DIFF
--- a/examples/typescript/simple/bulk.ts
+++ b/examples/typescript/simple/bulk.ts
@@ -16,6 +16,26 @@ async function main() {
   console.log(res[0].TransformedMessage);
   console.log(res[1].TransformedMessage);
 
+  // > Bulk Run a Task with runMany
+  const runManyRes = await simple.runMany([
+    {
+      input: {
+        Message: 'HeLlO WoRlD',
+      },
+    },
+    {
+      input: {
+        Message: 'Hello MoOn',
+      },
+      opts: {
+        priority: 3,
+      },
+    },
+  ]);
+
+  console.log(runManyRes[0].TransformedMessage);
+  console.log(runManyRes[1].TransformedMessage);
+
   // > Bulk Run Tasks from within a Task
   const parent = hatchet.task({
     name: 'simple',

--- a/frontend/docs/pages/v1/bulk-run.mdx
+++ b/frontend/docs/pages/v1/bulk-run.mdx
@@ -43,6 +43,15 @@ There are additional bulk methods available on the `Task` object.
 - `run`
 - `runNoWait`
 
+You can also use `runMany` and `runManyNoWait` for per-run options while keeping the same bulk execution behavior.
+
+<Snippet src={snippets.typescript.simple.bulk.bulk_run_a_task_with_run_many} />
+
+Additional `Task` bulk methods:
+
+- `runMany`
+- `runManyNoWait`
+
 As with the run methods, you can call bulk methods on the task fn context parameter within a task and the runs will be associated with the parent task in the dashboard.
 
 <Snippet

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to Hatchet's TypeScript SDK will be documented in this chang
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.0] - 2026-04-08
+
+### Added
+
+- runMany and runManyNoWait APIs for workflows and standalone tasks to support bulk runs with per-run options.
+- RunManyOpt input shape containing an input object and an options object.
+
+### Changed
+
+- Bulk docs to include runMany and runManyNoWait examples.
+
 ## [1.20.1] - 2026-04-07
 
 ### Fixed

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "1.20.1",
+  "version": "1.21.0",
   "description": "Background task orchestration & visibility for developers",
   "types": "dist/index.d.ts",
   "files": [

--- a/sdks/typescript/src/v1/declaration.ts
+++ b/sdks/typescript/src/v1/declaration.ts
@@ -96,6 +96,11 @@ export type RunOpts = {
   >;
 };
 
+export type RunManyOpt<I extends InputType = UnknownInputType> = {
+  input: I;
+  opts?: RunOpts;
+};
+
 /**
  * Helper type to safely extract output types from task results
  * @hidden
@@ -448,6 +453,81 @@ export class BaseWorkflowDeclaration<
   }
 
   /**
+   * Synchronously trigger multiple workflow runs without waiting for completion.
+   * @param runs A list of run requests containing input and per-run options.
+   * @returns WorkflowRunRef values in the same order as input runs.
+   * @throws Error if the workflow is not bound to a Hatchet client.
+   */
+  async runManyNoWait(
+    runs: RunManyOpt<I>[],
+    _standaloneTaskName?: string
+  ): Promise<WorkflowRunRef<O>[]> {
+    if (!this.client) {
+      throw UNBOUND_ERR;
+    }
+
+    const parentRunContext = parentRunContextManager.getContext();
+
+    const hasChildKeyOrSticky = runs.some((run) => run.opts?.childKey || run.opts?.sticky);
+
+    if (!parentRunContext && hasChildKeyOrSticky) {
+      this.client.admin.logger.warn(
+        'ignoring childKey or sticky because run is not being spawned from a parent task'
+      );
+    }
+
+    const inheritedSignal = parentRunContext?.signal;
+
+    throwIfAborted(inheritedSignal, {
+      isTrigger: true,
+      context: parentRunContext?.parentTaskRunExternalId
+        ? `task run ${parentRunContext.parentTaskRunExternalId}`
+        : undefined,
+      warn: (message) => this.client!.admin.logger.warn(message),
+    });
+
+    parentRunContextManager.incrementChildIndex(runs.length);
+
+    const baseOpts = {
+      parentId: parentRunContext?.parentId,
+      parentTaskRunExternalId: parentRunContext?.parentTaskRunExternalId,
+      childIndex: parentRunContext?.childIndex,
+    };
+
+    let resp: WorkflowRunRef<O>[] = [];
+    for (let i = 0; i < runs.length; i += 500) {
+      const batch = runs.slice(i, i + 500);
+      const batchResp = await this.client.admin.runWorkflows<I, O>(
+        batch.map((run, batchIndex) => {
+          const { sticky, ...restOpts } = run.opts ?? {};
+
+          return {
+            workflowName: this.definition.name,
+            input: run.input,
+            options: {
+              ...baseOpts,
+              ...restOpts,
+              childIndex: (baseOpts.childIndex ?? 0) + i + batchIndex,
+              desiredWorkerId: sticky ? parentRunContext?.desiredWorkerId : undefined,
+              childKey: run.opts?.childKey,
+            },
+          };
+        })
+      );
+      resp = resp.concat(batchResp);
+    }
+
+    resp.forEach((ref) => {
+      if (_standaloneTaskName) {
+        ref._standaloneTaskName = _standaloneTaskName;
+      }
+      ref.defaultSignal = inheritedSignal;
+    });
+
+    return resp;
+  }
+
+  /**
    * @alias run
    * Triggers a workflow run and waits for the result.
    * @template I - The input type for the workflow
@@ -516,6 +596,47 @@ export class BaseWorkflowDeclaration<
 
     const res = await this.runNoWait(input, options, _standaloneTaskName);
     return res.result();
+  }
+
+  /**
+   * Executes many workflow runs and waits for all results.
+   * @param runs A list of run requests containing input and per-run options.
+   * @returns Results in the same order as input runs.
+   */
+  async runMany(runs: RunManyOpt<I>[], _standaloneTaskName?: string): Promise<O[]> {
+    if (!this.client) {
+      throw UNBOUND_ERR;
+    }
+
+    const durableCtx = parentRunContextManager.getContext()?.durableContext;
+    if (durableCtx) {
+      return durableCtx.spawnChildren(
+        runs.map((run) => ({
+          workflow: this,
+          input: run.input,
+          options: run.opts,
+        }))
+      );
+    }
+
+    const refs = await this.runManyNoWait(runs, _standaloneTaskName);
+    const returnExceptions = runs.some((run) => run.opts?.returnExceptions);
+
+    if (returnExceptions) {
+      const settled = await Promise.allSettled(refs.map((ref) => ref.result()));
+      return settled.map((s) => {
+        if (s.status === 'fulfilled') {
+          return s.value;
+        }
+        const { reason } = s;
+        if (reason instanceof Error) {
+          return reason;
+        }
+        return new Error(Array.isArray(reason) ? reason.join('; ') : String(reason));
+      }) as O[];
+    }
+
+    return Promise.all(refs.map((ref) => ref.result()));
   }
 
   /**
@@ -728,6 +849,7 @@ export class BaseWorkflowDeclaration<
  * - Scheduled execution with `schedule()`
  * - Cron-based recurring execution with `cron()`
  * - Bulk execution by passing an array input to `run()` and `runNoWait()`
+ * - Per-run bulk execution options with `runMany()` and `runManyNoWait()`
  *
  * Tasks within workflows can be defined with `workflow.task()` or
  * `workflow.durableTask()` and arranged into complex dependency patterns.
@@ -1021,6 +1143,32 @@ export class TaskWorkflowDeclaration<
       : (super.runNoWait(input, options, this._standalone_task_name) as Promise<
           WorkflowRunRef<O & Resolved<GlobalOutput, MiddlewareAfter>>
         >);
+  }
+
+  /**
+   * Triggers many task runs and waits for all results.
+   * @param runs - The list of inputs and optional per-run options.
+   * @returns A promise that resolves with ordered task outputs.
+   */
+  async runMany(
+    runs: RunManyOpt<I & GlobalInput>[]
+  ): Promise<(O & Resolved<GlobalOutput, MiddlewareAfter>)[]> {
+    return super.runMany(runs, this._standalone_task_name) as Promise<
+      (O & Resolved<GlobalOutput, MiddlewareAfter>)[]
+    >;
+  }
+
+  /**
+   * Triggers many task runs without waiting for completion.
+   * @param runs - The list of inputs and optional per-run options.
+   * @returns WorkflowRunRef values for each scheduled run.
+   */
+  async runManyNoWait(
+    runs: RunManyOpt<I & GlobalInput>[]
+  ): Promise<WorkflowRunRef<O & Resolved<GlobalOutput, MiddlewareAfter>>[]> {
+    return super.runManyNoWait(runs, this._standalone_task_name) as Promise<
+      WorkflowRunRef<O & Resolved<GlobalOutput, MiddlewareAfter>>[]
+    >;
   }
 
   /**

--- a/sdks/typescript/src/v1/examples/simple/bulk.ts
+++ b/sdks/typescript/src/v1/examples/simple/bulk.ts
@@ -17,6 +17,27 @@ async function main() {
   console.log(res[1].TransformedMessage);
   // !!
 
+  // > Bulk Run a Task with runMany
+  const runManyRes = await simple.runMany([
+    {
+      input: {
+        Message: 'HeLlO WoRlD',
+      },
+    },
+    {
+      input: {
+        Message: 'Hello MoOn',
+      },
+      opts: {
+        priority: 3,
+      },
+    },
+  ]);
+
+  console.log(runManyRes[0].TransformedMessage);
+  console.log(runManyRes[1].TransformedMessage);
+  // !!
+
   // > Bulk Run Tasks from within a Task
   const parent = hatchet.task({
     name: 'simple',

--- a/sdks/typescript/src/v1/examples/simple/simple.e2e.ts
+++ b/sdks/typescript/src/v1/examples/simple/simple.e2e.ts
@@ -1,5 +1,6 @@
-import { makeE2EClient } from '../__e2e__/harness';
+import { makeE2EClient, poll } from '../__e2e__/harness';
 import { helloWorld, helloWorldDurable } from './e2e-workflows';
+import { V1TaskStatus } from '../../../clients/rest/generated/data-contracts';
 
 describe('simple-run-modes-e2e', () => {
   const hatchet = makeE2EClient();
@@ -20,4 +21,46 @@ describe('simple-run-modes-e2e', () => {
       expect([x1, x2, x3, x4, x5]).toEqual([expected, expected, expected, expected, expected]);
     }
   }, 90_000);
+
+  it('supports runMany variants with per-item options', async () => {
+    const expected = { result: 'Hello, world!' };
+
+    for (const task of [helloWorld, helloWorldDurable]) {
+      const runs = [
+        { input: {}, opts: { additionalMetadata: { test_case: 'run-many-a' } } },
+        {
+          input: {},
+          opts: { additionalMetadata: { test_case: 'run-many-b' }, priority: 3 },
+        },
+      ];
+
+      const waited = await task.runMany(runs);
+      expect(waited).toEqual([expected, expected]);
+
+      const refs = await task.runManyNoWait(runs);
+      const outputs = await Promise.all(refs.map((r) => r.output));
+      expect(outputs).toEqual([expected, expected]);
+
+      const [detailsA, detailsB] = await Promise.all(
+        refs.map((ref) =>
+          poll(async () => hatchet.runs.get(ref), {
+            timeoutMs: 30_000,
+            intervalMs: 100,
+            label: 'run details available',
+            shouldStop: (d) =>
+              [V1TaskStatus.QUEUED, V1TaskStatus.RUNNING, V1TaskStatus.COMPLETED].includes(
+                d.run.status as any
+              ),
+          })
+        )
+      );
+
+      expect((detailsA.run as any).additionalMetadata || {}).toMatchObject({
+        test_case: 'run-many-a',
+      });
+      expect((detailsB.run as any).additionalMetadata || {}).toMatchObject({
+        test_case: 'run-many-b',
+      });
+    }
+  }, 120_000);
 });


### PR DESCRIPTION
# Description

This PR introduces explicit multi-run APIs for workflow execution by adding runMany and runManyNoWait with a unified run option shape per run item.
New multi-run approach:

Existing run and runNoWait behavior remains available for current usage patterns.
A new RunManyOpt input shape is added:
- input: workflow input
- opts: optional run options for that specific run

runMany and runManyNoWait now provide per-run option control in a single bulk call.

Fixes [#3398](https://github.com/hatchet-dev/hatchet/issues/3398)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [x] Test changes (add, refactor, improve or change a test)
- [x] This change requires a documentation update

## What's Changed

- [x] Added RunManyOpt and new workflow APIs:
  - runMany
  - runManyNoWait
- [x] Added per-run options support through RunManyOpt.opts.
- [x] Kept existing run and runNoWait flows intact while introducing explicit multi-run methods.
- [x] Added and updated tests to cover multi-run behavior and per-item options handling.
- [x] Updated TypeScript docs content to describe runMany and runManyNoWait as an additional option while keeping existing run examples.