### PR TITLE
fix: update metadata handling in createHatchetExporter function to fix OTEL bug in TS SDK

### DIFF
--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -85,6 +85,7 @@
     "zod-to-json-schema": "^3.24.1"
   },
   "optionalDependencies": {
+    "@grpc/grpc-js": "^1.14.3",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.208.0",

--- a/sdks/typescript/pnpm-lock.yaml
+++ b/sdks/typescript/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
         specifier: ^8.56.1
         version: 8.56.1(eslint@10.0.3)(typescript@5.9.2)
     optionalDependencies:
+      '@grpc/grpc-js':
+        specifier: ^1.14.3
+        version: 1.14.3
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0

--- a/sdks/typescript/src/opentelemetry/hatchet-exporter.ts
+++ b/sdks/typescript/src/opentelemetry/hatchet-exporter.ts
@@ -129,10 +129,15 @@ class HatchetAttributeSpanProcessor extends BatchSpanProcessor {
 function createHatchetExporter(config: ClientConfig): InstanceType<typeof OTLPTraceExporter> {
   const insecure = config.tls_config.tls_strategy === 'none';
 
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const grpc = require('@grpc/grpc-js') as typeof import('@grpc/grpc-js');
+  const metadata = new grpc.Metadata();
+  metadata.set('authorization', `Bearer ${config.token}`);
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const opts: Record<string, any> = {
     url: `${insecure ? 'http' : 'https'}://${config.host_port}`,
-    metadata: { authorization: `Bearer ${config.token}` },
+    metadata,
   };
 
   if (!insecure && config.tls_config.ca_file) {


### PR DESCRIPTION

# Description

Replaced inline metadata object with grpc.Metadata instance for setting authorization header in the createHatchetExporter function. this fixes the bug "{"stack":"TypeError: userProvidedConfiguration.metadata(...).clone is not a function\n    at Object.metadata" in the typescript SDK when using opentelemetry


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


