### PR TITLE
fix(ci): Incorrect engine labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,7 +27,6 @@ github_actions:
 
 engine:
   - changed-files:
-      - all-globs-to-all-files: "!cmd/hatchet-cli/.goreleaser.yaml"
       # TODO: Disambiguating between components is non-trivial,
       # For now, we rely on a mixture of files changed + title scoping.
       - any-glob-to-any-file:
@@ -36,6 +35,7 @@ engine:
           - "internal/**"
           - "api/**"
           - "sql/**"
+      - all-globs-to-any-file: "!cmd/hatchet-cli/.goreleaser.yaml"
 
 dashboard:
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -26,6 +26,10 @@ github_actions:
         - ".github/labeler.yml"
 
 engine:
+  # ensures that ALL of the provided options must match for the label to be applied
+- all:
+  # NOTE: Linting fails in vscode due to the JSON schema at https://www.schemastore.org/pull-request-labeler.json
+  # not being applied correctly via the redhat YAML extension. See https://github.com/actions/labeler/issues/746
   - changed-files:
       # TODO: Disambiguating between components is non-trivial,
       # For now, we rely on a mixture of files changed + title scoping.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -35,7 +35,8 @@ engine:
           - "internal/**"
           - "api/**"
           - "sql/**"
-      - all-globs-to-any-file: "!cmd/hatchet-cli/.goreleaser.yaml"
+      - all-globs-to-all-files:
+        - "!cmd/hatchet-cli/.goreleaser.yml"
 
 dashboard:
   - changed-files:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,6 +11,8 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+    - name: Clone repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213
       with:
         sync-labels: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,3 +12,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213
+      with:
+        sync-labels: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,8 +11,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - name: Clone repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213
       with:
         sync-labels: true


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The negation in the `.github/labeler.yml` has caused introduced a false positive that labels anything not matching the negation as `engine`. This PR aims to fix this by ensuring we correctly skip the `.goreleaser.yml` file.

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] CI (any automation pipeline changes)
## What's Changed

- Fixes negation to ensure we only label as `engine` when the following conditions are BOTH true:
   - Any file within the following is changed `["cmd/**", "pkg/**", "internal/**", "api/**",  "sql/**"]`
   - At least one changed file is NOT `cmd/hatchet-cli/.goreleaser.yaml`

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)


## Testing
- Tested on my local fork -- where just a change to `sdks/python` was made and labeled correctly in PR https://github.com/gregfurman/hatchet/pull/289




<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
