### PR TITLE
Fix: validate ADMIN_PASSWORD in seed against the API password policy

### DIFF
--- a/cmd/hatchet-admin/cli/seed/seed.go
+++ b/cmd/hatchet-admin/cli/seed/seed.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hatchet-dev/hatchet/pkg/config/database"
 	v1 "github.com/hatchet-dev/hatchet/pkg/repository"
+	"github.com/hatchet-dev/hatchet/pkg/validator"
 )
 
 func SeedDatabase(dc *database.Layer) error {
@@ -17,6 +18,12 @@ func SeedDatabase(dc *database.Layer) error {
 	var userID uuid.UUID
 
 	if shouldSeedUser {
+		// Login enforces the password policy; rejecting here avoids creating
+		// an admin that can't sign in.
+		if !validator.IsValidPassword(dc.Seed.AdminPassword) {
+			return fmt.Errorf("ADMIN_PASSWORD does not meet the password policy: %s", validator.PasswordErr)
+		}
+
 		// seed an example user
 		hashedPw, err := v1.HashPassword(dc.Seed.AdminPassword)
 

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -28,7 +28,7 @@ func newValidator() *validator.Validate {
 	})
 
 	_ = validate.RegisterValidation("password", func(fl validator.FieldLevel) bool {
-		return passwordValidation(fl.Field().String())
+		return IsValidPassword(fl.Field().String())
 	})
 
 	_ = validate.RegisterValidation("uuid", func(fl validator.FieldLevel) bool {
@@ -89,7 +89,9 @@ func newValidator() *validator.Validate {
 	return validate
 }
 
-func passwordValidation(pw string) bool {
+// IsValidPassword reports whether pw matches the policy enforced by the
+// "password" struct tag: 8 to 64 chars, at least one number, upper, and lower.
+func IsValidPassword(pw string) bool {
 	pwLen := len(pw)
 	var hasNumber, hasUpper, hasLower bool
 

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -117,6 +117,29 @@ type passwordResource struct {
 	Password string `validate:"password"`
 }
 
+func TestIsValidPassword(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"valid password", "ValidPass1", true},
+		{"too short", "Short1", false},
+		{"missing number", "NoNumberHere", false},
+		{"missing uppercase", "nouppercase1", false},
+		{"missing lowercase", "NOLOWERCASE1", false},
+		{"empty", "", false},
+		{"max length (64)", "ValidPassword1AValidPassword1AValidPassword1AValidPassword1A1234", true},
+		{"too long (65)", "ValidPassword1AValidPassword1AValidPassword1AValidPassword1A12345", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsValidPassword(tt.input))
+		})
+	}
+}
+
 func TestValidatorPassword(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
The hatchet-admin seed currently accepts any non-empty `ADMIN_PASSWORD` and writes a user that can never log in, since login enforces the 8 to 64 char + upper/lower/number policy. Apply the same rule at seed time and fail fast.

Fixes #3711

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)