### PR TITLE
fix(engine): prepare to remove `desired_worker_labels` from `v1_dag`

### DIFF
--- a/pkg/repository/match.go
+++ b/pkg/repository/match.go
@@ -575,7 +575,6 @@ func (m *sharedRepository) processEventMatches(ctx context.Context, tx sqlcv1.DB
 
 		dagIdsToInput := make(map[int64][]byte)
 		dagIdsToMetadata := make(map[int64][]byte)
-		dagIdsToDesiredWorkerLabels := make(map[int64][]byte)
 
 		for _, dagData := range dagInputDatas {
 			retrieveOpts := RetrievePayloadOpts{
@@ -594,7 +593,6 @@ func (m *sharedRepository) processEventMatches(ctx context.Context, tx sqlcv1.DB
 
 			dagIdsToInput[dagData.DagID] = payload
 			dagIdsToMetadata[dagData.DagID] = dagData.AdditionalMetadata
-			dagIdsToDesiredWorkerLabels[dagData.DagID] = dagData.DesiredWorkerLabels
 		}
 
 		// determine which tasks to create based on step ids
@@ -670,18 +668,9 @@ func (m *sharedRepository) processEventMatches(ctx context.Context, tx sqlcv1.DB
 						opt.DagId = &match.TriggerDagID.Int64
 						opt.DagInsertedAt = match.TriggerDagInsertedAt
 
-						// Prefer labels stored on the match; fall back to the DAG for rows
-						// created before the migration added trigger_desired_worker_labels.
-						// fixme: remove this later when we've upgraded everyone and are sure there are no
-						// more dags with desired worker labels only on the dag row
-						rawLabels := match.TriggerDesiredWorkerLabels
-						if len(rawLabels) == 0 {
-							rawLabels = dagIdsToDesiredWorkerLabels[match.TriggerDagID.Int64]
-						}
-
-						if len(rawLabels) > 0 {
+						if len(match.TriggerDesiredWorkerLabels) > 0 {
 							var labels []*sqlcv1.GetDesiredLabelsRow
-							if err := json.Unmarshal(rawLabels, &labels); err != nil {
+							if err := json.Unmarshal(match.TriggerDesiredWorkerLabels, &labels); err != nil {
 								m.l.Error().Err(err).Msgf("failed to unmarshal desired worker labels for dag id %d and dag inserted at %s", *opt.DagId, opt.DagInsertedAt.Time)
 							}
 

--- a/pkg/repository/sqlcv1/dags.sql
+++ b/pkg/repository/sqlcv1/dags.sql
@@ -4,7 +4,7 @@ WITH input AS (
         unnest(@dagIds::bigint[]) AS dag_id,
         unnest(@dagInsertedAts::timestamptz[]) AS dag_inserted_at
 )
-SELECT dd.*, d.desired_worker_labels, d.external_id
+SELECT dd.*, d.external_id
 FROM v1_dag d
 JOIN v1_dag_data dd ON (d.id, d.inserted_at) = (dd.dag_id, dd.dag_inserted_at)
 WHERE (d.id, d.inserted_at) IN (

--- a/pkg/repository/sqlcv1/dags.sql.go
+++ b/pkg/repository/sqlcv1/dags.sql.go
@@ -107,7 +107,7 @@ WITH input AS (
         unnest($1::bigint[]) AS dag_id,
         unnest($2::timestamptz[]) AS dag_inserted_at
 )
-SELECT dd.dag_id, dd.dag_inserted_at, dd.input, dd.additional_metadata, d.desired_worker_labels, d.external_id
+SELECT dd.dag_id, dd.dag_inserted_at, dd.input, dd.additional_metadata, d.external_id
 FROM v1_dag d
 JOIN v1_dag_data dd ON (d.id, d.inserted_at) = (dd.dag_id, dd.dag_inserted_at)
 WHERE (d.id, d.inserted_at) IN (
@@ -122,12 +122,11 @@ type GetDAGDataParams struct {
 }
 
 type GetDAGDataRow struct {
-	DagID               int64              `json:"dag_id"`
-	DagInsertedAt       pgtype.Timestamptz `json:"dag_inserted_at"`
-	Input               []byte             `json:"input"`
-	AdditionalMetadata  []byte             `json:"additional_metadata"`
-	DesiredWorkerLabels []byte             `json:"desired_worker_labels"`
-	ExternalID          uuid.UUID          `json:"external_id"`
+	DagID              int64              `json:"dag_id"`
+	DagInsertedAt      pgtype.Timestamptz `json:"dag_inserted_at"`
+	Input              []byte             `json:"input"`
+	AdditionalMetadata []byte             `json:"additional_metadata"`
+	ExternalID         uuid.UUID          `json:"external_id"`
 }
 
 func (q *Queries) GetDAGData(ctx context.Context, db DBTX, arg GetDAGDataParams) ([]*GetDAGDataRow, error) {
@@ -144,7 +143,6 @@ func (q *Queries) GetDAGData(ctx context.Context, db DBTX, arg GetDAGDataParams)
 			&i.DagInsertedAt,
 			&i.Input,
 			&i.AdditionalMetadata,
-			&i.DesiredWorkerLabels,
 			&i.ExternalID,
 		); err != nil {
 			return nil, err


### PR DESCRIPTION
# Description

When I initially implemented dynamic labels, I did it wrong and put the labels on the `v1_dag` instead of the `v1_match`, which was a mistake. It's been long enough running the correct version now that this is safe to remove, so planning to drop the column after removing all the refs to it

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI use

</details>
