### PR TITLE
Lint all supported Python versions

### DIFF
--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -21,6 +21,9 @@ defaults:
 jobs:
   lint:
     runs-on: ubicloud-standard-4
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -28,7 +31,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.14'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
         uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1

--- a/sdks/python/hatchet_sdk/opentelemetry/instrumentor.py
+++ b/sdks/python/hatchet_sdk/opentelemetry/instrumentor.py
@@ -1,5 +1,4 @@
 import json
-import sys
 from collections.abc import Callable, Collection, Coroutine, Sequence
 from datetime import datetime, timedelta, timezone
 from importlib.metadata import version
@@ -452,16 +451,16 @@ class HatchetInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
     ) -> list[Any]:
-        if sys.version_info >= (3, 14):
-            import annotationlib
+        try:
+            import annotationlib  # type: ignore[import-not-found]
 
             # Python 3.14+ with PEP 749 can fail evaluating annotations lazily,
             # so use Format.STRING to avoid resolving type hints.
             sig = inspect.signature(
                 wrapped_func,
-                annotation_format=annotationlib.Format.STRING,
+                annotation_format=annotationlib.Format.STRING,  # type: ignore[call-arg]
             )
-        else:
+        except Exception:
             # Fallback for Python < 3.14 where annotation_format is not supported
             sig = inspect.signature(wrapped_func)
 

--- a/sdks/python/hatchet_sdk/opentelemetry/instrumentor.py
+++ b/sdks/python/hatchet_sdk/opentelemetry/instrumentor.py
@@ -452,13 +452,13 @@ class HatchetInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         kwargs: dict[str, Any],
     ) -> list[Any]:
         try:
-            import annotationlib  # type: ignore[import-not-found]
+            import annotationlib  # type: ignore[import-not-found, unused-ignore]
 
             # Python 3.14+ with PEP 749 can fail evaluating annotations lazily,
             # so use Format.STRING to avoid resolving type hints.
             sig = inspect.signature(
                 wrapped_func,
-                annotation_format=annotationlib.Format.STRING,  # type: ignore[call-arg]
+                annotation_format=annotationlib.Format.STRING,  # type: ignore[call-arg, unused-ignore]
             )
         except Exception:
             # Fallback for Python < 3.14 where annotation_format is not supported

--- a/sdks/python/hatchet_sdk/opentelemetry/instrumentor.py
+++ b/sdks/python/hatchet_sdk/opentelemetry/instrumentor.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from collections.abc import Callable, Collection, Coroutine, Sequence
 from datetime import datetime, timedelta, timezone
 from importlib.metadata import version
@@ -451,7 +452,7 @@ class HatchetInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
     ) -> list[Any]:
-        try:
+        if sys.version_info >= (3, 14):
             import annotationlib
 
             # Python 3.14+ with PEP 749 can fail evaluating annotations lazily,
@@ -460,7 +461,7 @@ class HatchetInstrumentor(BaseInstrumentor):  # type: ignore[misc]
                 wrapped_func,
                 annotation_format=annotationlib.Format.STRING,
             )
-        except Exception:
+        else:
             # Fallback for Python < 3.14 where annotation_format is not supported
             sig = inspect.signature(wrapped_func)
 


### PR DESCRIPTION
# Description

To avoid issues surrounding features available in later Python versions that aren't in 3.10, lint all supported Python versions

Fixes # (issue)

## Type of change

- [x] CI (any automation pipeline changes)

