### PR TITLE
fix(repository): key failureOpts by taskId in failTasksTx to fix wrong error message after dedup

### DIFF
--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -830,6 +830,7 @@ func (r *TaskRepositoryImpl) failTasksTx(ctx context.Context, tx sqlcv1.DBTX, te
 	defer span.End()
 
 	tasks := make([]TaskIdInsertedAtRetryCount, len(failureOpts))
+	errorMessageByTaskKey := make(map[string]string, len(failureOpts))
 	appFailureTaskIds := make([]int64, 0)
 	appFailureTaskInsertedAts := make([]pgtype.Timestamptz, 0)
 	appFailureTaskRetryCounts := make([]int32, 0)
@@ -841,6 +842,7 @@ func (r *TaskRepositoryImpl) failTasksTx(ctx context.Context, tx sqlcv1.DBTX, te
 
 	for i, failureOpt := range failureOpts {
 		tasks[i] = *failureOpt.TaskIdInsertedAtRetryCount
+		errorMessageByTaskKey[fmt.Sprintf("%d:%d", failureOpt.Id, failureOpt.RetryCount)] = failureOpt.ErrorMessage
 
 		if failureOpt.IsAppError {
 			appFailureTaskIds = append(appFailureTaskIds, failureOpt.Id)
@@ -937,7 +939,8 @@ func (r *TaskRepositoryImpl) failTasksTx(ctx context.Context, tx sqlcv1.DBTX, te
 	outputs := make([][]byte, len(releasedTasks))
 
 	for i, releasedTask := range releasedTasks {
-		out := NewFailedTaskOutputEvent(releasedTask, failureOpts[i].ErrorMessage).Bytes()
+		errMsg := errorMessageByTaskKey[fmt.Sprintf("%d:%d", releasedTask.ID, releasedTask.RetryCount)]
+		out := NewFailedTaskOutputEvent(releasedTask, errMsg).Bytes()
 
 		outputs[i] = out
 	}


### PR DESCRIPTION
# Description

Fixes https://github.com/hatchet-dev/hatchet/issues/4131

`failTasksTx` built `tasks[]` parallel to `failureOpts[]` (position `i` matched), then called `uniqueSet(tasks)` which deduplicates and may reorder the slice. After that, `releasedTasks` was derived from the deduped `tasks`, but the event emission at line 940 still indexed `failureOpts[i]` by position — now misaligned after dedup/reorder.

On a mixed-error batch (e.g. `[{T1,"errA"},{T2,"errB"},{T1,"errA"}]`), `uniqueSet` returns `[T1,T2]` but if order shifts, T2's event gets T1's error message.

**Fix**: build `errorMessageByTaskKey map[string]string` keyed by `"taskId:retryCount"` before `uniqueSet`, then look up by `releasedTask.ID:releasedTask.RetryCount` at event emission — stable regardless of dedup ordering.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] In `failTasksTx` (`pkg/repository/task.go`): build `errorMessageByTaskKey` map from `failureOpts` before `uniqueSet` call, keyed by `taskId:retryCount`
- [x] Replace positional `failureOpts[i].ErrorMessage` lookup with map lookup by `releasedTask.ID` + `releasedTask.RetryCount`

## Checklist

Changes have been:

- [x] Tested (manually verified compile; no existing unit tests for this path)
- [x] Linted and formatted

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Claude Code (claude-sonnet-4-6) used to identify the bug location, derive context, and generate the fix. The fix logic and file:line references were verified by direct code reading.

</details>