### PR TITLE
Fix: Remove dual writes into temp tables for status updates

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260505195258_v1_0_104.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260505195258_v1_0_104.sql
@@ -1,0 +1,56 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION v1_tasks_olap_status_update_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    UPDATE
+        v1_runs_olap r
+    SET
+        readable_status = n.readable_status
+    FROM new_rows n
+    WHERE
+        r.id = n.id
+        AND r.inserted_at = n.inserted_at
+        AND r.kind = 'TASK';
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION v1_tasks_olap_status_update_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    UPDATE
+        v1_runs_olap r
+    SET
+        readable_status = n.readable_status
+    FROM new_rows n
+    WHERE
+        r.id = n.id
+        AND r.inserted_at = n.inserted_at
+        AND r.kind = 'TASK';
+
+    -- insert tmp events into task status updates table if we have a dag_id
+    INSERT INTO v1_task_status_updates_tmp (
+        tenant_id,
+        dag_id,
+        dag_inserted_at
+    )
+    SELECT
+        tenant_id,
+        dag_id,
+        dag_inserted_at
+    FROM new_rows
+    WHERE dag_id IS NOT NULL;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -1714,7 +1714,6 @@ func (r *OLAPRepositoryImpl) acquireAdvisoryLocksForWorkflowRuns(ctx context.Con
 func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, workflowRunIds []uuid.UUID) (*StatusUpdateResult, error) {
 	eventsToWrite := make([]sqlcv1.CreateTaskEventsOLAPParams, 0)
 	eventsForStatusUpdate := make([]sqlcv1.CreateTaskEventsOLAPParams, 0, len(events))
-	tmpEventsToWrite := make([]sqlcv1.CreateTaskEventsOLAPTmpParams, 0)
 	payloadsToWrite := make([]StoreOLAPPayloadOpts, 0)
 
 	for _, event := range events {
@@ -1727,16 +1726,6 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 			}
 
 			eventsToWrite = append(eventsToWrite, event)
-
-			tmpEventsToWrite = append(tmpEventsToWrite, sqlcv1.CreateTaskEventsOLAPTmpParams{
-				TenantID:       event.TenantID,
-				TaskID:         event.TaskID,
-				TaskInsertedAt: event.TaskInsertedAt,
-				EventType:      event.EventType,
-				RetryCount:     event.RetryCount,
-				ReadableStatus: event.ReadableStatus,
-				WorkerID:       event.WorkerID,
-			})
 		}
 
 		eventsForStatusUpdate = append(eventsForStatusUpdate, event)
@@ -1768,13 +1757,6 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 
 	if len(eventsToWrite) > 0 {
 		_, err = r.queries.CreateTaskEventsOLAP(ctx, tx, eventsToWrite)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if len(tmpEventsToWrite) > 0 {
-		_, err = r.queries.CreateTaskEventsOLAPTmp(ctx, tx, tmpEventsToWrite)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -1714,6 +1714,7 @@ func (r *OLAPRepositoryImpl) acquireAdvisoryLocksForWorkflowRuns(ctx context.Con
 func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, workflowRunIds []uuid.UUID) (*StatusUpdateResult, error) {
 	eventsToWrite := make([]sqlcv1.CreateTaskEventsOLAPParams, 0)
 	eventsForStatusUpdate := make([]sqlcv1.CreateTaskEventsOLAPParams, 0, len(events))
+	tmpEventsToWrite := make([]sqlcv1.CreateTaskEventsOLAPTmpParams, 0)
 	payloadsToWrite := make([]StoreOLAPPayloadOpts, 0)
 
 	for _, event := range events {
@@ -1726,6 +1727,16 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 			}
 
 			eventsToWrite = append(eventsToWrite, event)
+
+			tmpEventsToWrite = append(tmpEventsToWrite, sqlcv1.CreateTaskEventsOLAPTmpParams{
+				TenantID:       event.TenantID,
+				TaskID:         event.TaskID,
+				TaskInsertedAt: event.TaskInsertedAt,
+				EventType:      event.EventType,
+				RetryCount:     event.RetryCount,
+				ReadableStatus: event.ReadableStatus,
+				WorkerID:       event.WorkerID,
+			})
 		}
 
 		eventsForStatusUpdate = append(eventsForStatusUpdate, event)
@@ -1760,6 +1771,10 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if len(tmpEventsToWrite) > 0 {
+		_, err = r.queries.CreateTaskEventsOLAPTmp(ctx, tx, tmpEventsToWrite)
 	}
 
 	statusUpdates := r.prepareStatusUpdateBatch(ctx, tenantId, eventsForStatusUpdate)

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -1775,6 +1775,9 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 
 	if len(tmpEventsToWrite) > 0 {
 		_, err = r.queries.CreateTaskEventsOLAPTmp(ctx, tx, tmpEventsToWrite)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	statusUpdates := r.prepareStatusUpdateBatch(ctx, tenantId, eventsForStatusUpdate)

--- a/pkg/repository/sqlcv1/copyfrom.go
+++ b/pkg/repository/sqlcv1/copyfrom.go
@@ -203,44 +203,6 @@ func (q *Queries) CreateTaskEventsOLAP(ctx context.Context, db DBTX, arg []Creat
 	return db.CopyFrom(ctx, []string{"v1_task_events_olap"}, []string{"tenant_id", "task_id", "task_inserted_at", "event_type", "workflow_id", "event_timestamp", "readable_status", "retry_count", "error_message", "output", "worker_id", "additional__event_data", "additional__event_message", "external_id", "durable_invocation_count"}, &iteratorForCreateTaskEventsOLAP{rows: arg})
 }
 
-// iteratorForCreateTaskEventsOLAPTmp implements pgx.CopyFromSource.
-type iteratorForCreateTaskEventsOLAPTmp struct {
-	rows                 []CreateTaskEventsOLAPTmpParams
-	skippedFirstNextCall bool
-}
-
-func (r *iteratorForCreateTaskEventsOLAPTmp) Next() bool {
-	if len(r.rows) == 0 {
-		return false
-	}
-	if !r.skippedFirstNextCall {
-		r.skippedFirstNextCall = true
-		return true
-	}
-	r.rows = r.rows[1:]
-	return len(r.rows) > 0
-}
-
-func (r iteratorForCreateTaskEventsOLAPTmp) Values() ([]interface{}, error) {
-	return []interface{}{
-		r.rows[0].TenantID,
-		r.rows[0].TaskID,
-		r.rows[0].TaskInsertedAt,
-		r.rows[0].EventType,
-		r.rows[0].ReadableStatus,
-		r.rows[0].RetryCount,
-		r.rows[0].WorkerID,
-	}, nil
-}
-
-func (r iteratorForCreateTaskEventsOLAPTmp) Err() error {
-	return nil
-}
-
-func (q *Queries) CreateTaskEventsOLAPTmp(ctx context.Context, db DBTX, arg []CreateTaskEventsOLAPTmpParams) (int64, error) {
-	return db.CopyFrom(ctx, []string{"v1_task_events_olap_tmp"}, []string{"tenant_id", "task_id", "task_inserted_at", "event_type", "readable_status", "retry_count", "worker_id"}, &iteratorForCreateTaskEventsOLAPTmp{rows: arg})
-}
-
 // iteratorForInsertLogLine implements pgx.CopyFromSource.
 type iteratorForInsertLogLine struct {
 	rows                 []InsertLogLineParams

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -154,25 +154,6 @@ WHERE
     END
 ;
 
--- name: CreateTaskEventsOLAPTmp :copyfrom
-INSERT INTO v1_task_events_olap_tmp (
-    tenant_id,
-    task_id,
-    task_inserted_at,
-    event_type,
-    readable_status,
-    retry_count,
-    worker_id
-) VALUES (
-    $1,
-    $2,
-    $3,
-    $4,
-    $5,
-    $6,
-    $7
-);
-
 -- name: CreateTaskEventsOLAP :copyfrom
 INSERT INTO v1_task_events_olap (
     tenant_id,

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -530,16 +530,6 @@ type CreateTaskEventsOLAPParams struct {
 	DurableInvocationCount int32                `json:"durable_invocation_count"`
 }
 
-type CreateTaskEventsOLAPTmpParams struct {
-	TenantID       uuid.UUID            `json:"tenant_id"`
-	TaskID         int64                `json:"task_id"`
-	TaskInsertedAt pgtype.Timestamptz   `json:"task_inserted_at"`
-	EventType      V1EventTypeOlap      `json:"event_type"`
-	ReadableStatus V1ReadableStatusOlap `json:"readable_status"`
-	RetryCount     int32                `json:"retry_count"`
-	WorkerID       *uuid.UUID           `json:"worker_id"`
-}
-
 const createV1PayloadOLAPCutoverTemporaryTable = `-- name: CreateV1PayloadOLAPCutoverTemporaryTable :exec
 SELECT copy_v1_payloads_olap_partition_structure($1::DATE)
 `

--- a/sql/schema/v1-olap.sql
+++ b/sql/schema/v1-olap.sql
@@ -628,19 +628,6 @@ BEGIN
         AND r.inserted_at = n.inserted_at
         AND r.kind = 'TASK';
 
-    -- insert tmp events into task status updates table if we have a dag_id
-    INSERT INTO v1_task_status_updates_tmp (
-        tenant_id,
-        dag_id,
-        dag_inserted_at
-    )
-    SELECT
-        tenant_id,
-        dag_id,
-        dag_inserted_at
-    FROM new_rows
-    WHERE dag_id IS NOT NULL;
-
     RETURN NULL;
 END;
 $$


### PR DESCRIPTION
# Description

Removes the dual writes into the temp tables by dropping the insert in a trigger (for dags) and dropping the explicit write of the events into the temp table (for tasks)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
