### PR TITLE
Fix: Increase limit default to 10k

### DIFF
--- a/api/v1/server/handlers/workers/list.go
+++ b/api/v1/server/handlers/workers/list.go
@@ -125,7 +125,7 @@ func (t *WorkerService) workerListV1(ctx echo.Context, tenant *sqlcv1.Tenant, re
 
 	sixSecAgo := time.Now().Add(-24 * time.Hour)
 
-	limit := 50
+	limit := 10000 // default to 10k for backwards compat (more or less) to before when we had no `LIMIT` set
 	offset := 0
 
 	opts := &v1.ListWorkersOpts{

--- a/pkg/repository/sqlcv1/workers.sql
+++ b/pkg/repository/sqlcv1/workers.sql
@@ -155,7 +155,7 @@ ORDER BY
 OFFSET
     COALESCE(sqlc.narg('offset'), 0)
 LIMIT
-    COALESCE(sqlc.narg('limit'), 50);
+    COALESCE(sqlc.narg('limit'), 10000);
 
 -- name: CountWorkers :one
 SELECT count(*)

--- a/pkg/repository/sqlcv1/workers.sql.go
+++ b/pkg/repository/sqlcv1/workers.sql.go
@@ -1330,7 +1330,7 @@ ORDER BY
 OFFSET
     COALESCE($6, 0)
 LIMIT
-    COALESCE($7, 50)
+    COALESCE($7, 10000)
 `
 
 type ListWorkersParams struct {


### PR DESCRIPTION
# Description

Increases the default `LIMIT` on the worker list query to 10k to roughly preserve backwards compat with the previous behavior, where we had no limit

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI use

</details>
