### PR TITLE
feat(migrate): redact DSNs and emit structured phase errors in hatchet-migrate

### DIFF
--- a/cmd/hatchet-migrate/migrate/run.go
+++ b/cmd/hatchet-migrate/migrate/run.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sethvargo/go-retry"
 
 	_ "github.com/hatchet-dev/hatchet/cmd/hatchet-migrate/migrate/migrations" // register go migrations
+	"github.com/hatchet-dev/hatchet/pkg/migratediag"
 )
 
 //go:embed migrations/*.sql
@@ -37,6 +38,12 @@ func WithUpToPenultimate() RunMigrationsOpt {
 }
 
 func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) {
+	if err := runMigrationsImpl(ctx, opts...); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func runMigrationsImpl(ctx context.Context, opts ...RunMigrationsOpt) error {
 	// Set default options
 	options := &runMigrationsOpt{}
 
@@ -44,16 +51,27 @@ func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) {
 		opt(options)
 	}
 
+	const (
+		databaseEnvVar = "DATABASE_URL"
+		phaseName      = "oss"
+	)
+
+	rawURL := os.Getenv(databaseEnvVar)
+	if rawURL == "" {
+		return migratediag.MissingEnvError(databaseEnvVar, phaseName)
+	}
+
+	dsn := migratediag.SummarizePostgresDSN(rawURL)
+
 	var db *sql.DB
 	var conn *sql.Conn
 
 	retryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
 
 	err := retry.Do(retryCtx, retry.NewConstant(1*time.Second), func(ctx context.Context) error {
 		var err error
 		if db == nil {
-			db, err = goose.OpenDBWithDriver("postgres", os.Getenv("DATABASE_URL"))
+			db, err = goose.OpenDBWithDriver("postgres", rawURL)
 
 			if err != nil {
 				return retry.RetryableError(fmt.Errorf("failed to open DB: %w", err))
@@ -69,34 +87,36 @@ func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) {
 		return nil
 	})
 
+	cancel()
+
 	if err != nil {
-		log.Fatalf("goose: failed to open DB: %v", err)
+		stage := "connect"
+		if db == nil {
+			stage = "open"
+		}
+		return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, stage, err)
 	}
 
 	defer func() {
 		if err := conn.Close(); err != nil {
-			log.Fatalf("goose: failed to close DB connection: %v", err)
+			log.Printf("%v", migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "close DB connection", err))
 		}
 
 		if err := db.Close(); err != nil {
-			log.Fatalf("goose: failed to close DB: %v", err)
+			log.Printf("%v", migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "close DB", err))
 		}
 	}()
-
-	if err != nil {
-		log.Fatalf("goose: failed to open DB connection: %v", err)
-	}
 
 	locker, err := lock.NewPostgresSessionLocker()
 
 	if err != nil {
-		log.Fatalf("goose: failed to create locker: %v", err)
+		return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "create session locker", err)
 	}
 
 	err = locker.SessionLock(ctx, conn)
 
 	if err != nil {
-		log.Fatalf("goose: failed to lock session: %v", err)
+		return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "session lock", err)
 	}
 
 	// Check whether the goose migrations table exists.
@@ -105,7 +125,7 @@ func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) {
 		query := TableExists("goose_db_version")
 		err = conn.QueryRowContext(ctx, query).Scan(&gooseExists)
 		if err != nil {
-			log.Fatalf("goose: failed to check goose migrations table existence: %v", err)
+			return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "check goose_db_version existence", err)
 		}
 	}
 
@@ -115,7 +135,7 @@ func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) {
 		createTableSQL := CreateTable("goose_db_version")
 		_, err = conn.ExecContext(ctx, createTableSQL)
 		if err != nil {
-			log.Fatalf("goose: failed to create goose migrations table: %v", err)
+			return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "create goose_db_version table", err)
 		}
 
 		// Insert a 0 version.
@@ -123,7 +143,7 @@ func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) {
 		_, err = conn.ExecContext(ctx, insertQuery, 0, true)
 
 		if err != nil {
-			log.Fatalf("goose: failed to insert baseline migration: %v", err)
+			return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "insert baseline version 0", err)
 		}
 
 		// Determine baseline version from atlas or prisma migrations.
@@ -134,7 +154,7 @@ func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) {
 		atlasExistQuery := "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'atlas_schema_revisions' AND table_name = 'atlas_schema_revisions')"
 		err = conn.QueryRowContext(ctx, atlasExistQuery).Scan(&atlasExists)
 		if err != nil {
-			log.Fatalf("goose: error checking atlas_schema_revisions existence: %v", err)
+			return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "check atlas_schema_revisions existence", err)
 		}
 
 		fmt.Printf("Does existing atlas schema exist? %v\n", atlasExists)
@@ -156,7 +176,7 @@ func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) {
 			prismaExistQuery := "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = '_prisma_migrations')"
 			err = conn.QueryRowContext(ctx, prismaExistQuery).Scan(&prismaExists)
 			if err != nil {
-				log.Fatalf("goose: error checking _prisma_migrations existence: %v", err)
+				return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "check _prisma_migrations existence", err)
 			}
 
 			fmt.Printf("Does existing prisma schema exist? %v\n", prismaExists)
@@ -177,11 +197,11 @@ func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) {
 		if baseline != "" {
 			fsys, err := fs.Sub(embedMigrations, "migrations")
 			if err != nil {
-				log.Fatalf("goose: failed to create sub filesystem: %v", err)
+				return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "create migrations sub filesystem", err)
 			}
 			entries, err := fs.ReadDir(fsys, ".")
 			if err != nil {
-				log.Fatalf("goose: failed to read migrations directory: %v", err)
+				return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "read migrations directory", err)
 			}
 
 			type migration struct {
@@ -213,11 +233,11 @@ func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) {
 				insertQuery := InsertVersion("goose_db_version")
 				v, err := strconv.ParseInt(m.version, 10, 64)
 				if err != nil {
-					log.Fatalf("goose: invalid migration version %s: %v", m.version, err)
+					return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "parse baseline migration version", fmt.Errorf("invalid migration version %s: %w", m.version, err))
 				}
 				_, err = conn.ExecContext(ctx, insertQuery, v, true)
 				if err != nil {
-					log.Fatalf("goose: failed to insert baseline migration %s: %v", m.filename, err)
+					return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "insert baseline migration", fmt.Errorf("%s: %w", m.filename, err))
 				}
 			}
 		}
@@ -226,13 +246,13 @@ func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) {
 	err = locker.SessionUnlock(ctx, conn)
 
 	if err != nil {
-		log.Fatalf("goose: failed to unlock session: %v", err)
+		return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "session unlock", err)
 	}
 
 	// decouple from existing structure
 	fsys, err := fs.Sub(embedMigrations, "migrations")
 	if err != nil {
-		log.Fatalf("goose: failed to create sub filesystem: %v", err)
+		return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "create migrations sub filesystem", err)
 	}
 	goose.SetBaseFS(fsys)
 
@@ -241,24 +261,26 @@ func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) {
 		migrations, err := listMigrations()
 
 		if err != nil {
-			log.Fatalf("goose: failed to list migrations: %v", err)
+			return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "list migrations", err)
 		}
 
 		if len(migrations) < 2 {
-			log.Fatalf("goose: not enough migrations to roll back to penultimate version")
+			return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "select penultimate migration", fmt.Errorf("not enough migrations to roll back to penultimate version"))
 		}
 
 		err = goose.UpTo(db, ".", migrations[len(migrations)-2].Version)
 
 		if err != nil {
-			log.Fatalf("goose: failed to apply migrations up to penultimate version: %v", err)
+			return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "apply migrations up to penultimate version", err)
 		}
 	default:
 		err = goose.Up(db, ".")
 		if err != nil {
-			log.Fatalf("goose: failed to apply migrations: %v", err)
+			return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "apply migrations", err)
 		}
 	}
+
+	return nil
 }
 
 // Copied from https://github.com/pressly/goose/blob/6a70e744c8eb2dc4bb90ba641cb03b42d8eef6cd/internal/dialect/dialectquery/postgres.go
@@ -328,11 +350,23 @@ func listMigrations() (goose.Migrations, error) {
 // RunDownMigration runs down migrations to a specific version.
 func RunDownMigration(ctx context.Context, targetVersion string) {
 	if err := runDownMigrationImpl(ctx, targetVersion); err != nil {
-		log.Fatalf("goose: %v", err)
+		log.Fatal(err)
 	}
 }
 
 func runDownMigrationImpl(ctx context.Context, targetVersion string) error {
+	const (
+		databaseEnvVar = "DATABASE_URL"
+		phaseName      = "oss-down"
+	)
+
+	rawURL := os.Getenv(databaseEnvVar)
+	if rawURL == "" {
+		return migratediag.MissingEnvError(databaseEnvVar, phaseName)
+	}
+
+	dsn := migratediag.SummarizePostgresDSN(rawURL)
+
 	var db *sql.DB
 	var conn *sql.Conn
 
@@ -341,7 +375,7 @@ func runDownMigrationImpl(ctx context.Context, targetVersion string) error {
 	err := retry.Do(retryCtx, retry.NewConstant(1*time.Second), func(ctx context.Context) error {
 		var err error
 		if db == nil {
-			db, err = goose.OpenDBWithDriver("postgres", os.Getenv("DATABASE_URL"))
+			db, err = goose.OpenDBWithDriver("postgres", rawURL)
 
 			if err != nil {
 				return retry.RetryableError(fmt.Errorf("failed to open DB: %w", err))
@@ -360,19 +394,23 @@ func runDownMigrationImpl(ctx context.Context, targetVersion string) error {
 	cancel()
 
 	if err != nil {
-		return fmt.Errorf("failed to open DB: %w", err)
+		stage := "connect"
+		if db == nil {
+			stage = "open"
+		}
+		return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, stage, err)
 	}
 
 	defer func() {
 		if conn != nil {
 			if err := conn.Close(); err != nil {
-				log.Printf("goose: failed to close DB connection: %v", err)
+				log.Printf("%v", migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "close DB connection", err))
 			}
 		}
 
 		if db != nil {
 			if err := db.Close(); err != nil {
-				log.Printf("goose: failed to close DB: %v", err)
+				log.Printf("%v", migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "close DB", err))
 			}
 		}
 	}()
@@ -380,39 +418,39 @@ func runDownMigrationImpl(ctx context.Context, targetVersion string) error {
 	locker, err := lock.NewPostgresSessionLocker()
 
 	if err != nil {
-		return fmt.Errorf("failed to create locker: %w", err)
+		return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "create session locker", err)
 	}
 
 	err = locker.SessionLock(ctx, conn)
 
 	if err != nil {
-		return fmt.Errorf("failed to lock session: %w", err)
+		return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "session lock", err)
 	}
 
 	defer func() {
 		if err := locker.SessionUnlock(ctx, conn); err != nil {
-			log.Printf("goose: failed to unlock session: %v", err)
+			log.Printf("%v", migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "session unlock", err))
 		}
 	}()
 
 	fsys, err := fs.Sub(embedMigrations, "migrations")
 	if err != nil {
-		return fmt.Errorf("failed to create sub filesystem: %w", err)
+		return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "create migrations sub filesystem", err)
 	}
 	goose.SetBaseFS(fsys)
 
 	targetVersionInt, err := strconv.ParseInt(targetVersion, 10, 64)
 	if err != nil {
-		return fmt.Errorf("invalid target version %s: %w", targetVersion, err)
+		return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "parse target version", fmt.Errorf("invalid target version %s: %w", targetVersion, err))
 	}
 
 	currentVersion, err := goose.GetDBVersion(db)
 	if err != nil {
-		return fmt.Errorf("failed to get current database version: %w", err)
+		return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "get current database version", err)
 	}
 
 	if currentVersion < targetVersionInt {
-		return fmt.Errorf("target version %d is higher than current version %d. Use standard migration (without --down flag) to upgrade", targetVersionInt, currentVersion)
+		return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "validate target version", fmt.Errorf("target version %d is higher than current version %d. Use standard migration (without --down flag) to upgrade", targetVersionInt, currentVersion))
 	}
 
 	if currentVersion == targetVersionInt {
@@ -424,7 +462,7 @@ func runDownMigrationImpl(ctx context.Context, targetVersion string) error {
 
 	err = goose.DownTo(db, ".", targetVersionInt)
 	if err != nil {
-		return fmt.Errorf("failed to migrate down to version %d: %w", targetVersionInt, err)
+		return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "apply down migration", fmt.Errorf("target version %d: %w", targetVersionInt, err))
 	}
 
 	fmt.Printf("Successfully migrated down to version %d\n", targetVersionInt)

--- a/pkg/migratediag/dsn.go
+++ b/pkg/migratediag/dsn.go
@@ -1,0 +1,130 @@
+// Package migratediag provides redacted DSN summaries and uniform migration
+// phase errors for hatchet-migrate and related migration binaries.
+package migratediag
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// ErrMissingEnv identifies a missing database DSN environment variable.
+var ErrMissingEnv = errors.New("missing database environment variable")
+
+// DSNSummary is a redacted database connection string summary safe for logs.
+type DSNSummary string
+
+const (
+	emptyDSN       DSNSummary = "<empty DSN>"
+	unparseableDSN DSNSummary = "<unparseable DSN>"
+)
+
+// SummarizePostgresDSN returns a redacted, single-line summary of a postgres
+// connection string suitable for logs and error messages.
+//
+// The DSN is parsed via pgconn.ParseConfig, the same parser the pgx driver
+// uses, so both URL form and libpq keyword form are handled. The summary emits
+// only fields that are safe to log: host, port, database name, RuntimeParams
+// keys, and a "tls" pseudo-key when TLS is enabled.
+//
+// For example, postgres://user:pass@db:5432/app?sslmode=require&application_name=migrate
+// becomes postgres://<redacted>@db:5432/app?keys=application_name,tls.
+func SummarizePostgresDSN(raw string) DSNSummary {
+	if raw == "" {
+		return emptyDSN
+	}
+
+	cfg, err := pgconn.ParseConfig(raw)
+	if err != nil {
+		return unparseableDSN
+	}
+
+	var b strings.Builder
+	b.WriteString("postgres://<redacted>@")
+	b.WriteString(cfg.Host)
+	if cfg.Port != 0 {
+		fmt.Fprintf(&b, ":%d", cfg.Port)
+	}
+	if cfg.Database != "" {
+		b.WriteString("/")
+		b.WriteString(cfg.Database)
+	}
+
+	keys := make([]string, 0, len(cfg.RuntimeParams)+1)
+	for k := range cfg.RuntimeParams {
+		keys = append(keys, k)
+	}
+	if cfg.TLSConfig != nil {
+		keys = append(keys, "tls")
+	}
+	sort.Strings(keys)
+
+	if len(keys) > 0 {
+		b.WriteString("?keys=")
+		b.WriteString(strings.Join(keys, ","))
+	}
+
+	return DSNSummary(b.String())
+}
+
+// SummarizeURLDSN returns a redacted, single-line summary of a URL-shaped
+// connection string suitable for logs and error messages.
+//
+// It preserves only fields that are safe to log: scheme, host, port, path, and
+// query parameter keys. It should not be used for postgres DSNs, which can also
+// arrive in libpq keyword form.
+func SummarizeURLDSN(raw string) DSNSummary {
+	if raw == "" {
+		return emptyDSN
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		return unparseableDSN
+	}
+
+	var b strings.Builder
+
+	if u.Scheme != "" {
+		b.WriteString(u.Scheme)
+		b.WriteString("://")
+	}
+
+	if u.User != nil {
+		b.WriteString("<redacted>@")
+	}
+
+	b.WriteString(u.Host)
+	b.WriteString(u.Path)
+
+	if u.RawQuery != "" {
+		values, qerr := url.ParseQuery(u.RawQuery)
+		if qerr == nil && len(values) > 0 {
+			keys := make([]string, 0, len(values))
+			for k := range values {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+
+			b.WriteString("?keys=")
+			b.WriteString(strings.Join(keys, ","))
+		}
+	}
+
+	return DSNSummary(b.String())
+}
+
+// MissingEnvError returns a phase error for a missing DSN environment variable.
+func MissingEnvError(envVar, phase string) error {
+	return PhaseError(envVar, phase, emptyDSN, "read env", ErrMissingEnv)
+}
+
+// PhaseError wraps the original error with migration phase, DSN source, stage,
+// and a redacted DSN summary.
+func PhaseError(envVar, phase string, dsnSummary DSNSummary, stage string, err error) error {
+	return fmt.Errorf("hatchet-migrate[%s %s]: failed during %s on %s: %w", envVar, phase, stage, dsnSummary, err)
+}

--- a/pkg/migratediag/dsn_test.go
+++ b/pkg/migratediag/dsn_test.go
@@ -1,0 +1,194 @@
+package migratediag
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestSummarizePostgresDSN(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty",
+			in:   "",
+			want: "<empty DSN>",
+		},
+		{
+			name: "url form with creds, query and tls",
+			in:   "postgres://alice:s3cret@db.example.com:5432/mydb?sslmode=require&application_name=hatchet-migrate&channel_binding=prefer",
+			want: "postgres://<redacted>@db.example.com:5432/mydb?keys=application_name,tls",
+		},
+		{
+			name: "url form with sslmode=disable",
+			in:   "postgres://alice:s3cret@db.example.com:5432/mydb?sslmode=disable",
+			want: "postgres://<redacted>@db.example.com:5432/mydb",
+		},
+		{
+			name: "libpq keyword form with password",
+			in:   "host=db.example.com port=5432 user=alice password=hunter2 dbname=mydb sslmode=require application_name=hatchet-migrate",
+			want: "postgres://<redacted>@db.example.com:5432/mydb?keys=application_name,tls",
+		},
+		{
+			name: "libpq keyword form without port",
+			in:   "host=/var/run/postgresql user=alice password=hunter2 dbname=mydb sslmode=disable",
+			want: "postgres://<redacted>@/var/run/postgresql:5432/mydb",
+		},
+		{
+			name: "unparseable",
+			in:   "postgres://user:p%ZZword@host/db",
+			want: "<unparseable DSN>",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := SummarizePostgresDSN(tc.in)
+			if string(got) != tc.want {
+				t.Fatalf("SummarizePostgresDSN(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSummarizePostgresDSN_NeverLeaksSecrets(t *testing.T) {
+	t.Parallel()
+
+	const (
+		username = "alice"
+		password = "s3cret-do-not-log"
+		appName  = "very-specific-app-name-value"
+	)
+
+	cases := []string{
+		"postgres://" + username + ":" + password + "@db.example.com:5432/mydb?application_name=" + appName + "&sslmode=require",
+		"host=db.example.com port=5432 user=" + username + " password=" + password + " dbname=mydb application_name=" + appName + " sslmode=require",
+	}
+
+	for _, in := range cases {
+		got := SummarizePostgresDSN(in)
+		for _, leak := range []string{username, password, appName} {
+			if strings.Contains(string(got), leak) {
+				t.Fatalf("SummarizePostgresDSN leaked %q in %q (input: %q)", leak, got, in)
+			}
+		}
+	}
+}
+
+func TestSummarizeURLDSN(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty",
+			in:   "",
+			want: "<empty DSN>",
+		},
+		{
+			name: "url with username, password and query params",
+			in:   "clickhouse://alice:s3cret@db.example.com:9000/mydb?sslmode=require&channel_binding=prefer",
+			want: "clickhouse://<redacted>@db.example.com:9000/mydb?keys=channel_binding,sslmode",
+		},
+		{
+			name: "url without credentials",
+			in:   "clickhouse://db.example.com:9000/mydb",
+			want: "clickhouse://db.example.com:9000/mydb",
+		},
+		{
+			name: "url without query string",
+			in:   "clickhouse://alice:s3cret@db.example.com:9000/mydb",
+			want: "clickhouse://<redacted>@db.example.com:9000/mydb",
+		},
+		{
+			name: "clickhousess url with credentials and query",
+			in:   "clickhousess://user:hunter2@ch.example.com:9440/analytics?compress=true&secure=true",
+			want: "clickhousess://<redacted>@ch.example.com:9440/analytics?keys=compress,secure",
+		},
+		{
+			name: "host without port",
+			in:   "clickhouse://user:pw@db.example.com/mydb",
+			want: "clickhouse://<redacted>@db.example.com/mydb",
+		},
+		{
+			name: "unparseable url",
+			in:   "clickhouse://user:p%ZZword@host/db",
+			want: "<unparseable DSN>",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := SummarizeURLDSN(tc.in)
+			if string(got) != tc.want {
+				t.Fatalf("SummarizeURLDSN(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSummarizeURLDSN_NeverLeaksSecrets(t *testing.T) {
+	t.Parallel()
+
+	const (
+		username  = "alice"
+		password  = "s3cret-do-not-log"
+		queryVal  = "require-tls-1.3-only"
+		queryVal2 = "prefer-channel-binding"
+	)
+
+	in := "clickhousess://" + username + ":" + password +
+		"@db.example.com:9440/mydb?sslmode=" + queryVal + "&channel_binding=" + queryVal2
+
+	got := SummarizeURLDSN(in)
+
+	for _, leak := range []string{username, password, queryVal, queryVal2} {
+		if strings.Contains(string(got), leak) {
+			t.Fatalf("SummarizeURLDSN leaked sensitive substring %q in %q", leak, got)
+		}
+	}
+}
+
+func TestPhaseError(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("context deadline exceeded")
+	got := PhaseError(
+		"CLOUD_DATABASE_URL",
+		"cloud-extension",
+		DSNSummary("postgres://<redacted>@db.example.com:5432/cloud?keys=tls"),
+		"connect",
+		cause,
+	)
+	want := "hatchet-migrate[CLOUD_DATABASE_URL cloud-extension]: failed during connect on " +
+		"postgres://<redacted>@db.example.com:5432/cloud?keys=tls: context deadline exceeded"
+	if got.Error() != want {
+		t.Fatalf("PhaseError mismatch:\n got: %q\nwant: %q", got.Error(), want)
+	}
+	if !errors.Is(got, cause) {
+		t.Fatalf("PhaseError did not wrap original error: %v", got)
+	}
+}
+
+func TestMissingEnvError(t *testing.T) {
+	t.Parallel()
+
+	got := MissingEnvError("DATABASE_URL", "oss")
+	want := "hatchet-migrate[DATABASE_URL oss]: failed during read env on <empty DSN>: missing database environment variable"
+	if got.Error() != want {
+		t.Fatalf("MissingEnvError mismatch:\n got: %q\nwant: %q", got.Error(), want)
+	}
+	if !errors.Is(got, ErrMissingEnv) {
+		t.Fatalf("MissingEnvError did not wrap ErrMissingEnv: %v", got)
+	}
+}


### PR DESCRIPTION
# Description

`hatchet-migrate` previously logged migration failures as `goose: failed to <thing>: <err>`, with no indication of which DSN it was talking to or which phase of the migration was running. That made the logs hard to diagnose.

This PR introduces a small `pkg/migratediag` package and rewires every error path in `cmd/hatchet-migrate/migrate/run.go` through it.

## Type of change

- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [x] Chore (changes which are not directly related to any business logic)

## What's Changed

Operator-visible behavior, a failed migration will show something like this:
```
2026/05/11 11:21:03 hatchet-migrate[DATABASE_URL oss]: failed during apply migrations on postgres://<redacted>@db.internal:5432/hatchet?keys=application_name,tls: context deadline exceeded
exit status 1
```