### PR TITLE
fix: Occasional empty payloads on DAG task retries

### DIFF
--- a/pkg/repository/match_data.go
+++ b/pkg/repository/match_data.go
@@ -123,13 +123,10 @@ func NewMatchData(mcAggregatedData []byte) (*MatchData, error) {
 			}
 		}
 	}
+
 	for k, v := range triggerDataMap {
 		var action sqlcv1.V1MatchConditionAction
-		// we already handled this case in the loop above, skip it
-		// so we don't end up with a null action
-		if k == "CREATE_MATCH" {
-			continue
-		}
+
 		switch k {
 		case "CREATE":
 			action = sqlcv1.V1MatchConditionActionCREATE
@@ -139,6 +136,10 @@ func NewMatchData(mcAggregatedData []byte) (*MatchData, error) {
 			action = sqlcv1.V1MatchConditionActionCANCEL
 		case "SKIP":
 			action = sqlcv1.V1MatchConditionActionSKIP
+		// we already handled this case in the loop above, skip it
+		// so we don't end up with a null action
+		case "CREATE_MATCH":
+			continue
 		}
 
 		triggerDataKeys := map[string][]interface{}{}

--- a/pkg/repository/match_data.go
+++ b/pkg/repository/match_data.go
@@ -123,10 +123,13 @@ func NewMatchData(mcAggregatedData []byte) (*MatchData, error) {
 			}
 		}
 	}
-
 	for k, v := range triggerDataMap {
 		var action sqlcv1.V1MatchConditionAction
-
+		// we already handled this case in the loop above, skip it
+		// so we don't end up with a null action
+		if k == "CREATE_MATCH" {
+			continue
+		}
 		switch k {
 		case "CREATE":
 			action = sqlcv1.V1MatchConditionActionCREATE

--- a/sdks/go/e2e/dag_payload_test.go
+++ b/sdks/go/e2e/dag_payload_test.go
@@ -1,0 +1,34 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
+)
+
+type dagPayloadInput struct {
+	WorkflowKey string `json:"workflow_key"`
+}
+
+// Regression test for empty payloads on task replay. Runs 10 at the same time because the original bug was from
+// go's map iteration ordering, which is nondeterministic, so would be flaky otherwise.
+func TestDAGPayloadFreshRunConcurrent(t *testing.T) {
+	const n = 10
+	ctx := newTestContext(t)
+
+	refs := make([]*hatchet.WorkflowRunRef, n)
+	for i := range n {
+		ref, err := testDAGPayloadWorkflow.RunNoWait(ctx, dagPayloadInput{WorkflowKey: "test-value"})
+		require.NoError(t, err)
+		refs[i] = ref
+	}
+
+	for i, ref := range refs {
+		_, err := ref.Result()
+		require.NoError(t, err, "run %d: step B failed (payload not propagated)", i)
+	}
+}

--- a/sdks/go/e2e/worker.go
+++ b/sdks/go/e2e/worker.go
@@ -80,6 +80,10 @@ var (
 	testNonEvictableSleep       *hatchet.StandaloneTask
 	testEvictionChildTask       *hatchet.StandaloneTask
 	testEvictionBulkChildTask   *hatchet.StandaloneTask
+
+	// dag payload propagation test workflow
+	testDAGPayloadWorkflow *hatchet.Workflow
+	testDAGPayloadStepA    *hatchet.Task
 )
 
 func registerAllWorkflows(client *hatchet.Client) {
@@ -499,6 +503,65 @@ func registerAllWorkflows(client *hatchet.Client) {
 		hatchet.WithExecutionTimeout(5*time.Minute),
 		hatchet.WithEvictionPolicy(nonEvictablePolicy),
 	)
+
+	// --- DAG payload propagation test workflow ---
+	// Reproduces the bug where downstream tasks don't receive the workflow input or
+	// parent outputs. Both steps fail immediately if their payload is null/empty,
+	// so any test that runs this workflow will fail if the bug is present.
+	testDAGPayloadWorkflow = client.NewWorkflow("dag-payload-test-workflow")
+
+	type DAGPayloadInput struct {
+		WorkflowKey string `json:"workflow_key"`
+		Iteration   int    `json:"iteration"`
+	}
+
+	type StepAOutput struct {
+		Message string `json:"message"`
+	}
+
+	testDAGPayloadStepA = testDAGPayloadWorkflow.NewTask("dag-payload-step-a",
+		func(ctx hatchet.Context, input DAGPayloadInput) (StepAOutput, error) {
+			if input.WorkflowKey == "" {
+				return StepAOutput{}, fmt.Errorf("step A received empty workflow input")
+			}
+			return StepAOutput{Message: "hello-from-step-a"}, nil
+		},
+		hatchet.WithRetries(2),
+		hatchet.WithRetryBackoff(30, 130),
+	)
+
+	testDAGPayloadWorkflow.NewTask("dag-payload-step-b",
+		func(ctx hatchet.Context, input DAGPayloadInput) (map[string]any, error) {
+			// Fail on first attempt to reproduce the customer failure mode.
+			// The retry is where the bug manifests: if the payload isn't propagated
+			// to the retry, the checks below will catch it.
+			if ctx.RetryCount() == 0 {
+				return nil, fmt.Errorf("deliberate first-attempt failure")
+			}
+			fmt.Println(input.WorkflowKey, ctx.RetryCount())
+			if input.WorkflowKey == "" {
+				fmt.Println("could not get input workflow key")
+				return nil, fmt.Errorf("step B received empty workflow input on retry")
+			}
+			var parentOut StepAOutput
+			if err := ctx.ParentOutput(testDAGPayloadStepA, &parentOut); err != nil {
+				return nil, fmt.Errorf("step B could not read step A parent output on retry: %w", err)
+			}
+			if parentOut.Message == "" {
+				return nil, fmt.Errorf("step B received empty parent output from step A on retry")
+			}
+			return map[string]any{"ok": true}, nil
+		},
+		hatchet.WithParents(testDAGPayloadStepA),
+		hatchet.WithRetries(2),
+		hatchet.WithRetryBackoff(4, 130),
+		// mirrors the Python: wait_for=[SleepCondition(duration=WORKER_DRAINING_INITIAL_DELAY)]
+		hatchet.WithWaitFor(hatchet.SleepCondition(3*time.Second)),
+		// mirrors the Python: skip_if=[ParentCondition(parent=detect, expression="...")]
+		// expression is intentionally impossible so the step never actually skips
+		hatchet.WithSkipIf(hatchet.ParentCondition(testDAGPayloadStepA, "output.message == 'skip-me'")),
+		hatchet.WithExecutionTimeout(2*time.Minute),
+	)
 }
 
 func startTestWorker(client *hatchet.Client) (*hatchet.Worker, func() error, error) {
@@ -508,6 +571,7 @@ func startTestWorker(client *hatchet.Client) (*hatchet.Worker, func() error, err
 		hatchet.WithWorkflows(
 			testDurableWorkflow,
 			testDagChildWorkflow,
+			testDAGPayloadWorkflow,
 			testWaitForSleepTwice,
 			testSpawnChildTask,
 			testDurableWithSpawn,

--- a/sdks/go/e2e/worker.go
+++ b/sdks/go/e2e/worker.go
@@ -521,9 +521,6 @@ func registerAllWorkflows(client *hatchet.Client) {
 
 	testDAGPayloadStepA = testDAGPayloadWorkflow.NewTask("dag-payload-step-a",
 		func(ctx hatchet.Context, input DAGPayloadInput) (StepAOutput, error) {
-			if input.WorkflowKey == "" {
-				return StepAOutput{}, fmt.Errorf("step A received empty workflow input")
-			}
 			return StepAOutput{Message: "hello-from-step-a"}, nil
 		},
 		hatchet.WithRetries(2),
@@ -538,9 +535,7 @@ func registerAllWorkflows(client *hatchet.Client) {
 			if ctx.RetryCount() == 0 {
 				return nil, fmt.Errorf("deliberate first-attempt failure")
 			}
-			fmt.Println(input.WorkflowKey, ctx.RetryCount())
 			if input.WorkflowKey == "" {
-				fmt.Println("could not get input workflow key")
 				return nil, fmt.Errorf("step B received empty workflow input on retry")
 			}
 			var parentOut StepAOutput
@@ -555,11 +550,8 @@ func registerAllWorkflows(client *hatchet.Client) {
 		hatchet.WithParents(testDAGPayloadStepA),
 		hatchet.WithRetries(2),
 		hatchet.WithRetryBackoff(4, 130),
-		// mirrors the Python: wait_for=[SleepCondition(duration=WORKER_DRAINING_INITIAL_DELAY)]
-		hatchet.WithWaitFor(hatchet.SleepCondition(3*time.Second)),
-		// mirrors the Python: skip_if=[ParentCondition(parent=detect, expression="...")]
-		// expression is intentionally impossible so the step never actually skips
-		hatchet.WithSkipIf(hatchet.ParentCondition(testDAGPayloadStepA, "output.message == 'skip-me'")),
+		// needed to replicate the match condition bug
+		hatchet.WithWaitFor(hatchet.SleepCondition(1*time.Second)),
 		hatchet.WithExecutionTimeout(2*time.Minute),
 	)
 }


### PR DESCRIPTION
# Description

This fixes a bug that manifested as random failures in DAG workflow tasks that happened because the action was getting set to nil because CREATE_MATCH didn't exist in the case statement, and should have been skipped.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...
