### PR TITLE
Fix: Persist dashboard column visibility across reloads (#3822)

### DIFF
--- a/frontend/app/src/hooks/use-local-storage-state.tsx
+++ b/frontend/app/src/hooks/use-local-storage-state.tsx
@@ -2,10 +2,12 @@ import { useEffect, useState } from 'react';
 
 const LOCAL_STORAGE_EVENT = 'hatchet:local-storage';
 
+type SetStateValue<T> = T | ((prev: T) => T);
+
 export function useLocalStorageState<T>(
   key: string,
   defaultValue: T,
-): [T, (value: T) => void] {
+): [T, (value: SetStateValue<T>) => void] {
   const [state, setState] = useState<T>(() => {
     try {
       const item = window.localStorage.getItem(key);
@@ -15,15 +17,21 @@ export function useLocalStorageState<T>(
     }
   });
 
-  const setValue = (value: T) => {
+  const setValue = (value: SetStateValue<T>) => {
     try {
-      setState(value);
-      window.localStorage.setItem(key, JSON.stringify(value));
-      // Ensure other hook instances in the same tab update too (the native `storage`
-      // event does not fire within the same document).
-      window.dispatchEvent(
-        new CustomEvent(LOCAL_STORAGE_EVENT, { detail: { key, value } }),
-      );
+      setState((prev) => {
+        const next =
+          typeof value === 'function' ? (value as (prev: T) => T)(prev) : value;
+        window.localStorage.setItem(key, JSON.stringify(next));
+        // Ensure other hook instances in the same tab update too (the native `storage`
+        // event does not fire within the same document).
+        window.dispatchEvent(
+          new CustomEvent(LOCAL_STORAGE_EVENT, {
+            detail: { key, value: next },
+          }),
+        );
+        return next;
+      });
     } catch (error) {
       console.warn(`Error setting localStorage key "${key}":`, error);
     }

--- a/frontend/app/src/pages/main/v1/events/index.tsx
+++ b/frontend/app/src/pages/main/v1/events/index.tsx
@@ -20,6 +20,7 @@ import { SimpleTable } from '@/components/v1/molecules/simple-table/simple-table
 import { Button } from '@/components/v1/ui/button';
 import { CodeHighlighter } from '@/components/v1/ui/code-highlighter';
 import { Separator } from '@/components/v1/ui/separator';
+import { useLocalStorageState } from '@/hooks/use-local-storage-state';
 import { useSidePanel } from '@/hooks/use-side-panel';
 import { V1Event, V1Filter } from '@/lib/api';
 import { docsPages } from '@/lib/generated/docs';
@@ -56,11 +57,12 @@ export default function Events() {
     key: 'table',
   });
 
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
-    [idKey]: false,
-    [EventColumn.payload]: false,
-    [scopeKey]: false,
-  });
+  const [columnVisibility, setColumnVisibility] =
+    useLocalStorageState<VisibilityState>('hatchet:columns:events', {
+      [idKey]: false,
+      [EventColumn.payload]: false,
+      [scopeKey]: false,
+    });
 
   const tableColumns = columns({
     onRowClick: (row: V1Event) => {

--- a/frontend/app/src/pages/main/v1/filters/index.tsx
+++ b/frontend/app/src/pages/main/v1/filters/index.tsx
@@ -10,11 +10,11 @@ import { useFilters } from './hooks/use-filters';
 import { DocsButton } from '@/components/v1/docs/docs-button';
 import { DataTable } from '@/components/v1/molecules/data-table/data-table';
 import { ToolbarType } from '@/components/v1/molecules/data-table/data-table-toolbar';
+import { useLocalStorageState } from '@/hooks/use-local-storage-state';
 import { useSidePanel } from '@/hooks/use-side-panel';
 import { V1Filter } from '@/lib/api';
 import { docsPages } from '@/lib/generated/docs';
 import { VisibilityState } from '@tanstack/react-table';
-import { useState } from 'react';
 
 export default function Filters() {
   const sidePanel = useSidePanel();
@@ -38,9 +38,10 @@ export default function Filters() {
     key: 'table',
   });
 
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
-    [isDeclarativeKey]: false,
-  });
+  const [columnVisibility, setColumnVisibility] =
+    useLocalStorageState<VisibilityState>('hatchet:columns:filters', {
+      [isDeclarativeKey]: false,
+    });
 
   const handleRowClick = (filter: V1Filter) => {
     sidePanel.open({

--- a/frontend/app/src/pages/main/v1/rate-limits/index.tsx
+++ b/frontend/app/src/pages/main/v1/rate-limits/index.tsx
@@ -8,20 +8,22 @@ import { RateLimitWithMetadata } from './hooks/use-rate-limits';
 import { DocsButton } from '@/components/v1/docs/docs-button';
 import { DataTable } from '@/components/v1/molecules/data-table/data-table';
 import { ToolbarType } from '@/components/v1/molecules/data-table/data-table-toolbar';
+import { useLocalStorageState } from '@/hooks/use-local-storage-state';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
 import api from '@/lib/api';
 import { docsPages } from '@/lib/generated/docs';
 import { useApiError } from '@/lib/hooks';
 import { useMutation } from '@tanstack/react-query';
 import { VisibilityState } from '@tanstack/react-table';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 export default function RateLimits() {
   return <RateLimitsTable />;
 }
 
 function RateLimitsTable() {
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+  const [columnVisibility, setColumnVisibility] =
+    useLocalStorageState<VisibilityState>('hatchet:columns:rate-limits', {});
   const { tenantId } = useCurrentTenantId();
   const { handleApiError } = useApiError({});
 

--- a/frontend/app/src/pages/main/v1/recurring/index.tsx
+++ b/frontend/app/src/pages/main/v1/recurring/index.tsx
@@ -14,6 +14,7 @@ import {
   ToolbarType,
 } from '@/components/v1/molecules/data-table/data-table-toolbar';
 import { Button } from '@/components/v1/ui/button';
+import { useLocalStorageState } from '@/hooks/use-local-storage-state';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
 import { CronWorkflows } from '@/lib/api';
 import { docsPages } from '@/lib/generated/docs';
@@ -25,7 +26,8 @@ export default function CronsTable() {
   const [triggerWorkflow, setTriggerWorkflow] = useState(false);
   const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
 
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+  const [columnVisibility, setColumnVisibility] =
+    useLocalStorageState<VisibilityState>('hatchet:columns:recurring', {});
 
   const {
     crons,

--- a/frontend/app/src/pages/main/v1/scheduled-runs/index.tsx
+++ b/frontend/app/src/pages/main/v1/scheduled-runs/index.tsx
@@ -22,6 +22,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/v1/ui/dropdown-menu';
+import { useLocalStorageState } from '@/hooks/use-local-storage-state';
 import { useSidePanel } from '@/hooks/use-side-panel';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
 import {
@@ -61,7 +62,10 @@ export default function ScheduledRunsTable({
     useState<string | null>(null);
 
   const [columnVisibility, setColumnVisibility] =
-    useState<VisibilityState>(initColumnVisibility);
+    useLocalStorageState<VisibilityState>(
+      'hatchet:columns:scheduled-runs',
+      initColumnVisibility,
+    );
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
   const {

--- a/frontend/app/src/pages/main/v1/workers/index.tsx
+++ b/frontend/app/src/pages/main/v1/workers/index.tsx
@@ -4,6 +4,7 @@ import { ToolbarType } from '@/components/v1/molecules/data-table/data-table-too
 import { DataTable } from '@/components/v1/molecules/data-table/data-table.tsx';
 import { Loading } from '@/components/v1/ui/loading.tsx';
 import { useRefetchInterval } from '@/contexts/refetch-interval-context';
+import { useLocalStorageState } from '@/hooks/use-local-storage-state';
 import { usePagination } from '@/hooks/use-pagination';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
 import { useZodColumnFilters } from '@/hooks/use-zod-column-filters';
@@ -42,7 +43,8 @@ export default function Workers() {
     resetFilters,
   } = useZodColumnFilters(workersQuerySchema, paramKey, { s: statusKey });
 
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+  const [columnVisibility, setColumnVisibility] =
+    useLocalStorageState<VisibilityState>('hatchet:columns:workers', {});
 
   const handleSetOpenLabelsPopover = useCallback(
     (id: string | null) => setOpenLabelsPopover(id),

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
@@ -7,10 +7,23 @@ import { useMetrics } from './use-metrics';
 import { useRuns } from './use-runs';
 import { useRunsTableFilters } from './use-runs-table-filters';
 import { useToolbarFilters } from './use-toolbar-filters';
+import { useLocalStorageState } from '@/hooks/use-local-storage-state';
 import { V1TaskRunMetrics, V1TaskSummary } from '@/lib/api';
 import { RowSelectionState, VisibilityState } from '@tanstack/react-table';
 import { PaginationState, Updater } from '@tanstack/react-table';
-import { createContext, useContext, useMemo, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+
+const ALWAYS_HIDDEN_RUN_COLUMNS: VisibilityState = {
+  parentTaskExternalId: false,
+  flattenDAGs: false,
+  runningFilter: false,
+};
 
 type DisplayProps = {
   hideMetrics?: boolean;
@@ -36,6 +49,10 @@ type RunsProviderProps = {
   filterVisibility?: Record<string, boolean>;
   display?: DisplayProps;
   runFilters?: RunFilteringProps;
+  // When provided, column visibility is persisted to localStorage under
+  // `hatchet:columns:<persistColumnVisibilityKey>`. Use a stable key — avoid
+  // embedding per-row IDs to prevent unbounded localStorage growth.
+  persistColumnVisibilityKey?: string;
 };
 
 type RunsContextType = {
@@ -85,6 +102,7 @@ export const RunsProvider = ({
   filterVisibility = {},
   display,
   runFilters,
+  persistColumnVisibilityKey,
 }: RunsProviderProps) => {
   const [isActionModalOpen, setIsActionModalOpen] = useState(false);
   const [selectedActionType, setSelectedActionType] =
@@ -94,12 +112,46 @@ export const RunsProvider = ({
   const [showQueueMetrics, setShowQueueMetrics] = useState(false);
   const [showTriggerWorkflow, setShowTriggerWorkflow] = useState(false);
 
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
-    ...initColumnVisibility,
-    parentTaskExternalId: false, // Always hidden, used for filtering only
-    flattenDAGs: false, // Always hidden, used for filtering only
-    runningFilter: false, // Always hidden, used for filtering only
-  });
+  const initialVisibility: VisibilityState = useMemo(
+    () => ({
+      ...initColumnVisibility,
+      ...ALWAYS_HIDDEN_RUN_COLUMNS,
+    }),
+    [initColumnVisibility],
+  );
+
+  const [persistedVisibility, setPersistedVisibility] =
+    useLocalStorageState<VisibilityState>(
+      `hatchet:columns:${persistColumnVisibilityKey ?? '__none__'}`,
+      initialVisibility,
+    );
+  const [transientVisibility, setTransientVisibility] =
+    useState<VisibilityState>(initialVisibility);
+
+  const columnVisibility: VisibilityState = useMemo(
+    () =>
+      persistColumnVisibilityKey
+        ? { ...persistedVisibility, ...ALWAYS_HIDDEN_RUN_COLUMNS }
+        : transientVisibility,
+    [persistColumnVisibilityKey, persistedVisibility, transientVisibility],
+  );
+
+  const setColumnVisibility = useCallback(
+    (updater: Updater<VisibilityState>) => {
+      if (persistColumnVisibilityKey) {
+        setPersistedVisibility((prev) => {
+          const next = typeof updater === 'function' ? updater(prev) : updater;
+          return { ...next, ...ALWAYS_HIDDEN_RUN_COLUMNS };
+        });
+      } else {
+        setTransientVisibility((prev) => {
+          const next = typeof updater === 'function' ? updater(prev) : updater;
+          return { ...next, ...ALWAYS_HIDDEN_RUN_COLUMNS };
+        });
+      }
+    },
+    [persistColumnVisibilityKey, setPersistedVisibility],
+  );
 
   const {
     workflowId,

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/index.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/index.tsx
@@ -4,7 +4,10 @@ import { RunsProvider } from './hooks/runs-provider';
 export default function Tasks() {
   return (
     <div className="size-full flex-grow">
-      <RunsProvider tableKey="workflow-runs-main">
+      <RunsProvider
+        tableKey="workflow-runs-main"
+        persistColumnVisibilityKey="workflow-runs-main"
+      >
         <RunsTable />
       </RunsProvider>
     </div>

--- a/frontend/app/src/pages/main/v1/workflows/index.tsx
+++ b/frontend/app/src/pages/main/v1/workflows/index.tsx
@@ -8,15 +8,16 @@ import { DocsButton } from '@/components/v1/docs/docs-button';
 import { ToolbarType } from '@/components/v1/molecules/data-table/data-table-toolbar';
 import { DataTable } from '@/components/v1/molecules/data-table/data-table.tsx';
 import { Loading } from '@/components/v1/ui/loading.tsx';
+import { useLocalStorageState } from '@/hooks/use-local-storage-state';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
 import { docsPages } from '@/lib/generated/docs';
 import { VisibilityState } from '@tanstack/react-table';
-import { useState } from 'react';
 
 export default function WorkflowTable() {
   const { tenantId } = useCurrentTenantId();
 
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+  const [columnVisibility, setColumnVisibility] =
+    useLocalStorageState<VisibilityState>('hatchet:columns:workflows', {});
 
   const {
     workflows,


### PR DESCRIPTION
# Description

Persists dashboard column-visibility selections to `localStorage` so they survive page reloads and navigation. Reuses the existing `useLocalStorageState` hook (extended to accept updater functions, matching `useState`'s API).

For `RunsProvider`, persistence is opt-in via a new `persistColumnVisibilityKey` prop — only `/runs` opts in, since other consumers use dynamic `tableKey`s like `task-runs-${id}` that would bloat `localStorage`.

Fixes #3822

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Extended `useLocalStorageState` to accept updater functions
- [x] Persisted column visibility on 7 table pages: events, workers, scheduled-runs, workflows, filters, recurring, rate-limits
- [x] Added opt-in `persistColumnVisibilityKey` prop to `RunsProvider`; enabled on `/runs`

## Test plan

Verified locally against a full dev stack:

- Hide column → reload → stays hidden (events, workers, runs)
- Navigate away and back → stays hidden
- `localStorage` shows `hatchet:columns:*` keys for stable pages only; dynamic tableKeys don't persist
- Cross-tab sync works
- Lint, prettier, typecheck, unit tests all clean
