### PR TITLE
feat: add built-in OIDC authentication support

### DIFF
--- a/api-contracts/openapi/openapi.yaml
+++ b/api-contracts/openapi/openapi.yaml
@@ -101,6 +101,10 @@ paths:
     $ref: "./paths/user/user.yaml#/oauth-start-github"
   /api/v1/users/github/callback:
     $ref: "./paths/user/user.yaml#/oauth-callback-github"
+  /api/v1/users/oidc/start:
+    $ref: "./paths/user/user.yaml#/oauth-start-oidc"
+  /api/v1/users/oidc/callback:
+    $ref: "./paths/user/user.yaml#/oauth-callback-oidc"
   /api/v1/tenants/{tenant}/slack/start:
     $ref: "./paths/user/user.yaml#/oauth-start-slack"
   /api/v1/users/slack/callback:

--- a/api-contracts/openapi/paths/user/user.yaml
+++ b/api-contracts/openapi/paths/user/user.yaml
@@ -228,6 +228,36 @@ oauth-callback-github:
     summary: Complete OAuth flow
     tags:
       - User
+oauth-start-oidc:
+  get:
+    description: Starts the OIDC OAuth flow
+    operationId: user:update:oidc-oauth-start
+    responses:
+      "302":
+        description: Successfully started the OAuth flow
+        headers:
+          location:
+            schema:
+              type: string
+    security: []
+    summary: Start OIDC OAuth flow
+    tags:
+      - User
+oauth-callback-oidc:
+  get:
+    description: Completes the OIDC OAuth flow
+    operationId: user:update:oidc-oauth-callback
+    responses:
+      "302":
+        description: Successfully completed the OAuth flow
+        headers:
+          location:
+            schema:
+              type: string
+    security: []
+    summary: Complete OIDC OAuth flow
+    tags:
+      - User
 oauth-start-slack:
   get:
     x-resources: ["tenant"]

--- a/api/v1/server/handlers/metadata/get.go
+++ b/api/v1/server/handlers/metadata/get.go
@@ -21,6 +21,10 @@ func (u *MetadataService) MetadataGet(ctx echo.Context, request gen.MetadataGetR
 		authTypes = append(authTypes, "github")
 	}
 
+	if u.config.Auth.ConfigFile.OIDC.Enabled {
+		authTypes = append(authTypes, "oidc")
+	}
+
 	pylonAppID := u.config.Pylon.AppID
 
 	var posthogConfig *gen.APIMetaPosthog

--- a/api/v1/server/handlers/users/oidc_oauth_callback.go
+++ b/api/v1/server/handlers/users/oidc_oauth_callback.go
@@ -1,0 +1,174 @@
+package users
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/jackc/pgx/v5"
+	"github.com/labstack/echo/v4"
+	"golang.org/x/oauth2"
+
+	"github.com/hatchet-dev/hatchet/api/v1/server/authn"
+	"github.com/hatchet-dev/hatchet/api/v1/server/middleware/redirect"
+	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
+	"github.com/hatchet-dev/hatchet/pkg/analytics"
+	"github.com/hatchet-dev/hatchet/pkg/config/server"
+	v1 "github.com/hatchet-dev/hatchet/pkg/repository"
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
+)
+
+// Note: we want all errors to redirect, otherwise the user will be greeted with raw JSON in the middle of the login flow.
+func (u *UserService) UserUpdateOidcOauthCallback(ctx echo.Context, _ gen.UserUpdateOidcOauthCallbackRequestObject) (gen.UserUpdateOidcOauthCallbackResponseObject, error) {
+	isValid, _, err := authn.NewSessionHelpers(u.config.SessionStore).ValidateOAuthState(ctx, "oidc")
+
+	if err != nil || !isValid {
+		return nil, redirect.GetRedirectWithError(ctx, u.config.Logger, err, "Could not log in. Please try again and make sure cookies are enabled.")
+	}
+
+	token, err := u.config.Auth.OIDCOAuthConfig.Exchange(ctx.Request().Context(), ctx.Request().URL.Query().Get("code"))
+
+	if err != nil {
+		return nil, redirect.GetRedirectWithError(ctx, u.config.Logger, err, "Forbidden")
+	}
+
+	if !token.Valid() {
+		return nil, redirect.GetRedirectWithError(ctx, u.config.Logger, fmt.Errorf("invalid token"), "Forbidden")
+	}
+
+	user, err := u.upsertOIDCUserFromToken(ctx.Request().Context(), u.config, token)
+
+	if err != nil {
+		if errors.Is(err, ErrNotInRestrictedDomain) {
+			return nil, redirect.GetRedirectWithError(ctx, u.config.Logger, err, "Email is not in the restricted domain group.")
+		}
+
+		return nil, redirect.GetRedirectWithError(ctx, u.config.Logger, err, "Internal error.")
+	}
+
+	err = authn.NewSessionHelpers(u.config.SessionStore).SaveAuthenticated(ctx, user)
+
+	if err != nil {
+		return nil, redirect.GetRedirectWithError(ctx, u.config.Logger, err, "Internal error.")
+	}
+
+	analyticsCtx := context.WithValue(ctx.Request().Context(), analytics.UserIDKey, user.ID)
+	analyticsCtx = context.WithValue(analyticsCtx, analytics.SourceKey, analytics.SourceUI)
+	u.config.Analytics.Enqueue(
+		analyticsCtx,
+		analytics.User, analytics.Login,
+		user.ID.String(),
+		map[string]interface{}{"provider": "oidc"},
+	)
+
+	return gen.UserUpdateOidcOauthCallback302Response{
+		Headers: gen.UserUpdateOidcOauthCallback302ResponseHeaders{
+			Location: u.config.Runtime.ServerURL,
+		},
+	}, nil
+}
+
+func (u *UserService) upsertOIDCUserFromToken(ctx context.Context, config *server.ServerConfig, tok *oauth2.Token) (*sqlcv1.User, error) {
+	claims, err := getOIDCClaimsFromToken(ctx, config, tok)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := u.checkUserRestrictionsForEmail(config, claims.Email); err != nil {
+		return nil, err
+	}
+
+	expiresAt := tok.Expiry
+
+	accessTokenEncrypted, err := config.Encryption.Encrypt([]byte(tok.AccessToken), "oidc_access_token")
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt access token: %s", err.Error())
+	}
+
+	refreshToken := tok.RefreshToken
+	if refreshToken == "" {
+		refreshToken = "none"
+	}
+
+	refreshTokenEncrypted, err := config.Encryption.Encrypt([]byte(refreshToken), "oidc_refresh_token")
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt refresh token: %s", err.Error())
+	}
+
+	oauthOpts := &v1.OAuthOpts{
+		Provider:       "oidc",
+		ProviderUserId: claims.Sub,
+		AccessToken:    accessTokenEncrypted,
+		RefreshToken:   refreshTokenEncrypted,
+		ExpiresAt:      &expiresAt,
+	}
+
+	user, err := u.config.V1.User().GetUserByEmail(ctx, claims.Email)
+
+	switch err {
+	case nil:
+		user, err = u.config.V1.User().UpdateUser(ctx, user.ID, &v1.UpdateUserOpts{
+			EmailVerified: v1.BoolPtr(claims.EmailVerified),
+			Name:          v1.StringPtr(claims.Name),
+			OAuth:         oauthOpts,
+		})
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to update user: %s", err.Error())
+		}
+	case pgx.ErrNoRows:
+		user, err = u.config.V1.User().CreateUser(ctx, &v1.CreateUserOpts{
+			Email:         claims.Email,
+			EmailVerified: v1.BoolPtr(claims.EmailVerified),
+			Name:          v1.StringPtr(claims.Name),
+			OAuth:         oauthOpts,
+		})
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to create user: %s", err.Error())
+		}
+	default:
+		return nil, fmt.Errorf("failed to get user: %s", err.Error())
+	}
+
+	return user, nil
+}
+
+type oidcClaims struct {
+	Email         string `json:"email"`
+	EmailVerified bool   `json:"email_verified"`
+	Name          string `json:"name"`
+	Sub           string `json:"sub"`
+}
+
+func getOIDCClaimsFromToken(ctx context.Context, config *server.ServerConfig, tok *oauth2.Token) (*oidcClaims, error) {
+	verifier := config.Auth.OIDCProvider.Verifier(&oidc.Config{
+		ClientID: config.Auth.OIDCOAuthConfig.ClientID,
+	})
+
+	rawIDToken, ok := tok.Extra("id_token").(string)
+	if !ok {
+		return nil, fmt.Errorf("no id_token in token response")
+	}
+
+	idToken, err := verifier.Verify(ctx, rawIDToken)
+	if err != nil {
+		return nil, fmt.Errorf("failed to verify ID token: %s", err.Error())
+	}
+
+	claims := &oidcClaims{}
+	if err := idToken.Claims(claims); err != nil {
+		return nil, fmt.Errorf("failed to parse ID token claims: %s", err.Error())
+	}
+
+	if claims.Email == "" {
+		return nil, fmt.Errorf("OIDC provider did not return an email claim")
+	}
+
+	if claims.Sub == "" {
+		return nil, fmt.Errorf("OIDC provider did not return a sub claim")
+	}
+
+	return claims, nil
+}

--- a/api/v1/server/handlers/users/oidc_oauth_callback.go
+++ b/api/v1/server/handlers/users/oidc_oauth_callback.go
@@ -21,6 +21,10 @@ import (
 
 // Note: we want all errors to redirect, otherwise the user will be greeted with raw JSON in the middle of the login flow.
 func (u *UserService) UserUpdateOidcOauthCallback(ctx echo.Context, _ gen.UserUpdateOidcOauthCallbackRequestObject) (gen.UserUpdateOidcOauthCallbackResponseObject, error) {
+	if u.config.Auth.OIDCOAuthConfig == nil || u.config.Auth.OIDCProvider == nil {
+		return nil, redirect.GetRedirectWithError(ctx, u.config.Logger, nil, "OIDC authentication is not configured.")
+	}
+
 	isValid, _, err := authn.NewSessionHelpers(u.config.SessionStore).ValidateOAuthState(ctx, "oidc")
 
 	if err != nil || !isValid {
@@ -79,6 +83,10 @@ func (u *UserService) upsertOIDCUserFromToken(ctx context.Context, config *serve
 		return nil, err
 	}
 
+	if !claims.EmailVerified {
+		return nil, fmt.Errorf("OIDC provider did not verify the email address")
+	}
+
 	expiresAt := tok.Expiry
 
 	accessTokenEncrypted, err := config.Encryption.Encrypt([]byte(tok.AccessToken), "oidc_access_token")
@@ -118,6 +126,10 @@ func (u *UserService) upsertOIDCUserFromToken(ctx context.Context, config *serve
 			return nil, fmt.Errorf("failed to update user: %s", err.Error())
 		}
 	case pgx.ErrNoRows:
+		if !config.Runtime.AllowSignup {
+			return nil, fmt.Errorf("user signup is disabled")
+		}
+
 		user, err = u.config.V1.User().CreateUser(ctx, &v1.CreateUserOpts{
 			Email:         claims.Email,
 			EmailVerified: v1.BoolPtr(claims.EmailVerified),
@@ -160,6 +172,33 @@ func getOIDCClaimsFromToken(ctx context.Context, config *server.ServerConfig, to
 	claims := &oidcClaims{}
 	if err := idToken.Claims(claims); err != nil {
 		return nil, fmt.Errorf("failed to parse ID token claims: %s", err.Error())
+	}
+
+	// Fall back to UserInfo endpoint when the ID token is missing optional claims.
+	// The OIDC spec does not require providers to include email/name in the ID token.
+	if claims.Email == "" || claims.Name == "" || !claims.EmailVerified {
+		userInfo, uiErr := config.Auth.OIDCProvider.UserInfo(ctx, oauth2.StaticTokenSource(tok))
+		if uiErr == nil {
+			uiClaims := &oidcClaims{}
+			if err := userInfo.Claims(uiClaims); err == nil {
+				// Per OIDC spec, the UserInfo sub must match the ID token sub.
+				if uiClaims.Sub != "" && claims.Sub != "" && uiClaims.Sub != claims.Sub {
+					return nil, fmt.Errorf("OIDC UserInfo sub claim (%s) does not match ID token sub claim (%s)", uiClaims.Sub, claims.Sub)
+				}
+				if claims.Email == "" {
+					claims.Email = uiClaims.Email
+				}
+				if claims.Name == "" {
+					claims.Name = uiClaims.Name
+				}
+				if !claims.EmailVerified && uiClaims.EmailVerified {
+					claims.EmailVerified = true
+				}
+				if claims.Sub == "" {
+					claims.Sub = uiClaims.Sub
+				}
+			}
+		}
 	}
 
 	if claims.Email == "" {

--- a/api/v1/server/handlers/users/oidc_oauth_start.go
+++ b/api/v1/server/handlers/users/oidc_oauth_start.go
@@ -10,8 +10,8 @@ import (
 
 // Note: we want all errors to redirect, otherwise the user will be greeted with raw JSON in the middle of the login flow.
 func (u *UserService) UserUpdateOidcOauthStart(ctx echo.Context, _ gen.UserUpdateOidcOauthStartRequestObject) (gen.UserUpdateOidcOauthStartResponseObject, error) {
-	if !u.config.Runtime.AllowSignup {
-		return nil, redirect.GetRedirectWithError(ctx, u.config.Logger, nil, "User signup is disabled.")
+	if u.config.Auth.OIDCOAuthConfig == nil {
+		return nil, redirect.GetRedirectWithError(ctx, u.config.Logger, nil, "OIDC authentication is not configured.")
 	}
 
 	state, err := authn.NewSessionHelpers(u.config.SessionStore).SaveOAuthState(ctx, "oidc")

--- a/api/v1/server/handlers/users/oidc_oauth_start.go
+++ b/api/v1/server/handlers/users/oidc_oauth_start.go
@@ -1,0 +1,30 @@
+package users
+
+import (
+	"github.com/labstack/echo/v4"
+
+	"github.com/hatchet-dev/hatchet/api/v1/server/authn"
+	"github.com/hatchet-dev/hatchet/api/v1/server/middleware/redirect"
+	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
+)
+
+// Note: we want all errors to redirect, otherwise the user will be greeted with raw JSON in the middle of the login flow.
+func (u *UserService) UserUpdateOidcOauthStart(ctx echo.Context, _ gen.UserUpdateOidcOauthStartRequestObject) (gen.UserUpdateOidcOauthStartResponseObject, error) {
+	if !u.config.Runtime.AllowSignup {
+		return nil, redirect.GetRedirectWithError(ctx, u.config.Logger, nil, "User signup is disabled.")
+	}
+
+	state, err := authn.NewSessionHelpers(u.config.SessionStore).SaveOAuthState(ctx, "oidc")
+
+	if err != nil {
+		return nil, redirect.GetRedirectWithError(ctx, u.config.Logger, err, "Could not get cookie. Please make sure cookies are enabled.")
+	}
+
+	url := u.config.Auth.OIDCOAuthConfig.AuthCodeURL(state)
+
+	return gen.UserUpdateOidcOauthStart302Response{
+		Headers: gen.UserUpdateOidcOauthStart302ResponseHeaders{
+			Location: url,
+		},
+	}, nil
+}

--- a/api/v1/server/oas/gen/openapi.gen.go
+++ b/api/v1/server/oas/gen/openapi.gen.go
@@ -3674,6 +3674,12 @@ type ServerInterface interface {
 	// List tenant memberships
 	// (GET /api/v1/users/memberships)
 	TenantMembershipsList(ctx echo.Context) error
+	// Complete OIDC OAuth flow
+	// (GET /api/v1/users/oidc/callback)
+	UserUpdateOidcOauthCallback(ctx echo.Context) error
+	// Start OIDC OAuth flow
+	// (GET /api/v1/users/oidc/start)
+	UserUpdateOidcOauthStart(ctx echo.Context) error
 	// Change user password
 	// (POST /api/v1/users/password)
 	UserUpdatePassword(ctx echo.Context) error
@@ -7378,6 +7384,24 @@ func (w *ServerInterfaceWrapper) TenantMembershipsList(ctx echo.Context) error {
 	return err
 }
 
+// UserUpdateOidcOauthCallback converts echo context to params.
+func (w *ServerInterfaceWrapper) UserUpdateOidcOauthCallback(ctx echo.Context) error {
+	var err error
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.UserUpdateOidcOauthCallback(ctx)
+	return err
+}
+
+// UserUpdateOidcOauthStart converts echo context to params.
+func (w *ServerInterfaceWrapper) UserUpdateOidcOauthStart(ctx echo.Context) error {
+	var err error
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.UserUpdateOidcOauthStart(ctx)
+	return err
+}
+
 // UserUpdatePassword converts echo context to params.
 func (w *ServerInterfaceWrapper) UserUpdatePassword(ctx echo.Context) error {
 	var err error
@@ -7805,6 +7829,8 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.POST(baseURL+"/api/v1/users/login", wrapper.UserUpdateLogin)
 	router.POST(baseURL+"/api/v1/users/logout", wrapper.UserUpdateLogout)
 	router.GET(baseURL+"/api/v1/users/memberships", wrapper.TenantMembershipsList)
+	router.GET(baseURL+"/api/v1/users/oidc/callback", wrapper.UserUpdateOidcOauthCallback)
+	router.GET(baseURL+"/api/v1/users/oidc/start", wrapper.UserUpdateOidcOauthStart)
 	router.POST(baseURL+"/api/v1/users/password", wrapper.UserUpdatePassword)
 	router.POST(baseURL+"/api/v1/users/register", wrapper.UserCreate)
 	router.GET(baseURL+"/api/v1/users/slack/callback", wrapper.UserUpdateSlackOauthCallback)
@@ -12732,6 +12758,48 @@ func (response TenantMembershipsList403JSONResponse) VisitTenantMembershipsListR
 	return json.NewEncoder(w).Encode(response)
 }
 
+type UserUpdateOidcOauthCallbackRequestObject struct {
+}
+
+type UserUpdateOidcOauthCallbackResponseObject interface {
+	VisitUserUpdateOidcOauthCallbackResponse(w http.ResponseWriter) error
+}
+
+type UserUpdateOidcOauthCallback302ResponseHeaders struct {
+	Location string
+}
+
+type UserUpdateOidcOauthCallback302Response struct {
+	Headers UserUpdateOidcOauthCallback302ResponseHeaders
+}
+
+func (response UserUpdateOidcOauthCallback302Response) VisitUserUpdateOidcOauthCallbackResponse(w http.ResponseWriter) error {
+	w.Header().Set("location", fmt.Sprint(response.Headers.Location))
+	w.WriteHeader(302)
+	return nil
+}
+
+type UserUpdateOidcOauthStartRequestObject struct {
+}
+
+type UserUpdateOidcOauthStartResponseObject interface {
+	VisitUserUpdateOidcOauthStartResponse(w http.ResponseWriter) error
+}
+
+type UserUpdateOidcOauthStart302ResponseHeaders struct {
+	Location string
+}
+
+type UserUpdateOidcOauthStart302Response struct {
+	Headers UserUpdateOidcOauthStart302ResponseHeaders
+}
+
+func (response UserUpdateOidcOauthStart302Response) VisitUserUpdateOidcOauthStartResponse(w http.ResponseWriter) error {
+	w.Header().Set("location", fmt.Sprint(response.Headers.Location))
+	w.WriteHeader(302)
+	return nil
+}
+
 type UserUpdatePasswordRequestObject struct {
 	Body *UserUpdatePasswordJSONRequestBody
 }
@@ -13553,6 +13621,10 @@ type StrictServerInterface interface {
 	UserUpdateLogout(ctx echo.Context, request UserUpdateLogoutRequestObject) (UserUpdateLogoutResponseObject, error)
 
 	TenantMembershipsList(ctx echo.Context, request TenantMembershipsListRequestObject) (TenantMembershipsListResponseObject, error)
+
+	UserUpdateOidcOauthCallback(ctx echo.Context, request UserUpdateOidcOauthCallbackRequestObject) (UserUpdateOidcOauthCallbackResponseObject, error)
+
+	UserUpdateOidcOauthStart(ctx echo.Context, request UserUpdateOidcOauthStartRequestObject) (UserUpdateOidcOauthStartResponseObject, error)
 
 	UserUpdatePassword(ctx echo.Context, request UserUpdatePasswordRequestObject) (UserUpdatePasswordResponseObject, error)
 
@@ -16577,6 +16649,46 @@ func (sh *strictHandler) TenantMembershipsList(ctx echo.Context) error {
 	return nil
 }
 
+// UserUpdateOidcOauthCallback operation
+func (sh *strictHandler) UserUpdateOidcOauthCallback(ctx echo.Context) error {
+	var request UserUpdateOidcOauthCallbackRequestObject
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.UserUpdateOidcOauthCallback(ctx, request.(UserUpdateOidcOauthCallbackRequestObject))
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(UserUpdateOidcOauthCallbackResponseObject); ok {
+		return validResponse.VisitUserUpdateOidcOauthCallbackResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("Unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// UserUpdateOidcOauthStart operation
+func (sh *strictHandler) UserUpdateOidcOauthStart(ctx echo.Context) error {
+	var request UserUpdateOidcOauthStartRequestObject
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.UserUpdateOidcOauthStart(ctx, request.(UserUpdateOidcOauthStartRequestObject))
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(UserUpdateOidcOauthStartResponseObject); ok {
+		return validResponse.VisitUserUpdateOidcOauthStartResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("Unexpected response type: %T", response)
+	}
+	return nil
+}
+
 // UserUpdatePassword operation
 func (sh *strictHandler) UserUpdatePassword(ctx echo.Context) error {
 	var request UserUpdatePasswordRequestObject
@@ -17242,20 +17354,20 @@ var swaggerSpec = []string{
 	"0lclfXFsr0BffjhDgZmsrsIZdlDgAHY2HlUoGFdsoC05Z9AjmI5fT0i7u0f74WwGPQcF7fX5ha/P3c7r",
 	"s7NdrTuKQ0oDzGjbDwgiS6fnPAIfeWwyuimiCQpmDpQjmRVeRtj6q3y3870HAzpVLwYE9pgNnOrQ/K1G",
 	"x8xhQmq4OUyIHTuHycsbqwSThXtWqLs1UtVo04x6bO1TC7iYwBjPUdTgDqd0srvH8TPwc9ZNJKXYKoHr",
-	"J21+oVNR1F7qVrnUqRisJ8kIYPwUxhWuFGkudtrBke2rROqtHHN7StLFHASzdKJ90pZcBpmXIqoV563S",
-	"1ExpqmZ1Tvl5Zlxbn4rhjEriuOrazVvgSpUq9ZTaFt9LMPaJ4yXy2ofGluk3c1OSVL6ZyxL2gfuwlUeq",
-	"ER15j9+oaiRpw0erRxhjAYLR/YmuQbSTLlAYxo8aLX0QTMMPkHwRg260JrECaZah8fTo5OhElwNS8Tz6",
-	"K+36zaLc8LhisQVvywpi/wqdGJIkDnLIK9x0qJhNgoDyTzrF954cshdGPOVUmQWe4GQehg894Yh2/EP8",
-	"YBH+To860brsqMZ/t49sFwOZHcHSiXbsB2YZKi7haw+2lzdOFMPTVTI1en+JFt+smONY4NnGTCGbCr/6",
-	"Go4Rihu2TZS5t3yzGf9JDj13nxSooZipyrhCsZLWARHYSberZc89Yk9mlSltUVMeTXmT/fFc433NW2kd",
-	"q5lzphXPcSfTKp9lzRl/OB7LjX1HxYpbe2TJKbkU8CUvKGYfZKZW11d+rCRk+7QDe0HL24riz50bprNC",
-	"YCCRKNtdHJQlr6lB+S2nGWoursNshdOkGNxjlQisWQ3WBveivYyQaZJEKwWwDdB74cwRglgVilkxPqZb",
-	"p2HZc0IDletXCBRbMTis5a2X5i01Cm0dxrJR++y5q5keuBcMtnldMI8M21h5kZM0x2W7Vg6tJEJRPWzl",
-	"gVFBXI85a9REq3J5dJPydfFSxntMXzqMJ2WD8nj7wM+aEhW8wMQG6gevXj1YD9gsDpOI1f3IQJAbZQSF",
-	"dfoEl53aNCBbFhJr1uKSj0ptOa491CZWqv/VSHDJ1ERG5xaZVaNpsqCVcgTtpeQaa9jlyBlMmXUbJ5Q6",
-	"oNdlXOUDAjFJeQphZwqJO4eeqTpUJvj3XJESZLBi4qEXSzekwNsoz1CbXajNLrSF7EKNRLOQDdjiVSt3",
-	"kluJZeFbc0AmmJ9BLm9ZykmHqfVUwVbe7ZUKmJHiqipg0fFvAkEM49Txr6t1BWSeZFweJLHfedvpPH97",
-	"/n8BAAD//0mZWRb9YwMA",
+	"J21+oVNR1F7qVrnUqRisJ8kQeW5jA9bg8sLOGHODPPfwbFil5Vkh0d6M1Rx9B2HJaoy2CGD8FMYVbjxp",
+	"HQDawZHtq47zWznm9hT0izkIZulE+6SpuwwyL0VUq0q0Cnszhb36mOGUn2fGtXX5GM6oFhBXmXx4C1yp",
+	"zqdeetviewnGPnG8RF77yN0y/WZu6ZLKN3NRxz5wH7byQDqiI++xblkjSRs+mD7CGAsQjK53dA2inXS/",
+	"wzB+1NwQB8E0/ADJFzHoRuthK5Bm2UFPj06OTnT5RxWvt7/Srt8sSl2PKxZb8PStIPav0IkhSeIgh7zC",
+	"LZuK2SQIKP+kU3zvySF7YcTTnZVZ4AlO5mH40BNOkMc/xA8WqRfoUSdal50k+e/2WRXEQGYnxHSiHfsg",
+	"WqYpkPC1B9vLG8aKqRFUMjV6HooW36yY41jg2cZEJpuKmI4ajhGKG7ZN0rq3fLMZ310OPXfdFaihmKnK",
+	"9kOxktagEdhJt6tlzz1iT2YRLG1RUx5NeZP98Vzj+c9baZ36mWOwFc9xB+cqf3nNGX843vKN/ZbFiltb",
+	"eMkhvhRsKC8oZv93plbXVx2tJGT7lBd7QcvbyiCROzdMZ4XAQCJRtrsYPEteUxNCtJxmqPe5DrMVTpNi",
+	"YJlVErpm9X8b3Iv2MjqrSQK3FMA2OPSFs5YIYlUoZsXYrG6dhmXPCQ1Url8hSHHFwMSWt16at9QIyHUY",
+	"y0bts+euZnrgXjDY5nXBPDJs8zSIfLg5Ltu1cmglEYrqYSsPjAriesxZoyZalWqkm5SvyZgy3mP60mE8",
+	"KRuUZtwHftaUR+HFTTZQu3r1ytV6wGZxmESs5kwGgtwoIyis0ye47NSmoNmykFizDpx8VGpLwe2hNrFS",
+	"7blGgkumxTI6t8iMLk0TVa2Un2ovJddYwy5HzmDKrNs4odQBvS7jKh8QiEnKUwg7U0jcOfRMlckywb/n",
+	"ipQggxWTXr1YqisF3kY5rtrMVm1mqy1ktmokmoVswBavWrmT3EosC9+aAzLB/AxyectSTjpMracKtvJu",
+	"r1TAjBRXVQGLjn8TCGIYp45/Xa0rIPMk4/Igif3O207n+dvz/wsAAP//mjV1JXlmAwA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/frontend/app/src/pages/auth/components/auth-page.tsx
+++ b/frontend/app/src/pages/auth/components/auth-page.tsx
@@ -27,11 +27,13 @@ export function AuthPage({
   const basicEnabled = schemes.includes('basic');
   const googleEnabled = schemes.includes('google');
   const githubEnabled = schemes.includes('github');
+  const oidcEnabled = schemes.includes('oidc');
 
   const providers = [
     googleEnabled && 'google',
     githubEnabled && 'github',
-  ].filter(Boolean) as Array<'google' | 'github'>;
+    oidcEnabled && 'oidc',
+  ].filter(Boolean) as Array<'google' | 'github' | 'oidc'>;
 
   const sections = [
     providers.length > 0 && <SocialAuthButtons providers={providers} />,

--- a/frontend/app/src/pages/auth/components/social-auth.tsx
+++ b/frontend/app/src/pages/auth/components/social-auth.tsx
@@ -1,8 +1,9 @@
 import { Button } from '@/components/v1/ui/button';
 import { Icons } from '@/components/v1/ui/icons';
+import { LockKeyhole } from 'lucide-react';
 import React from 'react';
 
-export type SocialAuthProvider = 'google' | 'github';
+export type SocialAuthProvider = 'google' | 'github' | 'oidc';
 
 const PROVIDER_CONFIG: Record<
   SocialAuthProvider,
@@ -17,6 +18,11 @@ const PROVIDER_CONFIG: Record<
     href: '/api/v1/users/github/start',
     label: 'GitHub',
     icon: <Icons.gitHub className="size-4" />,
+  },
+  oidc: {
+    href: '/api/v1/users/oidc/start',
+    label: 'SSO',
+    icon: <LockKeyhole className="size-4" />,
   },
 };
 

--- a/go.mod
+++ b/go.mod
@@ -122,6 +122,7 @@ require (
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
+	github.com/coreos/go-oidc/v3 v3.18.0 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-sdk/config v0.1.0-alpha013 // indirect
@@ -133,6 +134,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logfmt/logfmt v0.6.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpSBQv6A=
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
+github.com/coreos/go-oidc/v3 v3.18.0 h1:V9orjXynvu5wiC9SemFTWnG4F45v403aIcjWo0d41+A=
+github.com/coreos/go-oidc/v3 v3.18.0/go.mod h1:DYCf24+ncYi+XkIH97GY1+dqoRlbaSI26KVTCI9SrY4=
 github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GKorA=
 github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
@@ -190,6 +192,8 @@ github.com/go-co-op/gocron/v2 v2.20.0 h1:9IMrnnVSWjfSh3E54gWmWCHbloQJLh6f9+nwyKf
 github.com/go-co-op/gocron/v2 v2.20.0/go.mod h1:5lEiCKk1oVJV39Zg7/YG10OnaVrDAV5GGR6O0663k6U=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logfmt/logfmt v0.6.1 h1:4hvbpePJKnIzH1B+8OR/JPbTx37NktoI9LE2QZBBkvE=
 github.com/go-logfmt/logfmt v0.6.1/go.mod h1:EV2pOAQoZaT1ZXZbqDl5hrymndi4SY9ED9/z6CO0XAk=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/pkg/auth/oauth/configs.go
+++ b/pkg/auth/oauth/configs.go
@@ -1,6 +1,8 @@
 package oauth
 
 import (
+	"strings"
+
 	"golang.org/x/oauth2"
 )
 
@@ -77,7 +79,7 @@ func NewOIDCClient(cfg *OIDCConfig) *oauth2.Config {
 			AuthURL:  cfg.AuthURL,
 			TokenURL: cfg.TokenURL,
 		},
-		RedirectURL: cfg.BaseURL + "/api/v1/users/oidc/callback",
+		RedirectURL: strings.TrimRight(cfg.BaseURL, "/") + "/api/v1/users/oidc/callback",
 		Scopes:      cfg.Scopes,
 	}
 }

--- a/pkg/auth/oauth/configs.go
+++ b/pkg/auth/oauth/configs.go
@@ -11,6 +11,16 @@ type Config struct {
 	BaseURL      string
 }
 
+type OIDCConfig struct {
+	ClientID     string
+	ClientSecret string
+	Scopes       []string
+	BaseURL      string
+	IssuerURL    string
+	AuthURL      string
+	TokenURL     string
+}
+
 const (
 	GoogleAuthURL  string = "https://accounts.google.com/o/oauth2/v2/auth"
 	GoogleTokenURL string = "https://oauth2.googleapis.com/token" // #nosec G101
@@ -55,6 +65,19 @@ func NewSlackClient(cfg *Config) *oauth2.Config {
 			TokenURL: SlackTokenURL,
 		},
 		RedirectURL: cfg.BaseURL + "/api/v1/users/slack/callback",
+		Scopes:      cfg.Scopes,
+	}
+}
+
+func NewOIDCClient(cfg *OIDCConfig) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     cfg.ClientID,
+		ClientSecret: cfg.ClientSecret,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  cfg.AuthURL,
+			TokenURL: cfg.TokenURL,
+		},
+		RedirectURL: cfg.BaseURL + "/api/v1/users/oidc/callback",
 		Scopes:      cfg.Scopes,
 	}
 }

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -622,6 +622,11 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 	}
 
 	if cf.Auth.OIDC.Enabled {
+		// Parse ScopesString before building OIDCOAuthConfig so the env var is used.
+		if cf.Auth.OIDC.ScopesString != "" {
+			cf.Auth.OIDC.Scopes = getStrArr(cf.Auth.OIDC.ScopesString)
+		}
+
 		if cf.Auth.OIDC.ClientID == "" {
 			return nil, nil, fmt.Errorf("oidc client id is required")
 		}
@@ -634,7 +639,23 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 			return nil, nil, fmt.Errorf("oidc issuer url is required")
 		}
 
-		oidcProvider, err := oidc.NewProvider(context.Background(), cf.Auth.OIDC.IssuerURL)
+		// Ensure "openid" scope is always present, since we rely on the ID token.
+		hasOpenID := false
+		for _, s := range cf.Auth.OIDC.Scopes {
+			if s == "openid" {
+				hasOpenID = true
+				break
+			}
+		}
+
+		if !hasOpenID {
+			cf.Auth.OIDC.Scopes = append([]string{"openid"}, cf.Auth.OIDC.Scopes...)
+		}
+
+		discoveryCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		oidcProvider, err := oidc.NewProvider(discoveryCtx, cf.Auth.OIDC.IssuerURL)
 		if err != nil {
 			return nil, nil, fmt.Errorf("could not create OIDC provider from issuer URL %s: %w", cf.Auth.OIDC.IssuerURL, err)
 		}

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -20,6 +20,8 @@ import (
 	"github.com/rs/zerolog"
 	"golang.org/x/oauth2"
 
+	"github.com/coreos/go-oidc/v3/oidc"
+
 	"github.com/hatchet-dev/hatchet/internal/integrations/alerting"
 	"github.com/hatchet-dev/hatchet/internal/services/ingestor"
 	"github.com/hatchet-dev/hatchet/pkg/analytics"
@@ -616,6 +618,38 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 			ClientSecret: cf.Auth.Github.ClientSecret,
 			BaseURL:      cf.Runtime.ServerURL,
 			Scopes:       cf.Auth.Github.Scopes,
+		})
+	}
+
+	if cf.Auth.OIDC.Enabled {
+		if cf.Auth.OIDC.ClientID == "" {
+			return nil, nil, fmt.Errorf("oidc client id is required")
+		}
+
+		if cf.Auth.OIDC.ClientSecret == "" {
+			return nil, nil, fmt.Errorf("oidc client secret is required")
+		}
+
+		if cf.Auth.OIDC.IssuerURL == "" {
+			return nil, nil, fmt.Errorf("oidc issuer url is required")
+		}
+
+		oidcProvider, err := oidc.NewProvider(context.Background(), cf.Auth.OIDC.IssuerURL)
+		if err != nil {
+			return nil, nil, fmt.Errorf("could not create OIDC provider from issuer URL %s: %w", cf.Auth.OIDC.IssuerURL, err)
+		}
+
+		endpoint := oidcProvider.Endpoint()
+
+		auth.OIDCProvider = oidcProvider
+		auth.OIDCOAuthConfig = oauth.NewOIDCClient(&oauth.OIDCConfig{
+			ClientID:     cf.Auth.OIDC.ClientID,
+			ClientSecret: cf.Auth.OIDC.ClientSecret,
+			BaseURL:      cf.Runtime.ServerURL,
+			Scopes:       cf.Auth.OIDC.Scopes,
+			IssuerURL:    cf.Auth.OIDC.IssuerURL,
+			AuthURL:      endpoint.AuthURL,
+			TokenURL:     endpoint.TokenURL,
 		})
 	}
 

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -505,6 +505,9 @@ type ConfigFileAuthOIDC struct {
 	ClientSecret string   `mapstructure:"clientSecret" json:"clientSecret,omitempty"`
 	IssuerURL    string   `mapstructure:"issuerURL" json:"issuerURL,omitempty"`
 	Scopes       []string `mapstructure:"scopes" json:"scopes,omitempty" default:"[\"openid\", \"profile\", \"email\"]"`
+	// ScopesString is used to bind the SERVER_AUTH_OIDC_SCOPES env var, since
+	// direct env-to-[]string binding is unreliable without a decode hook.
+	ScopesString string `mapstructure:"scopesString" json:"scopesString,omitempty"`
 }
 
 type ConfigFileAuthCookie struct {
@@ -858,6 +861,7 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("auth.oidc.clientSecret", "SERVER_AUTH_OIDC_CLIENT_SECRET")
 	_ = v.BindEnv("auth.oidc.issuerURL", "SERVER_AUTH_OIDC_ISSUER_URL")
 	_ = v.BindEnv("auth.oidc.scopes", "SERVER_AUTH_OIDC_SCOPES")
+	_ = v.BindEnv("auth.oidc.scopesString", "SERVER_AUTH_OIDC_SCOPES")
 
 	// task queue options
 	// legacy options

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"time"
 
+	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog"
 	"github.com/spf13/viper"
@@ -442,6 +443,8 @@ type ConfigFileAuth struct {
 
 	Github ConfigFileAuthGithub `mapstructure:"github" json:"github,omitempty"`
 
+	OIDC ConfigFileAuthOIDC `mapstructure:"oidc" json:"oidc,omitempty"`
+
 	ControlPlaneExchangeTokenConfig ConfigFileAuthControlPlaneExchangeToken `mapstructure:"controlPlaneExchangeToken" json:"controlPlaneExchangeToken,omitempty"`
 }
 
@@ -493,6 +496,15 @@ type ConfigFileAuthGithub struct {
 	ClientID     string   `mapstructure:"clientID" json:"clientID,omitempty"`
 	ClientSecret string   `mapstructure:"clientSecret" json:"clientSecret,omitempty"`
 	Scopes       []string `mapstructure:"scopes" json:"scopes,omitempty" default:"[\"read:user\", \"user:email\"]"`
+}
+
+type ConfigFileAuthOIDC struct {
+	Enabled bool `mapstructure:"enabled" json:"enabled,omitempty" default:"false"`
+
+	ClientID     string   `mapstructure:"clientID" json:"clientID,omitempty"`
+	ClientSecret string   `mapstructure:"clientSecret" json:"clientSecret,omitempty"`
+	IssuerURL    string   `mapstructure:"issuerURL" json:"issuerURL,omitempty"`
+	Scopes       []string `mapstructure:"scopes" json:"scopes,omitempty" default:"[\"openid\", \"profile\", \"email\"]"`
 }
 
 type ConfigFileAuthCookie struct {
@@ -591,6 +603,12 @@ type AuthConfig struct {
 	GoogleOAuthConfig *oauth2.Config
 
 	GithubOAuthConfig *oauth2.Config
+
+	OIDCOAuthConfig *oauth2.Config
+
+	// OIDCProvider is the cached OIDC provider, created at startup via discovery.
+	// Reuse this instead of calling oidc.NewProvider on every request.
+	OIDCProvider *oidc.Provider
 
 	JWTManager token.JWTManager
 
@@ -835,6 +853,11 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("auth.github.clientID", "SERVER_AUTH_GITHUB_CLIENT_ID")
 	_ = v.BindEnv("auth.github.clientSecret", "SERVER_AUTH_GITHUB_CLIENT_SECRET")
 	_ = v.BindEnv("auth.github.scopes", "SERVER_AUTH_GITHUB_SCOPES")
+	_ = v.BindEnv("auth.oidc.enabled", "SERVER_AUTH_OIDC_ENABLED")
+	_ = v.BindEnv("auth.oidc.clientID", "SERVER_AUTH_OIDC_CLIENT_ID")
+	_ = v.BindEnv("auth.oidc.clientSecret", "SERVER_AUTH_OIDC_CLIENT_SECRET")
+	_ = v.BindEnv("auth.oidc.issuerURL", "SERVER_AUTH_OIDC_ISSUER_URL")
+	_ = v.BindEnv("auth.oidc.scopes", "SERVER_AUTH_OIDC_SCOPES")
 
 	// task queue options
 	// legacy options


### PR DESCRIPTION
# Description

Add native OIDC authentication support for self-hosted Hatchet instances, enabling direct SSO integration with any OpenID Connect compliant provider (Keycloak, PocketID, Okta, Azure AD, etc.) without requiring external proxies like oauth2-proxy or Traefik forward auth.

Uses standard OIDC discovery (`.well-known/openid-configuration`) to auto-resolve authorization and token endpoints at startup, and verifies ID tokens using the provider's JWKS.

Closes #3052

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## What's Changed

- [x] Add `oidc_oauth_start.go` and `oidc_oauth_callback.go` handlers following the existing Google/GitHub OAuth pattern
- [x] Add `ConfigFileAuthOIDC` config struct with env var bindings (`SERVER_AUTH_OIDC_ENABLED`, `_CLIENT_ID`, `_CLIENT_SECRET`, `_ISSUER_URL`, `_SCOPES`)
- [x] Cache `oidc.Provider` at startup for ID token verification (no per-request OIDC discovery)
- [x] Add OIDC routes to OpenAPI spec (`/api/v1/users/oidc/start`, `/api/v1/users/oidc/callback`) and regenerate server code
- [x] Expose `oidc` auth scheme via `/api/v1/meta` endpoint
- [x] Add SSO button with lock icon to frontend auth page
- [x] Support existing domain restrictions for OIDC users
- [x] Default scopes: `openid`, `profile`, `email`
- [x] Uses `github.com/coreos/go-oidc/v3` for discovery and token verification