### PR TITLE
Fix: improve performance of cron schedule polling query

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260427190534_v1_0_102.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260427190534_v1_0_102.sql
@@ -1,0 +1,11 @@
+-- +goose NO TRANSACTION
+
+-- +goose Up
+-- +goose StatementBegin
+CREATE INDEX CONCURRENTLY idx_workflow_triggers_id_version_id_tenant_id ON "WorkflowTriggers" ("id", "workflowVersionId", "tenantId");
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX CONCURRENTLY idx_workflow_triggers_id_version_id_tenant_id;
+-- +goose StatementEnd

--- a/pkg/repository/sqlcv1/ticker.sql
+++ b/pkg/repository/sqlcv1/ticker.sql
@@ -132,10 +132,6 @@ latest_workflow_versions AS (
         "WorkflowVersion"
     WHERE
         "deletedAt" IS NULL
-        AND "workflowId" IN (
-            SELECT "workflowId"
-            FROM eligible_cron_with_versions
-        )
     ORDER BY "workflowId", "order" DESC
 ),
 eligible_cron_schedules AS (

--- a/pkg/repository/sqlcv1/ticker.sql
+++ b/pkg/repository/sqlcv1/ticker.sql
@@ -94,17 +94,7 @@ WHERE
 RETURNING *;
 
 -- name: PollCronSchedules :many
-WITH latest_workflow_versions AS (
-    SELECT
-        "workflowId",
-        MAX("order") as max_order
-    FROM
-        "WorkflowVersion"
-    WHERE
-        "deletedAt" IS NULL
-    GROUP BY "workflowId"
-),
-eligible_cron_with_versions AS (
+WITH eligible_cron_with_versions AS MATERIALIZED (
     SELECT
         cronSchedule."parentId",
         cronSchedule."cron",
@@ -133,6 +123,21 @@ eligible_cron_with_versions AS (
         )
     FOR UPDATE OF cronSchedule SKIP LOCKED
 ),
+latest_workflow_versions AS (
+    SELECT
+        DISTINCT ON ("workflowId")
+        "workflowId",
+        "id"
+    FROM
+        "WorkflowVersion"
+    WHERE
+        "deletedAt" IS NULL
+        AND "workflowId" IN (
+            SELECT "workflowId"
+            FROM eligible_cron_with_versions
+        )
+    ORDER BY "workflowId", "order" DESC
+),
 eligible_cron_schedules AS (
     SELECT
         ecv."parentId",
@@ -143,7 +148,7 @@ eligible_cron_schedules AS (
     FROM
         eligible_cron_with_versions as ecv
     JOIN
-        latest_workflow_versions as l ON ecv."workflowId" = l."workflowId" AND ecv."order" = l.max_order
+        latest_workflow_versions as l ON ecv."workflowId" = l."workflowId" AND ecv."workflowVersionId" = l."id"
 )
 UPDATE
     "WorkflowTriggerCronRef" as cronSchedules

--- a/pkg/repository/sqlcv1/ticker.sql.go
+++ b/pkg/repository/sqlcv1/ticker.sql.go
@@ -262,10 +262,6 @@ latest_workflow_versions AS (
         "WorkflowVersion"
     WHERE
         "deletedAt" IS NULL
-        AND "workflowId" IN (
-            SELECT "workflowId"
-            FROM eligible_cron_with_versions
-        )
     ORDER BY "workflowId", "order" DESC
 ),
 eligible_cron_schedules AS (

--- a/pkg/repository/sqlcv1/ticker.sql.go
+++ b/pkg/repository/sqlcv1/ticker.sql.go
@@ -224,17 +224,7 @@ func (q *Queries) ListTickers(ctx context.Context, db DBTX, arg ListTickersParam
 }
 
 const pollCronSchedules = `-- name: PollCronSchedules :many
-WITH latest_workflow_versions AS (
-    SELECT
-        "workflowId",
-        MAX("order") as max_order
-    FROM
-        "WorkflowVersion"
-    WHERE
-        "deletedAt" IS NULL
-    GROUP BY "workflowId"
-),
-eligible_cron_with_versions AS (
+WITH eligible_cron_with_versions AS MATERIALIZED (
     SELECT
         cronSchedule."parentId",
         cronSchedule."cron",
@@ -263,6 +253,21 @@ eligible_cron_with_versions AS (
         )
     FOR UPDATE OF cronSchedule SKIP LOCKED
 ),
+latest_workflow_versions AS (
+    SELECT
+        DISTINCT ON ("workflowId")
+        "workflowId",
+        "id"
+    FROM
+        "WorkflowVersion"
+    WHERE
+        "deletedAt" IS NULL
+        AND "workflowId" IN (
+            SELECT "workflowId"
+            FROM eligible_cron_with_versions
+        )
+    ORDER BY "workflowId", "order" DESC
+),
 eligible_cron_schedules AS (
     SELECT
         ecv."parentId",
@@ -273,7 +278,7 @@ eligible_cron_schedules AS (
     FROM
         eligible_cron_with_versions as ecv
     JOIN
-        latest_workflow_versions as l ON ecv."workflowId" = l."workflowId" AND ecv."order" = l.max_order
+        latest_workflow_versions as l ON ecv."workflowId" = l."workflowId" AND ecv."workflowVersionId" = l."id"
 )
 UPDATE
     "WorkflowTriggerCronRef" as cronSchedules


### PR DESCRIPTION
# Description

Improving the performance of the cron schedule polling query using the materialized cte trick to force a nested loop, and adding a covering index on some columns in the `WorkflowTriggers` bridge table

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
