### PR TITLE
Make sure we don't poll for work in case of deleted tenants

### DIFF
--- a/pkg/repository/sqlcv1/queue.sql
+++ b/pkg/repository/sqlcv1/queue.sql
@@ -505,12 +505,19 @@ RETURNING id, tenant_id, task_id, task_inserted_at, retry_count;
 WITH locked_qis as (
     SELECT qi.task_id, qi.task_inserted_at, qi.retry_count
     FROM v1_queue_item qi
-    WHERE NOT EXISTS (
-        SELECT 1
-        FROM v1_task vt
-        WHERE qi.task_id = vt.id
-            AND qi.task_inserted_at = vt.inserted_at
-    )
+    WHERE
+        NOT EXISTS (
+            SELECT 1
+            FROM v1_task vt
+            WHERE qi.task_id = vt.id
+                AND qi.task_inserted_at = vt.inserted_at
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM "Tenant" t
+            WHERE t."id" = qi.tenant_id
+                AND t."deletedAt" IS NOT NULL
+        )
     ORDER BY qi.id ASC
     LIMIT @batchSize::int
     FOR UPDATE SKIP LOCKED
@@ -525,12 +532,19 @@ WHERE (task_id, task_inserted_at, retry_count) IN (
 WITH locked_qis as (
     SELECT qi.task_id, qi.task_inserted_at, qi.task_retry_count
     FROM v1_retry_queue_item qi
-    WHERE NOT EXISTS (
-        SELECT 1
-        FROM v1_task vt
-        WHERE qi.task_id = vt.id
-        AND qi.task_inserted_at = vt.inserted_at
-    )
+    WHERE
+        NOT EXISTS (
+            SELECT 1
+            FROM v1_task vt
+            WHERE qi.task_id = vt.id
+                AND qi.task_inserted_at = vt.inserted_at
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM "Tenant" t
+            WHERE t."id" = qi.tenant_id
+                AND t."deletedAt" IS NOT NULL
+        )
     ORDER BY qi.task_id, qi.task_inserted_at, qi.task_retry_count
     LIMIT @batchSize::int
     FOR UPDATE SKIP LOCKED
@@ -545,12 +559,19 @@ WHERE (task_id, task_inserted_at) IN (
 WITH locked_qis as (
     SELECT qi.task_id, qi.task_inserted_at, qi.retry_count
     FROM v1_rate_limited_queue_items qi
-    WHERE NOT EXISTS (
-        SELECT 1
-        FROM v1_task vt
-        WHERE qi.task_id = vt.id
-        AND qi.task_inserted_at = vt.inserted_at
-    )
+    WHERE
+        NOT EXISTS (
+            SELECT 1
+            FROM v1_task vt
+            WHERE qi.task_id = vt.id
+                AND qi.task_inserted_at = vt.inserted_at
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM "Tenant" t
+            WHERE t."id" = qi.tenant_id
+                AND t."deletedAt" IS NOT NULL
+        )
     ORDER BY qi.task_id, qi.task_inserted_at, qi.retry_count
     LIMIT @batchSize::int
     FOR UPDATE SKIP LOCKED

--- a/pkg/repository/sqlcv1/queue.sql.go
+++ b/pkg/repository/sqlcv1/queue.sql.go
@@ -57,12 +57,19 @@ const cleanupV1QueueItem = `-- name: CleanupV1QueueItem :execresult
 WITH locked_qis as (
     SELECT qi.task_id, qi.task_inserted_at, qi.retry_count
     FROM v1_queue_item qi
-    WHERE NOT EXISTS (
-        SELECT 1
-        FROM v1_task vt
-        WHERE qi.task_id = vt.id
-            AND qi.task_inserted_at = vt.inserted_at
-    )
+    WHERE
+        NOT EXISTS (
+            SELECT 1
+            FROM v1_task vt
+            WHERE qi.task_id = vt.id
+                AND qi.task_inserted_at = vt.inserted_at
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM "Tenant" t
+            WHERE t."id" = qi.tenant_id
+                AND t."deletedAt" IS NOT NULL
+        )
     ORDER BY qi.id ASC
     LIMIT $1::int
     FOR UPDATE SKIP LOCKED
@@ -82,12 +89,19 @@ const cleanupV1RateLimitedQueueItem = `-- name: CleanupV1RateLimitedQueueItem :e
 WITH locked_qis as (
     SELECT qi.task_id, qi.task_inserted_at, qi.retry_count
     FROM v1_rate_limited_queue_items qi
-    WHERE NOT EXISTS (
-        SELECT 1
-        FROM v1_task vt
-        WHERE qi.task_id = vt.id
-        AND qi.task_inserted_at = vt.inserted_at
-    )
+    WHERE
+        NOT EXISTS (
+            SELECT 1
+            FROM v1_task vt
+            WHERE qi.task_id = vt.id
+                AND qi.task_inserted_at = vt.inserted_at
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM "Tenant" t
+            WHERE t."id" = qi.tenant_id
+                AND t."deletedAt" IS NOT NULL
+        )
     ORDER BY qi.task_id, qi.task_inserted_at, qi.retry_count
     LIMIT $1::int
     FOR UPDATE SKIP LOCKED
@@ -107,12 +121,19 @@ const cleanupV1RetryQueueItem = `-- name: CleanupV1RetryQueueItem :execresult
 WITH locked_qis as (
     SELECT qi.task_id, qi.task_inserted_at, qi.task_retry_count
     FROM v1_retry_queue_item qi
-    WHERE NOT EXISTS (
-        SELECT 1
-        FROM v1_task vt
-        WHERE qi.task_id = vt.id
-        AND qi.task_inserted_at = vt.inserted_at
-    )
+    WHERE
+        NOT EXISTS (
+            SELECT 1
+            FROM v1_task vt
+            WHERE qi.task_id = vt.id
+                AND qi.task_inserted_at = vt.inserted_at
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM "Tenant" t
+            WHERE t."id" = qi.tenant_id
+                AND t."deletedAt" IS NOT NULL
+        )
     ORDER BY qi.task_id, qi.task_inserted_at, qi.task_retry_count
     LIMIT $1::int
     FOR UPDATE SKIP LOCKED

--- a/pkg/repository/sqlcv1/tasks.sql
+++ b/pkg/repository/sqlcv1/tasks.sql
@@ -1107,12 +1107,19 @@ WHERE (task_id, task_inserted_at, retry_count) IN (
 WITH locked_cs AS (
     SELECT cs.task_id, cs.task_inserted_at, cs.task_retry_count
     FROM v1_concurrency_slot cs
-    WHERE NOT EXISTS (
-        SELECT 1
-        FROM v1_task vt
-        WHERE cs.task_id = vt.id
-            AND cs.task_inserted_at = vt.inserted_at
-    )
+    WHERE
+        NOT EXISTS (
+            SELECT 1
+            FROM v1_task vt
+            WHERE cs.task_id = vt.id
+                AND cs.task_inserted_at = vt.inserted_at
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM "Tenant" t
+            WHERE t."id" = cs.tenant_id
+                AND t."deletedAt" IS NOT NULL
+        )
     ORDER BY cs.task_id, cs.task_inserted_at, cs.task_retry_count, cs.strategy_id
     LIMIT @batchSize::int
     FOR UPDATE SKIP LOCKED

--- a/pkg/repository/sqlcv1/tasks.sql.go
+++ b/pkg/repository/sqlcv1/tasks.sql.go
@@ -90,12 +90,19 @@ const cleanupV1ConcurrencySlot = `-- name: CleanupV1ConcurrencySlot :execresult
 WITH locked_cs AS (
     SELECT cs.task_id, cs.task_inserted_at, cs.task_retry_count
     FROM v1_concurrency_slot cs
-    WHERE NOT EXISTS (
-        SELECT 1
-        FROM v1_task vt
-        WHERE cs.task_id = vt.id
-            AND cs.task_inserted_at = vt.inserted_at
-    )
+    WHERE
+        NOT EXISTS (
+            SELECT 1
+            FROM v1_task vt
+            WHERE cs.task_id = vt.id
+                AND cs.task_inserted_at = vt.inserted_at
+        )
+        OR EXISTS (
+            SELECT 1
+            FROM "Tenant" t
+            WHERE t."id" = cs.tenant_id
+                AND t."deletedAt" IS NOT NULL
+        )
     ORDER BY cs.task_id, cs.task_inserted_at, cs.task_retry_count, cs.strategy_id
     LIMIT $1::int
     FOR UPDATE SKIP LOCKED

--- a/pkg/repository/sqlcv1/ticker.sql
+++ b/pkg/repository/sqlcv1/ticker.sql
@@ -235,9 +235,14 @@ WITH active_tenant_alerts AS (
         alerts.*
     FROM
         "TenantAlertingSettings" as alerts
+    JOIN
+        "Tenant" as tenant ON tenant."id" = alerts."tenantId"
     WHERE
-        "lastAlertedAt" IS NULL OR
-        "lastAlertedAt" <= NOW() - convert_duration_to_interval(alerts."maxFrequency")
+        tenant."deletedAt" IS NULL
+        AND (
+            "lastAlertedAt" IS NULL OR
+            "lastAlertedAt" <= NOW() - convert_duration_to_interval(alerts."maxFrequency")
+        )
     FOR UPDATE SKIP LOCKED
 ),
 failed_run_count_by_tenant AS (
@@ -279,8 +284,11 @@ WITH expiring_tokens AS (
         t0."id", t0."name", t0."expiresAt"
     FROM
         "APIToken" as t0
+    JOIN
+        "Tenant" as tenant ON tenant."id" = t0."tenantId"
     WHERE
-        t0."revoked" = false
+        tenant."deletedAt" IS NULL
+        AND t0."revoked" = false
         AND t0."expiresAt" <= NOW() + INTERVAL '7 days'
         AND t0."expiresAt" >= NOW()
         AND (
@@ -326,8 +334,11 @@ WITH alerting_resource_limits AS (
         "TenantAlertingSettings" AS ta
     ON
         ta."tenantId" = rl."tenantId"::uuid
+    JOIN
+        "Tenant" AS tenant ON tenant."id" = rl."tenantId"
     WHERE
-        ta."enableTenantResourceLimitAlerts" = true
+        tenant."deletedAt" IS NULL
+        AND ta."enableTenantResourceLimitAlerts" = true
         AND (
             (rl."alarmValue" IS NOT NULL AND rl."value" >= rl."alarmValue")
             OR rl."value" >= rl."limitValue"

--- a/pkg/repository/sqlcv1/ticker.sql
+++ b/pkg/repository/sqlcv1/ticker.sql
@@ -119,8 +119,11 @@ eligible_cron_with_versions AS (
         "WorkflowTriggers" as triggers ON triggers."id" = cronSchedule."parentId"
     JOIN
         "WorkflowVersion" as versions ON versions."id" = triggers."workflowVersionId"
+    JOIN
+        "Tenant" as tenant ON tenant."id" = triggers."tenantId"
     WHERE cronSchedule."enabled" = TRUE
         AND versions."deletedAt" IS NULL
+        AND tenant."deletedAt" IS NULL
         AND (
             cronSchedule."tickerId" IS NULL
             OR NOT EXISTS (
@@ -181,11 +184,14 @@ WITH latest_workflow_versions AS (
     JOIN
         "Workflow" AS workflow ON workflow."id" = versions."workflowId"
     JOIN
+        "Tenant" AS tenant ON tenant."id" = workflow."tenantId"
+    JOIN
         latest_workflow_versions AS latestVersions ON latestVersions."workflowId" = workflow."id"
     WHERE
         "triggerAt" <= NOW() + INTERVAL '5 seconds'
         AND versions."deletedAt" IS NULL
         AND workflow."deletedAt" IS NULL
+        AND tenant."deletedAt" IS NULL
         AND (
             "tickerId" IS NULL
             OR NOT EXISTS (

--- a/pkg/repository/sqlcv1/ticker.sql.go
+++ b/pkg/repository/sqlcv1/ticker.sql.go
@@ -349,8 +349,11 @@ WITH expiring_tokens AS (
         t0."id", t0."name", t0."expiresAt"
     FROM
         "APIToken" as t0
+    JOIN
+        "Tenant" as tenant ON tenant."id" = t0."tenantId"
     WHERE
-        t0."revoked" = false
+        tenant."deletedAt" IS NULL
+        AND t0."revoked" = false
         AND t0."expiresAt" <= NOW() + INTERVAL '7 days'
         AND t0."expiresAt" >= NOW()
         AND (
@@ -543,9 +546,14 @@ WITH active_tenant_alerts AS (
         alerts.id, alerts."createdAt", alerts."updatedAt", alerts."deletedAt", alerts."tenantId", alerts."maxFrequency", alerts."lastAlertedAt", alerts."tickerId", alerts."enableExpiringTokenAlerts", alerts."enableWorkflowRunFailureAlerts", alerts."enableTenantResourceLimitAlerts"
     FROM
         "TenantAlertingSettings" as alerts
+    JOIN
+        "Tenant" as tenant ON tenant."id" = alerts."tenantId"
     WHERE
-        "lastAlertedAt" IS NULL OR
-        "lastAlertedAt" <= NOW() - convert_duration_to_interval(alerts."maxFrequency")
+        tenant."deletedAt" IS NULL
+        AND (
+            "lastAlertedAt" IS NULL OR
+            "lastAlertedAt" <= NOW() - convert_duration_to_interval(alerts."maxFrequency")
+        )
     FOR UPDATE SKIP LOCKED
 ),
 failed_run_count_by_tenant AS (
@@ -651,8 +659,11 @@ WITH alerting_resource_limits AS (
         "TenantAlertingSettings" AS ta
     ON
         ta."tenantId" = rl."tenantId"::uuid
+    JOIN
+        "Tenant" AS tenant ON tenant."id" = rl."tenantId"
     WHERE
-        ta."enableTenantResourceLimitAlerts" = true
+        tenant."deletedAt" IS NULL
+        AND ta."enableTenantResourceLimitAlerts" = true
         AND (
             (rl."alarmValue" IS NOT NULL AND rl."value" >= rl."alarmValue")
             OR rl."value" >= rl."limitValue"

--- a/pkg/repository/sqlcv1/ticker.sql.go
+++ b/pkg/repository/sqlcv1/ticker.sql.go
@@ -249,8 +249,11 @@ eligible_cron_with_versions AS (
         "WorkflowTriggers" as triggers ON triggers."id" = cronSchedule."parentId"
     JOIN
         "WorkflowVersion" as versions ON versions."id" = triggers."workflowVersionId"
+    JOIN
+        "Tenant" as tenant ON tenant."id" = triggers."tenantId"
     WHERE cronSchedule."enabled" = TRUE
         AND versions."deletedAt" IS NULL
+        AND tenant."deletedAt" IS NULL
         AND (
             cronSchedule."tickerId" IS NULL
             OR NOT EXISTS (
@@ -429,11 +432,14 @@ WITH latest_workflow_versions AS (
     JOIN
         "Workflow" AS workflow ON workflow."id" = versions."workflowId"
     JOIN
+        "Tenant" AS tenant ON tenant."id" = workflow."tenantId"
+    JOIN
         latest_workflow_versions AS latestVersions ON latestVersions."workflowId" = workflow."id"
     WHERE
         "triggerAt" <= NOW() + INTERVAL '5 seconds'
         AND versions."deletedAt" IS NULL
         AND workflow."deletedAt" IS NULL
+        AND tenant."deletedAt" IS NULL
         AND (
             "tickerId" IS NULL
             OR NOT EXISTS (


### PR DESCRIPTION
# Description

This PR adds checks to filter out (soft) deleted tenants from queuing any work and also updates the cleanup methods to get rid of any such DB entries that might have been added in the past.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
