### PR TITLE
chore(ci): Add contributor vouching

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -1,0 +1,29 @@
+# The list of vouched (or actively denounced) users for this repository.
+#
+# The high-level idea is that anyone can participate in contributing
+# to Hatchet, except if you have been explicitly denounced. A denounced
+# user is explicitly blocked from contributing (issues, PRs, etc. auto-closed).
+#
+# Maintainers and anyone already vouched in this file can vouch, denounce,
+# or unvouch users by commenting `vouch`, `denounce`, or `unvouch` on an
+# issue or PR. The target defaults to the issue/PR author, or can be
+# specified with `@username`. A reason may follow.
+#
+# Note: vouching a user also grants them the ability to vouch, denounce,
+# and unvouch others. Consider this when adding new entries.
+#
+# See https://github.com/mitchellh/vouch for details.
+#
+# Syntax:
+#   - One handle per line (without @), sorted alphabetically.
+#   - Optional platform prefix: platform:username (e.g., github:user).
+#   - Denounce with minus prefix: -username or -platform:username.
+#   - Optional details after a space following the handle.
+abelengar5
+bloggerbust
+gregfurman
+grutt
+igor-kupczynski
+meganeoleary
+mnafees
+mrkaye97

--- a/.github/workflows/vouch-check-issue.yml
+++ b/.github/workflows/vouch-check-issue.yml
@@ -1,0 +1,28 @@
+name: "Vouch - Check Issue"
+
+on:
+  issues:
+    types: [opened, reopened]
+  workflow_dispatch:
+    inputs:
+      issue-number:
+        description: 'Issue number to check'
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mitchellh/vouch/action/check-issue@c6d80ead49839655b61b422700b7a3bc9d0804a9 # v1.4.2
+        with:
+          issue-number: ${{ github.event.issue.number || inputs.issue-number }}
+          auto-close: true
+          # NOTE: auto-close only for explicitly denounced users.
+          require-vouch: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -1,0 +1,28 @@
+name: "Vouch - Check PR"
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: 'PR number to check'
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mitchellh/vouch/action/check-pr@c6d80ead49839655b61b422700b7a3bc9d0804a9 # v1.4.2
+        with:
+          pr-number: ${{ github.event.pull_request.number || inputs.pr-number }}
+          auto-close: true
+          # NOTE: auto-close only for explicitly denounced users.
+          require-vouch: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vouch-manage-by-issue.yml
+++ b/.github/workflows/vouch-manage-by-issue.yml
@@ -1,0 +1,48 @@
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: vouch-manage
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  manage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: mitchellh/vouch/action/manage-by-issue@c6d80ead49839655b61b422700b7a3bc9d0804a9 # v1.4.2
+        id: manage-by-issue
+        with:
+          repo: ${{ github.repository }}
+          issue-id: ${{ github.event.issue.number }}
+          comment-id: ${{ github.event.comment.id }}
+          # Create a PR for this.
+          pull-request: true
+          vouched-managers-file: .github/VOUCHED.td
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Label PR as denounced
+        if: steps.manage-by-issue.outputs.status == 'denounced' && github.event.issue.pull_request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --add-label "denounced"
+
+      - name: Label Issue as denounced
+        if: steps.manage-by-issue.outputs.status == 'denounced' && !github.event.issue.pull_request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --add-label "denounced"

--- a/.github/workflows/vouch-sync.yml
+++ b/.github/workflows/vouch-sync.yml
@@ -1,0 +1,42 @@
+name: "Vouch - Recheck open PRs and issues on VOUCHED change"
+
+on:
+  push:
+    branches: [main]
+    paths: [".github/VOUCHED.td"]
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch check-pr for each open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PRS=$(gh pr list --repo "${{ github.repository }}" --state open --json number --jq '.[].number')
+
+          for pr in $PRS; do
+            echo "Dispatching Vouch - Check PR for PR #$pr"
+            gh workflow run "Vouch - Check PR" \
+              --repo "${{ github.repository }}" \
+              --ref main \
+              -f pr-number="$pr"
+          done
+
+      - name: Dispatch check-issue for each open issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUES=$(gh issue list --repo "${{ github.repository }}" --state open --json number --jq '.[].number')
+
+          for issue in $ISSUES; do
+            echo "Dispatching Vouch - Check Issue for issue #$issue"
+            gh workflow run "Vouch - Check Issue" \
+              --repo "${{ github.repository }}" \
+              --ref main \
+              -f issue-number="$issue"
+          done


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds new vouching functionality that will allow us to better manage offending users, blocking them from contributing via the actions provided by https://github.com/mitchellh/vouch (used in ghostty).

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] CI (any automation pipeline changes)


## What's Changed

- Several `.github/workflow` files that will check if an issues/PR has been opened by a denounced user; closing it if true. Otherwise, when a user is denounced via a `denounce` comment, the following workflow is kicked off:
   - Label that issue/pr as denounced.
   - Open another PR adding the specified user to the denouncement list.
   - Once merged, check for `denounced` issues/prs and re-trigger auto closing job.

## TODO

- [ ] Add a `denounced` label for filtering of PRs and issues

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
