### PR TITLE
Improve logging for task reassignment even more

### DIFF
--- a/internal/operation/operation.go
+++ b/internal/operation/operation.go
@@ -131,7 +131,7 @@ func (o *SerialOperation) RunOrContinue(l *zerolog.Logger) {
 
 func (o *SerialOperation) Run(l *zerolog.Logger) {
 	if !o.setRunning(true, l) {
-		l.Info().Msg(fmt.Sprintf("SerialOperation %s skipped because it is already running, last run: %s ", o.operationId, o.lastRun))
+		l.Error().Msg(fmt.Sprintf("SerialOperation %s skipped because it is already running, last run: %s ", o.operationId, o.lastRun))
 		return
 	}
 

--- a/internal/services/controllers/task/process_reassignments.go
+++ b/internal/services/controllers/task/process_reassignments.go
@@ -22,7 +22,9 @@ func (tc *TasksControllerImpl) processTaskReassignments(ctx context.Context, ten
 	tenantIdUUID := uuid.MustParse(tenantId)
 
 	res, shouldContinue, err := tc.repov1.Tasks().ProcessTaskReassignments(ctx, tenantIdUUID)
-
+	if !shouldContinue {
+		tc.l.Error().Msg(fmt.Sprintf("Task reassignment stopping: %e", err))
+	}
 	if err != nil {
 		return false, fmt.Errorf("could not list step runs to reassign for tenant %s: %w", tenantId, err)
 	}

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -841,15 +841,7 @@ func (r *TaskRepositoryImpl) failTasksTx(ctx context.Context, tx sqlcv1.DBTX, te
 		if err != nil {
 			return nil, err
 		}
-		if len(internalFailureRetries) < len(internalFailureTaskIds) {
-			for i, taskId := range internalFailureTaskIds {
-				r.l.Warn().
-					Int64("task_id", taskId).
-					Int32("retry_count", internalFailureTaskRetryCounts[i]).
-					Str("tenant_id", tenantId.String()).
-					Msg("FailTaskInternalFailure skipped task - possible stale v1_task_runtime row with mismatched retry_count")
-			}
-		}
+
 		for _, task := range internalFailureRetries {
 			retriedTasks = append(retriedTasks, RetriedTask{
 				TaskIdInsertedAtRetryCount: &TaskIdInsertedAtRetryCount{

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -841,7 +841,15 @@ func (r *TaskRepositoryImpl) failTasksTx(ctx context.Context, tx sqlcv1.DBTX, te
 		if err != nil {
 			return nil, err
 		}
-
+		if len(internalFailureRetries) < len(internalFailureTaskIds) {
+			for i, taskId := range internalFailureTaskIds {
+				r.l.Warn().
+					Int64("task_id", taskId).
+					Int32("retry_count", internalFailureTaskRetryCounts[i]).
+					Str("tenant_id", tenantId.String()).
+					Msg("FailTaskInternalFailure skipped task - possible stale v1_task_runtime row with mismatched retry_count")
+			}
+		}
 		for _, task := range internalFailureRetries {
 			retriedTasks = append(retriedTasks, RetriedTask{
 				TaskIdInsertedAtRetryCount: &TaskIdInsertedAtRetryCount{
@@ -1319,6 +1327,9 @@ func (r *TaskRepositoryImpl) ProcessTaskReassignments(ctx context.Context, tenan
 	}
 
 	if len(toReassign) == 0 {
+		r.l.Error().
+			Str("tenant_id", tenantId.String()).
+			Msg("could not find any tasks to reassign")
 		return &FailTasksResponse{
 			FinalizedTaskResponse: &FinalizedTaskResponse{
 				ReleasedTasks:  make([]*sqlcv1.ReleaseTasksRow, 0),
@@ -1332,6 +1343,11 @@ func (r *TaskRepositoryImpl) ProcessTaskReassignments(ctx context.Context, tenan
 	failOpts := make([]FailTaskOpts, 0, len(toReassign))
 
 	for _, task := range toReassign {
+		r.l.Warn().
+			Int64("task_id", task.ID).
+			Int32("retry_count", task.RetryCount).
+			Str("tenant_id", tenantId.String()).
+			Msg("found task to reassign")
 		failOpts = append(failOpts, FailTaskOpts{
 			TaskIdInsertedAtRetryCount: &TaskIdInsertedAtRetryCount{
 				Id:         task.ID,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
