### PR TITLE
chore(cli): add Go quickstart dependency update task

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -244,6 +244,10 @@ tasks:
   generate-sqlc:
     cmds:
       - go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.29.0 generate --file pkg/repository/sqlcv1/sqlc.yaml
+  update-go-quickstart-deps:
+    desc: Update Go quickstart template Hatchet SDK to latest (or VERSION=vX.Y.Z)
+    cmds:
+      - bash ./hack/update-go-quickstart-deps.sh {{.VERSION | default "latest"}}
   lint:
     cmds:
       - task: lint-go

--- a/cmd/hatchet-cli/cli/templates/go/go.mod.embed
+++ b/cmd/hatchet-cli/cli/templates/go/go.mod.embed
@@ -3,7 +3,7 @@ module github.com/hatchet-dev/hatchet-go-quickstart
 go 1.25.9
 
 require (
-	github.com/hatchet-dev/hatchet v0.87.1
+	github.com/hatchet-dev/hatchet v0.88.6
 	github.com/joho/godotenv v1.5.1
 )
 

--- a/cmd/hatchet-cli/cli/templates/go/go.sum
+++ b/cmd/hatchet-cli/cli/templates/go/go.sum
@@ -78,8 +78,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
-github.com/hatchet-dev/hatchet v0.87.1 h1:3uzn6g+VZKwHqLII2mDwtCapweNfps2KdLMSCWafv0I=
-github.com/hatchet-dev/hatchet v0.87.1/go.mod h1:mcOO2ia03lAbTdG/ubLXFNXQJPltXUmhzM0E9TV4jhU=
+github.com/hatchet-dev/hatchet v0.88.6 h1:ws7EpdHLnotZN60tgspQct4NkmdDhQeKJQ/VwXaLVfU=
+github.com/hatchet-dev/hatchet v0.88.6/go.mod h1:mcOO2ia03lAbTdG/ubLXFNXQJPltXUmhzM0E9TV4jhU=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/hack/update-go-quickstart-deps.sh
+++ b/hack/update-go-quickstart-deps.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Update the Go quickstart template's Hatchet SDK dependency.
+#
+# The CLI stores Go template files with .embed suffixes:
+# - go.mod.embed
+# - *.go.embed
+#
+# The quickstart renderer strips that suffix when generating a user project.
+# This avoids two Go toolchain issues in the Hatchet repo:
+# - a real go.mod under templates/go would create a nested module boundary that
+#   //go:embed refuses to embed
+# - real *.go files under the template directory could be treated as source
+#   files in the main repo
+#
+# Dependabot cannot update go.mod.embed because its Go module file fetcher
+# discovers Go modules by looking for go.mod and go.work.
+#
+# This script copies the template into a temp directory, strips .embed suffixes
+# to simulate the generated project, runs go get and go mod tidy there, then
+# copies the updated go.mod/go.sum back into the embedded template files.
+#
+# Usage:
+#   bash hack/update-go-quickstart-deps.sh
+#   bash hack/update-go-quickstart-deps.sh v0.88.0
+
+set -euo pipefail
+
+TEMPLATE_DIR="cmd/hatchet-cli/cli/templates/go"
+VERSION="${1:-latest}"
+
+if [ ! -f "${TEMPLATE_DIR}/go.mod.embed" ]; then
+  echo "Error: ${TEMPLATE_DIR}/go.mod.embed not found. Run from the repo root." >&2
+  exit 1
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+echo "Copying template to temp directory..."
+cp -a "${TEMPLATE_DIR}/." "${TMPDIR}/"
+
+echo "Stripping .embed suffixes..."
+find "${TMPDIR}" -name '*.embed' -print0 | while IFS= read -r -d '' f; do
+  mv "${f}" "${f%.embed}"
+done
+
+echo "Updating github.com/hatchet-dev/hatchet to ${VERSION}..."
+(
+  cd "${TMPDIR}"
+  go get "github.com/hatchet-dev/hatchet@${VERSION}"
+  go mod tidy
+)
+
+echo "Copying updated files back..."
+cp "${TMPDIR}/go.mod" "${TEMPLATE_DIR}/go.mod.embed"
+cp "${TMPDIR}/go.sum" "${TEMPLATE_DIR}/go.sum"
+
+echo "Done. Updated files:"
+echo "  ${TEMPLATE_DIR}/go.mod.embed"
+echo "  ${TEMPLATE_DIR}/go.sum"


### PR DESCRIPTION
# Description

Add a script and Taskfile target for updating the embedded Go quickstart template dependencies. The script runs the update in a temporary project directory, strips `.embed` suffixes for compatability with the go toolchain, and copies the updated `go.mod` and `go.sum` back into the template.

This is necessary because the Go template uses `go.mod.embed`, which Dependabot will not discover given the current logic in the [file fetcher](https://github.com/dependabot/dependabot-core/blob/main/go_modules/lib/dependabot/go_modules/file_fetcher.rb)..  

This PR also runs the new task once to update the Go quickstart template from `v0.87.1` to `v0.88.6`.

## Type of change

* [x] Chore (changes which are not directly related to any business logic)

## What's Changed

* [x] Add `hack/update-go-quickstart-deps.sh` for updating the embedded Go quickstart template dependency files.
* [x] Add `task update-go-quickstart-deps` with optional `VERSION=vX.Y.Z` override.
* [x] Update the Go quickstart template Hatchet SDK dependency from `v0.87.1` to `v0.88.6`.

## Checklist

Changes have been:

* [x] Tested (unit, integration, or manually with steps specified)
* [x] Linted and formatted
* [x] Documented (where applicable)
* [ ] Added to CHANGELOG (where applicable) -- see [[Keep a Changelog](https://keepachangelog.com/en/1.0.0/)](https://keepachangelog.com/en/1.0.0/)

## Testing

Validated locally with:

```bash
bash -n hack/update-go-quickstart-deps.sh
bash hack/update-go-quickstart-deps.sh v0.88.6
bash hack/update-go-quickstart-deps.sh v0.88.6 # ran a second time to verifiy idempotency
bash hack/update-go-quickstart-deps.sh v99.99.99 # verified bad versions will not corrupt files
go build ./cmd/hatchet-cli/...
```

Also generated the Go quickstart template and verified the output contains `go.mod` rather than `go.mod.embed`, with `github.com/hatchet-dev/hatchet v0.88.6`.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

* [x] *I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md).*

* **Details**: Used Claude Code to investigate the Go quickstart template dependency automation, explain the `go.mod.embed` and `//go:embed` constraints and validate the solution.

</details>