### PR TITLE
fix: hatchet cloud billing authorization surface

### DIFF
--- a/frontend/app/src/lib/api/api.test.ts
+++ b/frontend/app/src/lib/api/api.test.ts
@@ -125,6 +125,7 @@ test('resolveExchangeTokenTenantId uses location tenant instead of stale storage
 
 test('getApiErrorStatus returns the HTTP response status', () => {
   assert.equal(getApiErrorStatus({ response: { status: 401 } }), 401);
+  assert.equal(getApiErrorStatus({ status: 403 }), 403);
 });
 
 test('getApiErrorStatus ignores non-HTTP errors', () => {

--- a/frontend/app/src/lib/api/api.test.ts
+++ b/frontend/app/src/lib/api/api.test.ts
@@ -1,5 +1,6 @@
 import {
   CONTROL_PLANE_TENANT_STORAGE_KEY,
+  getApiErrorStatus,
   readTenantIdFromLocation,
   resolveExchangeTokenTenantId,
 } from './api';
@@ -120,4 +121,13 @@ test('resolveExchangeTokenTenantId uses location tenant instead of stale storage
       assert.equal(resolveExchangeTokenTenantId({}), tenantA);
     });
   });
+});
+
+test('getApiErrorStatus returns the HTTP response status', () => {
+  assert.equal(getApiErrorStatus({ response: { status: 401 } }), 401);
+});
+
+test('getApiErrorStatus ignores non-HTTP errors', () => {
+  assert.equal(getApiErrorStatus(new Error('boom')), undefined);
+  assert.equal(getApiErrorStatus({ response: { status: '401' } }), undefined);
 });

--- a/frontend/app/src/lib/api/api.ts
+++ b/frontend/app/src/lib/api/api.ts
@@ -9,6 +9,7 @@ import qs from 'qs';
 import { validate as validateUuid } from 'uuid';
 
 type HttpErrorLike = {
+  status?: unknown;
   response?: {
     status?: unknown;
   };
@@ -19,12 +20,10 @@ export function getApiErrorStatus(error: unknown): number | undefined {
     return undefined;
   }
 
-  const response = (error as HttpErrorLike).response;
-  if (!response || typeof response.status !== 'number') {
-    return undefined;
-  }
+  const maybeError = error as HttpErrorLike;
+  const status = maybeError.status ?? maybeError.response?.status;
 
-  return response.status;
+  return typeof status === 'number' ? status : undefined;
 }
 
 // Extend Axios config with custom fields injected by the API code generator.

--- a/frontend/app/src/lib/api/api.ts
+++ b/frontend/app/src/lib/api/api.ts
@@ -8,6 +8,25 @@ import { InternalAxiosRequestConfig } from 'axios';
 import qs from 'qs';
 import { validate as validateUuid } from 'uuid';
 
+type HttpErrorLike = {
+  response?: {
+    status?: unknown;
+  };
+};
+
+export function getApiErrorStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') {
+    return undefined;
+  }
+
+  const response = (error as HttpErrorLike).response;
+  if (!response || typeof response.status !== 'number') {
+    return undefined;
+  }
+
+  return response.status;
+}
+
 // Extend Axios config with custom fields injected by the API code generator.
 // https://www.typescriptlang.org/docs/handbook/declaration-merging.html
 declare module 'axios' {

--- a/frontend/app/src/pages/organizations/$organization/billing.tsx
+++ b/frontend/app/src/pages/organizations/$organization/billing.tsx
@@ -17,6 +17,7 @@ import useCloud from '@/hooks/use-cloud';
 import useControlPlane from '@/hooks/use-control-plane';
 import { queries } from '@/lib/api';
 import type { TenantResourceLimit } from '@/lib/api';
+import { getApiErrorStatus } from '@/lib/api/api';
 import type { TenantResourceLimit as ControlPlaneTenantResourceLimit } from '@/lib/api/generated/control-plane/data-contracts';
 import { useSearchParams } from '@/lib/router-helpers';
 import { SettingsPageHeader } from '@/pages/main/v1/tenant-settings/components/settings-page-header';
@@ -67,6 +68,45 @@ function BillingMaintenanceCard() {
             Contact us
           </Button>
         )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function BillingErrorCard({
+  isRetrying,
+  isUnauthorized,
+  onRetry,
+}: {
+  isRetrying: boolean;
+  isUnauthorized: boolean;
+  onRetry: () => void;
+}) {
+  const pylon = usePylon();
+
+  return (
+    <Card variant="light" className="mt-6">
+      <CardHeader>
+        <CardTitle>
+          {isUnauthorized ? 'Unauthorized' : 'Billing unavailable'}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          {isUnauthorized
+            ? 'You must be an organization owner to view billing and usage details.'
+            : "We couldn't load this organization's billing and usage details. Please try again, or contact us if this keeps happening."}
+        </p>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Button onClick={onRetry} variant="outline" disabled={isRetrying}>
+            {isRetrying ? <Spinner /> : 'Try again'}
+          </Button>
+          {pylon.enabled && (
+            <Button onClick={pylon.show} variant="outline">
+              Contact us
+            </Button>
+          )}
+        </div>
       </CardContent>
     </Card>
   );
@@ -146,6 +186,8 @@ function OrganizationBillingContent() {
   const billingState = useQuery({
     ...queries.controlPlane.billing(organization),
     enabled: isCloudEnabled && !!cloud?.canBill,
+    retry: (failureCount, error) =>
+      getApiErrorStatus(error) !== 401 && failureCount < 3,
     refetchInterval: isSyncing ? SYNC_POLL_INTERVAL_MS : false,
   });
 
@@ -208,6 +250,20 @@ function OrganizationBillingContent() {
   });
 
   const organizationTenants = tenantResourceLimits.data?.tenants ?? [];
+
+  if (billingState.isError) {
+    const isUnauthorized = getApiErrorStatus(billingState.error) === 401;
+
+    return (
+      <BillingErrorCard
+        isRetrying={billingState.isFetching}
+        isUnauthorized={isUnauthorized}
+        onRetry={() => {
+          void billingState.refetch();
+        }}
+      />
+    );
+  }
 
   return (
     <>

--- a/frontend/app/src/pages/organizations/$organization/billing.tsx
+++ b/frontend/app/src/pages/organizations/$organization/billing.tsx
@@ -252,7 +252,8 @@ function OrganizationBillingContent() {
   const organizationTenants = tenantResourceLimits.data?.tenants ?? [];
 
   if (billingState.isError) {
-    const isUnauthorized = getApiErrorStatus(billingState.error) === 401;
+    const status = getApiErrorStatus(billingState.error);
+    const isUnauthorized = status === 401 || status === 403;
 
     return (
       <BillingErrorCard

--- a/frontend/app/src/pages/organizations/$organization/billing.tsx
+++ b/frontend/app/src/pages/organizations/$organization/billing.tsx
@@ -186,8 +186,10 @@ function OrganizationBillingContent() {
   const billingState = useQuery({
     ...queries.controlPlane.billing(organization),
     enabled: isCloudEnabled && !!cloud?.canBill,
-    retry: (failureCount, error) =>
-      getApiErrorStatus(error) !== 401 && failureCount < 3,
+    retry: (failureCount, error) => {
+      const status = getApiErrorStatus(error);
+      return status !== 401 && status !== 403 && failureCount < 3;
+    },
     refetchInterval: isSyncing ? SYNC_POLL_INTERVAL_MS : false,
   });
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Adds a message if a user is not authorized to view the billing page on hatchet cloud.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

<img width="2400" height="1858" alt="image" src="https://github.com/user-attachments/assets/615ec7b3-8bef-4e85-81b7-5467f04566e5" />

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: created the message component

</details>
