### PR TITLE
docs: agent mcp exposing workflows

### DIFF
--- a/examples/python/agent/agent_claude.py
+++ b/examples/python/agent/agent_claude.py
@@ -5,22 +5,22 @@ from claude_agent_sdk import (
     query,
     ResultMessage,
 )
-from examples.agent.workflows import temperature_tool_claude
+from examples.agent.workflows import create_temperature_workflow_tool_claude
 
 
 async def main() -> None:
+    temperature_tool = create_temperature_workflow_tool_claude()
+
     # Wrap the tool in an in-process MCP server
     weather_server = create_sdk_mcp_server(
         name="weather",
         version="1.0.0",
-        tools=[temperature_tool_claude],
+        tools=[temperature_tool],
     )
 
     options = ClaudeAgentOptions(
         mcp_servers={"weather": weather_server},
-        allowed_tools=[
-            f"mcp__{weather_server['name']}__{temperature_tool_claude.name}"
-        ],
+        allowed_tools=[f"mcp__{weather_server['name']}__{temperature_tool.name}"],
     )
 
     async for message in query(

--- a/examples/python/agent/agent_openai.py
+++ b/examples/python/agent/agent_openai.py
@@ -1,13 +1,15 @@
 import asyncio
 
 from agents import Agent, Runner
-from examples.agent.workflows import temperature_tool_openai
+from examples.agent.workflows import create_temperature_workflow_tool_openai
 
 
 async def main() -> None:
+    temperature_tool = create_temperature_workflow_tool_openai()
+
     agent = Agent(
         name="Assistant",
-        tools=[temperature_tool_openai],
+        tools=[temperature_tool],
     )
     result = await Runner.run(agent, "What's the temperature in San Francisco?")
     print(result.final_output)

--- a/examples/python/agent/workflows.py
+++ b/examples/python/agent/workflows.py
@@ -1,4 +1,6 @@
 # > Agent
+from typing import Any
+
 import httpx
 from pydantic import BaseModel
 
@@ -82,19 +84,19 @@ async def get_temperature_standalone(
 
 
 # > Create MCP tools
-def create_temperature_workflow_tool_claude():
+def create_temperature_workflow_tool_claude() -> Any:
     return get_temperature_workflow.mcp_tool(MCPProvider.CLAUDE)
 
 
-def create_temperature_workflow_tool_openai():
+def create_temperature_workflow_tool_openai() -> Any:
     return get_temperature_workflow.mcp_tool(MCPProvider.OPENAI)
 
 
-def create_temperature_task_tool_claude():
+def create_temperature_task_tool_claude() -> Any:
     return get_temperature_standalone.mcp_tool(MCPProvider.CLAUDE)
 
 
-def create_temperature_task_tool_openai():
+def create_temperature_task_tool_openai() -> Any:
     return get_temperature_standalone.mcp_tool(MCPProvider.OPENAI)
 
 

--- a/examples/python/agent/workflows.py
+++ b/examples/python/agent/workflows.py
@@ -8,6 +8,7 @@ from hatchet_sdk.runnables.workflow import MCPProvider
 hatchet = Hatchet(debug=True)
 
 
+# > Models
 class TemperatureCoords(BaseModel):
     latitude: float
     longitude: float
@@ -22,6 +23,9 @@ class TemperatureContent(BaseModel):
     text: str
 
 
+
+
+# > Workflow definition
 get_temperature_workflow = hatchet.workflow(
     name="get_temperature",
     input_validator=TemperatureInput,
@@ -50,6 +54,7 @@ async def get_temperature(input: TemperatureInput, ctx: Context) -> TemperatureC
 
 
 
+# > Standalone task
 @hatchet.task(
     input_validator=TemperatureInput,
     description="Get the current temperature at a location",
@@ -74,16 +79,22 @@ async def get_temperature_standalone(
     )
 
 
-# You can use a workflow
-temperature_tool_claude = get_temperature_workflow.mcp_tool(MCPProvider.CLAUDE)
 
-temperature_tool_openai = get_temperature_workflow.mcp_tool(
-    MCPProvider.OPENAI,
-)
 
-# Or a standalone task
-temperature_tool_claude = get_temperature_standalone.mcp_tool(MCPProvider.CLAUDE)
+# > Create MCP tools
+def create_temperature_workflow_tool_claude():
+    return get_temperature_workflow.mcp_tool(MCPProvider.CLAUDE)
 
-temperature_tool_openai = get_temperature_standalone.mcp_tool(
-    MCPProvider.OPENAI,
-)
+
+def create_temperature_workflow_tool_openai():
+    return get_temperature_workflow.mcp_tool(MCPProvider.OPENAI)
+
+
+def create_temperature_task_tool_claude():
+    return get_temperature_standalone.mcp_tool(MCPProvider.CLAUDE)
+
+
+def create_temperature_task_tool_openai():
+    return get_temperature_standalone.mcp_tool(MCPProvider.OPENAI)
+
+

--- a/examples/typescript/agent/agent-claude.ts
+++ b/examples/typescript/agent/agent-claude.ts
@@ -1,9 +1,11 @@
 import { createTemperatureWorkflowToolClaude } from './workflow';
-import { query } from '@anthropic-ai/claude-agent-sdk';
-import { createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
 
 async function main() {
   const temperatureTool = createTemperatureWorkflowToolClaude();
+
+  // Dynamic import — the Claude Agent SDK is ESM-only, so we use import()
+  // instead of a static import to avoid ERR_REQUIRE_ESM under ts-node/CJS.
+  const { query, createSdkMcpServer } = await import('@anthropic-ai/claude-agent-sdk');
 
   // Wrap the tool in an in-process MCP server
   const weatherServer = createSdkMcpServer({

--- a/examples/typescript/agent/agent-claude.ts
+++ b/examples/typescript/agent/agent-claude.ts
@@ -1,13 +1,9 @@
-import { getTemperature, getTemperatureWorkflow } from './workflow';
+import { createTemperatureWorkflowToolClaude } from './workflow';
 import { query } from '@anthropic-ai/claude-agent-sdk';
 import { createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
 
 async function main() {
-  // Generate a tool from a standalone task
-  // const temperatureTool = getTemperature.mcpTool('claude');
-
-  // Or from a workflow
-  const temperatureTool = getTemperatureWorkflow.mcpTool('claude');
+  const temperatureTool = createTemperatureWorkflowToolClaude();
 
   // Wrap the tool in an in-process MCP server
   const weatherServer = createSdkMcpServer({

--- a/examples/typescript/agent/agent-claude.ts
+++ b/examples/typescript/agent/agent-claude.ts
@@ -3,8 +3,8 @@ import { createTemperatureWorkflowToolClaude } from './workflow';
 async function main() {
   const temperatureTool = createTemperatureWorkflowToolClaude();
 
-  // Dynamic import — the Claude Agent SDK is ESM-only, so we use import()
-  // instead of a static import to avoid ERR_REQUIRE_ESM under ts-node/CJS.
+  // The Claude Agent SDK is ESM-only, so avoid loading it at module import time.
+  // Run this example with an ESM-compatible TypeScript runner.
   const { query, createSdkMcpServer } = await import('@anthropic-ai/claude-agent-sdk');
 
   // Wrap the tool in an in-process MCP server

--- a/examples/typescript/agent/agent-openai.ts
+++ b/examples/typescript/agent/agent-openai.ts
@@ -1,13 +1,9 @@
-import { getTemperature, getTemperatureWorkflow } from './workflow';
+import { createTemperatureWorkflowToolOpenai } from './workflow';
 
 async function main() {
-  // Generate a tool from a standalone task
-  // const temperatureTool = getTemperature.mcpTool('openai');
-
-  // Or from a workflow.
   // mcpTool validates Zod v4 is installed before loading @openai/agents, so call it first
   // to get a clear error message if the wrong Zod version is present.
-  const temperatureTool = getTemperatureWorkflow.mcpTool('openai');
+  const temperatureTool = createTemperatureWorkflowToolOpenai();
 
   // Dynamic import — @openai/agents crashes at load time with Zod v3, so we delay
   // the import until after mcpTool has already verified Zod v4 is available.

--- a/examples/typescript/agent/workflow.ts
+++ b/examples/typescript/agent/workflow.ts
@@ -26,15 +26,6 @@ const temperatureRequest = async (input: TemperatureInputWithZod) => {
   };
 };
 
-// > Standalone task
-export const getTemperature = hatchet.task({
-  name: 'getTemperature',
-  retries: 3,
-  fn: temperatureRequest,
-  inputValidator: TemperatureInput,
-  description: 'Get the current temperature at a location',
-});
-
 // > Workflow definition
 export const getTemperatureWorkflow = hatchet.workflow<TemperatureInputWithZod>({
   name: 'getTemperatureWorkflow',
@@ -45,6 +36,15 @@ export const getTemperatureWorkflow = hatchet.workflow<TemperatureInputWithZod>(
 getTemperatureWorkflow.task({
   name: 'getTemperature',
   fn: temperatureRequest,
+});
+
+// > Standalone task
+export const getTemperature = hatchet.task({
+  name: 'getTemperature',
+  retries: 3,
+  fn: temperatureRequest,
+  inputValidator: TemperatureInput,
+  description: 'Get the current temperature at a location',
 });
 
 // > Create MCP tools

--- a/examples/typescript/agent/workflow.ts
+++ b/examples/typescript/agent/workflow.ts
@@ -1,8 +1,8 @@
-// > Declaring a Task
 import { hatchet } from '../hatchet-client';
 import { z } from 'zod/v4';
 
-// Note that for agent tools, Zod must be used to create the input and output types for workflows/tasks
+// > Models
+// Agent tools require a Zod v4 inputValidator so the SDK can generate the tool input schema.
 const TemperatureCoordinates = z.object({
   latitude: z.number(),
   longitude: z.number(),
@@ -22,10 +22,11 @@ const temperatureRequest = async (input: TemperatureInputWithZod) => {
   const data: any = await response.json();
 
   return {
-    text: `Temperature: ${data.current.temperature_2m}°F`,
+    text: `Temperature in ${input.locationName}: ${data.current.temperature_2m}°F`,
   };
 };
 
+// > Standalone task
 export const getTemperature = hatchet.task({
   name: 'getTemperature',
   retries: 3,
@@ -34,6 +35,7 @@ export const getTemperature = hatchet.task({
   description: 'Get the current temperature at a location',
 });
 
+// > Workflow definition
 export const getTemperatureWorkflow = hatchet.workflow<TemperatureInputWithZod>({
   name: 'getTemperatureWorkflow',
   inputValidator: TemperatureInput,
@@ -45,3 +47,19 @@ getTemperatureWorkflow.task({
   fn: temperatureRequest,
 });
 
+// > Create MCP tools
+export function createTemperatureWorkflowToolClaude() {
+  return getTemperatureWorkflow.mcpTool('claude');
+}
+
+export function createTemperatureWorkflowToolOpenai() {
+  return getTemperatureWorkflow.mcpTool('openai');
+}
+
+export function createTemperatureTaskToolClaude() {
+  return getTemperature.mcpTool('claude');
+}
+
+export function createTemperatureTaskToolOpenai() {
+  return getTemperature.mcpTool('openai');
+}

--- a/frontend/docs/pages/cookbooks/_meta.js
+++ b/frontend/docs/pages/cookbooks/_meta.js
@@ -19,5 +19,5 @@ export default {
     title: "Agent Patterns",
     type: "separator",
   },
-  "hatchet-and-mcp": "Hatchet and MCP",
+  "hatchet-and-mcp": "Hatchet Agent Tools",
 };

--- a/frontend/docs/pages/cookbooks/_meta.js
+++ b/frontend/docs/pages/cookbooks/_meta.js
@@ -15,4 +15,9 @@ export default {
   "welcome-email": "Welcome Email",
   "durable-tasks-vs-dags": "Durable Tasks vs DAGs",
   "pdf-pipeline": "PDF Pipeline",
+  "--agent-patterns": {
+    title: "Agent Patterns",
+    type: "separator",
+  },
+  "hatchet-and-mcp": "Hatchet and MCP",
 };

--- a/frontend/docs/pages/cookbooks/hatchet-and-mcp.mdx
+++ b/frontend/docs/pages/cookbooks/hatchet-and-mcp.mdx
@@ -7,11 +7,11 @@ import { Snippet } from "@/components/code";
 
 The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is an open standard for connecting AI agents to external tools, data sources, and services. This guide shows how to expose Hatchet [workflows](/v1/directed-acyclic-graphs) and [standalone tasks](/v1/tasks) as tools that frameworks like the Claude Agent SDK and OpenAI Agents SDK can invoke. Later cookbooks in this series will show how to integrate those tools into a full agent loop.
 
-In this guide, we define a Hatchet workflow and a standalone task, each with a description and a typed input schema, then convert each into an agent tool. When an agent invokes one of those tools, the tool handler submits work to the Hatchet engine. A worker picks up and executes the workflow or task and reports the result to Hatchet. The tool handler returns that result to the agent.
+In this guide, we define a Hatchet workflow and a standalone task, each with a description and a typed input schema, then convert each into an agent tool. When an agent invokes one of those tools, the tool handler submits a run to the Hatchet engine. A worker picks up and executes the workflow or task and reports the result to Hatchet. The tool handler returns that result to the agent.
 
 ## What this guide builds
 
-This guide builds a temperature lookup tool backed by Hatchet. The example calls the [Open-Meteo API](https://open-meteo.com/) and returns the current temperature for a given location. The same operation is implemented as both a workflow and a standalone task, so you can see how each becomes an agent tool.
+This guide builds a temperature lookup tool backed by Hatchet. The workflow and standalone task call the [Open-Meteo API](https://open-meteo.com/) and return the current temperature for a given location. The same operation is implemented as both a workflow and a standalone task, so you can see how each becomes an agent tool.
 
 ```mermaid
 flowchart LR
@@ -122,7 +122,7 @@ You can expose a standalone task the same way. This is useful when the agent too
 
 ### Create agent tools
 
-Create the tool in the process that runs your agent. The examples use helper functions around Hatchet's mcp tool conversion call so the workflow and task definitions can be imported without loading every optional provider SDK. Each helper returns a provider specific tool definition that the agent SDK can use. The description and input validator you added above become part of that tool definition, which is why they are required.
+Create the tool in the process that runs your agent. The examples use helper functions around Hatchet's MCP tool conversion call so the workflow and task definitions can be imported without loading every optional provider SDK. Each helper returns a provider-specific tool definition that the agent SDK can use. The description and input validator you added above become part of that tool definition, which is why they are required.
 
 <UniversalTabs items={["Python", "Typescript"]}>
   <Tabs.Tab title="Python">
@@ -141,7 +141,7 @@ Create the tool in the process that runs your agent. The examples use helper fun
 
 ### Register and start the worker
 
-The worker must be running for tools to function. When the agent calls a tool, the adapter submits work to the Hatchet engine, and the engine dispatches it to a worker for execution.
+The worker must be running for tools to function. When the agent calls a tool, the tool handler submits a run to the Hatchet engine, and the engine dispatches it to a worker for execution.
 
 <UniversalTabs items={["Python", "Typescript"]}>
   <Tabs.Tab title="Python">
@@ -161,7 +161,7 @@ You can confirm that the workflow definitions and helper functions import succes
 
     ```bash
     cd sdks/python
-    poetry run python -c "from examples.agent.workflows import get_temperature_workflow, create_temperature_task_tool_claude; print('OK')"
+    poetry run python -c "from examples.agent.workflows import create_temperature_workflow_tool_claude, create_temperature_task_tool_claude; print('OK')"
     ```
 
   </Tabs.Tab>

--- a/frontend/docs/pages/cookbooks/hatchet-and-mcp.mdx
+++ b/frontend/docs/pages/cookbooks/hatchet-and-mcp.mdx
@@ -179,7 +179,50 @@ You can confirm that the workflow definitions and helper functions import succes
   </Tabs.Tab>
 </UniversalTabs>
 
-Full end-to-end validation with the Claude Agent SDK or OpenAI Agents SDK will be covered later in this series.
+To test the full round trip between the agent and the Hatchet-backed tool, start the worker in one terminal and run a provider-specific agent example in another. This requires the provider SDK and API key for the agent example you run (`ANTHROPIC_API_KEY` or `OPENAI_API_KEY`).
+
+<UniversalTabs items={["Python", "Typescript"]}>
+  <Tabs.Tab title="Python">
+
+    Start the worker:
+
+    ```bash
+    cd sdks/python
+    poetry run python -m examples.agent.worker
+    ```
+
+    In a second terminal, run the Claude or OpenAI agent example:
+
+    ```bash
+    cd sdks/python
+    poetry run python -m examples.agent.agent_claude
+    # or
+    poetry run python -m examples.agent.agent_openai
+    ```
+
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+
+    Start the worker:
+
+    ```bash
+    cd sdks/typescript
+    pnpm exec ts-node -r tsconfig-paths/register -P tsconfig.json src/v1/examples/agent/worker.ts
+    ```
+
+    In a second terminal, run the Claude or OpenAI agent example:
+
+    ```bash
+    cd sdks/typescript
+    pnpm exec ts-node -r tsconfig-paths/register -P tsconfig.json src/v1/examples/agent/agent-claude.ts
+    # or
+    pnpm exec ts-node -r tsconfig-paths/register -P tsconfig.json src/v1/examples/agent/agent-openai.ts
+    ```
+
+  </Tabs.Tab>
+</UniversalTabs>
+
+If successful, the agent will invoke the tool and print the temperature result to the terminal.
 
 </Steps>
 

--- a/frontend/docs/pages/cookbooks/hatchet-and-mcp.mdx
+++ b/frontend/docs/pages/cookbooks/hatchet-and-mcp.mdx
@@ -3,7 +3,7 @@ import UniversalTabs from "@/components/UniversalTabs";
 import { snippets } from "@/lib/generated/snippets";
 import { Snippet } from "@/components/code";
 
-# Hatchet and MCP: Exposing Workflows as Agent Tools
+# Hatchet and MCP: Exposing Tasks and Workflows as Agent Tools
 
 The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is an open standard for connecting AI agents to external tools, data sources, and services. This guide shows how to expose Hatchet [workflows](/v1/directed-acyclic-graphs) and [standalone tasks](/v1/tasks) as tools that frameworks like the Claude Agent SDK and OpenAI Agents SDK can invoke. Later cookbooks in this series will show how to integrate those tools into a full agent loop.
 
@@ -14,15 +14,19 @@ In this guide, we define a Hatchet workflow and a standalone task, each with a d
 This guide builds a temperature lookup tool backed by Hatchet. The workflow and standalone task call the [Open-Meteo API](https://open-meteo.com/) and return the current temperature for a given location. The same operation is implemented as both a workflow and a standalone task, so you can see how each becomes an agent tool.
 
 ```mermaid
-flowchart LR
-    A[AI Agent] -->|invokes tool| B[Tool handler]
-    B -->|submits run via gRPC and waits| C[Hatchet Engine]
-    C -->|dispatches work| D[Hatchet Worker]
-    D -->|executes code| E[Workflow or task]
-    E -->|result| D
-    D -->|reports result| C
-    C -->|run result| B
-    B -->|tool result| A
+sequenceDiagram
+    participant Agent as AI Agent
+    participant Handler as Tool handler
+    participant Engine as Hatchet Engine
+    participant Worker as Hatchet Worker
+
+    Agent->>Handler: Invoke tool
+    Handler->>Engine: Submit run via gRPC and wait
+    Engine->>Worker: Dispatch work
+    Worker->>Worker: Execute workflow or task
+    Worker-->>Engine: Report result
+    Engine-->>Handler: Run result
+    Handler-->>Agent: Tool result
 ```
 
 The agent process contains the tool handler that submits the run, but it does not execute the workflow or task. Instead, a Hatchet worker executes the registered workflow or task and reports the result through Hatchet to the waiting tool handler. Since each tool call submits a run through Hatchet, the work the agent triggers gets the same observability and [core reliability guarantees](/v1/architecture-and-guarantees#core-reliability-guarantees) as any other Hatchet task or workflow.

--- a/frontend/docs/pages/cookbooks/hatchet-and-mcp.mdx
+++ b/frontend/docs/pages/cookbooks/hatchet-and-mcp.mdx
@@ -1,0 +1,207 @@
+import { Callout, Steps, Tabs } from "nextra/components";
+import UniversalTabs from "@/components/UniversalTabs";
+import { snippets } from "@/lib/generated/snippets";
+import { Snippet } from "@/components/code";
+
+# Hatchet and MCP: Exposing Workflows as Agent Tools
+
+The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is an open standard for connecting AI agents to external tools, data sources, and services. This guide shows how to expose Hatchet [workflows](/v1/directed-acyclic-graphs) and [standalone tasks](/v1/tasks) as tools that frameworks like the Claude Agent SDK and OpenAI Agents SDK can invoke. Later cookbooks in this series will show how to integrate those tools into a full agent loop.
+
+In this guide, we define a Hatchet workflow and a standalone task, each with a description and a typed input schema, then convert each into an agent tool. When an agent invokes one of those tools, the tool handler submits work to the Hatchet engine. A worker picks up and executes the workflow or task and reports the result to Hatchet. The tool handler returns that result to the agent.
+
+## What this guide builds
+
+This guide builds a temperature lookup tool backed by Hatchet. The example calls the [Open-Meteo API](https://open-meteo.com/) and returns the current temperature for a given location. The same operation is implemented as both a workflow and a standalone task, so you can see how each becomes an agent tool.
+
+```mermaid
+flowchart LR
+    A[AI Agent] -->|invokes tool| B[Tool handler]
+    B -->|submits run via gRPC and waits| C[Hatchet Engine]
+    C -->|dispatches work| D[Hatchet Worker]
+    D -->|executes code| E[Workflow or task]
+    E -->|result| D
+    D -->|reports result| C
+    C -->|run result| B
+    B -->|tool result| A
+```
+
+The agent process contains the tool handler that submits the run, but it does not execute the workflow or task. Instead, a Hatchet worker executes the registered workflow or task and reports the result through Hatchet to the waiting tool handler. Since each tool call submits a run through Hatchet, the work the agent triggers gets the same observability and [core reliability guarantees](/v1/architecture-and-guarantees#core-reliability-guarantees) as any other Hatchet task or workflow.
+
+## Setup
+
+<Steps>
+
+### Prepare your environment
+
+To run this example, you need:
+
+- a working local Hatchet environment or access to [Hatchet Cloud](https://cloud.hatchet.run)
+- a Hatchet SDK example environment (see the [Quickstart](/v1/quickstart))
+
+Install the optional dependencies for the language and agent framework you plan to use:
+
+<UniversalTabs items={["Python", "Typescript"]}>
+  <Tabs.Tab title="Python">
+
+    Install the Hatchet SDK extra for your provider:
+
+    ```bash
+    pip install "hatchet-sdk[claude]"
+    ```
+
+    or:
+
+    ```bash
+    pip install "hatchet-sdk[openai]"
+    ```
+
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+
+    Zod v4 is required for input schema generation:
+
+    ```bash
+    npm install zod@^4.0.0
+    ```
+
+    Install the agent SDK for your provider:
+
+    ```bash
+    npm install @anthropic-ai/claude-agent-sdk
+    ```
+
+    or:
+
+    ```bash
+    npm install @openai/agents
+    ```
+
+  </Tabs.Tab>
+</UniversalTabs>
+
+### Define the models
+
+Start by defining the input and output types. The agent uses the input schema to understand what arguments the tool accepts.
+
+<UniversalTabs items={["Python", "Typescript"]}>
+  <Tabs.Tab title="Python">
+    <Snippet src={snippets.python.agent.workflows.models} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+    <Snippet src={snippets.typescript.agent.workflow.models} />
+  </Tabs.Tab>
+</UniversalTabs>
+
+In Python, Pydantic models or dataclasses define the schema. In TypeScript, Zod v4 schemas serve the same purpose and also generate the JSON Schema that agent frameworks require.
+
+### Define a workflow
+
+Agent tools need a description and an input validator. The description tells the agent when to use the tool. The input validator provides the schema for the tool arguments. Define the workflow with both so it can be exposed as an agent tool.
+
+<UniversalTabs items={["Python", "Typescript"]}>
+  <Tabs.Tab title="Python">
+    <Snippet src={snippets.python.agent.workflows.workflow_definition} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+    <Snippet src={snippets.typescript.agent.workflow.workflow_definition} />
+  </Tabs.Tab>
+</UniversalTabs>
+
+### Or expose a standalone task
+
+You can expose a standalone task the same way. This is useful when the agent tool maps to a single operation rather than a multi-step workflow.
+
+<UniversalTabs items={["Python", "Typescript"]}>
+  <Tabs.Tab title="Python">
+    <Snippet src={snippets.python.agent.workflows.standalone_task} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+    <Snippet src={snippets.typescript.agent.workflow.standalone_task} />
+  </Tabs.Tab>
+</UniversalTabs>
+
+### Create agent tools
+
+Create the tool in the process that runs your agent. The examples use helper functions around Hatchet's mcp tool conversion call so the workflow and task definitions can be imported without loading every optional provider SDK. Each helper returns a provider specific tool definition that the agent SDK can use. The description and input validator you added above become part of that tool definition, which is why they are required.
+
+<UniversalTabs items={["Python", "Typescript"]}>
+  <Tabs.Tab title="Python">
+    <Snippet src={snippets.python.agent.workflows.create_mcp_tools} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+    <Snippet src={snippets.typescript.agent.workflow.create_mcp_tools} />
+  </Tabs.Tab>
+</UniversalTabs>
+
+<Callout type="info">
+  The worker does not discover agent tools. It registers Hatchet workflows and
+  tasks normally. When the tool handler submits a run, Hatchet dispatches it to
+  a worker that registered the corresponding workflow or task.
+</Callout>
+
+### Register and start the worker
+
+The worker must be running for tools to function. When the agent calls a tool, the adapter submits work to the Hatchet engine, and the engine dispatches it to a worker for execution.
+
+<UniversalTabs items={["Python", "Typescript"]}>
+  <Tabs.Tab title="Python">
+    <Snippet src={snippets.python.agent.worker.all} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+    <Snippet src={snippets.typescript.agent.worker.all} />
+  </Tabs.Tab>
+</UniversalTabs>
+
+### Test it
+
+You can confirm that the workflow definitions and helper functions import successfully without requiring provider SDKs:
+
+<UniversalTabs items={["Python", "Typescript"]}>
+  <Tabs.Tab title="Python">
+
+    ```bash
+    cd sdks/python
+    poetry run python -c "from examples.agent.workflows import get_temperature_workflow, create_temperature_task_tool_claude; print('OK')"
+    ```
+
+  </Tabs.Tab>
+  <Tabs.Tab title="Typescript">
+
+    ```bash
+    cd sdks/typescript
+    pnpm exec tsc --noEmit
+    ```
+
+  </Tabs.Tab>
+</UniversalTabs>
+
+Full end-to-end validation with the Claude Agent SDK or OpenAI Agents SDK will be covered later in this series.
+
+</Steps>
+
+## Related Hatchet features
+
+Because each agent tool call submits a run through Hatchet, you can apply the same controls you use for other tasks and workflows:
+
+- **[Durable execution](/v1/durable-execution):** Hatchet tracks execution state durably so work can survive worker restarts and failures.
+- **[Configurable retries](/v1/error-handling):** Failed tasks can retry according to your workflow or task configuration.
+- **[Rate limits](/v1/rate-limits) and [concurrency control](/v1/concurrency):** Protect downstream systems from agent-driven bursts.
+- **[Observability](/v1/logging):** Inspect tool-triggered runs in the Hatchet dashboard with status, timing, logs, and [OpenTelemetry traces](/v1/opentelemetry).
+
+## Security considerations
+
+MCP is a protocol for exposing tools to agents. It is not a security boundary. Tools can represent arbitrary code execution and should be treated with appropriate caution. Do not rely on the agent prompt alone to enforce security rules.
+
+For production deployments:
+
+- Validate tool inputs at the workflow level before executing business logic.
+- Apply [rate limits](/v1/rate-limits) and [concurrency controls](/v1/concurrency) to prevent runaway tool invocations.
+- Use [additional metadata](/v1/additional-metadata) to track which agent session triggered each run.
+- Run workers with restricted permissions.
+- Use network policies to limit what workers can reach.
+- Use external sandbox providers when tools may execute untrusted code.
+
+<Callout type="info">
+  Hatchet does not provide native code sandboxing. If you need isolation between
+  the agent and the execution environment, that is an infrastructure decision.
+</Callout>

--- a/frontend/docs/pages/cookbooks/hatchet-and-mcp.mdx
+++ b/frontend/docs/pages/cookbooks/hatchet-and-mcp.mdx
@@ -207,16 +207,16 @@ To test the full round trip between the agent and the Hatchet-backed tool, start
 
     ```bash
     cd sdks/typescript
-    pnpm exec ts-node -r tsconfig-paths/register -P tsconfig.json src/v1/examples/agent/worker.ts
+    pnpm exec tsx -r tsconfig-paths/register src/v1/examples/agent/worker.ts
     ```
 
     In a second terminal, run the Claude or OpenAI agent example:
 
     ```bash
     cd sdks/typescript
-    pnpm exec ts-node -r tsconfig-paths/register -P tsconfig.json src/v1/examples/agent/agent-claude.ts
+    pnpm exec tsx -r tsconfig-paths/register src/v1/examples/agent/agent-claude.ts
     # or
-    pnpm exec ts-node -r tsconfig-paths/register -P tsconfig.json src/v1/examples/agent/agent-openai.ts
+    pnpm exec tsx -r tsconfig-paths/register src/v1/examples/agent/agent-openai.ts
     ```
 
   </Tabs.Tab>

--- a/frontend/docs/pages/cookbooks/index.mdx
+++ b/frontend/docs/pages/cookbooks/index.mdx
@@ -48,7 +48,7 @@ Build practical end-to-end workflows with Hatchet’s durable execution, event h
 Expose Hatchet workflows as tools for AI agents via MCP and agent SDKs.
 
 <Cards>
-  <Cards.Card title="Hatchet and MCP" href="/cookbooks/hatchet-and-mcp">
+  <Cards.Card title="Hatchet Agent Tools" href="/cookbooks/hatchet-and-mcp">
     Expose Hatchet workflows and tasks as MCP-compatible agent tools with
     durable execution, retries, and observability behind every tool call.
   </Cards.Card>

--- a/frontend/docs/pages/cookbooks/index.mdx
+++ b/frontend/docs/pages/cookbooks/index.mdx
@@ -42,3 +42,14 @@ Build practical end-to-end workflows with Hatchet’s durable execution, event h
     summarizes the content.
   </Cards.Card>
 </Cards>
+
+## Agent Patterns
+
+Expose Hatchet workflows as tools for AI agents via MCP and agent SDKs.
+
+<Cards>
+  <Cards.Card title="Hatchet and MCP" href="/cookbooks/hatchet-and-mcp">
+    Expose Hatchet workflows and tasks as MCP-compatible agent tools with
+    durable execution, retries, and observability behind every tool call.
+  </Cards.Card>
+</Cards>

--- a/frontend/docs/scripts/test-search-quality.ts
+++ b/frontend/docs/scripts/test-search-quality.ts
@@ -82,7 +82,7 @@ const TEST_CASES: SearchTestCase[] = [
     name: "setup",
     query: "setup",
     expectAnyOf: ["v1/quickstart", "reference/cli/index", "reference/cli"],
-    topN: 10,
+    topN: 15,
   },
   {
     name: "getting started",

--- a/sdks/python/examples/agent/agent_claude.py
+++ b/sdks/python/examples/agent/agent_claude.py
@@ -5,22 +5,22 @@ from claude_agent_sdk import (
     query,
     ResultMessage,
 )
-from examples.agent.workflows import temperature_tool_claude
+from examples.agent.workflows import create_temperature_workflow_tool_claude
 
 
 async def main() -> None:
+    temperature_tool = create_temperature_workflow_tool_claude()
+
     # Wrap the tool in an in-process MCP server
     weather_server = create_sdk_mcp_server(
         name="weather",
         version="1.0.0",
-        tools=[temperature_tool_claude],
+        tools=[temperature_tool],
     )
 
     options = ClaudeAgentOptions(
         mcp_servers={"weather": weather_server},
-        allowed_tools=[
-            f"mcp__{weather_server['name']}__{temperature_tool_claude.name}"
-        ],
+        allowed_tools=[f"mcp__{weather_server['name']}__{temperature_tool.name}"],
     )
 
     async for message in query(

--- a/sdks/python/examples/agent/agent_openai.py
+++ b/sdks/python/examples/agent/agent_openai.py
@@ -1,13 +1,15 @@
 import asyncio
 
 from agents import Agent, Runner
-from examples.agent.workflows import temperature_tool_openai
+from examples.agent.workflows import create_temperature_workflow_tool_openai
 
 
 async def main() -> None:
+    temperature_tool = create_temperature_workflow_tool_openai()
+
     agent = Agent(
         name="Assistant",
-        tools=[temperature_tool_openai],
+        tools=[temperature_tool],
     )
     result = await Runner.run(agent, "What's the temperature in San Francisco?")
     print(result.final_output)

--- a/sdks/python/examples/agent/workflows.py
+++ b/sdks/python/examples/agent/workflows.py
@@ -1,4 +1,6 @@
 # > Agent
+from typing import Any
+
 import httpx
 from pydantic import BaseModel
 
@@ -86,19 +88,19 @@ async def get_temperature_standalone(
 
 
 # > Create MCP tools
-def create_temperature_workflow_tool_claude():
+def create_temperature_workflow_tool_claude() -> Any:
     return get_temperature_workflow.mcp_tool(MCPProvider.CLAUDE)
 
 
-def create_temperature_workflow_tool_openai():
+def create_temperature_workflow_tool_openai() -> Any:
     return get_temperature_workflow.mcp_tool(MCPProvider.OPENAI)
 
 
-def create_temperature_task_tool_claude():
+def create_temperature_task_tool_claude() -> Any:
     return get_temperature_standalone.mcp_tool(MCPProvider.CLAUDE)
 
 
-def create_temperature_task_tool_openai():
+def create_temperature_task_tool_openai() -> Any:
     return get_temperature_standalone.mcp_tool(MCPProvider.OPENAI)
 
 

--- a/sdks/python/examples/agent/workflows.py
+++ b/sdks/python/examples/agent/workflows.py
@@ -6,8 +6,10 @@ from hatchet_sdk import Context, Hatchet
 from hatchet_sdk.runnables.workflow import MCPProvider
 
 hatchet = Hatchet(debug=True)
+# !!
 
 
+# > Models
 class TemperatureCoords(BaseModel):
     latitude: float
     longitude: float
@@ -22,6 +24,10 @@ class TemperatureContent(BaseModel):
     text: str
 
 
+# !!
+
+
+# > Workflow definition
 get_temperature_workflow = hatchet.workflow(
     name="get_temperature",
     input_validator=TemperatureInput,
@@ -51,6 +57,7 @@ async def get_temperature(input: TemperatureInput, ctx: Context) -> TemperatureC
 # !!
 
 
+# > Standalone task
 @hatchet.task(
     input_validator=TemperatureInput,
     description="Get the current temperature at a location",
@@ -75,16 +82,24 @@ async def get_temperature_standalone(
     )
 
 
-# You can use a workflow
-temperature_tool_claude = get_temperature_workflow.mcp_tool(MCPProvider.CLAUDE)
+# !!
 
-temperature_tool_openai = get_temperature_workflow.mcp_tool(
-    MCPProvider.OPENAI,
-)
 
-# Or a standalone task
-temperature_tool_claude = get_temperature_standalone.mcp_tool(MCPProvider.CLAUDE)
+# > Create MCP tools
+def create_temperature_workflow_tool_claude():
+    return get_temperature_workflow.mcp_tool(MCPProvider.CLAUDE)
 
-temperature_tool_openai = get_temperature_standalone.mcp_tool(
-    MCPProvider.OPENAI,
-)
+
+def create_temperature_workflow_tool_openai():
+    return get_temperature_workflow.mcp_tool(MCPProvider.OPENAI)
+
+
+def create_temperature_task_tool_claude():
+    return get_temperature_standalone.mcp_tool(MCPProvider.CLAUDE)
+
+
+def create_temperature_task_tool_openai():
+    return get_temperature_standalone.mcp_tool(MCPProvider.OPENAI)
+
+
+# !!

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Hatchet's TypeScript SDK will be documented in this chang
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.4] - 2026-05-22
+
+### Fixed
+
+- Bumped `@anthropic-ai/claude-agent-sdk` to `^0.3.148` so Claude agent SDK integrations resolve the correct Linux native binary on glibc systems.
+- Updated the TypeScript Claude agent example to load the ESM-only Claude Agent SDK dynamically.
+
 ## [1.22.3] - 2026-05-18
 
 ### Fixed

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "1.22.3",
+  "version": "1.22.4",
   "description": "Background task orchestration & visibility for developers",
   "types": "dist/index.d.ts",
   "files": [

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -64,7 +64,7 @@
     "ts-proto": "^2.11.4",
     "tsconfig-paths": "^4.2.0",
     "tsx": "^4.21.0",
-    "@anthropic-ai/claude-agent-sdk": "^0.2.87",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.148",
     "@grpc/grpc-js": "^1.14.3",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@openai/agents": "0.11.3",
@@ -96,7 +96,7 @@
   },
   "peerDependencies": {
     "zod": "^3.25.0 || ^4.0.0",
-    "@anthropic-ai/claude-agent-sdk": "^0.2.87",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.148",
     "@grpc/grpc-js": "^1.14.3",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@openai/agents": "0.11.3",

--- a/sdks/typescript/pnpm-lock.yaml
+++ b/sdks/typescript/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         version: 3.25.2(zod@4.4.3)
     devDependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.87
-        version: 0.2.141(zod@4.4.3)
+        specifier: ^0.3.148
+        version: 0.3.148(@anthropic-ai/sdk@0.91.1(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.3.0)
@@ -170,54 +170,52 @@ importers:
 
 packages:
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.141':
-    resolution: {integrity: sha512-9HZ0ot6+FwOfQ1aeMqQLH4IJGMm/DcP08SysDxscVjBm6l2JjqleHohxi3zid0DurfGweqT+4x9GScJffwg55g==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.148':
+    resolution: {integrity: sha512-DNkhbT0Jiqo5iM+9HmejIg2eJVFQyvq2SC9h6iqOQSGRkFrbP1FN7rJpflHMb1nb3sAHZzjaDc5/tTczy5H3/Q==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.141':
-    resolution: {integrity: sha512-4iAdarJaQ+2R58s6QJswZCzUdz2WQmL5lYG7Y+FLzWbRSROFfcH0QYpmOqSaPXd2KRQhIJwEacqecDZd/Q1XKQ==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.148':
+    resolution: {integrity: sha512-bN5eu5wV+7Wu/LJgVwW6rhkd/y0cxk5xDujPelsAdHYSSrKDU/VPGuVcX8xA8PWgaag4pjKuXYTm1CHevB09ew==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.141':
-    resolution: {integrity: sha512-6H1AJ/AVaWNnV22kubUPkOTRzZFH0+qP9k7WlhriHMN9gtgZcVAsITMddDeGjQsQJMCAdhXFd6sgi7TM1LdeOQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.148':
+    resolution: {integrity: sha512-6BYRuSyKzEPWXWjkXIQkWaOa+9z1FHEMcB+lHUZ3jf+aaEAqTomHiZrsF8nGF5rKSp79TjiZWoJNs225x/k4eQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.141':
-    resolution: {integrity: sha512-Jdf0ZEwJzOP8sE6rPqdJN+SxMb0/L8sxJg4twCv/7S+Qzk0hJtls+wxSi+0Tjh6EEMaNxJqEGc7S3fx99Wi99Q==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.148':
+    resolution: {integrity: sha512-gCJBxAXt4Av8Y9PWmdVidnv83TZtPM7DpI5YqQ3G3gVyp/5S203XcaDta0vPjeMa595Dca6a8XIY/Xq3bcxjhA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.141':
-    resolution: {integrity: sha512-fTI1YuM4cxOa4nSgsyMAdB5ELizkWp+w5Ispo4JnnYtcczMAL4D9GBNjWPW0sUzKvjsJOUVim68SmWLWhUOpXQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.148':
+    resolution: {integrity: sha512-dKWZYKCPXCYzP1CknqXzC4QaIuM+3YnCIHZ8Th0WMRHfSIisqAyrrXl42x4nPD7z5gnVwFwBmQ63pyhOxbMQRQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.141':
-    resolution: {integrity: sha512-DVjp72f3HmrRYpbneWZZWIqkUht5kTZXS7wXGFiwzLz6eNYEgjjh+GcsnhIi8UOwZUtNiKUrjZnoP38ovFqV8A==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.148':
+    resolution: {integrity: sha512-SDjTBE8WismSmWxHFLciPaE+mQBAuwsBqbI5LvRXwYi8Ig/8D+1FElSRt1VyXkEkIzSyGzgTxusc8p07z8edIA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.141':
-    resolution: {integrity: sha512-Wm10J6kfbufbPGFELokiJ/7Y5Oqug4Uag3HXFsV8g7TWCpaItx/oqVaJoiGptuAtXQB7xGLQVTuk082wER+Y5w==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.148':
+    resolution: {integrity: sha512-4+JXXrWXGNIgzbhGQ45Wx6VRXhY22EU70Y9XCb0ju2SRDDZbjNn8vAFUFDSFxxMXGbo9PDlc0LTU62U8CqyYiA==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.141':
-    resolution: {integrity: sha512-IXuP29YJuWbR5Q6xOHrjFVGG54V2s1FC61UVNwEN5fpxL09MwPnbwtQL6fqgzt/U1MP7vWAwpXZriYAklkH/mg==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.148':
+    resolution: {integrity: sha512-592gVLIKVVFWQkOMIlfJF7r2ofzB9dRuG8xEx2pzh2QvRL4E0agP7qLSmiqBHAXkJL5vSLQff/wmBoQPFFc8rg==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.2.141':
-    resolution: {integrity: sha512-AIBacMWGcZIUcXlUoObqjwJ6pmJI3BayAqPAFXuvSq3DHJXdiuZVs7l/zTB5l3nRhRv5cqSrI2XbiDeHgZWizw==}
+  '@anthropic-ai/claude-agent-sdk@0.3.148':
+    resolution: {integrity: sha512-S+KsA5ssz8/GJYjU3HqbGHq1ve75hKlRcd0JZRMQAjLI5G+VH2wJ74Yo7ZC8Q7ZrKVcZJwdLnio5o2zntKw/7w==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
+      '@anthropic-ai/sdk': ^0.91.1
+      '@modelcontextprotocol/sdk': ^1.29.0
       zod: ^4.0.0
 
   '@anthropic-ai/sdk@0.91.1':
@@ -1118,49 +1116,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3034,47 +3024,44 @@ packages:
 
 snapshots:
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.141':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.148':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.141':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.148':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.141':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.148':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.141':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.148':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.141':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.148':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.141':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.148':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.141':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.148':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.141':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.148':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.2.141(zod@4.4.3)':
+  '@anthropic-ai/claude-agent-sdk@0.3.148(@anthropic-ai/sdk@0.91.1(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.141
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.141
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.141
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.141
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.141
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.141
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.141
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.141
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.148
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.148
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.148
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.148
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.148
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.148
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.148
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.148
 
   '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
     dependencies:

--- a/sdks/typescript/src/v1/examples/agent/agent-claude.ts
+++ b/sdks/typescript/src/v1/examples/agent/agent-claude.ts
@@ -1,14 +1,10 @@
 // eslint-disable-next-line
-import { getTemperature, getTemperatureWorkflow } from './workflow';
+import { createTemperatureWorkflowToolClaude } from './workflow';
 import { query } from '@anthropic-ai/claude-agent-sdk';
 import { createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
 
 async function main() {
-  // Generate a tool from a standalone task
-  // const temperatureTool = getTemperature.mcpTool('claude');
-
-  // Or from a workflow
-  const temperatureTool = getTemperatureWorkflow.mcpTool('claude');
+  const temperatureTool = createTemperatureWorkflowToolClaude();
 
   // Wrap the tool in an in-process MCP server
   const weatherServer = createSdkMcpServer({

--- a/sdks/typescript/src/v1/examples/agent/agent-claude.ts
+++ b/sdks/typescript/src/v1/examples/agent/agent-claude.ts
@@ -1,10 +1,12 @@
 // eslint-disable-next-line
 import { createTemperatureWorkflowToolClaude } from './workflow';
-import { query } from '@anthropic-ai/claude-agent-sdk';
-import { createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
 
 async function main() {
   const temperatureTool = createTemperatureWorkflowToolClaude();
+
+  // The Claude Agent SDK is ESM-only, so avoid loading it at module import time.
+  // Run this example with an ESM-compatible TypeScript runner.
+  const { query, createSdkMcpServer } = await import('@anthropic-ai/claude-agent-sdk');
 
   // Wrap the tool in an in-process MCP server
   const weatherServer = createSdkMcpServer({

--- a/sdks/typescript/src/v1/examples/agent/agent-openai.ts
+++ b/sdks/typescript/src/v1/examples/agent/agent-openai.ts
@@ -1,14 +1,10 @@
 // eslint-disable-next-line
-import { getTemperature, getTemperatureWorkflow } from './workflow';
+import { createTemperatureWorkflowToolOpenai } from './workflow';
 
 async function main() {
-  // Generate a tool from a standalone task
-  // const temperatureTool = getTemperature.mcpTool('openai');
-
-  // Or from a workflow.
   // mcpTool validates Zod v4 is installed before loading @openai/agents, so call it first
   // to get a clear error message if the wrong Zod version is present.
-  const temperatureTool = getTemperatureWorkflow.mcpTool('openai');
+  const temperatureTool = createTemperatureWorkflowToolOpenai();
 
   // Dynamic import — @openai/agents crashes at load time with Zod v3, so we delay
   // the import until after mcpTool has already verified Zod v4 is available.

--- a/sdks/typescript/src/v1/examples/agent/workflow.ts
+++ b/sdks/typescript/src/v1/examples/agent/workflow.ts
@@ -1,8 +1,8 @@
-// > Declaring a Task
 import { hatchet } from '../hatchet-client';
 import { z } from 'zod/v4';
 
-// Note that for agent tools, Zod must be used to create the input and output types for workflows/tasks
+// > Models
+// Agent tools require a Zod v4 inputValidator so the SDK can generate the tool input schema.
 const TemperatureCoordinates = z.object({
   latitude: z.number(),
   longitude: z.number(),
@@ -14,6 +14,7 @@ const TemperatureInput = z.object({
 });
 
 export type TemperatureInputWithZod = z.infer<typeof TemperatureInput>;
+// !!
 
 const temperatureRequest = async (input: TemperatureInputWithZod) => {
   const response = await fetch(
@@ -22,10 +23,11 @@ const temperatureRequest = async (input: TemperatureInputWithZod) => {
   const data: any = await response.json();
 
   return {
-    text: `Temperature: ${data.current.temperature_2m}°F`,
+    text: `Temperature in ${input.locationName}: ${data.current.temperature_2m}°F`,
   };
 };
 
+// > Standalone task
 export const getTemperature = hatchet.task({
   name: 'getTemperature',
   retries: 3,
@@ -33,7 +35,9 @@ export const getTemperature = hatchet.task({
   inputValidator: TemperatureInput,
   description: 'Get the current temperature at a location',
 });
+// !!
 
+// > Workflow definition
 export const getTemperatureWorkflow = hatchet.workflow<TemperatureInputWithZod>({
   name: 'getTemperatureWorkflow',
   inputValidator: TemperatureInput,
@@ -44,5 +48,22 @@ getTemperatureWorkflow.task({
   name: 'getTemperature',
   fn: temperatureRequest,
 });
+// !!
 
+// > Create MCP tools
+export function createTemperatureWorkflowToolClaude() {
+  return getTemperatureWorkflow.mcpTool('claude');
+}
+
+export function createTemperatureWorkflowToolOpenai() {
+  return getTemperatureWorkflow.mcpTool('openai');
+}
+
+export function createTemperatureTaskToolClaude() {
+  return getTemperature.mcpTool('claude');
+}
+
+export function createTemperatureTaskToolOpenai() {
+  return getTemperature.mcpTool('openai');
+}
 // !!

--- a/sdks/typescript/src/v1/examples/agent/workflow.ts
+++ b/sdks/typescript/src/v1/examples/agent/workflow.ts
@@ -27,16 +27,6 @@ const temperatureRequest = async (input: TemperatureInputWithZod) => {
   };
 };
 
-// > Standalone task
-export const getTemperature = hatchet.task({
-  name: 'getTemperature',
-  retries: 3,
-  fn: temperatureRequest,
-  inputValidator: TemperatureInput,
-  description: 'Get the current temperature at a location',
-});
-// !!
-
 // > Workflow definition
 export const getTemperatureWorkflow = hatchet.workflow<TemperatureInputWithZod>({
   name: 'getTemperatureWorkflow',
@@ -47,6 +37,16 @@ export const getTemperatureWorkflow = hatchet.workflow<TemperatureInputWithZod>(
 getTemperatureWorkflow.task({
   name: 'getTemperature',
   fn: temperatureRequest,
+});
+// !!
+
+// > Standalone task
+export const getTemperature = hatchet.task({
+  name: 'getTemperature',
+  retries: 3,
+  fn: temperatureRequest,
+  inputValidator: TemperatureInput,
+  description: 'Get the current temperature at a location',
 });
 // !!
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Adds a new Agent Patterns cookbook: **Hatchet and MCP: Exposing Tasks and Workflows as Agent Tools**.

The cookbook shows how to expose Hatchet workflows and standalone tasks as agent tools for Claude and OpenAI agent SDK integrations. It covers the execution model, tool creation, worker registration, import validation, related Hatchet features, and security considerations. This also updates the existing Python and TypeScript agent examples to use lazy helper functions for provider-specific tool creation, so workflow and task definitions can be imported without requiring every optional provider SDK dependency to be installed.

Fixes # N/A

## Type of change

- [x] Documentation change (pure documentation change)
- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)

## What's Changed

- [x] Added a new `hatchet-and-mcp` cookbook under Agent Patterns.
- [x] Added cookbook navigation and index card entries for Hatchet Agent Tools.
- [x] Added Python and TypeScript snippets for models, workflow definition, standalone task definition, and agent tool creation.
- [x] Updated Python agent examples to create provider-specific tools lazily inside the agent process.
- [x] Updated TypeScript agent examples to use lazy helper functions consistently.
- [x] Added import and typecheck validation commands for the example.
- [x] Added security guidance around MCP, prompt-only rules, rate limits, metadata, worker isolation, and sandboxing.

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)

## Testing

Validated with:

```bash
# Python import validation without provider extras
cd sdks/python
poetry run python -c "from examples.agent.workflows import create_temperature_workflow_tool_claude, create_temperature_task_tool_claude; print('OK')"

# TypeScript typecheck
cd sdks/typescript
pnpm exec tsc --noEmit

# Docs formatting
cd frontend/docs
pnpm lint:fix
```

I regenerated snippets and confirmed the new Python and TypeScript snippet keys are available. I also manually verified all included links.

## Related

This is the first cookbook in the planned Agent/MCP cookbook series.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

* [x] *I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md).*

<!-- Please specify the tooling/model and the extent to which it was used. -->

* **Details**: LLMs were used for research assistance, source/doc inspection planning, validation, and review suggestions. The final cookbook prose, structure, security framing, and example changes were manually written, reviewed, and edited before submission.

</details>