### PR TITLE
feat(ci): scope failing job/test tables to last 24h

### DIFF
--- a/hack/ci/ci-dashboard/aggregate.py
+++ b/hack/ci/ci-dashboard/aggregate.py
@@ -19,13 +19,29 @@ from __future__ import annotations
 
 import sys
 from collections import Counter, defaultdict
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from lib import cache, config  # noqa: E402
 from lib import signatures as sig  # noqa: E402
+
+
+def _parse_ts(ts: str) -> datetime | None:
+    if not ts:
+        return None
+    if ts.endswith("Z"):
+        ts = ts[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(ts)
+    except ValueError:
+        return None
+
+
+def _in_table_window(run: dict, cutoff: datetime) -> bool:
+    created = _parse_ts(run.get("created_at") or "")
+    return created is not None and created >= cutoff
 
 
 def _scope(run: dict) -> str:
@@ -61,6 +77,7 @@ def _flaky_label(runs_total: int, fails: int, recovered: int) -> str:
 def main() -> int:
     runs = [r for r in cache.iter_runs() if r.get("gating")]
     runs_by_id = {r["id"]: r for r in runs}
+    table_cutoff = datetime.now(timezone.utc) - timedelta(hours=config.TABLE_WINDOW_HOURS)
 
     # job-level accumulation, keyed by (workflow, stripped job name)
     jobs: dict[tuple, dict] = defaultdict(lambda: {
@@ -77,7 +94,9 @@ def main() -> int:
     for run in runs:
         scope = _scope(run)
         date = (run.get("created_at") or "")[:10]
-        workflow_runs[run["wf_name"]] += 1
+        in_table_window = _in_table_window(run, table_cutoff)
+        if in_table_window:
+            workflow_runs[run["wf_name"]] += 1
 
         # run-level totals + trend (independent of job detail, so clean successes
         # without fetched jobs still count toward denominators / pass rate)
@@ -87,6 +106,9 @@ def main() -> int:
             if run.get("conclusion") == "failure":
                 totals[f"{scope}_fail_runs"] += 1
                 trend[date][f"{scope}_fails"] += 1
+
+        if not in_table_window:
+            continue
 
         by_attempt = run.get("jobs_by_attempt") or {}
         if not by_attempt:
@@ -124,7 +146,7 @@ def main() -> int:
 
     for jf in cache.iter_job_failures():
         run = runs_by_id.get(jf["run_id"])
-        if run is None:
+        if run is None or not _in_table_window(run, table_cutoff):
             continue
         scope = _scope(run)
         jkey = (jf["workflow"], sig.strip_matrix(jf["job_name"]))
@@ -237,6 +259,7 @@ def main() -> int:
     analysis = {
         "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "window_days": config.WINDOW_DAYS,
+        "table_window_hours": config.TABLE_WINDOW_HOURS,
         "since": cache.load_meta().get("since"),
         "totals": {
             **totals,

--- a/hack/ci/ci-dashboard/lib/config.py
+++ b/hack/ci/ci-dashboard/lib/config.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 REPO = "hatchet-dev/hatchet"
 WINDOW_DAYS = 14
+TABLE_WINDOW_HOURS = 24
 TOP_N = 10
 
 BASE_DIR = Path(__file__).resolve().parents[1]  # hack/ci/ci-dashboard/

--- a/hack/ci/ci-dashboard/render.py
+++ b/hack/ci/ci-dashboard/render.py
@@ -148,11 +148,14 @@ def main() -> int:
     classifications = cache.load_classifications()
     totals = analysis.get("totals", {})
     generated = analysis.get("generated_at", datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
+    window_days = analysis.get("window_days", config.WINDOW_DAYS)
+    table_hours = analysis.get("table_window_hours", config.TABLE_WINDOW_HOURS)
 
     parts = [
         f"# {config.DASHBOARD_TITLE}",
         "",
-        f"_Window: last {analysis.get('window_days', config.WINDOW_DAYS)} days · "
+        f"_Window: last {window_days} days (trend + pass rate) · "
+        f"tables: last {table_hours}h · "
         f"updated {generated} · auto-generated, do not edit by hand._",
         "",
         f"**Gating-CI pass rate** — PR: {_pct(totals.get('pr_pass_rate'))} "
@@ -164,11 +167,11 @@ def main() -> int:
         "",
         _mermaid_trend(analysis.get("trend", [])),
         "",
-        f"## Top {config.TOP_N} failing jobs",
+        f"## Top {config.TOP_N} failing jobs (last {table_hours}h)",
         "",
         _jobs_table(analysis.get("top_jobs", []), classifications),
         "",
-        f"## Top {config.TOP_N} failing tests",
+        f"## Top {config.TOP_N} failing tests (last {table_hours}h)",
         "",
         _tests_table(analysis.get("top_tests", []), classifications),
         "",
@@ -177,7 +180,8 @@ def main() -> int:
         _wins(analysis.get("wins", {})),
         "",
         "---",
-        f"_All counts cover the window above (last {analysis.get('window_days', config.WINDOW_DAYS)} days)._ "
+        f"_Trend and pass-rate totals cover the last {window_days} days; "
+        f"job/test tables cover the last {table_hours}h._ "
         "**fails** = gating runs where the job/test failed · "
         "**recovered** = failed on a first attempt but passed on re-run (a flakiness signal) · "
         "**runs** = total gating runs of that workflow · "


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description

The CI Health Dashboard (#4204) ranked top failing jobs and tests over the same 14-day window as the pass-rate trend. That makes the tables slow to reflect what is breaking CI right now.

This change keeps the 14-day window for collection, pass-rate totals, and the daily trend chart, but scopes the top failing jobs/tests tables to the last 24 hours so recent offenders surface immediately.

Fixes #4204

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] CI (any automation pipeline changes)

## What's Changed

- [x] Add `TABLE_WINDOW_HOURS = 24` in `hack/ci/ci-dashboard/lib/config.py`
- [x] Filter job/test aggregation in `aggregate.py` to runs within the last 24h
- [x] Update `render.py` header, section titles, and footer to document the split windows

## Checklist

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Cursor cloud agent implemented the config/aggregation/render changes for the 24h table window.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06d6a1c6-5834-4a9b-9570-4b179656b847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06d6a1c6-5834-4a9b-9570-4b179656b847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

