### PR TITLE
Fix: Allow partial successes on status updates

### DIFF
--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -148,7 +148,7 @@ jobs:
         run: |
           echo "Using HATCHET_CLIENT_NAMESPACE: $HATCHET_CLIENT_NAMESPACE"
 
-          poetry run pytest -s -vvv --maxfail=5 --capture=no --retries 3 --retry-delay 2 -n auto
+          poetry run pytest -s -vvv --maxfail=5 --capture=no --retries 3 --retry-delay 2 -n 8
 
       - name: Test with wheel
         run: |

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -292,7 +292,7 @@ tasks:
       RETRIES: '{{.RETRIES | default "3"}}'
       EXTRA_ARGS: '{{.EXTRA_ARGS | default ""}}'
     cmds:
-      - poetry run pytest -n 8 --retries 3 --retry-delay 5
+      - poetry run pytest -n 32 --retries 3 --retry-delay 5
   start-telemetry:
     cmds:
       - docker compose -f docker-compose.infra.yml up -d

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -292,7 +292,7 @@ tasks:
       RETRIES: '{{.RETRIES | default "3"}}'
       EXTRA_ARGS: '{{.EXTRA_ARGS | default ""}}'
     cmds:
-      - poetry run pytest -n auto --retries 3 --retry-delay 5
+      - poetry run pytest -n 8 --retries 3 --retry-delay 5
   start-telemetry:
     cmds:
       - docker compose -f docker-compose.infra.yml up -d

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -537,7 +537,7 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTasks(ctx, tenantId, createTaskOpts)
 
 		if err != nil {
-			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d tasks after 10 attempts, republishing to MQ", len(createTaskOpts))
+			tc.l.Error().Ctx(ctx).Msgf("failed to create tasks, republishing %d tasks: %v", len(createTaskOpts), err)
 			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
 		}
 
@@ -626,7 +626,7 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 
 		workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateDAGs(ctx, tenantId, createDAGOpts)
 		if err != nil {
-			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d DAGs after 10 attempts, republishing to MQ", len(createDAGOpts))
+			tc.l.Error().Ctx(ctx).Msgf("failed to create DAGs, republishing %d DAGs: %v", len(createDAGOpts), err)
 			return tc.republishCreatedDAGs(ctx, tenantId, createDAGOpts)
 		}
 
@@ -1021,7 +1021,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTaskEvents(ctx, tenantId, opts, eventExternalIdToWorkflowRunId)
 
 		if err != nil {
-			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d monitoring events after 10 attempts, republishing to MQ", len(opts))
+			tc.l.Error().Ctx(ctx).Msgf("failed to create task events, republishing %d events: %v", len(opts), err)
 			return tc.republishMonitoringEvents(ctx, tenantId, opts, externalIdToMsg)
 		}
 

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -832,7 +832,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 	timestamps := make([]pgtype.Timestamptz, 0)
 	eventExternalIds := make([]*uuid.UUID, 0)
 	var spanEvents []engineSpanEvent
-	msgsForOpt := make([]*tasktypes.CreateMonitoringEventPayload, 0)
+	workflowRunIdToMsgs := make(map[uuid.UUID][]*tasktypes.CreateMonitoringEventPayload)
 
 	for _, msg := range msgs {
 		taskMeta := taskIdsToMetas[msg.TaskId]
@@ -851,7 +851,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		taskInsertedAts = append(taskInsertedAts, taskMeta.InsertedAt)
 		workflowIds = append(workflowIds, taskMeta.WorkflowID)
 		workflowRunIDs = append(workflowRunIDs, taskMeta.WorkflowRunID)
-		msgsForOpt = append(msgsForOpt, msg)
+		workflowRunIdToMsgs[taskMeta.WorkflowRunID] = append(workflowRunIdToMsgs[taskMeta.WorkflowRunID], msg)
 		retryCounts = append(retryCounts, msg.RetryCount)
 		durableInvocationCounts = append(durableInvocationCounts, msg.DurableInvocationCount)
 		eventTypes = append(eventTypes, msg.EventType)
@@ -987,14 +987,25 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 
 	tc.synthesizeEngineSpans(ctx, tenantId, spanEvents)
 
-	for optIdx, runId := range workflowRunIDs {
+	for _, runId := range workflowRunIDs {
 		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[runId]; notAcquired {
-			msg, err := tasktypes.MonitoringEventMessageFromInternal(tenantId, *msgsForOpt[optIdx])
-			if err != nil {
-				return err
+			incomingMsgs, ok := workflowRunIdToMsgs[runId]
+
+			if !ok {
+				tc.l.Error().Ctx(ctx).Msgf("could not find incoming messages for workflow run id %s", runId)
+				continue
 			}
-			if err := tc.mq.SendMessage(ctx, msgqueue.OLAP_QUEUE, msg); err != nil {
-				return err
+
+			for _, incomingMsg := range incomingMsgs {
+				msg, err := tasktypes.MonitoringEventMessageFromInternal(tenantId, *incomingMsg)
+				if err != nil {
+					tc.l.Error().Ctx(ctx).Err(err).Msgf("could not create message for workflow run id %s", runId)
+					continue
+				}
+
+				if err := tc.mq.SendMessage(ctx, msgqueue.OLAP_QUEUE, msg); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -547,6 +547,8 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 
 		createTaskOpts = failedOpts
 		tc.emitStandaloneTaskRootSpans(ctx, tenantId, succeededOpts)
+
+		time.Sleep(25 * time.Millisecond)
 	}
 
 	return nil
@@ -616,6 +618,8 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 
 		createDAGOpts = failedOpts
 		tc.emitWorkflowRunRootSpans(ctx, tenantId, succeededOpts)
+
+		time.Sleep(25 * time.Millisecond)
 	}
 
 	return nil
@@ -1034,6 +1038,8 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		if len(spanEventsForSuccessfullyLockedRuns) > 0 {
 			tc.synthesizeEngineSpans(ctx, tenantId, spanEventsForSuccessfullyLockedRuns)
 		}
+
+		time.Sleep(25 * time.Millisecond)
 	}
 
 	return nil

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -831,10 +831,9 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 	eventMessages := make([]string, 0)
 	timestamps := make([]pgtype.Timestamptz, 0)
 	eventExternalIds := make([]*uuid.UUID, 0)
-	var spanEvents []engineSpanEvent
-	workflowRunIdToMsgs := make(map[uuid.UUID][]*tasktypes.CreateMonitoringEventPayload)
+	msgIxToSpanEvent := make(map[int]engineSpanEvent)
 
-	for _, msg := range msgs {
+	for ix, msg := range msgs {
 		taskMeta := taskIdsToMetas[msg.TaskId]
 
 		if taskMeta == nil {
@@ -851,7 +850,6 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		taskInsertedAts = append(taskInsertedAts, taskMeta.InsertedAt)
 		workflowIds = append(workflowIds, taskMeta.WorkflowID)
 		workflowRunIDs = append(workflowRunIDs, taskMeta.WorkflowRunID)
-		workflowRunIdToMsgs[taskMeta.WorkflowRunID] = append(workflowRunIdToMsgs[taskMeta.WorkflowRunID], msg)
 		retryCounts = append(retryCounts, msg.RetryCount)
 		durableInvocationCounts = append(durableInvocationCounts, msg.DurableInvocationCount)
 		eventTypes = append(eventTypes, msg.EventType)
@@ -861,7 +859,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		externalId := uuid.New()
 		eventExternalIds = append(eventExternalIds, &externalId)
 
-		spanEvents = append(spanEvents, engineSpanEvent{
+		msgIxToSpanEvent[ix] = engineSpanEvent{
 			taskID:             msg.TaskId,
 			insertedAt:         taskMeta.InsertedAt.Time,
 			taskInsertedAt:     taskMeta.InsertedAt.Time,
@@ -878,7 +876,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 			workflowID:         taskMeta.WorkflowID,
 			workflowVersionID:  taskMeta.WorkflowVersionID,
 			stepID:             taskMeta.StepID,
-		})
+		}
 
 		if msg.WorkerId != nil {
 			workerIds = append(workerIds, *msg.WorkerId)
@@ -986,34 +984,34 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 	}
 
 	var spanEventsForSuccessfullyLockedRuns []engineSpanEvent
-	for i, runId := range workflowRunIDs {
-		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[runId]; !notAcquired {
-			spanEventsForSuccessfullyLockedRuns = append(spanEventsForSuccessfullyLockedRuns, spanEvents[i])
+	var toRequeue []*tasktypes.CreateMonitoringEventPayload
+
+	for ix, msg := range msgs {
+		taskMeta := taskIdsToMetas[msg.TaskId]
+
+		_, lockNotAcquired := workflowRunIdsOfLocksNotAcquired[taskMeta.WorkflowRunID]
+
+		if lockNotAcquired {
+			toRequeue = append(toRequeue, msg)
+		} else {
+			spanEvent := msgIxToSpanEvent[ix]
+			spanEventsForSuccessfullyLockedRuns = append(spanEventsForSuccessfullyLockedRuns, spanEvent)
 		}
 	}
 
-	tc.synthesizeEngineSpans(ctx, tenantId, spanEventsForSuccessfullyLockedRuns)
+	if len(spanEventsForSuccessfullyLockedRuns) > 0 {
+		tc.synthesizeEngineSpans(ctx, tenantId, spanEventsForSuccessfullyLockedRuns)
+	}
 
-	for _, runId := range workflowRunIDs {
-		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[runId]; notAcquired {
-			incomingMsgs, ok := workflowRunIdToMsgs[runId]
+	for _, incomingMsg := range toRequeue {
+		msg, err := tasktypes.MonitoringEventMessageFromInternal(tenantId, *incomingMsg)
+		if err != nil {
+			tc.l.Error().Ctx(ctx).Err(err).Msgf("could not create message for workflow run id %s", incomingMsg.TaskId)
+			continue
+		}
 
-			if !ok {
-				tc.l.Error().Ctx(ctx).Msgf("could not find incoming messages for workflow run id %s", runId)
-				continue
-			}
-
-			for _, incomingMsg := range incomingMsgs {
-				msg, err := tasktypes.MonitoringEventMessageFromInternal(tenantId, *incomingMsg)
-				if err != nil {
-					tc.l.Error().Ctx(ctx).Err(err).Msgf("could not create message for workflow run id %s", runId)
-					continue
-				}
-
-				if err := tc.mq.SendMessage(ctx, msgqueue.OLAP_QUEUE, msg); err != nil {
-					return err
-				}
-			}
+		if err := tc.mq.SendMessage(ctx, msgqueue.OLAP_QUEUE, msg); err != nil {
+			return err
 		}
 	}
 
@@ -1025,6 +1023,13 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 	idInsertedAtToExternalId := make(map[v1.IdInsertedAt]*uuid.UUID)
 
 	for _, opt := range opts {
+		taskMeta := taskIdsToMetas[opt.TaskID]
+		_, lockNotAcquired := workflowRunIdsOfLocksNotAcquired[taskMeta.WorkflowRunID]
+
+		if lockNotAcquired {
+			continue
+		}
+
 		// generating a dummy id + inserted at to use for creating the external keys for the task events
 		// we do this since we don't have the id + inserted at of the events themselves on the opts, and we don't
 		// actually need those for anything once the keys are created.

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -824,7 +824,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 	durableInvocationCounts := make([]int32, 0)
 	workerIds := make([]uuid.UUID, 0)
 	workflowIds := make([]uuid.UUID, 0)
-	workflowRunIDs := make([]uuid.UUID, 0)
+	eventExternalIdToWorkflowRunId := make(map[uuid.UUID]uuid.UUID)
 	eventTypes := make([]sqlcv1.V1EventTypeOlap, 0)
 	readableStatuses := make([]sqlcv1.V1ReadableStatusOlap, 0)
 	eventPayloads := make([]string, 0)
@@ -849,7 +849,6 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		taskIds = append(taskIds, msg.TaskId)
 		taskInsertedAts = append(taskInsertedAts, taskMeta.InsertedAt)
 		workflowIds = append(workflowIds, taskMeta.WorkflowID)
-		workflowRunIDs = append(workflowRunIDs, taskMeta.WorkflowRunID)
 		retryCounts = append(retryCounts, msg.RetryCount)
 		durableInvocationCounts = append(durableInvocationCounts, msg.DurableInvocationCount)
 		eventTypes = append(eventTypes, msg.EventType)
@@ -858,6 +857,8 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		timestamps = append(timestamps, sqlchelpers.TimestamptzFromTime(msg.EventTimestamp))
 		externalId := uuid.New()
 		eventExternalIds = append(eventExternalIds, &externalId)
+
+		eventExternalIdToWorkflowRunId[externalId] = taskMeta.WorkflowRunID
 
 		msgIxToSpanEvent[ix] = engineSpanEvent{
 			taskID:             msg.TaskId,
@@ -973,7 +974,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		opts = append(opts, event)
 	}
 
-	result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTaskEvents(ctx, tenantId, opts, workflowRunIDs)
+	result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTaskEvents(ctx, tenantId, opts, eventExternalIdToWorkflowRunId)
 
 	if err != nil {
 		return err
@@ -988,6 +989,11 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 
 	for ix, msg := range msgs {
 		taskMeta := taskIdsToMetas[msg.TaskId]
+
+		if taskMeta == nil {
+			tc.l.Error().Ctx(ctx).Msgf("could not find task meta for task id %d", msg.TaskId)
+			continue
+		}
 
 		_, lockNotAcquired := workflowRunIdsOfLocksNotAcquired[taskMeta.WorkflowRunID]
 
@@ -1006,7 +1012,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 	for _, incomingMsg := range toRequeue {
 		msg, err := tasktypes.MonitoringEventMessageFromInternal(tenantId, *incomingMsg)
 		if err != nil {
-			tc.l.Error().Ctx(ctx).Err(err).Msgf("could not create message for workflow run id %s", incomingMsg.TaskId)
+			tc.l.Error().Ctx(ctx).Err(err).Msgf("could not create message for workflow run id %d", incomingMsg.TaskId)
 			continue
 		}
 

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -508,19 +508,21 @@ func (tc *OLAPControllerImpl) handleCelEvaluationFailure(ctx context.Context, te
 // handleCreatedTask is responsible for flushing a created task to the OLAP repository
 func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uuid.UUID, payloads [][]byte) error {
 	createTaskOpts := make([]*v1.V1TaskWithPayload, 0)
+	msgIdxForOpt := make([]int, 0)
 
 	msgs := msgqueue.JSONConvert[tasktypes.CreatedTaskPayload](payloads)
 
-	for _, msg := range msgs {
+	for msgIdx, msg := range msgs {
 		if !tc.sample(msg.WorkflowRunID.String()) {
 			tc.l.Debug().Ctx(ctx).Msgf("skipping task %d for workflow run %s", msg.ID, msg.WorkflowRunID.String())
 			continue
 		}
 
 		createTaskOpts = append(createTaskOpts, msg.V1TaskWithPayload)
+		msgIdxForOpt = append(msgIdxForOpt, msgIdx)
 	}
 
-	result, err := tc.repo.OLAP().CreateTasks(ctx, tenantId, createTaskOpts)
+	result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTasks(ctx, tenantId, createTaskOpts)
 	if err != nil {
 		return err
 	}
@@ -529,9 +531,20 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 		return err
 	}
 
-	tc.emitStandaloneTaskRootSpans(ctx, tenantId, createTaskOpts)
+	var succeededPayloads []*v1.V1TaskWithPayload
+	var failedPayloads [][]byte
 
-	return nil
+	for optIdx, opt := range createTaskOpts {
+		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[opt.WorkflowRunID]; notAcquired {
+			failedPayloads = append(failedPayloads, payloads[msgIdxForOpt[optIdx]])
+		} else {
+			succeededPayloads = append(succeededPayloads, opt)
+		}
+	}
+
+	tc.emitStandaloneTaskRootSpans(ctx, tenantId, succeededPayloads)
+
+	return tc.republishPayloads(ctx, msgqueue.MsgIDCreatedTask, tenantId, failedPayloads)
 }
 
 func (tc *OLAPControllerImpl) emitStandaloneTaskRootSpans(ctx context.Context, tenantId uuid.UUID, tasks []*v1.V1TaskWithPayload) {
@@ -563,24 +576,39 @@ func (tc *OLAPControllerImpl) emitStandaloneTaskRootSpans(ctx context.Context, t
 // handleCreatedDAG is responsible for flushing a created DAG to the OLAP repository
 func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uuid.UUID, payloads [][]byte) error {
 	createDAGOpts := make([]*v1.DAGWithData, 0)
+	msgIdxForOpt := make([]int, 0)
+
 	msgs := msgqueue.JSONConvert[tasktypes.CreatedDAGPayload](payloads)
 
-	for _, msg := range msgs {
+	for msgIdx, msg := range msgs {
 		if !tc.sample(msg.ExternalID.String()) {
 			tc.l.Debug().Ctx(ctx).Msgf("skipping dag %s", msg.ExternalID.String())
 			continue
 		}
 
 		createDAGOpts = append(createDAGOpts, msg.DAGWithData)
+		msgIdxForOpt = append(msgIdxForOpt, msgIdx)
 	}
 
-	if err := tc.repo.OLAP().CreateDAGs(ctx, tenantId, createDAGOpts); err != nil {
+	workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateDAGs(ctx, tenantId, createDAGOpts)
+	if err != nil {
 		return err
 	}
 
-	tc.emitWorkflowRunRootSpans(ctx, tenantId, createDAGOpts)
+	var succeededPayloads []*v1.DAGWithData
+	var failedPayloads [][]byte
 
-	return nil
+	for optIdx, opt := range createDAGOpts {
+		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[opt.ExternalID]; notAcquired {
+			failedPayloads = append(failedPayloads, payloads[msgIdxForOpt[optIdx]])
+		} else {
+			succeededPayloads = append(succeededPayloads, opt)
+		}
+	}
+
+	tc.emitWorkflowRunRootSpans(ctx, tenantId, succeededPayloads)
+
+	return tc.republishPayloads(ctx, msgqueue.MsgIDCreatedDAG, tenantId, failedPayloads)
 }
 
 func (tc *OLAPControllerImpl) emitWorkflowRunRootSpans(ctx context.Context, tenantId uuid.UUID, dags []*v1.DAGWithData) {
@@ -788,8 +816,9 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 	timestamps := make([]pgtype.Timestamptz, 0)
 	eventExternalIds := make([]*uuid.UUID, 0)
 	var spanEvents []engineSpanEvent
+	msgIdxForOpt := make([]int, 0)
 
-	for _, msg := range msgs {
+	for msgIdx, msg := range msgs {
 		taskMeta := taskIdsToMetas[msg.TaskId]
 
 		if taskMeta == nil {
@@ -806,6 +835,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		taskInsertedAts = append(taskInsertedAts, taskMeta.InsertedAt)
 		workflowIds = append(workflowIds, taskMeta.WorkflowID)
 		workflowRunIDs = append(workflowRunIDs, taskMeta.WorkflowRunID)
+		msgIdxForOpt = append(msgIdxForOpt, msgIdx)
 		retryCounts = append(retryCounts, msg.RetryCount)
 		durableInvocationCounts = append(durableInvocationCounts, msg.DurableInvocationCount)
 		eventTypes = append(eventTypes, msg.EventType)
@@ -929,7 +959,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		opts = append(opts, event)
 	}
 
-	result, err := tc.repo.OLAP().CreateTaskEvents(ctx, tenantId, opts, workflowRunIDs)
+	result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTaskEvents(ctx, tenantId, opts, workflowRunIDs)
 
 	if err != nil {
 		return err
@@ -940,6 +970,17 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 	}
 
 	tc.synthesizeEngineSpans(ctx, tenantId, spanEvents)
+
+	var failedPayloads [][]byte
+	for optIdx, runId := range workflowRunIDs {
+		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[runId]; notAcquired {
+			failedPayloads = append(failedPayloads, payloads[msgIdxForOpt[optIdx]])
+		}
+	}
+
+	if err := tc.republishPayloads(ctx, msgqueue.MsgIDCreateMonitoringEvent, tenantId, failedPayloads); err != nil {
+		return err
+	}
 
 	if !tc.repo.OLAP().PayloadStore().ExternalStoreEnabled() {
 		return nil
@@ -1020,6 +1061,20 @@ func (tc *OLAPControllerImpl) handleFailedWebhookValidation(ctx context.Context,
 	}
 
 	return tc.repo.OLAP().CreateIncomingWebhookValidationFailureLogs(ctx, tenantId, createFailedWebhookValidationOpts)
+}
+
+func (tc *OLAPControllerImpl) republishPayloads(ctx context.Context, msgID string, tenantId uuid.UUID, payloads [][]byte) error {
+	if len(payloads) == 0 {
+		return nil
+	}
+
+	return tc.mq.SendMessage(ctx, msgqueue.OLAP_QUEUE, &msgqueue.Message{
+		ID:         msgID,
+		TenantID:   tenantId,
+		Payloads:   payloads,
+		Persistent: true,
+		Retries:    5,
+	})
 }
 
 func (tc *OLAPControllerImpl) sample(workflowRunID string) bool {

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -985,7 +985,14 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		return err
 	}
 
-	tc.synthesizeEngineSpans(ctx, tenantId, spanEvents)
+	var spanEventsForSuccessfullyLockedRuns []engineSpanEvent
+	for i, runId := range workflowRunIDs {
+		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[runId]; !notAcquired {
+			spanEventsForSuccessfullyLockedRuns = append(spanEventsForSuccessfullyLockedRuns, spanEvents[i])
+		}
+	}
+
+	tc.synthesizeEngineSpans(ctx, tenantId, spanEventsForSuccessfullyLockedRuns)
 
 	for _, runId := range workflowRunIDs {
 		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[runId]; notAcquired {

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -557,7 +557,10 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 
 		createTaskOpts = failedOpts
 		tc.emitStandaloneTaskRootSpans(ctx, tenantId, succeededOpts)
-		time.Sleep(1 * time.Millisecond)
+
+		if len(failedOpts) > 0 {
+			time.Sleep(1 * time.Millisecond)
+		}
 	}
 
 	span.SetAttributes(
@@ -639,7 +642,10 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 
 		createDAGOpts = failedOpts
 		tc.emitWorkflowRunRootSpans(ctx, tenantId, succeededOpts)
-		time.Sleep(1 * time.Millisecond)
+
+		if len(failedOpts) > 0 {
+			time.Sleep(1 * time.Millisecond)
+		}
 	}
 
 	span.SetAttributes(
@@ -1071,7 +1077,9 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 			tc.synthesizeEngineSpans(ctx, tenantId, spanEventsForSuccessfullyLockedRuns)
 		}
 
-		time.Sleep(1 * time.Millisecond)
+		if len(remainingOpts) > 0 {
+			time.Sleep(1 * time.Millisecond)
+		}
 	}
 
 	span.SetAttributes(

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -990,6 +990,8 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		var spanEventsForSuccessfullyLockedRuns []engineSpanEvent
 		var remainingOpts []sqlcv1.CreateTaskEventsOLAPParams
 
+		justProcessed := make(map[uuid.UUID]bool)
+
 		for ix, msg := range msgs {
 			taskMeta := taskIdsToMetas[msg.TaskId]
 
@@ -1009,8 +1011,12 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 				if ok {
 					spanEventsForSuccessfullyLockedRuns = append(spanEventsForSuccessfullyLockedRuns, spanEvent)
 				}
-				processedRunIDs[taskMeta.WorkflowRunID] = true
+				justProcessed[taskMeta.WorkflowRunID] = true
 			}
+		}
+
+		for runID := range justProcessed {
+			processedRunIDs[runID] = true
 		}
 
 		for _, opt := range opts {

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -520,15 +520,18 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 	}
 
 	attempts := 0
-	var failedOpts []*v1.V1TaskWithPayload
-	var succeededOpts []*v1.V1TaskWithPayload
 
 	for {
 		if attempts > 10 {
 			break
 		}
 
-		failedOpts = []*v1.V1TaskWithPayload{}
+		if len(createTaskOpts) == 0 {
+			break
+		}
+
+		failedOpts := make([]*v1.V1TaskWithPayload, 0)
+		succeededOpts := make([]*v1.V1TaskWithPayload, 0)
 
 		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTasks(ctx, tenantId, createTaskOpts)
 		if err != nil {
@@ -550,6 +553,7 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 		createTaskOpts = failedOpts
 		tc.emitStandaloneTaskRootSpans(ctx, tenantId, succeededOpts)
 		attempts++
+		// qq: do we want to sleep here?
 	}
 
 	return nil
@@ -596,32 +600,38 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 		createDAGOpts = append(createDAGOpts, msg.DAGWithData)
 	}
 
-	workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateDAGs(ctx, tenantId, createDAGOpts)
-	if err != nil {
-		return err
-	}
+	attempts := 0
 
-	var succeededOpts []*v1.DAGWithData
-	var failedOpts []*v1.DAGWithData
-
-	for _, opt := range createDAGOpts {
-		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[opt.ExternalID]; notAcquired {
-			failedOpts = append(failedOpts, opt)
-		} else {
-			succeededOpts = append(succeededOpts, opt)
+	for {
+		if attempts > 10 {
+			break
 		}
-	}
 
-	tc.emitWorkflowRunRootSpans(ctx, tenantId, succeededOpts)
+		if len(createDAGOpts) == 0 {
+			break
+		}
 
-	for _, opt := range failedOpts {
-		msg, err := tasktypes.CreatedDAGMessage(tenantId, opt)
+		workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateDAGs(ctx, tenantId, createDAGOpts)
 		if err != nil {
 			return err
 		}
-		if err := tc.mq.SendMessage(ctx, msgqueue.OLAP_QUEUE, msg); err != nil {
-			return err
+
+		failedOpts := make([]*v1.DAGWithData, 0)
+		succeededOpts := make([]*v1.DAGWithData, 0)
+
+		for _, opt := range createDAGOpts {
+			if _, notAcquired := workflowRunIdsOfLocksNotAcquired[opt.ExternalID]; notAcquired {
+				failedOpts = append(failedOpts, opt)
+			} else {
+				succeededOpts = append(succeededOpts, opt)
+			}
 		}
+
+		createDAGOpts = failedOpts
+		tc.emitWorkflowRunRootSpans(ctx, tenantId, succeededOpts)
+		attempts++
+
+		// qq: do we want to sleep here?
 	}
 
 	return nil

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -523,21 +523,19 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 		createTaskOpts = append(createTaskOpts, msg.V1TaskWithPayload)
 	}
 
-	attempts := 1
-	for {
-		if len(createTaskOpts) == 0 {
-			break
-		}
-
+	attempts := 0
+	for len(createTaskOpts) > 0 {
 		if attempts >= 10 {
-			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d tasks after 10 attempts, republishing to MQ", len(createTaskOpts))
+			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d tasks after %d attempts, republishing to MQ", len(createTaskOpts), attempts)
 			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
 		}
+
+		attempts++
 
 		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTasks(ctx, tenantId, createTaskOpts)
 
 		if err != nil {
-			tc.l.Error().Ctx(ctx).Msgf("failed to create tasks, republishing %d tasks: %v", len(createTaskOpts), err)
+			tc.l.Error().Ctx(ctx).Err(err).Msgf("failed to create %d tasks on attempt %d, republishing to MQ", len(createTaskOpts), attempts)
 			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
 		}
 
@@ -559,7 +557,6 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 
 		createTaskOpts = failedOpts
 		tc.emitStandaloneTaskRootSpans(ctx, tenantId, succeededOpts)
-		attempts++
 	}
 
 	span.SetAttributes(
@@ -613,20 +610,18 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 		createDAGOpts = append(createDAGOpts, msg.DAGWithData)
 	}
 
-	attempts := 1
-	for {
-		if len(createDAGOpts) == 0 {
-			break
-		}
-
+	attempts := 0
+	for len(createDAGOpts) > 0 {
 		if attempts >= 10 {
-			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d DAGs after 10 attempts, republishing to MQ", len(createDAGOpts))
+			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d DAGs after %d attempts, republishing to MQ", len(createDAGOpts), attempts)
 			return tc.republishCreatedDAGs(ctx, tenantId, createDAGOpts)
 		}
 
+		attempts++
+
 		workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateDAGs(ctx, tenantId, createDAGOpts)
 		if err != nil {
-			tc.l.Error().Ctx(ctx).Msgf("failed to create DAGs, republishing %d DAGs: %v", len(createDAGOpts), err)
+			tc.l.Error().Ctx(ctx).Err(err).Msgf("failed to create %d DAGs on attempt %d, republishing to MQ", len(createDAGOpts), attempts)
 			return tc.republishCreatedDAGs(ctx, tenantId, createDAGOpts)
 		}
 
@@ -643,7 +638,6 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 
 		createDAGOpts = failedOpts
 		tc.emitWorkflowRunRootSpans(ctx, tenantId, succeededOpts)
-		attempts++
 	}
 
 	span.SetAttributes(
@@ -1007,27 +1001,24 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 
 	processedRunIDs := make(map[uuid.UUID]bool)
 
-	attempts := 1
-	for {
-		if len(opts) == 0 {
-			break
-		}
-
+	attempts := 0
+	for len(opts) > 0 {
 		if attempts >= 10 {
-			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d monitoring events after 10 attempts, republishing to MQ", len(opts))
+			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d monitoring events after %d attempts, republishing to MQ", len(opts), attempts)
 			return tc.republishMonitoringEvents(ctx, tenantId, opts, externalIdToMsg)
 		}
+
+		attempts++
 
 		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTaskEvents(ctx, tenantId, opts, eventExternalIdToWorkflowRunId)
 
 		if err != nil {
-			tc.l.Error().Ctx(ctx).Msgf("failed to create task events, republishing %d events: %v", len(opts), err)
+			tc.l.Error().Ctx(ctx).Err(err).Msgf("failed to create %d task events on attempt %d, republishing to MQ", len(opts), attempts)
 			return tc.republishMonitoringEvents(ctx, tenantId, opts, externalIdToMsg)
 		}
 
 		if err := tc.notifyStatusUpdates(ctx, result); err != nil {
-			tc.l.Error().Ctx(ctx).Err(err).Msg("failed to notify status updates for created monitoring events")
-			return err
+			tc.l.Error().Ctx(ctx).Err(err).Msg("failed to notify status updates for created monitoring events, continuing to process remaining events")
 		}
 
 		var spanEventsForSuccessfullyLockedRuns []engineSpanEvent
@@ -1077,8 +1068,6 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		if len(spanEventsForSuccessfullyLockedRuns) > 0 {
 			tc.synthesizeEngineSpans(ctx, tenantId, spanEventsForSuccessfullyLockedRuns)
 		}
-
-		attempts++
 	}
 
 	span.SetAttributes(

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -508,18 +508,16 @@ func (tc *OLAPControllerImpl) handleCelEvaluationFailure(ctx context.Context, te
 // handleCreatedTask is responsible for flushing a created task to the OLAP repository
 func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uuid.UUID, payloads [][]byte) error {
 	createTaskOpts := make([]*v1.V1TaskWithPayload, 0)
-	msgIdxForOpt := make([]int, 0)
 
 	msgs := msgqueue.JSONConvert[tasktypes.CreatedTaskPayload](payloads)
 
-	for msgIdx, msg := range msgs {
+	for _, msg := range msgs {
 		if !tc.sample(msg.WorkflowRunID.String()) {
 			tc.l.Debug().Ctx(ctx).Msgf("skipping task %d for workflow run %s", msg.ID, msg.WorkflowRunID.String())
 			continue
 		}
 
 		createTaskOpts = append(createTaskOpts, msg.V1TaskWithPayload)
-		msgIdxForOpt = append(msgIdxForOpt, msgIdx)
 	}
 
 	result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTasks(ctx, tenantId, createTaskOpts)
@@ -531,20 +529,30 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 		return err
 	}
 
-	var succeededPayloads []*v1.V1TaskWithPayload
-	var failedPayloads [][]byte
+	var succeededOpts []*v1.V1TaskWithPayload
+	var failedOpts []*v1.V1TaskWithPayload
 
-	for optIdx, opt := range createTaskOpts {
+	for _, opt := range createTaskOpts {
 		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[opt.WorkflowRunID]; notAcquired {
-			failedPayloads = append(failedPayloads, payloads[msgIdxForOpt[optIdx]])
+			failedOpts = append(failedOpts, opt)
 		} else {
-			succeededPayloads = append(succeededPayloads, opt)
+			succeededOpts = append(succeededOpts, opt)
 		}
 	}
 
-	tc.emitStandaloneTaskRootSpans(ctx, tenantId, succeededPayloads)
+	tc.emitStandaloneTaskRootSpans(ctx, tenantId, succeededOpts)
 
-	return tc.republishPayloads(ctx, msgqueue.MsgIDCreatedTask, tenantId, failedPayloads)
+	for _, opt := range failedOpts {
+		msg, err := tasktypes.CreatedTaskMessage(tenantId, opt)
+		if err != nil {
+			return err
+		}
+		if err := tc.mq.SendMessage(ctx, msgqueue.OLAP_QUEUE, msg); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (tc *OLAPControllerImpl) emitStandaloneTaskRootSpans(ctx context.Context, tenantId uuid.UUID, tasks []*v1.V1TaskWithPayload) {
@@ -576,18 +584,16 @@ func (tc *OLAPControllerImpl) emitStandaloneTaskRootSpans(ctx context.Context, t
 // handleCreatedDAG is responsible for flushing a created DAG to the OLAP repository
 func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uuid.UUID, payloads [][]byte) error {
 	createDAGOpts := make([]*v1.DAGWithData, 0)
-	msgIdxForOpt := make([]int, 0)
 
 	msgs := msgqueue.JSONConvert[tasktypes.CreatedDAGPayload](payloads)
 
-	for msgIdx, msg := range msgs {
+	for _, msg := range msgs {
 		if !tc.sample(msg.ExternalID.String()) {
 			tc.l.Debug().Ctx(ctx).Msgf("skipping dag %s", msg.ExternalID.String())
 			continue
 		}
 
 		createDAGOpts = append(createDAGOpts, msg.DAGWithData)
-		msgIdxForOpt = append(msgIdxForOpt, msgIdx)
 	}
 
 	workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateDAGs(ctx, tenantId, createDAGOpts)
@@ -595,20 +601,30 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 		return err
 	}
 
-	var succeededPayloads []*v1.DAGWithData
-	var failedPayloads [][]byte
+	var succeededOpts []*v1.DAGWithData
+	var failedOpts []*v1.DAGWithData
 
-	for optIdx, opt := range createDAGOpts {
+	for _, opt := range createDAGOpts {
 		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[opt.ExternalID]; notAcquired {
-			failedPayloads = append(failedPayloads, payloads[msgIdxForOpt[optIdx]])
+			failedOpts = append(failedOpts, opt)
 		} else {
-			succeededPayloads = append(succeededPayloads, opt)
+			succeededOpts = append(succeededOpts, opt)
 		}
 	}
 
-	tc.emitWorkflowRunRootSpans(ctx, tenantId, succeededPayloads)
+	tc.emitWorkflowRunRootSpans(ctx, tenantId, succeededOpts)
 
-	return tc.republishPayloads(ctx, msgqueue.MsgIDCreatedDAG, tenantId, failedPayloads)
+	for _, opt := range failedOpts {
+		msg, err := tasktypes.CreatedDAGMessage(tenantId, opt)
+		if err != nil {
+			return err
+		}
+		if err := tc.mq.SendMessage(ctx, msgqueue.OLAP_QUEUE, msg); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (tc *OLAPControllerImpl) emitWorkflowRunRootSpans(ctx context.Context, tenantId uuid.UUID, dags []*v1.DAGWithData) {
@@ -816,9 +832,9 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 	timestamps := make([]pgtype.Timestamptz, 0)
 	eventExternalIds := make([]*uuid.UUID, 0)
 	var spanEvents []engineSpanEvent
-	msgIdxForOpt := make([]int, 0)
+	msgsForOpt := make([]*tasktypes.CreateMonitoringEventPayload, 0)
 
-	for msgIdx, msg := range msgs {
+	for _, msg := range msgs {
 		taskMeta := taskIdsToMetas[msg.TaskId]
 
 		if taskMeta == nil {
@@ -835,7 +851,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		taskInsertedAts = append(taskInsertedAts, taskMeta.InsertedAt)
 		workflowIds = append(workflowIds, taskMeta.WorkflowID)
 		workflowRunIDs = append(workflowRunIDs, taskMeta.WorkflowRunID)
-		msgIdxForOpt = append(msgIdxForOpt, msgIdx)
+		msgsForOpt = append(msgsForOpt, msg)
 		retryCounts = append(retryCounts, msg.RetryCount)
 		durableInvocationCounts = append(durableInvocationCounts, msg.DurableInvocationCount)
 		eventTypes = append(eventTypes, msg.EventType)
@@ -971,15 +987,16 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 
 	tc.synthesizeEngineSpans(ctx, tenantId, spanEvents)
 
-	var failedPayloads [][]byte
 	for optIdx, runId := range workflowRunIDs {
 		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[runId]; notAcquired {
-			failedPayloads = append(failedPayloads, payloads[msgIdxForOpt[optIdx]])
+			msg, err := tasktypes.MonitoringEventMessageFromInternal(tenantId, *msgsForOpt[optIdx])
+			if err != nil {
+				return err
+			}
+			if err := tc.mq.SendMessage(ctx, msgqueue.OLAP_QUEUE, msg); err != nil {
+				return err
+			}
 		}
-	}
-
-	if err := tc.republishPayloads(ctx, msgqueue.MsgIDCreateMonitoringEvent, tenantId, failedPayloads); err != nil {
-		return err
 	}
 
 	if !tc.repo.OLAP().PayloadStore().ExternalStoreEnabled() {
@@ -1061,20 +1078,6 @@ func (tc *OLAPControllerImpl) handleFailedWebhookValidation(ctx context.Context,
 	}
 
 	return tc.repo.OLAP().CreateIncomingWebhookValidationFailureLogs(ctx, tenantId, createFailedWebhookValidationOpts)
-}
-
-func (tc *OLAPControllerImpl) republishPayloads(ctx context.Context, msgID string, tenantId uuid.UUID, payloads [][]byte) error {
-	if len(payloads) == 0 {
-		return nil
-	}
-
-	return tc.mq.SendMessage(ctx, msgqueue.OLAP_QUEUE, &msgqueue.Message{
-		ID:         msgID,
-		TenantID:   tenantId,
-		Payloads:   payloads,
-		Persistent: true,
-		Retries:    5,
-	})
 }
 
 func (tc *OLAPControllerImpl) sample(workflowRunID string) bool {

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -519,28 +519,23 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 		createTaskOpts = append(createTaskOpts, msg.V1TaskWithPayload)
 	}
 
-	attempts := 0
-
-	for {
-		if attempts > 10 {
-			break
+	for attempts := 0; len(createTaskOpts) > 0; attempts++ {
+		if attempts >= 10 {
+			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
 		}
 
-		if len(createTaskOpts) == 0 {
-			break
+		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTasks(ctx, tenantId, createTaskOpts)
+
+		if err != nil {
+			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
+		}
+
+		if err := tc.notifyStatusUpdates(ctx, result); err != nil {
+			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
 		}
 
 		failedOpts := make([]*v1.V1TaskWithPayload, 0)
 		succeededOpts := make([]*v1.V1TaskWithPayload, 0)
-
-		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTasks(ctx, tenantId, createTaskOpts)
-		if err != nil {
-			return err
-		}
-
-		if err := tc.notifyStatusUpdates(ctx, result); err != nil {
-			return err
-		}
 
 		for _, opt := range createTaskOpts {
 			if _, notAcquired := workflowRunIdsOfLocksNotAcquired[opt.WorkflowRunID]; notAcquired {
@@ -552,8 +547,6 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 
 		createTaskOpts = failedOpts
 		tc.emitStandaloneTaskRootSpans(ctx, tenantId, succeededOpts)
-		attempts++
-		// qq: do we want to sleep here?
 	}
 
 	return nil
@@ -600,20 +593,14 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 		createDAGOpts = append(createDAGOpts, msg.DAGWithData)
 	}
 
-	attempts := 0
-
-	for {
-		if attempts > 10 {
-			break
-		}
-
-		if len(createDAGOpts) == 0 {
-			break
+	for attempts := 0; len(createDAGOpts) > 0; attempts++ {
+		if attempts >= 10 {
+			return tc.republishCreatedDAGs(ctx, tenantId, createDAGOpts)
 		}
 
 		workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateDAGs(ctx, tenantId, createDAGOpts)
 		if err != nil {
-			return err
+			return tc.republishCreatedDAGs(ctx, tenantId, createDAGOpts)
 		}
 
 		failedOpts := make([]*v1.DAGWithData, 0)
@@ -629,9 +616,6 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 
 		createDAGOpts = failedOpts
 		tc.emitWorkflowRunRootSpans(ctx, tenantId, succeededOpts)
-		attempts++
-
-		// qq: do we want to sleep here?
 	}
 
 	return nil
@@ -835,6 +819,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 	workerIds := make([]uuid.UUID, 0)
 	workflowIds := make([]uuid.UUID, 0)
 	eventExternalIdToWorkflowRunId := make(map[uuid.UUID]uuid.UUID)
+	externalIdToMsg := make(map[uuid.UUID]*tasktypes.CreateMonitoringEventPayload)
 	eventTypes := make([]sqlcv1.V1EventTypeOlap, 0)
 	readableStatuses := make([]sqlcv1.V1ReadableStatusOlap, 0)
 	eventPayloads := make([]string, 0)
@@ -869,6 +854,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		eventExternalIds = append(eventExternalIds, &externalId)
 
 		eventExternalIdToWorkflowRunId[externalId] = taskMeta.WorkflowRunID
+		externalIdToMsg[externalId] = msg
 
 		msgIxToSpanEvent[ix] = engineSpanEvent{
 			taskID:             msg.TaskId,
@@ -984,55 +970,112 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		opts = append(opts, event)
 	}
 
-	result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTaskEvents(ctx, tenantId, opts, eventExternalIdToWorkflowRunId)
+	processedRunIDs := make(map[uuid.UUID]bool)
 
-	if err != nil {
-		return err
-	}
-
-	if err := tc.notifyStatusUpdates(ctx, result); err != nil {
-		return err
-	}
-
-	var spanEventsForSuccessfullyLockedRuns []engineSpanEvent
-	var toRequeue []*tasktypes.CreateMonitoringEventPayload
-
-	for ix, msg := range msgs {
-		taskMeta := taskIdsToMetas[msg.TaskId]
-
-		if taskMeta == nil {
-			tc.l.Error().Ctx(ctx).Msgf("could not find task meta for task id %d", msg.TaskId)
-			continue
+	for attempts := 0; len(opts) > 0; attempts++ {
+		if attempts >= 10 {
+			return tc.republishMonitoringEvents(ctx, tenantId, opts, externalIdToMsg)
 		}
 
-		_, lockNotAcquired := workflowRunIdsOfLocksNotAcquired[taskMeta.WorkflowRunID]
+		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTaskEvents(ctx, tenantId, opts, eventExternalIdToWorkflowRunId)
 
-		if lockNotAcquired {
-			toRequeue = append(toRequeue, msg)
-		} else {
-			spanEvent, ok := msgIxToSpanEvent[ix]
-			if ok {
-				spanEventsForSuccessfullyLockedRuns = append(spanEventsForSuccessfullyLockedRuns, spanEvent)
+		if err != nil {
+			return tc.republishMonitoringEvents(ctx, tenantId, opts, externalIdToMsg)
+		}
+
+		if err := tc.notifyStatusUpdates(ctx, result); err != nil {
+			return err
+		}
+
+		var spanEventsForSuccessfullyLockedRuns []engineSpanEvent
+		var remainingOpts []sqlcv1.CreateTaskEventsOLAPParams
+
+		for ix, msg := range msgs {
+			taskMeta := taskIdsToMetas[msg.TaskId]
+
+			if taskMeta == nil {
+				tc.l.Error().Ctx(ctx).Msgf("could not find task meta for task id %d", msg.TaskId)
+				continue
+			}
+
+			if processedRunIDs[taskMeta.WorkflowRunID] {
+				continue
+			}
+
+			_, lockNotAcquired := workflowRunIdsOfLocksNotAcquired[taskMeta.WorkflowRunID]
+
+			if !lockNotAcquired {
+				spanEvent, ok := msgIxToSpanEvent[ix]
+				if ok {
+					spanEventsForSuccessfullyLockedRuns = append(spanEventsForSuccessfullyLockedRuns, spanEvent)
+				}
+				processedRunIDs[taskMeta.WorkflowRunID] = true
 			}
 		}
-	}
 
-	if len(spanEventsForSuccessfullyLockedRuns) > 0 {
-		tc.synthesizeEngineSpans(ctx, tenantId, spanEventsForSuccessfullyLockedRuns)
-	}
-
-	for _, incomingMsg := range toRequeue {
-		msg, err := tasktypes.MonitoringEventMessageFromInternal(tenantId, *incomingMsg)
-		if err != nil {
-			tc.l.Error().Ctx(ctx).Err(err).Msgf("could not create message for task id %d", incomingMsg.TaskId)
-			continue
+		for _, opt := range opts {
+			taskMeta := taskIdsToMetas[opt.TaskID]
+			if taskMeta == nil {
+				continue
+			}
+			if _, lockNotAcquired := workflowRunIdsOfLocksNotAcquired[taskMeta.WorkflowRunID]; lockNotAcquired {
+				remainingOpts = append(remainingOpts, opt)
+			}
 		}
 
+		opts = remainingOpts
+
+		if len(spanEventsForSuccessfullyLockedRuns) > 0 {
+			tc.synthesizeEngineSpans(ctx, tenantId, spanEventsForSuccessfullyLockedRuns)
+		}
+	}
+
+	return nil
+}
+
+func (tc *OLAPControllerImpl) republishCreatedTasks(ctx context.Context, tenantId uuid.UUID, tasks []*v1.V1TaskWithPayload) error {
+	for _, task := range tasks {
+		msg, err := tasktypes.CreatedTaskMessage(tenantId, task)
+		if err != nil {
+			return err
+		}
 		if err := tc.mq.SendMessage(ctx, msgqueue.OLAP_QUEUE, msg); err != nil {
 			return err
 		}
 	}
+	return nil
+}
 
+func (tc *OLAPControllerImpl) republishCreatedDAGs(ctx context.Context, tenantId uuid.UUID, dags []*v1.DAGWithData) error {
+	for _, dag := range dags {
+		msg, err := tasktypes.CreatedDAGMessage(tenantId, dag)
+		if err != nil {
+			return err
+		}
+		if err := tc.mq.SendMessage(ctx, msgqueue.OLAP_QUEUE, msg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (tc *OLAPControllerImpl) republishMonitoringEvents(ctx context.Context, tenantId uuid.UUID, opts []sqlcv1.CreateTaskEventsOLAPParams, externalIdToMsg map[uuid.UUID]*tasktypes.CreateMonitoringEventPayload) error {
+	for _, opt := range opts {
+		if opt.ExternalID == nil {
+			continue
+		}
+		payload, ok := externalIdToMsg[*opt.ExternalID]
+		if !ok {
+			continue
+		}
+		msg, err := tasktypes.MonitoringEventMessageFromInternal(tenantId, *payload)
+		if err != nil {
+			return err
+		}
+		if err := tc.mq.SendMessage(ctx, msgqueue.OLAP_QUEUE, msg); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -519,36 +519,37 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 		createTaskOpts = append(createTaskOpts, msg.V1TaskWithPayload)
 	}
 
-	result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTasks(ctx, tenantId, createTaskOpts)
-	if err != nil {
-		return err
-	}
-
-	if err := tc.notifyStatusUpdates(ctx, result); err != nil {
-		return err
-	}
-
-	var succeededOpts []*v1.V1TaskWithPayload
+	attempts := 0
 	var failedOpts []*v1.V1TaskWithPayload
+	var succeededOpts []*v1.V1TaskWithPayload
 
-	for _, opt := range createTaskOpts {
-		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[opt.WorkflowRunID]; notAcquired {
-			failedOpts = append(failedOpts, opt)
-		} else {
-			succeededOpts = append(succeededOpts, opt)
+	for {
+		if attempts > 10 {
+			break
 		}
-	}
 
-	tc.emitStandaloneTaskRootSpans(ctx, tenantId, succeededOpts)
+		failedOpts = []*v1.V1TaskWithPayload{}
 
-	for _, opt := range failedOpts {
-		msg, err := tasktypes.CreatedTaskMessage(tenantId, opt)
+		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTasks(ctx, tenantId, createTaskOpts)
 		if err != nil {
 			return err
 		}
-		if err := tc.mq.SendMessage(ctx, msgqueue.OLAP_QUEUE, msg); err != nil {
+
+		if err := tc.notifyStatusUpdates(ctx, result); err != nil {
 			return err
 		}
+
+		for _, opt := range createTaskOpts {
+			if _, notAcquired := workflowRunIdsOfLocksNotAcquired[opt.WorkflowRunID]; notAcquired {
+				failedOpts = append(failedOpts, opt)
+			} else {
+				succeededOpts = append(succeededOpts, opt)
+			}
+		}
+
+		createTaskOpts = failedOpts
+		tc.emitStandaloneTaskRootSpans(ctx, tenantId, succeededOpts)
+		attempts++
 	}
 
 	return nil

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
-	"math/rand"
 	"strings"
 	"sync"
 	"time"
@@ -1022,71 +1021,6 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 			return err
 		}
 	}
-
-	if !tc.repo.OLAP().PayloadStore().ExternalStoreEnabled() {
-		return nil
-	}
-
-	offloadToExternalOpts := make([]v1.OffloadToExternalStoreOpts, 0)
-	idInsertedAtToExternalId := make(map[v1.IdInsertedAt]*uuid.UUID)
-
-	for _, opt := range opts {
-		taskMeta := taskIdsToMetas[opt.TaskID]
-		_, lockNotAcquired := workflowRunIdsOfLocksNotAcquired[taskMeta.WorkflowRunID]
-
-		if lockNotAcquired {
-			continue
-		}
-
-		// generating a dummy id + inserted at to use for creating the external keys for the task events
-		// we do this since we don't have the id + inserted at of the events themselves on the opts, and we don't
-		// actually need those for anything once the keys are created.
-		dummyId := rand.Int63()
-		// randomly jitter the inserted at time by +/- 300ms to make collisions virtually impossible
-		dummyInsertedAt := time.Now().Add(time.Duration(rand.Intn(2*300+1)-300) * time.Millisecond)
-
-		idInsertedAtToExternalId[v1.IdInsertedAt{
-			ID:         dummyId,
-			InsertedAt: sqlchelpers.TimestamptzFromTime(dummyInsertedAt),
-		}] = opt.ExternalID
-
-		offloadToExternalOpts = append(offloadToExternalOpts, v1.OffloadToExternalStoreOpts{
-			TenantId:   tenantId,
-			ExternalID: *opt.ExternalID,
-			InsertedAt: sqlchelpers.TimestamptzFromTime(dummyInsertedAt),
-			Payload:    opt.Output,
-		})
-	}
-
-	if len(offloadToExternalOpts) == 0 {
-		return nil
-	}
-
-	// retrieveOptsToKey, err := tc.repo.OLAP().PayloadStore().ExternalStore().Store(ctx, offloadToExternalOpts...)
-
-	// if err != nil {
-	// 	return err
-	// }
-
-	// offloadOpts := make([]v1.OffloadPayloadOpts, 0)
-
-	// for opt, key := range retrieveOptsToKey {
-	// 	externalId := idInsertedAtToExternalId[v1.IdInsertedAt{
-	// 		ID:         opt.Id,
-	// 		InsertedAt: opt.InsertedAt,
-	// 	}]
-
-	// 	offloadOpts = append(offloadOpts, v1.OffloadPayloadOpts{
-	// 		ExternalId:          externalId,
-	// 		ExternalLocationKey: string(key),
-	// 	})
-	// }
-
-	// err = tc.repo.OLAP().OffloadPayloads(ctx, tenantId, offloadOpts)
-
-	// if err != nil {
-	// 	return err
-	// }
 
 	return nil
 }

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -525,13 +525,13 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 
 	attempts := 1
 	for {
+		if len(createTaskOpts) == 0 {
+			break
+		}
+
 		if attempts >= 10 {
 			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d tasks after 10 attempts, republishing to MQ", len(createTaskOpts))
 			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
-		}
-
-		if len(createTaskOpts) == 0 {
-			break
 		}
 
 		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTasks(ctx, tenantId, createTaskOpts)
@@ -615,13 +615,13 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 
 	attempts := 1
 	for {
+		if len(createDAGOpts) == 0 {
+			break
+		}
+
 		if attempts >= 10 {
 			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d DAGs after 10 attempts, republishing to MQ", len(createDAGOpts))
 			return tc.republishCreatedDAGs(ctx, tenantId, createDAGOpts)
-		}
-
-		if len(createDAGOpts) == 0 {
-			break
 		}
 
 		workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateDAGs(ctx, tenantId, createDAGOpts)
@@ -1009,13 +1009,13 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 
 	attempts := 1
 	for {
+		if len(opts) == 0 {
+			break
+		}
+
 		if attempts >= 10 {
 			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d monitoring events after 10 attempts, republishing to MQ", len(opts))
 			return tc.republishMonitoringEvents(ctx, tenantId, opts, externalIdToMsg)
-		}
-
-		if len(opts) == 0 {
-			break
 		}
 
 		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTaskEvents(ctx, tenantId, opts, eventExternalIdToWorkflowRunId)
@@ -1117,8 +1117,10 @@ func (tc *OLAPControllerImpl) republishCreatedDAGs(ctx context.Context, tenantId
 func (tc *OLAPControllerImpl) republishMonitoringEvents(ctx context.Context, tenantId uuid.UUID, opts []sqlcv1.CreateTaskEventsOLAPParams, externalIdToMsg map[uuid.UUID]*tasktypes.CreateMonitoringEventPayload) error {
 	for _, opt := range opts {
 		if opt.ExternalID == nil {
+			tc.l.Error().Ctx(ctx).Msgf("cannot republish monitoring event for task event with nil external ID, task ID: %d", opt.TaskID)
 			continue
 		}
+
 		payload, ok := externalIdToMsg[*opt.ExternalID]
 		if !ok {
 			continue

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/rs/zerolog"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 
 	"github.com/hatchet-dev/hatchet/internal/datautils"
@@ -506,6 +507,9 @@ func (tc *OLAPControllerImpl) handleCelEvaluationFailure(ctx context.Context, te
 
 // handleCreatedTask is responsible for flushing a created task to the OLAP repository
 func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uuid.UUID, payloads [][]byte) error {
+	ctx, span := telemetry.NewSpan(ctx, "OLAPControllerImpl.handleCreatedTask")
+	defer span.End()
+
 	createTaskOpts := make([]*v1.V1TaskWithPayload, 0)
 
 	msgs := msgqueue.JSONConvert[tasktypes.CreatedTaskPayload](payloads)
@@ -519,18 +523,26 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 		createTaskOpts = append(createTaskOpts, msg.V1TaskWithPayload)
 	}
 
-	for attempts := 0; len(createTaskOpts) > 0; attempts++ {
+	attempts := 1
+	for {
 		if attempts >= 10 {
+			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d tasks after 10 attempts, republishing to MQ", len(createTaskOpts))
 			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
+		}
+
+		if len(createTaskOpts) == 0 {
+			break
 		}
 
 		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTasks(ctx, tenantId, createTaskOpts)
 
 		if err != nil {
+			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d tasks after 10 attempts, republishing to MQ", len(createTaskOpts))
 			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
 		}
 
 		if err := tc.notifyStatusUpdates(ctx, result); err != nil {
+			tc.l.Error().Ctx(ctx).Err(err).Msg("failed to notify status updates for created tasks")
 			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
 		}
 
@@ -547,9 +559,12 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 
 		createTaskOpts = failedOpts
 		tc.emitStandaloneTaskRootSpans(ctx, tenantId, succeededOpts)
-
-		time.Sleep(25 * time.Millisecond)
+		attempts++
 	}
+
+	span.SetAttributes(
+		attribute.Int("attempts", attempts),
+	)
 
 	return nil
 }
@@ -582,6 +597,9 @@ func (tc *OLAPControllerImpl) emitStandaloneTaskRootSpans(ctx context.Context, t
 
 // handleCreatedDAG is responsible for flushing a created DAG to the OLAP repository
 func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uuid.UUID, payloads [][]byte) error {
+	ctx, span := telemetry.NewSpan(ctx, "OLAPControllerImpl.handleCreatedDAG")
+	defer span.End()
+
 	createDAGOpts := make([]*v1.DAGWithData, 0)
 
 	msgs := msgqueue.JSONConvert[tasktypes.CreatedDAGPayload](payloads)
@@ -595,13 +613,20 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 		createDAGOpts = append(createDAGOpts, msg.DAGWithData)
 	}
 
-	for attempts := 0; len(createDAGOpts) > 0; attempts++ {
+	attempts := 1
+	for {
 		if attempts >= 10 {
+			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d DAGs after 10 attempts, republishing to MQ", len(createDAGOpts))
 			return tc.republishCreatedDAGs(ctx, tenantId, createDAGOpts)
+		}
+
+		if len(createDAGOpts) == 0 {
+			break
 		}
 
 		workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateDAGs(ctx, tenantId, createDAGOpts)
 		if err != nil {
+			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d DAGs after 10 attempts, republishing to MQ", len(createDAGOpts))
 			return tc.republishCreatedDAGs(ctx, tenantId, createDAGOpts)
 		}
 
@@ -618,9 +643,12 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 
 		createDAGOpts = failedOpts
 		tc.emitWorkflowRunRootSpans(ctx, tenantId, succeededOpts)
-
-		time.Sleep(25 * time.Millisecond)
+		attempts++
 	}
+
+	span.SetAttributes(
+		attribute.Int("attempts", attempts),
+	)
 
 	return nil
 }
@@ -796,6 +824,9 @@ func (tc *OLAPControllerImpl) emitEventSpans(ctx context.Context, tenantId uuid.
 
 // handleCreateMonitoringEvent is responsible for sending a group of monitoring events to the OLAP repository
 func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, tenantId uuid.UUID, payloads [][]byte) error {
+	ctx, span := telemetry.NewSpan(ctx, "OLAPControllerImpl.handleCreateMonitoringEvent")
+	defer span.End()
+
 	msgs := msgqueue.JSONConvert[tasktypes.CreateMonitoringEventPayload](payloads)
 
 	taskIdsToLookup := make([]int64, len(msgs))
@@ -976,18 +1007,26 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 
 	processedRunIDs := make(map[uuid.UUID]bool)
 
-	for attempts := 0; len(opts) > 0; attempts++ {
+	attempts := 1
+	for {
 		if attempts >= 10 {
+			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d monitoring events after 10 attempts, republishing to MQ", len(opts))
 			return tc.republishMonitoringEvents(ctx, tenantId, opts, externalIdToMsg)
+		}
+
+		if len(opts) == 0 {
+			break
 		}
 
 		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTaskEvents(ctx, tenantId, opts, eventExternalIdToWorkflowRunId)
 
 		if err != nil {
+			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d monitoring events after 10 attempts, republishing to MQ", len(opts))
 			return tc.republishMonitoringEvents(ctx, tenantId, opts, externalIdToMsg)
 		}
 
 		if err := tc.notifyStatusUpdates(ctx, result); err != nil {
+			tc.l.Error().Ctx(ctx).Err(err).Msg("failed to notify status updates for created monitoring events")
 			return err
 		}
 
@@ -1039,8 +1078,12 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 			tc.synthesizeEngineSpans(ctx, tenantId, spanEventsForSuccessfullyLockedRuns)
 		}
 
-		time.Sleep(25 * time.Millisecond)
+		attempts++
 	}
+
+	span.SetAttributes(
+		attribute.Int("attempts", attempts),
+	)
 
 	return nil
 }

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -557,6 +557,7 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 
 		createTaskOpts = failedOpts
 		tc.emitStandaloneTaskRootSpans(ctx, tenantId, succeededOpts)
+		time.Sleep(1 * time.Millisecond)
 	}
 
 	span.SetAttributes(
@@ -638,6 +639,7 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 
 		createDAGOpts = failedOpts
 		tc.emitWorkflowRunRootSpans(ctx, tenantId, succeededOpts)
+		time.Sleep(1 * time.Millisecond)
 	}
 
 	span.SetAttributes(
@@ -1068,6 +1070,8 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		if len(spanEventsForSuccessfullyLockedRuns) > 0 {
 			tc.synthesizeEngineSpans(ctx, tenantId, spanEventsForSuccessfullyLockedRuns)
 		}
+
+		time.Sleep(1 * time.Millisecond)
 	}
 
 	span.SetAttributes(

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -1000,8 +1000,10 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		if lockNotAcquired {
 			toRequeue = append(toRequeue, msg)
 		} else {
-			spanEvent := msgIxToSpanEvent[ix]
-			spanEventsForSuccessfullyLockedRuns = append(spanEventsForSuccessfullyLockedRuns, spanEvent)
+			spanEvent, ok := msgIxToSpanEvent[ix]
+			if ok {
+				spanEventsForSuccessfullyLockedRuns = append(spanEventsForSuccessfullyLockedRuns, spanEvent)
+			}
 		}
 	}
 
@@ -1012,7 +1014,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 	for _, incomingMsg := range toRequeue {
 		msg, err := tasktypes.MonitoringEventMessageFromInternal(tenantId, *incomingMsg)
 		if err != nil {
-			tc.l.Error().Ctx(ctx).Err(err).Msgf("could not create message for workflow run id %d", incomingMsg.TaskId)
+			tc.l.Error().Ctx(ctx).Err(err).Msgf("could not create message for task id %d", incomingMsg.TaskId)
 			continue
 		}
 

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -243,9 +243,9 @@ type OLAPRepository interface {
 	ListTaskRunEventsByWorkflowRunId(ctx context.Context, tenantId uuid.UUID, workflowRunId uuid.UUID) ([]*TaskEventWithPayloads, error)
 	ListWorkflowRunDisplayNames(ctx context.Context, tenantId uuid.UUID, externalIds []uuid.UUID) ([]*sqlcv1.ListWorkflowRunDisplayNamesRow, error)
 	ReadTaskRunMetrics(ctx context.Context, tenantId uuid.UUID, opts ReadTaskRunMetricsOpts) ([]TaskRunMetric, error)
-	CreateTasks(ctx context.Context, tenantId uuid.UUID, tasks []*V1TaskWithPayload) (*StatusUpdateResult, error)
-	CreateTaskEvents(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, workflowRunIds []uuid.UUID) (*StatusUpdateResult, error)
-	CreateDAGs(ctx context.Context, tenantId uuid.UUID, dags []*DAGWithData) error
+	CreateTasks(ctx context.Context, tenantId uuid.UUID, tasks []*V1TaskWithPayload) (*StatusUpdateResult, map[uuid.UUID]struct{}, error)
+	CreateTaskEvents(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, workflowRunIds []uuid.UUID) (*StatusUpdateResult, map[uuid.UUID]struct{}, error)
+	CreateDAGs(ctx context.Context, tenantId uuid.UUID, dags []*DAGWithData) (map[uuid.UUID]struct{}, error)
 	GetTaskPointMetrics(ctx context.Context, tenantId uuid.UUID, startTimestamp *time.Time, endTimestamp *time.Time, bucketInterval time.Duration) ([]*sqlcv1.GetTaskPointMetricsRow, error)
 	UpdateTaskStatuses(ctx context.Context, tenantIds []uuid.UUID) (bool, []UpdateTaskStatusRow, error)
 	UpdateDAGStatuses(ctx context.Context, tenantIds []uuid.UUID) (bool, []UpdateDAGStatusRow, error)
@@ -1711,12 +1711,68 @@ func (r *OLAPRepositoryImpl) acquireAdvisoryLocksForWorkflowRuns(ctx context.Con
 	return nil
 }
 
-func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, workflowRunIds []uuid.UUID) (*StatusUpdateResult, error) {
+func (r *OLAPRepositoryImpl) tryAcquireAdvisoryLocksForWorkflowRuns(ctx context.Context, tx pgx.Tx, workflowRunIds []uuid.UUID) (locksNotAcquired map[uuid.UUID]struct{}, err error) {
+	seen := make(map[uuid.UUID]struct{}, len(workflowRunIds))
+	type keyAndID struct {
+		key           int64
+		workflowRunId uuid.UUID
+	}
+	keyWorkflowRunIdTuples := make([]keyAndID, 0, len(workflowRunIds))
+
+	for _, id := range workflowRunIds {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		keyWorkflowRunIdTuples = append(keyWorkflowRunIdTuples, keyAndID{key: workflowRunAdvisoryInt(id), workflowRunId: id})
+	}
+
+	slices.SortFunc(keyWorkflowRunIdTuples, func(a, b keyAndID) int {
+		if a.key < b.key {
+			return -1
+		}
+		if a.key > b.key {
+			return 1
+		}
+		return 0
+	})
+
+	locksNotAcquired = make(map[uuid.UUID]struct{})
+
+	for _, t := range keyWorkflowRunIdTuples {
+		acquired, err := r.queries.TryAdvisoryLock(ctx, tx, t.key)
+		if err != nil {
+			return nil, fmt.Errorf("error trying advisory lock for workflow run: %w", err)
+		}
+		if !acquired {
+			locksNotAcquired[t.workflowRunId] = struct{}{}
+		}
+	}
+
+	return locksNotAcquired, nil
+}
+
+func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, workflowRunIds []uuid.UUID) (*StatusUpdateResult, map[uuid.UUID]struct{}, error) {
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rollback()
+
+	workflowRunIdsOfLocksNotAcquired, err := r.tryAcquireAdvisoryLocksForWorkflowRuns(ctx, tx, workflowRunIds)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	eventsToWrite := make([]sqlcv1.CreateTaskEventsOLAPParams, 0)
 	eventsForStatusUpdate := make([]sqlcv1.CreateTaskEventsOLAPParams, 0, len(events))
 	payloadsToWrite := make([]StoreOLAPPayloadOpts, 0)
 
-	for _, event := range events {
+	for i, event := range events {
+		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[workflowRunIds[i]]; notAcquired {
+			continue
+		}
+
 		key := getCacheKey(event)
 		output := event.Output
 
@@ -1742,23 +1798,13 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 	}
 
 	if len(eventsForStatusUpdate) == 0 {
-		return nil, nil
-	}
-
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
-	if err != nil {
-		return nil, err
-	}
-	defer rollback()
-
-	if err := r.acquireAdvisoryLocksForWorkflowRuns(ctx, tx, workflowRunIds); err != nil {
-		return nil, err
+		return nil, workflowRunIdsOfLocksNotAcquired, nil
 	}
 
 	if len(eventsToWrite) > 0 {
 		_, err = r.queries.CreateTaskEventsOLAP(ctx, tx, eventsToWrite)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
@@ -1767,7 +1813,7 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 
 	taskRows, err := r.queries.UpdateTaskStatusesFromMQ(ctx, tx, statusUpdates)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	for _, row := range taskRows {
@@ -1793,7 +1839,7 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 	if len(dagStatusUpdates.Dagids) > 0 {
 		dagRows, err = r.queries.UpdateDAGStatusesFromMQ(ctx, tx, dagStatusUpdates)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		for _, row := range dagRows {
@@ -1813,17 +1859,17 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 	if len(payloadsToWrite) > 0 {
 		_, err = r.PutPayloads(ctx, tx, tenantId, payloadsToWrite...)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
 	if err := commit(ctx); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	r.saveEventsToCache(eventsToWrite)
 
-	return result, nil
+	return result, workflowRunIdsOfLocksNotAcquired, nil
 }
 
 func (r *OLAPRepositoryImpl) UpdateTaskStatuses(ctx context.Context, tenantIds []uuid.UUID) (bool, []UpdateTaskStatusRow, error) {
@@ -2058,12 +2104,32 @@ func (r *OLAPRepositoryImpl) UpdateDAGStatuses(ctx context.Context, tenantIds []
 	return isSaturated, rows, nil
 }
 
-func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId uuid.UUID, tasks []*V1TaskWithPayload) (*StatusUpdateResult, error) {
+func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId uuid.UUID, tasks []*V1TaskWithPayload) (*StatusUpdateResult, map[uuid.UUID]struct{}, error) {
+	workflowRunIds := make([]uuid.UUID, len(tasks))
+	for i, task := range tasks {
+		workflowRunIds[i] = task.WorkflowRunID
+	}
+
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rollback()
+
+	workflowRunIdsOfLocksNotAcquired, err := r.tryAcquireAdvisoryLocksForWorkflowRuns(ctx, tx, workflowRunIds)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	params := sqlcv1.CreateTasksOLAPParams{}
 	putPayloadOpts := make([]StoreOLAPPayloadOpts, 0)
 	minInsertedAt := pgtype.Timestamptz{}
 
 	for _, task := range tasks {
+		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[task.WorkflowRunID]; notAcquired {
+			continue
+		}
+
 		payload := task.Payload
 
 		// fall back to input if payload is empty
@@ -2113,19 +2179,13 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId uuid.U
 		})
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
-	if err != nil {
-		return nil, err
-	}
-	defer rollback()
-
-	if err := r.acquireAdvisoryLocksForWorkflowRuns(ctx, tx, params.Workflowrunids); err != nil {
-		return nil, err
+	if len(params.Ids) == 0 {
+		return nil, workflowRunIdsOfLocksNotAcquired, nil
 	}
 
 	err = r.queries.CreateTasksOLAP(ctx, tx, params)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	reconciledTasks, err := r.queries.ReconcileTaskStatusesFromEvents(ctx, tx, sqlcv1.ReconcileTaskStatusesFromEventsParams{
@@ -2134,7 +2194,7 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId uuid.U
 		Mininsertedat:   minInsertedAt,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to reconcile task statuses from events: %w", err)
+		return nil, nil, fmt.Errorf("failed to reconcile task statuses from events: %w", err)
 	}
 
 	var dagRows []*sqlcv1.UpdateDAGStatusesFromMQRow
@@ -2157,18 +2217,18 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId uuid.U
 		if len(dagStatusUpdates.Dagids) > 0 {
 			dagRows, err = r.queries.UpdateDAGStatusesFromMQ(ctx, tx, dagStatusUpdates)
 			if err != nil {
-				return nil, fmt.Errorf("failed to update DAG statuses after reconcile: %w", err)
+				return nil, nil, fmt.Errorf("failed to update DAG statuses after reconcile: %w", err)
 			}
 		}
 	}
 
 	_, err = r.PutPayloads(ctx, tx, tenantId, putPayloadOpts...)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if err := commit(ctx); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	result := &StatusUpdateResult{
@@ -2186,14 +2246,34 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId uuid.U
 		})
 	}
 
-	return result, nil
+	return result, workflowRunIdsOfLocksNotAcquired, nil
 }
 
-func (r *OLAPRepositoryImpl) writeDAGBatch(ctx context.Context, tenantId uuid.UUID, dags []*DAGWithData) error {
+func (r *OLAPRepositoryImpl) writeDAGBatch(ctx context.Context, tenantId uuid.UUID, dags []*DAGWithData) (map[uuid.UUID]struct{}, error) {
+	dagIds := make([]uuid.UUID, len(dags))
+	for i, dag := range dags {
+		dagIds[i] = dag.ExternalID
+	}
+
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
+	if err != nil {
+		return nil, err
+	}
+	defer rollback()
+
+	workflowRunIdsOfLocksNotAcquired, err := r.tryAcquireAdvisoryLocksForWorkflowRuns(ctx, tx, dagIds)
+	if err != nil {
+		return nil, err
+	}
+
 	params := sqlcv1.CreateDAGsOLAPOverwriteParams{}
 	putPayloadOpts := make([]StoreOLAPPayloadOpts, 0)
 
 	for _, dag := range dags {
+		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[dag.ExternalID]; notAcquired {
+			continue
+		}
+
 		// todo: remove this when we remove dual writes
 		input := dag.Input
 		if !r.payloadStore.OLAPDualWritesEnabled() {
@@ -2219,42 +2299,36 @@ func (r *OLAPRepositoryImpl) writeDAGBatch(ctx context.Context, tenantId uuid.UU
 		})
 	}
 
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
-	if err != nil {
-		return err
-	}
-	defer rollback()
-
-	if err := r.acquireAdvisoryLocksForWorkflowRuns(ctx, tx, params.Externalids); err != nil {
-		return err
+	if len(params.Ids) == 0 {
+		return workflowRunIdsOfLocksNotAcquired, nil
 	}
 
 	err = r.queries.CreateDAGsOLAP(ctx, tx, params)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	_, err = r.PutPayloads(ctx, tx, tenantId, putPayloadOpts...)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := commit(ctx); err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return workflowRunIdsOfLocksNotAcquired, nil
 }
 
-func (r *OLAPRepositoryImpl) CreateTaskEvents(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, workflowRunIds []uuid.UUID) (*StatusUpdateResult, error) {
+func (r *OLAPRepositoryImpl) CreateTaskEvents(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, workflowRunIds []uuid.UUID) (*StatusUpdateResult, map[uuid.UUID]struct{}, error) {
 	return r.writeTaskEventBatch(ctx, tenantId, events, workflowRunIds)
 }
 
-func (r *OLAPRepositoryImpl) CreateTasks(ctx context.Context, tenantId uuid.UUID, tasks []*V1TaskWithPayload) (*StatusUpdateResult, error) {
+func (r *OLAPRepositoryImpl) CreateTasks(ctx context.Context, tenantId uuid.UUID, tasks []*V1TaskWithPayload) (*StatusUpdateResult, map[uuid.UUID]struct{}, error) {
 	return r.writeTaskBatch(ctx, tenantId, tasks)
 }
 
-func (r *OLAPRepositoryImpl) CreateDAGs(ctx context.Context, tenantId uuid.UUID, dags []*DAGWithData) error {
+func (r *OLAPRepositoryImpl) CreateDAGs(ctx context.Context, tenantId uuid.UUID, dags []*DAGWithData) (map[uuid.UUID]struct{}, error) {
 	return r.writeDAGBatch(ctx, tenantId, dags)
 }
 

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -1689,7 +1689,8 @@ func workflowRunAdvisoryInt(id uuid.UUID) int64 {
 	return int64(hasher.Sum64()) // nolint: gosec
 }
 
-func (r *OLAPRepositoryImpl) acquireAdvisoryLocksForWorkflowRuns(ctx context.Context, tx pgx.Tx, workflowRunIds []uuid.UUID) error {
+func (r *OLAPRepositoryImpl) tryAcquireAdvisoryLocksForWorkflowRuns(ctx context.Context, tx pgx.Tx, workflowRunIds []uuid.UUID) (locksNotAcquired map[uuid.UUID]struct{}, err error) {
+	keyToWorkflowRunId := make(map[int64]uuid.UUID, len(workflowRunIds))
 	seen := make(map[uuid.UUID]struct{}, len(workflowRunIds))
 	keys := make([]int64, 0, len(workflowRunIds))
 
@@ -1699,53 +1700,31 @@ func (r *OLAPRepositoryImpl) acquireAdvisoryLocksForWorkflowRuns(ctx context.Con
 		}
 
 		seen[id] = struct{}{}
-		keys = append(keys, workflowRunAdvisoryInt(id))
+		key := workflowRunAdvisoryInt(id)
+		keys = append(keys, key)
+		keyToWorkflowRunId[key] = id
 	}
 
 	slices.Sort(keys)
 
-	if err := r.queries.AdvisoryLockMany(ctx, tx, keys); err != nil {
-		return fmt.Errorf("failed to acquire advisory locks for workflow run: %w", err)
-	}
-
-	return nil
-}
-
-func (r *OLAPRepositoryImpl) tryAcquireAdvisoryLocksForWorkflowRuns(ctx context.Context, tx pgx.Tx, workflowRunIds []uuid.UUID) (locksNotAcquired map[uuid.UUID]struct{}, err error) {
-	seen := make(map[uuid.UUID]struct{}, len(workflowRunIds))
-	type keyAndID struct {
-		key           int64
-		workflowRunId uuid.UUID
-	}
-	keyWorkflowRunIdTuples := make([]keyAndID, 0, len(workflowRunIds))
-
-	for _, id := range workflowRunIds {
-		if _, ok := seen[id]; ok {
-			continue
-		}
-		seen[id] = struct{}{}
-		keyWorkflowRunIdTuples = append(keyWorkflowRunIdTuples, keyAndID{key: workflowRunAdvisoryInt(id), workflowRunId: id})
-	}
-
-	slices.SortFunc(keyWorkflowRunIdTuples, func(a, b keyAndID) int {
-		if a.key < b.key {
-			return -1
-		}
-		if a.key > b.key {
-			return 1
-		}
-		return 0
-	})
-
 	locksNotAcquired = make(map[uuid.UUID]struct{})
 
-	for _, t := range keyWorkflowRunIdTuples {
-		acquired, err := r.queries.TryAdvisoryLock(ctx, tx, t.key)
-		if err != nil {
-			return nil, fmt.Errorf("error trying advisory lock for workflow run: %w", err)
-		}
-		if !acquired {
-			locksNotAcquired[t.workflowRunId] = struct{}{}
+	lockResults, err := r.queries.TryAdvisoryLockMany(ctx, tx, keys)
+
+	if err != nil {
+		return nil, fmt.Errorf("error trying advisory lock for workflow run: %w", err)
+	}
+
+	for _, lock := range lockResults {
+		if !lock.Acquired {
+			workflowRunId, ok := keyToWorkflowRunId[lock.Key]
+
+			if !ok {
+				r.l.Error().Ctx(ctx).Msgf("could not find workflow run id for advisory lock key %d", lock.Key)
+				continue
+			}
+
+			locksNotAcquired[workflowRunId] = struct{}{}
 		}
 	}
 

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -1754,6 +1754,12 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 	payloadsToWrite := make([]StoreOLAPPayloadOpts, 0)
 
 	for _, event := range events {
+		if event.ExternalID == nil {
+			// note: this case shouldn't happen, just here for type safety
+			r.l.Error().Ctx(ctx).Msgf("event with ts %s and type %s has nil external id, skipping", event.EventTimestamp.Time.String(), event.EventType)
+			continue
+		}
+
 		workflowRunId, ok := eventExternalIdToWorkflowRunId[*event.ExternalID]
 
 		if !ok {

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -244,7 +244,7 @@ type OLAPRepository interface {
 	ListWorkflowRunDisplayNames(ctx context.Context, tenantId uuid.UUID, externalIds []uuid.UUID) ([]*sqlcv1.ListWorkflowRunDisplayNamesRow, error)
 	ReadTaskRunMetrics(ctx context.Context, tenantId uuid.UUID, opts ReadTaskRunMetricsOpts) ([]TaskRunMetric, error)
 	CreateTasks(ctx context.Context, tenantId uuid.UUID, tasks []*V1TaskWithPayload) (*StatusUpdateResult, map[uuid.UUID]struct{}, error)
-	CreateTaskEvents(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, workflowRunIds []uuid.UUID) (*StatusUpdateResult, map[uuid.UUID]struct{}, error)
+	CreateTaskEvents(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, eventExternalIdToWorkflowRunId map[uuid.UUID]uuid.UUID) (*StatusUpdateResult, map[uuid.UUID]struct{}, error)
 	CreateDAGs(ctx context.Context, tenantId uuid.UUID, dags []*DAGWithData) (map[uuid.UUID]struct{}, error)
 	GetTaskPointMetrics(ctx context.Context, tenantId uuid.UUID, startTimestamp *time.Time, endTimestamp *time.Time, bucketInterval time.Duration) ([]*sqlcv1.GetTaskPointMetricsRow, error)
 	UpdateTaskStatuses(ctx context.Context, tenantIds []uuid.UUID) (bool, []UpdateTaskStatusRow, error)
@@ -1731,12 +1731,18 @@ func (r *OLAPRepositoryImpl) tryAcquireAdvisoryLocksForWorkflowRuns(ctx context.
 	return locksNotAcquired, nil
 }
 
-func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, workflowRunIds []uuid.UUID) (*StatusUpdateResult, map[uuid.UUID]struct{}, error) {
+func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, eventExternalIdToWorkflowRunId map[uuid.UUID]uuid.UUID) (*StatusUpdateResult, map[uuid.UUID]struct{}, error) {
 	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 	if err != nil {
 		return nil, nil, err
 	}
 	defer rollback()
+
+	workflowRunIds := make([]uuid.UUID, 0, len(events))
+
+	for _, workflowRunId := range eventExternalIdToWorkflowRunId {
+		workflowRunIds = append(workflowRunIds, workflowRunId)
+	}
 
 	workflowRunIdsOfLocksNotAcquired, err := r.tryAcquireAdvisoryLocksForWorkflowRuns(ctx, tx, workflowRunIds)
 	if err != nil {
@@ -1747,8 +1753,15 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 	eventsForStatusUpdate := make([]sqlcv1.CreateTaskEventsOLAPParams, 0, len(events))
 	payloadsToWrite := make([]StoreOLAPPayloadOpts, 0)
 
-	for i, event := range events {
-		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[workflowRunIds[i]]; notAcquired {
+	for _, event := range events {
+		workflowRunId, ok := eventExternalIdToWorkflowRunId[*event.ExternalID]
+
+		if !ok {
+			r.l.Error().Ctx(ctx).Msgf("could not find workflow run id for event with external id %s", *event.ExternalID)
+			continue
+		}
+
+		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[workflowRunId]; notAcquired {
 			continue
 		}
 
@@ -2299,8 +2312,8 @@ func (r *OLAPRepositoryImpl) writeDAGBatch(ctx context.Context, tenantId uuid.UU
 	return workflowRunIdsOfLocksNotAcquired, nil
 }
 
-func (r *OLAPRepositoryImpl) CreateTaskEvents(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, workflowRunIds []uuid.UUID) (*StatusUpdateResult, map[uuid.UUID]struct{}, error) {
-	return r.writeTaskEventBatch(ctx, tenantId, events, workflowRunIds)
+func (r *OLAPRepositoryImpl) CreateTaskEvents(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, eventExternalIdToWorkflowRunId map[uuid.UUID]uuid.UUID) (*StatusUpdateResult, map[uuid.UUID]struct{}, error) {
+	return r.writeTaskEventBatch(ctx, tenantId, events, eventExternalIdToWorkflowRunId)
 }
 
 func (r *OLAPRepositoryImpl) CreateTasks(ctx context.Context, tenantId uuid.UUID, tasks []*V1TaskWithPayload) (*StatusUpdateResult, map[uuid.UUID]struct{}, error) {

--- a/pkg/repository/sqlcv1/concurrency.sql
+++ b/pkg/repository/sqlcv1/concurrency.sql
@@ -144,7 +144,7 @@ WHERE
 -- name: AdvisoryLock :exec
 SELECT pg_advisory_xact_lock(@key::bigint);
 
--- name: AdvisoryLockMany :exec
+-- name: TryAdvisoryLockMany :many
 WITH keys AS (
     SELECT UNNEST(@keys::BIGINT[]) AS key
 ), ordered_keys AS (
@@ -153,7 +153,7 @@ WITH keys AS (
     ORDER BY key
 )
 
-SELECT pg_advisory_xact_lock(key)
+SELECT key::BIGINT, pg_try_advisory_xact_lock(key)::BOOLEAN AS "acquired"
 FROM ordered_keys;
 
 -- name: TryAdvisoryLock :one

--- a/pkg/repository/sqlcv1/concurrency.sql.go
+++ b/pkg/repository/sqlcv1/concurrency.sql.go
@@ -21,24 +21,6 @@ func (q *Queries) AdvisoryLock(ctx context.Context, db DBTX, key int64) error {
 	return err
 }
 
-const advisoryLockMany = `-- name: AdvisoryLockMany :exec
-WITH keys AS (
-    SELECT UNNEST($1::BIGINT[]) AS key
-), ordered_keys AS (
-    SELECT key
-    FROM keys
-    ORDER BY key
-)
-
-SELECT pg_advisory_xact_lock(key)
-FROM ordered_keys
-`
-
-func (q *Queries) AdvisoryLockMany(ctx context.Context, db DBTX, keys []int64) error {
-	_, err := db.Exec(ctx, advisoryLockMany, keys)
-	return err
-}
-
 const checkStrategyActive = `-- name: CheckStrategyActive :one
 WITH latest_workflow_version AS (
     SELECT DISTINCT ON("workflowId")
@@ -1273,4 +1255,42 @@ func (q *Queries) TryAdvisoryLock(ctx context.Context, db DBTX, key int64) (bool
 	var locked bool
 	err := row.Scan(&locked)
 	return locked, err
+}
+
+const tryAdvisoryLockMany = `-- name: TryAdvisoryLockMany :many
+WITH keys AS (
+    SELECT UNNEST($1::BIGINT[]) AS key
+), ordered_keys AS (
+    SELECT key
+    FROM keys
+    ORDER BY key
+)
+
+SELECT key::BIGINT, pg_try_advisory_xact_lock(key)::BOOLEAN AS "acquired"
+FROM ordered_keys
+`
+
+type TryAdvisoryLockManyRow struct {
+	Key      int64 `json:"key"`
+	Acquired bool  `json:"acquired"`
+}
+
+func (q *Queries) TryAdvisoryLockMany(ctx context.Context, db DBTX, keys []int64) ([]*TryAdvisoryLockManyRow, error) {
+	rows, err := db.Query(ctx, tryAdvisoryLockMany, keys)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*TryAdvisoryLockManyRow
+	for rows.Next() {
+		var i TryAdvisoryLockManyRow
+		if err := rows.Scan(&i.Key, &i.Acquired); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }


### PR DESCRIPTION
# Description

Allowing partial successes on status update messages, and re-publishing failed payloads after so they get requeued and can retry. The goal here is to load shed, in hopes that the vast majority of payloads will succeed and only a small proportion will need to be re-pubbed

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

