### PR TITLE
Fix: Flaky durable branching test

### DIFF
--- a/sdks/go/e2e/durable_test.go
+++ b/sdks/go/e2e/durable_test.go
@@ -293,6 +293,8 @@ func TestDurableReplayReset(t *testing.T) {
 			_, err = sharedClient.Runs().BranchDurableTask(ctx, ref.RunId, nodeID, 1)
 			require.NoError(t, err)
 
+			time.Sleep(2 * time.Second)
+
 			start := time.Now()
 			resetResult, err := ref.Result()
 			require.NoError(t, err)

--- a/sdks/python/examples/durable/test_durable.py
+++ b/sdks/python/examples/durable/test_durable.py
@@ -329,9 +329,9 @@ async def test_event_lookback_before_wait(hatchet: Hatchet) -> None:
 
     result = await wait_for_event_lookback.aio_run(EventLookbackInput(user_id=user_id))
 
-    assert result.elapsed < 1, (
-        "Event lookback should find the event that was pushed before the wait started, so should be basically instantaneous"
-    )
+    assert (
+        result.elapsed < 1
+    ), "Event lookback should find the event that was pushed before the wait started, so should be basically instantaneous"
     assert result.event.order == "first"
 
 

--- a/sdks/python/examples/durable/test_durable.py
+++ b/sdks/python/examples/durable/test_durable.py
@@ -211,6 +211,7 @@ async def test_durable_replay_reset(hatchet: Hatchet, node_id: int) -> None:
     )
 
     start = time.time()
+    await asyncio.sleep(2)
     reset_result = await ref.aio_result()
     reset_elapsed = time.time() - start
 
@@ -248,7 +249,7 @@ async def test_durable_branching_off_branch(hatchet: Hatchet) -> None:
     )
 
     start = time.time()
-    await asyncio.sleep(1)
+    await asyncio.sleep(2)
     reset_result = await ref.aio_result()
     reset_elapsed = time.time() - start
 
@@ -268,7 +269,7 @@ async def test_durable_branching_off_branch(hatchet: Hatchet) -> None:
     )
 
     start = time.time()
-    await asyncio.sleep(1)
+    await asyncio.sleep(2)
     reset_result = await ref.aio_result()
     reset_elapsed = time.time() - start
 
@@ -328,9 +329,9 @@ async def test_event_lookback_before_wait(hatchet: Hatchet) -> None:
 
     result = await wait_for_event_lookback.aio_run(EventLookbackInput(user_id=user_id))
 
-    assert (
-        result.elapsed < 1
-    ), "Event lookback should find the event that was pushed before the wait started, so should be basically instantaneous"
+    assert result.elapsed < 1, (
+        "Event lookback should find the event that was pushed before the wait started, so should be basically instantaneous"
+    )
     assert result.event.order == "first"
 
 


### PR DESCRIPTION
# Description

There's a race condition on branching in these tests where we look for the result of the task before the replay has processed, so we get the result of the previous run back. Adding / extending a sleep a bit should help

## Type of change

- [x] Test changes (add, refactor, improve or change a test)
