### PR TITLE
feat: Add `getDetails` method to TS SDK

### DIFF
--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Hatchet's TypeScript SDK will be documented in this chang
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.0] - 2026-06-11
+
+### Added
+
+- Added a `getDetails` method to `hatchet.runs` to retrieve task details.
+
+
 ## [1.23.1] - 2026-06-09
 
 ### Added

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "description": "Background task orchestration & visibility for developers",
   "types": "dist/index.d.ts",
   "files": [

--- a/sdks/typescript/src/v1/client/features/runs.ts
+++ b/sdks/typescript/src/v1/client/features/runs.ts
@@ -6,6 +6,79 @@ import {
 } from '@hatchet/clients/listeners/run-listener/child-listener-client';
 import { WorkflowsClient } from './workflows';
 import { HatchetClient } from '../client';
+import {
+  AdminServiceClient,
+  AdminServiceDefinition,
+  GetRunDetailsResponse,
+  RunStatus,
+  runStatusToJSON,
+} from '@hatchet/protoc/v1/workflows';
+import { ClientConfig } from '@hatchet/clients/hatchet-client';
+import { createGrpcClient } from '@hatchet/util/grpc-helpers';
+
+export type RunDetail = {
+  status: V1TaskStatus;
+  done: boolean;
+  input: unknown;
+  additionalMetadata: unknown;
+  isEvicted: boolean;
+  taskRuns: Record<string, TaskRunDetail>;
+};
+
+export type TaskRunDetail = {
+  externalId: string;
+  readableId: string;
+  status: V1TaskStatus;
+  output: unknown;
+  error?: string;
+  isEvicted: boolean;
+};
+
+// EVICTED is not in V1TaskStatus; treat as RUNNING per the proto comment.
+const PROTO_STATUS_MAP: Record<RunStatus, V1TaskStatus> = {
+  [RunStatus.QUEUED]: V1TaskStatus.QUEUED,
+  [RunStatus.RUNNING]: V1TaskStatus.RUNNING,
+  [RunStatus.COMPLETED]: V1TaskStatus.COMPLETED,
+  [RunStatus.FAILED]: V1TaskStatus.FAILED,
+  [RunStatus.CANCELLED]: V1TaskStatus.CANCELLED,
+  [RunStatus.EVICTED]: V1TaskStatus.RUNNING,
+  [RunStatus.UNRECOGNIZED]: V1TaskStatus.RUNNING,
+};
+
+function decodeBytes(b: Uint8Array | undefined): unknown {
+  if (!b?.length) return null;
+  try {
+    return JSON.parse(new TextDecoder().decode(b));
+  } catch {
+    return null;
+  }
+}
+
+function toRunDetail(raw: GetRunDetailsResponse): RunDetail {
+  return {
+    status: PROTO_STATUS_MAP[raw.status] ?? V1TaskStatus.RUNNING,
+    done: raw.done,
+    input: decodeBytes(raw.input),
+    additionalMetadata: decodeBytes(raw.additionalMetadata),
+    isEvicted: raw.isEvicted,
+    taskRuns: Object.fromEntries(
+      Object.entries(raw.taskRuns).map(([id, tr]) => [
+        id,
+        {
+          externalId: tr.externalId,
+          readableId: tr.readableId,
+          status: PROTO_STATUS_MAP[tr.status] ?? V1TaskStatus.RUNNING,
+          output: decodeBytes(tr.output),
+          error: tr.error,
+          isEvicted: tr.isEvicted,
+        } satisfies TaskRunDetail,
+      ])
+    ),
+  };
+}
+
+// Keep runStatusToJSON importable for callers who want the raw proto status as a string.
+export { runStatusToJSON };
 
 export type RunFilter = {
   since?: Date;
@@ -85,13 +158,23 @@ export class RunsClient {
   tenantId: string;
   workflows: WorkflowsClient;
   listener: RunListenerClient;
+  private _config: ClientConfig;
+  private _adminGrpc: AdminServiceClient | undefined;
 
   constructor(client: HatchetClient) {
     this.api = client.api;
     this.tenantId = client.tenantId;
     this.workflows = client.workflows;
-
     this.listener = client._listener;
+    this._config = client.config;
+  }
+
+  private get adminGrpc(): AdminServiceClient {
+    if (!this._adminGrpc) {
+      const { client } = createGrpcClient(this._config, AdminServiceDefinition);
+      this._adminGrpc = client;
+    }
+    return this._adminGrpc;
   }
 
   /**
@@ -116,6 +199,16 @@ export class RunsClient {
 
     const { data } = await this.api.v1WorkflowRunGetStatus(runId);
     return data;
+  }
+
+  /**
+   * Gets run details
+   * @param run - The workflow run ID (string) or a WorkflowRunRef.
+   * @returns A promise resolving to GetRunDetailsResponse with task run statuses and outputs.
+   */
+  async getDetails<T = any>(run: string | WorkflowRunRef<T>): Promise<RunDetail> {
+    const runId = typeof run === 'string' ? run : await run.getWorkflowRunId();
+    return toRunDetail(await this.adminGrpc.getRunDetails({ externalId: runId }));
   }
 
   /**

--- a/sdks/typescript/src/v1/examples/run_details/get_details.e2e.ts
+++ b/sdks/typescript/src/v1/examples/run_details/get_details.e2e.ts
@@ -1,0 +1,50 @@
+import { randomUUID } from 'crypto';
+import { makeE2EClient, poll } from '../__e2e__/harness';
+import { runDetailTestWorkflow } from './workflow';
+import { V1TaskStatus } from '../../../clients/rest/generated/data-contracts';
+
+describe('getDetails-e2e', () => {
+  const hatchet = makeE2EClient();
+
+  it('returns gRPC run details that eventually show the run as done', async () => {
+    const mockInput = { foo: randomUUID() };
+
+    const ref = await runDetailTestWorkflow.runNoWait(mockInput);
+
+    const details = await poll(async () => hatchet.runs.getDetails(ref), {
+      timeoutMs: 60_000,
+      intervalMs: 500,
+      label: 'getDetails done=true',
+      shouldStop: (d) => d.done,
+    });
+    console.info(details);
+    expect(details.done).toBe(true);
+    expect([V1TaskStatus.COMPLETED, V1TaskStatus.FAILED, V1TaskStatus.CANCELLED]).toContain(
+      details.status
+    );
+    expect(Object.keys(details.taskRuns).length).toBeGreaterThan(0);
+
+    for (const taskRun of Object.values(details.taskRuns)) {
+      expect(taskRun.externalId).toBeTruthy();
+      expect(taskRun.readableId).toBeTruthy();
+      expect([V1TaskStatus.COMPLETED, V1TaskStatus.FAILED, V1TaskStatus.CANCELLED]).toContain(
+        taskRun.status
+      );
+    }
+  }, 120_000);
+
+  it('can be called mid-execution and returns in-progress task runs', async () => {
+    const ref = await runDetailTestWorkflow.runNoWait({ foo: randomUUID() });
+
+    // Poll until at least one task run appears (run has started)
+    const details = await poll(async () => hatchet.runs.getDetails(ref), {
+      timeoutMs: 30_000,
+      intervalMs: 100,
+      label: 'getDetails has task runs',
+      shouldStop: (d) => Object.keys(d.taskRuns).length > 0,
+    });
+
+    expect(details.status).toBeDefined();
+    expect(Object.keys(details.taskRuns).length).toBeGreaterThan(0);
+  }, 60_000);
+});

--- a/sdks/typescript/src/v1/index.ts
+++ b/sdks/typescript/src/v1/index.ts
@@ -1,5 +1,6 @@
 export * from './client/client';
 export * from './client/features';
+export type { RunDetail, TaskRunDetail } from './client/features/runs';
 export * from './client/worker/worker';
 export * from './declaration';
 export * from './conditions';


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Adds a `getDetails` method that uses gRPC rather than the REST client so it isn't effected by OLAP lag.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]
generating tests
</details>
