### PR TITLE
Ignore invalid step IDs when inserting or replaying tasks

### DIFF
--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -1786,7 +1786,16 @@ func (r *sharedRepository) createTasks(
 		stepIdsToConfig[step.ID] = step
 	}
 
-	return r.insertTasks(ctx, tx, tenantId, tasks, stepIdsToConfig)
+	filteredTasks := make([]CreateTaskOpts, 0, len(tasks))
+	for _, task := range tasks {
+		if _, ok := stepIdsToConfig[task.StepId]; !ok {
+			r.l.Warn().Ctx(ctx).Str("step_id", task.StepId.String()).Str("external_id", task.ExternalId.String()).Msg("skipping task: step not found (may have been deleted)")
+			continue
+		}
+		filteredTasks = append(filteredTasks, task)
+	}
+
+	return r.insertTasks(ctx, tx, tenantId, filteredTasks, stepIdsToConfig)
 }
 
 // insertTasks inserts new tasks into the database. note that we're using Postgres rules to automatically insert the created
@@ -2368,6 +2377,16 @@ func (r *sharedRepository) replayTasks(
 	for _, step := range steps {
 		stepIdsToConfig[step.ID] = step
 	}
+
+	filteredTasks := make([]ReplayTaskOpts, 0, len(tasks))
+	for _, task := range tasks {
+		if _, ok := stepIdsToConfig[task.StepId]; !ok {
+			r.l.Warn().Ctx(ctx).Str("step_id", task.StepId.String()).Str("external_id", task.ExternalId.String()).Msg("skipping replay task: step not found (may have been deleted)")
+			continue
+		}
+		filteredTasks = append(filteredTasks, task)
+	}
+	tasks = filteredTasks
 
 	concurrencyStrats, err := r.getConcurrencyExpressions(ctx, tx, tenantId, stepIdsToConfig)
 

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -1787,12 +1787,17 @@ func (r *sharedRepository) createTasks(
 	}
 
 	filteredTasks := make([]CreateTaskOpts, 0, len(tasks))
+
 	for _, task := range tasks {
 		if _, ok := stepIdsToConfig[task.StepId]; !ok {
 			r.l.Warn().Ctx(ctx).Str("step_id", task.StepId.String()).Str("external_id", task.ExternalId.String()).Msg("skipping task: step not found (may have been deleted)")
 			continue
 		}
 		filteredTasks = append(filteredTasks, task)
+	}
+
+	if len(filteredTasks) == 0 {
+		return []*V1TaskWithPayload{}, nil
 	}
 
 	return r.insertTasks(ctx, tx, tenantId, filteredTasks, stepIdsToConfig)
@@ -2379,6 +2384,7 @@ func (r *sharedRepository) replayTasks(
 	}
 
 	filteredTasks := make([]ReplayTaskOpts, 0, len(tasks))
+
 	for _, task := range tasks {
 		if _, ok := stepIdsToConfig[task.StepId]; !ok {
 			r.l.Warn().Ctx(ctx).Str("step_id", task.StepId.String()).Str("external_id", task.ExternalId.String()).Msg("skipping replay task: step not found (may have been deleted)")
@@ -2386,12 +2392,19 @@ func (r *sharedRepository) replayTasks(
 		}
 		filteredTasks = append(filteredTasks, task)
 	}
+
+	res := make([]*V1TaskWithPayload, 0)
+
+	if len(filteredTasks) == 0 {
+		return res, nil
+	}
+
 	tasks = filteredTasks
 
 	concurrencyStrats, err := r.getConcurrencyExpressions(ctx, tx, tenantId, stepIdsToConfig)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to get step expressions: %w", err)
+		return nil, fmt.Errorf("failed to get concurrency expressions: %w", err)
 	}
 
 	taskIds := make([]int64, len(tasks))
@@ -2567,8 +2580,6 @@ func (r *sharedRepository) replayTasks(
 
 		stepIdsToStorePayloadOpts[task.StepId] = append(stepIdsToStorePayloadOpts[task.StepId], storePayloadOpts)
 	}
-
-	res := make([]*V1TaskWithPayload, 0)
 
 	// for any initial states which are not queued, create a finalizing task event
 	eventTaskIdRetryCounts := make([]TaskIdInsertedAtRetryCount, 0)


### PR DESCRIPTION
# Description

Fixes a nil pointer panic when a batch of tasks includes an invalid step ID.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
