### PR TITLE
Fix: Payload external id dupe

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260505155051_v1_0_103.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260505155051_v1_0_103.sql
@@ -16,7 +16,7 @@ BEGIN
             SELECT DISTINCT durable_task_id, durable_task_inserted_at
             FROM v1_durable_event_log_entry
             WHERE result_payload_external_id IS NULL
-              AND (durable_task_id, durable_task_inserted_at) > (last_task_id, last_inserted_at)
+              AND (durable_task_id, durable_task_inserted_at) >= (last_task_id, last_inserted_at)
             ORDER BY durable_task_id, durable_task_inserted_at
             LIMIT batch_size
         ), updated AS (

--- a/cmd/hatchet-migrate/migrate/migrations/20260505155051_v1_0_103.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260505155051_v1_0_103.sql
@@ -6,7 +6,7 @@ ALTER TABLE v1_durable_event_log_entry ADD COLUMN result_payload_external_id UUI
 -- +goose StatementBegin
 DO $$
 DECLARE
-    batch_size INT := 1000;
+    batch_size INT := 100; -- small batches, since each durable task can have many event log entries
     rows_updated INT;
     last_task_id BIGINT := -1;
     last_inserted_at TIMESTAMPTZ := '1970-01-01T00:00:00Z';

--- a/cmd/hatchet-migrate/migrate/migrations/20260505155051_v1_0_103.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260505155051_v1_0_103.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE v1_durable_event_log_entry ADD COLUMN result_payload_external_id UUID NOT NULL DEFAULT gen_random_uuid();
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE v1_durable_event_log_entry DROP COLUMN result_payload_external_id;
+-- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20260505155051_v1_0_103.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260505155051_v1_0_103.sql
@@ -16,7 +16,7 @@ BEGIN
             SELECT DISTINCT durable_task_id, durable_task_inserted_at
             FROM v1_durable_event_log_entry
             WHERE result_payload_external_id IS NULL
-              AND (durable_task_id, durable_task_inserted_at) >= (last_task_id, last_inserted_at)
+              AND (durable_task_id, durable_task_inserted_at) > (last_task_id, last_inserted_at)
             ORDER BY durable_task_id, durable_task_inserted_at
             LIMIT batch_size
         ), updated AS (

--- a/cmd/hatchet-migrate/migrate/migrations/20260505155051_v1_0_103.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260505155051_v1_0_103.sql
@@ -1,6 +1,50 @@
 -- +goose Up
 -- +goose StatementBegin
-ALTER TABLE v1_durable_event_log_entry ADD COLUMN result_payload_external_id UUID NOT NULL DEFAULT gen_random_uuid();
+ALTER TABLE v1_durable_event_log_entry ADD COLUMN result_payload_external_id UUID;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DO $$
+DECLARE
+    batch_size INT := 1000;
+    rows_updated INT;
+    last_task_id BIGINT := -1;
+    last_inserted_at TIMESTAMPTZ := '1970-01-01T00:00:00Z';
+BEGIN
+    LOOP
+        WITH batch_keys AS (
+            SELECT DISTINCT durable_task_id, durable_task_inserted_at
+            FROM v1_durable_event_log_entry
+            WHERE result_payload_external_id IS NULL
+              AND (durable_task_id, durable_task_inserted_at) > (last_task_id, last_inserted_at)
+            ORDER BY durable_task_id, durable_task_inserted_at
+            LIMIT batch_size
+        ), updated AS (
+            UPDATE v1_durable_event_log_entry e
+            SET result_payload_external_id = gen_random_uuid()
+            FROM batch_keys b
+            WHERE (e.durable_task_id, e.durable_task_inserted_at) = (b.durable_task_id, b.durable_task_inserted_at)
+            RETURNING e.durable_task_id, e.durable_task_inserted_at
+        )
+
+        SELECT
+            count(*) OVER (),
+            durable_task_id,
+            durable_task_inserted_at
+        INTO rows_updated, last_task_id, last_inserted_at
+        FROM updated
+        ORDER BY durable_task_id DESC, durable_task_inserted_at DESC
+        LIMIT 1;
+
+        EXIT WHEN rows_updated IS NULL OR rows_updated = 0;
+    END LOOP;
+END;
+$$;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE v1_durable_event_log_entry ALTER COLUMN result_payload_external_id SET DEFAULT gen_random_uuid();
+ALTER TABLE v1_durable_event_log_entry ALTER COLUMN result_payload_external_id SET NOT NULL;
 -- +goose StatementEnd
 
 -- +goose Down

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -824,7 +824,7 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 				storePayloadOpts = append(storePayloadOpts, StorePayloadOpts{
 					Id:         createdRow.ID,
 					InsertedAt: createdRow.InsertedAt,
-					ExternalId: createdRow.ExternalID,
+					ExternalId: createdRow.ResultPayloadExternalID,
 					Type:       sqlcv1.V1PayloadTypeDURABLEEVENTLOGENTRYRESULTDATA,
 					Payload:    opt.ResultPayload,
 					TenantId:   opts.TenantId,
@@ -1514,7 +1514,7 @@ func (r *durableEventsRepository) CompleteMemoEntry(ctx context.Context, opts Co
 		err = r.payloadStore.Store(ctx, r.pool, StorePayloadOpts{
 			Id:         entry.ID,
 			InsertedAt: entry.InsertedAt,
-			ExternalId: entry.ExternalID,
+			ExternalId: entry.ResultPayloadExternalID,
 			Type:       sqlcv1.V1PayloadTypeDURABLEEVENTLOGENTRYRESULTDATA,
 			Payload:    opts.Payload,
 			TenantId:   opts.TenantId,

--- a/pkg/repository/match.go
+++ b/pkg/repository/match.go
@@ -840,7 +840,7 @@ func (m *sharedRepository) processEventMatches(ctx context.Context, tx sqlcv1.DB
 				InsertedAt: cb.InsertedAt,
 				Type:       sqlcv1.V1PayloadTypeDURABLEEVENTLOGENTRYRESULTDATA,
 				Payload:    initialEntry.Data,
-				ExternalId: cb.ExternalID,
+				ExternalId: cb.ResultPayloadExternalID,
 				TenantId:   tenantId,
 			})
 		}

--- a/pkg/repository/sqlcv1/durable_event_log.sql.go
+++ b/pkg/repository/sqlcv1/durable_event_log.sql.go
@@ -56,10 +56,10 @@ WITH inputs AS (
         CASE WHEN i.wait_data = '' THEN NULL ELSE i.wait_data::JSONB END
     FROM inputs i
     ON CONFLICT (durable_task_id, durable_task_inserted_at, branch_id, node_id) DO NOTHING
-    RETURNING tenant_id, external_id, inserted_at, id, durable_task_id, durable_task_inserted_at, kind, node_id, branch_id, idempotency_key, is_satisfied, satisfied_at, user_message, wait_data
+    RETURNING tenant_id, external_id, result_payload_external_id, inserted_at, id, durable_task_id, durable_task_inserted_at, kind, node_id, branch_id, idempotency_key, is_satisfied, satisfied_at, user_message, wait_data
 )
 
-SELECT i.tenant_id, i.external_id, i.inserted_at, i.id, i.durable_task_id, i.durable_task_inserted_at, i.kind, i.node_id, i.branch_id, i.idempotency_key, i.is_satisfied, i.satisfied_at, i.user_message, i.wait_data, lf.latest_invocation_count AS invocation_count
+SELECT i.tenant_id, i.external_id, i.result_payload_external_id, i.inserted_at, i.id, i.durable_task_id, i.durable_task_inserted_at, i.kind, i.node_id, i.branch_id, i.idempotency_key, i.is_satisfied, i.satisfied_at, i.user_message, i.wait_data, lf.latest_invocation_count AS invocation_count
 FROM inserts i
 JOIN v1_durable_event_log_file lf ON (lf.durable_task_id, lf.durable_task_inserted_at) = (i.durable_task_id, i.durable_task_inserted_at)
 `
@@ -79,21 +79,22 @@ type BulkCreateDurableEventLogEntriesParams struct {
 }
 
 type BulkCreateDurableEventLogEntriesRow struct {
-	TenantID              uuid.UUID             `json:"tenant_id"`
-	ExternalID            uuid.UUID             `json:"external_id"`
-	InsertedAt            pgtype.Timestamptz    `json:"inserted_at"`
-	ID                    int64                 `json:"id"`
-	DurableTaskID         int64                 `json:"durable_task_id"`
-	DurableTaskInsertedAt pgtype.Timestamptz    `json:"durable_task_inserted_at"`
-	Kind                  V1DurableEventLogKind `json:"kind"`
-	NodeID                int64                 `json:"node_id"`
-	BranchID              int64                 `json:"branch_id"`
-	IdempotencyKey        []byte                `json:"idempotency_key"`
-	IsSatisfied           bool                  `json:"is_satisfied"`
-	SatisfiedAt           pgtype.Timestamptz    `json:"satisfied_at"`
-	UserMessage           pgtype.Text           `json:"user_message"`
-	WaitData              []byte                `json:"wait_data"`
-	InvocationCount       int32                 `json:"invocation_count"`
+	TenantID                uuid.UUID             `json:"tenant_id"`
+	ExternalID              uuid.UUID             `json:"external_id"`
+	ResultPayloadExternalID uuid.UUID             `json:"result_payload_external_id"`
+	InsertedAt              pgtype.Timestamptz    `json:"inserted_at"`
+	ID                      int64                 `json:"id"`
+	DurableTaskID           int64                 `json:"durable_task_id"`
+	DurableTaskInsertedAt   pgtype.Timestamptz    `json:"durable_task_inserted_at"`
+	Kind                    V1DurableEventLogKind `json:"kind"`
+	NodeID                  int64                 `json:"node_id"`
+	BranchID                int64                 `json:"branch_id"`
+	IdempotencyKey          []byte                `json:"idempotency_key"`
+	IsSatisfied             bool                  `json:"is_satisfied"`
+	SatisfiedAt             pgtype.Timestamptz    `json:"satisfied_at"`
+	UserMessage             pgtype.Text           `json:"user_message"`
+	WaitData                []byte                `json:"wait_data"`
+	InvocationCount         int32                 `json:"invocation_count"`
 }
 
 func (q *Queries) BulkCreateDurableEventLogEntries(ctx context.Context, db DBTX, arg BulkCreateDurableEventLogEntriesParams) ([]*BulkCreateDurableEventLogEntriesRow, error) {
@@ -120,6 +121,7 @@ func (q *Queries) BulkCreateDurableEventLogEntries(ctx context.Context, db DBTX,
 		if err := rows.Scan(
 			&i.TenantID,
 			&i.ExternalID,
+			&i.ResultPayloadExternalID,
 			&i.InsertedAt,
 			&i.ID,
 			&i.DurableTaskID,
@@ -150,7 +152,7 @@ WITH inputs AS (
         UNNEST($3::BIGINT[]) AS branch_id,
         UNNEST($4::BIGINT[]) AS node_id
 )
-SELECT e.tenant_id, e.external_id, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.user_message, e.wait_data, lf.latest_invocation_count AS invocation_count
+SELECT e.tenant_id, e.external_id, e.result_payload_external_id, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.user_message, e.wait_data, lf.latest_invocation_count AS invocation_count
 FROM v1_durable_event_log_entry e
 JOIN inputs i ON e.branch_id = i.branch_id AND e.node_id = i.node_id
 JOIN v1_durable_event_log_file lf ON (lf.durable_task_id, lf.durable_task_inserted_at) = (e.durable_task_id, e.durable_task_inserted_at)
@@ -166,21 +168,22 @@ type BulkGetDurableEventLogEntriesParams struct {
 }
 
 type BulkGetDurableEventLogEntriesRow struct {
-	TenantID              uuid.UUID             `json:"tenant_id"`
-	ExternalID            uuid.UUID             `json:"external_id"`
-	InsertedAt            pgtype.Timestamptz    `json:"inserted_at"`
-	ID                    int64                 `json:"id"`
-	DurableTaskID         int64                 `json:"durable_task_id"`
-	DurableTaskInsertedAt pgtype.Timestamptz    `json:"durable_task_inserted_at"`
-	Kind                  V1DurableEventLogKind `json:"kind"`
-	NodeID                int64                 `json:"node_id"`
-	BranchID              int64                 `json:"branch_id"`
-	IdempotencyKey        []byte                `json:"idempotency_key"`
-	IsSatisfied           bool                  `json:"is_satisfied"`
-	SatisfiedAt           pgtype.Timestamptz    `json:"satisfied_at"`
-	UserMessage           pgtype.Text           `json:"user_message"`
-	WaitData              []byte                `json:"wait_data"`
-	InvocationCount       int32                 `json:"invocation_count"`
+	TenantID                uuid.UUID             `json:"tenant_id"`
+	ExternalID              uuid.UUID             `json:"external_id"`
+	ResultPayloadExternalID uuid.UUID             `json:"result_payload_external_id"`
+	InsertedAt              pgtype.Timestamptz    `json:"inserted_at"`
+	ID                      int64                 `json:"id"`
+	DurableTaskID           int64                 `json:"durable_task_id"`
+	DurableTaskInsertedAt   pgtype.Timestamptz    `json:"durable_task_inserted_at"`
+	Kind                    V1DurableEventLogKind `json:"kind"`
+	NodeID                  int64                 `json:"node_id"`
+	BranchID                int64                 `json:"branch_id"`
+	IdempotencyKey          []byte                `json:"idempotency_key"`
+	IsSatisfied             bool                  `json:"is_satisfied"`
+	SatisfiedAt             pgtype.Timestamptz    `json:"satisfied_at"`
+	UserMessage             pgtype.Text           `json:"user_message"`
+	WaitData                []byte                `json:"wait_data"`
+	InvocationCount         int32                 `json:"invocation_count"`
 }
 
 func (q *Queries) BulkGetDurableEventLogEntries(ctx context.Context, db DBTX, arg BulkGetDurableEventLogEntriesParams) ([]*BulkGetDurableEventLogEntriesRow, error) {
@@ -200,6 +203,7 @@ func (q *Queries) BulkGetDurableEventLogEntries(ctx context.Context, db DBTX, ar
 		if err := rows.Scan(
 			&i.TenantID,
 			&i.ExternalID,
+			&i.ResultPayloadExternalID,
 			&i.InsertedAt,
 			&i.ID,
 			&i.DurableTaskID,
@@ -297,7 +301,7 @@ func (q *Queries) GetAndLockLogFile(ctx context.Context, db DBTX, arg GetAndLock
 }
 
 const getDurableEventLogEntry = `-- name: GetDurableEventLogEntry :one
-SELECT tenant_id, external_id, inserted_at, id, durable_task_id, durable_task_inserted_at, kind, node_id, branch_id, idempotency_key, is_satisfied, satisfied_at, user_message, wait_data
+SELECT tenant_id, external_id, result_payload_external_id, inserted_at, id, durable_task_id, durable_task_inserted_at, kind, node_id, branch_id, idempotency_key, is_satisfied, satisfied_at, user_message, wait_data
 FROM v1_durable_event_log_entry
 WHERE durable_task_id = $1::BIGINT
   AND durable_task_inserted_at = $2::TIMESTAMPTZ
@@ -323,6 +327,7 @@ func (q *Queries) GetDurableEventLogEntry(ctx context.Context, db DBTX, arg GetD
 	err := row.Scan(
 		&i.TenantID,
 		&i.ExternalID,
+		&i.ResultPayloadExternalID,
 		&i.InsertedAt,
 		&i.ID,
 		&i.DurableTaskID,
@@ -502,7 +507,7 @@ func (q *Queries) ListDurableEventLogBranchPoints(ctx context.Context, db DBTX, 
 }
 
 const listDurableEventLogForTask = `-- name: ListDurableEventLogForTask :many
-SELECT e.tenant_id, e.external_id, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.user_message, e.wait_data, t.external_id AS durable_task_external_id, t.display_name AS durable_task_display_name
+SELECT e.tenant_id, e.external_id, e.result_payload_external_id, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.user_message, e.wait_data, t.external_id AS durable_task_external_id, t.display_name AS durable_task_display_name
 FROM v1_durable_event_log_entry e
 JOIN v1_task t ON (t.id, t.inserted_at) = (e.durable_task_id, e.durable_task_inserted_at)
 WHERE e.durable_task_id = $1::BIGINT
@@ -522,22 +527,23 @@ type ListDurableEventLogForTaskParams struct {
 }
 
 type ListDurableEventLogForTaskRow struct {
-	TenantID               uuid.UUID             `json:"tenant_id"`
-	ExternalID             uuid.UUID             `json:"external_id"`
-	InsertedAt             pgtype.Timestamptz    `json:"inserted_at"`
-	ID                     int64                 `json:"id"`
-	DurableTaskID          int64                 `json:"durable_task_id"`
-	DurableTaskInsertedAt  pgtype.Timestamptz    `json:"durable_task_inserted_at"`
-	Kind                   V1DurableEventLogKind `json:"kind"`
-	NodeID                 int64                 `json:"node_id"`
-	BranchID               int64                 `json:"branch_id"`
-	IdempotencyKey         []byte                `json:"idempotency_key"`
-	IsSatisfied            bool                  `json:"is_satisfied"`
-	SatisfiedAt            pgtype.Timestamptz    `json:"satisfied_at"`
-	UserMessage            pgtype.Text           `json:"user_message"`
-	WaitData               []byte                `json:"wait_data"`
-	DurableTaskExternalID  uuid.UUID             `json:"durable_task_external_id"`
-	DurableTaskDisplayName string                `json:"durable_task_display_name"`
+	TenantID                uuid.UUID             `json:"tenant_id"`
+	ExternalID              uuid.UUID             `json:"external_id"`
+	ResultPayloadExternalID uuid.UUID             `json:"result_payload_external_id"`
+	InsertedAt              pgtype.Timestamptz    `json:"inserted_at"`
+	ID                      int64                 `json:"id"`
+	DurableTaskID           int64                 `json:"durable_task_id"`
+	DurableTaskInsertedAt   pgtype.Timestamptz    `json:"durable_task_inserted_at"`
+	Kind                    V1DurableEventLogKind `json:"kind"`
+	NodeID                  int64                 `json:"node_id"`
+	BranchID                int64                 `json:"branch_id"`
+	IdempotencyKey          []byte                `json:"idempotency_key"`
+	IsSatisfied             bool                  `json:"is_satisfied"`
+	SatisfiedAt             pgtype.Timestamptz    `json:"satisfied_at"`
+	UserMessage             pgtype.Text           `json:"user_message"`
+	WaitData                []byte                `json:"wait_data"`
+	DurableTaskExternalID   uuid.UUID             `json:"durable_task_external_id"`
+	DurableTaskDisplayName  string                `json:"durable_task_display_name"`
 }
 
 func (q *Queries) ListDurableEventLogForTask(ctx context.Context, db DBTX, arg ListDurableEventLogForTaskParams) ([]*ListDurableEventLogForTaskRow, error) {
@@ -558,6 +564,7 @@ func (q *Queries) ListDurableEventLogForTask(ctx context.Context, db DBTX, arg L
 		if err := rows.Scan(
 			&i.TenantID,
 			&i.ExternalID,
+			&i.ResultPayloadExternalID,
 			&i.InsertedAt,
 			&i.ID,
 			&i.DurableTaskID,
@@ -597,7 +604,7 @@ WITH inputs AS (
 )
 
 SELECT
-    e.tenant_id, e.external_id, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.user_message, e.wait_data,
+    e.tenant_id, e.external_id, e.result_payload_external_id, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.user_message, e.wait_data,
     twn.external_id AS task_external_id,
     lf.latest_invocation_count AS invocation_count
 FROM v1_durable_event_log_entry e
@@ -616,22 +623,23 @@ type ListSatisfiedEntriesParams struct {
 }
 
 type ListSatisfiedEntriesRow struct {
-	TenantID              uuid.UUID             `json:"tenant_id"`
-	ExternalID            uuid.UUID             `json:"external_id"`
-	InsertedAt            pgtype.Timestamptz    `json:"inserted_at"`
-	ID                    int64                 `json:"id"`
-	DurableTaskID         int64                 `json:"durable_task_id"`
-	DurableTaskInsertedAt pgtype.Timestamptz    `json:"durable_task_inserted_at"`
-	Kind                  V1DurableEventLogKind `json:"kind"`
-	NodeID                int64                 `json:"node_id"`
-	BranchID              int64                 `json:"branch_id"`
-	IdempotencyKey        []byte                `json:"idempotency_key"`
-	IsSatisfied           bool                  `json:"is_satisfied"`
-	SatisfiedAt           pgtype.Timestamptz    `json:"satisfied_at"`
-	UserMessage           pgtype.Text           `json:"user_message"`
-	WaitData              []byte                `json:"wait_data"`
-	TaskExternalID        uuid.UUID             `json:"task_external_id"`
-	InvocationCount       int32                 `json:"invocation_count"`
+	TenantID                uuid.UUID             `json:"tenant_id"`
+	ExternalID              uuid.UUID             `json:"external_id"`
+	ResultPayloadExternalID uuid.UUID             `json:"result_payload_external_id"`
+	InsertedAt              pgtype.Timestamptz    `json:"inserted_at"`
+	ID                      int64                 `json:"id"`
+	DurableTaskID           int64                 `json:"durable_task_id"`
+	DurableTaskInsertedAt   pgtype.Timestamptz    `json:"durable_task_inserted_at"`
+	Kind                    V1DurableEventLogKind `json:"kind"`
+	NodeID                  int64                 `json:"node_id"`
+	BranchID                int64                 `json:"branch_id"`
+	IdempotencyKey          []byte                `json:"idempotency_key"`
+	IsSatisfied             bool                  `json:"is_satisfied"`
+	SatisfiedAt             pgtype.Timestamptz    `json:"satisfied_at"`
+	UserMessage             pgtype.Text           `json:"user_message"`
+	WaitData                []byte                `json:"wait_data"`
+	TaskExternalID          uuid.UUID             `json:"task_external_id"`
+	InvocationCount         int32                 `json:"invocation_count"`
 }
 
 func (q *Queries) ListSatisfiedEntries(ctx context.Context, db DBTX, arg ListSatisfiedEntriesParams) ([]*ListSatisfiedEntriesRow, error) {
@@ -646,6 +654,7 @@ func (q *Queries) ListSatisfiedEntries(ctx context.Context, db DBTX, arg ListSat
 		if err := rows.Scan(
 			&i.TenantID,
 			&i.ExternalID,
+			&i.ResultPayloadExternalID,
 			&i.InsertedAt,
 			&i.ID,
 			&i.DurableTaskID,
@@ -680,7 +689,7 @@ WHERE durable_task_id = $1::BIGINT
   AND durable_task_inserted_at = $2::TIMESTAMPTZ
   AND branch_id = $3::BIGINT
   AND node_id = $4::BIGINT
-RETURNING tenant_id, external_id, inserted_at, id, durable_task_id, durable_task_inserted_at, kind, node_id, branch_id, idempotency_key, is_satisfied, satisfied_at, user_message, wait_data
+RETURNING tenant_id, external_id, result_payload_external_id, inserted_at, id, durable_task_id, durable_task_inserted_at, kind, node_id, branch_id, idempotency_key, is_satisfied, satisfied_at, user_message, wait_data
 `
 
 type MarkDurableEventLogEntrySatisfiedParams struct {
@@ -701,6 +710,7 @@ func (q *Queries) MarkDurableEventLogEntrySatisfied(ctx context.Context, db DBTX
 	err := row.Scan(
 		&i.TenantID,
 		&i.ExternalID,
+		&i.ResultPayloadExternalID,
 		&i.InsertedAt,
 		&i.ID,
 		&i.DurableTaskID,
@@ -734,10 +744,10 @@ WITH inputs AS (
       AND v1_durable_event_log_entry.durable_task_inserted_at = inputs.durable_task_inserted_at
       AND v1_durable_event_log_entry.node_id = inputs.node_id
       AND v1_durable_event_log_entry.branch_id = inputs.branch_id
-    RETURNING v1_durable_event_log_entry.tenant_id, v1_durable_event_log_entry.external_id, v1_durable_event_log_entry.inserted_at, v1_durable_event_log_entry.id, v1_durable_event_log_entry.durable_task_id, v1_durable_event_log_entry.durable_task_inserted_at, v1_durable_event_log_entry.kind, v1_durable_event_log_entry.node_id, v1_durable_event_log_entry.branch_id, v1_durable_event_log_entry.idempotency_key, v1_durable_event_log_entry.is_satisfied, v1_durable_event_log_entry.satisfied_at, v1_durable_event_log_entry.user_message, v1_durable_event_log_entry.wait_data
+    RETURNING v1_durable_event_log_entry.tenant_id, v1_durable_event_log_entry.external_id, v1_durable_event_log_entry.result_payload_external_id, v1_durable_event_log_entry.inserted_at, v1_durable_event_log_entry.id, v1_durable_event_log_entry.durable_task_id, v1_durable_event_log_entry.durable_task_inserted_at, v1_durable_event_log_entry.kind, v1_durable_event_log_entry.node_id, v1_durable_event_log_entry.branch_id, v1_durable_event_log_entry.idempotency_key, v1_durable_event_log_entry.is_satisfied, v1_durable_event_log_entry.satisfied_at, v1_durable_event_log_entry.user_message, v1_durable_event_log_entry.wait_data
 )
 
-SELECT updated.tenant_id, updated.external_id, updated.inserted_at, updated.id, updated.durable_task_id, updated.durable_task_inserted_at, updated.kind, updated.node_id, updated.branch_id, updated.idempotency_key, updated.is_satisfied, updated.satisfied_at, updated.user_message, updated.wait_data, lf.latest_invocation_count AS invocation_count
+SELECT updated.tenant_id, updated.external_id, updated.result_payload_external_id, updated.inserted_at, updated.id, updated.durable_task_id, updated.durable_task_inserted_at, updated.kind, updated.node_id, updated.branch_id, updated.idempotency_key, updated.is_satisfied, updated.satisfied_at, updated.user_message, updated.wait_data, lf.latest_invocation_count AS invocation_count
 FROM updated
 JOIN v1_durable_event_log_file lf ON (lf.durable_task_id, lf.durable_task_inserted_at) = (updated.durable_task_id, updated.durable_task_inserted_at)
 `
@@ -750,21 +760,22 @@ type UpdateDurableEventLogEntriesSatisfiedParams struct {
 }
 
 type UpdateDurableEventLogEntriesSatisfiedRow struct {
-	TenantID              uuid.UUID             `json:"tenant_id"`
-	ExternalID            uuid.UUID             `json:"external_id"`
-	InsertedAt            pgtype.Timestamptz    `json:"inserted_at"`
-	ID                    int64                 `json:"id"`
-	DurableTaskID         int64                 `json:"durable_task_id"`
-	DurableTaskInsertedAt pgtype.Timestamptz    `json:"durable_task_inserted_at"`
-	Kind                  V1DurableEventLogKind `json:"kind"`
-	NodeID                int64                 `json:"node_id"`
-	BranchID              int64                 `json:"branch_id"`
-	IdempotencyKey        []byte                `json:"idempotency_key"`
-	IsSatisfied           bool                  `json:"is_satisfied"`
-	SatisfiedAt           pgtype.Timestamptz    `json:"satisfied_at"`
-	UserMessage           pgtype.Text           `json:"user_message"`
-	WaitData              []byte                `json:"wait_data"`
-	InvocationCount       int32                 `json:"invocation_count"`
+	TenantID                uuid.UUID             `json:"tenant_id"`
+	ExternalID              uuid.UUID             `json:"external_id"`
+	ResultPayloadExternalID uuid.UUID             `json:"result_payload_external_id"`
+	InsertedAt              pgtype.Timestamptz    `json:"inserted_at"`
+	ID                      int64                 `json:"id"`
+	DurableTaskID           int64                 `json:"durable_task_id"`
+	DurableTaskInsertedAt   pgtype.Timestamptz    `json:"durable_task_inserted_at"`
+	Kind                    V1DurableEventLogKind `json:"kind"`
+	NodeID                  int64                 `json:"node_id"`
+	BranchID                int64                 `json:"branch_id"`
+	IdempotencyKey          []byte                `json:"idempotency_key"`
+	IsSatisfied             bool                  `json:"is_satisfied"`
+	SatisfiedAt             pgtype.Timestamptz    `json:"satisfied_at"`
+	UserMessage             pgtype.Text           `json:"user_message"`
+	WaitData                []byte                `json:"wait_data"`
+	InvocationCount         int32                 `json:"invocation_count"`
 }
 
 func (q *Queries) UpdateDurableEventLogEntriesSatisfied(ctx context.Context, db DBTX, arg UpdateDurableEventLogEntriesSatisfiedParams) ([]*UpdateDurableEventLogEntriesSatisfiedRow, error) {
@@ -784,6 +795,7 @@ func (q *Queries) UpdateDurableEventLogEntriesSatisfied(ctx context.Context, db 
 		if err := rows.Scan(
 			&i.TenantID,
 			&i.ExternalID,
+			&i.ResultPayloadExternalID,
 			&i.InsertedAt,
 			&i.ID,
 			&i.DurableTaskID,

--- a/pkg/repository/sqlcv1/models.go
+++ b/pkg/repository/sqlcv1/models.go
@@ -3167,20 +3167,21 @@ type V1DurableEventLogBranchPoint struct {
 }
 
 type V1DurableEventLogEntry struct {
-	TenantID              uuid.UUID             `json:"tenant_id"`
-	ExternalID            uuid.UUID             `json:"external_id"`
-	InsertedAt            pgtype.Timestamptz    `json:"inserted_at"`
-	ID                    int64                 `json:"id"`
-	DurableTaskID         int64                 `json:"durable_task_id"`
-	DurableTaskInsertedAt pgtype.Timestamptz    `json:"durable_task_inserted_at"`
-	Kind                  V1DurableEventLogKind `json:"kind"`
-	NodeID                int64                 `json:"node_id"`
-	BranchID              int64                 `json:"branch_id"`
-	IdempotencyKey        []byte                `json:"idempotency_key"`
-	IsSatisfied           bool                  `json:"is_satisfied"`
-	SatisfiedAt           pgtype.Timestamptz    `json:"satisfied_at"`
-	UserMessage           pgtype.Text           `json:"user_message"`
-	WaitData              []byte                `json:"wait_data"`
+	TenantID                uuid.UUID             `json:"tenant_id"`
+	ExternalID              uuid.UUID             `json:"external_id"`
+	ResultPayloadExternalID uuid.UUID             `json:"result_payload_external_id"`
+	InsertedAt              pgtype.Timestamptz    `json:"inserted_at"`
+	ID                      int64                 `json:"id"`
+	DurableTaskID           int64                 `json:"durable_task_id"`
+	DurableTaskInsertedAt   pgtype.Timestamptz    `json:"durable_task_inserted_at"`
+	Kind                    V1DurableEventLogKind `json:"kind"`
+	NodeID                  int64                 `json:"node_id"`
+	BranchID                int64                 `json:"branch_id"`
+	IdempotencyKey          []byte                `json:"idempotency_key"`
+	IsSatisfied             bool                  `json:"is_satisfied"`
+	SatisfiedAt             pgtype.Timestamptz    `json:"satisfied_at"`
+	UserMessage             pgtype.Text           `json:"user_message"`
+	WaitData                []byte                `json:"wait_data"`
 }
 
 type V1DurableEventLogFile struct {

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -2330,6 +2330,8 @@ CREATE TABLE v1_durable_event_log_entry (
 
     -- need an external id for consistency with the payload store logic (unfortunately)
     external_id UUID NOT NULL,
+    result_payload_external_id UUID NOT NULL DEFAULT gen_random_uuid(),
+
     -- The id and inserted_at of the durable task which created this entry
     -- The inserted_at time of this event from a DB clock perspective.
     -- Important: for consistency, this should always be auto-generated via the CURRENT_TIMESTAMP!


### PR DESCRIPTION
# Description

Janky, unfortunate fix to duplicate external ids causing payload writes to conflict. Basically, we're using the same row in the durable event log for two payloads (the incoming one, and the result), which doesn't work since we need a unique external id, so this adds a second external id col with a default to use for storing the result payloads. It's a bit unfortunate, but it seems like the best fix that maintains the current logic and keeps the external ids in the payloads table unique.

Important note here is that this is non-breaking since on the core db we always retrieve payloads by id + inserted at + type right now, so this is only for internal logic and offloads

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

