### PR TITLE
Fix: add backoff to sleeps

### DIFF
--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"math"
 	"strings"
 	"sync"
 	"time"
@@ -559,7 +560,7 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 		tc.emitStandaloneTaskRootSpans(ctx, tenantId, succeededOpts)
 
 		if len(failedOpts) > 0 {
-			time.Sleep(1 * time.Millisecond)
+			tc.sleepWithBackoff(attempts)
 		}
 	}
 
@@ -568,6 +569,11 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 	)
 
 	return nil
+}
+
+func (oc *OLAPControllerImpl) sleepWithBackoff(attempt int) {
+	backoffFactor := math.Exp2(float64(attempt))
+	time.Sleep(time.Duration(backoffFactor) * time.Millisecond)
 }
 
 func (tc *OLAPControllerImpl) emitStandaloneTaskRootSpans(ctx context.Context, tenantId uuid.UUID, tasks []*v1.V1TaskWithPayload) {
@@ -644,7 +650,7 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 		tc.emitWorkflowRunRootSpans(ctx, tenantId, succeededOpts)
 
 		if len(failedOpts) > 0 {
-			time.Sleep(1 * time.Millisecond)
+			tc.sleepWithBackoff(attempts)
 		}
 	}
 
@@ -1078,7 +1084,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		}
 
 		if len(remainingOpts) > 0 {
-			time.Sleep(1 * time.Millisecond)
+			tc.sleepWithBackoff(attempts)
 		}
 	}
 

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -559,7 +559,7 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 		createTaskOpts = failedOpts
 		tc.emitStandaloneTaskRootSpans(ctx, tenantId, succeededOpts)
 
-		if len(failedOpts) > 0 {
+		if len(failedOpts) > 0 && attempts < 10 {
 			tc.sleepWithBackoff(attempts)
 		}
 	}
@@ -649,7 +649,7 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 		createDAGOpts = failedOpts
 		tc.emitWorkflowRunRootSpans(ctx, tenantId, succeededOpts)
 
-		if len(failedOpts) > 0 {
+		if len(failedOpts) > 0 && attempts < 10 {
 			tc.sleepWithBackoff(attempts)
 		}
 	}
@@ -1083,7 +1083,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 			tc.synthesizeEngineSpans(ctx, tenantId, spanEventsForSuccessfullyLockedRuns)
 		}
 
-		if len(remainingOpts) > 0 {
+		if len(remainingOpts) > 0 && attempts < 10 {
 			tc.sleepWithBackoff(attempts)
 		}
 	}


### PR DESCRIPTION
# Description

Adds exponential backoff to sleeps when we retry messages on the OLAP side in-memory to allow more time for the thing being waited on to process

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

