### PR TITLE
docs(ts): use ctx.logger.info in v1 TypeScript examples

### DIFF
--- a/sdks/typescript/src/v1/examples/affinity/affinity-workers.ts
+++ b/sdks/typescript/src/v1/examples/affinity/affinity-workers.ts
@@ -18,7 +18,7 @@ workflow.task({
       results.push(result);
     }
     ctx.logger.info('Spawned 50 child workflows');
-    ctx.logger.info('Results:', await Promise.all(results));
+    ctx.logger.info('Results', { results });
 
     return { step1: 'step1 results!' };
   },

--- a/sdks/typescript/src/v1/examples/affinity/affinity-workers.ts
+++ b/sdks/typescript/src/v1/examples/affinity/affinity-workers.ts
@@ -17,8 +17,8 @@ workflow.task({
       const result = await childWorkflow.run({});
       results.push(result);
     }
-    console.log('Spawned 50 child workflows');
-    console.log('Results:', await Promise.all(results));
+    ctx.logger.info('Spawned 50 child workflows');
+    ctx.logger.info('Results:', await Promise.all(results));
 
     return { step1: 'step1 results!' };
   },

--- a/sdks/typescript/src/v1/examples/bulk_operations/workflow.ts
+++ b/sdks/typescript/src/v1/examples/bulk_operations/workflow.ts
@@ -4,7 +4,7 @@ export const bulkReplayTest1 = hatchet.task({
   name: 'bulk-replay-test-1',
   retries: 1,
   fn: async (_input, ctx) => {
-    ctx.logger.info('retrying bulk replay test task', ctx.retryCount());
+    ctx.logger.info('retrying bulk replay test task', { retryCount: ctx.retryCount() });
     if (ctx.retryCount() === 0) {
       throw new Error('This is a test error to trigger a retry.');
     }
@@ -15,7 +15,7 @@ export const bulkReplayTest2 = hatchet.task({
   name: 'bulk-replay-test-2',
   retries: 1,
   fn: async (_input, ctx) => {
-    ctx.logger.info('retrying bulk replay test task', ctx.retryCount());
+    ctx.logger.info('retrying bulk replay test task', { retryCount: ctx.retryCount() });
     if (ctx.retryCount() === 0) {
       throw new Error('This is a test error to trigger a retry.');
     }
@@ -26,7 +26,7 @@ export const bulkReplayTest3 = hatchet.task({
   name: 'bulk-replay-test-3',
   retries: 1,
   fn: async (_input, ctx) => {
-    ctx.logger.info('retrying bulk replay test task', ctx.retryCount());
+    ctx.logger.info('retrying bulk replay test task', { retryCount: ctx.retryCount() });
     if (ctx.retryCount() === 0) {
       throw new Error('This is a test error to trigger a retry.');
     }

--- a/sdks/typescript/src/v1/examples/bulk_operations/workflow.ts
+++ b/sdks/typescript/src/v1/examples/bulk_operations/workflow.ts
@@ -4,7 +4,7 @@ export const bulkReplayTest1 = hatchet.task({
   name: 'bulk-replay-test-1',
   retries: 1,
   fn: async (_input, ctx) => {
-    console.log('retrying bulk replay test task', ctx.retryCount());
+    ctx.logger.info('retrying bulk replay test task', ctx.retryCount());
     if (ctx.retryCount() === 0) {
       throw new Error('This is a test error to trigger a retry.');
     }
@@ -15,7 +15,7 @@ export const bulkReplayTest2 = hatchet.task({
   name: 'bulk-replay-test-2',
   retries: 1,
   fn: async (_input, ctx) => {
-    console.log('retrying bulk replay test task', ctx.retryCount());
+    ctx.logger.info('retrying bulk replay test task', ctx.retryCount());
     if (ctx.retryCount() === 0) {
       throw new Error('This is a test error to trigger a retry.');
     }
@@ -26,7 +26,7 @@ export const bulkReplayTest3 = hatchet.task({
   name: 'bulk-replay-test-3',
   retries: 1,
   fn: async (_input, ctx) => {
-    console.log('retrying bulk replay test task', ctx.retryCount());
+    ctx.logger.info('retrying bulk replay test task', ctx.retryCount());
     if (ctx.retryCount() === 0) {
       throw new Error('This is a test error to trigger a retry.');
     }

--- a/sdks/typescript/src/v1/examples/cancellation/cancellation-workflow.ts
+++ b/sdks/typescript/src/v1/examples/cancellation/cancellation-workflow.ts
@@ -39,16 +39,16 @@ cancellationWorkflow.task({
 // > Abort Signal
 export const abortSignal = hatchet.task({
   name: 'abort-signal',
-  fn: async (_, { abortController }) => {
+  fn: async (_, ctx) => {
     try {
       const response = await axios.get('https://api.example.com/data', {
-        signal: abortController.signal,
+        signal: ctx.abortController.signal,
       });
       // Handle the response
     } catch (error) {
       if (axios.isCancel(error)) {
         // Request was canceled
-        console.log('Request canceled');
+        ctx.logger.info('Request canceled');
       } else {
         // Handle other errors
       }

--- a/sdks/typescript/src/v1/examples/cancellations/workflow.ts
+++ b/sdks/typescript/src/v1/examples/cancellations/workflow.ts
@@ -22,16 +22,16 @@ export const cancellation = hatchet.task({
 // > Abort Signal
 export const abortSignal = hatchet.task({
   name: 'abort-signal',
-  fn: async (_, { abortController }) => {
+  fn: async (_, ctx) => {
     try {
       const response = await axios.get('https://api.example.com/data', {
-        signal: abortController.signal,
+        signal: ctx.abortController.signal,
       });
       // Handle the response
     } catch (error) {
       if (axios.isCancel(error)) {
         // Request was canceled
-        console.log('Request canceled');
+        ctx.logger.info('Request canceled');
       } else {
         // Handle other errors
       }

--- a/sdks/typescript/src/v1/examples/conditions/workflow.ts
+++ b/sdks/typescript/src/v1/examples/conditions/workflow.ts
@@ -32,7 +32,7 @@ dagWithConditions.task({
   parents: [firstTask],
   waitFor: Or({ eventKey: 'user:event' }, { sleepFor: '10s' }),
   fn: async (_, ctx) => {
-    ctx.logger.info('triggered by condition', ctx.triggers());
+    ctx.logger.info('triggered by condition', { triggers: ctx.triggers() });
 
     return {
       Completed: true,

--- a/sdks/typescript/src/v1/examples/conditions/workflow.ts
+++ b/sdks/typescript/src/v1/examples/conditions/workflow.ts
@@ -32,7 +32,7 @@ dagWithConditions.task({
   parents: [firstTask],
   waitFor: Or({ eventKey: 'user:event' }, { sleepFor: '10s' }),
   fn: async (_, ctx) => {
-    console.log('triggered by condition', ctx.triggers());
+    ctx.logger.info('triggered by condition', ctx.triggers());
 
     return {
       Completed: true,

--- a/sdks/typescript/src/v1/examples/dag_match_condition/workflow.ts
+++ b/sdks/typescript/src/v1/examples/dag_match_condition/workflow.ts
@@ -32,7 +32,7 @@ dagWithConditions.task({
   parents: [firstTask],
   waitFor: Or({ eventKey: 'user:event' }, { sleepFor: '10s' }),
   fn: async (_, ctx) => {
-    ctx.logger.info('triggered by condition', ctx.triggers());
+    ctx.logger.info('triggered by condition', { triggers: ctx.triggers() });
 
     return {
       Completed: true,

--- a/sdks/typescript/src/v1/examples/dag_match_condition/workflow.ts
+++ b/sdks/typescript/src/v1/examples/dag_match_condition/workflow.ts
@@ -32,7 +32,7 @@ dagWithConditions.task({
   parents: [firstTask],
   waitFor: Or({ eventKey: 'user:event' }, { sleepFor: '10s' }),
   fn: async (_, ctx) => {
-    console.log('triggered by condition', ctx.triggers());
+    ctx.logger.info('triggered by condition', ctx.triggers());
 
     return {
       Completed: true,

--- a/sdks/typescript/src/v1/examples/durable-event/workflow.ts
+++ b/sdks/typescript/src/v1/examples/durable-event/workflow.ts
@@ -8,7 +8,7 @@ export const durableEvent = hatchet.durableTask({
   fn: async (_, ctx) => {
     const res = await ctx.waitForEvent('user:update');
 
-    ctx.logger.info('res', res);
+    ctx.logger.info('res', { res });
 
     return {
       Value: 'done',
@@ -25,7 +25,7 @@ export const durableEventWithFilter = hatchet.durableTask({
     const res = await ctx.waitForEvent('user:update', "input.userId == '1234'");
     // !!
 
-    ctx.logger.info('res', res);
+    ctx.logger.info('res', { res });
 
     return {
       Value: 'done',

--- a/sdks/typescript/src/v1/examples/durable-event/workflow.ts
+++ b/sdks/typescript/src/v1/examples/durable-event/workflow.ts
@@ -8,7 +8,7 @@ export const durableEvent = hatchet.durableTask({
   fn: async (_, ctx) => {
     const res = await ctx.waitForEvent('user:update');
 
-    console.log('res', res);
+    ctx.logger.info('res', res);
 
     return {
       Value: 'done',
@@ -25,7 +25,7 @@ export const durableEventWithFilter = hatchet.durableTask({
     const res = await ctx.waitForEvent('user:update', "input.userId == '1234'");
     // !!
 
-    console.log('res', res);
+    ctx.logger.info('res', res);
 
     return {
       Value: 'done',

--- a/sdks/typescript/src/v1/examples/durable-sleep/workflow.ts
+++ b/sdks/typescript/src/v1/examples/durable-sleep/workflow.ts
@@ -12,7 +12,7 @@ durableSleep.durableTask({
   fn: async (_, ctx) => {
     ctx.logger.info('sleeping for 5s');
     const sleepRes = await ctx.sleepFor('5s');
-    ctx.logger.info('done sleeping for 5s', sleepRes);
+    ctx.logger.info('done sleeping for 5s', { sleepRes });
 
     return {
       Value: 'done',

--- a/sdks/typescript/src/v1/examples/durable-sleep/workflow.ts
+++ b/sdks/typescript/src/v1/examples/durable-sleep/workflow.ts
@@ -10,9 +10,9 @@ durableSleep.durableTask({
   name: 'durable-sleep',
   executionTimeout: '10m',
   fn: async (_, ctx) => {
-    console.log('sleeping for 5s');
+    ctx.logger.info('sleeping for 5s');
     const sleepRes = await ctx.sleepFor('5s');
-    console.log('done sleeping for 5s', sleepRes);
+    ctx.logger.info('done sleeping for 5s', sleepRes);
 
     return {
       Value: 'done',

--- a/sdks/typescript/src/v1/examples/durable/workflow.ts
+++ b/sdks/typescript/src/v1/examples/durable/workflow.ts
@@ -17,8 +17,8 @@ export const durableWorkflow = hatchet.workflow({
 
 durableWorkflow.task({
   name: 'ephemeral_task',
-  fn: async () => {
-    console.log('Running non-durable task');
+  fn: async (_, ctx) => {
+    ctx.logger.info('Running non-durable task');
   },
 });
 
@@ -26,13 +26,13 @@ durableWorkflow.durableTask({
   name: 'durable_task',
   executionTimeout: '10m',
   fn: async (_input, ctx) => {
-    console.log('Waiting for sleep');
+    ctx.logger.info('Waiting for sleep');
     const sleepResult = await ctx.sleepFor(SLEEP_TIME, { label: 'waiting for sleep' });
-    console.log('Sleep finished');
+    ctx.logger.info('Sleep finished');
 
-    console.log('Waiting for event');
+    ctx.logger.info('Waiting for event');
     const event = await ctx.waitForEvent(EVENT_KEY, 'true');
-    console.log('Event received');
+    ctx.logger.info('Event received');
 
     return {
       status: 'success',

--- a/sdks/typescript/src/v1/examples/durable_event/workflow.ts
+++ b/sdks/typescript/src/v1/examples/durable_event/workflow.ts
@@ -10,7 +10,7 @@ export const durableEvent = hatchet.durableTask({
   fn: async (_, ctx) => {
     const res = await ctx.waitForEvent(EVENT_KEY);
 
-    ctx.logger.info('res', res);
+    ctx.logger.info('res', { res });
 
     return {
       Value: 'done',
@@ -27,7 +27,7 @@ export const durableEventWithFilter = hatchet.durableTask({
     const res = await ctx.waitForEvent(EVENT_KEY, "input.userId == '1234'");
     // !!
 
-    ctx.logger.info('res', res);
+    ctx.logger.info('res', { res });
 
     return {
       Value: 'done',
@@ -43,7 +43,7 @@ export const durableEventWithLookback = hatchet.durableTask({
   fn: async (_, ctx) => {
     const res = await ctx.waitForEvent(EVENT_KEY, undefined, undefined, SCOPE, '1m');
 
-    ctx.logger.info('res', res);
+    ctx.logger.info('res', { res });
 
     return {
       Value: 'done',

--- a/sdks/typescript/src/v1/examples/durable_event/workflow.ts
+++ b/sdks/typescript/src/v1/examples/durable_event/workflow.ts
@@ -10,7 +10,7 @@ export const durableEvent = hatchet.durableTask({
   fn: async (_, ctx) => {
     const res = await ctx.waitForEvent(EVENT_KEY);
 
-    console.log('res', res);
+    ctx.logger.info('res', res);
 
     return {
       Value: 'done',
@@ -27,7 +27,7 @@ export const durableEventWithFilter = hatchet.durableTask({
     const res = await ctx.waitForEvent(EVENT_KEY, "input.userId == '1234'");
     // !!
 
-    console.log('res', res);
+    ctx.logger.info('res', res);
 
     return {
       Value: 'done',
@@ -43,7 +43,7 @@ export const durableEventWithLookback = hatchet.durableTask({
   fn: async (_, ctx) => {
     const res = await ctx.waitForEvent(EVENT_KEY, undefined, undefined, SCOPE, '1m');
 
-    console.log('res', res);
+    ctx.logger.info('res', res);
 
     return {
       Value: 'done',

--- a/sdks/typescript/src/v1/examples/durable_sleep/workflow.ts
+++ b/sdks/typescript/src/v1/examples/durable_sleep/workflow.ts
@@ -12,7 +12,7 @@ durableSleep.durableTask({
   fn: async (_, ctx) => {
     ctx.logger.info('sleeping for 5s');
     const sleepRes = await ctx.sleepFor('5s');
-    ctx.logger.info('done sleeping for 5s', sleepRes);
+    ctx.logger.info('done sleeping for 5s', { sleepRes });
 
     return {
       Value: 'done',

--- a/sdks/typescript/src/v1/examples/durable_sleep/workflow.ts
+++ b/sdks/typescript/src/v1/examples/durable_sleep/workflow.ts
@@ -10,9 +10,9 @@ durableSleep.durableTask({
   name: 'durable-sleep',
   executionTimeout: '10m',
   fn: async (_, ctx) => {
-    console.log('sleeping for 5s');
+    ctx.logger.info('sleeping for 5s');
     const sleepRes = await ctx.sleepFor('5s');
-    console.log('done sleeping for 5s', sleepRes);
+    ctx.logger.info('done sleeping for 5s', sleepRes);
 
     return {
       Value: 'done',

--- a/sdks/typescript/src/v1/examples/events/workflow.ts
+++ b/sdks/typescript/src/v1/examples/events/workflow.ts
@@ -75,7 +75,7 @@ upper.task({
 lowerWithFilter.task({
   name: 'lowerWithFilter',
   fn: (input, ctx) => {
-    ctx.logger.info('filterPayload', ctx.filterPayload());
+    ctx.logger.info('filterPayload', { filterPayload: ctx.filterPayload() });
   },
 });
 // !!

--- a/sdks/typescript/src/v1/examples/events/workflow.ts
+++ b/sdks/typescript/src/v1/examples/events/workflow.ts
@@ -75,7 +75,7 @@ upper.task({
 lowerWithFilter.task({
   name: 'lowerWithFilter',
   fn: (input, ctx) => {
-    console.log(ctx.filterPayload());
+    ctx.logger.info('filterPayload', ctx.filterPayload());
   },
 });
 // !!

--- a/sdks/typescript/src/v1/examples/middleware/client.ts
+++ b/sdks/typescript/src/v1/examples/middleware/client.ts
@@ -12,7 +12,7 @@ export type GlobalOutputType = {
 
 const myMiddleware = {
   before: (input, ctx) => {
-    ctx.logger.info('before', input.first);
+    ctx.logger.info('before', { first: input.first });
     return { ...input, dependency: 'abc-123' };
   },
   after: (output, ctx, input) => {
@@ -29,7 +29,7 @@ export const hatchetWithMiddleware = HatchetClient.init<
 // > Chaining middleware
 const firstMiddleware = {
   before: (input, ctx) => {
-    ctx.logger.info('before', input.first);
+    ctx.logger.info('before', { first: input.first });
     return { ...input, dependency: 'abc-123' };
   },
   after: (output, ctx, input) => {
@@ -39,7 +39,7 @@ const firstMiddleware = {
 
 const secondMiddleware = {
   before: (input, ctx) => {
-    ctx.logger.info('before', input.dependency); // available from previous middleware
+    ctx.logger.info('before', { dependency: input.dependency }); // available from previous middleware
     return { ...input, anotherDep: true };
   },
   after: (output, ctx, input) => {

--- a/sdks/typescript/src/v1/examples/middleware/client.ts
+++ b/sdks/typescript/src/v1/examples/middleware/client.ts
@@ -12,7 +12,7 @@ export type GlobalOutputType = {
 
 const myMiddleware = {
   before: (input, ctx) => {
-    console.log('before', input.first);
+    ctx.logger.info('before', input.first);
     return { ...input, dependency: 'abc-123' };
   },
   after: (output, ctx, input) => {
@@ -29,7 +29,7 @@ export const hatchetWithMiddleware = HatchetClient.init<
 // > Chaining middleware
 const firstMiddleware = {
   before: (input, ctx) => {
-    console.log('before', input.first);
+    ctx.logger.info('before', input.first);
     return { ...input, dependency: 'abc-123' };
   },
   after: (output, ctx, input) => {
@@ -39,7 +39,7 @@ const firstMiddleware = {
 
 const secondMiddleware = {
   before: (input, ctx) => {
-    console.log('before', input.dependency); // available from previous middleware
+    ctx.logger.info('before', input.dependency); // available from previous middleware
     return { ...input, anotherDep: true };
   },
   after: (output, ctx, input) => {

--- a/sdks/typescript/src/v1/examples/middleware/workflow.ts
+++ b/sdks/typescript/src/v1/examples/middleware/workflow.ts
@@ -11,10 +11,10 @@ type TaskOutput = {
 export const taskWithMiddleware = hatchetWithMiddleware.task<TaskInput, TaskOutput>({
   name: 'task-with-middleware',
   fn: (input, ctx) => {
-    ctx.logger.info('task', input.message); // string  (from TaskInput)
-    ctx.logger.info('task', input.first); // number  (from GlobalInputType)
-    ctx.logger.info('task', input.second); // number  (from GlobalInputType)
-    ctx.logger.info('task', input.dependency); // string  (from Pre Middleware)
+    ctx.logger.info('task', { message: input.message }); // string  (from TaskInput)
+    ctx.logger.info('task', { first: input.first }); // number  (from GlobalInputType)
+    ctx.logger.info('task', { second: input.second }); // number  (from GlobalInputType)
+    ctx.logger.info('task', { dependency: input.dependency }); // string  (from Pre Middleware)
     return {
       message: input.message,
       extra: 1,

--- a/sdks/typescript/src/v1/examples/middleware/workflow.ts
+++ b/sdks/typescript/src/v1/examples/middleware/workflow.ts
@@ -10,11 +10,11 @@ type TaskOutput = {
 
 export const taskWithMiddleware = hatchetWithMiddleware.task<TaskInput, TaskOutput>({
   name: 'task-with-middleware',
-  fn: (input, _ctx) => {
-    console.log('task', input.message); // string  (from TaskInput)
-    console.log('task', input.first); // number  (from GlobalInputType)
-    console.log('task', input.second); // number  (from GlobalInputType)
-    console.log('task', input.dependency); // string  (from Pre Middleware)
+  fn: (input, ctx) => {
+    ctx.logger.info('task', input.message); // string  (from TaskInput)
+    ctx.logger.info('task', input.first); // number  (from GlobalInputType)
+    ctx.logger.info('task', input.second); // number  (from GlobalInputType)
+    ctx.logger.info('task', input.dependency); // string  (from Pre Middleware)
     return {
       message: input.message,
       extra: 1,

--- a/sdks/typescript/src/v1/examples/on_event/workflow.ts
+++ b/sdks/typescript/src/v1/examples/on_event/workflow.ts
@@ -75,7 +75,7 @@ upper.task({
 lowerWithFilter.task({
   name: 'lowerWithFilter',
   fn: (input, ctx) => {
-    ctx.logger.info('filterPayload', ctx.filterPayload());
+    ctx.logger.info('filterPayload', { filterPayload: ctx.filterPayload() });
   },
 });
 // !!

--- a/sdks/typescript/src/v1/examples/on_event/workflow.ts
+++ b/sdks/typescript/src/v1/examples/on_event/workflow.ts
@@ -75,7 +75,7 @@ upper.task({
 lowerWithFilter.task({
   name: 'lowerWithFilter',
   fn: (input, ctx) => {
-    console.log(ctx.filterPayload());
+    ctx.logger.info('filterPayload', ctx.filterPayload());
   },
 });
 // !!

--- a/sdks/typescript/src/v1/examples/on_failure/workflow.ts
+++ b/sdks/typescript/src/v1/examples/on_failure/workflow.ts
@@ -21,7 +21,7 @@ failureWorkflow.onFailure({
   name: 'on_failure',
   fn: async (_input, ctx) => {
     ctx.logger.info(`onFailure for run: ${ctx.workflowRunId()}`);
-    ctx.logger.info('upstream errors:', ctx.errors());
+    ctx.logger.info('upstream errors', { errors: ctx.errors() });
 
     return {
       status: 'success',

--- a/sdks/typescript/src/v1/examples/on_failure/workflow.ts
+++ b/sdks/typescript/src/v1/examples/on_failure/workflow.ts
@@ -20,8 +20,8 @@ failureWorkflow.task({
 failureWorkflow.onFailure({
   name: 'on_failure',
   fn: async (_input, ctx) => {
-    console.log('onFailure for run:', ctx.workflowRunId());
-    console.log('upstream errors:', ctx.errors());
+    ctx.logger.info(`onFailure for run: ${ctx.workflowRunId()}`);
+    ctx.logger.info('upstream errors:', ctx.errors());
 
     return {
       status: 'success',

--- a/sdks/typescript/src/v1/examples/on_success/workflow.ts
+++ b/sdks/typescript/src/v1/examples/on_success/workflow.ts
@@ -25,7 +25,7 @@ onSuccessDag.task({
 // 👀 onSuccess handler will run if all tasks in the workflow succeed
 onSuccessDag.onSuccess({
   fn: (_, ctx) => {
-    console.log('onSuccess for run:', ctx.workflowRunId());
+    ctx.logger.info(`onSuccess for run: ${ctx.workflowRunId()}`);
     return {
       'on-success': 'success',
     };

--- a/sdks/typescript/src/v1/examples/rate_limit/workflow.ts
+++ b/sdks/typescript/src/v1/examples/rate_limit/workflow.ts
@@ -20,8 +20,8 @@ const task1 = hatchet.task({
       units: 1,
     },
   ],
-  fn: (input) => {
-    console.log('executed task1');
+  fn: (_input, ctx) => {
+    ctx.logger.info('executed task1');
   },
 });
 
@@ -30,8 +30,8 @@ const task1 = hatchet.task({
 // > Dynamic
 const task2 = hatchet.task({
   name: 'task2',
-  fn: (input: { userId: string }) => {
-    console.log('executed task2 for user: ', input.userId);
+  fn: (input: { userId: string }, ctx) => {
+    ctx.logger.info(`executed task2 for user: ${input.userId}`);
   },
   rateLimits: [
     {

--- a/sdks/typescript/src/v1/examples/retries/workflow.ts
+++ b/sdks/typescript/src/v1/examples/retries/workflow.ts
@@ -18,7 +18,7 @@ export const retriesWithCount = hatchet.task({
     // > Get the current retry count
     const retryCount = ctx.retryCount();
 
-    console.log(`Retry count: ${retryCount}`);
+    ctx.logger.info(`Retry count: ${retryCount}`);
 
     if (retryCount < 2) {
       throw new Error('intentional failure');

--- a/sdks/typescript/src/v1/examples/webhooks/workflow.ts
+++ b/sdks/typescript/src/v1/examples/webhooks/workflow.ts
@@ -33,9 +33,9 @@ export const handleStripePayment = hatchet.task({
   on: {
     event: 'stripe:payment_intent.succeeded',
   },
-  fn: async (input: StripePaymentInput) => {
+  fn: async (input: StripePaymentInput, ctx) => {
     const { customer, amount } = input.data.object;
-    console.log(`Payment of ${amount} from ${customer}`);
+    ctx.logger.info(`Payment of ${amount} from ${customer}`);
     return { customer, amount };
   },
 });
@@ -58,11 +58,11 @@ export const handleGitHubPR = hatchet.task({
   on: {
     event: 'github:pull_request:opened',
   },
-  fn: async (input: GitHubPRInput) => {
+  fn: async (input: GitHubPRInput, ctx) => {
     const repo = input.repository.full_name;
     const prNumber = input.pull_request.number;
     const { title } = input.pull_request;
-    console.log(`PR #${prNumber} opened on ${repo}: ${title}`);
+    ctx.logger.info(`PR #${prNumber} opened on ${repo}: ${title}`);
     return { repo, pr: prNumber };
   },
 });
@@ -83,9 +83,9 @@ export const handleSlackMention = hatchet.task({
   on: {
     event: 'slack:event:app_mention',
   },
-  fn: async (input: SlackEventInput) => {
+  fn: async (input: SlackEventInput, ctx) => {
     const { user, text, channel } = input.event;
-    console.log(`Mentioned by ${user} in ${channel}: ${text}`);
+    ctx.logger.info(`Mentioned by ${user} in ${channel}: ${text}`);
     return { handled: true };
   },
 });
@@ -104,8 +104,8 @@ export const handleSlackCommand = hatchet.task({
   on: {
     event: 'slack:command:/deploy',
   },
-  fn: async (input: SlackCommandInput) => {
-    console.log(`${input.user_name} ran ${input.command} ${input.text}`);
+  fn: async (input: SlackCommandInput, ctx) => {
+    ctx.logger.info(`${input.user_name} ran ${input.command} ${input.text}`);
     return { command: input.command, args: input.text };
   },
 });
@@ -123,9 +123,9 @@ export const handleSlackInteraction = hatchet.task({
   on: {
     event: 'slack:interaction:block_actions',
   },
-  fn: async (input: SlackInteractionInput) => {
+  fn: async (input: SlackInteractionInput, ctx) => {
     const [action] = input.actions;
-    console.log(`${input.user.username} clicked button: ${action.action_id}`);
+    ctx.logger.info(`${input.user.username} clicked button: ${action.action_id}`);
     return { action: action.action_id };
   },
 });

--- a/sdks/typescript/src/v1/examples/welcome_email/workflow.ts
+++ b/sdks/typescript/src/v1/examples/welcome_email/workflow.ts
@@ -26,7 +26,7 @@ export const welcomeEmail = hatchet.durableTask<SignupInput, WelcomeEmailResult>
   executionTimeout: '5m',
   fn: async (input, ctx) => {
     // Step 1: Send the welcome email
-    console.log(`Sending welcome email to ${input.email}: finish your first onboarding step`);
+    ctx.logger.info(`Sending welcome email to ${input.email}: finish your first onboarding step`);
 
     // Step 2: Wait for the user to complete onboarding, or time out
     // (use a longer duration for a more realistic workflow)
@@ -52,12 +52,12 @@ export const welcomeEmail = hatchet.durableTask<SignupInput, WelcomeEmailResult>
 
     if (onboardingCompleted) {
       // Step 3a: User completed onboarding -> skip follow-up
-      console.log(`User ${input.user_id} completed onboarding, skipping follow-up`);
+      ctx.logger.info(`User ${input.user_id} completed onboarding, skipping follow-up`);
       return { userId: input.user_id, welcomeSent: true, followUpSent: false };
     }
 
     // Step 3b: Timeout -> send follow-up email
-    console.log(`Sending follow-up email to ${input.email}: need help finishing onboarding?`);
+    ctx.logger.info(`Sending follow-up email to ${input.email}: need help finishing onboarding?`);
     return { userId: input.user_id, welcomeSent: true, followUpSent: true };
   },
 });


### PR DESCRIPTION
# Description

Updates v1 TypeScript examples under `sdks/typescript/src/v1/examples` so task and workflow handlers log through `ctx.logger.info` instead of `console.log`, matching the SDK’s supported logging path and keeping run output visible in Hatchet’s logging pipeline.

I'm not sure if this was passed over (in what I assume was an upgrade from the non-versioned examples to v1), or if it was intentional; but seeing last month's celebration posts of new logging capabilities, I thought it was worth updating the examples to show it. In my new experience using Hatchet, my LLM which had access to the docs was able to set up logging using the provided ctx.logger without any issue, but I'd like for the examples to be clearer on what I assume is best practice.

Where handlers did not already take context, the second parameter `ctx` was added (e.g. webhook tasks, rate-limit examples, the non-durable task in the durable workflow example). Middleware `before` hooks and abort-signal examples now use the same logger on the provided context. Driver scripts (`run.ts`, `event.ts`, e2e helpers, agents, etc.) were left unchanged because they do not receive task context.

## Type of change

- [x] Documentation change (pure documentation change)
