### PR TITLE
Cache CEL programs in order to avoid expensive heap allocations on each event match

### DIFF
--- a/pkg/repository/match.go
+++ b/pkg/repository/match.go
@@ -920,8 +920,8 @@ func (m *sharedRepository) processCELExpressions(ctx context.Context, events []C
 		if !ok {
 			ast, issues := m.env.Compile(expr)
 
-			if issues != nil {
-				m.l.Error().Ctx(ctx).Msgf("failed to compile CEL expression: %s", issues.String())
+			if issues != nil && issues.Err() != nil {
+				m.l.Error().Ctx(ctx).Err(issues.Err()).Msgf("failed to compile CEL expression: %s", expr)
 				continue
 			}
 

--- a/pkg/repository/match.go
+++ b/pkg/repository/match.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"slices"
 	"time"
 
@@ -915,7 +916,11 @@ func (m *sharedRepository) processCELExpressions(ctx context.Context, events []C
 			expr = "true"
 		}
 
-		program, ok := m.celProgramCache.Get(expr)
+		hasher := fnv.New64a()
+		hasher.Write([]byte(expr))
+		exprHash := hasher.Sum64()
+
+		program, ok := m.celProgramCache.Get(exprHash)
 
 		if !ok {
 			ast, issues := m.env.Compile(expr)
@@ -932,7 +937,7 @@ func (m *sharedRepository) processCELExpressions(ctx context.Context, events []C
 				continue
 			}
 
-			m.celProgramCache.Add(expr, compiled)
+			m.celProgramCache.Add(exprHash, compiled)
 			program = compiled
 		}
 

--- a/pkg/repository/match.go
+++ b/pkg/repository/match.go
@@ -915,18 +915,25 @@ func (m *sharedRepository) processCELExpressions(ctx context.Context, events []C
 			expr = "true"
 		}
 
-		ast, issues := m.env.Compile(expr)
+		program, ok := m.celProgramCache.Get(expr)
 
-		if issues != nil {
-			m.l.Error().Ctx(ctx).Msgf("failed to compile CEL expression: %s", issues.String())
-			continue
-		}
+		if !ok {
+			ast, issues := m.env.Compile(expr)
 
-		program, err := m.env.Program(ast)
+			if issues != nil {
+				m.l.Error().Ctx(ctx).Msgf("failed to compile CEL expression: %s", issues.String())
+				continue
+			}
 
-		if err != nil {
-			m.l.Error().Ctx(ctx).Err(err).Msgf("failed to create CEL program: %s", expr)
-			continue
+			compiled, err := m.env.Program(ast)
+
+			if err != nil {
+				m.l.Error().Ctx(ctx).Err(err).Msgf("failed to create CEL program: %s", expr)
+				continue
+			}
+
+			m.celProgramCache.Add(expr, compiled)
+			program = compiled
 		}
 
 		programs[condition.ID] = program

--- a/pkg/repository/shared.go
+++ b/pkg/repository/shared.go
@@ -43,6 +43,7 @@ type sharedRepository struct {
 
 	celParser       *cel.CELParser
 	env             *celgo.Env
+	celProgramCache *lru.Cache[string, celgo.Program]
 	taskLookupCache *lru.Cache[taskExternalIdTenantIdTuple, *sqlcv1.FlattenExternalIdsRow]
 	payloadStore    PayloadStoreRepository
 	m               TenantLimitRepository
@@ -86,6 +87,12 @@ func newSharedRepository(
 		log.Fatalf("failed to create LRU cache: %v", err)
 	}
 
+	celProgramCache, err := lru.New[string, celgo.Program](10000)
+
+	if err != nil {
+		log.Fatalf("failed to create CEL program cache: %v", err)
+	}
+
 	s := &sharedRepository{
 		pool:                        pool,
 		ddlPool:                     ddlPool,
@@ -101,6 +108,7 @@ func newSharedRepository(
 		stepIdSlotRequestsCache:     stepIdSlotRequestsCache,
 		celParser:                   celParser,
 		env:                         env,
+		celProgramCache:             celProgramCache,
 		taskLookupCache:             lookupCache,
 		payloadStore:                payloadStore,
 	}

--- a/pkg/repository/shared.go
+++ b/pkg/repository/shared.go
@@ -43,7 +43,7 @@ type sharedRepository struct {
 
 	celParser       *cel.CELParser
 	env             *celgo.Env
-	celProgramCache *lru.Cache[string, celgo.Program]
+	celProgramCache *lru.Cache[uint64, celgo.Program]
 	taskLookupCache *lru.Cache[taskExternalIdTenantIdTuple, *sqlcv1.FlattenExternalIdsRow]
 	payloadStore    PayloadStoreRepository
 	m               TenantLimitRepository
@@ -87,7 +87,7 @@ func newSharedRepository(
 		log.Fatalf("failed to create LRU cache: %v", err)
 	}
 
-	celProgramCache, err := lru.New[string, celgo.Program](10000)
+	celProgramCache, err := lru.New[uint64, celgo.Program](50000)
 
 	if err != nil {
 		log.Fatalf("failed to create CEL program cache: %v", err)


### PR DESCRIPTION
# Description

Parsing and compiling CEL expressions on each event match leads to significant memory pressure. This PR attempts to relieve this pressure by introducing a non-expiring per-process LRU cache to reuse already parsed and compiled CEL programs (expressions).

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
