### PR TITLE
Proposal: DI-style declaration of task parents

### DIFF
--- a/sdks/python/examples/dag/worker.py
+++ b/sdks/python/examples/dag/worker.py
@@ -1,10 +1,10 @@
 import random
 import time
 from datetime import timedelta
-
+from typing import Annotated
 from pydantic import BaseModel
 
-from hatchet_sdk import Context, EmptyModel, Hatchet
+from hatchet_sdk import Context, EmptyModel, Hatchet, Parent
 
 
 class StepOutput(BaseModel):
@@ -38,10 +38,16 @@ async def step2(input: EmptyModel, ctx: Context) -> StepOutput:
     return StepOutput(random_number=random.randint(1, 100))
 
 
-@dag_workflow.task(parents=[step1, step2])
-async def step3(input: EmptyModel, ctx: Context) -> RandomSum:
-    one = ctx.task_output(step1).random_number
-    two = ctx.task_output(step2).random_number
+@dag_workflow.task()
+async def step3(
+    input: EmptyModel,
+    ctx: Context,
+    step_1: Annotated[StepOutput, Parent(step1)],
+    step_2: Annotated[StepOutput, Parent(step2)],
+) -> RandomSum:
+    print(step_1)
+    one = step_1.random_number
+    two = step_2.random_number
 
     return RandomSum(sum=one + two)
 

--- a/sdks/python/hatchet_sdk/__init__.py
+++ b/sdks/python/hatchet_sdk/__init__.py
@@ -141,7 +141,7 @@ from hatchet_sdk.exceptions import (
 from hatchet_sdk.features.cel import CELEvaluationResult, CELFailure, CELSuccess
 from hatchet_sdk.features.runs import BulkCancelReplayOpts, RunFilter
 from hatchet_sdk.hatchet import Hatchet
-from hatchet_sdk.runnables.task import Depends, Task
+from hatchet_sdk.runnables.task import Depends, Parent, Task
 from hatchet_sdk.runnables.types import (
     DefaultFilter,
     EmptyModel,
@@ -241,6 +241,7 @@ __all__ = [
     "OpenTelemetryConfig",
     "OrGroup",
     "PaginationResponse",
+    "Parent",
     "ParentCondition",
     "Priority",
     "PullRequest",

--- a/sdks/python/hatchet_sdk/context/context.py
+++ b/sdks/python/hatchet_sdk/context/context.py
@@ -318,6 +318,12 @@ class Context:
         from hatchet_sdk.runnables.types import R
         from hatchet_sdk.serde import HATCHET_PYDANTIC_SENTINEL
 
+        warn(
+            "`task_output` is deprecated and will be removed in v2.0.0. Declare parent tasks as dependencies instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         if self.was_skipped(task):
             raise ValueError(f"{task.name} was skipped")
 

--- a/sdks/python/hatchet_sdk/runnables/task.py
+++ b/sdks/python/hatchet_sdk/runnables/task.py
@@ -373,22 +373,31 @@ class Task(Generic[TWorkflowInput, R]):
         finally:
             resolution_stack.discard(fn_name)
 
-    def _extract_parent(self, p: Parameter) -> "Task[Any, Any] | None":
+    def _extract_parent(self, param_name: str, p: Parameter) -> "Task[Any, Any] | None":
         annotation = p.annotation
         if is_typealiastype(annotation):
             annotation = annotation.__value__
 
-        if get_origin(annotation) is Annotated:
-            args = get_args(annotation)
+        if get_origin(annotation) is not Annotated:
+            return None
 
-            if len(args) < 2:
-                return None
+        args = get_args(annotation)
+        if len(args) < 2:
+            return None
 
-            metadata = args[1:]
+        declared = args[0]
 
-            for item in metadata:
-                if isinstance(item, Parent):
-                    return item.task
+        for item in args[1:]:
+            if isinstance(item, Parent):
+                parent_return = get_type_hints(item.task._fn).get("return")
+                if parent_return is not None and declared != parent_return:
+                    raise InvalidDependencyError(
+                        f"Task '{self.name}' declares parameter '{param_name}' "
+                        f"as '{declared}', but parent task "
+                        f"'{item.task.name}' returns '{parent_return}'. "
+                        f"These must match."
+                    )
+                return item.task
 
         return None
 
@@ -398,7 +407,7 @@ class Task(Generic[TWorkflowInput, R]):
         return {
             n: task
             for n, p in sig.parameters.items()
-            if (task := self._extract_parent(p))
+            if (task := self._extract_parent(n, p))
         }
 
     async def _parse_parameter(

--- a/sdks/python/hatchet_sdk/runnables/task.py
+++ b/sdks/python/hatchet_sdk/runnables/task.py
@@ -201,13 +201,13 @@ class Task(Generic[TWorkflowInput, R]):
         if isinstance(resolved_parents, dict):
             # if it's a dict, they're using the new method
             self.parents = list(resolved_parents.values())
-            self.parent_kwarg_name_to_parent_task_name: dict[str, str] | None = {
-                k: v.name for k, v in resolved_parents.items()
-            }
+            self.parent_kwarg_name_to_parent_task: dict[str, Task[Any, Any]] | None = (
+                resolved_parents
+            )
         else:
             # otherwise, it's the legacy method, which we can remove in v2.0.0
             self.parents = resolved_parents
-            self.parent_kwarg_name_to_parent_task_name = None
+            self.parent_kwarg_name_to_parent_task = None
 
         self.retries = retries
         self.rate_limits = rate_limits or []

--- a/sdks/python/hatchet_sdk/runnables/task.py
+++ b/sdks/python/hatchet_sdk/runnables/task.py
@@ -195,7 +195,20 @@ class Task(Generic[TWorkflowInput, R]):
         self.execution_timeout = execution_timeout
         self.schedule_timeout = schedule_timeout
         self.name = name
-        self.parents = parents or []
+
+        resolved_parents = self._resolve_parents(parents)
+
+        if isinstance(resolved_parents, dict):
+            # if it's a dict, they're using the new method
+            self.parents = list(resolved_parents.values())
+            self.parent_kwarg_name_to_parent_task_name: dict[str, str] | None = {
+                k: v.name for k, v in resolved_parents.items()
+            }
+        else:
+            # otherwise, it's the legacy method, which we can remove in v2.0.0
+            self.parents = resolved_parents
+            self.parent_kwarg_name_to_parent_task_name = None
+
         self.retries = retries
         self.rate_limits = rate_limits or []
         self.desired_worker_labels: list[DesiredWorkerLabel] = (
@@ -223,7 +236,7 @@ class Task(Generic[TWorkflowInput, R]):
 
     def _resolve_parents(
         self, declarative: "list[Task[Any, Any]] | None"
-    ) -> "list[Task[Any, Any]]":
+    ) -> "dict[str, Task[Any, Any]] | list[Task[Any, Any]]":
         if declarative:
             return declarative
 
@@ -379,12 +392,14 @@ class Task(Generic[TWorkflowInput, R]):
 
         return None
 
-    def _extract_parents(self) -> "list[Task[Any, Any]]":
+    def _extract_parents(self) -> "dict[str, Task[Any, Any]]":
         sig = signature(self._fn)
 
-        return [
-            task for p in sig.parameters.values() if (task := self._extract_parent(p))
-        ]
+        return {
+            n: task
+            for n, p in sig.parameters.items()
+            if (task := self._extract_parent(p))
+        }
 
     async def _parse_parameter(
         self,
@@ -473,21 +488,33 @@ class Task(Generic[TWorkflowInput, R]):
                     await asyncio.to_thread(cm.__exit__, None, None, None)
 
     def call(
-        self, ctx: Context | DurableContext, dependencies: dict[str, Any] | None = None
+        self,
+        ctx: Context | DurableContext,
+        dependencies: dict[str, Any] | None = None,
+        parent_outputs: dict[str, Any] | None = None,
     ) -> R:
         if self._is_async_function:
             raise TypeError(f"{self.name} is not a sync function. Use `acall` instead.")
 
         workflow_input = self._workflow._get_workflow_input(ctx)
         dependencies = dependencies or {}
+        parent_outputs = parent_outputs or {}
 
         if is_sync_fn(self._fn):  # type: ignore
-            return self._fn(workflow_input, cast(Context, ctx), **dependencies)  # type: ignore
+            return self._fn(
+                workflow_input,  # type: ignore
+                ctx,
+                **dependencies,
+                **parent_outputs,
+            )
 
         raise TypeError(f"{self.name} is not a sync function. Use `acall` instead.")
 
     async def aio_call(
-        self, ctx: Context | DurableContext, dependencies: dict[str, Any] | None = None
+        self,
+        ctx: Context | DurableContext,
+        dependencies: dict[str, Any] | None = None,
+        parent_outputs: dict[str, Any] | None = None,
     ) -> R:
         if not self._is_async_function:
             raise TypeError(
@@ -496,9 +523,15 @@ class Task(Generic[TWorkflowInput, R]):
 
         workflow_input = self._workflow._get_workflow_input(ctx)
         dependencies = dependencies or {}
+        parent_outputs = parent_outputs or {}
 
         if is_async_fn(self._fn):  # type: ignore
-            return await self._fn(workflow_input, cast(Context, ctx), **dependencies)  # type: ignore
+            return await self._fn(
+                workflow_input,  # type: ignore
+                ctx,
+                **dependencies,
+                **parent_outputs,
+            )
 
         raise TypeError(f"{self.name} is not an async function. Use `call` instead.")
 

--- a/sdks/python/hatchet_sdk/runnables/task.py
+++ b/sdks/python/hatchet_sdk/runnables/task.py
@@ -87,6 +87,11 @@ def is_sync_context_manager(obj: Any) -> TypeGuard[AbstractContextManager[Any]]:
     return hasattr(obj, "__enter__") and hasattr(obj, "__exit__")
 
 
+class Parent(Generic[R]):
+    def __init__(self, task: "Task[Any, R]") -> None:
+        self.task = task
+
+
 class DependencyFunc(Protocol[T_co, TWorkflowInput_contra]):
     def __call__(
         self, input: TWorkflowInput_contra, ctx: Context, *args: Any, **kwargs: Any
@@ -215,6 +220,14 @@ class Task(Generic[TWorkflowInput, R]):
             logger.warning(
                 f"{self.fn.__name__} is defined as a synchronous, durable task. in the future, durable tasks will only support `async`. please update this durable task to be async, or make it non-durable."
             )
+
+    def _resolve_parents(
+        self, declarative: "list[Task[Any, Any]] | None"
+    ) -> "list[Task[Any, Any]]":
+        if declarative:
+            return declarative
+
+        return self._extract_parents()
 
     @property
     def fn(self):  # type: ignore[no-untyped-def]
@@ -346,6 +359,32 @@ class Task(Generic[TWorkflowInput, R]):
             return dependencies
         finally:
             resolution_stack.discard(fn_name)
+
+    def _extract_parent(self, p: Parameter) -> "Task[Any, Any] | None":
+        annotation = p.annotation
+        if is_typealiastype(annotation):
+            annotation = annotation.__value__
+
+        if get_origin(annotation) is Annotated:
+            args = get_args(annotation)
+
+            if len(args) < 2:
+                return None
+
+            metadata = args[1:]
+
+            for item in metadata:
+                if isinstance(item, Parent):
+                    return item.task
+
+        return None
+
+    def _extract_parents(self) -> "list[Task[Any, Any]]":
+        sig = signature(self._fn)
+
+        return [
+            task for p in sig.parameters.values() if (task := self._extract_parent(p))
+        ]
 
     async def _parse_parameter(
         self,

--- a/sdks/python/hatchet_sdk/runnables/workflow.py
+++ b/sdks/python/hatchet_sdk/runnables/workflow.py
@@ -1374,6 +1374,13 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
 
         _warn_if_str_duration(schedule_timeout, execution_timeout)
 
+        if parents is not None:
+            warnings.warn(
+                "Support for providing a list of parents on the task decorator is deprecated, and will be removed in v2.0.0. Please pass declare parents as positional arguments to the task instead.",
+                DeprecationWarning,
+                stacklevel=4,
+            )
+
         computed_params = ComputedTaskParameters(
             schedule_timeout=schedule_timeout,
             execution_timeout=execution_timeout,
@@ -1487,6 +1494,13 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
 
         :returns: A decorator which creates a `Task` object.
         """
+
+        if parents is not None:
+            warnings.warn(
+                "Support for providing a list of parents on the task decorator is deprecated, and will be removed in v2.0.0. Please pass declare parents as positional arguments to the task instead.",
+                DeprecationWarning,
+                stacklevel=4,
+            )
 
         _warn_if_str_duration(schedule_timeout, execution_timeout)
 

--- a/sdks/python/hatchet_sdk/worker/runner/runner.py
+++ b/sdks/python/hatchet_sdk/worker/runner/runner.py
@@ -338,10 +338,10 @@ class Runner:
 
         parent_output_kwargs = (
             {
-                kwarg_name: ctx._data.parents[task_name]
-                for kwarg_name, task_name in task.parent_kwarg_name_to_parent_task_name.items()
+                kwarg_name: ctx.task_output(task)
+                for kwarg_name, task in task.parent_kwarg_name_to_parent_task.items()
             }
-            if task.parent_kwarg_name_to_parent_task_name
+            if task.parent_kwarg_name_to_parent_task
             else None
         )
 
@@ -367,12 +367,13 @@ class Runner:
         async with task._unpack_dependencies_with_cleanup(ctx) as dependencies:
             parent_output_kwargs = (
                 {
-                    kwarg_name: ctx._data.parents[task_name]
-                    for kwarg_name, task_name in task.parent_kwarg_name_to_parent_task_name.items()
+                    kwarg_name: ctx.task_output(task)
+                    for kwarg_name, task in task.parent_kwarg_name_to_parent_task.items()
                 }
-                if task.parent_kwarg_name_to_parent_task_name
+                if task.parent_kwarg_name_to_parent_task
                 else None
             )
+
             try:
                 if task._is_async_function:
                     return await task.aio_call(ctx, dependencies, parent_output_kwargs)

--- a/sdks/python/hatchet_sdk/worker/runner/runner.py
+++ b/sdks/python/hatchet_sdk/worker/runner/runner.py
@@ -336,7 +336,16 @@ class Runner:
         if action.step_run_id:
             self.threads[action.key] = current_thread()
 
-        return task.call(ctx, dependencies)
+        parent_output_kwargs = (
+            {
+                kwarg_name: ctx._data.parents[task_name]
+                for kwarg_name, task_name in task.parent_kwarg_name_to_parent_task_name.items()
+            }
+            if task.parent_kwarg_name_to_parent_task_name
+            else None
+        )
+
+        return task.call(ctx, dependencies, parent_outputs=parent_output_kwargs)
 
     # We wrap all actions in an async func
     async def async_wrapped_action_func(
@@ -356,9 +365,17 @@ class Runner:
         )
 
         async with task._unpack_dependencies_with_cleanup(ctx) as dependencies:
+            parent_output_kwargs = (
+                {
+                    kwarg_name: ctx._data.parents[task_name]
+                    for kwarg_name, task_name in task.parent_kwarg_name_to_parent_task_name.items()
+                }
+                if task.parent_kwarg_name_to_parent_task_name
+                else None
+            )
             try:
                 if task._is_async_function:
-                    return await task.aio_call(ctx, dependencies)
+                    return await task.aio_call(ctx, dependencies, parent_output_kwargs)
 
                 pfunc = functools.partial(
                     # we must copy the context vars to the new thread, as only asyncio natively supports


### PR DESCRIPTION
# Description

Been considering this idea of using a DI-style syntax for declaring parent tasks in a DAG instead of the declarative way we have. Idea below:

```python
@dag_workflow.task()
async def step1(input: EmptyModel, ctx: Context) -> StepOutput:
    return StepOutput(random_number=random.randint(1, 100))


@dag_workflow.task()
async def step2(
    input: EmptyModel,
    ctx: Context,
    step_1: Annotated[StepOutput, Parent(step1)],
) -> RandomSum:
    one = step_1.random_number

    return RandomSum(sum=one + 1)
```

Decided to push this to collect feedback, but ultimately I think we should not adopt this for two reasons:

1. `Annotated` breaks the type checker
2. It's conceptually confusing that a) all of the other declarative config for the task lives on the decorator and b) if you want to use DAG conditions, you need to refer to parents on the decorator

So I'll probably close this in a few days

## Type of change

- [x] New feature (non-breaking change which adds functionality)
