### PR TITLE
fix(ci): Properly ref annotated tag

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -113,7 +113,7 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch the tag object
-        run: git fetch --force origin tag "$GITHUB_TAG"
+        run: git fetch --force origin tag "${{ github.ref_name }}"
 
       - name: Determine previous release tag
         id: prev

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -113,7 +113,7 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch the tag object
-        run: git fetch --force origin tag "${{ github.ref_name }}"
+        run: git fetch --force origin tag "$GITHUB_REF_NAME"
 
       - name: Determine previous release tag
         id: prev


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Fix passing in of GitHub ref into generate changelog script.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] CI (any automation pipeline changes)

## What's Changed

- Correctly inject GitHub tag into `generate-changelog` job when creating release notes.

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
