### PR TITLE
fix: Use new connection from ddlPool to set timeout on task partition creation

### DIFF
--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -370,20 +370,25 @@ func (r *TaskRepositoryImpl) UpdateTablePartitions(ctx context.Context) error {
 	// important: uses the ddlPool because these operations are critical (shouldn't be blocked by the main app pool)
 	// and not all can run inside of a transaction (e.g. DETACH PARTITION CONCURRENTLY),
 	// so they cannot go through pgbouncer when it's configured.
+	ddlConn, release, err := sqlchelpers.AcquireConnectionWithStatementTimeout(ctx, r.ddlPool, r.l, 30*60*1000) // nolint:govet
+	if err != nil {
+		r.l.Error().Err(err).Msg("failed to acquire connection from ddlPool")
+	}
 	releaseCreateConn := func() {
 		resetCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		if _, resetErr := r.ddlPool.Exec(resetCtx, "SET lock_timeout = 0"); resetErr != nil {
+		defer release()
+		if _, resetErr := ddlConn.Exec(resetCtx, "SET lock_timeout = 0"); resetErr != nil {
 			r.l.Error().Err(resetErr).Msg("failed to reset lock_timeout on DDL connection")
 		}
 	}
 
-	if _, err = r.ddlPool.Exec(ctx, "SET lock_timeout = '5s'"); err != nil {
+	if _, err = ddlConn.Exec(ctx, "SET lock_timeout = '5s'"); err != nil {
 		releaseCreateConn()
 		return fmt.Errorf("failed to set lock_timeout: %w", err)
 	}
 
-	err = r.queries.CreatePartitions(ctx, r.ddlPool, pgtype.Date{
+	err = r.queries.CreatePartitions(ctx, ddlConn, pgtype.Date{
 		Time:  today,
 		Valid: true,
 	})
@@ -396,7 +401,7 @@ func (r *TaskRepositoryImpl) UpdateTablePartitions(ctx context.Context) error {
 		return err
 	}
 
-	err = r.queries.CreatePartitions(ctx, r.ddlPool, pgtype.Date{
+	err = r.queries.CreatePartitions(ctx, ddlConn, pgtype.Date{
 		Time:  tomorrow,
 		Valid: true,
 	})


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Before we were setting the lock timeout on `r.ddlPool` directly, which would potentially pick a new connection, and not roll back the timeout correctly.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
