### PR TITLE
feat(docs): python support agent cookbook example

### DIFF
--- a/examples/python/support_agent/trigger.py
+++ b/examples/python/support_agent/trigger.py
@@ -30,4 +30,3 @@ result = ref.result()
 print(f"Workflow completed: {result}")
 
 
-# !!

--- a/examples/python/support_agent/worker.py
+++ b/examples/python/support_agent/worker.py
@@ -175,6 +175,7 @@ async def support_agent(
 
 
 
+
 # > Worker registration
 def main() -> None:
     worker = hatchet.worker(
@@ -182,6 +183,7 @@ def main() -> None:
         workflows=[support_agent, triage_ticket, generate_reply, escalate_ticket],
     )
     worker.start()
+
 
 if __name__ == "__main__":
     main()

--- a/examples/python/support_agent/worker.py
+++ b/examples/python/support_agent/worker.py
@@ -175,7 +175,7 @@ async def support_agent(
 
 
 
-
+# > Worker registration
 def main() -> None:
     worker = hatchet.worker(
         "support-agent-worker",
@@ -183,6 +183,7 @@ def main() -> None:
     )
     worker.start()
 
-
 if __name__ == "__main__":
     main()
+
+

--- a/examples/python/support_agent/worker.py
+++ b/examples/python/support_agent/worker.py
@@ -41,7 +41,6 @@ class EscalationOutput(BaseModel):
     assigned_to: str
 
 
-# !!
 
 
 # > Triage task
@@ -69,7 +68,6 @@ async def triage_ticket(input: SupportTicketInput, ctx: Context) -> TriageOutput
     return TriageOutput(category=category, priority=priority)
 
 
-# !!
 
 
 # > Generate reply task
@@ -84,9 +82,8 @@ async def generate_reply(input: SupportTicketInput, ctx: Context) -> ReplyOutput
             "We are looking into this and will get back to you shortly."
         )
 
-    import importlib
+    import anthropic
 
-    anthropic = importlib.import_module("anthropic")
     client = anthropic.AsyncAnthropic(api_key=api_key)
 
     response = await client.messages.create(
@@ -110,7 +107,6 @@ async def generate_reply(input: SupportTicketInput, ctx: Context) -> ReplyOutput
     return ReplyOutput(message=text)
 
 
-# !!
 
 
 # > Escalate task
@@ -123,7 +119,6 @@ async def escalate_ticket(input: SupportTicketInput, ctx: Context) -> Escalation
     )
 
 
-# !!
 
 
 # > Support agent workflow
@@ -179,7 +174,6 @@ async def support_agent(
     }
 
 
-# !!
 
 
 def main() -> None:

--- a/examples/python/worker.py
+++ b/examples/python/worker.py
@@ -76,6 +76,12 @@ from examples.return_exceptions.worker import (
 from examples.run_details.worker import run_detail_test_workflow
 from examples.serde.worker import serde_workflow
 from examples.simple.worker import simple, simple_durable
+from examples.support_agent.worker import (
+    escalate_ticket,
+    generate_reply,
+    support_agent,
+    triage_ticket,
+)
 from examples.timeout.worker import refresh_timeout_wf, timeout_wf
 from examples.webhook_with_scope.worker import (
     webhook_with_scope,
@@ -171,6 +177,10 @@ def main() -> None:
             otel_simple_task,
             otel_spawn_parent,
             otel_workflow,
+            support_agent,
+            triage_ticket,
+            generate_reply,
+            escalate_ticket,
         ],
         lifespan=lifespan,
     )

--- a/frontend/docs/pages/cookbooks/_meta.js
+++ b/frontend/docs/pages/cookbooks/_meta.js
@@ -7,4 +7,9 @@ export default {
   "webhooks-stripe": "Stripe",
   "webhooks-github": "GitHub",
   "webhooks-slack": "Slack",
+  "--workflow-patterns": {
+    title: "Workflow Patterns",
+    type: "separator",
+  },
+  "workflow-support-agent": "Support Agent",
 };

--- a/frontend/docs/pages/cookbooks/index.mdx
+++ b/frontend/docs/pages/cookbooks/index.mdx
@@ -23,3 +23,14 @@ Receive webhooks from external services and use them to trigger tasks in Hatchet
     Respond to Slack events like messages, reactions, and slash commands.
   </Cards.Card>
 </Cards>
+
+## Workflow Patterns
+
+Build practical end-to-end workflows with Hatchet’s durable execution, event handling, and task orchestration primitives.
+
+<Cards>
+  <Cards.Card title="Support Agent" href="/cookbooks/workflow-support-agent">
+    Build a durable support workflow that triages tickets, waits for customer
+    replies, and escalates on timeout.
+  </Cards.Card>
+</Cards>

--- a/frontend/docs/pages/cookbooks/workflow-support-agent.mdx
+++ b/frontend/docs/pages/cookbooks/workflow-support-agent.mdx
@@ -1,0 +1,132 @@
+import { Steps } from "nextra/components";
+import { snippets } from "@/lib/generated/snippets";
+import { Snippet } from "@/components/code";
+
+# How to Create a Support Agent Using Hatchet
+
+Support workflows are a natural fit for Hatchet because they combine human input, long waits, and time-based escalation. In this cookbook, we will build a simple support agent that triages a ticket, generates an initial reply, then waits for either a customer response or a timeout. If the customer replies, the workflow resolves. If no reply arrives in time, the workflow escalates the ticket to a human team.
+
+## What this example builds
+
+This example implements the following durable support workflow:
+
+```
+      +-------------------------+
+      | Support ticket received |
+      +-------------------------+
+                  |
+                  v
+        +--------------------+
+        | Triage the ticket  |
+        +--------------------+
+                  |
+                  v
+      +--------------------------+
+      | Generate initial reply   |
+      +--------------------------+
+                  |
+                  v
+    +------------------------------+
+    | Wait for reply or timeout    |
+    +------------------------------+
+             /            \
+            v              v
++----------------+   +--------------------+
+| Customer reply |   | Timeout fires      |
++----------------+   +--------------------+
+        |                     |
+        v                     v
++----------------+  +----------------------+
+| Resolve ticket |  | Escalate to human    |
++----------------+  +----------------------+
+```
+
+The workflow is built around Hatchet’s durable execution model, child task spawning, and event waiting primitives.
+
+## Setup
+
+<Steps>
+
+### Prepare your environment
+
+To run this example, you will need:
+
+- a working local Hatchet environment or access to Hatchet Cloud
+- the Python SDK example environment
+- optionally, an `ANTHROPIC_API_KEY`
+
+Without `ANTHROPIC_API_KEY`, the example still runs using a canned fallback reply.
+
+### Define the models
+
+Start with a few small Pydantic models for the workflow input and outputs.
+
+<Snippet src={snippets.python.support_agent.worker.models} />
+
+These models keep the task boundaries explicit and make the workflow easier to follow.
+
+### Add the child tasks
+
+The durable workflow delegates its work to a few small child tasks.
+
+First, add a task to classify the incoming ticket:
+
+<Snippet src={snippets.python.support_agent.worker.triage_task} />
+
+Next, add a task to generate the initial support reply. This task calls Claude when `ANTHROPIC_API_KEY` is present, and falls back to a fixed response when it is not.
+
+<Snippet src={snippets.python.support_agent.worker.generate_reply_task} />
+
+Finally, add a task to represent escalation to a human team:
+
+<Snippet src={snippets.python.support_agent.worker.escalate_task} />
+
+### Build the durable workflow
+
+Now tie everything together in a durable Hatchet workflow.
+
+<Snippet src={snippets.python.support_agent.worker.support_agent_workflow} />
+
+This workflow:
+
+1. triages the ticket
+2. generates an initial reply
+3. waits for either a scoped customer reply event or a timeout
+4. resolves or escalates depending on which condition fires first
+
+The key detail that makes this workflow reliable is `consider_events_since` on the reply event condition. A customer reply could arrive while the workflow is still finishing the triage or reply-generation steps. By using `consider_events_since`, the workflow can still capture that reply when the wait becomes active.
+
+### Trigger the workflow
+
+The example also includes a small trigger script that starts the workflow, pushes a scoped reply event, and waits for the result.
+
+<Snippet src={snippets.python.support_agent.trigger.trigger_the_workflow} />
+
+Because the workflow uses `consider_events_since`, the trigger can push the reply event immediately after starting the support agent.
+
+### Test it
+
+This example includes two end-to-end tests against a live Hatchet instance:
+
+- a resolved path, where the customer reply event arrives before the timeout
+- a timeout path, where no reply arrives and the workflow escalates
+
+Together, these tests validate both branches of the support workflow and confirm that early reply events are handled safely without coordination sleeps.
+
+</Steps>
+
+## Why Hatchet fits this workflow
+
+This example is small, but it illustrates why support workflows map naturally to Hatchet:
+
+- the workflow needs to preserve state across multiple steps
+- it needs to wait for human input
+- it needs to branch on timeout versus event
+- it should not lose early reply events
+- it benefits from being inspectable and testable as a single durable workflow
+
+A simpler queue can handle isolated tasks, but the full interaction becomes much easier to model when the workflow itself is durable.
+
+## Next steps
+
+From here, you could extend this example by integrating with a real ticketing system, escalating only when the customer explicitly asks for a human and supporting multi-turn conversations instead of resolving on the first reply. For a first support-agent example, this version is enough to show the core idea clearly. Hatchet makes it straightforward to build a durable support workflow that can wait, react, and escalate without fragile coordination logic.

--- a/frontend/docs/pages/cookbooks/workflow-support-agent.mdx
+++ b/frontend/docs/pages/cookbooks/workflow-support-agent.mdx
@@ -65,7 +65,7 @@ Keeping triage, reply generation, and escalation as separate tasks keeps the wor
 
 ### Build the durable workflow
 
-Now tie everything together in a [durable Hatchet workflow](/v1/durable-execution).
+Now tie everything together in a [durable Hatchet workflow](/v1/durable-execution). A durable workflow is a good fit here because this interaction may stay open for some time while waiting for a customer reply. Hatchet persists the workflow state and its wait conditions, so the workflow can survive long delays, worker restarts, or even a worker crash, then continue later on another worker. That gives you a straightforward way to model the whole interaction without adding custom recovery logic.
 
 <Snippet src={snippets.python.support_agent.worker.support_agent_workflow} />
 
@@ -75,7 +75,7 @@ The detail that matters most here is [`consider_events_since`](/v1/durable-event
 
 ### Register and start the worker
 
-To run this workflow, register the workflow and its child tasks on a Hatchet worker, then start it.
+To run this workflow, register the workflow and its tasks on a Hatchet worker, then start it.
 
 <Snippet src={snippets.python.support_agent.worker.worker_registration} />
 
@@ -108,9 +108,7 @@ Together, these tests validate both branches of the workflow and confirm that ea
 
 ## Why Hatchet fits this workflow
 
-The interesting part of this example is not the LLM call. It is the combination of waiting, branching, and keeping the full interaction in one place. A support flow like this usually needs to preserve state across several steps, wait for human input, and react differently depending on whether a reply arrives before a deadline.
-
-Hatchet supports that model well because the workflow can own the whole interaction directly. Instead of stitching together separate jobs, external timers, and custom retry logic, you can express the event wait and timeout branch as part of the workflow itself. That also makes the result easier to inspect and easier to test.
+The interesting part of this example is not the LLM call. It is the combination of waiting, branching, and keeping the full interaction in one place. A support flow like this usually needs to preserve state across several steps, wait for human input, and react differently depending on whether a reply arrives before a deadline. Hatchet fits that pattern well because you can express the event wait and timeout branch directly in the workflow. That makes the control flow easier to inspect, easier to test, and easier to extend as the interaction becomes more complex.
 
 ## Next steps
 

--- a/frontend/docs/pages/cookbooks/workflow-support-agent.mdx
+++ b/frontend/docs/pages/cookbooks/workflow-support-agent.mdx
@@ -10,35 +10,15 @@ Support workflows can become difficult to manage and scale once they involve lon
 
 This example implements the following durable support workflow:
 
-```
-      +-------------------------+
-      | Support ticket received |
-      +-------------------------+
-                  |
-                  v
-        +--------------------+
-        | Triage the ticket  |
-        +--------------------+
-                  |
-                  v
-      +--------------------------+
-      | Generate initial reply   |
-      +--------------------------+
-                  |
-                  v
-    +------------------------------+
-    | Wait for reply or timeout    |
-    +------------------------------+
-             /            \
-            v              v
-+----------------+   +--------------------+
-| Customer reply |   | Timeout fires      |
-+----------------+   +--------------------+
-        |                     |
-        v                     v
-+----------------+  +----------------------+
-| Resolve ticket |  | Escalate to human    |
-+----------------+  +----------------------+
+```mermaid
+flowchart TD
+    A[Support ticket received] --> B[Triage the ticket]
+    B --> C[Generate initial reply]
+    C --> D[Wait for reply or timeout]
+    D --> E[Customer reply]
+    D --> F[Timeout fires]
+    E --> G[Resolve ticket]
+    F --> H[Escalate to human support]
 ```
 
 Hatchet’s durable execution model helps keep the whole interaction in one workflow rather than scattering it across separate queue jobs and ad hoc timers.

--- a/frontend/docs/pages/cookbooks/workflow-support-agent.mdx
+++ b/frontend/docs/pages/cookbooks/workflow-support-agent.mdx
@@ -100,7 +100,7 @@ The key detail that makes this workflow reliable is `consider_events_since` on t
 
 To run this workflow, register the workflow and its child tasks on a Hatchet worker, then start it.
 
-<Snippet src={snippets.python.support_agent.worker.worker_main} />
+<Snippet src={snippets.python.support_agent.worker.worker_registration} />
 
 With the worker running, you can trigger the workflow and observe either the resolved or escalated outcome.
 

--- a/frontend/docs/pages/cookbooks/workflow-support-agent.mdx
+++ b/frontend/docs/pages/cookbooks/workflow-support-agent.mdx
@@ -96,6 +96,14 @@ This workflow:
 
 The key detail that makes this workflow reliable is `consider_events_since` on the reply event condition. A customer reply could arrive while the workflow is still finishing the triage or reply-generation steps. By using `consider_events_since`, the workflow can still capture that reply when the wait becomes active.
 
+### Register and start the worker
+
+To run this workflow, register the workflow and its child tasks on a Hatchet worker, then start it.
+
+<Snippet src={snippets.python.support_agent.worker.worker_main} />
+
+With the worker running, you can trigger the workflow and observe either the resolved or escalated outcome.
+
 ### Trigger the workflow
 
 The example also includes a small trigger script that starts the workflow, pushes a scoped reply event, and waits for the result.

--- a/frontend/docs/pages/cookbooks/workflow-support-agent.mdx
+++ b/frontend/docs/pages/cookbooks/workflow-support-agent.mdx
@@ -4,7 +4,7 @@ import { Snippet } from "@/components/code";
 
 # How to Create a Support Agent Using Hatchet
 
-Support workflows can become difficult to manage and scale once they involve long waits, human replies, and escalation rules. In this cookbook, we will build a simple support agent that triages a ticket, generates an initial reply, and then waits for either a customer response or a timeout. If the customer replies, the workflow resolves. If no reply arrives in time, the workflow escalates the ticket to human support agent.
+Many real-world workflows become difficult to manage once they involve multiple steps, long waits, human replies, and escalation rules. Support is one example, but the same pattern also shows up in onboarding, approvals, incident response, and other operational flows. In this cookbook, we will build a simple support agent that triages a ticket, generates an initial reply, and then waits for either a customer response or a timeout. If the customer replies, the workflow resolves. If no reply arrives in time, the workflow escalates the ticket to a human support agent.
 
 ## What this example builds
 

--- a/frontend/docs/pages/cookbooks/workflow-support-agent.mdx
+++ b/frontend/docs/pages/cookbooks/workflow-support-agent.mdx
@@ -4,7 +4,7 @@ import { Snippet } from "@/components/code";
 
 # How to Create a Support Agent Using Hatchet
 
-Support workflows are a natural fit for Hatchet because they combine human input, long waits, and time-based escalation. In this cookbook, we will build a simple support agent that triages a ticket, generates an initial reply, then waits for either a customer response or a timeout. If the customer replies, the workflow resolves. If no reply arrives in time, the workflow escalates the ticket to human support personnel.
+Support workflows can become difficult to manage and scale once they involve long waits, human replies, and escalation rules. In this cookbook, we will build a simple support agent that triages a ticket, generates an initial reply, and then waits for either a customer response or a timeout. If the customer replies, the workflow resolves. If no reply arrives in time, the workflow escalates the ticket to human support agent.
 
 ## What this example builds
 
@@ -41,7 +41,7 @@ This example implements the following durable support workflow:
 +----------------+  +----------------------+
 ```
 
-The workflow is built around Hatchet’s durable execution model, child task spawning, and event waiting primitives.
+Hatchet’s durable execution model helps keep the whole interaction in one workflow rather than scattering it across separate queue jobs and ad hoc timers.
 
 ## Setup
 
@@ -63,7 +63,7 @@ Start with a few small Pydantic models for the workflow input and outputs.
 
 <Snippet src={snippets.python.support_agent.worker.models} />
 
-These models keep the task boundaries explicit and make the workflow easier to follow.
+The models keep the inputs and outputs for each task explicit, which makes the workflow easier to inspect and test.
 
 ### Add the child tasks
 
@@ -73,13 +73,15 @@ First, add a task to classify the incoming ticket:
 
 <Snippet src={snippets.python.support_agent.worker.triage_task} />
 
-Next, add a task to generate the initial support reply. This task calls Claude when `ANTHROPIC_API_KEY` is present, and falls back to a fixed response when it is not.
+Next, add a task to generate the initial support reply. This task calls Claude when `ANTHROPIC_API_KEY` is present and falls back to a fixed response when it is not.
 
 <Snippet src={snippets.python.support_agent.worker.generate_reply_task} />
 
-Finally, add a task to represent escalation to a human team:
+Finally, add a task to represent escalation to the support team:
 
 <Snippet src={snippets.python.support_agent.worker.escalate_task} />
+
+Keeping triage, reply generation, and escalation as separate tasks keeps the workflow itself small and makes each piece easier to reason about.
 
 ### Build the durable workflow
 
@@ -87,14 +89,9 @@ Now tie everything together in a durable Hatchet workflow.
 
 <Snippet src={snippets.python.support_agent.worker.support_agent_workflow} />
 
-This workflow:
+As you can see, the workflow runs triage first, generates an initial reply, and then waits for one of two things to happen: either a customer reply event arrives for that ticket, or the timeout fires. From there, the workflow either resolves the ticket or escalates it.
 
-1. triages the ticket
-2. generates an initial reply
-3. waits for either a scoped customer reply event or a timeout
-4. resolves or escalates depending on which condition fires first
-
-The key detail that makes this workflow reliable is `consider_events_since` on the reply event condition. A customer reply could arrive while the workflow is still finishing the triage or reply-generation steps. By using `consider_events_since`, the workflow can still capture that reply when the wait becomes active.
+The detail that matters most here is `consider_events_since` on the reply event condition. A customer reply could arrive while the workflow is still finishing triage or generating the first response. By using `consider_events_since`, the workflow can still pick up that reply once the wait becomes active instead of missing it because the event arrived slightly early.
 
 ### Register and start the worker
 
@@ -119,22 +116,22 @@ This example includes two end-to-end tests against a live Hatchet instance:
 - a resolved path, where the customer reply event arrives before the timeout
 - a timeout path, where no reply arrives and the workflow escalates
 
-Together, these tests validate both branches of the support workflow and confirm that early reply events are handled safely without coordination sleeps.
+If you are running the Python SDK examples locally, you can run the support agent tests with:
+
+```bash
+pytest examples/support_agent/test_support_agent.py
+```
+
+Together, these tests validate both branches of the workflow and confirm that early reply events are handled safely without coordination sleeps.
 
 </Steps>
 
 ## Why Hatchet fits this workflow
 
-This example is small, but it illustrates why support workflows map naturally to Hatchet:
+The interesting part of this example is not the LLM call. It is the combination of waiting, branching, and keeping the full interaction in one place. A support flow like this usually needs to preserve state across several steps, wait for human input, and react differently depending on whether a reply arrives before a deadline.
 
-- the workflow needs to preserve state across multiple steps
-- it needs to wait for human input
-- it needs to branch on timeout versus event
-- it should not lose early reply events
-- it benefits from being inspectable and testable as a single durable workflow
-
-A simpler queue can handle isolated tasks, but the full interaction becomes much easier to model when the workflow itself is durable.
+Hatchet supports that model well because the workflow can own the whole interaction directly. Instead of stitching together separate jobs, external timers, and custom retry logic, you can express the event wait and timeout branch as part of the workflow itself. That also makes the result easier to inspect and easier to test.
 
 ## Next steps
 
-From here, you could extend this example by integrating with a real ticketing system, escalating only when the customer explicitly asks for a human and supporting multi-turn conversations instead of resolving on the first reply. For a first support-agent example, this version is enough to show the core idea clearly. Hatchet makes it straightforward to build a durable support workflow that can wait, react, and escalate without fragile coordination logic.
+A natural next step would be to connect this workflow to a real ticketing system and carry the conversation beyond a single reply. You could also make escalation depend on the content of the customer response instead of only on timeout. For this cookbook, though, the smaller version is enough to show the core pattern: start work immediately, wait safely for a reply, and escalate when the deadline passes.

--- a/frontend/docs/pages/cookbooks/workflow-support-agent.mdx
+++ b/frontend/docs/pages/cookbooks/workflow-support-agent.mdx
@@ -31,8 +31,8 @@ Hatchet’s durable execution model helps keep the whole interaction in one work
 
 To run this example, you will need:
 
-- a working local Hatchet environment or access to Hatchet Cloud
-- the Python SDK example environment
+- a working local Hatchet environment or access to [Hatchet Cloud](https://cloud.onhatchet.run)
+- the Python SDK example environment (see the [Quickstart](/v1/quickstart))
 - optionally, an `ANTHROPIC_API_KEY`
 
 Without `ANTHROPIC_API_KEY`, the example still runs using a fixed fallback reply.
@@ -45,9 +45,9 @@ Start with a few small Pydantic models for the workflow input and outputs.
 
 The models keep the inputs and outputs for each task explicit, which makes the workflow easier to inspect and test.
 
-### Add the child tasks
+### Add the workflow tasks
 
-The durable workflow delegates its work to a few small child tasks.
+The durable workflow delegates its work to a few small [tasks](/v1/tasks).
 
 First, add a task to classify the incoming ticket:
 
@@ -65,13 +65,13 @@ Keeping triage, reply generation, and escalation as separate tasks keeps the wor
 
 ### Build the durable workflow
 
-Now tie everything together in a durable Hatchet workflow.
+Now tie everything together in a [durable Hatchet workflow](/v1/durable-execution).
 
 <Snippet src={snippets.python.support_agent.worker.support_agent_workflow} />
 
 As you can see, the workflow runs triage first, generates an initial reply, and then waits for one of two things to happen: either a customer reply event arrives for that ticket, or the timeout fires. From there, the workflow either resolves the ticket or escalates it.
 
-The detail that matters most here is `consider_events_since` on the reply event condition. A customer reply could arrive while the workflow is still finishing triage or generating the first response. By using `consider_events_since`, the workflow can still pick up that reply once the wait becomes active instead of missing it because the event arrived slightly early.
+The detail that matters most here is [`consider_events_since`](/v1/durable-event-waits#lookback-windows) on the reply event condition. A customer reply could arrive while the workflow is still finishing triage or generating the first response. By using `consider_events_since`, the workflow can still pick up that reply once the wait becomes active instead of missing it because the event arrived slightly early.
 
 ### Register and start the worker
 

--- a/frontend/docs/pages/cookbooks/workflow-support-agent.mdx
+++ b/frontend/docs/pages/cookbooks/workflow-support-agent.mdx
@@ -4,7 +4,7 @@ import { Snippet } from "@/components/code";
 
 # How to Create a Support Agent Using Hatchet
 
-Support workflows are a natural fit for Hatchet because they combine human input, long waits, and time-based escalation. In this cookbook, we will build a simple support agent that triages a ticket, generates an initial reply, then waits for either a customer response or a timeout. If the customer replies, the workflow resolves. If no reply arrives in time, the workflow escalates the ticket to a human team.
+Support workflows are a natural fit for Hatchet because they combine human input, long waits, and time-based escalation. In this cookbook, we will build a simple support agent that triages a ticket, generates an initial reply, then waits for either a customer response or a timeout. If the customer replies, the workflow resolves. If no reply arrives in time, the workflow escalates the ticket to human support personnel.
 
 ## What this example builds
 
@@ -55,7 +55,7 @@ To run this example, you will need:
 - the Python SDK example environment
 - optionally, an `ANTHROPIC_API_KEY`
 
-Without `ANTHROPIC_API_KEY`, the example still runs using a canned fallback reply.
+Without `ANTHROPIC_API_KEY`, the example still runs using a fixed fallback reply.
 
 ### Define the models
 

--- a/sdks/python/examples/support_agent/test_support_agent.py
+++ b/sdks/python/examples/support_agent/test_support_agent.py
@@ -1,0 +1,58 @@
+from uuid import uuid4
+
+import pytest
+
+from examples.support_agent.worker import (
+    REPLY_EVENT_KEY,
+    SupportTicketInput,
+    support_agent,
+)
+from hatchet_sdk import Hatchet
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_support_agent_reply_before_timeout(hatchet: Hatchet) -> None:
+    """Customer replies before timeout -> workflow resolves."""
+    ticket_id = f"test-{uuid4().hex[:8]}"
+    ticket = SupportTicketInput(
+        ticket_id=ticket_id,
+        customer_email="alice@example.com",
+        subject="Login broken",
+        body="I can't log in since this morning.",
+    )
+
+    ref = await support_agent.aio_run(ticket, wait_for_result=False)
+
+    # The workflow uses consider_events_since lookback, so the reply event
+    # is captured even if pushed before the or-group wait becomes active.
+    await hatchet.event.aio_push(
+        REPLY_EVENT_KEY,
+        {"message": "Actually, I just needed to clear my cookies. Fixed!"},
+        scope=ticket.ticket_id,
+    )
+
+    result = await ref.aio_result()
+
+    assert result["ticket_id"] == ticket_id
+    assert result["status"] == "resolved"
+    assert result["triage_category"] is not None
+    assert result["initial_reply"] is not None
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_support_agent_timeout_escalation(hatchet: Hatchet) -> None:
+    """No customer reply -> workflow escalates after timeout."""
+    ticket_id = f"test-{uuid4().hex[:8]}"
+    ticket = SupportTicketInput(
+        ticket_id=ticket_id,
+        customer_email="bob@example.com",
+        subject="Billing issue",
+        body="I was charged twice for my subscription.",
+    )
+
+    result = await support_agent.aio_run(ticket)
+
+    assert result["ticket_id"] == ticket_id
+    assert result["status"] == "escalated"
+    assert result["triage_category"] is not None
+    assert result["initial_reply"] is not None

--- a/sdks/python/examples/support_agent/trigger.py
+++ b/sdks/python/examples/support_agent/trigger.py
@@ -1,0 +1,29 @@
+from examples.support_agent.worker import (
+    REPLY_EVENT_KEY,
+    SupportTicketInput,
+    hatchet,
+    support_agent,
+)
+
+ticket = SupportTicketInput(
+    ticket_id="ticket-42",
+    customer_email="alice@example.com",
+    subject="Login broken",
+    body="I can't log in since this morning.",
+)
+
+# Start the support agent workflow
+ref = support_agent.run(ticket, wait_for_result=False)
+print(f"Started workflow run: {ref.workflow_run_id}")
+
+# Push a customer reply event (scoped to this ticket)
+print("Pushing customer reply event...")
+hatchet.event.push(
+    REPLY_EVENT_KEY,
+    {"message": "I cleared my cookies and it works now. Thanks!"},
+    scope=ticket.ticket_id,
+)
+
+# Wait for the workflow to complete
+result = ref.result()
+print(f"Workflow completed: {result}")

--- a/sdks/python/examples/support_agent/worker.py
+++ b/sdks/python/examples/support_agent/worker.py
@@ -181,7 +181,7 @@ async def support_agent(
 
 # !!
 
-
+# > Worker registration
 def main() -> None:
     worker = hatchet.worker(
         "support-agent-worker",
@@ -189,6 +189,8 @@ def main() -> None:
     )
     worker.start()
 
-
 if __name__ == "__main__":
     main()
+
+
+# !!

--- a/sdks/python/examples/support_agent/worker.py
+++ b/sdks/python/examples/support_agent/worker.py
@@ -1,0 +1,193 @@
+import os
+from datetime import timedelta
+from typing import Any
+
+from pydantic import BaseModel
+
+from hatchet_sdk import (
+    Context,
+    DurableContext,
+    Hatchet,
+    SleepCondition,
+    UserEventCondition,
+    or_,
+)
+
+hatchet = Hatchet()
+
+REPLY_EVENT_KEY = "support:customer-reply"
+TIMEOUT_SECONDS = 5
+
+
+# > Models
+class SupportTicketInput(BaseModel):
+    ticket_id: str
+    customer_email: str
+    subject: str
+    body: str
+
+
+class TriageOutput(BaseModel):
+    category: str
+    priority: str
+
+
+class ReplyOutput(BaseModel):
+    message: str
+
+
+class EscalationOutput(BaseModel):
+    reason: str
+    assigned_to: str
+
+
+# !!
+
+
+# > Triage task
+@hatchet.task(input_validator=SupportTicketInput)
+async def triage_ticket(input: SupportTicketInput, ctx: Context) -> TriageOutput:
+    """Classify the ticket into a category and priority."""
+    subject = input.subject.lower()
+    body = input.body.lower()
+    text = subject + " " + body
+
+    if any(word in text for word in ["bill", "charge", "payment", "invoice"]):
+        category = "billing"
+    elif any(word in text for word in ["login", "password", "auth", "access"]):
+        category = "account"
+    else:
+        category = "technical"
+
+    if any(word in text for word in ["urgent", "critical", "down", "outage"]):
+        priority = "high"
+    elif any(word in text for word in ["twice", "broken", "error"]):
+        priority = "medium"
+    else:
+        priority = "low"
+
+    return TriageOutput(category=category, priority=priority)
+
+
+# !!
+
+
+# > Generate reply task
+@hatchet.task(input_validator=SupportTicketInput)
+async def generate_reply(input: SupportTicketInput, ctx: Context) -> ReplyOutput:
+    """Generate an initial support reply using Claude."""
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+
+    if not api_key:
+        return ReplyOutput(
+            message=f"Thank you for contacting support about: {input.subject}. "
+            "We are looking into this and will get back to you shortly."
+        )
+
+    import anthropic
+
+    client = anthropic.AsyncAnthropic(api_key=api_key)
+
+    response = await client.messages.create(
+        model="claude-sonnet-4-20250514",
+        max_tokens=300,
+        messages=[
+            {
+                "role": "user",
+                "content": (
+                    f"You are a friendly support agent. Write a brief, helpful initial "
+                    f"reply to this support ticket.\n\n"
+                    f"Subject: {input.subject}\n"
+                    f"Message: {input.body}\n\n"
+                    f"Keep the reply under 3 sentences."
+                ),
+            }
+        ],
+    )
+
+    text = response.content[0].text
+    return ReplyOutput(message=text)
+
+
+# !!
+
+
+# > Escalate task
+@hatchet.task(input_validator=SupportTicketInput)
+async def escalate_ticket(input: SupportTicketInput, ctx: Context) -> EscalationOutput:
+    """Escalate an unresolved ticket to the human support team."""
+    return EscalationOutput(
+        reason=f"No customer reply within {TIMEOUT_SECONDS}s timeout",
+        assigned_to="support-team@example.com",
+    )
+
+
+# !!
+
+
+# > Support agent workflow
+@hatchet.durable_task(input_validator=SupportTicketInput)
+async def support_agent(
+    input: SupportTicketInput, ctx: DurableContext
+) -> dict[str, Any]:
+    # Step 1: Triage the ticket
+    triage = await triage_ticket.aio_run(input)
+
+    # Step 2: Generate an initial reply
+    reply = await generate_reply.aio_run(input)
+
+    # Step 3: Wait for a customer reply or timeout
+    now = await ctx.aio_now()
+    consider_events_since = now - timedelta(minutes=5)
+
+    wait_result = await ctx.aio_wait_for(
+        "await-customer-reply",
+        or_(
+            SleepCondition(timedelta(seconds=TIMEOUT_SECONDS)),
+            UserEventCondition(
+                event_key=REPLY_EVENT_KEY,
+                scope=input.ticket_id,
+                consider_events_since=consider_events_since,
+            ),
+        ),
+    )
+
+    # The or-group result is {"CREATE": {"<condition_key>": ...}}.
+    # Check whether the reply event condition was the one that resolved.
+    resolved_key = list(wait_result["CREATE"].keys())[0]
+    customer_replied = resolved_key == REPLY_EVENT_KEY
+
+    if not customer_replied:
+        # Step 4a: Timeout -> escalate
+        await escalate_ticket.aio_run(input)
+        return {
+            "ticket_id": input.ticket_id,
+            "status": "escalated",
+            "triage_category": triage.category,
+            "triage_priority": triage.priority,
+            "initial_reply": reply.message,
+        }
+
+    # Step 4b: Customer replied -> resolve
+    return {
+        "ticket_id": input.ticket_id,
+        "status": "resolved",
+        "triage_category": triage.category,
+        "triage_priority": triage.priority,
+        "initial_reply": reply.message,
+    }
+
+
+# !!
+
+
+def main() -> None:
+    worker = hatchet.worker(
+        "support-agent-worker",
+        workflows=[support_agent, triage_ticket, generate_reply, escalate_ticket],
+    )
+    worker.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/sdks/python/examples/support_agent/worker.py
+++ b/sdks/python/examples/support_agent/worker.py
@@ -181,6 +181,7 @@ async def support_agent(
 
 # !!
 
+
 # > Worker registration
 def main() -> None:
     worker = hatchet.worker(
@@ -188,6 +189,7 @@ def main() -> None:
         workflows=[support_agent, triage_ticket, generate_reply, escalate_ticket],
     )
     worker.start()
+
 
 if __name__ == "__main__":
     main()

--- a/sdks/python/examples/worker.py
+++ b/sdks/python/examples/worker.py
@@ -76,6 +76,12 @@ from examples.return_exceptions.worker import (
 from examples.run_details.worker import run_detail_test_workflow
 from examples.serde.worker import serde_workflow
 from examples.simple.worker import simple, simple_durable
+from examples.support_agent.worker import (
+    escalate_ticket,
+    generate_reply,
+    support_agent,
+    triage_ticket,
+)
 from examples.timeout.worker import refresh_timeout_wf, timeout_wf
 from examples.webhook_with_scope.worker import (
     webhook_with_scope,
@@ -171,6 +177,10 @@ def main() -> None:
             otel_simple_task,
             otel_spawn_parent,
             otel_workflow,
+            support_agent,
+            triage_ticket,
+            generate_reply,
+            escalate_ticket,
         ],
         lifespan=lifespan,
     )


### PR DESCRIPTION
# Description

Adds a new cookbook docs page for building a support agent with Hatchet, along with the supporting Python example and trigger/example files.

This PR introduces a practical end-to-end workflow example that:
- receives a support ticket
- triages it
- generates an initial reply
- waits for either a customer reply event or a timeout
- resolves when a reply arrives
- escalates when the timeout fires first

It also adds a new Workflow Patterns section to the cookbooks index so this example is separate from the existing webhook-focused cookbook entries.

The Python example uses the snippet markers and was validated locally against a live Hatchet instance. The current implementation supports live Claude interaction when `ANTHROPIC_API_KEY` is set, and a fixed fallback reply when it is not.

## Type of change

- [x] Documentation change (pure documentation change)

## What's Changed

- [x] Add a new cookbook page: `workflow-support-agent.mdx`
- [x] Add a new "Workflow Patterns" section to the cookbooks index
- [x] Add a Python support agent example under `examples/python/support_agent/`
- [x] Add a snippet region for the trigger script
- [x] Register the support agent example in the central Python example worker
- [x] Add E2E coverage for the resolved and timeout/escalation paths
- [x] Document a durable workflow pattern that uses `consider_events_since` to safely capture early reply events