### PR TITLE
Fix: Add exclusive lock, run analyze

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260424205453_v1_0_100.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260424205453_v1_0_100.sql
@@ -16,6 +16,7 @@ BEGIN
         old_parent := base_name;
         new_parent := base_name || '_new';
 
+        EXECUTE format('LOCK TABLE %I IN ACCESS EXCLUSIVE MODE', old_parent);
         EXECUTE format('DROP TABLE IF EXISTS %I CASCADE', old_parent);
         EXECUTE format('ALTER TABLE %I RENAME TO %I', new_parent, old_parent);
 

--- a/cmd/hatchet-migrate/migrate/migrations/20260427142714_v1_0_101.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260427142714_v1_0_101.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ANALYZE v1_runs_olap, v1_tasks_olap, v1_dags_olap;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- empty
+-- +goose StatementEnd


### PR DESCRIPTION
# Description

Adds an exclusive lock to prevent deadlocking in the migration, and then runs analyze afterwards

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
