### PR TITLE
fix: dedupe security check in hatchet-lite

### DIFF
--- a/cmd/hatchet-api/api/run.go
+++ b/cmd/hatchet-api/api/run.go
@@ -38,9 +38,14 @@ func init() {
 	}
 }
 
-func Start(cf *loader.ConfigLoader, interruptCh <-chan interface{}, version string) error {
+func Start(
+	cf *loader.ConfigLoader,
+	interruptCh <-chan interface{},
+	version string,
+	overrides ...loader.ServerConfigFileOverride,
+) error {
 	// init the repository
-	configCleanup, server, err := cf.CreateServerFromConfig(version)
+	configCleanup, server, err := cf.CreateServerFromConfig(version, overrides...)
 	if err != nil {
 		return fmt.Errorf("error loading server config: %w", err)
 	}

--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -84,9 +84,14 @@ func init() {
 	}
 }
 
-func Run(ctx context.Context, cf *loader.ConfigLoader, version string) error {
+func Run(
+	ctx context.Context,
+	cf *loader.ConfigLoader,
+	version string,
+	overrides ...loader.ServerConfigFileOverride,
+) error {
 
-	serverCleanup, server, err := cf.CreateServerFromConfig(version)
+	serverCleanup, server, err := cf.CreateServerFromConfig(version, overrides...)
 	if err != nil {
 		return fmt.Errorf("could not load server config: %w", err)
 	}

--- a/cmd/hatchet-lite/main.go
+++ b/cmd/hatchet-lite/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hatchet-dev/hatchet/cmd/hatchet-staticfileserver/staticfileserver"
 	"github.com/hatchet-dev/hatchet/pkg/cmdutils"
 	"github.com/hatchet-dev/hatchet/pkg/config/loader"
+	"github.com/hatchet-dev/hatchet/pkg/config/server"
 )
 
 var printVersion bool
@@ -117,9 +118,13 @@ func start(cf *loader.ConfigLoader, interruptCh <-chan interface{}, version stri
 		return fmt.Errorf("error parsing API URL: %w", err)
 	}
 
+	disableSecurityCheck := func(scf *server.ServerConfigFile) {
+		scf.SecurityCheck.Enabled = false
+	}
+
 	// api process
 	go func() {
-		api.Start(cf, interruptCh, version) // nolint:errcheck
+		api.Start(cf, interruptCh, version, disableSecurityCheck) // nolint:errcheck
 	}()
 
 	// static file server
@@ -142,7 +147,7 @@ func start(cf *loader.ConfigLoader, interruptCh <-chan interface{}, version stri
 	defer cancel()
 
 	go func() {
-		if err := engine.Run(ctx, cf, version); err != nil {
+		if err := engine.Run(ctx, cf, version, disableSecurityCheck); err != nil {
 			log.Printf("engine failure: %s", err.Error())
 			os.Exit(1)
 		}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                    
Fixes #3910.                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                              
This PR prevents duplicate security alerts during `hatchet-lite` startup.                                                                                                                                                                       
                                                                                                                                                                                                                                              
`hatchet-lite` creates the server config once directly, then starts the API and engine, which each create the server config again. Since the security check runs from `CreateServerFromConfig`, the same security alert could be logged three times.                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                              
This change keeps the security check enabled for the initial `hatchet-lite` config creation, then passes a lite-only `ServerConfigFileOverride` to the API and engine startup paths to disable the subsequent checks.                           
                                                                                                                                                                                                                                              
This avoids mutating `SERVER_SECURITY_CHECK_ENABLED` globally while keeping the override scoped to lite mode.                                                                                                                                   
                                                                                                                                                                                                                                              
## Changes                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                              
- Allows `api.Start(...)` to accept variadic `loader.ServerConfigFileOverride` arguments.                                                                                                                                                       
- Allows `engine.Run(...)` to accept variadic `loader.ServerConfigFileOverride` arguments.                                                                                                                                                      
- Passes a lite-only override from `hatchet-lite` to disable duplicate security checks during API and engine config creation.                                                                                                                   
- Keeps standalone `hatchet-api` and `hatchet-engine` behavior unchanged because existing callers do not pass any overrides.

## Verification

- `go test ./cmd/hatchet-lite ./cmd/hatchet-api/api ./cmd/hatchet-engine/engine`

- Manually verified using the reproduction from #3910:
  - `ghcr.io/hatchet-dev/hatchet/hatchet-lite:v0.83.0` logs `Security Alert` 3 times.
  - A locally built image from this branch, with `main.Version` overridden to `v0.83.0`, logs `Security Alert` 1 time.
  - Confirmed the fixed `hatchet-lite` and `postgres` containers remained running, with Postgres healthy.