### PR TITLE
Fix: Improve performance of status metrics query

### DIFF
--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -1416,7 +1416,16 @@ WITH task_external_ids AS (
             ) AS u ON kv.key = u.k AND kv.value = u.v
         )
     )
+    AND tenant_id = @tenantId::UUID
+    AND inserted_at >= @createdAfter::TIMESTAMPTZ
+    AND (
+        sqlc.narg('createdBefore')::TIMESTAMPTZ IS NULL OR inserted_at <= sqlc.narg('createdBefore')::TIMESTAMPTZ
+    )
+    AND (
+        sqlc.narg('workflowIds')::UUID[] IS NULL OR workflow_id = ANY(sqlc.narg('workflowIds')::UUID[])
+    )
 )
+
 SELECT
     tenant_id,
     COUNT(*) FILTER (WHERE readable_status = 'QUEUED') AS total_queued,

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -1249,7 +1249,16 @@ WITH task_external_ids AS (
             ) AS u ON kv.key = u.k AND kv.value = u.v
         )
     )
+    AND tenant_id = $1::UUID
+    AND inserted_at >= $2::TIMESTAMPTZ
+    AND (
+        $3::TIMESTAMPTZ IS NULL OR inserted_at <= $3::TIMESTAMPTZ
+    )
+    AND (
+        $4::UUID[] IS NULL OR workflow_id = ANY($4::UUID[])
+    )
 )
+
 SELECT
     tenant_id,
     COUNT(*) FILTER (WHERE readable_status = 'QUEUED') AS total_queued,


### PR DESCRIPTION
# Description

Fixes #3790 

Adds some additional filters to the runs CTE to prune partitions and make use of the tenant index, which should hopefully improve performance a lot

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
