### PR TITLE
Fix: Child run caching

### DIFF
--- a/internal/services/admin/server_v1.go
+++ b/internal/services/admin/server_v1.go
@@ -254,7 +254,7 @@ func (i *AdminServiceImpl) ingest(ctx context.Context, tenantId uuid.UUID, opts 
 			localWorkerIds = i.localDispatcher.GetLocalWorkerIds()
 		}
 
-		localAssigned, schedulingErr := i.localScheduler.RunOptimisticScheduling(ctx, tenantId, opts, localWorkerIds)
+		localAssigned, schedulingErr := i.localScheduler.RunOptimisticScheduling(ctx, tenantId, optsToSend, localWorkerIds)
 
 		// if we have a scheduling error, we'll fall back to normal ingestion
 		if schedulingErr != nil {

--- a/sdks/python/examples/child_keys/test_child_key_caching.py
+++ b/sdks/python/examples/child_keys/test_child_key_caching.py
@@ -1,0 +1,48 @@
+import asyncio
+import pytest
+from examples.child_keys.worker import child_key_caching_test_parent, hatchet
+from uuid import uuid4
+from datetime import datetime, timedelta, timezone
+from hatchet_sdk import V1TaskStatus
+from hatchet_sdk.clients.rest.models.v1_task_summary import V1TaskSummary
+
+
+async def poll_until_all_terminal(test_run_id: str) -> list[V1TaskSummary]:
+    for _ in range(30):
+        print("polling for runs...")
+        runs = await hatchet.runs.aio_list(
+            since=datetime.now(timezone.utc) - timedelta(minutes=3),
+            additional_metadata={"test_run_id": test_run_id},
+        )
+
+        if len(runs.rows) == 0:
+            await asyncio.sleep(1)
+            continue
+
+        if all(
+            run.status in [V1TaskStatus.COMPLETED, V1TaskStatus.FAILED]
+            for run in runs.rows
+        ):
+            return runs.rows
+
+        await asyncio.sleep(1)
+    else:
+        raise TimeoutError("Not all runs reached terminal status within timeout")
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_child_key_caching() -> None:
+    test_run_id = str(uuid4())
+
+    await child_key_caching_test_parent.aio_run(
+        additional_metadata={"test_run_id": test_run_id},
+        wait_for_result=False,
+    )
+
+    runs = await poll_until_all_terminal(test_run_id)
+
+    for run in runs:
+        print()
+        print(run.model_dump_json(indent=2))
+
+    assert len(runs) == 4  ## 3 children + 1 parent

--- a/sdks/python/examples/child_keys/worker.py
+++ b/sdks/python/examples/child_keys/worker.py
@@ -1,0 +1,33 @@
+from hatchet_sdk import Context, Hatchet, EmptyModel
+import asyncio
+from pydantic import BaseModel
+
+hatchet = Hatchet()
+
+
+class ChildInput(BaseModel):
+    id: int
+
+
+@hatchet.task(input_validator=ChildInput)
+async def child_key_caching_test_child(input: ChildInput, ctx: Context) -> None:
+    print("executing child with id", input.id)
+    if input.id == 1 and ctx.attempt_number == 1:
+        for _ in range(15):
+            await asyncio.sleep(1)
+
+
+@hatchet.task(retries=1)
+async def child_key_caching_test_parent(_i: EmptyModel, ctx: Context) -> None:
+    children = [1, 2] if ctx.attempt_number == 1 else [2, 3, 1]
+
+    async with asyncio.timeout(3):
+        await child_key_caching_test_child.aio_run_many(
+            [
+                child_key_caching_test_child.create_bulk_run_item(
+                    input=ChildInput(id=i),
+                    child_key=f"child-{i}",
+                )
+                for i in children
+            ],
+        )

--- a/sdks/python/examples/worker.py
+++ b/sdks/python/examples/worker.py
@@ -95,6 +95,10 @@ from examples.opentelemetry_instrumentation.worker import (
     otel_simple_task,
     otel_spawn_parent,
 )
+from examples.child_keys.worker import (
+    child_key_caching_test_parent,
+    child_key_caching_test_child,
+)
 from hatchet_sdk import Hatchet
 
 hatchet = Hatchet()
@@ -185,6 +189,8 @@ def main() -> None:
             generate_reply,
             escalate_ticket,
             welcome_email,
+            child_key_caching_test_child,
+            child_key_caching_test_parent,
         ],
         lifespan=lifespan,
     )


### PR DESCRIPTION
# Description

Fixes an issue where child runs might not be properly cached if the child keys come in out of order, or the set of them changes in size

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
