### PR TITLE
Do not swallow top-level error when marking queue items as resolved

### DIFF
--- a/pkg/repository/scheduler_queue.go
+++ b/pkg/repository/scheduler_queue.go
@@ -197,6 +197,10 @@ func (d *queueRepository) MarkQueueItemsProcessed(ctx context.Context, r *Assign
 
 	succeeded, failed, err = d.markQueueItemsProcessed(ctx, d.tenantId, r, tx, false)
 
+	if err != nil {
+		return nil, nil, err
+	}
+
 	if err := commit(ctx); err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
# Description

We ignore the `err` returned by `markQueueItemsProcessed()` by re-assigning it when calling it `commit()`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
