### PR TITLE
add(typescript/test): Retry on errors when polling

### DIFF
--- a/sdks/typescript/src/v1/examples/__e2e__/harness.ts
+++ b/sdks/typescript/src/v1/examples/__e2e__/harness.ts
@@ -78,9 +78,13 @@ export async function poll<T>(
   const start = Date.now();
 
   while (true) {
-    const value = await fn();
-    if (shouldStop(value)) {
-      return value;
+    try {
+      const value = await fn();
+      if (shouldStop(value)) {
+        return value;
+      }
+    } catch {
+      // retry on transient errors
     }
     if (Date.now() - start > timeoutMs) {
       throw new Error(`Timed out waiting for ${label} after ${timeoutMs}ms`);


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Small PR to allow retries on when `poll` calls fail during e2e tests.

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

- Wraps `fn` in `poll` call with a `try-catch` to allow retrying when calls fail.
