### PR TITLE
fix(engine): extend lock timeouts significantly

### DIFF
--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -361,7 +361,7 @@ func runPartitionDDLWithLockTimeout(ctx context.Context, pool *pgxpool.Pool, log
 
 	defer rollback()
 
-	if _, err = tx.Exec(ctx, "SET LOCAL lock_timeout = '5s'"); err != nil {
+	if _, err = tx.Exec(ctx, "SET LOCAL lock_timeout = '1min'"); err != nil {
 		return fmt.Errorf("set lock_timeout: %w", err)
 	}
 
@@ -496,8 +496,7 @@ func (r *OLAPRepositoryImpl) UpdateTablePartitions(ctx context.Context) error {
 			release()
 		}
 
-		// Set a short lock_timeout so we fail fast rather than blocking behind ANALYZE.
-		if _, err = conn.Exec(ctx, "SET lock_timeout = '5s'"); err != nil {
+		if _, err = conn.Exec(ctx, "SET lock_timeout = '1min'"); err != nil {
 			releaseConn()
 			return fmt.Errorf("failed to set lock_timeout for detach: %w", err)
 		}

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -383,7 +383,7 @@ func (r *TaskRepositoryImpl) UpdateTablePartitions(ctx context.Context) error {
 		}
 	}
 
-	if _, err = ddlConn.Exec(ctx, "SET lock_timeout = '5s'"); err != nil {
+	if _, err = ddlConn.Exec(ctx, "SET lock_timeout = '1min'"); err != nil {
 		releaseCreateConn()
 		return fmt.Errorf("failed to set lock_timeout: %w", err)
 	}
@@ -449,8 +449,7 @@ func (r *TaskRepositoryImpl) UpdateTablePartitions(ctx context.Context) error {
 			release()
 		}
 
-		// Set a short lock_timeout so we fail fast rather than blocking behind ANALYZE.
-		if _, err = conn.Exec(ctx, "SET lock_timeout = '5s'"); err != nil {
+		if _, err = conn.Exec(ctx, "SET lock_timeout = '1min'"); err != nil {
 			releaseConn()
 			return fmt.Errorf("failed to set lock_timeout for detach: %w", err)
 		}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Extends the lock timeouts for detaching / attaching partitions significantly, since it seems like failing fast didn't work. Extending them beyond the old context timeout should help us see fewer timeouts while also getting the better behavior we want, where we don't loudly error on a failure

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI use

</details>
