### PR TITLE
fix(ci): Allow empty commit scope & `github_actions` autolabeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,6 +18,13 @@ vscode-ext:
   - changed-files:
       - any-glob-to-any-file: "frontend/vscode-extension/**"
 
+github_actions:
+  - changed-files:
+      - any-glob-to-any-file:
+        - ".github/workflows/**"
+        - ".github/dependabot.yml"
+        - ".github/labeler.yml"
+
 engine:
   - changed-files:
       # TODO: Disambiguating between components is non-trivial,

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -19,7 +19,6 @@ module.exports = {
       ],
     ],
     'subject-case': [0], // Level 0 ignores the rule
-    'scope-empty': [2, 'never'],
     'header-max-length': [2, 'always', 120],
   },
 };


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Auto-labels when `github_actions` have changed and allows commit scopes to be empty.

## Type of change


- [x] CI (any automation pipeline changes)
- [x] Chore (changes which are not directly related to any business logic)


## What's Changed

- Added autolabeling to gh actions PRs.
- Allows commit messages to have an empty scope.
