### PR TITLE
NO MERGE: Align durable_listener reconnect with workflow runs listener

### DIFF
--- a/pkg/client/durable_listener.go
+++ b/pkg/client/durable_listener.go
@@ -13,6 +13,7 @@ import (
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry"
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -26,8 +27,11 @@ type DurableEventHandler func(e DurableEvent) error
 type DurableEventsListener struct {
 	constructor func(context.Context) (contracts.V1Dispatcher_ListenForDurableEventClient, error)
 
-	client   contracts.V1Dispatcher_ListenForDurableEventClient
-	clientMu sync.RWMutex
+	client     contracts.V1Dispatcher_ListenForDurableEventClient
+	clientMu   sync.Mutex
+	generation uint64
+
+	reconnectGroup singleflight.Group
 
 	l *zerolog.Logger
 
@@ -59,7 +63,7 @@ func (r *subscribeClientImpl) getDurableEventsListener(
 		l:           r.l,
 	}
 
-	err := w.retryListen(ctx)
+	err := w.retrySubscribe(ctx)
 
 	if err != nil {
 		return nil, err
@@ -90,7 +94,26 @@ func (r *subscribeClientImpl) getDurableEventsListener(
 	return w, nil
 }
 
-func (w *DurableEventsListener) retryListen(ctx context.Context) error {
+// getClientSnapshot returns the current client and its generation under a
+// brief Mutex acquisition. Callers must use the snapshot for blocking gRPC
+// calls (Send/Recv) so they never hold the lock during I/O.
+func (w *DurableEventsListener) getClientSnapshot() (contracts.V1Dispatcher_ListenForDurableEventClient, uint64) {
+	w.clientMu.Lock()
+	defer w.clientMu.Unlock()
+	return w.client, w.generation
+}
+
+// retrySubscribe coalesces concurrent reconnection attempts via singleflight.
+// Multiple goroutines calling this concurrently will share a single
+// reconnection attempt.
+func (w *DurableEventsListener) retrySubscribe(ctx context.Context) error {
+	_, err, _ := w.reconnectGroup.Do("reconnect", func() (interface{}, error) {
+		return nil, w.doRetrySubscribe(ctx)
+	})
+	return err
+}
+
+func (w *DurableEventsListener) doRetrySubscribe(ctx context.Context) error {
 	w.clientMu.Lock()
 	defer w.clientMu.Unlock()
 
@@ -111,7 +134,6 @@ func (w *DurableEventsListener) retryListen(ctx context.Context) error {
 
 		w.client = client
 
-		// listen for all the same workflow runs
 		var rangeErr error
 
 		w.handlers.Range(func(key, value interface{}) bool {
@@ -132,9 +154,11 @@ func (w *DurableEventsListener) retryListen(ctx context.Context) error {
 		})
 
 		if rangeErr != nil {
+			retries++
 			continue
 		}
 
+		w.generation++
 		return nil
 	}
 
@@ -176,52 +200,84 @@ func (l *DurableEventsListener) AddSignal(
 }
 
 func (l *DurableEventsListener) retrySend(t listenTuple) error {
-	for i := range DefaultActionListenerRetryCount {
-		if i > 0 {
-			time.Sleep(DefaultActionListenerRetryInterval)
+	for i := 0; i < DefaultActionListenerRetryCount; i++ {
+		client, genBefore := l.getClientSnapshot()
+
+		if client == nil {
+			return fmt.Errorf("client is not connected")
 		}
 
-		err := func() error {
-			l.clientMu.RLock()
-			defer l.clientMu.RUnlock()
-
-			if l.client == nil {
-				return fmt.Errorf("client is not connected")
-			}
-
-			return l.client.Send(&contracts.ListenForDurableEventRequest{
-				TaskId:    t.taskId,
-				SignalKey: t.signalKey,
-			})
-		}()
+		err := client.Send(&contracts.ListenForDurableEventRequest{
+			TaskId:    t.taskId,
+			SignalKey: t.signalKey,
+		})
 
 		if err == nil {
 			return nil
 		}
+
+		l.l.Warn().Err(err).Msgf("failed to send durable event subscription, attempt %d/%d", i+1, DefaultActionListenerRetryCount)
+
+		// If Listen already reconnected the stream while we were sending, skip
+		// our own reconnect and retry the send on the new client immediately.
+		if _, genAfter := l.getClientSnapshot(); genAfter != genBefore {
+			continue
+		}
+
+		if retryErr := l.retrySubscribe(context.Background()); retryErr != nil {
+			l.l.Error().Err(retryErr).Msg("failed to resubscribe after send failure")
+		}
+
+		time.Sleep(DefaultActionListenerRetryInterval)
 	}
 
 	return fmt.Errorf("could not send to the worker after %d retries", DefaultActionListenerRetryCount)
 }
 
 func (l *DurableEventsListener) Listen(ctx context.Context) error {
+	consecutiveErrors := 0
+	maxConsecutiveErrors := 10
+
+	client, _ := l.getClientSnapshot()
+
 	for {
-		l.clientMu.RLock()
-		event, err := l.client.Recv()
-		l.clientMu.RUnlock()
+		if client == nil {
+			return fmt.Errorf("durable event listener client is not connected")
+		}
+
+		event, err := client.Recv()
 
 		if err != nil {
 			if errors.Is(err, io.EOF) || status.Code(err) == codes.Canceled {
 				return nil
 			}
 
-			retryErr := l.retryListen(ctx)
+			consecutiveErrors++
 
-			if retryErr != nil {
-				return retryErr
+			if status.Code(err) == codes.Unavailable {
+				l.l.Warn().Err(err).Msg("dispatcher is unavailable, retrying durable event subscribe after 1 second")
+				time.Sleep(1 * time.Second)
 			}
 
+			retryErr := l.retrySubscribe(ctx)
+
+			if retryErr != nil {
+				l.l.Error().Err(retryErr).Msgf("failed to resubscribe to durable events (consecutive errors: %d/%d)", consecutiveErrors, maxConsecutiveErrors)
+
+				if consecutiveErrors >= maxConsecutiveErrors {
+					return fmt.Errorf("failed to resubscribe to durable events after %d consecutive errors: %w", consecutiveErrors, retryErr)
+				}
+
+				time.Sleep(DefaultActionListenerRetryInterval)
+				continue
+			}
+
+			client, _ = l.getClientSnapshot()
+			consecutiveErrors = 0
 			continue
 		}
+
+		consecutiveErrors = 0
 
 		if err := l.handleEvent(event); err != nil {
 			return err
@@ -230,7 +286,15 @@ func (l *DurableEventsListener) Listen(ctx context.Context) error {
 }
 
 func (l *DurableEventsListener) Close() error {
-	return l.client.CloseSend()
+	l.clientMu.Lock()
+	client := l.client
+	l.clientMu.Unlock()
+
+	if client == nil {
+		return nil
+	}
+
+	return client.CloseSend()
 }
 
 func (l *DurableEventsListener) handleEvent(e *contracts.DurableEvent) error {

--- a/pkg/client/durable_listener_test.go
+++ b/pkg/client/durable_listener_test.go
@@ -238,3 +238,116 @@ func TestDurableEventsListenerDeliversEventAfterReconnectDuringRetryBackoff(t *t
 		t.Fatal("expected durable event to be delivered after reconnect during retrySend backoff")
 	}
 }
+
+// TestDurableEventsListenerRetrySendSkipsReconnectAfterListenerReconnects
+// verifies the generation-snapshot fast path: if a reconnect has already
+// happened (e.g. driven by Listen) between two retrySend iterations, retrySend
+// must observe the bumped generation and re-send on the new client without
+// triggering its own reconnect.
+func TestDurableEventsListenerRetrySendSkipsReconnectAfterListenerReconnects(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := zerolog.Nop()
+
+	sendOnOldStreamCh := make(chan struct{}, 1)
+	reconnectDone := make(chan struct{})
+
+	oldClient := &mockDurableEventClient{
+		sendFn: func(req *contracts.ListenForDurableEventRequest) error {
+			select {
+			case sendOnOldStreamCh <- struct{}{}:
+			default:
+			}
+			<-reconnectDone
+			return status.Error(codes.Unavailable, "stream broken")
+		},
+	}
+
+	newClient := &mockDurableEventClient{}
+
+	var constructorCount atomic.Int32
+	listener := &DurableEventsListener{
+		constructor: func(ctx context.Context) (contracts.V1Dispatcher_ListenForDurableEventClient, error) {
+			constructorCount.Add(1)
+			return newClient, nil
+		},
+		client: oldClient,
+		l:      &logger,
+	}
+
+	go func() {
+		<-sendOnOldStreamCh
+		if err := listener.retrySubscribe(ctx); err != nil {
+			t.Errorf("retrySubscribe: %v", err)
+		}
+		close(reconnectDone)
+	}()
+
+	addErr := make(chan error, 1)
+	go func() {
+		addErr <- listener.AddSignal("task-1", "signal-1", func(e DurableEvent) error {
+			return nil
+		})
+	}()
+
+	select {
+	case err := <-addErr:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("AddSignal did not return in time")
+	}
+
+	require.Equal(t, int32(1), constructorCount.Load(), "constructor should be invoked exactly once")
+	require.GreaterOrEqual(t, newClient.sendCount.Load(), int32(1), "new client should receive at least one Send")
+}
+
+// TestDurableEventsListenerCoalescesConcurrentReconnects verifies that
+// concurrent retrySubscribe callers are coalesced via singleflight, so a
+// single reconnect attempt is shared across goroutines.
+func TestDurableEventsListenerCoalescesConcurrentReconnects(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.Nop()
+
+	var constructorCount atomic.Int32
+	constructorStarted := make(chan struct{})
+	releaseConstructor := make(chan struct{})
+
+	newClient := &mockDurableEventClient{}
+
+	listener := &DurableEventsListener{
+		constructor: func(ctx context.Context) (contracts.V1Dispatcher_ListenForDurableEventClient, error) {
+			n := constructorCount.Add(1)
+			if n == 1 {
+				close(constructorStarted)
+				<-releaseConstructor
+			}
+			return newClient, nil
+		},
+		l: &logger,
+	}
+
+	const callers = 4
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for range callers {
+		go func() {
+			defer wg.Done()
+			errs <- listener.retrySubscribe(ctx)
+		}()
+	}
+
+	<-constructorStarted
+	// Give the remaining goroutines time to join the in-flight reconnect.
+	time.Sleep(50 * time.Millisecond)
+	close(releaseConstructor)
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, int32(1), constructorCount.Load(), "singleflight should coalesce concurrent reconnects")
+}


### PR DESCRIPTION
No merge: this is AI generated PR to see if we can align the patterns in two listeners. I do NOT intend to merge it as is, but rather to discuss the right way forward.

# Description

Aligns `DurableEventsListener` (`pkg/client/durable_listener.go`) with the reconnect pattern that `WorkflowRunsListener` (`pkg/client/listener.go`) already uses, so the two listeners share the same hardened lock + reconnect strategy.

This is a follow-up to #3848. That PR fixed the immediate read-lock-held-across-backoff race in `retrySend` with a minimal change. This PR generalizes it: lock-free `Send`/`Recv`, generation-counter snapshots, and `singleflight`-coalesced reconnects between `Listen` and `retrySend`.

Fixes # (n/a — refactor on top of #3848)

## Type of change

- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

- Switch `DurableEventsListener` to the snapshot + generation + `singleflight` reconnect pattern already used by `WorkflowRunsListener`.
- `Send`/`Recv` now run on a `getClientSnapshot()` copy, so the listener mutex is never held across gRPC I/O or backoff sleeps.
- Concurrent reconnects from `Listen` and `retrySend` are coalesced via `singleflight`; `retrySend` skips its own reconnect when it sees the generation bumped between attempts.
- `Listen` bails out after 10 consecutive reconnect failures and `Close` tolerates a nil client, matching `WorkflowRunsListener`.
- Tests cover the generation fast-path and singleflight coalescing in addition to the cases from #3848.


## Why

After #3848 there were two listeners with very similar shape but two different reconnect strategies. Aligning them:

- Removes the only remaining place where `clientMu` is held across `Send` (`doRetrySubscribe` still holds it briefly to swap the client and replay subscriptions, matching `listener.go`).
- Prevents redundant reconnects when both `Listen` and `retrySend` race to recover a broken stream.
- Makes future maintenance straightforward — both listeners now share the same mental model.

