### PR TITLE
fix: gate loadtest emission on registration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -523,20 +523,55 @@ jobs:
       - name: Start engine
         run: |
           go run ./cmd/hatchet-engine --config ./generated > /tmp/engine.log 2>&1 &
-          echo $! > /tmp/engine.pid
-          echo "Waiting 30s for engine to start..."
-          sleep 30
+          ENGINE_PID=$!
+          echo $ENGINE_PID > /tmp/engine.pid
+
+          echo "Waiting for engine gRPC port 7077..."
+          for _ in {1..60}; do
+            if ! kill -0 "$ENGINE_PID" 2>/dev/null; then
+              echo "Engine exited before becoming ready:"
+              tail -50 /tmp/engine.log
+              exit 1
+            fi
+
+            if nc -z localhost 7077; then
+              echo "Engine is accepting connections on port 7077"
+              exit 0
+            fi
+
+            sleep 1
+          done
+
+          echo "Timed out waiting for engine gRPC port 7077"
+          tail -50 /tmp/engine.log
+          exit 1
 
       - name: Run load test with migrations
         run: |
           HATCHET_CLIENT_TOKEN="${{ env.HATCHET_CLIENT_TOKEN }}" \
           HATCHET_CLIENT_TLS_STRATEGY=none \
           HATCHET_CLIENT_HOST_PORT=localhost:7077 \
-          go run ./cmd/hatchet-loadtest loadtest -e 10 -d 240s -w 60s -s 100 > /tmp/loadtest.log 2>&1 &
+          go run ./cmd/hatchet-loadtest loadtest -e 10 -d 240s -w 60s -s 100 \
+            --registrationTimeout 20s > /tmp/loadtest.log 2>&1 &
           LOADTEST_PID=$!
           echo $LOADTEST_PID > /tmp/loadtest.pid
 
+          (
+            while kill -0 "$LOADTEST_PID" 2>/dev/null; do
+              ENGINE_PID=$(cat /tmp/engine.pid)
+              if ! kill -0 "$ENGINE_PID" 2>/dev/null; then
+                echo "Engine died during load test:"
+                tail -50 /tmp/engine.log
+                kill "$LOADTEST_PID" 2>/dev/null || true
+                exit 1
+              fi
+              sleep 5
+            done
+          ) &
+          WATCHER=$!
+
           echo "Waiting 30s for load test to get started..."
+          # Keep this above the 20s registration timeout so PutWorkflow must succeed on the N-1 schema.
           sleep 30
 
           echo "Applying last migration..."
@@ -552,14 +587,32 @@ jobs:
           echo "Re-migration successful"
 
           echo "Waiting for load test to complete..."
-          if ! wait $LOADTEST_PID; then
+          set +e
+          wait $LOADTEST_PID
+          LOADTEST_RC=$?
+          set -e
+
+          kill "$WATCHER" 2>/dev/null || true
+          wait "$WATCHER" 2>/dev/null || true
+
+          if [ "$LOADTEST_RC" -ne 0 ]; then
             echo "=== Load test logs ==="
             cat /tmp/loadtest.log
             echo "=== Engine logs ==="
             cat /tmp/engine.log
-            exit 1
+            exit "$LOADTEST_RC"
           fi
           echo "Load test passed"
+
+      - name: Upload load-online-migrate logs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: load-online-migrate-logs
+          path: |
+            /tmp/engine.log
+            /tmp/loadtest.log
+          if-no-files-found: ignore
 
       - name: Teardown
         if: always()

--- a/cmd/hatchet-loadtest/do.go
+++ b/cmd/hatchet-loadtest/do.go
@@ -78,10 +78,14 @@ func do(config LoadTestConfig) error {
 	l.Info().Msgf("testing with duration=%s, eventsPerSecond=%d, delay=%s, wait=%s, concurrency=%d, averageDurationThreshold=%s", config.Duration, config.Events, config.Delay, config.Wait, config.Concurrency, config.AverageDurationThreshold)
 
 	after := 10 * time.Second
+	registrationTimeout := config.RegistrationTimeout
+	if registrationTimeout == 0 {
+		registrationTimeout = 60 * time.Second
+	}
 
 	// The worker may intentionally be delayed (WorkerDelay) before it starts consuming tasks.
-	// The test timeout must include this delay, otherwise we can cancel while work is still expected to complete.
-	timeout := config.WorkerDelay + after + config.Duration + config.Wait + 30*time.Second
+	// The test timeout must include registration and this delay, otherwise we can cancel while work is still expected to complete.
+	timeout := registrationTimeout + config.WorkerDelay + after + config.Duration + config.Wait + 30*time.Second
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -90,7 +94,7 @@ func do(config LoadTestConfig) error {
 	durations := make(chan executionEvent, config.Events)
 
 	// Compute running average for executed durations using a rolling average.
-	durationsResult := make(chan avgResult)
+	durationsResult := make(chan avgResult, 1)
 	go func() {
 		var count int64
 		var avg time.Duration
@@ -111,31 +115,19 @@ func do(config LoadTestConfig) error {
 		durationsResult <- avgResult{count: count, avg: avg, latencyResult: LatencyResult{snapshots: snapshots}}
 	}()
 
-	// Start worker and ensure it has time to register
-	workerStarted := make(chan struct{})
+	registered := make(chan error, 1)
 
 	go func() {
-		if config.WorkerDelay > 0 {
-			// run a worker to register the workflow
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			run(ctx, config, durations)
-			cancel()
-			l.Info().Msgf("wait %s before starting the worker", config.WorkerDelay)
-			time.Sleep(config.WorkerDelay)
-		}
-		l.Info().Msg("starting worker now")
-
-		// Signal that worker is starting
-		close(workerStarted)
-
-		count, uniques := run(ctx, config, durations)
+		count, uniques := run(ctx, config, durations, registered)
 		close(durations)
 		ch <- count
 		ch <- uniques
 	}()
 
-	// Wait for worker to start, then give it time to register workflows
-	<-workerStarted
+	if err := waitForRegistration(registered, registrationTimeout); err != nil {
+		return fmt.Errorf("❌ workflow registration failed within %s — engine must accept PutWorkflow on the current (pre-migration) schema: %w", registrationTimeout, err)
+	}
+
 	time.Sleep(after)
 
 	scheduled := make(chan time.Duration, config.Events)

--- a/cmd/hatchet-loadtest/emit.go
+++ b/cmd/hatchet-loadtest/emit.go
@@ -89,7 +89,7 @@ func emit(ctx context.Context, namespace string, amountPerSecond int, duration t
 						if ctx.Err() != nil {
 							return
 						}
-						panic(fmt.Errorf("error pushing event: %w", err))
+						panic(fmt.Errorf("error pushing event after exhausting gRPC retries — engine unreachable, check engine logs: %w", err))
 					}
 
 					atomic.AddInt64(&pushed, 1)

--- a/cmd/hatchet-loadtest/gate.go
+++ b/cmd/hatchet-loadtest/gate.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func waitForRegistration(registered <-chan error, timeout time.Duration) error {
+	select {
+	case err := <-registered:
+		return err
+	case <-time.After(timeout):
+		return fmt.Errorf("timed out after %s waiting for workflow registration", timeout)
+	}
+}

--- a/cmd/hatchet-loadtest/gate_test.go
+++ b/cmd/hatchet-loadtest/gate_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWaitForRegistrationSuccess(t *testing.T) {
+	registered := make(chan error, 1)
+	registered <- nil
+
+	if err := waitForRegistration(registered, time.Second); err != nil {
+		t.Fatalf("waitForRegistration() error = %v, want nil", err)
+	}
+}
+
+func TestWaitForRegistrationPropagatesError(t *testing.T) {
+	wantErr := errors.New("registration failed")
+	registered := make(chan error, 1)
+	registered <- wantErr
+
+	if err := waitForRegistration(registered, time.Second); !errors.Is(err, wantErr) {
+		t.Fatalf("waitForRegistration() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestWaitForRegistrationTimeout(t *testing.T) {
+	registered := make(chan error, 1)
+
+	err := waitForRegistration(registered, time.Millisecond)
+	if err == nil {
+		t.Fatal("waitForRegistration() error = nil, want timeout")
+	}
+
+	if !strings.Contains(err.Error(), "timed out after 1ms waiting for workflow registration") {
+		t.Fatalf("waitForRegistration() error = %q, want timeout message", err)
+	}
+}

--- a/cmd/hatchet-loadtest/load_e2e_test.go
+++ b/cmd/hatchet-loadtest/load_e2e_test.go
@@ -134,7 +134,7 @@ func TestLoadCLI(t *testing.T) {
 				Duration:                 240 * time.Second,
 				Events:                   10,
 				Delay:                    0 * time.Second,
-				WorkerDelay:              120 * time.Second, // will write 1200 events before the worker is ready
+				WorkerDelay:              120 * time.Second, // will write about 1100 events before the worker is ready
 				Wait:                     120 * time.Second,
 				Concurrency:              0,
 				Slots:                    100,

--- a/cmd/hatchet-loadtest/load_e2e_test.go
+++ b/cmd/hatchet-loadtest/load_e2e_test.go
@@ -145,7 +145,7 @@ func TestLoadCLI(t *testing.T) {
 				RlKeys:                   0,
 				RlLimit:                  0,
 				RlDurationUnit:           "",
-				AverageDurationThreshold: avgThreshold,
+				AverageDurationThreshold: 45 * time.Second, // includes intentional queue wait from WorkerDelay
 			},
 		},
 		{

--- a/cmd/hatchet-loadtest/main.go
+++ b/cmd/hatchet-loadtest/main.go
@@ -26,6 +26,7 @@ type LoadTestConfig struct {
 	Wait                     time.Duration
 	Delay                    time.Duration
 	WorkerDelay              time.Duration
+	RegistrationTimeout      time.Duration
 	Slots                    int
 	FailureRate              float32
 	PayloadSize              string
@@ -74,6 +75,8 @@ func main() {
 	loadtest.Flags().DurationVarP(&config.Delay, "delay", "D", 0, "delay specifies the time to wait in each event to simulate slow tasks")
 	loadtest.Flags().DurationVarP(&config.Wait, "wait", "w", 10*time.Second, "wait specifies the total time to wait until events complete")
 	loadtest.Flags().DurationVarP(&config.WorkerDelay, "workerDelay", "p", 0*time.Second, "workerDelay specifies the time to wait before starting the worker")
+	// CI's load-online-migrate passes 20s: it must stay below that workflow's 30s pre-migration sleep so registration is forced to succeed against the N-1 schema.
+	loadtest.Flags().DurationVar(&config.RegistrationTimeout, "registrationTimeout", 60*time.Second, "registrationTimeout specifies the total time to wait for workflow registration before emitting events")
 	loadtest.Flags().IntVarP(&config.Slots, "slots", "s", 0, "slots specifies the number of slots to use in the worker")
 	loadtest.Flags().Float32VarP(&config.FailureRate, "failureRate", "f", 0, "failureRate specifies the rate of failure for the worker")
 	loadtest.Flags().StringVarP(&config.PayloadSize, "payloadSize", "P", "0kb", "payload specifies the size of the payload to send")

--- a/cmd/hatchet-loadtest/rampup/do.go
+++ b/cmd/hatchet-loadtest/rampup/do.go
@@ -23,7 +23,8 @@ type taskTracker struct {
 func do(duration time.Duration, startEventsPerSecond, amount int, increase, delay, wait, maxAcceptableDuration, maxAcceptableSchedule time.Duration, includeDroppedEvents bool, concurrency int) error {
 	l.Debug().Msgf("testing with duration=%s, amount=%d, increase=%d, delay=%s, wait=%s, concurrency=%d", duration, amount, increase, delay, wait, concurrency)
 
-	ctx, cancel := context.WithTimeout(context.Background(), duration+10*time.Second+wait+5*time.Second)
+	registrationTimeout := 60 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), registrationTimeout+duration+10*time.Second+wait+5*time.Second)
 	defer cancel()
 
 	after := 10 * time.Second
@@ -144,9 +145,14 @@ func do(duration time.Duration, startEventsPerSecond, amount int, increase, dela
 		}
 	}()
 
+	registered := make(chan error, 1)
 	go func() {
-		run(ctx, delay, concurrency, maxAcceptableDuration, hook, executed, executionTimes)
+		run(ctx, delay, concurrency, maxAcceptableDuration, hook, executed, executionTimes, registered)
 	}()
+
+	if err := waitForRegistration(registered, registrationTimeout); err != nil {
+		panic(fmt.Errorf("workflow registration failed within %s: %w", registrationTimeout, err))
+	}
 
 	emitted := emit(ctx, startEventsPerSecond, amount, increase, duration, maxAcceptableSchedule, hook, scheduled, scheduledTimes)
 

--- a/cmd/hatchet-loadtest/rampup/gate.go
+++ b/cmd/hatchet-loadtest/rampup/gate.go
@@ -1,0 +1,15 @@
+package rampup
+
+import (
+	"fmt"
+	"time"
+)
+
+func waitForRegistration(registered <-chan error, timeout time.Duration) error {
+	select {
+	case err := <-registered:
+		return err
+	case <-time.After(timeout):
+		return fmt.Errorf("timed out after %s waiting for workflow registration", timeout)
+	}
+}

--- a/cmd/hatchet-loadtest/rampup/run.go
+++ b/cmd/hatchet-loadtest/rampup/run.go
@@ -18,7 +18,7 @@ func getConcurrencyKey(ctx worker.HatchetContext) (string, error) {
 	return "my-key", nil
 }
 
-func run(ctx context.Context, delay time.Duration, concurrency int, maxAcceptableDuration time.Duration, hook chan<- time.Duration, executedCh chan<- int64, executionTimes chan<- time.Duration) (int64, int64) {
+func run(ctx context.Context, delay time.Duration, concurrency int, maxAcceptableDuration time.Duration, hook chan<- time.Duration, executedCh chan<- int64, executionTimes chan<- time.Duration, registered chan<- error) (int64, int64) {
 	c, err := client.New(
 		client.WithLogLevel("warn"), // nolint: staticcheck
 	)
@@ -103,7 +103,14 @@ func run(ctx context.Context, delay time.Duration, concurrency int, maxAcceptabl
 	)
 
 	if err != nil {
-		panic(err)
+		registered <- fmt.Errorf("error registering workflow: %w", err)
+		return 0, 0
+	}
+
+	registered <- nil
+
+	if ctx.Err() != nil {
+		return 0, 0
 	}
 
 	cleanup, err := w.Start()

--- a/cmd/hatchet-loadtest/run.go
+++ b/cmd/hatchet-loadtest/run.go
@@ -27,7 +27,7 @@ type executionEvent struct {
 	duration  time.Duration
 }
 
-func run(ctx context.Context, config LoadTestConfig, executions chan<- executionEvent) (int64, int64) {
+func run(ctx context.Context, config LoadTestConfig, executions chan<- executionEvent, registered chan<- error) (int64, int64) {
 	hatchet, err := v1.NewHatchetClient(
 		v1.Config{
 			Namespace: config.Namespace,
@@ -174,8 +174,22 @@ func run(ctx context.Context, config LoadTestConfig, executions chan<- execution
 	)
 
 	if err != nil {
-		panic(fmt.Errorf("error creating worker: %w", err))
+		registered <- fmt.Errorf("error creating worker (workflow registration): %w", err)
+		return 0, 0
 	}
+
+	registered <- nil
+
+	if ctx.Err() != nil {
+		return 0, 0
+	}
+
+	if config.WorkerDelay > 0 {
+		l.Info().Msgf("waiting %s before starting the worker", config.WorkerDelay)
+		time.Sleep(config.WorkerDelay)
+	}
+
+	l.Info().Msg("starting worker now")
 
 	cleanup, err := worker.Start()
 	if err != nil {


### PR DESCRIPTION
# Description

Context: this test failed on over 50% of PRs recently, this is an attempt at fixing it. It's automated, as in it comes from an agent, but it was reviewed by a human before submitting. We will only gain adopting it :) Bonus: it also improves error messages on failures.

Fixes the `load-online-migrate` flake by gating loadtest event emission on confirmed workflow registration instead of a blind worker-start sleep. This turns slow or broken registration against the N-1 schema into an explicit registration failure and prevents pre-registration events from being counted as phantom losses.

The PR also improves diagnostics for the online-migration job: engine startup now polls the engine-only gRPC port (`7077`) with process liveness checks, the loadtest uses `--registrationTimeout 20s`, and failure logs are uploaded as artifacts. The 20s timeout intentionally stays below the workflow's 30s pre-migration sleep so `PutWorkflow` must succeed on the N-1 schema rather than after the migration.

This restores the documented `WorkerDelay` behavior too: the delayed-worker case now emits while the registered worker waits to start, so queue buildup is actually exercised again. The mid-test migration is now anchored after confirmed registration rather than process start; on a healthy engine this should be sub-second, but the stress window is deliberately tied to registration readiness.

Fixes #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI (any automation pipeline changes)
- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

- [x] Added a registration gate and `--registrationTimeout` for `cmd/hatchet-loadtest` before event emission starts.
- [x] Mirrored the registration gate in the `rampup` loadtest variant.
- [x] Added unit coverage for registration success, timeout, and registration-error propagation.
- [x] Replaced blind `load-online-migrate` engine startup sleep with readiness/liveness checks and failure artifacts.

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

- `go test ./cmd/hatchet-loadtest/... -run TestWaitForRegistration -count=1`
- `go test -c -tags load -o <tmp>/loadtest.test ./cmd/hatchet-loadtest`
- `go test -c -tags rampup -o <tmp>/rampup.test ./cmd/hatchet-loadtest/rampup`
- `git diff --check -- cmd/hatchet-loadtest .github/workflows/test.yml`
- Pre-commit hook: merge-conflict check, mixed line endings, EOF, trailing whitespace, YAML, `golangci-lint`

## Related

Example failing runs from the investigation:

- https://github.com/hatchet-dev/hatchet/actions/runs/27322189057
- https://github.com/hatchet-dev/hatchet/actions/runs/27093953949

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Cursor agent used to implement the registration gate, tests, CI workflow diagnostics, and local validation.

</details>