### PR TITLE
feat(engine): partition core tables

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260616165553_v1_0_118.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260616165553_v1_0_118.sql
@@ -1,0 +1,566 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION rename_partitions(
+    parent_table_name TEXT,
+    new_prefix TEXT
+)
+RETURNS TABLE(old_name TEXT, new_name TEXT)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    partition_record RECORD;
+    old_partition_name TEXT;
+    new_partition_name TEXT;
+    partition_suffix TEXT;
+BEGIN
+    FOR partition_record IN
+        SELECT c.relname AS partition_name
+        FROM pg_inherits i
+        JOIN pg_class c ON i.inhrelid = c.oid
+        JOIN pg_namespace n ON c.relnamespace = n.oid
+        JOIN pg_class parent ON i.inhparent = parent.oid
+        WHERE parent.relname = parent_table_name
+        ORDER BY c.relname
+    LOOP
+        old_partition_name := partition_record.partition_name;
+        partition_suffix := replace(old_partition_name, parent_table_name || '_', '');
+        new_partition_name := new_prefix || '_' || partition_suffix;
+
+        EXECUTE format('ALTER TABLE %I RENAME TO %I', old_partition_name, new_partition_name);
+        EXECUTE format('ALTER INDEX %I RENAME TO %I',
+            old_partition_name || '_pkey',
+            new_partition_name || '_pkey'
+        );
+
+        RETURN NEXT;
+        RAISE NOTICE 'Renamed: % -> %', old_partition_name, new_partition_name;
+    END LOOP;
+
+    RETURN;
+END;
+$$;
+
+CREATE TABLE IF NOT EXISTS v1_lookup_table_partitioned (
+    tenant_id UUID NOT NULL,
+    external_id UUID NOT NULL,
+    task_id BIGINT,
+    dag_id BIGINT,
+    inserted_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (external_id, inserted_at)
+) PARTITION BY RANGE (inserted_at);
+
+DO $$
+DECLARE
+    oldest_date DATE;
+    d DATE;
+    partition_count INTEGER;
+BEGIN
+    SELECT COUNT(*)
+    INTO partition_count
+    FROM pg_class c
+    JOIN pg_inherits i ON c.oid = i.inhrelid
+    JOIN pg_class parent ON i.inhparent = parent.oid
+    WHERE parent.relname = 'v1_lookup_table_partitioned'
+    AND c.relkind = 'r';
+
+    IF partition_count > 0 THEN
+        RAISE NOTICE 'Partitions already exist for v1_lookup_table_partitioned, skipping creation';
+        RETURN;
+    END IF;
+
+    SELECT (WITH t AS (SELECT * FROM v1_task ORDER BY id LIMIT 1) SELECT inserted_at::DATE FROM t)
+    INTO oldest_date;
+
+    IF oldest_date IS NULL THEN
+        oldest_date := (NOW() - INTERVAL '30 day')::DATE;
+    END IF;
+
+    d := oldest_date;
+    WHILE d <= (NOW() + INTERVAL '1 day')::DATE LOOP
+        PERFORM create_v1_weekly_range_partition('v1_lookup_table_partitioned', d);
+        d := d + INTERVAL '1 day';
+    END LOOP;
+END $$;
+
+-- Replication trigger: inserts into old table are forwarded to the new partitioned table
+-- during the backfill window so no writes are lost between backfill and cutover.
+CREATE OR REPLACE FUNCTION v1_lookup_table_partitioned_insert_function()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO v1_lookup_table_partitioned (
+        tenant_id,
+        external_id,
+        task_id,
+        dag_id,
+        inserted_at
+    )
+    SELECT
+        tenant_id,
+        external_id,
+        task_id,
+        dag_id,
+        inserted_at
+    FROM new_rows
+    ON CONFLICT (external_id, inserted_at) DO NOTHING;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER v1_lookup_table_partitioned_insert_trigger
+AFTER INSERT ON v1_lookup_table
+REFERENCING NEW TABLE AS new_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION v1_lookup_table_partitioned_insert_function();
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+INSERT INTO v1_lookup_table_partitioned (
+    tenant_id,
+    external_id,
+    task_id,
+    dag_id,
+    inserted_at
+)
+SELECT
+    tenant_id,
+    external_id,
+    id,
+    NULL::BIGINT,
+    inserted_at
+FROM v1_task
+ON CONFLICT (external_id, inserted_at) DO NOTHING;
+
+INSERT INTO v1_lookup_table_partitioned (
+    tenant_id,
+    external_id,
+    task_id,
+    dag_id,
+    inserted_at
+)
+SELECT
+    tenant_id,
+    external_id,
+    NULL::BIGINT,
+    id,
+    inserted_at
+FROM v1_dag
+ON CONFLICT (external_id, inserted_at) DO NOTHING;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS v1_lookup_table;
+DROP FUNCTION IF EXISTS v1_lookup_table_partitioned_insert_function;
+
+SELECT rename_partitions('v1_lookup_table_partitioned', 'v1_lookup_table');
+
+ALTER TABLE v1_lookup_table_partitioned RENAME TO v1_lookup_table;
+ALTER INDEX v1_lookup_table_partitioned_pkey RENAME TO v1_lookup_table_pkey;
+
+-- Update v1_task_insert_function to use new composite PK (external_id, inserted_at)
+CREATE OR REPLACE FUNCTION v1_task_insert_function()
+RETURNS TRIGGER AS $$
+DECLARE
+    rec RECORD;
+BEGIN
+    IF (SELECT COUNT(*) FROM new_table WHERE initial_state = 'QUEUED' AND concurrency_strategy_ids[1] IS NOT NULL) > 0 THEN
+        WITH new_slot_rows AS (
+            SELECT
+                id,
+                inserted_at,
+                retry_count,
+                tenant_id,
+                priority,
+                concurrency_parent_strategy_ids[1] AS parent_strategy_id,
+                CASE
+                    WHEN array_length(concurrency_parent_strategy_ids, 1) > 1 THEN concurrency_parent_strategy_ids[2:array_length(concurrency_parent_strategy_ids, 1)]
+                    ELSE '{}'::bigint[]
+                END AS next_parent_strategy_ids,
+                concurrency_strategy_ids[1] AS strategy_id,
+                external_id,
+                workflow_run_id,
+                CASE
+                    WHEN array_length(concurrency_strategy_ids, 1) > 1 THEN concurrency_strategy_ids[2:array_length(concurrency_strategy_ids, 1)]
+                    ELSE '{}'::bigint[]
+                END AS next_strategy_ids,
+                concurrency_keys[1] AS key,
+                CASE
+                    WHEN array_length(concurrency_keys, 1) > 1 THEN concurrency_keys[2:array_length(concurrency_keys, 1)]
+                    ELSE '{}'::text[]
+                END AS next_keys,
+                workflow_id,
+                workflow_version_id,
+                queue,
+                CURRENT_TIMESTAMP + convert_duration_to_interval(schedule_timeout) AS schedule_timeout_at
+            FROM new_table
+            WHERE initial_state = 'QUEUED' AND concurrency_strategy_ids[1] IS NOT NULL
+        )
+        INSERT INTO v1_concurrency_slot (
+            task_id,
+            task_inserted_at,
+            task_retry_count,
+            external_id,
+            tenant_id,
+            workflow_id,
+            workflow_version_id,
+            workflow_run_id,
+            parent_strategy_id,
+            next_parent_strategy_ids,
+            strategy_id,
+            next_strategy_ids,
+            priority,
+            key,
+            next_keys,
+            queue_to_notify,
+            schedule_timeout_at
+        )
+        SELECT
+            id,
+            inserted_at,
+            retry_count,
+            external_id,
+            tenant_id,
+            workflow_id,
+            workflow_version_id,
+            workflow_run_id,
+            parent_strategy_id,
+            next_parent_strategy_ids,
+            strategy_id,
+            next_strategy_ids,
+            COALESCE(priority, 1),
+            key,
+            next_keys,
+            queue,
+            schedule_timeout_at
+        FROM new_slot_rows;
+    END IF;
+
+    INSERT INTO v1_queue_item (
+        tenant_id,
+        queue,
+        task_id,
+        task_inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        schedule_timeout_at,
+        step_timeout,
+        priority,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label
+    )
+    SELECT
+        tenant_id,
+        queue,
+        id,
+        inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        CURRENT_TIMESTAMP + convert_duration_to_interval(schedule_timeout),
+        step_timeout,
+        COALESCE(priority, 1),
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label
+    FROM new_table
+    WHERE initial_state = 'QUEUED' AND concurrency_strategy_ids[1] IS NULL
+    ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
+    ;
+
+    IF (SELECT COUNT(*) FROM new_table WHERE dag_id IS NOT NULL AND dag_inserted_at IS NOT NULL) > 0 THEN
+        INSERT INTO v1_dag_to_task (
+            dag_id,
+            dag_inserted_at,
+            task_id,
+            task_inserted_at
+        )
+        SELECT
+            dag_id,
+            dag_inserted_at,
+            id,
+            inserted_at
+        FROM new_table
+        WHERE dag_id IS NOT NULL AND dag_inserted_at IS NOT NULL;
+    END IF;
+
+    INSERT INTO v1_lookup_table (
+        external_id,
+        tenant_id,
+        task_id,
+        inserted_at
+    )
+    SELECT
+        external_id,
+        tenant_id,
+        id,
+        inserted_at
+    FROM new_table
+    ON CONFLICT (external_id, inserted_at) DO NOTHING;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+
+-- Update v1_dag_insert_function to use new composite PK (external_id, inserted_at)
+CREATE OR REPLACE FUNCTION v1_dag_insert_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    INSERT INTO v1_lookup_table (
+        external_id,
+        tenant_id,
+        dag_id,
+        inserted_at
+    )
+    SELECT
+        external_id,
+        tenant_id,
+        id,
+        inserted_at
+    FROM new_table
+    ON CONFLICT (external_id, inserted_at) DO NOTHING;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS v1_lookup_table_original (
+    tenant_id UUID NOT NULL,
+    external_id UUID NOT NULL,
+    task_id BIGINT,
+    dag_id BIGINT,
+    inserted_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (external_id)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+INSERT INTO v1_lookup_table_original (
+    tenant_id,
+    external_id,
+    task_id,
+    dag_id,
+    inserted_at
+)
+SELECT
+    tenant_id,
+    external_id,
+    id,
+    NULL::BIGINT,
+    inserted_at
+FROM v1_task
+ON CONFLICT (external_id) DO NOTHING;
+
+INSERT INTO v1_lookup_table_original (
+    tenant_id,
+    external_id,
+    task_id,
+    dag_id,
+    inserted_at
+)
+SELECT
+    tenant_id,
+    external_id,
+    NULL::BIGINT,
+    id,
+    inserted_at
+FROM v1_dag
+ON CONFLICT (external_id) DO NOTHING;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS v1_lookup_table;
+
+ALTER TABLE v1_lookup_table_original RENAME TO v1_lookup_table;
+ALTER INDEX v1_lookup_table_original_pkey RENAME TO v1_lookup_table_pkey;
+
+CREATE OR REPLACE FUNCTION v1_task_insert_function()
+RETURNS TRIGGER AS $$
+DECLARE
+    rec RECORD;
+BEGIN
+    IF (SELECT COUNT(*) FROM new_table WHERE initial_state = 'QUEUED' AND concurrency_strategy_ids[1] IS NOT NULL) > 0 THEN
+        WITH new_slot_rows AS (
+            SELECT
+                id,
+                inserted_at,
+                retry_count,
+                tenant_id,
+                priority,
+                concurrency_parent_strategy_ids[1] AS parent_strategy_id,
+                CASE
+                    WHEN array_length(concurrency_parent_strategy_ids, 1) > 1 THEN concurrency_parent_strategy_ids[2:array_length(concurrency_parent_strategy_ids, 1)]
+                    ELSE '{}'::bigint[]
+                END AS next_parent_strategy_ids,
+                concurrency_strategy_ids[1] AS strategy_id,
+                external_id,
+                workflow_run_id,
+                CASE
+                    WHEN array_length(concurrency_strategy_ids, 1) > 1 THEN concurrency_strategy_ids[2:array_length(concurrency_strategy_ids, 1)]
+                    ELSE '{}'::bigint[]
+                END AS next_strategy_ids,
+                concurrency_keys[1] AS key,
+                CASE
+                    WHEN array_length(concurrency_keys, 1) > 1 THEN concurrency_keys[2:array_length(concurrency_keys, 1)]
+                    ELSE '{}'::text[]
+                END AS next_keys,
+                workflow_id,
+                workflow_version_id,
+                queue,
+                CURRENT_TIMESTAMP + convert_duration_to_interval(schedule_timeout) AS schedule_timeout_at
+            FROM new_table
+            WHERE initial_state = 'QUEUED' AND concurrency_strategy_ids[1] IS NOT NULL
+        )
+        INSERT INTO v1_concurrency_slot (
+            task_id,
+            task_inserted_at,
+            task_retry_count,
+            external_id,
+            tenant_id,
+            workflow_id,
+            workflow_version_id,
+            workflow_run_id,
+            parent_strategy_id,
+            next_parent_strategy_ids,
+            strategy_id,
+            next_strategy_ids,
+            priority,
+            key,
+            next_keys,
+            queue_to_notify,
+            schedule_timeout_at
+        )
+        SELECT
+            id,
+            inserted_at,
+            retry_count,
+            external_id,
+            tenant_id,
+            workflow_id,
+            workflow_version_id,
+            workflow_run_id,
+            parent_strategy_id,
+            next_parent_strategy_ids,
+            strategy_id,
+            next_strategy_ids,
+            COALESCE(priority, 1),
+            key,
+            next_keys,
+            queue,
+            schedule_timeout_at
+        FROM new_slot_rows;
+    END IF;
+
+    INSERT INTO v1_queue_item (
+        tenant_id,
+        queue,
+        task_id,
+        task_inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        schedule_timeout_at,
+        step_timeout,
+        priority,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label
+    )
+    SELECT
+        tenant_id,
+        queue,
+        id,
+        inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        CURRENT_TIMESTAMP + convert_duration_to_interval(schedule_timeout),
+        step_timeout,
+        COALESCE(priority, 1),
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label
+    FROM new_table
+    WHERE initial_state = 'QUEUED' AND concurrency_strategy_ids[1] IS NULL
+    ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
+    ;
+
+    IF (SELECT COUNT(*) FROM new_table WHERE dag_id IS NOT NULL AND dag_inserted_at IS NOT NULL) > 0 THEN
+        INSERT INTO v1_dag_to_task (
+            dag_id,
+            dag_inserted_at,
+            task_id,
+            task_inserted_at
+        )
+        SELECT
+            dag_id,
+            dag_inserted_at,
+            id,
+            inserted_at
+        FROM new_table
+        WHERE dag_id IS NOT NULL AND dag_inserted_at IS NOT NULL;
+    END IF;
+
+    INSERT INTO v1_lookup_table (
+        external_id,
+        tenant_id,
+        task_id,
+        inserted_at
+    )
+    SELECT
+        external_id,
+        tenant_id,
+        id,
+        inserted_at
+    FROM new_table
+    ON CONFLICT (external_id) DO NOTHING;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION v1_dag_insert_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    INSERT INTO v1_lookup_table (
+        external_id,
+        tenant_id,
+        dag_id,
+        inserted_at
+    )
+    SELECT
+        external_id,
+        tenant_id,
+        id,
+        inserted_at
+    FROM new_table
+    ON CONFLICT (external_id) DO NOTHING;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+
+DROP FUNCTION IF EXISTS rename_partitions(TEXT, TEXT);
+-- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20260616165555_v1_0_119.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260616165555_v1_0_119.sql
@@ -106,7 +106,7 @@ CREATE TABLE v1_dag_to_task_original (
     dag_inserted_at TIMESTAMPTZ NOT NULL,
     task_id BIGINT NOT NULL,
     task_inserted_at TIMESTAMPTZ NOT NULL,
-    CONSTRAINT v1_dag_to_task_pkey PRIMARY KEY (dag_id, dag_inserted_at, task_id, task_inserted_at)
+    CONSTRAINT v1_dag_to_task_original_pkey PRIMARY KEY (dag_id, dag_inserted_at, task_id, task_inserted_at)
 );
 
 INSERT INTO v1_dag_to_task_original
@@ -115,4 +115,5 @@ SELECT * FROM v1_dag_to_task;
 DROP TABLE v1_dag_to_task;
 
 ALTER TABLE v1_dag_to_task_original RENAME TO v1_dag_to_task;
+ALTER INDEX v1_dag_to_task_original_pkey RENAME TO v1_dag_to_task_pkey;
 -- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20260616165555_v1_0_119.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260616165555_v1_0_119.sql
@@ -1,0 +1,118 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS v1_dag_to_task_partitioned (
+    dag_id BIGINT NOT NULL,
+    dag_inserted_at TIMESTAMPTZ NOT NULL,
+    task_id BIGINT NOT NULL,
+    task_inserted_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (dag_id, dag_inserted_at, task_id, task_inserted_at)
+) PARTITION BY RANGE(dag_inserted_at);
+
+DO $$
+DECLARE
+    oldest_date DATE;
+    d DATE;
+    partition_count INTEGER;
+BEGIN
+    SELECT COUNT(*)
+    INTO partition_count
+    FROM pg_class c
+    JOIN pg_inherits i ON c.oid = i.inhrelid
+    JOIN pg_class parent ON i.inhparent = parent.oid
+    WHERE parent.relname = 'v1_dag_to_task_partitioned'
+    AND c.relkind = 'r';
+
+    IF partition_count > 0 THEN
+        RAISE NOTICE 'Partitions already exist for v1_dag_to_task_partitioned, skipping creation';
+        RETURN;
+    END IF;
+
+    SELECT (WITH t AS (SELECT * FROM v1_task ORDER BY id LIMIT 1) SELECT inserted_at::DATE FROM t)
+    INTO oldest_date;
+
+    IF oldest_date IS NULL THEN
+        oldest_date := NOW()::DATE;
+    END IF;
+
+    d := oldest_date;
+    WHILE d <= (NOW() + INTERVAL '1 day')::DATE LOOP
+        PERFORM create_v1_range_partition('v1_dag_to_task_partitioned', d);
+        d := d + INTERVAL '1 day';
+    END LOOP;
+END $$;
+
+CREATE OR REPLACE FUNCTION v1_dag_to_task_partitioned_insert_function()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO v1_dag_to_task_partitioned (
+        dag_id,
+        dag_inserted_at,
+        task_id,
+        task_inserted_at
+    )
+    SELECT
+        dag_id,
+        dag_inserted_at,
+        task_id,
+        task_inserted_at
+    FROM new_rows
+    ON CONFLICT (dag_id, dag_inserted_at, task_id, task_inserted_at) DO NOTHING;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER v1_dag_to_task_partitioned_insert_trigger
+AFTER INSERT ON v1_dag_to_task
+REFERENCING NEW TABLE AS new_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION v1_dag_to_task_partitioned_insert_function();
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+INSERT INTO v1_dag_to_task_partitioned (
+    dag_id,
+    dag_inserted_at,
+    task_id,
+    task_inserted_at
+)
+SELECT
+    dag_id,
+    dag_inserted_at,
+    task_id,
+    task_inserted_at
+FROM v1_dag_to_task
+WHERE dag_id >= (
+    SELECT MIN(id)
+    FROM v1_dag
+)
+ON CONFLICT (dag_id, dag_inserted_at, task_id, task_inserted_at) DO NOTHING;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS v1_dag_to_task;
+DROP FUNCTION IF EXISTS v1_dag_to_task_partitioned_insert_function;
+
+SELECT rename_partitions('v1_dag_to_task_partitioned', 'v1_dag_to_task');
+
+ALTER TABLE v1_dag_to_task_partitioned RENAME TO v1_dag_to_task;
+ALTER INDEX v1_dag_to_task_partitioned_pkey RENAME TO v1_dag_to_task_pkey;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+CREATE TABLE v1_dag_to_task_original (
+    dag_id BIGINT NOT NULL,
+    dag_inserted_at TIMESTAMPTZ NOT NULL,
+    task_id BIGINT NOT NULL,
+    task_inserted_at TIMESTAMPTZ NOT NULL,
+    CONSTRAINT v1_dag_to_task_pkey PRIMARY KEY (dag_id, dag_inserted_at, task_id, task_inserted_at)
+);
+
+INSERT INTO v1_dag_to_task_original
+SELECT * FROM v1_dag_to_task;
+
+DROP TABLE v1_dag_to_task;
+
+ALTER TABLE v1_dag_to_task_original RENAME TO v1_dag_to_task;
+-- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20260616165558_v1_0_120.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260616165558_v1_0_120.sql
@@ -1,0 +1,118 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS v1_dag_data_partitioned (
+    dag_id BIGINT NOT NULL,
+    dag_inserted_at TIMESTAMPTZ NOT NULL,
+    input JSONB NOT NULL,
+    additional_metadata JSONB,
+    PRIMARY KEY (dag_id, dag_inserted_at)
+) PARTITION BY RANGE(dag_inserted_at);
+
+DO $$
+DECLARE
+    oldest_date DATE;
+    d DATE;
+    partition_count INTEGER;
+BEGIN
+    SELECT COUNT(*)
+    INTO partition_count
+    FROM pg_class c
+    JOIN pg_inherits i ON c.oid = i.inhrelid
+    JOIN pg_class parent ON i.inhparent = parent.oid
+    WHERE parent.relname = 'v1_dag_data_partitioned'
+    AND c.relkind = 'r';
+
+    IF partition_count > 0 THEN
+        RAISE NOTICE 'Partitions already exist for v1_dag_data_partitioned, skipping creation';
+        RETURN;
+    END IF;
+
+    SELECT (WITH t AS (SELECT * FROM v1_task ORDER BY id LIMIT 1) SELECT inserted_at::DATE FROM t)
+    INTO oldest_date;
+
+    IF oldest_date IS NULL THEN
+        oldest_date := NOW()::DATE;
+    END IF;
+
+    d := oldest_date;
+    WHILE d <= (NOW() + INTERVAL '1 day')::DATE LOOP
+        PERFORM create_v1_range_partition('v1_dag_data_partitioned', d);
+        d := d + INTERVAL '1 day';
+    END LOOP;
+END $$;
+
+CREATE OR REPLACE FUNCTION v1_dag_data_partitioned_insert_function()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO v1_dag_data_partitioned (
+        dag_id,
+        dag_inserted_at,
+        input,
+        additional_metadata
+    )
+    SELECT
+        dag_id,
+        dag_inserted_at,
+        input,
+        additional_metadata
+    FROM new_rows
+    ON CONFLICT (dag_id, dag_inserted_at) DO NOTHING;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER v1_dag_data_partitioned_insert_trigger
+AFTER INSERT ON v1_dag_data
+REFERENCING NEW TABLE AS new_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION v1_dag_data_partitioned_insert_function();
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+INSERT INTO v1_dag_data_partitioned (
+    dag_id,
+    dag_inserted_at,
+    input,
+    additional_metadata
+)
+SELECT
+    dag_id,
+    dag_inserted_at,
+    input,
+    additional_metadata
+FROM v1_dag_data
+WHERE dag_id >= (
+    SELECT MIN(id)
+    FROM v1_dag
+)
+ON CONFLICT (dag_id, dag_inserted_at) DO NOTHING;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS v1_dag_data;
+DROP FUNCTION IF EXISTS v1_dag_data_partitioned_insert_function;
+
+SELECT rename_partitions('v1_dag_data_partitioned', 'v1_dag_data');
+
+ALTER TABLE v1_dag_data_partitioned RENAME TO v1_dag_data;
+ALTER INDEX v1_dag_data_partitioned_pkey RENAME TO v1_dag_data_pkey;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+CREATE TABLE v1_dag_data_original (
+    dag_id BIGINT NOT NULL,
+    dag_inserted_at TIMESTAMPTZ NOT NULL,
+    input JSONB NOT NULL,
+    additional_metadata JSONB,
+    CONSTRAINT v1_dag_input_pkey PRIMARY KEY (dag_id, dag_inserted_at)
+);
+
+INSERT INTO v1_dag_data_original
+SELECT * FROM v1_dag_data;
+
+DROP TABLE v1_dag_data;
+
+ALTER TABLE v1_dag_data_original RENAME TO v1_dag_data;
+-- +goose StatementEnd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     depends_on:
       - postgres
   rabbitmq:
-    image: "rabbitmq:4-management"
+    image: "rabbitmq:4.0-management"
     hostname: "rabbitmq"
     ports:
       - "5672:5672" # RabbitMQ

--- a/pkg/repository/sqlcv1/tasks.sql
+++ b/pkg/repository/sqlcv1/tasks.sql
@@ -1,16 +1,20 @@
 -- name: CreatePartitions :exec
 SELECT
-    create_v1_range_partition('v1_task', @date::date),
-    create_v1_range_partition('v1_dag', @date::date),
-    create_v1_range_partition('v1_task_event', @date::date),
-    create_v1_range_partition('v1_log_line', @date::date),
-    create_v1_range_partition('v1_payload', @date::date),
-    create_v1_range_partition('v1_event', @date::date),
-    create_v1_weekly_range_partition('v1_event_lookup_table', @date::date),
-    create_v1_range_partition('v1_event_to_run', @date::date),
-    create_v1_range_partition('v1_durable_event_log_file', @date::date),
-    create_v1_range_partition('v1_durable_event_log_entry', @date::date, 80),
-    create_v1_range_partition('v1_durable_event_log_branch_point', @date::date, 80)
+    -- intentionally formatted this way to limit merge conflicts + diff sizes
+    create_v1_range_partition('v1_task', @date::date)
+    , create_v1_range_partition('v1_dag', @date::date)
+    , create_v1_range_partition('v1_task_event', @date::date)
+    , create_v1_range_partition('v1_log_line', @date::date)
+    , create_v1_range_partition('v1_payload', @date::date)
+    , create_v1_range_partition('v1_event', @date::date)
+    , create_v1_weekly_range_partition('v1_event_lookup_table', @date::date)
+    , create_v1_range_partition('v1_event_to_run', @date::date)
+    , create_v1_range_partition('v1_durable_event_log_file', @date::date)
+    , create_v1_range_partition('v1_durable_event_log_entry', @date::date, 80)
+    , create_v1_range_partition('v1_durable_event_log_branch_point', @date::date, 80)
+    , create_v1_range_partition('v1_dag_to_task', @date::date)
+    , create_v1_range_partition('v1_dag_data', @date::date)
+    , create_v1_weekly_range_partition('v1_lookup_table', @date::date)
 ;
 
 -- name: EnsureTablePartitionsExist :one
@@ -50,28 +54,49 @@ SELECT
 FROM partition_check;
 
 -- name: ListPartitionsBeforeDate :many
-WITH task_partitions AS (
+WITH
+-- intentionally formatted this way to limit merge conflicts + diff sizes
+task_partitions AS (
     SELECT 'v1_task' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_task', @date::date) AS p
-), dag_partitions AS (
+)
+, dag_partitions AS (
     SELECT 'v1_dag' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_dag', @date::date) AS p
-), task_event_partitions AS (
+)
+, task_event_partitions AS (
     SELECT 'v1_task_event' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_task_event', @date::date) AS p
-), log_line_partitions AS (
+)
+, log_line_partitions AS (
     SELECT 'v1_log_line' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_log_line', @date::date) AS p
-), payload_partitions AS (
+)
+, payload_partitions AS (
     SELECT 'v1_payload' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_payload', @date::date) AS p
-), event_partitions AS (
+)
+, event_partitions AS (
     SELECT 'v1_event' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_event', @date::date) AS p
-), event_lookup_table_partitions AS (
+)
+, event_lookup_table_partitions AS (
     SELECT 'v1_event_lookup_table' AS parent_table, p::text as partition_name FROM get_v1_weekly_partitions_before_date('v1_event_lookup_table', @date::date) AS p
-), event_to_run_partitions AS (
+)
+, event_to_run_partitions AS (
     SELECT 'v1_event_to_run' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_event_to_run', @date::date) AS p
-), durable_event_log_file_partitions AS (
+)
+, durable_event_log_file_partitions AS (
     SELECT 'v1_durable_event_log_file' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_durable_event_log_file', @date::date) AS p
-), durable_event_log_entry_partitions AS (
+)
+, durable_event_log_entry_partitions AS (
     SELECT 'v1_durable_event_log_entry' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_durable_event_log_entry', @date::date) AS p
-), durable_event_log_branch_point_partitions AS (
+)
+, durable_event_log_branch_point_partitions AS (
     SELECT 'v1_durable_event_log_branch_point' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_durable_event_log_branch_point', @date::date) AS p
+)
+, dag_to_task_partitions AS (
+    SELECT 'v1_dag_to_task' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_dag_to_task', @date::date) AS p
+)
+, dag_data_partitions AS (
+    SELECT 'v1_dag_data' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_dag_data', @date::date) AS p
+)
+, lookup_table_partitions AS (
+    SELECT 'v1_lookup_table' AS parent_table, p::text as partition_name FROM get_v1_weekly_partitions_before_date('v1_lookup_table', @date::date) AS p
 )
 
 SELECT
@@ -148,6 +173,27 @@ SELECT
     *
 FROM
     durable_event_log_branch_point_partitions
+
+UNION ALL
+
+SELECT
+    *
+FROM
+    dag_to_task_partitions
+
+UNION ALL
+
+SELECT
+    *
+FROM
+    dag_data_partitions
+
+UNION ALL
+
+SELECT
+    *
+FROM
+    lookup_table_partitions
 ;
 
 -- name: DefaultTaskActivityGauge :one
@@ -1083,6 +1129,15 @@ ANALYZE v1_task_event;
 
 -- name: AnalyzeV1Dag :exec
 ANALYZE v1_dag;
+
+-- name: AnalyzeV1DAGToTask :exec
+ANALYZE v1_dag_to_task;
+
+-- name: AnalyzeV1DagData :exec
+ANALYZE v1_dag_data;
+
+-- name: AnalyzeV1LookupTable :exec
+ANALYZE v1_lookup_table;
 
 -- name: CleanupV1TaskRuntime :execresult
 WITH locked_trs AS (

--- a/pkg/repository/sqlcv1/tasks.sql.go
+++ b/pkg/repository/sqlcv1/tasks.sql.go
@@ -13,12 +13,39 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const analyzeV1DAGToTask = `-- name: AnalyzeV1DAGToTask :exec
+ANALYZE v1_dag_to_task
+`
+
+func (q *Queries) AnalyzeV1DAGToTask(ctx context.Context, db DBTX) error {
+	_, err := db.Exec(ctx, analyzeV1DAGToTask)
+	return err
+}
+
 const analyzeV1Dag = `-- name: AnalyzeV1Dag :exec
 ANALYZE v1_dag
 `
 
 func (q *Queries) AnalyzeV1Dag(ctx context.Context, db DBTX) error {
 	_, err := db.Exec(ctx, analyzeV1Dag)
+	return err
+}
+
+const analyzeV1DagData = `-- name: AnalyzeV1DagData :exec
+ANALYZE v1_dag_data
+`
+
+func (q *Queries) AnalyzeV1DagData(ctx context.Context, db DBTX) error {
+	_, err := db.Exec(ctx, analyzeV1DagData)
+	return err
+}
+
+const analyzeV1LookupTable = `-- name: AnalyzeV1LookupTable :exec
+ANALYZE v1_lookup_table
+`
+
+func (q *Queries) AnalyzeV1LookupTable(ctx context.Context, db DBTX) error {
+	_, err := db.Exec(ctx, analyzeV1LookupTable)
 	return err
 }
 
@@ -233,17 +260,21 @@ func (q *Queries) CreateEventToRuns(ctx context.Context, db DBTX, arg CreateEven
 
 const createPartitions = `-- name: CreatePartitions :exec
 SELECT
-    create_v1_range_partition('v1_task', $1::date),
-    create_v1_range_partition('v1_dag', $1::date),
-    create_v1_range_partition('v1_task_event', $1::date),
-    create_v1_range_partition('v1_log_line', $1::date),
-    create_v1_range_partition('v1_payload', $1::date),
-    create_v1_range_partition('v1_event', $1::date),
-    create_v1_weekly_range_partition('v1_event_lookup_table', $1::date),
-    create_v1_range_partition('v1_event_to_run', $1::date),
-    create_v1_range_partition('v1_durable_event_log_file', $1::date),
-    create_v1_range_partition('v1_durable_event_log_entry', $1::date, 80),
-    create_v1_range_partition('v1_durable_event_log_branch_point', $1::date, 80)
+    -- intentionally formatted this way to limit merge conflicts + diff sizes
+    create_v1_range_partition('v1_task', $1::date)
+    , create_v1_range_partition('v1_dag', $1::date)
+    , create_v1_range_partition('v1_task_event', $1::date)
+    , create_v1_range_partition('v1_log_line', $1::date)
+    , create_v1_range_partition('v1_payload', $1::date)
+    , create_v1_range_partition('v1_event', $1::date)
+    , create_v1_weekly_range_partition('v1_event_lookup_table', $1::date)
+    , create_v1_range_partition('v1_event_to_run', $1::date)
+    , create_v1_range_partition('v1_durable_event_log_file', $1::date)
+    , create_v1_range_partition('v1_durable_event_log_entry', $1::date, 80)
+    , create_v1_range_partition('v1_durable_event_log_branch_point', $1::date, 80)
+    , create_v1_range_partition('v1_dag_to_task', $1::date)
+    , create_v1_range_partition('v1_dag_data', $1::date)
+    , create_v1_weekly_range_partition('v1_lookup_table', $1::date)
 `
 
 func (q *Queries) CreatePartitions(ctx context.Context, db DBTX, date pgtype.Date) error {
@@ -1329,28 +1360,48 @@ func (q *Queries) ListMatchingTaskEvents(ctx context.Context, db DBTX, arg ListM
 }
 
 const listPartitionsBeforeDate = `-- name: ListPartitionsBeforeDate :many
-WITH task_partitions AS (
+WITH
+task_partitions AS (
     SELECT 'v1_task' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_task', $1::date) AS p
-), dag_partitions AS (
+)
+, dag_partitions AS (
     SELECT 'v1_dag' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_dag', $1::date) AS p
-), task_event_partitions AS (
+)
+, task_event_partitions AS (
     SELECT 'v1_task_event' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_task_event', $1::date) AS p
-), log_line_partitions AS (
+)
+, log_line_partitions AS (
     SELECT 'v1_log_line' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_log_line', $1::date) AS p
-), payload_partitions AS (
+)
+, payload_partitions AS (
     SELECT 'v1_payload' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_payload', $1::date) AS p
-), event_partitions AS (
+)
+, event_partitions AS (
     SELECT 'v1_event' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_event', $1::date) AS p
-), event_lookup_table_partitions AS (
+)
+, event_lookup_table_partitions AS (
     SELECT 'v1_event_lookup_table' AS parent_table, p::text as partition_name FROM get_v1_weekly_partitions_before_date('v1_event_lookup_table', $1::date) AS p
-), event_to_run_partitions AS (
+)
+, event_to_run_partitions AS (
     SELECT 'v1_event_to_run' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_event_to_run', $1::date) AS p
-), durable_event_log_file_partitions AS (
+)
+, durable_event_log_file_partitions AS (
     SELECT 'v1_durable_event_log_file' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_durable_event_log_file', $1::date) AS p
-), durable_event_log_entry_partitions AS (
+)
+, durable_event_log_entry_partitions AS (
     SELECT 'v1_durable_event_log_entry' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_durable_event_log_entry', $1::date) AS p
-), durable_event_log_branch_point_partitions AS (
+)
+, durable_event_log_branch_point_partitions AS (
     SELECT 'v1_durable_event_log_branch_point' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_durable_event_log_branch_point', $1::date) AS p
+)
+, dag_to_task_partitions AS (
+    SELECT 'v1_dag_to_task' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_dag_to_task', $1::date) AS p
+)
+, dag_data_partitions AS (
+    SELECT 'v1_dag_data' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_dag_data', $1::date) AS p
+)
+, lookup_table_partitions AS (
+    SELECT 'v1_lookup_table' AS parent_table, p::text as partition_name FROM get_v1_weekly_partitions_before_date('v1_lookup_table', $1::date) AS p
 )
 
 SELECT
@@ -1427,6 +1478,27 @@ SELECT
     parent_table, partition_name
 FROM
     durable_event_log_branch_point_partitions
+
+UNION ALL
+
+SELECT
+    parent_table, partition_name
+FROM
+    dag_to_task_partitions
+
+UNION ALL
+
+SELECT
+    parent_table, partition_name
+FROM
+    dag_data_partitions
+
+UNION ALL
+
+SELECT
+    parent_table, partition_name
+FROM
+    lookup_table_partitions
 `
 
 type ListPartitionsBeforeDateRow struct {
@@ -1434,6 +1506,7 @@ type ListPartitionsBeforeDateRow struct {
 	PartitionName string `json:"partition_name"`
 }
 
+// intentionally formatted this way to limit merge conflicts + diff sizes
 func (q *Queries) ListPartitionsBeforeDate(ctx context.Context, db DBTX, date pgtype.Date) ([]*ListPartitionsBeforeDateRow, error) {
 	rows, err := db.Query(ctx, listPartitionsBeforeDate, date)
 	if err != nil {

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -3994,6 +3994,24 @@ func (r *TaskRepositoryImpl) AnalyzeTaskTables(ctx context.Context) error {
 		return fmt.Errorf("error analyzing v1_dag: %v", err)
 	}
 
+	err = r.queries.AnalyzeV1DAGToTask(ctx, tx)
+
+	if err != nil {
+		return fmt.Errorf("error analyzing v1_dag_to_task: %v", err)
+	}
+
+	err = r.queries.AnalyzeV1DagData(ctx, tx)
+
+	if err != nil {
+		return fmt.Errorf("error analyzing v1_dag_data: %v", err)
+	}
+
+	err = r.queries.AnalyzeV1LookupTable(ctx, tx)
+
+	if err != nil {
+		return fmt.Errorf("error analyzing v1_lookup_table: %v", err)
+	}
+
 	err = r.queries.AnalyzeV1Payload(ctx, tx)
 
 	if err != nil {

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -319,8 +319,8 @@ CREATE TABLE v1_lookup_table (
     dag_id BIGINT,
     inserted_at TIMESTAMPTZ NOT NULL,
 
-    PRIMARY KEY (external_id)
-);
+    PRIMARY KEY (external_id, inserted_at)
+) PARTITION BY RANGE (inserted_at);
 
 CREATE TYPE v1_task_event_type AS ENUM (
     'COMPLETED',
@@ -720,15 +720,15 @@ CREATE TABLE v1_dag_to_task (
     task_id BIGINT NOT NULL,
     task_inserted_at TIMESTAMPTZ NOT NULL,
     CONSTRAINT v1_dag_to_task_pkey PRIMARY KEY (dag_id, dag_inserted_at, task_id, task_inserted_at)
-);
+) PARTITION BY RANGE(dag_inserted_at);
 
 CREATE TABLE v1_dag_data (
     dag_id BIGINT NOT NULL,
     dag_inserted_at TIMESTAMPTZ NOT NULL,
     input JSONB NOT NULL,
     additional_metadata JSONB,
-    CONSTRAINT v1_dag_input_pkey PRIMARY KEY (dag_id, dag_inserted_at)
-);
+    PRIMARY KEY (dag_id, dag_inserted_at)
+) PARTITION BY RANGE(dag_inserted_at);
 
 -- CreateTable
 CREATE TABLE v1_workflow_concurrency_slot (
@@ -1173,7 +1173,7 @@ BEGIN
         id,
         inserted_at
     FROM new_table
-    ON CONFLICT (external_id) DO NOTHING;
+    ON CONFLICT (external_id, inserted_at) DO NOTHING;
 
     RETURN NULL;
 END;
@@ -1673,7 +1673,7 @@ BEGIN
         id,
         inserted_at
     FROM new_table
-    ON CONFLICT (external_id) DO NOTHING;
+    ON CONFLICT (external_id, inserted_at) DO NOTHING;
 
     RETURN NULL;
 END;
@@ -2391,3 +2391,43 @@ CREATE TABLE v1_durable_event_log_branch_point (
 
     CONSTRAINT v1_durable_event_log_branch_point_pkey PRIMARY KEY (durable_task_id, durable_task_inserted_at, parent_branch_id, first_node_id_in_new_branch, next_branch_id)
 ) PARTITION BY RANGE(durable_task_inserted_at);
+
+CREATE OR REPLACE FUNCTION rename_partitions(
+    parent_table_name TEXT,
+    new_prefix TEXT
+)
+RETURNS TABLE(old_name TEXT, new_name TEXT)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    partition_record RECORD;
+    old_partition_name TEXT;
+    new_partition_name TEXT;
+    partition_suffix TEXT;
+BEGIN
+    FOR partition_record IN
+        SELECT c.relname AS partition_name
+        FROM pg_inherits i
+        JOIN pg_class c ON i.inhrelid = c.oid
+        JOIN pg_namespace n ON c.relnamespace = n.oid
+        JOIN pg_class parent ON i.inhparent = parent.oid
+        WHERE parent.relname = parent_table_name
+        ORDER BY c.relname
+    LOOP
+        old_partition_name := partition_record.partition_name;
+        partition_suffix := replace(old_partition_name, parent_table_name || '_', '');
+        new_partition_name := new_prefix || '_' || partition_suffix;
+
+        EXECUTE format('ALTER TABLE %I RENAME TO %I', old_partition_name, new_partition_name);
+        EXECUTE format('ALTER INDEX %I RENAME TO %I',
+            old_partition_name || '_pkey',
+            new_partition_name || '_pkey'
+        );
+
+        RETURN NEXT;
+        RAISE NOTICE 'Renamed: % -> %', old_partition_name, new_partition_name;
+    END LOOP;
+
+    RETURN;
+END;
+$$;


### PR DESCRIPTION
# Description

Revives #2227 

Partitions `v1_lookup_table`, `v1_dag_to_task`, and `v1_dag_data` so that they respect retention policies and don't grow infinitely over time

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI use, mostly copy/paste

</details>
