### PR TITLE
fix(vscode-xt): don't opentextdocument when a file read works just fine

### DIFF
--- a/frontend/vscode-extension/README.md
+++ b/frontend/vscode-extension/README.md
@@ -40,6 +40,10 @@ You can report issues in our [Github issues](https://github.com/hatchet-dev/hatc
 
 ## Changelog
 
+### 0.2.1
+
+- **Fix memory leak** — workspace annotation scanning now reads files via `vscode.workspace.fs.readFile` instead of `openTextDocument`, preventing Monaco text models from being created for every `.ts`/`.tsx` file in the workspace.
+
 ### 0.2.0
 
 - **Custom wrapper support** — annotate any factory function with `@hatchet-workflow` to get DAG visualization for variables it creates, with no other config required. Use `@hatchet-task-method` and `@hatchet-task-parents` to match your wrapper's API when it differs from the Hatchet defaults.

--- a/frontend/vscode-extension/package.json
+++ b/frontend/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "hatchet",
   "displayName": "Hatchet",
   "description": "Visualize Hatchet workflow DAGs inline in your editor",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "hatchet",
   "license": "MIT",
   "repository": {

--- a/frontend/vscode-extension/src/analysis/annotation-cache.ts
+++ b/frontend/vscode-extension/src/analysis/annotation-cache.ts
@@ -69,8 +69,8 @@ export class WorkflowAnnotationCache {
 
     if (!remove) {
       try {
-        const doc = await vscode.workspace.openTextDocument(uri);
-        const text = doc.getText();
+        const bytes = await vscode.workspace.fs.readFile(uri);
+        const text = new TextDecoder().decode(bytes);
         const found = scanFileForWorkflowAnnotations(text, uri.fsPath);
         if (found.length > 0) {
           this._byFile.set(

--- a/frontend/vscode-extension/src/analysis/lsp-analyzer.ts
+++ b/frontend/vscode-extension/src/analysis/lsp-analyzer.ts
@@ -59,15 +59,13 @@ export class LspAnalyzer {
           if (token.isCancellationRequested) return null;
 
           try {
-            const doc = await vscode.workspace.openTextDocument(location.uri);
+            const bytes = await vscode.workspace.fs.readFile(location.uri);
+            const allLines = new TextDecoder().decode(bytes).split(/\r?\n/);
             const refLine = location.range.start.line;
             const startLine = Math.max(0, refLine - 2);
-            const endLine = Math.min(doc.lineCount - 1, refLine + 30);
+            const endLine = Math.min(allLines.length - 1, refLine + 30);
 
-            const lines = Array.from(
-              { length: endLine - startLine + 1 },
-              (_, i) => doc.lineAt(startLine + i).text,
-            );
+            const lines = allLines.slice(startLine, endLine + 1);
 
             return extractTaskAtLocation(
               lines,


### PR DESCRIPTION
# Description

We're calling `openTextDocument` and there's some evidence this is kept open in the extension host process without ever getting cleaned up. For large codebases this can be a source of high memory usage. This PR replaces these with `fs.readFile`. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)