### PR TITLE
fix(engine): re-enable external id dupe check, add flag to enable dynamic window size

### DIFF
--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -1249,7 +1249,7 @@ func (oc *OLAPControllerImpl) processPayloadExternalCutovers(ctx context.Context
 		oc.l.Debug().Ctx(ctx).Msgf("payload external cutover: processing external cutover payloads")
 
 		p := oc.repo.Payloads()
-		err := oc.repo.OLAP().ProcessOLAPPayloadCutovers(ctx, p.ExternalStoreEnabled(), p.InlineStoreTTL(), p.ExternalCutoverBatchSize(), p.ExternalCutoverNumConcurrentOffloads())
+		err := oc.repo.OLAP().ProcessOLAPPayloadCutovers(ctx, p.ExternalStoreEnabled(), p.InlineStoreTTL(), p.ExternalCutoverBatchSize(), p.ExternalCutoverNumConcurrentOffloads(), p.EnableWindowSizeOptimization())
 
 		if err != nil {
 			span.RecordError(err)

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -342,6 +342,7 @@ func (c *ConfigLoader) InitDataLayer() (res *database.Layer, err error) {
 		ExternalCutoverBatchSize:             scf.PayloadStore.ExternalCutoverBatchSize,
 		ExternalCutoverNumConcurrentOffloads: scf.PayloadStore.ExternalCutoverNumConcurrentOffloads,
 		InlineStoreTTL:                       &inlineStoreTTL,
+		EnableWindowSizeOptimization:         scf.PayloadStore.EnableWindowSizeOptimization,
 	}
 
 	statusUpdateOpts := repov1.StatusUpdateBatchSizeLimits{

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -708,6 +708,7 @@ type PayloadStoreConfig struct {
 	ExternalCutoverBatchSize             int32         `mapstructure:"externalCutoverBatchSize" json:"externalCutoverBatchSize,omitempty" default:"1000"`
 	ExternalCutoverNumConcurrentOffloads int32         `mapstructure:"externalCutoverNumConcurrentOffloads" json:"externalCutoverNumConcurrentOffloads,omitempty" default:"10"`
 	InlineStoreTTLDays                   int32         `mapstructure:"inlineStoreTTLDays" json:"inlineStoreTTLDays,omitempty" default:"2"`
+	EnableWindowSizeOptimization         bool          `mapstructure:"enableWindowSizeOptimization" json:"enableWindowSizeOptimization,omitempty" default:"true"`
 }
 
 func (c *ServerConfig) HasService(name string) bool {
@@ -989,6 +990,7 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("payloadStore.externalCutoverBatchSize", "SERVER_PAYLOAD_STORE_EXTERNAL_CUTOVER_BATCH_SIZE")
 	_ = v.BindEnv("payloadStore.externalCutoverNumConcurrentOffloads", "SERVER_PAYLOAD_STORE_EXTERNAL_CUTOVER_NUM_CONCURRENT_OFFLOADS")
 	_ = v.BindEnv("payloadStore.inlineStoreTTLDays", "SERVER_PAYLOAD_STORE_INLINE_STORE_TTL_DAYS")
+	_ = v.BindEnv("payloadStore.enableWindowSizeOptimization", "SERVER_PAYLOAD_STORE_ENABLE_WINDOW_SIZE_OPTIMIZATION")
 
 	// cron operations options
 	_ = v.BindEnv("cronOperations.taskAnalyzeCronInterval", "SERVER_CRON_OPERATIONS_TASK_ANALYZE_CRON_INTERVAL")

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -3677,31 +3677,72 @@ func (p *OLAPRepositoryImpl) processSinglePartition(ctx context.Context, process
 		return nil
 	}
 
-	// connStatementTimeout := 5 * 60 * 1000 // 5 minutes
+	// if the job is running for the first time, check that there aren't any duplicate external ids before proceeding
+	if jobMeta.LastExternalId == uuid.Nil {
+		connStatementTimeout := 15 * 60 * 1000 // 15 minutes
 
-	// conn, release, err := sqlchelpers.AcquireConnectionWithStatementTimeout(ctx, p.pool, p.l, connStatementTimeout)
+		conn, release, err := sqlchelpers.AcquireConnectionWithStatementTimeout(ctx, p.pool, p.l, connStatementTimeout)
 
-	// if err != nil {
-	// 	return fmt.Errorf("failed to acquire connection with statement timeout: %w", err)
-	// }
+		if err != nil {
+			return fmt.Errorf("failed to acquire connection with statement timeout: %w", err)
+		}
 
-	// defer release()
+		defer release()
 
-	// duplicatedExternalIds, err := p.ValidateNoDuplicateOLAPExternalIds(ctx, conn, partitionDate)
+		stopLeaseExtension := make(chan struct{})
+		leaseExtensionDone := make(chan struct{})
 
-	// if err != nil {
-	// 	return fmt.Errorf("failed to validate no duplicate external ids: %w", err)
-	// }
+		go func() {
+			defer close(leaseExtensionDone)
 
-	// if len(duplicatedExternalIds) > 0 {
-	// 	var duplicatedIds []string
+			ticker := time.NewTicker(30 * time.Second)
+			defer ticker.Stop()
 
-	// 	for _, row := range duplicatedExternalIds {
-	// 		duplicatedIds = append(duplicatedIds, row.ExternalId.String())
-	// 	}
+			for {
+				select {
+				case <-stopLeaseExtension:
+					return
+				case <-ticker.C:
+					leaseTx, leaseCommit, leaseRollback, txErr := sqlchelpers.PrepareTx(ctx, p.pool, p.l)
 
-	// 	return fmt.Errorf("found duplicate external ids in partition %s. Sampled ids: %s", partitionDate.String(), strings.Join(duplicatedIds, ", "))
-	// }
+					if txErr != nil {
+						p.l.Error().Err(txErr).Msg("failed to prepare transaction for lease extension during duplicate check")
+						continue
+					}
+
+					_, txErr = p.acquireOrExtendJobLease(ctx, leaseTx, processId, partitionDate, jobMeta.LastExternalId)
+
+					if txErr != nil {
+						leaseRollback()
+						p.l.Error().Err(txErr).Msg("failed to extend lease during duplicate check")
+						continue
+					}
+
+					if txErr = leaseCommit(ctx); txErr != nil {
+						p.l.Error().Err(txErr).Msg("failed to commit lease extension during duplicate check")
+					}
+				}
+			}
+		}()
+
+		duplicatedExternalIds, err := p.ValidateNoDuplicateOLAPExternalIds(ctx, conn, partitionDate)
+		close(stopLeaseExtension)
+		<-leaseExtensionDone
+
+		if err != nil {
+			return fmt.Errorf("failed to validate no duplicate external ids: %w", err)
+		}
+
+		if len(duplicatedExternalIds) > 0 {
+			var duplicatedIds []string
+
+			for _, row := range duplicatedExternalIds {
+				duplicatedIds = append(duplicatedIds, row.ExternalId.String())
+			}
+
+			return fmt.Errorf("found duplicate external ids in partition %s. Sampled ids: %s", partitionDate.String(), strings.Join(duplicatedIds, ", "))
+		}
+	}
 
 	lastExternalId := jobMeta.LastExternalId
 

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -3709,6 +3709,7 @@ func (p *OLAPRepositoryImpl) processSinglePartition(ctx context.Context, process
 					}
 
 					if txErr = leaseCommit(ctx); txErr != nil {
+						leaseRollback()
 						p.l.Error().Err(txErr).Msg("failed to commit lease extension during duplicate check")
 					}
 				}

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -3070,19 +3070,9 @@ func (r *OLAPRepositoryImpl) readPayloads(ctx context.Context, tx sqlcv1.DBTX, t
 			key := ExternalPayloadLocationKey(payload.ExternalLocationKey.String)
 			var retrieveFromExternalOpt RetrieveFromExternalOpts
 
-			if strings.HasSuffix(string(key), ".index") {
-				retrieveFromExternalOpt = RetrieveFromExternalOpts{
-					Method: RetrieveFromExternalByIndexFile,
-					ByIndexFile: &RetrieveFromExternalByIndexFileOpt{
-						IndexFileKey: ExternalIndexFileLocationKey(key),
-						ExternalId:   payload.ExternalID,
-					},
-				}
-			} else {
-				retrieveFromExternalOpt = RetrieveFromExternalOpts{
-					Method: RetrieveFromExternalByKey,
-					ByKey:  &RetrieveFromExternalByKeyOpt{Key: key},
-				}
+			retrieveFromExternalOpt = RetrieveFromExternalOpts{
+				Method: RetrieveFromExternalByKey,
+				ByKey:  &RetrieveFromExternalByKeyOpt{Key: key},
 			}
 
 			externalIdToRetrieveFromExternalOpt[payload.ExternalID] = retrieveFromExternalOpt

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -283,7 +283,7 @@ type OLAPRepository interface {
 
 	ListWorkflowRunExternalIds(ctx context.Context, tenantId uuid.UUID, opts ListWorkflowRunOpts) ([]uuid.UUID, error)
 
-	ProcessOLAPPayloadCutovers(ctx context.Context, externalStoreEnabled bool, inlineStoreTTL *time.Duration, externalCutoverBatchSize, externalCutoverNumConcurrentOffloads int32) error
+	ProcessOLAPPayloadCutovers(ctx context.Context, externalStoreEnabled bool, inlineStoreTTL *time.Duration, externalCutoverBatchSize, externalCutoverNumConcurrentOffloads int32, enableWindowSizeOptimization bool) error
 
 	CountOLAPTempTableSizeForDAGStatusUpdates(ctx context.Context) (int64, error)
 	CountOLAPTempTableSizeForTaskStatusUpdates(ctx context.Context) (int64, error)
@@ -3421,7 +3421,7 @@ func (p *OLAPRepositoryImpl) OptimizeOLAPPayloadWindowSize(ctx context.Context, 
 	)
 }
 
-func (p *OLAPRepositoryImpl) processOLAPPayloadCutoverBatch(ctx context.Context, processId uuid.UUID, partitionDate PartitionDate, lastExternalId uuid.UUID, externalCutoverBatchSize, externalCutoverNumConcurrentOffloads int32) (*OLAPCutoverBatchOutcome, error) {
+func (p *OLAPRepositoryImpl) processOLAPPayloadCutoverBatch(ctx context.Context, processId uuid.UUID, partitionDate PartitionDate, lastExternalId uuid.UUID, externalCutoverBatchSize, externalCutoverNumConcurrentOffloads int32, enableWindowSizeOptimization bool) (*OLAPCutoverBatchOutcome, error) {
 	ctx, span := telemetry.NewSpan(ctx, "OLAPRepository.processOLAPPayloadCutoverBatch")
 	defer span.End()
 
@@ -3433,19 +3433,23 @@ func (p *OLAPRepositoryImpl) processOLAPPayloadCutoverBatch(ctx context.Context,
 
 	defer rollback()
 
-	windowSizePtr, err := p.OptimizeOLAPPayloadWindowSize(
-		ctx,
-		tx,
-		partitionDate,
-		externalCutoverBatchSize*externalCutoverNumConcurrentOffloads,
-		lastExternalId,
-	)
+	windowSize := externalCutoverBatchSize * externalCutoverNumConcurrentOffloads
 
-	if err != nil {
-		return nil, fmt.Errorf("failed to optimize olap payload window size: %w", err)
+	if enableWindowSizeOptimization {
+		windowSizePtr, err := p.OptimizeOLAPPayloadWindowSize(
+			ctx,
+			tx,
+			partitionDate,
+			windowSize,
+			lastExternalId,
+		)
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to optimize olap payload window size: %w", err)
+		}
+
+		windowSize = *windowSizePtr
 	}
-
-	windowSize := *windowSizePtr
 
 	payloadRanges, err := p.queries.CreateOLAPPayloadRangeChunks(ctx, tx, sqlcv1.CreateOLAPPayloadRangeChunksParams{
 		Chunksize:      externalCutoverBatchSize,
@@ -3659,7 +3663,7 @@ func (p *OLAPRepositoryImpl) prepareCutoverTableJob(ctx context.Context, process
 	}, nil
 }
 
-func (p *OLAPRepositoryImpl) processSinglePartition(ctx context.Context, processId uuid.UUID, partitionDate PartitionDate, inlineStoreTTL *time.Duration, externalCutoverBatchSize, externalCutoverNumConcurrentOffloads int32) error {
+func (p *OLAPRepositoryImpl) processSinglePartition(ctx context.Context, processId uuid.UUID, partitionDate PartitionDate, inlineStoreTTL *time.Duration, externalCutoverBatchSize, externalCutoverNumConcurrentOffloads int32, enableWindowSizeOptimization bool) error {
 	ctx, span := telemetry.NewSpan(ctx, "olap_repository.processSinglePartition")
 	defer span.End()
 
@@ -3702,7 +3706,7 @@ func (p *OLAPRepositoryImpl) processSinglePartition(ctx context.Context, process
 	lastExternalId := jobMeta.LastExternalId
 
 	for {
-		outcome, err := p.processOLAPPayloadCutoverBatch(ctx, processId, partitionDate, lastExternalId, externalCutoverBatchSize, externalCutoverNumConcurrentOffloads)
+		outcome, err := p.processOLAPPayloadCutoverBatch(ctx, processId, partitionDate, lastExternalId, externalCutoverBatchSize, externalCutoverNumConcurrentOffloads, enableWindowSizeOptimization)
 
 		if err != nil {
 			return fmt.Errorf("failed to process payload cutover batch: %w", err)
@@ -3751,7 +3755,7 @@ func (p *OLAPRepositoryImpl) createOLAPIndexBlock(ctx context.Context, tx pgx.Tx
 	})
 }
 
-func (p *OLAPRepositoryImpl) ProcessOLAPPayloadCutovers(ctx context.Context, externalStoreEnabled bool, inlineStoreTTL *time.Duration, externalCutoverBatchSize, externalCutoverNumConcurrentOffloads int32) error {
+func (p *OLAPRepositoryImpl) ProcessOLAPPayloadCutovers(ctx context.Context, externalStoreEnabled bool, inlineStoreTTL *time.Duration, externalCutoverBatchSize, externalCutoverNumConcurrentOffloads int32, enableWindowSizeOptimization bool) error {
 	if !externalStoreEnabled {
 		return nil
 	}
@@ -3778,7 +3782,7 @@ func (p *OLAPRepositoryImpl) ProcessOLAPPayloadCutovers(ctx context.Context, ext
 
 	for _, partition := range partitions {
 		p.l.Info().Ctx(ctx).Str("partition", partition.PartitionName).Msg("processing payload cutover for partition")
-		err = p.processSinglePartition(ctx, processId, PartitionDate(partition.PartitionDate), inlineStoreTTL, externalCutoverBatchSize, externalCutoverNumConcurrentOffloads)
+		err = p.processSinglePartition(ctx, processId, PartitionDate(partition.PartitionDate), inlineStoreTTL, externalCutoverBatchSize, externalCutoverNumConcurrentOffloads, enableWindowSizeOptimization)
 
 		if err != nil {
 			return fmt.Errorf("failed to process partition %s: %w", partition.PartitionName, err)

--- a/pkg/repository/payloadstore.go
+++ b/pkg/repository/payloadstore.go
@@ -858,7 +858,7 @@ func (p *payloadStoreRepositoryImpl) processSinglePartition(ctx context.Context,
 
 	// if the job is running for the first time, check that there aren't any duplicate external ids before proceeding
 	if jobMeta.LastExternalId == uuid.Nil {
-		connStatementTimeout := 5 * 60 * 1000 // 15 minutes
+		connStatementTimeout := 15 * 60 * 1000 // 15 minutes
 
 		conn, release, err := sqlchelpers.AcquireConnectionWithStatementTimeout(ctx, p.pool, p.l, connStatementTimeout)
 

--- a/pkg/repository/payloadstore.go
+++ b/pkg/repository/payloadstore.go
@@ -869,31 +869,72 @@ func (p *payloadStoreRepositoryImpl) processSinglePartition(ctx context.Context,
 		return nil
 	}
 
-	// connStatementTimeout := 5 * 60 * 1000 // 5 minutes
+	// if the job is running for the first time, check that there aren't any duplicate external ids before proceeding
+	if jobMeta.LastExternalId == uuid.Nil {
+		connStatementTimeout := 5 * 60 * 1000 // 15 minutes
 
-	// conn, release, err := sqlchelpers.AcquireConnectionWithStatementTimeout(ctx, p.pool, p.l, connStatementTimeout)
+		conn, release, err := sqlchelpers.AcquireConnectionWithStatementTimeout(ctx, p.pool, p.l, connStatementTimeout)
 
-	// if err != nil {
-	// 	return fmt.Errorf("failed to acquire connection with statement timeout: %w", err)
-	// }
+		if err != nil {
+			return fmt.Errorf("failed to acquire connection with statement timeout: %w", err)
+		}
 
-	// defer release()
+		defer release()
 
-	// duplicatedExternalIds, err := p.ValidateNoDuplicateExternalIds(ctx, conn, partitionDate)
+		stopLeaseExtension := make(chan struct{})
+		leaseExtensionDone := make(chan struct{})
 
-	// if err != nil {
-	// 	return fmt.Errorf("failed to validate no duplicate external ids: %w", err)
-	// }
+		go func() {
+			defer close(leaseExtensionDone)
 
-	// if len(duplicatedExternalIds) > 0 {
-	// 	var duplicatedIds []string
+			ticker := time.NewTicker(30 * time.Second)
+			defer ticker.Stop()
 
-	// 	for _, row := range duplicatedExternalIds {
-	// 		duplicatedIds = append(duplicatedIds, row.ExternalId.String())
-	// 	}
+			for {
+				select {
+				case <-stopLeaseExtension:
+					return
+				case <-ticker.C:
+					leaseTx, leaseCommit, leaseRollback, txErr := sqlchelpers.PrepareTx(ctx, p.pool, p.l)
 
-	// 	return fmt.Errorf("found duplicate external ids in partition %s. Sampled ids: %s", partitionDate.String(), strings.Join(duplicatedIds, ", "))
-	// }
+					if txErr != nil {
+						p.l.Error().Err(txErr).Msg("failed to prepare transaction for lease extension during duplicate check")
+						continue
+					}
+
+					_, txErr = p.acquireOrExtendJobLease(ctx, leaseTx, processId, partitionDate, jobMeta.LastExternalId)
+
+					if txErr != nil {
+						leaseRollback()
+						p.l.Error().Err(txErr).Msg("failed to extend lease during duplicate check")
+						continue
+					}
+
+					if txErr = leaseCommit(ctx); txErr != nil {
+						p.l.Error().Err(txErr).Msg("failed to commit lease extension during duplicate check")
+					}
+				}
+			}
+		}()
+
+		duplicatedExternalIds, err := p.ValidateNoDuplicateExternalIds(ctx, conn, partitionDate)
+		close(stopLeaseExtension)
+		<-leaseExtensionDone
+
+		if err != nil {
+			return fmt.Errorf("failed to validate no duplicate external ids: %w", err)
+		}
+
+		if len(duplicatedExternalIds) > 0 {
+			var duplicatedIds []string
+
+			for _, row := range duplicatedExternalIds {
+				duplicatedIds = append(duplicatedIds, row.ExternalId.String())
+			}
+
+			return fmt.Errorf("found duplicate external ids in partition %s. Sampled ids: %s", partitionDate.String(), strings.Join(duplicatedIds, ", "))
+		}
+	}
 
 	lastExternalId := jobMeta.LastExternalId
 

--- a/pkg/repository/payloadstore.go
+++ b/pkg/repository/payloadstore.go
@@ -898,6 +898,7 @@ func (p *payloadStoreRepositoryImpl) processSinglePartition(ctx context.Context,
 					}
 
 					if txErr = leaseCommit(ctx); txErr != nil {
+						leaseRollback()
 						p.l.Error().Err(txErr).Msg("failed to commit lease extension during duplicate check")
 					}
 				}

--- a/pkg/repository/payloadstore.go
+++ b/pkg/repository/payloadstore.go
@@ -357,22 +357,9 @@ func (p *payloadStoreRepositoryImpl) retrieve(ctx context.Context, tx sqlcv1.DBT
 			key := ExternalPayloadLocationKey(payload.ExternalLocationKey.String)
 			var retrieveFromExternalOpt RetrieveFromExternalOpts
 
-			// todo: this doesn't actually make sense, since
-			// we'd never write the index file into the payload location directly
-			// so we can remove this if block
-			if strings.HasSuffix(string(key), ".index") {
-				retrieveFromExternalOpt = RetrieveFromExternalOpts{
-					Method: RetrieveFromExternalByIndexFile,
-					ByIndexFile: &RetrieveFromExternalByIndexFileOpt{
-						IndexFileKey: ExternalIndexFileLocationKey(key),
-						ExternalId:   payload.ExternalID,
-					},
-				}
-			} else {
-				retrieveFromExternalOpt = RetrieveFromExternalOpts{
-					Method: RetrieveFromExternalByKey,
-					ByKey:  &RetrieveFromExternalByKeyOpt{Key: key},
-				}
+			retrieveFromExternalOpt = RetrieveFromExternalOpts{
+				Method: RetrieveFromExternalByKey,
+				ByKey:  &RetrieveFromExternalByKeyOpt{Key: key},
 			}
 
 			retrieveFromExternalOptsToOpts[retrieveFromExternalOpt] = opt

--- a/pkg/repository/payloadstore.go
+++ b/pkg/repository/payloadstore.go
@@ -115,6 +115,7 @@ type PayloadStoreRepository interface {
 	InlineStoreTTL() *time.Duration
 	ExternalCutoverBatchSize() int32
 	ExternalCutoverNumConcurrentOffloads() int32
+	EnableWindowSizeOptimization() bool
 	ExternalStoreEnabled() bool
 	ExternalStore() ExternalStore
 	ProcessPayloadCutovers(ctx context.Context) error
@@ -135,6 +136,7 @@ type payloadStoreRepositoryImpl struct {
 	externalCutoverProcessInterval       time.Duration
 	externalCutoverBatchSize             int32
 	externalCutoverNumConcurrentOffloads int32
+	enableWindowSizeOptimization         bool
 }
 
 type PayloadStoreRepositoryOpts struct {
@@ -146,6 +148,7 @@ type PayloadStoreRepositoryOpts struct {
 	ExternalCutoverBatchSize             int32
 	ExternalCutoverNumConcurrentOffloads int32
 	InlineStoreTTL                       *time.Duration
+	EnableWindowSizeOptimization         bool
 }
 
 func NewPayloadStoreRepository(
@@ -169,6 +172,7 @@ func NewPayloadStoreRepository(
 		externalCutoverProcessInterval:       opts.ExternalCutoverProcessInterval,
 		externalCutoverBatchSize:             opts.ExternalCutoverBatchSize,
 		externalCutoverNumConcurrentOffloads: opts.ExternalCutoverNumConcurrentOffloads,
+		enableWindowSizeOptimization:         opts.EnableWindowSizeOptimization,
 	}
 }
 
@@ -482,6 +486,10 @@ func (p *payloadStoreRepositoryImpl) ExternalCutoverNumConcurrentOffloads() int3
 	return p.externalCutoverNumConcurrentOffloads
 }
 
+func (p *payloadStoreRepositoryImpl) EnableWindowSizeOptimization() bool {
+	return p.enableWindowSizeOptimization
+}
+
 func (p *payloadStoreRepositoryImpl) ExternalStoreEnabled() bool {
 	return p.externalStoreEnabled
 }
@@ -606,19 +614,23 @@ func (p *payloadStoreRepositoryImpl) ProcessPayloadCutoverBatch(ctx context.Cont
 
 	defer rollback()
 
-	windowSizePtr, err := p.OptimizePayloadWindowSize(
-		ctx,
-		tx,
-		partitionDate,
-		p.externalCutoverBatchSize*p.externalCutoverNumConcurrentOffloads,
-		lastExternalId,
-	)
+	windowSize := p.externalCutoverBatchSize * p.externalCutoverNumConcurrentOffloads
 
-	if err != nil {
-		return nil, fmt.Errorf("failed to optimize payload window size: %w", err)
+	if p.enableWindowSizeOptimization {
+		windowSizePtr, err := p.OptimizePayloadWindowSize(
+			ctx,
+			tx,
+			partitionDate,
+			windowSize,
+			lastExternalId,
+		)
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to optimize payload window size: %w", err)
+		}
+
+		windowSize = *windowSizePtr
 	}
-
-	windowSize := *windowSizePtr
 
 	payloadRanges, err := p.queries.CreatePayloadRangeChunks(ctx, tx, sqlcv1.CreatePayloadRangeChunksParams{
 		Chunksize:      p.externalCutoverBatchSize,


### PR DESCRIPTION
# Description

Could more payload job fixes:

1. Re-enabled the external id dupe check with the auto-lease-extension thing
2. Adds a flag to toggle dynamic window sizing so we can shut it off on slow disks
3. Removes some dead code that'd from a previous idea that was left over that'd never be run

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)


<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Used Claude Code to wire up the new environment variables

</details>
