### PR TITLE
[Python] Hotfix: Retry tasks if `send_step_action_event` flakily fails

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.32.2] - 2026-04-15
+
+### Changed
+
+- Fixes a bug where failures sending a completed or failed event from the worker to the engine would fail the task and bypass any retries, even if some were configured on the task
+
 ## [1.32.1] - 2026-04-09
 
 ### Changed

--- a/sdks/python/hatchet_sdk/clients/dispatcher/dispatcher.py
+++ b/sdks/python/hatchet_sdk/clients/dispatcher/dispatcher.py
@@ -152,13 +152,13 @@ class DispatcherClient:
             message = f"failed to send step action event {event_type} for action {action.action_id}."
 
             if was_completed:
-                message += "\n**IMPORTANT**: the task completed successfully on the worker, but the engine failed to receive the completed event."
+                message += "**IMPORTANT**: the task completed successfully on the worker, but the engine failed to receive the completed event."
 
             if was_failed:
-                message += "\n**IMPORTANT**: the task failed, but the engine failed to receive the failed event."
+                message += "**IMPORTANT**: the task failed, but the engine failed to receive the failed event."
 
             if was_completed or was_failed:
-                message += "\nthe engine will eventually consider the task timed out, and invoke any retries configured on the task."
+                message += "the engine will eventually consider the task timed out, and invoke any retries configured on the task."
 
             logger.exception(message)
             return None

--- a/sdks/python/hatchet_sdk/clients/dispatcher/dispatcher.py
+++ b/sdks/python/hatchet_sdk/clients/dispatcher/dispatcher.py
@@ -147,12 +147,18 @@ class DispatcherClient:
         except Exception as e:
             # for step action events, send a failure event when we cannot send the completed event
             if event_type in (STEP_EVENT_TYPE_COMPLETED, STEP_EVENT_TYPE_FAILED):
-                await self._try_send_step_action_event(
-                    action,
-                    STEP_EVENT_TYPE_FAILED,
-                    "Failed to send finished event: " + str(e),
-                    should_not_retry=should_not_retry,
-                )
+                try:
+                    await self._try_send_step_action_event(
+                        action,
+                        STEP_EVENT_TYPE_FAILED,
+                        "Failed to send finished event: " + str(e),
+                        should_not_retry=should_not_retry,
+                    )
+                except Exception:
+                    ## fixme: this is a hack to not drop errors here
+                    ## not sure how to handle this case better since
+                    ## we probably don't want to raise here either
+                    return None
 
             return None
 

--- a/sdks/python/hatchet_sdk/clients/dispatcher/dispatcher.py
+++ b/sdks/python/hatchet_sdk/clients/dispatcher/dispatcher.py
@@ -13,7 +13,7 @@ from hatchet_sdk.clients.rest.tenacity_utils import (
     tenacity_retry,
     tenacity_should_retry,
 )
-from hatchet_sdk.config import ClientConfig
+from hatchet_sdk.config import ClientConfig, TenacityConfig
 from hatchet_sdk.connection import new_conn
 from hatchet_sdk.contracts.dispatcher_pb2 import (
     SDKS,
@@ -170,14 +170,17 @@ class DispatcherClient:
             should_not_retry=should_not_retry,
         )
 
-        send_step_action_event = tenacity_retry(
-            self.aio_client.SendStepActionEvent, self.config.tenacity
+        send = tenacity_retry(
+            self.aio_client.SendStepActionEvent,
+            TenacityConfig(
+                max_attempts=10,
+            ),
         )
 
         return cast(
             grpc.aio.UnaryUnaryCall[StepActionEvent, ActionEventResponse],
             # fixme: figure out how to get typing right here
-            await send_step_action_event(  # type: ignore[misc]
+            await send(  # type: ignore[misc]
                 event,
                 metadata=create_authorization_header(self.token),
             ),

--- a/sdks/python/hatchet_sdk/clients/dispatcher/dispatcher.py
+++ b/sdks/python/hatchet_sdk/clients/dispatcher/dispatcher.py
@@ -17,8 +17,6 @@ from hatchet_sdk.config import ClientConfig
 from hatchet_sdk.connection import new_conn
 from hatchet_sdk.contracts.dispatcher_pb2 import (
     SDKS,
-    STEP_EVENT_TYPE_COMPLETED,
-    STEP_EVENT_TYPE_FAILED,
     ActionEventResponse,
     GetVersionRequest,
     GetVersionResponse,
@@ -140,27 +138,9 @@ class DispatcherClient:
         payload: str | None,
         should_not_retry: bool,
     ) -> grpc.aio.UnaryUnaryCall[StepActionEvent, ActionEventResponse] | None:
-        try:
-            return await self._try_send_step_action_event(
-                action, event_type, payload, should_not_retry
-            )
-        except Exception as e:
-            # for step action events, send a failure event when we cannot send the completed event
-            if event_type in (STEP_EVENT_TYPE_COMPLETED, STEP_EVENT_TYPE_FAILED):
-                try:
-                    await self._try_send_step_action_event(
-                        action,
-                        STEP_EVENT_TYPE_FAILED,
-                        "Failed to send finished event: " + str(e),
-                        should_not_retry=should_not_retry,
-                    )
-                except Exception:
-                    ## fixme: this is a hack to not drop errors here
-                    ## not sure how to handle this case better since
-                    ## we probably don't want to raise here either
-                    return None
-
-            return None
+        return await self._try_send_step_action_event(
+            action, event_type, payload, should_not_retry
+        )
 
     async def _try_send_step_action_event(
         self,

--- a/sdks/python/hatchet_sdk/clients/dispatcher/dispatcher.py
+++ b/sdks/python/hatchet_sdk/clients/dispatcher/dispatcher.py
@@ -151,7 +151,7 @@ class DispatcherClient:
                     action,
                     STEP_EVENT_TYPE_FAILED,
                     "Failed to send finished event: " + str(e),
-                    should_not_retry=False,
+                    should_not_retry=should_not_retry,
                 )
 
             return None

--- a/sdks/python/hatchet_sdk/clients/dispatcher/dispatcher.py
+++ b/sdks/python/hatchet_sdk/clients/dispatcher/dispatcher.py
@@ -151,7 +151,7 @@ class DispatcherClient:
                     action,
                     STEP_EVENT_TYPE_FAILED,
                     "Failed to send finished event: " + str(e),
-                    should_not_retry=True,
+                    should_not_retry=False,
                 )
 
             return None

--- a/sdks/python/hatchet_sdk/clients/dispatcher/dispatcher.py
+++ b/sdks/python/hatchet_sdk/clients/dispatcher/dispatcher.py
@@ -32,6 +32,7 @@ from hatchet_sdk.contracts.dispatcher_pb2 import (
     WorkerRegisterResponse,
 )
 from hatchet_sdk.contracts.dispatcher_pb2_grpc import DispatcherStub
+from hatchet_sdk.logger import logger
 from hatchet_sdk.runnables.action import Action
 from hatchet_sdk.types.labels import WorkerLabel
 from hatchet_sdk.utils.api_auth import create_authorization_header
@@ -138,9 +139,15 @@ class DispatcherClient:
         payload: str | None,
         should_not_retry: bool,
     ) -> grpc.aio.UnaryUnaryCall[StepActionEvent, ActionEventResponse] | None:
-        return await self._try_send_step_action_event(
-            action, event_type, payload, should_not_retry
-        )
+        try:
+            return await self._try_send_step_action_event(
+                action, event_type, payload, should_not_retry
+            )
+        except Exception:
+            logger.exception(
+                f"Failed to send step action event {event_type} for action {action.action_id}"
+            )
+            return None
 
     async def _try_send_step_action_event(
         self,

--- a/sdks/python/hatchet_sdk/clients/dispatcher/dispatcher.py
+++ b/sdks/python/hatchet_sdk/clients/dispatcher/dispatcher.py
@@ -17,6 +17,8 @@ from hatchet_sdk.config import ClientConfig, TenacityConfig
 from hatchet_sdk.connection import new_conn
 from hatchet_sdk.contracts.dispatcher_pb2 import (
     SDKS,
+    STEP_EVENT_TYPE_COMPLETED,
+    STEP_EVENT_TYPE_FAILED,
     ActionEventResponse,
     GetVersionRequest,
     GetVersionResponse,
@@ -144,9 +146,21 @@ class DispatcherClient:
                 action, event_type, payload, should_not_retry
             )
         except Exception:
-            logger.exception(
-                f"Failed to send step action event {event_type} for action {action.action_id}"
-            )
+            was_completed = event_type == STEP_EVENT_TYPE_COMPLETED
+            was_failed = event_type == STEP_EVENT_TYPE_FAILED
+
+            message = f"failed to send step action event {event_type} for action {action.action_id}."
+
+            if was_completed:
+                message += "\n**IMPORTANT**: the task completed successfully on the worker, but the engine failed to receive the completed event."
+
+            if was_failed:
+                message += "\n**IMPORTANT**: the task failed, but the engine failed to receive the failed event."
+
+            if was_completed or was_failed:
+                message += "\nthe engine will eventually consider the task timed out, and invoke any retries configured on the task."
+
+            logger.exception(message)
             return None
 
     async def _try_send_step_action_event(

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hatchet-sdk"
-version = "1.32.1"
+version = "1.32.2"
 description = "This is the official Python SDK for Hatchet, a distributed, fault-tolerant task queue. The SDK allows you to easily integrate Hatchet's task scheduling and workflow orchestration capabilities into your Python applications."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
# Description

## [1.32.2] - 2026-04-15

### Changed

- Fixes a bug where failures sending a completed or failed event from the worker to the engine would fail the task and bypass any retries, even if some were configured on the task

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
