### PR TITLE
Test for listener recovery after Listen exits

### DIFF
--- a/pkg/client/durable_listener.go
+++ b/pkg/client/durable_listener.go
@@ -13,6 +13,7 @@ import (
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry"
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -26,8 +27,16 @@ type DurableEventHandler func(e DurableEvent) error
 type DurableEventsListener struct {
 	constructor func(context.Context) (contracts.V1Dispatcher_ListenForDurableEventClient, error)
 
-	client   contracts.V1Dispatcher_ListenForDurableEventClient
-	clientMu sync.RWMutex
+	client     contracts.V1Dispatcher_ListenForDurableEventClient
+	clientMu   sync.Mutex
+	generation uint64
+
+	reconnectGroup singleflight.Group
+
+	listenMu  sync.Mutex
+	listening bool
+	started   bool
+	closed    bool
 
 	l *zerolog.Logger
 
@@ -68,29 +77,40 @@ func (r *subscribeClientImpl) getDurableEventsListener(
 	r.durableEventsListener = w
 
 	go func() {
-		defer func() {
-			err := w.Close()
-
-			if err != nil {
-				r.l.Error().Ctx(ctx).Err(err).Msg("failed to close durable events listener")
-			}
-
-			r.durableEventsListenerMu.Lock()
-			r.durableEventsListener = nil
-			r.durableEventsListenerMu.Unlock()
-		}()
-
 		err := w.Listen(ctx)
 
 		if err != nil {
 			r.l.Error().Ctx(ctx).Err(err).Msg("failed to listen for durable events")
 		}
+
+		if ctx.Err() == nil {
+			return
+		}
+
+		err = w.Close()
+
+		if err != nil {
+			r.l.Error().Ctx(ctx).Err(err).Msg("failed to close durable events listener")
+		}
+
+		r.durableEventsListenerMu.Lock()
+		if r.durableEventsListener == w {
+			r.durableEventsListener = nil
+		}
+		r.durableEventsListenerMu.Unlock()
 	}()
 
 	return w, nil
 }
 
 func (w *DurableEventsListener) retryListen(ctx context.Context) error {
+	_, err, _ := w.reconnectGroup.Do("reconnect", func() (interface{}, error) {
+		return nil, w.doRetryListen(ctx)
+	})
+	return err
+}
+
+func (w *DurableEventsListener) doRetryListen(ctx context.Context) error {
 	w.clientMu.Lock()
 	defer w.clientMu.Unlock()
 
@@ -132,13 +152,83 @@ func (w *DurableEventsListener) retryListen(ctx context.Context) error {
 		})
 
 		if rangeErr != nil {
+			retries++
 			continue
 		}
 
+		w.generation++
 		return nil
 	}
 
 	return fmt.Errorf("could not listen for durable events on the worker after %d retries", retries)
+}
+
+func (w *DurableEventsListener) getClientSnapshot() (contracts.V1Dispatcher_ListenForDurableEventClient, uint64) {
+	w.clientMu.Lock()
+	defer w.clientMu.Unlock()
+	return w.client, w.generation
+}
+
+func (w *DurableEventsListener) listeningState() (bool, bool) {
+	w.listenMu.Lock()
+	defer w.listenMu.Unlock()
+	return w.listening, w.started
+}
+
+func (w *DurableEventsListener) tryStartListening() (bool, error) {
+	w.listenMu.Lock()
+	defer w.listenMu.Unlock()
+
+	if w.closed {
+		return false, fmt.Errorf("durable events listener is closed")
+	}
+
+	if w.listening {
+		return false, nil
+	}
+
+	w.listening = true
+	w.started = true
+	return true, nil
+}
+
+func (w *DurableEventsListener) finishListening() {
+	w.listenMu.Lock()
+	w.listening = false
+	w.listenMu.Unlock()
+}
+
+func (w *DurableEventsListener) startListening(ctx context.Context) error {
+	started, err := w.tryStartListening()
+	if err != nil || !started {
+		return err
+	}
+
+	go func() {
+		defer w.finishListening()
+
+		if err := w.listen(ctx); err != nil {
+			w.l.Error().Ctx(ctx).Err(err).Msg("failed to listen for durable events")
+		}
+	}()
+
+	return nil
+}
+
+func (w *DurableEventsListener) ensureListening(ctx context.Context, genBefore uint64) error {
+	listening, started := w.listeningState()
+	if listening || !started {
+		return nil
+	}
+
+	_, genAfter := w.getClientSnapshot()
+	if genAfter == genBefore {
+		if err := w.retryListen(ctx); err != nil {
+			return err
+		}
+	}
+
+	return w.startListening(ctx)
 }
 
 type threadSafeDurableEventHandlers struct {
@@ -151,6 +241,8 @@ func (l *DurableEventsListener) AddSignal(
 	signalKey string,
 	handler DurableEventHandler,
 ) error {
+	_, genBefore := l.getClientSnapshot()
+
 	t := listenTuple{
 		taskId:    taskId,
 		signalKey: signalKey,
@@ -172,31 +264,35 @@ func (l *DurableEventsListener) AddSignal(
 		return err
 	}
 
-	return nil
+	return l.ensureListening(context.Background(), genBefore)
 }
 
 func (l *DurableEventsListener) retrySend(t listenTuple) error {
 	for i := range DefaultActionListenerRetryCount {
-		if i > 0 {
-			time.Sleep(DefaultActionListenerRetryInterval)
+		client, genBefore := l.getClientSnapshot()
+
+		if client == nil {
+			return fmt.Errorf("client is not connected")
 		}
 
-		err := func() error {
-			l.clientMu.RLock()
-			defer l.clientMu.RUnlock()
-
-			if l.client == nil {
-				return fmt.Errorf("client is not connected")
-			}
-
-			return l.client.Send(&contracts.ListenForDurableEventRequest{
-				TaskId:    t.taskId,
-				SignalKey: t.signalKey,
-			})
-		}()
+		err := client.Send(&contracts.ListenForDurableEventRequest{
+			TaskId:    t.taskId,
+			SignalKey: t.signalKey,
+		})
 
 		if err == nil {
 			return nil
+		}
+
+		l.l.Warn().Err(err).Msgf("failed to send durable event subscription, attempt %d/%d", i+1, DefaultActionListenerRetryCount)
+
+		if _, genAfter := l.getClientSnapshot(); genAfter != genBefore {
+			continue
+		}
+
+		if retryErr := l.retryListen(context.Background()); retryErr != nil {
+			l.l.Error().Err(retryErr).Msg("failed to resubscribe after durable event send failure")
+			time.Sleep(DefaultActionListenerRetryInterval)
 		}
 	}
 
@@ -204,10 +300,21 @@ func (l *DurableEventsListener) retrySend(t listenTuple) error {
 }
 
 func (l *DurableEventsListener) Listen(ctx context.Context) error {
+	started, err := l.tryStartListening()
+	if err != nil || !started {
+		return err
+	}
+
+	defer l.finishListening()
+
+	return l.listen(ctx)
+}
+
+func (l *DurableEventsListener) listen(ctx context.Context) error {
+	client, _ := l.getClientSnapshot()
+
 	for {
-		l.clientMu.RLock()
-		event, err := l.client.Recv()
-		l.clientMu.RUnlock()
+		event, err := client.Recv()
 
 		if err != nil {
 			if errors.Is(err, io.EOF) || status.Code(err) == codes.Canceled {
@@ -220,6 +327,7 @@ func (l *DurableEventsListener) Listen(ctx context.Context) error {
 				return retryErr
 			}
 
+			client, _ = l.getClientSnapshot()
 			continue
 		}
 
@@ -230,7 +338,20 @@ func (l *DurableEventsListener) Listen(ctx context.Context) error {
 }
 
 func (l *DurableEventsListener) Close() error {
-	return l.client.CloseSend()
+	l.listenMu.Lock()
+	l.closed = true
+	l.listening = false
+	l.listenMu.Unlock()
+
+	l.clientMu.Lock()
+	client := l.client
+	l.clientMu.Unlock()
+
+	if client == nil {
+		return nil
+	}
+
+	return client.CloseSend()
 }
 
 func (l *DurableEventsListener) handleEvent(e *contracts.DurableEvent) error {

--- a/pkg/client/durable_listener_test.go
+++ b/pkg/client/durable_listener_test.go
@@ -238,3 +238,85 @@ func TestDurableEventsListenerDeliversEventAfterReconnectDuringRetryBackoff(t *t
 		t.Fatal("expected durable event to be delivered after reconnect during retrySend backoff")
 	}
 }
+
+// TestDurableEventsListenerEventsLostAfterListenExits exercises the path a
+// client takes when the Hatchet dispatcher is unavailable for long enough
+// that the SDK's DurableEventsListener.Listen goroutine returns (in
+// production: io.EOF on a graceful server shutdown, or maxConsecutiveErrors
+// during a sustained outage). Once the dispatcher comes back the gRPC
+// connection reconnects, but the durable listener's Listen loop is gone
+// and the listener instance can still be cached and reused by the SDK.
+//
+// A caller awaiting a durable signal goes through AddSignal(taskId,
+// signalKey, handler) and waits on a result channel. The listener should
+// either fully recover after Listen has exited so durable events arrive on
+// the caller's handler, or fail AddSignal loudly so the caller can rebuild
+// state. What it must not do is accept the subscription, claim success,
+// and then drop the durable event the server delivers on the rebuilt
+// stream.
+//
+// This test pins the contract: after Listen has returned, a durable event
+// for a (taskId, signalKey) that was subscribed via AddSignal is
+// dispatched to its handler.
+func TestDurableEventsListenerEventsLostAfterListenExits(t *testing.T) {
+	logger := zerolog.Nop()
+
+	deadClient := &mockDurableEventClient{
+		sendFn: func(req *contracts.ListenForDurableEventRequest) error {
+			return status.Error(codes.Unavailable, "stream broken")
+		},
+		recvFn: func() (*contracts.DurableEvent, error) {
+			return nil, io.EOF
+		},
+	}
+
+	newRecvCh := make(chan *contracts.DurableEvent, 1)
+	newClient := &mockDurableEventClient{
+		recvCh: newRecvCh,
+	}
+
+	var constructorCalls atomic.Int32
+	listener := &DurableEventsListener{
+		constructor: func(ctx context.Context) (contracts.V1Dispatcher_ListenForDurableEventClient, error) {
+			constructorCalls.Add(1)
+			return newClient, nil
+		},
+		client: deadClient,
+		l:      &logger,
+	}
+
+	listenDone := make(chan error, 1)
+	go func() {
+		listenDone <- listener.Listen(context.Background())
+	}()
+
+	select {
+	case err := <-listenDone:
+		require.NoError(t, err, "Listen should exit cleanly on EOF")
+	case <-time.After(time.Second):
+		t.Fatal("Listen did not exit on EOF in time")
+	}
+
+	received := make(chan DurableEvent, 1)
+	addErr := listener.AddSignal("task-1", "signal-1", func(e DurableEvent) error {
+		received <- e
+		return nil
+	})
+	require.NoError(t, addErr, "AddSignal must not fail on a listener whose Listen has exited; the listener should recover or report a recoverable error to the caller")
+	require.GreaterOrEqual(t, constructorCalls.Load(), int32(1), "the listener should rebuild the stream via the constructor after Listen exits")
+	require.GreaterOrEqual(t, newClient.sendCount.Load(), int32(1), "the rebuilt stream should receive the subscription")
+
+	newRecvCh <- &contracts.DurableEvent{
+		TaskId:    "task-1",
+		SignalKey: "signal-1",
+		Data:      []byte(`{"ok":true}`),
+	}
+
+	select {
+	case ev := <-received:
+		require.Equal(t, "task-1", ev.TaskId)
+		require.Equal(t, "signal-1", ev.SignalKey)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("durable event was not dispatched to the handler after Listen exited; the listener accepted the subscription but does not deliver events")
+	}
+}

--- a/pkg/client/listener.go
+++ b/pkg/client/listener.go
@@ -104,6 +104,11 @@ type WorkflowRunsListener struct {
 
 	reconnectGroup singleflight.Group
 
+	listenMu  sync.Mutex
+	listening bool
+	started   bool
+	closed    bool
+
 	l *zerolog.Logger
 
 	// map of workflow run ids to a list of handlers
@@ -138,23 +143,27 @@ func (r *subscribeClientImpl) getWorkflowRunsListener(
 	r.workflowRunListener = w
 
 	go func() {
-		defer func() {
-			err := w.Close()
-
-			if err != nil {
-				r.l.Error().Err(err).Msg("failed to close workflow run events listener")
-			}
-
-			r.workflowRunListenerMu.Lock()
-			r.workflowRunListener = nil
-			r.workflowRunListenerMu.Unlock()
-		}()
-
 		err := w.Listen(ctx)
 
 		if err != nil {
 			r.l.Error().Err(err).Msg("failed to listen for workflow run events")
 		}
+
+		if ctx.Err() == nil {
+			return
+		}
+
+		err = w.Close()
+
+		if err != nil {
+			r.l.Error().Err(err).Msg("failed to close workflow run events listener")
+		}
+
+		r.workflowRunListenerMu.Lock()
+		if r.workflowRunListener == w {
+			r.workflowRunListener = nil
+		}
+		r.workflowRunListenerMu.Unlock()
 	}()
 
 	return w, nil
@@ -165,6 +174,68 @@ func (w *WorkflowRunsListener) getClientSnapshot() (dispatchercontracts.Dispatch
 	w.clientMu.Lock()
 	defer w.clientMu.Unlock()
 	return w.client, w.generation
+}
+
+func (w *WorkflowRunsListener) listeningState() (bool, bool) {
+	w.listenMu.Lock()
+	defer w.listenMu.Unlock()
+	return w.listening, w.started
+}
+
+func (w *WorkflowRunsListener) tryStartListening() (bool, error) {
+	w.listenMu.Lock()
+	defer w.listenMu.Unlock()
+
+	if w.closed {
+		return false, fmt.Errorf("workflow run listener is closed")
+	}
+
+	if w.listening {
+		return false, nil
+	}
+
+	w.listening = true
+	w.started = true
+	return true, nil
+}
+
+func (w *WorkflowRunsListener) finishListening() {
+	w.listenMu.Lock()
+	w.listening = false
+	w.listenMu.Unlock()
+}
+
+func (w *WorkflowRunsListener) startListening(ctx context.Context) error {
+	started, err := w.tryStartListening()
+	if err != nil || !started {
+		return err
+	}
+
+	go func() {
+		defer w.finishListening()
+
+		if err := w.listen(ctx); err != nil {
+			w.l.Error().Err(err).Msg("failed to listen for workflow run events")
+		}
+	}()
+
+	return nil
+}
+
+func (w *WorkflowRunsListener) ensureListening(ctx context.Context, genBefore uint64) error {
+	listening, started := w.listeningState()
+	if listening || !started {
+		return nil
+	}
+
+	_, genAfter := w.getClientSnapshot()
+	if genAfter == genBefore {
+		if err := w.retrySubscribe(ctx); err != nil {
+			return err
+		}
+	}
+
+	return w.startListening(ctx)
 }
 
 // retrySubscribe coalesces concurrent reconnection attempts via singleflight.
@@ -238,6 +309,8 @@ func (l *WorkflowRunsListener) AddWorkflowRun(
 	workflowRunId, sessionId string,
 	handler WorkflowRunEventHandler,
 ) error {
+	_, genBefore := l.getClientSnapshot()
+
 	handlers, _ := l.handlers.LoadOrStore(workflowRunId, &threadSafeHandlers{
 		handlers: map[string]WorkflowRunEventHandler{},
 	})
@@ -255,7 +328,7 @@ func (l *WorkflowRunsListener) AddWorkflowRun(
 		return err
 	}
 
-	return nil
+	return l.ensureListening(context.Background(), genBefore)
 }
 
 func (l *WorkflowRunsListener) RemoveWorkflowRun(
@@ -305,15 +378,25 @@ func (l *WorkflowRunsListener) retrySend(workflowRunId string) error {
 
 		if retryErr := l.retrySubscribe(context.Background()); retryErr != nil {
 			l.l.Error().Err(retryErr).Msg("failed to resubscribe after send failure")
+			time.Sleep(DefaultActionListenerRetryInterval)
 		}
-
-		time.Sleep(DefaultActionListenerRetryInterval)
 	}
 
 	return fmt.Errorf("could not send to the worker after %d retries", DefaultActionListenerRetryCount)
 }
 
 func (l *WorkflowRunsListener) Listen(ctx context.Context) error {
+	started, err := l.tryStartListening()
+	if err != nil || !started {
+		return err
+	}
+
+	defer l.finishListening()
+
+	return l.listen(ctx)
+}
+
+func (l *WorkflowRunsListener) listen(ctx context.Context) error {
 	consecutiveErrors := 0
 	maxConsecutiveErrors := 10
 
@@ -362,6 +445,11 @@ func (l *WorkflowRunsListener) Listen(ctx context.Context) error {
 }
 
 func (l *WorkflowRunsListener) Close() error {
+	l.listenMu.Lock()
+	l.closed = true
+	l.listening = false
+	l.listenMu.Unlock()
+
 	l.clientMu.Lock()
 	client := l.client
 	l.clientMu.Unlock()

--- a/pkg/client/listener_test.go
+++ b/pkg/client/listener_test.go
@@ -529,6 +529,94 @@ func TestGetClientSnapshot_ReturnsCurrentClient(t *testing.T) {
 	assert.Equal(t, uint64(0), gen)
 }
 
+// TestWorkflowRunsListenerEventsLostAfterListenExits exercises the path a
+// client takes when the Hatchet dispatcher is unavailable for long enough
+// that the SDK's WorkflowRunsListener.Listen goroutine returns (in
+// production: the underlying gRPC stream eventually returns io.EOF on a
+// graceful server shutdown, or trips maxConsecutiveErrors during a
+// sustained outage). Once the dispatcher comes back the gRPC connection
+// reconnects and unary calls like TriggerWorkflow succeed again.
+//
+// The remaining question is whether status reads recover. A caller of
+// Workflow.Result() goes through the cached *WorkflowRunsListener,
+// AddWorkflowRun(...), and a wait on a result channel. The listener should
+// either fully recover after Listen has exited so events arrive on the
+// caller's handler, or fail AddWorkflowRun loudly so the caller can rebuild
+// state. What it must not do is accept the subscription, claim success,
+// and then drop the event the server delivers on the rebuilt stream.
+//
+// This test pins the contract: after Listen has returned, an event
+// produced for a workflow run that was subscribed via AddWorkflowRun is
+// dispatched to its handler.
+func TestWorkflowRunsListenerEventsLostAfterListenExits(t *testing.T) {
+	logger := zerolog.Nop()
+
+	// Stream 1: returns EOF on Recv to make Listen exit cleanly, and fails
+	// Send so retrySend has to reconnect (mirrors the real "stream is dead"
+	// state after an incident).
+	deadStream := &mockSubscribeClient{
+		sendFn: func(req *dispatchercontracts.SubscribeToWorkflowRunsRequest) error {
+			return status.Error(codes.Unavailable, "stream broken")
+		},
+		recvFn: func() (*dispatchercontracts.WorkflowRunEvent, error) {
+			return nil, io.EOF
+		},
+	}
+
+	// Stream 2: the post-reconnect stream that the server uses to deliver
+	// the workflow-run-finished event the caller is waiting for.
+	newRecvCh := make(chan *dispatchercontracts.WorkflowRunEvent, 1)
+	newStream := &mockSubscribeClient{
+		recvChan: newRecvCh,
+	}
+
+	var constructorCalls atomic.Int32
+	listener := &WorkflowRunsListener{
+		constructor: func(ctx context.Context) (dispatchercontracts.Dispatcher_SubscribeToWorkflowRunsClient, error) {
+			constructorCalls.Add(1)
+			return newStream, nil
+		},
+		client: deadStream,
+		l:      &logger,
+	}
+
+	// Drive Listen to exit, mirroring what happens when the SDK's listener
+	// goroutine returns after maxConsecutiveErrors during a long incident.
+	listenDone := make(chan error, 1)
+	go func() {
+		listenDone <- listener.Listen(context.Background())
+	}()
+
+	select {
+	case err := <-listenDone:
+		require.NoError(t, err, "Listen should exit cleanly on EOF")
+	case <-time.After(time.Second):
+		t.Fatal("Listen did not exit on EOF in time")
+	}
+
+	// Caller path mirrors Workflow.Result(): subscribe via the cached
+	// listener, then wait for the result on a channel.
+	received := make(chan WorkflowRunEvent, 1)
+	addErr := listener.AddWorkflowRun("run-1", "session-1", func(event WorkflowRunEvent) error {
+		received <- event
+		return nil
+	})
+	require.NoError(t, addErr, "AddWorkflowRun must not fail on a listener whose Listen has exited; the listener should recover or report a recoverable error to the caller")
+	require.GreaterOrEqual(t, constructorCalls.Load(), int32(1), "the listener should rebuild the stream via the constructor after Listen exits")
+	require.GreaterOrEqual(t, newStream.sendCount.Load(), int32(1), "the rebuilt stream should receive the subscription")
+
+	newRecvCh <- &dispatchercontracts.WorkflowRunEvent{
+		WorkflowRunId: "run-1",
+	}
+
+	select {
+	case ev := <-received:
+		assert.Equal(t, "run-1", ev.WorkflowRunId)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("workflow run event was not dispatched to the handler after Listen exited; the listener accepted the subscription but does not deliver events")
+	}
+}
+
 func TestWorkflowEventToDeprecatedWorkflowEvent_Success(t *testing.T) {
 	// Verifies successful conversion of WorkflowEvent to deprecated WorkflowEvent
 


### PR DESCRIPTION
# Description

After a Hatchet dispatcher outage long enough to trigger `Listen`'s `maxConsecutiveErrors` exit (or a graceful `io.EOF`), the gRPC connection reconnects and unary calls work again, but the cached `*WorkflowRunsListener` / `*DurableEventsListener` no longer has a goroutine reading its stream.

Adding new subscriptions on those listeners then either silently drops the server's events (workflow runs) or fails `AddSignal` after the full retry window (durable events). User-reported as "tasks run on the dashboard but `Result()` never returns".

## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

This PR adds two failing repros:
- `TestWorkflowRunsListenerEventsLostAfterListenExits`
- `TestDurableEventsListenerEventsLostAfterListenExits`

```
❯ go test ./pkg/client -run '^TestWorkflowRunsListenerEventsLostAfterListenExits$|^TestDurableEventsListenerEventsLostAfterListenExits$' -v

=== RUN   TestDurableEventsListenerEventsLostAfterListenExits
    durable_listener_test.go:305:
                Error Trace:    /Users/igor/src/hatchet-dev/hatchet/pkg/client/durable_listener_test.go:305
                Error:          Received unexpected error:
                                could not send to the worker after 5 retries
                Test:           TestDurableEventsListenerEventsLostAfterListenExits
                Messages:       AddSignal must not fail on a listener whose Listen has exited; the listener should recover or report a recoverable error to the caller
--- FAIL: TestDurableEventsListenerEventsLostAfterListenExits (20.00s)

=== RUN   TestWorkflowRunsListenerEventsLostAfterListenExits
    listener_test.go:616: workflow run event was not dispatched to the handler after Listen exited; the listener accepted the subscription but does not deliver events
--- FAIL: TestWorkflowRunsListenerEventsLostAfterListenExits (5.50s)

FAIL
FAIL    github.com/hatchet-dev/hatchet/pkg/client       25.798s
FAIL
```

Fix TBD