### PR TITLE
fix: inactivity timeout breaks when set to greater than 24.8 days due to integer overflow

### DIFF
--- a/frontend/app/src/hooks/use-organizations.ts
+++ b/frontend/app/src/hooks/use-organizations.ts
@@ -12,6 +12,12 @@ import { useQuery, useMutation } from '@tanstack/react-query';
 import { useMemo, useCallback } from 'react';
 import invariant from 'tiny-invariant';
 
+// Browser setTimeout uses a 32-bit signed int (~24.85 days max); anything larger
+// is silently clamped to 1ms and fires immediately. Cap well below that and at
+// a value that's actually meaningful for an inactivity logout.
+// https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#maximum_delay_value
+export const MAX_INACTIVITY_TIMEOUT_MS = 14 * 24 * 60 * 60 * 1000;
+
 /**
  * Hook for organization data and operations
  *
@@ -336,6 +342,9 @@ export function useOrganizations() {
     inactivityTimeoutMs: number,
     onSuccess: () => void,
   ) => {
+    if (inactivityTimeoutMs > MAX_INACTIVITY_TIMEOUT_MS) {
+      throw new Error(`Inactivity timeout must not exceed 14 days.`);
+    }
     updateOrganizationMutation.mutate(
       { organizationId, inactivity_timeout: `${inactivityTimeoutMs}ms` },
       {

--- a/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
@@ -39,7 +39,10 @@ import {
 } from '@/components/v1/ui/tooltip';
 import useControlPlane from '@/hooks/use-control-plane';
 import { useCurrentUser } from '@/hooks/use-current-user';
-import { useOrganizations } from '@/hooks/use-organizations';
+import {
+  MAX_INACTIVITY_TIMEOUT_MS,
+  useOrganizations,
+} from '@/hooks/use-organizations';
 import { TenantInvite, TenantMember, TenantMemberRole } from '@/lib/api';
 import {
   ManagementToken,
@@ -309,8 +312,12 @@ export function CloudOrganizationSettings({ orgId }: { orgId: string }) {
     [editedTimeout],
   );
 
+  const editedTimeoutExceedsMax =
+    parsedEditedTimeout !== null &&
+    parsedEditedTimeout > MAX_INACTIVITY_TIMEOUT_MS;
+
   const handleSaveTimeout = () => {
-    if (!orgId || parsedEditedTimeout === null) {
+    if (!orgId || parsedEditedTimeout === null || editedTimeoutExceedsMax) {
       return;
     }
     if (parsedEditedTimeout === currentInactivityTimeoutMs) {
@@ -717,7 +724,8 @@ export function CloudOrganizationSettings({ orgId }: { orgId: string }) {
                           onClick={handleSaveTimeout}
                           disabled={
                             updateOrganizationLoading ||
-                            parsedEditedTimeout === null
+                            parsedEditedTimeout === null ||
+                            editedTimeoutExceedsMax
                           }
                           hoverText="Save inactivity timeout"
                           className="shrink-0 bg-background/60 hover:bg-muted/50"
@@ -732,11 +740,18 @@ export function CloudOrganizationSettings({ orgId }: { orgId: string }) {
                     </div>
                     {editedTimeout.trim() !== '' && (
                       <p
-                        className={`text-xs ${parsedEditedTimeout === null ? 'text-destructive' : 'text-muted-foreground'}`}
+                        className={`text-xs ${
+                          parsedEditedTimeout === null ||
+                          editedTimeoutExceedsMax
+                            ? 'text-destructive'
+                            : 'text-muted-foreground'
+                        }`}
                       >
                         {parsedEditedTimeout === null
                           ? 'Invalid format — try 30m, 1h, 1h30m, 100ms'
-                          : `→ ${formatTimeoutMs(parsedEditedTimeout)}`}
+                          : editedTimeoutExceedsMax
+                            ? 'Inactivity timeout cannot exceed 14 days'
+                            : `→ ${formatTimeoutMs(parsedEditedTimeout)}`}
                       </p>
                     )}
                   </div>


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

When setting the inactivity timeout to something like 30 days, it immediately logs the user out without being able to get back in. This is because the `setTimeout` call accepts an integer millisecond value; when this overflows, it fires immediately, which logs the user out. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [X] Adds a simple check on the frontend to prevent setting this to greater than 14 days. 

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Tested (unit, integration, or manually with steps specified)
- [X] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [X] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude Code for debugging and patching. 

</details>
