### PR TITLE
docs(cookbooks): add welcome email cookbook

### DIFF
--- a/examples/python/welcome_email/trigger.py
+++ b/examples/python/welcome_email/trigger.py
@@ -1,0 +1,30 @@
+# > Trigger the workflow
+from examples.welcome_email.worker import (
+    ONBOARDING_EVENT_KEY,
+    SignupInput,
+    hatchet,
+    welcome_email,
+)
+
+signup = SignupInput(
+    email="alice@example.com",
+    user_id="user-123",
+)
+
+# Start the welcome-email workflow
+ref = welcome_email.run(signup, wait_for_result=False)
+print(f"Started workflow run: {ref.workflow_run_id}")
+
+# Push onboarding-completed event (scoped to this user)
+print("Pushing onboarding-completed event...")
+hatchet.event.push(
+    ONBOARDING_EVENT_KEY,
+    {"status": "done"},
+    scope=signup.user_id,
+)
+
+# Wait for the workflow to complete
+result = ref.result()
+print(f"Workflow completed: {result}")
+
+

--- a/examples/python/welcome_email/worker.py
+++ b/examples/python/welcome_email/worker.py
@@ -13,7 +13,7 @@ from hatchet_sdk import (
 hatchet = Hatchet()
 
 ONBOARDING_EVENT_KEY = "user:onboarding-completed"
-TIMEOUT_SECONDS = 30
+TIMEOUT_SECONDS = 5
 
 
 # > Models

--- a/examples/python/welcome_email/worker.py
+++ b/examples/python/welcome_email/worker.py
@@ -40,10 +40,10 @@ class WelcomeEmailResult(BaseModel):
 )
 async def welcome_email(input: SignupInput, ctx: DurableContext) -> WelcomeEmailResult:
     # Step 1: Send the welcome email
-    print(f"Sending welcome email to {input.email}")
+    print(f"Sending welcome email to {input.email}: finish your first onboarding step")
 
     # Step 2: Wait for the user to complete onboarding, or time out
-    # (use a longer duration like timedelta(hours=24) in production)
+    # (use a longer duration for a more realistic workflow)
     now = await ctx.aio_now()
     consider_events_since = now - timedelta(minutes=LOOKBACK_MINUTES)
 
@@ -76,7 +76,7 @@ async def welcome_email(input: SignupInput, ctx: DurableContext) -> WelcomeEmail
         )
 
     # Step 3b: Timeout -> send follow-up email
-    print(f"Sending follow-up email to {input.email}")
+    print(f"Sending follow-up email to {input.email}: need help finishing onboarding?")
     return WelcomeEmailResult(
         user_id=input.user_id,
         welcome_sent=True,

--- a/examples/python/welcome_email/worker.py
+++ b/examples/python/welcome_email/worker.py
@@ -1,0 +1,93 @@
+from datetime import timedelta
+
+from pydantic import BaseModel
+
+from hatchet_sdk import (
+    DurableContext,
+    Hatchet,
+    SleepCondition,
+    UserEventCondition,
+    or_,
+)
+
+hatchet = Hatchet()
+
+ONBOARDING_EVENT_KEY = "user:onboarding-completed"
+TIMEOUT_SECONDS = 30
+
+
+# > Models
+class SignupInput(BaseModel):
+    email: str
+    user_id: str
+
+
+class WelcomeEmailResult(BaseModel):
+    user_id: str
+    welcome_sent: bool
+    follow_up_sent: bool
+
+
+
+
+# > Welcome email task
+@hatchet.durable_task(
+    name="welcome-email",
+    on_events=["user:signup"],
+    input_validator=SignupInput,
+    execution_timeout=timedelta(minutes=5),
+)
+async def welcome_email(input: SignupInput, ctx: DurableContext) -> WelcomeEmailResult:
+    # Step 1: Send the welcome email
+    print(f"Sending welcome email to {input.email}")
+
+    # Step 2: Wait for the user to complete onboarding, or time out
+    # (use a longer duration like timedelta(hours=24) in production)
+    wait_result = await ctx.aio_wait_for(
+        "onboarding-or-timeout",
+        or_(
+            SleepCondition(timedelta(seconds=TIMEOUT_SECONDS)),
+            # Scope the event condition to this user so that another user's
+            # onboarding-completed event does not resolve this wait.
+            UserEventCondition(
+                event_key=ONBOARDING_EVENT_KEY,
+                scope=input.user_id,
+            ),
+        ),
+    )
+
+    # The or-group result is {"CREATE": {"<condition_key>": ...}}.
+    # Check whether the onboarding event was the one that resolved.
+    resolved_key = list(wait_result["CREATE"].keys())[0]
+    onboarding_completed = resolved_key == ONBOARDING_EVENT_KEY
+
+    if onboarding_completed:
+        # Step 3a: User completed onboarding -> skip follow-up
+        print(f"User {input.user_id} completed onboarding, skipping follow-up")
+        return WelcomeEmailResult(
+            user_id=input.user_id,
+            welcome_sent=True,
+            follow_up_sent=False,
+        )
+
+    # Step 3b: Timeout -> send follow-up email
+    print(f"Sending follow-up email to {input.email}")
+    return WelcomeEmailResult(
+        user_id=input.user_id,
+        welcome_sent=True,
+        follow_up_sent=True,
+    )
+
+
+
+
+# > Worker registration
+def main() -> None:
+    worker = hatchet.worker("welcome-email-worker", workflows=[welcome_email])
+    worker.start()
+
+
+if __name__ == "__main__":
+    main()
+
+

--- a/examples/python/welcome_email/worker.py
+++ b/examples/python/welcome_email/worker.py
@@ -14,6 +14,7 @@ hatchet = Hatchet()
 
 ONBOARDING_EVENT_KEY = "user:onboarding-completed"
 TIMEOUT_SECONDS = 5
+LOOKBACK_MINUTES = 5
 
 
 # > Models
@@ -43,6 +44,9 @@ async def welcome_email(input: SignupInput, ctx: DurableContext) -> WelcomeEmail
 
     # Step 2: Wait for the user to complete onboarding, or time out
     # (use a longer duration like timedelta(hours=24) in production)
+    now = await ctx.aio_now()
+    consider_events_since = now - timedelta(minutes=LOOKBACK_MINUTES)
+
     wait_result = await ctx.aio_wait_for(
         "onboarding-or-timeout",
         or_(
@@ -52,6 +56,7 @@ async def welcome_email(input: SignupInput, ctx: DurableContext) -> WelcomeEmail
             UserEventCondition(
                 event_key=ONBOARDING_EVENT_KEY,
                 scope=input.user_id,
+                consider_events_since=consider_events_since,
             ),
         ),
     )

--- a/examples/python/worker.py
+++ b/examples/python/worker.py
@@ -88,6 +88,7 @@ from examples.webhook_with_scope.worker import (
     webhook_with_static_payload,
 )
 from examples.webhooks.worker import webhook
+from examples.welcome_email.worker import welcome_email
 from examples.opentelemetry_instrumentation.worker import (
     otel_workflow,
     otel_simple_task,
@@ -181,6 +182,7 @@ def main() -> None:
             triage_ticket,
             generate_reply,
             escalate_ticket,
+            welcome_email,
         ],
         lifespan=lifespan,
     )

--- a/examples/typescript/e2e-worker.ts
+++ b/examples/typescript/e2e-worker.ts
@@ -64,6 +64,7 @@ import {
   generateReply,
   escalateTicket,
 } from './support_agent/workflow';
+import { welcomeEmail } from './welcome_email/workflow';
 
 const workflows = [
   bulkChild,
@@ -123,6 +124,7 @@ const workflows = [
   triageTicket,
   generateReply,
   escalateTicket,
+  welcomeEmail,
 ];
 
 async function main() {

--- a/examples/typescript/welcome_email/run.ts
+++ b/examples/typescript/welcome_email/run.ts
@@ -1,7 +1,7 @@
+// > Trigger the workflow
 import { hatchet } from '../hatchet-client';
 import { welcomeEmail, ONBOARDING_EVENT_KEY, SignupInput } from './workflow';
 
-// > Trigger the workflow
 async function main() {
   const input: SignupInput = {
     email: 'alice@example.com',

--- a/examples/typescript/welcome_email/run.ts
+++ b/examples/typescript/welcome_email/run.ts
@@ -1,0 +1,31 @@
+import { hatchet } from '../hatchet-client';
+import { welcomeEmail, ONBOARDING_EVENT_KEY, SignupInput } from './workflow';
+
+// > Trigger the workflow
+async function main() {
+  const input: SignupInput = {
+    email: 'alice@example.com',
+    user_id: 'user-123',
+  };
+
+  // Start the welcome-email workflow
+  const ref = await welcomeEmail.runNoWait(input);
+  const runId = await ref.getWorkflowRunId();
+  console.log(`Started workflow run: ${runId}`);
+
+  // Push onboarding-completed event (scoped to this user)
+  console.log('Pushing onboarding-completed event...');
+  await hatchet.events.push(ONBOARDING_EVENT_KEY, { status: 'done' }, { scope: input.user_id });
+
+  // Wait for the workflow to complete
+  const result = await ref.output;
+  console.log('Workflow completed:', result);
+}
+
+if (require.main === module) {
+  main()
+    .catch(console.error)
+    .finally(() => {
+      process.exit(0);
+    });
+}

--- a/examples/typescript/welcome_email/workflow.ts
+++ b/examples/typescript/welcome_email/workflow.ts
@@ -1,0 +1,55 @@
+import { Or } from '@hatchet-dev/typescript-sdk/v1/conditions';
+import { hatchet } from '../hatchet-client';
+
+const ONBOARDING_EVENT_KEY = 'user:onboarding-completed';
+const TIMEOUT_SECONDS = 30;
+
+// > Models
+export type SignupInput = {
+  email: string;
+  user_id: string;
+};
+
+export type WelcomeEmailResult = {
+  userId: string;
+  welcomeSent: boolean;
+  followUpSent: boolean;
+};
+
+// > Welcome email task
+export const welcomeEmail = hatchet.durableTask<SignupInput, WelcomeEmailResult>({
+  name: 'welcome-email',
+  onEvents: ['user:signup'],
+  executionTimeout: '5m',
+  fn: async (input, ctx) => {
+    // Step 1: Send the welcome email
+    console.log(`Sending welcome email to ${input.email}`);
+
+    // Step 2: Wait for the user to complete onboarding, or time out
+    // (use a longer duration like '24h' in production)
+    const waitResult = await ctx.waitFor(
+      Or(
+        { sleepFor: `${TIMEOUT_SECONDS}s` },
+        // Scope the event condition to this user so that another user's
+        // onboarding-completed event does not resolve this wait.
+        { eventKey: ONBOARDING_EVENT_KEY, scope: input.user_id }
+      )
+    );
+
+    // The or-group result is { CREATE: { <condition_key>: ... } }.
+    // Check whether the onboarding event was the one that resolved.
+    const create = (waitResult as Record<string, Record<string, unknown>>)['CREATE'] ?? waitResult;
+    const resolvedKey = Object.keys(create as Record<string, unknown>)[0] ?? '';
+    const onboardingCompleted = resolvedKey === ONBOARDING_EVENT_KEY;
+
+    if (onboardingCompleted) {
+      // Step 3a: User completed onboarding -> skip follow-up
+      console.log(`User ${input.user_id} completed onboarding, skipping follow-up`);
+      return { userId: input.user_id, welcomeSent: true, followUpSent: false };
+    }
+
+    // Step 3b: Timeout -> send follow-up email
+    console.log(`Sending follow-up email to ${input.email}`);
+    return { userId: input.user_id, welcomeSent: true, followUpSent: true };
+  },
+});

--- a/examples/typescript/welcome_email/workflow.ts
+++ b/examples/typescript/welcome_email/workflow.ts
@@ -1,8 +1,10 @@
 import { Or } from '@hatchet-dev/typescript-sdk/v1/conditions';
+import { durationToMs } from '@hatchet-dev/typescript-sdk/v1/client/duration';
 import { hatchet } from '../hatchet-client';
 
 export const ONBOARDING_EVENT_KEY = 'user:onboarding-completed';
 const TIMEOUT_SECONDS = 5;
+const LOOKBACK_WINDOW = '5m' as const;
 
 // > Models
 export type SignupInput = {
@@ -27,12 +29,17 @@ export const welcomeEmail = hatchet.durableTask<SignupInput, WelcomeEmailResult>
 
     // Step 2: Wait for the user to complete onboarding, or time out
     // (use a longer duration like '24h' in production)
+    const now = await ctx.now();
+    const considerEventsSince = new Date(
+      now.getTime() - durationToMs(LOOKBACK_WINDOW)
+    ).toISOString();
+
     const waitResult = await ctx.waitFor(
       Or(
         { sleepFor: `${TIMEOUT_SECONDS}s` },
         // Scope the event condition to this user so that another user's
         // onboarding-completed event does not resolve this wait.
-        { eventKey: ONBOARDING_EVENT_KEY, scope: input.user_id }
+        { eventKey: ONBOARDING_EVENT_KEY, scope: input.user_id, considerEventsSince }
       )
     );
 

--- a/examples/typescript/welcome_email/workflow.ts
+++ b/examples/typescript/welcome_email/workflow.ts
@@ -25,10 +25,10 @@ export const welcomeEmail = hatchet.durableTask<SignupInput, WelcomeEmailResult>
   executionTimeout: '5m',
   fn: async (input, ctx) => {
     // Step 1: Send the welcome email
-    console.log(`Sending welcome email to ${input.email}`);
+    console.log(`Sending welcome email to ${input.email}: finish your first onboarding step`);
 
     // Step 2: Wait for the user to complete onboarding, or time out
-    // (use a longer duration like '24h' in production)
+    // (use a longer duration for a more realistic workflow)
     const now = await ctx.now();
     const considerEventsSince = new Date(
       now.getTime() - durationToMs(LOOKBACK_WINDOW)
@@ -56,7 +56,7 @@ export const welcomeEmail = hatchet.durableTask<SignupInput, WelcomeEmailResult>
     }
 
     // Step 3b: Timeout -> send follow-up email
-    console.log(`Sending follow-up email to ${input.email}`);
+    console.log(`Sending follow-up email to ${input.email}: need help finishing onboarding?`);
     return { userId: input.user_id, welcomeSent: true, followUpSent: true };
   },
 });

--- a/examples/typescript/welcome_email/workflow.ts
+++ b/examples/typescript/welcome_email/workflow.ts
@@ -1,8 +1,8 @@
 import { Or } from '@hatchet-dev/typescript-sdk/v1/conditions';
 import { hatchet } from '../hatchet-client';
 
-const ONBOARDING_EVENT_KEY = 'user:onboarding-completed';
-const TIMEOUT_SECONDS = 30;
+export const ONBOARDING_EVENT_KEY = 'user:onboarding-completed';
+const TIMEOUT_SECONDS = 5;
 
 // > Models
 export type SignupInput = {

--- a/frontend/docs/pages/cookbooks/_meta.js
+++ b/frontend/docs/pages/cookbooks/_meta.js
@@ -12,4 +12,5 @@ export default {
     type: "separator",
   },
   "workflow-support-agent": "Support Agent",
+  "welcome-email": "Welcome Email",
 };

--- a/frontend/docs/pages/cookbooks/index.mdx
+++ b/frontend/docs/pages/cookbooks/index.mdx
@@ -33,4 +33,8 @@ Build practical end-to-end workflows with Hatchet’s durable execution, event h
     Build a durable support workflow that triages tickets, waits for customer
     replies, and escalates on timeout.
   </Cards.Card>
+  <Cards.Card title="Welcome Email" href="/cookbooks/welcome-email">
+    Send a welcome email after signup, wait for onboarding completion, and send
+    a follow-up only if the user does not finish in time.
+  </Cards.Card>
 </Cards>

--- a/frontend/docs/pages/cookbooks/welcome-email.mdx
+++ b/frontend/docs/pages/cookbooks/welcome-email.mdx
@@ -78,7 +78,7 @@ In TypeScript, workflows are registered through the shared example worker rather
 
 ### Trigger the workflow
 
-The durable task is configured with `on_events=["user:signup"]` (Python) / `onEvents: ['user:signup']` (TypeScript), so pushing a `user:signup` event starts the workflow. The event payload is passed through as-is to the task input, so both languages receive the same field names:
+The durable task is configured with `on_events=["user:signup"]` (Python) / `onEvents: ['user:signup']` (TypeScript), so in production you can start it by pushing a `user:signup` event. The event payload is passed through as-is to the task input, so both languages receive the same field names:
 
 ```json
 {
@@ -87,30 +87,44 @@ The durable task is configured with `on_events=["user:signup"]` (Python) / `onEv
 }
 ```
 
-Once the workflow is running and waiting, you can resolve it by pushing the onboarding event **with a matching scope**:
+The example also includes a trigger script that starts the workflow directly, pushes a scoped onboarding event, and waits for the result.
 
 <UniversalTabs items={["Python", "Typescript"]}>
   <Tabs.Tab title="Python">
-    ```python
-    hatchet.event.push(
-        "user:onboarding-completed",
-        {"status": "done"},
-        scope="user-123",
-    )
-    ```
+    <Snippet src={snippets.python.welcome_email.trigger.trigger_the_workflow} />
   </Tabs.Tab>
   <Tabs.Tab title="Typescript">
-    ```typescript
-    await hatchet.events.push(
-      'user:onboarding-completed',
-      { status: 'done' },
-      { scope: 'user-123' }
-    );
-    ```
+    <Snippet src={snippets.typescript.welcome_email.run.trigger_the_workflow} />
   </Tabs.Tab>
 </UniversalTabs>
 
-The scope value (`"user-123"`) must match the user ID that the workflow received in its signup input. The event payload itself is not used for correlation — only the scope matters.
+The onboarding event is pushed with a **scope** that matches the user ID from the signup input. The event payload itself is not used for correlation — only the scope matters. This is what prevents one user's onboarding event from resolving another user's wait.
+
+### Test it
+
+This example includes two end-to-end tests against a live Hatchet instance:
+
+- an onboarding path, where the scoped event arrives before the timeout and the follow-up is skipped
+- a timeout path, where no event arrives and the workflow sends the follow-up
+
+If you are running the SDK examples locally:
+
+<UniversalTabs items={["Python", "Typescript"]}>
+  <Tabs.Tab title="Python">
+
+    ```bash
+    pytest examples/welcome_email/test_welcome_email.py
+    ```
+
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+
+    ```bash
+    pnpm run test:e2e -- --testPathPattern=welcome_email
+    ```
+
+  </Tabs.Tab>
+</UniversalTabs>
 
 </Steps>
 

--- a/frontend/docs/pages/cookbooks/welcome-email.mdx
+++ b/frontend/docs/pages/cookbooks/welcome-email.mdx
@@ -1,0 +1,125 @@
+import { Steps, Tabs } from "nextra/components";
+import UniversalTabs from "@/components/UniversalTabs";
+import { snippets } from "@/lib/generated/snippets";
+import { Snippet } from "@/components/code";
+
+# Welcome Email
+
+When a new user signs up, most applications send a welcome email right away. What happens next is trickier: you want to send a follow-up nudge if the user hasn't completed onboarding after some time, but skip it if they have. That means your workflow needs to wait for an event that may or may not arrive, with a timeout as the fallback.
+
+This cookbook builds a small durable workflow in Hatchet that handles exactly that pattern:
+
+```mermaid
+flowchart TD
+    A[user:signup event] --> B[Send welcome email]
+    B --> C[Wait for onboarding or timeout]
+    C --> D[user:onboarding-completed]
+    C --> E[Timeout fires]
+    D --> F[Skip follow-up]
+    E --> G[Send follow-up email]
+```
+
+Hatchet's durable execution keeps the workflow alive across the wait. If the worker restarts or the wait lasts hours, the workflow picks up where it left off.
+
+## Setup
+
+<Steps>
+
+### Prepare your environment
+
+To run this example you need:
+
+- a working local Hatchet environment or access to [Hatchet Cloud](https://cloud.onhatchet.run)
+- a Hatchet SDK example environment (see the [Quickstart](/v1/quickstart))
+
+No external email provider is required. The example uses `print` / `console.log` in place of real email delivery.
+
+### Define the models
+
+Start by defining the input and output types. The workflow receives the new user's email and ID, and returns which emails were sent.
+
+<UniversalTabs items={["Python", "Typescript"]}>
+  <Tabs.Tab title="Python">
+    <Snippet src={snippets.python.welcome_email.worker.models} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+    <Snippet src={snippets.typescript.welcome_email.workflow.models} />
+  </Tabs.Tab>
+</UniversalTabs>
+
+### Build the durable task
+
+The core of this example is a single [durable task](/v1/durable-execution) that runs three steps in sequence:
+
+1. Send the welcome email immediately.
+2. Wait for either a `user:onboarding-completed` event scoped to this user, or a timeout.
+3. If the timeout fires, send a follow-up. If the onboarding event arrives first, skip it.
+
+<UniversalTabs items={["Python", "Typescript"]}>
+  <Tabs.Tab title="Python">
+    <Snippet src={snippets.python.welcome_email.worker.welcome_email_task} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+    <Snippet
+      src={snippets.typescript.welcome_email.workflow.welcome_email_task}
+    />
+  </Tabs.Tab>
+</UniversalTabs>
+
+The event condition uses a **scope** set to the current user's ID. When the `user:onboarding-completed` event is pushed later, it must be pushed with the same scope value. This ensures that one user's onboarding event does not accidentally satisfy another user's wait.
+
+### Register and start the worker
+
+Register the durable task on a Hatchet worker and start it.
+
+<Snippet src={snippets.python.welcome_email.worker.worker_registration} />
+
+In TypeScript, workflows are registered through the shared example worker rather than a per-example registration file.
+
+### Trigger the workflow
+
+The durable task is configured with `on_events=["user:signup"]` (Python) / `onEvents: ['user:signup']` (TypeScript), so pushing a `user:signup` event starts the workflow. The event payload is passed through as-is to the task input, so both languages receive the same field names:
+
+```json
+{
+  "email": "alice@example.com",
+  "user_id": "user-123"
+}
+```
+
+Once the workflow is running and waiting, you can resolve it by pushing the onboarding event **with a matching scope**:
+
+<UniversalTabs items={["Python", "Typescript"]}>
+  <Tabs.Tab title="Python">
+    ```python
+    hatchet.event.push(
+        "user:onboarding-completed",
+        {"status": "done"},
+        scope="user-123",
+    )
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+    ```typescript
+    await hatchet.events.push(
+      'user:onboarding-completed',
+      { status: 'done' },
+      { scope: 'user-123' }
+    );
+    ```
+  </Tabs.Tab>
+</UniversalTabs>
+
+The scope value (`"user-123"`) must match the user ID that the workflow received in its signup input. The event payload itself is not used for correlation — only the scope matters.
+
+</Steps>
+
+## The two paths
+
+**Timeout wins:** If no `user:onboarding-completed` event arrives before the timeout, the workflow sends the follow-up email. The result indicates that the follow-up was sent.
+
+**Onboarding event wins:** If the scoped event arrives before the timeout, the workflow skips the follow-up. The result indicates that only the welcome email was sent.
+
+## Next steps
+
+To use this in production, replace the `print` / `console.log` calls with your email provider's SDK. You may also want to extend the timeout to something like 24 hours and add retry or idempotency logic around the send step. Those concerns are provider-specific and intentionally outside this minimal example.

--- a/frontend/docs/pages/cookbooks/welcome-email.mdx
+++ b/frontend/docs/pages/cookbooks/welcome-email.mdx
@@ -66,7 +66,7 @@ The core of this example is a single [durable task](/v1/durable-execution) that 
   </Tabs.Tab>
 </UniversalTabs>
 
-In this example, `user:onboarding-completed` represents an activation event from your application. Your app would emit it when the user finishes the onboarding milestone. The welcome email points the user toward that step; the follow-up is only for users who do not complete it before the timeout.
+In this example, `user:onboarding-completed` represents an activation event from your application. Your app would emit it when the user finishes the onboarding milestone. The welcome email points the user toward that step; the follow-up is only for users who do not complete it before the timeout. The timeout itself is durable, so the workflow does not need to keep a worker process sleeping while it waits, and it can resume even if the worker restarts during the wait.
 
 The event condition uses a `scope` set to the current user's ID. When the `user:onboarding-completed` event is later pushed, it must include the same `scope` value. Scoping by user ID ensures that one user's onboarding event cannot satisfy another user's wait condition. The condition also includes a short lookback window. This lets the workflow pick up an onboarding event that arrived slightly before the wait became active. This can happen when the welcome email step and the onboarding event occur nearly at the same time.
 
@@ -74,9 +74,15 @@ The event condition uses a `scope` set to the current user's ID. When the `user:
 
 Register the durable task on a Hatchet worker and start it.
 
-<Snippet src={snippets.python.welcome_email.worker.worker_registration} />
-
-In TypeScript, workflows are registered through the shared example worker rather than a per-example registration file.
+<UniversalTabs items={["Python", "Typescript"]}>
+  <Tabs.Tab title="Python">
+    <Snippet src={snippets.python.welcome_email.worker.worker_registration} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+    In TypeScript, workflows are registered through the shared example worker
+    rather than a per-example registration file.
+  </Tabs.Tab>
+</UniversalTabs>
 
 ### Trigger the workflow
 

--- a/frontend/docs/pages/cookbooks/welcome-email.mdx
+++ b/frontend/docs/pages/cookbooks/welcome-email.mdx
@@ -5,9 +5,9 @@ import { Snippet } from "@/components/code";
 
 # Welcome Email
 
-When a new user signs up, most applications send a welcome email right away. What happens next is trickier: you want to send a follow-up nudge if the user hasn't completed onboarding after some time, but skip it if they have. That means your workflow needs to wait for an event that may or may not arrive, with a timeout as the fallback.
+Customer onboarding guides users through required setup, improves their product understanding, and helps them gain value faster. Sending a brief welcome email after signup with a helpful link to get started is common practice.
 
-This cookbook builds a small durable workflow in Hatchet that handles exactly that pattern:
+Users are busy people who often contend with changing priorities, so sometimes they disengage before onboarding is complete. To mitigate onboarding drop-off, you may want to send a follow-up email only to users who have not reached a milestone in time. What you need is a workflow that waits for an event that may or may not arrive, with a timeout triggering the appropriate fallback behavior. Let's build a small durable workflow in Hatchet that handles exactly that pattern:
 
 ```mermaid
 flowchart TD
@@ -19,7 +19,7 @@ flowchart TD
     E --> G[Send follow-up email]
 ```
 
-Hatchet's durable execution keeps the workflow alive across the wait. If the worker restarts or the wait lasts hours, the workflow picks up where it left off.
+Hatchet's durable execution keeps the workflow alive across the wait. If the worker restarts or the wait lasts days, the workflow picks up where it left off.
 
 ## Setup
 
@@ -66,9 +66,9 @@ The core of this example is a single [durable task](/v1/durable-execution) that 
   </Tabs.Tab>
 </UniversalTabs>
 
-The event condition uses a **scope** set to the current user's ID. When the `user:onboarding-completed` event is pushed later, it must be pushed with the same scope value. This ensures that one user's onboarding event does not accidentally satisfy another user's wait.
+In this example, `user:onboarding-completed` represents an activation event from your application. Your app would emit it when the user finishes the onboarding milestone. The welcome email points the user toward that step; the follow-up is only for users who do not complete it before the timeout.
 
-The condition also includes a lookback window (`consider_events_since` in Python, `considerEventsSince` in TypeScript). This lets the workflow pick up an onboarding event that arrived slightly before the wait became active — for example, if the welcome email step and the onboarding event happen nearly at the same time.
+The event condition uses a `scope` set to the current user's ID. When the `user:onboarding-completed` event is later pushed, it must include the same `scope` value. Scoping by user ID ensures that one user's onboarding event cannot satisfy another user's wait condition. The condition also includes a short lookback window. This lets the workflow pick up an onboarding event that arrived slightly before the wait became active. This can happen when the welcome email step and the onboarding event occur nearly at the same time.
 
 ### Register and start the worker
 
@@ -80,7 +80,7 @@ In TypeScript, workflows are registered through the shared example worker rather
 
 ### Trigger the workflow
 
-The durable task is configured with `on_events=["user:signup"]` (Python) / `onEvents: ['user:signup']` (TypeScript), so in production you can start it by pushing a `user:signup` event. The event payload is passed through as-is to the task input, so both languages receive the same field names:
+The durable task is configured to start from a `user:signup` event. The event payload is passed through as-is to the task input:
 
 ```json
 {
@@ -100,14 +100,12 @@ The example also includes a trigger script that starts the workflow directly, pu
   </Tabs.Tab>
 </UniversalTabs>
 
-The onboarding event is pushed with a **scope** that matches the user ID from the signup input. The event payload itself is not used for correlation — only the scope matters. This is what prevents one user's onboarding event from resolving another user's wait.
-
 ### Test it
 
 This example includes two end-to-end tests against a live Hatchet instance:
 
-- an onboarding path, where the scoped event arrives before the timeout and the follow-up is skipped
-- a timeout path, where no event arrives and the workflow sends the follow-up
+- an onboarding-completed test, where the scoped event arrives before the timeout and the follow-up is skipped
+- a timeout test, where no onboarding event arrives and the workflow sends the follow-up
 
 If you are running the SDK examples locally:
 
@@ -130,12 +128,6 @@ If you are running the SDK examples locally:
 
 </Steps>
 
-## The two paths
-
-**Timeout wins:** If no `user:onboarding-completed` event arrives before the timeout, the workflow sends the follow-up email. The result indicates that the follow-up was sent.
-
-**Onboarding event wins:** If the scoped event arrives before the timeout, the workflow skips the follow-up. The result indicates that only the welcome email was sent.
-
 ## Next steps
 
-To use this in production, replace the `print` / `console.log` calls with your email provider's SDK. You may also want to extend the timeout to something like 24 hours and add retry or idempotency logic around the send step. Those concerns are provider-specific and intentionally outside this minimal example.
+To send real emails from this example, replace the `print` / `console.log` calls with a call to your email provider. You may also want to extend the timeout to better suit your workflow. Provider-specific delivery concerns are intentionally outside this minimal example.

--- a/frontend/docs/pages/cookbooks/welcome-email.mdx
+++ b/frontend/docs/pages/cookbooks/welcome-email.mdx
@@ -68,6 +68,8 @@ The core of this example is a single [durable task](/v1/durable-execution) that 
 
 The event condition uses a **scope** set to the current user's ID. When the `user:onboarding-completed` event is pushed later, it must be pushed with the same scope value. This ensures that one user's onboarding event does not accidentally satisfy another user's wait.
 
+The condition also includes a lookback window (`consider_events_since` in Python, `considerEventsSince` in TypeScript). This lets the workflow pick up an onboarding event that arrived slightly before the wait became active — for example, if the welcome email step and the onboarding event happen nearly at the same time.
+
 ### Register and start the worker
 
 Register the durable task on a Hatchet worker and start it.

--- a/sdks/python/examples/welcome_email/test_welcome_email.py
+++ b/sdks/python/examples/welcome_email/test_welcome_email.py
@@ -29,9 +29,9 @@ async def test_welcome_email_onboarding_before_timeout(hatchet: Hatchet) -> None
 
     result = await ref.aio_result()
 
-    assert result["user_id"] == user_id
-    assert result["welcome_sent"] is True
-    assert result["follow_up_sent"] is False
+    assert result.user_id == user_id
+    assert result.welcome_sent is True
+    assert result.follow_up_sent is False
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -45,6 +45,6 @@ async def test_welcome_email_timeout_follow_up(hatchet: Hatchet) -> None:
 
     result = await welcome_email.aio_run(signup)
 
-    assert result["user_id"] == user_id
-    assert result["welcome_sent"] is True
-    assert result["follow_up_sent"] is True
+    assert result.user_id == user_id
+    assert result.welcome_sent is True
+    assert result.follow_up_sent is True

--- a/sdks/python/examples/welcome_email/test_welcome_email.py
+++ b/sdks/python/examples/welcome_email/test_welcome_email.py
@@ -1,0 +1,50 @@
+from uuid import uuid4
+
+import pytest
+
+from examples.welcome_email.worker import (
+    ONBOARDING_EVENT_KEY,
+    SignupInput,
+    welcome_email,
+)
+from hatchet_sdk import Hatchet
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_welcome_email_onboarding_before_timeout(hatchet: Hatchet) -> None:
+    """User completes onboarding before timeout -> follow-up skipped."""
+    user_id = f"test-{uuid4().hex[:8]}"
+    signup = SignupInput(
+        email="alice@example.com",
+        user_id=user_id,
+    )
+
+    ref = await welcome_email.aio_run(signup, wait_for_result=False)
+
+    await hatchet.event.aio_push(
+        ONBOARDING_EVENT_KEY,
+        {"status": "done"},
+        scope=signup.user_id,
+    )
+
+    result = await ref.aio_result()
+
+    assert result["user_id"] == user_id
+    assert result["welcome_sent"] is True
+    assert result["follow_up_sent"] is False
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_welcome_email_timeout_follow_up(hatchet: Hatchet) -> None:
+    """No onboarding event -> workflow times out and sends follow-up."""
+    user_id = f"test-{uuid4().hex[:8]}"
+    signup = SignupInput(
+        email="bob@example.com",
+        user_id=user_id,
+    )
+
+    result = await welcome_email.aio_run(signup)
+
+    assert result["user_id"] == user_id
+    assert result["welcome_sent"] is True
+    assert result["follow_up_sent"] is True

--- a/sdks/python/examples/welcome_email/trigger.py
+++ b/sdks/python/examples/welcome_email/trigger.py
@@ -1,0 +1,31 @@
+# > Trigger the workflow
+from examples.welcome_email.worker import (
+    ONBOARDING_EVENT_KEY,
+    SignupInput,
+    hatchet,
+    welcome_email,
+)
+
+signup = SignupInput(
+    email="alice@example.com",
+    user_id="user-123",
+)
+
+# Start the welcome-email workflow
+ref = welcome_email.run(signup, wait_for_result=False)
+print(f"Started workflow run: {ref.workflow_run_id}")
+
+# Push onboarding-completed event (scoped to this user)
+print("Pushing onboarding-completed event...")
+hatchet.event.push(
+    ONBOARDING_EVENT_KEY,
+    {"status": "done"},
+    scope=signup.user_id,
+)
+
+# Wait for the workflow to complete
+result = ref.result()
+print(f"Workflow completed: {result}")
+
+
+# !!

--- a/sdks/python/examples/welcome_email/worker.py
+++ b/sdks/python/examples/welcome_email/worker.py
@@ -13,7 +13,7 @@ from hatchet_sdk import (
 hatchet = Hatchet()
 
 ONBOARDING_EVENT_KEY = "user:onboarding-completed"
-TIMEOUT_SECONDS = 30
+TIMEOUT_SECONDS = 5
 
 
 # > Models

--- a/sdks/python/examples/welcome_email/worker.py
+++ b/sdks/python/examples/welcome_email/worker.py
@@ -41,10 +41,10 @@ class WelcomeEmailResult(BaseModel):
 )
 async def welcome_email(input: SignupInput, ctx: DurableContext) -> WelcomeEmailResult:
     # Step 1: Send the welcome email
-    print(f"Sending welcome email to {input.email}")
+    print(f"Sending welcome email to {input.email}: finish your first onboarding step")
 
     # Step 2: Wait for the user to complete onboarding, or time out
-    # (use a longer duration like timedelta(hours=24) in production)
+    # (use a longer duration for a more realistic workflow)
     now = await ctx.aio_now()
     consider_events_since = now - timedelta(minutes=LOOKBACK_MINUTES)
 
@@ -77,7 +77,7 @@ async def welcome_email(input: SignupInput, ctx: DurableContext) -> WelcomeEmail
         )
 
     # Step 3b: Timeout -> send follow-up email
-    print(f"Sending follow-up email to {input.email}")
+    print(f"Sending follow-up email to {input.email}: need help finishing onboarding?")
     return WelcomeEmailResult(
         user_id=input.user_id,
         welcome_sent=True,

--- a/sdks/python/examples/welcome_email/worker.py
+++ b/sdks/python/examples/welcome_email/worker.py
@@ -14,6 +14,7 @@ hatchet = Hatchet()
 
 ONBOARDING_EVENT_KEY = "user:onboarding-completed"
 TIMEOUT_SECONDS = 5
+LOOKBACK_MINUTES = 5
 
 
 # > Models
@@ -44,6 +45,9 @@ async def welcome_email(input: SignupInput, ctx: DurableContext) -> WelcomeEmail
 
     # Step 2: Wait for the user to complete onboarding, or time out
     # (use a longer duration like timedelta(hours=24) in production)
+    now = await ctx.aio_now()
+    consider_events_since = now - timedelta(minutes=LOOKBACK_MINUTES)
+
     wait_result = await ctx.aio_wait_for(
         "onboarding-or-timeout",
         or_(
@@ -53,6 +57,7 @@ async def welcome_email(input: SignupInput, ctx: DurableContext) -> WelcomeEmail
             UserEventCondition(
                 event_key=ONBOARDING_EVENT_KEY,
                 scope=input.user_id,
+                consider_events_since=consider_events_since,
             ),
         ),
     )

--- a/sdks/python/examples/welcome_email/worker.py
+++ b/sdks/python/examples/welcome_email/worker.py
@@ -1,0 +1,96 @@
+from datetime import timedelta
+
+from pydantic import BaseModel
+
+from hatchet_sdk import (
+    DurableContext,
+    Hatchet,
+    SleepCondition,
+    UserEventCondition,
+    or_,
+)
+
+hatchet = Hatchet()
+
+ONBOARDING_EVENT_KEY = "user:onboarding-completed"
+TIMEOUT_SECONDS = 30
+
+
+# > Models
+class SignupInput(BaseModel):
+    email: str
+    user_id: str
+
+
+class WelcomeEmailResult(BaseModel):
+    user_id: str
+    welcome_sent: bool
+    follow_up_sent: bool
+
+
+# !!
+
+
+# > Welcome email task
+@hatchet.durable_task(
+    name="welcome-email",
+    on_events=["user:signup"],
+    input_validator=SignupInput,
+    execution_timeout=timedelta(minutes=5),
+)
+async def welcome_email(input: SignupInput, ctx: DurableContext) -> WelcomeEmailResult:
+    # Step 1: Send the welcome email
+    print(f"Sending welcome email to {input.email}")
+
+    # Step 2: Wait for the user to complete onboarding, or time out
+    # (use a longer duration like timedelta(hours=24) in production)
+    wait_result = await ctx.aio_wait_for(
+        "onboarding-or-timeout",
+        or_(
+            SleepCondition(timedelta(seconds=TIMEOUT_SECONDS)),
+            # Scope the event condition to this user so that another user's
+            # onboarding-completed event does not resolve this wait.
+            UserEventCondition(
+                event_key=ONBOARDING_EVENT_KEY,
+                scope=input.user_id,
+            ),
+        ),
+    )
+
+    # The or-group result is {"CREATE": {"<condition_key>": ...}}.
+    # Check whether the onboarding event was the one that resolved.
+    resolved_key = list(wait_result["CREATE"].keys())[0]
+    onboarding_completed = resolved_key == ONBOARDING_EVENT_KEY
+
+    if onboarding_completed:
+        # Step 3a: User completed onboarding -> skip follow-up
+        print(f"User {input.user_id} completed onboarding, skipping follow-up")
+        return WelcomeEmailResult(
+            user_id=input.user_id,
+            welcome_sent=True,
+            follow_up_sent=False,
+        )
+
+    # Step 3b: Timeout -> send follow-up email
+    print(f"Sending follow-up email to {input.email}")
+    return WelcomeEmailResult(
+        user_id=input.user_id,
+        welcome_sent=True,
+        follow_up_sent=True,
+    )
+
+
+# !!
+
+
+# > Worker registration
+def main() -> None:
+    worker = hatchet.worker("welcome-email-worker", workflows=[welcome_email])
+    worker.start()
+
+
+if __name__ == "__main__":
+    main()
+
+
+# !!

--- a/sdks/python/examples/worker.py
+++ b/sdks/python/examples/worker.py
@@ -88,6 +88,7 @@ from examples.webhook_with_scope.worker import (
     webhook_with_static_payload,
 )
 from examples.webhooks.worker import webhook
+from examples.welcome_email.worker import welcome_email
 from examples.opentelemetry_instrumentation.worker import (
     otel_workflow,
     otel_simple_task,
@@ -181,6 +182,7 @@ def main() -> None:
             triage_ticket,
             generate_reply,
             escalate_ticket,
+            welcome_email,
         ],
         lifespan=lifespan,
     )

--- a/sdks/typescript/src/v1/examples/e2e-worker.ts
+++ b/sdks/typescript/src/v1/examples/e2e-worker.ts
@@ -64,6 +64,7 @@ import {
   generateReply,
   escalateTicket,
 } from './support_agent/workflow';
+import { welcomeEmail } from './welcome_email/workflow';
 
 const workflows = [
   bulkChild,
@@ -123,6 +124,7 @@ const workflows = [
   triageTicket,
   generateReply,
   escalateTicket,
+  welcomeEmail,
 ];
 
 async function main() {

--- a/sdks/typescript/src/v1/examples/welcome_email/run.ts
+++ b/sdks/typescript/src/v1/examples/welcome_email/run.ts
@@ -1,7 +1,7 @@
+// > Trigger the workflow
 import { hatchet } from '../hatchet-client';
 import { welcomeEmail, ONBOARDING_EVENT_KEY, SignupInput } from './workflow';
 
-// > Trigger the workflow
 async function main() {
   const input: SignupInput = {
     email: 'alice@example.com',

--- a/sdks/typescript/src/v1/examples/welcome_email/run.ts
+++ b/sdks/typescript/src/v1/examples/welcome_email/run.ts
@@ -1,0 +1,32 @@
+import { hatchet } from '../hatchet-client';
+import { welcomeEmail, ONBOARDING_EVENT_KEY, SignupInput } from './workflow';
+
+// > Trigger the workflow
+async function main() {
+  const input: SignupInput = {
+    email: 'alice@example.com',
+    user_id: 'user-123',
+  };
+
+  // Start the welcome-email workflow
+  const ref = await welcomeEmail.runNoWait(input);
+  const runId = await ref.getWorkflowRunId();
+  console.log(`Started workflow run: ${runId}`);
+
+  // Push onboarding-completed event (scoped to this user)
+  console.log('Pushing onboarding-completed event...');
+  await hatchet.events.push(ONBOARDING_EVENT_KEY, { status: 'done' }, { scope: input.user_id });
+
+  // Wait for the workflow to complete
+  const result = await ref.output;
+  console.log('Workflow completed:', result);
+}
+// !!
+
+if (require.main === module) {
+  main()
+    .catch(console.error)
+    .finally(() => {
+      process.exit(0);
+    });
+}

--- a/sdks/typescript/src/v1/examples/welcome_email/welcome_email.e2e.ts
+++ b/sdks/typescript/src/v1/examples/welcome_email/welcome_email.e2e.ts
@@ -1,0 +1,39 @@
+import { randomUUID } from 'crypto';
+import { makeE2EClient } from '../__e2e__/harness';
+import { welcomeEmail, ONBOARDING_EVENT_KEY, SignupInput } from './workflow';
+
+describe('welcome-email-e2e', () => {
+  const hatchet = makeE2EClient();
+
+  it('skips follow-up when onboarding completes before timeout', async () => {
+    const userId = `test-${randomUUID().slice(0, 8)}`;
+    const input: SignupInput = {
+      email: 'alice@example.com',
+      user_id: userId,
+    };
+
+    const ref = await welcomeEmail.runNoWait(input);
+
+    await hatchet.events.push(ONBOARDING_EVENT_KEY, { status: 'done' }, { scope: userId });
+
+    const result = await ref.output;
+
+    expect((result as any).userId).toBe(userId);
+    expect((result as any).welcomeSent).toBe(true);
+    expect((result as any).followUpSent).toBe(false);
+  }, 120_000);
+
+  it('sends follow-up when timeout fires', async () => {
+    const userId = `test-${randomUUID().slice(0, 8)}`;
+    const input: SignupInput = {
+      email: 'bob@example.com',
+      user_id: userId,
+    };
+
+    const result = await welcomeEmail.run(input);
+
+    expect((result as any).userId).toBe(userId);
+    expect((result as any).welcomeSent).toBe(true);
+    expect((result as any).followUpSent).toBe(true);
+  }, 120_000);
+});

--- a/sdks/typescript/src/v1/examples/welcome_email/workflow.ts
+++ b/sdks/typescript/src/v1/examples/welcome_email/workflow.ts
@@ -26,10 +26,10 @@ export const welcomeEmail = hatchet.durableTask<SignupInput, WelcomeEmailResult>
   executionTimeout: '5m',
   fn: async (input, ctx) => {
     // Step 1: Send the welcome email
-    console.log(`Sending welcome email to ${input.email}`);
+    console.log(`Sending welcome email to ${input.email}: finish your first onboarding step`);
 
     // Step 2: Wait for the user to complete onboarding, or time out
-    // (use a longer duration like '24h' in production)
+    // (use a longer duration for a more realistic workflow)
     const now = await ctx.now();
     const considerEventsSince = new Date(
       now.getTime() - durationToMs(LOOKBACK_WINDOW)
@@ -57,7 +57,7 @@ export const welcomeEmail = hatchet.durableTask<SignupInput, WelcomeEmailResult>
     }
 
     // Step 3b: Timeout -> send follow-up email
-    console.log(`Sending follow-up email to ${input.email}`);
+    console.log(`Sending follow-up email to ${input.email}: need help finishing onboarding?`);
     return { userId: input.user_id, welcomeSent: true, followUpSent: true };
   },
 });

--- a/sdks/typescript/src/v1/examples/welcome_email/workflow.ts
+++ b/sdks/typescript/src/v1/examples/welcome_email/workflow.ts
@@ -1,8 +1,10 @@
 import { Or } from '@hatchet/v1/conditions';
+import { durationToMs } from '@hatchet/v1/client/duration';
 import { hatchet } from '../hatchet-client';
 
 export const ONBOARDING_EVENT_KEY = 'user:onboarding-completed';
 const TIMEOUT_SECONDS = 5;
+const LOOKBACK_WINDOW = '5m' as const;
 
 // > Models
 export type SignupInput = {
@@ -28,12 +30,17 @@ export const welcomeEmail = hatchet.durableTask<SignupInput, WelcomeEmailResult>
 
     // Step 2: Wait for the user to complete onboarding, or time out
     // (use a longer duration like '24h' in production)
+    const now = await ctx.now();
+    const considerEventsSince = new Date(
+      now.getTime() - durationToMs(LOOKBACK_WINDOW)
+    ).toISOString();
+
     const waitResult = await ctx.waitFor(
       Or(
         { sleepFor: `${TIMEOUT_SECONDS}s` },
         // Scope the event condition to this user so that another user's
         // onboarding-completed event does not resolve this wait.
-        { eventKey: ONBOARDING_EVENT_KEY, scope: input.user_id }
+        { eventKey: ONBOARDING_EVENT_KEY, scope: input.user_id, considerEventsSince }
       )
     );
 

--- a/sdks/typescript/src/v1/examples/welcome_email/workflow.ts
+++ b/sdks/typescript/src/v1/examples/welcome_email/workflow.ts
@@ -1,8 +1,8 @@
 import { Or } from '@hatchet/v1/conditions';
 import { hatchet } from '../hatchet-client';
 
-const ONBOARDING_EVENT_KEY = 'user:onboarding-completed';
-const TIMEOUT_SECONDS = 30;
+export const ONBOARDING_EVENT_KEY = 'user:onboarding-completed';
+const TIMEOUT_SECONDS = 5;
 
 // > Models
 export type SignupInput = {

--- a/sdks/typescript/src/v1/examples/welcome_email/workflow.ts
+++ b/sdks/typescript/src/v1/examples/welcome_email/workflow.ts
@@ -1,0 +1,57 @@
+import { Or } from '@hatchet/v1/conditions';
+import { hatchet } from '../hatchet-client';
+
+const ONBOARDING_EVENT_KEY = 'user:onboarding-completed';
+const TIMEOUT_SECONDS = 30;
+
+// > Models
+export type SignupInput = {
+  email: string;
+  user_id: string;
+};
+
+export type WelcomeEmailResult = {
+  userId: string;
+  welcomeSent: boolean;
+  followUpSent: boolean;
+};
+// !!
+
+// > Welcome email task
+export const welcomeEmail = hatchet.durableTask<SignupInput, WelcomeEmailResult>({
+  name: 'welcome-email',
+  onEvents: ['user:signup'],
+  executionTimeout: '5m',
+  fn: async (input, ctx) => {
+    // Step 1: Send the welcome email
+    console.log(`Sending welcome email to ${input.email}`);
+
+    // Step 2: Wait for the user to complete onboarding, or time out
+    // (use a longer duration like '24h' in production)
+    const waitResult = await ctx.waitFor(
+      Or(
+        { sleepFor: `${TIMEOUT_SECONDS}s` },
+        // Scope the event condition to this user so that another user's
+        // onboarding-completed event does not resolve this wait.
+        { eventKey: ONBOARDING_EVENT_KEY, scope: input.user_id }
+      )
+    );
+
+    // The or-group result is { CREATE: { <condition_key>: ... } }.
+    // Check whether the onboarding event was the one that resolved.
+    const create = (waitResult as Record<string, Record<string, unknown>>)['CREATE'] ?? waitResult;
+    const resolvedKey = Object.keys(create as Record<string, unknown>)[0] ?? '';
+    const onboardingCompleted = resolvedKey === ONBOARDING_EVENT_KEY;
+
+    if (onboardingCompleted) {
+      // Step 3a: User completed onboarding -> skip follow-up
+      console.log(`User ${input.user_id} completed onboarding, skipping follow-up`);
+      return { userId: input.user_id, welcomeSent: true, followUpSent: false };
+    }
+
+    // Step 3b: Timeout -> send follow-up email
+    console.log(`Sending follow-up email to ${input.email}`);
+    return { userId: input.user_id, welcomeSent: true, followUpSent: true };
+  },
+});
+// !!


### PR DESCRIPTION
# Description

Adds a new multi-language cookbook for building a welcome email workflow with Hatchet.

The cookbook shows how to use a durable task to send a welcome email after signup, wait for a scoped onboarding-completed event or timeout, and send a follow-up email only when the timeout wins. It includes Python and TypeScript examples, trigger/run scripts, e2e tests, generated snippets, and cookbook navigation updates.

## Type of change

- [x] Documentation change (pure documentation change)

## What's Changed

- [x] Add Python and TypeScript welcome email durable workflow examples
- [x] Add trigger/run scripts demonstrating the onboarding-completed path
- [x] Add e2e tests for both branches:
  - onboarding event arrives before timeout -> follow-up skipped
  - timeout fires before onboarding event -> follow-up sent
- [x] Use scoped event correlation so one user’s onboarding event cannot resolve another user’s wait
- [x] Add a short lookback window so early onboarding events are not missed before the wait becomes active
- [x] Add a snippet-backed `Welcome Email` cookbook page
- [x] Add the cookbook to the cookbook navigation and index
- [x] Regenerate snippets and example mirrors