### PR TITLE
fix(engine): add retention cron to delete expired UserSession rows

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260616150822_v1_0_118.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260616150822_v1_0_118.sql
@@ -1,0 +1,8 @@
+-- +goose no transaction
+-- +goose Up
+-- Backs the retention cron's `DELETE FROM "UserSession" WHERE "expiresAt" < NOW()`.
+-- Without it each cleanup batch sequentially scans the table (see #3913).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "UserSession_expiresAt_idx" ON "UserSession" ("expiresAt");
+
+-- +goose Down
+DROP INDEX IF EXISTS "UserSession_expiresAt_idx";

--- a/internal/services/controllers/retention/controller.go
+++ b/internal/services/controllers/retention/controller.go
@@ -21,30 +21,32 @@ type RetentionController interface {
 }
 
 type RetentionControllerImpl struct {
-	l               *zerolog.Logger
-	repo            v1.Repository
-	dv              datautils.DataDecoderValidator
-	s               gocron.Scheduler
-	tenantAlerter   *alerting.TenantAlertManager
-	a               *hatcheterrors.Wrapped
-	p               *partition.Partition
-	dataRetention   bool
-	workerRetention bool
-	queueRetention  bool
+	l                *zerolog.Logger
+	repo             v1.Repository
+	dv               datautils.DataDecoderValidator
+	s                gocron.Scheduler
+	tenantAlerter    *alerting.TenantAlertManager
+	a                *hatcheterrors.Wrapped
+	p                *partition.Partition
+	dataRetention    bool
+	workerRetention  bool
+	queueRetention   bool
+	sessionRetention bool
 }
 
 type RetentionControllerOpt func(*RetentionControllerOpts)
 
 type RetentionControllerOpts struct {
-	l               *zerolog.Logger
-	repo            v1.Repository
-	dv              datautils.DataDecoderValidator
-	ta              *alerting.TenantAlertManager
-	alerter         hatcheterrors.Alerter
-	p               *partition.Partition
-	dataRetention   bool
-	workerRetention bool
-	queueRetention  bool
+	l                *zerolog.Logger
+	repo             v1.Repository
+	dv               datautils.DataDecoderValidator
+	ta               *alerting.TenantAlertManager
+	alerter          hatcheterrors.Alerter
+	p                *partition.Partition
+	dataRetention    bool
+	workerRetention  bool
+	queueRetention   bool
+	sessionRetention bool
 }
 
 func defaultRetentionControllerOpts() *RetentionControllerOpts {
@@ -52,12 +54,13 @@ func defaultRetentionControllerOpts() *RetentionControllerOpts {
 	alerter := hatcheterrors.NoOpAlerter{}
 
 	return &RetentionControllerOpts{
-		l:               &logger,
-		dv:              datautils.NewDataDecoderValidator(),
-		alerter:         alerter,
-		dataRetention:   true,
-		queueRetention:  true,
-		workerRetention: false,
+		l:                &logger,
+		dv:               datautils.NewDataDecoderValidator(),
+		alerter:          alerter,
+		dataRetention:    true,
+		queueRetention:   true,
+		workerRetention:  false,
+		sessionRetention: true,
 	}
 }
 
@@ -109,6 +112,12 @@ func WithWorkerRetention(b bool) RetentionControllerOpt {
 	}
 }
 
+func WithSessionRetention(b bool) RetentionControllerOpt {
+	return func(opts *RetentionControllerOpts) {
+		opts.sessionRetention = b
+	}
+}
+
 func New(fs ...RetentionControllerOpt) (*RetentionControllerImpl, error) {
 	opts := defaultRetentionControllerOpts()
 
@@ -141,16 +150,17 @@ func New(fs ...RetentionControllerOpt) (*RetentionControllerImpl, error) {
 	a.WithData(map[string]interface{}{"service": "retention-controller"})
 
 	return &RetentionControllerImpl{
-		l:               opts.l,
-		repo:            opts.repo,
-		dv:              opts.dv,
-		s:               s,
-		tenantAlerter:   opts.ta,
-		a:               a,
-		p:               opts.p,
-		dataRetention:   opts.dataRetention,
-		workerRetention: opts.workerRetention,
-		queueRetention:  opts.queueRetention,
+		l:                opts.l,
+		repo:             opts.repo,
+		dv:               opts.dv,
+		s:                s,
+		tenantAlerter:    opts.ta,
+		a:                a,
+		p:                opts.p,
+		dataRetention:    opts.dataRetention,
+		workerRetention:  opts.workerRetention,
+		queueRetention:   opts.queueRetention,
+		sessionRetention: opts.sessionRetention,
 	}, nil
 }
 
@@ -189,6 +199,23 @@ func (rc *RetentionControllerImpl) Start() (func() error, error) {
 		if err != nil {
 			cancel()
 			return nil, fmt.Errorf("could not set up runCleanupOldWorkers: %w", err)
+		}
+	}
+
+	if rc.sessionRetention {
+		sessionInterval := 24 * time.Hour
+
+		_, err := rc.s.NewJob(
+			gocron.DurationJob(sessionInterval),
+			gocron.NewTask(
+				rc.runCleanupExpiredUserSessions(ctx),
+			),
+			gocron.WithSingletonMode(gocron.LimitModeReschedule),
+		)
+
+		if err != nil {
+			cancel()
+			return nil, fmt.Errorf("could not set up runCleanupExpiredUserSessions: %w", err)
 		}
 	}
 

--- a/internal/services/controllers/retention/sessions.go
+++ b/internal/services/controllers/retention/sessions.go
@@ -1,0 +1,46 @@
+package retention
+
+import (
+	"context"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/pkg/telemetry"
+)
+
+func (rc *RetentionControllerImpl) runCleanupExpiredUserSessions(ctx context.Context) func() {
+	return func() {
+		rc.l.Debug().Ctx(ctx).Msg("retention controller: cleaning up expired user sessions")
+
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Minute)
+		defer cancel()
+
+		if err := rc.runCleanupExpiredUserSessionsQueries(ctx); err != nil {
+			rc.l.Err(err).Ctx(ctx).Msg("could not cleanup expired user sessions")
+		}
+	}
+}
+
+func (rc *RetentionControllerImpl) runCleanupExpiredUserSessionsQueries(ctx context.Context) error {
+	ctx, span := telemetry.NewSpan(ctx, "cleanup-expired-user-sessions")
+	defer span.End()
+
+	// batchSize bounds each delete so a large backlog of expired sessions drains
+	// across iterations instead of one long-running transaction.
+	const batchSize int32 = 10000
+
+	shouldContinue := true
+
+	for shouldContinue {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		var err error
+		shouldContinue, err = rc.repo.UserSession().DeleteExpired(ctx, batchSize)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/repository/sqlcv1/users.sql
+++ b/pkg/repository/sqlcv1/users.sql
@@ -154,3 +154,12 @@ DELETE FROM
 WHERE
     "id" = @id::uuid
 RETURNING *;
+
+-- name: CleanupExpiredUserSessions :execresult
+DELETE FROM "UserSession"
+WHERE "id" IN (
+    SELECT "id"
+    FROM "UserSession"
+    WHERE "expiresAt" < NOW()
+    LIMIT @batchSize::int
+);

--- a/pkg/repository/sqlcv1/users.sql.go
+++ b/pkg/repository/sqlcv1/users.sql.go
@@ -9,8 +9,23 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 )
+
+const cleanupExpiredUserSessions = `-- name: CleanupExpiredUserSessions :execresult
+DELETE FROM "UserSession"
+WHERE "id" IN (
+    SELECT "id"
+    FROM "UserSession"
+    WHERE "expiresAt" < NOW()
+    LIMIT $1::int
+)
+`
+
+func (q *Queries) CleanupExpiredUserSessions(ctx context.Context, db DBTX, batchsize int32) (pgconn.CommandTag, error) {
+	return db.Exec(ctx, cleanupExpiredUserSessions, batchsize)
+}
 
 const createUser = `-- name: CreateUser :one
 INSERT INTO "User" (

--- a/pkg/repository/user_session.go
+++ b/pkg/repository/user_session.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -37,6 +38,11 @@ type UserSessionRepository interface {
 	Update(ctx context.Context, sessionId uuid.UUID, opts *UpdateSessionOpts) (*sqlcv1.UserSession, error)
 	Delete(ctx context.Context, sessionId uuid.UUID) (*sqlcv1.UserSession, error)
 	GetById(ctx context.Context, sessionId uuid.UUID) (*sqlcv1.UserSession, error)
+
+	// DeleteExpired removes up to batchSize expired sessions in a single bounded
+	// transaction. It returns true when a full batch was deleted, signalling the
+	// caller to invoke it again until the backlog is drained.
+	DeleteExpired(ctx context.Context, batchSize int32) (bool, error)
 }
 
 type userSessionRepository struct {
@@ -164,4 +170,25 @@ func (r *userSessionRepository) GetById(ctx context.Context, sessionId uuid.UUID
 		r.pool,
 		sessionId,
 	)
+}
+
+func (r *userSessionRepository) DeleteExpired(ctx context.Context, batchSize int32) (bool, error) {
+	const timeout = 1000 * 60 * 3 // 3 minutes
+
+	tx, commit, rollback, err := sqlchelpers.PrepareTxWithStatementTimeout(ctx, r.pool, r.l, timeout)
+	if err != nil {
+		return false, fmt.Errorf("error beginning transaction: %w", err)
+	}
+	defer rollback()
+
+	result, err := r.queries.CleanupExpiredUserSessions(ctx, tx, batchSize)
+	if err != nil {
+		return false, fmt.Errorf("error cleaning up expired user sessions: %w", err)
+	}
+
+	if err := commit(ctx); err != nil {
+		return false, fmt.Errorf("error committing transaction: %w", err)
+	}
+
+	return result.RowsAffected() == int64(batchSize), nil
 }

--- a/sql/schema/v0.sql
+++ b/sql/schema/v0.sql
@@ -1418,6 +1418,9 @@ CREATE UNIQUE INDEX "UserPassword_userId_key" ON "UserPassword" ("userId" ASC);
 CREATE UNIQUE INDEX "UserSession_id_key" ON "UserSession" ("id" ASC);
 
 -- CreateIndex
+CREATE INDEX "UserSession_expiresAt_idx" ON "UserSession" ("expiresAt");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "WebhookWorker_id_key" ON "WebhookWorker" ("id" ASC);
 
 -- CreateIndex


### PR DESCRIPTION
Fixes #3913.

## Problem

The `UserSession` table grows unboundedly. On the reporter's self-hosted deployment it reached 2.6M rows (~1 GB) in 30 days, all `userId = NULL`, written once and never read again. PR #3923 fixed the root-cause insert (Bearer-authed requests no longer create phantom sessions), but nothing purges the rows that already expired: the only `DELETE` on the table is `DeleteUserSession` by id (explicit logout), and tenant retention doesn't cover this table.

This is the follow-up @gregfurman asked for in #3913 — "we should also be adding a cron to periodically clean up these expired entries."

## Fix

A periodic cleanup in the retention controller, modelled on the existing `runCleanupOldWorkers` / `runDeleteMessageQueueItems` jobs:

- **`CleanupExpiredUserSessions` sqlc query** — `DELETE` of expired rows via a `LIMIT`ed `id IN (SELECT …)` subquery, so each call deletes a bounded batch.
- **`UserSessionRepository.DeleteExpired(ctx, batchSize)`** — runs one batch inside a statement-timeout-bounded transaction (`PrepareTxWithStatementTimeout`, 3 min), returning whether a full batch was deleted. Same shape as `workerRepository.CleanupOldWorkers`.
- **`runCleanupExpiredUserSessions` retention job** — loops `DeleteExpired` until a partial batch (backlog drained), under a 30-min context timeout. Registered as a 24h `gocron` job with `SingletonMode`, mirroring the worker-retention block.
- **Index migration** (`v1_0_118`) — `CREATE INDEX CONCURRENTLY` on `"UserSession"("expiresAt")`. Without it each batch sequential-scans the table, which matters precisely because the backlog can be in the millions. Added `CONCURRENTLY` + `-- +goose no transaction` per the existing precedent (`v1_0_47`).

## Notes / decisions

- **Always-on, no config flag.** I followed the `queueRetention` / `dataRetention` precedent (always-on global cleanups) rather than `workerRetention` (which has an `EnableWorkerRetention` flag only because it defaults *off*). Deleting expired sessions is universally safe — they're unusable by definition — so there's no operator reason to disable it. A `WithSessionRetention` opt exists if you'd prefer it gated behind config; say the word and I'll wire `EnableSessionRetention` through `server.go` / `loader.go` / `run.go` to match the worker knob.
- **Batch size 10000**, same as `CleanupOldWorkers`.

## Testing

`go build` + `go vet` clean on the changed packages. The retention jobs are integration-level (no existing unit tests for `retention/` or the session repo), so I didn't add unit tests to match the existing convention — happy to add an integration test that seeds expired rows and asserts the drain if you'd like one before merge.

## AI usage disclosure

Per CONTRIBUTING.md#ai-usage: implemented with Claude Code (Opus). It traced the issue through the retention controller and repository layers, matched the existing `CleanupOldWorkers` cleanup pattern, regenerated the sqlc binding, and added the index migration. I reviewed every change against the repo's conventions before opening. Same human-directed workflow and disclosure as #4180 and #4214.
