### PR TITLE
chore(ci/dependabot): Group major changes together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,11 @@ updates:
         update-types:
           - "patch"
           - "minor"
+      go-modules-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
 
   - package-ecosystem: "pip"
     directories:
@@ -38,6 +43,11 @@ updates:
         update-types:
           - "patch"
           - "minor"
+      python-deps-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
 
   - package-ecosystem: "npm"
     directories:
@@ -55,6 +65,11 @@ updates:
         update-types:
           - "patch"
           - "minor"
+      npm-deps-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
 
   - package-ecosystem: "bundler"
     directories:
@@ -69,3 +84,8 @@ updates:
         update-types:
           - "patch"
           - "minor"
+      ruby-deps-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Groups `major` dependabot updates together per ecosystem, instead of just patch and minor.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] CI (any automation pipeline changes)

## What's Changed

- `major` updates are now grouped together.
