### PR TITLE
Add logging for serial operation

### DIFF
--- a/internal/operation/interval_test.go
+++ b/internal/operation/interval_test.go
@@ -2,6 +2,7 @@ package operation
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -156,6 +157,24 @@ func TestInterval_SetIntervalGauge_BackoffMechanism(t *testing.T) {
 	interval.SetIntervalGauge(0)
 	interval.SetIntervalGauge(0)
 	assert.Equal(t, 200*time.Millisecond, interval.currInterval, "Should double again after 3 more zero-row updates")
+}
+
+func TestInterval_SetIntervalGauge_BackoffOverflow(t *testing.T) {
+	interval := &Interval{
+		resourceId:      testResourceID,
+		maxJitter:       0,
+		startInterval:   50 * time.Millisecond,
+		currInterval:    50 * time.Millisecond,
+		maxInterval:     293 * 52 * 7 * 24 * time.Hour,
+		noActivityCount: 0,
+		incBackoffCount: 3,
+		repo:            v1.NewNoOpIntervalSettingsRepository(),
+	}
+
+	for range 6400 {
+		interval.SetIntervalGauge(0)
+		fmt.Println(interval.currInterval, interval.noActivityCount)
+	}
 }
 
 func TestInterval_SetIntervalGauge_ConcurrentAccess(t *testing.T) {

--- a/internal/operation/operation.go
+++ b/internal/operation/operation.go
@@ -2,6 +2,7 @@ package operation
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"sync"
 	"time"
@@ -130,6 +131,7 @@ func (o *SerialOperation) RunOrContinue(l *zerolog.Logger) {
 
 func (o *SerialOperation) Run(l *zerolog.Logger) {
 	if !o.setRunning(true, l) {
+		l.Info().Msg(fmt.Sprintf("SerialOperation %s skipped because it is already running, last run: %s ", o.operationId, o.lastRun))
 		return
 	}
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
