### PR TITLE
fix: go use durable listener for async results

### DIFF
--- a/pkg/client/admin.go
+++ b/pkg/client/admin.go
@@ -36,6 +36,74 @@ type ChildWorkflowOpts struct {
 	DesiredWorkerLabels map[string]*types.DesiredWorkerLabel
 }
 
+// NewChildWorkflowTriggerRequest builds the trigger request used to start a child workflow.
+func NewChildWorkflowTriggerRequest(workflowName string, input interface{}, opts *ChildWorkflowOpts, sharedMeta map[string]string) (*v1contracts.TriggerWorkflowRequest, error) {
+	if opts == nil {
+		opts = &ChildWorkflowOpts{}
+	}
+
+	inputBytes, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal input: %w", err)
+	}
+
+	if opts.ChildIndex < math.MinInt32 || opts.ChildIndex > math.MaxInt32 {
+		return nil, fmt.Errorf("child index out of range")
+	}
+	childIndex := int32(opts.ChildIndex) // nolint:gosec
+
+	request := &v1contracts.TriggerWorkflowRequest{
+		Name:                    workflowName,
+		Input:                   string(inputBytes),
+		ParentId:                &opts.ParentId,
+		ParentTaskRunExternalId: &opts.ParentTaskRunId,
+		ChildIndex:              &childIndex,
+		ChildKey:                opts.ChildKey,
+		DesiredWorkerId:         opts.DesiredWorkerId,
+	}
+
+	additionalMetadata := mergeAdditionalMetadata(sharedMeta, opts.AdditionalMetadata)
+	if additionalMetadata != nil {
+		if err := WithRunMetadata(additionalMetadata)(request); err != nil {
+			return nil, fmt.Errorf("could not apply run metadata: %w", err)
+		}
+	}
+
+	if opts.Priority != nil {
+		if err := WithPriority(*opts.Priority)(request); err != nil {
+			return nil, fmt.Errorf("could not apply run priority: %w", err)
+		}
+	}
+
+	if opts.DesiredWorkerLabels != nil {
+		if err := WithDesiredWorkerLabels(opts.DesiredWorkerLabels)(request); err != nil {
+			return nil, fmt.Errorf("could not apply desired worker labels: %w", err)
+		}
+	}
+
+	return request, nil
+}
+
+func mergeAdditionalMetadata(sharedMeta map[string]string, opt *map[string]string) map[string]string {
+	if sharedMeta == nil && opt == nil {
+		return nil
+	}
+
+	additionalMeta := make(map[string]string)
+
+	for key, value := range sharedMeta {
+		additionalMeta[key] = value
+	}
+
+	if opt != nil {
+		for key, value := range *opt {
+			additionalMeta[key] = value
+		}
+	}
+
+	return additionalMeta
+}
+
 type WorkflowRun struct {
 	Name    string
 	Input   interface{}
@@ -412,36 +480,14 @@ func (a *adminClientImpl) BulkRunWorkflow(workflows []*WorkflowRun) ([]string, e
 }
 
 func (a *adminClientImpl) RunChildWorkflow(workflowName string, input interface{}, opts *ChildWorkflowOpts) (string, error) {
-	inputBytes, err := json.Marshal(input)
-
-	if err != nil {
-		return "", fmt.Errorf("could not marshal input: %w", err)
-	}
-
 	workflowName = client.ApplyNamespace(workflowName, &a.namespace)
 
-	childIndex := int32(opts.ChildIndex) // nolint: gosec
-
-	metadataBytes, err := a.getAdditionalMetaBytes(opts.AdditionalMetadata)
-
+	request, err := NewChildWorkflowTriggerRequest(workflowName, input, opts, a.sharedMeta)
 	if err != nil {
-		return "", fmt.Errorf("could not get additional metadata: %w", err)
+		return "", err
 	}
 
-	metadata := string(metadataBytes)
-
-	res, err := a.client.TriggerWorkflow(a.ctx.newContext(context.Background()), &v1contracts.TriggerWorkflowRequest{
-		Name:                    workflowName,
-		Input:                   string(inputBytes),
-		ParentId:                &opts.ParentId,
-		ParentTaskRunExternalId: &opts.ParentTaskRunId,
-		ChildIndex:              &childIndex,
-		ChildKey:                opts.ChildKey,
-		DesiredWorkerId:         opts.DesiredWorkerId,
-		AdditionalMetadata:      &metadata,
-		Priority:                opts.Priority,
-		DesiredWorkerLabels:     desiredWorkerLabelsToProto(opts.DesiredWorkerLabels),
-	})
+	res, err := a.client.TriggerWorkflow(a.ctx.newContext(context.Background()), request)
 
 	if err != nil {
 		if status.Code(err) == codes.AlreadyExists {
@@ -468,43 +514,14 @@ func (a *adminClientImpl) RunChildWorkflows(workflows []*RunChildWorkflowsOpts) 
 	triggerWorkflowRequests := make([]*v1contracts.TriggerWorkflowRequest, len(workflows))
 
 	for i, workflow := range workflows {
-		if workflow.Opts == nil {
-			workflow.Opts = &ChildWorkflowOpts{}
-		}
-
-		inputBytes, err := json.Marshal(workflow.Input)
-
-		if err != nil {
-			return nil, fmt.Errorf("could not marshal input: %w", err)
-		}
-
 		workflowName := client.ApplyNamespace(workflow.WorkflowName, &a.namespace)
 
-		if workflow.Opts.ChildIndex < math.MinInt32 || workflow.Opts.ChildIndex > math.MaxInt32 {
-			return nil, fmt.Errorf("child index out of range")
-		}
-		childIndex := int32(workflow.Opts.ChildIndex) // nolint: gosec
-
-		metadataBytes, err := a.getAdditionalMetaBytes(workflow.Opts.AdditionalMetadata)
-
+		request, err := NewChildWorkflowTriggerRequest(workflowName, workflow.Input, workflow.Opts, a.sharedMeta)
 		if err != nil {
-			return nil, fmt.Errorf("could not get additional metadata: %w", err)
+			return nil, err
 		}
 
-		metadata := string(metadataBytes)
-
-		triggerWorkflowRequests[i] = &v1contracts.TriggerWorkflowRequest{
-			Name:                    workflowName,
-			Input:                   string(inputBytes),
-			ParentId:                &workflow.Opts.ParentId,
-			ParentTaskRunExternalId: &workflow.Opts.ParentTaskRunId,
-			ChildIndex:              &childIndex,
-			ChildKey:                workflow.Opts.ChildKey,
-			DesiredWorkerId:         workflow.Opts.DesiredWorkerId,
-			AdditionalMetadata:      &metadata,
-			Priority:                workflow.Opts.Priority,
-			DesiredWorkerLabels:     desiredWorkerLabelsToProto(workflow.Opts.DesiredWorkerLabels),
-		}
+		triggerWorkflowRequests[i] = request
 
 	}
 
@@ -784,28 +801,6 @@ func (a *adminClientImpl) getJobOpts(jobName string, job *types.WorkflowJob) (*a
 	jobOpt.Steps = stepOpts
 
 	return jobOpt, nil
-}
-
-func (a *adminClientImpl) getAdditionalMetaBytes(opt *map[string]string) ([]byte, error) {
-	additionalMeta := make(map[string]string)
-
-	for key, value := range a.sharedMeta {
-		additionalMeta[key] = value
-	}
-
-	if opt != nil {
-		for key, value := range *opt {
-			additionalMeta[key] = value
-		}
-	}
-
-	metadataBytes, err := json.Marshal(additionalMeta)
-
-	if err != nil {
-		return nil, fmt.Errorf("could not marshal additional metadata: %w", err)
-	}
-
-	return metadataBytes, nil
 }
 
 func (h *adminClientImpl) saveOrLoadListener() (*WorkflowRunsListener, error) {

--- a/pkg/client/durable_task_listener.go
+++ b/pkg/client/durable_task_listener.go
@@ -51,6 +51,14 @@ type CallbackResult struct {
 	Err  error
 }
 
+// TriggerRunAckEntry describes a child workflow spawned through the durable task
+// event log.
+type TriggerRunAckEntry struct {
+	WorkflowRunID string
+	NodeID        int64
+	BranchID      int64
+}
+
 // NonDeterminismError is returned by the engine when a durable task replay detects
 // a non-deterministic mutation (e.g. branching differently from the prior run).
 type NonDeterminismError struct {
@@ -464,6 +472,94 @@ func (l *DurableTaskListener) removePendingCallback(key PendingCallbackKey) {
 	delete(l.pendingCallbacks, key)
 }
 
+func (l *DurableTaskListener) SendTriggerRunsRequest(
+	ctx context.Context,
+	taskExternalID string,
+	invocationCount int32,
+	triggerOpts []*v1.TriggerWorkflowRequest,
+) ([]TriggerRunAckEntry, error) {
+	ackKey := PendingAckKey{TaskID: taskExternalID, SignalKey: int64(invocationCount)}
+	ackCh := l.AddPendingEventAck(ackKey)
+
+	if l.l != nil {
+		l.l.Debug().
+			Str("step_run_id", taskExternalID).
+			Int32("invocation_count", invocationCount).
+			Int("children", len(triggerOpts)).
+			Msg("DurableTaskListener: sending trigger_runs request")
+	}
+
+	l.SendRequest(&v1.DurableTaskRequest{
+		Message: &v1.DurableTaskRequest_TriggerRuns{
+			TriggerRuns: &v1.DurableTaskTriggerRunsRequest{
+				InvocationCount:       invocationCount,
+				DurableTaskExternalId: taskExternalID,
+				TriggerOpts:           triggerOpts,
+			},
+		},
+	})
+
+	select {
+	case <-ctx.Done():
+		l.removePendingEventAck(ackKey)
+		return nil, ctx.Err()
+	case ack := <-ackCh:
+		if ack.Err != nil {
+			return nil, ack.Err
+		}
+
+		triggerAck := ack.Resp.GetTriggerRunsAck()
+		if triggerAck == nil {
+			return nil, fmt.Errorf("trigger_runs ack missing for task %s invocation %d", taskExternalID, invocationCount)
+		}
+
+		runEntries := triggerAck.GetRunEntries()
+		entries := make([]TriggerRunAckEntry, 0, len(runEntries))
+		for _, entry := range runEntries {
+			entries = append(entries, TriggerRunAckEntry{
+				NodeID:        entry.GetNodeId(),
+				BranchID:      entry.GetBranchId(),
+				WorkflowRunID: entry.GetWorkflowRunExternalId(),
+			})
+		}
+
+		return entries, nil
+	}
+}
+
+// WaitForCallback waits for a durable event-log entry to complete and returns
+// the raw JSON payload recorded by the engine.
+func (l *DurableTaskListener) WaitForCallback(
+	ctx context.Context,
+	taskExternalID string,
+	invocationCount int32,
+	branchID int64,
+	nodeID int64,
+) ([]byte, error) {
+	cbKey := PendingCallbackKey{
+		TaskID:    taskExternalID,
+		SignalKey: int64(invocationCount),
+		BranchID:  branchID,
+		NodeID:    nodeID,
+	}
+	cbCh := l.AddPendingCallback(cbKey)
+
+	select {
+	case <-ctx.Done():
+		l.removePendingCallback(cbKey)
+		return nil, ctx.Err()
+	case result := <-cbCh:
+		if result.Err != nil {
+			return nil, result.Err
+		}
+		completed := result.Resp.GetEntryCompleted()
+		if completed == nil {
+			return nil, fmt.Errorf("durable callback missing entry_completed for task %s", taskExternalID)
+		}
+		return completed.GetPayload(), nil
+	}
+}
+
 // SendWaitForRequest registers a durable wait-for on the engine over the bidi DurableTask
 // stream. It mirrors the Python SDK's `listener.send_event(WaitForEvent(...))` + wait-for-callback
 // flow: the listener first sends a WaitFor request and blocks for the WaitForAck (which carries
@@ -521,28 +617,7 @@ func (l *DurableTaskListener) SendWaitForRequest(
 	}
 	ref := waitAck.GetRef()
 
-	cbKey := PendingCallbackKey{
-		TaskID:    taskExternalID,
-		SignalKey: int64(invocationCount),
-		BranchID:  ref.GetBranchId(),
-		NodeID:    ref.GetNodeId(),
-	}
-	cbCh := l.AddPendingCallback(cbKey)
-
-	select {
-	case <-ctx.Done():
-		l.removePendingCallback(cbKey)
-		return nil, ctx.Err()
-	case result := <-cbCh:
-		if result.Err != nil {
-			return nil, result.Err
-		}
-		completed := result.Resp.GetEntryCompleted()
-		if completed == nil {
-			return nil, fmt.Errorf("wait_for completion missing entry_completed for task %s", taskExternalID)
-		}
-		return completed.GetPayload(), nil
-	}
+	return l.WaitForCallback(ctx, taskExternalID, invocationCount, ref.GetBranchId(), ref.GetNodeId())
 }
 
 // MemoAckResult is what SendMemoRequest returns on a successful ack: the server-assigned

--- a/pkg/client/durable_task_listener.go
+++ b/pkg/client/durable_task_listener.go
@@ -83,7 +83,7 @@ type ServerEvictCallback func(taskExternalID string, invocationCount int32, reas
 type DurableTaskListener struct {
 	onServerEvict         ServerEvictCallback
 	pendingEvictionAcks   map[PendingAckKey]chan error
-	l                     *zerolog.Logger
+	l                     zerolog.Logger
 	connectFn             func(ctx context.Context) (v1.V1Dispatcher_DurableTaskClient, error)
 	cancel                context.CancelFunc
 	requestQueue          chan *v1.DurableTaskRequest
@@ -128,9 +128,14 @@ func NewDurableTaskListener(
 	l *zerolog.Logger,
 	opts ...DurableTaskListenerOpt,
 ) *DurableTaskListener {
+	logger := zerolog.Nop()
+	if l != nil {
+		logger = *l
+	}
+
 	dtl := &DurableTaskListener{
 		workerID:            workerID,
-		l:                   l,
+		l:                   logger,
 		reconnectInterval:   defaultReconnectInterval,
 		evictionAckTTL:      evictionAckTimeout,
 		connectFn:           connectFn,
@@ -331,9 +336,7 @@ func (l *DurableTaskListener) receiveLoop(ctx context.Context) {
 			if isCancelled(ctx) {
 				return
 			}
-			if l.l != nil {
-				l.l.Error().Err(err).Msg("DurableTaskListener: connection failed, retrying")
-			}
+			l.l.Error().Err(err).Msg("DurableTaskListener: connection failed, retrying")
 			time.Sleep(l.reconnectInterval)
 			continue
 		}
@@ -348,9 +351,7 @@ func (l *DurableTaskListener) receiveLoop(ctx context.Context) {
 				return
 			}
 			l.failPendingAcks(fmt.Errorf("connection reset: %w", err))
-			if l.l != nil {
-				l.l.Warn().Err(err).Msg("DurableTaskListener: stream ended, reconnecting")
-			}
+			l.l.Warn().Err(err).Msg("DurableTaskListener: stream ended, reconnecting")
 			time.Sleep(l.reconnectInterval)
 			continue
 		}
@@ -378,9 +379,7 @@ func (l *DurableTaskListener) handleStream(ctx context.Context, stream v1.V1Disp
 		return fmt.Errorf("failed to register worker on durable task stream: %w", err)
 	}
 
-	if l.l != nil {
-		l.l.Debug().Str("worker_id", l.workerID).Msg("DurableTaskListener: registered worker on stream")
-	}
+	l.l.Debug().Str("worker_id", l.workerID).Msg("DurableTaskListener: registered worker on stream")
 
 	streamCtx, cancelStream := context.WithCancel(ctx)
 	defer cancelStream()
@@ -481,13 +480,11 @@ func (l *DurableTaskListener) SendTriggerRunsRequest(
 	ackKey := PendingAckKey{TaskID: taskExternalID, SignalKey: int64(invocationCount)}
 	ackCh := l.AddPendingEventAck(ackKey)
 
-	if l.l != nil {
-		l.l.Debug().
-			Str("step_run_id", taskExternalID).
-			Int32("invocation_count", invocationCount).
-			Int("children", len(triggerOpts)).
-			Msg("DurableTaskListener: sending trigger_runs request")
-	}
+	l.l.Debug().
+		Str("step_run_id", taskExternalID).
+		Int32("invocation_count", invocationCount).
+		Int("children", len(triggerOpts)).
+		Msg("DurableTaskListener: sending trigger_runs request")
 
 	l.SendRequest(&v1.DurableTaskRequest{
 		Message: &v1.DurableTaskRequest_TriggerRuns{
@@ -581,12 +578,10 @@ func (l *DurableTaskListener) SendWaitForRequest(
 		labelPtr = &label
 	}
 
-	if l.l != nil {
-		l.l.Debug().
-			Str("step_run_id", taskExternalID).
-			Int32("invocation_count", invocationCount).
-			Msg("DurableTaskListener: sending wait_for request")
-	}
+	l.l.Debug().
+		Str("step_run_id", taskExternalID).
+		Int32("invocation_count", invocationCount).
+		Msg("DurableTaskListener: sending wait_for request")
 
 	l.SendRequest(&v1.DurableTaskRequest{
 		Message: &v1.DurableTaskRequest_WaitFor{
@@ -764,13 +759,11 @@ func (l *DurableTaskListener) dispatchResponse(resp *v1.DurableTaskResponse) {
 		invCount := evict.GetInvocationCount()
 		reason := evict.GetReason()
 
-		if l.l != nil {
-			l.l.Info().
-				Str("task_id", taskID).
-				Int32("invocation_count", invCount).
-				Str("reason", reason).
-				Msg("DurableTaskListener: received server eviction notice")
-		}
+		l.l.Info().
+			Str("task_id", taskID).
+			Int32("invocation_count", invCount).
+			Str("reason", reason).
+			Msg("DurableTaskListener: received server eviction notice")
 
 		l.CleanupTaskState(taskID, invCount)
 
@@ -781,9 +774,7 @@ func (l *DurableTaskListener) dispatchResponse(resp *v1.DurableTaskResponse) {
 			cb(taskID, invCount, reason)
 		}
 	default:
-		if l.l != nil {
-			l.l.Warn().Msg("DurableTaskListener: unknown response type")
-		}
+		l.l.Warn().Msg("DurableTaskListener: unknown response type")
 	}
 }
 

--- a/pkg/worker/context.go
+++ b/pkg/worker/context.go
@@ -570,6 +570,17 @@ func (h *hatchetContext) CurChildIndex() int {
 	return h.i
 }
 
+// Deprecated: NextChildIndex is an internal method used by the new Go SDK.
+// Use the new Go SDK at github.com/hatchet-dev/hatchet/sdks/go instead of using this directly. Migration guide: https://docs.hatchet.run/home/migration-guide-go
+func (h *hatchetContext) NextChildIndex() int {
+	h.indexMu.Lock()
+	defer h.indexMu.Unlock()
+
+	childIndex := h.i
+	h.i++
+	return childIndex
+}
+
 // Deprecated: IncChildIndex is an internal method used by the new Go SDK.
 // Use the new Go SDK at github.com/hatchet-dev/hatchet/sdks/go instead of using this directly. Migration guide: https://docs.hatchet.run/home/migration-guide-go
 func (h *hatchetContext) IncChildIndex() {

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -936,7 +936,7 @@ func (c *Client) runWorkflowInternal(ctx context.Context, otelCtx context.Contex
 			durableWorkflowName = fmt.Sprintf("%s%s", ns, durableWorkflowName)
 		}
 
-		durableRef, handled, durableErr := runDurableChildWorkflow(ctx, durableWorkflowName, input, runOpts)
+		durableRef, handled, durableErr := runDurableChildWorkflowIfSupported(ctx, durableWorkflowName, input, runOpts)
 		if handled {
 			if durableErr != nil {
 				span.SetStatus(codes.Error, durableErr.Error())

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/rs/zerolog"
@@ -725,10 +726,15 @@ func (st *StandaloneTask) OnFailure(fn any) {
 type WorkflowRunRef struct {
 	RunId      string
 	v0Workflow *v0Client.Workflow
+	resultFn   func() (*WorkflowResult, error)
 }
 
 // V0Workflow returns the underlying v0Client.Workflow.
 func (wr *WorkflowRunRef) Result() (*WorkflowResult, error) {
+	if wr.resultFn != nil {
+		return wr.resultFn()
+	}
+
 	result, err := wr.v0Workflow.Result()
 	if err != nil {
 		return nil, err
@@ -907,6 +913,7 @@ func (c *Client) runWorkflowInternal(ctx context.Context, otelCtx context.Contex
 	// Inject traceparent for cross-workflow trace propagation.
 	// Use otelCtx (not ctx) so the span's trace context is propagated.
 	additionalMetadata = injectTraceparentToMap(otelCtx, additionalMetadata)
+	runOpts.AdditionalMetadata = additionalMetadata
 
 	var v0Opts []v0Client.RunOptFunc
 	if additionalMetadata != nil {
@@ -915,17 +922,37 @@ func (c *Client) runWorkflowInternal(ctx context.Context, otelCtx context.Contex
 	if priority != nil {
 		v0Opts = append(v0Opts, v0Client.WithPriority(*priority))
 	}
+	if runOpts.DesiredWorkerLabels != nil {
+		v0Opts = append(v0Opts, v0Client.WithDesiredWorkerLabels(runOpts.DesiredWorkerLabels))
+	}
 
 	var v0Workflow *v0Client.Workflow
 	var err error
 
 	hCtx, ok := ctx.(Context)
 	if ok {
+		durableWorkflowName := workflowName
+		if ns := c.legacyClient.Namespace(); ns != "" && !strings.HasPrefix(durableWorkflowName, ns) {
+			durableWorkflowName = fmt.Sprintf("%s%s", ns, durableWorkflowName)
+		}
+
+		durableRef, handled, durableErr := runDurableChildWorkflow(ctx, durableWorkflowName, input, runOpts)
+		if handled {
+			if durableErr != nil {
+				span.SetStatus(codes.Error, durableErr.Error())
+				span.RecordError(durableErr)
+				return nil, durableErr
+			}
+			span.SetAttributes(attribute.String(hatchetotel.AttrChildWorkflowRunID, durableRef.RunId))
+			return durableRef, nil
+		}
+
 		v0Workflow, err = hCtx.SpawnWorkflow(workflowName, input, &worker.SpawnWorkflowOpts{
-			Key:                runOpts.Key,
-			Sticky:             runOpts.Sticky,
-			Priority:           priority,
-			AdditionalMetadata: additionalMetadata,
+			Key:                 runOpts.Key,
+			Sticky:              runOpts.Sticky,
+			Priority:            priority,
+			AdditionalMetadata:  additionalMetadata,
+			DesiredWorkerLabels: runOpts.DesiredWorkerLabels,
 		})
 	} else {
 		v0Workflow, err = c.legacyClient.Admin().RunWorkflow(workflowName, input, v0Opts...)
@@ -952,7 +979,12 @@ type RunManyOpt struct {
 // Returns workflow run IDs that can be used to track the run statuses.
 func (c *Client) RunMany(ctx context.Context, workflowName string, inputs []RunManyOpt) ([]WorkflowRunRef, error) {
 	tracer := otel.Tracer("github.com/hatchet-dev/hatchet/sdks/go")
-	ctx, span := tracer.Start(ctx, hatchetotel.SpanRunWorkflows,
+	originalCtx := ctx
+	otelCtx := ctx
+	if hCtx, ok := ctx.(Context); ok {
+		otelCtx = hCtx.GetContext()
+	}
+	otelCtx, span := tracer.Start(otelCtx, hatchetotel.SpanRunWorkflows,
 		trace.WithSpanKind(trace.SpanKindProducer),
 		trace.WithAttributes(
 			attribute.String(hatchetotel.AttrInstrumentor, hatchetotel.AttrInstrumentorValue),
@@ -962,11 +994,29 @@ func (c *Client) RunMany(ctx context.Context, workflowName string, inputs []RunM
 	)
 	defer span.End()
 
+	if _, ok := originalCtx.(Context); ok {
+		durableWorkflowName := workflowName
+		if ns := c.legacyClient.Namespace(); ns != "" && !strings.HasPrefix(durableWorkflowName, ns) {
+			durableWorkflowName = fmt.Sprintf("%s%s", ns, durableWorkflowName)
+		}
+
+		if durableRefs, handled, err := runManyDurableChildWorkflows(originalCtx, otelCtx, durableWorkflowName, inputs); handled {
+			if err != nil {
+				span.SetStatus(codes.Error, err.Error())
+				return durableRefs, err
+			}
+
+			span.SetStatus(codes.Ok, "")
+			return durableRefs, nil
+		}
+	}
+
 	var workflowRefs []WorkflowRunRef
 
 	var wg sync.WaitGroup
 	var errs []error
 	var errsMutex sync.Mutex
+	var workflowRefsMutex sync.Mutex
 
 	wg.Add(len(inputs))
 
@@ -974,7 +1024,7 @@ func (c *Client) RunMany(ctx context.Context, workflowName string, inputs []RunM
 		go func() {
 			defer wg.Done()
 
-			workflowRef, err := c.RunNoWait(ctx, workflowName, input.Input, input.Opts...)
+			workflowRef, err := c.RunNoWait(originalCtx, workflowName, input.Input, input.Opts...)
 			if err != nil {
 				errsMutex.Lock()
 				errs = append(errs, err)
@@ -982,7 +1032,9 @@ func (c *Client) RunMany(ctx context.Context, workflowName string, inputs []RunM
 				return
 			}
 
+			workflowRefsMutex.Lock()
 			workflowRefs = append(workflowRefs, *workflowRef)
+			workflowRefsMutex.Unlock()
 		}()
 	}
 

--- a/sdks/go/durable_child.go
+++ b/sdks/go/durable_child.go
@@ -1,0 +1,295 @@
+package hatchet
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	v1 "github.com/hatchet-dev/hatchet/internal/services/shared/proto/v1"
+	v0Client "github.com/hatchet-dev/hatchet/pkg/client" //nolint:staticcheck
+	"github.com/hatchet-dev/hatchet/pkg/worker"
+)
+
+type durableTaskRuntime interface {
+	DurableTaskListener() *v0Client.DurableTaskListener
+	DurableEvictionSupported() bool
+}
+
+type durableEvictionHookProvider interface {
+	DurableEvictionHook() worker.DurableEvictionHook
+}
+
+type childIndexProvider interface {
+	NextChildIndex() int
+}
+
+func runDurableChildWorkflow(
+	ctx context.Context,
+	workflowName string,
+	input any,
+	runOpts *runOpts,
+) (*WorkflowRunRef, bool, error) {
+	hCtx, ok := ctx.(Context)
+	if !ok {
+		return nil, false, nil
+	}
+
+	runtime, ok := ctx.(durableTaskRuntime)
+	if !ok || runtime.DurableTaskListener() == nil || !runtime.DurableEvictionSupported() {
+		return nil, false, nil
+	}
+
+	trigger, err := buildDurableChildTrigger(hCtx, workflowName, input, runOpts)
+	if err != nil {
+		return nil, true, err
+	}
+
+	invocationCount := hCtx.DurableTaskInvocationCount()
+	if invocationCount == 0 {
+		invocationCount = 1
+	}
+
+	listener := runtime.DurableTaskListener()
+	entries, err := listener.SendTriggerRunsRequest(
+		hCtx.GetContext(),
+		hCtx.StepRunId(),
+		invocationCount,
+		[]*v1.TriggerWorkflowRequest{trigger},
+	)
+	if err != nil {
+		return nil, true, fmt.Errorf("failed to spawn durable child workflow: %w", err)
+	}
+	if len(entries) == 0 {
+		return nil, true, fmt.Errorf("failed to spawn durable child workflow: no run entries returned")
+	}
+
+	entry := entries[0]
+	resultFn := func() (*WorkflowResult, error) {
+		payload, err := waitForDurableChildResult(ctx, listener, hCtx, invocationCount, workflowName, entry)
+		if err != nil {
+			return nil, err
+		}
+
+		return &WorkflowResult{
+			RunId:  entry.WorkflowRunID,
+			result: payload,
+		}, nil
+	}
+
+	return &WorkflowRunRef{
+		RunId:    entry.WorkflowRunID,
+		resultFn: resultFn,
+	}, true, nil
+}
+
+func runManyDurableChildWorkflows(
+	ctx context.Context,
+	otelCtx context.Context,
+	workflowName string,
+	inputs []RunManyOpt,
+) ([]WorkflowRunRef, bool, error) {
+	hCtx, ok := ctx.(Context)
+	if !ok {
+		return nil, false, nil
+	}
+
+	runtime, ok := ctx.(durableTaskRuntime)
+	if !ok || runtime.DurableTaskListener() == nil || !runtime.DurableEvictionSupported() {
+		return nil, false, nil
+	}
+
+	invocationCount := hCtx.DurableTaskInvocationCount()
+	if invocationCount == 0 {
+		invocationCount = 1
+	}
+
+	triggers := make([]*v1.TriggerWorkflowRequest, len(inputs))
+	for i, input := range inputs {
+		runOpts := &runOpts{}
+		for _, opt := range input.Opts {
+			opt(runOpts)
+		}
+		runOpts.AdditionalMetadata = injectTraceparentToMap(otelCtx, runOpts.AdditionalMetadata)
+
+		trigger, err := buildDurableChildTrigger(hCtx, workflowName, input.Input, runOpts)
+		if err != nil {
+			return nil, true, err
+		}
+		triggers[i] = trigger
+	}
+
+	listener := runtime.DurableTaskListener()
+	entries, err := listener.SendTriggerRunsRequest(
+		hCtx.GetContext(),
+		hCtx.StepRunId(),
+		invocationCount,
+		triggers,
+	)
+	if err != nil {
+		return nil, true, fmt.Errorf("failed to spawn durable child workflows: %w", err)
+	}
+	if len(entries) != len(triggers) {
+		return nil, true, fmt.Errorf("failed to spawn durable child workflows: expected %d run entries, got %d", len(triggers), len(entries))
+	}
+
+	refs := make([]WorkflowRunRef, len(entries))
+	for i, entry := range entries {
+		entry := entry
+		refs[i] = WorkflowRunRef{
+			RunId: entry.WorkflowRunID,
+			resultFn: func() (*WorkflowResult, error) {
+				payload, err := waitForDurableChildResult(ctx, listener, hCtx, invocationCount, workflowName, entry)
+				if err != nil {
+					return nil, err
+				}
+
+				return &WorkflowResult{
+					RunId:  entry.WorkflowRunID,
+					result: payload,
+				}, nil
+			},
+		}
+	}
+
+	return refs, true, nil
+}
+
+func buildDurableChildTrigger(
+	hCtx Context,
+	workflowName string,
+	input any,
+	runOpts *runOpts,
+) (*v1.TriggerWorkflowRequest, error) {
+	inputBytes, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal input: %w", err)
+	}
+
+	childIndexValue := hCtx.CurChildIndex()
+	if next, ok := hCtx.(childIndexProvider); ok {
+		childIndexValue = next.NextChildIndex()
+	} else {
+		hCtx.IncChildIndex()
+	}
+	childIndex := int32(childIndexValue) // nolint:gosec
+
+	var desiredWorkerID *string
+	if runOpts.Sticky != nil && *runOpts.Sticky {
+		if !hCtx.Worker().HasWorkflow(workflowName) {
+			return nil, fmt.Errorf("cannot run with sticky: workflow %s is not registered on this worker", workflowName)
+		}
+		workerID := hCtx.Worker().ID()
+		desiredWorkerID = &workerID
+	}
+
+	additionalMetadata, err := marshalAdditionalMetadata(runOpts.AdditionalMetadata)
+	if err != nil {
+		return nil, err
+	}
+	var priority *int32
+	if runOpts.Priority != nil {
+		priority = &[]int32{int32(*runOpts.Priority)}[0]
+	}
+
+	return &v1.TriggerWorkflowRequest{
+		Name:                    workflowName,
+		Input:                   string(inputBytes),
+		ParentId:                strPtr(hCtx.WorkflowRunId()),
+		ParentTaskRunExternalId: strPtr(hCtx.StepRunId()),
+		ChildIndex:              &childIndex,
+		ChildKey:                runOpts.Key,
+		AdditionalMetadata:      additionalMetadata,
+		DesiredWorkerId:         desiredWorkerID,
+		Priority:                priority,
+		DesiredWorkerLabels:     desiredWorkerLabelsToProto(runOpts.DesiredWorkerLabels),
+	}, nil
+}
+
+func waitForDurableChildResult(
+	ctx context.Context,
+	listener *v0Client.DurableTaskListener,
+	hCtx Context,
+	invocationCount int32,
+	workflowName string,
+	entry v0Client.TriggerRunAckEntry,
+) (any, error) {
+	if hookProvider, ok := ctx.(durableEvictionHookProvider); ok {
+		if hook := hookProvider.DurableEvictionHook(); hook != nil {
+			hook.MarkWaiting(hCtx.StepRunId(), "spawn_child", workflowName)
+			defer hook.MarkActive(hCtx.StepRunId())
+		}
+	}
+
+	payloadBytes, err := listener.WaitForCallback(
+		hCtx.GetContext(),
+		hCtx.StepRunId(),
+		invocationCount,
+		entry.BranchID,
+		entry.NodeID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to wait for durable child workflow: %w", err)
+	}
+
+	if len(payloadBytes) == 0 {
+		return map[string]any{}, nil
+	}
+
+	var payload any
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return nil, fmt.Errorf("failed to decode durable child workflow result: %w", err)
+	}
+
+	return payload, nil
+}
+
+func marshalAdditionalMetadata(metadata *map[string]string) (*string, error) {
+	if metadata == nil {
+		return nil, nil
+	}
+
+	metadataBytes, err := json.Marshal(metadata)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal additional metadata: %w", err)
+	}
+
+	metadataString := string(metadataBytes)
+	return &metadataString, nil
+}
+
+func desiredWorkerLabelsToProto(labels map[string]*DesiredWorkerLabel) map[string]*v1.DesiredWorkerLabels {
+	if labels == nil {
+		return nil
+	}
+
+	result := make(map[string]*v1.DesiredWorkerLabels, len(labels))
+	for key, label := range labels {
+		protoLabel := &v1.DesiredWorkerLabels{
+			Required: &label.Required,
+			Weight:   &label.Weight,
+		}
+
+		if label.Comparator != nil {
+			comparator := v1.WorkerLabelComparator(*label.Comparator)
+			protoLabel.Comparator = &comparator
+		}
+
+		switch v := label.Value.(type) {
+		case string:
+			protoLabel.StrValue = &v
+		case int:
+			intVal := int32(v) // nolint:gosec
+			protoLabel.IntValue = &intVal
+		case int32:
+			protoLabel.IntValue = &v
+		}
+
+		result[key] = protoLabel
+	}
+
+	return result
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/sdks/go/durable_child.go
+++ b/sdks/go/durable_child.go
@@ -23,7 +23,7 @@ type childIndexProvider interface {
 	NextChildIndex() int
 }
 
-func runDurableChildWorkflow(
+func runDurableChildWorkflowIfSupported(
 	ctx context.Context,
 	workflowName string,
 	input any,

--- a/sdks/go/durable_child.go
+++ b/sdks/go/durable_child.go
@@ -39,7 +39,12 @@ func runDurableChildWorkflow(
 		return nil, false, nil
 	}
 
-	trigger, err := buildDurableChildTrigger(hCtx, workflowName, input, runOpts)
+	childOpts, err := durableChildWorkflowOpts(hCtx, workflowName, runOpts)
+	if err != nil {
+		return nil, true, err
+	}
+
+	trigger, err := v0Client.NewChildWorkflowTriggerRequest(workflowName, input, childOpts, nil)
 	if err != nil {
 		return nil, true, err
 	}
@@ -111,7 +116,12 @@ func runManyDurableChildWorkflows(
 		}
 		runOpts.AdditionalMetadata = injectTraceparentToMap(otelCtx, runOpts.AdditionalMetadata)
 
-		trigger, err := buildDurableChildTrigger(hCtx, workflowName, input.Input, runOpts)
+		childOpts, err := durableChildWorkflowOpts(hCtx, workflowName, runOpts)
+		if err != nil {
+			return nil, true, err
+		}
+
+		trigger, err := v0Client.NewChildWorkflowTriggerRequest(workflowName, input.Input, childOpts, nil)
 		if err != nil {
 			return nil, true, err
 		}
@@ -154,24 +164,17 @@ func runManyDurableChildWorkflows(
 	return refs, true, nil
 }
 
-func buildDurableChildTrigger(
+func durableChildWorkflowOpts(
 	hCtx Context,
 	workflowName string,
-	input any,
 	runOpts *runOpts,
-) (*v1.TriggerWorkflowRequest, error) {
-	inputBytes, err := json.Marshal(input)
-	if err != nil {
-		return nil, fmt.Errorf("could not marshal input: %w", err)
-	}
-
+) (*v0Client.ChildWorkflowOpts, error) {
 	childIndexValue := hCtx.CurChildIndex()
 	if next, ok := hCtx.(childIndexProvider); ok {
 		childIndexValue = next.NextChildIndex()
 	} else {
 		hCtx.IncChildIndex()
 	}
-	childIndex := int32(childIndexValue) // nolint:gosec
 
 	var desiredWorkerID *string
 	if runOpts.Sticky != nil && *runOpts.Sticky {
@@ -182,26 +185,21 @@ func buildDurableChildTrigger(
 		desiredWorkerID = &workerID
 	}
 
-	additionalMetadata, err := marshalAdditionalMetadata(runOpts.AdditionalMetadata)
-	if err != nil {
-		return nil, err
-	}
 	var priority *int32
 	if runOpts.Priority != nil {
-		priority = &[]int32{int32(*runOpts.Priority)}[0]
+		priorityValue := int32(*runOpts.Priority)
+		priority = &priorityValue
 	}
 
-	return &v1.TriggerWorkflowRequest{
-		Name:                    workflowName,
-		Input:                   string(inputBytes),
-		ParentId:                strPtr(hCtx.WorkflowRunId()),
-		ParentTaskRunExternalId: strPtr(hCtx.StepRunId()),
-		ChildIndex:              &childIndex,
-		ChildKey:                runOpts.Key,
-		AdditionalMetadata:      additionalMetadata,
-		DesiredWorkerId:         desiredWorkerID,
-		Priority:                priority,
-		DesiredWorkerLabels:     desiredWorkerLabelsToProto(runOpts.DesiredWorkerLabels),
+	return &v0Client.ChildWorkflowOpts{
+		ParentId:            hCtx.WorkflowRunId(),
+		ParentTaskRunId:     hCtx.StepRunId(),
+		ChildIndex:          childIndexValue,
+		ChildKey:            runOpts.Key,
+		DesiredWorkerId:     desiredWorkerID,
+		AdditionalMetadata:  runOpts.AdditionalMetadata,
+		Priority:            priority,
+		DesiredWorkerLabels: runOpts.DesiredWorkerLabels,
 	}, nil
 }
 
@@ -235,61 +233,10 @@ func waitForDurableChildResult(
 		return map[string]any{}, nil
 	}
 
-	var payload any
+	var payload map[string]any
 	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
 		return nil, fmt.Errorf("failed to decode durable child workflow result: %w", err)
 	}
 
 	return payload, nil
-}
-
-func marshalAdditionalMetadata(metadata *map[string]string) (*string, error) {
-	if metadata == nil {
-		return nil, nil
-	}
-
-	metadataBytes, err := json.Marshal(metadata)
-	if err != nil {
-		return nil, fmt.Errorf("could not marshal additional metadata: %w", err)
-	}
-
-	metadataString := string(metadataBytes)
-	return &metadataString, nil
-}
-
-func desiredWorkerLabelsToProto(labels map[string]*DesiredWorkerLabel) map[string]*v1.DesiredWorkerLabels {
-	if labels == nil {
-		return nil
-	}
-
-	result := make(map[string]*v1.DesiredWorkerLabels, len(labels))
-	for key, label := range labels {
-		protoLabel := &v1.DesiredWorkerLabels{
-			Required: &label.Required,
-			Weight:   &label.Weight,
-		}
-
-		if label.Comparator != nil {
-			comparator := v1.WorkerLabelComparator(*label.Comparator)
-			protoLabel.Comparator = &comparator
-		}
-
-		switch v := label.Value.(type) {
-		case string:
-			protoLabel.StrValue = &v
-		case int:
-			intVal := int32(v) // nolint:gosec
-			protoLabel.IntValue = &intVal
-		case int32:
-			protoLabel.IntValue = &v
-		}
-
-		result[key] = protoLabel
-	}
-
-	return result
-}
-
-func strPtr(s string) *string {
-	return &s
 }

--- a/sdks/go/e2e/durable_test.go
+++ b/sdks/go/e2e/durable_test.go
@@ -36,6 +36,28 @@ func taskExternalID(t *testing.T, client *hatchet.Client, ctx context.Context, r
 	return ""
 }
 
+func workflowResultWithin(t *testing.T, ref *hatchet.WorkflowRunRef, timeout time.Duration) *hatchet.WorkflowResult {
+	t.Helper()
+	type result struct {
+		value *hatchet.WorkflowResult
+		err   error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		value, err := ref.Result()
+		ch <- result{value: value, err: err}
+	}()
+
+	select {
+	case result := <-ch:
+		require.NoError(t, result.err)
+		return result.value
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for workflow run %s result", ref.RunId)
+		return nil
+	}
+}
+
 func TestDurableWorkflow(t *testing.T) {
 	ctx := newTestContext(t)
 
@@ -118,12 +140,39 @@ func TestDurableChildSpawn(t *testing.T) {
 	assert.Equal(t, "hello from child 1", childOutput["message"])
 }
 
+func TestDurableChildSpawnReplay(t *testing.T) {
+	requireDurableEviction(t)
+	ctx := newTestContext(t)
+
+	ref, err := testDurableWithSpawn.RunNoWait(ctx, EmptyInput{})
+	require.NoError(t, err)
+
+	firstResult := workflowResultWithin(t, ref, 20*time.Second)
+	firstOutput := resultMap(t, firstResult, "durable-with-spawn")
+	firstChild, ok := firstOutput["child_output"].(map[string]any)
+	require.True(t, ok, "expected child_output to be a map")
+	assert.Equal(t, "hello from child 1", firstChild["message"])
+
+	_, err = sharedClient.Runs().Replay(ctx, rest.V1ReplayTaskRequest{
+		ExternalIds: toUUIDs(ref.RunId),
+	})
+	require.NoError(t, err)
+
+	replayResult := workflowResultWithin(t, ref, 20*time.Second)
+	replayOutput := resultMap(t, replayResult, "durable-with-spawn")
+	replayChild, ok := replayOutput["child_output"].(map[string]any)
+	require.True(t, ok, "expected child_output to be a map")
+	assert.Equal(t, "hello from child 1", replayChild["message"])
+}
+
 func TestDurableChildBulkSpawn(t *testing.T) {
 	ctx := newTestContext(t)
 	n := 8
 
+	start := time.Now()
 	result, err := testDurableWithBulkSpawn.Run(ctx, DurableBulkSpawnInput{N: n})
 	require.NoError(t, err)
+	elapsed := time.Since(start).Seconds()
 
 	var m map[string]any
 	err = result.Into(&m)
@@ -144,6 +193,38 @@ func TestDurableChildBulkSpawn(t *testing.T) {
 		seen[msg] = struct{}{}
 	}
 	assert.Len(t, seen, len(outputs))
+	assert.Less(t, elapsed, 2.0, "bulk durable child result collection should not scale linearly with child count")
+}
+
+func TestDurableChildLoopSpawn(t *testing.T) {
+	ctx := newTestContext(t)
+	n := 8
+
+	start := time.Now()
+	result, err := testDurableWithLoopSpawn.Run(ctx, DurableBulkSpawnInput{N: n})
+	require.NoError(t, err)
+	elapsed := time.Since(start).Seconds()
+
+	var m map[string]any
+	err = result.Into(&m)
+	require.NoError(t, err)
+	outputs, ok := m["child_outputs"].([]any)
+	require.True(t, ok, "expected child_outputs to be an array")
+
+	assert.GreaterOrEqual(t, len(outputs), n-1)
+	assert.LessOrEqual(t, len(outputs), n)
+
+	seen := make(map[string]struct{}, len(outputs))
+	for _, raw := range outputs {
+		child, ok := raw.(map[string]any)
+		require.True(t, ok, "expected each child output to be an object")
+
+		msg, ok := child["message"].(string)
+		require.True(t, ok, "expected child message to be a string")
+		seen[msg] = struct{}{}
+	}
+	assert.Len(t, seen, len(outputs))
+	assert.Less(t, elapsed, 4.0, "durable child RunNoWait result collection should not scale linearly with child count")
 }
 
 func TestDurableSleepEventSpawnReplay(t *testing.T) {

--- a/sdks/go/e2e/non_durable_test.go
+++ b/sdks/go/e2e/non_durable_test.go
@@ -1,0 +1,36 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNonDurableStandaloneTaskRun(t *testing.T) {
+	ctx := newTestContext(t)
+
+	result, err := testSpawnChildTask.Run(ctx, DurableBulkSpawnInput{N: 7})
+	require.NoError(t, err)
+
+	var output map[string]string
+	err = result.Into(&output)
+	require.NoError(t, err)
+	assert.Equal(t, "hello from child 7", output["message"])
+}
+
+func TestNonDurableStandaloneTaskRunNoWaitResult(t *testing.T) {
+	ctx := newTestContext(t)
+
+	ref, err := testSpawnChildTask.RunNoWait(ctx, DurableBulkSpawnInput{N: 8})
+	require.NoError(t, err)
+
+	result := workflowResultWithin(t, ref, 20*time.Second)
+	var output map[string]string
+	err = result.TaskOutput("spawn-child-task").Into(&output)
+	require.NoError(t, err)
+	assert.Equal(t, "hello from child 8", output["message"])
+}

--- a/sdks/go/e2e/worker.go
+++ b/sdks/go/e2e/worker.go
@@ -64,6 +64,7 @@ var (
 	testSpawnChildTask          *hatchet.StandaloneTask
 	testDurableWithSpawn        *hatchet.StandaloneTask
 	testDurableWithBulkSpawn    *hatchet.StandaloneTask
+	testDurableWithLoopSpawn    *hatchet.StandaloneTask
 	testDurableSleepEventSpawn  *hatchet.StandaloneTask
 	testDurableNonDeterminism   *hatchet.StandaloneTask
 	testDurableReplayReset      *hatchet.StandaloneTask
@@ -225,6 +226,33 @@ func registerAllWorkflows(client *hatchet.Client) {
 			if err != nil {
 				return nil, err
 			}
+			outputs := make([]map[string]string, len(refs))
+			for i, ref := range refs {
+				result, err := ref.Result()
+				if err != nil {
+					return nil, err
+				}
+				var m map[string]string
+				if err := result.TaskOutput("spawn-child-task").Into(&m); err != nil {
+					return nil, err
+				}
+				outputs[i] = m
+			}
+			return map[string]any{"child_outputs": outputs}, nil
+		},
+	)
+
+	testDurableWithLoopSpawn = client.NewStandaloneDurableTask("durable-with-loop-spawn",
+		func(ctx hatchet.DurableContext, input DurableBulkSpawnInput) (map[string]any, error) {
+			refs := make([]*hatchet.WorkflowRunRef, input.N)
+			for i := 0; i < input.N; i++ {
+				ref, err := testSpawnChildTask.RunNoWait(ctx, DurableBulkSpawnInput{N: i})
+				if err != nil {
+					return nil, err
+				}
+				refs[i] = ref
+			}
+
 			outputs := make([]map[string]string, len(refs))
 			for i, ref := range refs {
 				result, err := ref.Result()
@@ -568,6 +596,7 @@ func startTestWorker(client *hatchet.Client) (*hatchet.Worker, func() error, err
 			testSpawnChildTask,
 			testDurableWithSpawn,
 			testDurableWithBulkSpawn,
+			testDurableWithLoopSpawn,
 			testDurableSleepEventSpawn,
 			testDurableNonDeterminism,
 			testDurableReplayReset,

--- a/sdks/go/workflow.go
+++ b/sdks/go/workflow.go
@@ -635,14 +635,7 @@ func (w *Workflow) Run(ctx context.Context, input any, opts ...RunOptFunc) (*Wor
 		return nil, err
 	}
 
-	result, err := workflowRunRef.v0Workflow.Result()
-	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
-		span.RecordError(err)
-		return nil, err
-	}
-
-	workflowResult, err := result.Results()
+	workflowResult, err := workflowRunRef.Result()
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		span.RecordError(err)
@@ -650,7 +643,7 @@ func (w *Workflow) Run(ctx context.Context, input any, opts ...RunOptFunc) (*Wor
 	}
 
 	span.SetStatus(codes.Ok, "")
-	return &WorkflowResult{result: workflowResult, RunId: workflowRunRef.RunId}, nil
+	return workflowResult, nil
 }
 
 // RunNoWait executes the workflow with the provided input without waiting for completion.
@@ -709,6 +702,17 @@ func (w *Workflow) runWorkflowInternal(ctx context.Context, otelCtx context.Cont
 
 	hCtx, ok := ctx.(Context)
 	if ok {
+		durableRef, handled, durableErr := runDurableChildWorkflow(ctx, w.declaration.Name(), input, runOpts)
+		if handled {
+			if durableErr != nil {
+				span.SetStatus(codes.Error, durableErr.Error())
+				span.RecordError(durableErr)
+				return nil, durableErr
+			}
+			span.SetAttributes(attribute.String(hatchetotel.AttrChildWorkflowRunID, durableRef.RunId))
+			return durableRef, nil
+		}
+
 		v0Workflow, err = hCtx.SpawnWorkflow(w.declaration.Name(), input, &worker.SpawnWorkflowOpts{
 			Key:                 runOpts.Key,
 			Sticky:              runOpts.Sticky,
@@ -734,7 +738,12 @@ func (w *Workflow) runWorkflowInternal(ctx context.Context, otelCtx context.Cont
 // RunMany executes multiple workflow instances with different inputs.
 func (w *Workflow) RunMany(ctx context.Context, inputs []RunManyOpt) ([]WorkflowRunRef, error) {
 	tracer := otel.Tracer("github.com/hatchet-dev/hatchet/sdks/go")
-	ctx, span := tracer.Start(ctx, hatchetotel.SpanRunWorkflows,
+	originalCtx := ctx
+	otelCtx := ctx
+	if hCtx, ok := ctx.(Context); ok {
+		otelCtx = hCtx.GetContext()
+	}
+	otelCtx, span := tracer.Start(otelCtx, hatchetotel.SpanRunWorkflows,
 		trace.WithSpanKind(trace.SpanKindProducer),
 		trace.WithAttributes(
 			attribute.String(hatchetotel.AttrInstrumentor, hatchetotel.AttrInstrumentorValue),
@@ -743,6 +752,16 @@ func (w *Workflow) RunMany(ctx context.Context, inputs []RunManyOpt) ([]Workflow
 		),
 	)
 	defer span.End()
+
+	if durableRefs, handled, err := runManyDurableChildWorkflows(originalCtx, otelCtx, w.declaration.Name(), inputs); handled {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+			return durableRefs, err
+		}
+
+		span.SetStatus(codes.Ok, "")
+		return durableRefs, nil
+	}
 
 	var workflowRefs []WorkflowRunRef
 
@@ -756,7 +775,7 @@ func (w *Workflow) RunMany(ctx context.Context, inputs []RunManyOpt) ([]Workflow
 		go func() {
 			defer wg.Done()
 
-			workflowRef, err := w.RunNoWait(ctx, input.Input, input.Opts...)
+			workflowRef, err := w.RunNoWait(originalCtx, input.Input, input.Opts...)
 			if err != nil {
 				errsMutex.Lock()
 				errs = append(errs, err)

--- a/sdks/go/workflow.go
+++ b/sdks/go/workflow.go
@@ -702,7 +702,7 @@ func (w *Workflow) runWorkflowInternal(ctx context.Context, otelCtx context.Cont
 
 	hCtx, ok := ctx.(Context)
 	if ok {
-		durableRef, handled, durableErr := runDurableChildWorkflow(ctx, w.declaration.Name(), input, runOpts)
+		durableRef, handled, durableErr := runDurableChildWorkflowIfSupported(ctx, w.declaration.Name(), input, runOpts)
 		if handled {
 			if durableErr != nil {
 				span.SetStatus(codes.Error, durableErr.Error())


### PR DESCRIPTION
# Description

Async spawn methods (RunNoWait) did not correctly subscribe to durable state for durable children.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

Added test cases, verified failing before patch.


<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Used cursor to verify parity with python impl and iterate on tests.

</details>
