### PR TITLE
Fix: run payloads job at midnight

### DIFF
--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -3412,7 +3412,7 @@ func (p *OLAPRepositoryImpl) ProcessOLAPPayloadCutovers(ctx context.Context, ext
 	}
 
 	mostRecentPartitionToOffload := pgtype.Date{
-		Time:  time.Now().Add(-1 * (*inlineStoreTTL + 12*time.Hour)),
+		Time:  time.Now().Add(-1 * *inlineStoreTTL),
 		Valid: true,
 	}
 


### PR DESCRIPTION
# Description

Runs the payloads job at midnight utc instead of noon, to start the offload earlier and keep less data in the db

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

