### PR TITLE
fix(dashboard): use sh for dashboard entrypoint

### DIFF
--- a/build/package/dashboard-entrypoint.sh
+++ b/build/package/dashboard-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Trap SIGTERM and SIGINT signals to gracefully shut down
 trap 'shutdown' SIGTERM SIGINT


### PR DESCRIPTION
# Description

Fixes #4088

The dashboard image is built on `nginx:alpine`, which does not include Bash. The `build/package/dashboard-entrypoint.sh` uses a `#!/bin/bash` shebang. When the container starts, the kernel cannot find `/bin/bash`, causing startup to fail as described in the linked issue.

This PR changes the shebang from `#!/bin/bash` to `#!/bin/sh`.

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

* [x] Change the dashboard entrypoint shebang from `#!/bin/bash` to `#!/bin/sh`.

## Checklist

Changes have been:

* [x] Tested (unit, integration, or manually with steps specified)

## Testing

Validated the issue against the published `ghcr.io/hatchet-dev/hatchet/hatchet-dashboard:v0.88.6` image:

- Confirmed the image is Alpine-based.
- I am already familiar with alpine and know `/bin/sh` is present.

For extra precaution, I validated fix by checking the script with POSIX shell syntax validation:

```sh
sh -n build/package/dashboard-entrypoint.sh
dash -n build/package/dashboard-entrypoint.sh
bash -n build/package/dashboard-entrypoint.sh
```

Also ran the fixed script under `nginx:alpine` and confirmed `/bin/sh` can parse and execute it.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

* [ ] *I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md).*


* **Details**:  None. The issue and fix were both trivial.

</details>