### PR TITLE
refactor(cli): accept fs.FS for quickstart templates

### DIFF
--- a/cmd/hatchet-cli/cli/internal/templater/templater.go
+++ b/cmd/hatchet-cli/cli/internal/templater/templater.go
@@ -2,7 +2,6 @@ package templater
 
 import (
 	"bytes"
-	"embed"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -16,11 +15,11 @@ type Data struct {
 	PackageManager string
 }
 
-// Process reads all files from the specified directory within the embedded filesystem,
+// Process reads all files from the specified directory within the provided filesystem,
 // executes them as text/templates with the provided data, and writes the results
 // to the destination directory, preserving the directory structure.
 // Files named POST_QUICKSTART.md are skipped and not copied to the destination.
-func Process(fsys embed.FS, srcDir, dstDir string, data Data) error {
+func Process(fsys fs.FS, srcDir, dstDir string, data Data) error {
 	// Get a sub-filesystem rooted at srcDir
 	subFS, err := fs.Sub(fsys, srcDir)
 	if err != nil {
@@ -77,7 +76,7 @@ func Process(fsys embed.FS, srcDir, dstDir string, data Data) error {
 //   - package manager directory: templates/LANG/PACKAGE_MANAGER/
 //
 // For languages with a single package manager (go), it falls back to the language root directory.
-func ProcessMultiSource(fsys embed.FS, language, packageManager, dstDir string, data Data) error {
+func ProcessMultiSource(fsys fs.FS, language, packageManager, dstDir string, data Data) error {
 	// For Go, use the old behavior (no shared directory)
 	if language == "go" {
 		return Process(fsys, "templates/go", dstDir, data)
@@ -102,7 +101,7 @@ func ProcessMultiSource(fsys embed.FS, language, packageManager, dstDir string, 
 
 // ProcessPostQuickstart reads and processes the POST_QUICKSTART.md file from the template directory.
 // Returns the processed content as a string, or empty string if the file doesn't exist.
-func ProcessPostQuickstart(fsys embed.FS, srcDir string, data Data) (string, error) {
+func ProcessPostQuickstart(fsys fs.FS, srcDir string, data Data) (string, error) {
 	// Get a sub-filesystem rooted at srcDir
 	subFS, err := fs.Sub(fsys, srcDir)
 	if err != nil {
@@ -137,7 +136,7 @@ func ProcessPostQuickstart(fsys embed.FS, srcDir string, data Data) (string, err
 // For languages with multiple package managers, it looks in templates/LANG/PACKAGE_MANAGER/.
 // For Go, it looks in the templates/go/ directory.
 // Returns the processed content as a string, or empty string if the file doesn't exist.
-func ProcessPostQuickstartMultiSource(fsys embed.FS, language, packageManager string, data Data) (string, error) {
+func ProcessPostQuickstartMultiSource(fsys fs.FS, language, packageManager string, data Data) (string, error) {
 	var srcDir string
 	if language == "go" {
 		srcDir = "templates/go"


### PR DESCRIPTION
Refs #4107.

# Description

Phase 1 refactor for #4107. The quickstart templater (`cmd/hatchet-cli/cli/internal/templater/templater.go`) previously required a `embed.FS`. This refactors the four exported function signatures to accept the `fs.FS` interface instead.

No behavior changes. `quickstart.go` still declares `content embed.FS` via `//go:embed all:templates/*`, and `embed.FS` satisfies `fs.FS`, so the existing call sites in `quickstart.go` are unchanged. The templater only uses interface-level operations (`fs.Sub`, `fs.WalkDir`, `fs.ReadFile`).

## Type of change

- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)

## What's Changed

- [x] `Process`, `ProcessMultiSource`, `ProcessPostQuickstart`, and `ProcessPostQuickstartMultiSource` now take `fs.FS` instead of `embed.FS`
- [x] Removed the now-unused `embed` import from `templater.go`

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted

## Testing

- `go build ./cmd/hatchet-cli/...` passes
- `go test ./cmd/hatchet-cli/cli/internal/templater/... ./cmd/hatchet-cli/cli/...` passes (the templater package has no test files; the quickstart e2e test is build-tagged `e2e_cli` and exercises the CLI binary, so it is unaffected)
- `gofmt` and `go vet` clean on the templater package

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Claude Code was used to perform an impact scan of call sites and tests.

</details>