### PR TITLE
Skip cookie session creation for bearer requests

### DIFF
--- a/pkg/auth/cookie/sessionstore.go
+++ b/pkg/auth/cookie/sessionstore.go
@@ -215,6 +215,10 @@ func (store *UserSessionStore) Get(r *http.Request, name string) (*sessions.Sess
 func (store *UserSessionStore) Save(r *http.Request, w http.ResponseWriter, session *sessions.Session) error {
 	repo := store.repo
 
+	if isBearerAuthenticatedRequest(r) && session.IsNew && session.ID == "" {
+		return nil
+	}
+
 	if session.Options.MaxAge < 0 {
 		if session.ID != "" {
 			sessionID, parseErr := uuid.Parse(session.ID)
@@ -250,6 +254,10 @@ func (store *UserSessionStore) Save(r *http.Request, w http.ResponseWriter, sess
 
 	http.SetCookie(w, sessions.NewCookie(session.Name(), encoded, session.Options))
 	return nil
+}
+
+func isBearerAuthenticatedRequest(r *http.Request) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(r.Header.Get("Authorization"))), "bearer ")
 }
 
 // save writes encoded session.Values to a database record.

--- a/pkg/auth/cookie/sessionstore_test.go
+++ b/pkg/auth/cookie/sessionstore_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hatchet-dev/hatchet/pkg/auth/cookie"
 	"github.com/hatchet-dev/hatchet/pkg/config/database"
 	"github.com/hatchet-dev/hatchet/pkg/random"
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 )
 
 func TestSessionStoreSave(t *testing.T) {
@@ -34,6 +35,46 @@ func TestSessionStoreSave(t *testing.T) {
 		assert.Equal(t, "/", httpCookie.Path, "path is index")
 		assert.Equal(t, true, httpCookie.Secure, "cookie is secure")
 		assert.Equal(t, "hatchet.run", httpCookie.Domain, "domain is hatchet.run")
+
+		return nil
+	})
+}
+
+func TestSessionStoreSkipsNewSessionForBearerRequest(t *testing.T) {
+	t.Setenv("SERVER_MSGQUEUE_RABBITMQ_URL", "amqp://user:password@localhost:5672/")
+
+	time.Sleep(10 * time.Second) // TODO temp hack for tenant non-upsert issue
+	testutils.RunTestWithDatabase(t, func(conf *database.Layer) error {
+		const cookieName = "hatchet"
+
+		var createdSessions int
+		conf.V1.UserSession().RegisterCreateCallback(func(_ *sqlcv1.UserSession) {
+			createdSessions++
+		})
+
+		ss := newSessionStore(t, conf, cookieName)
+
+		req, err := http.NewRequest("GET", "https://hatchet.run", nil)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Authorization", "Bearer test-token")
+
+		session, err := ss.Get(req, cookieName)
+		if err != nil {
+			return err
+		}
+
+		session.Values["custom_data"] = "bearer-request"
+
+		rr := httptest.NewRecorder()
+		if err := ss.Save(req, rr, session); err != nil {
+			return err
+		}
+
+		assert.Empty(t, session.ID)
+		assert.Empty(t, rr.Result().Header.Values("Set-Cookie"))
+		assert.Equal(t, 0, createdSessions)
 
 		return nil
 	})


### PR DESCRIPTION
## Summary
- skip DB-backed cookie session creation for new requests authenticated with an `Authorization: Bearer ...` header
- avoid emitting a `Set-Cookie` header for those bearer-only requests
- add integration coverage that verifies bearer requests do not create `UserSession` rows

## Why
This addresses #3913. Bearer-authenticated SDK/worker REST traffic can pass through the cookie session store with no existing browser cookie. Before this change, `Save` generated a new anonymous `UserSession` row and cookie for that request, which can grow the `UserSession` table at API-call volume in self-hosted deployments.

The guard is intentionally narrow: it only applies when the request is bearer-authenticated, the session is new, and there is no existing session ID. Existing cookie-backed browser sessions and explicit logout/delete behavior continue through the existing paths.

## Tests
- Not run locally: this environment does not have `go`/`gofmt` installed in PATH.
- Verified with `git diff --check`.

## AI disclosure
This PR was prepared with AI assistance from OpenAI Codex. I reviewed the issue, inspected the affected session-store code, made the patch, and added the regression test with human-in-the-loop review.
