### PR TITLE
fix(dashboard): flip order of index on `v1_runs_olap` to improve needle-in-a-haystack query performance

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260608141858_v1_0_116.go
+++ b/cmd/hatchet-migrate/migrate/migrations/20260608141858_v1_0_116.go
@@ -41,7 +41,13 @@ func upV10116(ctx context.Context, db *sql.DB) error {
 	stmt := fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON v1_runs_olap (tenant_id, inserted_at DESC, readable_status);", quoteIdent(v10116NewIndexName("v1_runs_olap")))
 
 	if _, err := db.ExecContext(ctx, stmt); err != nil {
-		return fmt.Errorf("failed to create index on %s: %w", "v1_payload", err)
+		return fmt.Errorf("failed to create index on %s: %w", "v1_runs_olap", err)
+	}
+
+	stmt = fmt.Sprintf("DROP INDEX IF EXISTS %s;", quoteIdent(v10116OldIndexName("v1_runs_olap")))
+
+	if _, err := db.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("failed to drop old index on %s: %w", "v1_runs_olap", err)
 	}
 
 	return nil
@@ -68,7 +74,13 @@ func downV10116(ctx context.Context, db *sql.DB) error {
 	stmt := fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON v1_runs_olap (tenant_id, readable_status, inserted_at DESC);", quoteIdent(v10116OldIndexName("v1_runs_olap")))
 
 	if _, err := db.ExecContext(ctx, stmt); err != nil {
-		return fmt.Errorf("failed to create index on %s: %w", "v1_payload", err)
+		return fmt.Errorf("failed to create index on %s: %w", "v1_runs_olap", err)
+	}
+
+	stmt = fmt.Sprintf("DROP INDEX IF EXISTS %s;", quoteIdent(v10116NewIndexName("v1_runs_olap")))
+
+	if _, err := db.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("failed to drop new index on %s: %w", "v1_runs_olap", err)
 	}
 
 	return nil

--- a/cmd/hatchet-migrate/migrate/migrations/20260608141858_v1_0_116.go
+++ b/cmd/hatchet-migrate/migrate/migrations/20260608141858_v1_0_116.go
@@ -1,0 +1,75 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationNoTxContext(upV10116, downV10116)
+}
+
+func v10116NewIndexName(partition string) string {
+	return fmt.Sprintf("ix_%s_tenant_ins_at_status", partition)
+}
+
+func v10116OldIndexName(partition string) string {
+	return fmt.Sprintf("ix_%s_tenant_status_ins_at", partition)
+}
+
+func upV10116(ctx context.Context, db *sql.DB) error {
+	partitions, err := listLeafPartitions(ctx, db, "v1_runs_olap", 1)
+	if err != nil {
+		return err
+	}
+
+	for _, partition := range partitions {
+		stmt := fmt.Sprintf(
+			`CREATE INDEX CONCURRENTLY IF NOT EXISTS %s ON %s (tenant_id, inserted_at DESC, readable_status);`,
+			quoteIdent(v10116NewIndexName(partition)),
+			quoteIdent(partition),
+		)
+
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("failed to create index concurrently on %s: %w", partition, err)
+		}
+	}
+
+	stmt := fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON v1_runs_olap (tenant_id, inserted_at DESC, readable_status);", quoteIdent(v10116NewIndexName("v1_runs_olap")))
+
+	if _, err := db.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("failed to create index on %s: %w", "v1_payload", err)
+	}
+
+	return nil
+}
+
+func downV10116(ctx context.Context, db *sql.DB) error {
+	partitions, err := listLeafPartitions(ctx, db, "v1_runs_olap", 1)
+	if err != nil {
+		return err
+	}
+
+	for _, partition := range partitions {
+		stmt := fmt.Sprintf(
+			`CREATE INDEX CONCURRENTLY IF NOT EXISTS %s ON %s (tenant_id, readable_status, inserted_at DESC);`,
+			quoteIdent(v10116OldIndexName(partition)),
+			quoteIdent(partition),
+		)
+
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("failed to create index concurrently on %s: %w", partition, err)
+		}
+	}
+
+	stmt := fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON v1_runs_olap (tenant_id, readable_status, inserted_at DESC);", quoteIdent(v10116OldIndexName("v1_runs_olap")))
+
+	if _, err := db.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("failed to create index on %s: %w", "v1_payload", err)
+	}
+
+	return nil
+}

--- a/sql/schema/v1-olap.sql
+++ b/sql/schema/v1-olap.sql
@@ -204,7 +204,7 @@ CREATE TABLE v1_runs_olap (
 ) PARTITION BY RANGE(inserted_at);
 
 CREATE INDEX ix_v1_runs_olap_parent_task_external_id ON v1_runs_olap (parent_task_external_id) WHERE parent_task_external_id IS NOT NULL;
-CREATE INDEX ix_v1_runs_olap_tenant_status_ins_at ON v1_runs_olap (tenant_id, inserted_at DESC, readable_status);
+CREATE INDEX ix_v1_runs_olap_tenant_ins_at_status ON v1_runs_olap (tenant_id, inserted_at DESC, readable_status);
 
 -- LOOKUP TABLES --
 CREATE TABLE v1_lookup_table_olap (

--- a/sql/schema/v1-olap.sql
+++ b/sql/schema/v1-olap.sql
@@ -204,7 +204,7 @@ CREATE TABLE v1_runs_olap (
 ) PARTITION BY RANGE(inserted_at);
 
 CREATE INDEX ix_v1_runs_olap_parent_task_external_id ON v1_runs_olap (parent_task_external_id) WHERE parent_task_external_id IS NOT NULL;
-CREATE INDEX ix_v1_runs_olap_tenant_status_ins_at ON v1_runs_olap (tenant_id, readable_status, inserted_at DESC);
+CREATE INDEX ix_v1_runs_olap_tenant_status_ins_at ON v1_runs_olap (tenant_id, inserted_at DESC, readable_status);
 
 -- LOOKUP TABLES --
 CREATE TABLE v1_lookup_table_olap (


### PR DESCRIPTION
# Description

Flips the order of the old `(tenant_id, readable_status, inserted_at)` index to have the `inserted_at` come before the `readable_status`, which improves query performance significantly in situations where we're looking for e.g. running tasks, where the planner would usually try to use the PK because so few running statuses exist

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)


<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI was used in this PR

</details>
