### PR TITLE
feat(oas): generate tenant metadata for API requests

### DIFF
--- a/frontend/app/src/lib/api/generated/Api.ts
+++ b/frontend/app/src/lib/api/generated/Api.ts
@@ -287,6 +287,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -340,6 +341,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -384,6 +386,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -408,6 +411,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -535,6 +539,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -561,6 +566,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -603,6 +609,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -627,6 +634,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -651,6 +659,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -799,6 +808,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -880,6 +890,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -916,6 +927,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -972,6 +984,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -990,6 +1003,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "v1-event"],
     }), { resources: new Set<string>(["tenant", "v1-event"]) });
@@ -1008,6 +1022,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -1046,6 +1061,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -1070,6 +1086,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -1092,6 +1109,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "v1-filter"],
     }), { resources: new Set<string>(["tenant", "v1-filter"]) });
@@ -1113,6 +1131,7 @@ export class Api<
       method: "DELETE",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "v1-filter"],
     }), { resources: new Set<string>(["tenant", "v1-filter"]) });
@@ -1137,6 +1156,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "v1-filter"],
     }), { resources: new Set<string>(["tenant", "v1-filter"]) });
@@ -1175,6 +1195,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -1199,6 +1220,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -1221,6 +1243,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "v1-webhook"],
     }), { resources: new Set<string>(["tenant", "v1-webhook"]) });
@@ -1242,6 +1265,7 @@ export class Api<
       method: "DELETE",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "v1-webhook"],
     }), { resources: new Set<string>(["tenant", "v1-webhook"]) });
@@ -1264,6 +1288,7 @@ export class Api<
       method: "POST",
       body: data,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "v1-webhook"],
     }), { resources: new Set<string>(["tenant", "v1-webhook"]) });
@@ -1289,6 +1314,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "v1-webhook"],
     }), { resources: new Set<string>(["tenant", "v1-webhook"]) });
@@ -1313,6 +1339,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -1488,6 +1515,7 @@ export class Api<
       path: `/api/v1/tenants/${tenant}/slack/start`,
       method: "GET",
       secure: true,
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -1520,6 +1548,7 @@ export class Api<
     this.request<void, APIErrors>({
       path: `/api/v1/sns/${tenant}/${event}`,
       method: "POST",
+      xTenantId: tenant,
       ...params,
       xResources: [],
     }), { resources: new Set<string>([]) });
@@ -1538,6 +1567,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -1562,6 +1592,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -1586,6 +1617,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -1604,6 +1636,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -1622,6 +1655,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -1701,6 +1735,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -1919,6 +1954,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -1937,6 +1973,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -1955,6 +1992,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -1979,6 +2017,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -1997,6 +2036,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -2021,6 +2061,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "tenant-invite"],
     }), { resources: new Set<string>(["tenant", "tenant-invite"]) });
@@ -2042,6 +2083,7 @@ export class Api<
       method: "DELETE",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "tenant-invite"],
     }), { resources: new Set<string>(["tenant", "tenant-invite"]) });
@@ -2066,6 +2108,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -2084,6 +2127,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -2132,6 +2176,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -2150,6 +2195,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -2203,6 +2249,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -2227,6 +2274,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -2251,6 +2299,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -2275,6 +2324,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -2304,6 +2354,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -2344,6 +2395,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -2369,6 +2421,7 @@ export class Api<
       method: "DELETE",
       query: query,
       secure: true,
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -2387,6 +2440,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -2412,6 +2466,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "member"],
     }), { resources: new Set<string>(["tenant", "member"]) });
@@ -2434,6 +2489,7 @@ export class Api<
       method: "DELETE",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "member"],
     }), { resources: new Set<string>(["tenant", "member"]) });
@@ -2492,6 +2548,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "event-with-tenant"],
     }), { resources: new Set<string>(["tenant", "event-with-tenant"]) });
@@ -2510,6 +2567,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -2548,6 +2606,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -2573,6 +2632,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -2639,6 +2699,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -2661,6 +2722,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "scheduled-workflow-run"],
     }), { resources: new Set<string>(["tenant", "scheduled-workflow-run"]) });
@@ -2682,6 +2744,7 @@ export class Api<
       path: `/api/v1/tenants/${tenant}/workflows/scheduled/${scheduledWorkflowRun}`,
       method: "DELETE",
       secure: true,
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "scheduled-workflow-run"],
     }), { resources: new Set<string>(["tenant", "scheduled-workflow-run"]) });
@@ -2707,6 +2770,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "scheduled-workflow-run"],
     }), { resources: new Set<string>(["tenant", "scheduled-workflow-run"]) });
@@ -2731,6 +2795,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -2755,6 +2820,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -2780,6 +2846,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -2834,6 +2901,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -2856,6 +2924,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "cron-workflow"],
     }), { resources: new Set<string>(["tenant", "cron-workflow"]) });
@@ -2877,6 +2946,7 @@ export class Api<
       path: `/api/v1/tenants/${tenant}/workflows/crons/${cronWorkflow}`,
       method: "DELETE",
       secure: true,
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "cron-workflow"],
     }), { resources: new Set<string>(["tenant", "cron-workflow"]) });
@@ -2901,6 +2971,7 @@ export class Api<
       body: data,
       secure: true,
       type: ContentType.Json,
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "cron-workflow"],
     }), { resources: new Set<string>(["tenant", "cron-workflow"]) });
@@ -2930,6 +3001,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -3146,6 +3218,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -3202,6 +3275,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "workflow"],
     }), { resources: new Set<string>(["tenant", "workflow"]) });
@@ -3301,6 +3375,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -3325,6 +3400,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -3394,6 +3470,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -3416,6 +3493,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "workflow-run"],
     }), { resources: new Set<string>(["tenant", "workflow-run"]) });
@@ -3438,6 +3516,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "workflow-run"],
     }), { resources: new Set<string>(["tenant", "workflow-run"]) });
@@ -3456,6 +3535,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "step-run"],
     }), { resources: new Set<string>(["tenant", "step-run"]) });
@@ -3481,6 +3561,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "step-run"],
     }), { resources: new Set<string>(["tenant", "step-run"]) });
@@ -3503,6 +3584,7 @@ export class Api<
       method: "POST",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "step-run"],
     }), { resources: new Set<string>(["tenant", "step-run"]) });
@@ -3525,6 +3607,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "step-run"],
     }), { resources: new Set<string>(["tenant", "step-run"]) });
@@ -3561,6 +3644,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -3620,6 +3704,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -3643,6 +3728,7 @@ export class Api<
       secure: true,
       type: ContentType.Json,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -3698,6 +3784,7 @@ export class Api<
       method: "GET",
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant", "workflow-run"],
     }), { resources: new Set<string>(["tenant", "workflow-run"]) });
@@ -3714,6 +3801,7 @@ export class Api<
       path: `/api/v1/monitoring/${tenant}/probe`,
       method: "POST",
       secure: true,
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -3752,6 +3840,7 @@ export class Api<
       path: `/api/v1/tenants/${tenant}/prometheus-metrics`,
       method: "GET",
       secure: true,
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -3778,6 +3867,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });
@@ -3806,6 +3896,7 @@ export class Api<
       query: query,
       secure: true,
       format: "json",
+      xTenantId: tenant,
       ...params,
       xResources: ["tenant"],
     }), { resources: new Set<string>(["tenant"]) });

--- a/hack/oas/patch-api-resources.go
+++ b/hack/oas/patch-api-resources.go
@@ -4,6 +4,9 @@
 //
 //	api.v1TaskGet.resources.has("tenant") // true
 //
+// For operations whose path contains {tenant}, it also injects xTenantId: tenant
+// so the exchange-token interceptor can resolve the tenant without URL parsing.
+//
 // Run from the repo root after swagger-typescript-api generation:
 //
 //	go run ./hack/oas/patch-api-resources.go
@@ -41,6 +44,11 @@ type Operation struct {
 	XResources []string `yaml:"x-resources"`
 }
 
+type operationMetadata struct {
+	resources     []string
+	hasTenantPath bool
+}
+
 func main() {
 	// Load and parse OpenAPI spec.
 	specData, err := os.ReadFile(specPath)
@@ -53,22 +61,23 @@ func main() {
 		log.Fatalf("parsing %s: %v", specPath, err)
 	}
 
-	// Build lookup: "METHOD /path" -> resources (may be nil/empty).
-	resourcesMap := buildResourcesMap(spec)
+	metadataMap := buildOperationMetadataMap(spec)
 
-	// Read, transform, write Api.ts.
 	apiData, err := os.ReadFile(apiPath)
 	if err != nil {
 		log.Fatalf("reading %s: %v", apiPath, err)
 	}
 
-	result, total, withResources := transformApiTs(string(apiData), resourcesMap)
+	result, total, withResources, withTenantPath := transformApiTs(string(apiData), metadataMap)
 
 	if err := os.WriteFile(apiPath, []byte(result), 0644); err != nil { // nolint:gosec
 		log.Fatalf("writing %s: %v", apiPath, err)
 	}
 
-	fmt.Printf("patched %s: %d methods transformed (%d with x-resources)\n", apiPath, total, withResources)
+	fmt.Printf(
+		"patched %s: %d methods transformed (%d with x-resources, %d with xTenantId)\n",
+		apiPath, total, withResources, withTenantPath,
+	)
 }
 
 type resource struct {
@@ -76,10 +85,10 @@ type resource struct {
 	method string
 }
 
-// buildResourcesMap returns a map from "METHOD /path" to the x-resources list.
-func buildResourcesMap(spec OpenAPISpec) map[string][]string {
-	m := make(map[string][]string)
+func buildOperationMetadataMap(spec OpenAPISpec) map[string]operationMetadata {
+	m := make(map[string]operationMetadata)
 	for path, item := range spec.Paths {
+		hasTenantPath := strings.Contains(path, "{tenant}")
 		for _, entry := range []resource{
 			{op: item.Get, method: "GET"},
 			{op: item.Post, method: "POST"},
@@ -88,7 +97,10 @@ func buildResourcesMap(spec OpenAPISpec) map[string][]string {
 			{op: item.Delete, method: "DELETE"},
 		} {
 			if entry.op != nil {
-				m[entry.method+" "+path] = entry.op.XResources
+				m[entry.method+" "+path] = operationMetadata{
+					resources:     entry.op.XResources,
+					hasTenantPath: hasTenantPath,
+				}
 			}
 		}
 	}
@@ -107,7 +119,7 @@ func buildResourcesMap(spec OpenAPISpec) map[string][]string {
 //
 //	methodName = Object.assign((args) =>
 //	  this.request({...}), { resources: new Set<string>(["tenant"]) });
-func transformApiTs(content string, resourcesMap map[string][]string) (result string, total, withResources int) {
+func transformApiTs(content string, metadataMap map[string]operationMetadata) (result string, total, withResources, withTenantPath int) {
 	lines := strings.Split(content, "\n")
 	out := make([]string, 0, len(lines))
 
@@ -123,23 +135,22 @@ func transformApiTs(content string, resourcesMap map[string][]string) (result st
 			continue
 		}
 
-		// Collect JSDoc lines and extract the @request annotation.
 		jsdocLines, requestKey, advance := collectJSDoc(lines, i)
 		i += advance
 
-		// Collect the method body (everything up to and including "    });").
 		methodLines, advance := collectMethodBody(lines, i)
 		i += advance
 
-		// Look up resources; transform regardless (empty Set for unscoped methods).
-		// Skip if already patched (idempotent when run multiple times).
 		alreadyPatched := len(methodLines) > 0 && strings.Contains(methodLines[0], "Object.assign(")
 		if requestKey != "" && !alreadyPatched {
-			res := resourcesMap[requestKey]
-			methodLines = transformMethod(methodLines, res)
+			meta := metadataMap[requestKey]
+			methodLines = transformMethod(methodLines, meta)
 			total++
-			if len(res) > 0 {
+			if len(meta.resources) > 0 {
 				withResources++
+			}
+			if meta.hasTenantPath {
+				withTenantPath++
 			}
 		}
 
@@ -147,7 +158,7 @@ func transformApiTs(content string, resourcesMap map[string][]string) (result st
 		out = append(out, methodLines...)
 	}
 
-	return strings.Join(out, "\n"), total, withResources
+	return strings.Join(out, "\n"), total, withResources, withTenantPath
 }
 
 // collectJSDoc returns the JSDoc lines, the @request key ("METHOD /path"), and
@@ -216,31 +227,45 @@ func collectMethodBody(lines []string, start int) (methodLines []string, consume
 // available on the Axios config inside interceptors:
 //
 //	(config as any).xResources // ["tenant", "task"]
-func transformMethod(lines []string, resources []string) []string {
+//
+// When the OpenAPI path contains {tenant}, it injects xTenantId: tenant before
+// ...params so explicit caller params.xTenantId can still override.
+func transformMethod(lines []string, meta operationMetadata) []string {
 	if len(lines) < 2 {
 		return lines
 	}
 
-	// Split "  methodName = REST" into prefix and the part after " = ".
 	prefix, afterEq, ok := strings.Cut(lines[0], " = ")
 	if !ok {
-		return lines // unexpected format; leave unchanged
+		return lines
 	}
 
-	arrayLit := arrayLiteral(resources)
+	arrayLit := arrayLiteral(meta.resources)
+	middle := lines[1 : len(lines)-1]
+	if meta.hasTenantPath {
+		middle = injectXTenantId(middle)
+	}
 
-	// Rebuild the lines:
-	//   1. First line gets Object.assign( prepended.
-	//   2. Middle lines are unchanged.
-	//   3. A new xResources line is inserted before the closing    });
-	//   4. The closing    }); becomes    }), { resources: new Set<string>([...]) });
-	result := make([]string, 0, len(lines)+1)
+	result := make([]string, 0, len(lines)+2)
 	result = append(result, prefix+" = Object.assign("+afterEq)
-	result = append(result, lines[1:len(lines)-1]...)
+	result = append(result, middle...)
 	result = append(result, "      xResources: "+arrayLit+",")
 	result = append(result, "    }), { resources: new Set<string>("+arrayLit+") });")
 
 	return result
+}
+
+func injectXTenantId(lines []string) []string {
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "...params," {
+			out := make([]string, 0, len(lines)+1)
+			out = append(out, lines[:i]...)
+			out = append(out, "      xTenantId: tenant,")
+			out = append(out, lines[i:]...)
+			return out
+		}
+	}
+	return lines
 }
 
 // arrayLiteral builds a TypeScript array literal from a slice of strings:

--- a/hack/oas/patch-api-resources_test.go
+++ b/hack/oas/patch-api-resources_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildOperationMetadataMap_hasTenantPathFromOpenAPIPath(t *testing.T) {
+	t.Parallel()
+
+	spec := OpenAPISpec{
+		Paths: map[string]PathItem{
+			"/api/v1/tenants/{tenant}/workflows": {
+				Get: &Operation{XResources: []string{"tenant"}},
+			},
+			"/api/v1/stable/tasks/{task}": {
+				Get: &Operation{XResources: []string{"tenant", "task"}},
+			},
+		},
+	}
+
+	m := buildOperationMetadataMap(spec)
+
+	tenantMeta := m["GET /api/v1/tenants/{tenant}/workflows"]
+	if !tenantMeta.hasTenantPath {
+		t.Fatal("expected hasTenantPath for {tenant} path")
+	}
+	if len(tenantMeta.resources) != 1 || tenantMeta.resources[0] != "tenant" {
+		t.Fatalf("unexpected resources: %#v", tenantMeta.resources)
+	}
+
+	taskMeta := m["GET /api/v1/stable/tasks/{task}"]
+	if taskMeta.hasTenantPath {
+		t.Fatal("expected hasTenantPath false for task path without {tenant}")
+	}
+	if len(taskMeta.resources) != 2 {
+		t.Fatalf("unexpected resources: %#v", taskMeta.resources)
+	}
+}
+
+func TestTransformMethod_tenantPathInjectsXTenantIdBeforeParams(t *testing.T) {
+	t.Parallel()
+
+	input := []string{
+		"  tenantGet = (tenant: string, params: RequestParams = {}) =>",
+		"    this.request<Tenant, APIErrors>({",
+		"      path: " + "`/api/v1/tenants/${tenant}`" + ",",
+		"      method: \"GET\",",
+		"      secure: true,",
+		"      format: \"json\",",
+		"      ...params,",
+		"    });",
+	}
+
+	got := transformMethod(input, operationMetadata{
+		resources:     []string{"tenant"},
+		hasTenantPath: true,
+	})
+
+	joined := strings.Join(got, "\n")
+	if !strings.Contains(joined, "xTenantId: tenant,") {
+		t.Fatalf("missing xTenantId injection:\n%s", joined)
+	}
+	if !strings.Contains(joined, "xResources: [\"tenant\"],") {
+		t.Fatalf("missing xResources injection:\n%s", joined)
+	}
+
+	tenantIdx := strings.Index(joined, "xTenantId: tenant,")
+	paramsIdx := strings.Index(joined, "...params,")
+	resourcesIdx := strings.Index(joined, "xResources:")
+	if tenantIdx == -1 || paramsIdx == -1 || resourcesIdx == -1 {
+		t.Fatalf("missing expected lines:\n%s", joined)
+	}
+	if !(tenantIdx < paramsIdx && paramsIdx < resourcesIdx) {
+		t.Fatalf("expected xTenantId before ...params before xResources:\n%s", joined)
+	}
+}
+
+func TestTransformMethod_nonTenantPathSkipsXTenantId(t *testing.T) {
+	t.Parallel()
+
+	input := []string{
+		"  v1TaskGet = (task: string, params: RequestParams = {}) =>",
+		"    this.request<V1TaskSummary, APIErrors>({",
+		"      path: " + "`/api/v1/stable/tasks/${task}`" + ",",
+		"      method: \"GET\",",
+		"      secure: true,",
+		"      format: \"json\",",
+		"      ...params,",
+		"    });",
+	}
+
+	got := transformMethod(input, operationMetadata{
+		resources:     []string{"tenant", "task"},
+		hasTenantPath: false,
+	})
+
+	joined := strings.Join(got, "\n")
+	if strings.Contains(joined, "xTenantId:") {
+		t.Fatalf("unexpected xTenantId for non-tenant path:\n%s", joined)
+	}
+}
+
+func TestTransformMethod_tenantResourceWithoutTenantPathSkipsXTenantId(t *testing.T) {
+	t.Parallel()
+
+	input := []string{
+		"  v1WorkflowRunGet = (v1WorkflowRun: string, params: RequestParams = {}) =>",
+		"    this.request<V1WorkflowRunDetails, APIErrors>({",
+		"      path: " + "`/api/v1/stable/workflow-runs/${v1WorkflowRun}`" + ",",
+		"      method: \"GET\",",
+		"      secure: true,",
+		"      format: \"json\",",
+		"      ...params,",
+		"    });",
+	}
+
+	got := transformMethod(input, operationMetadata{
+		resources:     []string{"tenant", "v1-workflow-run"},
+		hasTenantPath: false,
+	})
+
+	if strings.Contains(strings.Join(got, "\n"), "xTenantId:") {
+		t.Fatal("expected no xTenantId when OpenAPI path lacks {tenant}")
+	}
+}
+
+func TestTransformApiTs_idempotentWhenAlreadyPatched(t *testing.T) {
+	t.Parallel()
+
+	content := "  /**\n" +
+		"   * @request GET:/api/v1/tenants/{tenant}\n" +
+		"   */\n" +
+		"  tenantGet = Object.assign((tenant: string, params: RequestParams = {}) =>\n" +
+		"    this.request<Tenant, APIErrors>({\n" +
+		"      path: `/api/v1/tenants/${tenant}`,\n" +
+		"      method: \"GET\",\n" +
+		"      ...params,\n" +
+		"      xResources: [\"tenant\"],\n" +
+		"    }), { resources: new Set<string>([\"tenant\"]) });\n"
+
+	metadataMap := map[string]operationMetadata{
+		"GET /api/v1/tenants/{tenant}": {
+			resources:     []string{"tenant"},
+			hasTenantPath: true,
+		},
+	}
+
+	result, total, _, withTenantPath := transformApiTs(content, metadataMap)
+	if total != 0 {
+		t.Fatalf("expected no transforms on already-patched method, got %d", total)
+	}
+	if withTenantPath != 0 {
+		t.Fatalf("expected withTenantPath 0, got %d", withTenantPath)
+	}
+	if result != content {
+		t.Fatal("expected content unchanged for idempotent run")
+	}
+}
+
+func TestTransformApiTs_patchesUnpatchedTenantMethod(t *testing.T) {
+	t.Parallel()
+
+	content := "  /**\n" +
+		"   * @request GET:/api/v1/tenants/{tenant}/workflows\n" +
+		"   */\n" +
+		"  workflowList = (\n" +
+		"    tenant: string,\n" +
+		"    params: RequestParams = {},\n" +
+		"  ) =>\n" +
+		"    this.request<WorkflowList, APIErrors>({\n" +
+		"      path: `/api/v1/tenants/${tenant}/workflows`,\n" +
+		"      method: \"GET\",\n" +
+		"      secure: true,\n" +
+		"      format: \"json\",\n" +
+		"      ...params,\n" +
+		"    });\n"
+
+	metadataMap := map[string]operationMetadata{
+		"GET /api/v1/tenants/{tenant}/workflows": {
+			resources:     []string{"tenant"},
+			hasTenantPath: true,
+		},
+	}
+
+	result, total, _, withTenantPath := transformApiTs(content, metadataMap)
+	if total != 1 {
+		t.Fatalf("expected 1 transform, got %d", total)
+	}
+	if withTenantPath != 1 {
+		t.Fatalf("expected withTenantPath 1, got %d", withTenantPath)
+	}
+	if !strings.Contains(result, "xTenantId: tenant,") {
+		t.Fatalf("expected xTenantId in result:\n%s", result)
+	}
+	if !strings.Contains(result, "Object.assign(") {
+		t.Fatal("expected Object.assign wrapper")
+	}
+}


### PR DESCRIPTION
# Description

Stacked on #4062 and should merge after that PR lands. This follow-up teaches the generated dashboard API patcher to add `xTenantId: tenant` for OpenAPI paths that contain `{tenant}`, so exchange-token selection uses request-local tenant metadata before relying on URL parsing or persisted state.

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (changes which are not directly related to any business logic)
- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

- Extend `hack/oas/patch-api-resources.go` to track `{tenant}` OpenAPI paths and inject `xTenantId: tenant` into generated methods.
- Add focused Go tests for tenant metadata injection, non-tenant skips, and idempotency.
- Regenerate the API client so tenant-path methods include explicit tenant metadata.

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Cursor agent assisted with implementation, tests, code generation, verification, and PR drafting.

</details>