### PR TITLE
Fix: Show tenant invite modal correctly

### DIFF
--- a/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
@@ -84,7 +84,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { AxiosError } from 'axios';
 import { formatDistanceToNow } from 'date-fns';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 const OFFICE_HOURS_URL = 'https://hatchet.run/office-hours';
 
@@ -155,6 +155,7 @@ export function CloudOrganizationSettings({ orgId }: { orgId: string }) {
   const [tenantToArchive, setTenantToArchive] =
     useState<OrganizationTenantWithRegion | null>(null);
   const [expandedTenantIds, setExpandedTenantIds] = useState<string[]>([]);
+  const autoExpandedTenantId = useRef<string | null>(null);
   const [editedName, setEditedName] = useState('');
   const [isEditingName, setIsEditingName] = useState(false);
   const [editedTimeout, setEditedTimeout] = useState('');
@@ -249,8 +250,21 @@ export function CloudOrganizationSettings({ orgId }: { orgId: string }) {
   // 1. tenants can expand
   // 2. you can add members to tenants from here
   useEffect(() => {
-    if (visibleTenants.length > 0 && !expandedTenantIds.length) {
-      setExpandedTenantIds([visibleTenants[0].id]);
+    const firstVisibleTenantId = visibleTenants[0]?.id;
+
+    if (!firstVisibleTenantId) {
+      autoExpandedTenantId.current = null;
+      return;
+    }
+
+    if (autoExpandedTenantId.current === firstVisibleTenantId) {
+      return;
+    }
+
+    autoExpandedTenantId.current = firstVisibleTenantId;
+
+    if (!expandedTenantIds.length) {
+      setExpandedTenantIds([firstVisibleTenantId]);
     }
   }, [visibleTenants, expandedTenantIds.length]);
 
@@ -1102,6 +1116,7 @@ export function OssOrganizationSettings() {
   const [tenantToArchive, setTenantToArchive] =
     useState<OrganizationTenantWithRegion | null>(null);
   const [expandedTenantIds, setExpandedTenantIds] = useState<string[]>([]);
+  const autoExpandedTenantId = useRef<string | null>(null);
 
   const visibleTenants = useMemo(
     () =>
@@ -1128,8 +1143,21 @@ export function OssOrganizationSettings() {
   // 1. tenants can expand
   // 2. you can add members to tenants from here
   useEffect(() => {
-    if (visibleTenants.length > 0 && !expandedTenantIds.length) {
-      setExpandedTenantIds([visibleTenants[0].id]);
+    const firstVisibleTenantId = visibleTenants[0]?.id;
+
+    if (!firstVisibleTenantId) {
+      autoExpandedTenantId.current = null;
+      return;
+    }
+
+    if (autoExpandedTenantId.current === firstVisibleTenantId) {
+      return;
+    }
+
+    autoExpandedTenantId.current = firstVisibleTenantId;
+
+    if (!expandedTenantIds.length) {
+      setExpandedTenantIds([firstVisibleTenantId]);
     }
   }, [visibleTenants, expandedTenantIds.length]);
 

--- a/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
@@ -1221,7 +1221,7 @@ function TenantsSection({
           onValueChange={setExpandedTenantIds}
           className="space-y-3 rounded-md border bg-background p-3"
         >
-          {tenants.map((tenant) => (
+          {tenants.map((tenant, ix) => (
             <div key={tenant.id}>
               <TenantAccordionItem
                 key={tenant.id}
@@ -1230,7 +1230,7 @@ function TenantsSection({
                 onArchive={onArchive}
                 canManageOrganization={canManageOrganization}
               />
-              <Separator className="my-3 last:hidden" />
+              {ix < tenants.length - 1 && <Separator className="my-4" />}
             </div>
           ))}
         </Accordion>

--- a/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
@@ -1,5 +1,4 @@
 import { SettingsPageHeader } from '../components/settings-page-header';
-import { CreateTenantInviteModal } from '@/components/modals/create-tenant-invite-modal';
 import { usePylon } from '@/components/support-chat';
 import { TenantRegionBadge } from '@/components/v1/molecules/nav-bar/tenant-region-badge';
 import RelativeDate from '@/components/v1/molecules/relative-date';

--- a/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
@@ -245,6 +245,9 @@ export function CloudOrganizationSettings({ orgId }: { orgId: string }) {
     [org?.tenants, organization?.tenants],
   );
 
+  // showing the first tenant as open, to make clearer that:
+  // 1. tenants can expand
+  // 2. you can add members to tenants from here
   useEffect(() => {
     if (visibleTenants.length > 0 && !expandedTenantIds.length) {
       setExpandedTenantIds([visibleTenants[0].id]);

--- a/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
@@ -1261,12 +1261,15 @@ function TenantAccordionItem({
     enabled: isExpanded,
   });
   const { isCloudEnabled } = useUserUniverse();
+  const { isControlPlaneEnabled } = useControlPlane();
 
   const tenantMembers = membersQuery.data?.rows || [];
   const tenantInvites = invitesQuery.data?.rows || [];
 
   const canInviteTenantMembers =
-    canManageOrganization || (!isCloudEnabled && Boolean(tenant.canManage));
+    canManageOrganization ||
+    // if both cloud and the control plane are disabled, we're on the OSS and tenant admins / owners can invite members to their tenants
+    (!(isCloudEnabled || isControlPlaneEnabled) && Boolean(tenant.canManage));
 
   return (
     <AccordionItem value={tenant.id} className="overflow-hidden bg-background">

--- a/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
@@ -154,13 +154,13 @@ export function CloudOrganizationSettings({ orgId }: { orgId: string }) {
     useState<OrganizationInvite | null>(null);
   const [tenantToArchive, setTenantToArchive] =
     useState<OrganizationTenantWithRegion | null>(null);
+  const [expandedTenantIds, setExpandedTenantIds] = useState<string[]>([]);
   const [editedName, setEditedName] = useState('');
   const [isEditingName, setIsEditingName] = useState(false);
   const [editedTimeout, setEditedTimeout] = useState('');
   const [isEditingTimeout, setIsEditingTimeout] = useState(false);
   const [newSsoDomain, setNewSsoDomain] = useState('');
   const [isAddingSsoDomain, setIsAddingSsoDomain] = useState(false);
-  const [expandedTenantIds, setExpandedTenantIds] = useState<string[]>([]);
 
   const organizationSsoDomainGetQuery = useQuery({
     ...orgApi.organizationSsoDomainGetQuery(orgId),
@@ -252,7 +252,7 @@ export function CloudOrganizationSettings({ orgId }: { orgId: string }) {
     if (visibleTenants.length > 0 && !expandedTenantIds.length) {
       setExpandedTenantIds([visibleTenants[0].id]);
     }
-  }, [visibleTenants]);
+  }, [visibleTenants, expandedTenantIds.length]);
 
   const handleSaveName = () => {
     const trimmedName = editedName.trim();
@@ -1131,7 +1131,7 @@ export function OssOrganizationSettings() {
     if (visibleTenants.length > 0 && !expandedTenantIds.length) {
       setExpandedTenantIds([visibleTenants[0].id]);
     }
-  }, [visibleTenants]);
+  }, [visibleTenants, expandedTenantIds.length]);
 
   return (
     <div className="h-full w-full flex-grow">

--- a/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
@@ -1098,7 +1098,7 @@ export function OssOrganizationSettings() {
 
   const [tenantToArchive, setTenantToArchive] =
     useState<OrganizationTenantWithRegion | null>(null);
-  const [expandedTenantIds, setExpandedTenantIds] = useState<string[]>();
+  const [expandedTenantIds, setExpandedTenantIds] = useState<string[]>([]);
 
   const visibleTenants = useMemo(
     () =>

--- a/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
@@ -1271,7 +1271,7 @@ function TenantAccordionItem({
   const tenantMembers = membersQuery.data?.rows || [];
   const tenantInvites = invitesQuery.data?.rows || [];
 
-  const canInviteTenantMembers =
+  const canManageTenantMembers =
     canManageOrganization ||
     // if both cloud and the control plane are disabled, we're on the OSS and tenant admins / owners can invite members to their tenants
     (!(isCloudEnabled || isControlPlaneEnabled) && Boolean(tenant.canManage));
@@ -1307,7 +1307,7 @@ function TenantAccordionItem({
         <div className="space-y-5">
           <div className="flex items-center justify-between">
             <h4 className="text-sm font-medium">Members</h4>
-            {canInviteTenantMembers && (
+            {canManageTenantMembers && (
               <Button
                 onClick={() =>
                   globalEmitter.emit('create-tenant-invite', {
@@ -1334,7 +1334,7 @@ function TenantAccordionItem({
             <TenantMemberList
               tenantId={tenant.id}
               members={tenantMembers}
-              canManage={canManageOrganization}
+              canManage={canManageTenantMembers}
               onMembersChanged={() => membersQuery.refetch()}
             />
           ) : (
@@ -1367,62 +1367,59 @@ function TenantMemberList({
   onMembersChanged: () => void;
 }) {
   const [memberToEdit, setMemberToEdit] = useState<TenantMember | null>(null);
-
-  const gridCols = canManage
-    ? 'grid-cols-[minmax(0,1.2fr)_minmax(0,1.6fr)_140px_140px_72px]'
-    : 'grid-cols-[minmax(0,1.2fr)_minmax(0,1.6fr)_140px_140px]';
+  const columns = useMemo(
+    () => [
+      {
+        columnLabel: 'Name',
+        cellRenderer: (member: TenantMember) => (
+          <span className="font-medium">{member.user.name}</span>
+        ),
+      },
+      {
+        columnLabel: 'Email',
+        cellRenderer: (member: TenantMember) => (
+          <span className="font-mono text-sm">{member.user.email}</span>
+        ),
+      },
+      {
+        columnLabel: 'Role',
+        cellRenderer: (member: TenantMember) => (
+          <Badge variant="outline">{member.role}</Badge>
+        ),
+      },
+      {
+        columnLabel: 'Joined',
+        cellRenderer: (member: TenantMember) => (
+          <RelativeDate date={member.metadata.createdAt} />
+        ),
+      },
+      ...(canManage
+        ? [
+            {
+              columnLabel: 'Actions',
+              cellRenderer: (member: TenantMember) => (
+                <TenantMemberActions
+                  member={member}
+                  tenantId={tenantId}
+                  onEditRoleClick={setMemberToEdit}
+                  onChangePasswordClick={() => {}}
+                  onDeleteSuccess={onMembersChanged}
+                />
+              ),
+            },
+          ]
+        : []),
+    ],
+    [canManage, onMembersChanged, tenantId],
+  );
 
   return (
     <>
-      <div className="rounded-md border border-border/70">
-        <div
-          className={`hidden ${gridCols} gap-3 border-b border-border/70 bg-muted/20 px-4 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground md:grid`}
-        >
-          <span>Name</span>
-          <span>Email</span>
-          <span>Role</span>
-          <span>Joined</span>
-          {canManage && <span className="text-right">Actions</span>}
-        </div>
-        <div>
-          {members.map((member) => (
-            <div
-              key={member.metadata.id}
-              className={`grid ${gridCols} gap-3 border-b border-border/50 px-4 py-3 last:border-b-0 md:items-center`}
-            >
-              <div>
-                <p className="text-xs text-muted-foreground md:hidden">Name</p>
-                <p className="font-medium">{member.user.name}</p>
-              </div>
-              <div>
-                <p className="text-xs text-muted-foreground md:hidden">Email</p>
-                <p className="font-mono text-sm">{member.user.email}</p>
-              </div>
-              <div>
-                <p className="text-xs text-muted-foreground md:hidden">Role</p>
-                <Badge variant="outline">{member.role}</Badge>
-              </div>
-              <div>
-                <p className="text-xs text-muted-foreground md:hidden">
-                  Joined
-                </p>
-                <RelativeDate date={member.metadata.createdAt} />
-              </div>
-              {canManage && (
-                <div className="flex justify-end">
-                  <TenantMemberActions
-                    member={member}
-                    tenantId={tenantId}
-                    onEditRoleClick={setMemberToEdit}
-                    onChangePasswordClick={() => {}}
-                    onDeleteSuccess={onMembersChanged}
-                  />
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
-      </div>
+      <SimpleTable
+        columns={columns}
+        data={members}
+        rowKey={(member) => member.metadata.id}
+      />
 
       {memberToEdit && (
         <TenantMemberUpdateDialog

--- a/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
@@ -1,4 +1,5 @@
 import { SettingsPageHeader } from '../components/settings-page-header';
+import { CreateTenantInviteModal } from '@/components/modals/create-tenant-invite-modal';
 import { usePylon } from '@/components/support-chat';
 import { TenantRegionBadge } from '@/components/v1/molecules/nav-bar/tenant-region-badge';
 import RelativeDate from '@/components/v1/molecules/relative-date';
@@ -115,6 +116,7 @@ function formatTimeoutMs(ms: number): string {
 // FIXME: remove this once we migrate everyone to the control plane
 type OrganizationTenantWithRegion = OrganizationTenant & {
   region?: ControlPlaneOrganizationTenant['region'];
+  canManage?: boolean;
 };
 
 export function CloudOrganizationSettings({ orgId }: { orgId: string }) {
@@ -153,7 +155,6 @@ export function CloudOrganizationSettings({ orgId }: { orgId: string }) {
     useState<OrganizationInvite | null>(null);
   const [tenantToArchive, setTenantToArchive] =
     useState<OrganizationTenantWithRegion | null>(null);
-  const [expandedTenantIds, setExpandedTenantIds] = useState<string[]>([]);
   const [editedName, setEditedName] = useState('');
   const [isEditingName, setIsEditingName] = useState(false);
   const [editedTimeout, setEditedTimeout] = useState('');
@@ -242,6 +243,13 @@ export function CloudOrganizationSettings({ orgId }: { orgId: string }) {
         (tenant) => tenant.status !== TenantStatusType.ARCHIVED,
       ) || [],
     [org?.tenants, organization?.tenants],
+  );
+
+  // showing the first tenant as open, to make clearer that:
+  // 1. tenants can expand
+  // 2. you can add members to tenants from here
+  const [expandedTenantIds, setExpandedTenantIds] = useState<string[]>(
+    visibleTenants.length > 0 ? [visibleTenants[0].id] : [],
   );
 
   const handleSaveName = () => {
@@ -1091,7 +1099,6 @@ export function OssOrganizationSettings() {
 
   const [tenantToArchive, setTenantToArchive] =
     useState<OrganizationTenantWithRegion | null>(null);
-  const [expandedTenantIds, setExpandedTenantIds] = useState<string[]>([]);
 
   const visibleTenants = useMemo(
     () =>
@@ -1105,10 +1112,20 @@ export function OssOrganizationSettings() {
             name: m.tenant.name,
             status: TenantStatusType.ACTIVE,
             slug: m.tenant.slug,
+            canManage:
+              m.role === TenantMemberRole.OWNER ||
+              m.role === TenantMemberRole.ADMIN,
           };
         })
         .filter((t): t is OrganizationTenantWithRegion => t !== null) || [],
     [tenantMemberships],
+  );
+
+  // showing the first tenant as open, to make clearer that:
+  // 1. tenants can expand
+  // 2. you can add members to tenants from here
+  const [expandedTenantIds, setExpandedTenantIds] = useState<string[]>(
+    visibleTenants.length > 0 ? [visibleTenants[0].id] : [],
   );
 
   return (
@@ -1243,9 +1260,13 @@ function TenantAccordionItem({
     ...tenantInviteListQuery(tenant.id),
     enabled: isExpanded,
   });
+  const { isCloudEnabled } = useUserUniverse();
 
   const tenantMembers = membersQuery.data?.rows || [];
   const tenantInvites = invitesQuery.data?.rows || [];
+
+  const canInviteTenantMembers =
+    canManageOrganization || (!isCloudEnabled && Boolean(tenant.canManage));
 
   return (
     <AccordionItem value={tenant.id} className="overflow-hidden bg-background">
@@ -1278,7 +1299,7 @@ function TenantAccordionItem({
         <div className="space-y-5">
           <div className="flex items-center justify-between">
             <h4 className="text-sm font-medium">Members</h4>
-            {canManageOrganization && (
+            {canInviteTenantMembers && (
               <Button
                 onClick={() =>
                   globalEmitter.emit('create-tenant-invite', {

--- a/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
@@ -84,7 +84,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { AxiosError } from 'axios';
 import { formatDistanceToNow } from 'date-fns';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 const OFFICE_HOURS_URL = 'https://hatchet.run/office-hours';
 
@@ -160,6 +160,7 @@ export function CloudOrganizationSettings({ orgId }: { orgId: string }) {
   const [isEditingTimeout, setIsEditingTimeout] = useState(false);
   const [newSsoDomain, setNewSsoDomain] = useState('');
   const [isAddingSsoDomain, setIsAddingSsoDomain] = useState(false);
+  const [expandedTenantIds, setExpandedTenantIds] = useState<string[]>([]);
 
   const organizationSsoDomainGetQuery = useQuery({
     ...orgApi.organizationSsoDomainGetQuery(orgId),
@@ -244,12 +245,11 @@ export function CloudOrganizationSettings({ orgId }: { orgId: string }) {
     [org?.tenants, organization?.tenants],
   );
 
-  // showing the first tenant as open, to make clearer that:
-  // 1. tenants can expand
-  // 2. you can add members to tenants from here
-  const [expandedTenantIds, setExpandedTenantIds] = useState<string[]>(
-    visibleTenants.length > 0 ? [visibleTenants[0].id] : [],
-  );
+  useEffect(() => {
+    if (visibleTenants.length > 0 && !expandedTenantIds.length) {
+      setExpandedTenantIds([visibleTenants[0].id]);
+    }
+  }, [visibleTenants]);
 
   const handleSaveName = () => {
     const trimmedName = editedName.trim();
@@ -1098,6 +1098,7 @@ export function OssOrganizationSettings() {
 
   const [tenantToArchive, setTenantToArchive] =
     useState<OrganizationTenantWithRegion | null>(null);
+  const [expandedTenantIds, setExpandedTenantIds] = useState<string[]>();
 
   const visibleTenants = useMemo(
     () =>
@@ -1123,9 +1124,11 @@ export function OssOrganizationSettings() {
   // showing the first tenant as open, to make clearer that:
   // 1. tenants can expand
   // 2. you can add members to tenants from here
-  const [expandedTenantIds, setExpandedTenantIds] = useState<string[]>(
-    visibleTenants.length > 0 ? [visibleTenants[0].id] : [],
-  );
+  useEffect(() => {
+    if (visibleTenants.length > 0 && !expandedTenantIds.length) {
+      setExpandedTenantIds([visibleTenants[0].id]);
+    }
+  }, [visibleTenants]);
 
   return (
     <div className="h-full w-full flex-grow">


### PR DESCRIPTION
# Description

Shows the tenant invite modal correctly when we're not in "org mode" on cloud / control plane. Also defaults the first tenant to being expanded to make it clearer that this is how you invite people

Fixes #3813

<img width="1728" height="958" alt="Screenshot 2026-05-04 at 1 48 32 PM" src="https://github.com/user-attachments/assets/c5445926-3cbe-4ad0-9f30-a1028bddce49" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
