### PR TITLE
Feat: Configurable OLAP MQ QoS

### DIFF
--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -285,7 +285,7 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 			olap.WithOperationsConfig(sc.Operations),
 			olap.WithAnalyzeCronInterval(sc.CronOperations.OLAPAnalyzeCronInterval),
 			olap.WithOLAPStatusUpdateBatchSizeLimits(sizeLimits),
-			olap.WithMQQos(sc.OLAPStatusUpdates.MQQos),
+			olap.WithMQQos(sc.Operations.OLAPMQQos),
 		)
 
 		if err != nil {
@@ -665,7 +665,7 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 				olap.WithPrometheusMetricsEnabled(sc.Prometheus.Enabled),
 				olap.WithAnalyzeCronInterval(sc.CronOperations.OLAPAnalyzeCronInterval),
 				olap.WithOLAPStatusUpdateBatchSizeLimits(sizeLimits),
-				olap.WithMQQos(sc.OLAPStatusUpdates.MQQos),
+				olap.WithMQQos(sc.Operations.OLAPMQQos),
 			)
 
 			if err != nil {

--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -285,6 +285,7 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 			olap.WithOperationsConfig(sc.Operations),
 			olap.WithAnalyzeCronInterval(sc.CronOperations.OLAPAnalyzeCronInterval),
 			olap.WithOLAPStatusUpdateBatchSizeLimits(sizeLimits),
+			olap.WithMQQos(sc.OLAPStatusUpdates.MQQos),
 		)
 
 		if err != nil {
@@ -664,6 +665,7 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 				olap.WithPrometheusMetricsEnabled(sc.Prometheus.Enabled),
 				olap.WithAnalyzeCronInterval(sc.CronOperations.OLAPAnalyzeCronInterval),
 				olap.WithOLAPStatusUpdateBatchSizeLimits(sizeLimits),
+				olap.WithMQQos(sc.OLAPStatusUpdates.MQQos),
 			)
 
 			if err != nil {

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -89,7 +89,7 @@ func defaultOLAPControllerOpts() *OLAPControllerOpts {
 		alerter:                  alerter,
 		prometheusMetricsEnabled: false,
 		analyzeCronInterval:      3 * time.Hour,
-		mqQos:                    200,
+		mqQos:                    2000,
 	}
 }
 

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -89,7 +89,6 @@ func defaultOLAPControllerOpts() *OLAPControllerOpts {
 		alerter:                  alerter,
 		prometheusMetricsEnabled: false,
 		analyzeCronInterval:      3 * time.Hour,
-		mqQos:                    2000,
 	}
 }
 

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -58,6 +58,7 @@ type OLAPControllerImpl struct {
 	dagPrometheusWorkerCtx       context.Context
 	dagPrometheusWorkerCancel    context.CancelFunc
 	statusUpdateBatchSizeLimits  v1.StatusUpdateBatchSizeLimits
+	mqQos                        int
 }
 
 type OLAPControllerOpt func(*OLAPControllerOpts)
@@ -75,6 +76,7 @@ type OLAPControllerOpts struct {
 	prometheusMetricsEnabled    bool
 	analyzeCronInterval         time.Duration
 	statusUpdateBatchSizeLimits v1.StatusUpdateBatchSizeLimits
+	mqQos                       int
 }
 
 func defaultOLAPControllerOpts() *OLAPControllerOpts {
@@ -87,6 +89,7 @@ func defaultOLAPControllerOpts() *OLAPControllerOpts {
 		alerter:                  alerter,
 		prometheusMetricsEnabled: false,
 		analyzeCronInterval:      3 * time.Hour,
+		mqQos:                    200,
 	}
 }
 
@@ -167,6 +170,12 @@ func WithOLAPStatusUpdateBatchSizeLimits(limits v1.StatusUpdateBatchSizeLimits) 
 	}
 }
 
+func WithMQQos(qos int) OLAPControllerOpt {
+	return func(opts *OLAPControllerOpts) {
+		opts.mqQos = qos
+	}
+}
+
 func New(fs ...OLAPControllerOpt) (*OLAPControllerImpl, error) {
 	opts := defaultOLAPControllerOpts()
 
@@ -226,6 +235,7 @@ func New(fs ...OLAPControllerOpt) (*OLAPControllerImpl, error) {
 		taskPrometheusUpdateCh:      taskPrometheusUpdateCh,
 		dagPrometheusUpdateCh:       dagPrometheusUpdateCh,
 		statusUpdateBatchSizeLimits: opts.statusUpdateBatchSizeLimits,
+		mqQos:                       opts.mqQos,
 	}
 
 	// Default jitter value
@@ -255,7 +265,7 @@ func (o *OLAPControllerImpl) Start() (func() error, error) {
 	if err != nil {
 		return nil, err
 	}
-	heavyReadMQ.SetQOS(2000)
+	heavyReadMQ.SetQOS(o.mqQos)
 
 	o.s.Start()
 

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -157,6 +157,9 @@ type OLAPStatusUpdateConfigFile struct {
 
 	// TaskBatchSizeLimit is the limit for how many task status updates to process in a single batch update
 	TaskBatchSizeLimit int `mapstructure:"taskBatchSizeLimit" json:"taskBatchSizeLimit,omitempty" default:"1000"`
+
+	// MQQos is the prefetch count (QOS) for the OLAP controller's message queue consumer
+	MQQos int `mapstructure:"mqQos" json:"mqQos,omitempty" default:"200"`
 }
 
 // General server runtime options
@@ -994,6 +997,7 @@ func BindAllEnv(v *viper.Viper) {
 	// OLAP status update options
 	_ = v.BindEnv("statusUpdates.dagBatchSizeLimit", "SERVER_OLAP_STATUS_UPDATE_DAG_BATCH_SIZE_LIMIT")
 	_ = v.BindEnv("statusUpdates.taskBatchSizeLimit", "SERVER_OLAP_STATUS_UPDATE_TASK_BATCH_SIZE_LIMIT")
+	_ = v.BindEnv("statusUpdates.mqQos", "SERVER_OLAP_STATUS_UPDATE_MQ_QOS")
 
 	// exchange token options
 	_ = v.BindEnv("auth.controlPlaneExchangeToken.enabled", "SERVER_AUTH_CONTROL_PLANE_EXCHANGE_TOKEN_ENABLED")

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -112,7 +112,7 @@ type ConfigFileOperations struct {
 	PollInterval int `mapstructure:"pollInterval" json:"pollInterval,omitempty" default:"2"`
 
 	// OLAPMQQos is the prefetch count (QOS) for the OLAP controller's message queue consumer
-	OLAPMQQos int `mapstructure:"olapMqQos" json:"olapMqQos,omitempty" default:"200"`
+	OLAPMQQos int `mapstructure:"olapMqQos" json:"olapMqQos,omitempty" default:"2000"`
 }
 
 type TaskOperationLimitsConfigFile struct {

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -110,6 +110,9 @@ type ConfigFileOperations struct {
 
 	// PollInterval is the polling interval for operations in seconds
 	PollInterval int `mapstructure:"pollInterval" json:"pollInterval,omitempty" default:"2"`
+
+	// OLAPMQQos is the prefetch count (QOS) for the OLAP controller's message queue consumer
+	OLAPMQQos int `mapstructure:"olapMqQos" json:"olapMqQos,omitempty" default:"200"`
 }
 
 type TaskOperationLimitsConfigFile struct {
@@ -157,9 +160,6 @@ type OLAPStatusUpdateConfigFile struct {
 
 	// TaskBatchSizeLimit is the limit for how many task status updates to process in a single batch update
 	TaskBatchSizeLimit int `mapstructure:"taskBatchSizeLimit" json:"taskBatchSizeLimit,omitempty" default:"1000"`
-
-	// MQQos is the prefetch count (QOS) for the OLAP controller's message queue consumer
-	MQQos int `mapstructure:"mqQos" json:"mqQos,omitempty" default:"200"`
 }
 
 // General server runtime options
@@ -997,7 +997,7 @@ func BindAllEnv(v *viper.Viper) {
 	// OLAP status update options
 	_ = v.BindEnv("statusUpdates.dagBatchSizeLimit", "SERVER_OLAP_STATUS_UPDATE_DAG_BATCH_SIZE_LIMIT")
 	_ = v.BindEnv("statusUpdates.taskBatchSizeLimit", "SERVER_OLAP_STATUS_UPDATE_TASK_BATCH_SIZE_LIMIT")
-	_ = v.BindEnv("statusUpdates.mqQos", "SERVER_OLAP_STATUS_UPDATE_MQ_QOS")
+	_ = v.BindEnv("olap.olapMqQos", "SERVER_OLAP_MQ_QOS")
 
 	// exchange token options
 	_ = v.BindEnv("auth.controlPlaneExchangeToken.enabled", "SERVER_AUTH_CONTROL_PLANE_EXCHANGE_TOKEN_ENABLED")


### PR DESCRIPTION
# Description

Adds an env var `SERVER_OLAP_MQ_QOS` we can set to configure the QoS for the OLAP MQ. Defaults to 2000 (the old hard-coded default)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
