### PR TITLE
fix(ci): Include ref in GH release body

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Generate release notes
         run: |
-          ./hack/ci/release-notes-cli.sh > release_notes.md
+          ./hack/ci/release-notes-cli.sh "${{ github.ref_name }}" > release_notes.md
           echo "" >> release_notes.md
           cat /tmp/CHANGES.md >> release_notes.md
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -327,7 +327,7 @@ tasks:
     prompt: Create new release for tag {{.TAG}}?
     cmds:
       # cleanup=verbatim: markdown header hashes are otherwise stripped as comments.
-      - ./hack/ci/release-notes-cli.sh {{.TAG}}| git tag --cleanup=verbatim -a -f {{.TAG}} HEAD -F -
+      - ./hack/ci/release-notes-cli.sh {{.TAG}} | git tag --cleanup=verbatim -a -f {{.TAG}} HEAD -F -
       - git push --force origin {{.TAG}}
 
   patch:


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Small fix to ensure we pass in the correct tag to the `release-notes-cli` script to extract release body for a given tag.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] CI (any automation pipeline changes)

## What's Changed

- Ensures the GH tag is passed in when extracting changes body

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
