### PR TITLE
fix: guard /managed-workers routes in self-hosted mode

### DIFF
--- a/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/index.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/index.tsx
@@ -1,3 +1,4 @@
+import { ManagedWorkersGate } from '../components/managed-workers-gate';
 import GithubButton from './components/github-button';
 import { ManagedWorkerActivity } from './components/managed-worker-activity';
 import { ManagedWorkerInstancesTable } from './components/managed-worker-instances-table';
@@ -30,7 +31,7 @@ import { useNavigate, useParams } from '@tanstack/react-router';
 import { isAxiosError } from 'axios';
 import { useState } from 'react';
 
-export default function ExpandedWorkflow() {
+function ExpandedWorkflowImpl() {
   const navigate = useNavigate();
   const [deleteWorker, setDeleteWorker] = useState(false);
   const { tenantId } = useCurrentTenantId();
@@ -216,4 +217,7 @@ export default function ExpandedWorkflow() {
       </div>
     </div>
   );
+}
+export default function ExpandedWorkflow() {
+  return <ManagedWorkersGate>{ExpandedWorkflowImpl()}</ManagedWorkersGate>;
 }

--- a/frontend/app/src/pages/main/v1/managed-workers/components/managed-workers-gate.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/components/managed-workers-gate.tsx
@@ -1,0 +1,50 @@
+import { Button } from '@/components/v1/ui/button';
+import useCloud from '@/hooks/use-cloud';
+import { useCurrentTenantId } from '@/hooks/use-tenant';
+import { ErrorPageLayout } from '@/pages/error/components/layout';
+import { appRoutes } from '@/router';
+import { useNavigate } from '@tanstack/react-router';
+import { CloudIcon } from 'lucide-react';
+import { PropsWithChildren } from 'react';
+
+export function ManagedWorkersGate({ children }: PropsWithChildren) {
+  const { cloud, featureFlags, isCloudEnabled } = useCloud();
+  const managedWorkerEnabled = featureFlags?.['managed-worker'] === 'true';
+  const navigate = useNavigate();
+  const { tenantId } = useCurrentTenantId();
+
+  // Cloud enabled but metadata not yet loaded
+  if (isCloudEnabled && !cloud) {
+    return null;
+  }
+
+  // Feature flag explicitly enables managed workers
+  if (managedWorkerEnabled) {
+    return <>{children}</>;
+  }
+
+  // Self-hosted mode — show informative message
+  if (!isCloudEnabled) {
+    return (
+      <ErrorPageLayout
+        icon={<CloudIcon className="h-5 w-5" />}
+        title="Managed Compute is not available"
+        description="Managed Compute is a cloud-only feature and is not supported in self-hosted deployments. Sign up for Hatchet Cloud to access this feature."
+        actions={
+          <Button
+            onClick={() =>
+              navigate({
+                to: appRoutes.tenantRunsRoute.to,
+                params: { tenant: tenantId },
+              })
+            }
+          >
+            Back to Dashboard
+          </Button>
+        }
+      />
+    );
+  }
+
+  return null;
+}

--- a/frontend/app/src/pages/main/v1/managed-workers/components/managed-workers-gate.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/components/managed-workers-gate.tsx
@@ -1,17 +1,13 @@
 import { Button } from '@/components/v1/ui/button';
 import useCloud from '@/hooks/use-cloud';
-import { useCurrentTenantId } from '@/hooks/use-tenant';
 import { ErrorPageLayout } from '@/pages/error/components/layout';
-import { appRoutes } from '@/router';
-import { useNavigate } from '@tanstack/react-router';
 import { CloudIcon } from 'lucide-react';
+import { Undo2 } from 'lucide-react';
 import { PropsWithChildren } from 'react';
 
 export function ManagedWorkersGate({ children }: PropsWithChildren) {
   const { cloud, featureFlags, isCloudEnabled } = useCloud();
   const managedWorkerEnabled = featureFlags?.['managed-worker'] === 'true';
-  const navigate = useNavigate();
-  const { tenantId } = useCurrentTenantId();
 
   // Cloud enabled but metadata not yet loaded
   if (isCloudEnabled && !cloud) {
@@ -29,22 +25,35 @@ export function ManagedWorkersGate({ children }: PropsWithChildren) {
       <ErrorPageLayout
         icon={<CloudIcon className="h-5 w-5" />}
         title="Managed Compute is not available"
-        description="Managed Compute is a cloud-only feature and is not supported in self-hosted deployments. Sign up for Hatchet Cloud to access this feature."
+        description="Managed Compute is a cloud-only feature and is not supported in self-hosted deployments."
         actions={
           <Button
-            onClick={() =>
-              navigate({
-                to: appRoutes.tenantRunsRoute.to,
-                params: { tenant: tenantId },
-              })
-            }
+            leftIcon={<Undo2 className="h-4 w-4" />}
+            onClick={() => window.history.back()}
+            variant="outline"
           >
-            Back to Dashboard
+            Go back
           </Button>
         }
       />
     );
   }
 
-  return null;
+  // Cloud user but managed-worker feature not enabled for this account
+  return (
+    <ErrorPageLayout
+      icon={<CloudIcon className="h-5 w-5" />}
+      title="Managed Compute is not enabled"
+      description="Managed Compute is not enabled for your account. Please contact support@hatchet.run to enable this feature."
+      actions={
+        <Button
+          leftIcon={<Undo2 className="h-4 w-4" />}
+          onClick={() => window.history.back()}
+          variant="outline"
+        >
+          Go back
+        </Button>
+      }
+    />
+  );
 }

--- a/frontend/app/src/pages/main/v1/managed-workers/create/index.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/create/index.tsx
@@ -1,30 +1,51 @@
 import { BillingRequired } from '../components/billing-required';
 import CreateWorkerForm from './components/create-worker-form';
 import { Separator } from '@/components/v1/ui/separator';
+import useCloud from '@/hooks/use-cloud';
 import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
 import { cloudApi } from '@/lib/api/api';
 import { CreateManagedWorkerRequest } from '@/lib/api/generated/cloud/data-contracts';
 import { managedCompute } from '@/lib/can/features/managed-compute';
 import { RejectReason } from '@/lib/can/shared/permission.base';
 import { useApiError } from '@/lib/hooks';
+import { NotFound } from '@/pages/error/components/not-found';
 import { appRoutes } from '@/router';
 import { ServerStackIcon } from '@heroicons/react/24/outline';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
+import { Spinner } from '@/components/v1/ui/loading';
 
 export default function CreateWorker() {
+  // ── Hooks ────────────────────────────────────────────────────────────────
   const navigate = useNavigate();
   const { tenant, billing, can } = useTenantDetails();
   const { tenantId } = useCurrentTenantId();
+  const { isCloudEnabled, isCloudLoading } = useCloud();
 
   const [portalLoading, setPortalLoading] = useState(false);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
   const { handleApiError } = useApiError({
     setFieldErrors: setFieldErrors,
   });
 
-  // Check if billing is required
+  const createManagedWorkerMutation = useMutation({
+    mutationKey: ['managed-worker:create', tenantId],
+    mutationFn: async (data: CreateManagedWorkerRequest) => {
+      const res = await cloudApi.managedWorkerCreate(tenantId, data);
+      return res.data;
+    },
+    onSuccess: (data) => {
+      navigate({
+        to: appRoutes.tenantManagedWorkerRoute.to,
+        params: { tenant: tenantId, managedWorker: data.metadata.id },
+      });
+    },
+    onError: handleApiError,
+  });
+
+  // ── Derived values ───────────────────────────────────────────────────────
   const [, rejectReason] = can(managedCompute.create());
   const isBillingRequired = rejectReason === RejectReason.BILLING_REQUIRED;
 
@@ -44,20 +65,21 @@ export default function CreateWorker() {
     }
   };
 
-  const createManagedWorkerMutation = useMutation({
-    mutationKey: ['managed-worker:create', tenantId],
-    mutationFn: async (data: CreateManagedWorkerRequest) => {
-      const res = await cloudApi.managedWorkerCreate(tenantId, data);
-      return res.data;
-    },
-    onSuccess: (data) => {
-      navigate({
-        to: appRoutes.tenantManagedWorkerRoute.to,
-        params: { tenant: tenantId, managedWorker: data.metadata.id },
-      });
-    },
-    onError: handleApiError,
-  });
+  // ── Early returns ─────────────────────────────────────────────────────────
+
+  // Wait for cloud metadata to resolve
+  if (isCloudLoading) {
+    return (
+      <div className="flex items-center justify-center h-screen">
+        <Spinner />
+      </div>
+    );
+  }
+
+  // Managed Compute is cloud-only; show 404 in self-hosted mode
+  if (!isCloudEnabled) {
+    return <NotFound />;
+  }
 
   // Show billing required page if billing is required
   if (isBillingRequired) {
@@ -71,6 +93,7 @@ export default function CreateWorker() {
     );
   }
 
+  // ── Render ────────────────────────────────────────────────────────────────
   return (
     <div className="h-full w-full flex-grow">
       <div className="mx-auto px-4 py-8 sm:px-6 lg:px-8">

--- a/frontend/app/src/pages/main/v1/managed-workers/create/index.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/create/index.tsx
@@ -15,34 +15,17 @@ import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 
 function CreateWorkerImpl() {
-  // ── Hooks ────────────────────────────────────────────────────────────────
   const navigate = useNavigate();
   const { tenant, billing, can } = useTenantDetails();
   const { tenantId } = useCurrentTenantId();
 
   const [portalLoading, setPortalLoading] = useState(false);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
-
   const { handleApiError } = useApiError({
     setFieldErrors: setFieldErrors,
   });
 
-  const createManagedWorkerMutation = useMutation({
-    mutationKey: ['managed-worker:create', tenantId],
-    mutationFn: async (data: CreateManagedWorkerRequest) => {
-      const res = await cloudApi.managedWorkerCreate(tenantId, data);
-      return res.data;
-    },
-    onSuccess: (data) => {
-      navigate({
-        to: appRoutes.tenantManagedWorkerRoute.to,
-        params: { tenant: tenantId, managedWorker: data.metadata.id },
-      });
-    },
-    onError: handleApiError,
-  });
-
-  // ── Derived values ───────────────────────────────────────────────────────
+  // Check if billing is required
   const [, rejectReason] = can(managedCompute.create());
   const isBillingRequired = rejectReason === RejectReason.BILLING_REQUIRED;
 
@@ -62,8 +45,22 @@ function CreateWorkerImpl() {
     }
   };
 
-  // ── Early returns ─────────────────────────────────────────────────────────
+  const createManagedWorkerMutation = useMutation({
+    mutationKey: ['managed-worker:create', tenantId],
+    mutationFn: async (data: CreateManagedWorkerRequest) => {
+      const res = await cloudApi.managedWorkerCreate(tenantId, data);
+      return res.data;
+    },
+    onSuccess: (data) => {
+      navigate({
+        to: appRoutes.tenantManagedWorkerRoute.to,
+        params: { tenant: tenantId, managedWorker: data.metadata.id },
+      });
+    },
+    onError: handleApiError,
+  });
 
+  // Show billing required page if billing is required
   if (isBillingRequired) {
     return (
       <BillingRequired
@@ -75,7 +72,6 @@ function CreateWorkerImpl() {
     );
   }
 
-  // ── Render ────────────────────────────────────────────────────────────────
   return (
     <div className="h-full w-full flex-grow">
       <div className="mx-auto px-4 py-8 sm:px-6 lg:px-8">

--- a/frontend/app/src/pages/main/v1/managed-workers/create/index.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/create/index.tsx
@@ -1,27 +1,24 @@
 import { BillingRequired } from '../components/billing-required';
+import { ManagedWorkersGate } from '../components/managed-workers-gate';
 import CreateWorkerForm from './components/create-worker-form';
 import { Separator } from '@/components/v1/ui/separator';
-import useCloud from '@/hooks/use-cloud';
 import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
 import { cloudApi } from '@/lib/api/api';
 import { CreateManagedWorkerRequest } from '@/lib/api/generated/cloud/data-contracts';
 import { managedCompute } from '@/lib/can/features/managed-compute';
 import { RejectReason } from '@/lib/can/shared/permission.base';
 import { useApiError } from '@/lib/hooks';
-import { NotFound } from '@/pages/error/components/not-found';
 import { appRoutes } from '@/router';
 import { ServerStackIcon } from '@heroicons/react/24/outline';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
-import { Spinner } from '@/components/v1/ui/loading';
 
-export default function CreateWorker() {
+function CreateWorkerImpl() {
   // ── Hooks ────────────────────────────────────────────────────────────────
   const navigate = useNavigate();
   const { tenant, billing, can } = useTenantDetails();
   const { tenantId } = useCurrentTenantId();
-  const { isCloudEnabled, isCloudLoading } = useCloud();
 
   const [portalLoading, setPortalLoading] = useState(false);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
@@ -67,21 +64,6 @@ export default function CreateWorker() {
 
   // ── Early returns ─────────────────────────────────────────────────────────
 
-  // Wait for cloud metadata to resolve
-  if (isCloudLoading) {
-    return (
-      <div className="flex items-center justify-center h-screen">
-        <Spinner />
-      </div>
-    );
-  }
-
-  // Managed Compute is cloud-only; show 404 in self-hosted mode
-  if (!isCloudEnabled) {
-    return <NotFound />;
-  }
-
-  // Show billing required page if billing is required
   if (isBillingRequired) {
     return (
       <BillingRequired
@@ -114,4 +96,8 @@ export default function CreateWorker() {
       </div>
     </div>
   );
+}
+
+export default function CreateWorker() {
+  return <ManagedWorkersGate>{CreateWorkerImpl()}</ManagedWorkersGate>;
 }

--- a/frontend/app/src/pages/main/v1/managed-workers/demo-template/index.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/demo-template/index.tsx
@@ -1,3 +1,4 @@
+import { ManagedWorkersGate } from '../components/managed-workers-gate';
 import { Button } from '@/components/v1/ui/button';
 import { Card } from '@/components/v1/ui/card';
 import { CodeHighlighter } from '@/components/v1/ui/code-highlighter';
@@ -32,7 +33,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { useState, useEffect, useCallback } from 'react';
 
-export default function DemoTemplate() {
+function DemoTemplateImpl() {
   const { tenantId } = useCurrentTenantId();
   const [deploying, setDeploying] = useState(false);
   const [deployed, setDeployed] = useState(false);
@@ -934,4 +935,7 @@ func main() {
       </div>
     </div>
   );
+}
+export default function DemoTemplate() {
+  return <ManagedWorkersGate>{DemoTemplateImpl()}</ManagedWorkersGate>;
 }

--- a/frontend/app/src/pages/main/v1/managed-workers/index.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/index.tsx
@@ -4,12 +4,14 @@ import { MonthlyUsageCard } from './components/monthly-usage-card';
 import { Button } from '@/components/v1/ui/button';
 import { Spinner } from '@/components/v1/ui/loading';
 import { Separator } from '@/components/v1/ui/separator';
+import useCloud from '@/hooks/use-cloud';
 import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
 import { cloudApi } from '@/lib/api/api';
 import { queries } from '@/lib/api/queries';
 import { managedCompute } from '@/lib/can/features/managed-compute';
 import { RejectReason } from '@/lib/can/shared/permission.base';
 import { useApiError } from '@/lib/hooks';
+import { NotFound } from '@/pages/error/components/not-found';
 import { appRoutes } from '@/router';
 import { PlusIcon, ArrowUpIcon } from '@radix-ui/react-icons';
 import { useQuery } from '@tanstack/react-query';
@@ -17,8 +19,11 @@ import { Link } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 
 export default function ManagedWorkers() {
+  // ── Hooks (must all be called unconditionally, before any early returns) ──
+
   const { tenant, billing, can } = useTenantDetails();
   const { tenantId } = useCurrentTenantId();
+  const { isCloudEnabled, isCloudLoading } = useCloud();
 
   const [portalLoading, setPortalLoading] = useState(false);
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
@@ -31,12 +36,6 @@ export default function ManagedWorkers() {
     ...queries.cloud.listManagedWorkers(tenantId),
   });
 
-  // Check if the user can create more worker pools
-  const workerPoolCount = listManagedWorkersQuery.data?.rows?.length || 0;
-  const [canCreateMoreWorkerPools] = can(
-    managedCompute.canCreateWorkerPool(workerPoolCount),
-  );
-
   // stop polling billing if there are payment methods
   useEffect(() => {
     if (billing?.hasPaymentMethods) {
@@ -44,11 +43,9 @@ export default function ManagedWorkers() {
     }
   }, [billing, billing?.hasPaymentMethods]);
 
-  const [, rejectReason] = can(managedCompute.create());
-
   const { handleApiError } = useApiError({});
 
-  const manageClicked = async () => {
+   const manageClicked = async () => {
     try {
       if (portalLoading) {
         return;
@@ -67,9 +64,31 @@ export default function ManagedWorkers() {
     }
   };
 
-  // Only show BillingRequired if there are no managed workers AND billing is required
+  // ── Derived values (not hooks) ──────────────────────────────────────────
+
+  const workerPoolCount = listManagedWorkersQuery.data?.rows?.length || 0;
+  const [canCreateMoreWorkerPools] = can(
+    managedCompute.canCreateWorkerPool(workerPoolCount),
+  );
+  const [, rejectReason] = can(managedCompute.create());
   const hasExistingWorkers =
     (listManagedWorkersQuery.data?.rows?.length || 0) > 0;
+
+  // ── Early returns ───────────────────────────────────────────────────────
+
+  // Wait for cloud metadata to resolve before rendering
+  if (isCloudLoading) {
+    return (
+      <div className="flex items-center justify-center h-screen">
+        <Spinner />
+      </div>
+    );
+  }
+
+  // Managed Compute is a cloud-only feature; show 404 in self-hosted mode
+  if (!isCloudEnabled) {
+    return <NotFound />;
+  }
 
   // Show loader while billing data is loading
   if (billing?.isLoading) {
@@ -92,12 +111,14 @@ export default function ManagedWorkers() {
     );
   }
 
-  // Get limit based on plan
+  // ── Handlers & helpers (safe after early returns) ───────────────────────
+
+ 
+
   const getWorkerPoolLimit = () => {
     if (!billing?.plan) {
       return 0;
     }
-
     switch (billing.plan) {
       case 'free':
         return 1;
@@ -106,12 +127,10 @@ export default function ManagedWorkers() {
       case 'growth':
         return 5;
       default:
-        // This covers 'enterprise' and any other plans
         return 5;
     }
   };
 
-  // Handler for when a user tries to add a worker pool but has reached their limit
   const handleAddWorkerPool = () => {
     if (!canCreateMoreWorkerPools) {
       setShowUpgradeModal(true);
@@ -155,6 +174,8 @@ export default function ManagedWorkers() {
       </div>
     );
   };
+
+  // ── Render ──────────────────────────────────────────────────────────────
 
   return (
     <div className="h-full w-full flex-grow">

--- a/frontend/app/src/pages/main/v1/managed-workers/index.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/index.tsx
@@ -1,29 +1,27 @@
 import { BillingRequired } from './components/billing-required';
+import { ManagedWorkersGate } from './components/managed-workers-gate';
 import { ManagedWorkersTable } from './components/managed-workers-table';
 import { MonthlyUsageCard } from './components/monthly-usage-card';
 import { Button } from '@/components/v1/ui/button';
 import { Spinner } from '@/components/v1/ui/loading';
 import { Separator } from '@/components/v1/ui/separator';
-import useCloud from '@/hooks/use-cloud';
 import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
 import { cloudApi } from '@/lib/api/api';
 import { queries } from '@/lib/api/queries';
 import { managedCompute } from '@/lib/can/features/managed-compute';
 import { RejectReason } from '@/lib/can/shared/permission.base';
 import { useApiError } from '@/lib/hooks';
-import { NotFound } from '@/pages/error/components/not-found';
 import { appRoutes } from '@/router';
-import { PlusIcon, ArrowUpIcon } from '@radix-ui/react-icons';
+import { ArrowUpIcon, PlusIcon } from '@radix-ui/react-icons';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 
-export default function ManagedWorkers() {
-  // ── Hooks (must all be called unconditionally, before any early returns) ──
+function ManagedWorkersImpl() {
+  // ── Hooks ────────────────────────────────────────────────────────────────
 
   const { tenant, billing, can } = useTenantDetails();
   const { tenantId } = useCurrentTenantId();
-  const { isCloudEnabled, isCloudLoading } = useCloud();
 
   const [portalLoading, setPortalLoading] = useState(false);
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
@@ -36,7 +34,6 @@ export default function ManagedWorkers() {
     ...queries.cloud.listManagedWorkers(tenantId),
   });
 
-  // stop polling billing if there are payment methods
   useEffect(() => {
     if (billing?.hasPaymentMethods) {
       billing?.setPollBilling(false);
@@ -45,7 +42,19 @@ export default function ManagedWorkers() {
 
   const { handleApiError } = useApiError({});
 
-   const manageClicked = async () => {
+  // ── Derived values ───────────────────────────────────────────────────────
+
+  const workerPoolCount = listManagedWorkersQuery.data?.rows?.length || 0;
+  const [canCreateMoreWorkerPools] = can(
+    managedCompute.canCreateWorkerPool(workerPoolCount),
+  );
+  const [, rejectReason] = can(managedCompute.create());
+  const hasExistingWorkers =
+    (listManagedWorkersQuery.data?.rows?.length || 0) > 0;
+
+  // ── Handlers ─────────────────────────────────────────────────────────────
+
+  const manageClicked = async () => {
     try {
       if (portalLoading) {
         return;
@@ -63,57 +72,6 @@ export default function ManagedWorkers() {
       setPortalLoading(false);
     }
   };
-
-  // ── Derived values (not hooks) ──────────────────────────────────────────
-
-  const workerPoolCount = listManagedWorkersQuery.data?.rows?.length || 0;
-  const [canCreateMoreWorkerPools] = can(
-    managedCompute.canCreateWorkerPool(workerPoolCount),
-  );
-  const [, rejectReason] = can(managedCompute.create());
-  const hasExistingWorkers =
-    (listManagedWorkersQuery.data?.rows?.length || 0) > 0;
-
-  // ── Early returns ───────────────────────────────────────────────────────
-
-  // Wait for cloud metadata to resolve before rendering
-  if (isCloudLoading) {
-    return (
-      <div className="flex items-center justify-center h-screen">
-        <Spinner />
-      </div>
-    );
-  }
-
-  // Managed Compute is a cloud-only feature; show 404 in self-hosted mode
-  if (!isCloudEnabled) {
-    return <NotFound />;
-  }
-
-  // Show loader while billing data is loading
-  if (billing?.isLoading) {
-    return (
-      <div className="flex items-center justify-center h-screen">
-        <Spinner />
-      </div>
-    );
-  }
-
-  // Don't show billing required page while billing data is still loading
-  if (rejectReason == RejectReason.BILLING_REQUIRED && !hasExistingWorkers) {
-    return (
-      <BillingRequired
-        tenant={tenant}
-        billing={billing}
-        manageClicked={manageClicked}
-        portalLoading={portalLoading}
-      />
-    );
-  }
-
-  // ── Handlers & helpers (safe after early returns) ───────────────────────
-
- 
 
   const getWorkerPoolLimit = () => {
     if (!billing?.plan) {
@@ -137,13 +95,35 @@ export default function ManagedWorkers() {
     }
   };
 
+  // ── Early returns ─────────────────────────────────────────────────────────
+
+  if (billing?.isLoading) {
+    return (
+      <div className="flex items-center justify-center h-screen">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (rejectReason == RejectReason.BILLING_REQUIRED && !hasExistingWorkers) {
+    return (
+      <BillingRequired
+        tenant={tenant}
+        billing={billing}
+        manageClicked={manageClicked}
+        portalLoading={portalLoading}
+      />
+    );
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
   const UpgradeModal = () => {
     if (!showUpgradeModal) {
       return null;
     }
 
     return (
-      // TODO use correct modal component
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 dark:bg-black/70">
         <div className="w-full max-w-md rounded-lg border border-border bg-background p-6 shadow-lg">
           <h3 className="mb-4 text-lg font-medium text-foreground">
@@ -174,8 +154,6 @@ export default function ManagedWorkers() {
       </div>
     );
   };
-
-  // ── Render ──────────────────────────────────────────────────────────────
 
   return (
     <div className="h-full w-full flex-grow">
@@ -218,4 +196,8 @@ export default function ManagedWorkers() {
       <UpgradeModal />
     </div>
   );
+}
+
+export default function ManagedWorkers() {
+  return <ManagedWorkersGate>{ManagedWorkersImpl()}</ManagedWorkersGate>;
 }

--- a/frontend/app/src/pages/main/v1/managed-workers/index.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/index.tsx
@@ -12,14 +12,12 @@ import { managedCompute } from '@/lib/can/features/managed-compute';
 import { RejectReason } from '@/lib/can/shared/permission.base';
 import { useApiError } from '@/lib/hooks';
 import { appRoutes } from '@/router';
-import { ArrowUpIcon, PlusIcon } from '@radix-ui/react-icons';
+import { PlusIcon, ArrowUpIcon } from '@radix-ui/react-icons';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 
 function ManagedWorkersImpl() {
-  // ── Hooks ────────────────────────────────────────────────────────────────
-
   const { tenant, billing, can } = useTenantDetails();
   const { tenantId } = useCurrentTenantId();
 
@@ -34,25 +32,22 @@ function ManagedWorkersImpl() {
     ...queries.cloud.listManagedWorkers(tenantId),
   });
 
+  // Check if the user can create more worker pools
+  const workerPoolCount = listManagedWorkersQuery.data?.rows?.length || 0;
+  const [canCreateMoreWorkerPools] = can(
+    managedCompute.canCreateWorkerPool(workerPoolCount),
+  );
+
+  // stop polling billing if there are payment methods
   useEffect(() => {
     if (billing?.hasPaymentMethods) {
       billing?.setPollBilling(false);
     }
   }, [billing, billing?.hasPaymentMethods]);
 
-  const { handleApiError } = useApiError({});
-
-  // ── Derived values ───────────────────────────────────────────────────────
-
-  const workerPoolCount = listManagedWorkersQuery.data?.rows?.length || 0;
-  const [canCreateMoreWorkerPools] = can(
-    managedCompute.canCreateWorkerPool(workerPoolCount),
-  );
   const [, rejectReason] = can(managedCompute.create());
-  const hasExistingWorkers =
-    (listManagedWorkersQuery.data?.rows?.length || 0) > 0;
 
-  // ── Handlers ─────────────────────────────────────────────────────────────
+  const { handleApiError } = useApiError({});
 
   const manageClicked = async () => {
     try {
@@ -73,30 +68,11 @@ function ManagedWorkersImpl() {
     }
   };
 
-  const getWorkerPoolLimit = () => {
-    if (!billing?.plan) {
-      return 0;
-    }
-    switch (billing.plan) {
-      case 'free':
-        return 1;
-      case 'starter':
-        return 2;
-      case 'growth':
-        return 5;
-      default:
-        return 5;
-    }
-  };
+  // Only show BillingRequired if there are no managed workers AND billing is required
+  const hasExistingWorkers =
+    (listManagedWorkersQuery.data?.rows?.length || 0) > 0;
 
-  const handleAddWorkerPool = () => {
-    if (!canCreateMoreWorkerPools) {
-      setShowUpgradeModal(true);
-    }
-  };
-
-  // ── Early returns ─────────────────────────────────────────────────────────
-
+  // Show loader while billing data is loading
   if (billing?.isLoading) {
     return (
       <div className="flex items-center justify-center h-screen">
@@ -105,6 +81,7 @@ function ManagedWorkersImpl() {
     );
   }
 
+  // Don't show billing required page while billing data is still loading
   if (rejectReason == RejectReason.BILLING_REQUIRED && !hasExistingWorkers) {
     return (
       <BillingRequired
@@ -116,7 +93,31 @@ function ManagedWorkersImpl() {
     );
   }
 
-  // ── Render ────────────────────────────────────────────────────────────────
+  // Get limit based on plan
+  const getWorkerPoolLimit = () => {
+    if (!billing?.plan) {
+      return 0;
+    }
+
+    switch (billing.plan) {
+      case 'free':
+        return 1;
+      case 'starter':
+        return 2;
+      case 'growth':
+        return 5;
+      default:
+        // This covers 'enterprise' and any other plans
+        return 5;
+    }
+  };
+
+  // Handler for when a user tries to add a worker pool but has reached their limit
+  const handleAddWorkerPool = () => {
+    if (!canCreateMoreWorkerPools) {
+      setShowUpgradeModal(true);
+    }
+  };
 
   const UpgradeModal = () => {
     if (!showUpgradeModal) {
@@ -124,6 +125,7 @@ function ManagedWorkersImpl() {
     }
 
     return (
+      // TODO use correct modal component
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 dark:bg-black/70">
         <div className="w-full max-w-md rounded-lg border border-border bg-background p-6 shadow-lg">
           <h3 className="mb-4 text-lg font-medium text-foreground">


### PR DESCRIPTION
Fixes #3896

## What
Added a `useCloud()` guard to the managed-workers index and create pages.
In self-hosted (Lite) mode both routes now return a 404 instead of
causing an infinite loading screen.

## Why
`isCloudEnabled` is `false` in self-hosted mode. Without the guard, the
page attempted to call cloud-only billing and compute APIs that don't
exist, resulting in an infinite spinner and a flood of failed requests.

## Changes
- `pages/main/v1/managed-workers/index.tsx` — added cloud guard
- `pages/main/v1/managed-workers/create/index.tsx` — added cloud guard

## Testing
Build the Vite app and launch Hatchet Lite per the steps in #3896.
Navigating to `/managed-workers` and `/managed-workers/create` now
returns a 404 page instead of the infinite loading screen.