### PR TITLE
fix: gate managed worker pages

### DIFF
--- a/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/index.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/$managed-worker/index.tsx
@@ -1,3 +1,4 @@
+import { ManagedWorkersGate } from '../components/managed-workers-gate';
 import GithubButton from './components/github-button';
 import { ManagedWorkerActivity } from './components/managed-worker-activity';
 import { ManagedWorkerInstancesTable } from './components/managed-worker-instances-table';
@@ -30,7 +31,7 @@ import { useNavigate, useParams } from '@tanstack/react-router';
 import { isAxiosError } from 'axios';
 import { useState } from 'react';
 
-export default function ExpandedWorkflow() {
+function ExpandedWorkflowImpl() {
   const navigate = useNavigate();
   const [deleteWorker, setDeleteWorker] = useState(false);
   const { tenantId } = useCurrentTenantId();
@@ -215,5 +216,13 @@ export default function ExpandedWorkflow() {
         </Tabs>
       </div>
     </div>
+  );
+}
+
+export default function ExpandedWorkflow() {
+  return (
+    <ManagedWorkersGate>
+      <ExpandedWorkflowImpl />
+    </ManagedWorkersGate>
   );
 }

--- a/frontend/app/src/pages/main/v1/managed-workers/components/managed-workers-gate.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/components/managed-workers-gate.tsx
@@ -1,0 +1,65 @@
+import { Button } from '@/components/v1/ui/button';
+import useCloud from '@/hooks/use-cloud';
+import { ErrorPageLayout } from '@/pages/error/components/layout';
+import { appRoutes } from '@/router';
+import { useParams } from '@tanstack/react-router';
+import { Cloud, LifeBuoy, Mail, Undo2 } from 'lucide-react';
+import { PropsWithChildren } from 'react';
+
+export function ManagedWorkersGate({ children }: PropsWithChildren) {
+  const params = useParams({ from: appRoutes.tenantRoute.to });
+  const { cloud, featureFlags, isCloudEnabled } = useCloud(params.tenant);
+  const managedWorkerEnabled = featureFlags?.['managed-worker'] === 'true';
+
+  if (isCloudEnabled && !cloud) {
+    return null;
+  }
+
+  if (managedWorkerEnabled) {
+    return <>{children}</>;
+  }
+
+  if (!isCloudEnabled) {
+    return (
+      <ErrorPageLayout
+        icon={<Cloud className="h-5 w-5" />}
+        title="Managed Workers is not available"
+        description="Managed Workers are only available in Hatchet Cloud."
+        actions={
+          <Button
+            leftIcon={<Undo2 className="h-4 w-4" />}
+            variant="outline"
+            onClick={() => window.history.back()}
+          >
+            Go back
+          </Button>
+        }
+      />
+    );
+  }
+
+  return (
+    <ErrorPageLayout
+      icon={<LifeBuoy className="h-5 w-5" />}
+      title="Managed Workers not enabled"
+      description="Managed Workers aren't enabled for your tenant. Contact support for more information."
+      actions={
+        <>
+          <Button
+            leftIcon={<Mail className="h-4 w-4" />}
+            onClick={() => window.open('mailto:support@hatchet.run', '_blank')}
+          >
+            Contact us
+          </Button>
+          <Button
+            leftIcon={<Undo2 className="h-4 w-4" />}
+            variant="outline"
+            onClick={() => window.history.back()}
+          >
+            Go back
+          </Button>
+        </>
+      }
+    />
+  );
+}

--- a/frontend/app/src/pages/main/v1/managed-workers/create/index.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/create/index.tsx
@@ -1,4 +1,5 @@
 import { BillingRequired } from '../components/billing-required';
+import { ManagedWorkersGate } from '../components/managed-workers-gate';
 import CreateWorkerForm from './components/create-worker-form';
 import { Separator } from '@/components/v1/ui/separator';
 import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
@@ -13,7 +14,7 @@ import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 
-export default function CreateWorker() {
+function CreateWorkerImpl() {
   const navigate = useNavigate();
   const { tenant, billing, can } = useTenantDetails();
   const { tenantId } = useCurrentTenantId();
@@ -90,5 +91,13 @@ export default function CreateWorker() {
         />
       </div>
     </div>
+  );
+}
+
+export default function CreateWorker() {
+  return (
+    <ManagedWorkersGate>
+      <CreateWorkerImpl />
+    </ManagedWorkersGate>
   );
 }

--- a/frontend/app/src/pages/main/v1/managed-workers/demo-template/index.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/demo-template/index.tsx
@@ -1,3 +1,4 @@
+import { ManagedWorkersGate } from '../components/managed-workers-gate';
 import { Button } from '@/components/v1/ui/button';
 import { Card } from '@/components/v1/ui/card';
 import { CodeHighlighter } from '@/components/v1/ui/code-highlighter';
@@ -32,7 +33,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { useState, useEffect, useCallback } from 'react';
 
-export default function DemoTemplate() {
+function DemoTemplateImpl() {
   const { tenantId } = useCurrentTenantId();
   const [deploying, setDeploying] = useState(false);
   const [deployed, setDeployed] = useState(false);
@@ -933,5 +934,13 @@ func main() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function DemoTemplate() {
+  return (
+    <ManagedWorkersGate>
+      <DemoTemplateImpl />
+    </ManagedWorkersGate>
   );
 }

--- a/frontend/app/src/pages/main/v1/managed-workers/index.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/index.tsx
@@ -1,4 +1,5 @@
 import { BillingRequired } from './components/billing-required';
+import { ManagedWorkersGate } from './components/managed-workers-gate';
 import { ManagedWorkersTable } from './components/managed-workers-table';
 import { MonthlyUsageCard } from './components/monthly-usage-card';
 import { Button } from '@/components/v1/ui/button';
@@ -16,7 +17,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 
-export default function ManagedWorkers() {
+function ManagedWorkersImpl() {
   const { tenant, billing, can } = useTenantDetails();
   const { tenantId } = useCurrentTenantId();
 
@@ -196,5 +197,13 @@ export default function ManagedWorkers() {
       </div>
       <UpgradeModal />
     </div>
+  );
+}
+
+export default function ManagedWorkers() {
+  return (
+    <ManagedWorkersGate>
+      <ManagedWorkersImpl />
+    </ManagedWorkersGate>
   );
 }


### PR DESCRIPTION
# Description

Adds a shared gate for managed worker pages so self-hosted deployments and cloud tenants without the managed worker feature enabled see an explanatory fallback instead of rendering pages that call cloud-only APIs.

Fixes #3896

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [x] Added a shared `ManagedWorkersGate` for managed worker routes.
- [x] Added fallback messaging for self-hosted deployments where managed workers are unavailable.
- [x] Added fallback messaging for cloud tenants where the managed worker feature flag is disabled.
- [x] Wrapped the managed worker list, create, demo template, and detail pages with the gate.

## Checklist

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

- Ran `task fmt-app`
- Checked IDE lints for edited files
- `pnpm --dir frontend/app run typecheck` fails because `cypress/support/seeded-users.generated` is missing in existing Cypress files, unrelated to this change.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Assisted with implementing the managed worker gate, applying review feedback, and drafting the PR description.

</details>