### PR TITLE
fix(sdks/ts): add default value for options parameter in runNoWait

### DIFF
--- a/sdks/typescript/src/v1/client/client.ts
+++ b/sdks/typescript/src/v1/client/client.ts
@@ -388,7 +388,7 @@ export class HatchetClient<
   async runNoWait<I extends InputType = UnknownInputType, O extends OutputType = void>(
     workflow: BaseWorkflowDeclaration<I, O> | LegacyWorkflow | string,
     input: I,
-    options: RunOpts
+    options: RunOpts = {}
   ): Promise<WorkflowRunRef<O>> {
     const name = getWorkflowName(workflow);
     return this.admin.runWorkflow<I, O>(name, input, options);


### PR DESCRIPTION
## Description

`runNoWait()` was missing `= {}` as the default value for the `options` parameter, causing a TypeScript error when the method is called without a third argument.

`run()` and `runAndWait()` both correctly default to `= {}`, making this an inconsistency in the API.

**File changed:** `sdks/typescript/src/v1/client/client.ts` (~line 391)

**Change:** `options: RunOpts` → `options: RunOpts = {}`

Fixes #4190

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this PR, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._
- **Details**: Claude helped me check the code and suggest fixes.

</details>