### PR TITLE
Cleanup old workers via daily gocron

### DIFF
--- a/internal/services/controllers/retention/controller.go
+++ b/internal/services/controllers/retention/controller.go
@@ -175,6 +175,23 @@ func (rc *RetentionControllerImpl) Start() (func() error, error) {
 		}
 	}
 
+	if rc.workerRetention {
+		workerInterval := time.Hour
+
+		_, err := rc.s.NewJob(
+			gocron.DurationJob(workerInterval),
+			gocron.NewTask(
+				rc.runCleanupOldWorkers(ctx),
+			),
+			gocron.WithSingletonMode(gocron.LimitModeReschedule),
+		)
+
+		if err != nil {
+			cancel()
+			return nil, fmt.Errorf("could not set up runCleanupOldWorkers: %w", err)
+		}
+	}
+
 	rc.s.Start()
 
 	cleanup := func() error {

--- a/internal/services/controllers/retention/controller.go
+++ b/internal/services/controllers/retention/controller.go
@@ -176,7 +176,7 @@ func (rc *RetentionControllerImpl) Start() (func() error, error) {
 	}
 
 	if rc.workerRetention {
-		workerInterval := time.Hour
+		workerInterval := 24 * time.Hour
 
 		_, err := rc.s.NewJob(
 			gocron.DurationJob(workerInterval),

--- a/internal/services/controllers/retention/worker.go
+++ b/internal/services/controllers/retention/worker.go
@@ -2,53 +2,25 @@ package retention
 
 import (
 	"context"
-	"fmt"
 	"time"
-
-	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
-	"github.com/hatchet-dev/hatchet/pkg/telemetry"
 )
-
-const cleanupOldWorkersSleepBetweenBatches = time.Second
 
 func (rc *RetentionControllerImpl) runCleanupOldWorkers(ctx context.Context) func() {
 	return func() {
 		rc.l.Debug().Ctx(ctx).Msg("retention controller: cleaning up old workers")
 
-		err := rc.ForTenants(ctx, rc.runCleanupOldWorkersForTenant)
-		if err != nil {
-			rc.l.Err(err).Ctx(ctx).Msg("could not cleanup old workers")
-		}
-	}
-}
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
 
-func (rc *RetentionControllerImpl) runCleanupOldWorkersForTenant(ctx context.Context, tenant sqlcv1.Tenant) error {
-	ctx, span := telemetry.NewSpan(ctx, "cleanup-old-workers-tenant")
-	defer span.End()
+		shouldContinue := true
+		var err error
 
-	cutoff, err := GetDataRetentionExpiredTime(tenant.DataRetentionPeriod)
-	if err != nil {
-		return fmt.Errorf("could not get cutoff for tenant %s: %w", tenant.ID.String(), err)
-	}
-
-	for {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
-		hasMore, err := rc.repo.Workers().DeleteOldWorkers(ctx, tenant.ID, cutoff)
-		if err != nil {
-			return fmt.Errorf("could not delete old workers for tenant %s: %w", tenant.ID.String(), err)
-		}
-
-		if !hasMore {
-			return nil
-		}
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(cleanupOldWorkersSleepBetweenBatches):
+		for shouldContinue {
+			shouldContinue, err = rc.repo.Workers().CleanupOldWorkers(ctx)
+			if err != nil {
+				rc.l.Err(err).Ctx(ctx).Msg("could not cleanup old workers")
+				return
+			}
 		}
 	}
 }

--- a/internal/services/controllers/retention/worker.go
+++ b/internal/services/controllers/retention/worker.go
@@ -1,0 +1,54 @@
+package retention
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
+	"github.com/hatchet-dev/hatchet/pkg/telemetry"
+)
+
+const cleanupOldWorkersSleepBetweenBatches = time.Second
+
+func (rc *RetentionControllerImpl) runCleanupOldWorkers(ctx context.Context) func() {
+	return func() {
+		rc.l.Debug().Ctx(ctx).Msg("retention controller: cleaning up old workers")
+
+		err := rc.ForTenants(ctx, rc.runCleanupOldWorkersForTenant)
+		if err != nil {
+			rc.l.Err(err).Ctx(ctx).Msg("could not cleanup old workers")
+		}
+	}
+}
+
+func (rc *RetentionControllerImpl) runCleanupOldWorkersForTenant(ctx context.Context, tenant sqlcv1.Tenant) error {
+	ctx, span := telemetry.NewSpan(ctx, "cleanup-old-workers-tenant")
+	defer span.End()
+
+	cutoff, err := GetDataRetentionExpiredTime(tenant.DataRetentionPeriod)
+	if err != nil {
+		return fmt.Errorf("could not get cutoff for tenant %s: %w", tenant.ID.String(), err)
+	}
+
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		hasMore, err := rc.repo.Workers().DeleteOldWorkers(ctx, tenant.ID, cutoff)
+		if err != nil {
+			return fmt.Errorf("could not delete old workers for tenant %s: %w", tenant.ID.String(), err)
+		}
+
+		if !hasMore {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(cleanupOldWorkersSleepBetweenBatches):
+		}
+	}
+}

--- a/internal/services/controllers/retention/worker.go
+++ b/internal/services/controllers/retention/worker.go
@@ -2,25 +2,47 @@ package retention
 
 import (
 	"context"
+	"fmt"
 	"time"
+
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
+	"github.com/hatchet-dev/hatchet/pkg/telemetry"
 )
 
 func (rc *RetentionControllerImpl) runCleanupOldWorkers(ctx context.Context) func() {
 	return func() {
 		rc.l.Debug().Ctx(ctx).Msg("retention controller: cleaning up old workers")
 
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Minute)
 		defer cancel()
 
-		shouldContinue := true
-		var err error
-
-		for shouldContinue {
-			shouldContinue, err = rc.repo.Workers().CleanupOldWorkers(ctx)
-			if err != nil {
-				rc.l.Err(err).Ctx(ctx).Msg("could not cleanup old workers")
-				return
-			}
+		if err := rc.ForTenants(ctx, rc.cleanupOldWorkersForTenant); err != nil {
+			rc.l.Err(err).Ctx(ctx).Msg("could not cleanup old workers")
 		}
 	}
+}
+
+func (rc *RetentionControllerImpl) cleanupOldWorkersForTenant(ctx context.Context, tenant sqlcv1.Tenant) error {
+	ctx, span := telemetry.NewSpan(ctx, "cleanup-old-workers-tenant")
+	defer span.End()
+
+	cutoff, err := GetDataRetentionExpiredTime(tenant.DataRetentionPeriod)
+	if err != nil {
+		return fmt.Errorf("could not get cutoff for tenant %s: %w", tenant.ID.String(), err)
+	}
+
+	shouldContinue := true
+
+	for shouldContinue {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		shouldContinue, err = rc.repo.Workers().CleanupOldWorkers(ctx, tenant.ID, cutoff)
+		if err != nil {
+			return fmt.Errorf("could not cleanup old workers for tenant %s: %w", tenant.ID.String(), err)
+		}
+	}
+
+	return nil
 }

--- a/pkg/repository/sqlcv1/tasks.sql
+++ b/pkg/repository/sqlcv1/tasks.sql
@@ -425,6 +425,7 @@ WITH tasks_on_inactive_workers AS (
         v1_task_runtime runtime ON w."id" = runtime.worker_id
     WHERE
         w."tenantId" = @tenantId::uuid
+        AND w."tenantId" = runtime.tenant_id
         AND w."lastHeartbeatAt" < NOW() - INTERVAL '30 seconds'
         -- evicted tasks are not eligible for re-assignment
         AND runtime.evicted_at IS NULL

--- a/pkg/repository/sqlcv1/tasks.sql.go
+++ b/pkg/repository/sqlcv1/tasks.sql.go
@@ -2016,6 +2016,7 @@ WITH tasks_on_inactive_workers AS (
         v1_task_runtime runtime ON w."id" = runtime.worker_id
     WHERE
         w."tenantId" = $1::uuid
+        AND w."tenantId" = runtime.tenant_id
         AND w."lastHeartbeatAt" < NOW() - INTERVAL '30 seconds'
         -- evicted tasks are not eligible for re-assignment
         AND runtime.evicted_at IS NULL

--- a/pkg/repository/sqlcv1/workers.sql
+++ b/pkg/repository/sqlcv1/workers.sql
@@ -379,36 +379,15 @@ SET
     "strValue" = sqlc.narg('strValue')::text
 RETURNING *;
 
--- name: DeleteOldWorkers :one
-WITH for_delete AS (
-    SELECT
-        "id"
-    FROM "Worker" w
-    WHERE
-        w."tenantId" = @tenantId::uuid AND
-        w."lastHeartbeatAt" < @lastHeartbeatBefore::timestamp
-    LIMIT sqlc.arg('limit') + 1
-), expired_with_limit AS (
-    SELECT
-        for_delete."id" as "id"
-    FROM for_delete
-    LIMIT sqlc.arg('limit')
-), has_more AS (
-    SELECT
-        CASE
-            WHEN COUNT(*) > sqlc.arg('limit') THEN TRUE
-            ELSE FALSE
-        END as has_more
-    FROM for_delete
-), delete_events AS (
-    DELETE FROM "WorkerAssignEvent" wae
-    WHERE wae."workerId" IN (SELECT "id" FROM expired_with_limit)
-    RETURNING wae."id"
+-- name: CleanupOldWorkers :execresult
+WITH zombie_workers AS (
+    SELECT "id"
+    FROM "Worker"
+    WHERE "lastHeartbeatAt" < NOW() - INTERVAL '30 days'
+    LIMIT @batchSize::int
 )
-DELETE FROM "Worker" w
-WHERE w."id" IN (SELECT "id" FROM expired_with_limit)
-RETURNING
-    (SELECT has_more FROM has_more) as has_more;
+DELETE FROM "Worker"
+WHERE "id" IN (SELECT "id" FROM zombie_workers);
 
 -- name: ListDispatcherIdsForWorkers :many
 SELECT

--- a/pkg/repository/sqlcv1/workers.sql
+++ b/pkg/repository/sqlcv1/workers.sql
@@ -380,14 +380,15 @@ SET
 RETURNING *;
 
 -- name: CleanupOldWorkers :execresult
-WITH zombie_workers AS (
+WITH old_workers AS (
     SELECT "id"
     FROM "Worker"
-    WHERE "lastHeartbeatAt" < NOW() - INTERVAL '30 days'
+    WHERE "tenantId" = @tenantId::uuid
+      AND "lastHeartbeatAt" < @lastHeartbeatBefore::timestamp
     LIMIT @batchSize::int
 )
 DELETE FROM "Worker"
-WHERE "id" IN (SELECT "id" FROM zombie_workers);
+WHERE "id" IN (SELECT "id" FROM old_workers);
 
 -- name: ListDispatcherIdsForWorkers :many
 SELECT

--- a/pkg/repository/sqlcv1/workers.sql.go
+++ b/pkg/repository/sqlcv1/workers.sql.go
@@ -9,8 +9,24 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 )
+
+const cleanupOldWorkers = `-- name: CleanupOldWorkers :execresult
+WITH zombie_workers AS (
+    SELECT "id"
+    FROM "Worker"
+    WHERE "lastHeartbeatAt" < NOW() - INTERVAL '30 days'
+    LIMIT $1::int
+)
+DELETE FROM "Worker"
+WHERE "id" IN (SELECT "id" FROM zombie_workers)
+`
+
+func (q *Queries) CleanupOldWorkers(ctx context.Context, db DBTX, batchsize int32) (pgconn.CommandTag, error) {
+	return db.Exec(ctx, cleanupOldWorkers, batchsize)
+}
 
 const createWorker = `-- name: CreateWorker :one
 INSERT INTO "Worker" (
@@ -129,51 +145,6 @@ func (q *Queries) CreateWorkerSlotConfigs(ctx context.Context, db DBTX, arg Crea
 		arg.Maxunits,
 	)
 	return err
-}
-
-const deleteOldWorkers = `-- name: DeleteOldWorkers :one
-WITH for_delete AS (
-    SELECT
-        "id"
-    FROM "Worker" w
-    WHERE
-        w."tenantId" = $1::uuid AND
-        w."lastHeartbeatAt" < $2::timestamp
-    LIMIT $3 + 1
-), expired_with_limit AS (
-    SELECT
-        for_delete."id" as "id"
-    FROM for_delete
-    LIMIT $3
-), has_more AS (
-    SELECT
-        CASE
-            WHEN COUNT(*) > $3 THEN TRUE
-            ELSE FALSE
-        END as has_more
-    FROM for_delete
-), delete_events AS (
-    DELETE FROM "WorkerAssignEvent" wae
-    WHERE wae."workerId" IN (SELECT "id" FROM expired_with_limit)
-    RETURNING wae."id"
-)
-DELETE FROM "Worker" w
-WHERE w."id" IN (SELECT "id" FROM expired_with_limit)
-RETURNING
-    (SELECT has_more FROM has_more) as has_more
-`
-
-type DeleteOldWorkersParams struct {
-	Tenantid            uuid.UUID        `json:"tenantid"`
-	Lastheartbeatbefore pgtype.Timestamp `json:"lastheartbeatbefore"`
-	Limit               interface{}      `json:"limit"`
-}
-
-func (q *Queries) DeleteOldWorkers(ctx context.Context, db DBTX, arg DeleteOldWorkersParams) (bool, error) {
-	row := db.QueryRow(ctx, deleteOldWorkers, arg.Tenantid, arg.Lastheartbeatbefore, arg.Limit)
-	var has_more bool
-	err := row.Scan(&has_more)
-	return has_more, err
 }
 
 const deleteWorker = `-- name: DeleteWorker :one

--- a/pkg/repository/sqlcv1/workers.sql.go
+++ b/pkg/repository/sqlcv1/workers.sql.go
@@ -14,18 +14,25 @@ import (
 )
 
 const cleanupOldWorkers = `-- name: CleanupOldWorkers :execresult
-WITH zombie_workers AS (
+WITH old_workers AS (
     SELECT "id"
     FROM "Worker"
-    WHERE "lastHeartbeatAt" < NOW() - INTERVAL '30 days'
-    LIMIT $1::int
+    WHERE "tenantId" = $1::uuid
+      AND "lastHeartbeatAt" < $2::timestamp
+    LIMIT $3::int
 )
 DELETE FROM "Worker"
-WHERE "id" IN (SELECT "id" FROM zombie_workers)
+WHERE "id" IN (SELECT "id" FROM old_workers)
 `
 
-func (q *Queries) CleanupOldWorkers(ctx context.Context, db DBTX, batchsize int32) (pgconn.CommandTag, error) {
-	return db.Exec(ctx, cleanupOldWorkers, batchsize)
+type CleanupOldWorkersParams struct {
+	Tenantid            uuid.UUID        `json:"tenantid"`
+	Lastheartbeatbefore pgtype.Timestamp `json:"lastheartbeatbefore"`
+	Batchsize           int32            `json:"batchsize"`
+}
+
+func (q *Queries) CleanupOldWorkers(ctx context.Context, db DBTX, arg CleanupOldWorkersParams) (pgconn.CommandTag, error) {
+	return db.Exec(ctx, cleanupOldWorkers, arg.Tenantid, arg.Lastheartbeatbefore, arg.Batchsize)
 }
 
 const createWorker = `-- name: CreateWorker :one

--- a/pkg/repository/worker.go
+++ b/pkg/repository/worker.go
@@ -124,7 +124,7 @@ type WorkerRepository interface {
 
 	UpsertWorkerLabels(ctx context.Context, workerId uuid.UUID, opts []UpsertWorkerLabelOpts) ([]*sqlcv1.WorkerLabel, error)
 
-	DeleteOldWorkers(ctx context.Context, tenantId uuid.UUID, lastHeartbeatBefore time.Time) (bool, error)
+	CleanupOldWorkers(ctx context.Context) (bool, error)
 
 	GetDispatcherIdsForWorkers(ctx context.Context, tenantId uuid.UUID, workerIds []uuid.UUID) (map[uuid.UUID]uuid.UUID, map[uuid.UUID]struct{}, error)
 
@@ -723,22 +723,35 @@ func (w *workerRepository) UpsertWorkerLabels(ctx context.Context, workerId uuid
 	return affinities, nil
 }
 
-func (w *workerRepository) DeleteOldWorkers(ctx context.Context, tenantId uuid.UUID, lastHeartbeatBefore time.Time) (bool, error) {
-	hasMore, err := w.queries.DeleteOldWorkers(ctx, w.pool, sqlcv1.DeleteOldWorkersParams{
-		Tenantid:            tenantId,
-		Lastheartbeatbefore: sqlchelpers.TimestampFromTime(lastHeartbeatBefore),
-		Limit:               20,
-	})
+func (w *workerRepository) CleanupOldWorkers(ctx context.Context) (bool, error) {
+	const timeout = 1000 * 60 // 1 minute
+	const batchSize int32 = 10000
+	const lockName = "cleanup-old-workers"
 
+	tx, commit, rollback, err := sqlchelpers.PrepareTxWithStatementTimeout(ctx, w.pool, w.l, timeout)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return false, nil
-		}
+		return false, fmt.Errorf("error beginning transaction for %s: %w", lockName, err)
+	}
+	defer rollback()
 
-		return false, err
+	acquired, err := w.queries.TryAdvisoryLock(ctx, tx, hash(lockName))
+	if err != nil {
+		return false, fmt.Errorf("error acquiring advisory lock for %s: %w", lockName, err)
+	}
+	if !acquired {
+		return false, nil
 	}
 
-	return hasMore, nil
+	result, err := w.queries.CleanupOldWorkers(ctx, tx, batchSize)
+	if err != nil {
+		return false, fmt.Errorf("error cleaning up old workers: %w", err)
+	}
+
+	if err := commit(ctx); err != nil {
+		return false, fmt.Errorf("error committing transaction for %s: %w", lockName, err)
+	}
+
+	return result.RowsAffected() == int64(batchSize), nil
 }
 
 func (w *workerRepository) GetDispatcherIdsForWorkers(ctx context.Context, tenantId uuid.UUID, workerIds []uuid.UUID) (map[uuid.UUID]uuid.UUID, map[uuid.UUID]struct{}, error) {

--- a/pkg/repository/worker.go
+++ b/pkg/repository/worker.go
@@ -124,7 +124,7 @@ type WorkerRepository interface {
 
 	UpsertWorkerLabels(ctx context.Context, workerId uuid.UUID, opts []UpsertWorkerLabelOpts) ([]*sqlcv1.WorkerLabel, error)
 
-	CleanupOldWorkers(ctx context.Context) (bool, error)
+	CleanupOldWorkers(ctx context.Context, tenantId uuid.UUID, lastHeartbeatBefore time.Time) (bool, error)
 
 	GetDispatcherIdsForWorkers(ctx context.Context, tenantId uuid.UUID, workerIds []uuid.UUID) (map[uuid.UUID]uuid.UUID, map[uuid.UUID]struct{}, error)
 
@@ -723,10 +723,10 @@ func (w *workerRepository) UpsertWorkerLabels(ctx context.Context, workerId uuid
 	return affinities, nil
 }
 
-func (w *workerRepository) CleanupOldWorkers(ctx context.Context) (bool, error) {
-	const timeout = 1000 * 60 // 1 minute
+func (w *workerRepository) CleanupOldWorkers(ctx context.Context, tenantId uuid.UUID, lastHeartbeatBefore time.Time) (bool, error) {
+	const timeout = 1000 * 60 * 3 // 3 minutes
 	const batchSize int32 = 10000
-	const lockName = "cleanup-old-workers"
+	lockName := fmt.Sprintf("cleanup-old-workers:%s", tenantId.String())
 
 	tx, commit, rollback, err := sqlchelpers.PrepareTxWithStatementTimeout(ctx, w.pool, w.l, timeout)
 	if err != nil {
@@ -742,7 +742,11 @@ func (w *workerRepository) CleanupOldWorkers(ctx context.Context) (bool, error) 
 		return false, nil
 	}
 
-	result, err := w.queries.CleanupOldWorkers(ctx, tx, batchSize)
+	result, err := w.queries.CleanupOldWorkers(ctx, tx, sqlcv1.CleanupOldWorkersParams{
+		Tenantid:            tenantId,
+		Lastheartbeatbefore: sqlchelpers.TimestampFromTime(lastHeartbeatBefore),
+		Batchsize:           batchSize,
+	})
 	if err != nil {
 		return false, fmt.Errorf("error cleaning up old workers: %w", err)
 	}

--- a/pkg/repository/worker.go
+++ b/pkg/repository/worker.go
@@ -726,21 +726,12 @@ func (w *workerRepository) UpsertWorkerLabels(ctx context.Context, workerId uuid
 func (w *workerRepository) CleanupOldWorkers(ctx context.Context, tenantId uuid.UUID, lastHeartbeatBefore time.Time) (bool, error) {
 	const timeout = 1000 * 60 * 3 // 3 minutes
 	const batchSize int32 = 10000
-	lockName := fmt.Sprintf("cleanup-old-workers:%s", tenantId.String())
 
 	tx, commit, rollback, err := sqlchelpers.PrepareTxWithStatementTimeout(ctx, w.pool, w.l, timeout)
 	if err != nil {
-		return false, fmt.Errorf("error beginning transaction for %s: %w", lockName, err)
+		return false, fmt.Errorf("error beginning transaction: %w", err)
 	}
 	defer rollback()
-
-	acquired, err := w.queries.TryAdvisoryLock(ctx, tx, hash(lockName))
-	if err != nil {
-		return false, fmt.Errorf("error acquiring advisory lock for %s: %w", lockName, err)
-	}
-	if !acquired {
-		return false, nil
-	}
 
 	result, err := w.queries.CleanupOldWorkers(ctx, tx, sqlcv1.CleanupOldWorkersParams{
 		Tenantid:            tenantId,
@@ -752,7 +743,7 @@ func (w *workerRepository) CleanupOldWorkers(ctx context.Context, tenantId uuid.
 	}
 
 	if err := commit(ctx); err != nil {
-		return false, fmt.Errorf("error committing transaction for %s: %w", lockName, err)
+		return false, fmt.Errorf("error committing transaction: %w", err)
 	}
 
 	return result.RowsAffected() == int64(batchSize), nil


### PR DESCRIPTION
# Description

Adds a new retention gocron job to get rid of workers based on tenant retention period. Also starts using `tenant_id` for query `ListTasksToReassign` to start using index of `v1_task_runtime`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
