### PR TITLE
Fix: load correct credentials for mtls in otel

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.33.4] - 2026-05-08
+
+### Changed
+
+- Fixes a bug where TLS credentials are not passed to the OTLP span exporter.
+
 ## [1.33.3] - 2026-04-29
 
 ### Changed

--- a/sdks/python/hatchet_sdk/connection.py
+++ b/sdks/python/hatchet_sdk/connection.py
@@ -50,7 +50,7 @@ def new_conn(config: ClientConfig, aio: Literal[True]) -> grpc.aio.Channel: ...
 
 
 def new_conn(config: ClientConfig, aio: bool) -> grpc.Channel | grpc.aio.Channel:
-    credentials: grpc.ChannelCredentials | None = load_channel_credentials(config)
+    credentials = load_channel_credentials(config)
 
     start = grpc if not aio else grpc.aio
 

--- a/sdks/python/hatchet_sdk/connection.py
+++ b/sdks/python/hatchet_sdk/connection.py
@@ -6,15 +6,7 @@ import grpc
 from hatchet_sdk.config import ClientConfig
 
 
-@overload
-def new_conn(config: ClientConfig, aio: Literal[False]) -> grpc.Channel: ...
-
-
-@overload
-def new_conn(config: ClientConfig, aio: Literal[True]) -> grpc.aio.Channel: ...
-
-
-def new_conn(config: ClientConfig, aio: bool) -> grpc.Channel | grpc.aio.Channel:
+def load_channel_credentials(config: ClientConfig) -> grpc.ChannelCredentials | None:
     credentials: grpc.ChannelCredentials | None = None
 
     # load channel credentials
@@ -46,6 +38,20 @@ def new_conn(config: ClientConfig, aio: bool) -> grpc.Channel | grpc.aio.Channel
             certificate_chain=certificate_chain,
         )
 
+    return credentials
+
+
+@overload
+def new_conn(config: ClientConfig, aio: Literal[False]) -> grpc.Channel: ...
+
+
+@overload
+def new_conn(config: ClientConfig, aio: Literal[True]) -> grpc.aio.Channel: ...
+
+
+def new_conn(config: ClientConfig, aio: bool) -> grpc.Channel | grpc.aio.Channel:
+    credentials: grpc.ChannelCredentials | None = load_channel_credentials(config)
+
     start = grpc if not aio else grpc.aio
 
     channel_options: list[tuple[str, str | int]] = [
@@ -68,7 +74,7 @@ def new_conn(config: ClientConfig, aio: bool) -> grpc.Channel | grpc.aio.Channel
         # See discussion: https://github.com/hatchet-dev/hatchet/pull/2057#discussion_r2243233357
         os.environ["GRPC_POLL_STRATEGY"] = "poll"
 
-    if config.tls_config.strategy == "none":
+    if not credentials:
         conn = start.insecure_channel(
             target=config.host_port,
             options=channel_options,

--- a/sdks/python/hatchet_sdk/opentelemetry/instrumentor.py
+++ b/sdks/python/hatchet_sdk/opentelemetry/instrumentor.py
@@ -348,9 +348,7 @@ class HatchetInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         endpoint = self.config.host_port
         insecure = self.config.tls_config.strategy == "none"
         headers = (("authorization", f"Bearer {self.config.token}"),)
-        credentials: grpc.ChannelCredentials | None = load_channel_credentials(
-            self.config
-        )
+        credentials = load_channel_credentials(self.config)
 
         otlp_exporter = OTLPSpanExporter(
             endpoint=endpoint,

--- a/sdks/python/hatchet_sdk/opentelemetry/instrumentor.py
+++ b/sdks/python/hatchet_sdk/opentelemetry/instrumentor.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 
 import grpc
 
+from hatchet_sdk.connection import load_channel_credentials
 from hatchet_sdk.contracts import workflows_pb2 as v0_workflow_protos
 from hatchet_sdk.utils.typing import JSONSerializableMapping
 
@@ -347,12 +348,9 @@ class HatchetInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         endpoint = self.config.host_port
         insecure = self.config.tls_config.strategy == "none"
         headers = (("authorization", f"Bearer {self.config.token}"),)
-        credentials: grpc.ChannelCredentials | None = None
-
-        if self.config.tls_config.root_ca_file:
-            with open(self.config.tls_config.root_ca_file, "rb") as f:
-                root_certs = f.read()
-            credentials = grpc.ssl_channel_credentials(root_certificates=root_certs)
+        credentials: grpc.ChannelCredentials | None = load_channel_credentials(
+            self.config
+        )
 
         otlp_exporter = OTLPSpanExporter(
             endpoint=endpoint,

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hatchet-sdk"
-version = "1.33.3"
+version = "1.33.4"
 description = "This is the official Python SDK for Hatchet, a distributed, fault-tolerant task queue. The SDK allows you to easily integrate Hatchet's task scheduling and workflow orchestration capabilities into your Python applications."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
# Description

When using mtls mode, otel trace does not work because the client credentials aren't loaded into it.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- add a `load_channel_credentials` function
- use that function for otel and grpc connection
