### PR TITLE
Fix: Deadlock on trigger workflows

### DIFF
--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -619,13 +619,13 @@ func (r *sharedRepository) triggerWorkflows(
 		workflowVersionIds = append(workflowVersionIds, id)
 	}
 
-	var listStepsTx sqlcv1.DBTX = r.pool
+	var preflightTx sqlcv1.DBTX = r.pool
 
 	if existingTx != nil {
-		listStepsTx = existingTx.tx
+		preflightTx = existingTx.tx
 	}
 
-	workflowVersionToSteps, err := r.listStepsByWorkflowVersionIds(ctx, listStepsTx, tenantId, workflowVersionIds)
+	workflowVersionToSteps, err := r.listStepsByWorkflowVersionIds(ctx, preflightTx, tenantId, workflowVersionIds)
 
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get workflow versions for engine: %w", err)
@@ -669,7 +669,7 @@ func (r *sharedRepository) triggerWorkflows(
 	stepsToAdditionalMatches := make(map[uuid.UUID][]*sqlcv1.V1StepMatchCondition)
 
 	if len(stepsWithAdditionalMatchConditions) > 0 {
-		additionalMatches, err := r.queries.ListStepMatchConditions(ctx, listStepsTx, sqlcv1.ListStepMatchConditionsParams{
+		additionalMatches, err := r.queries.ListStepMatchConditions(ctx, preflightTx, sqlcv1.ListStepMatchConditionsParams{
 			Stepids:  stepsWithAdditionalMatchConditions,
 			Tenantid: tenantId,
 		})

--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -669,7 +669,7 @@ func (r *sharedRepository) triggerWorkflows(
 	stepsToAdditionalMatches := make(map[uuid.UUID][]*sqlcv1.V1StepMatchCondition)
 
 	if len(stepsWithAdditionalMatchConditions) > 0 {
-		additionalMatches, err := r.queries.ListStepMatchConditions(ctx, r.pool, sqlcv1.ListStepMatchConditionsParams{
+		additionalMatches, err := r.queries.ListStepMatchConditions(ctx, listStepsTx, sqlcv1.ListStepMatchConditionsParams{
 			Stepids:  stepsWithAdditionalMatchConditions,
 			Tenantid: tenantId,
 		})


### PR DESCRIPTION
# Description

Fixes a deadlock on trigger workflows where we still used `r.pool` instead of the open tx

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
