### PR TITLE
fix: Python test timeouts

### DIFF
--- a/sdks/python/hatchet_sdk/deprecated/action_listener_process.py
+++ b/sdks/python/hatchet_sdk/deprecated/action_listener_process.py
@@ -4,6 +4,8 @@ import asyncio
 import contextlib
 import logging
 import multiprocessing.synchronize
+import signal
+import threading
 import time
 from datetime import timedelta
 from multiprocessing import Queue
@@ -477,6 +479,14 @@ def legacy_worker_action_listener_process(
     worker_id_queue: "Queue[str]",
     stop_event: "multiprocessing.synchronize.Event",
 ) -> None:
+    # The parent controls this subprocess via stop_event + STOP_LOOP; OS signals
+    # must not kill the process before in-flight completion events are drained.
+    # Guard is needed because signal.signal() only works from the main thread
+    # (unit tests may invoke this from a non-main thread).
+    if threading.current_thread() is threading.main_thread():
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+
     async def run() -> None:
         process = LegacyWorkerActionListenerProcess(
             name=name,

--- a/sdks/python/hatchet_sdk/deprecated/action_listener_process.py
+++ b/sdks/python/hatchet_sdk/deprecated/action_listener_process.py
@@ -482,7 +482,6 @@ def legacy_worker_action_listener_process(
     worker_id_queue: "Queue[str]",
     stop_event: "multiprocessing.synchronize.Event",
 ) -> None:
-
     async def run() -> None:
         process = LegacyWorkerActionListenerProcess(
             name=name,

--- a/sdks/python/hatchet_sdk/deprecated/action_listener_process.py
+++ b/sdks/python/hatchet_sdk/deprecated/action_listener_process.py
@@ -5,7 +5,6 @@ import contextlib
 import logging
 import multiprocessing.synchronize
 import signal
-import threading
 import time
 from datetime import timedelta
 from multiprocessing import Queue
@@ -100,6 +99,10 @@ class LegacyWorkerActionListenerProcess:
             logger.setLevel(logging.DEBUG)
 
         self.client = Client(config=self.config, debug=self.debug)
+
+        loop = asyncio.get_event_loop()
+        loop.add_signal_handler(signal.SIGINT, lambda: None)
+        loop.add_signal_handler(signal.SIGTERM, lambda: None)
 
         if self.config.healthcheck.enabled:
             self._listener_health_gauge = Gauge(
@@ -479,13 +482,6 @@ def legacy_worker_action_listener_process(
     worker_id_queue: "Queue[str]",
     stop_event: "multiprocessing.synchronize.Event",
 ) -> None:
-    # The parent controls this subprocess via stop_event + STOP_LOOP; OS signals
-    # must not kill the process before in-flight completion events are drained.
-    # Guard is needed because signal.signal() only works from the main thread
-    # (unit tests may invoke this from a non-main thread).
-    if threading.current_thread() is threading.main_thread():
-        signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
 
     async def run() -> None:
         process = LegacyWorkerActionListenerProcess(

--- a/sdks/python/hatchet_sdk/worker/action_listener_process.py
+++ b/sdks/python/hatchet_sdk/worker/action_listener_process.py
@@ -3,7 +3,6 @@ import contextlib
 import logging
 import multiprocessing.synchronize
 import signal
-import threading
 import time
 import warnings
 from dataclasses import dataclass
@@ -114,6 +113,10 @@ class WorkerActionListenerProcess:
             logger.setLevel(logging.DEBUG)
 
         self.client = Client(config=self.config, debug=self.debug)
+
+        loop = asyncio.get_event_loop()
+        loop.add_signal_handler(signal.SIGINT, lambda: None)
+        loop.add_signal_handler(signal.SIGTERM, lambda: None)
 
         if self.config.healthcheck.enabled:
             self._listener_health_gauge = Gauge(
@@ -528,13 +531,6 @@ def worker_action_listener_process(
     worker_id_queue: "Queue[str]",
     stop_event: "multiprocessing.synchronize.Event",
 ) -> None:
-    # The parent controls this subprocess via stop_event + STOP_LOOP; OS signals
-    # must not kill the process before in-flight completion events are drained.
-    # Guard is needed because signal.signal() only works from the main thread
-    # (unit tests may invoke this from a non-main thread).
-    if threading.current_thread() is threading.main_thread():
-        signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
 
     async def run() -> None:
         process = WorkerActionListenerProcess(

--- a/sdks/python/hatchet_sdk/worker/action_listener_process.py
+++ b/sdks/python/hatchet_sdk/worker/action_listener_process.py
@@ -114,6 +114,8 @@ class WorkerActionListenerProcess:
 
         self.client = Client(config=self.config, debug=self.debug)
 
+        # explicit no-op on SIGINT and SIGTERM because shutdown is completely controlled
+        # by the parent worker process
         loop = asyncio.get_event_loop()
         loop.add_signal_handler(signal.SIGINT, lambda: None)
         loop.add_signal_handler(signal.SIGTERM, lambda: None)
@@ -531,7 +533,6 @@ def worker_action_listener_process(
     worker_id_queue: "Queue[str]",
     stop_event: "multiprocessing.synchronize.Event",
 ) -> None:
-
     async def run() -> None:
         process = WorkerActionListenerProcess(
             name=name,

--- a/sdks/python/hatchet_sdk/worker/action_listener_process.py
+++ b/sdks/python/hatchet_sdk/worker/action_listener_process.py
@@ -2,6 +2,8 @@ import asyncio
 import contextlib
 import logging
 import multiprocessing.synchronize
+import signal
+import threading
 import time
 import warnings
 from dataclasses import dataclass
@@ -526,6 +528,14 @@ def worker_action_listener_process(
     worker_id_queue: "Queue[str]",
     stop_event: "multiprocessing.synchronize.Event",
 ) -> None:
+    # The parent controls this subprocess via stop_event + STOP_LOOP; OS signals
+    # must not kill the process before in-flight completion events are drained.
+    # Guard is needed because signal.signal() only works from the main thread
+    # (unit tests may invoke this from a non-main thread).
+    if threading.current_thread() is threading.main_thread():
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+
     async def run() -> None:
         process = WorkerActionListenerProcess(
             name=name,

--- a/sdks/python/tests/unit/test_shutdown_ordering.py
+++ b/sdks/python/tests/unit/test_shutdown_ordering.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import multiprocessing
-import threading
 import time
 from dataclasses import dataclass
 from typing import Any
@@ -13,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from hatchet_sdk.clients.dispatcher.action_listener import ActionListener
+from hatchet_sdk.config import ClientConfig, HealthcheckConfig
 from hatchet_sdk.runnables.action import ActionType
 from hatchet_sdk.utils.typing import STOP_LOOP
 from hatchet_sdk.worker.action_listener_process import (
@@ -25,6 +25,61 @@ _LISTENER_MODULE = "hatchet_sdk.worker.action_listener_process"
 _ACTION_LISTENER_MODULE = "hatchet_sdk.clients.dispatcher.action_listener"
 
 _CTX = multiprocessing.get_context("spawn")
+
+
+def _subprocess_target(
+    name: str,
+    actions: list[str],
+    slot_config: dict[str, int],
+    config: Any,
+    action_queue: Any,
+    event_queue: Any,
+    handle_kill: bool,
+    debug: bool,
+    labels: list[Any],
+    worker_id_queue: Any,
+    stop_event: Any,
+) -> None:
+    """Module-level spawn target: sets up mocks then runs the listener process.
+
+    Must be defined at module level (not as a closure) so it can be pickled
+    by the spawn context, matching how _start_action_listener works in production.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from hatchet_sdk.clients.dispatcher.action_listener import ActionListener
+
+    with patch("hatchet_sdk.clients.dispatcher.action_listener.new_conn"):
+        listener = ActionListener(config=MagicMock(), worker_id="test-worker-id")
+    listener.cleanup = MagicMock()  # type: ignore[method-assign]
+    listener.get_listen_client = AsyncMock(  # type: ignore[method-assign]
+        side_effect=Exception("no gRPC server in tests")
+    )
+
+    mock_dispatcher = MagicMock()
+    mock_dispatcher.get_action_listener = AsyncMock(return_value=listener)
+    mock_dispatcher.send_step_action_event = AsyncMock()
+
+    with (
+        patch(
+            "hatchet_sdk.worker.action_listener_process.DispatcherClient",
+            return_value=mock_dispatcher,
+        ),
+        patch("hatchet_sdk.worker.action_listener_process.Client"),
+    ):
+        worker_action_listener_process(
+            name=name,
+            actions=actions,
+            slot_config=slot_config,
+            config=config,
+            action_queue=action_queue,
+            event_queue=event_queue,
+            handle_kill=handle_kill,
+            debug=debug,
+            labels=labels,
+            worker_id_queue=worker_id_queue,
+            stop_event=stop_event,
+        )
 
 
 @dataclass
@@ -168,51 +223,40 @@ async def test_worker_id_published_to_queue_on_start() -> None:
 def test_event_queue_drains_before_process_exits() -> None:
     """All events put into event_queue must be consumed before the subprocess exits.
 
-    Runs worker_action_listener_process in a thread (it calls asyncio.run()
-    internally) so we can exercise the full function with real queues without
-    a costly multiprocessing spawn.
+    Spawns worker_action_listener_process as a real separate process using the
+    same _CTX.Process / args pattern as _start_action_listener in production,
+    so the test covers signal handling and the full shutdown path.
     """
     action_queue: Any = _CTX.Queue()
     event_queue: Any = _CTX.Queue()
     worker_id_queue: Any = _CTX.Queue()
     stop_event = _CTX.Event()
 
-    config = MagicMock()
-    config.healthcheck.enabled = False
+    # ClientConfig must be picklable for spawn; model_construct skips JWT
+    # validation that would reject a dummy token.
+    config = ClientConfig.model_construct(
+        healthcheck=HealthcheckConfig(),
+        debug=False,
+        disable_log_capture=True,
+    )
 
-    consumed_events: list[str] = []
-    stub_listener = _make_listener()
-
-    async def fake_send(
-        action: Any, ev_type: Any, payload: Any, should_not_retry: Any
-    ) -> None:
-        consumed_events.append(str(ev_type))
-
-    mock_dispatcher = AsyncMock()
-    mock_dispatcher.get_action_listener = AsyncMock(return_value=stub_listener)
-    mock_dispatcher.send_step_action_event = AsyncMock(side_effect=fake_send)
-
-    def run_subprocess() -> None:
-        with (
-            patch(f"{_LISTENER_MODULE}.DispatcherClient", return_value=mock_dispatcher),
-            patch(f"{_LISTENER_MODULE}.Client"),
-        ):
-            worker_action_listener_process(
-                name="test-worker",
-                actions=["test_action"],
-                slot_config={"default": 1, "durable": 0},
-                config=config,
-                action_queue=action_queue,
-                event_queue=event_queue,
-                handle_kill=False,
-                debug=False,
-                labels=[],
-                worker_id_queue=worker_id_queue,
-                stop_event=stop_event,
-            )
-
-    thread = threading.Thread(target=run_subprocess, daemon=True)
-    thread.start()
+    proc = _CTX.Process(
+        target=_subprocess_target,
+        args=(
+            "test-worker",
+            ["test_action"],
+            {"default": 1, "durable": 0},
+            config,
+            action_queue,
+            event_queue,
+            False,
+            False,
+            [],
+            worker_id_queue,
+            stop_event,
+        ),
+    )
+    proc.start()
 
     # Wait for the subprocess to publish its worker_id (ready signal).
     deadline = time.monotonic() + 10.0
@@ -221,8 +265,8 @@ def test_event_queue_drains_before_process_exits() -> None:
         time.sleep(0.05)
 
     # Simulate the runner finishing a task: put a completion event in the queue.
-    # _FakeAction is a module-level dataclass so it can be pickled across the
-    # multiprocessing.Queue feeder thread.
+    # _FakeAction is a module-level dataclass so it is picklable across the
+    # spawn boundary.
     fake_event = ActionEvent(
         action=_FakeAction(),  # type: ignore
         type=ActionType.START_STEP_RUN,
@@ -238,8 +282,8 @@ def test_event_queue_drains_before_process_exits() -> None:
     time.sleep(0.05)
     event_queue.put(STOP_LOOP)  # stops event_send_loop
 
-    thread.join(timeout=15.0)
-    assert not thread.is_alive(), "subprocess thread should have exited after STOP_LOOP"
+    proc.join(timeout=15.0)
+    assert proc.exitcode is not None, "subprocess should have exited after STOP_LOOP"
 
     # The event_queue must be fully drained before the subprocess exited.
     assert (


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Explicitly ignores sigterms on the child listener processes so they don't get insta-killed and leave the worker hanging. The worker is completely responsible for shutting down the child processes, so this is fine.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
