### PR TITLE
Fix: Hide github tab if managed workers are disabled

### DIFF
--- a/frontend/app/src/pages/main/v1/tenant-settings/integrations/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/integrations/index.tsx
@@ -53,12 +53,13 @@ import { ReactNode, useMemo, useState } from 'react';
 import invariant from 'tiny-invariant';
 
 export default function Integrations() {
-  const { cloud } = useCloud();
+  const { cloud, featureFlags } = useCloud();
   const integrations = useApiMetaIntegrations();
 
   const hasEmailIntegration = integrations?.find((i) => i.name === 'email');
   const hasSlackIntegration = integrations?.find((i) => i.name === 'slack');
   const hasGithubIntegration = cloud?.canLinkGithub;
+  const managedWorkerEnabled = featureFlags?.['managed-worker'] === 'true';
 
   return (
     <div className="h-full w-full flex-grow">
@@ -76,7 +77,7 @@ export default function Integrations() {
             <TabsTrigger value="ingestors" variant="underlined">
               Ingestors
             </TabsTrigger>
-            {hasGithubIntegration && (
+            {hasGithubIntegration && managedWorkerEnabled && (
               <TabsTrigger value="github" variant="underlined">
                 GitHub
               </TabsTrigger>


### PR DESCRIPTION
# Description

Hides the GitHub integration tab if managed workers are disabled

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)


<details id="ai-disclosure">
No AI used in this PR

</details>
