### PR TITLE
chore: Separate dashboard labeling & semver task fix

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -34,8 +34,11 @@ engine:
           - "pkg/**"
           - "internal/**"
           - "api/**"
-          - "frontend/app/src/**"
           - "sql/**"
+
+dashboard:
+  - changed-files:
+      - any-glob-to-any-file: "frontend/app/src/**"
 
 documentation:
   - changed-files:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -313,7 +313,7 @@ tasks:
     desc: Bump patch version (e.g. v0.83.16 → v0.83.17) and push the tag
     cmds:
       - |
-        current=$(git describe --tags --abbrev=0)
+        current=$(git describe --tags --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*')
         IFS='.' read -r major minor patch <<< "${current#v}"
         patch=$((patch + 1))
         next="v${major}.${minor}.${patch}"
@@ -325,7 +325,7 @@ tasks:
     desc: Bump minor version (e.g. v0.83.16 → v0.84.0) and push the tag
     cmds:
       - |
-        current=$(git describe --tags --abbrev=0)
+        current=$(git describe --tags --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*')
         IFS='.' read -r major minor patch <<< "${current#v}"
         minor=$((minor + 1))
         next="v${major}.${minor}.0"
@@ -337,7 +337,7 @@ tasks:
     desc: Bump to next alpha pre-release (e.g. v0.83.16 → v0.83.16-alpha.0, or v0.83.16-alpha.0 → v0.83.16-alpha.1)
     cmds:
       - |
-        current=$(git describe --tags --abbrev=0)
+        current=$(git describe --tags --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*')
         base="${current%%-alpha.*}"
         if [[ "${current}" == *-alpha.* ]]; then
           alpha_num="${current##*-alpha.}"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Labeling PRs affecting the frontend with `engine` label is confusing. This PR will instead ensure they're labeled as `dashboard`.

Also, fixes a bug with the Taskfile to ensure we don't use SDK tags when doing a version bump.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (changes which are not directly related to any business logic)

## What's Changed

- Ensures the version bump tasks only ever work on hatchet tags (i.e matching `vX.Y.X`).
- Labels frontend changes with `dashboard` label.
