### PR TITLE
fix: set cloud enabled when control plane is enabled

### DIFF
--- a/frontend/app/src/hooks/use-cloud.ts
+++ b/frontend/app/src/hooks/use-cloud.ts
@@ -4,6 +4,7 @@ import {
   FeatureFlags,
 } from '@/lib/api/generated/cloud/data-contracts';
 import { useQuery } from '@tanstack/react-query';
+import useControlPlane from '@/hooks/use-control-plane';
 
 export const metadataIndicatesCloudEnabled = (cloudMeta: APICloudMetadata) => {
   // @ts-expect-error errors is returned when this is oss
@@ -66,11 +67,12 @@ type UseCloudReturn =
 
 export default function useCloud(tenantId?: string): UseCloudReturn {
   const cloudMetaQuery = useQuery(getCloudMetadataQuery);
+  const { isControlPlaneEnabled, controlPlaneMeta } = useControlPlane();
 
   const featureFlagsQuery = useQuery({
     queryKey: ['feature-flags:list', tenantId],
     retry: false,
-    enabled: cloudMetaQuery.data?.isCloudEnabled && !!tenantId,
+    enabled: !isControlPlaneEnabled && cloudMetaQuery.data?.isCloudEnabled && !!tenantId,
     queryFn: async () => {
       try {
         // This shouldn't be possible because of the `enabled` above, and yet, Josh found it happening at runtime
@@ -85,6 +87,22 @@ export default function useCloud(tenantId?: string): UseCloudReturn {
     },
     staleTime: 1000 * 60,
   });
+
+  if (isControlPlaneEnabled) {
+    return {
+      cloud: {
+        canBill: true,
+        canLinkGithub: true,
+        metricsEnabled: true,
+        requireBillingForManagedCompute: true,
+        inactivityLogoutMs: controlPlaneMeta?.inactivityLogoutMs,
+      },
+      isCloudEnabled: true,
+      isCloudLoaded: true,
+      isCloudLoading: false,
+      featureFlags: null,
+    };
+  }
 
   if (cloudMetaQuery.data && cloudMetaQuery.data.isCloudEnabled) {
     return {

--- a/frontend/app/src/hooks/use-cloud.ts
+++ b/frontend/app/src/hooks/use-cloud.ts
@@ -1,10 +1,10 @@
+import useControlPlane from '@/hooks/use-control-plane';
 import { cloudApi } from '@/lib/api/api';
 import {
   APICloudMetadata,
   FeatureFlags,
 } from '@/lib/api/generated/cloud/data-contracts';
 import { useQuery } from '@tanstack/react-query';
-import useControlPlane from '@/hooks/use-control-plane';
 
 export const metadataIndicatesCloudEnabled = (cloudMeta: APICloudMetadata) => {
   // @ts-expect-error errors is returned when this is oss
@@ -72,7 +72,10 @@ export default function useCloud(tenantId?: string): UseCloudReturn {
   const featureFlagsQuery = useQuery({
     queryKey: ['feature-flags:list', tenantId],
     retry: false,
-    enabled: !isControlPlaneEnabled && cloudMetaQuery.data?.isCloudEnabled && !!tenantId,
+    enabled:
+      !isControlPlaneEnabled &&
+      cloudMetaQuery.data?.isCloudEnabled &&
+      !!tenantId,
     queryFn: async () => {
       try {
         // This shouldn't be possible because of the `enabled` above, and yet, Josh found it happening at runtime

--- a/frontend/app/src/hooks/use-cloud.ts
+++ b/frontend/app/src/hooks/use-cloud.ts
@@ -73,8 +73,7 @@ export default function useCloud(tenantId?: string): UseCloudReturn {
     queryKey: ['feature-flags:list', tenantId],
     retry: false,
     enabled:
-      !isControlPlaneEnabled &&
-      cloudMetaQuery.data?.isCloudEnabled &&
+      (isControlPlaneEnabled || cloudMetaQuery.data?.isCloudEnabled) &&
       !!tenantId,
     queryFn: async () => {
       try {
@@ -103,7 +102,7 @@ export default function useCloud(tenantId?: string): UseCloudReturn {
       isCloudEnabled: true,
       isCloudLoaded: true,
       isCloudLoading: false,
-      featureFlags: null,
+      featureFlags: featureFlagsQuery.data?.data || null,
     };
   }
 


### PR DESCRIPTION
# Description

Sets cloud enabled to true whenever the control plane is enabled so we can hit the organization cases. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)