### PR TITLE
feat(ts-sdk): add durable content step checkpoinitng

### DIFF
--- a/sdks/typescript/src/v1/client/worker/context.ts
+++ b/sdks/typescript/src/v1/client/worker/context.ts
@@ -22,7 +22,7 @@ import WorkflowRunRef from '@hatchet/util/workflow-run-ref';
 import { Conditions, Render } from '@hatchet/v1/conditions';
 import { conditionsToPb } from '@hatchet/v1/conditions/transformer';
 import { CreateWorkflowDurableTaskOpts, CreateWorkflowTaskOpts } from '@hatchet/v1/task';
-import { JsonObject, OutputType } from '@hatchet/v1/types';
+import { JsonObject, JsonValue, OutputType } from '@hatchet/v1/types';
 import { Action as ConditionAction } from '@hatchet/protoc/v1/shared/condition';
 import { HatchetClient } from '@hatchet/v1';
 import { applyNamespace } from '@hatchet/util/apply-namespace';
@@ -44,6 +44,7 @@ import { waitForPreEviction } from './deprecated/pre-eviction';
 type TriggerData = Record<string, Record<string, any>>;
 
 type ChildRunOpts = RunOpts & { key?: string; sticky?: boolean };
+type StepResult = Exclude<JsonValue, undefined>;
 
 export interface SleepResult {
   /** The sleep duration in milliseconds. */
@@ -1115,6 +1116,29 @@ export class DurableContext<T, K = {}> extends Context<T, K> {
       return { ts: new Date().toISOString() };
     }, ['now']);
     return new Date(result.ts);
+  }
+
+  /**
+   * Runs a dynamic side effect once and checkpoints its result in the durable event log.
+   * On replay, the stored result is returned without running `fn` again.
+   *
+   * @param name - Stable step name used as the checkpoint key.
+   * @param fn - Function that performs the side effect and returns a JSON-serializable result.
+   * @returns The checkpointed result.
+   */
+  async step<R extends StepResult>(name: string, fn: () => R | Promise<R>): Promise<R> {
+    if (!name) {
+      throw new HatchetError('ctx.step requires a non-empty name');
+    }
+
+    return this.memo(async () => fn(), ['step', name]);
+  }
+
+  /**
+   * Alias for `step`.
+   */
+  async checkpoint<R extends StepResult>(name: string, fn: () => R | Promise<R>): Promise<R> {
+    return this.step(name, fn);
   }
 
   private async _waitForPreEviction(

--- a/sdks/typescript/src/v1/examples/simple/types.test-d.ts
+++ b/sdks/typescript/src/v1/examples/simple/types.test-d.ts
@@ -226,6 +226,19 @@ test('durableTask should propagate generics', () => {
   expectType<TaskWorkflowDeclaration<In, Out>>(task);
 });
 
+test('durableTask context should expose checkpointed steps', () => {
+  hatchet.durableTask({
+    name: '',
+    fn: async (_input, ctx) => {
+      expectType<Promise<{ out: string }>>(ctx.step('load-user', () => ({ out: 'string' })));
+      expectType<Promise<'high'>>(ctx.step('score', () => 'high'));
+      expectType<Promise<{ out: string }>>(
+        ctx.checkpoint('load-user', async () => ({ out: 'string' }))
+      );
+    },
+  });
+});
+
 // Test onSuccess handler type inference
 test('workflow onSuccess should inherit workflow input type', () => {
   type In = { in: string };


### PR DESCRIPTION
fixes #3992 

# Description

Adds `ctx.step(name, fn)` and `ctx.checkpoint(name, fn)` to the TypeScript `DurableContext`, backed by the existing durable memo event path. This lets durable tasks checkpoint dynamic side effects without registering separate child tasks.

Fixes #3992

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

- [x] Added `DurableContext.step()` for named, checkpointed side effects.
- [x] Added `DurableContext.checkpoint()` as an alias for `step()`.
- [x] Added type coverage for checkpointed object and primitive results.

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable)

## Testing

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/prettier "src/v1/client/worker/context.ts" "src/v1/examples/simple/types.test-d.ts" --check`
- `./node_modules/.bin/jest src/v1/examples/simple/types.test.ts --runInBand`

---