### PR TITLE
Fix: OTel trace lookup insert deadlock

### DIFF
--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -3634,14 +3634,6 @@ func (o *OLAPRepositoryImpl) CreateSpanLookupTableEntries(ctx context.Context, t
 		return nil
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, o.pool, o.l)
-
-	if err != nil {
-		return err
-	}
-
-	defer rollback()
-
 	lookupTenantIds := make([]uuid.UUID, 0)
 	lookupExternalIds := make([]uuid.UUID, 0)
 	lookupRetryCounts := make([]int32, 0)
@@ -3683,6 +3675,14 @@ func (o *OLAPRepositoryImpl) CreateSpanLookupTableEntries(ctx context.Context, t
 			}
 		}
 	}
+
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, o.pool, o.l)
+
+	if err != nil {
+		return err
+	}
+
+	defer rollback()
 
 	err = o.queries.InsertOTelTraceLookup(ctx, tx, sqlcv1.InsertOTelTraceLookupParams{
 		Tenantids:   lookupTenantIds,

--- a/pkg/repository/sqlcv1/otel.sql
+++ b/pkg/repository/sqlcv1/otel.sql
@@ -61,6 +61,7 @@ SELECT
     retry_count,
     start_time
 FROM inputs
+ORDER BY tenant_id, trace_id, start_time, span_id
 ON CONFLICT (tenant_id, trace_id, start_time, span_id) DO NOTHING
 ;
 
@@ -87,6 +88,7 @@ SELECT
     trace_id,
     start_time
 FROM inputs
+ORDER BY tenant_id, external_id, retry_count, start_time
 ON CONFLICT (tenant_id, external_id, retry_count, start_time) DO NOTHING
 ;
 

--- a/pkg/repository/sqlcv1/otel.sql.go
+++ b/pkg/repository/sqlcv1/otel.sql.go
@@ -35,6 +35,7 @@ SELECT
     trace_id,
     start_time
 FROM inputs
+ORDER BY tenant_id, external_id, retry_count, start_time
 ON CONFLICT (tenant_id, external_id, retry_count, start_time) DO NOTHING
 `
 
@@ -120,6 +121,7 @@ SELECT
     retry_count,
     start_time
 FROM inputs
+ORDER BY tenant_id, trace_id, start_time, span_id
 ON CONFLICT (tenant_id, trace_id, start_time, span_id) DO NOTHING
 `
 


### PR DESCRIPTION
# Description

Adds explicit ordering to the OTel inserts to try to avoid deadlocking, and also moves the tx creation later in the lookup insert to try to keep the tx open for as little time as possible

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
