### PR TITLE
Generate insecure keysets locally

### DIFF
--- a/cmd/hatchet-admin/cli/k8s.go
+++ b/cmd/hatchet-admin/cli/k8s.go
@@ -190,10 +190,9 @@ func runK8sQuickstart() error {
 	}
 
 	if k8sQuickstartOverwrite || res.encryptionMasterKeyset == "" || res.encryptionJwtPrivateKeyset == "" || res.encryptionJwtPublicKeyset == "" {
-		masterKeyBytes, privateEc256, publicEc256, _, eErr := encryption.GenerateLocalKeys()
-
-		if eErr != nil {
-			return eErr
+		masterKeyBytes, privateEc256, publicEc256, _, generationErr := encryption.GenerateLocalKeys()
+		if generationErr != nil {
+			return generationErr
 		}
 
 		res.encryptionMasterKeyset = string(masterKeyBytes)

--- a/cmd/hatchet-admin/cli/k8s.go
+++ b/cmd/hatchet-admin/cli/k8s.go
@@ -190,10 +190,10 @@ func runK8sQuickstart() error {
 	}
 
 	if k8sQuickstartOverwrite || res.encryptionMasterKeyset == "" || res.encryptionJwtPrivateKeyset == "" || res.encryptionJwtPublicKeyset == "" {
-		masterKeyBytes, privateEc256, publicEc256, err := encryption.GenerateLocalKeys()
+		masterKeyBytes, privateEc256, publicEc256, _, eErr := encryption.GenerateLocalKeys()
 
-		if err != nil {
-			return err
+		if eErr != nil {
+			return eErr
 		}
 
 		res.encryptionMasterKeyset = string(masterKeyBytes)

--- a/cmd/hatchet-admin/cli/keyset.go
+++ b/cmd/hatchet-admin/cli/keyset.go
@@ -75,13 +75,7 @@ func init() {
 }
 
 func runCreateLocalKeysets() error {
-	masterKeyBytes, privateEc256, publicEc256, err := encryption.GenerateLocalKeys()
-
-	if err != nil {
-		return err
-	}
-
-	privateInsecureEc256, publicInsecureEc256, err := encryption.GenerateInsecureLocalKeys()
+	masterKeyBytes, privateEc256, publicEc256, publicHandleEc256, err := encryption.GenerateLocalKeys()
 
 	if err != nil {
 		return err
@@ -107,13 +101,7 @@ func runCreateLocalKeysets() error {
 			return err
 		}
 
-		err = os.WriteFile(encryptionKeyDir+"/private_insecure_ec256.key", privateInsecureEc256, 0600)
-
-		if err != nil {
-			return err
-		}
-
-		err = os.WriteFile(encryptionKeyDir+"/public_insecure_ec256.key", publicInsecureEc256, 0600)
+		err = os.WriteFile(encryptionKeyDir+"/public_handle_ec256.key", publicHandleEc256, 0600)
 
 		if err != nil {
 			return err
@@ -147,7 +135,7 @@ func runCreateCloudKMSJWTKeyset() error {
 		return err
 	}
 
-	privateEc256, publicEc256, err := encryption.GenerateJWTKeysetsFromCloudKMS(cloudKMSKeyURI, credentials)
+	privateEc256, publicEc256, publicHandle, err := encryption.GenerateJWTKeysetsFromCloudKMS(cloudKMSKeyURI, credentials)
 
 	if err != nil {
 		return err
@@ -162,6 +150,12 @@ func runCreateCloudKMSJWTKeyset() error {
 		}
 
 		err = os.WriteFile(encryptionKeyDir+"/public_ec256.key", publicEc256, 0600)
+
+		if err != nil {
+			return err
+		}
+
+		err = os.WriteFile(encryptionKeyDir+"/public_handle_ec256.key", publicHandle, 0600)
 
 		if err != nil {
 			return err

--- a/cmd/hatchet-admin/cli/keyset.go
+++ b/cmd/hatchet-admin/cli/keyset.go
@@ -101,7 +101,7 @@ func runCreateLocalKeysets() error {
 			return err
 		}
 
-		err = os.WriteFile(encryptionKeyDir+"/public_handle_ec256.key", insecurePublicHandleEc256, 0600)
+		err = os.WriteFile(encryptionKeyDir+"/public_handle_unencrypted_ec256.key", insecurePublicHandleEc256, 0600)
 
 		if err != nil {
 			return err
@@ -158,7 +158,7 @@ func runCreateCloudKMSJWTKeyset() error {
 			return err
 		}
 
-		err = os.WriteFile(encryptionKeyDir+"/public_handle_ec256.key", insecurePublicHandleEc256, 0600)
+		err = os.WriteFile(encryptionKeyDir+"/public_handle_unencrypted_ec256.key", insecurePublicHandleEc256, 0600)
 
 		if err != nil {
 			return err

--- a/cmd/hatchet-admin/cli/keyset.go
+++ b/cmd/hatchet-admin/cli/keyset.go
@@ -81,6 +81,12 @@ func runCreateLocalKeysets() error {
 		return err
 	}
 
+	privateInsecureEc256, publicInsecureEc256, err := encryption.GenerateInsecureLocalKeys()
+
+	if err != nil {
+		return err
+	}
+
 	if encryptionKeyDir != "" {
 		// we write these as .key files so that they're gitignored by default
 		err = os.WriteFile(encryptionKeyDir+"/master.key", masterKeyBytes, 0600)
@@ -96,6 +102,18 @@ func runCreateLocalKeysets() error {
 		}
 
 		err = os.WriteFile(encryptionKeyDir+"/public_ec256.key", publicEc256, 0600)
+
+		if err != nil {
+			return err
+		}
+
+		err = os.WriteFile(encryptionKeyDir+"/private_insecure_ec256.key", privateInsecureEc256, 0600)
+
+		if err != nil {
+			return err
+		}
+
+		err = os.WriteFile(encryptionKeyDir+"/public_insecure_ec256.key", publicInsecureEc256, 0600)
 
 		if err != nil {
 			return err

--- a/cmd/hatchet-admin/cli/keyset.go
+++ b/cmd/hatchet-admin/cli/keyset.go
@@ -75,7 +75,7 @@ func init() {
 }
 
 func runCreateLocalKeysets() error {
-	masterKeyBytes, privateEc256, publicEc256, publicHandleEc256, err := encryption.GenerateLocalKeys()
+	masterKeyBytes, privateEc256, publicEc256, insecurePublicHandleEc256, err := encryption.GenerateLocalKeys()
 
 	if err != nil {
 		return err
@@ -101,7 +101,7 @@ func runCreateLocalKeysets() error {
 			return err
 		}
 
-		err = os.WriteFile(encryptionKeyDir+"/public_handle_ec256.key", publicHandleEc256, 0600)
+		err = os.WriteFile(encryptionKeyDir+"/public_handle_ec256.key", insecurePublicHandleEc256, 0600)
 
 		if err != nil {
 			return err
@@ -115,6 +115,9 @@ func runCreateLocalKeysets() error {
 
 		fmt.Println("Public EC256 Keyset:")
 		fmt.Println(string(publicEc256))
+
+		fmt.Println("Insecure Public Handle EC256 Keyset:")
+		fmt.Println(string(insecurePublicHandleEc256))
 	}
 
 	return nil
@@ -135,7 +138,7 @@ func runCreateCloudKMSJWTKeyset() error {
 		return err
 	}
 
-	privateEc256, publicEc256, publicHandle, err := encryption.GenerateJWTKeysetsFromCloudKMS(cloudKMSKeyURI, credentials)
+	privateEc256, publicEc256, insecurePublicHandleEc256, err := encryption.GenerateJWTKeysetsFromCloudKMS(cloudKMSKeyURI, credentials)
 
 	if err != nil {
 		return err
@@ -155,7 +158,7 @@ func runCreateCloudKMSJWTKeyset() error {
 			return err
 		}
 
-		err = os.WriteFile(encryptionKeyDir+"/public_handle_ec256.key", publicHandle, 0600)
+		err = os.WriteFile(encryptionKeyDir+"/public_handle_ec256.key", insecurePublicHandleEc256, 0600)
 
 		if err != nil {
 			return err
@@ -166,6 +169,9 @@ func runCreateCloudKMSJWTKeyset() error {
 
 		fmt.Println("Public EC256 Keyset:")
 		fmt.Println(string(publicEc256))
+
+		fmt.Println("Insecure Public Handle EC256 Keyset:")
+		fmt.Println(string(insecurePublicHandleEc256))
 	}
 
 	return nil

--- a/cmd/hatchet-admin/cli/quickstart.go
+++ b/cmd/hatchet-admin/cli/quickstart.go
@@ -232,7 +232,7 @@ func generateKeys(generated *generatedConfigFiles) error {
 
 	// if using local keys, generate master key
 	if !generated.sc.Encryption.CloudKMS.Enabled {
-		masterKeyBytes, privateEc256, publicEc256, err := encryption.GenerateLocalKeys()
+		masterKeyBytes, privateEc256, publicEc256, _, err := encryption.GenerateLocalKeys()
 
 		if err != nil {
 			return err
@@ -250,7 +250,7 @@ func generateKeys(generated *generatedConfigFiles) error {
 
 	// generate jwt keys
 	if generated.sc.Encryption.CloudKMS.Enabled && (overwrite || (generated.sc.Encryption.JWT.PublicJWTKeyset == "") || (generated.sc.Encryption.JWT.PrivateJWTKeyset == "")) {
-		privateEc256, publicEc256, err := encryption.GenerateJWTKeysetsFromCloudKMS(
+		privateEc256, publicEc256, _, err := encryption.GenerateJWTKeysetsFromCloudKMS(
 			generated.sc.Encryption.CloudKMS.KeyURI,
 			[]byte(generated.sc.Encryption.CloudKMS.CredentialsJSON),
 		)

--- a/pkg/auth/token/token_test.go
+++ b/pkg/auth/token/token_test.go
@@ -188,7 +188,7 @@ func TestRevokeTenantTokenCache(t *testing.T) {
 func getJWTManager(t *testing.T, conf *database.Layer) token.JWTManager {
 	t.Helper()
 
-	masterKeyBytes, privateJWTBytes, publicJWTBytes, err := encryption.GenerateLocalKeys()
+	masterKeyBytes, privateJWTBytes, publicJWTBytes, _, err := encryption.GenerateLocalKeys()
 
 	if err != nil {
 		t.Fatal(err.Error())

--- a/pkg/encryption/cloudkms.go
+++ b/pkg/encryption/cloudkms.go
@@ -29,23 +29,23 @@ func NewCloudKMSEncryption(keyUri string, credentialsJSON, privateEc256, publicE
 	return newWithClient(client, keyUri, privateEc256, publicEc256)
 }
 
-func GenerateJWTKeysetsFromCloudKMS(keyUri string, credentialsJSON []byte) (privateEc256 []byte, publicEc256 []byte, err error) {
+func GenerateJWTKeysetsFromCloudKMS(keyUri string, credentialsJSON []byte) (privateEc256 []byte, publicEc256 []byte, publicHandle []byte, err error) {
 	client, err := gcpkms.NewClientWithOptions(context.Background(), keyUri, option.WithCredentialsJSON(credentialsJSON))
 
 	if err != nil {
-		return nil, nil, err
+		return
 	}
 
 	return generateJWTKeysetsWithClient(keyUri, client)
 }
 
-func generateJWTKeysetsWithClient(keyUri string, client registry.KMSClient) (privateEc256 []byte, publicEc256 []byte, err error) {
+func generateJWTKeysetsWithClient(keyUri string, client registry.KMSClient) (privateEc256 []byte, publicEc256 []byte, publicHandle []byte, err error) {
 	registry.RegisterKMSClient(client)
 
 	remote, err := client.GetAEAD(keyUri)
 
 	if err != nil {
-		return nil, nil, err
+		return
 	}
 
 	return generateJWTKeysets(remote)

--- a/pkg/encryption/cloudkms_test.go
+++ b/pkg/encryption/cloudkms_test.go
@@ -20,7 +20,7 @@ func TestNewCloudKMSEncryptionValid(t *testing.T) {
 	assert.NoError(t, err)
 
 	// generate JWT keysets
-	privateEc256, publicEc256, err := generateJWTKeysetsWithClient(fakeKeyURI, client)
+	privateEc256, publicEc256, _, err := generateJWTKeysetsWithClient(fakeKeyURI, client)
 
 	if err != nil {
 		t.Fatal(err)
@@ -50,7 +50,7 @@ func TestEncryptDecryptCloudKMS(t *testing.T) {
 	assert.NoError(t, err)
 
 	// generate JWT keysets
-	privateEc256, publicEc256, err := generateJWTKeysetsWithClient(fakeKeyURI, client)
+	privateEc256, publicEc256, _, err := generateJWTKeysetsWithClient(fakeKeyURI, client)
 
 	if err != nil {
 		t.Fatal(err)
@@ -84,7 +84,7 @@ func TestEncryptDecryptCloudKMSStringBase64(t *testing.T) {
 	assert.NoError(t, err)
 
 	// generate JWT keysets
-	privateEc256, publicEc256, err := generateJWTKeysetsWithClient(fakeKeyURI, client)
+	privateEc256, publicEc256, _, err := generateJWTKeysetsWithClient(fakeKeyURI, client)
 
 	if err != nil {
 		t.Fatal(err)
@@ -118,7 +118,7 @@ func TestEncryptDecryptCloudKMSWithEmptyDataID(t *testing.T) {
 	assert.NoError(t, err)
 
 	// generate JWT keysets
-	privateEc256, publicEc256, err := generateJWTKeysetsWithClient(fakeKeyURI, client)
+	privateEc256, publicEc256, _, err := generateJWTKeysetsWithClient(fakeKeyURI, client)
 
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/encryption/local.go
+++ b/pkg/encryption/local.go
@@ -81,6 +81,16 @@ func GenerateLocalKeys() (masterKey []byte, privateEc256 []byte, publicEc256 []b
 	return masterKey, privateEc256, publicEc256, nil
 }
 
+func GenerateInsecureLocalKeys() (privateEc256 []byte, publicEc256 []byte, err error) {
+	privateEc256, publicEc256, err = generateInsecureJWTKeysets()
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return privateEc256, publicEc256, nil
+}
+
 func generateLocalMasterKey() ([]byte, *keyset.Handle, error) {
 	aeadTemplate := aead.AES256GCMKeyTemplate()
 
@@ -123,6 +133,38 @@ func generateJWTKeysets(masterKey tink.AEAD) (privateEc256 []byte, publicEc256 [
 	}
 
 	publicEc256, err = bytesFromHandle(publicHandle, masterKey)
+
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// generateJWTKeysets creates the keysets for JWT signing and verification encrypted with the
+// masterKey. The masterKey can be from a remote KMS service or a local keyset.
+func generateInsecureJWTKeysets() (privateEc256 []byte, publicEc256 []byte, err error) {
+	privateHandle, err := keyset.NewHandle(jwt.ES256Template())
+
+	if err != nil {
+		err = fmt.Errorf("failed to create new keyset handle with ES256 template: %w", err)
+		return
+	}
+
+	privateEc256, err = insecureBytesFromHandle(privateHandle)
+
+	if err != nil {
+		return
+	}
+
+	publicHandle, err := privateHandle.Public()
+
+	if err != nil {
+		err = fmt.Errorf("failed to get public keyset: %w", err)
+		return
+	}
+
+	publicEc256, err = insecureBytesFromHandle(publicHandle)
 
 	if err != nil {
 		return

--- a/pkg/encryption/local.go
+++ b/pkg/encryption/local.go
@@ -122,7 +122,6 @@ func generateJWTKeysets(masterKey tink.AEAD) (privateEc256 []byte, publicEc256 [
 	}
 
 	insecurePublicHandleEc256, err = insecureBytesFromHandle(publicHandle)
-
 	if err != nil {
 		return
 	}

--- a/pkg/encryption/local.go
+++ b/pkg/encryption/local.go
@@ -59,7 +59,7 @@ func NewLocalEncryption(masterKey []byte, privateEc256 []byte, publicEc256 []byt
 	}, nil
 }
 
-func GenerateLocalKeys() (masterKey []byte, privateEc256 []byte, publicEc256 []byte, publicHandleEc256 []byte, err error) {
+func GenerateLocalKeys() (masterKey []byte, privateEc256 []byte, publicEc256 []byte, insecurePublicHandleEc256 []byte, err error) {
 	masterKey, masterHandle, err := generateLocalMasterKey()
 
 	if err != nil {
@@ -72,13 +72,13 @@ func GenerateLocalKeys() (masterKey []byte, privateEc256 []byte, publicEc256 []b
 		return
 	}
 
-	privateEc256, publicEc256, publicHandleEc256, err = generateJWTKeysets(a)
+	privateEc256, publicEc256, insecurePublicHandleEc256, err = generateJWTKeysets(a)
 
 	if err != nil {
 		return
 	}
 
-	return masterKey, privateEc256, publicEc256, publicHandleEc256, nil
+	return masterKey, privateEc256, publicEc256, insecurePublicHandleEc256, nil
 }
 
 func generateLocalMasterKey() ([]byte, *keyset.Handle, error) {
@@ -101,7 +101,7 @@ func generateLocalMasterKey() ([]byte, *keyset.Handle, error) {
 
 // generateJWTKeysets creates the keysets for JWT signing and verification encrypted with the
 // masterKey. The masterKey can be from a remote KMS service or a local keyset.
-func generateJWTKeysets(masterKey tink.AEAD) (privateEc256 []byte, publicEc256 []byte, publicHandleEc256 []byte, err error) {
+func generateJWTKeysets(masterKey tink.AEAD) (privateEc256 []byte, publicEc256 []byte, insecurePublicHandleEc256 []byte, err error) {
 	privateHandle, err := keyset.NewHandle(jwt.ES256Template())
 
 	if err != nil {
@@ -116,10 +116,14 @@ func generateJWTKeysets(masterKey tink.AEAD) (privateEc256 []byte, publicEc256 [
 	}
 
 	publicHandle, err := privateHandle.Public()
-	publicHandleEc256, err = insecureBytesFromHandle(publicHandle)
-
 	if err != nil {
 		err = fmt.Errorf("failed to get public keyset: %w", err)
+		return
+	}
+
+	insecurePublicHandleEc256, err = insecureBytesFromHandle(publicHandle)
+
+	if err != nil {
 		return
 	}
 

--- a/pkg/encryption/local.go
+++ b/pkg/encryption/local.go
@@ -59,36 +59,26 @@ func NewLocalEncryption(masterKey []byte, privateEc256 []byte, publicEc256 []byt
 	}, nil
 }
 
-func GenerateLocalKeys() (masterKey []byte, privateEc256 []byte, publicEc256 []byte, err error) {
+func GenerateLocalKeys() (masterKey []byte, privateEc256 []byte, publicEc256 []byte, publicHandleEc256 []byte, err error) {
 	masterKey, masterHandle, err := generateLocalMasterKey()
 
 	if err != nil {
-		return nil, nil, nil, err
+		return
 	}
 
 	a, err := aead.New(masterHandle)
 
 	if err != nil {
-		return nil, nil, nil, err
+		return
 	}
 
-	privateEc256, publicEc256, err = generateJWTKeysets(a)
+	privateEc256, publicEc256, publicHandleEc256, err = generateJWTKeysets(a)
 
 	if err != nil {
-		return nil, nil, nil, err
+		return
 	}
 
-	return masterKey, privateEc256, publicEc256, nil
-}
-
-func GenerateInsecureLocalKeys() (privateEc256 []byte, publicEc256 []byte, err error) {
-	privateEc256, publicEc256, err = generateInsecureJWTKeysets()
-
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return privateEc256, publicEc256, nil
+	return masterKey, privateEc256, publicEc256, publicHandleEc256, nil
 }
 
 func generateLocalMasterKey() ([]byte, *keyset.Handle, error) {
@@ -111,7 +101,7 @@ func generateLocalMasterKey() ([]byte, *keyset.Handle, error) {
 
 // generateJWTKeysets creates the keysets for JWT signing and verification encrypted with the
 // masterKey. The masterKey can be from a remote KMS service or a local keyset.
-func generateJWTKeysets(masterKey tink.AEAD) (privateEc256 []byte, publicEc256 []byte, err error) {
+func generateJWTKeysets(masterKey tink.AEAD) (privateEc256 []byte, publicEc256 []byte, publicHandleEc256 []byte, err error) {
 	privateHandle, err := keyset.NewHandle(jwt.ES256Template())
 
 	if err != nil {
@@ -126,6 +116,7 @@ func generateJWTKeysets(masterKey tink.AEAD) (privateEc256 []byte, publicEc256 [
 	}
 
 	publicHandle, err := privateHandle.Public()
+	publicHandleEc256, err = insecureBytesFromHandle(publicHandle)
 
 	if err != nil {
 		err = fmt.Errorf("failed to get public keyset: %w", err)
@@ -133,38 +124,6 @@ func generateJWTKeysets(masterKey tink.AEAD) (privateEc256 []byte, publicEc256 [
 	}
 
 	publicEc256, err = bytesFromHandle(publicHandle, masterKey)
-
-	if err != nil {
-		return
-	}
-
-	return
-}
-
-// generateJWTKeysets creates the keysets for JWT signing and verification encrypted with the
-// masterKey. The masterKey can be from a remote KMS service or a local keyset.
-func generateInsecureJWTKeysets() (privateEc256 []byte, publicEc256 []byte, err error) {
-	privateHandle, err := keyset.NewHandle(jwt.ES256Template())
-
-	if err != nil {
-		err = fmt.Errorf("failed to create new keyset handle with ES256 template: %w", err)
-		return
-	}
-
-	privateEc256, err = insecureBytesFromHandle(privateHandle)
-
-	if err != nil {
-		return
-	}
-
-	publicHandle, err := privateHandle.Public()
-
-	if err != nil {
-		err = fmt.Errorf("failed to get public keyset: %w", err)
-		return
-	}
-
-	publicEc256, err = insecureBytesFromHandle(publicHandle)
 
 	if err != nil {
 		return

--- a/pkg/encryption/local_test.go
+++ b/pkg/encryption/local_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNewLocalEncryptionValidKeyset(t *testing.T) {
 	// Generate a new keyset
-	aes256Gcm, privateEc256, publicEc256, err := GenerateLocalKeys()
+	aes256Gcm, privateEc256, publicEc256, _, err := GenerateLocalKeys()
 	assert.NoError(t, err)
 
 	// Create encryption service
@@ -27,7 +27,7 @@ func TestNewLocalEncryptionInvalidKeyset(t *testing.T) {
 }
 
 func TestEncryptDecrypt(t *testing.T) {
-	aes256Gcm, privateEc256, publicEc256, _ := GenerateLocalKeys()
+	aes256Gcm, privateEc256, publicEc256, _, _ := GenerateLocalKeys()
 	svc, _ := NewLocalEncryption(aes256Gcm, privateEc256, publicEc256)
 
 	plaintext := []byte("test message")
@@ -46,7 +46,7 @@ func TestEncryptDecrypt(t *testing.T) {
 }
 
 func TestEncryptDecryptStringBase64(t *testing.T) {
-	aes256Gcm, privateEc256, publicEc256, _ := GenerateLocalKeys()
+	aes256Gcm, privateEc256, publicEc256, _, _ := GenerateLocalKeys()
 	svc, _ := NewLocalEncryption(aes256Gcm, privateEc256, publicEc256)
 
 	plaintext := "test message"
@@ -65,7 +65,7 @@ func TestEncryptDecryptStringBase64(t *testing.T) {
 }
 
 func TestDecryptWithInvalidKey(t *testing.T) {
-	aes256Gcm, privateEc256, publicEc256, _ := GenerateLocalKeys()
+	aes256Gcm, privateEc256, publicEc256, _, _ := GenerateLocalKeys()
 	svc, _ := NewLocalEncryption(aes256Gcm, privateEc256, publicEc256)
 
 	plaintext := []byte("test message")
@@ -75,7 +75,7 @@ func TestDecryptWithInvalidKey(t *testing.T) {
 	ciphertext, _ := svc.Encrypt(plaintext, dataID)
 
 	// Generate a new keyset for decryption
-	aes256Gcm, privateEc256, publicEc256, _ = GenerateLocalKeys()
+	aes256Gcm, privateEc256, publicEc256, _, _ = GenerateLocalKeys()
 	newSvc, _ := NewLocalEncryption(aes256Gcm, privateEc256, publicEc256)
 
 	// Attempt to decrypt with a different key
@@ -84,7 +84,7 @@ func TestDecryptWithInvalidKey(t *testing.T) {
 }
 
 func TestEncryptDecryptWithEmptyDataID(t *testing.T) {
-	aes256Gcm, privateEc256, publicEc256, _ := GenerateLocalKeys()
+	aes256Gcm, privateEc256, publicEc256, _, _ := GenerateLocalKeys()
 	svc, _ := NewLocalEncryption(aes256Gcm, privateEc256, publicEc256)
 
 	plaintext := []byte("test message")

--- a/pkg/testing/harness/engine.go
+++ b/pkg/testing/harness/engine.go
@@ -531,7 +531,7 @@ func setTestingKeysInEnv() {
 
 	_ = os.Setenv("SERVER_AUTH_COOKIE_SECRETS", fmt.Sprintf("%s %s", cookieHashKey, cookieBlockKey))
 
-	masterKeyBytes, privateEc256, publicEc256, err := encryption.GenerateLocalKeys()
+	masterKeyBytes, privateEc256, publicEc256, _, err := encryption.GenerateLocalKeys()
 
 	if err != nil {
 		log.Fatalf("could not generate local keys: %v", err)


### PR DESCRIPTION
# Description

Adds an additional keyset which has the public key without encryption from the master key so that they can be used for verifying exchange tokens. 

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...
