### PR TITLE
WIP: fix(ci): E2E test selection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -335,7 +335,7 @@ jobs:
         run: |
           # Disable gzip compression for load tests to reduce CPU overhead
           # Compression adds overhead without benefit for 0kb payloads
-          HATCHET_CLIENT_DISABLE_GZIP_COMPRESSION=true go test -tags load ./... -p 5 -v -race -failfast -timeout 20m
+          HATCHET_CLIENT_DISABLE_GZIP_COMPRESSION=true go test -tags load ./cmd/hatchet-loadtest/... -p 5 -v -race -failfast -timeout 20m
         env:
           TESTING_MATRIX_MIGRATE: ${{ matrix.migrate-strategy }}
           TESTING_MATRIX_RABBITMQ_ENABLED: ${{ matrix.rabbitmq-enabled }}
@@ -379,7 +379,7 @@ jobs:
         run: |
           # Disable gzip compression for load tests to reduce CPU overhead
           # Compression adds overhead without benefit for 0kb payloads
-          HATCHET_CLIENT_DISABLE_GZIP_COMPRESSION=true go test -tags load ./... -p 5 -v -race -failfast -timeout 20m
+          HATCHET_CLIENT_DISABLE_GZIP_COMPRESSION=true go test -tags load ./cmd/hatchet-loadtest/... ./pkg/repository/... -p 5 -v -race -failfast -timeout 20m
         env:
           TESTING_MATRIX_MIGRATE: ${{ matrix.migrate-strategy }}
           TESTING_MATRIX_RABBITMQ_ENABLED: ${{ matrix.rabbitmq-enabled }}
@@ -620,7 +620,7 @@ jobs:
         run: |
           # Disable gzip compression for load tests to reduce CPU overhead
           # Compression adds overhead without benefit for 0kb payloads
-          HATCHET_CLIENT_DISABLE_GZIP_COMPRESSION=true go test -tags load ./... -p 5 -v -race -failfast -timeout 20m
+          HATCHET_CLIENT_DISABLE_GZIP_COMPRESSION=true go test -tags load ./cmd/hatchet-loadtest/... -p 5 -v -race -failfast -timeout 20m
         env:
           # This job adds go-deadlock + -race overhead; relax perf threshold to avoid flakes.
           HATCHET_LOADTEST_AVERAGE_DURATION_THRESHOLD: 1s
@@ -664,7 +664,7 @@ jobs:
 
       - name: Test
         run: |
-          go test -tags rampup ./... -p 5 -v -race -failfast -timeout 20m
+          go test -tags rampup ./cmd/hatchet-loadtest/rampup/... -p 5 -v -race -failfast -timeout 20m
         env:
           TESTING_MATRIX_MIGRATE: ${{ matrix.migrate-strategy }}
           TESTING_MATRIX_RABBITMQ_ENABLED: ${{ matrix.rabbitmq-enabled }}

--- a/pkg/testing/harness/engine_test.go
+++ b/pkg/testing/harness/engine_test.go
@@ -1,3 +1,5 @@
+//go:build e2e || integration
+
 package harness
 
 import (


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

We are running all e2e tests in each `rampup` and `load` scenario. Instead, we should be specifying the test suite we actually want run instead of running everything.

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] CI (any automation pipeline changes)
- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

- Further specifies test selection in `load` and `rampup` tests.
