### PR TITLE
fix(ci): allow changelog dir in gen-examples allowlists

### DIFF
--- a/.github/workflows/gen-examples.yml
+++ b/.github/workflows/gen-examples.yml
@@ -39,7 +39,7 @@ jobs:
           # Check if there are any changes
           if [ -n "$(git status --porcelain)" ]; then
             CHANGED_FILES=$(git status --porcelain | awk '{print $2}')
-            NON_EXAMPLES_CHANGES=$(echo "$CHANGED_FILES" | grep -v "^examples/" || true)
+            NON_EXAMPLES_CHANGES=$(echo "$CHANGED_FILES" | grep -v "^examples/" | grep -v "^frontend/docs/pages/reference/changelog/" || true)
 
             if [ -n "$NON_EXAMPLES_CHANGES" ]; then
               echo "Error: Changes detected outside of examples directory:"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

The [generate examples workflow](https://github.com/hatchet-dev/hatchet/actions/runs/27309080341/job/80674468106) aborts when `task generate-docs` also regenerates changelog MDX via `sync-changelog`, because the post-generation safety check only allows changes under `examples/`. This allowlists `frontend/docs/pages/reference/changelog/` so those autogenerated files no longer fail the check.

This complements (but is separate from) #4145, which syncs the current changelog drift.

Fixes # (issue)

## Type of change

- [x] CI (any automation pipeline changes)

## What's Changed

- [x] Whitelist `frontend/docs/pages/reference/changelog/` in the gen-examples workflow's "changes outside of examples directory" check

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Assisted with locating the workflow check, applying the whitelist change, and opening this draft PR.

</details>