### PR TITLE
[Python] Hotfix: `wait_for_result=False` not respected in durable child spawning

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.33.3] - 2026-04-29
+
+### Changed
+
+- Fixes a bug where passing `wait_for_result=False` when spawning children out of a durable task would not be respected, causing unexpected errors and broken functionality.
+
 ## [1.33.2] - 2026-04-22
 
 ### Added

--- a/sdks/python/hatchet_sdk/runnables/workflow.py
+++ b/sdks/python/hatchet_sdk/runnables/workflow.py
@@ -1104,16 +1104,23 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
                 input=self._serialize_input(input, target="string"),
                 options=opts,
             )
-            refs = await durable_ctx._spawn_children_no_wait([config])
-            if not refs:
+            durable_spawn_results = await durable_ctx._spawn_children_no_wait([config])
+            if not durable_spawn_results:
                 raise RuntimeError(
                     "Failed to spawn durable child workflow: no run references returned"
                 )
 
+            durable_spawn_result = durable_spawn_results[0]
+
+            if not wait_for_result:
+                return self._client._client.admin.get_workflow_run(
+                    durable_spawn_result.workflow_run_external_id
+                )
+
             return await durable_ctx._aio_result_for_spawned_child(
-                node_id=refs[0].node_id,
-                branch_id=refs[0].branch_id,
-                workflow_name=refs[0].workflow_name,
+                node_id=durable_spawn_result.node_id,
+                branch_id=durable_spawn_result.branch_id,
+                workflow_name=durable_spawn_result.workflow_name,
             )
 
         ref = await self._client._client.admin.aio_run_workflow(
@@ -1952,6 +1959,7 @@ class Standalone(BaseWorkflow[TWorkflowInput], Generic[TWorkflowInput, R]):
                 desired_worker_id=desired_worker_id,
                 desired_worker_labels=desired_worker_labels,
             )
+
             return TaskRunRef[TWorkflowInput, R](self, ref)
 
         res = await self._workflow.aio_run(

--- a/sdks/python/hatchet_sdk/runnables/workflow.py
+++ b/sdks/python/hatchet_sdk/runnables/workflow.py
@@ -1238,7 +1238,6 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
         :returns: A list of results for each workflow run, or a list of WorkflowRunRef if wait_for_result is False.
         """
 
-        ## fixme: this might need a no-wait flavor?
         durable_ctx = ctx_durable_context.get()
         if durable_ctx is not None and durable_ctx._supports_durable_eviction:
             durable_spawn_results = await durable_ctx._spawn_children_no_wait(workflows)

--- a/sdks/python/hatchet_sdk/runnables/workflow.py
+++ b/sdks/python/hatchet_sdk/runnables/workflow.py
@@ -1241,7 +1241,16 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
         ## fixme: this might need a no-wait flavor?
         durable_ctx = ctx_durable_context.get()
         if durable_ctx is not None and durable_ctx._supports_durable_eviction:
-            spawned_refs = await durable_ctx._spawn_children_no_wait(workflows)
+            durable_spawn_results = await durable_ctx._spawn_children_no_wait(workflows)
+
+            if not wait_for_result:
+                return [
+                    self._client._client.admin.get_workflow_run(
+                        durable_spawn_result.workflow_run_external_id
+                    )
+                    for durable_spawn_result in durable_spawn_results
+                ]
+
             return await asyncio.gather(
                 *[
                     durable_ctx._aio_result_for_spawned_child(
@@ -1249,7 +1258,7 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
                         branch_id=ref.branch_id,
                         workflow_name=ref.workflow_name,
                     )
-                    for ref in spawned_refs
+                    for ref in durable_spawn_results
                 ],
                 return_exceptions=return_exceptions,
             )

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hatchet-sdk"
-version = "1.33.2"
+version = "1.33.3"
 description = "This is the official Python SDK for Hatchet, a distributed, fault-tolerant task queue. The SDK allows you to easily integrate Hatchet's task scheduling and workflow orchestration capabilities into your Python applications."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
# Description

## [1.33.3] - 2026-04-29

### Changed

- Fixes a bug where passing `wait_for_result=False` when spawning children out of a durable task would not be respected, causing unexpected errors and broken functionality.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

