### PR TITLE
fix(sdks/ts): resolve workflows.get() returning wrong workflow for prefix-shared names

### DIFF
--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hatchet's TypeScript SDK will be documented in this chang
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `WorkflowsClient.get()` now finds the exact workflow name match from list results instead of taking the first result, preventing incorrect workflow ID resolution when a name prefix-match returns multiple workflows.
+
 ## [1.23.0] - 2026-05-27
 
 ### Added

--- a/sdks/typescript/src/v1/client/features/workflows.ts
+++ b/sdks/typescript/src/v1/client/features/workflows.ts
@@ -105,9 +105,8 @@ export class WorkflowsClient {
       });
 
       if (data && data.rows && data.rows.length > 0) {
-        const [wf] = data.rows;
+        const wf = data.rows.find((row) => row.name === name) ?? data.rows[0];
 
-        // Cache the result
         this.workflowCache.set(name, {
           workflow: wf,
           expiry: Date.now() + this.cacheTTL,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

The SDK's `workflows.get(name)` calls the backend `ListWorkflows` endpoint with the name as a search filter. The backend SQL uses `ILIKE concat('%', @search, '%')` (substring match), which can return workflows whose names share a prefix with the target. The SDK then takes `rows[0]` without verifying the exact name match, so when a prefix-sharing workflow appears first in the results (ordering is `createdAt DESC`, non-deterministic for same timestamps), the wrong workflow ID is returned.

This causes `runs.list({ workflowNames: [...] })` to filter by an incorrect workflow ID, returning zero results even when active runs exist for the exact workflow name.

Fix by using `.find()` to locate the exact name match from the returned rows, falling back to `rows[0]` defensively.

Fixes #4020

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- Fix `WorkflowsClient.get()` to find exact workflow name match from list results instead of blindly taking `rows[0]`

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's AI_POLICY.md._

- **Details**: Claude Code was used to help investigate the bug, implement the fix, and verify tests.

</details>
Make sure the "I acknowledge" checkbox shows [x] (checked) since we're disclosing.