### PR TITLE
chore(local/devex): Set main.Version via LDFLAGS

### DIFF
--- a/hack/dev/start-api.sh
+++ b/hack/dev/start-api.sh
@@ -8,4 +8,6 @@ set -a
 . .env
 set +a
 
-npx --yes nodemon --signal SIGINT --config nodemon.api.json --exec go run ./cmd/hatchet-api
+npx --yes nodemon --signal SIGINT --config nodemon.api.json --exec go run \
+    -ldflags="-X main.Version=$(git rev-parse --short HEAD)" \
+     ./cmd/hatchet-api

--- a/hack/dev/start-engine.sh
+++ b/hack/dev/start-engine.sh
@@ -6,4 +6,6 @@ set -a
 . .env
 set +a
 
-npx --yes nodemon --signal SIGINT --config nodemon.engine.json --exec go run ./cmd/hatchet-engine --no-graceful-shutdown
+npx --yes nodemon --signal SIGINT --config nodemon.engine.json --exec go run \
+    -ldflags="-X main.Version=$(git rev-parse --short HEAD)" \
+    ./cmd/hatchet-engine --no-graceful-shutdown

--- a/hack/dev/start-lite.sh
+++ b/hack/dev/start-lite.sh
@@ -8,4 +8,6 @@ set -a
 . .env
 set +a
 
-npx --yes nodemon --signal SIGINT --config nodemon.api.json --exec go run ./cmd/hatchet-lite
+npx --yes nodemon --signal SIGINT --config nodemon.api.json --exec go run \
+    -ldflags="-X main.Version=$(git rev-parse --short HEAD)" \
+    ./cmd/hatchet-lite


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Currently, `main.Version` defaults to `v0.1.0-alpha.0`. While we expect to override this at release time, running hatchet locally will always fail security checks as the tag in question is invalid.

This PR ensures we inject the current commit's SHA as the `main.Version` when running locally via the scripts in `hack/dev`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (changes which are not directly related to any business logic)


## What's Changed

- Includes a `-ldflags="-X main.Version=$(git rev-parse --short HEAD)"` flag on the `hack/dev/start-{api,engine,lite}.sh` scripts.

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)

