### PR TITLE
fix(dashboard): persist sidebar scroll position across navigation

### DIFF
--- a/frontend/app/src/components/hooks/use-sidebar.tsx
+++ b/frontend/app/src/components/hooks/use-sidebar.tsx
@@ -14,7 +14,6 @@ type SidebarState = 'open' | 'closed';
 const SIDEBAR_WIDTH_LEGACY_KEY = 'v1SidebarWidth';
 const SIDEBAR_WIDTH_EXPANDED_KEY = 'v1SidebarWidthExpanded';
 const SIDEBAR_COLLAPSED_KEY = 'v1SidebarCollapsed';
-const SIDEBAR_SCROLL_KEY = 'v1SidebarScroll';
 
 // Tailwind's `md` breakpoint (px). Used to decide when the v1 sidebar is a persistent column.
 const WIDE_BREAKPOINT_PX = 768;
@@ -45,8 +44,6 @@ type SidebarProviderState = {
   toggleCollapsed: () => void;
   expandedWidth: number;
   setExpandedWidth: (width: number) => void;
-  scrollPosition: number;
-  setScrollPosition: (pos: number) => void;
 };
 
 const initialState: SidebarProviderState = {
@@ -60,8 +57,6 @@ const initialState: SidebarProviderState = {
   toggleCollapsed: () => null,
   expandedWidth: DEFAULT_EXPANDED_SIDEBAR_WIDTH,
   setExpandedWidth: () => null,
-  scrollPosition: 0,
-  setScrollPosition: () => null,
 };
 
 const SidebarProviderContext =
@@ -121,11 +116,6 @@ export function SidebarProvider({
     setCollapsed(!collapsed);
   }, [collapsed, setCollapsed]);
 
-  const [scrollPosition, setScrollPosition] = useLocalStorageState(
-    SIDEBAR_SCROLL_KEY,
-    0,
-  );
-
   useEffect(() => {
     const handleResize = () => {
       setIsWide(window.innerWidth >= WIDE_BREAKPOINT_PX);
@@ -168,8 +158,6 @@ export function SidebarProvider({
         toggleCollapsed,
         expandedWidth,
         setExpandedWidth,
-        scrollPosition,
-        setScrollPosition,
       }}
     >
       {children}

--- a/frontend/app/src/components/hooks/use-sidebar.tsx
+++ b/frontend/app/src/components/hooks/use-sidebar.tsx
@@ -14,6 +14,7 @@ type SidebarState = 'open' | 'closed';
 const SIDEBAR_WIDTH_LEGACY_KEY = 'v1SidebarWidth';
 const SIDEBAR_WIDTH_EXPANDED_KEY = 'v1SidebarWidthExpanded';
 const SIDEBAR_COLLAPSED_KEY = 'v1SidebarCollapsed';
+const SIDEBAR_SCROLL_KEY = 'v1SidebarScroll';
 
 // Tailwind's `md` breakpoint (px). Used to decide when the v1 sidebar is a persistent column.
 const WIDE_BREAKPOINT_PX = 768;
@@ -44,6 +45,8 @@ type SidebarProviderState = {
   toggleCollapsed: () => void;
   expandedWidth: number;
   setExpandedWidth: (width: number) => void;
+  scrollPosition: number;
+  setScrollPosition: (pos: number) => void;
 };
 
 const initialState: SidebarProviderState = {
@@ -57,6 +60,8 @@ const initialState: SidebarProviderState = {
   toggleCollapsed: () => null,
   expandedWidth: DEFAULT_EXPANDED_SIDEBAR_WIDTH,
   setExpandedWidth: () => null,
+  scrollPosition: 0,
+  setScrollPosition: () => null,
 };
 
 const SidebarProviderContext =
@@ -116,6 +121,11 @@ export function SidebarProvider({
     setCollapsed(!collapsed);
   }, [collapsed, setCollapsed]);
 
+  const [scrollPosition, setScrollPosition] = useLocalStorageState(
+    SIDEBAR_SCROLL_KEY,
+    0,
+  );
+
   useEffect(() => {
     const handleResize = () => {
       setIsWide(window.innerWidth >= WIDE_BREAKPOINT_PX);
@@ -158,6 +168,8 @@ export function SidebarProvider({
         toggleCollapsed,
         expandedWidth,
         setExpandedWidth,
+        scrollPosition,
+        setScrollPosition,
       }}
     >
       {children}

--- a/frontend/app/src/components/v1/nav/side-nav.tsx
+++ b/frontend/app/src/components/v1/nav/side-nav.tsx
@@ -76,7 +76,7 @@ export function SideNav({ className, navItems: navSections }: SideNavProps) {
     setCollapsed: setStoredCollapsed,
     expandedWidth: storedExpandedWidth,
     setExpandedWidth: setStoredExpandedWidth,
-    scrollPosition, 
+    scrollPosition,
     setScrollPosition,
   } = useSidebar();
   const { tenantId } = useTenantDetails();
@@ -255,17 +255,16 @@ export function SideNav({ className, navItems: navSections }: SideNavProps) {
     setLiveWidth(null);
     setIsResizing(false);
   }, [setStoredCollapsed, storedCollapsed]);
-  
+
   useEffect(() => {
     if (scrollRef.current) {
       scrollRef.current.scrollTop = scrollPosition;
     }
-  }, []);
+  }, [scrollPosition]);
 
   if (sidebarOpen === 'closed') {
     return null;
   }
-
 
   return (
     <div
@@ -468,12 +467,14 @@ export function SideNav({ className, navItems: navSections }: SideNavProps) {
             <div
               ref={scrollRef}
               data-cy="v1-sidebar-scroll"
-                onScroll={() => {
-                  if (scrollSaveTimer.current) clearTimeout(scrollSaveTimer.current);
-                  scrollSaveTimer.current = setTimeout(() => {
-                    setScrollPosition(scrollRef.current?.scrollTop ?? 0);
-                  }, 100);
-                }}
+              onScroll={() => {
+                if (scrollSaveTimer.current) {
+                  clearTimeout(scrollSaveTimer.current);
+                }
+                scrollSaveTimer.current = setTimeout(() => {
+                  setScrollPosition(scrollRef.current?.scrollTop ?? 0);
+                }, 100);
+              }}
               className="min-h-0 flex-1 overflow-auto overscroll-contain touch-pan-y [-webkit-overflow-scrolling:touch] [scrollbar-gutter:stable] scrollbar-thin scrollbar-track-transparent scrollbar-thumb-muted-foreground"
             >
               <div className="px-4 py-4">

--- a/frontend/app/src/components/v1/nav/side-nav.tsx
+++ b/frontend/app/src/components/v1/nav/side-nav.tsx
@@ -30,6 +30,7 @@ import React, {
   useMemo,
   useRef,
   useState,
+  useLayoutEffect
 } from 'react';
 
 interface SideNavProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -67,6 +68,8 @@ export type SideNavSection = {
   items: SideNavItem[];
 };
 
+const savedScrollTop = { current: 0 };
+
 export function SideNav({ className, navItems: navSections }: SideNavProps) {
   const {
     sidebarOpen,
@@ -76,8 +79,6 @@ export function SideNav({ className, navItems: navSections }: SideNavProps) {
     setCollapsed: setStoredCollapsed,
     expandedWidth: storedExpandedWidth,
     setExpandedWidth: setStoredExpandedWidth,
-    scrollPosition,
-    setScrollPosition,
   } = useSidebar();
   const { tenantId } = useTenantDetails();
   const navigate = useNavigate();
@@ -92,7 +93,6 @@ export function SideNav({ className, navItems: navSections }: SideNavProps) {
   const [showResizeToggle, setShowResizeToggle] = useState(false);
   const sidebarRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
-  const scrollSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const onNavLinkClick = useCallback(() => {
     if (isWide) {
@@ -250,17 +250,17 @@ export function SideNav({ className, navItems: navSections }: SideNavProps) {
     [tenantId],
   );
 
+  useLayoutEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = savedScrollTop.current;
+    }
+  }, []);
+
   const toggleCollapsed = useCallback(() => {
     setStoredCollapsed(!storedCollapsed);
     setLiveWidth(null);
     setIsResizing(false);
   }, [setStoredCollapsed, storedCollapsed]);
-
-  useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollPosition;
-    }
-  }, [scrollPosition]);
 
   if (sidebarOpen === 'closed') {
     return null;
@@ -468,12 +468,7 @@ export function SideNav({ className, navItems: navSections }: SideNavProps) {
               ref={scrollRef}
               data-cy="v1-sidebar-scroll"
               onScroll={() => {
-                if (scrollSaveTimer.current) {
-                  clearTimeout(scrollSaveTimer.current);
-                }
-                scrollSaveTimer.current = setTimeout(() => {
-                  setScrollPosition(scrollRef.current?.scrollTop ?? 0);
-                }, 100);
+                savedScrollTop.current = scrollRef.current?.scrollTop ?? 0;
               }}
               className="min-h-0 flex-1 overflow-auto overscroll-contain touch-pan-y [-webkit-overflow-scrolling:touch] [scrollbar-gutter:stable] scrollbar-thin scrollbar-track-transparent scrollbar-thumb-muted-foreground"
             >

--- a/frontend/app/src/components/v1/nav/side-nav.tsx
+++ b/frontend/app/src/components/v1/nav/side-nav.tsx
@@ -76,6 +76,8 @@ export function SideNav({ className, navItems: navSections }: SideNavProps) {
     setCollapsed: setStoredCollapsed,
     expandedWidth: storedExpandedWidth,
     setExpandedWidth: setStoredExpandedWidth,
+    scrollPosition, 
+    setScrollPosition,
   } = useSidebar();
   const { tenantId } = useTenantDetails();
   const navigate = useNavigate();
@@ -89,6 +91,8 @@ export function SideNav({ className, navItems: navSections }: SideNavProps) {
   const didDragRef = useRef(false);
   const [showResizeToggle, setShowResizeToggle] = useState(false);
   const sidebarRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const scrollSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const onNavLinkClick = useCallback(() => {
     if (isWide) {
@@ -251,10 +255,17 @@ export function SideNav({ className, navItems: navSections }: SideNavProps) {
     setLiveWidth(null);
     setIsResizing(false);
   }, [setStoredCollapsed, storedCollapsed]);
+  
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollPosition;
+    }
+  }, []);
 
   if (sidebarOpen === 'closed') {
     return null;
   }
+
 
   return (
     <div
@@ -455,7 +466,14 @@ export function SideNav({ className, navItems: navSections }: SideNavProps) {
           <>
             {/* Scrollable navigation area (keep scrollbar flush to sidebar edge) */}
             <div
+              ref={scrollRef}
               data-cy="v1-sidebar-scroll"
+                onScroll={() => {
+                  if (scrollSaveTimer.current) clearTimeout(scrollSaveTimer.current);
+                  scrollSaveTimer.current = setTimeout(() => {
+                    setScrollPosition(scrollRef.current?.scrollTop ?? 0);
+                  }, 100);
+                }}
               className="min-h-0 flex-1 overflow-auto overscroll-contain touch-pan-y [-webkit-overflow-scrolling:touch] [scrollbar-gutter:stable] scrollbar-thin scrollbar-track-transparent scrollbar-thumb-muted-foreground"
             >
               <div className="px-4 py-4">

--- a/frontend/app/src/components/v1/nav/side-nav.tsx
+++ b/frontend/app/src/components/v1/nav/side-nav.tsx
@@ -30,7 +30,7 @@ import React, {
   useMemo,
   useRef,
   useState,
-  useLayoutEffect
+  useLayoutEffect,
 } from 'react';
 
 interface SideNavProps extends React.HTMLAttributes<HTMLDivElement> {


### PR DESCRIPTION
## Description
When navigating between routes using the sidebar (especially Settings items), 
the sidebar scroll position resets to the top instead of maintaining its 
previous position.

## Steps to Reproduce
1. Open the dashboard with enough sidebar items to require scrolling
2. Scroll down in the sidebar to the Settings section
3. Click any Settings nav item (General, API Tokens, etc.)
4. Observe sidebar jumps back to top

## Expected
Sidebar maintains its scroll position after navigation

## Root Cause
The sidebar scroll container has no scroll position persistence. On re-render 
triggered by route change, the scroll position resets to 0.

## Fix
- Add `scrollPosition` and `setScrollPosition` to `useSidebar` hook using 
  existing `useLocalStorageState` pattern (consistent with how `collapsed` 
  and `expandedWidth` are persisted)
- Restore scroll position on mount via `useEffect`
- Save scroll position on scroll with 100ms debounce to avoid excessive 
  localStorage writes

## Files Changed
- `frontend/app/src/components/hooks/use-sidebar.tsx`
- `frontend/app/src/components/v1/nav/side-nav.tsx`

<details open id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, 
in accordance with Hatchet's AI_POLICY.md._
- **Details**: Claude was used to help identify root cause and suggest fixes.

</details>