### PR TITLE
Feat: add cron schedule time to additional meta

### DIFF
--- a/internal/services/ticker/cron.go
+++ b/internal/services/ticker/cron.go
@@ -90,13 +90,27 @@ func (t *TickerImpl) handleScheduleCron(ctx context.Context, cron *sqlcv1.PollCr
 
 	cronUUID := uuid.New()
 
+	var job gocron.Job
+
 	// schedule the cron
-	_, err := t.userCronScheduler.NewJob(
+	job, err := t.userCronScheduler.NewJob(
 		// the gocron library accepts either 5 or 6 term crontabs when withSeconds is true
 		gocron.CronJob(cron.Cron, true),
-		gocron.NewTask(
-			t.runCronWorkflow(tenantId, workflowVersionId, cron.Cron, cronParentId, &cron.Name.String, cron.Input, additionalMetadata, &cron.Priority),
-		),
+		gocron.NewTask(func() {
+			scheduledAt, err := job.LastRunStartedAt()
+
+			if err != nil {
+				t.l.Error().Ctx(ctx).Err(err).Msg("could not get scheduled time for cron job")
+				scheduledAt = time.Now()
+			}
+
+			t.runCronWorkflow(
+				tenantId, workflowVersionId, cron.Cron,
+				cronParentId, &cron.Name.String, cron.Input,
+				additionalMetadata, &cron.Priority,
+				scheduledAt.Truncate(time.Second),
+			)()
+		}),
 		gocron.WithIdentifier(cronUUID),
 	)
 
@@ -119,7 +133,7 @@ func (t *TickerImpl) handleScheduleCron(ctx context.Context, cron *sqlcv1.PollCr
 	return nil
 }
 
-func (t *TickerImpl) runCronWorkflow(tenantId, workflowVersionId uuid.UUID, cron, cronParentId string, cronName *string, input []byte, additionalMetadata map[string]interface{}, priority *int32) func() {
+func (t *TickerImpl) runCronWorkflow(tenantId, workflowVersionId uuid.UUID, cron, cronParentId string, cronName *string, input []byte, additionalMetadata map[string]interface{}, priority *int32, scheduledAt time.Time) func() {
 	return func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
@@ -133,7 +147,7 @@ func (t *TickerImpl) runCronWorkflow(tenantId, workflowVersionId uuid.UUID, cron
 			return
 		}
 
-		err = t.runCronWorkflowV1(ctx, tenantId, workflowVersion, cron, cronParentId, cronName, input, additionalMetadata, priority)
+		err = t.runCronWorkflowV1(ctx, tenantId, workflowVersion, cron, cronParentId, cronName, input, additionalMetadata, priority, scheduledAt)
 
 		if err != nil {
 			t.l.Error().Ctx(ctx).Err(err).Msg("could not run cron workflow")

--- a/internal/services/ticker/cron.go
+++ b/internal/services/ticker/cron.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-co-op/gocron/v2"
@@ -91,27 +92,39 @@ func (t *TickerImpl) handleScheduleCron(ctx context.Context, cron *sqlcv1.PollCr
 	cronUUID := uuid.New()
 
 	var job gocron.Job
+	var scheduledAtPtr atomic.Pointer[time.Time]
 
 	// schedule the cron
 	job, err := t.userCronScheduler.NewJob(
 		// the gocron library accepts either 5 or 6 term crontabs when withSeconds is true
 		gocron.CronJob(cron.Cron, true),
 		gocron.NewTask(func() {
-			scheduledAt, err := job.LastRunStartedAt()
-
-			if err != nil {
-				t.l.Error().Ctx(ctx).Err(err).Msg("could not get scheduled time for cron job")
-				scheduledAt = time.Now().UTC()
+			scheduledAt := scheduledAtPtr.Load()
+			if scheduledAt == nil {
+				// this should be pretty rare in practice, since we're assigning the `scheduledAtPtr` immediately before
+				// it triggers, but just here for nil safety
+				now := time.Now().UTC()
+				scheduledAt = &now
 			}
 
 			t.runCronWorkflow(
 				tenantId, workflowVersionId, cron.Cron,
 				cronParentId, &cron.Name.String, cron.Input,
 				additionalMetadata, &cron.Priority,
-				scheduledAt.Truncate(time.Second),
+				*scheduledAt,
 			)()
 		}),
 		gocron.WithIdentifier(cronUUID),
+		gocron.WithEventListeners(
+			// this runs sync before the gocron task in the same goroutine,
+			// and before gocron reschedules the job — so NextRun() here returns the
+			// scheduled fire time for the current run, not the subsequent one.
+			gocron.BeforeJobRuns(func(_ uuid.UUID, _ string) {
+				if nextRun, err := job.NextRun(); err == nil && !nextRun.IsZero() {
+					scheduledAtPtr.Store(&nextRun)
+				}
+			}),
+		),
 	)
 
 	if err != nil {

--- a/internal/services/ticker/cron.go
+++ b/internal/services/ticker/cron.go
@@ -101,7 +101,7 @@ func (t *TickerImpl) handleScheduleCron(ctx context.Context, cron *sqlcv1.PollCr
 
 			if err != nil {
 				t.l.Error().Ctx(ctx).Err(err).Msg("could not get scheduled time for cron job")
-				scheduledAt = time.Now()
+				scheduledAt = time.Now().UTC()
 			}
 
 			t.runCronWorkflow(

--- a/internal/services/ticker/cron_v1.go
+++ b/internal/services/ticker/cron_v1.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -15,13 +16,14 @@ import (
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 )
 
-func (t *TickerImpl) runCronWorkflowV1(ctx context.Context, tenantId uuid.UUID, workflowVersion *sqlcv1.GetWorkflowVersionForEngineRow, cron, cronParentId string, cronName *string, input []byte, additionalMetadata map[string]interface{}, priority *int32) error {
+func (t *TickerImpl) runCronWorkflowV1(ctx context.Context, tenantId uuid.UUID, workflowVersion *sqlcv1.GetWorkflowVersionForEngineRow, cron, cronParentId string, cronName *string, input []byte, additionalMetadata map[string]interface{}, priority *int32, scheduledAt time.Time) error {
 	if additionalMetadata == nil {
 		additionalMetadata = make(map[string]interface{})
 	}
 
 	metadata := map[string]any{
 		constants.CronExpressionKey.String(): cron,
+		constants.CronScheduledAt.String():   scheduledAt.Format(time.RFC3339),
 	}
 
 	if cronName != nil {

--- a/internal/services/ticker/cron_v1.go
+++ b/internal/services/ticker/cron_v1.go
@@ -22,8 +22,8 @@ func (t *TickerImpl) runCronWorkflowV1(ctx context.Context, tenantId uuid.UUID, 
 	}
 
 	metadata := map[string]any{
-		constants.CronExpressionKey.String(): cron,
-		constants.CronScheduledAt.String():   scheduledAt.Format(time.RFC3339),
+		constants.CronExpressionKey.String():  cron,
+		constants.CronScheduledAtKey.String(): scheduledAt.Format(time.RFC3339),
 	}
 
 	if cronName != nil {

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -3,15 +3,15 @@ package constants
 type MetadataKey string
 
 const (
-	CorrelationIdKey  MetadataKey = "correlationId"
-	ResourceIdKey     MetadataKey = "resourceId"
-	ResourceTypeKey   MetadataKey = "resourceType"
-	GRPCMethodKey     MetadataKey = "grpc_method"
-	EventIDKey        MetadataKey = "hatchet__event_id"
-	EventKeyKey       MetadataKey = "hatchet__event_key"
-	CronExpressionKey MetadataKey = "hatchet__cron_expression"
-	CronNameKey       MetadataKey = "hatchet__cron_name"
-	CronScheduledAt   MetadataKey = "hatchet__cron_scheduled_at"
+	CorrelationIdKey   MetadataKey = "correlationId"
+	ResourceIdKey      MetadataKey = "resourceId"
+	ResourceTypeKey    MetadataKey = "resourceType"
+	GRPCMethodKey      MetadataKey = "grpc_method"
+	EventIDKey         MetadataKey = "hatchet__event_id"
+	EventKeyKey        MetadataKey = "hatchet__event_key"
+	CronExpressionKey  MetadataKey = "hatchet__cron_expression"
+	CronNameKey        MetadataKey = "hatchet__cron_name"
+	CronScheduledAtKey MetadataKey = "hatchet__cron_scheduled_at"
 )
 
 func (k MetadataKey) String() string {

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -11,6 +11,7 @@ const (
 	EventKeyKey       MetadataKey = "hatchet__event_key"
 	CronExpressionKey MetadataKey = "hatchet__cron_expression"
 	CronNameKey       MetadataKey = "hatchet__cron_name"
+	CronScheduledAt   MetadataKey = "hatchet__cron_scheduled_at"
 )
 
 func (k MetadataKey) String() string {


### PR DESCRIPTION
# Description

Adds the cron schedule time to the additional metadata under `hatchet__cron_scheduled_at`. I think this is the closest we can realistically get to the time the cron is supposed to be triggered at without writing the _next_ run to the db somewhere, or holding it in memory and risking a crash, a deploy, etc.


Some worker logs (booted the worker to register the cron, shut it down, let a couple seconds pass, and booted it up again to see what would happen in the case of the worker being offline):

```python
@hatchet.task(on_crons=["* * * * * *"])
def simple(input: EmptyModel, ctx: Context) -> None:
    now = datetime.now(tz=UTC)
    scheduled = ctx.cron_scheduled_at

    print(
        f"Current time: {now.isoformat()}. Scheduled to run at: {scheduled.isoformat()}"
    )
```


```
matt@Matts-MacBook-Pro-4 python % prp examples/simple/worker.py
[INFO]  🪓 -- 2026-05-11 22:47:11,441 - ------------------------------------------
[INFO]  🪓 -- 2026-05-11 22:47:11,441 - STARTING HATCHET...
[INFO]  🪓 -- 2026-05-11 22:47:11,446 - starting runner...
[INFO]  🪓 -- 2026-05-11 22:47:12,073 - rx: start step run: c5ed194c-928c-43e8-a790-31e5796aee30/simple:simple
[INFO]  🪓 -- 2026-05-11 22:47:12,074 - run: start step: simple:simple/c5ed194c-928c-43e8-a790-31e5796aee30
[INFO]  🪓 -- 2026-05-11 22:47:12,074 - durable event listener connecting...
[INFO]  🪓 -- 2026-05-11 22:47:12,074 - durable event listener connected
Current time: 2026-05-12T02:47:12.075544+00:00. Scheduled to run at: 2026-05-12T02:47:12+00:00
Current time: 2026-05-12T02:47:12.076176+00:00. Scheduled to run at: 2026-05-12T02:47:08+00:00
Current time: 2026-05-12T02:47:12.076892+00:00. Scheduled to run at: 2026-05-12T02:47:10+00:00
Current time: 2026-05-12T02:47:12.078608+00:00. Scheduled to run at: 2026-05-12T02:47:09+00:00
Current time: 2026-05-12T02:47:12.080096+00:00. Scheduled to run at: 2026-05-12T02:47:07+00:00
Current time: 2026-05-12T02:47:12.082019+00:00. Scheduled to run at: 2026-05-12T02:47:11+00:00
Current time: 2026-05-12T02:47:13.022134+00:00. Scheduled to run at: 2026-05-12T02:47:13+00:00
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)
