### PR TITLE
fix(engine): durable multi slot defaulting to no slots on the legacy path

### DIFF
--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -61,8 +61,12 @@ func (s *DispatcherImpl) Register(ctx context.Context, request *contracts.Worker
 	if len(request.SlotConfig) > 0 {
 		opts.SlotConfig = request.SlotConfig
 	} else {
-		// default to 100 slots
-		opts.SlotConfig = map[string]int32{v1.SlotTypeDefault: 100}
+		// default to 100 slots for both slot types so that legacy workers (which don't
+		// send slot_config) can still receive durable tasks
+		opts.SlotConfig = map[string]int32{
+			v1.SlotTypeDefault: 100,
+			v1.SlotTypeDurable: 100,
+		}
 	}
 
 	// fixme: deprecated remove in a future release feb6 2026
@@ -71,7 +75,10 @@ func (s *DispatcherImpl) Register(ctx context.Context, request *contracts.Worker
 			return nil, status.Errorf(codes.InvalidArgument, "either slot_config or slots (deprecated) must be provided, not both")
 		}
 
-		opts.SlotConfig = map[string]int32{v1.SlotTypeDefault: *request.Slots}
+		opts.SlotConfig = map[string]int32{
+			v1.SlotTypeDefault: *request.Slots,
+			v1.SlotTypeDurable: *request.Slots,
+		}
 	}
 
 	if apiErrors, err := s.v.ValidateAPI(opts); err != nil {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
