### PR TITLE
Fix: Durable eviction / restore causing duplicate queue items

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260509015727_v1_0_106.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260509015727_v1_0_106.sql
@@ -34,6 +34,612 @@ CREATE UNIQUE INDEX v1_queue_item_task_idx ON v1_queue_item (
     task_inserted_at ASC,
     retry_count ASC
 );
+
+CREATE OR REPLACE FUNCTION v1_task_insert_function()
+RETURNS TRIGGER AS $$
+DECLARE
+    rec RECORD;
+BEGIN
+    -- Only insert if there's a single task with initial_state = 'QUEUED' and concurrency_strategy_ids is not null
+    IF (SELECT COUNT(*) FROM new_table WHERE initial_state = 'QUEUED' AND concurrency_strategy_ids[1] IS NOT NULL) > 0 THEN
+        WITH new_slot_rows AS (
+            SELECT
+                id,
+                inserted_at,
+                retry_count,
+                tenant_id,
+                priority,
+                concurrency_parent_strategy_ids[1] AS parent_strategy_id,
+                CASE
+                    WHEN array_length(concurrency_parent_strategy_ids, 1) > 1 THEN concurrency_parent_strategy_ids[2:array_length(concurrency_parent_strategy_ids, 1)]
+                    ELSE '{}'::bigint[]
+                END AS next_parent_strategy_ids,
+                concurrency_strategy_ids[1] AS strategy_id,
+                external_id,
+                workflow_run_id,
+                CASE
+                    WHEN array_length(concurrency_strategy_ids, 1) > 1 THEN concurrency_strategy_ids[2:array_length(concurrency_strategy_ids, 1)]
+                    ELSE '{}'::bigint[]
+                END AS next_strategy_ids,
+                concurrency_keys[1] AS key,
+                CASE
+                    WHEN array_length(concurrency_keys, 1) > 1 THEN concurrency_keys[2:array_length(concurrency_keys, 1)]
+                    ELSE '{}'::text[]
+                END AS next_keys,
+                workflow_id,
+                workflow_version_id,
+                queue,
+                CURRENT_TIMESTAMP + convert_duration_to_interval(schedule_timeout) AS schedule_timeout_at
+            FROM new_table
+            WHERE initial_state = 'QUEUED' AND concurrency_strategy_ids[1] IS NOT NULL
+        )
+        INSERT INTO v1_concurrency_slot (
+            task_id,
+            task_inserted_at,
+            task_retry_count,
+            external_id,
+            tenant_id,
+            workflow_id,
+            workflow_version_id,
+            workflow_run_id,
+            parent_strategy_id,
+            next_parent_strategy_ids,
+            strategy_id,
+            next_strategy_ids,
+            priority,
+            key,
+            next_keys,
+            queue_to_notify,
+            schedule_timeout_at
+        )
+        SELECT
+            id,
+            inserted_at,
+            retry_count,
+            external_id,
+            tenant_id,
+            workflow_id,
+            workflow_version_id,
+            workflow_run_id,
+            parent_strategy_id,
+            next_parent_strategy_ids,
+            strategy_id,
+            next_strategy_ids,
+            COALESCE(priority, 1),
+            key,
+            next_keys,
+            queue,
+            schedule_timeout_at
+        FROM new_slot_rows;
+    END IF;
+
+    INSERT INTO v1_queue_item (
+        tenant_id,
+        queue,
+        task_id,
+        task_inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        schedule_timeout_at,
+        step_timeout,
+        priority,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label
+    )
+    SELECT
+        tenant_id,
+        queue,
+        id,
+        inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        CURRENT_TIMESTAMP + convert_duration_to_interval(schedule_timeout),
+        step_timeout,
+        COALESCE(priority, 1),
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label
+    FROM new_table
+    WHERE initial_state = 'QUEUED' AND concurrency_strategy_ids[1] IS NULL
+    ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
+    ;
+
+    -- Only insert into v1_dag and v1_dag_to_task if dag_id and dag_inserted_at are not null
+    IF (SELECT COUNT(*) FROM new_table WHERE dag_id IS NOT NULL AND dag_inserted_at IS NOT NULL) > 0 THEN
+        INSERT INTO v1_dag_to_task (
+            dag_id,
+            dag_inserted_at,
+            task_id,
+            task_inserted_at
+        )
+        SELECT
+            dag_id,
+            dag_inserted_at,
+            id,
+            inserted_at
+        FROM new_table
+        WHERE dag_id IS NOT NULL AND dag_inserted_at IS NOT NULL;
+    END IF;
+
+    INSERT INTO v1_lookup_table (
+        external_id,
+        tenant_id,
+        task_id,
+        inserted_at
+    )
+    SELECT
+        external_id,
+        tenant_id,
+        id,
+        inserted_at
+    FROM new_table
+    ON CONFLICT (external_id) DO NOTHING;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION v1_task_update_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    WITH new_retry_rows AS (
+        SELECT
+            nt.id,
+            nt.inserted_at,
+            nt.retry_count,
+            nt.tenant_id,
+            -- Convert the retry_after based on min(retry_backoff_factor ^ retry_count, retry_max_backoff)
+            NOW() + (LEAST(nt.retry_max_backoff, POWER(nt.retry_backoff_factor, nt.app_retry_count)) * interval '1 second') AS retry_after
+        FROM new_table nt
+        JOIN old_table ot ON ot.id = nt.id
+        WHERE nt.initial_state = 'QUEUED'
+            AND nt.retry_backoff_factor IS NOT NULL
+            AND ot.app_retry_count IS DISTINCT FROM nt.app_retry_count
+            AND nt.app_retry_count != 0
+    )
+    INSERT INTO v1_retry_queue_item (
+        task_id,
+        task_inserted_at,
+        task_retry_count,
+        retry_after,
+        tenant_id
+    )
+    SELECT
+        id,
+        inserted_at,
+        retry_count,
+        retry_after,
+        tenant_id
+    FROM new_retry_rows;
+
+    WITH new_slot_rows AS (
+        SELECT
+            nt.id,
+            nt.inserted_at,
+            nt.retry_count,
+            nt.tenant_id,
+            nt.workflow_run_id,
+            nt.external_id,
+            nt.concurrency_parent_strategy_ids[1] AS parent_strategy_id,
+            CASE
+                WHEN array_length(nt.concurrency_parent_strategy_ids, 1) > 1 THEN nt.concurrency_parent_strategy_ids[2:array_length(nt.concurrency_parent_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_parent_strategy_ids,
+            nt.concurrency_strategy_ids[1] AS strategy_id,
+            CASE
+                WHEN array_length(nt.concurrency_strategy_ids, 1) > 1 THEN nt.concurrency_strategy_ids[2:array_length(nt.concurrency_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_strategy_ids,
+            nt.concurrency_keys[1] AS key,
+            CASE
+                WHEN array_length(nt.concurrency_keys, 1) > 1 THEN nt.concurrency_keys[2:array_length(nt.concurrency_keys, 1)]
+                ELSE '{}'::text[]
+            END AS next_keys,
+            nt.workflow_id,
+            nt.workflow_version_id,
+            nt.queue,
+            CURRENT_TIMESTAMP + convert_duration_to_interval(nt.schedule_timeout) AS schedule_timeout_at
+        FROM new_table nt
+        JOIN old_table ot ON ot.id = nt.id
+        WHERE nt.initial_state = 'QUEUED'
+            -- Concurrency strategy id should never be null
+            AND nt.concurrency_strategy_ids[1] IS NOT NULL
+            AND (nt.retry_backoff_factor IS NULL OR ot.app_retry_count IS NOT DISTINCT FROM nt.app_retry_count OR nt.app_retry_count = 0)
+            AND ot.retry_count IS DISTINCT FROM nt.retry_count
+    ), updated_slot AS (
+        UPDATE
+            v1_concurrency_slot cs
+        SET
+            task_retry_count = nt.retry_count,
+            schedule_timeout_at = nt.schedule_timeout_at,
+            is_filled = FALSE,
+            priority = 4
+        FROM
+            new_slot_rows nt
+        WHERE
+            cs.task_id = nt.id
+            AND cs.task_inserted_at = nt.inserted_at
+            AND cs.strategy_id = nt.strategy_id
+        RETURNING cs.*
+    ), slots_to_insert AS (
+        -- select the rows that were not updated
+        SELECT
+            nt.*
+        FROM
+            new_slot_rows nt
+        LEFT JOIN
+            updated_slot cs ON cs.task_id = nt.id AND cs.task_inserted_at = nt.inserted_at AND cs.strategy_id = nt.strategy_id
+        WHERE
+            cs.task_id IS NULL
+    )
+    INSERT INTO v1_concurrency_slot (
+        task_id,
+        task_inserted_at,
+        task_retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        priority,
+        key,
+        next_keys,
+        queue_to_notify,
+        schedule_timeout_at
+    )
+    SELECT
+        id,
+        inserted_at,
+        retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        4,
+        key,
+        next_keys,
+        queue,
+        schedule_timeout_at
+    FROM slots_to_insert;
+
+    INSERT INTO v1_queue_item (
+        tenant_id,
+        queue,
+        task_id,
+        task_inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        schedule_timeout_at,
+        step_timeout,
+        priority,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label
+    )
+    SELECT
+        nt.tenant_id,
+        nt.queue,
+        nt.id,
+        nt.inserted_at,
+        nt.external_id,
+        nt.action_id,
+        nt.step_id,
+        nt.workflow_id,
+        nt.workflow_run_id,
+        CURRENT_TIMESTAMP + convert_duration_to_interval(nt.schedule_timeout),
+        nt.step_timeout,
+        4,
+        nt.sticky,
+        nt.desired_worker_id,
+        nt.retry_count,
+        nt.desired_worker_label
+    FROM new_table nt
+    JOIN old_table ot ON ot.id = nt.id
+    WHERE nt.initial_state = 'QUEUED'
+        AND nt.concurrency_strategy_ids[1] IS NULL
+        AND (nt.retry_backoff_factor IS NULL OR ot.app_retry_count IS NOT DISTINCT FROM nt.app_retry_count OR nt.app_retry_count = 0)
+        AND ot.retry_count IS DISTINCT FROM nt.retry_count
+    ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION v1_retry_queue_item_delete_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    WITH new_slot_rows AS (
+        SELECT
+            t.id,
+            t.inserted_at,
+            t.retry_count,
+            t.tenant_id,
+            t.workflow_run_id,
+            t.external_id,
+            t.concurrency_parent_strategy_ids[1] AS parent_strategy_id,
+            CASE
+                WHEN array_length(t.concurrency_parent_strategy_ids, 1) > 1 THEN t.concurrency_parent_strategy_ids[2:array_length(t.concurrency_parent_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_parent_strategy_ids,
+            t.concurrency_strategy_ids[1] AS strategy_id,
+            CASE
+                WHEN array_length(t.concurrency_strategy_ids, 1) > 1 THEN t.concurrency_strategy_ids[2:array_length(t.concurrency_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_strategy_ids,
+            t.concurrency_keys[1] AS key,
+            CASE
+                WHEN array_length(t.concurrency_keys, 1) > 1 THEN t.concurrency_keys[2:array_length(t.concurrency_keys, 1)]
+                ELSE '{}'::text[]
+            END AS next_keys,
+            t.workflow_id,
+            t.workflow_version_id,
+            t.queue,
+            CURRENT_TIMESTAMP + convert_duration_to_interval(t.schedule_timeout) AS schedule_timeout_at
+        FROM deleted_rows dr
+        JOIN
+            v1_task t ON t.id = dr.task_id AND t.inserted_at = dr.task_inserted_at
+        WHERE
+            dr.retry_after <= NOW()
+            AND t.initial_state = 'QUEUED'
+            -- Check to see if the task has a concurrency strategy
+            AND t.concurrency_strategy_ids[1] IS NOT NULL
+    )
+    INSERT INTO v1_concurrency_slot (
+        task_id,
+        task_inserted_at,
+        task_retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        priority,
+        key,
+        next_keys,
+        queue_to_notify,
+        schedule_timeout_at
+    )
+    SELECT
+        id,
+        inserted_at,
+        retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        4,
+        key,
+        next_keys,
+        queue,
+        schedule_timeout_at
+    FROM new_slot_rows;
+
+    WITH tasks AS (
+        SELECT
+            t.*
+        FROM
+            deleted_rows dr
+        JOIN v1_task t ON t.id = dr.task_id AND t.inserted_at = dr.task_inserted_at
+        WHERE
+            dr.retry_after <= NOW()
+            AND t.initial_state = 'QUEUED'
+            AND t.concurrency_strategy_ids[1] IS NULL
+    )
+    INSERT INTO v1_queue_item (
+        tenant_id,
+        queue,
+        task_id,
+        task_inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        schedule_timeout_at,
+        step_timeout,
+        priority,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label
+    )
+    SELECT
+        tenant_id,
+        queue,
+        id,
+        inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        CURRENT_TIMESTAMP + convert_duration_to_interval(schedule_timeout),
+        step_timeout,
+        4,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label
+    FROM tasks
+    ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
+    ;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION v1_concurrency_slot_update_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    -- If the concurrency slot has next_keys, insert a new slot for the next key
+    WITH new_slot_rows AS (
+        SELECT
+            t.id,
+            t.inserted_at,
+            t.retry_count,
+            t.tenant_id,
+            t.priority,
+            t.queue,
+            t.workflow_run_id,
+            t.external_id,
+            nt.next_parent_strategy_ids[1] AS parent_strategy_id,
+            CASE
+                WHEN array_length(nt.next_parent_strategy_ids, 1) > 1 THEN nt.next_parent_strategy_ids[2:array_length(nt.next_parent_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_parent_strategy_ids,
+            nt.next_strategy_ids[1] AS strategy_id,
+            CASE
+                WHEN array_length(nt.next_strategy_ids, 1) > 1 THEN nt.next_strategy_ids[2:array_length(nt.next_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_strategy_ids,
+            nt.next_keys[1] AS key,
+            CASE
+                WHEN array_length(nt.next_keys, 1) > 1 THEN nt.next_keys[2:array_length(nt.next_keys, 1)]
+                ELSE '{}'::text[]
+            END AS next_keys,
+            t.workflow_id,
+            t.workflow_version_id,
+            CURRENT_TIMESTAMP + convert_duration_to_interval(t.schedule_timeout) AS schedule_timeout_at
+        FROM new_table nt
+        JOIN old_table ot USING (task_id, task_inserted_at, task_retry_count, key)
+        JOIN v1_task t ON t.id = nt.task_id AND t.inserted_at = nt.task_inserted_at
+        WHERE
+            COALESCE(array_length(nt.next_keys, 1), 0) != 0
+            AND nt.is_filled = TRUE
+            AND nt.is_filled IS DISTINCT FROM ot.is_filled
+    )
+    INSERT INTO v1_concurrency_slot (
+        task_id,
+        task_inserted_at,
+        task_retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        priority,
+        key,
+        next_keys,
+        schedule_timeout_at,
+        queue_to_notify
+    )
+    SELECT
+        id,
+        inserted_at,
+        retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        COALESCE(priority, 1),
+        key,
+        next_keys,
+        schedule_timeout_at,
+        queue
+    FROM new_slot_rows;
+
+    -- If the concurrency slot does not have next_keys, insert an item into v1_queue_item
+    WITH tasks AS (
+        SELECT
+            t.*
+        FROM
+            new_table nt
+        JOIN old_table ot USING (task_id, task_inserted_at, task_retry_count, key)
+        JOIN v1_task t ON t.id = nt.task_id AND t.inserted_at = nt.task_inserted_at
+        WHERE
+            COALESCE(array_length(nt.next_keys, 1), 0) = 0
+            AND nt.is_filled = TRUE
+            AND nt.is_filled IS DISTINCT FROM ot.is_filled
+    )
+    INSERT INTO v1_queue_item (
+        tenant_id,
+        queue,
+        task_id,
+        task_inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        schedule_timeout_at,
+        step_timeout,
+        priority,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label
+    )
+    SELECT
+        tenant_id,
+        queue,
+        id,
+        inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        CURRENT_TIMESTAMP + convert_duration_to_interval(schedule_timeout),
+        step_timeout,
+        COALESCE(priority, 1),
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label
+    FROM tasks
+    ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
+    ;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
 -- +goose StatementEnd
 
 -- +goose Down
@@ -45,4 +651,604 @@ CREATE INDEX v1_queue_item_task_idx ON v1_queue_item (
     task_inserted_at ASC,
     retry_count ASC
 );
+
+CREATE OR REPLACE FUNCTION v1_task_insert_function()
+RETURNS TRIGGER AS $$
+DECLARE
+    rec RECORD;
+BEGIN
+    -- Only insert if there's a single task with initial_state = 'QUEUED' and concurrency_strategy_ids is not null
+    IF (SELECT COUNT(*) FROM new_table WHERE initial_state = 'QUEUED' AND concurrency_strategy_ids[1] IS NOT NULL) > 0 THEN
+        WITH new_slot_rows AS (
+            SELECT
+                id,
+                inserted_at,
+                retry_count,
+                tenant_id,
+                priority,
+                concurrency_parent_strategy_ids[1] AS parent_strategy_id,
+                CASE
+                    WHEN array_length(concurrency_parent_strategy_ids, 1) > 1 THEN concurrency_parent_strategy_ids[2:array_length(concurrency_parent_strategy_ids, 1)]
+                    ELSE '{}'::bigint[]
+                END AS next_parent_strategy_ids,
+                concurrency_strategy_ids[1] AS strategy_id,
+                external_id,
+                workflow_run_id,
+                CASE
+                    WHEN array_length(concurrency_strategy_ids, 1) > 1 THEN concurrency_strategy_ids[2:array_length(concurrency_strategy_ids, 1)]
+                    ELSE '{}'::bigint[]
+                END AS next_strategy_ids,
+                concurrency_keys[1] AS key,
+                CASE
+                    WHEN array_length(concurrency_keys, 1) > 1 THEN concurrency_keys[2:array_length(concurrency_keys, 1)]
+                    ELSE '{}'::text[]
+                END AS next_keys,
+                workflow_id,
+                workflow_version_id,
+                queue,
+                CURRENT_TIMESTAMP + convert_duration_to_interval(schedule_timeout) AS schedule_timeout_at
+            FROM new_table
+            WHERE initial_state = 'QUEUED' AND concurrency_strategy_ids[1] IS NOT NULL
+        )
+        INSERT INTO v1_concurrency_slot (
+            task_id,
+            task_inserted_at,
+            task_retry_count,
+            external_id,
+            tenant_id,
+            workflow_id,
+            workflow_version_id,
+            workflow_run_id,
+            parent_strategy_id,
+            next_parent_strategy_ids,
+            strategy_id,
+            next_strategy_ids,
+            priority,
+            key,
+            next_keys,
+            queue_to_notify,
+            schedule_timeout_at
+        )
+        SELECT
+            id,
+            inserted_at,
+            retry_count,
+            external_id,
+            tenant_id,
+            workflow_id,
+            workflow_version_id,
+            workflow_run_id,
+            parent_strategy_id,
+            next_parent_strategy_ids,
+            strategy_id,
+            next_strategy_ids,
+            COALESCE(priority, 1),
+            key,
+            next_keys,
+            queue,
+            schedule_timeout_at
+        FROM new_slot_rows;
+    END IF;
+
+    INSERT INTO v1_queue_item (
+        tenant_id,
+        queue,
+        task_id,
+        task_inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        schedule_timeout_at,
+        step_timeout,
+        priority,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label
+    )
+    SELECT
+        tenant_id,
+        queue,
+        id,
+        inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        CURRENT_TIMESTAMP + convert_duration_to_interval(schedule_timeout),
+        step_timeout,
+        COALESCE(priority, 1),
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label
+    FROM new_table
+    WHERE initial_state = 'QUEUED' AND concurrency_strategy_ids[1] IS NULL
+    ;
+
+    -- Only insert into v1_dag and v1_dag_to_task if dag_id and dag_inserted_at are not null
+    IF (SELECT COUNT(*) FROM new_table WHERE dag_id IS NOT NULL AND dag_inserted_at IS NOT NULL) > 0 THEN
+        INSERT INTO v1_dag_to_task (
+            dag_id,
+            dag_inserted_at,
+            task_id,
+            task_inserted_at
+        )
+        SELECT
+            dag_id,
+            dag_inserted_at,
+            id,
+            inserted_at
+        FROM new_table
+        WHERE dag_id IS NOT NULL AND dag_inserted_at IS NOT NULL;
+    END IF;
+
+    INSERT INTO v1_lookup_table (
+        external_id,
+        tenant_id,
+        task_id,
+        inserted_at
+    )
+    SELECT
+        external_id,
+        tenant_id,
+        id,
+        inserted_at
+    FROM new_table
+    ON CONFLICT (external_id) DO NOTHING;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION v1_task_update_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    WITH new_retry_rows AS (
+        SELECT
+            nt.id,
+            nt.inserted_at,
+            nt.retry_count,
+            nt.tenant_id,
+            -- Convert the retry_after based on min(retry_backoff_factor ^ retry_count, retry_max_backoff)
+            NOW() + (LEAST(nt.retry_max_backoff, POWER(nt.retry_backoff_factor, nt.app_retry_count)) * interval '1 second') AS retry_after
+        FROM new_table nt
+        JOIN old_table ot ON ot.id = nt.id
+        WHERE nt.initial_state = 'QUEUED'
+            AND nt.retry_backoff_factor IS NOT NULL
+            AND ot.app_retry_count IS DISTINCT FROM nt.app_retry_count
+            AND nt.app_retry_count != 0
+    )
+    INSERT INTO v1_retry_queue_item (
+        task_id,
+        task_inserted_at,
+        task_retry_count,
+        retry_after,
+        tenant_id
+    )
+    SELECT
+        id,
+        inserted_at,
+        retry_count,
+        retry_after,
+        tenant_id
+    FROM new_retry_rows;
+
+    WITH new_slot_rows AS (
+        SELECT
+            nt.id,
+            nt.inserted_at,
+            nt.retry_count,
+            nt.tenant_id,
+            nt.workflow_run_id,
+            nt.external_id,
+            nt.concurrency_parent_strategy_ids[1] AS parent_strategy_id,
+            CASE
+                WHEN array_length(nt.concurrency_parent_strategy_ids, 1) > 1 THEN nt.concurrency_parent_strategy_ids[2:array_length(nt.concurrency_parent_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_parent_strategy_ids,
+            nt.concurrency_strategy_ids[1] AS strategy_id,
+            CASE
+                WHEN array_length(nt.concurrency_strategy_ids, 1) > 1 THEN nt.concurrency_strategy_ids[2:array_length(nt.concurrency_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_strategy_ids,
+            nt.concurrency_keys[1] AS key,
+            CASE
+                WHEN array_length(nt.concurrency_keys, 1) > 1 THEN nt.concurrency_keys[2:array_length(nt.concurrency_keys, 1)]
+                ELSE '{}'::text[]
+            END AS next_keys,
+            nt.workflow_id,
+            nt.workflow_version_id,
+            nt.queue,
+            CURRENT_TIMESTAMP + convert_duration_to_interval(nt.schedule_timeout) AS schedule_timeout_at
+        FROM new_table nt
+        JOIN old_table ot ON ot.id = nt.id
+        WHERE nt.initial_state = 'QUEUED'
+            -- Concurrency strategy id should never be null
+            AND nt.concurrency_strategy_ids[1] IS NOT NULL
+            AND (nt.retry_backoff_factor IS NULL OR ot.app_retry_count IS NOT DISTINCT FROM nt.app_retry_count OR nt.app_retry_count = 0)
+            AND ot.retry_count IS DISTINCT FROM nt.retry_count
+    ), updated_slot AS (
+        UPDATE
+            v1_concurrency_slot cs
+        SET
+            task_retry_count = nt.retry_count,
+            schedule_timeout_at = nt.schedule_timeout_at,
+            is_filled = FALSE,
+            priority = 4
+        FROM
+            new_slot_rows nt
+        WHERE
+            cs.task_id = nt.id
+            AND cs.task_inserted_at = nt.inserted_at
+            AND cs.strategy_id = nt.strategy_id
+        RETURNING cs.*
+    ), slots_to_insert AS (
+        -- select the rows that were not updated
+        SELECT
+            nt.*
+        FROM
+            new_slot_rows nt
+        LEFT JOIN
+            updated_slot cs ON cs.task_id = nt.id AND cs.task_inserted_at = nt.inserted_at AND cs.strategy_id = nt.strategy_id
+        WHERE
+            cs.task_id IS NULL
+    )
+    INSERT INTO v1_concurrency_slot (
+        task_id,
+        task_inserted_at,
+        task_retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        priority,
+        key,
+        next_keys,
+        queue_to_notify,
+        schedule_timeout_at
+    )
+    SELECT
+        id,
+        inserted_at,
+        retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        4,
+        key,
+        next_keys,
+        queue,
+        schedule_timeout_at
+    FROM slots_to_insert;
+
+    INSERT INTO v1_queue_item (
+        tenant_id,
+        queue,
+        task_id,
+        task_inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        schedule_timeout_at,
+        step_timeout,
+        priority,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label
+    )
+    SELECT
+        nt.tenant_id,
+        nt.queue,
+        nt.id,
+        nt.inserted_at,
+        nt.external_id,
+        nt.action_id,
+        nt.step_id,
+        nt.workflow_id,
+        nt.workflow_run_id,
+        CURRENT_TIMESTAMP + convert_duration_to_interval(nt.schedule_timeout),
+        nt.step_timeout,
+        4,
+        nt.sticky,
+        nt.desired_worker_id,
+        nt.retry_count,
+        nt.desired_worker_label
+    FROM new_table nt
+    JOIN old_table ot ON ot.id = nt.id
+    WHERE nt.initial_state = 'QUEUED'
+        AND nt.concurrency_strategy_ids[1] IS NULL
+        AND (nt.retry_backoff_factor IS NULL OR ot.app_retry_count IS NOT DISTINCT FROM nt.app_retry_count OR nt.app_retry_count = 0)
+        AND ot.retry_count IS DISTINCT FROM nt.retry_count;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION v1_retry_queue_item_delete_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    WITH new_slot_rows AS (
+        SELECT
+            t.id,
+            t.inserted_at,
+            t.retry_count,
+            t.tenant_id,
+            t.workflow_run_id,
+            t.external_id,
+            t.concurrency_parent_strategy_ids[1] AS parent_strategy_id,
+            CASE
+                WHEN array_length(t.concurrency_parent_strategy_ids, 1) > 1 THEN t.concurrency_parent_strategy_ids[2:array_length(t.concurrency_parent_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_parent_strategy_ids,
+            t.concurrency_strategy_ids[1] AS strategy_id,
+            CASE
+                WHEN array_length(t.concurrency_strategy_ids, 1) > 1 THEN t.concurrency_strategy_ids[2:array_length(t.concurrency_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_strategy_ids,
+            t.concurrency_keys[1] AS key,
+            CASE
+                WHEN array_length(t.concurrency_keys, 1) > 1 THEN t.concurrency_keys[2:array_length(t.concurrency_keys, 1)]
+                ELSE '{}'::text[]
+            END AS next_keys,
+            t.workflow_id,
+            t.workflow_version_id,
+            t.queue,
+            CURRENT_TIMESTAMP + convert_duration_to_interval(t.schedule_timeout) AS schedule_timeout_at
+        FROM deleted_rows dr
+        JOIN
+            v1_task t ON t.id = dr.task_id AND t.inserted_at = dr.task_inserted_at
+        WHERE
+            dr.retry_after <= NOW()
+            AND t.initial_state = 'QUEUED'
+            -- Check to see if the task has a concurrency strategy
+            AND t.concurrency_strategy_ids[1] IS NOT NULL
+    )
+    INSERT INTO v1_concurrency_slot (
+        task_id,
+        task_inserted_at,
+        task_retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        priority,
+        key,
+        next_keys,
+        queue_to_notify,
+        schedule_timeout_at
+    )
+    SELECT
+        id,
+        inserted_at,
+        retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        4,
+        key,
+        next_keys,
+        queue,
+        schedule_timeout_at
+    FROM new_slot_rows;
+
+    WITH tasks AS (
+        SELECT
+            t.*
+        FROM
+            deleted_rows dr
+        JOIN v1_task t ON t.id = dr.task_id AND t.inserted_at = dr.task_inserted_at
+        WHERE
+            dr.retry_after <= NOW()
+            AND t.initial_state = 'QUEUED'
+            AND t.concurrency_strategy_ids[1] IS NULL
+    )
+    INSERT INTO v1_queue_item (
+        tenant_id,
+        queue,
+        task_id,
+        task_inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        schedule_timeout_at,
+        step_timeout,
+        priority,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label
+    )
+    SELECT
+        tenant_id,
+        queue,
+        id,
+        inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        CURRENT_TIMESTAMP + convert_duration_to_interval(schedule_timeout),
+        step_timeout,
+        4,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label
+    FROM tasks;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION v1_concurrency_slot_update_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    -- If the concurrency slot has next_keys, insert a new slot for the next key
+    WITH new_slot_rows AS (
+        SELECT
+            t.id,
+            t.inserted_at,
+            t.retry_count,
+            t.tenant_id,
+            t.priority,
+            t.queue,
+            t.workflow_run_id,
+            t.external_id,
+            nt.next_parent_strategy_ids[1] AS parent_strategy_id,
+            CASE
+                WHEN array_length(nt.next_parent_strategy_ids, 1) > 1 THEN nt.next_parent_strategy_ids[2:array_length(nt.next_parent_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_parent_strategy_ids,
+            nt.next_strategy_ids[1] AS strategy_id,
+            CASE
+                WHEN array_length(nt.next_strategy_ids, 1) > 1 THEN nt.next_strategy_ids[2:array_length(nt.next_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_strategy_ids,
+            nt.next_keys[1] AS key,
+            CASE
+                WHEN array_length(nt.next_keys, 1) > 1 THEN nt.next_keys[2:array_length(nt.next_keys, 1)]
+                ELSE '{}'::text[]
+            END AS next_keys,
+            t.workflow_id,
+            t.workflow_version_id,
+            CURRENT_TIMESTAMP + convert_duration_to_interval(t.schedule_timeout) AS schedule_timeout_at
+        FROM new_table nt
+        JOIN old_table ot USING (task_id, task_inserted_at, task_retry_count, key)
+        JOIN v1_task t ON t.id = nt.task_id AND t.inserted_at = nt.task_inserted_at
+        WHERE
+            COALESCE(array_length(nt.next_keys, 1), 0) != 0
+            AND nt.is_filled = TRUE
+            AND nt.is_filled IS DISTINCT FROM ot.is_filled
+    )
+    INSERT INTO v1_concurrency_slot (
+        task_id,
+        task_inserted_at,
+        task_retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        priority,
+        key,
+        next_keys,
+        schedule_timeout_at,
+        queue_to_notify
+    )
+    SELECT
+        id,
+        inserted_at,
+        retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        COALESCE(priority, 1),
+        key,
+        next_keys,
+        schedule_timeout_at,
+        queue
+    FROM new_slot_rows;
+
+    -- If the concurrency slot does not have next_keys, insert an item into v1_queue_item
+    WITH tasks AS (
+        SELECT
+            t.*
+        FROM
+            new_table nt
+        JOIN old_table ot USING (task_id, task_inserted_at, task_retry_count, key)
+        JOIN v1_task t ON t.id = nt.task_id AND t.inserted_at = nt.task_inserted_at
+        WHERE
+            COALESCE(array_length(nt.next_keys, 1), 0) = 0
+            AND nt.is_filled = TRUE
+            AND nt.is_filled IS DISTINCT FROM ot.is_filled
+    )
+    INSERT INTO v1_queue_item (
+        tenant_id,
+        queue,
+        task_id,
+        task_inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        schedule_timeout_at,
+        step_timeout,
+        priority,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label
+    )
+    SELECT
+        tenant_id,
+        queue,
+        id,
+        inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        CURRENT_TIMESTAMP + convert_duration_to_interval(schedule_timeout),
+        step_timeout,
+        COALESCE(priority, 1),
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label
+    FROM tasks;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
 -- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20260509015727_v1_0_106.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260509015727_v1_0_106.sql
@@ -6,8 +6,7 @@ WITH duplicate_tasks AS (
     SELECT
         task_id,
         task_inserted_at,
-        retry_count,
-        COUNT(*) AS count
+        retry_count
     FROM v1_queue_item
     GROUP BY task_id, task_inserted_at, retry_count
     HAVING COUNT(*) > 1

--- a/cmd/hatchet-migrate/migrate/migrations/20260509015727_v1_0_106.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260509015727_v1_0_106.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+
+DROP INDEX CONCURRENTLY IF EXISTS v1_queue_item_task_idx;
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS v1_queue_item_task_idx ON v1_queue_item (
+    task_id ASC,
+    task_inserted_at ASC,
+    retry_count ASC
+);
+
+-- +goose Down
+-- +goose NO TRANSACTION
+
+DROP INDEX CONCURRENTLY IF EXISTS v1_queue_item_task_idx;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS v1_queue_item_task_idx ON v1_queue_item (
+    task_id ASC,
+    task_inserted_at ASC,
+    retry_count ASC
+);

--- a/cmd/hatchet-migrate/migrate/migrations/20260509015727_v1_0_106.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260509015727_v1_0_106.sql
@@ -1,21 +1,48 @@
 -- +goose Up
--- +goose NO TRANSACTION
+-- +goose StatementBegin
+LOCK TABLE v1_queue_item IN ACCESS EXCLUSIVE MODE;
 
-DROP INDEX CONCURRENTLY IF EXISTS v1_queue_item_task_idx;
+WITH duplicate_tasks AS (
+    SELECT
+        task_id,
+        task_inserted_at,
+        retry_count,
+        COUNT(*) AS count
+    FROM v1_queue_item
+    GROUP BY task_id, task_inserted_at, retry_count
+    HAVING COUNT(*) > 1
+), with_row_numbers AS (
+    SELECT *, ROW_NUMBER() OVER (PARTITION BY task_id, task_inserted_at, retry_count ORDER BY id) AS rn
+    FROM v1_queue_item
+    WHERE (task_id, task_inserted_at, retry_count) IN (
+        SELECT task_id, task_inserted_at, retry_count
+        FROM duplicate_tasks
+    )
+)
 
-CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS v1_queue_item_task_idx ON v1_queue_item (
+DELETE FROM v1_queue_item
+WHERE id IN (
+    SELECT id
+    FROM with_row_numbers
+    WHERE rn > 1
+);
+
+DROP INDEX v1_queue_item_task_idx;
+
+CREATE UNIQUE INDEX v1_queue_item_task_idx ON v1_queue_item (
     task_id ASC,
     task_inserted_at ASC,
     retry_count ASC
 );
+-- +goose StatementEnd
 
 -- +goose Down
--- +goose NO TRANSACTION
+-- +goose StatementBegin
+DROP INDEX v1_queue_item_task_idx;
 
-DROP INDEX CONCURRENTLY IF EXISTS v1_queue_item_task_idx;
-
-CREATE INDEX CONCURRENTLY IF NOT EXISTS v1_queue_item_task_idx ON v1_queue_item (
+CREATE INDEX v1_queue_item_task_idx ON v1_queue_item (
     task_id ASC,
     task_inserted_at ASC,
     retry_count ASC
 );
+-- +goose StatementEnd

--- a/pkg/repository/scheduler_queue.go
+++ b/pkg/repository/scheduler_queue.go
@@ -286,7 +286,6 @@ func (d *sharedRepository) markQueueItemsProcessed(ctx context.Context, tenantId
 	taskIds := make([]int64, 0, len(r.Assigned))
 	taskInsertedAts := make([]pgtype.Timestamptz, 0, len(r.Assigned))
 	workerIds := make([]uuid.UUID, 0, len(r.Assigned))
-	seenTaskIds := make(map[int64]*sqlcv1.V1QueueItem)
 
 	var minTaskInsertedAt pgtype.Timestamptz
 
@@ -294,19 +293,6 @@ func (d *sharedRepository) markQueueItemsProcessed(ctx context.Context, tenantId
 	// deleted from the v1_queue_items table, so we should not assign them
 	for id, assignedItem := range queueItemIdsToAssignedItem {
 		if _, ok := queuedItemsMap[id]; ok {
-			if qi, seen := seenTaskIds[assignedItem.QueueItem.TaskID]; seen {
-				d.l.Error().
-					Int64("task_id", assignedItem.QueueItem.TaskID).
-					Str("task_inserted_at", qi.TaskInsertedAt.Time.String()).
-					Int64("new_retry_count", int64(qi.RetryCount)).
-					Int64("old_retry_count", int64(assignedItem.QueueItem.RetryCount)).
-					Msg("duplicate task id seen when preparing queue items for `UpdateTasksToAssigned`")
-			}
-
-			seenTaskIds[assignedItem.QueueItem.TaskID] = assignedItem.QueueItem
-			// todo: add this back if we remove the error log above for deduping
-			// taskIdToAssignedItem[assignedItem.QueueItem.TaskID] = assignedItem
-
 			taskIds = append(taskIds, assignedItem.QueueItem.TaskID)
 			taskInsertedAts = append(taskInsertedAts, assignedItem.QueueItem.TaskInsertedAt)
 			workerIds = append(workerIds, assignedItem.WorkerId)

--- a/pkg/repository/sqlcv1/queue.sql
+++ b/pkg/repository/sqlcv1/queue.sql
@@ -499,6 +499,7 @@ SELECT
     retry_count,
     desired_worker_label
 FROM ready_items
+ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
 RETURNING id, tenant_id, task_id, task_inserted_at, retry_count;
 
 -- name: CleanupV1QueueItem :execresult

--- a/pkg/repository/sqlcv1/queue.sql.go
+++ b/pkg/repository/sqlcv1/queue.sql.go
@@ -833,6 +833,7 @@ SELECT
     retry_count,
     desired_worker_label
 FROM ready_items
+ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
 RETURNING id, tenant_id, task_id, task_inserted_at, retry_count
 `
 

--- a/pkg/repository/sqlcv1/tasks-overwrite.go
+++ b/pkg/repository/sqlcv1/tasks-overwrite.go
@@ -860,13 +860,6 @@ WITH input AS (
         AND r.evicted_at IS NOT NULL
     ORDER BY r.task_id, r.task_inserted_at, r.retry_count
     FOR UPDATE
-), cleared_eviction AS (
-    UPDATE v1_task_runtime r
-    SET evicted_at = NULL
-    FROM evicted_runtimes er
-    WHERE r.task_id = er.task_id
-        AND r.task_inserted_at = er.task_inserted_at
-        AND r.retry_count = er.retry_count
 ), selected_tasks AS (
     SELECT
         t.*
@@ -887,6 +880,7 @@ WITH input AS (
         t.step_timeout, 4, t.sticky, t.desired_worker_id, t.retry_count, t.desired_worker_label
     FROM
         selected_tasks t
+	ON CONFLICT DO NOTHING
     RETURNING task_id, task_inserted_at
 )
 SELECT

--- a/pkg/repository/sqlcv1/tasks-overwrite.go
+++ b/pkg/repository/sqlcv1/tasks-overwrite.go
@@ -887,7 +887,6 @@ WITH input AS (
         t.step_timeout, 4, t.sticky, t.desired_worker_id, t.retry_count, t.desired_worker_label
     FROM
         selected_tasks t
-    ON CONFLICT DO NOTHING
     RETURNING task_id, task_inserted_at
 )
 SELECT

--- a/pkg/repository/sqlcv1/tasks-overwrite.go
+++ b/pkg/repository/sqlcv1/tasks-overwrite.go
@@ -860,6 +860,13 @@ WITH input AS (
         AND r.evicted_at IS NOT NULL
     ORDER BY r.task_id, r.task_inserted_at, r.retry_count
     FOR UPDATE
+), cleared_eviction AS (
+    UPDATE v1_task_runtime r
+    SET evicted_at = NULL
+    FROM evicted_runtimes er
+    WHERE r.task_id = er.task_id
+        AND r.task_inserted_at = er.task_inserted_at
+        AND r.retry_count = er.retry_count
 ), selected_tasks AS (
     SELECT
         t.*

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -1140,7 +1140,9 @@ BEGIN
         retry_count,
         desired_worker_label
     FROM new_table
-    WHERE initial_state = 'QUEUED' AND concurrency_strategy_ids[1] IS NULL;
+    WHERE initial_state = 'QUEUED' AND concurrency_strategy_ids[1] IS NULL
+    ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
+    ;
 
     -- Only insert into v1_dag and v1_dag_to_task if dag_id and dag_inserted_at are not null
     IF (SELECT COUNT(*) FROM new_table WHERE dag_id IS NOT NULL AND dag_inserted_at IS NOT NULL) > 0 THEN
@@ -1357,7 +1359,9 @@ BEGIN
     WHERE nt.initial_state = 'QUEUED'
         AND nt.concurrency_strategy_ids[1] IS NULL
         AND (nt.retry_backoff_factor IS NULL OR ot.app_retry_count IS NOT DISTINCT FROM nt.app_retry_count OR nt.app_retry_count = 0)
-        AND ot.retry_count IS DISTINCT FROM nt.retry_count;
+        AND ot.retry_count IS DISTINCT FROM nt.retry_count
+    ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
+    ;
 
     RETURN NULL;
 END;
@@ -1495,7 +1499,9 @@ BEGIN
         desired_worker_id,
         retry_count,
         desired_worker_label
-    FROM tasks;
+    FROM tasks
+    ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
+    ;
 
     RETURN NULL;
 END;
@@ -1636,7 +1642,9 @@ BEGIN
         desired_worker_id,
         retry_count,
         desired_worker_label
-    FROM tasks;
+    FROM tasks
+    ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
+    ;
 
     RETURN NULL;
 END;

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -408,7 +408,7 @@ CREATE INDEX v1_queue_item_list_idx ON v1_queue_item (
     id ASC
 );
 
-CREATE INDEX v1_queue_item_task_idx ON v1_queue_item (
+CREATE UNIQUE INDEX v1_queue_item_task_idx ON v1_queue_item (
     task_id ASC,
     task_inserted_at ASC,
     retry_count ASC


### PR DESCRIPTION
# Description

We didn't have a unique constraint on `v1_queue_item(task_id, task_inserted_at, retry_count)`, so the `ON CONFLICT DO NOTHING` on the durable restore was doing nothing, and we were inserting duplicate queue items for a single task.

I think this was happening in a specific case where a task had been evicted, and then a callback fired, which fired an update that marked the task as un-evicted, but there was a race with this insert, which broke. I wasn't able to repro in a vacuum beyond running all the python tests (putting the engine under some load), so it was a little tough to pin down exactly how it was happening

Unfortunately we need to acquire an exclusive lock on the table to delete dupes and then create the unique index (which we also can't do concurrently because we can't lock a table outside of a transaction), so we need to expect a few seconds of this table being locked, unfortunately

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
