### PR TITLE
Fix durable listener race

### DIFF
--- a/pkg/client/durable_listener.go
+++ b/pkg/client/durable_listener.go
@@ -176,24 +176,28 @@ func (l *DurableEventsListener) AddSignal(
 }
 
 func (l *DurableEventsListener) retrySend(t listenTuple) error {
-	l.clientMu.RLock()
-	defer l.clientMu.RUnlock()
+	for i := range DefaultActionListenerRetryCount {
+		if i > 0 {
+			time.Sleep(DefaultActionListenerRetryInterval)
+		}
 
-	if l.client == nil {
-		return fmt.Errorf("client is not connected")
-	}
+		err := func() error {
+			l.clientMu.RLock()
+			defer l.clientMu.RUnlock()
 
-	for i := 0; i < DefaultActionListenerRetryCount; i++ {
-		err := l.client.Send(&contracts.ListenForDurableEventRequest{
-			TaskId:    t.taskId,
-			SignalKey: t.signalKey,
-		})
+			if l.client == nil {
+				return fmt.Errorf("client is not connected")
+			}
+
+			return l.client.Send(&contracts.ListenForDurableEventRequest{
+				TaskId:    t.taskId,
+				SignalKey: t.signalKey,
+			})
+		}()
 
 		if err == nil {
 			return nil
 		}
-
-		time.Sleep(DefaultActionListenerRetryInterval)
 	}
 
 	return fmt.Errorf("could not send to the worker after %d retries", DefaultActionListenerRetryCount)

--- a/pkg/client/durable_listener_test.go
+++ b/pkg/client/durable_listener_test.go
@@ -1,0 +1,240 @@
+package client
+
+import (
+	"context"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	contracts "github.com/hatchet-dev/hatchet/internal/services/shared/proto/v1"
+)
+
+type mockDurableEventClient struct {
+	sendFn      func(req *contracts.ListenForDurableEventRequest) error
+	recvFn      func() (*contracts.DurableEvent, error)
+	closeSendFn func() error
+	recvCh      chan *contracts.DurableEvent
+	sendCount   atomic.Int32
+}
+
+func (m *mockDurableEventClient) Send(req *contracts.ListenForDurableEventRequest) error {
+	m.sendCount.Add(1)
+	if m.sendFn != nil {
+		return m.sendFn(req)
+	}
+	return nil
+}
+
+func (m *mockDurableEventClient) Recv() (*contracts.DurableEvent, error) {
+	if m.recvFn != nil {
+		return m.recvFn()
+	}
+	if m.recvCh == nil {
+		return nil, io.EOF
+	}
+	event, ok := <-m.recvCh
+	if !ok {
+		return nil, io.EOF
+	}
+	return event, nil
+}
+
+func (m *mockDurableEventClient) CloseSend() error {
+	if m.closeSendFn != nil {
+		return m.closeSendFn()
+	}
+	return nil
+}
+
+func (m *mockDurableEventClient) Header() (metadata.MD, error) {
+	return nil, nil
+}
+
+func (m *mockDurableEventClient) Trailer() metadata.MD {
+	return nil
+}
+
+func (m *mockDurableEventClient) Context() context.Context {
+	return context.Background()
+}
+
+func (m *mockDurableEventClient) SendMsg(msg interface{}) error {
+	return nil
+}
+
+func (m *mockDurableEventClient) RecvMsg(msg interface{}) error {
+	return nil
+}
+
+// TestDurableEventsListenerReconnectsWhileRetrySendBacksOff verifies that a
+// stream disconnect can reconnect while AddSignal is retrying a send on the
+// broken stream. This is the lock-contention repro: retrySend must not hold a
+// reader lock for the full retry/backoff window.
+func TestDurableEventsListenerReconnectsWhileRetrySendBacksOff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := zerolog.Nop()
+	sendAttempted := make(chan struct{})
+	var closeSendAttempted sync.Once
+
+	// The old stream fails both Send and Recv so AddSignal enters retrySend while
+	// Listen tries to recover the stream through retryListen.
+	oldClient := &mockDurableEventClient{
+		sendFn: func(req *contracts.ListenForDurableEventRequest) error {
+			closeSendAttempted.Do(func() {
+				close(sendAttempted)
+			})
+			return status.Error(codes.Unavailable, "stream broken")
+		},
+		recvFn: func() (*contracts.DurableEvent, error) {
+			return nil, status.Error(codes.Unavailable, "stream broken")
+		},
+	}
+
+	newClient := &mockDurableEventClient{
+		recvFn: func() (*contracts.DurableEvent, error) {
+			<-ctx.Done()
+			return nil, status.Error(codes.Canceled, "context canceled")
+		},
+	}
+
+	// The constructor should be reachable immediately after Recv reports the
+	// disconnect, even while the sender is waiting to retry.
+	constructorCalled := make(chan struct{})
+	var closeConstructorCalled sync.Once
+
+	listener := &DurableEventsListener{
+		constructor: func(ctx context.Context) (contracts.V1Dispatcher_ListenForDurableEventClient, error) {
+			closeConstructorCalled.Do(func() {
+				close(constructorCalled)
+			})
+			return newClient, nil
+		},
+		client: oldClient,
+		l:      &logger,
+	}
+
+	addErr := make(chan error, 1)
+	go func() {
+		addErr <- listener.AddSignal("task-1", "signal-1", func(e DurableEvent) error {
+			return nil
+		})
+	}()
+
+	// Wait until AddSignal has definitely attempted to use the broken stream
+	// before forcing Listen down the reconnect path.
+	require.Eventually(t, func() bool {
+		select {
+		case <-sendAttempted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	listenErr := make(chan error, 1)
+	go func() {
+		listenErr <- listener.Listen(ctx)
+	}()
+
+	select {
+	case <-constructorCalled:
+	case err := <-addErr:
+		require.NoError(t, err)
+	case err := <-listenErr:
+		require.NoError(t, err)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected durable event listener to reconnect while retrySend is backing off")
+	}
+}
+
+// TestDurableEventsListenerDeliversEventAfterReconnectDuringRetryBackoff
+// verifies the user-visible symptom: after a disconnect during AddSignal's
+// retry window, the listener should reconnect and deliver the durable event
+// from the new stream without waiting for retrySend to exhaust all attempts.
+func TestDurableEventsListenerDeliversEventAfterReconnectDuringRetryBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := zerolog.Nop()
+	sendAttempted := make(chan struct{})
+	var closeSendAttempted sync.Once
+
+	// The first stream simulates a dead gRPC stream: sends fail, and the receive
+	// loop observes the disconnect that should trigger reconnection.
+	oldClient := &mockDurableEventClient{
+		sendFn: func(req *contracts.ListenForDurableEventRequest) error {
+			closeSendAttempted.Do(func() {
+				close(sendAttempted)
+			})
+			return status.Error(codes.Unavailable, "stream broken")
+		},
+		recvFn: func() (*contracts.DurableEvent, error) {
+			return nil, status.Error(codes.Unavailable, "stream broken")
+		},
+	}
+
+	newClient := &mockDurableEventClient{
+		recvCh: make(chan *contracts.DurableEvent, 1),
+	}
+
+	// Reconnection immediately makes the awaited event available on the new stream.
+	// If reconnect is blocked by retrySend, this event will not reach the handler.
+	listener := &DurableEventsListener{
+		constructor: func(ctx context.Context) (contracts.V1Dispatcher_ListenForDurableEventClient, error) {
+			newClient.recvCh <- &contracts.DurableEvent{
+				TaskId:    "task-1",
+				SignalKey: "signal-1",
+				Data:      []byte(`{"ok":true}`),
+			}
+			return newClient, nil
+		},
+		client: oldClient,
+		l:      &logger,
+	}
+
+	received := make(chan DurableEvent, 1)
+	addErr := make(chan error, 1)
+	go func() {
+		addErr <- listener.AddSignal("task-1", "signal-1", func(e DurableEvent) error {
+			received <- e
+			return nil
+		})
+	}()
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-sendAttempted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	listenErr := make(chan error, 1)
+	go func() {
+		listenErr <- listener.Listen(ctx)
+	}()
+
+	select {
+	case event := <-received:
+		require.Equal(t, "task-1", event.TaskId)
+		require.Equal(t, "signal-1", event.SignalKey)
+		require.JSONEq(t, `{"ok":true}`, string(event.Data))
+	case err := <-addErr:
+		require.NoError(t, err)
+	case err := <-listenErr:
+		require.NoError(t, err)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected durable event to be delivered after reconnect during retrySend backoff")
+	}
+}

--- a/sdks/go/e2e/durable_test.go
+++ b/sdks/go/e2e/durable_test.go
@@ -294,6 +294,7 @@ func TestDurableReplayReset(t *testing.T) {
 			require.NoError(t, err)
 
 			start := time.Now()
+			pollUntilRunStatus(t, ctx, sharedClient, ref.RunId, string(rest.V1TaskStatusRUNNING))
 			resetResult, err := ref.Result()
 			require.NoError(t, err)
 			resetElapsed := time.Since(start).Seconds()
@@ -340,7 +341,7 @@ func TestDurableBranchingOffBranch(t *testing.T) {
 	require.NoError(t, err)
 
 	start := time.Now()
-	time.Sleep(1 * time.Second)
+	pollUntilRunStatus(t, ctx, sharedClient, ref.RunId, string(rest.V1TaskStatusRUNNING))
 	resetResult, err := ref.Result()
 	require.NoError(t, err)
 	resetElapsed := time.Since(start).Seconds()
@@ -359,7 +360,7 @@ func TestDurableBranchingOffBranch(t *testing.T) {
 	require.NoError(t, err)
 
 	start = time.Now()
-	time.Sleep(1 * time.Second)
+	pollUntilRunStatus(t, ctx, sharedClient, ref.RunId, string(rest.V1TaskStatusRUNNING))
 	resetResult2, err := ref.Result()
 	require.NoError(t, err)
 	resetElapsed2 := time.Since(start).Seconds()

--- a/sdks/typescript/src/v1/examples/bulk_operations/bulk_replay.e2e.ts
+++ b/sdks/typescript/src/v1/examples/bulk_operations/bulk_replay.e2e.ts
@@ -6,7 +6,7 @@ import { bulkReplayTest1, bulkReplayTest2, bulkReplayTest3 } from './workflow';
 describe('bulk-replay-e2e', () => {
   const hatchet = makeE2EClient();
 
-  it('bulk replays matching runs and increments attempt', async () => {
+  it('bulk replays matching runs and increments retry count', async () => {
     const testRunId = makeTestScope('bulk_replay');
     const n = 20;
 
@@ -29,6 +29,7 @@ describe('bulk-replay-e2e', () => {
           limit: 1000,
           workflowNames,
           additionalMetadata: meta,
+          onlyTasks: true,
         }),
       {
         timeoutMs: 120_000,
@@ -41,6 +42,9 @@ describe('bulk-replay-e2e', () => {
     );
 
     expect(initialRuns.rows).toHaveLength(expectedTotal);
+    const initialRetryCounts = new Map(
+      (initialRuns.rows || []).map((r: any) => [r.metadata.id, r.retryCount ?? 0])
+    );
 
     // Equivalent to Python's aio_bulk_replay: runs.replay with filter.
     await hatchet.runs.replay({
@@ -58,18 +62,19 @@ describe('bulk-replay-e2e', () => {
           limit: 1000,
           workflowNames,
           additionalMetadata: meta,
+          onlyTasks: true,
         }),
       {
         timeoutMs: 120_000,
         intervalMs: 200,
-        label: 'bulk replay attempts visible',
+        label: 'bulk replay retry counts visible',
         shouldStop: (runs) =>
           (runs.rows || []).length === expectedTotal &&
           (runs.rows || []).every(
             (r: any) =>
               r.status === V1TaskStatus.COMPLETED &&
-              (r.retryCount ?? 0) >= 1 &&
-              (r.attempt ?? 0) >= 2
+              (r.retryCount ?? 0) >
+                (initialRetryCounts.get(r.metadata.id) ?? Number.MAX_SAFE_INTEGER)
           ),
       }
     );


### PR DESCRIPTION
# Description

Fixes a Go SDK durable event listener reconnect race where `retrySend` held `clientMu.RLock()` across retry backoff sleeps. When the stream disconnected, `retryListen` could not acquire the write lock to replace the broken stream, so durable event replies could be delayed until retries were exhausted.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

This adds unit-tests for this case and changes `retrySend` to acquire the read lock only around each send attempt, allowing reconnects to proceed between retries. Adds unit coverage for reconnecting during retry backoff and delivering the durable event after reconnect.

The fix is cheery-picked from https://github.com/hatchet-dev/hatchet/pull/3845

Test commit only:
```
❯ go test ./pkg/client -run '^TestDurableEventsListener' -v
=== RUN   TestDurableEventsListenerReconnectsWhileRetrySendBacksOff
    durable_listener_test.go:156: expected durable event listener to reconnect while retrySend is backing off
--- FAIL: TestDurableEventsListenerReconnectsWhileRetrySendBacksOff (0.21s)
=== RUN   TestDurableEventsListenerDeliversEventAfterReconnectDuringRetryBackoff
    durable_listener_test.go:238: expected durable event to be delivered after reconnect during retrySend backoff
--- FAIL: TestDurableEventsListenerDeliversEventAfterReconnectDuringRetryBackoff (0.21s)
FAIL
FAIL    github.com/hatchet-dev/hatchet/pkg/client       0.713s
FAIL
```

With the cherry picked fix:
```
❯ go test ./pkg/client -run '^TestDurableEventsListener' -v
=== RUN   TestDurableEventsListenerReconnectsWhileRetrySendBacksOff
--- PASS: TestDurableEventsListenerReconnectsWhileRetrySendBacksOff (0.01s)
=== RUN   TestDurableEventsListenerDeliversEventAfterReconnectDuringRetryBackoff
--- PASS: TestDurableEventsListenerDeliversEventAfterReconnectDuringRetryBackoff (0.01s)
PASS
ok      github.com/hatchet-dev/hatchet/pkg/client       0.339s
```

**Note**: leaving as draft, as I want to think it through once more. Open for feedback for the time being.