### PR TITLE
fix: respect priority for group round robin

### DIFF
--- a/pkg/repository/sqlcv1/concurrency-overwrite.go
+++ b/pkg/repository/sqlcv1/concurrency-overwrite.go
@@ -55,7 +55,7 @@ WITH filled_parent_slots AS (
         )
         AND cs.is_filled = FALSE
     ORDER BY
-        task_id, task_inserted_at
+        cs.priority DESC, cs.sort_id ASC
     FOR UPDATE
 ), updated_slots AS (
     UPDATE

--- a/pkg/repository/sqlcv1/concurrency.sql
+++ b/pkg/repository/sqlcv1/concurrency.sql
@@ -227,7 +227,7 @@ WITH eligible_slots_per_group AS (
             wcs_all.key = distinct_keys.key
             AND wcs_all.tenant_id = @tenantId::uuid
             AND wcs_all.strategy_id = @strategyId::bigint
-        ORDER BY wcs_all.sort_id ASC
+        ORDER BY wcs_all.priority DESC, wcs_all.sort_id ASC
         LIMIT @maxRuns::int
     ) cs ON true
 ), schedule_timeout_slots AS (

--- a/pkg/repository/sqlcv1/concurrency.sql.go
+++ b/pkg/repository/sqlcv1/concurrency.sql.go
@@ -859,7 +859,7 @@ WITH eligible_slots_per_group AS (
             wcs_all.key = distinct_keys.key
             AND wcs_all.tenant_id = $1::uuid
             AND wcs_all.strategy_id = $2::bigint
-        ORDER BY wcs_all.sort_id ASC
+        ORDER BY wcs_all.priority DESC, wcs_all.sort_id ASC
         LIMIT $3::int
     ) cs ON true
 ), schedule_timeout_slots AS (


### PR DESCRIPTION

# Description

Reassigns of a task with priority will not get a higher internal super priority on concurrency queues. Therefore, it is possible to be stuck in a reassign state if there is a backlog on a concurrency key.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## What's Changed

- [x] Add a list of tasks or features here...

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: helped in writing queries to investigate and confirm state

</details>
