### PR TITLE
Fix load CLI DAG timing budget

### DIFF
--- a/cmd/hatchet-loadtest/do.go
+++ b/cmd/hatchet-loadtest/do.go
@@ -74,23 +74,61 @@ type avgResult struct {
 	latencyResult LatencyResult
 }
 
-func do(config LoadTestConfig) error {
-	l.Info().Msgf("testing with duration=%s, eventsPerSecond=%d, delay=%s, wait=%s, concurrency=%d, averageDurationThreshold=%s", config.Duration, config.Events, config.Delay, config.Wait, config.Concurrency, config.AverageDurationThreshold)
+type loadTestTiming struct {
+	registrationTimeout time.Duration
+	startupDelay        time.Duration
+	safetyBuffer        time.Duration
+	safetyTimeout       time.Duration
+	activeWindow        time.Duration
+}
 
-	after := 10 * time.Second
+type runResult struct {
+	executed int64
+	uniques  int64
+}
+
+func calculateLoadTestTiming(config LoadTestConfig) loadTestTiming {
 	registrationTimeout := config.RegistrationTimeout
 	if registrationTimeout == 0 {
 		registrationTimeout = 60 * time.Second
 	}
 
-	// The worker may intentionally be delayed (WorkerDelay) before it starts consuming tasks.
-	// The test timeout must include registration and this delay, otherwise we can cancel while work is still expected to complete.
-	timeout := registrationTimeout + config.WorkerDelay + after + config.Duration + config.Wait + 30*time.Second
+	startupDelay := 10 * time.Second
+	safetyBuffer := 30 * time.Second
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
+	return loadTestTiming{
+		registrationTimeout: registrationTimeout,
+		startupDelay:        startupDelay,
+		safetyBuffer:        safetyBuffer,
+		safetyTimeout:       registrationTimeout + config.WorkerDelay + startupDelay + config.Duration + config.Wait + safetyBuffer,
+		activeWindow:        startupDelay + config.Duration + config.Wait,
+	}
+}
 
-	ch := make(chan int64, 2)
+func waitOrDone(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func do(config LoadTestConfig) error {
+	l.Info().Msgf("testing with duration=%s, eventsPerSecond=%d, delay=%s, wait=%s, concurrency=%d, averageDurationThreshold=%s", config.Duration, config.Events, config.Delay, config.Wait, config.Concurrency, config.AverageDurationThreshold)
+
+	timing := calculateLoadTestTiming(config)
+
+	safetyCtx, safetyCancel := context.WithTimeout(context.Background(), timing.safetyTimeout)
+	defer safetyCancel()
+
+	workerCtx, stopWorker := context.WithCancel(safetyCtx)
+	defer stopWorker()
+
+	ch := make(chan runResult, 1)
 	durations := make(chan executionEvent, config.Events)
 
 	// Compute running average for executed durations using a rolling average.
@@ -118,17 +156,18 @@ func do(config LoadTestConfig) error {
 	registered := make(chan error, 1)
 
 	go func() {
-		count, uniques := run(ctx, config, durations, registered)
+		count, uniques := run(workerCtx, config, durations, registered)
 		close(durations)
-		ch <- count
-		ch <- uniques
+		ch <- runResult{executed: count, uniques: uniques}
 	}()
 
-	if err := waitForRegistration(registered, registrationTimeout); err != nil {
-		return fmt.Errorf("❌ workflow registration failed within %s — engine must accept PutWorkflow on the current (pre-migration) schema: %w", registrationTimeout, err)
+	if err := waitForRegistration(registered, timing.registrationTimeout); err != nil {
+		return fmt.Errorf("❌ workflow registration failed within %s — engine must accept PutWorkflow on the current (pre-migration) schema: %w", timing.registrationTimeout, err)
 	}
 
-	time.Sleep(after)
+	if err := waitOrDone(safetyCtx, timing.startupDelay); err != nil {
+		return fmt.Errorf("LOADTEST_SAFETY_TIMEOUT: safety deadline reached during startup delay: activeWindow=%s safetyTimeout=%s: %w", timing.activeWindow, timing.safetyTimeout, err)
+	}
 
 	scheduled := make(chan time.Duration, config.Events)
 
@@ -153,11 +192,28 @@ func do(config LoadTestConfig) error {
 		scheduledResult <- avgResult{count: count, avg: avg, latencyResult: LatencyResult{snapshots: snapshots}}
 	}()
 
-	emitted := emit(ctx, config.Namespace, config.Events, config.Duration, scheduled, config.PayloadSize)
+	emitted := emit(safetyCtx, config.Namespace, config.Events, config.Duration, scheduled, config.PayloadSize)
 	close(scheduled)
 
-	executed := <-ch
-	uniques := <-ch
+	if err := safetyCtx.Err(); err != nil {
+		return fmt.Errorf("LOADTEST_SAFETY_TIMEOUT: safety deadline reached while emitting events: pushed=%d activeWindow=%s safetyTimeout=%s: %w", emitted, timing.activeWindow, timing.safetyTimeout, err)
+	}
+
+	if err := waitOrDone(safetyCtx, config.Wait); err != nil {
+		return fmt.Errorf("LOADTEST_SAFETY_TIMEOUT: safety deadline reached while waiting for executions: pushed=%d wait=%s activeWindow=%s safetyTimeout=%s: %w", emitted, config.Wait, timing.activeWindow, timing.safetyTimeout, err)
+	}
+
+	stopWorker()
+
+	var result runResult
+	select {
+	case result = <-ch:
+	case <-safetyCtx.Done():
+		return fmt.Errorf("LOADTEST_SAFETY_TIMEOUT: worker did not stop before safety deadline: pushed=%d activeWindow=%s safetyTimeout=%s: %w", emitted, timing.activeWindow, timing.safetyTimeout, safetyCtx.Err())
+	}
+
+	executed := result.executed
+	uniques := result.uniques
 
 	finalDurationResult := <-durationsResult
 	finalScheduledResult := <-scheduledResult
@@ -230,7 +286,21 @@ func do(config LoadTestConfig) error {
 	thresholdWithTolerance := config.AverageDurationThreshold + tolerance
 
 	if finalDurationResult.avg > thresholdWithTolerance {
-		return fmt.Errorf("❌ average duration per executed event is greater than the threshold (with tolerance): %s > %s (threshold: %s, tolerance: %s)", finalDurationResult.avg, thresholdWithTolerance, config.AverageDurationThreshold, tolerance)
+		return fmt.Errorf(
+			"LOADTEST_THRESHOLD_EXCEEDED: average duration per executed event exceeded threshold: observed=%s thresholdWithTolerance=%s threshold=%s tolerance=%s dagSteps=%d eventFanout=%d pushed=%d executed=%d uniques=%d eventsPerSecond=%d activeWindow=%s safetyTimeout=%s",
+			finalDurationResult.avg,
+			thresholdWithTolerance,
+			config.AverageDurationThreshold,
+			tolerance,
+			config.DagSteps,
+			config.EventFanout,
+			emitted,
+			executed,
+			uniques,
+			config.Events,
+			timing.activeWindow,
+			timing.safetyTimeout,
+		)
 	}
 
 	log.Printf("✅ success")

--- a/cmd/hatchet-loadtest/gate_test.go
+++ b/cmd/hatchet-loadtest/gate_test.go
@@ -38,3 +38,59 @@ func TestWaitForRegistrationTimeout(t *testing.T) {
 		t.Fatalf("waitForRegistration() error = %q, want timeout message", err)
 	}
 }
+
+func TestLoadTestTimingUsesDefaultRegistrationTimeout(t *testing.T) {
+	timing := calculateLoadTestTiming(LoadTestConfig{
+		Duration: 240 * time.Second,
+		Wait:     60 * time.Second,
+	})
+
+	if timing.registrationTimeout != time.Minute {
+		t.Fatalf("registrationTimeout = %s, want 1m0s", timing.registrationTimeout)
+	}
+
+	if timing.activeWindow != 310*time.Second {
+		t.Fatalf("activeWindow = %s, want 5m10s", timing.activeWindow)
+	}
+
+	if timing.safetyTimeout != 400*time.Second {
+		t.Fatalf("safetyTimeout = %s, want 6m40s", timing.safetyTimeout)
+	}
+}
+
+func TestLoadTestTimingAccountsForWorkerDelayInSafetyOnly(t *testing.T) {
+	timing := calculateLoadTestTiming(LoadTestConfig{
+		Duration:    240 * time.Second,
+		Wait:        120 * time.Second,
+		WorkerDelay: 120 * time.Second,
+	})
+
+	if timing.activeWindow != 370*time.Second {
+		t.Fatalf("activeWindow = %s, want 6m10s", timing.activeWindow)
+	}
+
+	if timing.safetyTimeout != 580*time.Second {
+		t.Fatalf("safetyTimeout = %s, want 9m40s", timing.safetyTimeout)
+	}
+}
+
+func TestLoadTestTimingUsesExplicitRegistrationTimeout(t *testing.T) {
+	timing := calculateLoadTestTiming(LoadTestConfig{
+		RegistrationTimeout: 20 * time.Second,
+		WorkerDelay:         5 * time.Second,
+		Duration:            30 * time.Second,
+		Wait:                40 * time.Second,
+	})
+
+	if timing.registrationTimeout != 20*time.Second {
+		t.Fatalf("registrationTimeout = %s, want 20s", timing.registrationTimeout)
+	}
+
+	if timing.activeWindow != 80*time.Second {
+		t.Fatalf("activeWindow = %s, want 1m20s", timing.activeWindow)
+	}
+
+	if timing.safetyTimeout != 135*time.Second {
+		t.Fatalf("safetyTimeout = %s, want 2m15s", timing.safetyTimeout)
+	}
+}

--- a/cmd/hatchet-loadtest/run.go
+++ b/cmd/hatchet-loadtest/run.go
@@ -186,7 +186,17 @@ func run(ctx context.Context, config LoadTestConfig, executions chan<- execution
 
 	if config.WorkerDelay > 0 {
 		l.Info().Msgf("waiting %s before starting the worker", config.WorkerDelay)
-		time.Sleep(config.WorkerDelay)
+		timer := time.NewTimer(config.WorkerDelay)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
+			return 0, 0
+		}
+	}
+
+	if ctx.Err() != nil {
+		return 0, 0
 	}
 
 	l.Info().Msg("starting worker now")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description

Fixes the load CLI test orchestration so normal completion stops the worker after the intended active window instead of waiting for the hard safety deadline. This should reduce `TestLoadCLI/test_with_DAG` wall time in `load-pgbouncer` and make remaining threshold failures easier for the auto-generated dashboard to classify.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

- [x] Split load-test timing into an intended active window and a hard safety timeout.
- [x] Stop the worker after emit plus the configured wait window instead of after safety timeout expiry.
- [x] Add parseable `LOADTEST_SAFETY_TIMEOUT` and `LOADTEST_THRESHOLD_EXCEEDED` messages.
- [x] Add focused non-load timing helper tests.

## Checklist

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

- `gofmt -w cmd/hatchet-loadtest/do.go cmd/hatchet-loadtest/run.go cmd/hatchet-loadtest/gate_test.go`
- `git diff --check`
- Not run: `go test ./cmd/hatchet-loadtest -run 'TestWaitForRegistration|TestLoadTestTiming' -count=1` because this environment has Go 1.22.2 and `go.mod` requires Go >= 1.26. The default toolchain auto-download also failed with `toolchain not available`.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Used Cursor agent to investigate CI logs, implement the load-test timing/context changes, and add focused timing tests.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a220a1-eafb-4f7f-b349-8e206169e189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a220a1-eafb-4f7f-b349-8e206169e189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

