### PR TITLE
Fix: Prune partitions in reconciliation query with min inserted at filter

### DIFF
--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -2079,6 +2079,7 @@ func (r *OLAPRepositoryImpl) UpdateDAGStatuses(ctx context.Context, tenantIds []
 func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId uuid.UUID, tasks []*V1TaskWithPayload) (*StatusUpdateResult, error) {
 	params := sqlcv1.CreateTasksOLAPParams{}
 	putPayloadOpts := make([]StoreOLAPPayloadOpts, 0)
+	minInsertedAt := pgtype.Timestamptz{}
 
 	for _, task := range tasks {
 		payload := task.Payload
@@ -2119,6 +2120,10 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId uuid.U
 		params.Inputs = append(params.Inputs, payloadToWriteToTask)
 		params.Isdurables = append(params.Isdurables, task.IsDurable.Bool)
 
+		if !minInsertedAt.Valid || task.InsertedAt.Time.Before(minInsertedAt.Time) {
+			minInsertedAt = task.InsertedAt
+		}
+
 		putPayloadOpts = append(putPayloadOpts, StoreOLAPPayloadOpts{
 			ExternalId: task.ExternalID,
 			InsertedAt: task.InsertedAt,
@@ -2144,6 +2149,7 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId uuid.U
 	reconciledTasks, err := r.queries.ReconcileTaskStatusesFromEvents(ctx, tx, sqlcv1.ReconcileTaskStatusesFromEventsParams{
 		Taskids:         params.Ids,
 		Taskinsertedats: params.Insertedats,
+		Mininsertedat:   minInsertedAt,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to reconcile task statuses from events: %w", err)

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -2367,13 +2367,17 @@ WITH inputs AS (
 ), locked_tasks AS (
     SELECT *
     FROM v1_tasks_olap
-    WHERE (id, inserted_at) IN (SELECT task_id, task_inserted_at FROM inputs)
+    WHERE
+        (id, inserted_at) IN (SELECT task_id, task_inserted_at FROM inputs)
+        AND inserted_at >= @minInsertedAt::TIMESTAMPTZ
     ORDER BY inserted_at, id
     FOR UPDATE
 ), relevant_events AS MATERIALIZED (
     SELECT *
     FROM v1_task_events_olap
-    WHERE (task_id, task_inserted_at) IN (SELECT task_id, task_inserted_at FROM inputs)
+    WHERE
+        (task_id, task_inserted_at) IN (SELECT task_id, task_inserted_at FROM inputs)
+        AND inserted_at >= @minInsertedAt::TIMESTAMPTZ
 ), max_retry_counts AS (
     SELECT
         task_id,

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -2377,7 +2377,7 @@ WITH inputs AS (
     FROM v1_task_events_olap
     WHERE
         (task_id, task_inserted_at) IN (SELECT task_id, task_inserted_at FROM inputs)
-        AND inserted_at >= @minInsertedAt::TIMESTAMPTZ
+        AND task_inserted_at >= @minInsertedAt::TIMESTAMPTZ
 ), max_retry_counts AS (
     SELECT
         task_id,

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -3338,13 +3338,17 @@ WITH inputs AS (
 ), locked_tasks AS (
     SELECT tenant_id, id, inserted_at, external_id, queue, action_id, step_id, workflow_id, workflow_version_id, workflow_run_id, schedule_timeout, step_timeout, priority, sticky, desired_worker_id, display_name, input, additional_metadata, readable_status, latest_retry_count, latest_worker_id, dag_id, dag_inserted_at, parent_task_external_id, is_durable
     FROM v1_tasks_olap
-    WHERE (id, inserted_at) IN (SELECT task_id, task_inserted_at FROM inputs)
+    WHERE
+        (id, inserted_at) IN (SELECT task_id, task_inserted_at FROM inputs)
+        AND inserted_at >= $3::TIMESTAMPTZ
     ORDER BY inserted_at, id
     FOR UPDATE
 ), relevant_events AS MATERIALIZED (
     SELECT tenant_id, id, inserted_at, external_id, task_id, task_inserted_at, event_type, workflow_id, event_timestamp, readable_status, retry_count, error_message, output, worker_id, additional__event_data, additional__event_message, durable_invocation_count
     FROM v1_task_events_olap
-    WHERE (task_id, task_inserted_at) IN (SELECT task_id, task_inserted_at FROM inputs)
+    WHERE
+        (task_id, task_inserted_at) IN (SELECT task_id, task_inserted_at FROM inputs)
+        AND inserted_at >= $3::TIMESTAMPTZ
 ), max_retry_counts AS (
     SELECT
         task_id,
@@ -3383,6 +3387,7 @@ RETURNING t.tenant_id, t.id, t.inserted_at, t.external_id, t.readable_status, t.
 type ReconcileTaskStatusesFromEventsParams struct {
 	Taskids         []int64              `json:"taskids"`
 	Taskinsertedats []pgtype.Timestamptz `json:"taskinsertedats"`
+	Mininsertedat   pgtype.Timestamptz   `json:"mininsertedat"`
 }
 
 type ReconcileTaskStatusesFromEventsRow struct {
@@ -3398,7 +3403,7 @@ type ReconcileTaskStatusesFromEventsRow struct {
 }
 
 func (q *Queries) ReconcileTaskStatusesFromEvents(ctx context.Context, db DBTX, arg ReconcileTaskStatusesFromEventsParams) ([]*ReconcileTaskStatusesFromEventsRow, error) {
-	rows, err := db.Query(ctx, reconcileTaskStatusesFromEvents, arg.Taskids, arg.Taskinsertedats)
+	rows, err := db.Query(ctx, reconcileTaskStatusesFromEvents, arg.Taskids, arg.Taskinsertedats, arg.Mininsertedat)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -3348,7 +3348,7 @@ WITH inputs AS (
     FROM v1_task_events_olap
     WHERE
         (task_id, task_inserted_at) IN (SELECT task_id, task_inserted_at FROM inputs)
-        AND inserted_at >= $3::TIMESTAMPTZ
+        AND task_inserted_at >= $3::TIMESTAMPTZ
 ), max_retry_counts AS (
     SELECT
         task_id,


### PR DESCRIPTION
# Description

Adds some partition pruning to hopefully speed up the reconciliation query a bit

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
