### PR TITLE
fix: go sdk api response status code validation

### DIFF
--- a/sdks/go/features/utils.go
+++ b/sdks/go/features/utils.go
@@ -12,8 +12,8 @@ func validateJSON200Response[T any](statusCode int, body []byte, json200 *T) err
 }
 
 func validateStatusCodeResponse(statusCode int, body []byte) error {
-	if statusCode != 200 {
-		return errors.Newf("received non-200 response from server. got status %d with body '%s'", statusCode, string(body))
+	if statusCode < 200 || statusCode >= 300 {
+		return errors.Newf("received non-2xx response from server. got status %d with body '%s'", statusCode, string(body))
 	}
 	return nil
 }


### PR DESCRIPTION
# Description

Successful delete operation in go SDK with status code 204 is treated as error due to misconfigured status_code validation. 

How to reproduce:
`err = client.Crons().Delete(context.Background(), createdCron.Metadata.Id)
		if err != nil {
			return err
		}`

error: `failed: received non-200 response from server. got status 204 with body ''`

examples:
1. https://github.com/hatchet-dev/hatchet/blob/main/api-contracts/openapi/paths/workflow/workflow.yaml#L1098-L1100
2. https://github.com/hatchet-dev/hatchet/blob/main/api-contracts/openapi/paths/workflow/workflow.yaml#L117-L119
.
.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

