### PR TITLE
feat: move billing to control plane

### DIFF
--- a/frontend/app/src/components/modals/welcome-modal.tsx
+++ b/frontend/app/src/components/modals/welcome-modal.tsx
@@ -9,11 +9,11 @@ import { HatchetLogo } from '@/components/v1/ui/hatchet-logo';
 import { Spinner } from '@/components/v1/ui/loading.tsx';
 import { useAnalytics } from '@/hooks/use-analytics';
 import { queries } from '@/lib/api';
-import { cloudApi } from '@/lib/api/api';
+import { controlPlaneApi } from '@/lib/api/api';
 import {
   SubscriptionPlanCode,
   SubscriptionPeriod,
-} from '@/lib/api/generated/cloud/data-contracts';
+} from '@/lib/api/generated/control-plane/data-contracts';
 import { appRoutes } from '@/router';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
@@ -41,16 +41,19 @@ export function WelcomeModal({ tenantId, open, onClose }: WelcomeModalProps) {
       if (!tenantId) {
         throw new Error('No tenant id');
       }
-      const response = await cloudApi.tenantSubscriptionUpdate(tenantId, {
-        plan: SubscriptionPlanCode.Developer,
-        period: SubscriptionPeriod.Monthly,
-      });
+      const response = await controlPlaneApi.tenantSubscriptionUpdate(
+        tenantId,
+        {
+          plan: SubscriptionPlanCode.Developer,
+          period: SubscriptionPeriod.Monthly,
+        },
+      );
       return response.data;
     },
     onSuccess: (data) => {
       localStorage.removeItem(WELCOME_KEY);
       onClose();
-      if (data && 'checkoutUrl' in data) {
+      if (data.checkoutUrl) {
         window.location.href = data.checkoutUrl;
       }
     },

--- a/frontend/app/src/components/v1/cloud/billing/plan-selector.tsx
+++ b/frontend/app/src/components/v1/cloud/billing/plan-selector.tsx
@@ -12,7 +12,7 @@ import {
   Coupon,
   SubscriptionPlan,
   SubscriptionPlanFeatureGroup,
-} from '@/lib/api/generated/cloud/data-contracts';
+} from '@/lib/api/generated/control-plane/data-contracts';
 import { CheckIcon, Cross2Icon } from '@radix-ui/react-icons';
 import { useQuery } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';

--- a/frontend/app/src/components/v1/cloud/billing/subscription.tsx
+++ b/frontend/app/src/components/v1/cloud/billing/subscription.tsx
@@ -21,22 +21,22 @@ import {
 } from '@/components/v1/ui/tooltip';
 import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
 import { queries } from '@/lib/api';
-import { cloudApi } from '@/lib/api/api';
+import { controlPlaneApi } from '@/lib/api/api';
 import {
-  TenantSubscription,
+  TenantBillingStateSubscription,
   SubscriptionPlan,
   SubscriptionPlanCode,
   SubscriptionPeriod,
   Coupon,
-} from '@/lib/api/generated/cloud/data-contracts';
+} from '@/lib/api/generated/control-plane/data-contracts';
 import { useApiError } from '@/lib/hooks';
 import queryClient from '@/query-client';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import React, { useEffect, useMemo, useState } from 'react';
 
 interface SubscriptionProps {
-  active?: TenantSubscription;
-  upcoming?: TenantSubscription;
+  active?: TenantBillingStateSubscription;
+  upcoming?: TenantBillingStateSubscription;
   plans?: SubscriptionPlan[];
   coupons?: Coupon[];
 }
@@ -110,7 +110,7 @@ export const Subscription: React.FC<SubscriptionProps> = ({
         return;
       }
       setPortalLoading(true);
-      const link = await cloudApi.billingPortalLinkGet(tenantId);
+      const link = await controlPlaneApi.billingPortalLinkGet(tenantId);
       window.open(link.data.url, '_blank');
     } catch (e) {
       handleApiError(e as any);
@@ -124,14 +124,17 @@ export const Subscription: React.FC<SubscriptionProps> = ({
     mutationFn: async ({ plan_code }: { plan_code: string }) => {
       const [plan, period] = plan_code.split('_');
       setLoading(plan_code);
-      const response = await cloudApi.tenantSubscriptionUpdate(tenantId, {
-        plan: plan as SubscriptionPlanCode,
-        period: period as SubscriptionPeriod,
-      });
+      const response = await controlPlaneApi.tenantSubscriptionUpdate(
+        tenantId,
+        {
+          plan: plan as SubscriptionPlanCode,
+          period: period as SubscriptionPeriod,
+        },
+      );
       return response.data;
     },
     onSuccess: async (data) => {
-      if (data && 'checkoutUrl' in data) {
+      if (data.checkoutUrl) {
         window.location.href = data.checkoutUrl;
         return;
       }

--- a/frontend/app/src/lib/api/generated/cloud/Api.ts
+++ b/frontend/app/src/lib/api/generated/cloud/Api.ts
@@ -17,7 +17,6 @@ import {
   APIErrors,
   APITokenList,
   AuditLogList,
-  AutumnWebhookEvent,
   Build,
   CreateManagedWorkerFromTemplateRequest,
   CreateManagedWorkerRequest,
@@ -51,15 +50,9 @@ import {
   RejectOrganizationInviteRequest,
   RemoveOrganizationMembersRequest,
   RuntimeConfigActionsResponse,
-  SubscriptionPlanList,
-  TenantBillingState,
-  TenantCreditBalance,
-  TenantPaymentMethodList,
   UpdateManagedWorkerRequest,
   UpdateOrganizationRequest,
   UpdateOrganizationTenantRequest,
-  UpdateTenantSubscriptionRequest,
-  UpdateTenantSubscriptionResponse,
   UserOffer,
   VectorPushRequest,
   WorkflowRunEventsMetricsCounts,
@@ -770,141 +763,6 @@ export class Api<
       body: data,
       secure: true,
       type: ContentType.Json,
-      ...params,
-      xResources: ["tenant"],
-    }), { resources: new Set<string>(["tenant"]) });
-  /**
-   * @description List all available subscription plans and their features
-   *
-   * @tags Billing
-   * @name SubscriptionPlansList
-   * @summary List subscription plans
-   * @request GET:/api/v1/billing/plans
-   */
-  subscriptionPlansList = Object.assign((params: RequestParams = {}) =>
-    this.request<SubscriptionPlanList, APIErrors>({
-      path: `/api/v1/billing/plans`,
-      method: "GET",
-      format: "json",
-      ...params,
-      xResources: [],
-    }), { resources: new Set<string>([]) });
-  /**
-   * @description Receive a webhook message from Autumn
-   *
-   * @tags Billing
-   * @name AutumnEventCreate
-   * @summary Receive a webhook message from Autumn
-   * @request POST:/api/v1/billing/autumn/webhook
-   */
-  autumnEventCreate = Object.assign((data: AutumnWebhookEvent, params: RequestParams = {}) =>
-    this.request<void, APIErrors>({
-      path: `/api/v1/billing/autumn/webhook`,
-      method: "POST",
-      body: data,
-      type: ContentType.Json,
-      ...params,
-      xResources: [],
-    }), { resources: new Set<string>([]) });
-  /**
-   * @description Gets the billing state for a tenant
-   *
-   * @tags Tenant
-   * @name TenantBillingStateGet
-   * @summary Get the billing state for a tenant
-   * @request GET:/api/v1/billing/tenants/{tenant}
-   * @secure
-   */
-  tenantBillingStateGet = Object.assign((tenant: string, params: RequestParams = {}) =>
-    this.request<TenantBillingState, APIErrors | APIError>({
-      path: `/api/v1/billing/tenants/${tenant}`,
-      method: "GET",
-      secure: true,
-      format: "json",
-      ...params,
-      xResources: ["tenant"],
-    }), { resources: new Set<string>(["tenant"]) });
-  /**
-   * @description Update a subscription
-   *
-   * @tags Billing
-   * @name TenantSubscriptionUpdate
-   * @summary Create a new subscription
-   * @request PATCH:/api/v1/billing/tenants/{tenant}/subscription
-   * @secure
-   */
-  tenantSubscriptionUpdate = Object.assign((
-    tenant: string,
-    data: UpdateTenantSubscriptionRequest,
-    params: RequestParams = {},
-  ) =>
-    this.request<UpdateTenantSubscriptionResponse, APIErrors>({
-      path: `/api/v1/billing/tenants/${tenant}/subscription`,
-      method: "PATCH",
-      body: data,
-      secure: true,
-      type: ContentType.Json,
-      format: "json",
-      ...params,
-      xResources: ["tenant"],
-    }), { resources: new Set<string>(["tenant"]) });
-  /**
-   * @description Get the billing portal link
-   *
-   * @tags Billing
-   * @name BillingPortalLinkGet
-   * @summary Create a link to the billing portal
-   * @request GET:/api/v1/billing/tenants/{tenant}/billing-portal-link
-   * @secure
-   */
-  billingPortalLinkGet = Object.assign((tenant: string, params: RequestParams = {}) =>
-    this.request<
-      {
-        /** The url to the billing portal */
-        url?: string;
-      },
-      APIErrors
-    >({
-      path: `/api/v1/billing/tenants/${tenant}/billing-portal-link`,
-      method: "GET",
-      secure: true,
-      format: "json",
-      ...params,
-      xResources: ["tenant"],
-    }), { resources: new Set<string>(["tenant"]) });
-  /**
-   * @description Get the payment methods for a tenant
-   *
-   * @tags Billing
-   * @name TenantPaymentMethodsGet
-   * @summary Get the payment methods for a tenant
-   * @request GET:/api/v1/billing/tenants/{tenant}/payment-methods
-   * @secure
-   */
-  tenantPaymentMethodsGet = Object.assign((tenant: string, params: RequestParams = {}) =>
-    this.request<TenantPaymentMethodList, APIErrors>({
-      path: `/api/v1/billing/tenants/${tenant}/payment-methods`,
-      method: "GET",
-      secure: true,
-      format: "json",
-      ...params,
-      xResources: ["tenant"],
-    }), { resources: new Set<string>(["tenant"]) });
-  /**
-   * @description Get the Stripe credit balance for a tenant
-   *
-   * @tags Billing
-   * @name TenantCreditBalanceGet
-   * @summary Get the Stripe credit balance for a tenant
-   * @request GET:/api/v1/billing/tenants/{tenant}/credit-balance
-   * @secure
-   */
-  tenantCreditBalanceGet = Object.assign((tenant: string, params: RequestParams = {}) =>
-    this.request<TenantCreditBalance, APIErrors>({
-      path: `/api/v1/billing/tenants/${tenant}/credit-balance`,
-      method: "GET",
-      secure: true,
-      format: "json",
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });

--- a/frontend/app/src/lib/api/generated/control-plane/Api.ts
+++ b/frontend/app/src/lib/api/generated/control-plane/Api.ts
@@ -40,14 +40,20 @@ import {
   RemoveOrganizationMembersRequest,
   SsoConfig,
   SsoDomainArray,
+  SubscriptionPlanList,
+  TenantBillingState,
+  TenantCreditBalance,
   TenantExchangeToken,
   TenantInvite,
   TenantInviteList,
   TenantMember,
   TenantMemberList,
+  TenantPaymentMethodList,
   UpdateOrganizationRequest,
   UpdateTenantInviteRequest,
   UpdateTenantMemberRequest,
+  UpdateTenantSubscriptionRequest,
+  UpdateTenantSubscriptionResponse,
   User,
   UserChangePasswordRequest,
   UserLoginRequest,
@@ -1140,6 +1146,118 @@ export class Api<
       path: `/api/v1/control-plane/tenants/${tenant}/invites/${tenantInvite}`,
       method: "DELETE",
       secure: true,
+      ...params,
+    });
+  /**
+   * @description List all available subscription plans and their features
+   *
+   * @tags Billing
+   * @name SubscriptionPlansList
+   * @summary List subscription plans
+   * @request GET:/api/v1/control-plane/billing/plans
+   */
+  subscriptionPlansList = (params: RequestParams = {}) =>
+    this.request<SubscriptionPlanList, APIErrors>({
+      path: `/api/v1/control-plane/billing/plans`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Gets the billing state for a tenant
+   *
+   * @tags Tenant
+   * @name TenantBillingStateGet
+   * @summary Get the billing state for a tenant
+   * @request GET:/api/v1/control-plane/billing/tenants/{tenant}
+   * @secure
+   */
+  tenantBillingStateGet = (tenant: string, params: RequestParams = {}) =>
+    this.request<TenantBillingState, APIErrors | APIError>({
+      path: `/api/v1/control-plane/billing/tenants/${tenant}`,
+      method: "GET",
+      secure: true,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Update a subscription
+   *
+   * @tags Billing
+   * @name TenantSubscriptionUpdate
+   * @summary Update subscription
+   * @request PATCH:/api/v1/control-plane/billing/tenants/{tenant}/subscription
+   * @secure
+   */
+  tenantSubscriptionUpdate = (
+    tenant: string,
+    data: UpdateTenantSubscriptionRequest,
+    params: RequestParams = {},
+  ) =>
+    this.request<UpdateTenantSubscriptionResponse, APIErrors>({
+      path: `/api/v1/control-plane/billing/tenants/${tenant}/subscription`,
+      method: "PATCH",
+      body: data,
+      secure: true,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get the billing portal link
+   *
+   * @tags Billing
+   * @name BillingPortalLinkGet
+   * @summary Create a link to the billing portal
+   * @request GET:/api/v1/control-plane/billing/tenants/{tenant}/billing-portal-link
+   * @secure
+   */
+  billingPortalLinkGet = (tenant: string, params: RequestParams = {}) =>
+    this.request<
+      {
+        /** The url to the billing portal */
+        url?: string;
+      },
+      APIErrors
+    >({
+      path: `/api/v1/control-plane/billing/tenants/${tenant}/billing-portal-link`,
+      method: "GET",
+      secure: true,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get the payment methods for a tenant
+   *
+   * @tags Billing
+   * @name TenantPaymentMethodsGet
+   * @summary Get the payment methods for a tenant
+   * @request GET:/api/v1/control-plane/billing/tenants/{tenant}/payment-methods
+   * @secure
+   */
+  tenantPaymentMethodsGet = (tenant: string, params: RequestParams = {}) =>
+    this.request<TenantPaymentMethodList, APIErrors>({
+      path: `/api/v1/control-plane/billing/tenants/${tenant}/payment-methods`,
+      method: "GET",
+      secure: true,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get the Stripe credit balance for a tenant
+   *
+   * @tags Billing
+   * @name TenantCreditBalanceGet
+   * @summary Get the Stripe credit balance for a tenant
+   * @request GET:/api/v1/control-plane/billing/tenants/{tenant}/credit-balance
+   * @secure
+   */
+  tenantCreditBalanceGet = (tenant: string, params: RequestParams = {}) =>
+    this.request<TenantCreditBalance, APIErrors>({
+      path: `/api/v1/control-plane/billing/tenants/${tenant}/credit-balance`,
+      method: "GET",
+      secure: true,
+      format: "json",
       ...params,
     });
 }

--- a/frontend/app/src/lib/api/generated/control-plane/data-contracts.ts
+++ b/frontend/app/src/lib/api/generated/control-plane/data-contracts.ts
@@ -10,6 +10,26 @@
  * ---------------------------------------------------------------
  */
 
+export enum CouponFrequency {
+  Once = "once",
+  Recurring = "recurring",
+}
+
+export enum SubscriptionPeriod {
+  Monthly = "monthly",
+  Yearly = "yearly",
+}
+
+export enum SubscriptionPlanCode {
+  Free = "free",
+  Starter = "starter",
+  Growth = "growth",
+  Developer = "developer",
+  Team = "team",
+  Scale = "scale",
+  Dedicated = "dedicated",
+}
+
 /** SHARED when the shard is in the general pool; DEDICATED when it is pinned to specific organizations. */
 export enum OrganizationAvailableShardClass {
   SHARED = "SHARED",
@@ -398,6 +418,219 @@ export type SsoDomainArray = SsoDomain[];
 export interface SsoConfig {
   /** @example false */
   forceSSO: boolean;
+}
+
+export interface TenantBillingState {
+  /** The subscription associated with this policy. */
+  currentSubscription: TenantBillingStateSubscription;
+  /** The upcoming subscription associated with this policy. */
+  upcomingSubscription?: TenantBillingStateSubscription;
+  /** A list of plans available for the tenant. */
+  plans: SubscriptionPlan[];
+  /** A list of coupons applied to the tenant. */
+  coupons?: Coupon[];
+}
+
+export interface TenantPaymentMethod {
+  /** The brand of the payment method. */
+  brand: string;
+  /** The last 4 digits of the card. */
+  last4?: string;
+  /** The expiration date of the card. */
+  expiration?: string;
+  /** The description of the payment method. */
+  description?: string;
+}
+
+export type TenantPaymentMethodList = TenantPaymentMethod[];
+
+export interface TenantCreditBalance {
+  /** The Stripe customer balance in cents. Negative means customer credit. */
+  balanceCents: number;
+  /** ISO currency code for the Stripe customer balance. */
+  currency: string;
+  /** Human-readable description for the active credit balance, if available. */
+  description?: string;
+  /**
+   * The timestamp at which the current credit balance is scheduled to expire.
+   * @format date-time
+   */
+  expiresAt?: string;
+}
+
+export interface TenantSubscription {
+  /** The plan code associated with the tenant subscription. */
+  plan: SubscriptionPlanCode;
+  /** The period associated with the tenant subscription. */
+  period?: SubscriptionPeriod;
+  /**
+   * The start date of the tenant subscription.
+   * @format date-time
+   */
+  startedAt: string;
+  /**
+   * The end date of the tenant subscription.
+   * @format date-time
+   */
+  endsAt?: string;
+}
+
+export interface TenantBillingStateSubscription {
+  /** The plan code associated with the tenant subscription. */
+  plan: SubscriptionPlanCode;
+  /** The period associated with the tenant subscription. */
+  period?: SubscriptionPeriod;
+  /**
+   * The start date of the tenant subscription.
+   * @format date-time
+   */
+  startedAt: string;
+  /**
+   * The end date of the tenant subscription.
+   * @format date-time
+   */
+  endsAt?: string;
+}
+
+export interface UpdateTenantSubscriptionState {
+  /** The plan code associated with the tenant subscription. */
+  plan: SubscriptionPlanCode;
+  /** The period associated with the tenant subscription. */
+  period?: SubscriptionPeriod;
+  /**
+   * The start date of the tenant subscription.
+   * @format date-time
+   */
+  startedAt: string;
+  /**
+   * The end date of the tenant subscription.
+   * @format date-time
+   */
+  endsAt?: string;
+}
+
+export interface SubscriptionPlanFeatureDisplay {
+  /** Main display text for this feature (e.g. "100,000 task runs"). */
+  primaryText: string;
+  /** Secondary display text (e.g. "then $10 per 1,000,000 task runs"). */
+  secondaryText?: string;
+}
+
+export interface SubscriptionPlanFeatureOverage {
+  /**
+   * Price per billing units of overage usage.
+   * @format double
+   */
+  price: number;
+  /**
+   * Number of units per price increment.
+   * @format int64
+   */
+  billingUnits: number;
+  /** How overage is charged (e.g. "pay_per_use", "prepaid"). */
+  usageModel: string;
+}
+
+export interface SubscriptionPlanFeature {
+  /** The identifier of the feature. */
+  featureId: string;
+  /** Human-readable name of the feature. */
+  name: string;
+  /** The type of the feature (e.g. "boolean", "single_use", "continuous_use"). */
+  featureType: string;
+  /** Whether this feature is part of this plan. False for features added for cross-plan comparison. */
+  included: boolean;
+  /**
+   * The included usage for this feature in the plan.
+   * @format int64
+   */
+  includedUsage: number;
+  /** Whether this feature has unlimited usage. */
+  unlimited: boolean;
+  /** Overage pricing details, if applicable. */
+  overage?: SubscriptionPlanFeatureOverage;
+  /** Pre-formatted display text for this feature. */
+  display?: SubscriptionPlanFeatureDisplay;
+}
+
+export interface SubscriptionPlanFeatureGroup {
+  /** The name of the feature group (e.g. "Usage", "Infrastructure"). */
+  name: string;
+  /** The features in this group. */
+  features: SubscriptionPlanFeature[];
+}
+
+export interface SubscriptionPlan {
+  /** The code of the plan. */
+  planCode: string;
+  /** The name of the plan. */
+  name: string;
+  /** The description of the plan. */
+  description: string;
+  /** The price of the plan. */
+  amountCents: number;
+  /** The period of the plan. */
+  period?: SubscriptionPeriod;
+  /** Whether this is a legacy plan and is no longer offered to new customers. */
+  legacy?: boolean;
+  /** The features included in this plan, organized by group. */
+  featureGroups?: SubscriptionPlanFeatureGroup[];
+}
+
+export interface SubscriptionPlanFreeLimit {
+  /** The feature identifier. */
+  featureId: string;
+  /** Human-readable name of the limit. */
+  name: string;
+  /**
+   * The daily limit value.
+   * @format int64
+   */
+  limit: number;
+}
+
+export interface SubscriptionPlanList {
+  plans: SubscriptionPlan[];
+  /** Abbreviated daily limits for the free plan. */
+  freeLimits: SubscriptionPlanFreeLimit[];
+}
+
+export interface UpdateTenantSubscriptionRequest {
+  /** The code of the plan. */
+  plan: SubscriptionPlanCode;
+  /** The period of the plan. */
+  period?: SubscriptionPeriod;
+}
+
+export interface UpdateTenantSubscriptionResponse {
+  /** The URL to the checkout page. */
+  checkoutUrl?: string;
+  currentSubscription?: UpdateTenantSubscriptionState;
+  upcomingSubscription?: UpdateTenantSubscriptionState;
+}
+
+export interface CheckoutURLResponse {
+  /** The URL to the checkout page. */
+  checkoutUrl: string;
+}
+
+export interface Coupon {
+  /** The name of the coupon. */
+  name: string;
+  /** The amount off of the coupon. */
+  amount_cents?: number;
+  /** The amount remaining on the coupon. */
+  amount_cents_remaining?: number;
+  /** The currency of the coupon. */
+  amount_currency?: string;
+  /** The frequency of the coupon. */
+  frequency: CouponFrequency;
+  /** The frequency duration of the coupon. */
+  frequency_duration?: number;
+  /** The frequency duration remaining of the coupon. */
+  frequency_duration_remaining?: number;
+  /** The percentage off of the coupon. */
+  percent?: number;
 }
 
 export interface OrganizationEntitlements {

--- a/frontend/app/src/lib/api/queries.ts
+++ b/frontend/app/src/lib/api/queries.ts
@@ -1,5 +1,5 @@
 import { WebhookWorkerCreateRequest } from '.';
-import api, { cloudApi } from './api';
+import api, { cloudApi, controlPlaneApi } from './api';
 import { TemplateOptions } from './generated/cloud/data-contracts';
 import { createQueryKeyStore } from '@lukemorales/query-key-factory';
 import invariant from 'tiny-invariant';
@@ -31,27 +31,23 @@ export const queries = createQueryKeyStore({
   cloud: {
     billing: (tenant: string) => ({
       queryKey: ['billing-state:get', tenant],
-      queryFn: async () => (await cloudApi.tenantBillingStateGet(tenant)).data,
+      queryFn: async () =>
+        (await controlPlaneApi.tenantBillingStateGet(tenant)).data,
     }),
     creditBalance: (tenant: string) => ({
       queryKey: ['credit-balance:get', tenant],
-      queryFn: async () => (await cloudApi.tenantCreditBalanceGet(tenant)).data,
+      queryFn: async () =>
+        (await controlPlaneApi.tenantCreditBalanceGet(tenant)).data,
     }),
     subscriptionPlans: () => ({
       queryKey: ['subscription-plans:list'],
-      queryFn: async () =>
-        (
-          await cloudApi.subscriptionPlansList({
-            secure: true,
-            useExchangeToken: true,
-          })
-        ).data,
+      queryFn: async () => (await controlPlaneApi.subscriptionPlansList()).data,
     }),
 
     paymentMethods: (tenant: string) => ({
       queryKey: ['payment-methods:get', tenant],
       queryFn: async () =>
-        (await cloudApi.tenantPaymentMethodsGet(tenant)).data,
+        (await controlPlaneApi.tenantPaymentMethodsGet(tenant)).data,
     }),
 
     getComputeCost: (tenant: string) => ({

--- a/frontend/app/src/lib/atoms.ts
+++ b/frontend/app/src/lib/atoms.ts
@@ -1,5 +1,5 @@
 import { Tenant } from './api';
-import { TenantBillingState } from './api/generated/cloud/data-contracts';
+import { TenantBillingState } from './api/generated/control-plane/data-contracts';
 import { atom } from 'jotai';
 
 const getInitialValue = <T>(key: string, defaultValue?: T): T | undefined => {

--- a/frontend/app/src/pages/main/v1/managed-workers/create/index.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/create/index.tsx
@@ -2,7 +2,7 @@ import { BillingRequired } from '../components/billing-required';
 import CreateWorkerForm from './components/create-worker-form';
 import { Separator } from '@/components/v1/ui/separator';
 import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
-import { cloudApi } from '@/lib/api/api';
+import { cloudApi, controlPlaneApi } from '@/lib/api/api';
 import { CreateManagedWorkerRequest } from '@/lib/api/generated/cloud/data-contracts';
 import { managedCompute } from '@/lib/can/features/managed-compute';
 import { RejectReason } from '@/lib/can/shared/permission.base';
@@ -35,7 +35,7 @@ export default function CreateWorker() {
       }
       setPortalLoading(true);
       billing?.setPollBilling(true);
-      const link = await cloudApi.billingPortalLinkGet(tenantId);
+      const link = await controlPlaneApi.billingPortalLinkGet(tenantId);
       window.open(link.data.url, '_blank');
     } catch (e) {
       handleApiError(e as any);

--- a/frontend/app/src/pages/main/v1/managed-workers/index.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/index.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/v1/ui/button';
 import { Spinner } from '@/components/v1/ui/loading';
 import { Separator } from '@/components/v1/ui/separator';
 import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
-import { cloudApi } from '@/lib/api/api';
+import { controlPlaneApi } from '@/lib/api/api';
 import { queries } from '@/lib/api/queries';
 import { managedCompute } from '@/lib/can/features/managed-compute';
 import { RejectReason } from '@/lib/can/shared/permission.base';
@@ -58,7 +58,7 @@ export default function ManagedWorkers() {
       if (!tenantId) {
         return;
       }
-      const link = await cloudApi.billingPortalLinkGet(tenantId);
+      const link = await controlPlaneApi.billingPortalLinkGet(tenantId);
       window.open(link.data.url, '_blank');
     } catch (e) {
       handleApiError(e as any);


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Moves the billing api from the cloud service to the control plane.

## Type of change

- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)


## What's Changed

- [x]  Moves requests from cloud shards to control plane
- [x] Does not affect OSS users

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: I used AI to refactor which client to call.

</details>
