### PR TITLE
chore(ci): Fix ruby ecosystem reference in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,12 +45,12 @@ updates:
     schedule:
       interval: "daily"
 
-  - package-ecosystem: "rubygems"
+  - package-ecosystem: "bundler"
     directory: "/sdks/ruby/src"
     schedule:
       interval: "daily"
 
-  - package-ecosystem: "rubygems"
+  - package-ecosystem: "bundler"
     directory: "/sdks/ruby/examples"
     schedule:
       interval: "daily"


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The dependabot-supported packager for Ruby is `bundler` (see [docs](https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories#supported-ecosystems-maintained-by-github)). We currently reference the non-existent (or unsupported) `rubygems` which gives us the following error in https://github.com/hatchet-dev/hatchet/network/updates:

```sh
The property '#/updates/9/package-ecosystem' value "rubygems" did not match one of the following values: npm, bundler, composer, devcontainers, dotnet-sdk, maven, mix, cargo, gradle, nuget, gomod, docker, docker-compose, elm, gitsubmodule, github-actions, pip, terraform, pub, rust-toolchain, swift, bun, uv, vcpkg, helm, conda, julia, bazel, opentofu
The property '#/updates/10/package-ecosystem' value "rubygems" did not match one of the following values: npm, bundler, composer, devcontainers, dotnet-sdk, maven, mix, cargo, gradle, nuget, gomod, docker, docker-compose, elm, gitsubmodule, github-actions, pip, terraform, pub, rust-toolchain, swift, bun, uv, vcpkg, helm, conda, julia, bazel, opentofu
```


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] CI (any automation pipeline changes)

## What's Changed

- Removes references to incorrect `package-ecosystem` for Ruby dependabot updates.
