### PR TITLE
fix(engine): drain grpc streams and bound graceful shutdown

### DIFF
--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -158,6 +158,7 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 	p.AddCleanupMethods(cleanup)
 
 	var h *health.Health
+	var healthCleanup func() error
 	healthProbes := sc.HasService("health")
 	if healthProbes {
 		h = health.New(sc.V1.Health(), sc.MessageQueueV1, sc.Version, l)
@@ -165,10 +166,7 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 		if err != nil {
 			return fmt.Errorf("could not start health: %w", err)
 		}
-		cleanup.Add(
-			cleanupHealth,
-			"health",
-		)
+		healthCleanup = cleanupHealth
 	}
 
 	var localScheduler *schedulerv1.Scheduler
@@ -435,6 +433,7 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 			grpc.WithTLSConfig(sc.TLSConfig),
 			grpc.WithPort(sc.Runtime.GRPCPort),
 			grpc.WithBindAddress(sc.Runtime.GRPCBindAddress),
+			grpc.WithShutdownTimeout(sc.Runtime.GRPCShutdownTimeout),
 		}
 
 		if sc.Observability.Enabled {
@@ -470,6 +469,11 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 		}
 
 		cleanupGrpcApi := func() error {
+			// hang up long-lived subscriber streams first so that GracefulStop does not
+			// block on them until the pod is killed
+			d.CancelStreamSessions()
+			dv1.CancelStreamSessions()
+
 			g := new(errgroup.Group)
 
 			g.Go(func() error {
@@ -516,6 +520,13 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 		)
 	}
 
+	// the health server is shut down as late as possible so that readiness and
+	// liveness probes (and the load balancer health check) observe the not-ready
+	// state for the entire teardown
+	if healthCleanup != nil {
+		cleanup.Add(healthCleanup, "health")
+	}
+
 	cleanup.Add(
 		telemetryShutdown,
 		"telemetry",
@@ -560,6 +571,7 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 
 	healthProbes := sc.Runtime.Healthcheck
 	var h *health.Health
+	var healthCleanup func() error
 
 	if healthProbes {
 		h = health.New(sc.V1.Health(), sc.MessageQueueV1, sc.Version, l)
@@ -569,7 +581,7 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 		if err != nil {
 			return fmt.Errorf("could not start health: %w", err)
 		}
-		cleanup.Add(clean, "health")
+		healthCleanup = clean
 	}
 
 	if sc.HasService("all") || sc.HasService("controllers") {
@@ -869,6 +881,7 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 			grpc.WithTLSConfig(sc.TLSConfig),
 			grpc.WithPort(sc.Runtime.GRPCPort),
 			grpc.WithBindAddress(sc.Runtime.GRPCBindAddress),
+			grpc.WithShutdownTimeout(sc.Runtime.GRPCShutdownTimeout),
 		}
 
 		if sc.Observability.Enabled {
@@ -904,6 +917,11 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 		}
 
 		grpcApiCleanup := func() error {
+			// hang up long-lived subscriber streams first so that GracefulStop does not
+			// block on them until the pod is killed
+			d.CancelStreamSessions()
+			dv1.CancelStreamSessions()
+
 			g := new(errgroup.Group)
 
 			g.Go(func() error {
@@ -947,6 +965,13 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 			grpcApiCleanup,
 			"grpc",
 		)
+	}
+
+	// the health server is shut down as late as possible so that readiness and
+	// liveness probes (and the load balancer health check) observe the not-ready
+	// state for the entire teardown
+	if healthCleanup != nil {
+		cleanup.Add(healthCleanup, "health")
 	}
 
 	cleanup.Add(

--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hatchet-dev/hatchet/internal/msgqueue"
 	"github.com/hatchet-dev/hatchet/internal/services/dispatcher/contracts"
 	"github.com/hatchet-dev/hatchet/internal/services/shared/recoveryutils"
+	"github.com/hatchet-dev/hatchet/internal/services/shared/streams"
 	tasktypes "github.com/hatchet-dev/hatchet/internal/services/shared/tasktypes/v1"
 	"github.com/hatchet-dev/hatchet/internal/syncx"
 	"github.com/hatchet-dev/hatchet/pkg/analytics"
@@ -48,13 +49,21 @@ type DispatcherImpl struct {
 	workflowRunBufferSize               int
 	streamEventBufferTimeout            time.Duration
 
-	dispatcherId uuid.UUID
-	workers      *workers
-	a            *hatcheterrors.Wrapped
+	dispatcherId   uuid.UUID
+	workers        *workers
+	a              *hatcheterrors.Wrapped
+	streamSessions *streams.Registry
 
 	durableCallbackFn func(taskExternalId uuid.UUID, invocationCount int32, branchId, nodeId int64, payload []byte) error
 	analytics         analytics.Analytics
 	version           string
+}
+
+// CancelStreamSessions hangs up all registered long-lived subscriber streams. It is
+// called during shutdown before GracefulStop, which would otherwise block on them
+// until the process is killed.
+func (d *DispatcherImpl) CancelStreamSessions() {
+	d.streamSessions.CancelAll()
 }
 
 var ErrWorkerNotFound = fmt.Errorf("worker not found")
@@ -274,6 +283,7 @@ func New(fs ...DispatcherOpt) (*DispatcherImpl, error) {
 		repov1:                              opts.repov1,
 		dispatcherId:                        opts.dispatcherId,
 		workers:                             &workers{},
+		streamSessions:                      streams.NewRegistry(),
 		s:                                   s,
 		a:                                   a,
 		cache:                               opts.cache,

--- a/internal/services/dispatcher/server_v1.go
+++ b/internal/services/dispatcher/server_v1.go
@@ -321,6 +321,9 @@ func (s *DispatcherImpl) subscribeToWorkflowRunsV1(server contracts.Dispatcher_S
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	deregister := s.streamSessions.Register(cancel)
+	defer deregister()
+
 	wg := sync.WaitGroup{}
 	sendMu := sync.Mutex{}
 	ringIndex := 0
@@ -874,6 +877,9 @@ func (s *DispatcherImpl) subscribeToWorkflowEventsByWorkflowRunIdV1(workflowRunI
 	ctx, cancel := context.WithCancel(stream.Context())
 	defer cancel()
 
+	deregister := s.streamSessions.Register(cancel)
+	defer deregister()
+
 	retries := 0
 	foundWorkflowRun := false
 
@@ -1059,6 +1065,9 @@ func (s *DispatcherImpl) subscribeToWorkflowEventsByAdditionalMetaV1(key string,
 
 	ctx, cancel := context.WithCancel(stream.Context())
 	defer cancel()
+
+	deregister := s.streamSessions.Register(cancel)
+	defer deregister()
 
 	wg := sync.WaitGroup{}
 

--- a/internal/services/dispatcher/v1/dispatcher.go
+++ b/internal/services/dispatcher/v1/dispatcher.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hatchet-dev/hatchet/internal/msgqueue"
 	"github.com/hatchet-dev/hatchet/internal/services/controllers/task/trigger"
 	contracts "github.com/hatchet-dev/hatchet/internal/services/shared/proto/v1"
+	"github.com/hatchet-dev/hatchet/internal/services/shared/streams"
 	"github.com/hatchet-dev/hatchet/internal/syncx"
 	"github.com/hatchet-dev/hatchet/pkg/analytics"
 	"github.com/hatchet-dev/hatchet/pkg/logger"
@@ -19,6 +20,7 @@ import (
 type DispatcherService interface {
 	contracts.V1DispatcherServer
 	DeliverDurableEventLogEntryCompletion(taskExternalId uuid.UUID, invocationCount int32, branchId, nodeId int64, payload []byte) error
+	CancelStreamSessions()
 }
 
 type DispatcherServiceImpl struct {
@@ -30,6 +32,7 @@ type DispatcherServiceImpl struct {
 
 	durableInvocations syncx.Map[uuid.UUID, *durableTaskInvocation]
 	workerInvocations  syncx.Map[uuid.UUID, *durableTaskInvocation]
+	streamSessions     *streams.Registry
 	repo               v1.Repository
 	mq                 msgqueue.MessageQueue
 	v                  validator.Validator
@@ -95,6 +98,13 @@ func WithAnalytics(a analytics.Analytics) DispatcherServiceOpt {
 	}
 }
 
+// CancelStreamSessions hangs up all registered long-lived streams (durable event
+// and durable task listeners). It is called during shutdown before GracefulStop,
+// which would otherwise block on them until the process is killed.
+func (d *DispatcherServiceImpl) CancelStreamSessions() {
+	d.streamSessions.CancelAll()
+}
+
 func NewDispatcherService(fs ...DispatcherServiceOpt) (DispatcherService, error) {
 	opts := defaultDispatcherServiceOpts()
 
@@ -122,5 +132,7 @@ func NewDispatcherService(fs ...DispatcherServiceOpt) (DispatcherService, error)
 		pubBuffer:     pubBuffer,
 		dispatcherId:  opts.dispatcherId,
 		analytics:     opts.analytics,
+
+		streamSessions: streams.NewRegistry(),
 	}, nil
 }

--- a/internal/services/dispatcher/v1/server.go
+++ b/internal/services/dispatcher/v1/server.go
@@ -167,6 +167,9 @@ func (d *DispatcherServiceImpl) ListenForDurableEvent(server contracts.V1Dispatc
 	ctx, cancel := context.WithCancel(server.Context())
 	defer cancel()
 
+	deregister := d.streamSessions.Register(cancel)
+	defer deregister()
+
 	wg := sync.WaitGroup{}
 	sendMu := sync.Mutex{}
 	iterMu := sync.Mutex{}
@@ -345,6 +348,9 @@ func (d *DispatcherServiceImpl) DurableTask(server contracts.V1Dispatcher_Durabl
 
 	ctx, cancel := context.WithCancel(server.Context())
 	defer cancel()
+
+	deregister := d.streamSessions.Register(cancel)
+	defer deregister()
 
 	invocation := &durableTaskInvocation{
 		server:   server,

--- a/internal/services/dispatcher/v1/server.go
+++ b/internal/services/dispatcher/v1/server.go
@@ -359,12 +359,8 @@ func (d *DispatcherServiceImpl) DurableTask(server contracts.V1Dispatcher_Durabl
 	}
 
 	registeredTasks := make(map[uuid.UUID]struct{})
-	tasksMu := sync.Mutex{}
 
 	defer func() {
-		tasksMu.Lock()
-		defer tasksMu.Unlock()
-
 		for taskId := range registeredTasks {
 			d.durableInvocations.Delete(taskId)
 		}
@@ -377,33 +373,57 @@ func (d *DispatcherServiceImpl) DurableTask(server contracts.V1Dispatcher_Durabl
 			return
 		}
 
-		tasksMu.Lock()
-		defer tasksMu.Unlock()
-
 		if _, exists := registeredTasks[taskExtId]; !exists {
 			d.durableInvocations.Store(taskExtId, invocation)
 			registeredTasks[taskExtId] = struct{}{}
 		}
 	}
 
-	// the receive loop runs in its own goroutine so that the handler can observe
-	// context cancellation (e.g. the server shutdown hanging up this stream) while
-	// blocked in Recv, which is only interrupted by the stream ending, not by ctx
+	type recvResult struct {
+		req *contracts.DurableTaskRequest
+		err error
+	}
+
+	msgCh := make(chan recvResult)
+
+	// Recv runs in its own goroutine because it is only interrupted by the stream
+	// ending, not by ctx; this lets the handler observe context cancellation (e.g.
+	// server shutdown hanging up this stream) while a Recv is pending. The goroutine
+	// does nothing but Recv and hand off, so all processing and the deferred cleanup
+	// stay serialized on the handler goroutine. Once the handler returns, gRPC
+	// cancels server.Context(), which unblocks the pending channel send (or the next
+	// Recv) and lets the goroutine exit.
 	go func() {
 		for {
 			req, err := server.Recv()
-			if err != nil {
-				cancel()
 
-				if errors.Is(err, io.EOF) || status.Code(err) == codes.Canceled {
-					return
-				}
-
-				d.l.Error().Err(err).Msg("error receiving durable task request")
+			select {
+			case msgCh <- recvResult{req: req, err: err}:
+			case <-ctx.Done():
 				return
 			}
 
-			switch msg := req.GetMessage().(type) {
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case r := <-msgCh:
+			if r.err != nil {
+				if errors.Is(r.err, io.EOF) || status.Code(r.err) == codes.Canceled {
+					return nil
+				}
+
+				d.l.Error().Err(r.err).Msg("error receiving durable task request")
+				return r.err
+			}
+
+			switch msg := r.req.GetMessage().(type) {
 			case *contracts.DurableTaskRequest_Memo:
 				registerTask(msg.Memo.DurableTaskExternalId)
 			case *contracts.DurableTaskRequest_TriggerRuns:
@@ -412,15 +432,11 @@ func (d *DispatcherServiceImpl) DurableTask(server contracts.V1Dispatcher_Durabl
 				registerTask(msg.WaitFor.DurableTaskExternalId)
 			}
 
-			if err := d.handleDurableTaskRequest(ctx, invocation, req); err != nil {
+			if err := d.handleDurableTaskRequest(ctx, invocation, r.req); err != nil {
 				d.l.Error().Err(err).Msg("error handling durable task request")
 			}
 		}
-	}()
-
-	<-ctx.Done()
-
-	return nil
+	}
 }
 
 func (d *DispatcherServiceImpl) handleDurableTaskRequest(

--- a/internal/services/dispatcher/v1/server.go
+++ b/internal/services/dispatcher/v1/server.go
@@ -359,7 +359,12 @@ func (d *DispatcherServiceImpl) DurableTask(server contracts.V1Dispatcher_Durabl
 	}
 
 	registeredTasks := make(map[uuid.UUID]struct{})
+	tasksMu := sync.Mutex{}
+
 	defer func() {
+		tasksMu.Lock()
+		defer tasksMu.Unlock()
+
 		for taskId := range registeredTasks {
 			d.durableInvocations.Delete(taskId)
 		}
@@ -371,41 +376,51 @@ func (d *DispatcherServiceImpl) DurableTask(server contracts.V1Dispatcher_Durabl
 		if err != nil {
 			return
 		}
+
+		tasksMu.Lock()
+		defer tasksMu.Unlock()
+
 		if _, exists := registeredTasks[taskExtId]; !exists {
 			d.durableInvocations.Store(taskExtId, invocation)
 			registeredTasks[taskExtId] = struct{}{}
 		}
 	}
 
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
+	// the receive loop runs in its own goroutine so that the handler can observe
+	// context cancellation (e.g. the server shutdown hanging up this stream) while
+	// blocked in Recv, which is only interrupted by the stream ending, not by ctx
+	go func() {
+		for {
+			req, err := server.Recv()
+			if err != nil {
+				cancel()
 
-		req, err := server.Recv()
-		if err != nil {
-			if errors.Is(err, io.EOF) || status.Code(err) == codes.Canceled {
-				return nil
+				if errors.Is(err, io.EOF) || status.Code(err) == codes.Canceled {
+					return
+				}
+
+				d.l.Error().Err(err).Msg("error receiving durable task request")
+				return
 			}
-			d.l.Error().Err(err).Msg("error receiving durable task request")
-			return err
-		}
 
-		switch msg := req.GetMessage().(type) {
-		case *contracts.DurableTaskRequest_Memo:
-			registerTask(msg.Memo.DurableTaskExternalId)
-		case *contracts.DurableTaskRequest_TriggerRuns:
-			registerTask(msg.TriggerRuns.DurableTaskExternalId)
-		case *contracts.DurableTaskRequest_WaitFor:
-			registerTask(msg.WaitFor.DurableTaskExternalId)
-		}
+			switch msg := req.GetMessage().(type) {
+			case *contracts.DurableTaskRequest_Memo:
+				registerTask(msg.Memo.DurableTaskExternalId)
+			case *contracts.DurableTaskRequest_TriggerRuns:
+				registerTask(msg.TriggerRuns.DurableTaskExternalId)
+			case *contracts.DurableTaskRequest_WaitFor:
+				registerTask(msg.WaitFor.DurableTaskExternalId)
+			}
 
-		if err := d.handleDurableTaskRequest(ctx, invocation, req); err != nil {
-			d.l.Error().Err(err).Msg("error handling durable task request")
+			if err := d.handleDurableTaskRequest(ctx, invocation, req); err != nil {
+				d.l.Error().Err(err).Msg("error handling durable task request")
+			}
 		}
-	}
+	}()
+
+	<-ctx.Done()
+
+	return nil
 }
 
 func (d *DispatcherServiceImpl) handleDurableTaskRequest(

--- a/internal/services/dispatcher/v1/server_durable_task_test.go
+++ b/internal/services/dispatcher/v1/server_durable_task_test.go
@@ -1,0 +1,132 @@
+package v1
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+
+	contracts "github.com/hatchet-dev/hatchet/internal/services/shared/proto/v1"
+	"github.com/hatchet-dev/hatchet/internal/services/shared/streams"
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
+)
+
+// fakeDurableTaskServer stubs the bidi stream; the embedded interface is left nil
+// because the handler only uses Context and Recv on these test paths.
+type fakeDurableTaskServer struct {
+	contracts.V1Dispatcher_DurableTaskServer
+
+	ctx  context.Context
+	recv func() (*contracts.DurableTaskRequest, error)
+}
+
+func (f *fakeDurableTaskServer) Context() context.Context { return f.ctx }
+
+func (f *fakeDurableTaskServer) Recv() (*contracts.DurableTaskRequest, error) { return f.recv() }
+
+func newTestDispatcher() *DispatcherServiceImpl {
+	l := zerolog.Nop()
+
+	return &DispatcherServiceImpl{
+		l:              &l,
+		streamSessions: streams.NewRegistry(),
+	}
+}
+
+func tenantContext() context.Context {
+	//nolint:staticcheck // the handler reads the tenant with a plain string key
+	return context.WithValue(context.Background(), "tenant", &sqlcv1.Tenant{ID: uuid.New()})
+}
+
+func runDurableTask(d *DispatcherServiceImpl, server contracts.V1Dispatcher_DurableTaskServer) <-chan error {
+	done := make(chan error, 1)
+
+	go func() {
+		done <- d.DurableTask(server)
+	}()
+
+	return done
+}
+
+// A shutdown drain (CancelStreamSessions) must unblock the handler promptly and
+// return nil even while a Recv is pending; this is the property the graceful
+// shutdown work relies on.
+func TestDurableTaskReturnsNilOnSessionCancel(t *testing.T) {
+	d := newTestDispatcher()
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	recvStarted := make(chan struct{})
+
+	server := &fakeDurableTaskServer{
+		ctx: tenantContext(),
+		recv: func() (*contracts.DurableTaskRequest, error) {
+			close(recvStarted)
+			<-release
+			return nil, io.EOF
+		},
+	}
+
+	done := runDurableTask(d, server)
+
+	// only cancel once Recv is pending, so the test pins the drain-while-blocked
+	// behavior instead of passing via the registry's late-register immediate cancel
+	select {
+	case <-recvStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Recv was never called")
+	}
+
+	d.CancelStreamSessions()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected nil error on session cancel, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("DurableTask did not return after session cancel; Recv is still pending")
+	}
+}
+
+func TestDurableTaskSurfacesRecvError(t *testing.T) {
+	d := newTestDispatcher()
+	recvErr := errors.New("transport broke")
+
+	server := &fakeDurableTaskServer{
+		ctx:  tenantContext(),
+		recv: func() (*contracts.DurableTaskRequest, error) { return nil, recvErr },
+	}
+
+	select {
+	case err := <-runDurableTask(d, server):
+		if !errors.Is(err, recvErr) {
+			t.Fatalf("expected recv error to be surfaced, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("DurableTask did not return after recv error")
+	}
+}
+
+func TestDurableTaskReturnsNilOnEOF(t *testing.T) {
+	d := newTestDispatcher()
+
+	server := &fakeDurableTaskServer{
+		ctx:  tenantContext(),
+		recv: func() (*contracts.DurableTaskRequest, error) { return nil, io.EOF },
+	}
+
+	select {
+	case err := <-runDurableTask(d, server):
+		if err != nil {
+			t.Fatalf("expected nil error on EOF, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("DurableTask did not return after EOF")
+	}
+}

--- a/internal/services/grpc/server.go
+++ b/internal/services/grpc/server.go
@@ -66,6 +66,8 @@ type Server struct {
 	otelCollector otelcol.OTelCollector
 	tls           *tls.Config
 	insecure      bool
+
+	shutdownTimeout time.Duration
 }
 
 type ServerOpt func(*ServerOpts)
@@ -85,6 +87,8 @@ type ServerOpts struct {
 	otelCollector otelcol.OTelCollector
 	tls           *tls.Config
 	insecure      bool
+
+	shutdownTimeout time.Duration
 }
 
 func defaultServerOpts() *ServerOpts {
@@ -98,6 +102,8 @@ func defaultServerOpts() *ServerOpts {
 		port:        7070,
 		bindAddress: "127.0.0.1",
 		insecure:    false,
+
+		shutdownTimeout: 10 * time.Second,
 	}
 }
 
@@ -152,6 +158,17 @@ func WithTLSConfig(tls *tls.Config) ServerOpt {
 func WithInsecure() ServerOpt {
 	return func(opts *ServerOpts) {
 		opts.insecure = true
+	}
+}
+
+// WithShutdownTimeout bounds how long the server waits for in-flight RPCs and
+// streams to drain on graceful shutdown before forcing a hard stop. Non-positive
+// values are ignored.
+func WithShutdownTimeout(timeout time.Duration) ServerOpt {
+	return func(opts *ServerOpts) {
+		if timeout > 0 {
+			opts.shutdownTimeout = timeout
+		}
 	}
 }
 
@@ -218,6 +235,8 @@ func NewServer(fs ...ServerOpt) (*Server, error) {
 		otelCollector: opts.otelCollector,
 		tls:           opts.tls,
 		insecure:      opts.insecure,
+
+		shutdownTimeout: opts.shutdownTimeout,
 	}, nil
 }
 
@@ -366,7 +385,22 @@ func (s *Server) startGRPC() (func() error, error) {
 	}()
 
 	cleanup := func() error {
-		grpcServer.GracefulStop()
+		stopped := make(chan struct{})
+
+		go func() {
+			defer close(stopped)
+			grpcServer.GracefulStop()
+		}()
+
+		select {
+		case <-stopped:
+			s.l.Debug().Msg("grpc server stopped gracefully")
+		case <-time.After(s.shutdownTimeout):
+			s.l.Error().Msgf("grpc server did not drain within %s, forcing a hard stop", s.shutdownTimeout)
+			grpcServer.Stop()
+			<-stopped
+		}
+
 		return nil
 	}
 

--- a/internal/services/shared/streams/registry.go
+++ b/internal/services/shared/streams/registry.go
@@ -15,6 +15,7 @@ import (
 type Registry struct {
 	sessions map[uuid.UUID]context.CancelFunc
 	mu       sync.Mutex
+	closed   bool
 }
 
 func NewRegistry() *Registry {
@@ -26,9 +27,18 @@ func NewRegistry() *Registry {
 // Register adds a stream session's cancel function to the registry and returns a
 // deregister function which the stream handler must defer.
 func (r *Registry) Register(cancel context.CancelFunc) (deregister func()) {
-	id := uuid.New()
-
 	r.mu.Lock()
+
+	if r.closed {
+		// shutdown already drained the registry: hang up the late stream
+		// immediately instead of letting it block GracefulStop
+		r.mu.Unlock()
+		cancel()
+
+		return func() {}
+	}
+
+	id := uuid.New()
 	r.sessions[id] = cancel
 	r.mu.Unlock()
 
@@ -39,9 +49,12 @@ func (r *Registry) Register(cancel context.CancelFunc) (deregister func()) {
 	}
 }
 
-// CancelAll cancels every registered session. It is called once during shutdown.
+// CancelAll cancels every registered session and closes the registry: any
+// session registered afterwards is cancelled immediately. It is called once
+// during shutdown.
 func (r *Registry) CancelAll() {
 	r.mu.Lock()
+	r.closed = true
 	cancels := make([]context.CancelFunc, 0, len(r.sessions))
 
 	for _, cancel := range r.sessions {

--- a/internal/services/shared/streams/registry.go
+++ b/internal/services/shared/streams/registry.go
@@ -1,0 +1,57 @@
+package streams
+
+import (
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// Registry tracks cancellation functions for long-lived gRPC streams (e.g. workflow
+// run subscriptions and durable event listeners) so they can be hung up during
+// graceful shutdown. grpc.Server.GracefulStop waits for open streams to finish;
+// without an active hangup, subscriber streams would block shutdown until the
+// process is killed.
+type Registry struct {
+	sessions map[uuid.UUID]context.CancelFunc
+	mu       sync.Mutex
+}
+
+func NewRegistry() *Registry {
+	return &Registry{
+		sessions: make(map[uuid.UUID]context.CancelFunc),
+	}
+}
+
+// Register adds a stream session's cancel function to the registry and returns a
+// deregister function which the stream handler must defer.
+func (r *Registry) Register(cancel context.CancelFunc) (deregister func()) {
+	id := uuid.New()
+
+	r.mu.Lock()
+	r.sessions[id] = cancel
+	r.mu.Unlock()
+
+	return func() {
+		r.mu.Lock()
+		delete(r.sessions, id)
+		r.mu.Unlock()
+	}
+}
+
+// CancelAll cancels every registered session. It is called once during shutdown.
+func (r *Registry) CancelAll() {
+	r.mu.Lock()
+	cancels := make([]context.CancelFunc, 0, len(r.sessions))
+
+	for _, cancel := range r.sessions {
+		cancels = append(cancels, cancel)
+	}
+
+	r.sessions = make(map[uuid.UUID]context.CancelFunc)
+	r.mu.Unlock()
+
+	for _, cancel := range cancels {
+		cancel()
+	}
+}

--- a/internal/services/shared/streams/registry_test.go
+++ b/internal/services/shared/streams/registry_test.go
@@ -1,0 +1,61 @@
+package streams
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestRegistryCancelAll(t *testing.T) {
+	r := NewRegistry()
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	ctx2, cancel2 := context.WithCancel(context.Background())
+
+	deregister1 := r.Register(cancel1)
+	defer deregister1()
+	deregister2 := r.Register(cancel2)
+	defer deregister2()
+
+	r.CancelAll()
+
+	for _, ctx := range []context.Context{ctx1, ctx2} {
+		select {
+		case <-ctx.Done():
+		case <-time.After(time.Second):
+			t.Fatal("expected context to be cancelled by CancelAll")
+		}
+	}
+}
+
+func TestRegistryDeregister(t *testing.T) {
+	r := NewRegistry()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	deregister := r.Register(cancel)
+	deregister()
+
+	r.CancelAll()
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("deregistered session should not be cancelled by CancelAll")
+	default:
+	}
+}
+
+func TestRegistryCancelAllResets(t *testing.T) {
+	r := NewRegistry()
+
+	_, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r.Register(cancel)
+	r.CancelAll()
+
+	if len(r.sessions) != 0 {
+		t.Fatalf("expected empty registry after CancelAll, got %d sessions", len(r.sessions))
+	}
+}

--- a/internal/services/shared/streams/registry_test.go
+++ b/internal/services/shared/streams/registry_test.go
@@ -59,3 +59,18 @@ func TestRegistryCancelAllResets(t *testing.T) {
 		t.Fatalf("expected empty registry after CancelAll, got %d sessions", len(r.sessions))
 	}
 }
+
+func TestRegistryRegisterAfterCancelAll(t *testing.T) {
+	r := NewRegistry()
+	r.CancelAll()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	deregister := r.Register(cancel)
+	defer deregister()
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("session registered after CancelAll should be cancelled immediately")
+	}
+}

--- a/pkg/cleanup/cleanup.go
+++ b/pkg/cleanup/cleanup.go
@@ -22,7 +22,7 @@ type Cleanup struct {
 func New(logger *zerolog.Logger) Cleanup {
 	return Cleanup{
 		Fns:       []CleanupFn{},
-		TimeLimit: time.Second * 25,
+		TimeLimit: time.Second * 15,
 		logger:    logger,
 	}
 }
@@ -35,12 +35,22 @@ func (c *Cleanup) Add(fn func() error, name string) {
 }
 
 func (c *Cleanup) Run() error {
-	// 1st and last line + 2 lines for each fn. Makes sure we don't block on the chan send
-	lines := make(chan string)
+	// 1st and last line + 2 lines for each fn. The buffer makes sure we don't block
+	// on the chan send: the logger goroutine only starts draining once the context
+	// is resolved, and an unbuffered send would stall Run for the full TimeLimit
+	// before any cleanup fn executes
+	lines := make(chan string, 2+2*len(c.Fns))
+	loggerDone := make(chan struct{})
+	// registered first so it runs last: wait for the logger to drain after
+	// cancel() resolves the context and close(lines) ends its loop, otherwise the
+	// process can exit before the shutdown logs are written
+	defer func() { <-loggerDone }()
 	defer close(lines)
 	ctx, cancel := context.WithTimeout(context.Background(), c.TimeLimit)
 	defer cancel()
 	go func() {
+		defer close(loggerDone)
+
 		// log at the debug level by default
 		logger := c.logger.Debug
 		<-ctx.Done()

--- a/pkg/cleanup/cleanup.go
+++ b/pkg/cleanup/cleanup.go
@@ -22,7 +22,7 @@ type Cleanup struct {
 func New(logger *zerolog.Logger) Cleanup {
 	return Cleanup{
 		Fns:       []CleanupFn{},
-		TimeLimit: time.Second * 9,
+		TimeLimit: time.Second * 25,
 		logger:    logger,
 	}
 }

--- a/pkg/cleanup/cleanup_test.go
+++ b/pkg/cleanup/cleanup_test.go
@@ -1,0 +1,37 @@
+package cleanup
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// Run must not stall waiting for the log-promotion deadline: the logger
+// goroutine only drains the lines channel once the context resolves, so an
+// unbuffered channel would block Run for the full TimeLimit before any
+// cleanup fn executes.
+func TestRunDoesNotStallUntilTimeLimit(t *testing.T) {
+	logger := zerolog.Nop()
+	c := New(&logger)
+	c.TimeLimit = 5 * time.Second
+
+	ran := false
+	c.Add(func() error {
+		ran = true
+		return nil
+	}, "noop")
+
+	start := time.Now()
+	if err := c.Run(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !ran {
+		t.Fatal("cleanup fn did not run")
+	}
+
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("Run took %s; should complete well before the %s TimeLimit", elapsed, c.TimeLimit)
+	}
+}

--- a/pkg/client/dispatcher.go
+++ b/pkg/client/dispatcher.go
@@ -514,8 +514,6 @@ func (a *actionListenerImpl) retrySubscribe(ctx context.Context) error {
 	retries := 0
 
 	for retries < DefaultActionListenerRetryCount {
-		time.Sleep(DefaultActionListenerRetryInterval)
-
 		var err error
 		var listenClient dispatchercontracts.Dispatcher_ListenClient
 
@@ -532,6 +530,7 @@ func (a *actionListenerImpl) retrySubscribe(ctx context.Context) error {
 		if err != nil {
 			retries++
 			a.l.Error().Ctx(ctx).Err(err).Msgf("could not subscribe to the worker")
+			time.Sleep(DefaultActionListenerRetryInterval)
 			continue
 		}
 

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -206,6 +206,9 @@ type ConfigFileRuntime struct {
 	// GRPCRateLimit is the rate limit for the grpc server. We count limits separately for the Workflow, Dispatcher and Events services. Workflow and Events service are set to this rate, Dispatcher is 10X this rate. The rate limit is per second, per engine, per api token.
 	GRPCRateLimit float64 `mapstructure:"grpcRateLimit" json:"grpcRateLimit,omitempty" default:"1000"`
 
+	// GRPCShutdownTimeout is the maximum time to wait for the grpc server to drain in-flight requests and streams on graceful shutdown before forcing a hard stop
+	GRPCShutdownTimeout time.Duration `mapstructure:"grpcShutdownTimeout" json:"grpcShutdownTimeout,omitempty" default:"10s"`
+
 	// EnforceLimits controls whether the server enforces tenant limits
 	EnforceLimits bool `mapstructure:"enforceLimits" json:"enforceLimits,omitempty" default:"false"`
 
@@ -740,6 +743,7 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("runtime.grpcWorkerMaxLockAcquisitionTime", "SERVER_GRPC_WORKER_MAX_LOCK_ACQUISITION_TIME")
 	_ = v.BindEnv("runtime.grpcStaticStreamWindowSize", "SERVER_GRPC_STATIC_STREAM_WINDOW_SIZE")
 	_ = v.BindEnv("runtime.grpcRateLimit", "SERVER_GRPC_RATE_LIMIT")
+	_ = v.BindEnv("runtime.grpcShutdownTimeout", "SERVER_GRPC_SHUTDOWN_TIMEOUT")
 	_ = v.BindEnv("runtime.schedulerConcurrencyRateLimit", "SCHEDULER_CONCURRENCY_RATE_LIMIT")
 	_ = v.BindEnv("runtime.schedulerConcurrencyPollingMinInterval", "SCHEDULER_CONCURRENCY_POLLING_MIN_INTERVAL")
 	_ = v.BindEnv("runtime.schedulerConcurrencyPollingMaxInterval", "SCHEDULER_CONCURRENCY_POLLING_MAX_INTERVAL")


### PR DESCRIPTION
# Description

On every engine rollout, `GracefulStop()` blocks indefinitely on long-lived subscriber streams (`SubscribeToWorkflowEvents`, `SubscribeToWorkflowRuns`, `ListenForDurableEvent`, `DurableTask`) — unlike worker `ListenV2` streams, nothing closes them server-side. The pod is then SIGKILLed at the end of the grace period mid-stream, producing bursts of broken pipe / `UNAVAILABLE` errors on workers and clients (and error-promoted shutdown logs from the cleanup module), even though no work is lost.

This PR makes engine shutdown deterministic:

- A new `streams.Registry` tracks cancel functions for long-lived subscriber/durable streams; the gRPC teardown cancels all sessions first, so `GracefulStop` can complete.
- `GracefulStop` is bounded by a new `runtime.grpcShutdownTimeout` config (`SERVER_GRPC_SHUTDOWN_TIMEOUT`, default `10s`), falling back to a hard `Stop()` with an error log.
- The health server is moved from second to the end of the teardown (only telemetry shutdown and the server/database disconnects follow it), so `/ready` and `/live` reflect the not-ready state for effectively the entire teardown — this is what makes load balancer health checks against `/ready` meaningful during shutdown.
- The cleanup module's `lines` channel is now buffered per its own comment: previously the logger goroutine only started draining once the promotion deadline fired, so `Run()` stalled for the full `TimeLimit` (9s) on *every* shutdown before executing any cleanup fn, and always error-promoted the logs. With the stall fixed, `TimeLimit` is purely a log-promotion threshold; it is raised from 9s to 15s so it only trips when the 10s gRPC drain bound is exhausted and the rest of cleanup is slow.
- On the worker side, `retrySubscribe` no longer sleeps before the first retry attempt, so workers resubscribe immediately when the engine hangs up their stream during a drain.

## Shutdown behavior: before vs after

Before — `GracefulStop` waits forever on subscriber streams, and the kill is what "closes" them:

```mermaid
sequenceDiagram
    participant K8s as kubelet
    participant Engine as EnginePod
    participant Worker as WorkerSDK
    participant Sub as RunSubscriber
    K8s->>Engine: SIGTERM
    Engine->>Engine: health server torn down almost first
    Engine->>Worker: ListenV2 closed (fin)
    Engine->>Engine: GracefulStop waits on subscriber streams
    Note over Engine,Sub: nothing closes these streams server-side,<br/>they end only when the client hangs up
    K8s->>Engine: SIGKILL at end of grace period
    Engine--xWorker: connection severed (broken pipe)
    Engine--xSub: stream severed (UNAVAILABLE)
    Note over Engine: remaining cleanup fns never run
```

After — streams are hung up first, so `GracefulStop` completes and the pod exits cleanly:

```mermaid
sequenceDiagram
    participant K8s as kubelet
    participant Engine as EnginePod
    participant Worker as WorkerSDK
    participant Sub as RunSubscriber
    K8s->>Engine: SIGTERM
    Engine->>Engine: readiness flips to 503 (health server stays up)
    Engine->>Engine: CancelStreamSessions on both dispatchers
    Engine->>Sub: subscriber streams end promptly (cancelled)
    Engine->>Worker: ListenV2 closed (fin)
    Worker->>Worker: reconnects to a healthy replica
    Engine->>Engine: GracefulStop completes (10s bound, hard Stop fallback)
    Engine->>Engine: remaining cleanup, health server shut down at the end
    Engine->>K8s: clean exit, no SIGKILL
```


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] `internal/services/shared/streams`: new session registry; closed after `CancelAll()` so late registrations are cancelled immediately (+ unit tests)
- [x] `internal/services/dispatcher` + `internal/services/dispatcher/v1`: register stream sessions in the five long-lived handlers; `CancelStreamSessions()` on both services. `DurableTask` is restructured so a recv-only goroutine hands messages to the handler goroutine over a channel: cancellation hangs up idle streams, processing is serialized with the deferred stream cleanup (no re-registration after cleanup), and unexpected `Recv` errors are returned to the client again (+ unit tests)
- [x] `internal/services/grpc/server.go`: bounded `GracefulStop` with `WithShutdownTimeout` opt
- [x] `pkg/config/server/server.go`: `runtime.grpcShutdownTimeout` (default 10s)
- [x] `cmd/hatchet-engine/engine/run.go`: cancel sessions at top of gRPC teardown (v0 + v1 paths); health cleanup moved to the end
- [x] `pkg/client/dispatcher.go`: `retrySubscribe` sleeps after a failed attempt instead of before the first one
- [x] `pkg/cleanup/cleanup.go`: buffer the `lines` channel (fixes a `TimeLimit`-long stall before any cleanup fn ran), wait for the logger to drain before returning, TimeLimit 9s → 15s (+ unit test)

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted

## Testing

- New unit tests for the stream session registry and the cleanup module (`go test -race ./internal/services/shared/streams/... ./pkg/cleanup/...`)
- New unit tests for the `DurableTask` stream lifecycle: session cancel unblocks a pending `Recv` and returns nil, recv errors are surfaced, EOF returns nil (`go test -race ./internal/services/dispatcher/v1/...`)
- Existing dispatcher tests pass (`go test ./internal/services/dispatcher/...`)
- `go build` + `go vet` clean on all touched packages
- Manual verification planned: SIGTERM a local engine with an active worker + run subscription, confirm exit within ~10s and prompt stream termination

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Implementation and PR description written with Cursor (Fable 5), based on a shutdown-path audit; reviewed by a human before merge.

</details>
