### PR TITLE
fix(config): make TLS minimum version configurable

### DIFF
--- a/frontend/docs/pages/contributing/sdks.mdx
+++ b/frontend/docs/pages/contributing/sdks.mdx
@@ -18,6 +18,7 @@ Each SDK should support the following environment variables:
 | `HATCHET_CLIENT_TLS_ROOT_CA_FILE` | The path to the TLS root CA file to use.                                                                                                               | Only if the server certificate is not signed by a public authority that's available to your environment | N/A                                       |
 | `HATCHET_CLIENT_TLS_ROOT_CA`      | The TLS root CA to use.                                                                                                                                | Only if the server certificate is not signed by a public authority that's available to your environment | N/A                                       |
 | `HATCHET_CLIENT_TLS_SERVER_NAME`  | The TLS server name to use.                                                                                                                            | No                                                                                                      | Defaults to the `host` of the `host:port` |
+| `HATCHET_CLIENT_TLS_MIN_VERSION`  | The minimum TLS version. Valid values are `1.2` and `1.3`.                                                                                             | No                                                                                                      | `1.3`                                     |
 
 The following environment variables are deprecated:
 

--- a/frontend/docs/pages/self-hosting/configuration-options.mdx
+++ b/frontend/docs/pages/self-hosting/configuration-options.mdx
@@ -293,6 +293,7 @@ Variables marked with ⚠️ are conditionally required when specific features a
 | `SERVER_TLS_ROOT_CA`                                     | TLS root CA                      |               |
 | `SERVER_TLS_ROOT_CA_FILE`                                | Path to the TLS root CA file     |               |
 | `SERVER_TLS_SERVER_NAME`                                 | TLS server name                  |               |
+| `SERVER_TLS_MIN_VERSION`                                 | Minimum TLS version (1.2, 1.3)   | `1.3`         |
 | `SERVER_INTERNAL_CLIENT_BASE_STRATEGY`                   | Internal client TLS strategy     |               |
 | `SERVER_INTERNAL_CLIENT_BASE_INHERIT_BASE`               | Inherit base TLS config          | `true`        |
 | `SERVER_INTERNAL_CLIENT_TLS_BASE_CERT`                   | Internal client TLS cert         |               |

--- a/frontend/docs/pages/self-hosting/worker-configuration-options.mdx
+++ b/frontend/docs/pages/self-hosting/worker-configuration-options.mdx
@@ -39,6 +39,7 @@ These variables enable a local HTTP server that exposes `/health` and `/metrics`
 | `HATCHET_CLIENT_TLS_KEY_FILE`     | Path to TLS key file           |               |
 | `HATCHET_CLIENT_TLS_ROOT_CA_FILE` | Path to TLS root CA file       |               |
 | `HATCHET_CLIENT_TLS_SERVER_NAME`  | TLS server name                |               |
+| `HATCHET_CLIENT_TLS_MIN_VERSION`  | Minimum TLS version (1.2, 1.3) | `1.3`         |
 
 ## Logging Configuration
 

--- a/pkg/config/client/client.go
+++ b/pkg/config/client/client.go
@@ -95,6 +95,7 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("tls.base.tlsCert", "HATCHET_CLIENT_TLS_CERT")
 	_ = v.BindEnv("tls.base.tlsKey", "HATCHET_CLIENT_TLS_KEY")
 	_ = v.BindEnv("tls.base.tlsRootCA", "HATCHET_CLIENT_TLS_ROOT_CA")
+	_ = v.BindEnv("tls.base.tlsMinVersion", "HATCHET_CLIENT_TLS_MIN_VERSION")
 	_ = v.BindEnv("tls.tlsServerName", "HATCHET_CLIENT_TLS_SERVER_NAME")
 }
 

--- a/pkg/config/loader/loaderutils/tls.go
+++ b/pkg/config/loader/loaderutils/tls.go
@@ -5,10 +5,24 @@ import (
 	"crypto/x509"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/hatchet-dev/hatchet/pkg/config/client"
 	"github.com/hatchet-dev/hatchet/pkg/config/shared"
 )
+
+// ParseTLSMinVersion parses a TLS minimum version string.
+// Empty defaults to TLS 1.3.
+func ParseTLSMinVersion(s string) (uint16, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "1.3", "tls1.3", "tls_1.3", "tls13":
+		return tls.VersionTLS13, nil
+	case "1.2", "tls1.2", "tls_1.2", "tls12":
+		return tls.VersionTLS12, nil
+	default:
+		return 0, fmt.Errorf("unsupported TLS minimum version %q: must be \"1.2\" or \"1.3\"", s)
+	}
+}
 
 func LoadClientTLSConfig(tlsConfig *client.ClientTLSConfigFile, serverName string) (*tls.Config, error) {
 	res, ca, err := LoadBaseTLSConfig(&tlsConfig.Base)
@@ -94,8 +108,13 @@ func LoadBaseTLSConfig(tlsConfig *shared.TLSConfigFile) (*tls.Config, *x509.Cert
 		}
 	}
 
+	minVersion, err := ParseTLSMinVersion(tlsConfig.TLSMinVersion)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	res := &tls.Config{
-		MinVersion: tls.VersionTLS13,
+		MinVersion: minVersion,
 	}
 
 	if len(x509Cert.Certificate) != 0 {

--- a/pkg/config/loader/loaderutils/tls_test.go
+++ b/pkg/config/loader/loaderutils/tls_test.go
@@ -1,0 +1,167 @@
+//go:build !e2e && !load && !rampup && !integration
+
+package loaderutils
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hatchet-dev/hatchet/pkg/config/shared"
+)
+
+func TestParseTLSMinVersion(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    uint16
+		wantErr bool
+	}{
+		{name: "empty defaults to TLS 1.3", input: "", want: tls.VersionTLS13},
+		{name: "1.3", input: "1.3", want: tls.VersionTLS13},
+		{name: "tls1.3", input: "tls1.3", want: tls.VersionTLS13},
+		{name: "TLS1.3 uppercase", input: "TLS1.3", want: tls.VersionTLS13},
+		{name: "tls_1.3", input: "tls_1.3", want: tls.VersionTLS13},
+		{name: "tls13", input: "tls13", want: tls.VersionTLS13},
+		{name: "1.2", input: "1.2", want: tls.VersionTLS12},
+		{name: "tls1.2", input: "tls1.2", want: tls.VersionTLS12},
+		{name: "TLS1.2 uppercase", input: "TLS1.2", want: tls.VersionTLS12},
+		{name: "tls_1.2", input: "tls_1.2", want: tls.VersionTLS12},
+		{name: "tls12", input: "tls12", want: tls.VersionTLS12},
+		{name: "leading/trailing whitespace", input: "  1.2  ", want: tls.VersionTLS12},
+		{name: "1.1 rejected", input: "1.1", wantErr: true},
+		{name: "1.0 rejected", input: "1.0", wantErr: true},
+		{name: "arbitrary string rejected", input: "latest", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseTLSMinVersion(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "unsupported TLS minimum version")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestLoadBaseTLSConfig_DefaultMinVersion(t *testing.T) {
+	cfg := &shared.TLSConfigFile{}
+	res, _, err := LoadBaseTLSConfig(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, uint16(tls.VersionTLS13), res.MinVersion)
+}
+
+func TestLoadBaseTLSConfig_ConfiguredMinVersion(t *testing.T) {
+	cfg := &shared.TLSConfigFile{TLSMinVersion: "1.2"}
+	res, _, err := LoadBaseTLSConfig(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, uint16(tls.VersionTLS12), res.MinVersion)
+}
+
+func TestLoadBaseTLSConfig_InvalidMinVersion(t *testing.T) {
+	cfg := &shared.TLSConfigFile{TLSMinVersion: "1.0"}
+	_, _, err := LoadBaseTLSConfig(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported TLS minimum version")
+}
+
+func TestTLS12Handshake(t *testing.T) {
+	cert := generateSelfSignedCert(t)
+
+	serverCfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MaxVersion:   tls.VersionTLS12,
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", serverCfg)
+	require.NoError(t, err)
+	defer ln.Close()
+
+	addr := ln.Addr().String()
+
+	t.Run("TLS 1.3 client fails against TLS 1.2 server", func(t *testing.T) {
+		serverDone := acceptAndClose(ln)
+
+		conn, err := tls.Dial("tcp", addr, &tls.Config{
+			MinVersion:         tls.VersionTLS13,
+			InsecureSkipVerify: true, //nolint:gosec // self-signed test cert
+		})
+		if err == nil {
+			conn.Close()
+			t.Fatal("expected handshake failure with TLS 1.3 minimum against TLS 1.2 server")
+		}
+
+		<-serverDone
+	})
+
+	t.Run("TLS 1.2 client succeeds against TLS 1.2 server", func(t *testing.T) {
+		serverDone := acceptAndClose(ln)
+
+		conn, err := tls.Dial("tcp", addr, &tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: true, //nolint:gosec // self-signed test cert
+		})
+		require.NoError(t, err)
+		conn.Close()
+
+		<-serverDone
+	})
+}
+
+// acceptAndClose accepts one TLS connection and closes done when the server
+// goroutine exits, allowing the test to wait for handshake cleanup.
+func acceptAndClose(ln net.Listener) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		if tlsConn, ok := conn.(*tls.Conn); ok {
+			_ = tlsConn.Handshake()
+		}
+		conn.Close()
+	}()
+	return done
+}
+
+func generateSelfSignedCert(t *testing.T) tls.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{Organization: []string{"Test"}},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return tls.Certificate{
+		Certificate: [][]byte{derBytes},
+		PrivateKey:  key,
+	}
+}

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -898,6 +898,7 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("tls.tlsKeyFile", "SERVER_TLS_KEY_FILE")
 	_ = v.BindEnv("tls.tlsRootCA", "SERVER_TLS_ROOT_CA")
 	_ = v.BindEnv("tls.tlsRootCAFile", "SERVER_TLS_ROOT_CA_FILE")
+	_ = v.BindEnv("tls.tlsMinVersion", "SERVER_TLS_MIN_VERSION")
 	_ = v.BindEnv("tls.tlsServerName", "SERVER_TLS_SERVER_NAME")
 
 	// logger options

--- a/pkg/config/shared/shared.go
+++ b/pkg/config/shared/shared.go
@@ -10,6 +10,9 @@ type TLSConfigFile struct {
 	TLSKeyFile    string `mapstructure:"tlsKeyFile" json:"tlsKeyFile,omitempty"`
 	TLSRootCA     string `mapstructure:"tlsRootCA" json:"tlsRootCA,omitempty"`
 	TLSRootCAFile string `mapstructure:"tlsRootCAFile" json:"tlsRootCAFile,omitempty"`
+
+	// TLSMinVersion sets the minimum TLS version ("1.2" or "1.3"). Defaults to TLS 1.3.
+	TLSMinVersion string `mapstructure:"tlsMinVersion" json:"tlsMinVersion,omitempty"`
 }
 
 type LoggerConfigFile struct {


### PR DESCRIPTION
# Description

Fixes #4069

Hatchet currently hard-codes `tls.Config.MinVersion` to `tls.VersionTLS13` in the shared TLS config loader. This causes client TLS connections to fail against endpoints that only support TLS 1.2. This PR makes the TLS minimum version configurable

New config/env options:

* `HATCHET_CLIENT_TLS_MIN_VERSION`
* `SERVER_TLS_MIN_VERSION`

Supports versions `1.2` and `1.3`

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [x] Test changes (add, refactor, improve or change a test)
* [x] This change requires a documentation update

## What's Changed

* [x] Add `tlsMinVersion` to the shared TLS config.
* [x] Add `HATCHET_CLIENT_TLS_MIN_VERSION` for client/worker TLS configuration.
* [x] Add `SERVER_TLS_MIN_VERSION` for server TLS configuration.
* [x] Default unset TLS min version to TLS 1.3.
* [x] Allow TLS 1.2 only when explicitly configured.
* [x] Reject unsupported TLS minimum versions, including TLS 1.0 and TLS 1.1.
* [x] Add tests for parsing, config loading, invalid values, and TLS 1.2 handshake behavior.
* [x] Update self-hosting configuration docs for the new env vars.

## Checklist

Changes have been:

* [x] Tested (unit, integration, or manually with steps specified)
* [x] Linted and formatted
* [x] Documented (where applicable)
* [ ] Added to CHANGELOG (where applicable) -- see [[Keep a Changelog](https://keepachangelog.com/en/1.0.0/)](https://keepachangelog.com/en/1.0.0/)

## Testing

Ran:

```sh
gofmt -w \
  pkg/config/client/client.go \
  pkg/config/loader/loaderutils/tls.go \
  pkg/config/loader/loaderutils/tls_test.go \
  pkg/config/server/server.go \
  pkg/config/shared/shared.go

go test ./pkg/config/loader/loaderutils/... -v
go test ./pkg/config/loader/loaderutils/... -run TestTLS12Handshake -count=100 -v
go test ./pkg/config/loader/loaderutils/... -run TestTLS12Handshake -race -count=50 -v
go vet ./pkg/config/...
```

Also validated that:

* Default config produces `tls.VersionTLS13`.
* `TLSMinVersion: "1.2"` produces `tls.VersionTLS12`.
* Invalid values such as `1.0`, `1.1`, and arbitrary strings return a clear error.
* A TLS 1.2 client can connect to a TLS 1.2-only test server, while a TLS 1.3-minimum client cannot.

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->

<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

* [x] *I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md).*

<!-- Please specify the tooling/model and the extent to which it was used. -->

* **Details**: Claude Code was used to help investigate the reported TLS behavior, draft the initial tests, review the patch for security/configuration concerns. 

</details>