### PR TITLE
feat(cookbooks): add TypeScript support agent example

### DIFF
--- a/examples/python/support_agent/worker.py
+++ b/examples/python/support_agent/worker.py
@@ -17,6 +17,7 @@ hatchet = Hatchet()
 
 REPLY_EVENT_KEY = "support:customer-reply"
 TIMEOUT_SECONDS = 5
+LOOKBACK_MINUTES = 5
 
 
 # > Models
@@ -135,7 +136,7 @@ async def support_agent(
 
     # Step 3: Wait for a customer reply or timeout
     now = await ctx.aio_now()
-    consider_events_since = now - timedelta(minutes=5)
+    consider_events_since = now - timedelta(minutes=LOOKBACK_MINUTES)
 
     wait_result = await ctx.aio_wait_for(
         "await-customer-reply",

--- a/examples/typescript/e2e-worker.ts
+++ b/examples/typescript/e2e-worker.ts
@@ -58,6 +58,12 @@ import {
   scenarioTask,
   orchestratorTask,
 } from './child_index/workflow';
+import {
+  supportAgent,
+  triageTicket,
+  generateReply,
+  escalateTicket,
+} from './support_agent/workflow';
 
 const workflows = [
   bulkChild,
@@ -113,6 +119,10 @@ const workflows = [
   childIndexParent,
   scenarioTask,
   orchestratorTask,
+  supportAgent,
+  triageTicket,
+  generateReply,
+  escalateTicket,
 ];
 
 async function main() {

--- a/examples/typescript/support_agent/run.ts
+++ b/examples/typescript/support_agent/run.ts
@@ -1,0 +1,37 @@
+import { hatchet } from '../hatchet-client';
+import { supportAgent, REPLY_EVENT_KEY, SupportTicketInput } from './workflow';
+
+// > Trigger the workflow
+async function main() {
+  const input: SupportTicketInput = {
+    ticketId: 'ticket-42',
+    customerEmail: 'alice@example.com',
+    subject: 'Login broken',
+    body: "I can't log in since this morning.",
+  };
+
+  // Start the support agent workflow
+  const ref = await supportAgent.runNoWait(input);
+  const runId = await ref.getWorkflowRunId();
+  console.log(`Started workflow run: ${runId}`);
+
+  // Push a customer reply event (scoped to this ticket)
+  console.log('Pushing customer reply event...');
+  await hatchet.events.push(
+    REPLY_EVENT_KEY,
+    { message: 'I cleared my cookies and it works now. Thanks!' },
+    { scope: input.ticketId }
+  );
+
+  // Wait for the workflow to complete
+  const result = await ref.output;
+  console.log('Workflow completed:', result);
+}
+
+if (require.main === module) {
+  main()
+    .catch(console.error)
+    .finally(() => {
+      process.exit(0);
+    });
+}

--- a/examples/typescript/support_agent/workflow.ts
+++ b/examples/typescript/support_agent/workflow.ts
@@ -16,6 +16,20 @@ export type SupportTicketInput = {
   body: string;
 };
 
+export type TriageOutput = {
+  category: string;
+  priority: string;
+};
+
+export type ReplyOutput = {
+  message: string;
+};
+
+export type EscalationOutput = {
+  reason: string;
+  assignedTo: string;
+};
+
 // > Triage task
 // Classify the ticket into a category and priority.
 export const triageTicket = hatchet.task({
@@ -46,13 +60,41 @@ export const triageTicket = hatchet.task({
 });
 
 // > Generate reply task
-// Generate an initial support reply (fallback-only in TypeScript v1).
+// Generate an initial support reply using Claude.
 export const generateReply = hatchet.task({
   name: 'generate-reply',
   fn: async (input: SupportTicketInput) => {
-    return {
-      message: `Thank you for contacting support about: ${input.subject}. We are looking into this and will get back to you shortly.`,
-    };
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+
+    if (!apiKey) {
+      return {
+        message: `Thank you for contacting support about: ${input.subject}. We are looking into this and will get back to you shortly.`,
+      };
+    }
+
+    const anthropic = require('@anthropic-ai/sdk');
+    const Anthropic = anthropic.default || anthropic;
+    const client = new Anthropic({ apiKey });
+
+    const response = await client.messages.create({
+      model: 'claude-sonnet-4-20250514',
+      max_tokens: 300,
+      messages: [
+        {
+          role: 'user' as const,
+          content:
+            `You are a friendly support agent. Write a brief, helpful initial ` +
+            `reply to this support ticket.\n\n` +
+            `Subject: ${input.subject}\n` +
+            `Message: ${input.body}\n\n` +
+            `Keep the reply under 3 sentences.`,
+        },
+      ],
+    });
+
+    const [block] = response.content;
+    const text = block?.type === 'text' ? block.text : '';
+    return { message: text };
   },
 });
 

--- a/examples/typescript/support_agent/workflow.ts
+++ b/examples/typescript/support_agent/workflow.ts
@@ -1,0 +1,130 @@
+import { Or, SleepCondition, UserEventCondition } from '@hatchet-dev/typescript-sdk/v1/conditions';
+import { durationToMs } from '@hatchet-dev/typescript-sdk/v1/client/duration';
+import { hatchet } from '../hatchet-client';
+
+export const REPLY_EVENT_KEY = 'support:customer-reply';
+const REPLY_LABEL = 'reply' as const;
+const TIMEOUT_LABEL = 'timeout' as const;
+export const TIMEOUT_SECONDS = 5;
+const LOOKBACK_WINDOW = '5m' as const;
+
+// > Models
+export type SupportTicketInput = {
+  ticketId: string;
+  customerEmail: string;
+  subject: string;
+  body: string;
+};
+
+// > Triage task
+// Classify the ticket into a category and priority.
+export const triageTicket = hatchet.task({
+  name: 'triage-ticket',
+  fn: async (input: SupportTicketInput) => {
+    const text = `${input.subject} ${input.body}`.toLowerCase();
+
+    let category: string;
+    if (['bill', 'charge', 'payment', 'invoice'].some((w) => text.includes(w))) {
+      category = 'billing';
+    } else if (['login', 'password', 'auth', 'access'].some((w) => text.includes(w))) {
+      category = 'account';
+    } else {
+      category = 'technical';
+    }
+
+    let priority: string;
+    if (['urgent', 'critical', 'down', 'outage'].some((w) => text.includes(w))) {
+      priority = 'high';
+    } else if (['twice', 'broken', 'error'].some((w) => text.includes(w))) {
+      priority = 'medium';
+    } else {
+      priority = 'low';
+    }
+
+    return { category, priority };
+  },
+});
+
+// > Generate reply task
+// Generate an initial support reply (fallback-only in TypeScript v1).
+export const generateReply = hatchet.task({
+  name: 'generate-reply',
+  fn: async (input: SupportTicketInput) => {
+    return {
+      message: `Thank you for contacting support about: ${input.subject}. We are looking into this and will get back to you shortly.`,
+    };
+  },
+});
+
+// > Escalate task
+// Escalate an unresolved ticket to the human support team.
+export const escalateTicket = hatchet.task({
+  name: 'escalate-ticket',
+  fn: async (input: SupportTicketInput) => {
+    return {
+      reason: `No customer reply within ${TIMEOUT_SECONDS}s timeout`,
+      assignedTo: 'support-team@example.com',
+    };
+  },
+});
+
+// > Support agent workflow
+export const supportAgent = hatchet.durableTask({
+  name: 'support-agent',
+  executionTimeout: '10m',
+  fn: async (input: SupportTicketInput, ctx) => {
+    // Step 1: Triage the ticket
+    const triage = await triageTicket.run(input);
+
+    // Step 2: Generate an initial reply
+    const reply = await generateReply.run(input);
+
+    // Step 3: Wait for a customer reply or timeout
+    const now = await ctx.now();
+    const considerEventsSince = new Date(
+      now.getTime() - durationToMs(LOOKBACK_WINDOW)
+    ).toISOString();
+
+    const waitResult = await ctx.waitFor(
+      Or(
+        new SleepCondition(`${TIMEOUT_SECONDS}s`, TIMEOUT_LABEL),
+        new UserEventCondition(
+          REPLY_EVENT_KEY,
+          '',
+          REPLY_LABEL,
+          undefined,
+          input.ticketId,
+          considerEventsSince
+        )
+      )
+    );
+
+    // Determine which condition fired. ctx.waitFor returns
+    // { CREATE: { <label>: ... } } where <label> is the readableDataKey
+    // we assigned above ('timeout' or 'reply').
+    const create = (waitResult as Record<string, Record<string, unknown>>)['CREATE'] ?? waitResult;
+    const resolvedLabel = Object.keys(create as Record<string, unknown>)[0] ?? '';
+    const customerReplied = resolvedLabel === REPLY_LABEL;
+
+    if (!customerReplied) {
+      // Step 4a: Timeout -> escalate
+      await escalateTicket.run(input);
+      return {
+        ticketId: input.ticketId,
+        status: 'escalated' as const,
+        triageCategory: triage.category,
+        triagePriority: triage.priority,
+        initialReply: reply.message,
+      };
+    }
+
+    // Step 4b: Customer replied -> resolve
+    return {
+      ticketId: input.ticketId,
+      status: 'resolved' as const,
+      triageCategory: triage.category,
+      triagePriority: triage.priority,
+      initialReply: reply.message,
+    };
+  },
+});

--- a/frontend/docs/pages/cookbooks/workflow-support-agent.mdx
+++ b/frontend/docs/pages/cookbooks/workflow-support-agent.mdx
@@ -1,4 +1,5 @@
-import { Steps } from "nextra/components";
+import { Steps, Tabs } from "nextra/components";
+import UniversalTabs from "@/components/UniversalTabs";
 import { snippets } from "@/lib/generated/snippets";
 import { Snippet } from "@/components/code";
 
@@ -21,7 +22,7 @@ flowchart TD
     F --> H[Escalate to human support]
 ```
 
-Hatchet’s durable execution model helps keep the whole interaction in one workflow rather than scattering it across separate queue jobs and ad hoc timers.
+Hatchet's durable execution model helps keep the whole interaction in one workflow rather than scattering it across separate queue jobs and ad hoc timers.
 
 ## Setup
 
@@ -32,16 +33,23 @@ Hatchet’s durable execution model helps keep the whole interaction in one work
 To run this example, you will need:
 
 - a working local Hatchet environment or access to [Hatchet Cloud](https://cloud.onhatchet.run)
-- the Python SDK example environment (see the [Quickstart](/v1/quickstart))
-- optionally, an `ANTHROPIC_API_KEY`
+- a Hatchet SDK example environment (see the [Quickstart](/v1/quickstart))
+- optionally, an `ANTHROPIC_API_KEY` for live LLM replies
 
-Without `ANTHROPIC_API_KEY`, the example still runs using a fixed fallback reply.
+Without `ANTHROPIC_API_KEY`, the example runs using a fixed fallback reply. To use the live Claude path, you also need the Anthropic SDK installed for your language.
 
 ### Define the models
 
-Start with a few small Pydantic models for the workflow input and outputs.
+Start by defining the types for the workflow input and task outputs.
 
-<Snippet src={snippets.python.support_agent.worker.models} />
+<UniversalTabs items={["Python", "Typescript"]}>
+  <Tabs.Tab title="Python">
+    <Snippet src={snippets.python.support_agent.worker.models} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+    <Snippet src={snippets.typescript.support_agent.workflow.models} />
+  </Tabs.Tab>
+</UniversalTabs>
 
 The models keep the inputs and outputs for each task explicit, which makes the workflow easier to inspect and test.
 
@@ -51,15 +59,38 @@ The durable workflow delegates its work to a few small [tasks](/v1/tasks).
 
 First, add a task to classify the incoming ticket:
 
-<Snippet src={snippets.python.support_agent.worker.triage_task} />
+<UniversalTabs items={["Python", "Typescript"]}>
+  <Tabs.Tab title="Python">
+    <Snippet src={snippets.python.support_agent.worker.triage_task} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+    <Snippet src={snippets.typescript.support_agent.workflow.triage_task} />
+  </Tabs.Tab>
+</UniversalTabs>
 
-Next, add a task to generate the initial support reply. This task calls Claude when `ANTHROPIC_API_KEY` is present and falls back to a fixed response when it is not.
+Next, add a task to generate the initial support reply. When `ANTHROPIC_API_KEY` is set, the task calls Claude to produce the reply. Otherwise it returns a fixed fallback response.
 
-<Snippet src={snippets.python.support_agent.worker.generate_reply_task} />
+<UniversalTabs items={["Python", "Typescript"]}>
+  <Tabs.Tab title="Python">
+    <Snippet src={snippets.python.support_agent.worker.generate_reply_task} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+    <Snippet
+      src={snippets.typescript.support_agent.workflow.generate_reply_task}
+    />
+  </Tabs.Tab>
+</UniversalTabs>
 
 Finally, add a task to represent escalation to the support team:
 
-<Snippet src={snippets.python.support_agent.worker.escalate_task} />
+<UniversalTabs items={["Python", "Typescript"]}>
+  <Tabs.Tab title="Python">
+    <Snippet src={snippets.python.support_agent.worker.escalate_task} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+    <Snippet src={snippets.typescript.support_agent.workflow.escalate_task} />
+  </Tabs.Tab>
+</UniversalTabs>
 
 Keeping triage, reply generation, and escalation as separate tasks keeps the workflow itself small and makes each piece easier to reason about.
 
@@ -67,11 +98,22 @@ Keeping triage, reply generation, and escalation as separate tasks keeps the wor
 
 Now tie everything together in a [durable Hatchet workflow](/v1/durable-execution). A durable workflow is a good fit here because this interaction may stay open for some time while waiting for a customer reply. Hatchet persists the workflow state and its wait conditions, so the workflow can survive long delays, worker restarts, or even a worker crash, then continue later on another worker. That gives you a straightforward way to model the whole interaction without adding custom recovery logic.
 
-<Snippet src={snippets.python.support_agent.worker.support_agent_workflow} />
+<UniversalTabs items={["Python", "Typescript"]}>
+  <Tabs.Tab title="Python">
+    <Snippet
+      src={snippets.python.support_agent.worker.support_agent_workflow}
+    />
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+    <Snippet
+      src={snippets.typescript.support_agent.workflow.support_agent_workflow}
+    />
+  </Tabs.Tab>
+</UniversalTabs>
 
-As you can see, the workflow runs triage first, generates an initial reply, and then waits for one of two things to happen: either a customer reply event arrives for that ticket, or the timeout fires. From there, the workflow either resolves the ticket or escalates it.
+The workflow runs triage first, generates an initial reply, and then waits for one of two things to happen: either a customer reply event arrives for that ticket, or the timeout fires. From there, the workflow either resolves the ticket or escalates it.
 
-The detail that matters most here is [`consider_events_since`](/v1/durable-event-waits#lookback-windows) on the reply event condition. A customer reply could arrive while the workflow is still finishing triage or generating the first response. By using `consider_events_since`, the workflow can still pick up that reply once the wait becomes active instead of missing it because the event arrived slightly early.
+The detail that matters most here is the lookback window on the reply event condition. A customer reply could arrive while the workflow is still finishing triage or generating the first response. By using a lookback window ([`consider_events_since`](/v1/durable-event-waits#lookback-windows) in Python, `considerEventsSince` in TypeScript), the workflow can still pick up that reply once the wait becomes active instead of missing it because the event arrived slightly early.
 
 ### Register and start the worker
 
@@ -79,15 +121,24 @@ To run this workflow, register the workflow and its tasks on a Hatchet worker, t
 
 <Snippet src={snippets.python.support_agent.worker.worker_registration} />
 
+In TypeScript, workflows are registered through the shared example worker rather than a per-example registration file.
+
 With the worker running, you can trigger the workflow and observe either the resolved or escalated outcome.
 
 ### Trigger the workflow
 
 The example also includes a small trigger script that starts the workflow, pushes a scoped reply event, and waits for the result.
 
-<Snippet src={snippets.python.support_agent.trigger.trigger_the_workflow} />
+<UniversalTabs items={["Python", "Typescript"]}>
+  <Tabs.Tab title="Python">
+    <Snippet src={snippets.python.support_agent.trigger.trigger_the_workflow} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+    <Snippet src={snippets.typescript.support_agent.run.trigger_the_workflow} />
+  </Tabs.Tab>
+</UniversalTabs>
 
-Because the workflow uses `consider_events_since`, the trigger can push the reply event immediately after starting the support agent.
+Because the workflow uses a lookback window, the trigger can push the reply event immediately after starting the support agent.
 
 ### Test it
 
@@ -96,11 +147,24 @@ This example includes two end-to-end tests against a live Hatchet instance:
 - a resolved path, where the customer reply event arrives before the timeout
 - a timeout path, where no reply arrives and the workflow escalates
 
-If you are running the Python SDK examples locally, you can run the support agent tests with:
+If you are running the SDK examples locally:
 
-```bash
-pytest examples/support_agent/test_support_agent.py
-```
+<UniversalTabs items={["Python", "Typescript"]}>
+  <Tabs.Tab title="Python">
+
+    ```bash
+    pytest examples/support_agent/test_support_agent.py
+    ```
+
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+
+    ```bash
+    pnpm run test:e2e -- --testPathPattern=support_agent
+    ```
+
+  </Tabs.Tab>
+</UniversalTabs>
 
 Together, these tests validate both branches of the workflow and confirm that early reply events are handled safely without coordination sleeps.
 

--- a/sdks/python/examples/support_agent/worker.py
+++ b/sdks/python/examples/support_agent/worker.py
@@ -17,6 +17,7 @@ hatchet = Hatchet()
 
 REPLY_EVENT_KEY = "support:customer-reply"
 TIMEOUT_SECONDS = 5
+LOOKBACK_MINUTES = 5
 
 
 # > Models
@@ -139,7 +140,7 @@ async def support_agent(
 
     # Step 3: Wait for a customer reply or timeout
     now = await ctx.aio_now()
-    consider_events_since = now - timedelta(minutes=5)
+    consider_events_since = now - timedelta(minutes=LOOKBACK_MINUTES)
 
     wait_result = await ctx.aio_wait_for(
         "await-customer-reply",

--- a/sdks/typescript/src/v1/examples/e2e-worker.ts
+++ b/sdks/typescript/src/v1/examples/e2e-worker.ts
@@ -58,6 +58,12 @@ import {
   scenarioTask,
   orchestratorTask,
 } from './child_index/workflow';
+import {
+  supportAgent,
+  triageTicket,
+  generateReply,
+  escalateTicket,
+} from './support_agent/workflow';
 
 const workflows = [
   bulkChild,
@@ -113,6 +119,10 @@ const workflows = [
   childIndexParent,
   scenarioTask,
   orchestratorTask,
+  supportAgent,
+  triageTicket,
+  generateReply,
+  escalateTicket,
 ];
 
 async function main() {

--- a/sdks/typescript/src/v1/examples/support_agent/run.ts
+++ b/sdks/typescript/src/v1/examples/support_agent/run.ts
@@ -1,0 +1,38 @@
+import { hatchet } from '../hatchet-client';
+import { supportAgent, REPLY_EVENT_KEY, SupportTicketInput } from './workflow';
+
+// > Trigger the workflow
+async function main() {
+  const input: SupportTicketInput = {
+    ticketId: 'ticket-42',
+    customerEmail: 'alice@example.com',
+    subject: 'Login broken',
+    body: "I can't log in since this morning.",
+  };
+
+  // Start the support agent workflow
+  const ref = await supportAgent.runNoWait(input);
+  const runId = await ref.getWorkflowRunId();
+  console.log(`Started workflow run: ${runId}`);
+
+  // Push a customer reply event (scoped to this ticket)
+  console.log('Pushing customer reply event...');
+  await hatchet.events.push(
+    REPLY_EVENT_KEY,
+    { message: 'I cleared my cookies and it works now. Thanks!' },
+    { scope: input.ticketId }
+  );
+
+  // Wait for the workflow to complete
+  const result = await ref.output;
+  console.log('Workflow completed:', result);
+}
+// !!
+
+if (require.main === module) {
+  main()
+    .catch(console.error)
+    .finally(() => {
+      process.exit(0);
+    });
+}

--- a/sdks/typescript/src/v1/examples/support_agent/support_agent.e2e.ts
+++ b/sdks/typescript/src/v1/examples/support_agent/support_agent.e2e.ts
@@ -1,0 +1,51 @@
+import { randomUUID } from 'crypto';
+import { makeE2EClient } from '../__e2e__/harness';
+import { supportAgent, REPLY_EVENT_KEY, SupportTicketInput } from './workflow';
+
+describe('support-agent-e2e', () => {
+  const hatchet = makeE2EClient();
+
+  it('resolves when customer replies before timeout', async () => {
+    const ticketId = `test-${randomUUID().slice(0, 8)}`;
+    const input: SupportTicketInput = {
+      ticketId,
+      customerEmail: 'alice@example.com',
+      subject: 'Login broken',
+      body: "I can't log in since this morning.",
+    };
+
+    const ref = await supportAgent.runNoWait(input);
+
+    // The workflow uses considerEventsSince lookback, so the reply event
+    // is captured even if pushed before the or-group wait becomes active.
+    await hatchet.events.push(
+      REPLY_EVENT_KEY,
+      { message: 'I cleared my cookies and it works now.' },
+      { scope: ticketId }
+    );
+
+    const result = await ref.output;
+
+    expect((result as any).ticketId).toBe(ticketId);
+    expect((result as any).status).toBe('resolved');
+    expect((result as any).triageCategory).toBeTruthy();
+    expect((result as any).initialReply).toBeTruthy();
+  }, 120_000);
+
+  it('escalates when no reply arrives before timeout', async () => {
+    const ticketId = `test-${randomUUID().slice(0, 8)}`;
+    const input: SupportTicketInput = {
+      ticketId,
+      customerEmail: 'bob@example.com',
+      subject: 'Billing issue',
+      body: 'I was charged twice for my subscription.',
+    };
+
+    const result = await supportAgent.run(input);
+
+    expect((result as any).ticketId).toBe(ticketId);
+    expect((result as any).status).toBe('escalated');
+    expect((result as any).triageCategory).toBeTruthy();
+    expect((result as any).initialReply).toBeTruthy();
+  }, 120_000);
+});

--- a/sdks/typescript/src/v1/examples/support_agent/workflow.ts
+++ b/sdks/typescript/src/v1/examples/support_agent/workflow.ts
@@ -15,6 +15,20 @@ export type SupportTicketInput = {
   subject: string;
   body: string;
 };
+
+export type TriageOutput = {
+  category: string;
+  priority: string;
+};
+
+export type ReplyOutput = {
+  message: string;
+};
+
+export type EscalationOutput = {
+  reason: string;
+  assignedTo: string;
+};
 // !!
 
 // > Triage task
@@ -48,13 +62,42 @@ export const triageTicket = hatchet.task({
 // !!
 
 // > Generate reply task
-// Generate an initial support reply (fallback-only in TypeScript v1).
+// Generate an initial support reply using Claude.
 export const generateReply = hatchet.task({
   name: 'generate-reply',
   fn: async (input: SupportTicketInput) => {
-    return {
-      message: `Thank you for contacting support about: ${input.subject}. We are looking into this and will get back to you shortly.`,
-    };
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+
+    if (!apiKey) {
+      return {
+        message: `Thank you for contacting support about: ${input.subject}. We are looking into this and will get back to you shortly.`,
+      };
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const anthropic = require('@anthropic-ai/sdk');
+    const Anthropic = anthropic.default || anthropic;
+    const client = new Anthropic({ apiKey });
+
+    const response = await client.messages.create({
+      model: 'claude-sonnet-4-20250514',
+      max_tokens: 300,
+      messages: [
+        {
+          role: 'user' as const,
+          content:
+            `You are a friendly support agent. Write a brief, helpful initial ` +
+            `reply to this support ticket.\n\n` +
+            `Subject: ${input.subject}\n` +
+            `Message: ${input.body}\n\n` +
+            `Keep the reply under 3 sentences.`,
+        },
+      ],
+    });
+
+    const [block] = response.content;
+    const text = block?.type === 'text' ? block.text : '';
+    return { message: text };
   },
 });
 // !!

--- a/sdks/typescript/src/v1/examples/support_agent/workflow.ts
+++ b/sdks/typescript/src/v1/examples/support_agent/workflow.ts
@@ -1,0 +1,135 @@
+import { Or, SleepCondition, UserEventCondition } from '@hatchet/v1/conditions';
+import { durationToMs } from '@hatchet/v1/client/duration';
+import { hatchet } from '../hatchet-client';
+
+export const REPLY_EVENT_KEY = 'support:customer-reply';
+const REPLY_LABEL = 'reply' as const;
+const TIMEOUT_LABEL = 'timeout' as const;
+export const TIMEOUT_SECONDS = 5;
+const LOOKBACK_WINDOW = '5m' as const;
+
+// > Models
+export type SupportTicketInput = {
+  ticketId: string;
+  customerEmail: string;
+  subject: string;
+  body: string;
+};
+// !!
+
+// > Triage task
+// Classify the ticket into a category and priority.
+export const triageTicket = hatchet.task({
+  name: 'triage-ticket',
+  fn: async (input: SupportTicketInput) => {
+    const text = `${input.subject} ${input.body}`.toLowerCase();
+
+    let category: string;
+    if (['bill', 'charge', 'payment', 'invoice'].some((w) => text.includes(w))) {
+      category = 'billing';
+    } else if (['login', 'password', 'auth', 'access'].some((w) => text.includes(w))) {
+      category = 'account';
+    } else {
+      category = 'technical';
+    }
+
+    let priority: string;
+    if (['urgent', 'critical', 'down', 'outage'].some((w) => text.includes(w))) {
+      priority = 'high';
+    } else if (['twice', 'broken', 'error'].some((w) => text.includes(w))) {
+      priority = 'medium';
+    } else {
+      priority = 'low';
+    }
+
+    return { category, priority };
+  },
+});
+// !!
+
+// > Generate reply task
+// Generate an initial support reply (fallback-only in TypeScript v1).
+export const generateReply = hatchet.task({
+  name: 'generate-reply',
+  fn: async (input: SupportTicketInput) => {
+    return {
+      message: `Thank you for contacting support about: ${input.subject}. We are looking into this and will get back to you shortly.`,
+    };
+  },
+});
+// !!
+
+// > Escalate task
+// Escalate an unresolved ticket to the human support team.
+export const escalateTicket = hatchet.task({
+  name: 'escalate-ticket',
+  fn: async (input: SupportTicketInput) => {
+    return {
+      reason: `No customer reply within ${TIMEOUT_SECONDS}s timeout`,
+      assignedTo: 'support-team@example.com',
+    };
+  },
+});
+// !!
+
+// > Support agent workflow
+export const supportAgent = hatchet.durableTask({
+  name: 'support-agent',
+  executionTimeout: '10m',
+  fn: async (input: SupportTicketInput, ctx) => {
+    // Step 1: Triage the ticket
+    const triage = await triageTicket.run(input);
+
+    // Step 2: Generate an initial reply
+    const reply = await generateReply.run(input);
+
+    // Step 3: Wait for a customer reply or timeout
+    const now = await ctx.now();
+    const considerEventsSince = new Date(
+      now.getTime() - durationToMs(LOOKBACK_WINDOW)
+    ).toISOString();
+
+    const waitResult = await ctx.waitFor(
+      Or(
+        new SleepCondition(`${TIMEOUT_SECONDS}s`, TIMEOUT_LABEL),
+        new UserEventCondition(
+          REPLY_EVENT_KEY,
+          '',
+          REPLY_LABEL,
+          undefined,
+          input.ticketId,
+          considerEventsSince
+        )
+      )
+    );
+
+    // Determine which condition fired. ctx.waitFor returns
+    // { CREATE: { <label>: ... } } where <label> is the readableDataKey
+    // we assigned above ('timeout' or 'reply').
+    const create = (waitResult as Record<string, Record<string, unknown>>)['CREATE'] ?? waitResult;
+    const resolvedLabel = Object.keys(create as Record<string, unknown>)[0] ?? '';
+    const customerReplied = resolvedLabel === REPLY_LABEL;
+
+    if (!customerReplied) {
+      // Step 4a: Timeout -> escalate
+      await escalateTicket.run(input);
+      return {
+        ticketId: input.ticketId,
+        status: 'escalated' as const,
+        triageCategory: triage.category,
+        triagePriority: triage.priority,
+        initialReply: reply.message,
+      };
+    }
+
+    // Step 4b: Customer replied -> resolve
+    return {
+      ticketId: input.ticketId,
+      status: 'resolved' as const,
+      triageCategory: triage.category,
+      triagePriority: triage.priority,
+      initialReply: reply.message,
+    };
+  },
+});
+// !!


### PR DESCRIPTION
# Description

This PR adds a TypeScript companion example for the support-agent cookbook and updates the cookbook article to present both Python and TypeScript snippets side by side.

The TypeScript example mirrors the existing Python support-agent workflow as closely as practical while following the TypeScript SDK’s existing example conventions. It includes the same overall workflow fallback behavior when `ANTHROPIC_API_KEY` is not set, and optional live Claude reply when it is set.

The cookbook article is updated to use multi-language tabs for Python and TypeScript, with the prose kept as language-agnostic as practical. The setup section also clarifies that live Claude replies require both `ANTHROPIC_API_KEY` and the Anthropic SDK for the language being used.

## Type of change
- [x] Chore (changes which are not directly related to any business logic)

## What's Changed

- [x] Add a TypeScript support-agent example for the cookbook
- [x] Add TypeScript support-agent workflow typing for input and task outputs
- [x] Add optional live Claude reply support to the TypeScript example while preserving fallback behavior
- [x] Update the support-agent cookbook article to show Python + TypeScript snippets in tabs
- [x] Add per-language setup/testing guidance to the cookbook where appropriate
- [x] Keep the TypeScript example aligned with the existing Python example while preserving TypeScript SDK conventions
- [x] Regenerate snippet outputs required by the docs pipeline