### PR TITLE
fix: avoid invalid user FK in cookie test

### DIFF
--- a/pkg/auth/cookie/sessionstore_test.go
+++ b/pkg/auth/cookie/sessionstore_test.go
@@ -57,7 +57,6 @@ func TestSessionStoreLogoutClearsCookieWhenSessionRowMissing(t *testing.T) {
 		}
 
 		session.Values["authenticated"] = true
-		session.Values["user_id"] = uuid.New().String()
 
 		rr := httptest.NewRecorder()
 		if err := ss.Save(req, rr, session); err != nil {


### PR DESCRIPTION
# Description

Removes the synthetic `user_id` from the stale-session logout test so the setup does not violate the `UserSession.userId` foreign key. Keeps the test focused on verifying that logout clears the browser cookie when the backing session row is missing.

Fixes https://github.com/hatchet-dev/hatchet/pull/3858#issuecomment-4420055150

## Type of change

- [x] Test changes (add, refactor, improve or change a test)


## What's Changed

