### PR TITLE
fix(ci): Staging in generate examples action

### DIFF
--- a/.github/workflows/gen-examples.yml
+++ b/.github/workflows/gen-examples.yml
@@ -60,7 +60,7 @@ jobs:
           git config --local user.name "GitHub Action"
           BRANCH_NAME="regenerate-examples-${{ github.sha }}"
           git checkout -b "$BRANCH_NAME"
-          git add examples/
+          git add -u && git add examples/
           git commit -m "chore: regenerate examples"
           git push origin "$BRANCH_NAME"
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

We need to ensure uncommitted files are staged before opening a PR using the re-generated examples + docs. 

Since we guard against files not in `examples/` or `changelog/`, and always stage the entire `examples/` directory, the `-u` ensures the modified changelogs are correctly staged.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] CI (any automation pipeline changes)
- [x] Chore (changes which are not directly related to any business logic)


## What's Changed

- Stages all modified files in addition to the entire `examples/` repo.

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
