### PR TITLE
chore(ci): Enforce conventional commits & PR autolabeling

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -14,6 +14,10 @@ sdk-ruby:
   - changed-files:
       - any-glob-to-any-file: "sdks/ruby/**"
 
+vscode-ext:
+  - changed-files:
+      - any-glob-to-any-file: "frontend/vscode-extension/**"
+
 engine:
   - changed-files:
       # TODO: Disambiguating between components is non-trivial,

--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,0 +1,37 @@
+sdk-go:
+  - changed-files:
+      - any-glob-to-any-file: "sdks/go/**"
+
+sdk-py:
+  - changed-files:
+      - any-glob-to-any-file: "sdks/python/**"
+
+sdk-ts:
+  - changed-files:
+      - any-glob-to-any-file: "sdks/typescript/**"
+
+sdk-ruby:
+  - changed-files:
+      - any-glob-to-any-file: "sdks/ruby/**"
+
+engine:
+  - changed-files:
+      # TODO: Disambiguating between components is non-trivial,
+      # For now, we rely on a mixture of files changed + title scoping.
+      - any-glob-to-any-file:
+          - "cmd/**"
+          - "pkg/**"
+          - "internal/**"
+          - "api/**"
+          - "frontend/app/src/**"
+          - "sql/**"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "README.md"
+          - "AI_POLICY.md"
+          - "CONTRIBUTING.md"
+          - "SECURITY.md"
+          - "frontend/docs/**"
+          - "examples/**"

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -13,13 +13,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+        with:
+          version: 10
+          run_install: false
 
-      - name: Set up node
+      - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24.x
-          cache: 'pnpm'
+          node-version: "24"
+
 
       - name: Install commitlint
         run: |

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,32 @@
+name: Commit Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Set up node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.x
+          cache: 'pnpm'
+
+      - name: Install commitlint
+        run: |
+          pnpm install --save-dev @commitlint/cli @commitlint/config-conventional
+
+      - name: Validate PR title (used as squash commit message)
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "$PR_TITLE" | npx commitlint

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,13 @@
+name: "Pull Request Labeler"
+
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,43 @@ If your changes require documentation updates, modify the relevant files in [`fr
 
 For configuration changes, see [Updating Configuration](contributing/developer-guides/updating-configuration.md).
 
+### Guidelines
+
+Pull request titles should be conform to the [conventional commit](https://www.conventionalcommits.org/) format i.e
+
+```
+<type>(<scope>): <short description>
+```
+
+#### Scope
+
+Pull request titles can be (optionally) scoped to specify the affected area of the codebase. If multiple scopes apply, they can be provided as a comma-delimited list, e.g. `feat(sdks/go,sdks/ts): ...`. An empty scope implies the change is cross-cutting or not changelog-relevant, e.g. `chore: fix typo in README`.
+
+Please use the following when scoping your changes:
+
+**Hatchet core:**
+- `engine`
+- `api`
+- `migrate`
+- `admin`
+- `cli`
+- `dashboard`
+- `lite`
+
+**Hatchet SDKs:**
+- `sdks/python`
+- `sdks/ruby`
+- `sdks/go`
+- `sdks/ts`
+
+**Other:**
+- `ci`
+- `docs`
+- `devex`
+
+> [!NOTE]
+> Future tooling will rely on scoping to disambiguate the surface area of changes, so please scope your PR where applicable. This list is subject to change.
+
 ## Testing
 
 Hatchet uses Go build tags to categorize tests into different test suites. For example, these build tags mark a test as unit-only:

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,25 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      [
+        'build', // Build system or external dependencies
+        'chore', // Other changes that don't modify src or test files
+        'ci', // CI configuration changes
+        'docs', // Documentation only changes
+        'feat', // New feature
+        'fix', // Bug fix
+        'refactor', // Code change that neither fixes a bug nor adds a feature
+        'revert', // Revert a previous commit
+        'style', // Code style changes (formatting, linting, etc.)
+        'test', // Adding or updating tests
+        'perf', // Performance improvements
+      ],
+    ],
+    'subject-case': [0], // Level 0 ignores the rule
+    'scope-empty': [2, 'never'],
+    'header-max-length': [2, 'always', 120],
+  },
+};


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Introduces automatic PR labelling and enforces conventional commit formatting for PR titles.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] CI (any automation pipeline changes)
- [x] Chore (changes which are not directly related to any business logic)

## What's Changed

- Configured auto-labelling for SDKs, engine, and docs in `.github/labeler.yaml` & `.github/workflows/labeler.yml`
- Enforces conventional commit formatting in `.github/workflows/commitlint.yml` with config in `commitlint.config.js`
- Included section on conventional commit format in `CONTRIBUTING.md`