### PR TITLE
fix: configurable schedulerCheckActive Interval

### DIFF
--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -717,6 +717,8 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 		cf.Runtime.SchedulerConcurrencyRateLimit,
 		cf.Runtime.SchedulerConcurrencyPollingMinInterval,
 		cf.Runtime.SchedulerConcurrencyPollingMaxInterval,
+		cf.Runtime.SchedulerCheckActiveMinInterval,
+		cf.Runtime.SchedulerCheckActiveMaxInterval,
 		cf.Runtime.SchedulerAdvisoryLockTimeout,
 		cf.Runtime.OptimisticSchedulingEnabled,
 		cf.Runtime.OptimisticSchedulingSlots,

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -297,7 +297,12 @@ type ConfigFileRuntime struct {
 	// SchedulerConcurrencyPollingMaxInterval is the maximum interval for concurrency polling
 	SchedulerConcurrencyPollingMaxInterval time.Duration `mapstructure:"schedulerConcurrencyPollingMaxInterval" json:"schedulerConcurrencyPollingMaxInterval,omitempty" default:"5s"`
 
-	// SchedulerConcurrencyPollingMaxInterval is the maximum interval for concurrency polling
+	// SchedulerCheckActiveMinInterval is the minimum interval for the check-active polling loop
+	SchedulerCheckActiveMinInterval time.Duration `mapstructure:"schedulerCheckActiveMinInterval" json:"schedulerCheckActiveMinInterval,omitempty" default:"30s"`
+
+	// SchedulerCheckActiveMaxInterval is the maximum interval for the check-active polling loop
+	SchedulerCheckActiveMaxInterval time.Duration `mapstructure:"schedulerCheckActiveMaxInterval" json:"schedulerCheckActiveMaxInterval,omitempty" default:"60s"`
+
 	SchedulerAdvisoryLockTimeout time.Duration `mapstructure:"schedulerAdvisoryLockTimeout" json:"schedulerAdvisoryLockTimeout,omitempty" default:"5s"`
 
 	// LogIngestionEnabled controls whether the server enables log ingestion for tasks
@@ -728,6 +733,8 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("runtime.schedulerConcurrencyRateLimit", "SCHEDULER_CONCURRENCY_RATE_LIMIT")
 	_ = v.BindEnv("runtime.schedulerConcurrencyPollingMinInterval", "SCHEDULER_CONCURRENCY_POLLING_MIN_INTERVAL")
 	_ = v.BindEnv("runtime.schedulerConcurrencyPollingMaxInterval", "SCHEDULER_CONCURRENCY_POLLING_MAX_INTERVAL")
+	_ = v.BindEnv("runtime.schedulerCheckActiveMinInterval", "SCHEDULER_CHECK_ACTIVE_MIN_INTERVAL")
+	_ = v.BindEnv("runtime.schedulerCheckActiveMaxInterval", "SCHEDULER_CHECK_ACTIVE_MAX_INTERVAL")
 	_ = v.BindEnv("runtime.schedulerAdvisoryLockTimeout", "SCHEDULER_ADVISORY_LOCK_TIMEOUT")
 	_ = v.BindEnv("servicesString", "SERVER_SERVICES")
 	_ = v.BindEnv("pausedControllers", "SERVER_PAUSED_CONTROLLERS")

--- a/pkg/scheduling/v1/concurrency.go
+++ b/pkg/scheduling/v1/concurrency.go
@@ -48,6 +48,10 @@ type ConcurrencyManager struct {
 
 	maxPollingInterval time.Duration
 
+	minCheckActiveInterval time.Duration
+
+	maxCheckActiveInterval time.Duration
+
 	advisoryLock       *timeout_lock.KeyedTimeoutLock[int64]
 	advisoryParentLock *timeout_lock.KeyedTimeoutLock[int64]
 }
@@ -58,18 +62,20 @@ func newConcurrencyManager(conf *sharedConfig, tenantId uuid.UUID, strategy *sql
 	notifyConcurrencyCh := make(chan map[string]string, 2)
 
 	c := &ConcurrencyManager{
-		repo:                repo,
-		strategy:            strategy,
-		tenantId:            tenantId,
-		l:                   conf.l,
-		notifyConcurrencyCh: notifyConcurrencyCh,
-		resultsCh:           resultsCh,
-		notifyMu:            newMu(conf.l),
-		rateLimiter:         newConcurrencyRateLimiter(conf.schedulerConcurrencyRateLimit),
-		minPollingInterval:  conf.schedulerConcurrencyPollingMinInterval,
-		maxPollingInterval:  conf.schedulerConcurrencyPollingMaxInterval,
-		advisoryLock:        advisoryLock,
-		advisoryParentLock:  advisoryParentLock,
+		repo:                   repo,
+		strategy:               strategy,
+		tenantId:               tenantId,
+		l:                      conf.l,
+		notifyConcurrencyCh:    notifyConcurrencyCh,
+		resultsCh:              resultsCh,
+		notifyMu:               newMu(conf.l),
+		rateLimiter:            newConcurrencyRateLimiter(conf.schedulerConcurrencyRateLimit),
+		minPollingInterval:     conf.schedulerConcurrencyPollingMinInterval,
+		maxPollingInterval:     conf.schedulerConcurrencyPollingMaxInterval,
+		minCheckActiveInterval: conf.schedulerCheckActiveMinInterval,
+		maxCheckActiveInterval: conf.schedulerCheckActiveMaxInterval,
+		advisoryLock:           advisoryLock,
+		advisoryParentLock:     advisoryParentLock,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -192,7 +198,11 @@ func (c *ConcurrencyManager) loopConcurrency(ctx context.Context) {
 }
 
 func (c *ConcurrencyManager) loopCheckActive(ctx context.Context) {
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := randomticker.NewRandomTicker(
+		c.minCheckActiveInterval,
+		c.maxCheckActiveInterval,
+	)
+	defer ticker.Stop()
 
 	for {
 		select {

--- a/pkg/scheduling/v1/concurrency_integration_test.go
+++ b/pkg/scheduling/v1/concurrency_integration_test.go
@@ -375,6 +375,8 @@ func TestConcurrency_MultipleStrategiesContention(t *testing.T) {
 			20,
 			5*time.Millisecond,
 			6*time.Millisecond,
+			50*time.Millisecond,
+			100*time.Millisecond,
 			5*time.Millisecond,
 			false,
 			1,

--- a/pkg/scheduling/v1/pool.go
+++ b/pkg/scheduling/v1/pool.go
@@ -27,6 +27,10 @@ type sharedConfig struct {
 
 	schedulerConcurrencyPollingMaxInterval time.Duration
 
+	schedulerCheckActiveMinInterval time.Duration
+
+	schedulerCheckActiveMaxInterval time.Duration
+
 	schedulerAdvisoryLockTimeout time.Duration
 }
 
@@ -54,6 +58,8 @@ func NewSchedulingPool(
 	schedulerConcurrencyRateLimit int,
 	schedulerConcurrencyPollingMinInterval time.Duration,
 	schedulerConcurrencyPollingMaxInterval time.Duration,
+	schedulerCheckActiveMinInterval time.Duration,
+	schedulerCheckActiveMaxInterval time.Duration,
 	schedulerAdvisoryLockTimeout time.Duration,
 	optimisticSchedulingEnabled bool,
 	optimisticSlots int,
@@ -71,6 +77,8 @@ func NewSchedulingPool(
 			schedulerConcurrencyRateLimit:          schedulerConcurrencyRateLimit,
 			schedulerConcurrencyPollingMinInterval: schedulerConcurrencyPollingMinInterval,
 			schedulerConcurrencyPollingMaxInterval: schedulerConcurrencyPollingMaxInterval,
+			schedulerCheckActiveMinInterval:        schedulerCheckActiveMinInterval,
+			schedulerCheckActiveMaxInterval:        schedulerCheckActiveMaxInterval,
 			schedulerAdvisoryLockTimeout:           schedulerAdvisoryLockTimeout,
 		},
 		resultsCh:                   resultsCh,

--- a/pkg/scheduling/v1/scheduler_integration_test.go
+++ b/pkg/scheduling/v1/scheduler_integration_test.go
@@ -193,13 +193,15 @@ func TestScheduler_ReplenishIntegration_SingleActionUtilizationEqualsMaxRuns(t *
 		pool, cleanup, err := schedv1.NewSchedulingPool(
 			conf.V1.Scheduler(),
 			&l,
-			100,                 // singleQueueLimit
-			20,                  // schedulerConcurrencyRateLimit
-			10*time.Millisecond, // schedulerConcurrencyPollingMinInterval
-			50*time.Millisecond, // schedulerConcurrencyPollingMaxInterval
-			5*time.Millisecond,  // schedulerAdvisoryLockTimeout
-			false,               // optimisticSchedulingEnabled
-			1,                   // optimisticSlots
+			100,                  // singleQueueLimit
+			20,                   // schedulerConcurrencyRateLimit
+			10*time.Millisecond,  // schedulerConcurrencyPollingMinInterval
+			50*time.Millisecond,  // schedulerConcurrencyPollingMaxInterval
+			50*time.Millisecond,  // schedulerCheckActiveMinInterval
+			100*time.Millisecond, // schedulerCheckActiveMaxInterval
+			5*time.Millisecond,   // schedulerAdvisoryLockTimeout
+			false,                // optimisticSchedulingEnabled
+			1,                    // optimisticSlots
 		)
 		require.NoError(t, err)
 		defer func() { _ = cleanup() }()
@@ -240,6 +242,8 @@ func TestScheduler_ReplenishIntegration_MultipleActionsDoesNotMultiplySlots(t *t
 			20,
 			10*time.Millisecond,
 			50*time.Millisecond,
+			50*time.Millisecond,
+			100*time.Millisecond,
 			5*time.Millisecond,
 			false,
 			1,
@@ -279,6 +283,8 @@ func TestScheduler_ReplenishIntegration_IsSafeUnderConcurrentSnapshots(t *testin
 			20,
 			10*time.Millisecond,
 			50*time.Millisecond,
+			50*time.Millisecond,
+			100*time.Millisecond,
 			5*time.Millisecond,
 			false,
 			1,
@@ -332,6 +338,8 @@ func TestScheduler_PoolIntegration_RemovingTenantStopsSnapshots(t *testing.T) {
 			20,
 			10*time.Millisecond,
 			50*time.Millisecond,
+			50*time.Millisecond,
+			100*time.Millisecond,
 			5*time.Millisecond,
 			false,
 			1,


### PR DESCRIPTION
# Description

Make the check-active polling interval for concurrency strategies configurable (default 30s-60s, up from hardcoded 5s) to reduce excessive database load when there are many active concurrency strategies

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

