### PR TITLE
Fix: Add row count check before swapping

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260424190713_v1_0_99.go
+++ b/cmd/hatchet-migrate/migrate/migrations/20260424190713_v1_0_99.go
@@ -536,8 +536,8 @@ func up20260424190713(ctx context.Context, db *sql.DB) error {
 			return fmt.Errorf("backfill %s_new: %w", v1RunsOlapTable, err)
 		}
 
-		newCount := db.QueryRow("SELECT count(*) FROM v1_runs_olap_new")
-		existingCount := db.QueryRow("SELECT count(*) FROM v1_runs_olap")
+		newCount := db.QueryRowContext(ctx, "SELECT count(*) FROM v1_runs_olap_new")
+		existingCount := db.QueryRowContext(ctx, "SELECT count(*) FROM v1_runs_olap")
 		var newCountVal, existingCountVal int64
 
 		if err := newCount.Scan(&newCountVal); err != nil {
@@ -576,8 +576,8 @@ func up20260424190713(ctx context.Context, db *sql.DB) error {
 			return fmt.Errorf("backfill %s_new: %w", v1TasksOlapTable, err)
 		}
 
-		newCount := db.QueryRow("SELECT count(*) FROM v1_tasks_olap_new")
-		existingCount := db.QueryRow("SELECT count(*) FROM v1_tasks_olap")
+		newCount := db.QueryRowContext(ctx, "SELECT count(*) FROM v1_tasks_olap_new")
+		existingCount := db.QueryRowContext(ctx, "SELECT count(*) FROM v1_tasks_olap")
 		var newCountVal, existingCountVal int64
 
 		if err := newCount.Scan(&newCountVal); err != nil {
@@ -612,8 +612,8 @@ func up20260424190713(ctx context.Context, db *sql.DB) error {
 			return fmt.Errorf("backfill %s_new: %w", v1DagsOlapTable, err)
 		}
 
-		newCount := db.QueryRow("SELECT count(*) FROM v1_dags_olap_new")
-		existingCount := db.QueryRow("SELECT count(*) FROM v1_dags_olap")
+		newCount := db.QueryRowContext(ctx, "SELECT count(*) FROM v1_dags_olap_new")
+		existingCount := db.QueryRowContext(ctx, "SELECT count(*) FROM v1_dags_olap")
 		var newCountVal, existingCountVal int64
 
 		if err := newCount.Scan(&newCountVal); err != nil {

--- a/cmd/hatchet-migrate/migrate/migrations/20260424190713_v1_0_99.go
+++ b/cmd/hatchet-migrate/migrate/migrations/20260424190713_v1_0_99.go
@@ -536,19 +536,32 @@ func up20260424190713(ctx context.Context, db *sql.DB) error {
 			return fmt.Errorf("backfill %s_new: %w", v1RunsOlapTable, err)
 		}
 
-		newCount := db.QueryRowContext(ctx, "SELECT count(*) FROM v1_runs_olap_new")
-		existingCount := db.QueryRowContext(ctx, "SELECT count(*) FROM v1_runs_olap")
+		newCount := db.QueryRowContext(
+			ctx,
+			`
+			WITH counts AS (
+				SELECT
+					(SELECT COUNT(*) FROM v1_runs_olap_new) AS new_count,
+					(SELECT COUNT(*) FROM v1_runs_olap) AS existing_count
+			)
+
+			SELECT
+				new_count = existing_count AS counts_match,
+				new_count,
+				existing_count
+			FROM counts
+			`,
+		)
+
+		var countsMatch bool
 		var newCountVal, existingCountVal int64
 
-		if err := newCount.Scan(&newCountVal); err != nil {
-			return fmt.Errorf("counting rows in v1_runs_olap_new: %w", err)
-		}
-		if err := existingCount.Scan(&existingCountVal); err != nil {
-			return fmt.Errorf("counting rows in v1_runs_olap: %w", err)
+		if err := newCount.Scan(&countsMatch, &newCountVal, &existingCountVal); err != nil {
+			return fmt.Errorf("counting rows in v1_runs_olap_new and v1_runs_olap: %w", err)
 		}
 
-		if newCountVal != existingCountVal {
-			return fmt.Errorf("row count mismatch after backfill for %s: new=%d, existing=%d", v1RunsOlapTable, newCountVal, existingCountVal)
+		if !countsMatch {
+			return fmt.Errorf("row count mismatch after backfill for v1_runs_olap: new=%d, existing=%d", newCountVal, existingCountVal)
 		}
 
 		return nil
@@ -576,18 +589,31 @@ func up20260424190713(ctx context.Context, db *sql.DB) error {
 			return fmt.Errorf("backfill %s_new: %w", v1TasksOlapTable, err)
 		}
 
-		newCount := db.QueryRowContext(ctx, "SELECT count(*) FROM v1_tasks_olap_new")
-		existingCount := db.QueryRowContext(ctx, "SELECT count(*) FROM v1_tasks_olap")
+		newCount := db.QueryRowContext(
+			ctx,
+			`
+			WITH counts AS (
+				SELECT
+					(SELECT COUNT(*) FROM v1_tasks_olap_new) AS new_count,
+					(SELECT COUNT(*) FROM v1_tasks_olap) AS existing_count
+			)
+
+			SELECT
+				new_count = existing_count AS counts_match,
+				new_count,
+				existing_count
+			FROM counts
+			`,
+		)
+
+		var countsMatch bool
 		var newCountVal, existingCountVal int64
 
-		if err := newCount.Scan(&newCountVal); err != nil {
-			return fmt.Errorf("counting rows in v1_tasks_olap_new: %w", err)
-		}
-		if err := existingCount.Scan(&existingCountVal); err != nil {
-			return fmt.Errorf("counting rows in v1_tasks_olap: %w", err)
+		if err := newCount.Scan(&countsMatch, &newCountVal, &existingCountVal); err != nil {
+			return fmt.Errorf("counting rows in %s_new and %s: %w", v1TasksOlapTable, v1TasksOlapTable, err)
 		}
 
-		if newCountVal != existingCountVal {
+		if !countsMatch {
 			return fmt.Errorf("row count mismatch after backfill for %s: new=%d, existing=%d", v1TasksOlapTable, newCountVal, existingCountVal)
 		}
 
@@ -612,18 +638,31 @@ func up20260424190713(ctx context.Context, db *sql.DB) error {
 			return fmt.Errorf("backfill %s_new: %w", v1DagsOlapTable, err)
 		}
 
-		newCount := db.QueryRowContext(ctx, "SELECT count(*) FROM v1_dags_olap_new")
-		existingCount := db.QueryRowContext(ctx, "SELECT count(*) FROM v1_dags_olap")
+		newCount := db.QueryRowContext(
+			ctx,
+			`
+			WITH counts AS (
+				SELECT
+					(SELECT COUNT(*) FROM v1_dags_olap_new) AS new_count,
+					(SELECT COUNT(*) FROM v1_dags_olap) AS existing_count
+			)
+
+			SELECT
+				new_count = existing_count AS counts_match,
+				new_count,
+				existing_count
+			FROM counts
+			`,
+		)
+
+		var countsMatch bool
 		var newCountVal, existingCountVal int64
 
-		if err := newCount.Scan(&newCountVal); err != nil {
-			return fmt.Errorf("counting rows in v1_dags_olap_new: %w", err)
-		}
-		if err := existingCount.Scan(&existingCountVal); err != nil {
-			return fmt.Errorf("counting rows in v1_dags_olap: %w", err)
+		if err := newCount.Scan(&countsMatch, &newCountVal, &existingCountVal); err != nil {
+			return fmt.Errorf("counting rows in %s_new and %s: %w", v1DagsOlapTable, v1DagsOlapTable, err)
 		}
 
-		if newCountVal != existingCountVal {
+		if !countsMatch {
 			return fmt.Errorf("row count mismatch after backfill for %s: new=%d, existing=%d", v1DagsOlapTable, newCountVal, existingCountVal)
 		}
 

--- a/cmd/hatchet-migrate/migrate/migrations/20260424190713_v1_0_99.go
+++ b/cmd/hatchet-migrate/migrate/migrations/20260424190713_v1_0_99.go
@@ -536,6 +536,21 @@ func up20260424190713(ctx context.Context, db *sql.DB) error {
 			return fmt.Errorf("backfill %s_new: %w", v1RunsOlapTable, err)
 		}
 
+		newCount := db.QueryRow("SELECT count(*) FROM v1_runs_olap_new")
+		existingCount := db.QueryRow("SELECT count(*) FROM v1_runs_olap")
+		var newCountVal, existingCountVal int64
+
+		if err := newCount.Scan(&newCountVal); err != nil {
+			return fmt.Errorf("counting rows in v1_runs_olap_new: %w", err)
+		}
+		if err := existingCount.Scan(&existingCountVal); err != nil {
+			return fmt.Errorf("counting rows in v1_runs_olap: %w", err)
+		}
+
+		if newCountVal != existingCountVal {
+			return fmt.Errorf("row count mismatch after backfill for %s: new=%d, existing=%d", v1RunsOlapTable, newCountVal, existingCountVal)
+		}
+
 		return nil
 	})
 
@@ -561,6 +576,21 @@ func up20260424190713(ctx context.Context, db *sql.DB) error {
 			return fmt.Errorf("backfill %s_new: %w", v1TasksOlapTable, err)
 		}
 
+		newCount := db.QueryRow("SELECT count(*) FROM v1_tasks_olap_new")
+		existingCount := db.QueryRow("SELECT count(*) FROM v1_tasks_olap")
+		var newCountVal, existingCountVal int64
+
+		if err := newCount.Scan(&newCountVal); err != nil {
+			return fmt.Errorf("counting rows in v1_tasks_olap_new: %w", err)
+		}
+		if err := existingCount.Scan(&existingCountVal); err != nil {
+			return fmt.Errorf("counting rows in v1_tasks_olap: %w", err)
+		}
+
+		if newCountVal != existingCountVal {
+			return fmt.Errorf("row count mismatch after backfill for %s: new=%d, existing=%d", v1TasksOlapTable, newCountVal, existingCountVal)
+		}
+
 		return nil
 	})
 
@@ -580,6 +610,21 @@ func up20260424190713(ctx context.Context, db *sql.DB) error {
 		}
 		if _, err := db.ExecContext(ctx, v1DagsOlapBackfill); err != nil {
 			return fmt.Errorf("backfill %s_new: %w", v1DagsOlapTable, err)
+		}
+
+		newCount := db.QueryRow("SELECT count(*) FROM v1_dags_olap_new")
+		existingCount := db.QueryRow("SELECT count(*) FROM v1_dags_olap")
+		var newCountVal, existingCountVal int64
+
+		if err := newCount.Scan(&newCountVal); err != nil {
+			return fmt.Errorf("counting rows in v1_dags_olap_new: %w", err)
+		}
+		if err := existingCount.Scan(&existingCountVal); err != nil {
+			return fmt.Errorf("counting rows in v1_dags_olap: %w", err)
+		}
+
+		if newCountVal != existingCountVal {
+			return fmt.Errorf("row count mismatch after backfill for %s: new=%d, existing=%d", v1DagsOlapTable, newCountVal, existingCountVal)
 		}
 
 		return nil


### PR DESCRIPTION
# Description

Adds a row count check to make sure we have the same number of rows in the original table as the new one after backfilling
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

