### PR TITLE
fix(engine): exclude evicted runtimes from timeouts

### DIFF
--- a/pkg/repository/sqlcv1/tasks.sql
+++ b/pkg/repository/sqlcv1/tasks.sql
@@ -390,6 +390,8 @@ WITH expired_runtimes AS (
     WHERE
         tenant_id = @tenantId::uuid
         AND timeout_at <= NOW()
+        -- evicted tasks are not eligible for timeout
+        AND evicted_at IS NULL
     ORDER BY
         task_id, task_inserted_at, retry_count
     LIMIT
@@ -431,6 +433,7 @@ WITH tasks_on_inactive_workers AS (
         AND runtime.evicted_at IS NULL
     LIMIT
         COALESCE(sqlc.narg('limit')::integer, 1000)
+    FOR UPDATE OF runtime SKIP LOCKED
 )
 SELECT
     v1_task.id,

--- a/pkg/repository/sqlcv1/tasks.sql.go
+++ b/pkg/repository/sqlcv1/tasks.sql.go
@@ -2049,6 +2049,7 @@ WITH tasks_on_inactive_workers AS (
         AND runtime.evicted_at IS NULL
     LIMIT
         COALESCE($2::integer, 1000)
+    FOR UPDATE OF runtime SKIP LOCKED
 )
 SELECT
     v1_task.id,
@@ -2103,6 +2104,8 @@ WITH expired_runtimes AS (
     WHERE
         tenant_id = $1::uuid
         AND timeout_at <= NOW()
+        -- evicted tasks are not eligible for timeout
+        AND evicted_at IS NULL
     ORDER BY
         task_id, task_inserted_at, retry_count
     LIMIT

--- a/pkg/repository/task_timeout_eviction_test.go
+++ b/pkg/repository/task_timeout_eviction_test.go
@@ -1,0 +1,86 @@
+//go:build !e2e && !load && !rampup && !integration
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
+)
+
+// TestListTasksToTimeout_ExcludesEvictedRuntimes verifies that evicted
+// tasks are not selected for timeout processing.
+func TestListTasksToTimeout_ExcludesEvictedRuntimes(t *testing.T) {
+	pool, cleanup := setupPostgresWithMigration(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	tenantID := uuid.New()
+	workerID := uuid.New()
+	stepID := uuid.New()
+	workflowID := uuid.New()
+	workflowVersionID := uuid.New()
+	workflowRunID := uuid.New()
+
+	now := time.Now().UTC()
+	pastTimeout := now.Add(-5 * time.Minute)
+
+	_, err := pool.Exec(ctx, `
+		INSERT INTO "Tenant" ("id", "name", "slug", "createdAt", "updatedAt")
+		VALUES ($1, 'test-tenant', 'test-tenant', NOW(), NOW())
+	`, tenantID)
+	require.NoError(t, err)
+
+	_, err = pool.Exec(ctx, `
+		INSERT INTO "Worker" ("id", "tenantId", "name", "lastHeartbeatAt", "createdAt", "updatedAt")
+		VALUES ($1, $2, 'test-worker', NOW(), NOW(), NOW())
+	`, workerID, tenantID)
+	require.NoError(t, err)
+
+	// Insert two v1_task rows: one for the evicted runtime, one for the non-evicted runtime.
+	// Use OVERRIDING SYSTEM VALUE to set the identity column.
+	_, err = pool.Exec(ctx, `
+		INSERT INTO v1_task (id, inserted_at, tenant_id, queue, action_id, step_id, step_readable_id,
+			workflow_id, workflow_version_id, workflow_run_id, schedule_timeout,
+			step_timeout, sticky, external_id, display_name, input, step_index)
+		OVERRIDING SYSTEM VALUE
+		VALUES
+			(1, $1, $2, 'default', 'test-action', $3, 'test-step', $4, $5, $6, '5m', '30s', 'NONE', $7, 'test-task-1', '{}', 0),
+			(2, $1, $2, 'default', 'test-action', $3, 'test-step', $4, $5, $6, '5m', '30s', 'NONE', $8, 'test-task-2', '{}', 1)
+	`, now, tenantID, stepID, workflowID, workflowVersionID, workflowRunID, uuid.New(), uuid.New())
+	require.NoError(t, err)
+
+	// Insert two v1_task_runtime rows, both with timeout_at in the past:
+	// - Task 1: evicted and should NOT be returned
+	// - Task 2: not evicted and SHOULD be returned
+	_, err = pool.Exec(ctx, `
+		INSERT INTO v1_task_runtime (task_id, task_inserted_at, retry_count, worker_id, tenant_id, timeout_at, evicted_at)
+		VALUES
+			(1, $1, 0, $2, $3, $4, $5),
+			(2, $1, 0, $2, $3, $4, NULL)
+	`, now, workerID, tenantID, pastTimeout, now.Add(-3*time.Minute))
+	require.NoError(t, err)
+
+	queries := sqlcv1.New()
+
+	results, err := queries.ListTasksToTimeout(ctx, pool, sqlcv1.ListTasksToTimeoutParams{
+		Tenantid: tenantID,
+		Limit:    pgtype.Int4{Int32: 100, Valid: true},
+	})
+	require.NoError(t, err)
+
+	// Only the non-evicted runtime (task_id=2) should be returned
+	assert.Len(t, results, 1, "should return exactly one task (the non-evicted one)")
+	if len(results) == 1 {
+		assert.Equal(t, int64(2), results[0].ID, "returned task should be the non-evicted one (id=2)")
+	}
+}


### PR DESCRIPTION
# Description

This fixes two task runtime issues:

1. `ListTasksToTimeout` now excludes evicted runtimes, preventing evicted durable tasks from being wrongly timed out.
2. `ListTasksToReassign` now uses `FOR UPDATE OF runtime SKIP LOCKED`, preventing timeout and reassign loops from selecting the same runtime row concurrently.

A regression test was added for the timeout behavior to confirm that evicted runtimes are excluded while non-evicted expired runtimes are still returned.

Fixes #4128
Fixes #4130

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] Test changes (add, refactor, improve or change a test)

## What's Changed

* [x] Exclude evicted runtimes from `ListTasksToTimeout`.
* [x] Add `FOR UPDATE OF runtime SKIP LOCKED` to `ListTasksToReassign`.
* [x] Add a repository regression test confirming evicted runtimes are not returned by `ListTasksToTimeout`.
* [x] Update the generated SQLC query text in `tasks.sql.go` to match `tasks.sql`.

## Checklist

Changes have been:

* [x] Tested (unit, integration, or manually with steps specified)
* [x] Linted and formatted

## Testing

Validated with:

```sh
go test -run TestListTasksToTimeout_ExcludesEvictedRuntimes ./pkg/repository/
go test ./pkg/repository/
go build ./pkg/repository/sqlcv1/...
go build ./pkg/repository/...
go build ./internal/services/controllers/task/...
go vet ./pkg/repository/...
```

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

* [x] *I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md).*

<!-- Please specify the tooling/model and the extent to which it was used. -->

* **Details**: Claude Code was used to help investigate the reported task runtime correctness issues. It also recommended minimal SQL changes which I agreed with and used. For quickness, I had claude draft the regression test. I reviewed the changes and validated them locally before submitting.

</details>