### PR TITLE
Batch process worker cleanup and also cleanup `v1_worker_slot_config`

### DIFF
--- a/internal/services/controllers/retention/shared.go
+++ b/internal/services/controllers/retention/shared.go
@@ -2,7 +2,9 @@ package retention
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -20,9 +22,7 @@ func GetDataRetentionExpiredTime(duration string) (time.Time, error) {
 	return time.Now().UTC().Add(-d), nil
 }
 
-func (rc *RetentionControllerImpl) ForTenants(ctx context.Context, f func(ctx context.Context, tenant sqlcv1.Tenant) error) error {
-
-	// list all tenants
+func (rc *RetentionControllerImpl) ForTenants(ctx context.Context, perTenantTimeout time.Duration, f func(ctx context.Context, tenant sqlcv1.Tenant) error) error {
 	tenants, err := rc.p.ListTenantsForController(ctx, sqlcv1.TenantMajorEngineVersionV0)
 
 	if err != nil {
@@ -30,19 +30,28 @@ func (rc *RetentionControllerImpl) ForTenants(ctx context.Context, f func(ctx co
 	}
 
 	g := new(errgroup.Group)
+	g.SetLimit(50)
 
-	for i := range tenants {
-		index := i
+	var (
+		mu   sync.Mutex
+		errs []error
+	)
+
+	for _, tenant := range tenants {
 		g.Go(func() error {
-			return f(ctx, *tenants[index])
+			tenantCtx, cancel := context.WithTimeout(ctx, perTenantTimeout)
+			defer cancel()
+
+			if err := f(tenantCtx, *tenant); err != nil {
+				mu.Lock()
+				errs = append(errs, fmt.Errorf("tenant %s: %w", tenant.ID.String(), err))
+				mu.Unlock()
+			}
+			return nil
 		})
 	}
 
-	err = g.Wait()
+	_ = g.Wait()
 
-	if err != nil {
-		return fmt.Errorf("could not run for tenants: %w", err)
-	}
-
-	return nil
+	return errors.Join(errs...)
 }

--- a/internal/services/controllers/retention/worker.go
+++ b/internal/services/controllers/retention/worker.go
@@ -16,7 +16,7 @@ func (rc *RetentionControllerImpl) runCleanupOldWorkers(ctx context.Context) fun
 		ctx, cancel := context.WithTimeout(ctx, 30*time.Minute)
 		defer cancel()
 
-		if err := rc.ForTenants(ctx, rc.cleanupOldWorkersForTenant); err != nil {
+		if err := rc.ForTenants(ctx, 5*time.Minute, rc.cleanupOldWorkersForTenant); err != nil {
 			rc.l.Err(err).Ctx(ctx).Msg("could not cleanup old workers")
 		}
 	}

--- a/pkg/repository/sqlcv1/workers.sql
+++ b/pkg/repository/sqlcv1/workers.sql
@@ -386,6 +386,9 @@ WITH old_workers AS (
     WHERE "tenantId" = @tenantId::uuid
       AND "lastHeartbeatAt" < @lastHeartbeatBefore::timestamp
     LIMIT @batchSize::int
+), deleted_worker_slot_configs AS (
+    DELETE FROM v1_worker_slot_config
+    WHERE worker_id IN (SELECT "id" FROM old_workers)
 )
 DELETE FROM "Worker"
 WHERE "id" IN (SELECT "id" FROM old_workers);

--- a/pkg/repository/sqlcv1/workers.sql.go
+++ b/pkg/repository/sqlcv1/workers.sql.go
@@ -20,6 +20,9 @@ WITH old_workers AS (
     WHERE "tenantId" = $1::uuid
       AND "lastHeartbeatAt" < $2::timestamp
     LIMIT $3::int
+), deleted_worker_slot_configs AS (
+    DELETE FROM v1_worker_slot_config
+    WHERE worker_id IN (SELECT "id" FROM old_workers)
 )
 DELETE FROM "Worker"
 WHERE "id" IN (SELECT "id" FROM old_workers)


### PR DESCRIPTION
# Description

Follow up to https://github.com/hatchet-dev/hatchet/pull/3663

This PR
- Adds cleanup step for old `v1_worker_slot_config` which would otherwise be orphaned once the `"Worker"` records were deleted
- Makes sure to batch process 50 tenant worker cleanups concurrently at a time

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (changes which are not directly related to any business logic)
