### PR TITLE
Fix: fetching state causing redirect loop on signup

### DIFF
--- a/frontend/app/src/components/v1/molecules/nav-bar/organization-selector.tsx
+++ b/frontend/app/src/components/v1/molecules/nav-bar/organization-selector.tsx
@@ -58,7 +58,7 @@ function OrganizationGroup({
     e.stopPropagation();
     onClose();
     onNavigate({
-      to: appRoutes.organizationsRoute.to,
+      to: appRoutes.tenantSettingsOrganizationRoute.to,
       params: {
         organization: organization.metadata.id,
       },

--- a/frontend/app/src/pages/authenticated.tsx
+++ b/frontend/app/src/pages/authenticated.tsx
@@ -139,6 +139,7 @@ function AuthenticatedInner() {
   const {
     isCloudEnabled,
     isLoaded: isUserUniverseLoaded,
+    isFetching: isUserUniverseFetching,
     organizations,
     tenantMemberships,
   } = useUserUniverse();
@@ -195,7 +196,8 @@ function AuthenticatedInner() {
     const okayToMakeOnboardingRedirectDecisions =
       pendingInvitesQuery.isSuccess &&
       !isOnboardingPage &&
-      isUserUniverseLoaded;
+      isUserUniverseLoaded &&
+      !isUserUniverseFetching;
 
     const shouldHaveAnOrganizationButDoesnt =
       isCloudEnabled && isUserUniverseLoaded && organizations.length === 0;
@@ -310,6 +312,7 @@ function AuthenticatedInner() {
     setLastTenant,
     isCloudEnabled,
     isUserUniverseLoaded,
+    isUserUniverseFetching,
     organizations,
     isOnboardingCreateOrganizationPage,
     isOnboardingCreateTenantPage,

--- a/frontend/app/src/providers/user-universe.tsx
+++ b/frontend/app/src/providers/user-universe.tsx
@@ -21,6 +21,7 @@ import invariant from 'tiny-invariant';
 type UserUniverse = {
   isCloudEnabled: boolean;
   isLoaded: boolean;
+  isFetching: boolean;
   organizations: OrganizationForUserList['rows'] | null;
   tenantMemberships: TenantMember[] | null;
   invalidate: () => Promise<void>;
@@ -182,6 +183,7 @@ export function UserUniverseProvider({
   const value = useMemo<UserUniverse>(() => {
     const tenantMembershipAndOrganizationsAreLoaded =
       tenantMembershipAndOrganizationsQuery.isSuccess;
+    const isFetching = tenantMembershipAndOrganizationsQuery.isFetching;
     if (isCloudEnabled) {
       const getWithOrganizations = get as () => Promise<{
         organizations: OrganizationForUserList['rows'];
@@ -194,6 +196,7 @@ export function UserUniverseProvider({
         return {
           isCloudEnabled,
           isLoaded: tenantMembershipAndOrganizationsAreLoaded,
+          isFetching,
           organizations:
             tenantMembershipAndOrganizationsQuery.data.organizations,
           tenantMemberships:
@@ -207,6 +210,7 @@ export function UserUniverseProvider({
       return {
         isCloudEnabled,
         isLoaded: tenantMembershipAndOrganizationsAreLoaded,
+        isFetching,
         organizations: null,
         tenantMemberships: null,
         get: getWithOrganizations,
@@ -222,6 +226,7 @@ export function UserUniverseProvider({
         ? {
             isCloudEnabled,
             isLoaded: tenantMembershipAndOrganizationsAreLoaded,
+            isFetching,
             organizations: null,
             tenantMemberships:
               tenantMembershipAndOrganizationsQuery.data.tenantMemberships,
@@ -232,6 +237,7 @@ export function UserUniverseProvider({
         : {
             isCloudEnabled,
             isLoaded: tenantMembershipAndOrganizationsAreLoaded,
+            isFetching,
             organizations: null,
             tenantMemberships: null,
             get: getWithoutOrganizations,


### PR DESCRIPTION
# Description

Fixes a redirect loop on signup / accepting an org invite that wouldn't let you past the accept invite / create tenant / etc. screen

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
