### PR TITLE
fix(engine): Durable DAG child output bug

### DIFF
--- a/examples/python/durable/worker.py
+++ b/examples/python/durable/worker.py
@@ -20,19 +20,31 @@ from hatchet_sdk.exceptions import NonDeterminismError
 hatchet = Hatchet()
 
 
-dag_child_workflow = hatchet.workflow(name="dag-child-workflow")
+class DagChildWorkflowInput(BaseModel):
+    child_index: int = 0
+    sleep_1_duration: int = 1
+    sleep_2_duration: int = 5
+
+
+dag_child_workflow = hatchet.workflow(
+    name="dag-child-workflow", input_validator=DagChildWorkflowInput
+)
 
 
 @dag_child_workflow.task()
-async def dag_child_1(input: EmptyModel, ctx: Context) -> dict[str, str]:
-    await asyncio.sleep(1)
-    return {"result": "child1"}
+async def dag_child_1(
+    input: DagChildWorkflowInput, ctx: Context
+) -> dict[str, str | int]:
+    await asyncio.sleep(input.sleep_1_duration)
+    return {"result": "child1", "child_index": input.child_index}
 
 
 @dag_child_workflow.task(parents=[dag_child_1])
-async def dag_child_2(input: EmptyModel, ctx: Context) -> dict[str, str]:
-    await asyncio.sleep(5)
-    return {"result": "child2"}
+async def dag_child_2(
+    input: DagChildWorkflowInput, ctx: Context
+) -> dict[str, str | int]:
+    await asyncio.sleep(input.sleep_2_duration)
+    return {"result": "child2", "child_index": input.child_index}
 
 
 @hatchet.durable_task(execution_timeout=timedelta(seconds=10))
@@ -54,6 +66,45 @@ async def durable_spawn_dag(input: EmptyModel, ctx: DurableContext) -> dict[str,
         "spawn_duration": spawn_duration,
         "spawn_result": spawn_result,
     }
+
+
+class DurableSpawnManyDagsResultSingleton(BaseModel):
+    has_both_child_outputs: bool
+    child_index: int
+
+
+class DurableSpawnManyDagsResult(BaseModel):
+    results: list[DurableSpawnManyDagsResultSingleton]
+
+
+@hatchet.durable_task(execution_timeout=timedelta(seconds=10))
+async def durable_spawn_many_dags(
+    input: EmptyModel, ctx: DurableContext
+) -> DurableSpawnManyDagsResult:
+    results = await dag_child_workflow.aio_run_many(
+        [
+            dag_child_workflow.create_bulk_run_item(
+                input=DagChildWorkflowInput(
+                    sleep_1_duration=0,
+                    sleep_2_duration=0,
+                    child_index=i,
+                )
+            )
+            for i in range(20)
+        ]
+    )
+
+    return DurableSpawnManyDagsResult(
+        results=[
+            DurableSpawnManyDagsResultSingleton(
+                has_both_child_outputs=(
+                    "dag_child_1" in result and "dag_child_2" in result
+                ),
+                child_index=result["dag_child_1"]["child_index"],
+            )
+            for result in results
+        ]
+    )
 
 
 # > Create a durable workflow
@@ -470,6 +521,7 @@ def main() -> None:
             wait_for_event_lookback,
             wait_for_or_event_lookback,
             wait_for_two_events_second_pushed_first,
+            durable_spawn_many_dags,
         ],
     )
     worker.start()

--- a/examples/python/worker.py
+++ b/examples/python/worker.py
@@ -48,6 +48,7 @@ from examples.durable.worker import (
     wait_for_or_event_lookback,
     wait_for_two_events_second_pushed_first,
     durable_child_key_dedup_replay,
+    durable_spawn_many_dags,
 )
 from examples.durable_event.worker import (
     durable_event_task,
@@ -193,6 +194,7 @@ def main() -> None:
             durable_parent_child_key_bug,
             child_child_key_bug,
             durable_child_key_dedup_replay,
+            durable_spawn_many_dags,
         ],
         lifespan=lifespan,
     )

--- a/pkg/repository/output.go
+++ b/pkg/repository/output.go
@@ -146,6 +146,8 @@ func ExtractOutputFromMatchData(data []byte) ([]byte, error) {
 	// it's confusing because in other places we use the task events on the SDK itself to aggregate
 	// the outputs of each child into a map, but here we do it on the engine. it'd be a good fixme for the future
 	// to consolidate the different ways we handle this kind of thing in different places to be more consistent.
+	// I (Matt) opted to do it this way in https://github.com/hatchet-dev/hatchet/pull/4008 to maintain
+	// backwards compatibility, and because it was the simplest bug fix for the issue we saw at the time.
 	var outer map[string]map[string][]json.RawMessage
 	if err := json.Unmarshal(data, &outer); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal match data: %w", err)

--- a/pkg/repository/output.go
+++ b/pkg/repository/output.go
@@ -147,7 +147,22 @@ func ExtractOutputFromMatchData(data []byte) ([]byte, error) {
 	}
 
 	for _, keyMap := range outer {
-		for _, entries := range keyMap {
+		if len(keyMap) == 0 {
+			continue
+		}
+
+		if len(keyMap) == 1 {
+			if entries, ok := keyMap["output"]; ok && len(entries) > 0 {
+				var event TaskOutputEvent
+				if err := json.Unmarshal(entries[0], &event); err != nil {
+					return nil, fmt.Errorf("failed to unmarshal task output event from match data: %w", err)
+				}
+				return event.Output, nil
+			}
+		}
+
+		aggregated := make(map[string]json.RawMessage, len(keyMap))
+		for key, entries := range keyMap {
 			if len(entries) == 0 {
 				continue
 			}
@@ -157,8 +172,17 @@ func ExtractOutputFromMatchData(data []byte) ([]byte, error) {
 				return nil, fmt.Errorf("failed to unmarshal task output event from match data: %w", err)
 			}
 
-			return event.Output, nil
+			if len(event.Output) > 0 {
+				aggregated[key] = json.RawMessage(event.Output)
+			}
 		}
+
+		result, err := json.Marshal(aggregated)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal aggregated DAG output: %w", err)
+		}
+
+		return result, nil
 	}
 
 	return nil, fmt.Errorf("no entries found in match data")

--- a/pkg/repository/output.go
+++ b/pkg/repository/output.go
@@ -159,6 +159,10 @@ func ExtractOutputFromMatchData(data []byte) ([]byte, error) {
 		}
 
 		if len(keyMap) == 1 {
+			// this is a special case: if the child is a DAG, we want to return the output
+			// of each task in the DAG keyed by the task name (below), but if it's a standalone task,
+			// we want to return the task's output directly without the extra nesting, so we have to handle this
+			// situation separately
 			if entries, ok := keyMap["output"]; ok && len(entries) > 0 {
 				var event TaskOutputEvent
 				if err := json.Unmarshal(entries[0], &event); err != nil {

--- a/pkg/repository/output.go
+++ b/pkg/repository/output.go
@@ -141,6 +141,11 @@ func newTaskEventFromBytes(b []byte) (*TaskOutputEvent, error) {
 }
 
 func ExtractOutputFromMatchData(data []byte) ([]byte, error) {
+	// note: this is kind of an unfortunate method we need for durable execution in order to return
+	// the result payload of the child that was spawned from a durable task to the parent.
+	// it's confusing because in other places we use the task events on the SDK itself to aggregate
+	// the outputs of each child into a map, but here we do it on the engine. it'd be a good fixme for the future
+	// to consolidate the different ways we handle this kind of thing in different places to be more consistent.
 	var outer map[string]map[string][]json.RawMessage
 	if err := json.Unmarshal(data, &outer); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal match data: %w", err)

--- a/sdks/python/examples/durable/test_durable.py
+++ b/sdks/python/examples/durable/test_durable.py
@@ -357,9 +357,9 @@ async def test_event_lookback_before_wait(hatchet: Hatchet) -> None:
 
     result = await wait_for_event_lookback.aio_run(EventLookbackInput(user_id=user_id))
 
-    assert result.elapsed < 1 + TIMING_TOLERANCE, (
-        "Event lookback should find the event that was pushed before the wait started, so should be basically instantaneous"
-    )
+    assert (
+        result.elapsed < 1 + TIMING_TOLERANCE
+    ), "Event lookback should find the event that was pushed before the wait started, so should be basically instantaneous"
     assert result.event.order == "first"
 
 

--- a/sdks/python/examples/durable/test_durable.py
+++ b/sdks/python/examples/durable/test_durable.py
@@ -429,7 +429,21 @@ async def test_engine_picks_most_recent_event(hatchet: Hatchet) -> None:
 
 @pytest.mark.asyncio(loop_scope="session")
 async def test_dag_spawn_returns_full_output(hatchet: Hatchet) -> None:
-    result = await durable_spawn_many_dags.aio_run()
+    ref = await durable_spawn_many_dags.aio_run(wait_for_result=False)
+    result = await ref.aio_result()
 
     assert {singleton.child_index for singleton in result.results} == set(range(20))
     assert all(singleton.has_both_child_outputs for singleton in result.results)
+
+    await hatchet.runs.aio_replay(ref.workflow_run_id)
+
+    await asyncio.sleep(5)
+
+    replayed_result = await ref.aio_result()
+
+    assert {singleton.child_index for singleton in replayed_result.results} == set(
+        range(20)
+    )
+    assert all(
+        singleton.has_both_child_outputs for singleton in replayed_result.results
+    )

--- a/sdks/python/examples/durable/test_durable.py
+++ b/sdks/python/examples/durable/test_durable.py
@@ -29,6 +29,7 @@ from examples.durable.worker import (
     wait_for_event_lookback,
     wait_for_or_event_lookback,
     wait_for_two_events_second_pushed_first,
+    durable_spawn_many_dags,
 )
 from hatchet_sdk import Hatchet
 
@@ -356,9 +357,9 @@ async def test_event_lookback_before_wait(hatchet: Hatchet) -> None:
 
     result = await wait_for_event_lookback.aio_run(EventLookbackInput(user_id=user_id))
 
-    assert (
-        result.elapsed < 1 + TIMING_TOLERANCE
-    ), "Event lookback should find the event that was pushed before the wait started, so should be basically instantaneous"
+    assert result.elapsed < 1 + TIMING_TOLERANCE, (
+        "Event lookback should find the event that was pushed before the wait started, so should be basically instantaneous"
+    )
     assert result.event.order == "first"
 
 
@@ -424,3 +425,11 @@ async def test_engine_picks_most_recent_event(hatchet: Hatchet) -> None:
     payload = cast(dict[str, str], json.loads(event.payload))
 
     assert res.event.order == payload["order"]
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_dag_spawn_returns_full_output(hatchet: Hatchet) -> None:
+    result = await durable_spawn_many_dags.aio_run()
+
+    assert {singleton.child_index for singleton in result.results} == set(range(20))
+    assert all(singleton.has_both_child_outputs for singleton in result.results)

--- a/sdks/python/examples/durable/worker.py
+++ b/sdks/python/examples/durable/worker.py
@@ -94,15 +94,13 @@ async def durable_spawn_many_dags(
         ]
     )
 
-    print(results[0])
-
     return DurableSpawnManyDagsResult(
         results=[
             DurableSpawnManyDagsResultSingleton(
                 has_both_child_outputs=(
                     "dag_child_1" in result and "dag_child_2" in result
                 ),
-                child_index=result["dag_child_1"]["result"]["child_index"],
+                child_index=result["dag_child_1"]["child_index"],
             )
             for result in results
         ]

--- a/sdks/python/examples/durable/worker.py
+++ b/sdks/python/examples/durable/worker.py
@@ -20,19 +20,31 @@ from hatchet_sdk.exceptions import NonDeterminismError
 hatchet = Hatchet()
 
 
-dag_child_workflow = hatchet.workflow(name="dag-child-workflow")
+class DagChildWorkflowInput(BaseModel):
+    child_index: int = 0
+    sleep_1_duration: int = 1
+    sleep_2_duration: int = 5
+
+
+dag_child_workflow = hatchet.workflow(
+    name="dag-child-workflow", input_validator=DagChildWorkflowInput
+)
 
 
 @dag_child_workflow.task()
-async def dag_child_1(input: EmptyModel, ctx: Context) -> dict[str, str]:
-    await asyncio.sleep(1)
-    return {"result": "child1"}
+async def dag_child_1(
+    input: DagChildWorkflowInput, ctx: Context
+) -> dict[str, str | int]:
+    await asyncio.sleep(input.sleep_1_duration)
+    return {"result": "child1", "child_index": input.child_index}
 
 
 @dag_child_workflow.task(parents=[dag_child_1])
-async def dag_child_2(input: EmptyModel, ctx: Context) -> dict[str, str]:
-    await asyncio.sleep(5)
-    return {"result": "child2"}
+async def dag_child_2(
+    input: DagChildWorkflowInput, ctx: Context
+) -> dict[str, str | int]:
+    await asyncio.sleep(input.sleep_2_duration)
+    return {"result": "child2", "child_index": input.child_index}
 
 
 @hatchet.durable_task(execution_timeout=timedelta(seconds=10))
@@ -54,6 +66,47 @@ async def durable_spawn_dag(input: EmptyModel, ctx: DurableContext) -> dict[str,
         "spawn_duration": spawn_duration,
         "spawn_result": spawn_result,
     }
+
+
+class DurableSpawnManyDagsResultSingleton(BaseModel):
+    has_both_child_outputs: bool
+    child_index: int
+
+
+class DurableSpawnManyDagsResult(BaseModel):
+    results: list[DurableSpawnManyDagsResultSingleton]
+
+
+@hatchet.durable_task(execution_timeout=timedelta(seconds=10))
+async def durable_spawn_many_dags(
+    input: EmptyModel, ctx: DurableContext
+) -> DurableSpawnManyDagsResult:
+    results = await dag_child_workflow.aio_run_many(
+        [
+            dag_child_workflow.create_bulk_run_item(
+                input=DagChildWorkflowInput(
+                    sleep_1_duration=0,
+                    sleep_2_duration=0,
+                    child_index=i,
+                )
+            )
+            for i in range(20)
+        ]
+    )
+
+    print(results[0])
+
+    return DurableSpawnManyDagsResult(
+        results=[
+            DurableSpawnManyDagsResultSingleton(
+                has_both_child_outputs=(
+                    "dag_child_1" in result and "dag_child_2" in result
+                ),
+                child_index=result["dag_child_1"]["result"]["child_index"],
+            )
+            for result in results
+        ]
+    )
 
 
 # > Create a durable workflow
@@ -474,6 +527,7 @@ def main() -> None:
             wait_for_event_lookback,
             wait_for_or_event_lookback,
             wait_for_two_events_second_pushed_first,
+            durable_spawn_many_dags,
         ],
     )
     worker.start()

--- a/sdks/python/examples/worker.py
+++ b/sdks/python/examples/worker.py
@@ -48,6 +48,7 @@ from examples.durable.worker import (
     wait_for_or_event_lookback,
     wait_for_two_events_second_pushed_first,
     durable_child_key_dedup_replay,
+    durable_spawn_many_dags,
 )
 from examples.durable_event.worker import (
     durable_event_task,
@@ -193,6 +194,7 @@ def main() -> None:
             durable_parent_child_key_bug,
             child_child_key_bug,
             durable_child_key_dedup_replay,
+            durable_spawn_many_dags,
         ],
         lifespan=lifespan,
     )


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Fixes a bug when spawning a DAG from durable tasks where we'd return the output of a single task in the DAG as the DAG's output, instead of returning the usual map from the task name to the task output. This is a bit of an unfortunate fix since it creates a new way of getting DAG outputs from the engine, since on the `WorkflowRunRef` we currently use the output events, but I think that it's probably the least confusing way to do this that will be backwards compatible.

Also added a test that spawns a bunch of DAGs and makes sure they all have all the correct keys returned

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)


<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI was used in this PR

</details>
