### PR TITLE
chore(ci): Rework for individual SDK GH releases

### DIFF
--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -295,6 +295,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -316,5 +318,25 @@ jobs:
           fi
 
           sh publish.sh
+          echo "VERSION_TAG=$NEW_VERSION" >> $GITHUB_ENV
         env:
           POETRY_PYPI_TOKEN_PYPI: ${{ secrets.POETRY_PYPI_TOKEN_PYPI }}
+
+      - name: "Generate release notes"
+        if: env.VERSION_TAG != ''
+        working-directory: ${{ github.workspace }}
+        run: ./hack/ci/release-notes.sh python > ./release_notes.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Release"
+        if: env.VERSION_TAG != ''
+        working-directory: ${{ github.workspace }}
+        run: |
+          gh release create "py/${VERSION_TAG}" \
+            --target "$GITHUB_SHA" \
+            --title "Python SDK ${VERSION_TAG}" \
+            --notes-file ./release_notes.md \
+            --latest=false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sdk-ruby.yml
+++ b/.github/workflows/sdk-ruby.yml
@@ -418,3 +418,23 @@ jobs:
           gem build hatchet-sdk.gemspec
           NEW_VERSION=$(ruby -e "require_relative 'lib/hatchet/version'; puts Hatchet::VERSION")
           gem push hatchet-sdk-${NEW_VERSION}.gem
+          echo "VERSION_TAG=$NEW_VERSION" >> $GITHUB_ENV
+
+      - name: "Generate release notes"
+        if: env.VERSION_TAG != ''
+        working-directory: ${{ github.workspace }}
+        run: ./hack/ci/release-notes.sh ruby > ./release_notes.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Release"
+        if: env.VERSION_TAG != ''
+        working-directory: ${{ github.workspace }}
+        run: |
+          gh release create "rb/${VERSION_TAG}" \
+            --target "$GITHUB_SHA" \
+            --title "Ruby SDK ${VERSION_TAG}" \
+            --notes-file ./release_notes.md \
+            --latest=false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sdk-typescript-manual-publish.yml
+++ b/.github/workflows/sdk-typescript-manual-publish.yml
@@ -65,7 +65,7 @@ jobs:
         if: env.VERSION_TAG != ''
         working-directory: ${{ github.workspace }}
         run: |
-          gh release create "sdk-ts/${VERSION_TAG}" \
+          gh release create "ts/${VERSION_TAG}" \
             --target "$GITHUB_SHA" \
             --title "Typescript SDK ${VERSION_TAG}" \
             --notes-file ./release_notes.md \

--- a/.github/workflows/sdk-typescript-manual-publish.yml
+++ b/.github/workflows/sdk-typescript-manual-publish.yml
@@ -50,5 +50,25 @@ jobs:
           else
               pnpm publish:ci
           fi
+          echo "VERSION_TAG=$NEW_VERSION" >> $GITHUB_ENV
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: "Generate release notes"
+        if: env.VERSION_TAG != ''
+        working-directory: ${{ github.workspace }}
+        run: ./hack/ci/release-notes.sh typescript > ./release_notes.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Release"
+        if: env.VERSION_TAG != ''
+        working-directory: ${{ github.workspace }}
+        run: |
+          gh release create "sdk-ts/${VERSION_TAG}" \
+            --target "$GITHUB_SHA" \
+            --title "Typescript SDK ${VERSION_TAG}" \
+            --notes-file ./release_notes.md \
+            --latest=false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sdk-typescript.yml
+++ b/.github/workflows/sdk-typescript.yml
@@ -405,5 +405,25 @@ jobs:
           else
               pnpm publish:ci
           fi
+          echo "VERSION_TAG=$NEW_VERSION" >> $GITHUB_ENV
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: "Generate release notes"
+        if: env.VERSION_TAG != ''
+        working-directory: ${{ github.workspace }}
+        run: ./hack/ci/release-notes.sh typescript > ./release_notes.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Release"
+        if: env.VERSION_TAG != ''
+        working-directory: ${{ github.workspace }}
+        run: |
+          gh release create "ts/${VERSION_TAG}" \
+            --target "$GITHUB_SHA" \
+            --title "Typescript SDK ${VERSION_TAG}" \
+            --notes-file ./release_notes.md \
+            --latest=false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/hack/ci/release-notes.sh
+++ b/hack/ci/release-notes.sh
@@ -68,7 +68,7 @@ generate_release_notes() {
     ruby)
       file="sdks/ruby/src/lib/hatchet/version.rb"
       pattern='VERSION ='
-      sdk_dir="sdks/ruby/"
+      sdk_dir="sdks/ruby/src"
       ;;
     *)
       echo "Unknown SDK: $sdk" >&2
@@ -76,8 +76,8 @@ generate_release_notes() {
       ;;
   esac
 
-  get_latest_entry "$(dirname $file)"
-  get_instructions "$(dirname $file)"
+  get_latest_entry "$sdk_dir"
+  get_instructions "$sdk_dir"
 
   local line
   line=$(grep -n "$pattern" "$file" | head -1 | cut -d: -f1)
@@ -92,7 +92,7 @@ generate_release_notes() {
   echo "## What's Changed?"
   echo
 
-  get_pr_history "$sdk_dir" "$since_hash" "$until_hash"
+  get_pr_history "$since_hash" "$until_hash" "$sdk_dir"
 }
 
 

--- a/hack/ci/release-notes.sh
+++ b/hack/ci/release-notes.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+
+# HACK(gregfurman): While we don't have proper conventional commits & sufficient version tagging
+# history, let's bootstrap the commit history between 2 releases of each SDK.
+
+get_pr_history() {
+  local since_hash="$1" until_hash="$2"
+  shift 2
+  git log "${since_hash}..${until_hash}" --pretty=format:'%s' -- "$@" \
+    | grep -oE '#[0-9]+' | tr -d '#' | sort -u \
+    | while read -r pr; do
+        gh pr view "$pr" \
+          --repo hatchet-dev/hatchet \
+          --json number,title,author,labels \
+          --jq '"- \(.title) (#\(.number)) by @\(.author.login)"'
+      done
+}
+
+get_latest_entry() {
+  local sdk="$1"
+  awk '
+  /^## \[Unreleased\]/ {
+      release++;
+      print "";
+      print "NOTE: This is a release candidate.";
+      next;
+  }
+  /^## \[[0-9]+\.[0-9]+\.[0-9]+\]/ {
+      release++;
+      next;
+  }
+  {
+      if (release == 1) print;
+      if (release > 1) exit;
+  }' "$sdk/CHANGELOG.md"
+}
+
+
+get_instructions() {
+  local sdk="$1"
+  awk '
+  /^## (Installation|Documentation)/ {
+    printing=1
+  }
+  /^## / && printing && !/^## (Installation|Documentation)/ {
+    printing=0
+  }
+  printing
+  ' "$sdk/README.md"
+}
+
+generate_release_notes() {
+  local sdk="$1"
+  local file
+  local pattern
+  local sdk_dir
+  case "$sdk" in
+    python)
+      file="sdks/python/pyproject.toml"
+      pattern='^version ='
+      sdk_dir="sdks/python/"
+      ;;
+    typescript)
+      file="sdks/typescript/package.json"
+      pattern='"version"'
+      sdk_dir="sdks/typescript/"
+      ;;
+    ruby)
+      file="sdks/ruby/src/lib/hatchet/version.rb"
+      pattern='VERSION ='
+      sdk_dir="sdks/ruby/"
+      ;;
+    *)
+      echo "Unknown SDK: $sdk" >&2
+      return 1
+      ;;
+  esac
+
+  get_latest_entry "$(dirname $file)"
+  get_instructions "$(dirname $file)"
+
+  local line
+  line=$(grep -n "$pattern" "$file" | head -1 | cut -d: -f1)
+
+  local hashes
+  hashes=$(git log -2 -L "$line,$line:$file" --pretty=format:"%h" -s)
+
+  local until_hash since_hash
+  until_hash=$(echo "$hashes" | sed -n '1p')
+  since_hash=$(echo "$hashes" | sed -n '2p')
+
+  echo "## What's Changed?"
+  echo
+
+  get_pr_history "$sdk_dir" "$since_hash" "$until_hash"
+}
+
+
+echo "## Overview"
+
+generate_release_notes "$1"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Does an empty GH release of each SDK in order to publish respective release notes.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] CI (any automation pipeline changes)
- [x] Chore (changes which are not directly related to any business logic)

## What's Changed

- Adds a `release_notes.sh` script used to generate release notes for each SDK.
- Updates each SDKs publish job to generate release notes + trigger a GH release on successful publish.
- The following tags will be created for each SDK release:
   - python - `py/vX.Y.Z` 
   - ruby - `rb/vX.Y.Z` 
   - typescript - `ts/vX.Y.Z` 
