### PR TITLE
fix(typescript-sdk): add workflow span fallback for dashboard-triggered runs

### DIFF
--- a/sdks/typescript/src/opentelemetry/instrumentor.test.ts
+++ b/sdks/typescript/src/opentelemetry/instrumentor.test.ts
@@ -1,0 +1,71 @@
+import { propagation } from '@opentelemetry/api';
+import { W3CTraceContextPropagator } from '@opentelemetry/core';
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { HatchetInstrumentor } from './instrumentor';
+
+describe('HatchetInstrumentor worker spans', () => {
+  it('creates a workflow-level parent span for dashboard-triggered step runs', async () => {
+    const exporter = new InMemorySpanExporter();
+    const provider = new BasicTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+
+    propagation.setGlobalPropagator(new W3CTraceContextPropagator());
+
+    const dashboardTracer = provider.getTracer('dashboard-test');
+    const dashboardSpan = dashboardTracer.startSpan('dashboard-trigger');
+    const dashboardSpanContext = dashboardSpan.spanContext();
+    const carrier: Record<string, string> = {
+      traceparent: `00-${dashboardSpanContext.traceId}-${dashboardSpanContext.spanId}-01`,
+    };
+    dashboardSpan.end();
+
+    class FakeWorker {
+      workerId = 'worker-1';
+
+      async handleStartStepRun(_action: unknown) {
+        return undefined;
+      }
+
+      async handleCancelStepRun() {
+        return undefined;
+      }
+    }
+
+    const instrumentor = new HatchetInstrumentor();
+    instrumentor.setTracerProvider(provider);
+    (instrumentor as any)._patchHandleStartStepRun(FakeWorker.prototype);
+
+    const worker = new FakeWorker();
+    await worker.handleStartStepRun({
+      tenantId: 'tenant-1',
+      workflowRunId: 'workflow-run-1',
+      taskId: 'task-1',
+      taskRunExternalId: 'step-run-1',
+      retryCount: 0,
+      parentWorkflowRunId: '',
+      childWorkflowIndex: 0,
+      childWorkflowKey: '',
+      actionPayload: '{"input":true}',
+      jobName: 'find-subprocessors',
+      actionId: 'find-subprocessors:resolve-parent-company',
+      taskName: 'resolve-parent-company',
+      workflowId: 'workflow-1',
+      workflowVersionId: 'workflow-version-1',
+      additionalMetadata: JSON.stringify(carrier),
+    } as any);
+
+    const spans = exporter.getFinishedSpans();
+    const workflowSpan = spans.find((span) => span.name === 'hatchet.workflow_run');
+    const stepSpan = spans.find((span) => span.name === 'hatchet.start_step_run');
+
+    expect(workflowSpan).toBeDefined();
+    expect(stepSpan).toBeDefined();
+    expect(stepSpan?.parentSpanContext?.spanId).toBe(workflowSpan?.spanContext().spanId);
+    expect(workflowSpan?.parentSpanContext?.spanId).toBe(dashboardSpanContext.spanId);
+  });
+});

--- a/sdks/typescript/src/opentelemetry/instrumentor.ts
+++ b/sdks/typescript/src/opentelemetry/instrumentor.ts
@@ -46,7 +46,7 @@ const otelInstrumentation =
   require('@opentelemetry/instrumentation') as typeof import('@opentelemetry/instrumentation');
 /* eslint-enable @typescript-eslint/no-require-imports */
 
-const { context, propagation, SpanKind, SpanStatusCode, diag } = otelApi;
+const { context, propagation, SpanKind, SpanStatusCode, diag, trace, isSpanContextValid } = otelApi;
 
 const {
   InstrumentationBase,
@@ -80,6 +80,7 @@ type HatchetInstrumentationConfig = OpenTelemetryConfig &
   };
 type Carrier = Record<string, string>;
 
+const TRIGGER_SPAN_EXPORTED_KEY = 'hatchet__trigger_span_exported';
 const INSTRUMENTOR_NAME = '@hatchet-dev/typescript-sdk';
 // FIXME: refactor version check to use the new pattern introduced in #2954
 const SUPPORTED_VERSIONS = ['>=1.16.0'];
@@ -103,6 +104,22 @@ function injectSourceInfo(carrier: Carrier): void {
     carrier['hatchet__source_workflow_run_id'] = wfRunId;
     carrier['hatchet__source_step_run_id'] = stepRunId;
   }
+}
+
+function markTriggerSpanAsExported(carrier: Carrier): void {
+  carrier[TRIGGER_SPAN_EXPORTED_KEY] = 'true';
+}
+
+function shouldCreateWorkflowRunSpan(
+  carrier: Carrier | undefined,
+  parentContext: OtelContext
+): boolean {
+  if (!carrier || carrier[TRIGGER_SPAN_EXPORTED_KEY] === 'true') {
+    return false;
+  }
+
+  const parentSpanContext = trace.getSpanContext(parentContext);
+  return parentSpanContext ? isSpanContextValid(parentSpanContext) : false;
 }
 
 function getActionOtelAttributes(
@@ -351,6 +368,7 @@ export class HatchetInstrumentor extends InstrumentationBase<HatchetInstrumentat
           (span: Span) => {
             const enhancedMetadata: Carrier = { ...(options.additionalMetadata ?? {}) };
             injectContext(enhancedMetadata);
+            markTriggerSpanAsExported(enhancedMetadata);
             injectSourceInfo(enhancedMetadata);
 
             const enhancedOptions: PushEventOptions = {
@@ -406,6 +424,7 @@ export class HatchetInstrumentor extends InstrumentationBase<HatchetInstrumentat
                 ...((input.additionalMetadata as Carrier) ?? {}),
               };
               injectContext(enhancedMetadata);
+              markTriggerSpanAsExported(enhancedMetadata);
               injectSourceInfo(enhancedMetadata);
               return {
                 ...input,
@@ -500,6 +519,7 @@ export class HatchetInstrumentor extends InstrumentationBase<HatchetInstrumentat
           (span: Span) => {
             const enhancedMetadata: Carrier = { ...(options?.additionalMetadata ?? {}) };
             injectContext(enhancedMetadata);
+            markTriggerSpanAsExported(enhancedMetadata);
 
             const enhancedOptions = {
               ...options,
@@ -564,6 +584,7 @@ export class HatchetInstrumentor extends InstrumentationBase<HatchetInstrumentat
             const enhancedWorkflowRuns = workflowRuns.map((run) => {
               const enhancedMetadata: Carrier = { ...(run.options?.additionalMetadata ?? {}) };
               injectContext(enhancedMetadata);
+              markTriggerSpanAsExported(enhancedMetadata);
               return {
                 ...run,
                 options: {
@@ -658,27 +679,61 @@ export class HatchetInstrumentor extends InstrumentationBase<HatchetInstrumentat
           }
           setHatchetSpanAttributes(hatchetAttrs);
 
+          const runStepSpan = (stepParentContext: OtelContext) =>
+            tracer.startActiveSpan(
+              spanName,
+              {
+                kind: SpanKind.CONSUMER,
+                attributes,
+              },
+              stepParentContext,
+              (span: Span) => {
+                return original
+                  .call(this, action)
+                  .then((taskError: Error | undefined) => {
+                    if (taskError instanceof Error) {
+                      span.recordException(taskError);
+                      span.setStatus({ code: SpanStatusCode.ERROR, message: taskError.message });
+                    } else {
+                      span.setStatus({ code: SpanStatusCode.OK });
+                    }
+                    return taskError;
+                  })
+                  .finally(() => {
+                    span.end();
+                  });
+              }
+            );
+
+          if (!shouldCreateWorkflowRunSpan(additionalMetadata, parentContext)) {
+            return runStepSpan(parentContext);
+          }
+
           return tracer.startActiveSpan(
-            spanName,
+            'hatchet.workflow_run',
             {
               kind: SpanKind.CONSUMER,
               attributes,
             },
             parentContext,
-            (span: Span) => {
-              return original
-                .call(this, action)
+            (workflowSpan: Span) => {
+              const workflowContext = trace.setSpan(context.active(), workflowSpan);
+
+              return runStepSpan(workflowContext)
                 .then((taskError: Error | undefined) => {
                   if (taskError instanceof Error) {
-                    span.recordException(taskError);
-                    span.setStatus({ code: SpanStatusCode.ERROR, message: taskError.message });
+                    workflowSpan.recordException(taskError);
+                    workflowSpan.setStatus({
+                      code: SpanStatusCode.ERROR,
+                      message: taskError.message,
+                    });
                   } else {
-                    span.setStatus({ code: SpanStatusCode.OK });
+                    workflowSpan.setStatus({ code: SpanStatusCode.OK });
                   }
                   return taskError;
                 })
                 .finally(() => {
-                  span.end();
+                  workflowSpan.end();
                 });
             }
           );
@@ -791,6 +846,7 @@ export class HatchetInstrumentor extends InstrumentationBase<HatchetInstrumentat
             // Inject traceparent into additionalMetadata for context propagation
             const enhancedMetadata: Carrier = { ...(input.additionalMetadata ?? {}) };
             injectContext(enhancedMetadata);
+            markTriggerSpanAsExported(enhancedMetadata);
 
             const enhancedInput = {
               ...input,


### PR DESCRIPTION
Dashboard-triggered runs arrive at the worker with a propagated `traceparent`, but no exported producer span from the TS SDK side. That left step spans attached to a missing parent and the workflow envelope never showed up in traces.

This adds a worker-side `hatchet.workflow_run` fallback span when a valid upstream trace context exists but the metadata was not marked as coming from an SDK-exported trigger span. SDK-triggered runs still use their existing producer spans because instrumented trigger paths now mark the injected metadata before the worker sees it.

Verification:
- `pnpm test:unit -- --runInBand src/opentelemetry/instrumentor.test.ts`
- `pnpm lint:check && npx tsc`
- `pnpm test:unit` is still noisy in this environment because unrelated admin-client tests hit local gRPC connection failures (`ECONNREFUSED 127.0.0.1:50051`).

Fixes #3706