### PR TITLE
Feat: Add error if counts don't match so we can debug

### DIFF
--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -3680,24 +3680,22 @@ func (p *OLAPRepositoryImpl) processSinglePartition(ctx context.Context, process
 			return fmt.Errorf("failed to diff source and target partitions: %w", err)
 		}
 
-		if (rowCounts.SourcePartitionCount - rowCounts.TempPartitionCount) > maxCountDiff {
-			numExternalIdsToSample := 20
-			exampleExternalIds := make([]string, 0, numExternalIdsToSample)
-			for i, r := range missingRows {
-				if i >= numExternalIdsToSample {
-					break
-				}
-
-				exampleExternalIds = append(exampleExternalIds, r.ExternalID.String())
+		numExternalIdsToSample := 20
+		exampleExternalIds := make([]string, 0, numExternalIdsToSample)
+		for i, r := range missingRows {
+			if i >= numExternalIdsToSample {
+				break
 			}
 
-			p.l.Error().
-				Str("partition_date", partitionDate.String()).
-				Int64("source_partition_count", rowCounts.SourcePartitionCount).
-				Int64("temp_partition_count", rowCounts.TempPartitionCount).
-				Str("example_external_ids", strings.Join(exampleExternalIds, ", ")).
-				Msg("row counts do not match between temp and source partitions")
+			exampleExternalIds = append(exampleExternalIds, r.ExternalID.String())
 		}
+
+		p.l.Error().
+			Str("partition_date", partitionDate.String()).
+			Int64("source_partition_count", rowCounts.SourcePartitionCount).
+			Int64("temp_partition_count", rowCounts.TempPartitionCount).
+			Str("example_external_ids", strings.Join(exampleExternalIds, ", ")).
+			Msg("row counts do not match between temp and source partitions")
 
 		missingPayloadsToInsert := make([]sqlcv1.CutoverOLAPPayloadToInsert, 0, len(missingRows))
 

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -13,6 +13,7 @@ import (
 	"math/rand"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -3677,6 +3678,25 @@ func (p *OLAPRepositoryImpl) processSinglePartition(ctx context.Context, process
 
 		if err != nil {
 			return fmt.Errorf("failed to diff source and target partitions: %w", err)
+		}
+
+		if (rowCounts.SourcePartitionCount - rowCounts.TempPartitionCount) > maxCountDiff {
+			numExternalIdsToSample := 20
+			exampleExternalIds := make([]string, 0, numExternalIdsToSample)
+			for i, r := range missingRows {
+				if i >= numExternalIdsToSample {
+					break
+				}
+
+				exampleExternalIds = append(exampleExternalIds, r.ExternalID.String())
+			}
+
+			p.l.Error().
+				Str("partition_date", partitionDate.String()).
+				Int64("source_partition_count", rowCounts.SourcePartitionCount).
+				Int64("temp_partition_count", rowCounts.TempPartitionCount).
+				Str("example_external_ids", strings.Join(exampleExternalIds, ", ")).
+				Msg("row counts do not match between temp and source partitions")
 		}
 
 		missingPayloadsToInsert := make([]sqlcv1.CutoverOLAPPayloadToInsert, 0, len(missingRows))

--- a/pkg/repository/payloadstore.go
+++ b/pkg/repository/payloadstore.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -879,6 +880,25 @@ func (p *payloadStoreRepositoryImpl) processSinglePartition(ctx context.Context,
 
 		if err != nil {
 			return fmt.Errorf("failed to diff source and target partitions: %w", err)
+		}
+
+		if (rowCounts.SourcePartitionCount - rowCounts.TempPartitionCount) > maxCountDiff {
+			numExternalIdsToSample := 20
+			exampleExternalIds := make([]string, 0, numExternalIdsToSample)
+			for i, r := range missingRows {
+				if i >= numExternalIdsToSample {
+					break
+				}
+
+				exampleExternalIds = append(exampleExternalIds, r.ExternalID.String())
+			}
+
+			p.l.Error().
+				Str("partition_date", partitionDate.String()).
+				Int64("source_partition_count", rowCounts.SourcePartitionCount).
+				Int64("temp_partition_count", rowCounts.TempPartitionCount).
+				Str("example_external_ids", strings.Join(exampleExternalIds, ", ")).
+				Msg("row counts do not match between temp and source partitions")
 		}
 
 		missingPayloadsToInsert := make([]sqlcv1.CutoverPayloadToInsert, 0, len(missingRows))

--- a/pkg/repository/payloadstore.go
+++ b/pkg/repository/payloadstore.go
@@ -882,24 +882,22 @@ func (p *payloadStoreRepositoryImpl) processSinglePartition(ctx context.Context,
 			return fmt.Errorf("failed to diff source and target partitions: %w", err)
 		}
 
-		if (rowCounts.SourcePartitionCount - rowCounts.TempPartitionCount) > maxCountDiff {
-			numExternalIdsToSample := 20
-			exampleExternalIds := make([]string, 0, numExternalIdsToSample)
-			for i, r := range missingRows {
-				if i >= numExternalIdsToSample {
-					break
-				}
-
-				exampleExternalIds = append(exampleExternalIds, r.ExternalID.String())
+		numExternalIdsToSample := 20
+		exampleExternalIds := make([]string, 0, numExternalIdsToSample)
+		for i, r := range missingRows {
+			if i >= numExternalIdsToSample {
+				break
 			}
 
-			p.l.Error().
-				Str("partition_date", partitionDate.String()).
-				Int64("source_partition_count", rowCounts.SourcePartitionCount).
-				Int64("temp_partition_count", rowCounts.TempPartitionCount).
-				Str("example_external_ids", strings.Join(exampleExternalIds, ", ")).
-				Msg("row counts do not match between temp and source partitions")
+			exampleExternalIds = append(exampleExternalIds, r.ExternalID.String())
 		}
+
+		p.l.Error().
+			Str("partition_date", partitionDate.String()).
+			Int64("source_partition_count", rowCounts.SourcePartitionCount).
+			Int64("temp_partition_count", rowCounts.TempPartitionCount).
+			Str("example_external_ids", strings.Join(exampleExternalIds, ", ")).
+			Msg("row counts do not match between temp and source partitions")
 
 		missingPayloadsToInsert := make([]sqlcv1.CutoverPayloadToInsert, 0, len(missingRows))
 


### PR DESCRIPTION
# Description

Adds an error log in the payload jobs if the row counts don't match so we can debug, and make sure we're not missing anything before doing the "magic" offload

## Type of change

- [x] New feature (non-breaking change which adds functionality)

