### PR TITLE
Update docs for `additional_metadata` re: filtering semantics (#3640)

### DIFF
--- a/frontend/docs/pages/v1/additional-metadata.mdx
+++ b/frontend/docs/pages/v1/additional-metadata.mdx
@@ -75,15 +75,15 @@ For example, you can filter events by the `source` metadata keys to quickly find
 
 ## Filtering Semantics
 
-When filtering **runs** (via `runs.list`, the dashboard runs view, or the REST endpoint `GET /api/v1/stable/tenants/{tenant}/workflow-runs`) with multiple `additional_metadata` key/value pairs, Hatchet returns runs that match **any** of the provided pairs (logical `OR`), not all of them.
+When filtering **runs** with `additional_metadata`, Hatchet returns runs that match **any** of the provided pairs (logical `OR`), not all of them.
 
-<Callout type="warning">
+<Callout type="info">
   For example, filtering runs with `{ first_name: "john", last_name: "doe" }`
   returns runs whose metadata matches *either* `first_name: "john"` *or*
   `last_name: "doe"`, not only runs that match both.
 </Callout>
 
-Event filtering behaves differently: filtering **events** with multiple `additional_metadata` pairs requires all pairs to match (logical `AND`), since events use JSONB containment under the hood.
+Event filtering behaves differently: filtering **events** with multiple `additional_metadata` pairs requires all pairs to match (logical `AND`), since events use `JSONB` containment under the hood.
 
 ## Use Cases
 

--- a/frontend/docs/pages/v1/additional-metadata.mdx
+++ b/frontend/docs/pages/v1/additional-metadata.mdx
@@ -73,6 +73,18 @@ For example, you can filter events by the `source` metadata keys to quickly find
 
 ![Blocks](/addl-meta.gif)
 
+## Filtering Semantics
+
+When filtering **runs** (via `runs.list`, the dashboard runs view, or the REST endpoint `GET /api/v1/stable/tenants/{tenant}/workflow-runs`) with multiple `additional_metadata` key/value pairs, Hatchet returns runs that match **any** of the provided pairs (logical `OR`), not all of them.
+
+<Callout type="warning">
+  For example, filtering runs with `{ first_name: "john", last_name: "doe" }`
+  returns runs whose metadata matches *either* `first_name: "john"` *or*
+  `last_name: "doe"`, not only runs that match both.
+</Callout>
+
+Event filtering behaves differently: filtering **events** with multiple `additional_metadata` pairs requires all pairs to match (logical `AND`), since events use JSONB containment under the hood.
+
 ## Use Cases
 
 Some common use cases for additional metadata include:

--- a/frontend/docs/pages/v1/additional-metadata.mdx
+++ b/frontend/docs/pages/v1/additional-metadata.mdx
@@ -85,6 +85,12 @@ When filtering **runs** with `additional_metadata`, Hatchet returns runs that ma
 
 Event filtering behaves differently: filtering **events** with multiple `additional_metadata` pairs requires all pairs to match (logical `AND`), since events use `JSONB` containment under the hood.
 
+<Callout type="info">
+  For example, filtering events with `{ first_name: "john", last_name: "doe" }`
+  returns only events whose metadata matches *both* `first_name: "john"` *and*
+  `last_name: "doe"`.
+</Callout>
+
 ## Use Cases
 
 Some common use cases for additional metadata include:


### PR DESCRIPTION
# Description

Update docs for additional_metadata re: filtering semantics.

Fixes #3640.

## Type of change

- [x] Documentation change (pure documentation change)

## What's Changed

Added a section "Filtering Semantics" calling out that filtering with multiple `additional_metadata` keys with `OR` semantics.

<img width="906" height="384" alt="SCR-20260422-mmwv" src="https://github.com/user-attachments/assets/e9c6351c-d45f-4fc8-ab4f-4235115df44b" />
