### PR TITLE
Added validation for seed password

### DIFF
--- a/cmd/hatchet-admin/cli/seed/seed.go
+++ b/cmd/hatchet-admin/cli/seed/seed.go
@@ -19,7 +19,12 @@ func SeedDatabase(dc *database.Layer) error {
 
 	if shouldSeedUser {
 		// validate the password meets complexity requirements before hashing
-		if !validator.ValidatePassword(dc.Seed.AdminPassword) {
+		v := validator.NewDefaultValidator()
+		opts := struct {
+			Password string `validate:"password"`
+		}{dc.Seed.AdminPassword}
+
+		if err := v.Validate(opts); err != nil {
 			return fmt.Errorf("ADMIN_PASSWORD does not meet requirements: must be between 8 and 64 characters and contain at least one uppercase letter, one lowercase letter, and one number")
 		}
 

--- a/cmd/hatchet-admin/cli/seed/seed.go
+++ b/cmd/hatchet-admin/cli/seed/seed.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hatchet-dev/hatchet/pkg/config/database"
 	v1 "github.com/hatchet-dev/hatchet/pkg/repository"
+	"github.com/hatchet-dev/hatchet/pkg/validator"
 )
 
 func SeedDatabase(dc *database.Layer) error {
@@ -17,6 +18,11 @@ func SeedDatabase(dc *database.Layer) error {
 	var userID uuid.UUID
 
 	if shouldSeedUser {
+		// validate the password meets complexity requirements before hashing
+		if !validator.ValidatePassword(dc.Seed.AdminPassword) {
+			return fmt.Errorf("ADMIN_PASSWORD does not meet requirements: must be between 8 and 64 characters and contain at least one uppercase letter, one lowercase letter, and one number")
+		}
+
 		// seed an example user
 		hashedPw, err := v1.HashPassword(dc.Seed.AdminPassword)
 

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -28,7 +28,7 @@ func newValidator() *validator.Validate {
 	})
 
 	_ = validate.RegisterValidation("password", func(fl validator.FieldLevel) bool {
-		return ValidatePassword(fl.Field().String())
+		return passwordValidation(fl.Field().String())
 	})
 
 	_ = validate.RegisterValidation("uuid", func(fl validator.FieldLevel) bool {

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -89,10 +89,7 @@ func newValidator() *validator.Validate {
 	return validate
 }
 
-// ValidatePassword returns true if the password meets complexity requirements:
-// between 8 and 64 characters, with at least one uppercase letter, one lowercase
-// letter, and one number.
-func ValidatePassword(pw string) bool {
+func passwordValidation(pw string) bool {
 	pwLen := len(pw)
 	var hasNumber, hasUpper, hasLower bool
 

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -28,7 +28,7 @@ func newValidator() *validator.Validate {
 	})
 
 	_ = validate.RegisterValidation("password", func(fl validator.FieldLevel) bool {
-		return passwordValidation(fl.Field().String())
+		return ValidatePassword(fl.Field().String())
 	})
 
 	_ = validate.RegisterValidation("uuid", func(fl validator.FieldLevel) bool {
@@ -89,7 +89,10 @@ func newValidator() *validator.Validate {
 	return validate
 }
 
-func passwordValidation(pw string) bool {
+// ValidatePassword returns true if the password meets complexity requirements:
+// between 8 and 64 characters, with at least one uppercase letter, one lowercase
+// letter, and one number.
+func ValidatePassword(pw string) bool {
 	pwLen := len(pw)
 	var hasNumber, hasUpper, hasLower bool
 


### PR DESCRIPTION
# Description

Fixes the seed job accepting any value for ADMIN_PASSWORD without validation, which resulted in an admin account that could not be used to log in. The seed job now rejects passwords that don't meet complexity requirements before hashing and writing to the database.

Fixes #3711

Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [x] Test changes (add, refactor, improve or change a test)

What's Changed
- Renamed passwordValidation to ValidatePassword in pkg/validator/validator.go to export it for reuse outside the package
- Added password validation to SeedDatabase in cmd/hatchet-admin/cli/seed/seed.go — the seed job now returns a clear error and exits early if ADMIN_PASSWORD does not meet complexity requirements (8–64 characters, at least one uppercase letter, one lowercase letter, and one number)
