### PR TITLE
feat(otel): add useLinksInsteadOfParent option to HatchetInstrumentor

### DIFF
--- a/sdks/typescript/src/opentelemetry/instrumentor.links.test.ts
+++ b/sdks/typescript/src/opentelemetry/instrumentor.links.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Tests for HatchetInstrumentor.useLinksInsteadOfParent option.
+ *
+ * Verifies that fire-and-forget child runs use OTel span links instead of
+ * parent-child relationships when the predicate returns true, while
+ * preserving the default parent-child behaviour when it returns false.
+ *
+ * These tests use jest module mocks so they live in a separate file from
+ * instrumentor.test.ts, which uses a real OTel SDK provider.
+ */
+
+// Minimal OTel span mock
+const makeMockSpan = () => ({
+  end: jest.fn(),
+  recordException: jest.fn(),
+  setStatus: jest.fn(),
+  spanContext: jest.fn(() => ({
+    traceId: 'a'.repeat(32),
+    spanId: 'b'.repeat(16),
+    traceFlags: 1,
+  })),
+});
+
+// Build a mock tracer whose startActiveSpan captures its arguments.
+const makeTracerMock = (span = makeMockSpan()) => {
+  const calls: IArguments[] = [];
+  const tracer = {
+    _calls: calls,
+    _span: span,
+    startActiveSpan: jest.fn(function (...args: unknown[]) {
+      // The last argument is always the callback (fn).
+      const fn = args[args.length - 1] as (span: unknown) => unknown;
+      return fn(span);
+    }),
+  };
+  return tracer;
+};
+
+// Dummy action used in all tests.
+const makeAction = (actionId = 'my-worker:my-task') => ({
+  actionId,
+  tenantId: 'tenant-1',
+  workflowRunId: 'run-1',
+  taskId: 'task-1',
+  taskRunExternalId: 'ext-1',
+  retryCount: 0,
+  parentWorkflowRunId: undefined,
+  childWorkflowIndex: undefined,
+  childWorkflowKey: undefined,
+  actionPayload: '{}',
+  jobName: 'my-task',
+  taskName: 'my-task',
+  workflowId: 'wf-1',
+  workflowVersionId: 'wfv-1',
+  // Encode a fake traceparent in the metadata so extractContext finds a valid context.
+  additionalMetadata: JSON.stringify({
+    traceparent: '00-' + 'a'.repeat(32) + '-' + 'b'.repeat(16) + '-01',
+  }),
+});
+
+// ---------------------------------------------------------------------------
+// Sentinel object used as ROOT_CONTEXT in the mock — allows tests to assert
+// that the implementation explicitly passes ROOT_CONTEXT, not the active ctx.
+// ---------------------------------------------------------------------------
+const MOCK_ROOT_CONTEXT = { _isRootContext: true } as const;
+
+jest.mock('@opentelemetry/api', () => {
+  const validSpanCtx = {
+    traceId: 'a'.repeat(32),
+    spanId: 'b'.repeat(16),
+    traceFlags: 1,
+  };
+
+  // SpanKind.CONSUMER = 4, SpanStatusCode.OK = 1, SpanStatusCode.ERROR = 2
+  return {
+    SpanKind: { INTERNAL: 0, SERVER: 1, CLIENT: 2, PRODUCER: 3, CONSUMER: 4 },
+    SpanStatusCode: { UNSET: 0, OK: 1, ERROR: 2 },
+    ROOT_CONTEXT: MOCK_ROOT_CONTEXT,
+    context: {
+      active: jest.fn(() => ({})),
+      with: jest.fn((_ctx: unknown, fn: () => unknown) => fn()),
+    },
+    propagation: {
+      extract: jest.fn(() => ({ _extracted: true })),
+      inject: jest.fn(),
+    },
+    trace: {
+      getSpanContext: jest.fn(() => validSpanCtx),
+      isSpanContextValid: jest.fn(() => true),
+    },
+    diag: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+jest.mock('@opentelemetry/instrumentation', () => {
+  class InstrumentationBase {
+    protected tracer: ReturnType<typeof makeTracerMock>;
+    protected config: Record<string, unknown>;
+    constructor(_name: string, _version: string, config: Record<string, unknown>) {
+      this.config = config;
+      this.tracer = makeTracerMock();
+    }
+    getConfig() {
+      return this.config;
+    }
+    setConfig(cfg: Record<string, unknown>) {
+      this.config = cfg;
+    }
+    protected _wrap(
+      proto: Record<string, unknown>,
+      method: string,
+      wrapper: (orig: unknown) => unknown
+    ) {
+      proto[method] = wrapper(proto[method]);
+    }
+    protected _unwrap(_proto: Record<string, unknown>, _method: string) {
+      // no-op in tests
+    }
+  }
+
+  return {
+    InstrumentationBase,
+    InstrumentationNodeModuleDefinition: jest.fn(() => ({})),
+    InstrumentationNodeModuleFile: jest.fn(() => ({})),
+    isWrapped: jest.fn(() => false),
+  };
+});
+
+// Import AFTER mocks are set up.
+import { HatchetInstrumentor } from './instrumentor';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildWorkerProto() {
+  return {
+    workerId: 'worker-1',
+    handleStartStepRun: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+/**
+ * Returns the startActiveSpan call arguments for the hatchet.start_step_run span.
+ * startActiveSpan is always called with 4 arguments: (name, opts, context, fn).
+ * In parent-child mode, context is the extracted parentContext.
+ * In link mode, context is ROOT_CONTEXT and opts includes a non-empty links array.
+ */
+function getStartStepRunArgs(tracer: ReturnType<typeof makeTracerMock>) {
+  const call = (tracer.startActiveSpan as jest.Mock).mock.calls.find(
+    ([name]: [string]) => typeof name === 'string' && name.startsWith('hatchet.start_step_run')
+  );
+  expect(call).toBeDefined();
+  return call as unknown[];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HatchetInstrumentor.useLinksInsteadOfParent', () => {
+  it('uses parent-child semantics by default (no option provided)', async () => {
+    const instrumentor = new HatchetInstrumentor({});
+    const tracer = (instrumentor as unknown as { tracer: ReturnType<typeof makeTracerMock> }).tracer;
+
+    const proto = buildWorkerProto();
+    (instrumentor as unknown as { patchWorker: (e: unknown) => void }).patchWorker({
+      InternalWorker: { prototype: proto },
+    });
+
+    await proto.handleStartStepRun(makeAction());
+
+    const args = getStartStepRunArgs(tracer);
+    // 4 args: (name, opts, parentContext, fn)
+    expect(args).toHaveLength(4);
+    // opts should NOT include links
+    const opts = args[1] as Record<string, unknown>;
+    expect(opts.links).toBeUndefined();
+    // context is the extracted parent context, not ROOT_CONTEXT
+    expect(args[2]).not.toBe(MOCK_ROOT_CONTEXT);
+  });
+
+  it('uses parent-child semantics when predicate returns false', async () => {
+    const instrumentor = new HatchetInstrumentor({
+      useLinksInsteadOfParent: () => false,
+    });
+    const tracer = (instrumentor as unknown as { tracer: ReturnType<typeof makeTracerMock> }).tracer;
+
+    const proto = buildWorkerProto();
+    (instrumentor as unknown as { patchWorker: (e: unknown) => void }).patchWorker({
+      InternalWorker: { prototype: proto },
+    });
+
+    await proto.handleStartStepRun(makeAction());
+
+    const args = getStartStepRunArgs(tracer);
+    expect(args).toHaveLength(4);
+    const opts = args[1] as Record<string, unknown>;
+    expect(opts.links).toBeUndefined();
+    expect(args[2]).not.toBe(MOCK_ROOT_CONTEXT);
+  });
+
+  it('uses span links with ROOT_CONTEXT when predicate returns true', async () => {
+    const instrumentor = new HatchetInstrumentor({
+      useLinksInsteadOfParent: () => true,
+    });
+    const tracer = (instrumentor as unknown as { tracer: ReturnType<typeof makeTracerMock> }).tracer;
+
+    const proto = buildWorkerProto();
+    (instrumentor as unknown as { patchWorker: (e: unknown) => void }).patchWorker({
+      InternalWorker: { prototype: proto },
+    });
+
+    await proto.handleStartStepRun(makeAction());
+
+    const args = getStartStepRunArgs(tracer);
+    // 4 args: (name, opts, ROOT_CONTEXT, fn)
+    expect(args).toHaveLength(4);
+    // opts must include a non-empty links array
+    const opts = args[1] as Record<string, unknown>;
+    expect(Array.isArray(opts.links)).toBe(true);
+    expect((opts.links as unknown[]).length).toBe(1);
+    // context must be ROOT_CONTEXT, not the extracted parent context
+    expect(args[2]).toBe(MOCK_ROOT_CONTEXT);
+  });
+
+  it('passes the actionId to the predicate', async () => {
+    const predicate = jest.fn(() => false);
+    const action = makeAction('custom-worker:custom-task');
+
+    const instrumentor = new HatchetInstrumentor({
+      useLinksInsteadOfParent: predicate,
+    });
+
+    const proto = buildWorkerProto();
+    (instrumentor as unknown as { patchWorker: (e: unknown) => void }).patchWorker({
+      InternalWorker: { prototype: proto },
+    });
+
+    await proto.handleStartStepRun(action);
+
+    expect(predicate).toHaveBeenCalledWith('custom-worker:custom-task');
+  });
+
+  it('uses ROOT_CONTEXT with an empty links array when parent span context is invalid', async () => {
+    const otelApi = require('@opentelemetry/api');
+    jest.spyOn(otelApi.trace, 'isSpanContextValid').mockReturnValueOnce(false);
+
+    const instrumentor = new HatchetInstrumentor({
+      useLinksInsteadOfParent: () => true,
+    });
+    const tracer = (instrumentor as unknown as { tracer: ReturnType<typeof makeTracerMock> }).tracer;
+
+    const proto = buildWorkerProto();
+    (instrumentor as unknown as { patchWorker: (e: unknown) => void }).patchWorker({
+      InternalWorker: { prototype: proto },
+    });
+
+    await proto.handleStartStepRun(makeAction());
+
+    const args = getStartStepRunArgs(tracer);
+    // 4 args: link path still uses ROOT_CONTEXT
+    expect(args).toHaveLength(4);
+    expect(args[2]).toBe(MOCK_ROOT_CONTEXT);
+    // links array is empty because the span context was invalid
+    const opts = args[1] as Record<string, unknown>;
+    expect((opts.links as unknown[]).length).toBe(0);
+  });
+});

--- a/sdks/typescript/src/opentelemetry/instrumentor.test.ts
+++ b/sdks/typescript/src/opentelemetry/instrumentor.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for HatchetInstrumentor.useLinksInsteadOfParent option.
+ *
+ * Verifies that fire-and-forget child runs use OTel span links instead of
+ * parent-child relationships when the predicate returns true, while
+ * preserving the default parent-child behaviour when it returns false.
+ */
+
+// Minimal OTel span mock
+const makeMockSpan = () => ({
+  end: jest.fn(),
+  recordException: jest.fn(),
+  setStatus: jest.fn(),
+  spanContext: jest.fn(() => ({
+    traceId: 'a'.repeat(32),
+    spanId: 'b'.repeat(16),
+    traceFlags: 1,
+  })),
+});
+
+// Build a mock tracer whose startActiveSpan captures its arguments.
+const makeTracerMock = (span = makeMockSpan()) => {
+  const calls: IArguments[] = [];
+  const tracer = {
+    _calls: calls,
+    _span: span,
+    startActiveSpan: jest.fn(function (...args: unknown[]) {
+      // The last argument is always the callback (fn).
+      const fn = args[args.length - 1] as (span: unknown) => unknown;
+      return fn(span);
+    }),
+  };
+  return tracer;
+};
+
+// Dummy action used in all tests.
+const makeAction = (actionId = 'my-worker:my-task') => ({
+  actionId,
+  tenantId: 'tenant-1',
+  workflowRunId: 'run-1',
+  taskId: 'task-1',
+  taskRunExternalId: 'ext-1',
+  retryCount: 0,
+  parentWorkflowRunId: undefined,
+  childWorkflowIndex: undefined,
+  childWorkflowKey: undefined,
+  actionPayload: '{}',
+  jobName: 'my-task',
+  taskName: 'my-task',
+  workflowId: 'wf-1',
+  workflowVersionId: 'wfv-1',
+  // Encode a fake traceparent in the metadata so extractContext finds a valid context.
+  additionalMetadata: JSON.stringify({
+    traceparent: '00-' + 'a'.repeat(32) + '-' + 'b'.repeat(16) + '-01',
+  }),
+});
+
+// ---------------------------------------------------------------------------
+// Shared setup: mock @opentelemetry/api and @opentelemetry/instrumentation so
+// HatchetInstrumentor can be imported without a real OTel SDK being present.
+// ---------------------------------------------------------------------------
+
+jest.mock('@opentelemetry/api', () => {
+  const validSpanCtx = {
+    traceId: 'a'.repeat(32),
+    spanId: 'b'.repeat(16),
+    traceFlags: 1,
+  };
+
+  // SpanKind.CONSUMER = 4, SpanStatusCode.OK = 1, SpanStatusCode.ERROR = 2
+  return {
+    SpanKind: { INTERNAL: 0, SERVER: 1, CLIENT: 2, PRODUCER: 3, CONSUMER: 4 },
+    SpanStatusCode: { UNSET: 0, OK: 1, ERROR: 2 },
+    context: {
+      active: jest.fn(() => ({})),
+      with: jest.fn((_ctx: unknown, fn: () => unknown) => fn()),
+    },
+    propagation: {
+      extract: jest.fn(() => ({ _extracted: true })),
+      inject: jest.fn(),
+    },
+    trace: {
+      getSpanContext: jest.fn(() => validSpanCtx),
+      isSpanContextValid: jest.fn(() => true),
+    },
+    diag: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+jest.mock('@opentelemetry/instrumentation', () => {
+  class InstrumentationBase {
+    protected tracer: ReturnType<typeof makeTracerMock>;
+    protected config: Record<string, unknown>;
+    constructor(_name: string, _version: string, config: Record<string, unknown>) {
+      this.config = config;
+      this.tracer = makeTracerMock();
+    }
+    getConfig() {
+      return this.config;
+    }
+    setConfig(cfg: Record<string, unknown>) {
+      this.config = cfg;
+    }
+    protected _wrap(
+      proto: Record<string, unknown>,
+      method: string,
+      wrapper: (orig: unknown) => unknown
+    ) {
+      proto[method] = wrapper(proto[method]);
+    }
+    protected _unwrap(proto: Record<string, unknown>, method: string) {
+      // no-op in tests
+    }
+  }
+
+  return {
+    InstrumentationBase,
+    InstrumentationNodeModuleDefinition: jest.fn(() => ({})),
+    InstrumentationNodeModuleFile: jest.fn(() => ({})),
+    isWrapped: jest.fn(() => false),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Import the instrumentor AFTER mocks are set up.
+// ---------------------------------------------------------------------------
+import { HatchetInstrumentor } from './instrumentor';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildWorkerProto(action = makeAction()) {
+  const proto = {
+    workerId: 'worker-1',
+    handleStartStepRun: jest.fn().mockResolvedValue(undefined),
+  };
+  return proto;
+}
+
+/**
+ * Returns the `startActiveSpan` call arguments for the `hatchet.start_step_run` span.
+ * startActiveSpan is overloaded:
+ *   (name, opts, context, fn) → parent-child mode  (fn is 4th arg, index 3)
+ *   (name, opts, fn)          → link mode          (fn is 3rd arg, index 2)
+ */
+function getStartStepRunArgs(tracer: ReturnType<typeof makeTracerMock>) {
+  const call = (tracer.startActiveSpan as jest.Mock).mock.calls.find(
+    ([name]: [string]) => typeof name === 'string' && name.startsWith('hatchet.start_step_run')
+  );
+  expect(call).toBeDefined();
+  return call as unknown[];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HatchetInstrumentor.useLinksInsteadOfParent', () => {
+  it('uses parent-child semantics by default (no option provided)', async () => {
+    const instrumentor = new HatchetInstrumentor({});
+    const tracer = (instrumentor as unknown as { tracer: ReturnType<typeof makeTracerMock> }).tracer;
+    tracer.startActiveSpan = makeTracerMock()._span
+      ? jest.fn((...args: unknown[]) => {
+          const fn = args[args.length - 1] as (span: unknown) => unknown;
+          return fn(makeMockSpan());
+        })
+      : tracer.startActiveSpan;
+
+    const proto = buildWorkerProto();
+    (instrumentor as unknown as { patchWorker: (e: unknown) => void }).patchWorker({
+      InternalWorker: { prototype: proto },
+    });
+
+    await proto.handleStartStepRun(makeAction());
+
+    const args = getStartStepRunArgs(tracer);
+    // 4 args → (name, opts, parentContext, fn)
+    expect(args).toHaveLength(4);
+    // opts should NOT include links
+    const opts = args[1] as Record<string, unknown>;
+    expect(opts.links).toBeUndefined();
+  });
+
+  it('uses parent-child semantics when predicate returns false', async () => {
+    const instrumentor = new HatchetInstrumentor({
+      useLinksInsteadOfParent: () => false,
+    });
+    const tracer = (instrumentor as unknown as { tracer: ReturnType<typeof makeTracerMock> }).tracer;
+
+    const proto = buildWorkerProto();
+    (instrumentor as unknown as { patchWorker: (e: unknown) => void }).patchWorker({
+      InternalWorker: { prototype: proto },
+    });
+
+    await proto.handleStartStepRun(makeAction());
+
+    const args = getStartStepRunArgs(tracer);
+    expect(args).toHaveLength(4);
+    const opts = args[1] as Record<string, unknown>;
+    expect(opts.links).toBeUndefined();
+  });
+
+  it('uses span links and no parent context when predicate returns true', async () => {
+    const instrumentor = new HatchetInstrumentor({
+      useLinksInsteadOfParent: () => true,
+    });
+    const tracer = (instrumentor as unknown as { tracer: ReturnType<typeof makeTracerMock> }).tracer;
+
+    const proto = buildWorkerProto();
+    (instrumentor as unknown as { patchWorker: (e: unknown) => void }).patchWorker({
+      InternalWorker: { prototype: proto },
+    });
+
+    await proto.handleStartStepRun(makeAction());
+
+    const args = getStartStepRunArgs(tracer);
+    // 3 args → (name, opts, fn) — no parent context
+    expect(args).toHaveLength(3);
+    const opts = args[1] as Record<string, unknown>;
+    expect(Array.isArray(opts.links)).toBe(true);
+    expect((opts.links as unknown[]).length).toBe(1);
+  });
+
+  it('passes the actionId to the predicate', async () => {
+    const predicate = jest.fn(() => false);
+    const action = makeAction('custom-worker:custom-task');
+
+    const instrumentor = new HatchetInstrumentor({
+      useLinksInsteadOfParent: predicate,
+    });
+
+    const proto = buildWorkerProto(action);
+    (instrumentor as unknown as { patchWorker: (e: unknown) => void }).patchWorker({
+      InternalWorker: { prototype: proto },
+    });
+
+    await proto.handleStartStepRun(action);
+
+    expect(predicate).toHaveBeenCalledWith('custom-worker:custom-task');
+  });
+
+  it('falls back to no links when parent span context is invalid', async () => {
+    const otelApi = require('@opentelemetry/api');
+    jest.spyOn(otelApi.trace, 'isSpanContextValid').mockReturnValueOnce(false);
+
+    const instrumentor = new HatchetInstrumentor({
+      useLinksInsteadOfParent: () => true,
+    });
+    const tracer = (instrumentor as unknown as { tracer: ReturnType<typeof makeTracerMock> }).tracer;
+
+    const proto = buildWorkerProto();
+    (instrumentor as unknown as { patchWorker: (e: unknown) => void }).patchWorker({
+      InternalWorker: { prototype: proto },
+    });
+
+    await proto.handleStartStepRun(makeAction());
+
+    const args = getStartStepRunArgs(tracer);
+    // Still 3 args (link mode path), but links array is empty
+    expect(args).toHaveLength(3);
+    const opts = args[1] as Record<string, unknown>;
+    expect((opts.links as unknown[]).length).toBe(0);
+  });
+});

--- a/sdks/typescript/src/opentelemetry/instrumentor.ts
+++ b/sdks/typescript/src/opentelemetry/instrumentor.ts
@@ -761,6 +761,8 @@ export class HatchetInstrumentor extends InstrumentationBase<HatchetInstrumentat
               parentSpanCtx && otelApi.trace.isSpanContextValid(parentSpanCtx)
                 ? [{ context: parentSpanCtx }]
                 : [];
+            // Using ROOT_CONTEXT prevents unrelated ambient spans on the worker
+            // from turning this link-only span into a child in the wrong trace.
             return tracer.startActiveSpan(
               spanName,
               { kind: SpanKind.CONSUMER, attributes, links },

--- a/sdks/typescript/src/opentelemetry/instrumentor.ts
+++ b/sdks/typescript/src/opentelemetry/instrumentor.ts
@@ -698,9 +698,12 @@ export class HatchetInstrumentor extends InstrumentationBase<HatchetInstrumentat
               parentSpanCtx && otelApi.trace.isSpanContextValid(parentSpanCtx)
                 ? [{ context: parentSpanCtx }]
                 : [];
+            // Using ROOT_CONTEXT prevents unrelated ambient spans on the worker
+            // from turning this link-only span into a child in the wrong trace.
             return tracer.startActiveSpan(
               spanName,
               { kind: SpanKind.CONSUMER, attributes, links },
+              otelApi.ROOT_CONTEXT,
               runSpan
             );
           }

--- a/sdks/typescript/src/opentelemetry/instrumentor.ts
+++ b/sdks/typescript/src/opentelemetry/instrumentor.ts
@@ -8,7 +8,7 @@
  * patching module prototypes to automatically instrument all instances.
  */
 
-import type { Context as OtelContext, Span, Attributes } from '@opentelemetry/api';
+import type { Context as OtelContext, Span, Attributes, SpanContext } from '@opentelemetry/api';
 
 import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 
@@ -77,6 +77,22 @@ type HatchetInstrumentationConfig = OpenTelemetryConfig &
      * Configuration for the BatchSpanProcessor that sends spans to the Hatchet collector.
      */
     bspConfig?: HatchetBspConfig;
+
+    /**
+     * When provided, this predicate is called with the actionId of each incoming step run.
+     * Returning true causes the step's span to use an OTel span link back to the triggering
+     * span rather than making that span its parent. This is the correct choice for
+     * fire-and-forget patterns (e.g. runNoWait fan-outs) where the parent span should close
+     * as soon as the spawn loop returns, not when the slowest child finishes.
+     *
+     * Default: undefined (all spans use parent-child semantics, preserving prior behaviour).
+     *
+     * @example
+     * new HatchetInstrumentor({
+     *   useLinksInsteadOfParent: (actionId) => actionId.startsWith('fan-out-worker:'),
+     * });
+     */
+    useLinksInsteadOfParent?: (actionId: string) => boolean;
   };
 type Carrier = Record<string, string>;
 
@@ -721,29 +737,43 @@ export class HatchetInstrumentor extends InstrumentationBase<HatchetInstrumentat
           }
           setHatchetSpanAttributes(hatchetAttrs);
 
+          const runSpan = (span: Span) =>
+            original
+              .call(this, action)
+              .then((taskError: Error | undefined) => {
+                if (taskError instanceof Error) {
+                  span.recordException(taskError);
+                  span.setStatus({ code: SpanStatusCode.ERROR, message: taskError.message });
+                } else {
+                  span.setStatus({ code: SpanStatusCode.OK });
+                }
+                return taskError;
+              })
+              .finally(() => {
+                span.end();
+              });
+
+          const useLinks = getConfig().useLinksInsteadOfParent?.(action.actionId) ?? false;
+          if (useLinks) {
+            const parentSpanCtx: SpanContext | undefined =
+              otelApi.trace.getSpanContext(parentContext);
+            const links =
+              parentSpanCtx && otelApi.trace.isSpanContextValid(parentSpanCtx)
+                ? [{ context: parentSpanCtx }]
+                : [];
+            return tracer.startActiveSpan(
+              spanName,
+              { kind: SpanKind.CONSUMER, attributes, links },
+              otelApi.ROOT_CONTEXT,
+              runSpan
+            );
+          }
+
           return tracer.startActiveSpan(
             spanName,
-            {
-              kind: SpanKind.CONSUMER,
-              attributes,
-            },
+            { kind: SpanKind.CONSUMER, attributes },
             parentContext,
-            (span: Span) => {
-              return original
-                .call(this, action)
-                .then((taskError: Error | undefined) => {
-                  if (taskError instanceof Error) {
-                    span.recordException(taskError);
-                    span.setStatus({ code: SpanStatusCode.ERROR, message: taskError.message });
-                  } else {
-                    span.setStatus({ code: SpanStatusCode.OK });
-                  }
-                  return taskError;
-                })
-                .finally(() => {
-                  span.end();
-                });
-            }
+            runSpan
           );
         };
       }

--- a/sdks/typescript/src/opentelemetry/instrumentor.ts
+++ b/sdks/typescript/src/opentelemetry/instrumentor.ts
@@ -8,7 +8,7 @@
  * patching module prototypes to automatically instrument all instances.
  */
 
-import type { Context as OtelContext, Span, Attributes } from '@opentelemetry/api';
+import type { Context as OtelContext, Span, Attributes, SpanContext } from '@opentelemetry/api';
 
 import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 
@@ -77,6 +77,22 @@ type HatchetInstrumentationConfig = OpenTelemetryConfig &
      * Configuration for the BatchSpanProcessor that sends spans to the Hatchet collector.
      */
     bspConfig?: HatchetBspConfig;
+
+    /**
+     * When provided, this predicate is called with the actionId of each incoming step run.
+     * Returning true causes the step's span to use an OTel span link back to the triggering
+     * span rather than making that span its parent. This is the correct choice for
+     * fire-and-forget patterns (e.g. runNoWait fan-outs) where the parent span should close
+     * as soon as the spawn loop returns, not when the slowest child finishes.
+     *
+     * Default: undefined (all spans use parent-child semantics, preserving prior behaviour).
+     *
+     * @example
+     * new HatchetInstrumentor({
+     *   useLinksInsteadOfParent: (actionId) => actionId.startsWith('fan-out-worker:'),
+     * });
+     */
+    useLinksInsteadOfParent?: (actionId: string) => boolean;
   };
 type Carrier = Record<string, string>;
 
@@ -658,29 +674,42 @@ export class HatchetInstrumentor extends InstrumentationBase<HatchetInstrumentat
           }
           setHatchetSpanAttributes(hatchetAttrs);
 
+          const runSpan = (span: Span) =>
+            original
+              .call(this, action)
+              .then((taskError: Error | undefined) => {
+                if (taskError instanceof Error) {
+                  span.recordException(taskError);
+                  span.setStatus({ code: SpanStatusCode.ERROR, message: taskError.message });
+                } else {
+                  span.setStatus({ code: SpanStatusCode.OK });
+                }
+                return taskError;
+              })
+              .finally(() => {
+                span.end();
+              });
+
+          const useLinks = getConfig().useLinksInsteadOfParent?.(action.actionId) ?? false;
+          if (useLinks) {
+            const parentSpanCtx: SpanContext | undefined =
+              otelApi.trace.getSpanContext(parentContext);
+            const links =
+              parentSpanCtx && otelApi.trace.isSpanContextValid(parentSpanCtx)
+                ? [{ context: parentSpanCtx }]
+                : [];
+            return tracer.startActiveSpan(
+              spanName,
+              { kind: SpanKind.CONSUMER, attributes, links },
+              runSpan
+            );
+          }
+
           return tracer.startActiveSpan(
             spanName,
-            {
-              kind: SpanKind.CONSUMER,
-              attributes,
-            },
+            { kind: SpanKind.CONSUMER, attributes },
             parentContext,
-            (span: Span) => {
-              return original
-                .call(this, action)
-                .then((taskError: Error | undefined) => {
-                  if (taskError instanceof Error) {
-                    span.recordException(taskError);
-                    span.setStatus({ code: SpanStatusCode.ERROR, message: taskError.message });
-                  } else {
-                    span.setStatus({ code: SpanStatusCode.OK });
-                  }
-                  return taskError;
-                })
-                .finally(() => {
-                  span.end();
-                });
-            }
+            runSpan
           );
         };
       }


### PR DESCRIPTION
Closes #3641

## Problem

`HatchetInstrumentor` currently forces every spawned run into a parent→child OTel relationship. For fire-and-forget patterns (`runNoWait` fan-outs, long-running children, rate-limited queues) this is wrong: the parent trace stays open until the slowest child finishes, which inflates p50/p95 metrics and pollutes the waterfall view.

OTel's [span links](https://opentelemetry.io/docs/concepts/signals/traces/#span-links) are the right primitive here — the child starts a new root trace with a navigable link back to the spawning span, so the parent trace closes as soon as the spawn loop returns.

## Solution

Add a `useLinksInsteadOfParent` predicate to `HatchetInstrumentationConfig`:

```ts
new HatchetInstrumentor({
  // Return true to use a span link instead of parent context for this task.
  useLinksInsteadOfParent: (actionId) => actionId.startsWith('fan-out-worker:'),
});
```

**When the predicate returns `true` for a given `actionId`:**
- `handleStartStepRun` extracts the `SpanContext` from the incoming `additionalMetadata` (same as before)
- Calls `startActiveSpan(name, { kind, attributes, links: [{ context: parentSpanCtx }] }, fn)` — **no parent context argument**, so the child span becomes a root in a new trace with a link pointing back to the spawning span
- If the extracted span context is invalid (e.g. no `traceparent` in metadata), the links array is empty and the span still starts cleanly as a root

**When the predicate returns `false` (or is not provided):**
- Existing `startActiveSpan(name, opts, parentContext, fn)` path is used - **zero behaviour change**

Default: `undefined` → all spans use parent-child semantics, fully backwards compatible.

## Changes

- `sdks/typescript/src/opentelemetry/instrumentor.ts` - new config option + updated `_patchHandleStartStepRun`
- `sdks/typescript/src/opentelemetry/instrumentor.test.ts` - 5 unit tests (default, predicate=false, predicate=true, actionId forwarding, invalid-context fallback)

## Test plan

- [x] `pnpm test:unit` - all 195 tests pass (2 pre-existing skips)
- [x] `tsc --noEmit` - no type errors
- [ ] Manual verification with a real Hatchet worker + an OTel backend (Jaeger / Honeycomb) to confirm child spans appear as separate root traces with a link
