### PR TITLE
Feat: Enable event log on core db

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260403175605_v1_0_94.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260403175605_v1_0_94.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+DROP INDEX v1_event_key_idx;
+CREATE INDEX v1_event_key_scope_idx ON v1_event (tenant_id, key, scope);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX v1_event_key_scope_idx;
+CREATE INDEX v1_event_key_idx ON v1_event (tenant_id, key);
+-- +goose StatementEnd

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -350,7 +350,6 @@ func (c *ConfigLoader) InitDataLayer() (res *database.Layer, err error) {
 		statusUpdateOpts,
 		scf.Runtime.Limits,
 		scf.Runtime.EnforceLimits,
-		scf.Runtime.EnableDurableUserEventLog,
 	)
 
 	if readReplicaPool != nil {

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -294,10 +294,6 @@ type ConfigFileRuntime struct {
 	// TaskOperationLimits controls the limits for various task operations
 	TaskOperationLimits TaskOperationLimitsConfigFile `mapstructure:"taskOperationLimits" json:"taskOperationLimits,omitempty"`
 
-	// EnableDurableUserEventLog controls whether we enable the durable event log for user events. By default, we don't persist user events
-	// to the core database, we only use them to trigger workflows. Enabling this will persist them to the core database.
-	EnableDurableUserEventLog bool `mapstructure:"enableDurableUserEventLog" json:"enableDurableUserEventLog,omitempty" default:"false"`
-
 	// WorkflowRunBufferSize is the buffer size for workflow run event batching in the dispatcher
 	WorkflowRunBufferSize int `mapstructure:"workflowRunBufferSize" json:"workflowRunBufferSize,omitempty" default:"1000"`
 
@@ -825,9 +821,6 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("runtime.grpcTriggerWriteSlots", "SERVER_GRPC_TRIGGER_WRITE_SLOTS")
 	_ = v.BindEnv("runtime.updateHashFactor", "SERVER_UPDATE_HASH_FACTOR")
 	_ = v.BindEnv("runtime.updateConcurrentFactor", "SERVER_UPDATE_CONCURRENT_FACTOR")
-
-	// enable durable user event log
-	_ = v.BindEnv("runtime.enableDurableUserEventLog", "SERVER_ENABLE_DURABLE_USER_EVENT_LOG")
 
 	// internal client options
 	_ = v.BindEnv("internalClient.base.tlsStrategy", "SERVER_INTERNAL_CLIENT_BASE_STRATEGY")

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -317,12 +317,11 @@ func NewOLAPRepositoryFromPool(
 	payloadStoreOpts PayloadStoreRepositoryOpts,
 	statusUpdateBatchSizeLimits StatusUpdateBatchSizeLimits,
 	cacheDuration time.Duration,
-	enableDurableUserEventLog bool,
 	shouldPartitionOtelTables bool,
 ) (OLAPRepository, func() error) {
 	v := validator.NewDefaultValidator()
 
-	shared, cleanupShared := newSharedRepository(pool, nil, v, l, payloadStoreOpts, tenantLimitConfig, enforceLimits, cacheDuration, enableDurableUserEventLog)
+	shared, cleanupShared := newSharedRepository(pool, nil, v, l, payloadStoreOpts, tenantLimitConfig, enforceLimits, cacheDuration)
 
 	return newOLAPRepository(shared, olapRetentionPeriod, shouldPartitionEventsTables, shouldPartitionOtelTables, statusUpdateBatchSizeLimits), cleanupShared
 }

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -101,11 +101,10 @@ func NewRepository(
 	statusUpdateBatchSizeLimits StatusUpdateBatchSizeLimits,
 	tenantLimitConfig limits.LimitConfigFile,
 	enforceLimits bool,
-	enableDurableUserEventLog bool,
 ) (Repository, func() error) {
 	v := validator.NewDefaultValidator()
 
-	shared, cleanupShared := newSharedRepository(pool, directPool, v, l, payloadStoreOpts, tenantLimitConfig, enforceLimits, cacheDuration, enableDurableUserEventLog)
+	shared, cleanupShared := newSharedRepository(pool, directPool, v, l, payloadStoreOpts, tenantLimitConfig, enforceLimits, cacheDuration)
 
 	mq, cleanupMq := newMessageQueueRepository(shared)
 
@@ -116,7 +115,7 @@ func NewRepository(
 		health:            newHealthRepository(shared),
 		messageQueue:      mq,
 		rateLimit:         newRateLimitRepository(shared),
-		triggers:          newTriggerRepository(shared, enableDurableUserEventLog),
+		triggers:          newTriggerRepository(shared),
 		tasks:             newTaskRepository(shared, taskRetentionPeriod, maxInternalRetryCount, taskLimits.TimeoutLimit, taskLimits.ReassignLimit, taskLimits.RetryQueueLimit, taskLimits.DurableSleepLimit),
 		scheduler:         newSchedulerRepository(shared),
 		matches:           newMatchRepository(shared),

--- a/pkg/repository/shared.go
+++ b/pkg/repository/shared.go
@@ -46,8 +46,6 @@ type sharedRepository struct {
 	taskLookupCache *lru.Cache[taskExternalIdTenantIdTuple, *sqlcv1.FlattenExternalIdsRow]
 	payloadStore    PayloadStoreRepository
 	m               TenantLimitRepository
-
-	enableDurableUserEventLog bool
 }
 
 func newSharedRepository(
@@ -59,7 +57,6 @@ func newSharedRepository(
 	c limits.LimitConfigFile,
 	shouldEnforceLimits bool,
 	cacheDuration time.Duration,
-	enableDurableUserEventLog bool,
 ) (*sharedRepository, func() error) {
 	queries := sqlcv1.New()
 	queueCache := cache.New(5 * time.Minute)
@@ -107,7 +104,6 @@ func newSharedRepository(
 		env:                         env,
 		taskLookupCache:             lookupCache,
 		payloadStore:                payloadStore,
-		enableDurableUserEventLog:   enableDurableUserEventLog,
 	}
 
 	tenantLimitRepository := newTenantLimitRepository(s, c, shouldEnforceLimits, cacheDuration)

--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -145,14 +145,11 @@ type TriggerRepository interface {
 
 type TriggerRepositoryImpl struct {
 	*sharedRepository
-
-	enableDurableUserEventLog bool
 }
 
-func newTriggerRepository(s *sharedRepository, enableDurableUserEventLog bool) TriggerRepository {
+func newTriggerRepository(s *sharedRepository) TriggerRepository {
 	return &TriggerRepositoryImpl{
-		sharedRepository:          s,
-		enableDurableUserEventLog: enableDurableUserEventLog,
+		sharedRepository: s,
 	}
 }
 
@@ -2037,24 +2034,22 @@ func (r *sharedRepository) prepareTriggerFromEvents(ctx context.Context, tx sqlc
 	uniqueEventKeys := make(map[string]struct{})
 
 	for _, opt := range opts {
-		if r.enableDurableUserEventLog {
-			createCoreEventsTenantIds = append(createCoreEventsTenantIds, tenantId)
-			createCoreEventsExternalIds = append(createCoreEventsExternalIds, opt.ExternalId)
-			createCoreEventsSeenAts = append(createCoreEventsSeenAts, sqlchelpers.TimestamptzFromTime(seenAt))
-			createCoreEventsKeys = append(createCoreEventsKeys, opt.Key)
-			eventExternalIdsToPayloads[opt.ExternalId] = opt.Data
-			createCoreEventsAdditionalMetadatas = append(createCoreEventsAdditionalMetadatas, opt.AdditionalMetadata)
-			if opt.Scope != nil {
-				createCoreEventsScopes = append(createCoreEventsScopes, pgtype.Text{String: *opt.Scope, Valid: true})
-			} else {
-				createCoreEventsScopes = append(createCoreEventsScopes, pgtype.Text{Valid: false})
-			}
+		createCoreEventsTenantIds = append(createCoreEventsTenantIds, tenantId)
+		createCoreEventsExternalIds = append(createCoreEventsExternalIds, opt.ExternalId)
+		createCoreEventsSeenAts = append(createCoreEventsSeenAts, sqlchelpers.TimestamptzFromTime(seenAt))
+		createCoreEventsKeys = append(createCoreEventsKeys, opt.Key)
+		eventExternalIdsToPayloads[opt.ExternalId] = opt.Data
+		createCoreEventsAdditionalMetadatas = append(createCoreEventsAdditionalMetadatas, opt.AdditionalMetadata)
+		if opt.Scope != nil {
+			createCoreEventsScopes = append(createCoreEventsScopes, pgtype.Text{String: *opt.Scope, Valid: true})
+		} else {
+			createCoreEventsScopes = append(createCoreEventsScopes, pgtype.Text{Valid: false})
+		}
 
-			if opt.TriggeringWebhookName != nil {
-				createCoreEventsTriggeringWebhookNames = append(createCoreEventsTriggeringWebhookNames, pgtype.Text{String: *opt.TriggeringWebhookName, Valid: true})
-			} else {
-				createCoreEventsTriggeringWebhookNames = append(createCoreEventsTriggeringWebhookNames, pgtype.Text{Valid: false})
-			}
+		if opt.TriggeringWebhookName != nil {
+			createCoreEventsTriggeringWebhookNames = append(createCoreEventsTriggeringWebhookNames, pgtype.Text{String: *opt.TriggeringWebhookName, Valid: true})
+		} else {
+			createCoreEventsTriggeringWebhookNames = append(createCoreEventsTriggeringWebhookNames, pgtype.Text{Valid: false})
 		}
 
 		eventKeysToOpts[opt.Key] = append(eventKeysToOpts[opt.Key], opt)
@@ -2214,20 +2209,18 @@ func (r *sharedRepository) prepareTriggerFromEvents(ctx context.Context, tx sqlc
 		}
 	}
 
-	if r.enableDurableUserEventLog {
-		createCoreEventOpts = &createCoreUserEventOpts{
-			params: sqlcv1.BulkCreateEventsParams{
-				Tenantids:              createCoreEventsTenantIds,
-				Externalids:            createCoreEventsExternalIds,
-				Seenats:                createCoreEventsSeenAts,
-				Keys:                   createCoreEventsKeys,
-				Additionalmetadatas:    createCoreEventsAdditionalMetadatas,
-				Scopes:                 createCoreEventsScopes,
-				TriggeringWebhookNames: createCoreEventsTriggeringWebhookNames,
-			},
-			externalIdToEventIdAndFilterId: externalIdToEventIdAndFilterId,
-			externalIdsToPayloads:          eventExternalIdsToPayloads,
-		}
+	createCoreEventOpts = &createCoreUserEventOpts{
+		params: sqlcv1.BulkCreateEventsParams{
+			Tenantids:              createCoreEventsTenantIds,
+			Externalids:            createCoreEventsExternalIds,
+			Seenats:                createCoreEventsSeenAts,
+			Keys:                   createCoreEventsKeys,
+			Additionalmetadatas:    createCoreEventsAdditionalMetadatas,
+			Scopes:                 createCoreEventsScopes,
+			TriggeringWebhookNames: createCoreEventsTriggeringWebhookNames,
+		},
+		externalIdToEventIdAndFilterId: externalIdToEventIdAndFilterId,
+		externalIdsToPayloads:          eventExternalIdsToPayloads,
 	}
 
 	return triggerOpts, createCoreEventOpts, externalIdToEventIdAndFilterId, celEvaluationFailures, nil

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -2239,7 +2239,7 @@ CREATE TABLE v1_event (
     PRIMARY KEY (tenant_id, seen_at, id)
 ) PARTITION BY RANGE(seen_at);
 
-CREATE INDEX v1_event_key_idx ON v1_event (tenant_id, key);
+CREATE INDEX v1_event_key_scope_idx ON v1_event (tenant_id, key, scope);
 
 CREATE TABLE v1_event_lookup_table (
     tenant_id UUID NOT NULL,


### PR DESCRIPTION
# Description

Removes the env var to enable the event log on the core db, and just enables it.

Also modified the event key index to include the scope for future use (should be a trivial migration since nobody's using the event log yet)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
