### PR TITLE
Fix: Reconcile missed status updates post-deploy

### DIFF
--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -379,6 +379,19 @@ func (o *OLAPControllerImpl) Start() (func() error, error) {
 		return nil, wrappedErr
 	}
 
+	_, err = o.s.NewJob(
+		gocron.DurationJob(10*time.Minute),
+		gocron.NewTask(
+			o.runReconcileMissedTaskStatusUpdates(ctx),
+		),
+		gocron.WithSingletonMode(gocron.LimitModeReschedule),
+	)
+
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("could not schedule reconcile missed task status updates: %w", err)
+	}
+
 	cleanupBuffer, err := mqBuffer.Start()
 
 	if err != nil {

--- a/internal/services/controllers/olap/process_task_status_updates.go
+++ b/internal/services/controllers/olap/process_task_status_updates.go
@@ -48,6 +48,26 @@ func (o *OLAPControllerImpl) runTaskStatusUpdates(ctx context.Context) func() {
 	}
 }
 
+func (o *OLAPControllerImpl) runReconcileMissedTaskStatusUpdates(ctx context.Context) func() {
+	return func() {
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+
+		tenantIds, err := o.p.ListTenantsForController(ctx)
+
+		if err != nil {
+			o.l.Error().Ctx(ctx).Err(err).Msg("could not list tenants for reconcile missed task status updates")
+			return
+		}
+
+		for _, tenantId := range tenantIds {
+			if err := o.repo.OLAP().ReconcileMissedTaskStatusUpdates(ctx, tenantId); err != nil {
+				o.l.Error().Ctx(ctx).Err(err).Str("tenant_id", tenantId.String()).Msg("could not reconcile missed task status updates")
+			}
+		}
+	}
+}
+
 func (o *OLAPControllerImpl) notifyTasksUpdated(ctx context.Context, rows []v1.UpdateTaskStatusRow) error {
 	tenantIdToPayloads := make(map[uuid.UUID][]tasktypes.NotifyFinalizedPayload)
 

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -289,6 +289,7 @@ type OLAPRepository interface {
 	CountOLAPTempTableSizeForDAGStatusUpdates(ctx context.Context) (int64, error)
 	CountOLAPTempTableSizeForTaskStatusUpdates(ctx context.Context) (int64, error)
 	ListYesterdayRunCountsByStatus(ctx context.Context) (map[sqlcv1.V1ReadableStatusOlap]int64, error)
+	ReconcileMissedTaskStatusUpdates(ctx context.Context, tenantId uuid.UUID) error
 
 	CreateSpans(ctx context.Context, tenantId uuid.UUID, opts *CreateSpansOpts) error
 	ListSpansByTraceId(ctx context.Context, tenantId uuid.UUID, traceId []byte, offset, limit int64) (*ListSpansResult, error)
@@ -4084,6 +4085,10 @@ func protoSpanKindToDB(kind tracev1.Span_SpanKind) sqlcv1.V1OtelSpanKind {
 	default:
 		return sqlcv1.V1OtelSpanKindUNSPECIFIED
 	}
+}
+
+func (r *OLAPRepositoryImpl) ReconcileMissedTaskStatusUpdates(ctx context.Context, tenantId uuid.UUID) error {
+	return r.queries.ReconcileMissedTaskStatusUpdates(ctx, r.pool, tenantId)
 }
 
 func protoStatusCodeToDB(code tracev1.Status_StatusCode) sqlcv1.V1OtelStatusCode {

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -2424,7 +2424,7 @@ WITH tasks AS (
             WHEN BOOL_OR(readable_status = 'FAILED') THEN 'FAILED'
             WHEN BOOL_OR(readable_status = 'CANCELLED') THEN 'CANCELLED'
             WHEN BOOL_OR(readable_status = 'COMPLETED') THEN 'COMPLETED'
-        END AS computed_status
+        END::v1_readable_status_olap AS computed_status
     FROM v1_task_events_olap
     WHERE
         (task_id, task_inserted_at, retry_count) IN (SELECT id, inserted_at, latest_retry_count FROM tasks)

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -2413,7 +2413,7 @@ WITH tasks AS (
     SELECT *
     FROM v1_tasks_olap
     WHERE tenant_id = @tenantId::UUID
-        AND readable_status = 'RUNNING'
+        AND readable_status IN ('QUEUED', 'RUNNING')
         AND inserted_at > NOW() - INTERVAL '1 hour'
         AND inserted_at < NOW() - INTERVAL '2 minutes'
 ), computed_statuses AS (

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -2407,3 +2407,27 @@ WHERE
         OR (s.retry_count = t.latest_retry_count AND t.readable_status = 'EVICTED' AND s.status != 'EVICTED')
     )
 RETURNING t.tenant_id, t.id, t.inserted_at, t.external_id, t.readable_status, t.latest_worker_id, t.workflow_id, t.dag_id, t.dag_inserted_at;
+
+-- name: ReconcileMissedTaskStatusUpdates :exec
+WITH tasks AS (
+    SELECT *
+    FROM v1_tasks_olap
+    WHERE tenant_id = @tenantId::UUID
+        AND readable_status = 'RUNNING'
+        AND inserted_at > NOW() - INTERVAL '1 hour'
+        AND inserted_at < NOW() - INTERVAL '2 minutes'
+), has_completed_event AS (
+    SELECT task_id, task_inserted_at
+    FROM v1_task_events_olap
+    WHERE
+        (task_id, task_inserted_at) IN (SELECT id, inserted_at FROM tasks)
+        AND inserted_at > NOW() - INTERVAL '1 hour'
+        AND inserted_at < NOW() - INTERVAL '2 minutes'
+    GROUP BY task_id, task_inserted_at
+    HAVING BOOL_OR(readable_status = 'COMPLETED')
+)
+
+UPDATE v1_tasks_olap
+SET readable_status = 'COMPLETED'
+WHERE (id, inserted_at) IN (SELECT task_id, task_inserted_at FROM has_completed_event)
+;

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -2416,18 +2416,26 @@ WITH tasks AS (
         AND readable_status = 'RUNNING'
         AND inserted_at > NOW() - INTERVAL '1 hour'
         AND inserted_at < NOW() - INTERVAL '2 minutes'
-), has_completed_event AS (
-    SELECT task_id, task_inserted_at
+), computed_statuses AS (
+    SELECT
+        task_id,
+        task_inserted_at,
+        CASE
+            WHEN BOOL_OR(readable_status = 'FAILED') THEN 'FAILED'
+            WHEN BOOL_OR(readable_status = 'CANCELLED') THEN 'CANCELLED'
+            WHEN BOOL_OR(readable_status = 'COMPLETED') THEN 'COMPLETED'
+        END AS computed_status
     FROM v1_task_events_olap
     WHERE
-        (task_id, task_inserted_at) IN (SELECT id, inserted_at FROM tasks)
+        (task_id, task_inserted_at, retry_count) IN (SELECT id, inserted_at, latest_retry_count FROM tasks)
         AND inserted_at > NOW() - INTERVAL '1 hour'
         AND inserted_at < NOW() - INTERVAL '2 minutes'
     GROUP BY task_id, task_inserted_at
-    HAVING BOOL_OR(readable_status = 'COMPLETED')
+    HAVING BOOL_OR(readable_status IN ('FAILED', 'CANCELLED', 'COMPLETED'))
 )
 
 UPDATE v1_tasks_olap
-SET readable_status = 'COMPLETED'
-WHERE (id, inserted_at) IN (SELECT task_id, task_inserted_at FROM has_completed_event)
+SET readable_status = c.computed_status
+FROM computed_statuses c
+WHERE (id, inserted_at) = (c.task_id, c.task_inserted_at)
 ;

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -3346,7 +3346,7 @@ WITH tasks AS (
             WHEN BOOL_OR(readable_status = 'FAILED') THEN 'FAILED'
             WHEN BOOL_OR(readable_status = 'CANCELLED') THEN 'CANCELLED'
             WHEN BOOL_OR(readable_status = 'COMPLETED') THEN 'COMPLETED'
-        END AS computed_status
+        END::v1_readable_status_olap AS computed_status
     FROM v1_task_events_olap
     WHERE
         (task_id, task_inserted_at, retry_count) IN (SELECT id, inserted_at, latest_retry_count FROM tasks)

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -3338,20 +3338,28 @@ WITH tasks AS (
         AND readable_status = 'RUNNING'
         AND inserted_at > NOW() - INTERVAL '1 hour'
         AND inserted_at < NOW() - INTERVAL '2 minutes'
-), has_completed_event AS (
-    SELECT task_id, task_inserted_at
+), computed_statuses AS (
+    SELECT
+        task_id,
+        task_inserted_at,
+        CASE
+            WHEN BOOL_OR(readable_status = 'FAILED') THEN 'FAILED'
+            WHEN BOOL_OR(readable_status = 'CANCELLED') THEN 'CANCELLED'
+            WHEN BOOL_OR(readable_status = 'COMPLETED') THEN 'COMPLETED'
+        END AS computed_status
     FROM v1_task_events_olap
     WHERE
-        (task_id, task_inserted_at) IN (SELECT id, inserted_at FROM tasks)
+        (task_id, task_inserted_at, retry_count) IN (SELECT id, inserted_at, latest_retry_count FROM tasks)
         AND inserted_at > NOW() - INTERVAL '1 hour'
         AND inserted_at < NOW() - INTERVAL '2 minutes'
     GROUP BY task_id, task_inserted_at
-    HAVING BOOL_OR(readable_status = 'COMPLETED')
+    HAVING BOOL_OR(readable_status IN ('FAILED', 'CANCELLED', 'COMPLETED'))
 )
 
 UPDATE v1_tasks_olap
-SET readable_status = 'COMPLETED'
-WHERE (id, inserted_at) IN (SELECT task_id, task_inserted_at FROM has_completed_event)
+SET readable_status = c.computed_status
+FROM computed_statuses c
+WHERE (id, inserted_at) = (c.task_id, c.task_inserted_at)
 `
 
 func (q *Queries) ReconcileMissedTaskStatusUpdates(ctx context.Context, db DBTX, tenantid uuid.UUID) error {

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -3330,6 +3330,35 @@ func (q *Queries) ReadWorkflowRunByExternalId(ctx context.Context, db DBTX, work
 	return &i, err
 }
 
+const reconcileMissedTaskStatusUpdates = `-- name: ReconcileMissedTaskStatusUpdates :exec
+WITH tasks AS (
+    SELECT tenant_id, id, inserted_at, external_id, queue, action_id, step_id, workflow_id, workflow_version_id, workflow_run_id, schedule_timeout, step_timeout, priority, sticky, desired_worker_id, display_name, input, additional_metadata, readable_status, latest_retry_count, latest_worker_id, dag_id, dag_inserted_at, parent_task_external_id, is_durable
+    FROM v1_tasks_olap
+    WHERE tenant_id = $1::UUID
+        AND readable_status = 'RUNNING'
+        AND inserted_at > NOW() - INTERVAL '1 hour'
+        AND inserted_at < NOW() - INTERVAL '2 minutes'
+), has_completed_event AS (
+    SELECT task_id, task_inserted_at
+    FROM v1_task_events_olap
+    WHERE
+        (task_id, task_inserted_at) IN (SELECT id, inserted_at FROM tasks)
+        AND inserted_at > NOW() - INTERVAL '1 hour'
+        AND inserted_at < NOW() - INTERVAL '2 minutes'
+    GROUP BY task_id, task_inserted_at
+    HAVING BOOL_OR(readable_status = 'COMPLETED')
+)
+
+UPDATE v1_tasks_olap
+SET readable_status = 'COMPLETED'
+WHERE (id, inserted_at) IN (SELECT task_id, task_inserted_at FROM has_completed_event)
+`
+
+func (q *Queries) ReconcileMissedTaskStatusUpdates(ctx context.Context, db DBTX, tenantid uuid.UUID) error {
+	_, err := db.Exec(ctx, reconcileMissedTaskStatusUpdates, tenantid)
+	return err
+}
+
 const reconcileTaskStatusesFromEvents = `-- name: ReconcileTaskStatusesFromEvents :many
 WITH inputs AS (
     SELECT

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -3335,7 +3335,7 @@ WITH tasks AS (
     SELECT tenant_id, id, inserted_at, external_id, queue, action_id, step_id, workflow_id, workflow_version_id, workflow_run_id, schedule_timeout, step_timeout, priority, sticky, desired_worker_id, display_name, input, additional_metadata, readable_status, latest_retry_count, latest_worker_id, dag_id, dag_inserted_at, parent_task_external_id, is_durable
     FROM v1_tasks_olap
     WHERE tenant_id = $1::UUID
-        AND readable_status = 'RUNNING'
+        AND readable_status IN ('QUEUED', 'RUNNING')
         AND inserted_at > NOW() - INTERVAL '1 hour'
         AND inserted_at < NOW() - INTERVAL '2 minutes'
 ), computed_statuses AS (


### PR DESCRIPTION
# Description

Adds some reconciliation queries to recompute task statuses post-deploy. Will plan to remove this when we remove the temp table inserts

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
