### PR TITLE
ci: manual dispatch for release

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -65,6 +65,7 @@ jobs:
           workdir: cmd/hatchet-cli
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_PREVIOUS_TAG: ${{ needs.verify.outputs.prev_tag }}
           # Homebrew tap token
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           # macOS signing and notarization secrets
@@ -91,6 +92,7 @@ jobs:
     outputs:
       # We should only be triggering a release when using an annotated tag type.
       should_release: ${{ steps.tag_name.outputs.tag_type == 'tag' }}
+      prev_tag: ${{ steps.prev.outputs.prev_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -107,6 +109,15 @@ jobs:
           echo "Tag [$GITHUB_TAG] is of type [$tag_type]."
           echo "tag_type=$tag_type" >> $GITHUB_OUTPUT
 
+      - name: Determine previous release tag
+        id: prev
+        run: |
+          PREV_TAG=$(gh release view --json tagName --jq .tagName)
+          echo "Previous release tag: $PREV_TAG"
+          echo "prev_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   generate-changelog:
     name: Generate release_notes.md artifact
     runs-on: ubuntu-latest
@@ -114,6 +125,7 @@ jobs:
     if: needs.verify.outputs.should_release == 'true'
     env:
       GITHUB_TAG: ${{ inputs.tag || github.ref_name }}
+      PREV_TAG: ${{ needs.verify.outputs.prev_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -122,15 +134,6 @@ jobs:
 
       - name: Fetch the tag object
         run: git fetch --force origin tag "$GITHUB_TAG"
-
-      - name: Determine previous release tag
-        id: prev
-        run: |
-          PREV_TAG=$(gh release view --json tagName --jq .tagName)
-          echo "Previous release tag: $PREV_TAG"
-          echo "PREV_TAG=$PREV_TAG" >> "$GITHUB_ENV"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate release section
         uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -5,6 +5,12 @@ on:
     tags:
       - "v*" # Trigger on version tags like v0.73.10
       - "!v*-alpha*" # Do not trigger for alpha releases
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build (e.g. v0.89.0)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -16,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [verify, generate-changelog]
     env:
-      GITHUB_TAG: ${{ github.ref_name }}
+      GITHUB_TAG: ${{ inputs.tag || github.ref_name }}
     if: needs.verify.outputs.should_release == 'true'
     steps:
       - name: Checkout
@@ -81,7 +87,7 @@ jobs:
     name: Verify Release Tag
     runs-on: ubuntu-latest
     env:
-      GITHUB_TAG: ${{ github.ref_name }}
+      GITHUB_TAG: ${{ inputs.tag || github.ref_name }}
     outputs:
       # We should only be triggering a release when using an annotated tag type.
       should_release: ${{ steps.tag_name.outputs.tag_type == 'tag' }}
@@ -106,6 +112,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [verify]
     if: needs.verify.outputs.should_release == 'true'
+    env:
+      GITHUB_TAG: ${{ inputs.tag || github.ref_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -113,7 +121,7 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch the tag object
-        run: git fetch --force origin tag "$GITHUB_REF_NAME"
+        run: git fetch --force origin tag "$GITHUB_TAG"
 
       - name: Determine previous release tag
         id: prev
@@ -128,14 +136,14 @@ jobs:
         uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5
         with:
           config: cliff.toml
-          args: ${{ env.PREV_TAG }}..${{ github.ref_name }}
+          args: ${{ env.PREV_TAG }}..${{ env.GITHUB_TAG }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OUTPUT: /tmp/CHANGES.md
 
       - name: Generate release notes
         run: |
-          ./hack/ci/release-notes-cli.sh "${{ github.ref_name }}" > release_notes.md
+          ./hack/ci/release-notes-cli.sh "$GITHUB_TAG" > release_notes.md
           echo "" >> release_notes.md
           cat /tmp/CHANGES.md >> release_notes.md
 

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,8 @@ override.tf.json
 *_override.tf
 *_override.tf.json
 
+release_notes.md
+
 # Include override files you do wish to add to version control using negated pattern
 #
 # !example_override.tf


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Allows us to manually trigger a release for a tag and ensure that `release_notes.md` is not included in working tree -- causing a goreleaser failure due to a dirty state.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] CI (any automation pipeline changes)


## What's Changed

- Release workflow now allows for `GITHUB_TAG` to be defined by an incoming `github.ref_name` or a `workflow_dispatch` triggers' `input.tag`

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
