### PR TITLE
fix: disable hover preloading for sidebar navigation links

### DIFF
--- a/frontend/app/src/components/v1/nav/side-nav.tsx
+++ b/frontend/app/src/components/v1/nav/side-nav.tsx
@@ -394,6 +394,7 @@ export function SideNav({ className, navItems: navSections }: SideNavProps) {
                                   <Link
                                     to={child.to}
                                     params={commonParams}
+                                    preload={false}
                                     onClick={onNavLinkClick}
                                   >
                                     {child.name}

--- a/frontend/app/src/components/v1/nav/sidebar-buttons.tsx
+++ b/frontend/app/src/components/v1/nav/sidebar-buttons.tsx
@@ -85,7 +85,7 @@ export function SidebarButtonPrimary(
     collapsibleChildren.length > 0 ? open : Boolean(matchRoute({ to, params }));
 
   const primaryLink = (
-    <Link to={to} params={params} onClick={onNavLinkClick}>
+    <Link to={to} params={params} preload={false} onClick={onNavLinkClick}>
       <Button
         variant="ghost"
         className={cn(
@@ -131,7 +131,7 @@ export function SidebarButtonSecondary({
   const selected = Boolean(matchRoute({ to, params })) || hasPrefix;
 
   return (
-    <Link to={to} params={params} onClick={onNavLinkClick}>
+    <Link to={to} params={params} preload={false} onClick={onNavLinkClick}>
       <Button
         variant="ghost"
         size="sm"


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

On hovering over sidebar/navigation section trigger multiple API request even when the user does not click or navigated. This can overload on network traffic when users move their mouse across the sidebar and also may increase API and Backend load.

Fixes #4205 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->
- Ran `git diff --check`
- Attempted `corepack pnpm typecheck`, but the local Windows/pnpm install could not execute `tsc` in this environment

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
