### PR TITLE
chore: Include SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+Security and bug fixes are provided for the current major version of Hatchet. We recommend keeping up to date with the latest releases. Depending on the scope of the changes, fixes can either be part of the next minor version or as an on-demand patch version.
+
+Production vulnerabilities triaged as `HIGH` to `CRITICAL` are given priority and might be enough to cause a new version to be immediately released.
+
+## Reporting a Vulnerability
+
+<!-- We encourage responsible disclosure of security vulnerabilities. If you have found or suspect a vulnerability in Hatchet, please use the **"Report a vulnerability"** button under the **Security** tab of the relevant GitHub repository. This opens a private channel directly with the maintainers. -->
+
+If you are unable to use GitHub's vulnerability reporting workflow, you can reach us at [security@hatchet.run](mailto:security@hatchet.run).
+
+Please note that we do not operate a bug bounty program, but we genuinely appreciate any reports that help us build a more secure project.
+
+## Scope
+
+This policy applies to the open-source repositories under the [hatchet-dev organization](https://github.com/hatchet-dev) on GitHub.
+
+For security concerns related to the hosted service at `cloud.onhatchet.run`, please contact [security@hatchet.run](mailto:security@hatchet.run) directly.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ Production vulnerabilities triaged as `HIGH` to `CRITICAL` are given priority an
 
 ## Reporting a Vulnerability
 
-<!-- We encourage responsible disclosure of security vulnerabilities. If you have found or suspect a vulnerability in Hatchet, please use the **"Report a vulnerability"** button under the **Security** tab of the relevant GitHub repository. This opens a private channel directly with the maintainers. -->
+We encourage responsible disclosure of security vulnerabilities. If you have found or suspect a vulnerability in Hatchet, please use the [**"Report a vulnerability"** button](https://github.com/hatchet-dev/hatchet/security/advisories/new) under the **Security** tab. This opens a private channel directly with the maintainers.
 
 If you are unable to use GitHub's vulnerability reporting workflow, you can reach us at [security@hatchet.run](mailto:security@hatchet.run).
 


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Includes a `SECURITY.md` for the hatchet repo. While user-reporting via the Security tab is not enabled, this just advises users to email security@hatchet.run directly.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (changes which are not directly related to any business logic)


## What's Changed

- Adds a `SECURITY.md`
