### PR TITLE
Fix: limit the number of re-pubs to be the max death count

### DIFF
--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -286,6 +286,7 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 			olap.WithAnalyzeCronInterval(sc.CronOperations.OLAPAnalyzeCronInterval),
 			olap.WithOLAPStatusUpdateBatchSizeLimits(sizeLimits),
 			olap.WithMQQos(sc.Operations.OLAPMQQos),
+			olap.WithMaxRequeueCount(sc.MQMaxDeathCount),
 		)
 
 		if err != nil {
@@ -666,6 +667,7 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 				olap.WithAnalyzeCronInterval(sc.CronOperations.OLAPAnalyzeCronInterval),
 				olap.WithOLAPStatusUpdateBatchSizeLimits(sizeLimits),
 				olap.WithMQQos(sc.Operations.OLAPMQQos),
+				olap.WithMaxRequeueCount(sc.MQMaxDeathCount),
 			)
 
 			if err != nil {

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -1117,7 +1117,7 @@ func (tc *OLAPControllerImpl) republishCreatedTasks(ctx context.Context, tenantI
 			tc.l.Error().Ctx(ctx).Msgf("dropping task %d after %d requeue attempts", task.ID, tc.maxRequeueCount)
 			continue
 		}
-		msg, err := tasktypes.RepublishCreatedTaskMessage(tenantId, updated)
+		msg, err := tasktypes.CreatedTaskMessage(tenantId, updated)
 		if err != nil {
 			return err
 		}
@@ -1136,7 +1136,7 @@ func (tc *OLAPControllerImpl) republishCreatedDAGs(ctx context.Context, tenantId
 			tc.l.Error().Ctx(ctx).Msgf("dropping dag %s after %d requeue attempts", dag.ExternalID.String(), tc.maxRequeueCount)
 			continue
 		}
-		msg, err := tasktypes.RepublishCreatedDAGMessage(tenantId, updated)
+		msg, err := tasktypes.CreatedDAGMessage(tenantId, updated)
 		if err != nil {
 			return err
 		}

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -1135,7 +1135,7 @@ func (tc *OLAPControllerImpl) republishCreatedTasks(ctx context.Context, tenantI
 		updated := *task
 		updated.RequeueCount++
 		if updated.RequeueCount > tc.maxRequeueCount {
-			tc.l.Error().Ctx(ctx).Msgf("dropping task %d after %d requeue attempts", task.ID, tc.maxRequeueCount)
+			tc.l.Error().Ctx(ctx).Msgf("dropping task %s after %d requeue attempts", task.ExternalID.String(), tc.maxRequeueCount)
 			continue
 		}
 		msg, err := tasktypes.CreatedTaskMessage(tenantId, updated)

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -557,13 +557,11 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTasks(ctx, tenantId, extractCreatedTaskData(createTaskOpts))
 
 		if err != nil {
-			tc.l.Error().Ctx(ctx).Err(err).Int("count", len(createTaskOpts)).Int("attempt", attempts).Int("requeue_count", maxRequeueCount).Msg("failed to create tasks, republishing to MQ")
-			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
+			return fmt.Errorf("failed to create tasks: %w", err)
 		}
 
 		if err := tc.notifyStatusUpdates(ctx, result); err != nil {
-			tc.l.Error().Ctx(ctx).Err(err).Int("count", len(createTaskOpts)).Int("attempt", attempts).Int("requeue_count", maxRequeueCount).Msg("failed to notify status updates for created tasks, republishing to MQ")
-			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
+			return fmt.Errorf("failed to notify status updates: %w", err)
 		}
 
 		failedOpts := make([]*tasktypes.CreatedTaskPayload, 0)
@@ -658,9 +656,9 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 		attempts++
 
 		workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateDAGs(ctx, tenantId, extractCreatedDAGData(createDAGOpts))
+
 		if err != nil {
-			tc.l.Error().Ctx(ctx).Err(err).Int("count", len(createDAGOpts)).Int("attempt", attempts).Int("requeue_count", maxRequeueCount).Msg("failed to create DAGs, republishing to MQ")
-			return tc.republishCreatedDAGs(ctx, tenantId, createDAGOpts)
+			return fmt.Errorf("failed to create DAGs: %w", err)
 		}
 
 		failedOpts := make([]*tasktypes.CreatedDAGPayload, 0)
@@ -1062,12 +1060,11 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTaskEvents(ctx, tenantId, opts, eventExternalIdToWorkflowRunId)
 
 		if err != nil {
-			tc.l.Error().Ctx(ctx).Err(err).Int("count", len(opts)).Int("attempt", attempts).Int("requeue_count", maxRequeueCount).Msg("failed to create task events, republishing to MQ")
-			return tc.republishMonitoringEvents(ctx, tenantId, opts, externalIdToMsg)
+			return fmt.Errorf("failed to create task events: %w", err)
 		}
 
 		if err := tc.notifyStatusUpdates(ctx, result); err != nil {
-			tc.l.Error().Ctx(ctx).Err(err).Msg("failed to notify status updates for created monitoring events, continuing to process remaining events")
+			return fmt.Errorf("failed to notify status updates: %w", err)
 		}
 
 		var spanEventsForSuccessfullyLockedRuns []engineSpanEvent

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -540,8 +540,15 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 
 	attempts := 0
 	for len(createTaskOpts) > 0 {
+		maxRequeueCount := 0
+		for _, opt := range createTaskOpts {
+			if opt.RequeueCount > maxRequeueCount {
+				maxRequeueCount = opt.RequeueCount
+			}
+		}
+
 		if attempts >= 10 {
-			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d tasks after %d attempts, republishing to MQ", len(createTaskOpts), attempts)
+			tc.l.Error().Ctx(ctx).Int("requeue_count", maxRequeueCount).Msgf("failed to acquire locks for %d tasks after %d attempts, republishing to MQ", len(createTaskOpts), attempts)
 			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
 		}
 
@@ -550,12 +557,12 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTasks(ctx, tenantId, extractCreatedTaskData(createTaskOpts))
 
 		if err != nil {
-			tc.l.Error().Ctx(ctx).Err(err).Msgf("failed to create %d tasks on attempt %d, republishing to MQ", len(createTaskOpts), attempts)
+			tc.l.Error().Ctx(ctx).Err(err).Int("requeue_count", maxRequeueCount).Msgf("failed to create %d tasks on attempt %d, republishing to MQ", len(createTaskOpts), attempts)
 			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
 		}
 
 		if err := tc.notifyStatusUpdates(ctx, result); err != nil {
-			tc.l.Error().Ctx(ctx).Err(err).Msg("failed to notify status updates for created tasks")
+			tc.l.Error().Ctx(ctx).Err(err).Int("requeue_count", maxRequeueCount).Msg("failed to notify status updates for created tasks, republishing to MQ")
 			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
 		}
 
@@ -636,8 +643,15 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 
 	attempts := 0
 	for len(createDAGOpts) > 0 {
+		maxRequeueCount := 0
+		for _, opt := range createDAGOpts {
+			if opt.RequeueCount > maxRequeueCount {
+				maxRequeueCount = opt.RequeueCount
+			}
+		}
+
 		if attempts >= 10 {
-			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d DAGs after %d attempts, republishing to MQ", len(createDAGOpts), attempts)
+			tc.l.Error().Ctx(ctx).Int("requeue_count", maxRequeueCount).Msgf("failed to acquire locks for %d DAGs after %d attempts, republishing to MQ", len(createDAGOpts), attempts)
 			return tc.republishCreatedDAGs(ctx, tenantId, createDAGOpts)
 		}
 
@@ -645,7 +659,7 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 
 		workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateDAGs(ctx, tenantId, extractCreatedDAGData(createDAGOpts))
 		if err != nil {
-			tc.l.Error().Ctx(ctx).Err(err).Msgf("failed to create %d DAGs on attempt %d, republishing to MQ", len(createDAGOpts), attempts)
+			tc.l.Error().Ctx(ctx).Err(err).Int("requeue_count", maxRequeueCount).Msgf("failed to create %d DAGs on attempt %d, republishing to MQ", len(createDAGOpts), attempts)
 			return tc.republishCreatedDAGs(ctx, tenantId, createDAGOpts)
 		}
 
@@ -1031,8 +1045,15 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 
 	attempts := 0
 	for len(opts) > 0 {
+		maxRequeueCount := 0
+		for _, msg := range externalIdToMsg {
+			if msg.RequeueCount > maxRequeueCount {
+				maxRequeueCount = msg.RequeueCount
+			}
+		}
+
 		if attempts >= 10 {
-			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d monitoring events after %d attempts, republishing to MQ", len(opts), attempts)
+			tc.l.Error().Ctx(ctx).Int("requeue_count", maxRequeueCount).Msgf("failed to acquire locks for %d monitoring events after %d attempts, republishing to MQ", len(opts), attempts)
 			return tc.republishMonitoringEvents(ctx, tenantId, opts, externalIdToMsg)
 		}
 
@@ -1041,7 +1062,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTaskEvents(ctx, tenantId, opts, eventExternalIdToWorkflowRunId)
 
 		if err != nil {
-			tc.l.Error().Ctx(ctx).Err(err).Msgf("failed to create %d task events on attempt %d, republishing to MQ", len(opts), attempts)
+			tc.l.Error().Ctx(ctx).Err(err).Int("requeue_count", maxRequeueCount).Msgf("failed to create %d task events on attempt %d, republishing to MQ", len(opts), attempts)
 			return tc.republishMonitoringEvents(ctx, tenantId, opts, externalIdToMsg)
 		}
 

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -181,6 +181,10 @@ func WithMQQos(qos int) OLAPControllerOpt {
 
 func WithMaxRequeueCount(count int) OLAPControllerOpt {
 	return func(opts *OLAPControllerOpts) {
+		if count <= 0 {
+			return
+		}
+
 		opts.maxRequeueCount = count
 	}
 }
@@ -526,11 +530,6 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 	msgs := msgqueue.JSONConvert[tasktypes.CreatedTaskPayload](payloads)
 
 	for _, msg := range msgs {
-		if msg.RequeueCount >= tc.maxRequeueCount {
-			tc.l.Error().Ctx(ctx).Msgf("dropping task %d after %d requeue attempts", msg.ID, msg.RequeueCount)
-			continue
-		}
-
 		if !tc.sample(msg.WorkflowRunID.String()) {
 			tc.l.Debug().Ctx(ctx).Msgf("skipping task %d for workflow run %s", msg.ID, msg.WorkflowRunID.String())
 			continue
@@ -627,11 +626,6 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 	msgs := msgqueue.JSONConvert[tasktypes.CreatedDAGPayload](payloads)
 
 	for _, msg := range msgs {
-		if msg.RequeueCount >= tc.maxRequeueCount {
-			tc.l.Error().Ctx(ctx).Msgf("dropping dag %s after %d requeue attempts", msg.ExternalID.String(), msg.RequeueCount)
-			continue
-		}
-
 		if !tc.sample(msg.ExternalID.String()) {
 			tc.l.Debug().Ctx(ctx).Msgf("skipping dag %s", msg.ExternalID.String())
 			continue
@@ -855,16 +849,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 	ctx, span := telemetry.NewSpan(ctx, "OLAPControllerImpl.handleCreateMonitoringEvent")
 	defer span.End()
 
-	allMsgs := msgqueue.JSONConvert[tasktypes.CreateMonitoringEventPayload](payloads)
-
-	msgs := make([]*tasktypes.CreateMonitoringEventPayload, 0, len(allMsgs))
-	for _, msg := range allMsgs {
-		if msg.RequeueCount >= tc.maxRequeueCount {
-			tc.l.Error().Ctx(ctx).Msgf("dropping monitoring event for task %d after %d requeue attempts", msg.TaskId, msg.RequeueCount)
-			continue
-		}
-		msgs = append(msgs, msg)
-	}
+	msgs := msgqueue.JSONConvert[tasktypes.CreateMonitoringEventPayload](payloads)
 
 	taskIdsToLookup := make([]int64, len(msgs))
 
@@ -1128,6 +1113,10 @@ func (tc *OLAPControllerImpl) republishCreatedTasks(ctx context.Context, tenantI
 	for _, task := range tasks {
 		updated := *task
 		updated.RequeueCount++
+		if updated.RequeueCount > tc.maxRequeueCount {
+			tc.l.Error().Ctx(ctx).Msgf("dropping task %d after %d requeue attempts", task.ID, tc.maxRequeueCount)
+			continue
+		}
 		msg, err := tasktypes.RepublishCreatedTaskMessage(tenantId, updated)
 		if err != nil {
 			return err
@@ -1143,6 +1132,10 @@ func (tc *OLAPControllerImpl) republishCreatedDAGs(ctx context.Context, tenantId
 	for _, dag := range dags {
 		updated := *dag
 		updated.RequeueCount++
+		if updated.RequeueCount > tc.maxRequeueCount {
+			tc.l.Error().Ctx(ctx).Msgf("dropping dag %s after %d requeue attempts", dag.ExternalID.String(), tc.maxRequeueCount)
+			continue
+		}
 		msg, err := tasktypes.RepublishCreatedDAGMessage(tenantId, updated)
 		if err != nil {
 			return err
@@ -1167,6 +1160,10 @@ func (tc *OLAPControllerImpl) republishMonitoringEvents(ctx context.Context, ten
 		}
 		updated := *payload
 		updated.RequeueCount++
+		if updated.RequeueCount > tc.maxRequeueCount {
+			tc.l.Error().Ctx(ctx).Msgf("dropping monitoring event for task %d after %d requeue attempts", payload.TaskId, tc.maxRequeueCount)
+			continue
+		}
 		msg, err := tasktypes.MonitoringEventMessageFromInternal(tenantId, updated)
 		if err != nil {
 			return err

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -548,7 +548,7 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 		}
 
 		if attempts >= 10 {
-			tc.l.Error().Ctx(ctx).Int("requeue_count", maxRequeueCount).Msgf("failed to acquire locks for %d tasks after %d attempts, republishing to MQ", len(createTaskOpts), attempts)
+			tc.l.Error().Ctx(ctx).Int("count", len(createTaskOpts)).Int("attempts", attempts).Int("requeue_count", maxRequeueCount).Msg("failed to acquire locks for tasks, republishing to MQ")
 			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
 		}
 
@@ -557,12 +557,12 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTasks(ctx, tenantId, extractCreatedTaskData(createTaskOpts))
 
 		if err != nil {
-			tc.l.Error().Ctx(ctx).Err(err).Int("requeue_count", maxRequeueCount).Msgf("failed to create %d tasks on attempt %d, republishing to MQ", len(createTaskOpts), attempts)
+			tc.l.Error().Ctx(ctx).Err(err).Int("count", len(createTaskOpts)).Int("attempt", attempts).Int("requeue_count", maxRequeueCount).Msg("failed to create tasks, republishing to MQ")
 			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
 		}
 
 		if err := tc.notifyStatusUpdates(ctx, result); err != nil {
-			tc.l.Error().Ctx(ctx).Err(err).Int("requeue_count", maxRequeueCount).Msg("failed to notify status updates for created tasks, republishing to MQ")
+			tc.l.Error().Ctx(ctx).Err(err).Int("count", len(createTaskOpts)).Int("attempt", attempts).Int("requeue_count", maxRequeueCount).Msg("failed to notify status updates for created tasks, republishing to MQ")
 			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
 		}
 
@@ -651,7 +651,7 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 		}
 
 		if attempts >= 10 {
-			tc.l.Error().Ctx(ctx).Int("requeue_count", maxRequeueCount).Msgf("failed to acquire locks for %d DAGs after %d attempts, republishing to MQ", len(createDAGOpts), attempts)
+			tc.l.Error().Ctx(ctx).Int("count", len(createDAGOpts)).Int("attempts", attempts).Int("requeue_count", maxRequeueCount).Msg("failed to acquire locks for DAGs, republishing to MQ")
 			return tc.republishCreatedDAGs(ctx, tenantId, createDAGOpts)
 		}
 
@@ -659,7 +659,7 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 
 		workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateDAGs(ctx, tenantId, extractCreatedDAGData(createDAGOpts))
 		if err != nil {
-			tc.l.Error().Ctx(ctx).Err(err).Int("requeue_count", maxRequeueCount).Msgf("failed to create %d DAGs on attempt %d, republishing to MQ", len(createDAGOpts), attempts)
+			tc.l.Error().Ctx(ctx).Err(err).Int("count", len(createDAGOpts)).Int("attempt", attempts).Int("requeue_count", maxRequeueCount).Msg("failed to create DAGs, republishing to MQ")
 			return tc.republishCreatedDAGs(ctx, tenantId, createDAGOpts)
 		}
 
@@ -1053,7 +1053,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		}
 
 		if attempts >= 10 {
-			tc.l.Error().Ctx(ctx).Int("requeue_count", maxRequeueCount).Msgf("failed to acquire locks for %d monitoring events after %d attempts, republishing to MQ", len(opts), attempts)
+			tc.l.Error().Ctx(ctx).Int("count", len(opts)).Int("attempts", attempts).Int("requeue_count", maxRequeueCount).Msg("failed to acquire locks for monitoring events, republishing to MQ")
 			return tc.republishMonitoringEvents(ctx, tenantId, opts, externalIdToMsg)
 		}
 
@@ -1062,7 +1062,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTaskEvents(ctx, tenantId, opts, eventExternalIdToWorkflowRunId)
 
 		if err != nil {
-			tc.l.Error().Ctx(ctx).Err(err).Int("requeue_count", maxRequeueCount).Msgf("failed to create %d task events on attempt %d, republishing to MQ", len(opts), attempts)
+			tc.l.Error().Ctx(ctx).Err(err).Int("count", len(opts)).Int("attempt", attempts).Int("requeue_count", maxRequeueCount).Msg("failed to create task events, republishing to MQ")
 			return tc.republishMonitoringEvents(ctx, tenantId, opts, externalIdToMsg)
 		}
 

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -540,14 +540,14 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 
 	attempts := 0
 	for len(createTaskOpts) > 0 {
-		maxRequeueCount := 0
-		for _, opt := range createTaskOpts {
-			if opt.RequeueCount > maxRequeueCount {
-				maxRequeueCount = opt.RequeueCount
-			}
-		}
-
 		if attempts >= 10 {
+			maxRequeueCount := 0
+			for _, opt := range createTaskOpts {
+				if opt.RequeueCount > maxRequeueCount {
+					maxRequeueCount = opt.RequeueCount
+				}
+			}
+
 			tc.l.Error().Ctx(ctx).Int("count", len(createTaskOpts)).Int("attempts", attempts).Int("requeue_count", maxRequeueCount).Msg("failed to acquire locks for tasks, republishing to MQ")
 			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
 		}
@@ -641,14 +641,14 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 
 	attempts := 0
 	for len(createDAGOpts) > 0 {
-		maxRequeueCount := 0
-		for _, opt := range createDAGOpts {
-			if opt.RequeueCount > maxRequeueCount {
-				maxRequeueCount = opt.RequeueCount
-			}
-		}
-
 		if attempts >= 10 {
+			maxRequeueCount := 0
+			for _, opt := range createDAGOpts {
+				if opt.RequeueCount > maxRequeueCount {
+					maxRequeueCount = opt.RequeueCount
+				}
+			}
+
 			tc.l.Error().Ctx(ctx).Int("count", len(createDAGOpts)).Int("attempts", attempts).Int("requeue_count", maxRequeueCount).Msg("failed to acquire locks for DAGs, republishing to MQ")
 			return tc.republishCreatedDAGs(ctx, tenantId, createDAGOpts)
 		}
@@ -1043,14 +1043,14 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 
 	attempts := 0
 	for len(opts) > 0 {
-		maxRequeueCount := 0
-		for _, msg := range externalIdToMsg {
-			if msg.RequeueCount > maxRequeueCount {
-				maxRequeueCount = msg.RequeueCount
-			}
-		}
-
 		if attempts >= 10 {
+			maxRequeueCount := 0
+			for _, msg := range externalIdToMsg {
+				if msg.RequeueCount > maxRequeueCount {
+					maxRequeueCount = msg.RequeueCount
+				}
+			}
+
 			tc.l.Error().Ctx(ctx).Int("count", len(opts)).Int("attempts", attempts).Int("requeue_count", maxRequeueCount).Msg("failed to acquire locks for monitoring events, republishing to MQ")
 			return tc.republishMonitoringEvents(ctx, tenantId, opts, externalIdToMsg)
 		}

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -50,6 +50,7 @@ type OLAPControllerImpl struct {
 	processTenantAlertOperations *queueutils.OperationPool
 	samplingHashThreshold        *int64
 	olapConfig                   *server.ConfigFileOperations
+	maxRequeueCount              int
 	prometheusMetricsEnabled     bool
 	analyzeCronInterval          time.Duration
 	taskPrometheusUpdateCh       chan taskPrometheusUpdate
@@ -74,6 +75,7 @@ type OLAPControllerOpts struct {
 	ta                          *alerting.TenantAlertManager
 	samplingHashThreshold       *int64
 	olapConfig                  *server.ConfigFileOperations
+	maxRequeueCount             int
 	prometheusMetricsEnabled    bool
 	analyzeCronInterval         time.Duration
 	statusUpdateBatchSizeLimits v1.StatusUpdateBatchSizeLimits
@@ -90,6 +92,7 @@ func defaultOLAPControllerOpts() *OLAPControllerOpts {
 		alerter:                  alerter,
 		prometheusMetricsEnabled: false,
 		analyzeCronInterval:      3 * time.Hour,
+		maxRequeueCount:          5,
 	}
 }
 
@@ -176,6 +179,12 @@ func WithMQQos(qos int) OLAPControllerOpt {
 	}
 }
 
+func WithMaxRequeueCount(count int) OLAPControllerOpt {
+	return func(opts *OLAPControllerOpts) {
+		opts.maxRequeueCount = count
+	}
+}
+
 func New(fs ...OLAPControllerOpt) (*OLAPControllerImpl, error) {
 	opts := defaultOLAPControllerOpts()
 
@@ -230,6 +239,7 @@ func New(fs ...OLAPControllerOpt) (*OLAPControllerImpl, error) {
 		ta:                          opts.ta,
 		samplingHashThreshold:       opts.samplingHashThreshold,
 		olapConfig:                  opts.olapConfig,
+		maxRequeueCount:             opts.maxRequeueCount,
 		prometheusMetricsEnabled:    opts.prometheusMetricsEnabled,
 		analyzeCronInterval:         opts.analyzeCronInterval,
 		taskPrometheusUpdateCh:      taskPrometheusUpdateCh,
@@ -511,55 +521,61 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 	ctx, span := telemetry.NewSpan(ctx, "OLAPControllerImpl.handleCreatedTask")
 	defer span.End()
 
-	createTaskOpts := make([]*v1.V1TaskWithPayload, 0)
+	createTaskPayloads := make([]*tasktypes.CreatedTaskPayload, 0)
 
 	msgs := msgqueue.JSONConvert[tasktypes.CreatedTaskPayload](payloads)
 
 	for _, msg := range msgs {
+		if msg.RequeueCount >= tc.maxRequeueCount {
+			tc.l.Error().Ctx(ctx).Msgf("dropping task %d after %d requeue attempts", msg.ID, msg.RequeueCount)
+			continue
+		}
+
 		if !tc.sample(msg.WorkflowRunID.String()) {
 			tc.l.Debug().Ctx(ctx).Msgf("skipping task %d for workflow run %s", msg.ID, msg.WorkflowRunID.String())
 			continue
 		}
 
-		createTaskOpts = append(createTaskOpts, msg.V1TaskWithPayload)
+		createTaskPayloads = append(createTaskPayloads, msg)
 	}
 
 	attempts := 0
-	for len(createTaskOpts) > 0 {
+	for len(createTaskPayloads) > 0 {
 		if attempts >= 10 {
-			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d tasks after %d attempts, republishing to MQ", len(createTaskOpts), attempts)
-			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
+			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d tasks after %d attempts, republishing to MQ", len(createTaskPayloads), attempts)
+			return tc.republishCreatedTasks(ctx, tenantId, createTaskPayloads)
 		}
 
 		attempts++
 
-		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTasks(ctx, tenantId, createTaskOpts)
+		taskData := extractCreatedTaskData(createTaskPayloads)
+		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTasks(ctx, tenantId, taskData)
 
 		if err != nil {
-			tc.l.Error().Ctx(ctx).Err(err).Msgf("failed to create %d tasks on attempt %d, republishing to MQ", len(createTaskOpts), attempts)
-			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
+			tc.l.Error().Ctx(ctx).Err(err).Msgf("failed to create %d tasks on attempt %d, republishing to MQ", len(createTaskPayloads), attempts)
+			return tc.republishCreatedTasks(ctx, tenantId, createTaskPayloads)
 		}
 
 		if err := tc.notifyStatusUpdates(ctx, result); err != nil {
 			tc.l.Error().Ctx(ctx).Err(err).Msg("failed to notify status updates for created tasks")
-			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
+			return tc.republishCreatedTasks(ctx, tenantId, createTaskPayloads)
 		}
 
-		failedOpts := make([]*v1.V1TaskWithPayload, 0)
-		succeededOpts := make([]*v1.V1TaskWithPayload, 0)
+		failedPayloads := make([]*tasktypes.CreatedTaskPayload, 0)
+		succeededPayloads := make([]*tasktypes.CreatedTaskPayload, 0)
 
-		for _, opt := range createTaskOpts {
-			if _, notAcquired := workflowRunIdsOfLocksNotAcquired[opt.WorkflowRunID]; notAcquired {
-				failedOpts = append(failedOpts, opt)
+		for _, payload := range createTaskPayloads {
+			if _, notAcquired := workflowRunIdsOfLocksNotAcquired[payload.WorkflowRunID]; notAcquired {
+				failedPayloads = append(failedPayloads, payload)
 			} else {
-				succeededOpts = append(succeededOpts, opt)
+				succeededPayloads = append(succeededPayloads, payload)
 			}
 		}
 
-		createTaskOpts = failedOpts
-		tc.emitStandaloneTaskRootSpans(ctx, tenantId, succeededOpts)
+		createTaskPayloads = failedPayloads
+		tc.emitStandaloneTaskRootSpans(ctx, tenantId, extractCreatedTaskData(succeededPayloads))
 
-		if len(failedOpts) > 0 && attempts < 10 {
+		if len(failedPayloads) > 0 && attempts < 10 {
 			tc.sleepWithBackoff(attempts)
 		}
 	}
@@ -607,49 +623,55 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 	ctx, span := telemetry.NewSpan(ctx, "OLAPControllerImpl.handleCreatedDAG")
 	defer span.End()
 
-	createDAGOpts := make([]*v1.DAGWithData, 0)
+	createDAGPayloads := make([]*tasktypes.CreatedDAGPayload, 0)
 
 	msgs := msgqueue.JSONConvert[tasktypes.CreatedDAGPayload](payloads)
 
 	for _, msg := range msgs {
+		if msg.RequeueCount >= tc.maxRequeueCount {
+			tc.l.Error().Ctx(ctx).Msgf("dropping dag %s after %d requeue attempts", msg.ExternalID.String(), msg.RequeueCount)
+			continue
+		}
+
 		if !tc.sample(msg.ExternalID.String()) {
 			tc.l.Debug().Ctx(ctx).Msgf("skipping dag %s", msg.ExternalID.String())
 			continue
 		}
 
-		createDAGOpts = append(createDAGOpts, msg.DAGWithData)
+		createDAGPayloads = append(createDAGPayloads, msg)
 	}
 
 	attempts := 0
-	for len(createDAGOpts) > 0 {
+	for len(createDAGPayloads) > 0 {
 		if attempts >= 10 {
-			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d DAGs after %d attempts, republishing to MQ", len(createDAGOpts), attempts)
-			return tc.republishCreatedDAGs(ctx, tenantId, createDAGOpts)
+			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d DAGs after %d attempts, republishing to MQ", len(createDAGPayloads), attempts)
+			return tc.republishCreatedDAGs(ctx, tenantId, createDAGPayloads)
 		}
 
 		attempts++
 
-		workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateDAGs(ctx, tenantId, createDAGOpts)
+		dagData := extractCreatedDAGData(createDAGPayloads)
+		workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateDAGs(ctx, tenantId, dagData)
 		if err != nil {
-			tc.l.Error().Ctx(ctx).Err(err).Msgf("failed to create %d DAGs on attempt %d, republishing to MQ", len(createDAGOpts), attempts)
-			return tc.republishCreatedDAGs(ctx, tenantId, createDAGOpts)
+			tc.l.Error().Ctx(ctx).Err(err).Msgf("failed to create %d DAGs on attempt %d, republishing to MQ", len(createDAGPayloads), attempts)
+			return tc.republishCreatedDAGs(ctx, tenantId, createDAGPayloads)
 		}
 
-		failedOpts := make([]*v1.DAGWithData, 0)
-		succeededOpts := make([]*v1.DAGWithData, 0)
+		failedPayloads := make([]*tasktypes.CreatedDAGPayload, 0)
+		succeededPayloads := make([]*tasktypes.CreatedDAGPayload, 0)
 
-		for _, opt := range createDAGOpts {
-			if _, notAcquired := workflowRunIdsOfLocksNotAcquired[opt.ExternalID]; notAcquired {
-				failedOpts = append(failedOpts, opt)
+		for _, payload := range createDAGPayloads {
+			if _, notAcquired := workflowRunIdsOfLocksNotAcquired[payload.ExternalID]; notAcquired {
+				failedPayloads = append(failedPayloads, payload)
 			} else {
-				succeededOpts = append(succeededOpts, opt)
+				succeededPayloads = append(succeededPayloads, payload)
 			}
 		}
 
-		createDAGOpts = failedOpts
-		tc.emitWorkflowRunRootSpans(ctx, tenantId, succeededOpts)
+		createDAGPayloads = failedPayloads
+		tc.emitWorkflowRunRootSpans(ctx, tenantId, extractCreatedDAGData(succeededPayloads))
 
-		if len(failedOpts) > 0 && attempts < 10 {
+		if len(failedPayloads) > 0 && attempts < 10 {
 			tc.sleepWithBackoff(attempts)
 		}
 	}
@@ -835,7 +857,16 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 	ctx, span := telemetry.NewSpan(ctx, "OLAPControllerImpl.handleCreateMonitoringEvent")
 	defer span.End()
 
-	msgs := msgqueue.JSONConvert[tasktypes.CreateMonitoringEventPayload](payloads)
+	allMsgs := msgqueue.JSONConvert[tasktypes.CreateMonitoringEventPayload](payloads)
+
+	msgs := make([]*tasktypes.CreateMonitoringEventPayload, 0, len(allMsgs))
+	for _, msg := range allMsgs {
+		if msg.RequeueCount >= tc.maxRequeueCount {
+			tc.l.Error().Ctx(ctx).Msgf("dropping monitoring event for task %d after %d requeue attempts", msg.TaskId, msg.RequeueCount)
+			continue
+		}
+		msgs = append(msgs, msg)
+	}
 
 	taskIdsToLookup := make([]int64, len(msgs))
 
@@ -1095,9 +1126,11 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 	return nil
 }
 
-func (tc *OLAPControllerImpl) republishCreatedTasks(ctx context.Context, tenantId uuid.UUID, tasks []*v1.V1TaskWithPayload) error {
+func (tc *OLAPControllerImpl) republishCreatedTasks(ctx context.Context, tenantId uuid.UUID, tasks []*tasktypes.CreatedTaskPayload) error {
 	for _, task := range tasks {
-		msg, err := tasktypes.CreatedTaskMessage(tenantId, task)
+		updated := *task
+		updated.RequeueCount++
+		msg, err := tasktypes.RepublishCreatedTaskMessage(tenantId, updated)
 		if err != nil {
 			return err
 		}
@@ -1108,9 +1141,11 @@ func (tc *OLAPControllerImpl) republishCreatedTasks(ctx context.Context, tenantI
 	return nil
 }
 
-func (tc *OLAPControllerImpl) republishCreatedDAGs(ctx context.Context, tenantId uuid.UUID, dags []*v1.DAGWithData) error {
+func (tc *OLAPControllerImpl) republishCreatedDAGs(ctx context.Context, tenantId uuid.UUID, dags []*tasktypes.CreatedDAGPayload) error {
 	for _, dag := range dags {
-		msg, err := tasktypes.CreatedDAGMessage(tenantId, dag)
+		updated := *dag
+		updated.RequeueCount++
+		msg, err := tasktypes.RepublishCreatedDAGMessage(tenantId, updated)
 		if err != nil {
 			return err
 		}
@@ -1132,7 +1167,9 @@ func (tc *OLAPControllerImpl) republishMonitoringEvents(ctx context.Context, ten
 		if !ok {
 			continue
 		}
-		msg, err := tasktypes.MonitoringEventMessageFromInternal(tenantId, *payload)
+		updated := *payload
+		updated.RequeueCount++
+		msg, err := tasktypes.MonitoringEventMessageFromInternal(tenantId, updated)
 		if err != nil {
 			return err
 		}
@@ -1161,6 +1198,22 @@ func (tc *OLAPControllerImpl) handleFailedWebhookValidation(ctx context.Context,
 	}
 
 	return tc.repo.OLAP().CreateIncomingWebhookValidationFailureLogs(ctx, tenantId, createFailedWebhookValidationOpts)
+}
+
+func extractCreatedTaskData(payloads []*tasktypes.CreatedTaskPayload) []*v1.V1TaskWithPayload {
+	result := make([]*v1.V1TaskWithPayload, len(payloads))
+	for i, p := range payloads {
+		result[i] = p.V1TaskWithPayload
+	}
+	return result
+}
+
+func extractCreatedDAGData(payloads []*tasktypes.CreatedDAGPayload) []*v1.DAGWithData {
+	result := make([]*v1.DAGWithData, len(payloads))
+	for i, p := range payloads {
+		result[i] = p.DAGWithData
+	}
+	return result
 }
 
 func (tc *OLAPControllerImpl) sample(workflowRunID string) bool {

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -521,7 +521,7 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 	ctx, span := telemetry.NewSpan(ctx, "OLAPControllerImpl.handleCreatedTask")
 	defer span.End()
 
-	createTaskPayloads := make([]*tasktypes.CreatedTaskPayload, 0)
+	createTaskOpts := make([]*tasktypes.CreatedTaskPayload, 0)
 
 	msgs := msgqueue.JSONConvert[tasktypes.CreatedTaskPayload](payloads)
 
@@ -536,46 +536,45 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 			continue
 		}
 
-		createTaskPayloads = append(createTaskPayloads, msg)
+		createTaskOpts = append(createTaskOpts, msg)
 	}
 
 	attempts := 0
-	for len(createTaskPayloads) > 0 {
+	for len(createTaskOpts) > 0 {
 		if attempts >= 10 {
-			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d tasks after %d attempts, republishing to MQ", len(createTaskPayloads), attempts)
-			return tc.republishCreatedTasks(ctx, tenantId, createTaskPayloads)
+			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d tasks after %d attempts, republishing to MQ", len(createTaskOpts), attempts)
+			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
 		}
 
 		attempts++
 
-		taskData := extractCreatedTaskData(createTaskPayloads)
-		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTasks(ctx, tenantId, taskData)
+		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTasks(ctx, tenantId, extractCreatedTaskData(createTaskOpts))
 
 		if err != nil {
-			tc.l.Error().Ctx(ctx).Err(err).Msgf("failed to create %d tasks on attempt %d, republishing to MQ", len(createTaskPayloads), attempts)
-			return tc.republishCreatedTasks(ctx, tenantId, createTaskPayloads)
+			tc.l.Error().Ctx(ctx).Err(err).Msgf("failed to create %d tasks on attempt %d, republishing to MQ", len(createTaskOpts), attempts)
+			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
 		}
 
 		if err := tc.notifyStatusUpdates(ctx, result); err != nil {
 			tc.l.Error().Ctx(ctx).Err(err).Msg("failed to notify status updates for created tasks")
-			return tc.republishCreatedTasks(ctx, tenantId, createTaskPayloads)
+			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
 		}
 
-		failedPayloads := make([]*tasktypes.CreatedTaskPayload, 0)
-		succeededPayloads := make([]*tasktypes.CreatedTaskPayload, 0)
+		failedOpts := make([]*tasktypes.CreatedTaskPayload, 0)
+		succeededOpts := make([]*tasktypes.CreatedTaskPayload, 0)
 
-		for _, payload := range createTaskPayloads {
-			if _, notAcquired := workflowRunIdsOfLocksNotAcquired[payload.WorkflowRunID]; notAcquired {
-				failedPayloads = append(failedPayloads, payload)
+		for _, opt := range createTaskOpts {
+			if _, notAcquired := workflowRunIdsOfLocksNotAcquired[opt.WorkflowRunID]; notAcquired {
+				failedOpts = append(failedOpts, opt)
 			} else {
-				succeededPayloads = append(succeededPayloads, payload)
+				succeededOpts = append(succeededOpts, opt)
 			}
 		}
 
-		createTaskPayloads = failedPayloads
-		tc.emitStandaloneTaskRootSpans(ctx, tenantId, extractCreatedTaskData(succeededPayloads))
+		createTaskOpts = failedOpts
+		tc.emitStandaloneTaskRootSpans(ctx, tenantId, extractCreatedTaskData(succeededOpts))
 
-		if len(failedPayloads) > 0 && attempts < 10 {
+		if len(failedOpts) > 0 && attempts < 10 {
 			tc.sleepWithBackoff(attempts)
 		}
 	}
@@ -623,7 +622,7 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 	ctx, span := telemetry.NewSpan(ctx, "OLAPControllerImpl.handleCreatedDAG")
 	defer span.End()
 
-	createDAGPayloads := make([]*tasktypes.CreatedDAGPayload, 0)
+	createDAGOpts := make([]*tasktypes.CreatedDAGPayload, 0)
 
 	msgs := msgqueue.JSONConvert[tasktypes.CreatedDAGPayload](payloads)
 
@@ -638,40 +637,39 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 			continue
 		}
 
-		createDAGPayloads = append(createDAGPayloads, msg)
+		createDAGOpts = append(createDAGOpts, msg)
 	}
 
 	attempts := 0
-	for len(createDAGPayloads) > 0 {
+	for len(createDAGOpts) > 0 {
 		if attempts >= 10 {
-			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d DAGs after %d attempts, republishing to MQ", len(createDAGPayloads), attempts)
-			return tc.republishCreatedDAGs(ctx, tenantId, createDAGPayloads)
+			tc.l.Error().Ctx(ctx).Msgf("failed to acquire locks for %d DAGs after %d attempts, republishing to MQ", len(createDAGOpts), attempts)
+			return tc.republishCreatedDAGs(ctx, tenantId, createDAGOpts)
 		}
 
 		attempts++
 
-		dagData := extractCreatedDAGData(createDAGPayloads)
-		workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateDAGs(ctx, tenantId, dagData)
+		workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateDAGs(ctx, tenantId, extractCreatedDAGData(createDAGOpts))
 		if err != nil {
-			tc.l.Error().Ctx(ctx).Err(err).Msgf("failed to create %d DAGs on attempt %d, republishing to MQ", len(createDAGPayloads), attempts)
-			return tc.republishCreatedDAGs(ctx, tenantId, createDAGPayloads)
+			tc.l.Error().Ctx(ctx).Err(err).Msgf("failed to create %d DAGs on attempt %d, republishing to MQ", len(createDAGOpts), attempts)
+			return tc.republishCreatedDAGs(ctx, tenantId, createDAGOpts)
 		}
 
-		failedPayloads := make([]*tasktypes.CreatedDAGPayload, 0)
-		succeededPayloads := make([]*tasktypes.CreatedDAGPayload, 0)
+		failedOpts := make([]*tasktypes.CreatedDAGPayload, 0)
+		succeededOpts := make([]*tasktypes.CreatedDAGPayload, 0)
 
-		for _, payload := range createDAGPayloads {
-			if _, notAcquired := workflowRunIdsOfLocksNotAcquired[payload.ExternalID]; notAcquired {
-				failedPayloads = append(failedPayloads, payload)
+		for _, opt := range createDAGOpts {
+			if _, notAcquired := workflowRunIdsOfLocksNotAcquired[opt.ExternalID]; notAcquired {
+				failedOpts = append(failedOpts, opt)
 			} else {
-				succeededPayloads = append(succeededPayloads, payload)
+				succeededOpts = append(succeededOpts, opt)
 			}
 		}
 
-		createDAGPayloads = failedPayloads
-		tc.emitWorkflowRunRootSpans(ctx, tenantId, extractCreatedDAGData(succeededPayloads))
+		createDAGOpts = failedOpts
+		tc.emitWorkflowRunRootSpans(ctx, tenantId, extractCreatedDAGData(succeededOpts))
 
-		if len(failedPayloads) > 0 && attempts < 10 {
+		if len(failedOpts) > 0 && attempts < 10 {
 			tc.sleepWithBackoff(attempts)
 		}
 	}

--- a/internal/services/controllers/olap/signal/signal.go
+++ b/internal/services/controllers/olap/signal/signal.go
@@ -57,7 +57,7 @@ func (s *OLAPSignaler) SignalDAGsCreated(ctx context.Context, tenantId uuid.UUID
 	// TODO: make this transactionally safe?
 	for _, dag := range dags {
 		dagCp := dag
-		msg, err := tasktypes.CreatedDAGMessage(tenantId, dagCp)
+		msg, err := tasktypes.CreatedDAGMessage(tenantId, tasktypes.CreatedDAGPayload{DAGWithData: dagCp})
 
 		if err != nil {
 			s.l.Err(err).Ctx(ctx).Msg("could not create message for olap queue")
@@ -99,7 +99,7 @@ func (s *OLAPSignaler) SignalTasksCreated(ctx context.Context, tenantId uuid.UUI
 			skippedTasks = append(skippedTasks, task)
 		}
 
-		msg, err := tasktypes.CreatedTaskMessage(tenantId, task)
+		msg, err := tasktypes.CreatedTaskMessage(tenantId, tasktypes.CreatedTaskPayload{V1TaskWithPayload: task})
 
 		if err != nil {
 			s.l.Err(err).Ctx(ctx).Msg("could not create message for olap queue")

--- a/internal/services/shared/tasktypes/v1/olap.go
+++ b/internal/services/shared/tasktypes/v1/olap.go
@@ -30,6 +30,7 @@ func CELEvaluationFailureMessage(tenantId uuid.UUID, failures []v1.CELEvaluation
 
 type CreatedTaskPayload struct {
 	*v1.V1TaskWithPayload
+	RequeueCount int `json:"requeue_count"`
 }
 
 func CreatedTaskMessage(tenantId uuid.UUID, task *v1.V1TaskWithPayload) (*msgqueue.Message, error) {
@@ -38,14 +39,23 @@ func CreatedTaskMessage(tenantId uuid.UUID, task *v1.V1TaskWithPayload) (*msgque
 		msgqueue.MsgIDCreatedTask,
 		false,
 		true,
-		CreatedTaskPayload{
-			V1TaskWithPayload: task,
-		},
+		CreatedTaskPayload{V1TaskWithPayload: task},
+	)
+}
+
+func RepublishCreatedTaskMessage(tenantId uuid.UUID, payload CreatedTaskPayload) (*msgqueue.Message, error) {
+	return msgqueue.NewTenantMessage(
+		tenantId,
+		msgqueue.MsgIDCreatedTask,
+		false,
+		true,
+		payload,
 	)
 }
 
 type CreatedDAGPayload struct {
 	*v1.DAGWithData
+	RequeueCount int `json:"requeue_count"`
 }
 
 func CreatedDAGMessage(tenantId uuid.UUID, dag *v1.DAGWithData) (*msgqueue.Message, error) {
@@ -54,9 +64,17 @@ func CreatedDAGMessage(tenantId uuid.UUID, dag *v1.DAGWithData) (*msgqueue.Messa
 		msgqueue.MsgIDCreatedDAG,
 		false,
 		true,
-		CreatedDAGPayload{
-			DAGWithData: dag,
-		},
+		CreatedDAGPayload{DAGWithData: dag},
+	)
+}
+
+func RepublishCreatedDAGMessage(tenantId uuid.UUID, payload CreatedDAGPayload) (*msgqueue.Message, error) {
+	return msgqueue.NewTenantMessage(
+		tenantId,
+		msgqueue.MsgIDCreatedDAG,
+		false,
+		true,
+		payload,
 	)
 }
 
@@ -90,6 +108,8 @@ func CreatedEventTriggerMessage(tenantId uuid.UUID, eventTriggers CreatedEventTr
 
 type CreateMonitoringEventPayload struct {
 	TaskId int64 `json:"task_id"`
+
+	RequeueCount int `json:"requeue_count"`
 
 	RetryCount             int32 `json:"retry_count"`
 	DurableInvocationCount int32 `json:"durable_invocation_count"`

--- a/internal/services/shared/tasktypes/v1/olap.go
+++ b/internal/services/shared/tasktypes/v1/olap.go
@@ -33,17 +33,7 @@ type CreatedTaskPayload struct {
 	RequeueCount int `json:"requeue_count"`
 }
 
-func CreatedTaskMessage(tenantId uuid.UUID, task *v1.V1TaskWithPayload) (*msgqueue.Message, error) {
-	return msgqueue.NewTenantMessage(
-		tenantId,
-		msgqueue.MsgIDCreatedTask,
-		false,
-		true,
-		CreatedTaskPayload{V1TaskWithPayload: task},
-	)
-}
-
-func RepublishCreatedTaskMessage(tenantId uuid.UUID, payload CreatedTaskPayload) (*msgqueue.Message, error) {
+func CreatedTaskMessage(tenantId uuid.UUID, payload CreatedTaskPayload) (*msgqueue.Message, error) {
 	return msgqueue.NewTenantMessage(
 		tenantId,
 		msgqueue.MsgIDCreatedTask,
@@ -58,17 +48,7 @@ type CreatedDAGPayload struct {
 	RequeueCount int `json:"requeue_count"`
 }
 
-func CreatedDAGMessage(tenantId uuid.UUID, dag *v1.DAGWithData) (*msgqueue.Message, error) {
-	return msgqueue.NewTenantMessage(
-		tenantId,
-		msgqueue.MsgIDCreatedDAG,
-		false,
-		true,
-		CreatedDAGPayload{DAGWithData: dag},
-	)
-}
-
-func RepublishCreatedDAGMessage(tenantId uuid.UUID, payload CreatedDAGPayload) (*msgqueue.Message, error) {
+func CreatedDAGMessage(tenantId uuid.UUID, payload CreatedDAGPayload) (*msgqueue.Message, error) {
 	return msgqueue.NewTenantMessage(
 		tenantId,
 		msgqueue.MsgIDCreatedDAG,

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -814,6 +814,7 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 		Operations:             cf.OLAP,
 		CronOperations:         cf.CronOperations,
 		OLAPStatusUpdates:      cf.OLAPStatusUpdates,
+		MQMaxDeathCount:        cf.MessageQueue.RabbitMQ.MaxDeathCount,
 	}, nil
 }
 

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -695,6 +695,8 @@ type ServerConfig struct {
 	CronOperations CronOperationsConfigFile
 
 	OLAPStatusUpdates OLAPStatusUpdateConfigFile
+
+	MQMaxDeathCount int
 }
 
 type PayloadStoreConfig struct {


### PR DESCRIPTION
# Description

Limits the number of rabbit re-pubs to be the same as the max retry count on message ack failures, so that we don't have an infinite loop of messages failing over and over again with no recourse

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

