### PR TITLE
fix: Cron row accumulation leading to query slowdown

### DIFF
--- a/pkg/repository/sqlcv1/workflows.sql
+++ b/pkg/repository/sqlcv1/workflows.sql
@@ -444,6 +444,13 @@ FROM triggersToUpdate
 WHERE "WorkflowTriggerCronRef"."id" = triggersToUpdate."id"
 ;
 
+-- name: DeleteOldDefaultCronTriggersForWorkflowVersion :exec
+DELETE FROM "WorkflowTriggerCronRef"
+USING "WorkflowTriggers"
+WHERE "WorkflowTriggerCronRef"."parentId" = "WorkflowTriggers"."id"
+    AND "WorkflowTriggers"."workflowVersionId" = @oldWorkflowVersionId::uuid
+    AND "WorkflowTriggerCronRef"."method" = 'DEFAULT';
+
 -- name: MoveScheduledTriggerToNewWorkflowTriggers :exec
 WITH triggersToUpdate AS (
     SELECT scheduledTrigger."id" FROM "WorkflowTriggerScheduledRef" scheduledTrigger

--- a/pkg/repository/sqlcv1/workflows.sql.go
+++ b/pkg/repository/sqlcv1/workflows.sql.go
@@ -983,6 +983,19 @@ func (q *Queries) CreateWorkflowVersion(ctx context.Context, db DBTX, arg Create
 	return &i, err
 }
 
+const deleteOldDefaultCronTriggersForWorkflowVersion = `-- name: DeleteOldDefaultCronTriggersForWorkflowVersion :exec
+DELETE FROM "WorkflowTriggerCronRef"
+USING "WorkflowTriggers"
+WHERE "WorkflowTriggerCronRef"."parentId" = "WorkflowTriggers"."id"
+    AND "WorkflowTriggers"."workflowVersionId" = $1::uuid
+    AND "WorkflowTriggerCronRef"."method" = 'DEFAULT'
+`
+
+func (q *Queries) DeleteOldDefaultCronTriggersForWorkflowVersion(ctx context.Context, db DBTX, oldworkflowversionid uuid.UUID) error {
+	_, err := db.Exec(ctx, deleteOldDefaultCronTriggersForWorkflowVersion, oldworkflowversionid)
+	return err
+}
+
 const getLatestWorkflowVersionForWorkflows = `-- name: GetLatestWorkflowVersionForWorkflows :many
 SELECT DISTINCT ON (wv."workflowId")
     wv."id"

--- a/pkg/repository/workflow.go
+++ b/pkg/repository/workflow.go
@@ -599,6 +599,14 @@ func (r *workflowRepository) createWorkflowVersionTxs(ctx context.Context, tx sq
 			return nil, fmt.Errorf("could not move existing cron triggers to new workflow triggers: %w", err)
 		}
 
+		// delete DEFAULT cron refs from the old version — they were re-created fresh above for the new version,
+		// and leaving them accumulates dead rows that the PollCronSchedules query locks every 15 seconds
+		err = r.queries.DeleteOldDefaultCronTriggersForWorkflowVersion(ctx, tx, oldWorkflowVersion.WorkflowVersion.ID)
+
+		if err != nil {
+			return nil, fmt.Errorf("could not delete old DEFAULT cron triggers: %w", err)
+		}
+
 		// move existing scheduled triggers to the new workflow version
 		err = r.queries.MoveScheduledTriggerToNewWorkflowTriggers(ctx, tx, sqlcv1.MoveScheduledTriggerToNewWorkflowTriggersParams{
 			Oldworkflowversionid: oldWorkflowVersion.WorkflowVersion.ID,

--- a/pkg/repository/workflow_cron_cleanup_test.go
+++ b/pkg/repository/workflow_cron_cleanup_test.go
@@ -1,0 +1,176 @@
+//go:build !e2e && !load && !rampup && !integration
+
+package repository
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hatchet-dev/hatchet/pkg/repository/cache"
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
+	"github.com/hatchet-dev/hatchet/pkg/validator"
+)
+
+// internalTenantId is the "internal" tenant seeded by migration 20240216133745_v0_11_0.sql.
+// It always exists after RunMigrations and is the standard tenant used in repository-layer tests.
+var internalTenantId = uuid.MustParse("8d420720-ef03-41dc-9c73-1c93f276db97")
+
+func newWorkflowTestRepository(pool *pgxpool.Pool) *workflowRepository {
+	logger := zerolog.Nop()
+	shared := &sharedRepository{
+		pool:       pool,
+		ddlPool:    pool,
+		l:          &logger,
+		queries:    sqlcv1.New(),
+		v:          validator.NewDefaultValidator(),
+		queueCache: cache.New(5 * time.Minute),
+	}
+	return &workflowRepository{sharedRepository: shared}
+}
+
+func countCronRefsForWorkflowName(ctx context.Context, t *testing.T, pool *pgxpool.Pool, workflowName string) int {
+	t.Helper()
+	var count int
+	err := pool.QueryRow(ctx, `
+		SELECT count(c.*)
+		FROM "WorkflowTriggerCronRef" c
+		JOIN "WorkflowTriggers" tr ON tr."id" = c."parentId"
+		JOIN "WorkflowVersion" wv ON wv."id" = tr."workflowVersionId"
+		JOIN "Workflow" w ON w."id" = wv."workflowId"
+		WHERE w."name" = $1
+		  AND w."deletedAt" IS NULL
+	`, workflowName).Scan(&count)
+	require.NoError(t, err)
+	return count
+}
+
+// minimalWorkflowOpts returns valid workflow opts with a single step.
+// Pass a unique description to force a new checksum on re-registration.
+func minimalWorkflowOpts(name, description string, cronTriggers []string) *CreateWorkflowVersionOpts {
+	desc := description
+	return &CreateWorkflowVersionOpts{
+		Name:         name,
+		Description:  &desc,
+		CronTriggers: cronTriggers,
+		Tasks: []CreateStepOpts{
+			{
+				ReadableId: "step1",
+				Action:     "integration:step1",
+			},
+		},
+	}
+}
+
+// TestDefaultCronTriggersCleanedUpOnReregistration is the core regression test.
+// Before the fix, each call to PutWorkflowVersion with a new version left the old
+// DEFAULT WorkflowTriggerCronRef rows in the database. These accumulated over time
+// and were still scanned and locked by PollCronSchedules every 15 seconds, causing
+// the performance degradation observed at 8pm each day.
+func TestDefaultCronTriggersCleanedUpOnReregistration(t *testing.T) {
+	pool, cleanup := setupPostgresWithMigration(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	repo := newWorkflowTestRepository(pool)
+
+	const workflowName = "cron-cleanup-test"
+	cronTriggers := []string{"0 * * * *", "30 * * * *"}
+
+	// Register v1
+	_, err := repo.PutWorkflowVersion(ctx, internalTenantId, minimalWorkflowOpts(workflowName, "v1", cronTriggers))
+	require.NoError(t, err)
+
+	count := countCronRefsForWorkflowName(ctx, t, pool, workflowName)
+	assert.Equal(t, 2, count, "should have 2 cron refs after initial registration")
+
+	// Register v2 — same crons, different description forces a new checksum and new version
+	_, err = repo.PutWorkflowVersion(ctx, internalTenantId, minimalWorkflowOpts(workflowName, "v2", cronTriggers))
+	require.NoError(t, err)
+
+	count = countCronRefsForWorkflowName(ctx, t, pool, workflowName)
+	assert.Equal(t, 2, count, "should still have 2 cron refs after re-registration — old DEFAULT rows must be deleted")
+}
+
+// TestDefaultCronsDontAccumulateAcrossMultipleVersions ensures the fix holds up
+// across many re-registrations (the scenario of daily deployments over weeks).
+func TestDefaultCronsDontAccumulateAcrossMultipleVersions(t *testing.T) {
+	pool, cleanup := setupPostgresWithMigration(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	repo := newWorkflowTestRepository(pool)
+
+	const workflowName = "cron-no-accumulation-test"
+	cronTriggers := []string{"0 0 * * *"}
+
+	for i := 0; i < 5; i++ {
+		desc := fmt.Sprintf("version-%d", i)
+		_, err := repo.PutWorkflowVersion(ctx, internalTenantId, minimalWorkflowOpts(workflowName, desc, cronTriggers))
+		require.NoError(t, err)
+	}
+
+	count := countCronRefsForWorkflowName(ctx, t, pool, workflowName)
+	assert.Equal(t, 1, count, "should have exactly 1 cron ref regardless of how many versions were registered")
+}
+
+// TestOnlyDefaultCronsAreDeleted verifies that the cleanup targets only DEFAULT-method crons.
+// API-method crons (created via the API after workflow registration) must not be deleted —
+// the existing MoveCronTriggerToNewWorkflowTriggers call migrates them to the new version instead.
+func TestOnlyDefaultCronsAreDeleted(t *testing.T) {
+	pool, cleanup := setupPostgresWithMigration(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	repo := newWorkflowTestRepository(pool)
+
+	const workflowName = "api-cron-method-test"
+
+	// Register v1 with one DEFAULT cron
+	v1, err := repo.PutWorkflowVersion(ctx, internalTenantId, minimalWorkflowOpts(workflowName, "v1", []string{"0 * * * *"}))
+	require.NoError(t, err)
+
+	// Insert an API-method cron directly against v1's WorkflowTriggers record
+	queries := sqlcv1.New()
+	var triggersId uuid.UUID
+	err = pool.QueryRow(ctx,
+		`SELECT "id" FROM "WorkflowTriggers" WHERE "workflowVersionId" = $1`,
+		v1.WorkflowVersion.ID,
+	).Scan(&triggersId)
+	require.NoError(t, err)
+
+	_, err = queries.CreateWorkflowTriggerCronRef(ctx, pool, sqlcv1.CreateWorkflowTriggerCronRefParams{
+		Workflowtriggersid: triggersId,
+		Crontrigger:        "15 * * * *",
+		Method:             sqlcv1.NullWorkflowTriggerCronRefMethods{WorkflowTriggerCronRefMethods: sqlcv1.WorkflowTriggerCronRefMethodsAPI, Valid: true},
+	})
+	require.NoError(t, err)
+
+	// Register v2 — this should delete v1's DEFAULT cron and migrate v1's API cron
+	_, err = repo.PutWorkflowVersion(ctx, internalTenantId, minimalWorkflowOpts(workflowName, "v2", []string{"0 * * * *"}))
+	require.NoError(t, err)
+
+	// Only DEFAULT crons from the old version should be gone; API cron was migrated
+	var defaultCount, apiCount int
+	err = pool.QueryRow(ctx, `
+		SELECT count(*) FILTER (WHERE c."method" = 'DEFAULT'),
+		       count(*) FILTER (WHERE c."method" = 'API')
+		FROM "WorkflowTriggerCronRef" c
+		JOIN "WorkflowTriggers" tr ON tr."id" = c."parentId"
+		JOIN "WorkflowVersion" wv ON wv."id" = tr."workflowVersionId"
+		JOIN "Workflow" w ON w."id" = wv."workflowId"
+		WHERE w."name" = $1
+		  AND w."deletedAt" IS NULL
+	`, workflowName).Scan(&defaultCount, &apiCount)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, defaultCount, "should have exactly 1 DEFAULT cron on the new version")
+	assert.Equal(t, 1, apiCount, "API cron should be migrated to the new version, not deleted")
+}

--- a/pkg/repository/workflow_cron_cleanup_test.go
+++ b/pkg/repository/workflow_cron_cleanup_test.go
@@ -19,8 +19,6 @@ import (
 	"github.com/hatchet-dev/hatchet/pkg/validator"
 )
 
-// internalTenantId is the "internal" tenant seeded by migration 20240216133745_v0_11_0.sql.
-// It always exists after RunMigrations and is the standard tenant used in repository-layer tests.
 var internalTenantId = uuid.MustParse("8d420720-ef03-41dc-9c73-1c93f276db97")
 
 func newWorkflowTestRepository(pool *pgxpool.Pool) *workflowRepository {
@@ -69,11 +67,6 @@ func minimalWorkflowOpts(name, description string, cronTriggers []string) *Creat
 	}
 }
 
-// TestDefaultCronTriggersCleanedUpOnReregistration is the core regression test.
-// Before the fix, each call to PutWorkflowVersion with a new version left the old
-// DEFAULT WorkflowTriggerCronRef rows in the database. These accumulated over time
-// and were still scanned and locked by PollCronSchedules every 15 seconds, causing
-// the performance degradation observed at 8pm each day.
 func TestDefaultCronTriggersCleanedUpOnReregistration(t *testing.T) {
 	pool, cleanup := setupPostgresWithMigration(t)
 	defer cleanup()
@@ -99,8 +92,6 @@ func TestDefaultCronTriggersCleanedUpOnReregistration(t *testing.T) {
 	assert.Equal(t, 2, count, "should still have 2 cron refs after re-registration — old DEFAULT rows must be deleted")
 }
 
-// TestDefaultCronsDontAccumulateAcrossMultipleVersions ensures the fix holds up
-// across many re-registrations (the scenario of daily deployments over weeks).
 func TestDefaultCronsDontAccumulateAcrossMultipleVersions(t *testing.T) {
 	pool, cleanup := setupPostgresWithMigration(t)
 	defer cleanup()
@@ -121,9 +112,6 @@ func TestDefaultCronsDontAccumulateAcrossMultipleVersions(t *testing.T) {
 	assert.Equal(t, 1, count, "should have exactly 1 cron ref regardless of how many versions were registered")
 }
 
-// TestOnlyDefaultCronsAreDeleted verifies that the cleanup targets only DEFAULT-method crons.
-// API-method crons (created via the API after workflow registration) must not be deleted —
-// the existing MoveCronTriggerToNewWorkflowTriggers call migrates them to the new version instead.
 func TestOnlyDefaultCronsAreDeleted(t *testing.T) {
 	pool, cleanup := setupPostgresWithMigration(t)
 	defer cleanup()


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

When we register a workflow, we insert a new `WorkflowTriggerCronRef` with method DEFAULT, and the new workflow version. We also migrate old API cron triggers to the new workflow version. However, when a workflow is then registered *again*, it will create another `WorkflowTriggerCronRef`, and the old one becomes orphaned as it is method=DEFAULT, so not touched by MoveCronTriggerToNewWorkflowTriggers. This will lead to an accumulation of old cron rows, which build up and slow down `PollCronSchedules`. 

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: generating repro test, research.

</details>
