### PR TITLE
fix(sdks/go): register standalone task cron and event triggers

### DIFF
--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -596,6 +596,23 @@ func (st *StandaloneTask) Dump() (*v1.CreateWorkflowVersionRequest, []internal.N
 // This interface allows both WorkflowOption and TaskOption to be used interchangeably.
 type StandaloneTaskOption any
 
+// promoteTaskTriggers moves cron and event triggers from task options to workflow
+// options. The engine treats these as workflow-level concerns, but the standalone
+// task API exposes them as TaskOption (WithCron, WithEvents) for ergonomics.
+func promoteTaskTriggers(taskOptions []TaskOption, workflowOptions []WorkflowOption) []WorkflowOption {
+	cfg := &taskConfig{}
+	for _, opt := range taskOptions {
+		opt(cfg)
+	}
+	if len(cfg.onCron) > 0 {
+		workflowOptions = append(workflowOptions, WithWorkflowCron(cfg.onCron...))
+	}
+	if len(cfg.onEvents) > 0 {
+		workflowOptions = append(workflowOptions, WithWorkflowEvents(cfg.onEvents...))
+	}
+	return workflowOptions
+}
+
 // NewStandaloneTask creates a standalone task that can be triggered independently.
 // This is a specialized workflow containing only one task, making it easier to create
 // simple single-task workflows without the workflow boilerplate.
@@ -626,6 +643,8 @@ func (c *Client) NewStandaloneTask(name string, fn any, options ...StandaloneTas
 			panic("invalid option type for standalone task - must be WorkflowOption or TaskOption")
 		}
 	}
+
+	workflowOptions = promoteTaskTriggers(taskOptions, workflowOptions)
 
 	// Create a workflow with the same name as the task
 	workflow := c.NewWorkflow(name, workflowOptions...)
@@ -669,6 +688,8 @@ func (c *Client) NewStandaloneDurableTask(name string, fn any, options ...Standa
 			panic("invalid option type for standalone durable task - must be WorkflowOption or TaskOption")
 		}
 	}
+
+	workflowOptions = promoteTaskTriggers(taskOptions, workflowOptions)
 
 	// Create a workflow with the same name as the task
 	workflow := c.NewWorkflow(name, workflowOptions...)

--- a/sdks/go/standalone_triggers_test.go
+++ b/sdks/go/standalone_triggers_test.go
@@ -1,0 +1,82 @@
+//go:build !e2e && !load && !rampup && !integration
+
+package hatchet
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+
+	v0Client "github.com/hatchet-dev/hatchet/pkg/client"
+	cloudrest "github.com/hatchet-dev/hatchet/pkg/client/cloud/rest"
+	"github.com/hatchet-dev/hatchet/pkg/client/rest"
+)
+
+// stubV0Client implements v0Client.Client with minimal stubs so that
+// NewStandaloneTask can build a declaration without a live server.
+type stubV0Client struct{}
+
+func (s *stubV0Client) Admin() v0Client.AdminClient              { return nil }
+func (s *stubV0Client) Cron() v0Client.CronClient                { return nil }
+func (s *stubV0Client) Schedule() v0Client.ScheduleClient        { return nil }
+func (s *stubV0Client) Dispatcher() v0Client.DispatcherClient    { return nil }
+func (s *stubV0Client) Event() v0Client.EventClient              { return nil }
+func (s *stubV0Client) Subscribe() v0Client.SubscribeClient      { return nil }
+func (s *stubV0Client) API() *rest.ClientWithResponses           { return nil }
+func (s *stubV0Client) CloudAPI() *cloudrest.ClientWithResponses { return nil }
+func (s *stubV0Client) Logger() *zerolog.Logger                  { l := zerolog.Nop(); return &l }
+func (s *stubV0Client) TenantId() string                         { return "00000000-0000-0000-0000-000000000000" }
+func (s *stubV0Client) Namespace() string                        { return "" }
+func (s *stubV0Client) CloudRegisterID() *string                 { return nil }
+func (s *stubV0Client) RunnableActions() []string                { return nil }
+
+// newTestClient returns a Client backed by a stub, suitable for
+// offline tests with no server
+func newTestClient() *Client {
+	return &Client{legacyClient: &stubV0Client{}}
+}
+
+// sampleTaskFn is a minimal function matching the standalone task signature.
+func sampleTaskFn(_ Context, _ any) (any, error) { return nil, nil }
+
+// sampleDurableFn is a minimal function matching the standalone durable task signature.
+func sampleDurableFn(_ DurableContext, _ any) (any, error) { return nil, nil }
+
+// WithCron and WithEvents on standalone tasks should appear in the registration request.
+
+func TestNewStandaloneTask_WithCron(t *testing.T) {
+	c := newTestClient()
+	task := c.NewStandaloneTask("cron-task", sampleTaskFn, WithCron("*/5 * * * *"))
+	req, _, _, _ := task.Dump()
+	assert.Equal(t, []string{"*/5 * * * *"}, req.CronTriggers)
+}
+
+func TestNewStandaloneTask_WithEvents(t *testing.T) {
+	c := newTestClient()
+	task := c.NewStandaloneTask("event-task", sampleTaskFn, WithEvents("user:created"))
+	req, _, _, _ := task.Dump()
+	assert.Equal(t, []string{"user:created"}, req.EventTriggers)
+}
+
+func TestNewStandaloneDurableTask_WithCron(t *testing.T) {
+	c := newTestClient()
+	task := c.NewStandaloneDurableTask("durable-cron", sampleDurableFn, WithCron("0 0 * * *"))
+	req, _, _, _ := task.Dump()
+	assert.Equal(t, []string{"0 0 * * *"}, req.CronTriggers)
+}
+
+func TestNewStandaloneTask_MultipleCrons(t *testing.T) {
+	c := newTestClient()
+	task := c.NewStandaloneTask("multi-cron", sampleTaskFn, WithCron("*/5 * * * *", "0 0 * * *"))
+	req, _, _, _ := task.Dump()
+	assert.Equal(t, []string{"*/5 * * * *", "0 0 * * *"}, req.CronTriggers)
+}
+
+func TestNewStandaloneTask_NoTriggers(t *testing.T) {
+	c := newTestClient()
+	task := c.NewStandaloneTask("plain", sampleTaskFn)
+	req, _, _, _ := task.Dump()
+	assert.Empty(t, req.CronTriggers)
+	assert.Empty(t, req.EventTriggers)
+}

--- a/sdks/go/standalone_triggers_test.go
+++ b/sdks/go/standalone_triggers_test.go
@@ -45,18 +45,47 @@ func sampleDurableFn(_ DurableContext, _ any) (any, error) { return nil, nil }
 
 // WithCron and WithEvents on standalone tasks should appear in the registration request.
 
-func TestNewStandaloneTask_WithCron(t *testing.T) {
-	c := newTestClient()
-	task := c.NewStandaloneTask("cron-task", sampleTaskFn, WithCron("*/5 * * * *"))
-	req, _, _, _ := task.Dump()
-	assert.Equal(t, []string{"*/5 * * * *"}, req.CronTriggers)
-}
+func TestNewStandaloneTask_Triggers(t *testing.T) {
+	tests := []struct {
+		name       string
+		taskName   string
+		options    []StandaloneTaskOption
+		wantCron   []string
+		wantEvents []string
+	}{
+		{
+			name:     "with cron",
+			taskName: "cron-task",
+			options:  []StandaloneTaskOption{WithCron("*/5 * * * *")},
+			wantCron: []string{"*/5 * * * *"},
+		},
+		{
+			name:       "with events",
+			taskName:   "event-task",
+			options:    []StandaloneTaskOption{WithEvents("user:created")},
+			wantEvents: []string{"user:created"},
+		},
+		{
+			name:     "multiple crons",
+			taskName: "multi-cron",
+			options:  []StandaloneTaskOption{WithCron("*/5 * * * *", "0 0 * * *")},
+			wantCron: []string{"*/5 * * * *", "0 0 * * *"},
+		},
+		{
+			name:     "no triggers",
+			taskName: "plain",
+		},
+	}
 
-func TestNewStandaloneTask_WithEvents(t *testing.T) {
-	c := newTestClient()
-	task := c.NewStandaloneTask("event-task", sampleTaskFn, WithEvents("user:created"))
-	req, _, _, _ := task.Dump()
-	assert.Equal(t, []string{"user:created"}, req.EventTriggers)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newTestClient()
+			task := c.NewStandaloneTask(tt.taskName, sampleTaskFn, tt.options...)
+			req, _, _, _ := task.Dump()
+			assert.Equal(t, tt.wantCron, req.CronTriggers)
+			assert.Equal(t, tt.wantEvents, req.EventTriggers)
+		})
+	}
 }
 
 func TestNewStandaloneDurableTask_WithCron(t *testing.T) {
@@ -64,19 +93,4 @@ func TestNewStandaloneDurableTask_WithCron(t *testing.T) {
 	task := c.NewStandaloneDurableTask("durable-cron", sampleDurableFn, WithCron("0 0 * * *"))
 	req, _, _, _ := task.Dump()
 	assert.Equal(t, []string{"0 0 * * *"}, req.CronTriggers)
-}
-
-func TestNewStandaloneTask_MultipleCrons(t *testing.T) {
-	c := newTestClient()
-	task := c.NewStandaloneTask("multi-cron", sampleTaskFn, WithCron("*/5 * * * *", "0 0 * * *"))
-	req, _, _, _ := task.Dump()
-	assert.Equal(t, []string{"*/5 * * * *", "0 0 * * *"}, req.CronTriggers)
-}
-
-func TestNewStandaloneTask_NoTriggers(t *testing.T) {
-	c := newTestClient()
-	task := c.NewStandaloneTask("plain", sampleTaskFn)
-	req, _, _, _ := task.Dump()
-	assert.Empty(t, req.CronTriggers)
-	assert.Empty(t, req.EventTriggers)
 }


### PR DESCRIPTION
# Description

Fixes #4127

`WithCron` and `WithEvents` were accepted by `NewStandaloneTask`, but the triggers were not included in the workflow registration request. Standalone tasks are implemented as single-task workflows, and triggers need to be registered at the workflow level.

This PR registers standalone task cron and event triggers as workflow-level triggers before creating the underlying workflow. The same fix is applied to `NewStandaloneDurableTask`.

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] Test changes (add, refactor, improve or change a test)

## What's Changed

* [x] Register `WithCron` from standalone task options as workflow-level cron triggers.
* [x] Register `WithEvents` from standalone task options as workflow-level event triggers.
* [x] Apply the same behavior to `NewStandaloneTask` and `NewStandaloneDurableTask`.
* [x] Add Go SDK tests covering standalone task cron and event trigger registration output.

## Checklist

Changes have been:

* [x] Tested (unit, integration, or manually with steps specified)
* [x] Linted and formatted

## Testing

```sh
gofmt -w sdks/go/client.go sdks/go/standalone_triggers_test.go
go test -run "TestNewStandalone" ./sdks/go/
go test ./sdks/go/
go build ./sdks/go/...
go vet ./sdks/go/...
```

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

* [x] *I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md).*

* **Details**: Claude Code was used to investigate the bug and advise on a minimal fix. I validated the fix locally before submitting.

</details>