### PR TITLE
fix: disable version info for control plane, add sync for tenant alerting settings

### DIFF
--- a/frontend/app/src/pages/main/info/components/version-info.tsx
+++ b/frontend/app/src/pages/main/info/components/version-info.tsx
@@ -1,15 +1,22 @@
 import { Spinner } from '@/components/v1/ui/loading';
 import useCloud from '@/hooks/use-cloud';
+import useControlPlane from '@/hooks/use-control-plane';
 import { queries } from '@/lib/api';
 import { useQuery } from '@tanstack/react-query';
 import React from 'react';
 
 export const VersionInfo: React.FC = () => {
+  const { isControlPlaneEnabled } = useControlPlane();
   const { data, isLoading, isError, error } = useQuery({
     ...queries.info.getVersion,
+    enabled: !isControlPlaneEnabled,
   });
 
   const { isCloudEnabled } = useCloud();
+
+  if (isControlPlaneEnabled) {
+    return null;
+  }
 
   if (isLoading) {
     return (

--- a/pkg/repository/sqlcv1/sync.sql
+++ b/pkg/repository/sqlcv1/sync.sql
@@ -147,3 +147,9 @@ SET
     "role" = @role::"TenantMemberRole"
 WHERE "id" = @id::uuid
 RETURNING *;
+
+-- name: SyncUpsertTenantAlertingSettings :one
+INSERT INTO "TenantAlertingSettings" ("id", "tenantId")
+VALUES (@id::uuid, @tenantId::uuid)
+ON CONFLICT DO NOTHING
+RETURNING *;

--- a/pkg/repository/sqlcv1/sync.sql
+++ b/pkg/repository/sqlcv1/sync.sql
@@ -151,5 +151,7 @@ RETURNING *;
 -- name: SyncUpsertTenantAlertingSettings :one
 INSERT INTO "TenantAlertingSettings" ("id", "tenantId")
 VALUES (@id::uuid, @tenantId::uuid)
-ON CONFLICT DO NOTHING
+ON CONFLICT ("id") DO UPDATE
+-- dummy update to avoid "ON CONFLICT DO NOTHING" which doesn't return the row
+SET "tenantId" = EXCLUDED."tenantId"
 RETURNING *;

--- a/pkg/repository/sqlcv1/sync.sql.go
+++ b/pkg/repository/sqlcv1/sync.sql.go
@@ -251,6 +251,37 @@ func (q *Queries) SyncUpsertTenant(ctx context.Context, db DBTX, arg SyncUpsertT
 	return &i, err
 }
 
+const syncUpsertTenantAlertingSettings = `-- name: SyncUpsertTenantAlertingSettings :one
+INSERT INTO "TenantAlertingSettings" ("id", "tenantId")
+VALUES ($1::uuid, $2::uuid)
+ON CONFLICT DO NOTHING
+RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "maxFrequency", "lastAlertedAt", "tickerId", "enableExpiringTokenAlerts", "enableWorkflowRunFailureAlerts", "enableTenantResourceLimitAlerts"
+`
+
+type SyncUpsertTenantAlertingSettingsParams struct {
+	ID       uuid.UUID `json:"id"`
+	Tenantid uuid.UUID `json:"tenantid"`
+}
+
+func (q *Queries) SyncUpsertTenantAlertingSettings(ctx context.Context, db DBTX, arg SyncUpsertTenantAlertingSettingsParams) (*TenantAlertingSettings, error) {
+	row := db.QueryRow(ctx, syncUpsertTenantAlertingSettings, arg.ID, arg.Tenantid)
+	var i TenantAlertingSettings
+	err := row.Scan(
+		&i.ID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.TenantId,
+		&i.MaxFrequency,
+		&i.LastAlertedAt,
+		&i.TickerId,
+		&i.EnableExpiringTokenAlerts,
+		&i.EnableWorkflowRunFailureAlerts,
+		&i.EnableTenantResourceLimitAlerts,
+	)
+	return &i, err
+}
+
 const syncUpsertTenantInvite = `-- name: SyncUpsertTenantInvite :one
 INSERT INTO "TenantInviteLink" (
     "id",

--- a/pkg/repository/sqlcv1/sync.sql.go
+++ b/pkg/repository/sqlcv1/sync.sql.go
@@ -254,7 +254,8 @@ func (q *Queries) SyncUpsertTenant(ctx context.Context, db DBTX, arg SyncUpsertT
 const syncUpsertTenantAlertingSettings = `-- name: SyncUpsertTenantAlertingSettings :one
 INSERT INTO "TenantAlertingSettings" ("id", "tenantId")
 VALUES ($1::uuid, $2::uuid)
-ON CONFLICT DO NOTHING
+ON CONFLICT ("id") DO UPDATE
+SET "tenantId" = EXCLUDED."tenantId"
 RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "maxFrequency", "lastAlertedAt", "tickerId", "enableExpiringTokenAlerts", "enableWorkflowRunFailureAlerts", "enableTenantResourceLimitAlerts"
 `
 
@@ -263,6 +264,7 @@ type SyncUpsertTenantAlertingSettingsParams struct {
 	Tenantid uuid.UUID `json:"tenantid"`
 }
 
+// dummy update to avoid "ON CONFLICT DO NOTHING" which doesn't return the row
 func (q *Queries) SyncUpsertTenantAlertingSettings(ctx context.Context, db DBTX, arg SyncUpsertTenantAlertingSettingsParams) (*TenantAlertingSettings, error) {
 	row := db.QueryRow(ctx, syncUpsertTenantAlertingSettings, arg.ID, arg.Tenantid)
 	var i TenantAlertingSettings

--- a/pkg/repository/sync.go
+++ b/pkg/repository/sync.go
@@ -40,6 +40,8 @@ type SyncRepository interface {
 	SyncUpsertTenantMember(ctx context.Context, db sqlcv1.DBTX, arg sqlcv1.SyncUpsertTenantMemberParams) (*sqlcv1.TenantMember, error)
 	SyncUpdateTenantMember(ctx context.Context, db sqlcv1.DBTX, arg sqlcv1.SyncUpdateTenantMemberParams) (*sqlcv1.TenantMember, error)
 	SyncDeleteTenantMember(ctx context.Context, db sqlcv1.DBTX, id uuid.UUID) error
+
+	SyncUpsertTenantAlertingSettings(ctx context.Context, db sqlcv1.DBTX, arg sqlcv1.SyncUpsertTenantAlertingSettingsParams) (*sqlcv1.TenantAlertingSettings, error)
 }
 
 type syncRepository struct {
@@ -98,4 +100,8 @@ func (r *syncRepository) SyncUpdateTenantMember(ctx context.Context, db sqlcv1.D
 
 func (r *syncRepository) SyncDeleteTenantMember(ctx context.Context, db sqlcv1.DBTX, id uuid.UUID) error {
 	return r.queries.DeleteTenantMember(ctx, db, id)
+}
+
+func (r *syncRepository) SyncUpsertTenantAlertingSettings(ctx context.Context, db sqlcv1.DBTX, arg sqlcv1.SyncUpsertTenantAlertingSettingsParams) (*sqlcv1.TenantAlertingSettings, error) {
+	return r.queries.SyncUpsertTenantAlertingSettings(ctx, db, arg)
 }


### PR DESCRIPTION
# Description

There's no user-friendly version concept for the control plane beyond what exists on the tenant, which we'll move into the tenant settings tab eventually. Also adds a sync method for tenant alerting settings. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)