### PR TITLE
Fix: Python worker pause on shutdown

### DIFF
--- a/examples/python/bug_tests/worker_pause_on_sigterm/worker.py
+++ b/examples/python/bug_tests/worker_pause_on_sigterm/worker.py
@@ -1,0 +1,24 @@
+import time
+
+from hatchet_sdk import Context, EmptyModel, Hatchet
+
+hatchet = Hatchet()
+
+WORKER_NAME = "pause-on-sigterm-worker"
+
+
+@hatchet.task()
+def long_sleep(input: EmptyModel, ctx: Context) -> None:
+    time.sleep(6)
+
+
+def main() -> None:
+    worker = hatchet.worker(
+        WORKER_NAME,
+        workflows=[long_sleep],
+    )
+    worker.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.32.1] - 2026-04-09
+
+### Changed
+
+- Fixes a bug in the shutdown handlers that wouldn't correctly trigger graceful shutdown if only the parent process received a shutdown signal like `SIGTERM`, which might often be the case on e.g. Kubernetes.
+
 ## [1.32.0] - 2026-04-07
 
 ### Added

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixes a bug in the shutdown handlers that wouldn't correctly trigger graceful shutdown if only the parent process received a shutdown signal like `SIGTERM`, which might often be the case on e.g. Kubernetes.
+- Fixes an issue where we generated protobufs using a more recent grpcio version than the minimum allowed, causing breakages on older versions.
 
 ## [1.32.0] - 2026-04-07
 

--- a/sdks/python/conftest.py
+++ b/sdks/python/conftest.py
@@ -9,7 +9,7 @@ from pytest import FixtureRequest
 from hatchet_sdk import Hatchet
 from hatchet_sdk.deprecated.deprecation import semver_less_than
 from hatchet_sdk.engine_version import MinEngineVersion
-from tests.worker_fixture import hatchet_worker
+from tests.worker_fixture import get_free_port, hatchet_worker
 
 
 @pytest_asyncio.fixture(scope="session", loop_scope="session")
@@ -63,9 +63,9 @@ def worker() -> Generator[Popen[bytes], None, None]:
 def _on_demand_worker_fixture(
     request: FixtureRequest,
 ) -> Generator[Popen[bytes], None, None]:
-    command, port = cast(tuple[list[str], int], request.param)
+    command = cast(list[str], request.param)
 
-    with hatchet_worker(command, port) as proc:
+    with hatchet_worker(command, get_free_port()) as proc:
         yield proc
 
 

--- a/sdks/python/examples/bug_tests/worker_pause_on_sigterm/test_worker_pause_on_sigterm.py
+++ b/sdks/python/examples/bug_tests/worker_pause_on_sigterm/test_worker_pause_on_sigterm.py
@@ -13,15 +13,12 @@ from hatchet_sdk import EmptyModel, Hatchet, RunStatus
 @pytest.mark.parametrize(
     "on_demand_worker",
     [
-        (
-            [
-                "poetry",
-                "run",
-                "python",
-                "examples/bug_tests/worker_pause_on_sigterm/worker.py",
-            ],
-            8010,
-        )
+        [
+            "poetry",
+            "run",
+            "python",
+            "examples/bug_tests/worker_pause_on_sigterm/worker.py",
+        ]
     ],
     indirect=True,
 )
@@ -43,13 +40,15 @@ async def test_worker_pauses_when_only_parent_receives_sigterm(
     parent = psutil.Process(on_demand_worker.pid)
     parent.send_signal(signal.SIGTERM)
 
-    await asyncio.sleep(3)
-
-    worker_list = await hatchet.workers.aio_list()
-    matching = [w for w in (worker_list.rows or []) if w.name == WORKER_NAME]
-
-    assert matching
-    assert matching[0].status == "PAUSED"
+    matching = []
+    for _ in range(30):
+        worker_list = await hatchet.workers.aio_list()
+        matching = [w for w in (worker_list.rows or []) if w.name == WORKER_NAME]
+        if matching and matching[0].status == "PAUSED":
+            break
+        await asyncio.sleep(1)
+    else:
+        assert False, f"Worker {WORKER_NAME} never reported PAUSED"
 
     for _ in range(30):
         run = await hatchet.runs.aio_get_details(ref.workflow_run_id)

--- a/sdks/python/examples/bug_tests/worker_pause_on_sigterm/test_worker_pause_on_sigterm.py
+++ b/sdks/python/examples/bug_tests/worker_pause_on_sigterm/test_worker_pause_on_sigterm.py
@@ -43,8 +43,14 @@ async def test_worker_pauses_when_only_parent_receives_sigterm(
     matching = []
     for _ in range(30):
         worker_list = await hatchet.workers.aio_list()
-        matching = [w for w in (worker_list.rows or []) if w.name == WORKER_NAME]
-        if matching and matching[0].status == "PAUSED":
+
+        matching = [
+            w
+            for w in (worker_list.rows or [])
+            if w.name == WORKER_NAME and w.status == "PAUSED"
+        ]
+
+        if matching:
             break
         await asyncio.sleep(1)
     else:

--- a/sdks/python/examples/bug_tests/worker_pause_on_sigterm/test_worker_pause_on_sigterm.py
+++ b/sdks/python/examples/bug_tests/worker_pause_on_sigterm/test_worker_pause_on_sigterm.py
@@ -47,7 +47,8 @@ async def test_worker_pauses_when_only_parent_receives_sigterm(
         matching = [
             w
             for w in (worker_list.rows or [])
-            if w.name == WORKER_NAME and w.status == "PAUSED"
+            if w.name == hatchet.config.apply_namespace(WORKER_NAME)
+            and w.status == "PAUSED"
         ]
 
         if matching:

--- a/sdks/python/examples/bug_tests/worker_pause_on_sigterm/test_worker_pause_on_sigterm.py
+++ b/sdks/python/examples/bug_tests/worker_pause_on_sigterm/test_worker_pause_on_sigterm.py
@@ -51,6 +51,10 @@ async def test_worker_pauses_when_only_parent_receives_sigterm(
     assert matching
     assert matching[0].status == "PAUSED"
 
-    await hatchet.runs.aio_cancel(ref.workflow_run_id)
-
-    await asyncio.sleep(3)
+    for _ in range(30):
+        run = await hatchet.runs.aio_get_details(ref.workflow_run_id)
+        if run.status == RunStatus.COMPLETED:
+            break
+        await asyncio.sleep(1)
+    else:
+        assert False, "Task never completed"

--- a/sdks/python/examples/bug_tests/worker_pause_on_sigterm/test_worker_pause_on_sigterm.py
+++ b/sdks/python/examples/bug_tests/worker_pause_on_sigterm/test_worker_pause_on_sigterm.py
@@ -1,0 +1,56 @@
+import asyncio
+import signal
+from subprocess import Popen
+from typing import Any
+
+import psutil
+import pytest
+
+from examples.bug_tests.worker_pause_on_sigterm.worker import long_sleep, WORKER_NAME
+from hatchet_sdk import EmptyModel, Hatchet, RunStatus
+
+
+@pytest.mark.parametrize(
+    "on_demand_worker",
+    [
+        (
+            [
+                "poetry",
+                "run",
+                "python",
+                "examples/bug_tests/worker_pause_on_sigterm/worker.py",
+            ],
+            8010,
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_worker_pauses_when_only_parent_receives_sigterm(
+    hatchet: Hatchet,
+    on_demand_worker: Popen[Any],
+) -> None:
+    ref = await long_sleep.aio_run(input=EmptyModel(), wait_for_result=False)
+
+    for _ in range(30):
+        run = await hatchet.runs.aio_get_details(ref.workflow_run_id)
+        if run.status == RunStatus.RUNNING:
+            break
+        await asyncio.sleep(1)
+    else:
+        assert False, "Task never started running"
+
+    parent = psutil.Process(on_demand_worker.pid)
+    parent.send_signal(signal.SIGTERM)
+
+    await asyncio.sleep(3)
+
+    worker_list = await hatchet.workers.aio_list()
+    matching = [w for w in (worker_list.rows or []) if w.name == WORKER_NAME]
+
+    assert matching
+    assert matching[0].status == "PAUSED"
+
+    await hatchet.runs.aio_cancel(ref.workflow_run_id)
+
+    await asyncio.sleep(3)

--- a/sdks/python/examples/bug_tests/worker_pause_on_sigterm/worker.py
+++ b/sdks/python/examples/bug_tests/worker_pause_on_sigterm/worker.py
@@ -9,7 +9,7 @@ WORKER_NAME = "pause-on-sigterm-worker"
 
 @hatchet.task()
 def long_sleep(input: EmptyModel, ctx: Context) -> None:
-    time.sleep(10)
+    time.sleep(6)
 
 
 def main() -> None:

--- a/sdks/python/examples/bug_tests/worker_pause_on_sigterm/worker.py
+++ b/sdks/python/examples/bug_tests/worker_pause_on_sigterm/worker.py
@@ -1,0 +1,24 @@
+import time
+
+from hatchet_sdk import Context, EmptyModel, Hatchet
+
+hatchet = Hatchet()
+
+WORKER_NAME = "pause-on-sigterm-worker"
+
+
+@hatchet.task()
+def long_sleep(input: EmptyModel, ctx: Context) -> None:
+    time.sleep(10)
+
+
+def main() -> None:
+    worker = hatchet.worker(
+        WORKER_NAME,
+        workflows=[long_sleep],
+    )
+    worker.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/sdks/python/examples/durable_eviction/test_durable_eviction.py
+++ b/sdks/python/examples/durable_eviction/test_durable_eviction.py
@@ -304,10 +304,7 @@ async def test_multiple_eviction_cycle(hatchet: Hatchet) -> None:
 @pytest.mark.parametrize(
     "on_demand_worker",
     [
-        (
-            ["poetry", "run", "python", "-m", "examples.durable_eviction.worker"],
-            8004,
-        )
+        ["poetry", "run", "python", "-m", "examples.durable_eviction.worker"],
     ],
     indirect=True,
 )
@@ -373,16 +370,13 @@ async def test_evictable_cancel_after_eviction(hatchet: Hatchet) -> None:
 @pytest.mark.parametrize(
     "on_demand_worker",
     [
-        (
-            [
-                "poetry",
-                "run",
-                "python",
-                "-m",
-                "examples.durable_eviction.capacity_worker",
-            ],
-            8005,
-        )
+        [
+            "poetry",
+            "run",
+            "python",
+            "-m",
+            "examples.durable_eviction.capacity_worker",
+        ]
     ],
     indirect=True,
 )
@@ -406,16 +400,13 @@ async def test_capacity_eviction_fires(
 @pytest.mark.parametrize(
     "on_demand_worker",
     [
-        (
-            [
-                "poetry",
-                "run",
-                "python",
-                "-m",
-                "examples.durable_eviction.capacity_worker",
-            ],
-            8005,
-        )
+        [
+            "poetry",
+            "run",
+            "python",
+            "-m",
+            "examples.durable_eviction.capacity_worker",
+        ]
     ],
     indirect=True,
 )

--- a/sdks/python/examples/lifespans/test_lifespans.py
+++ b/sdks/python/examples/lifespans/test_lifespans.py
@@ -24,10 +24,7 @@ async def test_lifespans() -> None:
 @pytest.mark.parametrize(
     "on_demand_worker",
     [
-        (
-            ["poetry", "run", "python", "examples/lifespans/drain.py"],
-            8009,
-        )
+        ["poetry", "run", "python", "examples/lifespans/drain.py"],
     ],
     indirect=True,
 )

--- a/sdks/python/examples/priority/test_priority.py
+++ b/sdks/python/examples/priority/test_priority.py
@@ -64,12 +64,7 @@ async def dummy_runs() -> None:
 @pytest.mark.skip(reason="Very flaky test")
 @pytest.mark.parametrize(
     "on_demand_worker",
-    [
-        (
-            ["poetry", "run", "python", "examples/priority/worker.py", "--slots", "1"],
-            8003,
-        )
-    ],
+    [["poetry", "run", "python", "examples/priority/worker.py", "--slots", "1"]],
     indirect=True,
 )
 @pytest.mark.asyncio(loop_scope="session")
@@ -151,12 +146,7 @@ async def test_priority(
 @pytest.mark.skip(reason="Very flaky test")
 @pytest.mark.parametrize(
     "on_demand_worker",
-    [
-        (
-            ["poetry", "run", "python", "examples/priority/worker.py", "--slots", "1"],
-            8003,
-        )
-    ],
+    [["poetry", "run", "python", "examples/priority/worker.py", "--slots", "1"]],
     indirect=True,
 )
 @pytest.mark.asyncio(loop_scope="session")
@@ -289,12 +279,7 @@ def time_until_next_minute() -> float:
 )
 @pytest.mark.parametrize(
     "on_demand_worker",
-    [
-        (
-            ["poetry", "run", "python", "examples/priority/worker.py", "--slots", "1"],
-            8003,
-        )
-    ],
+    [["poetry", "run", "python", "examples/priority/worker.py", "--slots", "1"]],
     indirect=True,
 )
 @pytest.mark.asyncio(loop_scope="session")

--- a/sdks/python/examples/runtime_affinity/test_runtime_affinity.py
+++ b/sdks/python/examples/runtime_affinity/test_runtime_affinity.py
@@ -27,34 +27,28 @@ def on_demand_worker_b(
 @pytest.mark.parametrize(
     "on_demand_worker_a",
     [
-        (
-            [
-                "poetry",
-                "run",
-                "python",
-                "examples/runtime_affinity/worker.py",
-                "--label",
-                labels[0],
-            ],
-            8003,
-        )
+        [
+            "poetry",
+            "run",
+            "python",
+            "examples/runtime_affinity/worker.py",
+            "--label",
+            labels[0],
+        ]
     ],
     indirect=True,
 )
 @pytest.mark.parametrize(
     "on_demand_worker_b",
     [
-        (
-            [
-                "poetry",
-                "run",
-                "python",
-                "examples/runtime_affinity/worker.py",
-                "--label",
-                labels[1],
-            ],
-            8004,
-        )
+        [
+            "poetry",
+            "run",
+            "python",
+            "examples/runtime_affinity/worker.py",
+            "--label",
+            labels[1],
+        ]
     ],
     indirect=True,
 )

--- a/sdks/python/examples/streaming/test_streaming.py
+++ b/sdks/python/examples/streaming/test_streaming.py
@@ -11,10 +11,7 @@ from hatchet_sdk.clients.listeners.run_event_listener import StepRunEventType
 @pytest.mark.parametrize(
     "on_demand_worker",
     [
-        (
-            ["poetry", "run", "python", "examples/streaming/worker.py", "--slots", "1"],
-            8008,
-        )
+        ["poetry", "run", "python", "examples/streaming/worker.py", "--slots", "1"],
     ],
     indirect=True,
 )

--- a/sdks/python/generate.sh
+++ b/sdks/python/generate.sh
@@ -59,7 +59,7 @@ cp $tmp_dir/hatchet_sdk/clients/rest/api/__init__.py $dst_dir/api/__init__.py
 rm -rf $tmp_dir
 
 
-MIN_GRPCIO_VERSION=$(grep '^grpcio = ' pyproject.toml | cut -d'"' -f2 | tr -d '^')
+MIN_GRPCIO_VERSION=$(grep '"grpcio>=' pyproject.toml | cut -d'"' -f2 | cut -d'=' -f2 | cut -d',' -f1)
 
 poetry add "grpcio@$MIN_GRPCIO_VERSION" "grpcio-tools@$MIN_GRPCIO_VERSION"
 

--- a/sdks/python/hatchet_sdk/clients/rest/models/api_meta.py
+++ b/sdks/python/hatchet_sdk/clients/rest/models/api_meta.py
@@ -56,6 +56,11 @@ class APIMeta(BaseModel):
         description="whether or not users can change their password",
         alias="allowChangePassword",
     )
+    observability_enabled: Optional[StrictBool] = Field(
+        default=None,
+        description="whether or not observability (trace collection) is enabled on this instance",
+        alias="observabilityEnabled",
+    )
     __properties: ClassVar[List[str]] = [
         "auth",
         "pylonAppId",
@@ -64,6 +69,7 @@ class APIMeta(BaseModel):
         "allowInvites",
         "allowCreateTenant",
         "allowChangePassword",
+        "observabilityEnabled",
     ]
 
     model_config = ConfigDict(
@@ -137,6 +143,7 @@ class APIMeta(BaseModel):
                 "allowInvites": obj.get("allowInvites"),
                 "allowCreateTenant": obj.get("allowCreateTenant"),
                 "allowChangePassword": obj.get("allowChangePassword"),
+                "observabilityEnabled": obj.get("observabilityEnabled"),
             }
         )
         return _obj

--- a/sdks/python/hatchet_sdk/contracts/dispatcher_pb2_grpc.py
+++ b/sdks/python/hatchet_sdk/contracts/dispatcher_pb2_grpc.py
@@ -5,7 +5,7 @@ import warnings
 
 from hatchet_sdk.contracts import dispatcher_pb2 as dispatcher__pb2
 
-GRPC_GENERATED_VERSION = '1.80.0'
+GRPC_GENERATED_VERSION = '1.76.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/sdks/python/hatchet_sdk/contracts/events_pb2_grpc.py
+++ b/sdks/python/hatchet_sdk/contracts/events_pb2_grpc.py
@@ -5,7 +5,7 @@ import warnings
 
 from hatchet_sdk.contracts import events_pb2 as events__pb2
 
-GRPC_GENERATED_VERSION = '1.80.0'
+GRPC_GENERATED_VERSION = '1.76.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/sdks/python/hatchet_sdk/contracts/v1/dispatcher_pb2_grpc.py
+++ b/sdks/python/hatchet_sdk/contracts/v1/dispatcher_pb2_grpc.py
@@ -5,7 +5,7 @@ import warnings
 
 from hatchet_sdk.contracts.v1 import dispatcher_pb2 as v1_dot_dispatcher__pb2
 
-GRPC_GENERATED_VERSION = '1.80.0'
+GRPC_GENERATED_VERSION = '1.76.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/sdks/python/hatchet_sdk/contracts/v1/shared/condition_pb2_grpc.py
+++ b/sdks/python/hatchet_sdk/contracts/v1/shared/condition_pb2_grpc.py
@@ -4,7 +4,7 @@ import grpc
 import warnings
 
 
-GRPC_GENERATED_VERSION = '1.80.0'
+GRPC_GENERATED_VERSION = '1.76.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/sdks/python/hatchet_sdk/contracts/v1/shared/trigger_pb2_grpc.py
+++ b/sdks/python/hatchet_sdk/contracts/v1/shared/trigger_pb2_grpc.py
@@ -4,7 +4,7 @@ import grpc
 import warnings
 
 
-GRPC_GENERATED_VERSION = '1.80.0'
+GRPC_GENERATED_VERSION = '1.76.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/sdks/python/hatchet_sdk/contracts/v1/workflows_pb2_grpc.py
+++ b/sdks/python/hatchet_sdk/contracts/v1/workflows_pb2_grpc.py
@@ -5,7 +5,7 @@ import warnings
 
 from hatchet_sdk.contracts.v1 import workflows_pb2 as v1_dot_workflows__pb2
 
-GRPC_GENERATED_VERSION = '1.80.0'
+GRPC_GENERATED_VERSION = '1.76.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/sdks/python/hatchet_sdk/contracts/workflows_pb2_grpc.py
+++ b/sdks/python/hatchet_sdk/contracts/workflows_pb2_grpc.py
@@ -6,7 +6,7 @@ import warnings
 from hatchet_sdk.contracts.v1.shared import trigger_pb2 as v1_dot_shared_dot_trigger__pb2
 from hatchet_sdk.contracts import workflows_pb2 as workflows__pb2
 
-GRPC_GENERATED_VERSION = '1.80.0'
+GRPC_GENERATED_VERSION = '1.76.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/sdks/python/hatchet_sdk/worker/action_listener_process.py
+++ b/sdks/python/hatchet_sdk/worker/action_listener_process.py
@@ -111,10 +111,10 @@ class WorkerActionListenerProcess:
 
         loop = asyncio.get_event_loop()
         loop.add_signal_handler(
-            signal.SIGINT, lambda: asyncio.create_task(self.pause_task_assignment())
+            signal.SIGINT, lambda: asyncio.create_task(self.exit_gracefully())
         )
         loop.add_signal_handler(
-            signal.SIGTERM, lambda: asyncio.create_task(self.pause_task_assignment())
+            signal.SIGTERM, lambda: asyncio.create_task(self.exit_gracefully())
         )
         loop.add_signal_handler(
             signal.SIGQUIT, lambda: asyncio.create_task(self.exit_gracefully())

--- a/sdks/python/hatchet_sdk/worker/action_listener_process.py
+++ b/sdks/python/hatchet_sdk/worker/action_listener_process.py
@@ -111,10 +111,10 @@ class WorkerActionListenerProcess:
 
         loop = asyncio.get_event_loop()
         loop.add_signal_handler(
-            signal.SIGINT, lambda: asyncio.create_task(self.exit_gracefully())
+            signal.SIGINT, lambda: asyncio.create_task(self.pause_task_assignment())
         )
         loop.add_signal_handler(
-            signal.SIGTERM, lambda: asyncio.create_task(self.exit_gracefully())
+            signal.SIGTERM, lambda: asyncio.create_task(self.pause_task_assignment())
         )
         loop.add_signal_handler(
             signal.SIGQUIT, lambda: asyncio.create_task(self.exit_gracefully())

--- a/sdks/python/hatchet_sdk/worker/worker.py
+++ b/sdks/python/hatchet_sdk/worker/worker.py
@@ -732,18 +732,8 @@ class Worker:
 
         self._killing = True
 
-        for process in [
-            self._action_listener_process,
-            self._durable_action_listener_process,
-        ]:
-            if process is not None and process.pid is not None:
-                try:
-                    if process.is_alive():
-                        os.kill(process.pid, signal.SIGTERM)
-                except Exception:
-                    pass
-
         if self._action_runner:
+            # TODO-DURABLE: we nee to ensure that the worker is paused before calling this in all SDKs
             await self._action_runner.evict_all_waiting_durable_runs()
             await self._action_runner.wait_for_tasks()
             await self._action_runner.exit_gracefully()
@@ -754,7 +744,14 @@ class Worker:
             await self._legacy_durable_action_runner.wait_for_tasks()
             await self._legacy_durable_action_runner.exit_gracefully()
 
-        self._terminate_processes()
+        if self._action_listener_process and self._action_listener_process.is_alive():
+            self._action_listener_process.kill()
+
+        if (
+            self._durable_action_listener_process
+            and self._durable_action_listener_process.is_alive()
+        ):
+            self._durable_action_listener_process.kill()
 
         try:
             await self._cleanup_lifespan()

--- a/sdks/python/hatchet_sdk/worker/worker.py
+++ b/sdks/python/hatchet_sdk/worker/worker.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import multiprocessing
 import multiprocessing.context
 import os
@@ -732,8 +733,19 @@ class Worker:
 
         self._killing = True
 
+        # IMPORTANT: Ideally, we'd pause task assignment on the parent process,
+        # but only the listeners know what worker id we're on, so instead we need
+        # to propagate the SIGTERM to all child listener processes. Each child's SIGTERM
+        # handler calls pause_task_assignment() to pause assignment to this worker
+        for process in [
+            self._action_listener_process,
+            self._durable_action_listener_process,
+        ]:
+            if process is not None and process.pid is not None and process.is_alive():
+                with contextlib.suppress(ProcessLookupError):
+                    os.kill(process.pid, signal.SIGTERM)
+
         if self._action_runner:
-            # TODO-DURABLE: we nee to ensure that the worker is paused before calling this in all SDKs
             await self._action_runner.evict_all_waiting_durable_runs()
             await self._action_runner.wait_for_tasks()
             await self._action_runner.exit_gracefully()

--- a/sdks/python/hatchet_sdk/worker/worker.py
+++ b/sdks/python/hatchet_sdk/worker/worker.py
@@ -732,8 +732,18 @@ class Worker:
 
         self._killing = True
 
+        for process in [
+            self._action_listener_process,
+            self._durable_action_listener_process,
+        ]:
+            if process is not None and process.pid is not None:
+                try:
+                    if process.is_alive():
+                        os.kill(process.pid, signal.SIGTERM)
+                except Exception:
+                    pass
+
         if self._action_runner:
-            # TODO-DURABLE: we nee to ensure that the worker is paused before calling this in all SDKs
             await self._action_runner.evict_all_waiting_durable_runs()
             await self._action_runner.wait_for_tasks()
             await self._action_runner.exit_gracefully()
@@ -744,14 +754,7 @@ class Worker:
             await self._legacy_durable_action_runner.wait_for_tasks()
             await self._legacy_durable_action_runner.exit_gracefully()
 
-        if self._action_listener_process and self._action_listener_process.is_alive():
-            self._action_listener_process.kill()
-
-        if (
-            self._durable_action_listener_process
-            and self._durable_action_listener_process.is_alive()
-        ):
-            self._durable_action_listener_process.kill()
+        self._terminate_processes()
 
         try:
             await self._cleanup_lifespan()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hatchet-sdk"
-version = "1.32.0"
+version = "1.32.1"
 description = "This is the official Python SDK for Hatchet, a distributed, fault-tolerant task queue. The SDK allows you to easily integrate Hatchet's task scheduling and workflow orchestration capabilities into your Python applications."
 readme = "README.md"
 license = { text = "MIT" }

--- a/sdks/python/tests/child_spawn_cache_on_retry/test_child_spawn_cache_on_retry.py
+++ b/sdks/python/tests/child_spawn_cache_on_retry/test_child_spawn_cache_on_retry.py
@@ -14,7 +14,7 @@ from tests.child_spawn_cache_on_retry.worker import (
 
 @pytest.mark.parametrize(
     "on_demand_worker",
-    [(["poetry", "run", "python", "tests/worker.py", "--slots", "5"], 8005)],
+    [["poetry", "run", "python", "tests/worker.py", "--slots", "5"]],
     indirect=True,
 )
 @pytest.mark.asyncio(loop_scope="session")

--- a/sdks/python/tests/concurrency_strategies/test_concurrency_strategies.py
+++ b/sdks/python/tests/concurrency_strategies/test_concurrency_strategies.py
@@ -15,7 +15,7 @@ from tests.concurrency_strategies.workflow import (
 
 @pytest.mark.parametrize(
     "on_demand_worker",
-    [(["poetry", "run", "python", "tests/worker.py", "--slots", "1"], 8002)],
+    [["poetry", "run", "python", "tests/worker.py", "--slots", "1"]],
     indirect=True,
 )
 @pytest.mark.asyncio(loop_scope="session")

--- a/sdks/python/tests/correct_failure_on_timeout_with_multi_concurrency/test_case.py
+++ b/sdks/python/tests/correct_failure_on_timeout_with_multi_concurrency/test_case.py
@@ -16,7 +16,7 @@ from tests.correct_failure_on_timeout_with_multi_concurrency.workflow import (
 
 @pytest.mark.parametrize(
     "on_demand_worker",
-    [(["poetry", "run", "python", "tests/worker.py", "--slots", "1"], 8002)],
+    [["poetry", "run", "python", "tests/worker.py", "--slots", "1"]],
     indirect=True,
 )
 @pytest.mark.asyncio(loop_scope="session")

--- a/sdks/python/tests/worker_fixture.py
+++ b/sdks/python/tests/worker_fixture.py
@@ -1,14 +1,22 @@
 import logging
 import os
+import socket
 import subprocess
 import time
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from io import BytesIO
 from threading import Thread
+from typing import cast
 
 import psutil
 import requests
+
+
+def get_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return cast(int, s.getsockname()[1])
 
 
 def wait_for_worker_health(healthcheck_port: int) -> bool:


### PR DESCRIPTION
# Description

## [1.32.1] - 2026-04-09

### Changed

- Fixes a bug in the shutdown handlers that wouldn't correctly trigger graceful shutdown if only the parent process received a shutdown signal like `SIGTERM`, which might often be the case on e.g. Kubernetes.
- Fixes an issue where we generated protobufs using a more recent grpcio version than the minimum allowed, causing breakages on older versions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
