### PR TITLE
feat: show structured log fields in log viewer

### DIFF
--- a/frontend/app/src/components/v1/cloud/logging/log-metadata.test.ts
+++ b/frontend/app/src/components/v1/cloud/logging/log-metadata.test.ts
@@ -1,0 +1,25 @@
+import { formatLogMetadata, hasLogMetadata } from './log-metadata';
+import * as assert from 'node:assert';
+import { test } from 'node:test';
+
+test('hasLogMetadata returns true for non-empty metadata objects', () => {
+  assert.strictEqual(hasLogMetadata({ chunkIndex: 16 }), true);
+});
+
+test('hasLogMetadata returns false for missing or empty metadata', () => {
+  assert.strictEqual(hasLogMetadata(undefined), false);
+  assert.strictEqual(hasLogMetadata({}), false);
+});
+
+test('formatLogMetadata pretty-prints metadata fields', () => {
+  const formatted = formatLogMetadata({
+    chunkIndex: 16,
+    elapsedMs: 595,
+    evt: 'staff_comp_snapshot_upsert_complete',
+  });
+
+  assert.strictEqual(
+    formatted,
+    '{\n  "chunkIndex": 16,\n  "elapsedMs": 595,\n  "evt": "staff_comp_snapshot_upsert_complete"\n}',
+  );
+});

--- a/frontend/app/src/components/v1/cloud/logging/log-metadata.ts
+++ b/frontend/app/src/components/v1/cloud/logging/log-metadata.ts
@@ -1,0 +1,9 @@
+export function hasLogMetadata(
+  metadata: Record<string, unknown> | undefined,
+): metadata is Record<string, unknown> {
+  return !!metadata && Object.keys(metadata).length > 0;
+}
+
+export function formatLogMetadata(metadata: Record<string, unknown>): string {
+  return JSON.stringify(metadata, null, 2);
+}

--- a/frontend/app/src/components/v1/cloud/logging/log-viewer.tsx
+++ b/frontend/app/src/components/v1/cloud/logging/log-viewer.tsx
@@ -1,4 +1,5 @@
 import { AnsiLine } from './ansi-line';
+import { formatLogMetadata, hasLogMetadata } from './log-metadata';
 import {
   LogLine,
   V1LogLineLevelIncludingEvictionNotice,
@@ -19,7 +20,7 @@ import { V1LogLineLevel, V1TaskStatus } from '@/lib/api';
 import { cn } from '@/lib/utils';
 import { Link } from '@tanstack/react-router';
 import { ExternalLink, XCircle } from 'lucide-react';
-import { useMemo, useCallback, useRef, useState } from 'react';
+import { createElement, useCallback, useMemo, useRef, useState } from 'react';
 
 const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
   year: 'numeric',
@@ -177,6 +178,45 @@ function ErrorPopover({ error }: { error: string }) {
                 </pre>
               </div>
             </div>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function FieldsPopover({ metadata }: { metadata: Record<string, unknown> }) {
+  const formattedMetadata = formatLogMetadata(metadata);
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        onClick={(e) => e.stopPropagation()}
+        className="ml-2 shrink-0 inline-flex items-center gap-1 rounded border border-border px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground transition-colors hover:border-foreground/40 hover:bg-muted hover:text-foreground"
+      >
+        <span aria-hidden="true">{'{}'}</span>
+        Fields
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[320px] max-w-[90vw] border-border bg-popover p-0 text-left shadow-lg sm:w-[460px] md:w-[560px] lg:w-[680px]"
+        align="start"
+      >
+        <div className="space-y-3 p-4">
+          <div className="flex items-center gap-2 border-b border-border pb-2">
+            <span className="font-mono text-xs text-muted-foreground">
+              {'{}'}
+            </span>
+            <h3 className="font-medium text-foreground">Log Fields</h3>
+          </div>
+          <div className="max-h-[420px] overflow-auto rounded-md border border-border bg-muted/50">
+            {createElement(
+              'pre',
+              {
+                className:
+                  'm-0 whitespace-pre-wrap break-words p-4 text-left font-mono text-xs leading-relaxed text-foreground',
+              },
+              formattedMetadata,
+            )}
           </div>
         </div>
       </PopoverContent>
@@ -459,6 +499,9 @@ export function LogViewer({
                   {/* fixme: figure out how to use the type guard properly here */}
                   <AnsiLine text={log.line as string} />
                 </span>
+                {hasLogMetadata(log.metadata) && (
+                  <FieldsPopover metadata={log.metadata} />
+                )}
                 {log.error && <ErrorPopover error={log.error} />}
                 {log.linkTo && (
                   <TooltipProvider>

--- a/frontend/app/src/pages/main/v1/logs/hooks/use-tenant-logs.tsx
+++ b/frontend/app/src/pages/main/v1/logs/hooks/use-tenant-logs.tsx
@@ -44,6 +44,7 @@ function mapToLogLines(rows: V1LogLine[]): LogLine[] {
     timestamp: row.createdAt,
     line: row.message,
     level: row.level,
+    metadata: row.metadata as Record<string, unknown> | undefined,
     attempt: row.attempt,
     taskExternalId: row.taskExternalId,
     taskDisplayName: row.taskDisplayName,

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/workflow-run-logs.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/workflow-run-logs.tsx
@@ -33,6 +33,7 @@ function mapToLogLines(rows: V1LogLine[]): LogLine[] {
     timestamp: row.createdAt,
     line: row.message,
     level: row.level,
+    metadata: row.metadata as Record<string, unknown> | undefined,
     attempt: row.attempt,
     taskExternalId: row.taskExternalId,
     taskDisplayName: row.taskDisplayName,


### PR DESCRIPTION
# Description

Shows structured log metadata in the v1 log viewer. Log rows with non-empty metadata now render a `Fields` button next to the message; clicking it opens a popover with pretty-printed JSON fields.

Fixes #3859

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

- [x] Add helpers for detecting and formatting non-empty log metadata
- [x] Show a `Fields` popover in `LogViewer` when log rows include metadata
- [x] Pass `row.metadata` through tenant logs and workflow run logs
- [x] Add unit coverage for metadata visibility and pretty-printing

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable)

## Testing

- `cd frontend/app && corepack pnpm test:unit`
- `cd frontend/app && corepack pnpm exec eslint src/components/v1/cloud/logging/log-metadata.ts src/components/v1/cloud/logging/log-metadata.test.ts src/components/v1/cloud/logging/log-viewer.tsx src/pages/main/v1/logs/hooks/use-tenant-logs.tsx 'src/pages/main/v1/workflow-runs-v1/$run/v2components/workflow-run-logs.tsx'`
- `cd frontend/app && corepack pnpm exec prettier --check src/components/v1/cloud/logging/log-metadata.ts src/components/v1/cloud/logging/log-metadata.test.ts src/components/v1/cloud/logging/log-viewer.tsx src/pages/main/v1/logs/hooks/use-tenant-logs.tsx 'src/pages/main/v1/workflow-runs-v1/$run/v2components/workflow-run-logs.tsx'`
- `git diff upstream/main...HEAD --check`

## Related

Screenshots:
<img width="1280" height="720" alt="log-fields-button" src="https://github.com/user-attachments/assets/bed0d633-b35c-43af-86c9-f438ee561931" />
<img width="1280" height="720" alt="log-fields-popover" src="https://github.com/user-attachments/assets/71b4192a-ff67-43c5-8f07-5ce4454f4aae" />


<details id="ai-disclosure">
<summary><b>AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: LLM assistance was used to inspect the branch, draft the PR description, and prepare representative UI screenshot assets.

</details>