### PR TITLE
fix(server/authn): Re-order auth flow to prevent side effects on handleCookieAuth

### DIFF
--- a/api/v1/server/authn/middleware.go
+++ b/api/v1/server/authn/middleware.go
@@ -60,22 +60,6 @@ func (a *AuthN) authenticate(c echo.Context, r *middleware.RouteInfo) error {
 		return a.handleNoAuth(c)
 	}
 
-	var cookieErr error
-
-	if r.Security.CookieAuth() {
-		cookieErr = a.handleCookieAuth(c)
-
-		c.Set("auth_strategy", "cookie")
-
-		if cookieErr == nil {
-			return nil
-		}
-	}
-
-	if cookieErr != nil && !r.Security.BearerAuth() && !r.Security.CustomAuth() {
-		return cookieErr
-	}
-
 	var bearerErr error
 
 	if r.Security.BearerAuth() {
@@ -88,7 +72,7 @@ func (a *AuthN) authenticate(c echo.Context, r *middleware.RouteInfo) error {
 		}
 	}
 
-	if bearerErr != nil && !r.Security.CustomAuth() {
+	if bearerErr != nil && !r.Security.CustomAuth() && !r.Security.CookieAuth() {
 		return bearerErr
 	}
 
@@ -104,8 +88,26 @@ func (a *AuthN) authenticate(c echo.Context, r *middleware.RouteInfo) error {
 		}
 	}
 
-	if customErr != nil {
+	if customErr != nil && !r.Security.CookieAuth() {
 		return customErr
+	}
+
+	var cookieErr error
+
+	if r.Security.CookieAuth() {
+		// FIXME(gregfurman): handleCookieAuth (practically) always creates a new UserSession entry.
+		// Hence, the ordering of bearer -> custom -> cookie intentionally prevents this.
+		cookieErr = a.handleCookieAuth(c)
+
+		c.Set("auth_strategy", "cookie")
+
+		if cookieErr == nil {
+			return nil
+		}
+	}
+
+	if cookieErr != nil {
+		return cookieErr
 	}
 
 	return fmt.Errorf("no auth strategy found")
@@ -140,10 +142,6 @@ func (a *AuthN) handleCookieAuth(c echo.Context) error {
 	forbidden := echo.NewHTTPError(http.StatusForbidden, "Please provide valid credentials")
 
 	store := a.config.SessionStore
-
-	if _, err := c.Cookie(store.GetName()); err != nil {
-		return forbidden
-	}
 
 	session, err := store.Get(c.Request(), store.GetName())
 	ctx := c.Request().Context()

--- a/api/v1/server/authn/middleware.go
+++ b/api/v1/server/authn/middleware.go
@@ -141,6 +141,10 @@ func (a *AuthN) handleCookieAuth(c echo.Context) error {
 
 	store := a.config.SessionStore
 
+	if _, err := c.Cookie(store.GetName()); err != nil {
+		return forbidden
+	}
+
 	session, err := store.Get(c.Request(), store.GetName())
 	ctx := c.Request().Context()
 	if err != nil {

--- a/pkg/auth/cookie/sessionstore_test.go
+++ b/pkg/auth/cookie/sessionstore_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 
@@ -20,7 +19,7 @@ import (
 )
 
 func TestSessionStoreSave(t *testing.T) {
-	_ = os.Setenv("SERVER_MSGQUEUE_RABBITMQ_URL", "amqp://user:password@localhost:5672/")
+	t.Setenv("SERVER_MSGQUEUE_RABBITMQ_URL", "amqp://user:password@localhost:5672/")
 
 	time.Sleep(10 * time.Second) // TODO temp hack for tenant non-upsert issue
 	testutils.RunTestWithDatabase(t, func(conf *database.Layer) error {
@@ -41,6 +40,7 @@ func TestSessionStoreSave(t *testing.T) {
 }
 
 func TestSessionStoreLogoutClearsCookieWhenSessionRowMissing(t *testing.T) {
+	t.Setenv("SERVER_MSGQUEUE_RABBITMQ_URL", "amqp://user:password@localhost:5672/")
 	testutils.RunTestWithDatabase(t, func(conf *database.Layer) error {
 		const cookieName = "hatchet"
 
@@ -98,6 +98,7 @@ func TestSessionStoreLogoutClearsCookieWhenSessionRowMissing(t *testing.T) {
 }
 
 func TestSessionStoreGet(t *testing.T) {
+	t.Setenv("SERVER_MSGQUEUE_RABBITMQ_URL", "amqp://user:password@localhost:5672/")
 	testutils.RunTestWithDatabase(t, func(conf *database.Layer) error {
 		const cookieName = "hatchet"
 


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Currently, any HTTP request to a route that accepts cookie-based auth creates a new entry in the `UserSession` table, even when the request is ultimately authenticated via a different strategy (e.g. bearer auth using `HATCHET_CLIENT_API_TOKEN`).

This happens because `handleCookieAuth` saves an unauthenticated session as a side effect before falling through to the next auth strategy in the chain. For programmatic clients making many bearer-auth requests, this produces an unauthenticated `UserSession` row per request that is never referenced again and never cleaned up.

Hence, we should only create new `UserSession` entries when the request is actually attempting cookie-based auth.

Partial fix for #3913. See original issue for reproduction steps. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- When multiple authentication types are possible, ensure `cookieAuth` occurs last.
