### PR TITLE
fix(olap): don't lose status updates when replaying completed tasks

### DIFF
--- a/pkg/repository/olap_status_update_test.go
+++ b/pkg/repository/olap_status_update_test.go
@@ -103,6 +103,18 @@ func seedReplayTask(t *testing.T, ctx context.Context, repo *OLAPRepositoryImpl,
 		workerId:   uuid.New(),
 	}
 
+	createReplayTask(t, ctx, repo, f)
+
+	return f
+}
+
+// createReplayTask writes the fixture task through CreateTasks. Calling it
+// again for the same fixture simulates a redelivered CreateTasks message:
+// the insert is ON CONFLICT DO NOTHING and ReconcileTaskStatusesFromEvents
+// runs over the task's full event history.
+func createReplayTask(t *testing.T, ctx context.Context, repo *OLAPRepositoryImpl, f replayStatusFixture) {
+	t.Helper()
+
 	task := &V1TaskWithPayload{
 		V1Task: &sqlcv1.V1Task{
 			ID:                 f.taskId,
@@ -129,8 +141,6 @@ func seedReplayTask(t *testing.T, ctx context.Context, repo *OLAPRepositoryImpl,
 	_, locksNotAcquired, err := repo.CreateTasks(ctx, f.tenantId, []*V1TaskWithPayload{task})
 	require.NoError(t, err)
 	require.Empty(t, locksNotAcquired)
-
-	return f
 }
 
 func (f replayStatusFixture) event(eventType sqlcv1.V1EventTypeOlap, status sqlcv1.V1ReadableStatusOlap, retryCount int32) sqlcv1.CreateTaskEventsOLAPParams {
@@ -301,5 +311,41 @@ func TestOLAPStatusUpdate_ReplayOfCompletedTask(t *testing.T) {
 		}
 
 		runReplayStatusScenario(t, ctx, pool, f, applyBatch)
+	})
+
+	// ReconcileTaskStatusesFromEvents carries the same guard but aggregates
+	// over the task's full event history rather than one batch, so the
+	// stuck-RUNNING mode cannot occur — only the stale-retry-count mode can.
+	t.Run("reconcile_path", func(t *testing.T) {
+		f := seedReplayTask(t, ctx, repo, 3)
+		batches := replayEventBatches(f)
+
+		eventExternalIdToWorkflowRunId := map[uuid.UUID]uuid.UUID{f.externalId: f.externalId}
+		_, locksNotAcquired, err := repo.CreateTaskEvents(ctx, f.tenantId, batches[0], eventExternalIdToWorkflowRunId)
+		require.NoError(t, err)
+		require.Empty(t, locksNotAcquired)
+		assertOLAPTaskStatus(t, ctx, pool, f, "COMPLETED", 1)
+
+		// Write the replay's events (retry 2) into the events table without
+		// going through a status-update path, mimicking events whose inline
+		// status update did not reach this row.
+		for _, batch := range [][]sqlcv1.CreateTaskEventsOLAPParams{batches[1], batches[2]} {
+			for _, e := range batch {
+				_, err := pool.Exec(ctx, `
+					INSERT INTO v1_task_events_olap (
+						tenant_id, task_id, task_inserted_at, event_type, workflow_id, readable_status, retry_count, worker_id
+					) VALUES ($1, $2, $3, $4::v1_event_type_olap, $5, $6::v1_readable_status_olap, $7, $8)
+				`, e.TenantID, e.TaskID, e.TaskInsertedAt, string(e.EventType), e.WorkflowID, string(e.ReadableStatus), e.RetryCount, e.WorkerID)
+				require.NoError(t, err)
+			}
+		}
+
+		// A redelivered CreateTasks message reconciles the row against the
+		// event history: retry 2's highest-priority status is COMPLETED, the
+		// same readable status the row already has, so only latest_retry_count
+		// needs to advance.
+		createReplayTask(t, ctx, repo, f)
+		assertOLAPTaskStatus(t, ctx, pool, f, "COMPLETED", 2)
+		assertOLAPRunStatus(t, ctx, pool, f, "COMPLETED")
 	})
 }

--- a/pkg/repository/olap_status_update_test.go
+++ b/pkg/repository/olap_status_update_test.go
@@ -1,0 +1,305 @@
+//go:build !e2e && !load && !rampup && !integration
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hatchet-dev/hatchet/pkg/config/limits"
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
+	"github.com/hatchet-dev/hatchet/pkg/validator"
+)
+
+// createEnumAwarePool builds a pool that registers the v1_readable_status_olap
+// enum (and its array type) on each connection, mirroring the AfterConnect
+// hook in pkg/config/loader. The OLAP queries bind []V1ReadableStatusOlap
+// parameters, which pgx cannot encode without the registered types.
+func createEnumAwarePool(t *testing.T, basePool *pgxpool.Pool) *pgxpool.Pool {
+	ctx := context.Background()
+
+	config, err := pgxpool.ParseConfig(basePool.Config().ConnString())
+	require.NoError(t, err)
+
+	config.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+		if _, err := conn.Exec(ctx, "SET TIME ZONE 'UTC'"); err != nil {
+			return err
+		}
+
+		for _, typeName := range []string{"v1_readable_status_olap", "_v1_readable_status_olap"} {
+			pgType, err := conn.LoadType(ctx, typeName)
+			if err != nil {
+				return err
+			}
+
+			conn.TypeMap().RegisterType(pgType)
+		}
+
+		return nil
+	}
+
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	return pool
+}
+
+// createOLAPRepositoryWithPayloadStore builds an OLAP repository with a fully
+// initialized sharedRepository (including the payload store), which the task
+// and task-event write paths require.
+func createOLAPRepositoryWithPayloadStore(t *testing.T, pool *pgxpool.Pool) *OLAPRepositoryImpl {
+	logger := zerolog.Nop()
+
+	shared, cleanupShared := newSharedRepository(
+		pool,
+		pool,
+		validator.NewDefaultValidator(),
+		&logger,
+		PayloadStoreRepositoryOpts{},
+		limits.LimitConfigFile{},
+		false,
+		time.Minute,
+	)
+	t.Cleanup(func() { _ = cleanupShared() })
+
+	repo, ok := newOLAPRepository(
+		shared,
+		24*time.Hour,
+		false,
+		false,
+		StatusUpdateBatchSizeLimits{Task: 1000, DAG: 1000},
+	).(*OLAPRepositoryImpl)
+	require.True(t, ok)
+
+	return repo
+}
+
+type replayStatusFixture struct {
+	tenantId   uuid.UUID
+	taskId     int64
+	insertedAt pgtype.Timestamptz
+	externalId uuid.UUID
+	workflowId uuid.UUID
+	workerId   uuid.UUID
+}
+
+func seedReplayTask(t *testing.T, ctx context.Context, repo *OLAPRepositoryImpl, taskId int64) replayStatusFixture {
+	f := replayStatusFixture{
+		tenantId:   uuid.New(),
+		taskId:     taskId,
+		insertedAt: pgtype.Timestamptz{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true},
+		externalId: uuid.New(),
+		workflowId: uuid.New(),
+		workerId:   uuid.New(),
+	}
+
+	task := &V1TaskWithPayload{
+		V1Task: &sqlcv1.V1Task{
+			ID:                 f.taskId,
+			InsertedAt:         f.insertedAt,
+			TenantID:           f.tenantId,
+			Queue:              "default",
+			ActionID:           "test:replay-status",
+			StepID:             uuid.New(),
+			WorkflowID:         f.workflowId,
+			WorkflowVersionID:  uuid.New(),
+			WorkflowRunID:      f.externalId,
+			ScheduleTimeout:    "5m",
+			StepTimeout:        pgtype.Text{String: "60s", Valid: true},
+			Priority:           pgtype.Int4{Int32: 1, Valid: true},
+			Sticky:             sqlcv1.V1StickyStrategyNONE,
+			ExternalID:         f.externalId,
+			DisplayName:        "replay-status-test",
+			Input:              []byte(`{}`),
+			AdditionalMetadata: []byte(`{}`),
+		},
+		Payload: []byte(`{}`),
+	}
+
+	_, locksNotAcquired, err := repo.CreateTasks(ctx, f.tenantId, []*V1TaskWithPayload{task})
+	require.NoError(t, err)
+	require.Empty(t, locksNotAcquired)
+
+	return f
+}
+
+func (f replayStatusFixture) event(eventType sqlcv1.V1EventTypeOlap, status sqlcv1.V1ReadableStatusOlap, retryCount int32) sqlcv1.CreateTaskEventsOLAPParams {
+	e := sqlcv1.CreateTaskEventsOLAPParams{
+		TenantID:       f.tenantId,
+		TaskID:         f.taskId,
+		TaskInsertedAt: f.insertedAt,
+		EventType:      eventType,
+		WorkflowID:     f.workflowId,
+		EventTimestamp: pgtype.Timestamptz{Time: time.Now().UTC(), Valid: true},
+		ReadableStatus: status,
+		RetryCount:     retryCount,
+		Output:         []byte(`{}`),
+		ExternalID:     f.externalId,
+	}
+
+	if eventType == sqlcv1.V1EventTypeOlapASSIGNED {
+		workerId := f.workerId
+		e.WorkerID = &workerId
+	}
+
+	return e
+}
+
+func assertOLAPTaskStatus(t *testing.T, ctx context.Context, pool *pgxpool.Pool, f replayStatusFixture, wantStatus string, wantRetryCount int32) {
+	t.Helper()
+
+	var status string
+	var retryCount int32
+
+	err := pool.QueryRow(ctx, `
+		SELECT readable_status::text, latest_retry_count
+		FROM v1_tasks_olap
+		WHERE tenant_id = $1 AND id = $2
+	`, f.tenantId, f.taskId).Scan(&status, &retryCount)
+	require.NoError(t, err)
+
+	// Non-fatal so a failure after one batch still surfaces failures after
+	// later batches (the bug has two observable modes).
+	assert.Equal(t, wantStatus, status, "v1_tasks_olap.readable_status")
+	assert.Equal(t, wantRetryCount, retryCount, "v1_tasks_olap.latest_retry_count")
+}
+
+func assertOLAPRunStatus(t *testing.T, ctx context.Context, pool *pgxpool.Pool, f replayStatusFixture, wantStatus string) {
+	t.Helper()
+
+	var status string
+
+	err := pool.QueryRow(ctx, `
+		SELECT readable_status::text
+		FROM v1_runs_olap
+		WHERE tenant_id = $1 AND external_id = $2
+	`, f.tenantId, f.externalId).Scan(&status)
+	require.NoError(t, err)
+
+	assert.Equal(t, wantStatus, status, "v1_runs_olap.readable_status")
+}
+
+// replayEventBatches returns the three ingestion batches that reproduce the
+// lost-update on replay of a completed task. The task fails at retry 0,
+// succeeds at retry 1, and is then replayed by the user (retry 2). Because
+// OLAP ingestion is asynchronous, the replay's completion events can arrive
+// in a batch before its queued/assigned events.
+func replayEventBatches(f replayStatusFixture) [3][]sqlcv1.CreateTaskEventsOLAPParams {
+	initialLifecycle := []sqlcv1.CreateTaskEventsOLAPParams{
+		f.event(sqlcv1.V1EventTypeOlapQUEUED, sqlcv1.V1ReadableStatusOlapQUEUED, 0),
+		f.event(sqlcv1.V1EventTypeOlapASSIGNED, sqlcv1.V1ReadableStatusOlapRUNNING, 0),
+		f.event(sqlcv1.V1EventTypeOlapSTARTED, sqlcv1.V1ReadableStatusOlapRUNNING, 0),
+		f.event(sqlcv1.V1EventTypeOlapFAILED, sqlcv1.V1ReadableStatusOlapFAILED, 0),
+		f.event(sqlcv1.V1EventTypeOlapRETRYING, sqlcv1.V1ReadableStatusOlapQUEUED, 1),
+		f.event(sqlcv1.V1EventTypeOlapASSIGNED, sqlcv1.V1ReadableStatusOlapRUNNING, 1),
+		f.event(sqlcv1.V1EventTypeOlapSTARTED, sqlcv1.V1ReadableStatusOlapRUNNING, 1),
+		f.event(sqlcv1.V1EventTypeOlapFINISHED, sqlcv1.V1ReadableStatusOlapCOMPLETED, 1),
+	}
+
+	replayCompletion := []sqlcv1.CreateTaskEventsOLAPParams{
+		f.event(sqlcv1.V1EventTypeOlapSENTTOWORKER, sqlcv1.V1ReadableStatusOlapRUNNING, 2),
+		f.event(sqlcv1.V1EventTypeOlapSTARTED, sqlcv1.V1ReadableStatusOlapRUNNING, 2),
+		f.event(sqlcv1.V1EventTypeOlapFINISHED, sqlcv1.V1ReadableStatusOlapCOMPLETED, 2),
+	}
+
+	replayQueueing := []sqlcv1.CreateTaskEventsOLAPParams{
+		f.event(sqlcv1.V1EventTypeOlapRETRIEDBYUSER, sqlcv1.V1ReadableStatusOlapQUEUED, 2),
+		f.event(sqlcv1.V1EventTypeOlapQUEUED, sqlcv1.V1ReadableStatusOlapQUEUED, 2),
+		f.event(sqlcv1.V1EventTypeOlapASSIGNED, sqlcv1.V1ReadableStatusOlapRUNNING, 2),
+	}
+
+	return [3][]sqlcv1.CreateTaskEventsOLAPParams{initialLifecycle, replayCompletion, replayQueueing}
+}
+
+func runReplayStatusScenario(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	f replayStatusFixture,
+	applyBatch func(t *testing.T, events []sqlcv1.CreateTaskEventsOLAPParams),
+) {
+	batches := replayEventBatches(f)
+
+	applyBatch(t, batches[0])
+	assertOLAPTaskStatus(t, ctx, pool, f, "COMPLETED", 1)
+
+	// The replay's completion events arrive first. A newer retry count must
+	// bump latest_retry_count even though the readable status is already
+	// COMPLETED; otherwise the completion is swallowed.
+	applyBatch(t, batches[1])
+	assertOLAPTaskStatus(t, ctx, pool, f, "COMPLETED", 2)
+
+	// The replay's queueing events arrive last. They are stale relative to
+	// the already-ingested completion at the same retry count, so they must
+	// not regress the status back to RUNNING.
+	applyBatch(t, batches[2])
+	assertOLAPTaskStatus(t, ctx, pool, f, "COMPLETED", 2)
+	assertOLAPRunStatus(t, ctx, pool, f, "COMPLETED")
+}
+
+// TestOLAPStatusUpdate_ReplayOfCompletedTask is a regression test for runs
+// permanently stuck in RUNNING (or with a stale retry count) after a bulk
+// replay of completed tasks, when the replay's OLAP events are ingested
+// out of order across batches.
+func TestOLAPStatusUpdate_ReplayOfCompletedTask(t *testing.T) {
+	basePool, cleanup := setupPostgresWithMigration(t)
+	defer cleanup()
+
+	pool := createEnumAwarePool(t, basePool)
+	repo := createOLAPRepositoryWithPayloadStore(t, pool)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	// Creates the hash partitions of v1_task_events_olap_tmp and the date
+	// partitions of the OLAP tables, which the write paths rely on.
+	require.NoError(t, repo.UpdateTablePartitions(ctx))
+
+	t.Run("mq_path", func(t *testing.T) {
+		f := seedReplayTask(t, ctx, repo, 1)
+
+		applyBatch := func(t *testing.T, events []sqlcv1.CreateTaskEventsOLAPParams) {
+			t.Helper()
+
+			eventExternalIdToWorkflowRunId := map[uuid.UUID]uuid.UUID{f.externalId: f.externalId}
+
+			_, locksNotAcquired, err := repo.CreateTaskEvents(ctx, f.tenantId, events, eventExternalIdToWorkflowRunId)
+			require.NoError(t, err)
+			require.Empty(t, locksNotAcquired)
+		}
+
+		runReplayStatusScenario(t, ctx, pool, f, applyBatch)
+	})
+
+	t.Run("tmp_table_path", func(t *testing.T) {
+		f := seedReplayTask(t, ctx, repo, 2)
+
+		applyBatch := func(t *testing.T, events []sqlcv1.CreateTaskEventsOLAPParams) {
+			t.Helper()
+
+			for _, e := range events {
+				_, err := pool.Exec(ctx, `
+					INSERT INTO v1_task_events_olap_tmp (
+						tenant_id, task_id, task_inserted_at, event_type, readable_status, retry_count, worker_id
+					) VALUES ($1, $2, $3, $4::v1_event_type_olap, $5::v1_readable_status_olap, $6, $7)
+				`, e.TenantID, e.TaskID, e.TaskInsertedAt, string(e.EventType), string(e.ReadableStatus), e.RetryCount, e.WorkerID)
+				require.NoError(t, err)
+			}
+
+			_, _, err := repo.UpdateTaskStatuses(ctx, []uuid.UUID{f.tenantId})
+			require.NoError(t, err)
+		}
+
+		runReplayStatusScenario(t, ctx, pool, f, applyBatch)
+	})
+}

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -838,10 +838,16 @@ WITH tenants AS (
         (t.inserted_at, t.id, t.readable_status) = (tu.inserted_at, tu.id, tu.readable_status)
         AND
             (
-                -- a newer retry count always wins, even when the readable status is
-                -- unchanged: latest_retry_count must advance or a replay's terminal
-                -- status at the new retry count is swallowed, letting late queueing
-                -- events at that retry count regress the status afterwards
+                -- A newer retry count must always apply, even when the readable
+                -- status is unchanged, because this is the only chance to record it:
+                -- the deleted_events CTE below removes every processed event from
+                -- v1_task_events_olap_tmp regardless of whether this UPDATE matched,
+                -- so an event rejected here is never seen again. If a same-status
+                -- event from a newer retry were rejected (a replayed task's COMPLETED
+                -- at retry N ingested before its QUEUED/ASSIGNED events),
+                -- latest_retry_count would stay stale, and the late QUEUED/ASSIGNED
+                -- events at retry N would later pass this branch and leave the task
+                -- stuck at RUNNING.
                 (
                     tu.retry_count > t.latest_retry_count
                 ) OR
@@ -947,10 +953,15 @@ WITH inputs AS (
     JOIN inputs i ON (i.tenant_id, i.task_id, i.task_inserted_at) = (t.tenant_id, t.id, t.inserted_at)
     WHERE
         (
-            -- A newer retry count always wins, even when the readable status is
-            -- unchanged: latest_retry_count must advance or a replay's terminal
-            -- status at the new retry count is swallowed, letting late queueing
-            -- events at that retry count regress the status afterwards
+            -- A newer retry count must always apply, even when the readable
+            -- status is unchanged, because this is the only chance to record it:
+            -- the message this batch came from is acked once the transaction
+            -- commits, regardless of whether this update matched, so an event
+            -- rejected here is never seen again. If a same-status event from a
+            -- newer retry were rejected (a replayed task's COMPLETED at retry N
+            -- ingested before its QUEUED/ASSIGNED events), latest_retry_count
+            -- would stay stale, and the late QUEUED/ASSIGNED events at retry N
+            -- would later pass this branch and leave the task stuck at RUNNING.
             (
                 i.retry_count > t.latest_retry_count
             ) OR

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -838,10 +838,12 @@ WITH tenants AS (
         (t.inserted_at, t.id, t.readable_status) = (tu.inserted_at, tu.id, tu.readable_status)
         AND
             (
-                -- if the retry count is greater than the latest retry count, update the status
+                -- a newer retry count always wins, even when the readable status is
+                -- unchanged: latest_retry_count must advance or a replay's terminal
+                -- status at the new retry count is swallowed, letting late queueing
+                -- events at that retry count regress the status afterwards
                 (
                     tu.retry_count > t.latest_retry_count
-                    AND tu.max_readable_status != t.readable_status
                 ) OR
                 -- if the retry count is equal to the latest retry count, update the status if the priority is higher
                 (
@@ -945,10 +947,12 @@ WITH inputs AS (
     JOIN inputs i ON (i.tenant_id, i.task_id, i.task_inserted_at) = (t.tenant_id, t.id, t.inserted_at)
     WHERE
         (
-            -- If the retry count is greater than the latest retry count, update the status
+            -- A newer retry count always wins, even when the readable status is
+            -- unchanged: latest_retry_count must advance or a replay's terminal
+            -- status at the new retry count is swallowed, letting late queueing
+            -- events at that retry count regress the status afterwards
             (
                 i.retry_count > t.latest_retry_count
-                AND i.readable_status != t.readable_status
             ) OR
             -- If the retry count is equal, only update if the new status has higher priority
             (

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -2398,7 +2398,12 @@ FROM statuses_from_events s
 WHERE
     (t.id, t.inserted_at) = (s.task_id, s.task_inserted_at)
     AND (
-        (s.retry_count > t.latest_retry_count AND s.status != t.readable_status)
+        -- A newer retry count always applies, even when the readable status is
+        -- unchanged — same rationale as the guards in UpdateTaskStatuses and
+        -- UpdateTaskStatusesFromMQ: requiring the status to differ would skip
+        -- the latest_retry_count advance when the event history's newest retry
+        -- ends in the status the row already has.
+        (s.retry_count > t.latest_retry_count)
         OR (s.retry_count = t.latest_retry_count AND v1_status_to_priority(s.status) > v1_status_to_priority(t.readable_status))
         OR (s.retry_count = t.latest_retry_count AND t.readable_status = 'EVICTED' AND s.status != 'EVICTED')
     )

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -4007,10 +4007,16 @@ WITH tenants AS (
         (t.inserted_at, t.id, t.readable_status) = (tu.inserted_at, tu.id, tu.readable_status)
         AND
             (
-                -- a newer retry count always wins, even when the readable status is
-                -- unchanged: latest_retry_count must advance or a replay's terminal
-                -- status at the new retry count is swallowed, letting late queueing
-                -- events at that retry count regress the status afterwards
+                -- A newer retry count must always apply, even when the readable
+                -- status is unchanged, because this is the only chance to record it:
+                -- the deleted_events CTE below removes every processed event from
+                -- v1_task_events_olap_tmp regardless of whether this UPDATE matched,
+                -- so an event rejected here is never seen again. If a same-status
+                -- event from a newer retry were rejected (a replayed task's COMPLETED
+                -- at retry N ingested before its QUEUED/ASSIGNED events),
+                -- latest_retry_count would stay stale, and the late QUEUED/ASSIGNED
+                -- events at retry N would later pass this branch and leave the task
+                -- stuck at RUNNING.
                 (
                     tu.retry_count > t.latest_retry_count
                 ) OR
@@ -4171,10 +4177,15 @@ WITH inputs AS (
     JOIN inputs i ON (i.tenant_id, i.task_id, i.task_inserted_at) = (t.tenant_id, t.id, t.inserted_at)
     WHERE
         (
-            -- A newer retry count always wins, even when the readable status is
-            -- unchanged: latest_retry_count must advance or a replay's terminal
-            -- status at the new retry count is swallowed, letting late queueing
-            -- events at that retry count regress the status afterwards
+            -- A newer retry count must always apply, even when the readable
+            -- status is unchanged, because this is the only chance to record it:
+            -- the message this batch came from is acked once the transaction
+            -- commits, regardless of whether this update matched, so an event
+            -- rejected here is never seen again. If a same-status event from a
+            -- newer retry were rejected (a replayed task's COMPLETED at retry N
+            -- ingested before its QUEUED/ASSIGNED events), latest_retry_count
+            -- would stay stale, and the late QUEUED/ASSIGNED events at retry N
+            -- would later pass this branch and leave the task stuck at RUNNING.
             (
                 i.retry_count > t.latest_retry_count
             ) OR

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -4007,10 +4007,12 @@ WITH tenants AS (
         (t.inserted_at, t.id, t.readable_status) = (tu.inserted_at, tu.id, tu.readable_status)
         AND
             (
-                -- if the retry count is greater than the latest retry count, update the status
+                -- a newer retry count always wins, even when the readable status is
+                -- unchanged: latest_retry_count must advance or a replay's terminal
+                -- status at the new retry count is swallowed, letting late queueing
+                -- events at that retry count regress the status afterwards
                 (
                     tu.retry_count > t.latest_retry_count
-                    AND tu.max_readable_status != t.readable_status
                 ) OR
                 -- if the retry count is equal to the latest retry count, update the status if the priority is higher
                 (
@@ -4169,10 +4171,12 @@ WITH inputs AS (
     JOIN inputs i ON (i.tenant_id, i.task_id, i.task_inserted_at) = (t.tenant_id, t.id, t.inserted_at)
     WHERE
         (
-            -- If the retry count is greater than the latest retry count, update the status
+            -- A newer retry count always wins, even when the readable status is
+            -- unchanged: latest_retry_count must advance or a replay's terminal
+            -- status at the new retry count is swallowed, letting late queueing
+            -- events at that retry count regress the status afterwards
             (
                 i.retry_count > t.latest_retry_count
-                AND i.readable_status != t.readable_status
             ) OR
             -- If the retry count is equal, only update if the new status has higher priority
             (

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -3349,7 +3349,12 @@ FROM statuses_from_events s
 WHERE
     (t.id, t.inserted_at) = (s.task_id, s.task_inserted_at)
     AND (
-        (s.retry_count > t.latest_retry_count AND s.status != t.readable_status)
+        -- A newer retry count always applies, even when the readable status is
+        -- unchanged — same rationale as the guards in UpdateTaskStatuses and
+        -- UpdateTaskStatusesFromMQ: requiring the status to differ would skip
+        -- the latest_retry_count advance when the event history's newest retry
+        -- ends in the status the row already has.
+        (s.retry_count > t.latest_retry_count)
         OR (s.retry_count = t.latest_retry_count AND v1_status_to_priority(s.status) > v1_status_to_priority(t.readable_status))
         OR (s.retry_count = t.latest_retry_count AND t.readable_status = 'EVICTED' AND s.status != 'EVICTED')
     )


### PR DESCRIPTION
# Description

Bulk-replaying completed runs can leave them permanently stuck in `RUNNING` (or `COMPLETED` with a stale retry count) in the OLAP read model. This is the root cause of the flaky `bulk-replay-e2e › bulk replays matching runs and increments retry count` job (TS SDK, `old-engine-new-sdk`), which failed in 7 of 12 recent main runs with `Timed out waiting for bulk replay retry counts visible after 120000ms`.

The status-update guard in `UpdateTaskStatuses` and `UpdateTaskStatusesFromMQ` required the incoming readable status to *differ* from the current one even when the incoming retry count was newer. OLAP ingestion is asynchronous, so when a replayed attempt finishes quickly, its `COMPLETED` events (retry N+1) can be ingested in a batch before its `QUEUED`/`ASSIGNED` events:

1. The completion batch matches the current `COMPLETED` status, fails the guard, and is consumed without advancing `latest_retry_count` (stale retry count).
2. The late queueing batch then carries a newer retry count with a *different* status, passes the guard, and flips the run to `RUNNING` — permanently, since the completion was already consumed (stuck run).

The fix: a newer retry count always wins. Same-status updates are safe — the partition-dedup CTE only considers status-changing rows, and the `v1_runs_olap` trigger update is idempotent. Late same-retry-count events are still rejected by the existing priority comparison.

Structured red-green: the first commit adds the regression test (failing, with output quoted in the commit message), the second commit makes it pass. Checking out the first commit reproduces the failure.

**For the reviewers**

- There's a similar shaped query in https://github.com/hatchet-dev/hatchet/blob/1999231d62e366c8212946ba6ff525c02b70a0ac/pkg/repository/sqlcv1/olap.sql#L2401 if this one makes sense, I should update that one as well. WDYT?
- I wonder about a downstream impact; there will be slightly more writes (but that's needed for correctness)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Relax the newer-retry-count branch of the status-update guard in `UpdateTaskStatuses`, `UpdateTaskStatusesFromMQ`, and `ReconcileTaskStatusesFromEvents` (`pkg/repository/sqlcv1/olap.sql`), plus sqlc regen
- [x] Add `TestOLAPStatusUpdate_ReplayOfCompletedTask`, a deterministic Postgres-backed (testcontainers) regression test that drives both guard sites (MQ path via `CreateTaskEvents`, tmp-table path via `UpdateTaskStatuses`) with controlled batch boundaries and asserts `v1_tasks_olap` and `v1_runs_olap` end at `(COMPLETED, latest_retry_count=2)`
- [x] Cover the third guard site, `ReconcileTaskStatusesFromEvents` (run from `CreateTasks`, including redelivered messages): only the stale-retry-count mode is reachable there since it aggregates the full event history, verified red-green in the same commit pattern

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

- New regression test fails on `main` with exactly the two observed modes (stale `latest_retry_count`, then permanent `RUNNING` flip) and passes with the fix.
- Reproduced the original failure 2/2 locally against a v0.89.2 stack (postgres MQ, matching the failing CI job): stuck `RUNNING` row in `v1_tasks_olap` and a second task with stale `latest_retry_count`, matching the guard analysis.
- `task test` passes.

Note: the `sdk-typescript` e2e jobs that would have caught this currently run no tests due to a CI matrix misconfiguration (`matrix.test-cmd` is never defined); that fix plus version-gating the bulk-replay e2e for `old-engine-new-sdk` follows in a separate PR. The flake itself only stops once a release tag containing this fix exists.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Investigation, regression test, and fix authored with Cursor (Fable 5); reviewed and directed by the PR author.

</details>
