### PR TITLE
docs: add Tuning Engines TypeScript workflow example

### DIFF
--- a/examples/typescript/tuning-engines/README.md
+++ b/examples/typescript/tuning-engines/README.md
@@ -1,0 +1,24 @@
+# Tuning Engines governed AI workflow
+
+This example shows how to call a Tuning Engines OpenAI-compatible endpoint from
+a Hatchet TypeScript workflow. Hatchet owns durable execution, workers, retries,
+and workflow state. Tuning Engines owns governed model access, policy checks,
+budgets, audit logs, and runtime trace correlation.
+
+## Environment
+
+Set your Hatchet variables as usual, plus:
+
+```bash
+export TE_INFERENCE_KEY=sk-te-your-inference-key
+export TE_MODEL=auto
+```
+
+## Files
+
+- `workflow.ts` defines a workflow task that calls the governed AI endpoint.
+- `worker.ts` starts a Hatchet worker for the workflow.
+- `run.ts` triggers the workflow with a sample prompt.
+
+Use the Hatchet run id or your own workflow correlation id as the Tuning Engines
+`run_id` so usage, policy decisions, approvals, and traces can be correlated.

--- a/examples/typescript/tuning-engines/run.ts
+++ b/examples/typescript/tuning-engines/run.ts
@@ -1,0 +1,17 @@
+import { tuningEnginesWorkflow } from './workflow';
+
+async function main() {
+  const result = await tuningEnginesWorkflow.run({
+    prompt: 'Summarize why durable workflow retries are useful for AI tasks.',
+  });
+
+  console.log(result['governed-model-call']);
+}
+
+if (require.main === module) {
+  main()
+    .catch(console.error)
+    .finally(() => {
+      process.exit(0);
+    });
+}

--- a/examples/typescript/tuning-engines/worker.ts
+++ b/examples/typescript/tuning-engines/worker.ts
@@ -1,0 +1,14 @@
+import { hatchet } from '../hatchet-client';
+import { tuningEnginesWorkflow } from './workflow';
+
+async function main() {
+  const worker = await hatchet.worker('tuning-engines-worker', {
+    workflows: [tuningEnginesWorkflow],
+  });
+
+  await worker.start();
+}
+
+if (require.main === module) {
+  main();
+}

--- a/examples/typescript/tuning-engines/workflow.ts
+++ b/examples/typescript/tuning-engines/workflow.ts
@@ -1,0 +1,53 @@
+import { randomUUID } from 'crypto';
+
+import { hatchet } from '../hatchet-client';
+
+type Input = {
+  prompt: string;
+  runId?: string;
+};
+
+type Output = {
+  'governed-model-call': {
+    runId: string;
+    response: any;
+  };
+};
+
+export const tuningEnginesWorkflow = hatchet.workflow<Input, Output>({
+  name: 'tuning-engines-governed-ai',
+});
+
+tuningEnginesWorkflow.task({
+  name: 'governed-model-call',
+  fn: async (input) => {
+    const runId = input.runId || randomUUID();
+    const response = await fetch('https://api.tuningengines.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.TE_INFERENCE_KEY}`,
+        'Content-Type': 'application/json',
+        'X-TE-Run-ID': runId,
+      },
+      body: JSON.stringify({
+        model: process.env.TE_MODEL || 'auto',
+        messages: [{ role: 'user', content: input.prompt }],
+        metadata: {
+          run_id: runId,
+          request_id: randomUUID(),
+          runtime: 'hatchet',
+          event_type: 'model.call',
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Tuning Engines request failed: ${response.status}`);
+    }
+
+    return {
+      runId,
+      response: await response.json(),
+    };
+  },
+});


### PR DESCRIPTION
## Summary
- Add a TypeScript example workflow that calls Tuning Engines as a governed AI endpoint from a Hatchet task.
- Include README, worker, run script, and workflow files.
- Uses placeholder environment variables only.

## Testing
- git diff --check

No SDK or runtime code changed.