### PR TITLE
Fix: Significantly speed up event queries

### DIFF
--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -1775,7 +1775,7 @@ WHERE
         EXISTS (
             SELECT 1
             FROM v1_event_lookup_table_olap elt
-            WHERE elt.tenant_id = @tenantId::UUID AND elt.external_id = ANY(NULL::UUID[])
+            WHERE elt.tenant_id = @tenantId::UUID AND elt.external_id = ANY(sqlc.narg('eventIds')::UUID[])
         )
     )
     AND (
@@ -1837,7 +1837,7 @@ WITH included_events AS (
             EXISTS (
                 SELECT 1
                 FROM v1_event_lookup_table_olap elt
-                WHERE elt.tenant_id = @tenantId::UUID AND elt.external_id = ANY(NULL::UUID[])
+                WHERE elt.tenant_id = @tenantId::UUID AND elt.external_id = ANY(sqlc.narg('eventIds')::UUID[])
             )
         )
         AND (

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -1746,8 +1746,7 @@ WHERE
 
 -- name: ListEvents :many
 SELECT e.*
-FROM v1_event_lookup_table_olap elt
-JOIN v1_events_olap e ON (elt.tenant_id, elt.event_id, elt.event_seen_at) = (e.tenant_id, e.id, e.seen_at)
+FROM v1_events_olap e
 WHERE
     e.tenant_id = @tenantId
     AND (
@@ -1768,11 +1767,16 @@ WHERE
             WHERE
                 (etr.event_id, etr.event_seen_at) = (e.id, e.seen_at)
                 AND r.workflow_id = ANY(sqlc.narg('workflowIds')::UUID[]::UUID[])
+                AND r.inserted_at >= @since::TIMESTAMPTZ
         )
     )
     AND (
         sqlc.narg('eventIds')::UUID[] IS NULL OR
-        elt.external_id = ANY(sqlc.narg('eventIds')::UUID[])
+        EXISTS (
+            SELECT 1
+            FROM v1_event_lookup_table_olap elt
+            WHERE elt.tenant_id = @tenantId::UUID AND elt.external_id = ANY(NULL::UUID[])
+        )
     )
     AND (
         sqlc.narg('additionalMetadata')::JSONB IS NULL OR
@@ -1787,6 +1791,7 @@ WHERE
             WHERE
                 (etr.event_id, etr.event_seen_at) = (e.id, e.seen_at)
                 AND r.readable_status = ANY(CAST(sqlc.narg('statuses')::text[]::TEXT[] AS v1_readable_status_olap[]))
+                AND r.inserted_at >= @since::TIMESTAMPTZ
         )
     )
     AND (
@@ -1803,8 +1808,7 @@ LIMIT
 -- name: CountEvents :one
 WITH included_events AS (
     SELECT e.*
-    FROM v1_event_lookup_table_olap elt
-    JOIN v1_events_olap e ON (elt.tenant_id, elt.event_id, elt.event_seen_at) = (e.tenant_id, e.id, e.seen_at)
+    FROM v1_events_olap e
     WHERE
         e.tenant_id = @tenantId
         AND (
@@ -1825,11 +1829,16 @@ WITH included_events AS (
                 WHERE
                     (etr.event_id, etr.event_seen_at) = (e.id, e.seen_at)
                     AND r.workflow_id = ANY(sqlc.narg('workflowIds')::UUID[]::UUID[])
+                    AND r.inserted_at >= @since::TIMESTAMPTZ
             )
         )
         AND (
             sqlc.narg('eventIds')::UUID[] IS NULL OR
-            elt.external_id = ANY(sqlc.narg('eventIds')::UUID[])
+            EXISTS (
+                SELECT 1
+                FROM v1_event_lookup_table_olap elt
+                WHERE elt.tenant_id = @tenantId::UUID AND elt.external_id = ANY(NULL::UUID[])
+            )
         )
         AND (
             sqlc.narg('additionalMetadata')::JSONB IS NULL OR
@@ -1844,6 +1853,7 @@ WITH included_events AS (
                 WHERE
                     (etr.event_id, etr.event_seen_at) = (e.id, e.seen_at)
                     AND r.readable_status = ANY(CAST(sqlc.narg('statuses')::text[]::TEXT[] AS v1_readable_status_olap[]))
+                    AND r.inserted_at >= @since::TIMESTAMPTZ
             )
         )
         AND (

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -278,7 +278,7 @@ WITH included_events AS (
             EXISTS (
                 SELECT 1
                 FROM v1_event_lookup_table_olap elt
-                WHERE elt.tenant_id = $1::UUID AND elt.external_id = ANY(NULL::UUID[])
+                WHERE elt.tenant_id = $1::UUID AND elt.external_id = ANY($6::UUID[])
             )
         )
         AND (
@@ -1400,7 +1400,7 @@ WHERE
         EXISTS (
             SELECT 1
             FROM v1_event_lookup_table_olap elt
-            WHERE elt.tenant_id = $1::UUID AND elt.external_id = ANY(NULL::UUID[])
+            WHERE elt.tenant_id = $1::UUID AND elt.external_id = ANY($6::UUID[])
         )
     )
     AND (

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -249,8 +249,7 @@ func (q *Queries) ComputeOLAPPayloadBatchSize(ctx context.Context, db DBTX, arg 
 const countEvents = `-- name: CountEvents :one
 WITH included_events AS (
     SELECT e.tenant_id, e.id, e.external_id, e.seen_at, e.key, e.payload, e.additional_metadata, e.scope, e.triggering_webhook_name
-    FROM v1_event_lookup_table_olap elt
-    JOIN v1_events_olap e ON (elt.tenant_id, elt.event_id, elt.event_seen_at) = (e.tenant_id, e.id, e.seen_at)
+    FROM v1_events_olap e
     WHERE
         e.tenant_id = $1
         AND (
@@ -271,11 +270,16 @@ WITH included_events AS (
                 WHERE
                     (etr.event_id, etr.event_seen_at) = (e.id, e.seen_at)
                     AND r.workflow_id = ANY($5::UUID[]::UUID[])
+                    AND r.inserted_at >= $3::TIMESTAMPTZ
             )
         )
         AND (
             $6::UUID[] IS NULL OR
-            elt.external_id = ANY($6::UUID[])
+            EXISTS (
+                SELECT 1
+                FROM v1_event_lookup_table_olap elt
+                WHERE elt.tenant_id = $1::UUID AND elt.external_id = ANY(NULL::UUID[])
+            )
         )
         AND (
             $7::JSONB IS NULL OR
@@ -290,6 +294,7 @@ WITH included_events AS (
                 WHERE
                     (etr.event_id, etr.event_seen_at) = (e.id, e.seen_at)
                     AND r.readable_status = ANY(CAST($8::text[]::TEXT[] AS v1_readable_status_olap[]))
+                    AND r.inserted_at >= $3::TIMESTAMPTZ
             )
         )
         AND (
@@ -1366,8 +1371,7 @@ func (q *Queries) ListEventKeys(ctx context.Context, db DBTX, tenantid uuid.UUID
 
 const listEvents = `-- name: ListEvents :many
 SELECT e.tenant_id, e.id, e.external_id, e.seen_at, e.key, e.payload, e.additional_metadata, e.scope, e.triggering_webhook_name
-FROM v1_event_lookup_table_olap elt
-JOIN v1_events_olap e ON (elt.tenant_id, elt.event_id, elt.event_seen_at) = (e.tenant_id, e.id, e.seen_at)
+FROM v1_events_olap e
 WHERE
     e.tenant_id = $1
     AND (
@@ -1388,11 +1392,16 @@ WHERE
             WHERE
                 (etr.event_id, etr.event_seen_at) = (e.id, e.seen_at)
                 AND r.workflow_id = ANY($5::UUID[]::UUID[])
+                AND r.inserted_at >= $3::TIMESTAMPTZ
         )
     )
     AND (
         $6::UUID[] IS NULL OR
-        elt.external_id = ANY($6::UUID[])
+        EXISTS (
+            SELECT 1
+            FROM v1_event_lookup_table_olap elt
+            WHERE elt.tenant_id = $1::UUID AND elt.external_id = ANY(NULL::UUID[])
+        )
     )
     AND (
         $7::JSONB IS NULL OR
@@ -1407,6 +1416,7 @@ WHERE
             WHERE
                 (etr.event_id, etr.event_seen_at) = (e.id, e.seen_at)
                 AND r.readable_status = ANY(CAST($8::text[]::TEXT[] AS v1_readable_status_olap[]))
+                AND r.inserted_at >= $3::TIMESTAMPTZ
         )
     )
     AND (


### PR DESCRIPTION
# Description

Significantly speeds up event queries with a couple of fixes to:

1. Avoid an expensive join
2. Do some partition pruning on the runs tables

Should help a ton on instances with a lot of event volume, where sometimes that page just never loads

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
