### PR TITLE
Fix statement_timeout leakage from transaction-scoped timeouts

### DIFF
--- a/pkg/repository/sqlchelpers/tx.go
+++ b/pkg/repository/sqlchelpers/tx.go
@@ -69,28 +69,18 @@ func PrepareTxWithStatementTimeout(ctx context.Context, pool *pgxpool.Pool, l *z
 		).Caller(1).Msg("long transaction start")
 	}
 
-	commit := func(ctx context.Context) error {
-		// reset statement timeout
-		_, err = tx.Exec(ctx, "SET statement_timeout=30000")
-
-		if err != nil {
-			return err
-		}
-
-		return tx.Commit(ctx)
-	}
-
 	rollback := func() {
 		DeferRollback(ctx, l, tx.Rollback)
 	}
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET statement_timeout=%d", timeoutMs))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL statement_timeout=%d", timeoutMs))
 
 	if err != nil {
+		rollback()
 		return nil, nil, nil, err
 	}
 
-	return tx, commit, rollback, nil
+	return tx, tx.Commit, rollback, nil
 }
 
 // AcquireConnectionWithStatementTimeout acquires a connection from the pool and overwrites the default statement timeout on it.

--- a/pkg/repository/tenant.go
+++ b/pkg/repository/tenant.go
@@ -664,8 +664,8 @@ func (r *tenantRepository) UpdateControllerPartitionHeartbeat(ctx context.Contex
 
 	defer sqlchelpers.DeferRollback(ctx, r.l, tx.Rollback)
 
-	// set tx timeout to 5 seconds to avoid deadlocks
-	_, err = tx.Exec(ctx, "SET statement_timeout=5000")
+	// Limit only this transaction; plain SET would leak through the pooled connection.
+	_, err = tx.Exec(ctx, "SET LOCAL statement_timeout=5000")
 
 	if err != nil {
 		return "", err
@@ -702,8 +702,8 @@ func (r *tenantRepository) UpdateWorkerPartitionHeartbeat(ctx context.Context, p
 
 	defer sqlchelpers.DeferRollback(ctx, r.l, tx.Rollback)
 
-	// set tx timeout to 5 seconds to avoid deadlocks
-	_, err = tx.Exec(ctx, "SET statement_timeout=5000")
+	// Limit only this transaction; plain SET would leak through the pooled connection.
+	_, err = tx.Exec(ctx, "SET LOCAL statement_timeout=5000")
 
 	if err != nil {
 		return "", err
@@ -815,8 +815,8 @@ func (r *tenantRepository) UpdateSchedulerPartitionHeartbeat(ctx context.Context
 
 	defer sqlchelpers.DeferRollback(ctx, r.l, tx.Rollback)
 
-	// set tx timeout to 5 seconds to avoid deadlocks
-	_, err = tx.Exec(ctx, "SET statement_timeout=5000")
+	// Limit only this transaction; plain SET would leak through the pooled connection.
+	_, err = tx.Exec(ctx, "SET LOCAL statement_timeout=5000")
 
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Summary
- use `SET LOCAL statement_timeout=5000` for controller, worker, and scheduler partition heartbeat transactions so the 5s timeout cannot leak back into pgxpool connections after commit
- switch `PrepareTxWithStatementTimeout` to `SET LOCAL` and remove the manual 30s reset on commit
- roll back the transaction if applying the timeout fails after `pool.Begin` succeeds, avoiding a checked-out connection leak on that error path

Fixes #3898

## Verification
- Blocked locally: `go test ./pkg/repository/sqlchelpers ./pkg/repository -run 'Test.*Statement|Test.*Tenant|Test.*Partition'` could not run because `go` is not installed on PATH in this shell.
