### PR TITLE
fix(python, ts): durable listener hanging from race condition

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hatchet's Python SDK will be documented in this changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.33.9] - 2026-06-14
+
+### Fixed
+
+- Fixes a race condition in the durable event listener where an engine restart can cause the listener to get stuck because of the existence of two separate request queues that are not kept in sync, causing requests to hang indefinitely after being added to the old queue in some cases.
+
 ## [1.33.8] - 2026-06-12
 
 ### Fixed

--- a/sdks/python/hatchet_sdk/clients/listeners/durable_event_listener.py
+++ b/sdks/python/hatchet_sdk/clients/listeners/durable_event_listener.py
@@ -256,12 +256,13 @@ class DurableEventListener:
             await self._conn.close()
 
     async def _request_iterator(self) -> AsyncIterator[DurableTaskRequest]:
-        if not self._request_queue:
+        queue = self._request_queue
+        if queue is None:
             raise RuntimeError("Request queue not initialized")
 
         while self._running:
             with suppress(asyncio.TimeoutError):
-                yield await asyncio.wait_for(self._request_queue.get(), timeout=1.0)
+                yield await asyncio.wait_for(queue.get(), timeout=1.0)
 
     async def _send_loop(self) -> None:
         while self._running:

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hatchet-sdk"
-version = "1.33.8"
+version = "1.33.9"
 description = "This is the official Python SDK for Hatchet, a distributed, fault-tolerant task queue. The SDK allows you to easily integrate Hatchet's task scheduling and workflow orchestration capabilities into your Python applications."
 readme = "README.md"
 license = { text = "MIT" }

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hatchet's TypeScript SDK will be documented in this chang
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.2] - 2026-06-15
+
+### Fixed
+
+- Fixed a bug where the durable event listener's request iterator could survive a stream reconnect and drain items from the new queue into the dead stream, causing durable tasks to hang indefinitely after an engine restart. The iterator now captures its queue and abort signal at creation time and terminates cleanly when the connection is replaced.
+
 ## [1.24.1] - 2026-06-12
 
 ### Fixed

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "1.24.1",
+  "version": "1.24.2",
   "description": "Background task orchestration & visibility for developers",
   "types": "dist/index.d.ts",
   "files": [

--- a/sdks/typescript/src/clients/listeners/durable-listener/durable-listener-client.ts
+++ b/sdks/typescript/src/clients/listeners/durable-listener/durable-listener-client.ts
@@ -298,8 +298,9 @@ export class DurableListenerClient {
   private async _connect(): Promise<void> {
     this.logger.info('durable event listener connecting...');
 
-    this._requestQueue = [];
+    this._receiveAbort?.abort();
 
+    this._requestQueue = [];
     this._receiveAbort = new AbortController();
 
     this._enqueueRequest({
@@ -350,13 +351,17 @@ export class DurableListenerClient {
   }
 
   private async *_requestIterator(): AsyncIterable<DurableTaskRequest> {
-    while (this._running) {
-      while (this._requestQueue.length > 0) {
-        yield this._requestQueue.shift()!;
+    const queue = this._requestQueue;
+    const { signal } = this._receiveAbort!;
+
+    while (this._running && !signal.aborted) {
+      while (queue.length > 0) {
+        yield queue.shift()!;
       }
 
       await new Promise<void>((resolve) => {
         this._requestNotify = resolve;
+        signal.addEventListener('abort', resolve, { once: true });
       });
       this._requestNotify = undefined;
     }

--- a/sdks/typescript/src/clients/listeners/durable-listener/durable-listener-client.ts
+++ b/sdks/typescript/src/clients/listeners/durable-listener/durable-listener-client.ts
@@ -361,7 +361,7 @@ export class DurableListenerClient {
 
       await new Promise<void>((resolve) => {
         this._requestNotify = resolve;
-        signal.addEventListener('abort', resolve, { once: true });
+        signal.addEventListener('abort', () => resolve(), { once: true });
       });
       this._requestNotify = undefined;
     }


### PR DESCRIPTION
## [1.33.9] - 2026-06-14

### Fixed

- Fixes a race condition in the durable event listener where an engine restart can cause the listener to get stuck because of the existence of two separate request queues that are not kept in sync, causing requests to hang indefinitely after being added to the old queue in some cases.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)


<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI use in this PR

</details>
