### PR TITLE
feat(ci): Do not mark 'accepted' issues as 'stale'

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,3 +17,4 @@ jobs:
           days-before-stale: 90
           days-before-close: 5
           stale-issue-label: 'stale'
+          exempt-issue-labels: 'accepted'


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Currently, we automatically mark all inactive issues as stale after 90 days of no activity. However, some may remain open (i.e `good-first-issue`) despite no activity.

This PR ensures issues labelled as `accepted` will not be auto-closed -- instead remaining open (and visible) on our backlog.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] CI (any automation pipeline changes)

## What's Changed

- Exempts issues marked with an `accepted` label from being marked as stale and closed.

## TODO

- [x] Add a new `accepted` label (or equivalent)
