### PR TITLE
fix(test): Add healthcheck to harness engine startup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -341,6 +341,7 @@ jobs:
           TESTING_MATRIX_RABBITMQ_ENABLED: ${{ matrix.rabbitmq-enabled }}
           TESTING_MATRIX_PG_VERSION: ${{ matrix.pg-version }}
           TESTING_MATRIX_OPTIMISTIC_SCHEDULING: ${{ matrix.optimistic-scheduling }}
+          HATCHET_LOADTEST_STARTUP_SLEEP: 120s
 
   load-pgbouncer:
     runs-on: ubicloud-standard-8
@@ -385,6 +386,7 @@ jobs:
           TESTING_MATRIX_PG_VERSION: ${{ matrix.pg-version }}
           TESTING_MATRIX_OPTIMISTIC_SCHEDULING: ${{ matrix.optimistic-scheduling }}
           TESTING_MATRIX_PGBOUNCER_ENABLED: "true"
+          HATCHET_LOADTEST_STARTUP_SLEEP: 120s
 
   load-online-migrate:
     runs-on: ubicloud-standard-8
@@ -623,7 +625,7 @@ jobs:
           # This job adds go-deadlock + -race overhead; relax perf threshold to avoid flakes.
           HATCHET_LOADTEST_AVERAGE_DURATION_THRESHOLD: 1s
           # Give the engine a bit more time to come up under instrumentation.
-          HATCHET_LOADTEST_STARTUP_SLEEP: 30s
+          HATCHET_LOADTEST_STARTUP_SLEEP: 120s
           TESTING_MATRIX_MIGRATE: ${{ matrix.migrate-strategy }}
           TESTING_MATRIX_RABBITMQ_ENABLED: ${{ matrix.rabbitmq-enabled }}
           TESTING_MATRIX_PG_VERSION: ${{ matrix.pg-version }}
@@ -667,3 +669,4 @@ jobs:
           TESTING_MATRIX_MIGRATE: ${{ matrix.migrate-strategy }}
           TESTING_MATRIX_RABBITMQ_ENABLED: ${{ matrix.rabbitmq-enabled }}
           TESTING_MATRIX_PG_VERSION: ${{ matrix.pg-version }}
+          RAMP_UP_DURATION_TIMEOUT: 10s

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -669,4 +669,4 @@ jobs:
           TESTING_MATRIX_MIGRATE: ${{ matrix.migrate-strategy }}
           TESTING_MATRIX_RABBITMQ_ENABLED: ${{ matrix.rabbitmq-enabled }}
           TESTING_MATRIX_PG_VERSION: ${{ matrix.pg-version }}
-          RAMP_UP_DURATION_TIMEOUT: 10s
+          RAMP_UP_DURATION_TIMEOUT: 30s

--- a/cmd/hatchet-loadtest/load_e2e_test.go
+++ b/cmd/hatchet-loadtest/load_e2e_test.go
@@ -169,8 +169,9 @@ func TestLoadCLI(t *testing.T) {
 		},
 	}
 
-	// TODO instead of waiting, figure out when the engine setup is complete
-	time.Sleep(startupSleep)
+	if err := harness.WaitEngineReady(t.Context(), startupSleep); err != nil {
+		t.Fatalf("failed to bring up engine in time: %s", err)
+	}
 
 	for _, tt := range tests {
 		tt := tt // pin the loop variable

--- a/cmd/hatchet-loadtest/rampup/ramp_up_e2e_test.go
+++ b/cmd/hatchet-loadtest/rampup/ramp_up_e2e_test.go
@@ -76,8 +76,9 @@ func TestRampUp(t *testing.T) {
 		},
 	}}
 
-	// TODO instead of waiting, figure out when the engine setup is complete
-	time.Sleep(15 * time.Second)
+	if err := harness.WaitEngineReady(t.Context(), 120*time.Second); err != nil {
+		t.Fatalf("failed to bring up engine in time: %s", err)
+	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/testing/harness/engine.go
+++ b/pkg/testing/harness/engine.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"strconv"
@@ -121,7 +122,13 @@ func startEngine() func() {
 		cleanupPgBouncer = func() error { return nil }
 	}
 
-	grpcPort, err := findAvailablePort(7077)
+	grpcPort, err := getFreePort()
+
+	if err != nil {
+		log.Fatalf("failed to find available port: %v", err)
+	}
+
+	healthPort, err := getFreePort()
 
 	if err != nil {
 		log.Fatalf("failed to find available port: %v", err)
@@ -132,7 +139,8 @@ func startEngine() func() {
 	os.Setenv("SERVER_GRPC_INSECURE", "true")
 	os.Setenv("SERVER_GRPC_PORT", strconv.Itoa(grpcPort))
 	os.Setenv("SERVER_GRPC_BROADCAST_ADDRESS", fmt.Sprintf("localhost:%d", grpcPort))
-	os.Setenv("SERVER_HEALTHCHECK", "false")
+	os.Setenv("SERVER_HEALTHCHECK", "true")
+	os.Setenv("SERVER_HEALTHCHECK_PORT", strconv.Itoa(healthPort))
 	os.Setenv("HATCHET_CLIENT_TLS_STRATEGY", "none")
 	os.Setenv("SERVER_AUTH_COOKIE_DOMAIN", "app.dev.hatchet-tools.com")
 	os.Setenv("SERVER_LOGGER_LEVEL", "error")
@@ -559,4 +567,46 @@ func findAvailablePort(startPort int) (int, error) {
 	}
 
 	return 0, fmt.Errorf("no available port found in range %d-%d", startPort, maxPort)
+}
+
+func WaitEngineReady(ctx context.Context, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	healthPort := os.Getenv("SERVER_HEALTHCHECK_PORT")
+	if healthPort == "" {
+		return fmt.Errorf("SERVER_HEALTHCHECK_PORT not set")
+	}
+
+	addr := fmt.Sprintf("http://localhost:%s/ready", healthPort)
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, addr, nil)
+			resp, err := http.DefaultClient.Do(req) //nolint:gosec
+			if err != nil {
+				continue
+			}
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+	}
+}
+
+func getFreePort() (int, error) {
+	listener, err := net.Listen("tcp", ":0") //nolint:gosec
+	if err != nil {
+		return 0, err
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	_ = listener.Close()
+	return port, nil
 }

--- a/pkg/testing/harness/engine_test.go
+++ b/pkg/testing/harness/engine_test.go
@@ -1,5 +1,3 @@
-//go:build e2e
-
 package harness
 
 import (
@@ -14,5 +12,7 @@ func TestMain(m *testing.M) {
 // Tests that the engine starts up and shuts down correctly without leaking
 // goroutines.
 func TestStartupShutdown(t *testing.T) {
-	time.Sleep(5 * time.Second)
+	if err := WaitEngineReady(t.Context(), 120*time.Second); err != nil {
+		t.Errorf("failed to bring up engine in time: %s", err)
+	}
 }


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] CI (any automation pipeline changes)
- [x] Test changes (add, refactor, improve or change a test)


## What's Changed

- Fixes the `e2e`, `load`, and `rampup` tests
- Introduces a new `WaitEngineReady` fixture that we can use to poll the engine's `/ready` endpoint until it returns `200`
- Adds a simpler `getFreePort` fixture as well
