### PR TITLE
fix(engine): set the `eventSeenAt` on the ingest side of the mq

### DIFF
--- a/internal/services/controllers/olap/signal/signal.go
+++ b/internal/services/controllers/olap/signal/signal.go
@@ -684,15 +684,12 @@ func (s *OLAPSignaler) SendInternalEvents(ctx context.Context, tenantId uuid.UUI
 func (s *OLAPSignaler) SignalEventsCreated(ctx context.Context, tenantId uuid.UUID, eventIdToOpts map[uuid.UUID]v1.EventTriggerOpts, eventIdsToRuns map[uuid.UUID][]*v1.Run) error {
 	eventTriggerOpts := make([]tasktypes.CreatedEventTriggerPayloadSingleton, 0)
 
-	// FIXME: Should `SeenAt` be set on the SDK when the event is created?
-	eventSeenAt := time.Now()
-
 	for eventExternalId, runs := range eventIdsToRuns {
 		opts := eventIdToOpts[eventExternalId]
 
 		if len(runs) == 0 {
 			eventTriggerOpts = append(eventTriggerOpts, tasktypes.CreatedEventTriggerPayloadSingleton{
-				EventSeenAt:             eventSeenAt,
+				EventSeenAt:             opts.SeenAt,
 				EventKey:                opts.Key,
 				EventExternalId:         opts.ExternalId,
 				EventPayload:            opts.Data,
@@ -707,7 +704,7 @@ func (s *OLAPSignaler) SignalEventsCreated(ctx context.Context, tenantId uuid.UU
 					MaybeRunId:              &run.Id,
 					MaybeRunInsertedAt:      &run.InsertedAt,
 					MaybeRunExternalId:      &runExtID,
-					EventSeenAt:             eventSeenAt,
+					EventSeenAt:             opts.SeenAt,
 					EventKey:                opts.Key,
 					EventExternalId:         opts.ExternalId,
 					EventPayload:            opts.Data,

--- a/internal/services/controllers/olap/signal/signal.go
+++ b/internal/services/controllers/olap/signal/signal.go
@@ -687,9 +687,16 @@ func (s *OLAPSignaler) SignalEventsCreated(ctx context.Context, tenantId uuid.UU
 	for eventExternalId, runs := range eventIdsToRuns {
 		opts := eventIdToOpts[eventExternalId]
 
+		// need this for backwards compat when we deploy this version
+		// can remove later
+		seenAt := opts.SeenAt
+		if seenAt.IsZero() {
+			seenAt = time.Now().UTC()
+		}
+
 		if len(runs) == 0 {
 			eventTriggerOpts = append(eventTriggerOpts, tasktypes.CreatedEventTriggerPayloadSingleton{
-				EventSeenAt:             opts.SeenAt,
+				EventSeenAt:             seenAt,
 				EventKey:                opts.Key,
 				EventExternalId:         opts.ExternalId,
 				EventPayload:            opts.Data,
@@ -704,7 +711,7 @@ func (s *OLAPSignaler) SignalEventsCreated(ctx context.Context, tenantId uuid.UU
 					MaybeRunId:              &run.Id,
 					MaybeRunInsertedAt:      &run.InsertedAt,
 					MaybeRunExternalId:      &runExtID,
-					EventSeenAt:             opts.SeenAt,
+					EventSeenAt:             seenAt,
 					EventKey:                opts.Key,
 					EventExternalId:         opts.ExternalId,
 					EventPayload:            opts.Data,

--- a/internal/services/controllers/task/controller.go
+++ b/internal/services/controllers/task/controller.go
@@ -1070,6 +1070,7 @@ func (tc *TasksControllerImpl) handleProcessUserEventTrigger(ctx context.Context
 
 		opt := v1.EventTriggerOpts{
 			ExternalId:            msg.EventExternalId,
+			SeenAt:                msg.EventSeenAt,
 			Key:                   msg.EventKey,
 			Data:                  msg.EventData,
 			AdditionalMetadata:    msg.EventAdditionalMetadata,

--- a/internal/services/ingestor/ingestor_v1.go
+++ b/internal/services/ingestor/ingestor_v1.go
@@ -102,6 +102,7 @@ func (i *IngestorImpl) ingest(ctx context.Context, tenant *sqlcv1.Tenant, eventO
 		for _, event := range eventOpts {
 			opts = append(opts, v1.EventTriggerOpts{
 				ExternalId:            event.EventExternalId,
+				SeenAt:                event.EventSeenAt,
 				Key:                   event.EventKey,
 				Data:                  event.EventData,
 				AdditionalMetadata:    event.EventAdditionalMetadata,
@@ -154,6 +155,7 @@ func (i *IngestorImpl) ingest(ctx context.Context, tenant *sqlcv1.Tenant, eventO
 		for _, event := range eventOpts {
 			opts[event.EventExternalId] = v1.EventTriggerOpts{
 				ExternalId:            event.EventExternalId,
+				SeenAt:                event.EventSeenAt,
 				Key:                   event.EventKey,
 				Data:                  event.EventData,
 				AdditionalMetadata:    event.EventAdditionalMetadata,
@@ -269,8 +271,12 @@ func (i *IngestorImpl) ingestReplayedEventV1(ctx context.Context, tenant *sqlcv1
 func eventToPayload(tenantId uuid.UUID, key string, data, additionalMeta []byte, priority *int32, scope *string, triggeringWebhookName *string) tasktypes.UserEventTaskPayload {
 	eventId := uuid.New()
 
+	// FIXME: Should `SeenAt` be set on the SDK when the event is created?
+	eventSeenAt := time.Now().UTC()
+
 	return tasktypes.UserEventTaskPayload{
 		EventExternalId:         eventId,
+		EventSeenAt:             eventSeenAt,
 		EventKey:                key,
 		EventData:               data,
 		EventAdditionalMetadata: additionalMeta,

--- a/internal/services/shared/tasktypes/v1/event.go
+++ b/internal/services/shared/tasktypes/v1/event.go
@@ -11,6 +11,7 @@ import (
 
 type UserEventTaskPayload struct {
 	EventExternalId         uuid.UUID `json:"event_id" validate:"required"`
+	EventSeenAt             time.Time `json:"event_seen_at" validate:"required"`
 	EventKey                string    `json:"event_key" validate:"required"`
 	EventData               []byte    `json:"event_data" validate:"required"`
 	EventAdditionalMetadata []byte    `json:"event_additional_metadata"`

--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -25,6 +25,8 @@ import (
 type EventTriggerOpts struct {
 	ExternalId uuid.UUID
 
+	SeenAt time.Time
+
 	Key string
 
 	Data []byte


### PR DESCRIPTION
# Description

Fixes a bug that can cause duplicate events (and duplicate payloads) on the OLAP side by setting the `seenAt`, which we use in the events PK, on the consumer side of the mq instead of on the ingest side.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI use

</details>
