### PR TITLE
Fix: Separate transactions in payload migration

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260511174313_v1_0_108.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260511174313_v1_0_108.sql
@@ -1,5 +1,7 @@
+-- +goose NO TRANSACTION
 -- +goose Up
 -- +goose StatementBegin
+BEGIN;
 ALTER TABLE v1_payload ALTER COLUMN external_id SET DEFAULT gen_random_uuid();
 ALTER TABLE v1_payload
   ADD CONSTRAINT v1_payload_external_id_not_null CHECK (external_id IS NOT NULL) NOT VALID;
@@ -19,14 +21,21 @@ BEGIN
     );
     GET DIAGNOSTICS rows_updated = ROW_COUNT;
     EXIT WHEN rows_updated = 0;
-    PERFORM pg_sleep(0.1);
   END LOOP;
 END $$;
+COMMIT;
+-- +goose StatementEnd
 
+-- +goose StatementBegin
+BEGIN;
 ALTER TABLE v1_payload VALIDATE CONSTRAINT v1_payload_external_id_not_null;
 ALTER TABLE v1_payload ALTER COLUMN external_id SET NOT NULL;
 ALTER TABLE v1_payload DROP CONSTRAINT v1_payload_external_id_not_null;
+COMMIT;
+-- +goose StatementEnd
 
+-- +goose StatementBegin
+BEGIN;
 ALTER TABLE v1_payload_cutover_job_offset ADD COLUMN last_external_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000'::UUID;
 
 DROP FUNCTION list_paginated_payloads_for_offload(
@@ -596,6 +605,7 @@ BEGIN
     RETURN source_partition_name;
 END;
 $$;
+COMMIT;
 -- +goose StatementEnd
 
 -- +goose Down

--- a/cmd/hatchet-migrate/migrate/migrations/20260511174313_v1_0_108.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260511174313_v1_0_108.sql
@@ -1,7 +1,6 @@
 -- +goose NO TRANSACTION
 -- +goose Up
 -- +goose StatementBegin
-BEGIN;
 ALTER TABLE v1_payload ALTER COLUMN external_id SET DEFAULT gen_random_uuid();
 ALTER TABLE v1_payload
   ADD CONSTRAINT v1_payload_external_id_not_null CHECK (external_id IS NOT NULL) NOT VALID;
@@ -23,19 +22,15 @@ BEGIN
     EXIT WHEN rows_updated = 0;
   END LOOP;
 END $$;
-COMMIT;
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-BEGIN;
 ALTER TABLE v1_payload VALIDATE CONSTRAINT v1_payload_external_id_not_null;
 ALTER TABLE v1_payload ALTER COLUMN external_id SET NOT NULL;
 ALTER TABLE v1_payload DROP CONSTRAINT v1_payload_external_id_not_null;
-COMMIT;
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-BEGIN;
 ALTER TABLE v1_payload_cutover_job_offset ADD COLUMN last_external_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000'::UUID;
 
 DROP FUNCTION list_paginated_payloads_for_offload(
@@ -605,7 +600,6 @@ BEGIN
     RETURN source_partition_name;
 END;
 $$;
-COMMIT;
 -- +goose StatementEnd
 
 -- +goose Down


### PR DESCRIPTION
# Description

Fixes a locking issue in the payload migration by running it in separate statements, each in their own tx

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
