### PR TITLE
fix: Slow cold start when workflows are inactive > 1 day

### DIFF
--- a/pkg/scheduling/v1/queuer.go
+++ b/pkg/scheduling/v1/queuer.go
@@ -103,20 +103,15 @@ func (q *Queuer) Cleanup() {
 }
 
 func (q *Queuer) queue(ctx context.Context) {
-	if ok := q.queueMu.TryLock(); !ok {
-		return
+	ctx, span := telemetry.NewSpan(ctx, "notify-queue")
+	defer span.End()
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant.id", Value: q.tenantId.String()})
+
+	select {
+	case q.notifyQueueCh <- telemetry.GetCarrier(ctx):
+	default:
 	}
-
-	go func() {
-		defer q.queueMu.Unlock()
-
-		ctx, span := telemetry.NewSpan(ctx, "notify-queue")
-		defer span.End()
-
-		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant.id", Value: q.tenantId.String()})
-
-		q.notifyQueueCh <- telemetry.GetCarrier(ctx)
-	}()
 }
 
 func (q *Queuer) loopQueue(ctx context.Context) {

--- a/pkg/scheduling/v1/queuer.go
+++ b/pkg/scheduling/v1/queuer.go
@@ -103,15 +103,20 @@ func (q *Queuer) Cleanup() {
 }
 
 func (q *Queuer) queue(ctx context.Context) {
-	ctx, span := telemetry.NewSpan(ctx, "notify-queue")
-	defer span.End()
-
-	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant.id", Value: q.tenantId.String()})
-
-	select {
-	case q.notifyQueueCh <- telemetry.GetCarrier(ctx):
-	default:
+	if ok := q.queueMu.TryLock(); !ok {
+		return
 	}
+
+	go func() {
+		defer q.queueMu.Unlock()
+
+		telemetryCtx, span := telemetry.NewSpan(ctx, "notify-queue")
+		defer span.End()
+
+		telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant.id", Value: q.tenantId.String()})
+
+		q.notifyQueueCh <- telemetry.GetCarrier(telemetryCtx)
+	}()
 }
 
 func (q *Queuer) loopQueue(ctx context.Context) {

--- a/pkg/scheduling/v1/tenant_manager.go
+++ b/pkg/scheduling/v1/tenant_manager.go
@@ -386,9 +386,8 @@ func (t *tenantManager) notifyNewConcurrencyStrategy(ctx context.Context, strate
 }
 
 func (t *tenantManager) queue(ctx context.Context, queueNames []string) {
-	queueNamesMap := make(map[string]*Queuer, len(t.queuers))
-
 	t.queuersMu.RLock()
+	queueNamesMap := make(map[string]*Queuer, len(t.queuers))
 	for _, q := range t.queuers {
 		queueNamesMap[q.queueName] = q
 	}

--- a/pkg/scheduling/v1/tenant_manager.go
+++ b/pkg/scheduling/v1/tenant_manager.go
@@ -387,23 +387,22 @@ func (t *tenantManager) notifyNewConcurrencyStrategy(ctx context.Context, strate
 
 func (t *tenantManager) queue(ctx context.Context, queueNames []string) {
 	t.queuersMu.RLock()
-	queueNamesMap := make(map[string]*Queuer, len(t.queuers))
-	inactiveQueues := make([]string, 0)
-	for _, q := range t.queuers {
-		queueNamesMap[q.queueName] = q
-	}
+	requested := make(map[string]struct{}, len(queueNames))
 	for _, name := range queueNames {
-		if q, ok := queueNamesMap[name]; ok {
-			// queue already exists
+		requested[name] = struct{}{}
+	}
+	// iterate t.queuers (not queueNames) to keep queueMu acquisition order consistent
+	// across goroutines, avoiding lock-ordering warnings from go-deadlock
+	for _, q := range t.queuers {
+		if _, ok := requested[q.queueName]; ok {
 			q.queue(ctx)
-		} else {
-			inactiveQueues = append(inactiveQueues, name)
+			delete(requested, q.queueName)
 		}
 	}
 	t.queuersMu.RUnlock()
 
 	// this function sends to a channel that acquires the queuersMu, so needs to be outside lock.
-	for _, name := range inactiveQueues {
+	for name := range requested {
 		t.notifyNewQueue(ctx, name)
 	}
 }

--- a/pkg/scheduling/v1/tenant_manager.go
+++ b/pkg/scheduling/v1/tenant_manager.go
@@ -386,17 +386,19 @@ func (t *tenantManager) notifyNewConcurrencyStrategy(ctx context.Context, strate
 }
 
 func (t *tenantManager) queue(ctx context.Context, queueNames []string) {
-	queueNamesMap := make(map[string]struct{}, len(queueNames))
-
-	for _, name := range queueNames {
-		queueNamesMap[name] = struct{}{}
-	}
+	queueNamesMap := make(map[string]*Queuer, len(t.queuers))
 
 	t.queuersMu.RLock()
-
 	for _, q := range t.queuers {
-		if _, ok := queueNamesMap[q.queueName]; ok {
+		queueNamesMap[q.queueName] = q
+	}
+	for _, name := range queueNames {
+		if q, ok := queueNamesMap[name]; ok {
+			// queue already exists
 			q.queue(ctx)
+		} else {
+			// new or inactive queue, create it
+			t.notifyNewQueue(ctx, name)
 		}
 	}
 

--- a/pkg/scheduling/v1/tenant_manager.go
+++ b/pkg/scheduling/v1/tenant_manager.go
@@ -388,6 +388,7 @@ func (t *tenantManager) notifyNewConcurrencyStrategy(ctx context.Context, strate
 func (t *tenantManager) queue(ctx context.Context, queueNames []string) {
 	t.queuersMu.RLock()
 	queueNamesMap := make(map[string]*Queuer, len(t.queuers))
+	inactiveQueues := make([]string, 0)
 	for _, q := range t.queuers {
 		queueNamesMap[q.queueName] = q
 	}
@@ -396,12 +397,15 @@ func (t *tenantManager) queue(ctx context.Context, queueNames []string) {
 			// queue already exists
 			q.queue(ctx)
 		} else {
-			// new or inactive queue, create it
-			t.notifyNewQueue(ctx, name)
+			inactiveQueues = append(inactiveQueues, name)
 		}
 	}
-
 	t.queuersMu.RUnlock()
+
+	// this function sends to a channel that acquires the queuersMu, so needs to be outside lock.
+	for _, name := range inactiveQueues {
+		t.notifyNewQueue(ctx, name)
+	}
 }
 
 type AssignedItemWithTask struct {


### PR DESCRIPTION
# Description

When a workflow is triggered that was last triggered > 1 day prior, the call to `l.lr.ListQueues` in `acquireQueueLeases` does not pick up that workflow's queue lease. `acquireQueueLeases` is called with a polling interval of 5 seconds, which means that if a workflow is triggered, it would have to wait up to 5 seconds before `acquireQueueLeases` will be called, pick up the queue lease, notify the tenant manager, and finally have `addQueuer` get called in `TenantManager.listenForQueueLeases` to actually create the queue and have it get picked up in `runOptimisticScheduling`. This PR changes the logic in the TenantManager such that when a `check-tenant-queue` message is received, instead of just waking up the existing queues that exist in memory, it also creates new queues for queues that do not exist in memory, thus avoiding the aforementioned wait for the acquireQueueLeases poll. 

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...
