### PR TITLE
Fix: dedupe task ids before updating to assigned

### DIFF
--- a/pkg/repository/scheduler_queue.go
+++ b/pkg/repository/scheduler_queue.go
@@ -286,6 +286,7 @@ func (d *sharedRepository) markQueueItemsProcessed(ctx context.Context, tenantId
 	taskIds := make([]int64, 0, len(r.Assigned))
 	taskInsertedAts := make([]pgtype.Timestamptz, 0, len(r.Assigned))
 	workerIds := make([]uuid.UUID, 0, len(r.Assigned))
+	seenTaskIds := make(map[int64]struct{})
 
 	var minTaskInsertedAt pgtype.Timestamptz
 
@@ -293,6 +294,12 @@ func (d *sharedRepository) markQueueItemsProcessed(ctx context.Context, tenantId
 	// deleted from the v1_queue_items table, so we should not assign them
 	for id, assignedItem := range queueItemIdsToAssignedItem {
 		if _, ok := queuedItemsMap[id]; ok {
+			if _, seen := seenTaskIds[assignedItem.QueueItem.TaskID]; seen {
+				continue
+			}
+
+			seenTaskIds[assignedItem.QueueItem.TaskID] = struct{}{}
+
 			taskIds = append(taskIds, assignedItem.QueueItem.TaskID)
 			taskInsertedAts = append(taskInsertedAts, assignedItem.QueueItem.TaskInsertedAt)
 			workerIds = append(workerIds, assignedItem.WorkerId)

--- a/pkg/repository/scheduler_queue.go
+++ b/pkg/repository/scheduler_queue.go
@@ -298,7 +298,8 @@ func (d *sharedRepository) markQueueItemsProcessed(ctx context.Context, tenantId
 				d.l.Error().
 					Int64("task_id", assignedItem.QueueItem.TaskID).
 					Str("task_inserted_at", qi.TaskInsertedAt.Time.String()).
-					Int64("retry_count", int64(qi.RetryCount)).
+					Int64("new_retry_count", int64(qi.RetryCount)).
+					Int64("old_retry_count", int64(assignedItem.QueueItem.RetryCount)).
 					Msg("duplicate task id seen when preparing queue items for `UpdateTasksToAssigned`")
 			}
 

--- a/pkg/repository/scheduler_queue.go
+++ b/pkg/repository/scheduler_queue.go
@@ -290,6 +290,8 @@ func (d *sharedRepository) markQueueItemsProcessed(ctx context.Context, tenantId
 
 	var minTaskInsertedAt pgtype.Timestamptz
 
+	// if there are any idsToUnqueue that are not in the queuedItems, this means they were
+	// deleted from the v1_queue_items table, so we should not assign them
 	for id, assignedItem := range queueItemIdsToAssignedItem {
 		if _, ok := queuedItemsMap[id]; ok {
 			if _, seen := seenTaskIds[assignedItem.QueueItem.TaskID]; seen {

--- a/pkg/repository/scheduler_queue.go
+++ b/pkg/repository/scheduler_queue.go
@@ -290,8 +290,6 @@ func (d *sharedRepository) markQueueItemsProcessed(ctx context.Context, tenantId
 
 	var minTaskInsertedAt pgtype.Timestamptz
 
-	// if there are any idsToUnqueue that are not in the queuedItems, this means they were
-	// deleted from the v1_queue_items table, so we should not assign them
 	for id, assignedItem := range queueItemIdsToAssignedItem {
 		if _, ok := queuedItemsMap[id]; ok {
 			if _, seen := seenTaskIds[assignedItem.QueueItem.TaskID]; seen {
@@ -299,6 +297,7 @@ func (d *sharedRepository) markQueueItemsProcessed(ctx context.Context, tenantId
 			}
 
 			seenTaskIds[assignedItem.QueueItem.TaskID] = struct{}{}
+			taskIdToAssignedItem[assignedItem.QueueItem.TaskID] = assignedItem
 
 			taskIds = append(taskIds, assignedItem.QueueItem.TaskID)
 			taskInsertedAts = append(taskInsertedAts, assignedItem.QueueItem.TaskInsertedAt)

--- a/pkg/repository/scheduler_queue.go
+++ b/pkg/repository/scheduler_queue.go
@@ -286,7 +286,7 @@ func (d *sharedRepository) markQueueItemsProcessed(ctx context.Context, tenantId
 	taskIds := make([]int64, 0, len(r.Assigned))
 	taskInsertedAts := make([]pgtype.Timestamptz, 0, len(r.Assigned))
 	workerIds := make([]uuid.UUID, 0, len(r.Assigned))
-	seenTaskIds := make(map[int64]struct{})
+	seenTaskIds := make(map[int64]*sqlcv1.V1QueueItem)
 
 	var minTaskInsertedAt pgtype.Timestamptz
 
@@ -294,12 +294,17 @@ func (d *sharedRepository) markQueueItemsProcessed(ctx context.Context, tenantId
 	// deleted from the v1_queue_items table, so we should not assign them
 	for id, assignedItem := range queueItemIdsToAssignedItem {
 		if _, ok := queuedItemsMap[id]; ok {
-			if _, seen := seenTaskIds[assignedItem.QueueItem.TaskID]; seen {
-				continue
+			if qi, seen := seenTaskIds[assignedItem.QueueItem.TaskID]; seen {
+				d.l.Error().
+					Int64("task_id", assignedItem.QueueItem.TaskID).
+					Str("task_inserted_at", qi.TaskInsertedAt.Time.String()).
+					Int64("retry_count", int64(qi.RetryCount)).
+					Msg("duplicate task id seen when preparing queue items for `UpdateTasksToAssigned`")
 			}
 
-			seenTaskIds[assignedItem.QueueItem.TaskID] = struct{}{}
-			taskIdToAssignedItem[assignedItem.QueueItem.TaskID] = assignedItem
+			seenTaskIds[assignedItem.QueueItem.TaskID] = assignedItem.QueueItem
+			// todo: add this back if we remove the error log above for deduping
+			// taskIdToAssignedItem[assignedItem.QueueItem.TaskID] = assignedItem
 
 			taskIds = append(taskIds, assignedItem.QueueItem.TaskID)
 			taskInsertedAts = append(taskInsertedAts, assignedItem.QueueItem.TaskInsertedAt)


### PR DESCRIPTION
# Description

Seeing a bunch of these: 

```
ERR error marking queue items processed error="ERROR: ON CONFLICT DO UPDATE command cannot affect row a second time (SQLSTATE 21000)
```

which I think should be resolved by deduping before we do the update here

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
