### PR TITLE
Make all list partition calls specific to v1 tenants only

### DIFF
--- a/internal/operation/pool.go
+++ b/internal/operation/pool.go
@@ -78,7 +78,7 @@ func NewTenantOperationPool(p *partition.Partition, ql *zerolog.Logger, operatio
 				// list all tenants
 				innerCtx, innerCancel := context.WithTimeout(outerCtx, 5*time.Second)
 
-				tenants, err := p.ListTenantsForController(innerCtx, sqlcv1.TenantMajorEngineVersionV1)
+				tenants, err := p.ListTenantsForController(innerCtx)
 
 				if err != nil {
 					innerCancel()

--- a/internal/services/controllers/olap/process_alerts.go
+++ b/internal/services/controllers/olap/process_alerts.go
@@ -17,7 +17,7 @@ func (o *OLAPControllerImpl) runTenantProcessAlerts(ctx context.Context) func() 
 		o.l.Debug().Ctx(ctx).Msgf("partition: processing tenant alerts")
 
 		// list all tenants
-		tenants, err := o.p.ListTenantsForController(ctx, sqlcv1.TenantMajorEngineVersionV1)
+		tenants, err := o.p.ListTenantsForController(ctx)
 
 		if err != nil {
 			o.l.Error().Ctx(ctx).Err(err).Msg("could not list tenants")

--- a/internal/services/controllers/olap/process_dag_status_updates.go
+++ b/internal/services/controllers/olap/process_dag_status_updates.go
@@ -23,7 +23,7 @@ func (o *OLAPControllerImpl) runDAGStatusUpdates(ctx context.Context) func() {
 			o.l.Debug().Ctx(ctx).Msgf("partition: running status updates for dags")
 
 			// list all tenants
-			tenants, err := o.p.ListTenantsForController(ctx, sqlcv1.TenantMajorEngineVersionV1)
+			tenants, err := o.p.ListTenantsForController(ctx)
 
 			if err != nil {
 				o.l.Error().Ctx(ctx).Err(err).Msg("could not list tenants")

--- a/internal/services/controllers/olap/process_task_status_updates.go
+++ b/internal/services/controllers/olap/process_task_status_updates.go
@@ -23,7 +23,7 @@ func (o *OLAPControllerImpl) runTaskStatusUpdates(ctx context.Context) func() {
 			o.l.Debug().Ctx(ctx).Msgf("partition: running status updates for tasks")
 
 			// list all tenants
-			tenants, err := o.p.ListTenantsForController(ctx, sqlcv1.TenantMajorEngineVersionV1)
+			tenants, err := o.p.ListTenantsForController(ctx)
 
 			if err != nil {
 				o.l.Error().Ctx(ctx).Err(err).Msg("could not list tenants")

--- a/internal/services/controllers/retention/shared.go
+++ b/internal/services/controllers/retention/shared.go
@@ -23,7 +23,7 @@ func GetDataRetentionExpiredTime(duration string) (time.Time, error) {
 }
 
 func (rc *RetentionControllerImpl) ForTenants(ctx context.Context, perTenantTimeout time.Duration, f func(ctx context.Context, tenant sqlcv1.Tenant) error) error {
-	tenants, err := rc.p.ListTenantsForController(ctx, sqlcv1.TenantMajorEngineVersionV0)
+	tenants, err := rc.p.ListTenantsForController(ctx)
 
 	if err != nil {
 		return fmt.Errorf("could not list tenants: %w", err)

--- a/internal/services/partition/partition.go
+++ b/internal/services/partition/partition.go
@@ -176,16 +176,16 @@ func (p *Partition) GetInternalTenantForController(ctx context.Context) (*sqlcv1
 	return p.repo.GetInternalTenantForController(ctx, p.GetControllerPartitionId())
 }
 
-func (p *Partition) ListTenantsForController(ctx context.Context, majorVersion sqlcv1.TenantMajorEngineVersion) ([]*sqlcv1.Tenant, error) {
-	return p.repo.ListTenantsByControllerPartition(ctx, p.GetControllerPartitionId(), majorVersion)
+func (p *Partition) ListTenantsForController(ctx context.Context) ([]*sqlcv1.Tenant, error) {
+	return p.repo.ListTenantsByControllerPartition(ctx, p.GetControllerPartitionId())
 }
 
-func (p *Partition) ListTenantsForScheduler(ctx context.Context, majorVersion sqlcv1.TenantMajorEngineVersion) ([]*sqlcv1.Tenant, error) {
-	return p.repo.ListTenantsBySchedulerPartition(ctx, p.GetSchedulerPartitionId(), majorVersion)
+func (p *Partition) ListTenantsForScheduler(ctx context.Context) ([]*sqlcv1.Tenant, error) {
+	return p.repo.ListTenantsBySchedulerPartition(ctx, p.GetSchedulerPartitionId())
 }
 
-func (p *Partition) ListTenantsForWorkerPartition(ctx context.Context, majorVersion sqlcv1.TenantMajorEngineVersion) ([]*sqlcv1.Tenant, error) {
-	return p.repo.ListTenantsByWorkerPartition(ctx, p.GetWorkerPartitionId(), majorVersion)
+func (p *Partition) ListTenantsForWorkerPartition(ctx context.Context) ([]*sqlcv1.Tenant, error) {
+	return p.repo.ListTenantsByWorkerPartition(ctx, p.GetWorkerPartitionId())
 }
 
 func (p *Partition) runControllerPartitionHeartbeat(ctx context.Context) func() {

--- a/internal/services/scheduler/v1/scheduler.go
+++ b/internal/services/scheduler/v1/scheduler.go
@@ -393,7 +393,7 @@ func (s *Scheduler) runSetTenants(ctx context.Context) func() {
 		s.l.Debug().Ctx(ctx).Msgf("partition: checking step run requeue")
 
 		// list all tenants
-		tenants, err := s.repov1.Tenant().ListTenantsBySchedulerPartition(ctx, s.p.GetSchedulerPartitionId(), sqlcv1.TenantMajorEngineVersionV1)
+		tenants, err := s.repov1.Tenant().ListTenantsBySchedulerPartition(ctx, s.p.GetSchedulerPartitionId())
 
 		if err != nil {
 			s.l.Err(err).Ctx(ctx).Msg("could not list tenants")

--- a/pkg/repository/sqlcv1/tenants.sql
+++ b/pkg/repository/sqlcv1/tenants.sql
@@ -87,7 +87,7 @@ FROM
     "Tenant" as tenants
 WHERE
     "controllerPartitionId" = sqlc.arg('controllerPartitionId')::text
-    AND "version" = @majorVersion::"TenantMajorEngineVersion"
+    AND "version" = 'V1'::"TenantMajorEngineVersion"
     AND "deletedAt" IS NULL;
 
 -- name: ListTenantsByTenantWorkerPartitionId :many
@@ -97,7 +97,7 @@ FROM
     "Tenant" as tenants
 WHERE
     "workerPartitionId" = sqlc.arg('workerPartitionId')::text
-    AND "version" = @majorVersion::"TenantMajorEngineVersion"
+    AND "version" = 'V1'::"TenantMajorEngineVersion"
     AND "deletedAt" IS NULL;
 
 -- name: GetTenantByID :one
@@ -493,7 +493,7 @@ FROM
     "Tenant" as tenants
 WHERE
     "schedulerPartitionId" = sqlc.arg('schedulerPartitionId')::text
-    AND "version" = @majorVersion::"TenantMajorEngineVersion"
+    AND "version" = 'V1'::"TenantMajorEngineVersion"
     AND "deletedAt" IS NULL;
 
 -- name: UpsertTenantAlertingSettings :one

--- a/pkg/repository/sqlcv1/tenants.sql.go
+++ b/pkg/repository/sqlcv1/tenants.sql.go
@@ -1021,17 +1021,12 @@ FROM
     "Tenant" as tenants
 WHERE
     "controllerPartitionId" = $1::text
-    AND "version" = $2::"TenantMajorEngineVersion"
+    AND "version" = 'V1'::"TenantMajorEngineVersion"
     AND "deletedAt" IS NULL
 `
 
-type ListTenantsByControllerPartitionIdParams struct {
-	ControllerPartitionId string                   `json:"controllerPartitionId"`
-	Majorversion          TenantMajorEngineVersion `json:"majorversion"`
-}
-
-func (q *Queries) ListTenantsByControllerPartitionId(ctx context.Context, db DBTX, arg ListTenantsByControllerPartitionIdParams) ([]*Tenant, error) {
-	rows, err := db.Query(ctx, listTenantsByControllerPartitionId, arg.ControllerPartitionId, arg.Majorversion)
+func (q *Queries) ListTenantsByControllerPartitionId(ctx context.Context, db DBTX, controllerpartitionid string) ([]*Tenant, error) {
+	rows, err := db.Query(ctx, listTenantsByControllerPartitionId, controllerpartitionid)
 	if err != nil {
 		return nil, err
 	}
@@ -1075,17 +1070,12 @@ FROM
     "Tenant" as tenants
 WHERE
     "schedulerPartitionId" = $1::text
-    AND "version" = $2::"TenantMajorEngineVersion"
+    AND "version" = 'V1'::"TenantMajorEngineVersion"
     AND "deletedAt" IS NULL
 `
 
-type ListTenantsBySchedulerPartitionIdParams struct {
-	SchedulerPartitionId string                   `json:"schedulerPartitionId"`
-	Majorversion         TenantMajorEngineVersion `json:"majorversion"`
-}
-
-func (q *Queries) ListTenantsBySchedulerPartitionId(ctx context.Context, db DBTX, arg ListTenantsBySchedulerPartitionIdParams) ([]*Tenant, error) {
-	rows, err := db.Query(ctx, listTenantsBySchedulerPartitionId, arg.SchedulerPartitionId, arg.Majorversion)
+func (q *Queries) ListTenantsBySchedulerPartitionId(ctx context.Context, db DBTX, schedulerpartitionid string) ([]*Tenant, error) {
+	rows, err := db.Query(ctx, listTenantsBySchedulerPartitionId, schedulerpartitionid)
 	if err != nil {
 		return nil, err
 	}
@@ -1129,17 +1119,12 @@ FROM
     "Tenant" as tenants
 WHERE
     "workerPartitionId" = $1::text
-    AND "version" = $2::"TenantMajorEngineVersion"
+    AND "version" = 'V1'::"TenantMajorEngineVersion"
     AND "deletedAt" IS NULL
 `
 
-type ListTenantsByTenantWorkerPartitionIdParams struct {
-	WorkerPartitionId string                   `json:"workerPartitionId"`
-	Majorversion      TenantMajorEngineVersion `json:"majorversion"`
-}
-
-func (q *Queries) ListTenantsByTenantWorkerPartitionId(ctx context.Context, db DBTX, arg ListTenantsByTenantWorkerPartitionIdParams) ([]*Tenant, error) {
-	rows, err := db.Query(ctx, listTenantsByTenantWorkerPartitionId, arg.WorkerPartitionId, arg.Majorversion)
+func (q *Queries) ListTenantsByTenantWorkerPartitionId(ctx context.Context, db DBTX, workerpartitionid string) ([]*Tenant, error) {
+	rows, err := db.Query(ctx, listTenantsByTenantWorkerPartitionId, workerpartitionid)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repository/tenant.go
+++ b/pkg/repository/tenant.go
@@ -137,11 +137,11 @@ type TenantRepository interface {
 	GetInternalTenantForController(ctx context.Context, controllerPartitionId string) (*sqlcv1.Tenant, error)
 
 	// ListTenantsByPartition lists all tenants in the given partition
-	ListTenantsByControllerPartition(ctx context.Context, controllerPartitionId string, majorVersion sqlcv1.TenantMajorEngineVersion) ([]*sqlcv1.Tenant, error)
+	ListTenantsByControllerPartition(ctx context.Context, controllerPartitionId string) ([]*sqlcv1.Tenant, error)
 
-	ListTenantsByWorkerPartition(ctx context.Context, workerPartitionId string, majorVersion sqlcv1.TenantMajorEngineVersion) ([]*sqlcv1.Tenant, error)
+	ListTenantsByWorkerPartition(ctx context.Context, workerPartitionId string) ([]*sqlcv1.Tenant, error)
 
-	ListTenantsBySchedulerPartition(ctx context.Context, schedulerPartitionId string, majorVersion sqlcv1.TenantMajorEngineVersion) ([]*sqlcv1.Tenant, error)
+	ListTenantsBySchedulerPartition(ctx context.Context, schedulerPartitionId string) ([]*sqlcv1.Tenant, error)
 
 	// CreateEnginePartition creates a new partition for tenants within the engine
 	CreateControllerPartition(ctx context.Context) (string, error)
@@ -743,26 +743,20 @@ func (r *tenantRepository) GetInternalTenantForController(ctx context.Context, c
 	return tenant, nil
 }
 
-func (r *tenantRepository) ListTenantsByControllerPartition(ctx context.Context, controllerPartitionId string, majorVersion sqlcv1.TenantMajorEngineVersion) ([]*sqlcv1.Tenant, error) {
+func (r *tenantRepository) ListTenantsByControllerPartition(ctx context.Context, controllerPartitionId string) ([]*sqlcv1.Tenant, error) {
 	if controllerPartitionId == "" {
 		return nil, fmt.Errorf("partitionId is required")
 	}
 
-	return r.queries.ListTenantsByControllerPartitionId(ctx, r.pool, sqlcv1.ListTenantsByControllerPartitionIdParams{
-		ControllerPartitionId: controllerPartitionId,
-		Majorversion:          majorVersion,
-	})
+	return r.queries.ListTenantsByControllerPartitionId(ctx, r.pool, controllerPartitionId)
 }
 
-func (r *tenantRepository) ListTenantsByWorkerPartition(ctx context.Context, workerPartitionId string, majorVersion sqlcv1.TenantMajorEngineVersion) ([]*sqlcv1.Tenant, error) {
+func (r *tenantRepository) ListTenantsByWorkerPartition(ctx context.Context, workerPartitionId string) ([]*sqlcv1.Tenant, error) {
 	if workerPartitionId == "" {
 		return nil, fmt.Errorf("partitionId is required")
 	}
 
-	return r.queries.ListTenantsByTenantWorkerPartitionId(ctx, r.pool, sqlcv1.ListTenantsByTenantWorkerPartitionIdParams{
-		WorkerPartitionId: workerPartitionId,
-		Majorversion:      majorVersion,
-	})
+	return r.queries.ListTenantsByTenantWorkerPartitionId(ctx, r.pool, workerPartitionId)
 }
 
 func (r *tenantRepository) CreateControllerPartition(ctx context.Context) (string, error) {
@@ -850,15 +844,12 @@ func (r *tenantRepository) UpdateSchedulerPartitionHeartbeat(ctx context.Context
 	return partition.ID, nil
 }
 
-func (r *tenantRepository) ListTenantsBySchedulerPartition(ctx context.Context, schedulerPartitionId string, majorVersion sqlcv1.TenantMajorEngineVersion) ([]*sqlcv1.Tenant, error) {
+func (r *tenantRepository) ListTenantsBySchedulerPartition(ctx context.Context, schedulerPartitionId string) ([]*sqlcv1.Tenant, error) {
 	if schedulerPartitionId == "" {
 		return nil, fmt.Errorf("partitionId is required")
 	}
 
-	return r.queries.ListTenantsBySchedulerPartitionId(ctx, r.pool, sqlcv1.ListTenantsBySchedulerPartitionIdParams{
-		SchedulerPartitionId: schedulerPartitionId,
-		Majorversion:         majorVersion,
-	})
+	return r.queries.ListTenantsBySchedulerPartitionId(ctx, r.pool, schedulerPartitionId)
 }
 
 func (r *tenantRepository) CreateSchedulerPartition(ctx context.Context) (string, error) {


### PR DESCRIPTION
# Description

Time to make these calls only specific to v1 tenants. Cleans up a bit of the code.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (changes which are not directly related to any business logic)