### PR TITLE
chore(ci): Run e2e tests on main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: test
 on:
+  push:
+    branches:
+      - main
   pull_request:
     paths-ignore:
       - "sdks/typescript/**"


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Currently, we only ever run e2e tests in a PR. This makes it difficult to pin down exactly when failures/flakes are introduced.

## Type of change

- [x] CI (any automation pipeline changes)

## What's Changed

- Ensures that `push` events to `main` trigger all e2e tests.