### PR TITLE
docs(sdks/ts): fix broken documentation link in TypeScript SDK README

### DIFF
--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -32,7 +32,7 @@ pnpm add @hatchet-dev/typescript-sdk
 
 ## Quick Start
 
-For examples of how to use the Hatchet TypeScript SDK, including worker setup and task execution, please see our [official documentation](https://docs.hatchet.run/home/setup).
+For examples of how to use the Hatchet TypeScript SDK, including worker setup and task execution, please see our [official documentation](https://docs.hatchet.run/v1).
 
 ## Features
 


### PR DESCRIPTION
Fixes #4177

## Changes
Updated broken documentation link in `sdks/typescript/README.md`.

- **Before:** `https://docs.hatchet.run/home/setup` (404)
- **After:** `https://docs.hatchet.run/v1`

<details open id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: This change was identified, verified, and implemented manually without the use of AI assistance.

</details>