### PR TITLE
fix: block /managed-workers routes in self-hosted Lite mode (#3896)

### DIFF
--- a/frontend/app/src/router.tsx
+++ b/frontend/app/src/router.tsx
@@ -17,6 +17,7 @@ import {
   createRoute,
   createRouter,
   lazyRouteComponent,
+  notFound,
   redirect,
 } from '@tanstack/react-router';
 import { Outlet } from '@tanstack/react-router';
@@ -198,6 +199,24 @@ const v1RedirectRoute = createRoute({
     throw redirect({ to: appRoutes.authenticatedRoute.to });
   },
 });
+
+/**
+ * Throws a notFound response when the request originates from a self-hosted
+ * (Lite) deployment that has neither cloud nor control-plane support.
+ * Managed-compute routes are a cloud-only feature; visiting them in Lite mode
+ * produces an infinite loading screen because the billing/cloud queries never
+ * resolve (see GitHub issue hatchet-dev/hatchet#3896).
+ */
+async function requireCloudOrControlPlane() {
+  const [{ isCloudEnabled }, { isControlPlaneEnabled }] = await Promise.all([
+    queryClient.fetchQuery(getCloudMetadataQuery),
+    fetchControlPlaneStatus(),
+  ]);
+
+  if (!isCloudEnabled && !isControlPlaneEnabled) {
+    throw notFound();
+  }
+}
 
 async function getOrganizationIdForTenantInRouter(tenantId: string) {
   const [{ isCloudEnabled }, { isControlPlaneEnabled }] = await Promise.all([
@@ -438,6 +457,7 @@ const tenantWorkerRoute = createRoute({
 const tenantManagedWorkersRoute = createRoute({
   getParentRoute: () => tenantRoute,
   path: 'managed-workers',
+  loader: () => requireCloudOrControlPlane(),
   component: lazyRouteComponent(
     () => import('./pages/main/v1/managed-workers/index.tsx'),
     'default',
@@ -447,6 +467,7 @@ const tenantManagedWorkersRoute = createRoute({
 const tenantManagedWorkersTemplateRoute = createRoute({
   getParentRoute: () => tenantRoute,
   path: 'managed-workers/demo-template',
+  loader: () => requireCloudOrControlPlane(),
   component: lazyRouteComponent(
     () => import('./pages/main/v1/managed-workers/demo-template/index.tsx'),
     'default',
@@ -456,6 +477,7 @@ const tenantManagedWorkersTemplateRoute = createRoute({
 const tenantManagedWorkersCreateRoute = createRoute({
   getParentRoute: () => tenantRoute,
   path: 'managed-workers/create',
+  loader: () => requireCloudOrControlPlane(),
   component: lazyRouteComponent(
     () => import('./pages/main/v1/managed-workers/create/index.tsx'),
     'default',
@@ -465,6 +487,7 @@ const tenantManagedWorkersCreateRoute = createRoute({
 const tenantManagedWorkerRoute = createRoute({
   getParentRoute: () => tenantRoute,
   path: 'managed-workers/$managedWorker',
+  loader: () => requireCloudOrControlPlane(),
   component: lazyRouteComponent(
     () => import('./pages/main/v1/managed-workers/$managed-worker/index.tsx'),
     'default',


### PR DESCRIPTION
## What

In self-hosted (Lite) deployments, navigating directly to `/managed-workers` or `/managed-workers/create` shows an infinite loading screen instead of a 404 or an unsupported message.

## Why it happens

The managed-workers page component fires cloud-only queries (billing state, managed-compute costs, payment methods) that never resolve when the cloud metadata endpoint returns an error/404 — which is always the case in Lite mode. The sidebar already hides the "Managed Compute" nav link in Lite mode via the `managedWorkerEnabled` feature flag (which is never set when cloud is disabled), but the routes themselves had no guard, so direct URL access bypassed that check entirely.

## What changed

Added a `requireCloudOrControlPlane()` loader helper in `router.tsx` that checks `isCloudEnabled || isControlPlaneEnabled` (same two signals the rest of the router uses for cloud detection). If neither is true, it throws `notFound()`, which renders the existing `NotFound` component via the nearest `notFoundComponent` handler.

The loader is attached to all four managed-workers routes:
- `managed-workers` (index)
- `managed-workers/create`
- `managed-workers/demo-template`
- `managed-workers/$managedWorker`

This is a single-file, 23-line change — no new components, no new abstractions.

## How to test

1. Run Hatchet in self-hosted (Lite) mode (no cloud metadata endpoint configured).
2. Navigate directly to `http://localhost:<port>/tenants/<tenant-id>/managed-workers`.
3. **Before this fix**: infinite spinner.
4. **After this fix**: 404 page renders immediately.

For cloud/hosted deployments: behavior is unchanged — the loader resolves immediately since `isCloudEnabled` is true.

Fixes #3896