### PR TITLE
Fix: Payload external id duplicates from durable child spawning

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260521213214_v1_0_112.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260521213214_v1_0_112.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE v1_durable_event_log_entry ADD COLUMN child_task_external_id UUID;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE v1_durable_event_log_entry DROP COLUMN child_task_external_id;
+-- +goose StatementEnd

--- a/examples/python/durable/worker.py
+++ b/examples/python/durable/worker.py
@@ -392,6 +392,40 @@ async def durable_replay_reset(
     )
 
 
+class ChildKeyDedupResult(BaseModel):
+    runtime: float
+    child_1_output: dict[str, str]
+    child_2_output: dict[str, str]
+    child_3_output: dict[str, str]
+
+
+@hatchet.durable_task(execution_timeout=timedelta(seconds=30))
+async def durable_child_key_dedup_replay(
+    input: EmptyModel, ctx: DurableContext
+) -> ChildKeyDedupResult:
+    start = time.time()
+    await ctx.aio_sleep_for(timedelta(seconds=SLEEP_TIME))
+
+    child_1_output = await spawn_child_task.aio_run(
+        DurableBulkSpawnInput(n=1), child_key="child-a"
+    )
+    child_2_output = await spawn_child_task.aio_run(
+        DurableBulkSpawnInput(n=2), child_key="child-b"
+    )
+    child_3_output = await spawn_child_task.aio_run(
+        DurableBulkSpawnInput(n=3), child_key="child-a"
+    )
+
+    await ctx.aio_sleep_for(timedelta(seconds=SLEEP_TIME))
+
+    return ChildKeyDedupResult(
+        child_1_output=child_1_output,
+        child_2_output=child_2_output,
+        child_3_output=child_3_output,
+        runtime=time.time() - start,
+    )
+
+
 class SleepResult(BaseModel):
     message: str
     duration: float
@@ -432,6 +466,7 @@ def main() -> None:
             durable_sleep_event_spawn,
             durable_non_determinism,
             durable_replay_reset,
+            durable_child_key_dedup_replay,
             wait_for_event_lookback,
             wait_for_or_event_lookback,
             wait_for_two_events_second_pushed_first,

--- a/examples/python/worker.py
+++ b/examples/python/worker.py
@@ -47,6 +47,7 @@ from examples.durable.worker import (
     wait_for_event_lookback,
     wait_for_or_event_lookback,
     wait_for_two_events_second_pushed_first,
+    durable_child_key_dedup_replay,
 )
 from examples.durable_event.worker import (
     durable_event_task,
@@ -191,6 +192,7 @@ def main() -> None:
             welcome_email,
             durable_parent_child_key_bug,
             child_child_key_bug,
+            durable_child_key_dedup_replay,
         ],
         lifespan=lifespan,
     )

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -1432,17 +1432,16 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 		}
 	}
 
-	nonSkipCount := int64(0)
-	for _, e := range getOrCreateOpts.Entries {
-		if !e.ShouldSkip {
-			nonSkipCount++
+	maxNodeId := int64(0)
+	for _, le := range logEntries {
+		if le.Entry.NodeID > maxNodeId {
+			maxNodeId = le.Entry.NodeID
 		}
 	}
 
-	if nonSkipCount > 0 {
-		finalNodeId := baseNodeId + nonSkipCount - 1
+	if maxNodeId > 0 {
 		_, err = r.queries.UpdateLogFile(ctx, tx, sqlcv1.UpdateLogFileParams{
-			NodeId:                sqlchelpers.ToBigInt(&finalNodeId),
+			NodeId:                sqlchelpers.ToBigInt(&maxNodeId),
 			Durabletaskid:         task.ID,
 			Durabletaskinsertedat: task.InsertedAt,
 		})

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -428,19 +428,20 @@ func nonDeterminismDetail(opts IngestDurableTaskEventOpts, expectedKind sqlcv1.V
 }
 
 type GetOrCreateLogEntryOpt struct {
-	Kind            sqlcv1.V1DurableEventLogKind
-	IdempotencyKey  []byte
-	InputPayload    []byte
-	ResultPayload   []byte
-	NodeId          int64
-	BranchId        int64
-	InvocationCount int32
-	IsSatisfied     bool
-	UserMessage     *string
-	WaitData        string // JSON-encoded WaitData, empty string means no wait data
-	SatisfiedAt     *time.Time
-	ExternalId      uuid.UUID
-	ShouldSkip      bool
+	Kind                sqlcv1.V1DurableEventLogKind
+	IdempotencyKey      []byte
+	InputPayload        []byte
+	ResultPayload       []byte
+	NodeId              int64
+	BranchId            int64
+	InvocationCount     int32
+	IsSatisfied         bool
+	UserMessage         *string
+	WaitData            string // JSON-encoded WaitData, empty string means no wait data
+	SatisfiedAt         *time.Time
+	ExternalId          uuid.UUID
+	ChildTaskExternalId uuid.UUID
+	ShouldSkip          bool
 }
 
 type GetOrCreateLogEntryOpts struct {
@@ -771,6 +772,7 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 		createParams := sqlcv1.BulkCreateDurableEventLogEntriesParams{
 			Tenantids:              make([]uuid.UUID, 0),
 			Externalids:            make([]uuid.UUID, 0),
+			Childtaskexternalids:   make([]uuid.UUID, 0),
 			Durabletaskids:         make([]int64, 0),
 			Durabletaskinsertedats: make([]pgtype.Timestamptz, 0),
 			Kinds:                  make([]string, 0),
@@ -789,6 +791,7 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 			}
 			createParams.Tenantids = append(createParams.Tenantids, opts.TenantId)
 			createParams.Externalids = append(createParams.Externalids, externalId)
+			createParams.Childtaskexternalids = append(createParams.Childtaskexternalids, entry.ChildTaskExternalId)
 			createParams.Durabletaskids = append(createParams.Durabletaskids, opts.DurableTaskId)
 			createParams.Durabletaskinsertedats = append(createParams.Durabletaskinsertedats, opts.DurableTaskInsertedAt)
 			createParams.Kinds = append(createParams.Kinds, string(entry.Kind))
@@ -850,37 +853,41 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 		}
 	}
 
-	externalIdToSkipEntry := make(map[uuid.UUID]*sqlcv1.BulkGetDurableEventLogEntriesRow)
+	childTaskExternalIdToSkipEntry := make(map[uuid.UUID]*sqlcv1.BulkGetDurableEventLogEntriesRow)
 
 	if len(skipOpts) > 0 {
-		externalIds := make([]uuid.UUID, 0, len(skipOpts))
-		seenExternalIds := make(map[uuid.UUID]struct{}, len(skipOpts))
+		childTaskExternalIds := make([]uuid.UUID, 0, len(skipOpts))
+		seen := make(map[uuid.UUID]struct{}, len(skipOpts))
 		for _, o := range skipOpts {
-			if o.ExternalId == uuid.Nil {
-				return nil, fmt.Errorf("skipped child entries must include a non-nil external id")
+			if o.ChildTaskExternalId == uuid.Nil {
+				return nil, fmt.Errorf("skipped child entries must include a non-nil child task external id")
 			}
 
-			if _, ok := seenExternalIds[o.ExternalId]; ok {
+			if _, ok := seen[o.ChildTaskExternalId]; ok {
 				continue
 			}
 
-			seenExternalIds[o.ExternalId] = struct{}{}
-			externalIds = append(externalIds, o.ExternalId)
+			seen[o.ChildTaskExternalId] = struct{}{}
+			childTaskExternalIds = append(childTaskExternalIds, o.ChildTaskExternalId)
 		}
 
-		skipRows, err := r.queries.GetDurableEventLogEntriesByExternalIds(ctx, tx, sqlcv1.GetDurableEventLogEntriesByExternalIdsParams{
-			Durabletaskid:         opts.DurableTaskId,
-			Durabletaskinsertedat: opts.DurableTaskInsertedAt,
-			Externalids:           externalIds,
+		skipRows, err := r.queries.GetDurableEventLogEntriesByChildTaskExternalIds(ctx, tx, sqlcv1.GetDurableEventLogEntriesByChildTaskExternalIdsParams{
+			Durabletaskid:          opts.DurableTaskId,
+			Durabletaskinsertedat:  opts.DurableTaskInsertedAt,
+			Childtaskexternalids:   childTaskExternalIds,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("failed to get log entries by external ids: %w", err)
+			return nil, fmt.Errorf("failed to get log entries by child task external ids: %w", err)
 		}
 
 		for _, row := range skipRows {
-			externalIdToSkipEntry[row.ExternalID] = &sqlcv1.BulkGetDurableEventLogEntriesRow{
+			if row.ChildTaskExternalID == nil {
+				continue
+			}
+			childTaskExternalIdToSkipEntry[*row.ChildTaskExternalID] = &sqlcv1.BulkGetDurableEventLogEntriesRow{
 				TenantID:                row.TenantID,
 				ExternalID:              row.ExternalID,
+				ChildTaskExternalID:     row.ChildTaskExternalID,
 				ResultPayloadExternalID: row.ResultPayloadExternalID,
 				InsertedAt:              row.InsertedAt,
 				ID:                      row.ID,
@@ -899,9 +906,8 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 		}
 
 		for _, o := range skipOpts {
-			if _, ok := externalIdToSkipEntry[o.ExternalId]; !ok {
-				// todo: is raising the right thing to do here?
-				return nil, fmt.Errorf("expected to find log entry for skipped child external id %s", o.ExternalId)
+			if _, ok := childTaskExternalIdToSkipEntry[o.ChildTaskExternalId]; !ok {
+				return nil, fmt.Errorf("expected to find log entry for skipped child task external id %s", o.ChildTaskExternalId)
 			}
 		}
 	}
@@ -917,7 +923,7 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 		})
 	}
 
-	for _, entry := range externalIdToSkipEntry {
+	for _, entry := range childTaskExternalIdToSkipEntry {
 		retrieveOpts = append(retrieveOpts, RetrievePayloadOpts{
 			Id:         entry.ID,
 			InsertedAt: entry.InsertedAt,
@@ -967,6 +973,7 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 				Entry: &sqlcv1.BulkGetDurableEventLogEntriesRow{
 					TenantID:              created.TenantID,
 					ExternalID:            created.ExternalID,
+					ChildTaskExternalID:   created.ChildTaskExternalID,
 					ID:                    created.ID,
 					DurableTaskID:         created.DurableTaskID,
 					DurableTaskInsertedAt: created.DurableTaskInsertedAt,
@@ -985,7 +992,7 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 	}
 
 	for _, o := range skipOpts {
-		e := externalIdToSkipEntry[o.ExternalId]
+		e := childTaskExternalIdToSkipEntry[o.ChildTaskExternalId]
 		results = append(results, &EventLogEntryWithPayloads{
 			Entry:          e,
 			AlreadyExisted: true,
@@ -1059,9 +1066,9 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 
 			if triggerOpts.ShouldSkip {
 				innerOpts[i] = GetOrCreateLogEntryOpt{
-					Kind:       sqlcv1.V1DurableEventLogKindRUN,
-					ExternalId: triggerOpts.ExternalId,
-					ShouldSkip: true,
+					Kind:                sqlcv1.V1DurableEventLogKindRUN,
+					ChildTaskExternalId: triggerOpts.ExternalId,
+					ShouldSkip:          true,
 				}
 				continue
 			}
@@ -1081,14 +1088,14 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 			}
 
 			innerOpts[i] = GetOrCreateLogEntryOpt{
-				Kind:            sqlcv1.V1DurableEventLogKindRUN,
-				NodeId:          nodeId,
-				BranchId:        branchId,
-				ExternalId:      triggerOpts.ExternalId,
-				InvocationCount: opts.InvocationCount,
-				IdempotencyKey:  idempotencyKey,
-				InputPayload:    inputPayload,
-				WaitData:        marshalWaitData(waitDataFromTriggerOpt(triggerOpts)),
+				Kind:                sqlcv1.V1DurableEventLogKindRUN,
+				NodeId:              nodeId,
+				BranchId:            branchId,
+				ChildTaskExternalId: triggerOpts.ExternalId,
+				InvocationCount:     opts.InvocationCount,
+				IdempotencyKey:      idempotencyKey,
+				InputPayload:        inputPayload,
+				WaitData:            marshalWaitData(waitDataFromTriggerOpt(triggerOpts)),
 			}
 
 			nodeBranchKey := NodeIdBranchIdTuple{NodeId: nodeId, BranchId: branchId}
@@ -1199,9 +1206,11 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 		entries := make([]*IngestTriggerRunsEntry, len(getOrCreateOpts.Entries))
 
 		for i, entry := range logEntries {
-			workflowRunExternalId := entry.Entry.ExternalID
-			if triggerOpts := externalIdToTriggerOpts[workflowRunExternalId]; triggerOpts == nil {
-				triggerOpts = nodeIdBranchIdToTriggerOpts[NodeIdBranchIdTuple{
+			var workflowRunExternalId uuid.UUID
+			if entry.Entry.ChildTaskExternalID != nil {
+				workflowRunExternalId = *entry.Entry.ChildTaskExternalID
+			} else {
+				triggerOpts := nodeIdBranchIdToTriggerOpts[NodeIdBranchIdTuple{
 					NodeId:   entry.Entry.NodeID,
 					BranchId: entry.Entry.BranchID,
 				}]
@@ -1233,7 +1242,10 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 				continue
 			}
 
-			triggerOpts := externalIdToTriggerOpts[le.Entry.ExternalID]
+			var triggerOpts *WorkflowNameTriggerOpts
+			if le.Entry.ChildTaskExternalID != nil {
+				triggerOpts = externalIdToTriggerOpts[*le.Entry.ChildTaskExternalID]
+			}
 			if triggerOpts == nil {
 				triggerOpts = nodeIdBranchIdToTriggerOpts[NodeIdBranchIdTuple{
 					NodeId:   le.Entry.NodeID,

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -1201,10 +1201,13 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 		entries := make([]*IngestTriggerRunsEntry, len(getOrCreateOpts.Entries))
 
 		for i, entry := range logEntries {
-			if entry.Entry.ChildTaskExternalID == nil {
-				return nil, fmt.Errorf("RUN log entry at nodeId %d branchId %d is missing child_task_external_id", entry.Entry.NodeID, entry.Entry.BranchID)
+			// important: this is a hack for falling back for child_task_external_id
+			// for task runs created before this column was added, since those external ids
+			// were written to the external_id column on the event log entry
+			workflowRunExternalId := entry.Entry.ExternalID
+			if entry.Entry.ChildTaskExternalID != nil {
+				workflowRunExternalId = *entry.Entry.ChildTaskExternalID
 			}
-			workflowRunExternalId := *entry.Entry.ChildTaskExternalID
 
 			entries[i] = &IngestTriggerRunsEntry{
 				NodeId:                entry.Entry.NodeID,

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -1206,19 +1206,10 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 		entries := make([]*IngestTriggerRunsEntry, len(getOrCreateOpts.Entries))
 
 		for i, entry := range logEntries {
-			var workflowRunExternalId uuid.UUID
-			if entry.Entry.ChildTaskExternalID != nil {
-				workflowRunExternalId = *entry.Entry.ChildTaskExternalID
-			} else {
-				triggerOpts := nodeIdBranchIdToTriggerOpts[NodeIdBranchIdTuple{
-					NodeId:   entry.Entry.NodeID,
-					BranchId: entry.Entry.BranchID,
-				}]
-				if triggerOpts == nil {
-					return nil, fmt.Errorf("missing trigger opts for nodeId %d and branchId %d", entry.Entry.NodeID, entry.Entry.BranchID)
-				}
-				workflowRunExternalId = triggerOpts.ExternalId
+			if entry.Entry.ChildTaskExternalID == nil {
+				return nil, fmt.Errorf("RUN log entry at nodeId %d branchId %d is missing child_task_external_id", entry.Entry.NodeID, entry.Entry.BranchID)
 			}
+			workflowRunExternalId := *entry.Entry.ChildTaskExternalID
 
 			entries[i] = &IngestTriggerRunsEntry{
 				NodeId:                entry.Entry.NodeID,
@@ -1242,16 +1233,11 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 				continue
 			}
 
-			var triggerOpts *WorkflowNameTriggerOpts
-			if le.Entry.ChildTaskExternalID != nil {
-				triggerOpts = externalIdToTriggerOpts[*le.Entry.ChildTaskExternalID]
+			if le.Entry.ChildTaskExternalID == nil {
+				return nil, fmt.Errorf("new RUN log entry at nodeId %d branchId %d is missing child_task_external_id", le.Entry.NodeID, le.Entry.BranchID)
 			}
-			if triggerOpts == nil {
-				triggerOpts = nodeIdBranchIdToTriggerOpts[NodeIdBranchIdTuple{
-					NodeId:   le.Entry.NodeID,
-					BranchId: le.Entry.BranchID,
-				}]
-			}
+
+			triggerOpts := externalIdToTriggerOpts[*le.Entry.ChildTaskExternalID]
 			if triggerOpts != nil {
 				newTriggerOpts = append(newTriggerOpts, triggerOpts)
 			}

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -439,7 +439,6 @@ type GetOrCreateLogEntryOpt struct {
 	UserMessage         *string
 	WaitData            string // JSON-encoded WaitData, empty string means no wait data
 	SatisfiedAt         *time.Time
-	ExternalId          uuid.UUID
 	ChildTaskExternalId uuid.UUID
 	ShouldSkip          bool
 }
@@ -785,12 +784,8 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 		}
 
 		for _, entry := range nodeIdBranchIdToNewEntry {
-			externalId := entry.ExternalId
-			if externalId == uuid.Nil {
-				externalId = uuid.New()
-			}
 			createParams.Tenantids = append(createParams.Tenantids, opts.TenantId)
-			createParams.Externalids = append(createParams.Externalids, externalId)
+			createParams.Externalids = append(createParams.Externalids, uuid.New())
 			createParams.Childtaskexternalids = append(createParams.Childtaskexternalids, entry.ChildTaskExternalId)
 			createParams.Durabletaskids = append(createParams.Durabletaskids, opts.DurableTaskId)
 			createParams.Durabletaskinsertedats = append(createParams.Durabletaskinsertedats, opts.DurableTaskInsertedAt)
@@ -857,24 +852,24 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 
 	if len(skipOpts) > 0 {
 		childTaskExternalIds := make([]uuid.UUID, 0, len(skipOpts))
-		seen := make(map[uuid.UUID]struct{}, len(skipOpts))
+		seenChildTaskExternalIds := make(map[uuid.UUID]struct{}, len(skipOpts))
 		for _, o := range skipOpts {
 			if o.ChildTaskExternalId == uuid.Nil {
 				return nil, fmt.Errorf("skipped child entries must include a non-nil child task external id")
 			}
 
-			if _, ok := seen[o.ChildTaskExternalId]; ok {
+			if _, ok := seenChildTaskExternalIds[o.ChildTaskExternalId]; ok {
 				continue
 			}
 
-			seen[o.ChildTaskExternalId] = struct{}{}
+			seenChildTaskExternalIds[o.ChildTaskExternalId] = struct{}{}
 			childTaskExternalIds = append(childTaskExternalIds, o.ChildTaskExternalId)
 		}
 
 		skipRows, err := r.queries.GetDurableEventLogEntriesByChildTaskExternalIds(ctx, tx, sqlcv1.GetDurableEventLogEntriesByChildTaskExternalIdsParams{
-			Durabletaskid:          opts.DurableTaskId,
-			Durabletaskinsertedat:  opts.DurableTaskInsertedAt,
-			Childtaskexternalids:   childTaskExternalIds,
+			Durabletaskid:         opts.DurableTaskId,
+			Durabletaskinsertedat: opts.DurableTaskInsertedAt,
+			Childtaskexternalids:  childTaskExternalIds,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to get log entries by child task external ids: %w", err)

--- a/pkg/repository/sqlcv1/durable_event_log.sql
+++ b/pkg/repository/sqlcv1/durable_event_log.sql
@@ -44,6 +44,8 @@ RETURNING v1_durable_event_log_file.*
 -- name: UpdateLogFile :one
 UPDATE v1_durable_event_log_file
 SET
+    -- important: need `GREATEST` here to avoid moving the `latest_node_id` backwards in the case of child spawning with
+    -- a child_key set, which, if the child was cached, would not create a new log entry and thus not move the latest node forward
     latest_node_id = GREATEST(v1_durable_event_log_file.latest_node_id, COALESCE(sqlc.narg('nodeId')::BIGINT, v1_durable_event_log_file.latest_node_id)),
     latest_invocation_count = COALESCE(sqlc.narg('invocationCount')::INTEGER, v1_durable_event_log_file.latest_invocation_count),
     latest_branch_id = COALESCE(sqlc.narg('branchId')::BIGINT, v1_durable_event_log_file.latest_branch_id)

--- a/pkg/repository/sqlcv1/durable_event_log.sql
+++ b/pkg/repository/sqlcv1/durable_event_log.sql
@@ -157,21 +157,22 @@ JOIN v1_durable_event_log_file lf ON (lf.durable_task_id, lf.durable_task_insert
 WHERE e.durable_task_id = @durableTaskId::BIGINT
   AND e.durable_task_inserted_at = @durableTaskInsertedAt::TIMESTAMPTZ;
 
--- name: GetDurableEventLogEntriesByExternalIds :many
+-- name: GetDurableEventLogEntriesByChildTaskExternalIds :many
 SELECT e.*, lf.latest_invocation_count AS invocation_count
 FROM v1_durable_event_log_entry e
 JOIN v1_durable_event_log_file lf ON (lf.durable_task_id, lf.durable_task_inserted_at) = (e.durable_task_id, e.durable_task_inserted_at)
 WHERE
     e.durable_task_id = @durableTaskId::BIGINT
     AND e.durable_task_inserted_at = @durableTaskInsertedAt::TIMESTAMPTZ
-    AND e.external_id = ANY(@externalIds::UUID[])
-ORDER BY e.external_id, e.node_id ASC;
+    AND e.child_task_external_id = ANY(@childTaskExternalIds::UUID[])
+ORDER BY e.child_task_external_id, e.node_id ASC;
 
 -- name: BulkCreateDurableEventLogEntries :many
 WITH inputs AS (
     SELECT
         UNNEST(@tenantIds::UUID[]) AS tenant_id,
         UNNEST(@externalIds::UUID[]) AS external_id,
+        UNNEST(@childTaskExternalIds::UUID[]) AS child_task_external_id,
         UNNEST(@durableTaskIds::BIGINT[]) AS durable_task_id,
         UNNEST(@durableTaskInsertedAts::TIMESTAMPTZ[]) AS durable_task_inserted_at,
         UNNEST(@kinds::text[]) AS kind,
@@ -185,6 +186,7 @@ WITH inputs AS (
     INSERT INTO v1_durable_event_log_entry (
         tenant_id,
         external_id,
+        child_task_external_id,
         durable_task_id,
         durable_task_inserted_at,
         inserted_at,
@@ -199,6 +201,7 @@ WITH inputs AS (
     SELECT
         i.tenant_id,
         i.external_id,
+        NULLIF(i.child_task_external_id, '00000000-0000-0000-0000-000000000000'::UUID),
         i.durable_task_id,
         i.durable_task_inserted_at,
         NOW(),

--- a/pkg/repository/sqlcv1/durable_event_log.sql
+++ b/pkg/repository/sqlcv1/durable_event_log.sql
@@ -44,7 +44,7 @@ RETURNING v1_durable_event_log_file.*
 -- name: UpdateLogFile :one
 UPDATE v1_durable_event_log_file
 SET
-    latest_node_id = COALESCE(sqlc.narg('nodeId')::BIGINT, v1_durable_event_log_file.latest_node_id),
+    latest_node_id = GREATEST(v1_durable_event_log_file.latest_node_id, COALESCE(sqlc.narg('nodeId')::BIGINT, v1_durable_event_log_file.latest_node_id)),
     latest_invocation_count = COALESCE(sqlc.narg('invocationCount')::INTEGER, v1_durable_event_log_file.latest_invocation_count),
     latest_branch_id = COALESCE(sqlc.narg('branchId')::BIGINT, v1_durable_event_log_file.latest_branch_id)
 WHERE durable_task_id = @durableTaskId::BIGINT

--- a/pkg/repository/sqlcv1/durable_event_log.sql.go
+++ b/pkg/repository/sqlcv1/durable_event_log.sql.go
@@ -17,19 +17,21 @@ WITH inputs AS (
     SELECT
         UNNEST($1::UUID[]) AS tenant_id,
         UNNEST($2::UUID[]) AS external_id,
-        UNNEST($3::BIGINT[]) AS durable_task_id,
-        UNNEST($4::TIMESTAMPTZ[]) AS durable_task_inserted_at,
-        UNNEST($5::text[]) AS kind,
-        UNNEST($6::BIGINT[]) AS node_id,
-        UNNEST($7::BIGINT[]) AS branch_id,
-        UNNEST($8::BYTEA[]) AS idempotency_key,
-        UNNEST($9::BOOLEAN[]) AS is_satisfied,
-        UNNEST($10::TEXT[]) AS user_message,
-        UNNEST($11::TEXT[]) AS wait_data
+        UNNEST($3::UUID[]) AS child_task_external_id,
+        UNNEST($4::BIGINT[]) AS durable_task_id,
+        UNNEST($5::TIMESTAMPTZ[]) AS durable_task_inserted_at,
+        UNNEST($6::text[]) AS kind,
+        UNNEST($7::BIGINT[]) AS node_id,
+        UNNEST($8::BIGINT[]) AS branch_id,
+        UNNEST($9::BYTEA[]) AS idempotency_key,
+        UNNEST($10::BOOLEAN[]) AS is_satisfied,
+        UNNEST($11::TEXT[]) AS user_message,
+        UNNEST($12::TEXT[]) AS wait_data
 ), inserts AS (
     INSERT INTO v1_durable_event_log_entry (
         tenant_id,
         external_id,
+        child_task_external_id,
         durable_task_id,
         durable_task_inserted_at,
         inserted_at,
@@ -44,6 +46,7 @@ WITH inputs AS (
     SELECT
         i.tenant_id,
         i.external_id,
+        NULLIF(i.child_task_external_id, '00000000-0000-0000-0000-000000000000'::UUID),
         i.durable_task_id,
         i.durable_task_inserted_at,
         NOW(),
@@ -56,10 +59,10 @@ WITH inputs AS (
         CASE WHEN i.wait_data = '' THEN NULL ELSE i.wait_data::JSONB END
     FROM inputs i
     ON CONFLICT (durable_task_id, durable_task_inserted_at, branch_id, node_id) DO NOTHING
-    RETURNING tenant_id, external_id, result_payload_external_id, inserted_at, id, durable_task_id, durable_task_inserted_at, kind, node_id, branch_id, idempotency_key, is_satisfied, satisfied_at, user_message, wait_data
+    RETURNING tenant_id, external_id, result_payload_external_id, child_task_external_id, inserted_at, id, durable_task_id, durable_task_inserted_at, kind, node_id, branch_id, idempotency_key, is_satisfied, satisfied_at, user_message, wait_data
 )
 
-SELECT i.tenant_id, i.external_id, i.result_payload_external_id, i.inserted_at, i.id, i.durable_task_id, i.durable_task_inserted_at, i.kind, i.node_id, i.branch_id, i.idempotency_key, i.is_satisfied, i.satisfied_at, i.user_message, i.wait_data, lf.latest_invocation_count AS invocation_count
+SELECT i.tenant_id, i.external_id, i.result_payload_external_id, i.child_task_external_id, i.inserted_at, i.id, i.durable_task_id, i.durable_task_inserted_at, i.kind, i.node_id, i.branch_id, i.idempotency_key, i.is_satisfied, i.satisfied_at, i.user_message, i.wait_data, lf.latest_invocation_count AS invocation_count
 FROM inserts i
 JOIN v1_durable_event_log_file lf ON (lf.durable_task_id, lf.durable_task_inserted_at) = (i.durable_task_id, i.durable_task_inserted_at)
 `
@@ -67,6 +70,7 @@ JOIN v1_durable_event_log_file lf ON (lf.durable_task_id, lf.durable_task_insert
 type BulkCreateDurableEventLogEntriesParams struct {
 	Tenantids              []uuid.UUID          `json:"tenantids"`
 	Externalids            []uuid.UUID          `json:"externalids"`
+	Childtaskexternalids   []uuid.UUID          `json:"childtaskexternalids"`
 	Durabletaskids         []int64              `json:"durabletaskids"`
 	Durabletaskinsertedats []pgtype.Timestamptz `json:"durabletaskinsertedats"`
 	Kinds                  []string             `json:"kinds"`
@@ -82,6 +86,7 @@ type BulkCreateDurableEventLogEntriesRow struct {
 	TenantID                uuid.UUID             `json:"tenant_id"`
 	ExternalID              uuid.UUID             `json:"external_id"`
 	ResultPayloadExternalID uuid.UUID             `json:"result_payload_external_id"`
+	ChildTaskExternalID     *uuid.UUID            `json:"child_task_external_id"`
 	InsertedAt              pgtype.Timestamptz    `json:"inserted_at"`
 	ID                      int64                 `json:"id"`
 	DurableTaskID           int64                 `json:"durable_task_id"`
@@ -101,6 +106,7 @@ func (q *Queries) BulkCreateDurableEventLogEntries(ctx context.Context, db DBTX,
 	rows, err := db.Query(ctx, bulkCreateDurableEventLogEntries,
 		arg.Tenantids,
 		arg.Externalids,
+		arg.Childtaskexternalids,
 		arg.Durabletaskids,
 		arg.Durabletaskinsertedats,
 		arg.Kinds,
@@ -122,6 +128,7 @@ func (q *Queries) BulkCreateDurableEventLogEntries(ctx context.Context, db DBTX,
 			&i.TenantID,
 			&i.ExternalID,
 			&i.ResultPayloadExternalID,
+			&i.ChildTaskExternalID,
 			&i.InsertedAt,
 			&i.ID,
 			&i.DurableTaskID,
@@ -152,7 +159,7 @@ WITH inputs AS (
         UNNEST($3::BIGINT[]) AS branch_id,
         UNNEST($4::BIGINT[]) AS node_id
 )
-SELECT e.tenant_id, e.external_id, e.result_payload_external_id, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.user_message, e.wait_data, lf.latest_invocation_count AS invocation_count
+SELECT e.tenant_id, e.external_id, e.result_payload_external_id, e.child_task_external_id, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.user_message, e.wait_data, lf.latest_invocation_count AS invocation_count
 FROM v1_durable_event_log_entry e
 JOIN inputs i ON e.branch_id = i.branch_id AND e.node_id = i.node_id
 JOIN v1_durable_event_log_file lf ON (lf.durable_task_id, lf.durable_task_inserted_at) = (e.durable_task_id, e.durable_task_inserted_at)
@@ -171,6 +178,7 @@ type BulkGetDurableEventLogEntriesRow struct {
 	TenantID                uuid.UUID             `json:"tenant_id"`
 	ExternalID              uuid.UUID             `json:"external_id"`
 	ResultPayloadExternalID uuid.UUID             `json:"result_payload_external_id"`
+	ChildTaskExternalID     *uuid.UUID            `json:"child_task_external_id"`
 	InsertedAt              pgtype.Timestamptz    `json:"inserted_at"`
 	ID                      int64                 `json:"id"`
 	DurableTaskID           int64                 `json:"durable_task_id"`
@@ -204,6 +212,7 @@ func (q *Queries) BulkGetDurableEventLogEntries(ctx context.Context, db DBTX, ar
 			&i.TenantID,
 			&i.ExternalID,
 			&i.ResultPayloadExternalID,
+			&i.ChildTaskExternalID,
 			&i.InsertedAt,
 			&i.ID,
 			&i.DurableTaskID,
@@ -300,27 +309,28 @@ func (q *Queries) GetAndLockLogFile(ctx context.Context, db DBTX, arg GetAndLock
 	return &i, err
 }
 
-const getDurableEventLogEntriesByExternalIds = `-- name: GetDurableEventLogEntriesByExternalIds :many
-SELECT e.tenant_id, e.external_id, e.result_payload_external_id, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.user_message, e.wait_data, lf.latest_invocation_count AS invocation_count
+const getDurableEventLogEntriesByChildTaskExternalIds = `-- name: GetDurableEventLogEntriesByChildTaskExternalIds :many
+SELECT e.tenant_id, e.external_id, e.result_payload_external_id, e.child_task_external_id, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.user_message, e.wait_data, lf.latest_invocation_count AS invocation_count
 FROM v1_durable_event_log_entry e
 JOIN v1_durable_event_log_file lf ON (lf.durable_task_id, lf.durable_task_inserted_at) = (e.durable_task_id, e.durable_task_inserted_at)
 WHERE
     e.durable_task_id = $1::BIGINT
     AND e.durable_task_inserted_at = $2::TIMESTAMPTZ
-    AND e.external_id = ANY($3::UUID[])
-ORDER BY e.external_id, e.node_id ASC
+    AND e.child_task_external_id = ANY($3::UUID[])
+ORDER BY e.child_task_external_id, e.node_id ASC
 `
 
-type GetDurableEventLogEntriesByExternalIdsParams struct {
+type GetDurableEventLogEntriesByChildTaskExternalIdsParams struct {
 	Durabletaskid         int64              `json:"durabletaskid"`
 	Durabletaskinsertedat pgtype.Timestamptz `json:"durabletaskinsertedat"`
-	Externalids           []uuid.UUID        `json:"externalids"`
+	Childtaskexternalids  []uuid.UUID        `json:"childtaskexternalids"`
 }
 
-type GetDurableEventLogEntriesByExternalIdsRow struct {
+type GetDurableEventLogEntriesByChildTaskExternalIdsRow struct {
 	TenantID                uuid.UUID             `json:"tenant_id"`
 	ExternalID              uuid.UUID             `json:"external_id"`
 	ResultPayloadExternalID uuid.UUID             `json:"result_payload_external_id"`
+	ChildTaskExternalID     *uuid.UUID            `json:"child_task_external_id"`
 	InsertedAt              pgtype.Timestamptz    `json:"inserted_at"`
 	ID                      int64                 `json:"id"`
 	DurableTaskID           int64                 `json:"durable_task_id"`
@@ -336,19 +346,20 @@ type GetDurableEventLogEntriesByExternalIdsRow struct {
 	InvocationCount         int32                 `json:"invocation_count"`
 }
 
-func (q *Queries) GetDurableEventLogEntriesByExternalIds(ctx context.Context, db DBTX, arg GetDurableEventLogEntriesByExternalIdsParams) ([]*GetDurableEventLogEntriesByExternalIdsRow, error) {
-	rows, err := db.Query(ctx, getDurableEventLogEntriesByExternalIds, arg.Durabletaskid, arg.Durabletaskinsertedat, arg.Externalids)
+func (q *Queries) GetDurableEventLogEntriesByChildTaskExternalIds(ctx context.Context, db DBTX, arg GetDurableEventLogEntriesByChildTaskExternalIdsParams) ([]*GetDurableEventLogEntriesByChildTaskExternalIdsRow, error) {
+	rows, err := db.Query(ctx, getDurableEventLogEntriesByChildTaskExternalIds, arg.Durabletaskid, arg.Durabletaskinsertedat, arg.Childtaskexternalids)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*GetDurableEventLogEntriesByExternalIdsRow
+	var items []*GetDurableEventLogEntriesByChildTaskExternalIdsRow
 	for rows.Next() {
-		var i GetDurableEventLogEntriesByExternalIdsRow
+		var i GetDurableEventLogEntriesByChildTaskExternalIdsRow
 		if err := rows.Scan(
 			&i.TenantID,
 			&i.ExternalID,
 			&i.ResultPayloadExternalID,
+			&i.ChildTaskExternalID,
 			&i.InsertedAt,
 			&i.ID,
 			&i.DurableTaskID,
@@ -374,7 +385,7 @@ func (q *Queries) GetDurableEventLogEntriesByExternalIds(ctx context.Context, db
 }
 
 const getDurableEventLogEntry = `-- name: GetDurableEventLogEntry :one
-SELECT tenant_id, external_id, result_payload_external_id, inserted_at, id, durable_task_id, durable_task_inserted_at, kind, node_id, branch_id, idempotency_key, is_satisfied, satisfied_at, user_message, wait_data
+SELECT tenant_id, external_id, result_payload_external_id, child_task_external_id, inserted_at, id, durable_task_id, durable_task_inserted_at, kind, node_id, branch_id, idempotency_key, is_satisfied, satisfied_at, user_message, wait_data
 FROM v1_durable_event_log_entry
 WHERE durable_task_id = $1::BIGINT
   AND durable_task_inserted_at = $2::TIMESTAMPTZ
@@ -401,6 +412,7 @@ func (q *Queries) GetDurableEventLogEntry(ctx context.Context, db DBTX, arg GetD
 		&i.TenantID,
 		&i.ExternalID,
 		&i.ResultPayloadExternalID,
+		&i.ChildTaskExternalID,
 		&i.InsertedAt,
 		&i.ID,
 		&i.DurableTaskID,
@@ -580,7 +592,7 @@ func (q *Queries) ListDurableEventLogBranchPoints(ctx context.Context, db DBTX, 
 }
 
 const listDurableEventLogForTask = `-- name: ListDurableEventLogForTask :many
-SELECT e.tenant_id, e.external_id, e.result_payload_external_id, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.user_message, e.wait_data, t.external_id AS durable_task_external_id, t.display_name AS durable_task_display_name
+SELECT e.tenant_id, e.external_id, e.result_payload_external_id, e.child_task_external_id, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.user_message, e.wait_data, t.external_id AS durable_task_external_id, t.display_name AS durable_task_display_name
 FROM v1_durable_event_log_entry e
 JOIN v1_task t ON (t.id, t.inserted_at) = (e.durable_task_id, e.durable_task_inserted_at)
 WHERE e.durable_task_id = $1::BIGINT
@@ -603,6 +615,7 @@ type ListDurableEventLogForTaskRow struct {
 	TenantID                uuid.UUID             `json:"tenant_id"`
 	ExternalID              uuid.UUID             `json:"external_id"`
 	ResultPayloadExternalID uuid.UUID             `json:"result_payload_external_id"`
+	ChildTaskExternalID     *uuid.UUID            `json:"child_task_external_id"`
 	InsertedAt              pgtype.Timestamptz    `json:"inserted_at"`
 	ID                      int64                 `json:"id"`
 	DurableTaskID           int64                 `json:"durable_task_id"`
@@ -638,6 +651,7 @@ func (q *Queries) ListDurableEventLogForTask(ctx context.Context, db DBTX, arg L
 			&i.TenantID,
 			&i.ExternalID,
 			&i.ResultPayloadExternalID,
+			&i.ChildTaskExternalID,
 			&i.InsertedAt,
 			&i.ID,
 			&i.DurableTaskID,
@@ -677,7 +691,7 @@ WITH inputs AS (
 )
 
 SELECT
-    e.tenant_id, e.external_id, e.result_payload_external_id, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.user_message, e.wait_data,
+    e.tenant_id, e.external_id, e.result_payload_external_id, e.child_task_external_id, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.user_message, e.wait_data,
     twn.external_id AS task_external_id,
     lf.latest_invocation_count AS invocation_count
 FROM v1_durable_event_log_entry e
@@ -699,6 +713,7 @@ type ListSatisfiedEntriesRow struct {
 	TenantID                uuid.UUID             `json:"tenant_id"`
 	ExternalID              uuid.UUID             `json:"external_id"`
 	ResultPayloadExternalID uuid.UUID             `json:"result_payload_external_id"`
+	ChildTaskExternalID     *uuid.UUID            `json:"child_task_external_id"`
 	InsertedAt              pgtype.Timestamptz    `json:"inserted_at"`
 	ID                      int64                 `json:"id"`
 	DurableTaskID           int64                 `json:"durable_task_id"`
@@ -728,6 +743,7 @@ func (q *Queries) ListSatisfiedEntries(ctx context.Context, db DBTX, arg ListSat
 			&i.TenantID,
 			&i.ExternalID,
 			&i.ResultPayloadExternalID,
+			&i.ChildTaskExternalID,
 			&i.InsertedAt,
 			&i.ID,
 			&i.DurableTaskID,
@@ -762,7 +778,7 @@ WHERE durable_task_id = $1::BIGINT
   AND durable_task_inserted_at = $2::TIMESTAMPTZ
   AND branch_id = $3::BIGINT
   AND node_id = $4::BIGINT
-RETURNING tenant_id, external_id, result_payload_external_id, inserted_at, id, durable_task_id, durable_task_inserted_at, kind, node_id, branch_id, idempotency_key, is_satisfied, satisfied_at, user_message, wait_data
+RETURNING tenant_id, external_id, result_payload_external_id, child_task_external_id, inserted_at, id, durable_task_id, durable_task_inserted_at, kind, node_id, branch_id, idempotency_key, is_satisfied, satisfied_at, user_message, wait_data
 `
 
 type MarkDurableEventLogEntrySatisfiedParams struct {
@@ -784,6 +800,7 @@ func (q *Queries) MarkDurableEventLogEntrySatisfied(ctx context.Context, db DBTX
 		&i.TenantID,
 		&i.ExternalID,
 		&i.ResultPayloadExternalID,
+		&i.ChildTaskExternalID,
 		&i.InsertedAt,
 		&i.ID,
 		&i.DurableTaskID,
@@ -817,10 +834,10 @@ WITH inputs AS (
       AND v1_durable_event_log_entry.durable_task_inserted_at = inputs.durable_task_inserted_at
       AND v1_durable_event_log_entry.node_id = inputs.node_id
       AND v1_durable_event_log_entry.branch_id = inputs.branch_id
-    RETURNING v1_durable_event_log_entry.tenant_id, v1_durable_event_log_entry.external_id, v1_durable_event_log_entry.result_payload_external_id, v1_durable_event_log_entry.inserted_at, v1_durable_event_log_entry.id, v1_durable_event_log_entry.durable_task_id, v1_durable_event_log_entry.durable_task_inserted_at, v1_durable_event_log_entry.kind, v1_durable_event_log_entry.node_id, v1_durable_event_log_entry.branch_id, v1_durable_event_log_entry.idempotency_key, v1_durable_event_log_entry.is_satisfied, v1_durable_event_log_entry.satisfied_at, v1_durable_event_log_entry.user_message, v1_durable_event_log_entry.wait_data
+    RETURNING v1_durable_event_log_entry.tenant_id, v1_durable_event_log_entry.external_id, v1_durable_event_log_entry.result_payload_external_id, v1_durable_event_log_entry.child_task_external_id, v1_durable_event_log_entry.inserted_at, v1_durable_event_log_entry.id, v1_durable_event_log_entry.durable_task_id, v1_durable_event_log_entry.durable_task_inserted_at, v1_durable_event_log_entry.kind, v1_durable_event_log_entry.node_id, v1_durable_event_log_entry.branch_id, v1_durable_event_log_entry.idempotency_key, v1_durable_event_log_entry.is_satisfied, v1_durable_event_log_entry.satisfied_at, v1_durable_event_log_entry.user_message, v1_durable_event_log_entry.wait_data
 )
 
-SELECT updated.tenant_id, updated.external_id, updated.result_payload_external_id, updated.inserted_at, updated.id, updated.durable_task_id, updated.durable_task_inserted_at, updated.kind, updated.node_id, updated.branch_id, updated.idempotency_key, updated.is_satisfied, updated.satisfied_at, updated.user_message, updated.wait_data, lf.latest_invocation_count AS invocation_count
+SELECT updated.tenant_id, updated.external_id, updated.result_payload_external_id, updated.child_task_external_id, updated.inserted_at, updated.id, updated.durable_task_id, updated.durable_task_inserted_at, updated.kind, updated.node_id, updated.branch_id, updated.idempotency_key, updated.is_satisfied, updated.satisfied_at, updated.user_message, updated.wait_data, lf.latest_invocation_count AS invocation_count
 FROM updated
 JOIN v1_durable_event_log_file lf ON (lf.durable_task_id, lf.durable_task_inserted_at) = (updated.durable_task_id, updated.durable_task_inserted_at)
 `
@@ -836,6 +853,7 @@ type UpdateDurableEventLogEntriesSatisfiedRow struct {
 	TenantID                uuid.UUID             `json:"tenant_id"`
 	ExternalID              uuid.UUID             `json:"external_id"`
 	ResultPayloadExternalID uuid.UUID             `json:"result_payload_external_id"`
+	ChildTaskExternalID     *uuid.UUID            `json:"child_task_external_id"`
 	InsertedAt              pgtype.Timestamptz    `json:"inserted_at"`
 	ID                      int64                 `json:"id"`
 	DurableTaskID           int64                 `json:"durable_task_id"`
@@ -869,6 +887,7 @@ func (q *Queries) UpdateDurableEventLogEntriesSatisfied(ctx context.Context, db 
 			&i.TenantID,
 			&i.ExternalID,
 			&i.ResultPayloadExternalID,
+			&i.ChildTaskExternalID,
 			&i.InsertedAt,
 			&i.ID,
 			&i.DurableTaskID,

--- a/pkg/repository/sqlcv1/durable_event_log.sql.go
+++ b/pkg/repository/sqlcv1/durable_event_log.sql.go
@@ -915,6 +915,8 @@ func (q *Queries) UpdateDurableEventLogEntriesSatisfied(ctx context.Context, db 
 const updateLogFile = `-- name: UpdateLogFile :one
 UPDATE v1_durable_event_log_file
 SET
+    -- important: need ` + "`" + `GREATEST` + "`" + ` here to avoid moving the ` + "`" + `latest_node_id` + "`" + ` backwards in the case of child spawning with
+    -- a child_key set, which, if the child was cached, would not create a new log entry and thus not move the latest node forward
     latest_node_id = GREATEST(v1_durable_event_log_file.latest_node_id, COALESCE($1::BIGINT, v1_durable_event_log_file.latest_node_id)),
     latest_invocation_count = COALESCE($2::INTEGER, v1_durable_event_log_file.latest_invocation_count),
     latest_branch_id = COALESCE($3::BIGINT, v1_durable_event_log_file.latest_branch_id)

--- a/pkg/repository/sqlcv1/durable_event_log.sql.go
+++ b/pkg/repository/sqlcv1/durable_event_log.sql.go
@@ -915,7 +915,7 @@ func (q *Queries) UpdateDurableEventLogEntriesSatisfied(ctx context.Context, db 
 const updateLogFile = `-- name: UpdateLogFile :one
 UPDATE v1_durable_event_log_file
 SET
-    latest_node_id = COALESCE($1::BIGINT, v1_durable_event_log_file.latest_node_id),
+    latest_node_id = GREATEST(v1_durable_event_log_file.latest_node_id, COALESCE($1::BIGINT, v1_durable_event_log_file.latest_node_id)),
     latest_invocation_count = COALESCE($2::INTEGER, v1_durable_event_log_file.latest_invocation_count),
     latest_branch_id = COALESCE($3::BIGINT, v1_durable_event_log_file.latest_branch_id)
 WHERE durable_task_id = $4::BIGINT

--- a/pkg/repository/sqlcv1/models.go
+++ b/pkg/repository/sqlcv1/models.go
@@ -3170,6 +3170,7 @@ type V1DurableEventLogEntry struct {
 	TenantID                uuid.UUID             `json:"tenant_id"`
 	ExternalID              uuid.UUID             `json:"external_id"`
 	ResultPayloadExternalID uuid.UUID             `json:"result_payload_external_id"`
+	ChildTaskExternalID     *uuid.UUID            `json:"child_task_external_id"`
 	InsertedAt              pgtype.Timestamptz    `json:"inserted_at"`
 	ID                      int64                 `json:"id"`
 	DurableTaskID           int64                 `json:"durable_task_id"`

--- a/sdks/python/examples/durable/test_durable.py
+++ b/sdks/python/examples/durable/test_durable.py
@@ -356,9 +356,9 @@ async def test_event_lookback_before_wait(hatchet: Hatchet) -> None:
 
     result = await wait_for_event_lookback.aio_run(EventLookbackInput(user_id=user_id))
 
-    assert result.elapsed < 1 + TIMING_TOLERANCE, (
-        "Event lookback should find the event that was pushed before the wait started, so should be basically instantaneous"
-    )
+    assert (
+        result.elapsed < 1 + TIMING_TOLERANCE
+    ), "Event lookback should find the event that was pushed before the wait started, so should be basically instantaneous"
     assert result.event.order == "first"
 
 

--- a/sdks/python/examples/durable/test_durable.py
+++ b/sdks/python/examples/durable/test_durable.py
@@ -19,6 +19,7 @@ from examples.durable.worker import (
     durable_spawn_dag,
     durable_non_determinism,
     durable_replay_reset,
+    durable_child_key_dedup_replay,
     memo_task,
     MemoInput,
     DurableBulkSpawnInput,
@@ -143,6 +144,28 @@ async def test_durable_sleep_event_spawn_replay(hatchet: Hatchet) -> None:
 
     assert replayed_result["child_output"] == {"message": "hello from child 1"}
     assert replay_elapsed < SLEEP_TIME + TIMING_TOLERANCE
+
+
+@requires_durable_eviction
+@pytest.mark.asyncio(loop_scope="session")
+async def test_durable_child_key_dedup_replay(hatchet: Hatchet) -> None:
+    ref = await durable_child_key_dedup_replay.aio_run(wait_for_result=False)
+    result = await ref.aio_result()
+
+    assert result.runtime >= 2 * SLEEP_TIME
+    assert result.child_1_output == {"message": "hello from child 1"}
+    assert result.child_2_output == {"message": "hello from child 2"}
+    assert result.child_3_output == result.child_1_output
+
+    await hatchet.runs.aio_replay(ref.workflow_run_id)
+    await asyncio.sleep(5)
+
+    replayed_result = await ref.aio_result()
+
+    assert replayed_result.child_1_output == result.child_1_output
+    assert replayed_result.child_2_output == result.child_2_output
+    assert replayed_result.child_3_output == result.child_3_output
+    assert replayed_result.runtime < SLEEP_TIME
 
 
 @requires_durable_eviction
@@ -333,9 +356,9 @@ async def test_event_lookback_before_wait(hatchet: Hatchet) -> None:
 
     result = await wait_for_event_lookback.aio_run(EventLookbackInput(user_id=user_id))
 
-    assert (
-        result.elapsed < 1 + TIMING_TOLERANCE
-    ), "Event lookback should find the event that was pushed before the wait started, so should be basically instantaneous"
+    assert result.elapsed < 1 + TIMING_TOLERANCE, (
+        "Event lookback should find the event that was pushed before the wait started, so should be basically instantaneous"
+    )
     assert result.event.order == "first"
 
 

--- a/sdks/python/examples/durable/worker.py
+++ b/sdks/python/examples/durable/worker.py
@@ -396,6 +396,40 @@ async def durable_replay_reset(
     )
 
 
+class ChildKeyDedupResult(BaseModel):
+    runtime: float
+    child_1_output: dict[str, str]
+    child_2_output: dict[str, str]
+    child_3_output: dict[str, str]
+
+
+@hatchet.durable_task(execution_timeout=timedelta(seconds=30))
+async def durable_child_key_dedup_replay(
+    input: EmptyModel, ctx: DurableContext
+) -> ChildKeyDedupResult:
+    start = time.time()
+    await ctx.aio_sleep_for(timedelta(seconds=SLEEP_TIME))
+
+    child_1_output = await spawn_child_task.aio_run(
+        DurableBulkSpawnInput(n=1), child_key="child-a"
+    )
+    child_2_output = await spawn_child_task.aio_run(
+        DurableBulkSpawnInput(n=2), child_key="child-b"
+    )
+    child_3_output = await spawn_child_task.aio_run(
+        DurableBulkSpawnInput(n=3), child_key="child-a"
+    )
+
+    await ctx.aio_sleep_for(timedelta(seconds=SLEEP_TIME))
+
+    return ChildKeyDedupResult(
+        child_1_output=child_1_output,
+        child_2_output=child_2_output,
+        child_3_output=child_3_output,
+        runtime=time.time() - start,
+    )
+
+
 class SleepResult(BaseModel):
     message: str
     duration: float
@@ -436,6 +470,7 @@ def main() -> None:
             durable_sleep_event_spawn,
             durable_non_determinism,
             durable_replay_reset,
+            durable_child_key_dedup_replay,
             wait_for_event_lookback,
             wait_for_or_event_lookback,
             wait_for_two_events_second_pushed_first,

--- a/sdks/python/examples/worker.py
+++ b/sdks/python/examples/worker.py
@@ -47,6 +47,7 @@ from examples.durable.worker import (
     wait_for_event_lookback,
     wait_for_or_event_lookback,
     wait_for_two_events_second_pushed_first,
+    durable_child_key_dedup_replay,
 )
 from examples.durable_event.worker import (
     durable_event_task,
@@ -191,6 +192,7 @@ def main() -> None:
             welcome_email,
             durable_parent_child_key_bug,
             child_child_key_bug,
+            durable_child_key_dedup_replay,
         ],
         lifespan=lifespan,
     )

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -2322,9 +2322,10 @@ CREATE TYPE v1_durable_event_log_kind AS ENUM (
 CREATE TABLE v1_durable_event_log_entry (
     tenant_id UUID NOT NULL,
 
-    -- need an external id for consistency with the payload store logic (unfortunately)
     external_id UUID NOT NULL,
     result_payload_external_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    -- Only set for RUN entries; holds the external_id of the child task that was spawned.
+    child_task_external_id UUID,
 
     -- The id and inserted_at of the durable task which created this entry
     -- The inserted_at time of this event from a DB clock perspective.


### PR DESCRIPTION
# Description

Fixes a bug I introduced where child spawning would use the child's external id as the external id in the durable event log, which worked fine for the event log itself but broke the payload logic since we'd use the same external id for both the event log entry and the task input

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI use in this PR

</details>
