### PR TITLE
fix(dashboard): run frontend unit tests in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,20 @@ jobs:
       - name: Generate docs snippets and examples
         working-directory: frontend/snippets
         run: python3 generate.py
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - name: Setup pnpm
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
+        with:
+          version: 10.16.1
+          run_install: false
+      - name: Install frontend dependencies
+        working-directory: frontend/app
+        run: pnpm install --frozen-lockfile
+      - name: Test frontend
+        working-directory: frontend/app
+        run: pnpm run test:unit
       - name: Build frontend
         run: docker build -f ./build/package/frontend.dockerfile .
 


### PR DESCRIPTION
## Summary
- Run the existing `frontend/app` unit test script in the frontend build workflow before the Docker build.
- Set up Node 22 and repo-pinned pnpm 10.16.1 using pinned GitHub Actions.

## Test plan
- `CI=true corepack pnpm@10.16.1 install --frozen-lockfile`
- `corepack pnpm@10.16.1 run test:unit`
- `corepack pnpm@10.16.1 run build`