### PR TITLE
fix(client): reconnect durable and workflow run listeners after stream loss

### DIFF
--- a/pkg/client/durable_listener.go
+++ b/pkg/client/durable_listener.go
@@ -73,6 +73,14 @@ func (r *subscribeClientImpl) getDurableEventsListener(
 	}
 
 	r.durableEventsListener = w
+	if !w.startListening() {
+		if closeErr := w.Close(); closeErr != nil {
+			r.l.Error().Ctx(ctx).Err(closeErr).Msg("failed to close durable events listener")
+		}
+
+		r.durableEventsListener = nil
+		return nil, errListenerClosed
+	}
 
 	go func() {
 		defer func() {
@@ -88,8 +96,9 @@ func (r *subscribeClientImpl) getDurableEventsListener(
 			}
 			r.durableEventsListenerMu.Unlock()
 		}()
+		defer w.stopListening()
 
-		err := w.Listen(ctx)
+		err := w.listen(ctx)
 
 		if err != nil {
 			r.l.Error().Ctx(ctx).Err(err).Msg("failed to listen for durable events")

--- a/pkg/client/durable_listener.go
+++ b/pkg/client/durable_listener.go
@@ -34,6 +34,7 @@ type DurableEventsListener struct {
 	reconnectGroup singleflight.Group
 	listenMu       sync.Mutex
 	listening      bool
+	closed         bool
 
 	l *zerolog.Logger
 
@@ -99,6 +100,10 @@ func (r *subscribeClientImpl) getDurableEventsListener(
 }
 
 func (w *DurableEventsListener) retryListen(ctx context.Context) error {
+	if w.isClosed() {
+		return errListenerClosed
+	}
+
 	_, err, _ := w.reconnectGroup.Do("reconnect", func() (interface{}, error) {
 		return nil, w.doRetryListen(ctx)
 	})
@@ -108,6 +113,10 @@ func (w *DurableEventsListener) retryListen(ctx context.Context) error {
 func (w *DurableEventsListener) doRetryListen(ctx context.Context) error {
 	w.clientMu.Lock()
 	defer w.clientMu.Unlock()
+
+	if w.isClosed() {
+		return errListenerClosed
+	}
 
 	retries := 0
 
@@ -148,6 +157,10 @@ func (w *DurableEventsListener) doRetryListen(ctx context.Context) error {
 			continue
 		}
 
+		if w.isClosed() {
+			return errListenerClosed
+		}
+
 		w.client = client
 		w.generation++
 		return nil
@@ -168,11 +181,17 @@ func (w *DurableEventsListener) isListening() bool {
 	return w.listening
 }
 
+func (w *DurableEventsListener) isClosed() bool {
+	w.listenMu.Lock()
+	defer w.listenMu.Unlock()
+	return w.closed
+}
+
 func (w *DurableEventsListener) startListening() bool {
 	w.listenMu.Lock()
 	defer w.listenMu.Unlock()
 
-	if w.listening {
+	if w.listening || w.closed {
 		return false
 	}
 
@@ -187,6 +206,10 @@ func (w *DurableEventsListener) stopListening() {
 }
 
 func (w *DurableEventsListener) ensureListening(ctx context.Context) error {
+	if w.isClosed() {
+		return errListenerClosed
+	}
+
 	if w.isListening() {
 		return nil
 	}
@@ -196,6 +219,10 @@ func (w *DurableEventsListener) ensureListening(ctx context.Context) error {
 	}
 
 	if !w.startListening() {
+		if w.isClosed() {
+			return errListenerClosed
+		}
+
 		return nil
 	}
 
@@ -220,6 +247,10 @@ func (l *DurableEventsListener) AddSignal(
 	signalKey string,
 	handler DurableEventHandler,
 ) error {
+	if l.isClosed() {
+		return errListenerClosed
+	}
+
 	t := listenTuple{
 		taskId:    taskId,
 		signalKey: signalKey,
@@ -312,16 +343,19 @@ func (l *DurableEventsListener) listen(ctx context.Context) error {
 		event, err := client.Recv()
 
 		if err != nil {
-			if errors.Is(err, io.EOF) || status.Code(err) == codes.Canceled {
+			switch {
+			case errors.Is(err, io.EOF):
+				if !l.shouldReconnectOnEOF(ctx) {
+					return nil
+				}
+			case status.Code(err) == codes.Canceled:
 				return nil
-			}
-
-			consecutiveErrors++
-
-			if status.Code(err) == codes.Unavailable {
+			case status.Code(err) == codes.Unavailable:
 				l.l.Warn().Err(err).Msg("dispatcher is unavailable, retrying durable event listener after 1 second")
 				time.Sleep(1 * time.Second)
 			}
+
+			consecutiveErrors++
 
 			if _, genAfter := l.getClientSnapshot(); genAfter != generation {
 				client, generation = l.getClientSnapshot()
@@ -332,6 +366,10 @@ func (l *DurableEventsListener) listen(ctx context.Context) error {
 			retryErr := l.retryListen(ctx)
 
 			if retryErr != nil {
+				if errors.Is(retryErr, errListenerClosed) {
+					return nil
+				}
+
 				l.l.Error().Err(retryErr).Msgf("failed to relisten (consecutive errors: %d/%d)", consecutiveErrors, maxConsecutiveErrors)
 
 				if consecutiveErrors >= maxConsecutiveErrors {
@@ -356,6 +394,10 @@ func (l *DurableEventsListener) listen(ctx context.Context) error {
 }
 
 func (l *DurableEventsListener) Close() error {
+	l.listenMu.Lock()
+	l.closed = true
+	l.listenMu.Unlock()
+
 	l.clientMu.Lock()
 	client := l.client
 	l.clientMu.Unlock()
@@ -368,11 +410,13 @@ func (l *DurableEventsListener) Close() error {
 }
 
 func (l *DurableEventsListener) handleEvent(e *contracts.DurableEvent) error {
-	// find all handlers for this workflow run
-	handlers, ok := l.handlers.Load(listenTuple{
+	t := listenTuple{
 		taskId:    e.TaskId,
 		signalKey: e.SignalKey,
-	})
+	}
+
+	// find all handlers for this workflow run
+	handlers, ok := l.handlers.Load(t)
 
 	if !ok {
 		return nil
@@ -396,5 +440,33 @@ func (l *DurableEventsListener) handleEvent(e *contracts.DurableEvent) error {
 
 	err := eg.Wait()
 
+	if err == nil {
+		l.handlers.Delete(t)
+	}
+
 	return err
+}
+
+func (l *DurableEventsListener) hasHandlers() bool {
+	hasHandlers := false
+
+	l.handlers.Range(func(key, value interface{}) bool {
+		h := value.(*threadSafeDurableEventHandlers)
+
+		h.mu.RLock()
+		hasHandlers = len(h.handlers) > 0
+		h.mu.RUnlock()
+
+		return !hasHandlers
+	})
+
+	return hasHandlers
+}
+
+func (l *DurableEventsListener) shouldReconnectOnEOF(ctx context.Context) bool {
+	if ctx.Err() != nil || l.isClosed() {
+		return false
+	}
+
+	return l.hasHandlers()
 }

--- a/pkg/client/durable_listener.go
+++ b/pkg/client/durable_listener.go
@@ -13,6 +13,7 @@ import (
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry"
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -26,8 +27,13 @@ type DurableEventHandler func(e DurableEvent) error
 type DurableEventsListener struct {
 	constructor func(context.Context) (contracts.V1Dispatcher_ListenForDurableEventClient, error)
 
-	client   contracts.V1Dispatcher_ListenForDurableEventClient
-	clientMu sync.RWMutex
+	client     contracts.V1Dispatcher_ListenForDurableEventClient
+	clientMu   sync.Mutex
+	generation uint64
+
+	reconnectGroup singleflight.Group
+	listenMu       sync.Mutex
+	listening      bool
 
 	l *zerolog.Logger
 
@@ -68,7 +74,13 @@ func (r *subscribeClientImpl) getDurableEventsListener(
 	r.durableEventsListener = w
 
 	go func() {
-		defer func() {
+		err := w.Listen(ctx)
+
+		if err != nil {
+			r.l.Error().Ctx(ctx).Err(err).Msg("failed to listen for durable events")
+		}
+
+		if ctx.Err() != nil {
 			err := w.Close()
 
 			if err != nil {
@@ -76,14 +88,10 @@ func (r *subscribeClientImpl) getDurableEventsListener(
 			}
 
 			r.durableEventsListenerMu.Lock()
-			r.durableEventsListener = nil
+			if r.durableEventsListener == w {
+				r.durableEventsListener = nil
+			}
 			r.durableEventsListenerMu.Unlock()
-		}()
-
-		err := w.Listen(ctx)
-
-		if err != nil {
-			r.l.Error().Ctx(ctx).Err(err).Msg("failed to listen for durable events")
 		}
 	}()
 
@@ -91,6 +99,13 @@ func (r *subscribeClientImpl) getDurableEventsListener(
 }
 
 func (w *DurableEventsListener) retryListen(ctx context.Context) error {
+	_, err, _ := w.reconnectGroup.Do("reconnect", func() (interface{}, error) {
+		return nil, w.doRetryListen(ctx)
+	})
+	return err
+}
+
+func (w *DurableEventsListener) doRetryListen(ctx context.Context) error {
 	w.clientMu.Lock()
 	defer w.clientMu.Unlock()
 
@@ -109,15 +124,12 @@ func (w *DurableEventsListener) retryListen(ctx context.Context) error {
 			continue
 		}
 
-		w.client = client
-
-		// listen for all the same workflow runs
 		var rangeErr error
 
 		w.handlers.Range(func(key, value interface{}) bool {
 			t := key.(listenTuple)
 
-			err := w.client.Send(&contracts.ListenForDurableEventRequest{
+			err := client.Send(&contracts.ListenForDurableEventRequest{
 				TaskId:    t.taskId,
 				SignalKey: t.signalKey,
 			})
@@ -132,13 +144,70 @@ func (w *DurableEventsListener) retryListen(ctx context.Context) error {
 		})
 
 		if rangeErr != nil {
+			retries++
 			continue
 		}
 
+		w.client = client
+		w.generation++
 		return nil
 	}
 
 	return fmt.Errorf("could not listen for durable events on the worker after %d retries", retries)
+}
+
+func (w *DurableEventsListener) getClientSnapshot() (contracts.V1Dispatcher_ListenForDurableEventClient, uint64) {
+	w.clientMu.Lock()
+	defer w.clientMu.Unlock()
+	return w.client, w.generation
+}
+
+func (w *DurableEventsListener) isListening() bool {
+	w.listenMu.Lock()
+	defer w.listenMu.Unlock()
+	return w.listening
+}
+
+func (w *DurableEventsListener) startListening() bool {
+	w.listenMu.Lock()
+	defer w.listenMu.Unlock()
+
+	if w.listening {
+		return false
+	}
+
+	w.listening = true
+	return true
+}
+
+func (w *DurableEventsListener) stopListening() {
+	w.listenMu.Lock()
+	w.listening = false
+	w.listenMu.Unlock()
+}
+
+func (w *DurableEventsListener) ensureListening(ctx context.Context) error {
+	if w.isListening() {
+		return nil
+	}
+
+	if err := w.retryListen(ctx); err != nil {
+		return err
+	}
+
+	if !w.startListening() {
+		return nil
+	}
+
+	go func() {
+		defer w.stopListening()
+
+		if err := w.listen(ctx); err != nil {
+			w.l.Error().Ctx(ctx).Err(err).Msg("failed to listen for durable events")
+		}
+	}()
+
+	return nil
 }
 
 type threadSafeDurableEventHandlers struct {
@@ -155,6 +224,13 @@ func (l *DurableEventsListener) AddSignal(
 		taskId:    taskId,
 		signalKey: signalKey,
 	}
+
+	if !l.isListening() {
+		if err := l.ensureListening(context.Background()); err != nil {
+			return err
+		}
+	}
+
 	handlers, _ := l.handlers.LoadOrStore(t, &threadSafeDurableEventHandlers{
 		handlers: []DurableEventHandler{},
 	})
@@ -166,62 +242,112 @@ func (l *DurableEventsListener) AddSignal(
 	l.handlers.Store(t, h)
 	h.mu.Unlock()
 
-	err := l.retrySend(t)
+	if err := l.retrySend(t); err != nil {
+		if !l.isListening() {
+			if listenErr := l.ensureListening(context.Background()); listenErr != nil {
+				return listenErr
+			}
 
-	if err != nil {
+			return l.retrySend(t)
+		}
+
 		return err
 	}
 
-	return nil
+	return l.ensureListening(context.Background())
 }
 
 func (l *DurableEventsListener) retrySend(t listenTuple) error {
-	for i := range DefaultActionListenerRetryCount {
-		if i > 0 {
-			time.Sleep(DefaultActionListenerRetryInterval)
+	for i := 0; i < DefaultActionListenerRetryCount; i++ {
+		client, genBefore := l.getClientSnapshot()
+
+		if client == nil {
+			return fmt.Errorf("client is not connected")
 		}
 
-		err := func() error {
-			l.clientMu.RLock()
-			defer l.clientMu.RUnlock()
-
-			if l.client == nil {
-				return fmt.Errorf("client is not connected")
-			}
-
-			return l.client.Send(&contracts.ListenForDurableEventRequest{
-				TaskId:    t.taskId,
-				SignalKey: t.signalKey,
-			})
-		}()
+		err := client.Send(&contracts.ListenForDurableEventRequest{
+			TaskId:    t.taskId,
+			SignalKey: t.signalKey,
+		})
 
 		if err == nil {
 			return nil
 		}
+
+		l.l.Warn().Err(err).Msgf("failed to send durable event subscription, attempt %d/%d", i+1, DefaultActionListenerRetryCount)
+
+		if _, genAfter := l.getClientSnapshot(); genAfter != genBefore {
+			continue
+		}
+
+		if retryErr := l.retryListen(context.Background()); retryErr != nil {
+			l.l.Error().Err(retryErr).Msg("failed to relisten after send failure")
+		}
+
+		time.Sleep(DefaultActionListenerRetryInterval)
 	}
 
 	return fmt.Errorf("could not send to the worker after %d retries", DefaultActionListenerRetryCount)
 }
 
 func (l *DurableEventsListener) Listen(ctx context.Context) error {
+	if !l.startListening() {
+		return nil
+	}
+	defer l.stopListening()
+
+	return l.listen(ctx)
+}
+
+func (l *DurableEventsListener) listen(ctx context.Context) error {
+	consecutiveErrors := 0
+	maxConsecutiveErrors := 10
+
+	client, generation := l.getClientSnapshot()
+	if client == nil {
+		return fmt.Errorf("client is not connected")
+	}
+
 	for {
-		l.clientMu.RLock()
-		event, err := l.client.Recv()
-		l.clientMu.RUnlock()
+		event, err := client.Recv()
 
 		if err != nil {
 			if errors.Is(err, io.EOF) || status.Code(err) == codes.Canceled {
 				return nil
 			}
 
+			consecutiveErrors++
+
+			if status.Code(err) == codes.Unavailable {
+				l.l.Warn().Err(err).Msg("dispatcher is unavailable, retrying durable event listener after 1 second")
+				time.Sleep(1 * time.Second)
+			}
+
+			if _, genAfter := l.getClientSnapshot(); genAfter != generation {
+				client, generation = l.getClientSnapshot()
+				consecutiveErrors = 0
+				continue
+			}
+
 			retryErr := l.retryListen(ctx)
 
 			if retryErr != nil {
-				return retryErr
+				l.l.Error().Err(retryErr).Msgf("failed to relisten (consecutive errors: %d/%d)", consecutiveErrors, maxConsecutiveErrors)
+
+				if consecutiveErrors >= maxConsecutiveErrors {
+					return fmt.Errorf("failed to relisten after %d consecutive errors: %w", consecutiveErrors, retryErr)
+				}
+
+				time.Sleep(DefaultActionListenerRetryInterval)
+				continue
 			}
 
+			client, generation = l.getClientSnapshot()
+			consecutiveErrors = 0
 			continue
 		}
+
+		consecutiveErrors = 0
 
 		if err := l.handleEvent(event); err != nil {
 			return err
@@ -230,7 +356,15 @@ func (l *DurableEventsListener) Listen(ctx context.Context) error {
 }
 
 func (l *DurableEventsListener) Close() error {
-	return l.client.CloseSend()
+	l.clientMu.Lock()
+	client := l.client
+	l.clientMu.Unlock()
+
+	if client == nil {
+		return nil
+	}
+
+	return client.CloseSend()
 }
 
 func (l *DurableEventsListener) handleEvent(e *contracts.DurableEvent) error {

--- a/pkg/client/durable_listener.go
+++ b/pkg/client/durable_listener.go
@@ -124,9 +124,6 @@ func (w *DurableEventsListener) retryListen(ctx context.Context) error {
 }
 
 func (w *DurableEventsListener) doRetryListen(ctx context.Context) error {
-	w.clientMu.Lock()
-	defer w.clientMu.Unlock()
-
 	if w.isClosed() {
 		return errListenerClosed
 	}
@@ -136,6 +133,10 @@ func (w *DurableEventsListener) doRetryListen(ctx context.Context) error {
 	for retries < DefaultActionListenerRetryCount {
 		if retries > 0 {
 			time.Sleep(DefaultActionListenerRetryInterval)
+		}
+
+		if w.isClosed() {
+			return errListenerClosed
 		}
 
 		client, err := w.constructor(ctx)
@@ -166,16 +167,27 @@ func (w *DurableEventsListener) doRetryListen(ctx context.Context) error {
 		})
 
 		if rangeErr != nil {
+			if closeErr := client.CloseSend(); closeErr != nil {
+				w.l.Warn().Err(closeErr).Msg("failed to close durable event stream after replay failure")
+			}
+
 			retries++
 			continue
 		}
 
+		w.clientMu.Lock()
 		if w.isClosed() {
+			w.clientMu.Unlock()
+			if closeErr := client.CloseSend(); closeErr != nil {
+				w.l.Warn().Err(closeErr).Msg("failed to close durable event stream after listener closed")
+			}
+
 			return errListenerClosed
 		}
 
 		w.client = client
 		w.generation++
+		w.clientMu.Unlock()
 		return nil
 	}
 

--- a/pkg/client/durable_listener.go
+++ b/pkg/client/durable_listener.go
@@ -75,13 +75,7 @@ func (r *subscribeClientImpl) getDurableEventsListener(
 	r.durableEventsListener = w
 
 	go func() {
-		err := w.Listen(ctx)
-
-		if err != nil {
-			r.l.Error().Ctx(ctx).Err(err).Msg("failed to listen for durable events")
-		}
-
-		if ctx.Err() != nil {
+		defer func() {
 			err := w.Close()
 
 			if err != nil {
@@ -93,6 +87,12 @@ func (r *subscribeClientImpl) getDurableEventsListener(
 				r.durableEventsListener = nil
 			}
 			r.durableEventsListenerMu.Unlock()
+		}()
+
+		err := w.Listen(ctx)
+
+		if err != nil {
+			r.l.Error().Ctx(ctx).Err(err).Msg("failed to listen for durable events")
 		}
 	}()
 
@@ -104,8 +104,12 @@ func (w *DurableEventsListener) retryListen(ctx context.Context) error {
 		return errListenerClosed
 	}
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	_, err, _ := w.reconnectGroup.Do("reconnect", func() (interface{}, error) {
-		return nil, w.doRetryListen(ctx)
+		return nil, w.doRetryListen(context.Background())
 	})
 	return err
 }

--- a/pkg/client/durable_listener.go
+++ b/pkg/client/durable_listener.go
@@ -74,7 +74,7 @@ func (r *subscribeClientImpl) getDurableEventsListener(
 
 	r.durableEventsListener = w
 	if !w.startListening() {
-		if closeErr := w.Close(); closeErr != nil {
+		if closeErr := w.closeStream(); closeErr != nil {
 			r.l.Error().Ctx(ctx).Err(closeErr).Msg("failed to close durable events listener")
 		}
 
@@ -84,12 +84,6 @@ func (r *subscribeClientImpl) getDurableEventsListener(
 
 	go func() {
 		defer func() {
-			err := w.Close()
-
-			if err != nil {
-				r.l.Error().Ctx(ctx).Err(err).Msg("failed to close durable events listener")
-			}
-
 			r.durableEventsListenerMu.Lock()
 			if r.durableEventsListener == w {
 				r.durableEventsListener = nil
@@ -363,6 +357,11 @@ func (l *DurableEventsListener) listen(ctx context.Context) error {
 	if client == nil {
 		return fmt.Errorf("client is not connected")
 	}
+	defer func() {
+		if closeErr := client.CloseSend(); closeErr != nil {
+			l.l.Warn().Err(closeErr).Msg("failed to close durable event stream after listen exit")
+		}
+	}()
 
 	for {
 		event, err := client.Recv()
@@ -423,6 +422,10 @@ func (l *DurableEventsListener) Close() error {
 	l.closed = true
 	l.listenMu.Unlock()
 
+	return l.closeStream()
+}
+
+func (l *DurableEventsListener) closeStream() error {
 	l.clientMu.Lock()
 	client := l.client
 	l.clientMu.Unlock()

--- a/pkg/client/durable_listener_test.go
+++ b/pkg/client/durable_listener_test.go
@@ -74,6 +74,29 @@ func (m *mockDurableEventClient) RecvMsg(msg interface{}) error {
 	return nil
 }
 
+func TestDurableEventsListenerAddSignalSendsOnceWhenStarting(t *testing.T) {
+	logger := zerolog.Nop()
+	recvCh := make(chan *contracts.DurableEvent)
+
+	client := &mockDurableEventClient{
+		recvCh: recvCh,
+	}
+
+	listener := &DurableEventsListener{
+		constructor: func(ctx context.Context) (contracts.V1Dispatcher_ListenForDurableEventClient, error) {
+			return client, nil
+		},
+		l: &logger,
+	}
+
+	require.NoError(t, listener.AddSignal("task-1", "signal-1", func(e DurableEvent) error {
+		return nil
+	}))
+	require.Equal(t, int32(1), client.sendCount.Load())
+
+	close(recvCh)
+}
+
 // TestDurableEventsListenerReconnectsWhileRetrySendBacksOff verifies that a
 // stream disconnect can reconnect while AddSignal is retrying a send on the
 // broken stream. This is the lock-contention repro: retrySend must not hold a
@@ -96,7 +119,8 @@ func TestDurableEventsListenerReconnectsWhileRetrySendBacksOff(t *testing.T) {
 			return status.Error(codes.Unavailable, "stream broken")
 		},
 		recvFn: func() (*contracts.DurableEvent, error) {
-			return nil, status.Error(codes.Unavailable, "stream broken")
+			<-sendAttempted
+			return nil, status.Error(codes.Internal, "stream broken")
 		},
 	}
 
@@ -123,6 +147,13 @@ func TestDurableEventsListenerReconnectsWhileRetrySendBacksOff(t *testing.T) {
 		l:      &logger,
 	}
 
+	listenErr := make(chan error, 1)
+	go func() {
+		listenErr <- listener.Listen(ctx)
+	}()
+
+	require.Eventually(t, listener.isListening, time.Second, 10*time.Millisecond)
+
 	addErr := make(chan error, 1)
 	go func() {
 		addErr <- listener.AddSignal("task-1", "signal-1", func(e DurableEvent) error {
@@ -130,8 +161,6 @@ func TestDurableEventsListenerReconnectsWhileRetrySendBacksOff(t *testing.T) {
 		})
 	}()
 
-	// Wait until AddSignal has definitely attempted to use the broken stream
-	// before forcing Listen down the reconnect path.
 	require.Eventually(t, func() bool {
 		select {
 		case <-sendAttempted:
@@ -140,11 +169,6 @@ func TestDurableEventsListenerReconnectsWhileRetrySendBacksOff(t *testing.T) {
 			return false
 		}
 	}, time.Second, 10*time.Millisecond)
-
-	listenErr := make(chan error, 1)
-	go func() {
-		listenErr <- listener.Listen(ctx)
-	}()
 
 	select {
 	case <-constructorCalled:
@@ -179,7 +203,8 @@ func TestDurableEventsListenerDeliversEventAfterReconnectDuringRetryBackoff(t *t
 			return status.Error(codes.Unavailable, "stream broken")
 		},
 		recvFn: func() (*contracts.DurableEvent, error) {
-			return nil, status.Error(codes.Unavailable, "stream broken")
+			<-sendAttempted
+			return nil, status.Error(codes.Internal, "stream broken")
 		},
 	}
 
@@ -202,6 +227,13 @@ func TestDurableEventsListenerDeliversEventAfterReconnectDuringRetryBackoff(t *t
 		l:      &logger,
 	}
 
+	listenErr := make(chan error, 1)
+	go func() {
+		listenErr <- listener.Listen(ctx)
+	}()
+
+	require.Eventually(t, listener.isListening, time.Second, 10*time.Millisecond)
+
 	received := make(chan DurableEvent, 1)
 	addErr := make(chan error, 1)
 	go func() {
@@ -220,11 +252,6 @@ func TestDurableEventsListenerDeliversEventAfterReconnectDuringRetryBackoff(t *t
 		}
 	}, time.Second, 10*time.Millisecond)
 
-	listenErr := make(chan error, 1)
-	go func() {
-		listenErr <- listener.Listen(ctx)
-	}()
-
 	select {
 	case event := <-received:
 		require.Equal(t, "task-1", event.TaskId)
@@ -232,9 +259,68 @@ func TestDurableEventsListenerDeliversEventAfterReconnectDuringRetryBackoff(t *t
 		require.JSONEq(t, `{"ok":true}`, string(event.Data))
 	case err := <-addErr:
 		require.NoError(t, err)
+		select {
+		case event := <-received:
+			require.Equal(t, "task-1", event.TaskId)
+			require.Equal(t, "signal-1", event.SignalKey)
+			require.JSONEq(t, `{"ok":true}`, string(event.Data))
+		case <-time.After(200 * time.Millisecond):
+			t.Fatal("AddSignal returned before durable event was delivered after reconnect")
+		}
 	case err := <-listenErr:
 		require.NoError(t, err)
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("expected durable event to be delivered after reconnect during retrySend backoff")
+	}
+}
+
+func TestDurableEventsListenerRestartsAfterListenExits(t *testing.T) {
+	logger := zerolog.Nop()
+
+	initialClient := &mockDurableEventClient{
+		recvFn: func() (*contracts.DurableEvent, error) {
+			return nil, io.EOF
+		},
+	}
+	replacementClient := &mockDurableEventClient{
+		recvCh: make(chan *contracts.DurableEvent, 1),
+	}
+
+	listener := &DurableEventsListener{
+		constructor: func(ctx context.Context) (contracts.V1Dispatcher_ListenForDurableEventClient, error) {
+			return replacementClient, nil
+		},
+		client: initialClient,
+		l:      &logger,
+	}
+
+	listenErr := make(chan error, 1)
+	go func() {
+		listenErr <- listener.Listen(context.Background())
+	}()
+
+	require.NoError(t, <-listenErr)
+	require.False(t, listener.isListening())
+
+	received := make(chan DurableEvent, 1)
+	require.NoError(t, listener.AddSignal("task-1", "signal-1", func(e DurableEvent) error {
+		received <- e
+		return nil
+	}))
+
+	replacementClient.recvCh <- &contracts.DurableEvent{
+		TaskId:    "task-1",
+		SignalKey: "signal-1",
+		Data:      []byte(`{"ok":true}`),
+	}
+	close(replacementClient.recvCh)
+
+	select {
+	case event := <-received:
+		require.Equal(t, "task-1", event.TaskId)
+		require.Equal(t, "signal-1", event.SignalKey)
+		require.JSONEq(t, `{"ok":true}`, string(event.Data))
+	case <-time.After(time.Second):
+		t.Fatal("expected durable event after listener restarted")
 	}
 }

--- a/pkg/client/durable_listener_test.go
+++ b/pkg/client/durable_listener_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -23,6 +24,26 @@ type mockDurableEventClient struct {
 	closeSendFn func() error
 	recvCh      chan *contracts.DurableEvent
 	sendCount   atomic.Int32
+}
+
+type mockV1DispatcherClient struct {
+	listenForDurableEventFn func(ctx context.Context, opts ...grpc.CallOption) (contracts.V1Dispatcher_ListenForDurableEventClient, error)
+}
+
+func (m *mockV1DispatcherClient) DurableTask(ctx context.Context, opts ...grpc.CallOption) (contracts.V1Dispatcher_DurableTaskClient, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockV1DispatcherClient) RegisterDurableEvent(ctx context.Context, in *contracts.RegisterDurableEventRequest, opts ...grpc.CallOption) (*contracts.RegisterDurableEventResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockV1DispatcherClient) ListenForDurableEvent(ctx context.Context, opts ...grpc.CallOption) (contracts.V1Dispatcher_ListenForDurableEventClient, error) {
+	if m.listenForDurableEventFn != nil {
+		return m.listenForDurableEventFn(ctx, opts...)
+	}
+
+	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
 func (m *mockDurableEventClient) Send(req *contracts.ListenForDurableEventRequest) error {
@@ -96,6 +117,54 @@ func TestDurableEventsListenerAddSignalSendsOnceWhenStarting(t *testing.T) {
 
 	require.NoError(t, listener.Close())
 	close(recvCh)
+}
+
+func TestGetDurableEventsListenerImmediateAddDoesNotOpenSecondStream(t *testing.T) {
+	logger := zerolog.Nop()
+	closeCh := make(chan struct{})
+	var closeOnce sync.Once
+
+	client := &mockDurableEventClient{
+		recvFn: func() (*contracts.DurableEvent, error) {
+			<-closeCh
+			return nil, io.EOF
+		},
+		closeSendFn: func() error {
+			closeOnce.Do(func() {
+				close(closeCh)
+			})
+			return nil
+		},
+	}
+
+	constructorCalls := atomic.Int32{}
+
+	subscriber := &subscribeClientImpl{
+		clientv1: &mockV1DispatcherClient{
+			listenForDurableEventFn: func(ctx context.Context, opts ...grpc.CallOption) (contracts.V1Dispatcher_ListenForDurableEventClient, error) {
+				constructorCalls.Add(1)
+				return client, nil
+			},
+		},
+		l:   &logger,
+		ctx: newContextLoader("", nil),
+	}
+
+	listener, err := subscriber.getDurableEventsListener(context.Background())
+	require.NoError(t, err)
+	require.True(t, listener.isListening())
+
+	require.NoError(t, listener.AddSignal("task-1", "signal-1", func(e DurableEvent) error {
+		return nil
+	}))
+
+	require.Equal(t, int32(1), constructorCalls.Load())
+	require.Equal(t, int32(1), client.sendCount.Load())
+
+	require.NoError(t, listener.Close())
+	require.Eventually(t, func() bool {
+		return !listener.isListening()
+	}, time.Second, 10*time.Millisecond)
 }
 
 // TestDurableEventsListenerReconnectsWhileRetrySendBacksOff verifies that a

--- a/pkg/client/durable_listener_test.go
+++ b/pkg/client/durable_listener_test.go
@@ -251,6 +251,68 @@ func TestDurableEventsListenerReconnectsWhileRetrySendBacksOff(t *testing.T) {
 	}
 }
 
+func TestDurableEventsListenerReconnectDoesNotBlockClientSnapshot(t *testing.T) {
+	logger := zerolog.Nop()
+	constructorEntered := make(chan struct{})
+	releaseConstructor := make(chan struct{})
+	var closeConstructorEntered sync.Once
+
+	oldClient := &mockDurableEventClient{
+		recvCh: make(chan *contracts.DurableEvent),
+	}
+	newClient := &mockDurableEventClient{
+		recvCh: make(chan *contracts.DurableEvent),
+	}
+
+	listener := &DurableEventsListener{
+		constructor: func(ctx context.Context) (contracts.V1Dispatcher_ListenForDurableEventClient, error) {
+			closeConstructorEntered.Do(func() {
+				close(constructorEntered)
+			})
+			<-releaseConstructor
+			return newClient, nil
+		},
+		client: oldClient,
+		l:      &logger,
+	}
+
+	retryErr := make(chan error, 1)
+	go func() {
+		retryErr <- listener.retryListen(context.Background())
+	}()
+
+	select {
+	case <-constructorEntered:
+	case <-time.After(time.Second):
+		t.Fatal("reconnect did not reach constructor")
+	}
+
+	snapshotRead := make(chan struct {
+		client     contracts.V1Dispatcher_ListenForDurableEventClient
+		generation uint64
+	}, 1)
+	go func() {
+		client, generation := listener.getClientSnapshot()
+		snapshotRead <- struct {
+			client     contracts.V1Dispatcher_ListenForDurableEventClient
+			generation uint64
+		}{client: client, generation: generation}
+	}()
+
+	select {
+	case snapshot := <-snapshotRead:
+		require.Same(t, oldClient, snapshot.client)
+		require.Equal(t, uint64(0), snapshot.generation)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("getClientSnapshot blocked behind reconnect")
+	}
+
+	close(releaseConstructor)
+
+	require.NoError(t, <-retryErr)
+	require.NoError(t, listener.Close())
+}
+
 // TestDurableEventsListenerDeliversEventAfterReconnectDuringRetryBackoff
 // verifies the user-visible symptom: after a disconnect during AddSignal's
 // retry window, the listener should reconnect and deliver the durable event

--- a/pkg/client/durable_listener_test.go
+++ b/pkg/client/durable_listener_test.go
@@ -94,6 +94,7 @@ func TestDurableEventsListenerAddSignalSendsOnceWhenStarting(t *testing.T) {
 	}))
 	require.Equal(t, int32(1), client.sendCount.Load())
 
+	require.NoError(t, listener.Close())
 	close(recvCh)
 }
 
@@ -323,4 +324,64 @@ func TestDurableEventsListenerRestartsAfterListenExits(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("expected durable event after listener restarted")
 	}
+}
+
+func TestDurableEventsListenerReconnectsOnEOFWithRegisteredHandlers(t *testing.T) {
+	logger := zerolog.Nop()
+
+	initialClient := &mockDurableEventClient{
+		recvFn: func() (*contracts.DurableEvent, error) {
+			return nil, io.EOF
+		},
+	}
+	replacementClient := &mockDurableEventClient{
+		recvCh: make(chan *contracts.DurableEvent, 1),
+	}
+	constructorCalls := atomic.Int32{}
+
+	listener := &DurableEventsListener{
+		constructor: func(ctx context.Context) (contracts.V1Dispatcher_ListenForDurableEventClient, error) {
+			constructorCalls.Add(1)
+			return replacementClient, nil
+		},
+		client: initialClient,
+		l:      &logger,
+	}
+
+	received := make(chan DurableEvent, 1)
+	listener.handlers.Store(listenTuple{taskId: "task-1", signalKey: "signal-1"}, &threadSafeDurableEventHandlers{
+		handlers: []DurableEventHandler{
+			func(e DurableEvent) error {
+				received <- e
+				return nil
+			},
+		},
+	})
+
+	listenErr := make(chan error, 1)
+	go func() {
+		listenErr <- listener.Listen(context.Background())
+	}()
+
+	require.Eventually(t, func() bool {
+		return constructorCalls.Load() == 1 && replacementClient.sendCount.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	replacementClient.recvCh <- &contracts.DurableEvent{
+		TaskId:    "task-1",
+		SignalKey: "signal-1",
+		Data:      []byte(`{"ok":true}`),
+	}
+
+	select {
+	case event := <-received:
+		require.Equal(t, "task-1", event.TaskId)
+		require.Equal(t, "signal-1", event.SignalKey)
+		require.JSONEq(t, `{"ok":true}`, string(event.Data))
+	case <-time.After(time.Second):
+		t.Fatal("expected durable event after EOF reconnect")
+	}
+
+	close(replacementClient.recvCh)
+	require.NoError(t, <-listenErr)
 }

--- a/pkg/client/durable_listener_test.go
+++ b/pkg/client/durable_listener_test.go
@@ -167,6 +167,70 @@ func TestGetDurableEventsListenerImmediateAddDoesNotOpenSecondStream(t *testing.
 	}, time.Second, 10*time.Millisecond)
 }
 
+func TestGetDurableEventsListenerInternalCleanupDoesNotTerminallyCloseListener(t *testing.T) {
+	logger := zerolog.Nop()
+
+	initialClient := &mockDurableEventClient{
+		recvFn: func() (*contracts.DurableEvent, error) {
+			return nil, io.EOF
+		},
+	}
+	replacementClient := &mockDurableEventClient{
+		recvCh: make(chan *contracts.DurableEvent, 1),
+	}
+	constructorCalls := atomic.Int32{}
+
+	subscriber := &subscribeClientImpl{
+		clientv1: &mockV1DispatcherClient{
+			listenForDurableEventFn: func(ctx context.Context, opts ...grpc.CallOption) (contracts.V1Dispatcher_ListenForDurableEventClient, error) {
+				if constructorCalls.Add(1) == 1 {
+					return initialClient, nil
+				}
+
+				return replacementClient, nil
+			},
+		},
+		l:   &logger,
+		ctx: newContextLoader("", nil),
+	}
+
+	listener, err := subscriber.getDurableEventsListener(context.Background())
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return !listener.isListening()
+	}, time.Second, 10*time.Millisecond)
+
+	received := make(chan DurableEvent, 1)
+	require.NoError(t, listener.AddSignal("task-1", "signal-1", func(e DurableEvent) error {
+		received <- e
+		return nil
+	}))
+
+	require.Equal(t, int32(2), constructorCalls.Load())
+	require.Equal(t, int32(1), replacementClient.sendCount.Load())
+
+	replacementClient.recvCh <- &contracts.DurableEvent{
+		TaskId:    "task-1",
+		SignalKey: "signal-1",
+		Data:      []byte(`{"ok":true}`),
+	}
+
+	select {
+	case event := <-received:
+		require.Equal(t, "task-1", event.TaskId)
+		require.Equal(t, "signal-1", event.SignalKey)
+		require.JSONEq(t, `{"ok":true}`, string(event.Data))
+	case <-time.After(time.Second):
+		t.Fatal("expected durable event after internal cleanup")
+	}
+
+	close(replacementClient.recvCh)
+	require.Eventually(t, func() bool {
+		return !listener.isListening()
+	}, time.Second, 10*time.Millisecond)
+}
+
 // TestDurableEventsListenerReconnectsWhileRetrySendBacksOff verifies that a
 // stream disconnect can reconnect while AddSignal is retrying a send on the
 // broken stream. This is the lock-contention repro: retrySend must not hold a

--- a/pkg/client/listener.go
+++ b/pkg/client/listener.go
@@ -263,9 +263,6 @@ func (w *WorkflowRunsListener) retrySubscribe(ctx context.Context) error {
 }
 
 func (w *WorkflowRunsListener) doRetrySubscribe(ctx context.Context) error {
-	w.clientMu.Lock()
-	defer w.clientMu.Unlock()
-
 	if w.isClosed() {
 		return errListenerClosed
 	}
@@ -275,6 +272,10 @@ func (w *WorkflowRunsListener) doRetrySubscribe(ctx context.Context) error {
 	for retries < DefaultActionListenerRetryCount {
 		if retries > 0 {
 			time.Sleep(DefaultActionListenerRetryInterval)
+		}
+
+		if w.isClosed() {
+			return errListenerClosed
 		}
 
 		client, err := w.constructor(ctx)
@@ -304,16 +305,27 @@ func (w *WorkflowRunsListener) doRetrySubscribe(ctx context.Context) error {
 		})
 
 		if rangeErr != nil {
+			if closeErr := client.CloseSend(); closeErr != nil {
+				w.l.Warn().Err(closeErr).Msg("failed to close workflow run stream after replay failure")
+			}
+
 			retries++
 			continue
 		}
 
+		w.clientMu.Lock()
 		if w.isClosed() {
+			w.clientMu.Unlock()
+			if closeErr := client.CloseSend(); closeErr != nil {
+				w.l.Warn().Err(closeErr).Msg("failed to close workflow run stream after listener closed")
+			}
+
 			return errListenerClosed
 		}
 
 		w.client = client
 		w.generation++
+		w.clientMu.Unlock()
 		return nil
 	}
 

--- a/pkg/client/listener.go
+++ b/pkg/client/listener.go
@@ -143,13 +143,7 @@ func (r *subscribeClientImpl) getWorkflowRunsListener(
 	r.workflowRunListener = w
 
 	go func() {
-		err := w.Listen(ctx)
-
-		if err != nil {
-			r.l.Error().Err(err).Msg("failed to listen for workflow run events")
-		}
-
-		if ctx.Err() != nil {
+		defer func() {
 			err := w.Close()
 
 			if err != nil {
@@ -161,6 +155,12 @@ func (r *subscribeClientImpl) getWorkflowRunsListener(
 				r.workflowRunListener = nil
 			}
 			r.workflowRunListenerMu.Unlock()
+		}()
+
+		err := w.Listen(ctx)
+
+		if err != nil {
+			r.l.Error().Err(err).Msg("failed to listen for workflow run events")
 		}
 	}()
 
@@ -243,8 +243,12 @@ func (w *WorkflowRunsListener) retrySubscribe(ctx context.Context) error {
 		return errListenerClosed
 	}
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	_, err, _ := w.reconnectGroup.Do("reconnect", func() (interface{}, error) {
-		return nil, w.doRetrySubscribe(ctx)
+		return nil, w.doRetrySubscribe(context.Background())
 	})
 	return err
 }

--- a/pkg/client/listener.go
+++ b/pkg/client/listener.go
@@ -141,6 +141,14 @@ func (r *subscribeClientImpl) getWorkflowRunsListener(
 	}
 
 	r.workflowRunListener = w
+	if !w.startListening() {
+		if closeErr := w.Close(); closeErr != nil {
+			r.l.Error().Err(closeErr).Msg("failed to close workflow run events listener")
+		}
+
+		r.workflowRunListener = nil
+		return nil, errListenerClosed
+	}
 
 	go func() {
 		defer func() {
@@ -156,8 +164,9 @@ func (r *subscribeClientImpl) getWorkflowRunsListener(
 			}
 			r.workflowRunListenerMu.Unlock()
 		}()
+		defer w.stopListening()
 
-		err := w.Listen(ctx)
+		err := w.listen(ctx)
 
 		if err != nil {
 			r.l.Error().Err(err).Msg("failed to listen for workflow run events")

--- a/pkg/client/listener.go
+++ b/pkg/client/listener.go
@@ -103,6 +103,8 @@ type WorkflowRunsListener struct {
 	generation uint64
 
 	reconnectGroup singleflight.Group
+	listenMu       sync.Mutex
+	listening      bool
 
 	l *zerolog.Logger
 
@@ -138,7 +140,13 @@ func (r *subscribeClientImpl) getWorkflowRunsListener(
 	r.workflowRunListener = w
 
 	go func() {
-		defer func() {
+		err := w.Listen(ctx)
+
+		if err != nil {
+			r.l.Error().Err(err).Msg("failed to listen for workflow run events")
+		}
+
+		if ctx.Err() != nil {
 			err := w.Close()
 
 			if err != nil {
@@ -146,14 +154,10 @@ func (r *subscribeClientImpl) getWorkflowRunsListener(
 			}
 
 			r.workflowRunListenerMu.Lock()
-			r.workflowRunListener = nil
+			if r.workflowRunListener == w {
+				r.workflowRunListener = nil
+			}
 			r.workflowRunListenerMu.Unlock()
-		}()
-
-		err := w.Listen(ctx)
-
-		if err != nil {
-			r.l.Error().Err(err).Msg("failed to listen for workflow run events")
 		}
 	}()
 
@@ -165,6 +169,54 @@ func (w *WorkflowRunsListener) getClientSnapshot() (dispatchercontracts.Dispatch
 	w.clientMu.Lock()
 	defer w.clientMu.Unlock()
 	return w.client, w.generation
+}
+
+func (w *WorkflowRunsListener) isListening() bool {
+	w.listenMu.Lock()
+	defer w.listenMu.Unlock()
+	return w.listening
+}
+
+func (w *WorkflowRunsListener) startListening() bool {
+	w.listenMu.Lock()
+	defer w.listenMu.Unlock()
+
+	if w.listening {
+		return false
+	}
+
+	w.listening = true
+	return true
+}
+
+func (w *WorkflowRunsListener) stopListening() {
+	w.listenMu.Lock()
+	w.listening = false
+	w.listenMu.Unlock()
+}
+
+func (w *WorkflowRunsListener) ensureListening(ctx context.Context) error {
+	if w.isListening() {
+		return nil
+	}
+
+	if err := w.retrySubscribe(ctx); err != nil {
+		return err
+	}
+
+	if !w.startListening() {
+		return nil
+	}
+
+	go func() {
+		defer w.stopListening()
+
+		if err := w.listen(ctx); err != nil {
+			w.l.Error().Err(err).Msg("failed to listen for workflow run events")
+		}
+	}()
+
+	return nil
 }
 
 // retrySubscribe coalesces concurrent reconnection attempts via singleflight.
@@ -195,15 +247,12 @@ func (w *WorkflowRunsListener) doRetrySubscribe(ctx context.Context) error {
 			continue
 		}
 
-		w.client = client
-
-		// listen for all the same workflow runs
 		var rangeErr error
 
 		w.handlers.Range(func(key, value interface{}) bool {
 			workflowRunId := key.(string)
 
-			err := w.client.Send(&dispatchercontracts.SubscribeToWorkflowRunsRequest{
+			err := client.Send(&dispatchercontracts.SubscribeToWorkflowRunsRequest{
 				WorkflowRunId: workflowRunId,
 			})
 
@@ -221,6 +270,7 @@ func (w *WorkflowRunsListener) doRetrySubscribe(ctx context.Context) error {
 			continue
 		}
 
+		w.client = client
 		w.generation++
 		return nil
 	}
@@ -238,6 +288,12 @@ func (l *WorkflowRunsListener) AddWorkflowRun(
 	workflowRunId, sessionId string,
 	handler WorkflowRunEventHandler,
 ) error {
+	if !l.isListening() {
+		if err := l.ensureListening(context.Background()); err != nil {
+			return err
+		}
+	}
+
 	handlers, _ := l.handlers.LoadOrStore(workflowRunId, &threadSafeHandlers{
 		handlers: map[string]WorkflowRunEventHandler{},
 	})
@@ -249,13 +305,19 @@ func (l *WorkflowRunsListener) AddWorkflowRun(
 	l.handlers.Store(workflowRunId, h)
 	h.mu.Unlock()
 
-	err := l.retrySend(workflowRunId)
+	if err := l.retrySend(workflowRunId); err != nil {
+		if !l.isListening() {
+			if listenErr := l.ensureListening(context.Background()); listenErr != nil {
+				return listenErr
+			}
 
-	if err != nil {
+			return l.retrySend(workflowRunId)
+		}
+
 		return err
 	}
 
-	return nil
+	return l.ensureListening(context.Background())
 }
 
 func (l *WorkflowRunsListener) RemoveWorkflowRun(
@@ -314,11 +376,23 @@ func (l *WorkflowRunsListener) retrySend(workflowRunId string) error {
 }
 
 func (l *WorkflowRunsListener) Listen(ctx context.Context) error {
+	if !l.startListening() {
+		return nil
+	}
+	defer l.stopListening()
+
+	return l.listen(ctx)
+}
+
+func (l *WorkflowRunsListener) listen(ctx context.Context) error {
 	consecutiveErrors := 0
 	maxConsecutiveErrors := 10
 
 	// Take a snapshot of the client so we never hold the lock during a blocking Recv.
-	client, _ := l.getClientSnapshot()
+	client, generation := l.getClientSnapshot()
+	if client == nil {
+		return fmt.Errorf("client is not connected")
+	}
 
 	for {
 		event, err := client.Recv()
@@ -335,6 +409,12 @@ func (l *WorkflowRunsListener) Listen(ctx context.Context) error {
 				time.Sleep(1 * time.Second)
 			}
 
+			if _, genAfter := l.getClientSnapshot(); genAfter != generation {
+				client, generation = l.getClientSnapshot()
+				consecutiveErrors = 0
+				continue
+			}
+
 			retryErr := l.retrySubscribe(ctx)
 
 			if retryErr != nil {
@@ -348,7 +428,7 @@ func (l *WorkflowRunsListener) Listen(ctx context.Context) error {
 				continue
 			}
 
-			client, _ = l.getClientSnapshot()
+			client, generation = l.getClientSnapshot()
 			consecutiveErrors = 0
 			continue
 		}

--- a/pkg/client/listener.go
+++ b/pkg/client/listener.go
@@ -142,7 +142,7 @@ func (r *subscribeClientImpl) getWorkflowRunsListener(
 
 	r.workflowRunListener = w
 	if !w.startListening() {
-		if closeErr := w.Close(); closeErr != nil {
+		if closeErr := w.closeStream(); closeErr != nil {
 			r.l.Error().Err(closeErr).Msg("failed to close workflow run events listener")
 		}
 
@@ -152,12 +152,6 @@ func (r *subscribeClientImpl) getWorkflowRunsListener(
 
 	go func() {
 		defer func() {
-			err := w.Close()
-
-			if err != nil {
-				r.l.Error().Err(err).Msg("failed to close workflow run events listener")
-			}
-
 			r.workflowRunListenerMu.Lock()
 			if r.workflowRunListener == w {
 				r.workflowRunListener = nil
@@ -451,6 +445,11 @@ func (l *WorkflowRunsListener) listen(ctx context.Context) error {
 	if client == nil {
 		return fmt.Errorf("client is not connected")
 	}
+	defer func() {
+		if closeErr := client.CloseSend(); closeErr != nil {
+			l.l.Warn().Err(closeErr).Msg("failed to close workflow run stream after listen exit")
+		}
+	}()
 
 	for {
 		event, err := client.Recv()
@@ -511,6 +510,10 @@ func (l *WorkflowRunsListener) Close() error {
 	l.closed = true
 	l.listenMu.Unlock()
 
+	return l.closeStream()
+}
+
+func (l *WorkflowRunsListener) closeStream() error {
 	l.clientMu.Lock()
 	client := l.client
 	l.clientMu.Unlock()

--- a/pkg/client/listener.go
+++ b/pkg/client/listener.go
@@ -23,6 +23,8 @@ import (
 	"github.com/hatchet-dev/hatchet/pkg/validator"
 )
 
+var errListenerClosed = errors.New("listener is closed")
+
 // ResourceType represents the type of resource
 type ResourceType int32
 
@@ -105,6 +107,7 @@ type WorkflowRunsListener struct {
 	reconnectGroup singleflight.Group
 	listenMu       sync.Mutex
 	listening      bool
+	closed         bool
 
 	l *zerolog.Logger
 
@@ -177,11 +180,17 @@ func (w *WorkflowRunsListener) isListening() bool {
 	return w.listening
 }
 
+func (w *WorkflowRunsListener) isClosed() bool {
+	w.listenMu.Lock()
+	defer w.listenMu.Unlock()
+	return w.closed
+}
+
 func (w *WorkflowRunsListener) startListening() bool {
 	w.listenMu.Lock()
 	defer w.listenMu.Unlock()
 
-	if w.listening {
+	if w.listening || w.closed {
 		return false
 	}
 
@@ -196,6 +205,10 @@ func (w *WorkflowRunsListener) stopListening() {
 }
 
 func (w *WorkflowRunsListener) ensureListening(ctx context.Context) error {
+	if w.isClosed() {
+		return errListenerClosed
+	}
+
 	if w.isListening() {
 		return nil
 	}
@@ -205,6 +218,10 @@ func (w *WorkflowRunsListener) ensureListening(ctx context.Context) error {
 	}
 
 	if !w.startListening() {
+		if w.isClosed() {
+			return errListenerClosed
+		}
+
 		return nil
 	}
 
@@ -222,6 +239,10 @@ func (w *WorkflowRunsListener) ensureListening(ctx context.Context) error {
 // retrySubscribe coalesces concurrent reconnection attempts via singleflight.
 // Multiple goroutines calling this concurrently will share a single reconnection attempt.
 func (w *WorkflowRunsListener) retrySubscribe(ctx context.Context) error {
+	if w.isClosed() {
+		return errListenerClosed
+	}
+
 	_, err, _ := w.reconnectGroup.Do("reconnect", func() (interface{}, error) {
 		return nil, w.doRetrySubscribe(ctx)
 	})
@@ -231,6 +252,10 @@ func (w *WorkflowRunsListener) retrySubscribe(ctx context.Context) error {
 func (w *WorkflowRunsListener) doRetrySubscribe(ctx context.Context) error {
 	w.clientMu.Lock()
 	defer w.clientMu.Unlock()
+
+	if w.isClosed() {
+		return errListenerClosed
+	}
 
 	retries := 0
 
@@ -270,6 +295,10 @@ func (w *WorkflowRunsListener) doRetrySubscribe(ctx context.Context) error {
 			continue
 		}
 
+		if w.isClosed() {
+			return errListenerClosed
+		}
+
 		w.client = client
 		w.generation++
 		return nil
@@ -288,6 +317,10 @@ func (l *WorkflowRunsListener) AddWorkflowRun(
 	workflowRunId, sessionId string,
 	handler WorkflowRunEventHandler,
 ) error {
+	if l.isClosed() {
+		return errListenerClosed
+	}
+
 	if !l.isListening() {
 		if err := l.ensureListening(context.Background()); err != nil {
 			return err
@@ -398,16 +431,19 @@ func (l *WorkflowRunsListener) listen(ctx context.Context) error {
 		event, err := client.Recv()
 
 		if err != nil {
-			if errors.Is(err, io.EOF) || status.Code(err) == codes.Canceled {
+			switch {
+			case errors.Is(err, io.EOF):
+				if !l.shouldReconnectOnEOF(ctx) {
+					return nil
+				}
+			case status.Code(err) == codes.Canceled:
 				return nil
-			}
-
-			consecutiveErrors++
-
-			if status.Code(err) == codes.Unavailable {
+			case status.Code(err) == codes.Unavailable:
 				l.l.Warn().Err(err).Msg("dispatcher is unavailable, retrying subscribe after 1 second")
 				time.Sleep(1 * time.Second)
 			}
+
+			consecutiveErrors++
 
 			if _, genAfter := l.getClientSnapshot(); genAfter != generation {
 				client, generation = l.getClientSnapshot()
@@ -418,6 +454,10 @@ func (l *WorkflowRunsListener) listen(ctx context.Context) error {
 			retryErr := l.retrySubscribe(ctx)
 
 			if retryErr != nil {
+				if errors.Is(retryErr, errListenerClosed) {
+					return nil
+				}
+
 				l.l.Error().Err(retryErr).Msgf("failed to resubscribe (consecutive errors: %d/%d)", consecutiveErrors, maxConsecutiveErrors)
 
 				if consecutiveErrors >= maxConsecutiveErrors {
@@ -442,6 +482,10 @@ func (l *WorkflowRunsListener) listen(ctx context.Context) error {
 }
 
 func (l *WorkflowRunsListener) Close() error {
+	l.listenMu.Lock()
+	l.closed = true
+	l.listenMu.Unlock()
+
 	l.clientMu.Lock()
 	client := l.client
 	l.clientMu.Unlock()
@@ -485,6 +529,30 @@ func (l *WorkflowRunsListener) handleWorkflowRun(event *dispatchercontracts.Work
 	err := eg.Wait()
 
 	return err
+}
+
+func (l *WorkflowRunsListener) hasHandlers() bool {
+	hasHandlers := false
+
+	l.handlers.Range(func(key, value interface{}) bool {
+		h := value.(*threadSafeHandlers)
+
+		h.mu.RLock()
+		hasHandlers = len(h.handlers) > 0
+		h.mu.RUnlock()
+
+		return !hasHandlers
+	})
+
+	return hasHandlers
+}
+
+func (l *WorkflowRunsListener) shouldReconnectOnEOF(ctx context.Context) bool {
+	if ctx.Err() != nil || l.isClosed() {
+		return false
+	}
+
+	return l.hasHandlers()
 }
 
 type SubscribeClient interface {

--- a/pkg/client/listener_test.go
+++ b/pkg/client/listener_test.go
@@ -82,6 +82,29 @@ func (m *mockSubscribeClient) RecvMsg(msg interface{}) error {
 	return nil
 }
 
+func TestWorkflowRunsListenerAddWorkflowRunSendsOnceWhenStarting(t *testing.T) {
+	logger := zerolog.Nop()
+	recvChan := make(chan *dispatchercontracts.WorkflowRunEvent)
+
+	client := &mockSubscribeClient{
+		recvChan: recvChan,
+	}
+
+	listener := &WorkflowRunsListener{
+		constructor: func(ctx context.Context) (dispatchercontracts.Dispatcher_SubscribeToWorkflowRunsClient, error) {
+			return client, nil
+		},
+		l: &logger,
+	}
+
+	require.NoError(t, listener.AddWorkflowRun("run-1", "session-1", func(event WorkflowRunEvent) error {
+		return nil
+	}))
+	assert.Equal(t, int32(1), client.sendCount.Load())
+
+	close(recvChan)
+}
+
 func TestRetrySend_ResubscribesOnSendFailure(t *testing.T) {
 	// This test verifies that when Send() fails on a broken stream,
 	// retrySend will call retrySubscribe to establish a new stream
@@ -273,9 +296,13 @@ func TestListen_DispatchesEventsToHandlers(t *testing.T) {
 	}
 
 	var receivedEvent atomic.Value
-	listener.AddWorkflowRun("run-1", "session-1", func(event WorkflowRunEvent) error {
-		receivedEvent.Store(event)
-		return nil
+	listener.handlers.Store("run-1", &threadSafeHandlers{
+		handlers: map[string]WorkflowRunEventHandler{
+			"session-1": func(event WorkflowRunEvent) error {
+				receivedEvent.Store(event)
+				return nil
+			},
+		},
 	})
 
 	// Start Listen in a goroutine
@@ -343,6 +370,51 @@ func TestListen_ExitsOnCanceled(t *testing.T) {
 	assert.NoError(t, err, "Listen should return nil on Canceled")
 }
 
+func TestWorkflowRunsListenerRestartsAfterListenExits(t *testing.T) {
+	logger := zerolog.Nop()
+
+	initialClient := &mockSubscribeClient{
+		recvErr: io.EOF,
+	}
+	replacementClient := &mockSubscribeClient{
+		recvChan: make(chan *dispatchercontracts.WorkflowRunEvent, 1),
+	}
+
+	listener := &WorkflowRunsListener{
+		constructor: func(ctx context.Context) (dispatchercontracts.Dispatcher_SubscribeToWorkflowRunsClient, error) {
+			return replacementClient, nil
+		},
+		client: initialClient,
+		l:      &logger,
+	}
+
+	listenErr := make(chan error, 1)
+	go func() {
+		listenErr <- listener.Listen(context.Background())
+	}()
+
+	require.NoError(t, <-listenErr)
+	require.False(t, listener.isListening())
+
+	received := make(chan WorkflowRunEvent, 1)
+	require.NoError(t, listener.AddWorkflowRun("run-1", "session-1", func(event WorkflowRunEvent) error {
+		received <- event
+		return nil
+	}))
+
+	replacementClient.recvChan <- &dispatchercontracts.WorkflowRunEvent{
+		WorkflowRunId: "run-1",
+	}
+	close(replacementClient.recvChan)
+
+	select {
+	case event := <-received:
+		assert.Equal(t, "run-1", event.WorkflowRunId)
+	case <-time.After(time.Second):
+		t.Fatal("expected workflow run event after listener restarted")
+	}
+}
+
 func TestListen_ReconnectsAndUsesNewClient(t *testing.T) {
 	// Verifies that after a Recv error, Listen reconnects and reads from the new client.
 
@@ -372,9 +444,13 @@ func TestListen_ReconnectsAndUsesNewClient(t *testing.T) {
 	}
 
 	var receivedEvent atomic.Value
-	listener.AddWorkflowRun("run-1", "session-1", func(event WorkflowRunEvent) error {
-		receivedEvent.Store(event)
-		return nil
+	listener.handlers.Store("run-1", &threadSafeHandlers{
+		handlers: map[string]WorkflowRunEventHandler{
+			"session-1": func(event WorkflowRunEvent) error {
+				receivedEvent.Store(event)
+				return nil
+			},
+		},
 	})
 
 	listenErr := make(chan error, 1)

--- a/pkg/client/listener_test.go
+++ b/pkg/client/listener_test.go
@@ -102,6 +102,7 @@ func TestWorkflowRunsListenerAddWorkflowRunSendsOnceWhenStarting(t *testing.T) {
 	}))
 	assert.Equal(t, int32(1), client.sendCount.Load())
 
+	require.NoError(t, listener.Close())
 	close(recvChan)
 }
 
@@ -316,6 +317,11 @@ func TestListen_DispatchesEventsToHandlers(t *testing.T) {
 		WorkflowRunId: "run-1",
 	}
 
+	require.Eventually(t, func() bool {
+		return receivedEvent.Load() != nil
+	}, time.Second, 10*time.Millisecond)
+	listener.handlers.Delete("run-1")
+
 	// Close the channel to trigger EOF and cleanly end Listen
 	close(recvChan)
 
@@ -405,7 +411,6 @@ func TestWorkflowRunsListenerRestartsAfterListenExits(t *testing.T) {
 	replacementClient.recvChan <- &dispatchercontracts.WorkflowRunEvent{
 		WorkflowRunId: "run-1",
 	}
-	close(replacementClient.recvChan)
 
 	select {
 	case event := <-received:
@@ -413,6 +418,103 @@ func TestWorkflowRunsListenerRestartsAfterListenExits(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("expected workflow run event after listener restarted")
 	}
+
+	listener.RemoveWorkflowRun("run-1", "session-1")
+	close(replacementClient.recvChan)
+}
+
+func TestWorkflowRunsListenerReconnectsOnEOFWithRegisteredHandlers(t *testing.T) {
+	logger := zerolog.Nop()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	initialClient := &mockSubscribeClient{
+		recvErr: io.EOF,
+	}
+	replacementClient := &mockSubscribeClient{
+		recvChan: make(chan *dispatchercontracts.WorkflowRunEvent, 1),
+	}
+	constructorCalls := atomic.Int32{}
+
+	listener := &WorkflowRunsListener{
+		constructor: func(ctx context.Context) (dispatchercontracts.Dispatcher_SubscribeToWorkflowRunsClient, error) {
+			constructorCalls.Add(1)
+			return replacementClient, nil
+		},
+		client: initialClient,
+		l:      &logger,
+	}
+
+	received := make(chan WorkflowRunEvent, 1)
+	listener.handlers.Store("run-1", &threadSafeHandlers{
+		handlers: map[string]WorkflowRunEventHandler{
+			"session-1": func(event WorkflowRunEvent) error {
+				received <- event
+				return nil
+			},
+		},
+	})
+
+	listenErr := make(chan error, 1)
+	go func() {
+		listenErr <- listener.Listen(ctx)
+	}()
+
+	require.Eventually(t, func() bool {
+		return constructorCalls.Load() == 1 && replacementClient.sendCount.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	replacementClient.recvChan <- &dispatchercontracts.WorkflowRunEvent{
+		WorkflowRunId: "run-1",
+	}
+
+	select {
+	case event := <-received:
+		assert.Equal(t, "run-1", event.WorkflowRunId)
+	case <-time.After(time.Second):
+		t.Fatal("expected workflow run event after EOF reconnect")
+	}
+
+	listener.RemoveWorkflowRun("run-1", "session-1")
+	close(replacementClient.recvChan)
+	require.NoError(t, <-listenErr)
+}
+
+func TestWorkflowRunsListenerClosePreventsEOFReconnectAndAdd(t *testing.T) {
+	logger := zerolog.Nop()
+	constructorCalls := atomic.Int32{}
+
+	initialClient := &mockSubscribeClient{
+		recvErr: io.EOF,
+	}
+
+	listener := &WorkflowRunsListener{
+		constructor: func(ctx context.Context) (dispatchercontracts.Dispatcher_SubscribeToWorkflowRunsClient, error) {
+			constructorCalls.Add(1)
+			return &mockSubscribeClient{
+				recvChan: make(chan *dispatchercontracts.WorkflowRunEvent),
+			}, nil
+		},
+		client: initialClient,
+		l:      &logger,
+	}
+
+	listener.handlers.Store("run-1", &threadSafeHandlers{
+		handlers: map[string]WorkflowRunEventHandler{
+			"session-1": func(event WorkflowRunEvent) error {
+				return nil
+			},
+		},
+	})
+
+	require.NoError(t, listener.Close())
+	require.NoError(t, listener.listen(context.Background()))
+	assert.Equal(t, int32(0), constructorCalls.Load())
+
+	err := listener.AddWorkflowRun("run-2", "session-2", func(event WorkflowRunEvent) error {
+		return nil
+	})
+	require.ErrorIs(t, err, errListenerClosed)
 }
 
 func TestListen_ReconnectsAndUsesNewClient(t *testing.T) {
@@ -462,6 +564,11 @@ func TestListen_ReconnectsAndUsesNewClient(t *testing.T) {
 	newRecvChan <- &dispatchercontracts.WorkflowRunEvent{
 		WorkflowRunId: "run-1",
 	}
+
+	require.Eventually(t, func() bool {
+		return receivedEvent.Load() != nil
+	}, time.Second, 10*time.Millisecond)
+	listener.handlers.Delete("run-1")
 	close(newRecvChan)
 
 	err := <-listenErr

--- a/pkg/client/listener_test.go
+++ b/pkg/client/listener_test.go
@@ -223,6 +223,65 @@ func TestGetWorkflowRunsListenerImmediateAddDoesNotOpenSecondStream(t *testing.T
 	}, time.Second, 10*time.Millisecond)
 }
 
+func TestGetWorkflowRunsListenerInternalCleanupDoesNotTerminallyCloseListener(t *testing.T) {
+	logger := zerolog.Nop()
+
+	initialClient := &mockSubscribeClient{
+		recvErr: io.EOF,
+	}
+	replacementClient := &mockSubscribeClient{
+		recvChan: make(chan *dispatchercontracts.WorkflowRunEvent, 1),
+	}
+	constructorCalls := atomic.Int32{}
+
+	subscriber := &subscribeClientImpl{
+		client: &mockDispatcherClient{
+			subscribeToWorkflowRunsFn: func(ctx context.Context, opts ...grpc.CallOption) (dispatchercontracts.Dispatcher_SubscribeToWorkflowRunsClient, error) {
+				if constructorCalls.Add(1) == 1 {
+					return initialClient, nil
+				}
+
+				return replacementClient, nil
+			},
+		},
+		l:   &logger,
+		ctx: newContextLoader("", nil),
+	}
+
+	listener, err := subscriber.getWorkflowRunsListener(context.Background())
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return !listener.isListening()
+	}, time.Second, 10*time.Millisecond)
+
+	received := make(chan WorkflowRunEvent, 1)
+	require.NoError(t, listener.AddWorkflowRun("run-1", "session-1", func(event WorkflowRunEvent) error {
+		received <- event
+		return nil
+	}))
+
+	require.Equal(t, int32(2), constructorCalls.Load())
+	require.Equal(t, int32(1), replacementClient.sendCount.Load())
+
+	replacementClient.recvChan <- &dispatchercontracts.WorkflowRunEvent{
+		WorkflowRunId: "run-1",
+	}
+
+	select {
+	case event := <-received:
+		assert.Equal(t, "run-1", event.WorkflowRunId)
+	case <-time.After(time.Second):
+		t.Fatal("expected workflow run event after internal cleanup")
+	}
+
+	listener.RemoveWorkflowRun("run-1", "session-1")
+	close(replacementClient.recvChan)
+	require.Eventually(t, func() bool {
+		return !listener.isListening()
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestRetrySend_ResubscribesOnSendFailure(t *testing.T) {
 	// This test verifies that when Send() fails on a broken stream,
 	// retrySend will call retrySubscribe to establish a new stream

--- a/pkg/client/listener_test.go
+++ b/pkg/client/listener_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -31,6 +32,74 @@ type mockSubscribeClient struct {
 	closeSendFn func() error
 	sendFn      func(req *dispatchercontracts.SubscribeToWorkflowRunsRequest) error
 	recvFn      func() (*dispatchercontracts.WorkflowRunEvent, error)
+}
+
+type mockDispatcherClient struct {
+	subscribeToWorkflowRunsFn func(ctx context.Context, opts ...grpc.CallOption) (dispatchercontracts.Dispatcher_SubscribeToWorkflowRunsClient, error)
+}
+
+func (m *mockDispatcherClient) Register(ctx context.Context, in *dispatchercontracts.WorkerRegisterRequest, opts ...grpc.CallOption) (*dispatchercontracts.WorkerRegisterResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockDispatcherClient) Listen(ctx context.Context, in *dispatchercontracts.WorkerListenRequest, opts ...grpc.CallOption) (dispatchercontracts.Dispatcher_ListenClient, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockDispatcherClient) ListenV2(ctx context.Context, in *dispatchercontracts.WorkerListenRequest, opts ...grpc.CallOption) (dispatchercontracts.Dispatcher_ListenV2Client, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockDispatcherClient) Heartbeat(ctx context.Context, in *dispatchercontracts.HeartbeatRequest, opts ...grpc.CallOption) (*dispatchercontracts.HeartbeatResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockDispatcherClient) SubscribeToWorkflowEvents(ctx context.Context, in *dispatchercontracts.SubscribeToWorkflowEventsRequest, opts ...grpc.CallOption) (dispatchercontracts.Dispatcher_SubscribeToWorkflowEventsClient, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockDispatcherClient) SubscribeToWorkflowRuns(ctx context.Context, opts ...grpc.CallOption) (dispatchercontracts.Dispatcher_SubscribeToWorkflowRunsClient, error) {
+	if m.subscribeToWorkflowRunsFn != nil {
+		return m.subscribeToWorkflowRunsFn(ctx, opts...)
+	}
+
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockDispatcherClient) SendStepActionEvent(ctx context.Context, in *dispatchercontracts.StepActionEvent, opts ...grpc.CallOption) (*dispatchercontracts.ActionEventResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockDispatcherClient) SendGroupKeyActionEvent(ctx context.Context, in *dispatchercontracts.GroupKeyActionEvent, opts ...grpc.CallOption) (*dispatchercontracts.ActionEventResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockDispatcherClient) PutOverridesData(ctx context.Context, in *dispatchercontracts.OverridesData, opts ...grpc.CallOption) (*dispatchercontracts.OverridesDataResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockDispatcherClient) Unsubscribe(ctx context.Context, in *dispatchercontracts.WorkerUnsubscribeRequest, opts ...grpc.CallOption) (*dispatchercontracts.WorkerUnsubscribeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockDispatcherClient) RefreshTimeout(ctx context.Context, in *dispatchercontracts.RefreshTimeoutRequest, opts ...grpc.CallOption) (*dispatchercontracts.RefreshTimeoutResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockDispatcherClient) ReleaseSlot(ctx context.Context, in *dispatchercontracts.ReleaseSlotRequest, opts ...grpc.CallOption) (*dispatchercontracts.ReleaseSlotResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockDispatcherClient) RestoreEvictedTask(ctx context.Context, in *dispatchercontracts.RestoreEvictedTaskRequest, opts ...grpc.CallOption) (*dispatchercontracts.RestoreEvictedTaskResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockDispatcherClient) UpsertWorkerLabels(ctx context.Context, in *dispatchercontracts.UpsertWorkerLabelsRequest, opts ...grpc.CallOption) (*dispatchercontracts.UpsertWorkerLabelsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockDispatcherClient) GetVersion(ctx context.Context, in *dispatchercontracts.GetVersionRequest, opts ...grpc.CallOption) (*dispatchercontracts.GetVersionResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
 func (m *mockSubscribeClient) Send(req *dispatchercontracts.SubscribeToWorkflowRunsRequest) error {
@@ -104,6 +173,54 @@ func TestWorkflowRunsListenerAddWorkflowRunSendsOnceWhenStarting(t *testing.T) {
 
 	require.NoError(t, listener.Close())
 	close(recvChan)
+}
+
+func TestGetWorkflowRunsListenerImmediateAddDoesNotOpenSecondStream(t *testing.T) {
+	logger := zerolog.Nop()
+	closeCh := make(chan struct{})
+	var closeOnce sync.Once
+
+	client := &mockSubscribeClient{
+		recvFn: func() (*dispatchercontracts.WorkflowRunEvent, error) {
+			<-closeCh
+			return nil, io.EOF
+		},
+		closeSendFn: func() error {
+			closeOnce.Do(func() {
+				close(closeCh)
+			})
+			return nil
+		},
+	}
+
+	constructorCalls := atomic.Int32{}
+
+	subscriber := &subscribeClientImpl{
+		client: &mockDispatcherClient{
+			subscribeToWorkflowRunsFn: func(ctx context.Context, opts ...grpc.CallOption) (dispatchercontracts.Dispatcher_SubscribeToWorkflowRunsClient, error) {
+				constructorCalls.Add(1)
+				return client, nil
+			},
+		},
+		l:   &logger,
+		ctx: newContextLoader("", nil),
+	}
+
+	listener, err := subscriber.getWorkflowRunsListener(context.Background())
+	require.NoError(t, err)
+	require.True(t, listener.isListening())
+
+	require.NoError(t, listener.AddWorkflowRun("run-1", "session-1", func(event WorkflowRunEvent) error {
+		return nil
+	}))
+
+	require.Equal(t, int32(1), constructorCalls.Load())
+	require.Equal(t, int32(1), client.sendCount.Load())
+
+	require.NoError(t, listener.Close())
+	require.Eventually(t, func() bool {
+		return !listener.isListening()
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestRetrySend_ResubscribesOnSendFailure(t *testing.T) {

--- a/pkg/client/listener_test.go
+++ b/pkg/client/listener_test.go
@@ -274,6 +274,68 @@ func TestRetrySend_ResubscribesOnSendFailure(t *testing.T) {
 	assert.Equal(t, int32(1), workingClient.sendCount.Load(), "working client should have received exactly one send")
 }
 
+func TestWorkflowRunsListenerReconnectDoesNotBlockClientSnapshot(t *testing.T) {
+	logger := zerolog.Nop()
+	constructorEntered := make(chan struct{})
+	releaseConstructor := make(chan struct{})
+	var closeConstructorEntered sync.Once
+
+	oldClient := &mockSubscribeClient{
+		recvChan: make(chan *dispatchercontracts.WorkflowRunEvent),
+	}
+	newClient := &mockSubscribeClient{
+		recvChan: make(chan *dispatchercontracts.WorkflowRunEvent),
+	}
+
+	listener := &WorkflowRunsListener{
+		constructor: func(ctx context.Context) (dispatchercontracts.Dispatcher_SubscribeToWorkflowRunsClient, error) {
+			closeConstructorEntered.Do(func() {
+				close(constructorEntered)
+			})
+			<-releaseConstructor
+			return newClient, nil
+		},
+		client: oldClient,
+		l:      &logger,
+	}
+
+	retryErr := make(chan error, 1)
+	go func() {
+		retryErr <- listener.retrySubscribe(context.Background())
+	}()
+
+	select {
+	case <-constructorEntered:
+	case <-time.After(time.Second):
+		t.Fatal("reconnect did not reach constructor")
+	}
+
+	snapshotRead := make(chan struct {
+		client     dispatchercontracts.Dispatcher_SubscribeToWorkflowRunsClient
+		generation uint64
+	}, 1)
+	go func() {
+		client, generation := listener.getClientSnapshot()
+		snapshotRead <- struct {
+			client     dispatchercontracts.Dispatcher_SubscribeToWorkflowRunsClient
+			generation uint64
+		}{client: client, generation: generation}
+	}()
+
+	select {
+	case snapshot := <-snapshotRead:
+		require.Same(t, oldClient, snapshot.client)
+		require.Equal(t, uint64(0), snapshot.generation)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("getClientSnapshot blocked behind reconnect")
+	}
+
+	close(releaseConstructor)
+
+	require.NoError(t, <-retryErr)
+	require.NoError(t, listener.Close())
+}
+
 func TestRetrySend_FailsAfterMaxRetries(t *testing.T) {
 	// This test verifies that retrySend returns an error after
 	// exhausting all retry attempts when resubscribe also fails.

--- a/pkg/client/workflow.go
+++ b/pkg/client/workflow.go
@@ -123,6 +123,8 @@ func (c *Workflow) Result() (*WorkflowResult, error) {
 
 			break
 		}
+
+		retries++
 	}
 
 	if retries == DefaultActionListenerRetryCount && err != nil {

--- a/sdks/go/e2e/durable_test.go
+++ b/sdks/go/e2e/durable_test.go
@@ -114,6 +114,8 @@ func TestDurableSleepCancelReplay(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	pollUntilRunStatus(t, ctx, sharedClient, ref.RunId, string(rest.V1TaskStatusRUNNING))
+
 	result, err := ref.Result()
 	require.NoError(t, err)
 	replayElapsed := time.Since(replayStart).Seconds()


### PR DESCRIPTION
# Description

The v0 durable/workflow-run listeners could permanently lose or strand their gRPC streams across stream loss, especially during graceful server drains that surface as `io.EOF`. This PR hardens both shared listeners so registered handlers keep the stream alive through EOF, reconnects are coalesced, listener startup does not create duplicate streams, and reconnect attempts do not block normal send/close paths behind `clientMu`.

Fixes # (issue)

<details>
<summary><b>Ported vs. new (for reviewers)</b></summary>

**Ported into `DurableEventsListener` from the `WorkflowRunsListener` hardening in #2934**

- `singleflight`-coalesced reconnect (`reconnectGroup` + `retryListen` / `doRetryListen`, mirroring `retrySubscribe` / `doRetrySubscribe`).
- `generation` counter and `getClientSnapshot`, so `Recv` runs on a snapshot and `clientMu` is never held while blocking.
- `retrySend` comparing generation before/after a failed send and triggering a reconnect instead of retrying on the dead stream.
- Consecutive-error cap and the `codes.Unavailable` 1s backoff in the listen loop.
- nil-safe `Close`.

**New in this PR (applied to both listeners)**

- Lazy, restartable listen loop: `listening` state behind `listenMu`, `ensureListening` / `startListening` / `stopListening`, and `listen()` split out of `Listen()`. The loop starts on the first `AddSignal` / `AddWorkflowRun` and can restart after it exits, instead of leaving a dead listener.
- Internal listen-loop cleanup closes only the stream it owns and clears the shared listener reference only if the stored instance still matches, without terminally closing reusable listener objects.
- The new client is assigned only after subscription replay succeeds, so a failed reconnect can't leave a half-initialized client.
- Generation is tracked inside the listen loop, so an out-of-band reconnect is picked up without forcing another reconnect.
- EOF reconnects when handlers are still registered, so a rolling engine deploy does not strand an already-parked waiter.
- Initial listener startup marks `listening` synchronously before launching the goroutine, avoiding cold-start double-subscribe/leaked stream races.
- Reconnect loops no longer hold `clientMu` across sleeps, stream construction, or subscription replay; the mutex is only held for the final client/generation swap.
- Coalesced reconnects run on a stable background context after caller-context preflight, so one cancelled caller cannot poison the shared reconnect.
- `Workflow.Result()`: when `AddWorkflowRun` kept failing, the retry loop never advanced because `retries` was never incremented, so registration could spin indefinitely; this PR increments `retries` on each failed attempt.

</details>

## Behavioral changes / reviewer notes

- **`io.EOF` handling:** `io.EOF` is terminal for the listen loop only when there are no registered handlers left or the listener is shutting down. If handlers are still registered, EOF triggers reconnect and subscription replay instead of leaving waiters stranded on a dead stream.
- **Durable vs. workflow-run handlers:** durable event handlers are one-shot—they are removed after a successful dispatch. Workflow-run handlers stay registered until explicit removal (e.g. result delivery or cleanup), so they keep the stream subscribed across EOF/reconnect until the run is finished.
- **`AddSignal` / abandoned waiters:** there is no `RemoveSignal` API. A signal waiter that is abandoned without cancellation remains registered and therefore keeps EOF-driven reconnects active. That matches the durable one-shot waiter model (each `AddSignal` corresponds to an active wait); callers that need to drop a waiter should cancel the associated context rather than leaving it registered.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Brought `DurableEventsListener` to reconnect parity with `WorkflowRunsListener` (#2934).
- [x] Made both listeners' listen loops lazy and restartable so a dropped stream recovers instead of dying.
- [x] Assigned the reconnected client only after subscription replay succeeds; made `Close` nil-safe.
- [x] Reconnect on `io.EOF` when handlers are still registered.
- [x] Restored shared-listener cleanup on top-level listen exit without terminally closing reusable listener objects.
- [x] Prevented cold-start duplicate streams by marking listeners active before launching the receive goroutine.
- [x] Avoided holding `clientMu` across reconnect backoff/replay work.
- [x] Fixed `Workflow.Result()` infinite retry loop when `AddWorkflowRun` persistently fails (`retries` was never incremented).

## Checklist

Changes have been:

- [x] Tested (unit tests added in `durable_listener_test.go` and `listener_test.go`)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable)

## Testing

`go test ./pkg/client` -- covers broken-stream reconnect, EOF reconnect with registered handlers, listener restart after loop exit, immediate first `Add*` after `getXxx` without opening a second stream, reconnects that do not block client snapshots, the workflow result retry-counter fix, and internal stream cleanup that keeps cached listener pointers reusable.

---

<details id="ai-disclosure">
<summary><b>AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Cursor was used to help implement the listener reconnect hardening, add related tests, respond to review feedback, and draft/update this PR description.

</details>

