### PR TITLE
fix(ci): Rework release pipeline for tags

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,11 +27,11 @@ github_actions:
 
 engine:
   - changed-files:
+      - all-globs-to-all-files: "!cmd/hatchet-cli/.goreleaser.yaml"
       # TODO: Disambiguating between components is non-trivial,
       # For now, we rely on a mixture of files changed + title scoping.
       - any-glob-to-any-file:
           - "cmd/**"
-          - "!cmd/hatchet-cli/.goreleaser.yaml"
           - "pkg/**"
           - "internal/**"
           - "api/**"

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -4,169 +4,8 @@ on:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 name: Create prerelease w/ binaries and static assets
 jobs:
-  build-push-matrix:
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [api, admin, engine, migrate]
-        arch:
-          - {tag: amd64, runner: ubuntu-latest}
-          - {tag: arm64, runner: hatchet-arm64-2}
-    runs-on: ${{ matrix.arch.runner }}
-    name: build-push-hatchet-${{ matrix.target }}-${{ matrix.arch.tag }}
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Login to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Build
-        run: |
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
-            --build-arg SERVER_TARGET=${{ matrix.target }} \
-            --build-arg VERSION=${{ steps.tag_name.outputs.tag }} \
-            -t ghcr.io/hatchet-dev/hatchet/hatchet-${{ matrix.target }}:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }} \
-            --platform linux/${{ matrix.arch.tag }} \
-            .
-      - name: Push to GHCR
-        run: docker push ghcr.io/hatchet-dev/hatchet/hatchet-${{ matrix.target }}:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }}
-
-  build-push-frontend:
-    strategy:
-      fail-fast: false
-      matrix:
-        arch:
-          - {tag: amd64, runner: ubuntu-latest}
-          - {tag: arm64, runner: hatchet-arm64-2}
-    runs-on: ${{ matrix.arch.runner }}
-    name: build-push-hatchet-frontend-${{ matrix.arch.tag }}
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: '3.14'
-      - name: Generate docs snippets and examples
-        working-directory: frontend/snippets
-        run: python3 generate.py
-      - name: Login to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Build
-        run: |
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/frontend.dockerfile \
-            -t ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }} \
-            --platform linux/${{ matrix.arch.tag }} \
-            .
-      - name: Push to GHCR
-        run: docker push ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }}
-
-  build-push-loadtest:
-    strategy:
-      fail-fast: false
-      matrix:
-        arch:
-          - {tag: amd64, runner: ubuntu-latest}
-          - {tag: arm64, runner: hatchet-arm64-2}
-    runs-on: ${{ matrix.arch.runner }}
-    name: build-push-hatchet-loadtest-${{ matrix.arch.tag }}
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Login to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Build
-        run: |
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/loadtest.dockerfile \
-            -t ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }} \
-            --platform linux/${{ matrix.arch.tag }} \
-            .
-      - name: Push to GHCR
-        run: docker push ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }}
-
-  build-push-lite:
-    needs: build-push-matrix
-    strategy:
-      fail-fast: false
-      matrix:
-        arch:
-          - {tag: amd64, runner: ubuntu-latest}
-          - {tag: arm64, runner: hatchet-arm64-2}
-    runs-on: ${{ matrix.arch.runner }}
-    name: build-push-hatchet-lite-${{ matrix.arch.tag }}
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Login to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Build
-        run: |
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
-            --build-arg SERVER_TARGET=lite \
-            --build-arg VERSION=${{ steps.tag_name.outputs.tag }} \
-            --platform linux/${{ matrix.arch.tag }} \
-            -t hatchet-lite-tmp:${{ matrix.arch.tag }} \
-            .
-
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/lite.dockerfile \
-            -t ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }} \
-            --platform linux/${{ matrix.arch.tag }} \
-            --build-arg HATCHET_LITE_IMAGE=hatchet-lite-tmp:${{ matrix.arch.tag }} \
-            --build-arg HATCHET_ADMIN_IMAGE=ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }} \
-            --build-arg HATCHET_MIGRATE_IMAGE=ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }} \
-            .
-      - name: Push to GHCR
-        run: docker push ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }}
-
-  build-push-dashboard:
-    needs: build-push-matrix
-    strategy:
-      fail-fast: false
-      matrix:
-        arch:
-          - {tag: amd64, runner: ubuntu-latest}
-          - {tag: arm64, runner: hatchet-arm64-2}
-    runs-on: ${{ matrix.arch.runner }}
-    name: build-push-hatchet-dashboard-${{ matrix.arch.tag }}
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Login to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Build
-        run: |
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/dashboard.dockerfile \
-            -t ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }} \
-            --platform linux/${{ matrix.arch.tag }} \
-            --build-arg HATCHET_API_IMAGE=ghcr.io/hatchet-dev/hatchet/hatchet-api:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }} \
-            .
-      - name: Push to GHCR
-        run: docker push ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }}
-
-  combine:
-    needs: [build-push-matrix, build-push-frontend, build-push-loadtest, build-push-lite, build-push-dashboard]
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [api, admin, engine, migrate, frontend, loadtest, lite, dashboard]
+  build-push-hatchet-api-amd:
+    name: hatchet-api
     runs-on: ubuntu-latest
     steps:
       - name: Get tag name
@@ -174,11 +13,714 @@ jobs:
         run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
         env:
           GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Login to GHCR
+        id: login-ghcr
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Combine
-        env:
-          IMAGE: ghcr.io/hatchet-dev/hatchet/hatchet-${{ matrix.target }}:${{ steps.tag_name.outputs.tag }}
+      - name: Build
         run: |
-          docker manifest create $IMAGE $IMAGE-amd64 $IMAGE-arm64
-          docker manifest push $IMAGE
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
+            -t ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-amd64 \
+            --build-arg SERVER_TARGET=api \
+            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
+            --platform linux/amd64 \
+            .
+      - name: Push to GHCR
+        run: |
+          docker push ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-amd64
+  build-push-hatchet-api-arm:
+    name: hatchet-api
+    runs-on: hatchet-arm64-2
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Build
+        run: |
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
+            -t ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-arm64 \
+            --build-arg SERVER_TARGET=api \
+            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
+            --platform linux/arm64 \
+            .
+      - name: Push to GHCR
+        run: |
+          docker push ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-arm64
+  build-push-hatchet-api:
+    name: Combine hatchet-api
+    runs-on: ubuntu-latest
+    needs:
+      - build-push-hatchet-api-amd
+      - build-push-hatchet-api-arm
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Pull amd64
+        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-amd64
+      - name: Pull arm64
+        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-arm64
+      - name: Combine
+        run: |
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}} \
+            ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-arm64
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}
+  build-push-hatchet-admin-amd:
+    name: hatchet-admin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Build
+        run: |
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
+            -t ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-amd64 \
+            --build-arg SERVER_TARGET=admin \
+            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
+            --platform linux/amd64 \
+            .
+      - name: Push to GHCR
+        run: |
+          docker push ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-amd64
+  build-push-hatchet-admin-arm:
+    name: hatchet-admin
+    runs-on: hatchet-arm64-2
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Build
+        run: |
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
+            -t ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-arm64 \
+            --build-arg SERVER_TARGET=admin \
+            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
+            --platform linux/arm64 \
+            .
+      - name: Push to GHCR
+        run: |
+          docker push ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-arm64
+  build-push-hatchet-admin:
+    name: Combine hatchet-admin
+    runs-on: ubuntu-latest
+    needs:
+      - build-push-hatchet-admin-amd
+      - build-push-hatchet-admin-arm
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Pull amd64
+        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-amd64
+      - name: Pull arm64
+        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-arm64
+      - name: Combine
+        run: |
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}} \
+            ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-arm64
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}
+  build-push-hatchet-engine-amd:
+    name: hatchet-engine
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Build
+        run: |
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
+            -t ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-amd64 \
+            --build-arg SERVER_TARGET=engine \
+            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
+            --platform linux/amd64 \
+            .
+      - name: Push to GHCR
+        run: |
+          docker push ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-amd64
+  build-push-hatchet-engine-arm:
+    name: hatchet-engine
+    runs-on: hatchet-arm64-2
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Build
+        run: |
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
+            -t ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-arm64 \
+            --build-arg SERVER_TARGET=engine \
+            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
+            --platform linux/arm64 \
+            .
+      - name: Push to GHCR
+        run: |
+          docker push ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-arm64
+  build-push-hatchet-engine:
+    name: Combine hatchet-engine
+    runs-on: ubuntu-latest
+    needs:
+      - build-push-hatchet-engine-amd
+      - build-push-hatchet-engine-arm
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Pull amd64
+        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-amd64
+      - name: Pull arm64
+        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-arm64
+      - name: Combine
+        run: |
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}} \
+            ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-arm64
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}
+  build-push-hatchet-migrate-amd:
+    name: hatchet-migrate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Build
+        run: |
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
+            --build-arg SERVER_TARGET=migrate \
+            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
+            -t ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-amd64 \
+            --platform linux/amd64 \
+            .
+      - name: Push to GHCR
+        run: |
+          docker push ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-amd64
+  build-push-hatchet-migrate-arm:
+    name: hatchet-migrate
+    runs-on: hatchet-arm64-2
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Build
+        run: |
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
+            --build-arg SERVER_TARGET=migrate \
+            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
+            -t ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-arm64 \
+            --platform linux/arm64 \
+            .
+      - name: Push to GHCR
+        run: |
+          docker push ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-arm64
+  build-push-hatchet-migrate:
+    name: Combine hatchet-migrate
+    runs-on: ubuntu-latest
+    needs:
+      - build-push-hatchet-migrate-amd
+      - build-push-hatchet-migrate-arm
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Pull amd64
+        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-amd64
+      - name: Pull arm64
+        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-arm64
+      - name: Combine
+        run: |
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}} \
+            ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-arm64
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}
+  build-push-hatchet-frontend-amd:
+    name: hatchet-frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.14'
+      - name: Generate docs snippets and examples
+        working-directory: frontend/snippets
+        run: python3 generate.py
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Build
+        run: |
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/frontend.dockerfile \
+            -t ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-amd64 \
+            --platform linux/amd64 \
+            .
+      - name: Push to GHCR
+        run: |
+          docker push ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-amd64
+  build-push-hatchet-frontend-arm:
+    name: hatchet-frontend
+    runs-on: hatchet-arm64-2
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.14'
+      - name: Generate docs snippets and examples
+        working-directory: frontend/snippets
+        run: python3 generate.py
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Build
+        run: |
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/frontend.dockerfile \
+            -t ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-arm64 \
+            --platform linux/arm64 \
+            .
+      - name: Push to GHCR
+        run: |
+          docker push ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-arm64
+  build-push-hatchet-frontend:
+    name: Combine hatchet-frontend
+    runs-on: ubuntu-latest
+    needs:
+      - build-push-hatchet-frontend-amd
+      - build-push-hatchet-frontend-arm
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Pull amd64
+        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-amd64
+      - name: Pull arm64
+        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-arm64
+      - name: Combine
+        run: |
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}} \
+            ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-arm64
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}
+  build-push-hatchet-lite-amd:
+    name: hatchet-lite-amd
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.14'
+      - name: Generate docs snippets and examples
+        working-directory: frontend/snippets
+        run: python3 generate.py
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Build
+        run: |
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
+            --build-arg SERVER_TARGET=lite \
+            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
+            --platform linux/amd64 \
+            -t hatchet-lite-tmp:amd64 \
+            . &
+
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
+            --build-arg SERVER_TARGET=admin \
+            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
+            --platform linux/amd64 \
+            -t hatchet-admin-tmp:amd64 \
+            . &
+
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
+            --build-arg SERVER_TARGET=migrate \
+            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
+            --platform linux/amd64 \
+            -t hatchet-migrate-tmp:amd64 \
+            . &
+
+          wait
+
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/lite.dockerfile \
+            -t ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-amd64 \
+            --platform linux/amd64 \
+            --build-arg HATCHET_LITE_IMAGE=hatchet-lite-tmp:amd64 \
+            --build-arg HATCHET_ADMIN_IMAGE=hatchet-admin-tmp:amd64 \
+            --build-arg HATCHET_MIGRATE_IMAGE=hatchet-migrate-tmp:amd64 \
+            .
+      - name: Push to GHCR
+        run: |
+          docker push ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-amd64
+  build-push-hatchet-lite-arm:
+    name: hatchet-lite-arm
+    runs-on: hatchet-arm64-2
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.14'
+      - name: Generate docs snippets and examples
+        working-directory: frontend/snippets
+        run: python3 generate.py
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Build
+        run: |
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
+            --build-arg SERVER_TARGET=lite \
+            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
+            --platform linux/arm64 \
+            -t hatchet-lite-tmp:arm64 \
+            . &
+
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
+            --build-arg SERVER_TARGET=admin \
+            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
+            --platform linux/arm64 \
+            -t hatchet-admin-tmp:arm64 \
+            . &
+
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
+            --build-arg SERVER_TARGET=migrate \
+            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
+            --platform linux/arm64 \
+            -t hatchet-migrate-tmp:arm64 \
+            . &
+
+          wait
+
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/lite.dockerfile \
+            -t ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-arm64 \
+            --platform linux/arm64 \
+            --build-arg HATCHET_LITE_IMAGE=hatchet-lite-tmp:arm64 \
+            --build-arg HATCHET_ADMIN_IMAGE=hatchet-admin-tmp:arm64 \
+            --build-arg HATCHET_MIGRATE_IMAGE=hatchet-migrate-tmp:arm64 \
+            .
+      - name: Push to GHCR
+        run: |
+          docker push ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-arm64
+  combine-hatchet-lite:
+    name: Combine hatchet-lite
+    runs-on: ubuntu-latest
+    needs:
+      - build-push-hatchet-lite-amd
+      - build-push-hatchet-lite-arm
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Pull amd64
+        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-amd64
+      - name: Pull arm64
+        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-arm64
+      - name: Combine
+        run: |
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}} \
+            ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-arm64
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}
+  build-push-hatchet-dashboard-amd:
+    name: hatchet-dashboard-amd
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.14'
+      - name: Generate docs snippets and examples
+        working-directory: frontend/snippets
+        run: python3 generate.py
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Build
+        run: |
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
+            --build-arg SERVER_TARGET=api \
+            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
+            --platform linux/amd64 \
+            -t hatchet-api-tmp:amd64 \
+            .
+
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/dashboard.dockerfile \
+            -t ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-amd64 \
+            --platform linux/amd64 \
+            --build-arg HATCHET_API_IMAGE=hatchet-api-tmp:amd64 \
+            .
+      - name: Push to GHCR
+        run: |
+          docker push ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-amd64
+  build-push-hatchet-dashboard-arm:
+    name: hatchet-dashboard-arm
+    runs-on: hatchet-arm64-2
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.14'
+      - name: Generate docs snippets and examples
+        working-directory: frontend/snippets
+        run: python3 generate.py
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Build
+        run: |
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
+            --build-arg SERVER_TARGET=api \
+            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
+            --platform linux/arm64 \
+            -t hatchet-api-tmp:arm64 \
+            .
+
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/dashboard.dockerfile \
+            -t ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-arm64 \
+            --platform linux/arm64 \
+            --build-arg HATCHET_API_IMAGE=hatchet-api-tmp:arm64 \
+            .
+      - name: Push to GHCR
+        run: |
+          docker push ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-arm64
+  combine-hatchet-dashboard:
+    name: Combine hatchet-dashboard
+    runs-on: ubuntu-latest
+    needs:
+      - build-push-hatchet-dashboard-amd
+      - build-push-hatchet-dashboard-arm
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Pull amd64
+        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-amd64
+      - name: Pull arm64
+        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-arm64
+      - name: Combine
+        run: |
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}} \
+            ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-arm64
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}
+  build-push-hatchet-loadtest-amd:
+    name: hatchet-loadtest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Build
+        run: |
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/loadtest.dockerfile \
+            -t ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-amd64 \
+            --platform linux/amd64 \
+            .
+      - name: Push to GHCR
+        run: |
+          docker push ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-amd64
+  build-push-hatchet-loadtest-arm:
+    name: hatchet-loadtest
+    runs-on: hatchet-arm64-2
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Build
+        run: |
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/loadtest.dockerfile \
+            -t ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-arm64 \
+            --platform linux/arm64 \
+            .
+      - name: Push to GHCR
+        run: |
+          docker push ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-arm64
+  build-push-hatchet-loadtest:
+    name: Combine hatchet-loadtest
+    runs-on: ubuntu-latest
+    needs:
+      - build-push-hatchet-loadtest-amd
+      - build-push-hatchet-loadtest-arm
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Pull amd64
+        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-amd64
+      - name: Pull arm64
+        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-arm64
+      - name: Combine
+        run: |
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}} \
+            ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-arm64
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -4,325 +4,52 @@ on:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 name: Create prerelease w/ binaries and static assets
 jobs:
-  build-push-hatchet-api-amd:
-    name: hatchet-api
-    runs-on: ubuntu-latest
+  build-push-matrix:
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [api, admin, engine, migrate]
+        arch:
+          - {tag: amd64, runner: ubuntu-latest}
+          - {tag: arm64, runner: hatchet-arm64-2}
+    runs-on: ${{ matrix.arch.runner }}
+    name: build-push-hatchet-${{ matrix.target }}-${{ matrix.arch.tag }}
     steps:
       - name: Get tag name
         id: tag_name
         run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
         env:
           GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Login to GHCR
-        id: login-ghcr
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Build
         run: |
           DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
-            -t ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-amd64 \
-            --build-arg SERVER_TARGET=api \
-            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
-            --platform linux/amd64 \
+            --build-arg SERVER_TARGET=${{ matrix.target }} \
+            --build-arg VERSION=${{ steps.tag_name.outputs.tag }} \
+            -t ghcr.io/hatchet-dev/hatchet/hatchet-${{ matrix.target }}:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }} \
+            --platform linux/${{ matrix.arch.tag }} \
             .
       - name: Push to GHCR
-        run: |
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-amd64
-  build-push-hatchet-api-arm:
-    name: hatchet-api
-    runs-on: hatchet-arm64-2
+        run: docker push ghcr.io/hatchet-dev/hatchet/hatchet-${{ matrix.target }}:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }}
+
+  build-push-frontend:
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - {tag: amd64, runner: ubuntu-latest}
+          - {tag: arm64, runner: hatchet-arm64-2}
+    runs-on: ${{ matrix.arch.runner }}
+    name: build-push-hatchet-frontend-${{ matrix.arch.tag }}
     steps:
       - name: Get tag name
         id: tag_name
         run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
         env:
           GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Login to GHCR
-        id: login-ghcr
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Build
-        run: |
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
-            -t ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-arm64 \
-            --build-arg SERVER_TARGET=api \
-            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
-            --platform linux/arm64 \
-            .
-      - name: Push to GHCR
-        run: |
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-arm64
-  build-push-hatchet-api:
-    name: Combine hatchet-api
-    runs-on: ubuntu-latest
-    needs:
-      - build-push-hatchet-api-amd
-      - build-push-hatchet-api-arm
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Login to GHCR
-        id: login-ghcr
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Pull amd64
-        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-amd64
-      - name: Pull arm64
-        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-arm64
-      - name: Combine
-        run: |
-          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}} \
-            ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-amd64 \
-            ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-arm64
-          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}
-  build-push-hatchet-admin-amd:
-    name: hatchet-admin
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Login to GHCR
-        id: login-ghcr
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Build
-        run: |
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
-            -t ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-amd64 \
-            --build-arg SERVER_TARGET=admin \
-            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
-            --platform linux/amd64 \
-            .
-      - name: Push to GHCR
-        run: |
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-amd64
-  build-push-hatchet-admin-arm:
-    name: hatchet-admin
-    runs-on: hatchet-arm64-2
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Login to GHCR
-        id: login-ghcr
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Build
-        run: |
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
-            -t ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-arm64 \
-            --build-arg SERVER_TARGET=admin \
-            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
-            --platform linux/arm64 \
-            .
-      - name: Push to GHCR
-        run: |
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-arm64
-  build-push-hatchet-admin:
-    name: Combine hatchet-admin
-    runs-on: ubuntu-latest
-    needs:
-      - build-push-hatchet-admin-amd
-      - build-push-hatchet-admin-arm
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Login to GHCR
-        id: login-ghcr
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Pull amd64
-        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-amd64
-      - name: Pull arm64
-        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-arm64
-      - name: Combine
-        run: |
-          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}} \
-            ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-amd64 \
-            ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-arm64
-          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}
-  build-push-hatchet-engine-amd:
-    name: hatchet-engine
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Login to GHCR
-        id: login-ghcr
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Build
-        run: |
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
-            -t ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-amd64 \
-            --build-arg SERVER_TARGET=engine \
-            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
-            --platform linux/amd64 \
-            .
-      - name: Push to GHCR
-        run: |
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-amd64
-  build-push-hatchet-engine-arm:
-    name: hatchet-engine
-    runs-on: hatchet-arm64-2
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Login to GHCR
-        id: login-ghcr
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Build
-        run: |
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
-            -t ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-arm64 \
-            --build-arg SERVER_TARGET=engine \
-            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
-            --platform linux/arm64 \
-            .
-      - name: Push to GHCR
-        run: |
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-arm64
-  build-push-hatchet-engine:
-    name: Combine hatchet-engine
-    runs-on: ubuntu-latest
-    needs:
-      - build-push-hatchet-engine-amd
-      - build-push-hatchet-engine-arm
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Login to GHCR
-        id: login-ghcr
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Pull amd64
-        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-amd64
-      - name: Pull arm64
-        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-arm64
-      - name: Combine
-        run: |
-          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}} \
-            ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-amd64 \
-            ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-arm64
-          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}
-  build-push-hatchet-migrate-amd:
-    name: hatchet-migrate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Login to GHCR
-        id: login-ghcr
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Build
-        run: |
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
-            --build-arg SERVER_TARGET=migrate \
-            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
-            -t ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-amd64 \
-            --platform linux/amd64 \
-            .
-      - name: Push to GHCR
-        run: |
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-amd64
-  build-push-hatchet-migrate-arm:
-    name: hatchet-migrate
-    runs-on: hatchet-arm64-2
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Login to GHCR
-        id: login-ghcr
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Build
-        run: |
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
-            --build-arg SERVER_TARGET=migrate \
-            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
-            -t ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-arm64 \
-            --platform linux/arm64 \
-            .
-      - name: Push to GHCR
-        run: |
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-arm64
-  build-push-hatchet-migrate:
-    name: Combine hatchet-migrate
-    runs-on: ubuntu-latest
-    needs:
-      - build-push-hatchet-migrate-amd
-      - build-push-hatchet-migrate-arm
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Login to GHCR
-        id: login-ghcr
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Pull amd64
-        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-amd64
-      - name: Pull arm64
-        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-arm64
-      - name: Combine
-        run: |
-          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}} \
-            ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-amd64 \
-            ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-arm64
-          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}
-  build-push-hatchet-frontend-amd:
-    name: hatchet-frontend
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.14'
@@ -330,397 +57,128 @@ jobs:
         working-directory: frontend/snippets
         run: python3 generate.py
       - name: Login to GHCR
-        id: login-ghcr
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Build
         run: |
           DOCKER_BUILDKIT=1 docker build -f ./build/package/frontend.dockerfile \
-            -t ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-amd64 \
-            --platform linux/amd64 \
+            -t ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }} \
+            --platform linux/${{ matrix.arch.tag }} \
             .
       - name: Push to GHCR
-        run: |
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-amd64
-  build-push-hatchet-frontend-arm:
-    name: hatchet-frontend
-    runs-on: hatchet-arm64-2
+        run: docker push ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }}
+
+  build-push-loadtest:
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - {tag: amd64, runner: ubuntu-latest}
+          - {tag: arm64, runner: hatchet-arm64-2}
+    runs-on: ${{ matrix.arch.runner }}
+    name: build-push-hatchet-loadtest-${{ matrix.arch.tag }}
     steps:
       - name: Get tag name
         id: tag_name
         run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
         env:
           GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: '3.14'
-      - name: Generate docs snippets and examples
-        working-directory: frontend/snippets
-        run: python3 generate.py
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Login to GHCR
-        id: login-ghcr
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Build
-        run: |
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/frontend.dockerfile \
-            -t ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-arm64 \
-            --platform linux/arm64 \
-            .
-      - name: Push to GHCR
-        run: |
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-arm64
-  build-push-hatchet-frontend:
-    name: Combine hatchet-frontend
-    runs-on: ubuntu-latest
-    needs:
-      - build-push-hatchet-frontend-amd
-      - build-push-hatchet-frontend-arm
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Login to GHCR
-        id: login-ghcr
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Pull amd64
-        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-amd64
-      - name: Pull arm64
-        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-arm64
-      - name: Combine
-        run: |
-          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}} \
-            ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-amd64 \
-            ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-arm64
-          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}
-  build-push-hatchet-lite-amd:
-    name: hatchet-lite-amd
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: '3.14'
-      - name: Generate docs snippets and examples
-        working-directory: frontend/snippets
-        run: python3 generate.py
-      - name: Login to GHCR
-        id: login-ghcr
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-      - name: Build
-        run: |
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
-            --build-arg SERVER_TARGET=lite \
-            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
-            --platform linux/amd64 \
-            -t hatchet-lite-tmp:amd64 \
-            . &
-
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
-            --build-arg SERVER_TARGET=admin \
-            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
-            --platform linux/amd64 \
-            -t hatchet-admin-tmp:amd64 \
-            . &
-
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
-            --build-arg SERVER_TARGET=migrate \
-            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
-            --platform linux/amd64 \
-            -t hatchet-migrate-tmp:amd64 \
-            . &
-
-          wait
-
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/lite.dockerfile \
-            -t ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-amd64 \
-            --platform linux/amd64 \
-            --build-arg HATCHET_LITE_IMAGE=hatchet-lite-tmp:amd64 \
-            --build-arg HATCHET_ADMIN_IMAGE=hatchet-admin-tmp:amd64 \
-            --build-arg HATCHET_MIGRATE_IMAGE=hatchet-migrate-tmp:amd64 \
-            .
-      - name: Push to GHCR
-        run: |
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-amd64
-  build-push-hatchet-lite-arm:
-    name: hatchet-lite-arm
-    runs-on: hatchet-arm64-2
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: '3.14'
-      - name: Generate docs snippets and examples
-        working-directory: frontend/snippets
-        run: python3 generate.py
-      - name: Login to GHCR
-        id: login-ghcr
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-      - name: Build
-        run: |
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
-            --build-arg SERVER_TARGET=lite \
-            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
-            --platform linux/arm64 \
-            -t hatchet-lite-tmp:arm64 \
-            . &
-
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
-            --build-arg SERVER_TARGET=admin \
-            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
-            --platform linux/arm64 \
-            -t hatchet-admin-tmp:arm64 \
-            . &
-
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
-            --build-arg SERVER_TARGET=migrate \
-            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
-            --platform linux/arm64 \
-            -t hatchet-migrate-tmp:arm64 \
-            . &
-
-          wait
-
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/lite.dockerfile \
-            -t ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-arm64 \
-            --platform linux/arm64 \
-            --build-arg HATCHET_LITE_IMAGE=hatchet-lite-tmp:arm64 \
-            --build-arg HATCHET_ADMIN_IMAGE=hatchet-admin-tmp:arm64 \
-            --build-arg HATCHET_MIGRATE_IMAGE=hatchet-migrate-tmp:arm64 \
-            .
-      - name: Push to GHCR
-        run: |
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-arm64
-  combine-hatchet-lite:
-    name: Combine hatchet-lite
-    runs-on: ubuntu-latest
-    needs:
-      - build-push-hatchet-lite-amd
-      - build-push-hatchet-lite-arm
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Login to GHCR
-        id: login-ghcr
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Pull amd64
-        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-amd64
-      - name: Pull arm64
-        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-arm64
-      - name: Combine
-        run: |
-          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}} \
-            ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-amd64 \
-            ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-arm64
-          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}
-  build-push-hatchet-dashboard-amd:
-    name: hatchet-dashboard-amd
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: '3.14'
-      - name: Generate docs snippets and examples
-        working-directory: frontend/snippets
-        run: python3 generate.py
-      - name: Login to GHCR
-        id: login-ghcr
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-      - name: Build
-        run: |
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
-            --build-arg SERVER_TARGET=api \
-            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
-            --platform linux/amd64 \
-            -t hatchet-api-tmp:amd64 \
-            .
-
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/dashboard.dockerfile \
-            -t ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-amd64 \
-            --platform linux/amd64 \
-            --build-arg HATCHET_API_IMAGE=hatchet-api-tmp:amd64 \
-            .
-      - name: Push to GHCR
-        run: |
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-amd64
-  build-push-hatchet-dashboard-arm:
-    name: hatchet-dashboard-arm
-    runs-on: hatchet-arm64-2
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: '3.14'
-      - name: Generate docs snippets and examples
-        working-directory: frontend/snippets
-        run: python3 generate.py
-      - name: Login to GHCR
-        id: login-ghcr
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-      - name: Build
-        run: |
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
-            --build-arg SERVER_TARGET=api \
-            --build-arg VERSION=${{steps.tag_name.outputs.tag}} \
-            --platform linux/arm64 \
-            -t hatchet-api-tmp:arm64 \
-            .
-
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/dashboard.dockerfile \
-            -t ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-arm64 \
-            --platform linux/arm64 \
-            --build-arg HATCHET_API_IMAGE=hatchet-api-tmp:arm64 \
-            .
-      - name: Push to GHCR
-        run: |
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-arm64
-  combine-hatchet-dashboard:
-    name: Combine hatchet-dashboard
-    runs-on: ubuntu-latest
-    needs:
-      - build-push-hatchet-dashboard-amd
-      - build-push-hatchet-dashboard-arm
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Login to GHCR
-        id: login-ghcr
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Pull amd64
-        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-amd64
-      - name: Pull arm64
-        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-arm64
-      - name: Combine
-        run: |
-          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}} \
-            ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-amd64 \
-            ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-arm64
-          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}
-  build-push-hatchet-loadtest-amd:
-    name: hatchet-loadtest
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get tag name
-        id: tag_name
-        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Login to GHCR
-        id: login-ghcr
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Build
         run: |
           DOCKER_BUILDKIT=1 docker build -f ./build/package/loadtest.dockerfile \
-            -t ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-amd64 \
-            --platform linux/amd64 \
+            -t ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }} \
+            --platform linux/${{ matrix.arch.tag }} \
             .
       - name: Push to GHCR
-        run: |
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-amd64
-  build-push-hatchet-loadtest-arm:
-    name: hatchet-loadtest
-    runs-on: hatchet-arm64-2
+        run: docker push ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }}
+
+  build-push-lite:
+    needs: build-push-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - {tag: amd64, runner: ubuntu-latest}
+          - {tag: arm64, runner: hatchet-arm64-2}
+    runs-on: ${{ matrix.arch.runner }}
+    name: build-push-hatchet-lite-${{ matrix.arch.tag }}
     steps:
       - name: Get tag name
         id: tag_name
         run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
         env:
           GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Login to GHCR
-        id: login-ghcr
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Build
         run: |
-          DOCKER_BUILDKIT=1 docker build -f ./build/package/loadtest.dockerfile \
-            -t ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-arm64 \
-            --platform linux/arm64 \
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/servers.dockerfile \
+            --build-arg SERVER_TARGET=lite \
+            --build-arg VERSION=${{ steps.tag_name.outputs.tag }} \
+            --platform linux/${{ matrix.arch.tag }} \
+            -t hatchet-lite-tmp:${{ matrix.arch.tag }} \
+            .
+
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/lite.dockerfile \
+            -t ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }} \
+            --platform linux/${{ matrix.arch.tag }} \
+            --build-arg HATCHET_LITE_IMAGE=hatchet-lite-tmp:${{ matrix.arch.tag }} \
+            --build-arg HATCHET_ADMIN_IMAGE=ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }} \
+            --build-arg HATCHET_MIGRATE_IMAGE=ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }} \
             .
       - name: Push to GHCR
-        run: |
-          docker push ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-arm64
-  build-push-hatchet-loadtest:
-    name: Combine hatchet-loadtest
-    runs-on: ubuntu-latest
-    needs:
-      - build-push-hatchet-loadtest-amd
-      - build-push-hatchet-loadtest-arm
+        run: docker push ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }}
+
+  build-push-dashboard:
+    needs: build-push-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - {tag: amd64, runner: ubuntu-latest}
+          - {tag: arm64, runner: hatchet-arm64-2}
+    runs-on: ${{ matrix.arch.runner }}
+    name: build-push-hatchet-dashboard-${{ matrix.arch.tag }}
     steps:
       - name: Get tag name
         id: tag_name
         run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
         env:
           GITHUB_TAG: ${{ github.ref }}
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Login to GHCR
-        id: login-ghcr
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Pull amd64
-        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-amd64
-      - name: Pull arm64
-        run: docker pull ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-arm64
-      - name: Combine
+      - name: Build
         run: |
-          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}} \
-            ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-amd64 \
-            ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-arm64
-          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}
+          DOCKER_BUILDKIT=1 docker build -f ./build/package/dashboard.dockerfile \
+            -t ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }} \
+            --platform linux/${{ matrix.arch.tag }} \
+            --build-arg HATCHET_API_IMAGE=ghcr.io/hatchet-dev/hatchet/hatchet-api:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }} \
+            .
+      - name: Push to GHCR
+        run: docker push ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{ steps.tag_name.outputs.tag }}-${{ matrix.arch.tag }}
+
+  combine:
+    needs: [build-push-matrix, build-push-frontend, build-push-loadtest, build-push-lite, build-push-dashboard]
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [api, admin, engine, migrate, frontend, loadtest, lite, dashboard]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get tag name
+        id: tag_name
+        run: echo "tag=${GITHUB_TAG/refs\/tags\//}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Login to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Combine
+        env:
+          IMAGE: ghcr.io/hatchet-dev/hatchet/hatchet-${{ matrix.target }}:${{ steps.tag_name.outputs.tag }}
+        run: |
+          docker manifest create $IMAGE $IMAGE-amd64 $IMAGE-arm64
+          docker manifest push $IMAGE

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,9 +10,34 @@ on:
         required: true
 name: Release
 jobs:
+  verify:
+      runs-on: ubuntu-latest
+      if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+      outputs:
+        tag: ${{ steps.tag_name.outputs.tag }}
+        should_publish: ${{ steps.skip.outputs.should_publish }}
+      steps:
+        - id: tag_name
+          run: |
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+            else
+              echo "tag=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
+            fi
+
+        - id: skip
+          run: |
+            tag="${{ steps.tag_name.outputs.tag }}"
+            if echo "$tag" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            fi
+
   load:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubicloud-standard-8
+    needs: [verify]
+    if: needs.verify.outputs.should_publish == 'true'
     timeout-minutes: 30
     strategy:
       matrix:
@@ -23,6 +48,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.verify.outputs.tag }}
+          fetch-depth: 0
 
       - name: Install Task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
@@ -52,20 +80,13 @@ jobs:
           TESTING_MATRIX_PG_VERSION: ${{ matrix.pg-version }}
   push-hatchet-server:
     name: Push latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    needs: [verify]
+    if: needs.verify.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Get tag name
         id: tag_name
-        run: |
-          if [ -z "${{ github.event.inputs.tag }}" ]; then
-            tag=${GITHUB_TAG/refs\/tags\//}
-          else
-            tag=${{ github.event.inputs.tag }}
-          fi
-          echo ::set-output name=tag::$tag
-        env:
-          GITHUB_TAG: ${{ github.ref }}
+        run: echo "tag=${{ needs.verify.outputs.tag }}" >> "$GITHUB_OUTPUT"
       - name: Login to GHCR
         id: login-ghcr
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,31 +54,98 @@ jobs:
     name: Push latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target:
-          [api, engine, admin, frontend, migrate, lite, dashboard, loadtest]
     steps:
       - name: Get tag name
         id: tag_name
         run: |
-          tag="${{ github.event.inputs.tag }}"
-          if [ -z "$tag" ]; then
-            tag="${GITHUB_REF#refs/tags/}"
+          if [ -z "${{ github.event.inputs.tag }}" ]; then
+            tag=${GITHUB_TAG/refs\/tags\//}
+          else
+            tag=${{ github.event.inputs.tag }}
           fi
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-
-      - name: Login to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
-      - name: Pull and push ${{ matrix.image }}
+          echo ::set-output name=tag::$tag
         env:
-          IMAGE: ghcr.io/hatchet-dev/hatchet/hatchet-${{ matrix.image }}
-          TAG: ${{ steps.tag_name.outputs.tag }}
+          GITHUB_TAG: ${{ github.ref }}
+      - name: Login to GHCR
+        id: login-ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Pull and push hatchet-api
         run: |
-          docker pull "$IMAGE:$TAG-amd64"
-          docker pull "$IMAGE:$TAG-arm64"
-          docker manifest create "$IMAGE:latest" \
-            "$IMAGE:$TAG-amd64" \
-            "$IMAGE:$TAG-arm64"
-          docker manifest push "$IMAGE:latest"
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-arm64
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-amd64
+
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-api:latest \
+            ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-arm64
+
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-api:latest
+      - name: Pull and push hatchet-engine
+        run: |
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-arm64
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-amd64
+
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-engine:latest \
+            ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-arm64
+
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-engine:latest
+      - name: Pull and push hatchet-admin
+        run: |
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-arm64
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-amd64
+
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-admin:latest \
+            ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-arm64
+
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-admin:latest
+      - name: Pull and push hatchet-frontend
+        run: |
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-arm64
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-amd64
+
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-frontend:latest \
+            ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-arm64
+
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-frontend:latest
+      - name: Pull and push hatchet-migrate
+        run: |
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-arm64
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-amd64
+
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-migrate:latest \
+            ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-arm64
+
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-migrate:latest
+      - name: Pull and push hatchet-lite
+        run: |
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-arm64
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-amd64
+
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-lite:latest \
+            ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-arm64
+
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-lite:latest
+      - name: Pull and push hatchet-dashboard
+        run: |
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-arm64
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-amd64
+
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:latest \
+            ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-arm64
+
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:latest
+      - name: Pull and push hatchet-loadtest
+        run: |
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-arm64
+          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-amd64
+
+          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:latest \
+            ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-amd64 \
+            ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-arm64
+
+          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,8 @@
 on:
-  push:
-    tags:
-      - "v*" # Trigger on version tags like v0.73.10
-      - "!v*-alpha*" # Do not trigger for alpha releases
+  workflow_run:
+    workflows: ["Create prerelease w/ binaries and static assets"]
+    types:
+      - completed
   workflow_dispatch:
     inputs:
       tag:
@@ -11,6 +11,7 @@ on:
 name: Release
 jobs:
   load:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubicloud-standard-8
     timeout-minutes: 30
     strategy:
@@ -51,99 +52,33 @@ jobs:
           TESTING_MATRIX_PG_VERSION: ${{ matrix.pg-version }}
   push-hatchet-server:
     name: Push latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          [api, engine, admin, frontend, migrate, lite, dashboard, loadtest]
     steps:
       - name: Get tag name
         id: tag_name
         run: |
-          if [ -z "${{ github.event.inputs.tag }}" ]; then
-            tag=${GITHUB_TAG/refs\/tags\//}
-          else
-            tag=${{ github.event.inputs.tag }}
+          tag="${{ github.event.inputs.tag }}"
+          if [ -z "$tag" ]; then
+            tag="${GITHUB_REF#refs/tags/}"
           fi
-          echo ::set-output name=tag::$tag
-        env:
-          GITHUB_TAG: ${{ github.ref }}
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
       - name: Login to GHCR
-        id: login-ghcr
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-      - name: Pull and push hatchet-api
+
+      - name: Pull and push ${{ matrix.image }}
+        env:
+          IMAGE: ghcr.io/hatchet-dev/hatchet/hatchet-${{ matrix.image }}
+          TAG: ${{ steps.tag_name.outputs.tag }}
         run: |
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-arm64
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-amd64
-
-          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-api:latest \
-            ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-amd64 \
-            ghcr.io/hatchet-dev/hatchet/hatchet-api:${{steps.tag_name.outputs.tag}}-arm64
-
-          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-api:latest
-      - name: Pull and push hatchet-engine
-        run: |
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-arm64
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-amd64
-
-          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-engine:latest \
-            ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-amd64 \
-            ghcr.io/hatchet-dev/hatchet/hatchet-engine:${{steps.tag_name.outputs.tag}}-arm64
-
-          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-engine:latest
-      - name: Pull and push hatchet-admin
-        run: |
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-arm64
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-amd64
-
-          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-admin:latest \
-            ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-amd64 \
-            ghcr.io/hatchet-dev/hatchet/hatchet-admin:${{steps.tag_name.outputs.tag}}-arm64
-
-          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-admin:latest
-      - name: Pull and push hatchet-frontend
-        run: |
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-arm64
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-amd64
-
-          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-frontend:latest \
-            ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-amd64 \
-            ghcr.io/hatchet-dev/hatchet/hatchet-frontend:${{steps.tag_name.outputs.tag}}-arm64
-
-          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-frontend:latest
-      - name: Pull and push hatchet-migrate
-        run: |
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-arm64
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-amd64
-
-          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-migrate:latest \
-            ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-amd64 \
-            ghcr.io/hatchet-dev/hatchet/hatchet-migrate:${{steps.tag_name.outputs.tag}}-arm64
-
-          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-migrate:latest
-      - name: Pull and push hatchet-lite
-        run: |
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-arm64
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-amd64
-
-          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-lite:latest \
-            ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-amd64 \
-            ghcr.io/hatchet-dev/hatchet/hatchet-lite:${{steps.tag_name.outputs.tag}}-arm64
-
-          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-lite:latest
-      - name: Pull and push hatchet-dashboard
-        run: |
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-arm64
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-amd64
-
-          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:latest \
-            ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-amd64 \
-            ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:${{steps.tag_name.outputs.tag}}-arm64
-
-          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:latest
-      - name: Pull and push hatchet-loadtest
-        run: |
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-arm64
-          docker pull ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-amd64
-
-          docker manifest create ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:latest \
-            ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-amd64 \
-            ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:${{steps.tag_name.outputs.tag}}-arm64
-
-          docker manifest push ghcr.io/hatchet-dev/hatchet/hatchet-loadtest:latest
+          docker pull "$IMAGE:$TAG-amd64"
+          docker pull "$IMAGE:$TAG-arm64"
+          docker manifest create "$IMAGE:latest" \
+            "$IMAGE:$TAG-amd64" \
+            "$IMAGE:$TAG-arm64"
+          docker manifest push "$IMAGE:latest"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Fixes a race condition where the `pre-release.yaml` pipeline has not completed before the `release.yaml` is triggered -- causing flakes on `docker pull` for the intermediate images we want to promote to `latest`

Refactors to include more matrix usage for image build jobs, since there is a lot of repetition.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI (any automation pipeline changes)

## What's Changed

- Fixes `release.yaml` to only run after successful completion of `pre-release.yaml` workflow.
- Refactors `release.yaml` and `pre-release.yaml` to use `matrix` strategy to keep things DRY.

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude web app to automate each job to leverage matrix approach in `pre-release.yml`.

</details>
