### PR TITLE
fix(docs): fix broken contact us links

### DIFF
--- a/frontend/docs/pages/v1/architecture-and-guarantees.mdx
+++ b/frontend/docs/pages/v1/architecture-and-guarantees.mdx
@@ -90,7 +90,7 @@ Hatchet aims to sit in the middle: more structure than a simple queue, but simpl
 
 - **Workflow orchestration** with dependencies, retries, and timeouts
 - **Durable background jobs** where “don’t lose work” matters
-- **Moderate to high throughput** systems (and a path to higher scale with tuning/sharding). If you’re pushing the limits, [contact us](https://hatchet.run/contact).
+- **Moderate to high throughput** systems (and a path to higher scale with tuning/sharding). If you’re pushing the limits, [contact us](mailto:support@hatchet.run).
 - **Multi-language / polyglot workers**
 - **Teams already on PostgreSQL** who want operational simplicity
 - **Cloud or air-gapped environments** ([Hatchet Cloud](https://cloud.hatchet.run) or [self-hosting](/self-hosting))
@@ -129,7 +129,7 @@ The engine and API server are designed to restart without losing state, which al
 Real-world performance depends heavily on topology (worker ↔ engine network latency), database sizing, and workload shape.
 
 - **Dispatch latency**: often sub-50ms with PostgreSQL-backed storage; in optimized, “hot worker” setups it can be closer to ~25ms P95.
-- **Throughput**: varies by setup. PostgreSQL-only deployments often handle hundreds of tasks/sec per engine instance; higher throughput typically requires additional tuning and/or components like RabbitMQ. With tuning and sharding, Hatchet can scale into the high tens of thousands of tasks/sec—[contact us](https://hatchet.run/contact) if you want to design for that.
+- **Throughput**: varies by setup. PostgreSQL-only deployments often handle hundreds of tasks/sec per engine instance; higher throughput typically requires additional tuning and/or components like RabbitMQ. With tuning and sharding, Hatchet can scale into the high tens of thousands of tasks/sec—[contact us](mailto:support@hatchet.run) if you want to design for that.
 - **Common bottlenecks**: DB connection limits, large payloads (e.g. > 1MB), complex dependency graphs, and cross-region latency.
 
 <Callout type="warning">

--- a/frontend/docs/pages/v1/region-availability.mdx
+++ b/frontend/docs/pages/v1/region-availability.mdx
@@ -17,4 +17,4 @@ We are expanding availability. Planned or available regions include:
 
 ## Request a region
 
-We are always open to rolling out new regions based on demand. If you need a specific region for latency or compliance, [contact us](https://hatchet.run/contact) and we can discuss availability.
+We are always open to rolling out new regions based on demand. If you need a specific region for latency or compliance, [contact us](mailto:support@hatchet.run) and we can discuss availability.

--- a/frontend/docs/pages/v1/security/index.mdx
+++ b/frontend/docs/pages/v1/security/index.mdx
@@ -33,4 +33,4 @@ When you self-host Hatchet, your security posture depends on how you deploy and 
 - **Use least privilege**: run Hatchet with the minimum DB permissions needed; don't reuse "admin" DB credentials.
 - **Stay current**: keep Hatchet and dependencies up to date to pick up security fixes.
 
-See [Self Hosting](/self-hosting) for deployment and configuration guidance, or [contact us](https://hatchet.run/contact) for help.
+See [Self Hosting](/self-hosting) for deployment and configuration guidance, or [contact us](mailto:support@hatchet.run) for help.


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

The "contact us" link in the docs appears to be broken on multiple pages.


Fixes #4121 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
