### PR TITLE
fix: race condition in analytics provider and cross-domain cookies

### DIFF
--- a/frontend/app/src/providers/posthog.tsx
+++ b/frontend/app/src/providers/posthog.tsx
@@ -4,7 +4,7 @@ import { useAppContext } from '@/providers/app-context';
 import { useLocation } from '@tanstack/react-router';
 import posthog from 'posthog-js';
 import { PostHogProvider as PhProvider, usePostHog } from 'posthog-js/react';
-import { useEffect, useRef, useMemo, createContext } from 'react';
+import { useEffect, useMemo, useState, createContext } from 'react';
 
 const CROSS_DOMAIN_SESSION_ID_KEY = 'session_id';
 const CROSS_DOMAIN_DISTINCT_ID_KEY = 'distinct_id';
@@ -33,7 +33,7 @@ interface PostHogProviderProps {
 export function PostHogProvider({ children, user }: PostHogProviderProps) {
   const { meta } = useApiMeta();
   const { tenant } = useAppContext();
-  const initializedRef = useRef(false);
+  const [initialized, setInitialized] = useState(false);
 
   const config = useMemo(() => {
     if (import.meta.env.DEV) {
@@ -62,7 +62,7 @@ export function PostHogProvider({ children, user }: PostHogProviderProps) {
   }, []);
 
   useEffect(() => {
-    if (initializedRef.current) {
+    if (initialized) {
       return;
     }
 
@@ -89,15 +89,16 @@ export function PostHogProvider({ children, user }: PostHogProviderProps) {
         maskTextSelector: '*',
       },
       persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: true,
       bootstrap: bootstrapIds || undefined,
     });
 
-    initializedRef.current = true;
-  }, [config, tenant, bootstrapIds]);
+    setInitialized(true);
+  }, [config, tenant, bootstrapIds, initialized]);
 
   // Handle user identification
   useEffect(() => {
-    if (!initializedRef.current || !user) {
+    if (!initialized || !user) {
       return;
     }
 
@@ -110,11 +111,11 @@ export function PostHogProvider({ children, user }: PostHogProviderProps) {
       email: user.email,
       name: user.name,
     });
-  }, [user]);
+  }, [user, initialized]);
 
   // Handle opt-out changes
   useEffect(() => {
-    if (!initializedRef.current) {
+    if (!initialized) {
       return;
     }
 
@@ -124,10 +125,10 @@ export function PostHogProvider({ children, user }: PostHogProviderProps) {
     } else {
       posthog.opt_in_capturing();
     }
-  }, [tenant?.analyticsOptOut]);
+  }, [tenant?.analyticsOptOut, initialized]);
 
   const contextValue: PostHogContextValue = {
-    isReady: initializedRef.current,
+    isReady: initialized,
   };
 
   return (

--- a/frontend/docs/providers/posthog.tsx
+++ b/frontend/docs/providers/posthog.tsx
@@ -37,6 +37,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
         },
         disable_session_recording: true,
         persistence: "localStorage+cookie",
+        cross_subdomain_cookie: true,
         before_send: (event) => {
           // You can customize exception events for better grouping
           return event;


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Fixes a race condition in analytics where the user identify call is not re-triggered when we fully initialize the posthog provider. Also adds cross-domain cookie support for the posthog provider. 

Not relevant for self-hosted instances. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [X] Updates to the Posthog provider to fix a race condition
- [X] Setting `cross_domain_cookie: true` on the PH provider

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Tested (unit, integration, or manually with steps specified)
- [X] Linted and formatted
- [X] Documented (where applicable)

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [X] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

Fixing the race condition and dropping `useRef` following my guidance. 

- **Details**: [e.g. generating tests, writing docs]

</details>
