### PR TITLE
Fix: Propagate desired label overrides to all DAG tasks

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260409022005_v1_0_95.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260409022005_v1_0_95.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE v1_dag ADD COLUMN desired_worker_labels JSONB;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE v1_dag DROP COLUMN desired_worker_labels;
+-- +goose StatementEnd

--- a/examples/python/runtime_affinity/worker.py
+++ b/examples/python/runtime_affinity/worker.py
@@ -10,8 +10,16 @@ class AffinityResult(BaseModel):
     worker_id: str
 
 
-@hatchet.task()
-async def affinity_example_task(i: EmptyModel, c: Context) -> AffinityResult:
+runtime_affinity_workflow = hatchet.workflow(name="runtime_affinity_workflow")
+
+
+@runtime_affinity_workflow.task()
+async def affinity_task_1(i: EmptyModel, c: Context) -> AffinityResult:
+    return AffinityResult(worker_id=c.worker_id)
+
+
+@runtime_affinity_workflow.task(parents=[affinity_task_1])
+async def affinity_task_2(i: EmptyModel, c: Context) -> AffinityResult:
     return AffinityResult(worker_id=c.worker_id)
 
 
@@ -23,7 +31,7 @@ def main() -> None:
     worker = hatchet.worker(
         "runtime-affinity-worker",
         labels={"affinity": args.label},
-        workflows=[affinity_example_task],
+        workflows=[runtime_affinity_workflow],
     )
 
     worker.start()

--- a/examples/typescript/runtime_affinity/workflow.ts
+++ b/examples/typescript/runtime_affinity/workflow.ts
@@ -1,7 +1,24 @@
 import { hatchet } from '../hatchet-client';
 
-export const affinityExampleTask = hatchet.task({
-  name: 'affinity-example-task',
+type AffinityOutput = {
+  affinity_t1: { worker_id: string | undefined };
+  affinity_t2: { worker_id: string | undefined };
+};
+
+export const affinityExampleTask = hatchet.workflow<{}, AffinityOutput>({
+  name: 'runtime_affinity_workflow',
+});
+
+const affinityT1 = affinityExampleTask.task({
+  name: 'affinity_t1',
+  fn: async (input, ctx) => {
+    return { worker_id: ctx.worker.id() };
+  },
+});
+
+affinityExampleTask.task({
+  name: 'affinity_t2',
+  parents: [affinityT1],
   fn: async (input, ctx) => {
     return { worker_id: ctx.worker.id() };
   },

--- a/pkg/repository/match.go
+++ b/pkg/repository/match.go
@@ -567,6 +567,7 @@ func (m *sharedRepository) processEventMatches(ctx context.Context, tx sqlcv1.DB
 
 		dagIdsToInput := make(map[int64][]byte)
 		dagIdsToMetadata := make(map[int64][]byte)
+		dagIdsToDesiredWorkerLabels := make(map[int64][]*sqlcv1.GetDesiredLabelsRow)
 
 		for _, dagData := range dagInputDatas {
 			retrieveOpts := RetrievePayloadOpts{
@@ -584,6 +585,13 @@ func (m *sharedRepository) processEventMatches(ctx context.Context, tx sqlcv1.DB
 
 			dagIdsToInput[dagData.DagID] = payload
 			dagIdsToMetadata[dagData.DagID] = dagData.AdditionalMetadata
+
+			if len(dagData.DesiredWorkerLabels) > 0 {
+				var labels []*sqlcv1.GetDesiredLabelsRow
+				if err := json.Unmarshal(dagData.DesiredWorkerLabels, &labels); err == nil {
+					dagIdsToDesiredWorkerLabels[dagData.DagID] = labels
+				}
+			}
 		}
 
 		// determine which tasks to create based on step ids
@@ -657,6 +665,16 @@ func (m *sharedRepository) processEventMatches(ctx context.Context, tx sqlcv1.DB
 					if match.TriggerDagID.Valid && match.TriggerDagInsertedAt.Valid {
 						opt.DagId = &match.TriggerDagID.Int64
 						opt.DagInsertedAt = match.TriggerDagInsertedAt
+
+						if dagLabels, ok := dagIdsToDesiredWorkerLabels[match.TriggerDagID.Int64]; ok && len(dagLabels) > 0 {
+							labels := make([]*sqlcv1.GetDesiredLabelsRow, len(dagLabels))
+							for i, l := range dagLabels {
+								lCopy := *l
+								lCopy.StepId = *match.TriggerStepID
+								labels[i] = &lCopy
+							}
+							opt.DesiredWorkerLabels = labels
+						}
 					}
 
 					if match.TriggerParentTaskExternalID != nil {

--- a/pkg/repository/match.go
+++ b/pkg/repository/match.go
@@ -590,6 +590,8 @@ func (m *sharedRepository) processEventMatches(ctx context.Context, tx sqlcv1.DB
 				var labels []*sqlcv1.GetDesiredLabelsRow
 				if err := json.Unmarshal(dagData.DesiredWorkerLabels, &labels); err == nil {
 					dagIdsToDesiredWorkerLabels[dagData.DagID] = labels
+				} else {
+					m.l.Error().Err(err).Msgf("failed to unmarshal desired worker labels for dag id %d and dag inserted at %s", dagData.DagID, dagData.DagInsertedAt)
 				}
 			}
 		}

--- a/pkg/repository/match.go
+++ b/pkg/repository/match.go
@@ -591,7 +591,7 @@ func (m *sharedRepository) processEventMatches(ctx context.Context, tx sqlcv1.DB
 				if err := json.Unmarshal(dagData.DesiredWorkerLabels, &labels); err == nil {
 					dagIdsToDesiredWorkerLabels[dagData.DagID] = labels
 				} else {
-					m.l.Error().Err(err).Msgf("failed to unmarshal desired worker labels for dag id %d and dag inserted at %s", dagData.DagID, dagData.DagInsertedAt)
+					m.l.Error().Err(err).Msgf("failed to unmarshal desired worker labels for dag id %d and dag inserted at %s", dagData.DagID, dagData.DagInsertedAt.Time)
 				}
 			}
 		}

--- a/pkg/repository/sqlcv1/dags.sql
+++ b/pkg/repository/sqlcv1/dags.sql
@@ -19,17 +19,13 @@ JOIN
 -- name: CreateDAGs :many
 WITH input AS (
     SELECT
-        *
-    FROM
-        (
-            SELECT
-                unnest(@tenantIds::uuid[]) AS tenant_id,
-                unnest(@externalIds::uuid[]) AS external_id,
-                unnest(@displayNames::text[]) AS display_name,
-                unnest(@workflowIds::uuid[]) AS workflow_id,
-                unnest(@workflowVersionIds::uuid[]) AS workflow_version_id,
-                unnest(@parentTaskExternalIds::uuid[]) AS parent_task_external_id
-        ) AS subquery
+        unnest(@tenantIds::uuid[]) AS tenant_id,
+        unnest(@externalIds::uuid[]) AS external_id,
+        unnest(@displayNames::text[]) AS display_name,
+        unnest(@workflowIds::uuid[]) AS workflow_id,
+        unnest(@workflowVersionIds::uuid[]) AS workflow_version_id,
+        unnest(@parentTaskExternalIds::uuid[]) AS parent_task_external_id,
+        unnest(@desiredWorkerLabels::jsonb[]) AS desired_worker_labels
 )
 INSERT INTO v1_dag (
     tenant_id,
@@ -37,7 +33,8 @@ INSERT INTO v1_dag (
     display_name,
     workflow_id,
     workflow_version_id,
-    parent_task_external_id
+    parent_task_external_id,
+    desired_worker_labels
 )
 SELECT
     i.tenant_id,
@@ -45,7 +42,8 @@ SELECT
     i.display_name,
     i.workflow_id,
     i.workflow_version_id,
-    NULLIF(i.parent_task_external_id, '00000000-0000-0000-0000-000000000000'::uuid)
+    NULLIF(i.parent_task_external_id, '00000000-0000-0000-0000-000000000000'::uuid),
+    i.desired_worker_labels
 FROM
     input i
 RETURNING

--- a/pkg/repository/sqlcv1/dags.sql
+++ b/pkg/repository/sqlcv1/dags.sql
@@ -1,20 +1,16 @@
 -- name: GetDAGData :many
 WITH input AS (
     SELECT
-        *
-    FROM
-        (
-            SELECT
-                unnest(@dagIds::bigint[]) AS dag_id,
-                unnest(@dagInsertedAts::timestamptz[]) AS dag_inserted_at
-        ) AS subquery
+        unnest(@dagIds::bigint[]) AS dag_id,
+        unnest(@dagInsertedAts::timestamptz[]) AS dag_inserted_at
 )
-SELECT
-    *
-FROM
-    v1_dag_data
-JOIN
-    input USING (dag_id, dag_inserted_at);
+SELECT dd.*, d.desired_worker_labels
+FROM v1_dag d
+JOIN v1_dag_data dd ON (d.id, d.inserted_at) = (dd.dag_id, dd.dag_inserted_at)
+WHERE (d.id, d.inserted_at) IN (
+    SELECT dag_id, dag_inserted_at
+    FROM input
+);
 
 -- name: CreateDAGs :many
 WITH input AS (

--- a/pkg/repository/sqlcv1/dags.sql.go
+++ b/pkg/repository/sqlcv1/dags.sql.go
@@ -22,17 +22,13 @@ type CreateDAGDataParams struct {
 const createDAGs = `-- name: CreateDAGs :many
 WITH input AS (
     SELECT
-        tenant_id, external_id, display_name, workflow_id, workflow_version_id, parent_task_external_id
-    FROM
-        (
-            SELECT
-                unnest($1::uuid[]) AS tenant_id,
-                unnest($2::uuid[]) AS external_id,
-                unnest($3::text[]) AS display_name,
-                unnest($4::uuid[]) AS workflow_id,
-                unnest($5::uuid[]) AS workflow_version_id,
-                unnest($6::uuid[]) AS parent_task_external_id
-        ) AS subquery
+        unnest($1::uuid[]) AS tenant_id,
+        unnest($2::uuid[]) AS external_id,
+        unnest($3::text[]) AS display_name,
+        unnest($4::uuid[]) AS workflow_id,
+        unnest($5::uuid[]) AS workflow_version_id,
+        unnest($6::uuid[]) AS parent_task_external_id,
+        unnest($7::jsonb[]) AS desired_worker_labels
 )
 INSERT INTO v1_dag (
     tenant_id,
@@ -40,7 +36,8 @@ INSERT INTO v1_dag (
     display_name,
     workflow_id,
     workflow_version_id,
-    parent_task_external_id
+    parent_task_external_id,
+    desired_worker_labels
 )
 SELECT
     i.tenant_id,
@@ -48,11 +45,12 @@ SELECT
     i.display_name,
     i.workflow_id,
     i.workflow_version_id,
-    NULLIF(i.parent_task_external_id, '00000000-0000-0000-0000-000000000000'::uuid)
+    NULLIF(i.parent_task_external_id, '00000000-0000-0000-0000-000000000000'::uuid),
+    i.desired_worker_labels
 FROM
     input i
 RETURNING
-    id, inserted_at, tenant_id, external_id, display_name, workflow_id, workflow_version_id, parent_task_external_id
+    id, inserted_at, tenant_id, external_id, display_name, workflow_id, workflow_version_id, parent_task_external_id, desired_worker_labels
 `
 
 type CreateDAGsParams struct {
@@ -62,6 +60,7 @@ type CreateDAGsParams struct {
 	Workflowids           []uuid.UUID `json:"workflowids"`
 	Workflowversionids    []uuid.UUID `json:"workflowversionids"`
 	Parenttaskexternalids []uuid.UUID `json:"parenttaskexternalids"`
+	Desiredworkerlabels   [][]byte    `json:"desiredworkerlabels"`
 }
 
 func (q *Queries) CreateDAGs(ctx context.Context, db DBTX, arg CreateDAGsParams) ([]*V1Dag, error) {
@@ -72,6 +71,7 @@ func (q *Queries) CreateDAGs(ctx context.Context, db DBTX, arg CreateDAGsParams)
 		arg.Workflowids,
 		arg.Workflowversionids,
 		arg.Parenttaskexternalids,
+		arg.Desiredworkerlabels,
 	)
 	if err != nil {
 		return nil, err
@@ -89,6 +89,7 @@ func (q *Queries) CreateDAGs(ctx context.Context, db DBTX, arg CreateDAGsParams)
 			&i.WorkflowID,
 			&i.WorkflowVersionID,
 			&i.ParentTaskExternalID,
+			&i.DesiredWorkerLabels,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/repository/sqlcv1/dags.sql.go
+++ b/pkg/repository/sqlcv1/dags.sql.go
@@ -104,20 +104,16 @@ func (q *Queries) CreateDAGs(ctx context.Context, db DBTX, arg CreateDAGsParams)
 const getDAGData = `-- name: GetDAGData :many
 WITH input AS (
     SELECT
-        dag_id, dag_inserted_at
-    FROM
-        (
-            SELECT
-                unnest($1::bigint[]) AS dag_id,
-                unnest($2::timestamptz[]) AS dag_inserted_at
-        ) AS subquery
+        unnest($1::bigint[]) AS dag_id,
+        unnest($2::timestamptz[]) AS dag_inserted_at
 )
-SELECT
-    v1_dag_data.dag_id, v1_dag_data.dag_inserted_at, input, additional_metadata, input.dag_id, input.dag_inserted_at
-FROM
-    v1_dag_data
-JOIN
-    input USING (dag_id, dag_inserted_at)
+SELECT dd.dag_id, dd.dag_inserted_at, dd.input, dd.additional_metadata, d.desired_worker_labels
+FROM v1_dag d
+JOIN v1_dag_data dd ON (d.id, d.inserted_at) = (dd.dag_id, dd.dag_inserted_at)
+WHERE (d.id, d.inserted_at) IN (
+    SELECT dag_id, dag_inserted_at
+    FROM input
+)
 `
 
 type GetDAGDataParams struct {
@@ -126,12 +122,11 @@ type GetDAGDataParams struct {
 }
 
 type GetDAGDataRow struct {
-	DagID              int64              `json:"dag_id"`
-	DagInsertedAt      pgtype.Timestamptz `json:"dag_inserted_at"`
-	Input              []byte             `json:"input"`
-	AdditionalMetadata []byte             `json:"additional_metadata"`
-	DagID_2            interface{}        `json:"dag_id_2"`
-	DagInsertedAt_2    interface{}        `json:"dag_inserted_at_2"`
+	DagID               int64              `json:"dag_id"`
+	DagInsertedAt       pgtype.Timestamptz `json:"dag_inserted_at"`
+	Input               []byte             `json:"input"`
+	AdditionalMetadata  []byte             `json:"additional_metadata"`
+	DesiredWorkerLabels []byte             `json:"desired_worker_labels"`
 }
 
 func (q *Queries) GetDAGData(ctx context.Context, db DBTX, arg GetDAGDataParams) ([]*GetDAGDataRow, error) {
@@ -148,8 +143,7 @@ func (q *Queries) GetDAGData(ctx context.Context, db DBTX, arg GetDAGDataParams)
 			&i.DagInsertedAt,
 			&i.Input,
 			&i.AdditionalMetadata,
-			&i.DagID_2,
-			&i.DagInsertedAt_2,
+			&i.DesiredWorkerLabels,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/repository/sqlcv1/models.go
+++ b/pkg/repository/sqlcv1/models.go
@@ -3116,6 +3116,7 @@ type V1Dag struct {
 	WorkflowID           uuid.UUID          `json:"workflow_id"`
 	WorkflowVersionID    uuid.UUID          `json:"workflow_version_id"`
 	ParentTaskExternalID *uuid.UUID         `json:"parent_task_external_id"`
+	DesiredWorkerLabels  []byte             `json:"desired_worker_labels"`
 }
 
 type V1DagData struct {

--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -129,6 +129,9 @@ type createDAGOpts struct {
 	AdditionalMetadata []byte
 
 	ParentTaskExternalID *uuid.UUID
+
+	// (optional) overrides for desired worker labels, propagated to all downstream tasks
+	DesiredWorkerLabels []*sqlcv1.GetDesiredLabelsRow
 }
 
 type TriggerRepository interface {
@@ -1126,6 +1129,7 @@ func (r *sharedRepository) triggerWorkflows(
 				WorkflowName:         tuple.workflowName,
 				AdditionalMetadata:   tuple.additionalMetadata,
 				ParentTaskExternalID: tuple.parentExternalId,
+				DesiredWorkerLabels:  tuple.desiredWorkerLabels,
 			})
 		}
 	}
@@ -1364,6 +1368,7 @@ func (r *sharedRepository) createDAGs(ctx context.Context, tx sqlcv1.DBTX, tenan
 	workflowVersionIds := make([]uuid.UUID, 0, len(opts))
 	parentTaskExternalIds := make([]uuid.UUID, 0, len(opts))
 	dagIdToOpt := make(map[uuid.UUID]createDAGOpts, 0)
+	desiredWorkerLabels := make([][]byte, 0, len(opts))
 
 	unix := time.Now().UnixMilli()
 
@@ -1380,6 +1385,18 @@ func (r *sharedRepository) createDAGs(ctx context.Context, tx sqlcv1.DBTX, tenan
 			parentTaskExternalIds = append(parentTaskExternalIds, *opt.ParentTaskExternalID)
 		}
 
+		var desiredWorkerLabelsBytes []byte
+		var err error
+
+		if len(opt.DesiredWorkerLabels) > 0 {
+			desiredWorkerLabelsBytes, err = json.Marshal(opt.DesiredWorkerLabels)
+			if err != nil {
+				return nil, fmt.Errorf("could not marshal desired worker labels: %w", err)
+			}
+		}
+
+		desiredWorkerLabels = append(desiredWorkerLabels, desiredWorkerLabelsBytes)
+
 		dagIdToOpt[opt.ExternalId] = opt
 	}
 
@@ -1390,6 +1407,7 @@ func (r *sharedRepository) createDAGs(ctx context.Context, tx sqlcv1.DBTX, tenan
 		Workflowids:           workflowIds,
 		Workflowversionids:    workflowVersionIds,
 		Parenttaskexternalids: parentTaskExternalIds,
+		Desiredworkerlabels:   desiredWorkerLabels,
 	})
 
 	if err != nil {

--- a/sdks/python/examples/runtime_affinity/test_runtime_affinity.py
+++ b/sdks/python/examples/runtime_affinity/test_runtime_affinity.py
@@ -93,5 +93,5 @@ async def test_runtime_affinity(
                 ),
             ],
         )
-        assert res["affinity_t1"]["worker_id"] == worker_label_to_id[target_worker]
-        assert res["affinity_t2"]["worker_id"] == worker_label_to_id[target_worker]
+        assert res["affinity_task_1"]["worker_id"] == worker_label_to_id[target_worker]
+        assert res["affinity_task_2"]["worker_id"] == worker_label_to_id[target_worker]

--- a/sdks/python/examples/runtime_affinity/test_runtime_affinity.py
+++ b/sdks/python/examples/runtime_affinity/test_runtime_affinity.py
@@ -3,7 +3,7 @@ from hatchet_sdk import Hatchet
 from hatchet_sdk.labels import DesiredWorkerLabel
 from subprocess import Popen
 from typing import Any, Generator
-from examples.runtime_affinity.worker import affinity_example_task
+from examples.runtime_affinity.worker import runtime_affinity_workflow
 from random import choice
 from conftest import _on_demand_worker_fixture
 
@@ -84,7 +84,7 @@ async def test_runtime_affinity(
 
     for _ in range(20):
         target_worker = choice(labels)
-        res = await affinity_example_task.aio_run(
+        res = await runtime_affinity_workflow.aio_run(
             desired_worker_labels=[
                 DesiredWorkerLabel(
                     key="affinity",
@@ -93,4 +93,5 @@ async def test_runtime_affinity(
                 ),
             ],
         )
-        assert res.worker_id == worker_label_to_id[target_worker]
+        assert res["affinity_t1"]["worker_id"] == worker_label_to_id[target_worker]
+        assert res["affinity_t2"]["worker_id"] == worker_label_to_id[target_worker]

--- a/sdks/python/examples/runtime_affinity/worker.py
+++ b/sdks/python/examples/runtime_affinity/worker.py
@@ -10,8 +10,16 @@ class AffinityResult(BaseModel):
     worker_id: str
 
 
-@hatchet.task()
-async def affinity_example_task(i: EmptyModel, c: Context) -> AffinityResult:
+runtime_affinity_workflow = hatchet.workflow(name="runtime_affinity_workflow")
+
+
+@runtime_affinity_workflow.task()
+async def affinity_task_1(i: EmptyModel, c: Context) -> AffinityResult:
+    return AffinityResult(worker_id=c.worker_id)
+
+
+@runtime_affinity_workflow.task(parents=[affinity_task_1])
+async def affinity_task_2(i: EmptyModel, c: Context) -> AffinityResult:
     return AffinityResult(worker_id=c.worker_id)
 
 
@@ -23,7 +31,7 @@ def main() -> None:
     worker = hatchet.worker(
         "runtime-affinity-worker",
         labels={"affinity": args.label},
-        workflows=[affinity_example_task],
+        workflows=[runtime_affinity_workflow],
     )
 
     worker.start()

--- a/sdks/typescript/src/v1/examples/runtime_affinity/runtime-affinity.e2e.ts
+++ b/sdks/typescript/src/v1/examples/runtime_affinity/runtime-affinity.e2e.ts
@@ -74,7 +74,8 @@ describe('runtime-affinity-e2e', () => {
         }
       );
 
-      expect(res.worker_id).toBe(workerLabelToId[targetWorker]);
+      expect(res.affinity_t1.worker_id).toBe(workerLabelToId[targetWorker]);
+      expect(res.affinity_t2.worker_id).toBe(workerLabelToId[targetWorker]);
     }
   }, 120_000);
 });

--- a/sdks/typescript/src/v1/examples/runtime_affinity/workflow.ts
+++ b/sdks/typescript/src/v1/examples/runtime_affinity/workflow.ts
@@ -1,7 +1,24 @@
 import { hatchet } from '../hatchet-client';
 
-export const affinityExampleTask = hatchet.task({
-  name: 'affinity-example-task',
+type AffinityOutput = {
+  affinity_t1: { worker_id: string | undefined };
+  affinity_t2: { worker_id: string | undefined };
+};
+
+export const affinityExampleTask = hatchet.workflow<{}, AffinityOutput>({
+  name: 'runtime_affinity_workflow',
+});
+
+const affinityT1 = affinityExampleTask.task({
+  name: 'affinity_t1',
+  fn: async (input, ctx) => {
+    return { worker_id: ctx.worker.id() };
+  },
+});
+
+affinityExampleTask.task({
+  name: 'affinity_t2',
+  parents: [affinityT1],
   fn: async (input, ctx) => {
     return { worker_id: ctx.worker.id() };
   },

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -703,6 +703,7 @@ CREATE TABLE v1_dag (
     workflow_id UUID NOT NULL,
     workflow_version_id UUID NOT NULL,
     parent_task_external_id UUID,
+    desired_worker_labels JSONB,
     CONSTRAINT v1_dag_pkey PRIMARY KEY (id, inserted_at)
 ) PARTITION BY RANGE(inserted_at);
 


### PR DESCRIPTION
# Description

Fixes a bug where downstream (non-root) DAG tasks wouldn't inherit the trigger-time desired worker label, causing downstream tasks to run on random workers

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
