### PR TITLE
fix(ci/dependabot): invalid overlapping ecosystem configs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,19 +33,6 @@ updates:
         update-types:
           - "major"
 
-  - package-ecosystem: "gomod"
-    directories:
-      - "/"
-      - "/examples/go/quickstart"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
-    groups:
-      go-modules-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
-
   - package-ecosystem: "pip"
     directories:
       - "/sdks/python"
@@ -70,21 +57,6 @@ updates:
           - "*"
         update-types:
           - "major"
-
-  - package-ecosystem: "pip"
-    directories:
-      - "/sdks/python"
-      - "/sdks/python/examples/quickstart"
-      - "/cmd/hatchet-cli/cli/templates/python/poetry"
-      - "/examples/python/quickstart"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
-    groups:
-      python-deps-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
 
   - package-ecosystem: "npm"
     directories:
@@ -112,22 +84,6 @@ updates:
         update-types:
           - "major"
 
-  - package-ecosystem: "npm"
-    directories:
-      - "/frontend/app"
-      - "/frontend/docs"
-      - "/sdks/typescript"
-      - "/cmd/hatchet-cli/cli/templates/typescript/pnpm"
-      - "/examples/typescript"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
-    groups:
-      npm-deps-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
-
   - package-ecosystem: "bundler"
     directories:
       - "/sdks/ruby/src"
@@ -150,16 +106,3 @@ updates:
           - "*"
         update-types:
           - "major"
-
-  - package-ecosystem: "bundler"
-    directories:
-      - "/sdks/ruby/src"
-      - "/sdks/ruby/examples"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
-    groups:
-      ruby-deps-security:
-        applies-to: security-updates
-        patterns:
-          - "*"


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Dependabot does not support multiple ecosystems being configured with overlapping directories. Instead, this PR reverts back to the original approach but changes version updates to weekly.

```
Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'gomod' has overlapping directories.
Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'pip' has overlapping directories.
Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'npm' has overlapping directories.
Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'bundler' has overlapping directories.
```

## Type of change

- [x] CI (any automation pipeline changes)

## What's Changed

- Reverts security updates ecosystem configurations in favour of just version updates
