### PR TITLE
fix(engine): scope partition-heartbeat statement_timeout with SET LOCAL to prevent pool leak

### DIFF
--- a/pkg/repository/tenant.go
+++ b/pkg/repository/tenant.go
@@ -664,14 +664,17 @@ func (r *tenantRepository) UpdateControllerPartitionHeartbeat(ctx context.Contex
 
 	defer sqlchelpers.DeferRollback(ctx, r.l, tx.Rollback)
 
-	// set tx timeouts to 5 seconds to avoid deadlocks
-	_, err = tx.Exec(ctx, "SET statement_timeout=5000")
+	// scope both timeouts to this transaction. SET LOCAL reverts them on
+	// COMMIT/ROLLBACK; a plain SET would persist for the lifetime of the
+	// pooled connection and leak to unrelated callers that later check it
+	// out (e.g. Heartbeat).
+	_, err = tx.Exec(ctx, "SET LOCAL statement_timeout=5000")
 
 	if err != nil {
 		return "", err
 	}
 
-	_, err = tx.Exec(ctx, "SET idle_in_transaction_session_timeout=5000")
+	_, err = tx.Exec(ctx, "SET LOCAL idle_in_transaction_session_timeout=5000")
 
 	if err != nil {
 		return "", err
@@ -708,14 +711,17 @@ func (r *tenantRepository) UpdateWorkerPartitionHeartbeat(ctx context.Context, p
 
 	defer sqlchelpers.DeferRollback(ctx, r.l, tx.Rollback)
 
-	// set tx timeouts to 5 seconds to avoid deadlocks
-	_, err = tx.Exec(ctx, "SET statement_timeout=5000")
+	// scope both timeouts to this transaction. SET LOCAL reverts them on
+	// COMMIT/ROLLBACK; a plain SET would persist for the lifetime of the
+	// pooled connection and leak to unrelated callers that later check it
+	// out (e.g. Heartbeat).
+	_, err = tx.Exec(ctx, "SET LOCAL statement_timeout=5000")
 
 	if err != nil {
 		return "", err
 	}
 
-	_, err = tx.Exec(ctx, "SET idle_in_transaction_session_timeout=5000")
+	_, err = tx.Exec(ctx, "SET LOCAL idle_in_transaction_session_timeout=5000")
 
 	if err != nil {
 		return "", err
@@ -827,14 +833,17 @@ func (r *tenantRepository) UpdateSchedulerPartitionHeartbeat(ctx context.Context
 
 	defer sqlchelpers.DeferRollback(ctx, r.l, tx.Rollback)
 
-	// set tx timeouts to 5 seconds to avoid deadlocks
-	_, err = tx.Exec(ctx, "SET statement_timeout=5000")
+	// scope both timeouts to this transaction. SET LOCAL reverts them on
+	// COMMIT/ROLLBACK; a plain SET would persist for the lifetime of the
+	// pooled connection and leak to unrelated callers that later check it
+	// out (e.g. Heartbeat).
+	_, err = tx.Exec(ctx, "SET LOCAL statement_timeout=5000")
 
 	if err != nil {
 		return "", err
 	}
 
-	_, err = tx.Exec(ctx, "SET idle_in_transaction_session_timeout=5000")
+	_, err = tx.Exec(ctx, "SET LOCAL idle_in_transaction_session_timeout=5000")
 
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Fixes #3898

## Problem

The three partition-heartbeat helpers in `pkg/repository/tenant.go` — `UpdateControllerPartitionHeartbeat`, `UpdateWorkerPartitionHeartbeat`, and `UpdateSchedulerPartitionHeartbeat` — lower `statement_timeout` to 5s with a **plain** `SET` inside a transaction that then commits:

```go
_, err = tx.Exec(ctx, "SET statement_timeout=5000")
...
if err := tx.Commit(ctx); err != nil { return "", err }
```

Per the [PostgreSQL `SET` docs](https://www.postgresql.org/docs/current/sql-set.html), a plain `SET` is **session-scoped** and survives `COMMIT`, so the lowered value persists for the lifetime of that backend connection. When `pgxpool` returns the connection to the pool, the next caller inherits the 5s timeout. The most visible casualty is the dispatcher's `Heartbeat` RPC, whose only write is a bare `UPDATE "Worker" … WHERE id = $1` with no `SET` of its own (`UpdateWorkerHeartbeat`): on a tainted connection it aborts at the 5s mark with SQLSTATE `57014`:

```
ERR error="ERROR: canceling statement due to statement timeout (SQLSTATE 57014)" service=grpc
ERR finished call grpc.code=Internal grpc.method=Heartbeat grpc.time_ms=5167.774 grpc.service=Dispatcher
```

The `~5167ms` duration matching the `5000ms` timeout is the fingerprint — the pool default of 30s never applied. Workers then log missed heartbeats and a few consecutive misses mark the worker inactive. These helpers run on a fast cadence on every controller/worker/scheduler partition on every engine instance, so over time a large fraction of pool connections get tainted.

## Fix

Use `SET LOCAL` in the three helpers. `SET LOCAL` scopes the change to the current transaction and is automatically reverted on `COMMIT`/`ROLLBACK`, which is exactly the intent of the original "set tx timeout to 5 seconds" comment — with zero leakage to other pool callers and zero overhead.

## Scope notes

- I deliberately did **not** add an `AfterRelease` pool hook to re-normalize the GUC on check-in. That would issue a `SET` round-trip on every connection release on a hot path; `SET LOCAL` removes the leak at the source for free, so the hook is unnecessary cost.
- `pkg/repository/sqlchelpers/tx.go::PrepareTxWithStatementTimeout` uses a plain `SET` too but does not leak today (it resets to 30000 before commit and `ROLLBACK` reverts the rest), and #3930 is already reworking that path, so I left it untouched to avoid a collision.
- `pkg/config/loader/loader.go`'s `SET statement_timeout=30000` is the intended per-connection session default and is correct as-is.

I was not able to run `go build` in my environment, but the change is a pure SQL string-literal swap inside the existing `tx.Exec(ctx, ...)` calls (same signature/arity), so it is compile-safe.

<details open id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Claude Code (Opus 4.8) implemented this PR. It read issue #3898, applied the `SET` -> `SET LOCAL` change to the three partition-heartbeat helpers in `tenant.go`, and added the explanatory comment. The root-cause diagnosis and proposed fix were laid out in the issue. I reviewed the diff and confirmed it matches the issue's prescribed fix and Postgres `SET LOCAL` semantics.

</details>
