### PR TITLE
ci: post comment on failure instead of failing

### DIFF
--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -174,6 +174,10 @@ jobs:
   old-engine-new-sdk:
     runs-on: ubicloud-standard-4
     timeout-minutes: 20
+    continue-on-error: true
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -280,6 +284,14 @@ jobs:
         with:
           name: ${{ env.HATCHET_CLIENT_NAMESPACE }}-api-logs
           path: /tmp/api.log
+
+      - name: Comment on PR
+        if: failure() && github.event_name == 'pull_request'
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body "⚠️ **Optional test failure**: The \`old-engine-new-sdk\` (Python) job failed on this PR. This check is non-mandatory and does not block merging, but may be worth investigating. [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Teardown
         if: always()

--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -174,7 +174,6 @@ jobs:
   old-engine-new-sdk:
     runs-on: ubicloud-standard-4
     timeout-minutes: 20
-    continue-on-error: true
     permissions:
       contents: read
       pull-requests: write
@@ -253,6 +252,8 @@ jobs:
           echo "HATCHET_CLIENT_NAMESPACE=old-engine-new-sdk-${SHORT_SHA}" >> $GITHUB_ENV
 
       - name: Run pytest
+        id: run-tests
+        continue-on-error: true
         env:
           HATCHET_CLIENT_TLS_STRATEGY: none
           HATCHET_CLIENT_WORKER_HEALTHCHECK_ENABLED: "True"
@@ -286,7 +287,7 @@ jobs:
           path: /tmp/api.log
 
       - name: Comment on PR
-        if: failure() && github.event_name == 'pull_request'
+        if: steps.run-tests.outcome == 'failure' && github.event_name == 'pull_request'
         run: |
           gh pr comment ${{ github.event.pull_request.number }} \
             --body "⚠️ **Optional test failure**: The \`old-engine-new-sdk\` (Python) job failed on this PR. This check is non-mandatory and does not block merging, but may be worth investigating. [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"

--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -177,6 +177,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/sdk-ruby.yml
+++ b/.github/workflows/sdk-ruby.yml
@@ -227,7 +227,6 @@ jobs:
   old-engine-new-sdk:
     runs-on: ubicloud-standard-4
     timeout-minutes: 20
-    continue-on-error: true
     permissions:
       contents: read
       pull-requests: write
@@ -293,6 +292,8 @@ jobs:
           echo "HATCHET_CLIENT_NAMESPACE=old-engine-new-sdk-rb-${SHORT_SHA}" >> $GITHUB_ENV
 
       - name: Run unit tests
+        id: unit-tests
+        continue-on-error: true
         env:
           HATCHET_CLIENT_TLS_STRATEGY: none
           HATCHET_CLIENT_WORKER_HEALTHCHECK_ENABLED: "true"
@@ -302,6 +303,8 @@ jobs:
           bundle exec rspec --format documentation --tag ~integration
 
       - name: Run integration tests
+        id: integration-tests
+        continue-on-error: true
         env:
           HATCHET_CLIENT_TLS_STRATEGY: none
           HATCHET_CLIENT_WORKER_HEALTHCHECK_ENABLED: "true"
@@ -336,6 +339,8 @@ jobs:
           exit 1
 
       - name: Run e2e tests
+        id: e2e-tests
+        continue-on-error: true
         working-directory: ./sdks/ruby/examples
         env:
           HATCHET_CLIENT_TLS_STRATEGY: none
@@ -374,7 +379,7 @@ jobs:
           path: /tmp/api.log
 
       - name: Comment on PR
-        if: failure() && github.event_name == 'pull_request'
+        if: always() && (steps.unit-tests.outcome == 'failure' || steps.integration-tests.outcome == 'failure' || steps.e2e-tests.outcome == 'failure') && github.event_name == 'pull_request'
         run: |
           gh pr comment ${{ github.event.pull_request.number }} \
             --body "⚠️ **Optional test failure**: The \`old-engine-new-sdk\` (Ruby) job failed on this PR. This check is non-mandatory and does not block merging, but may be worth investigating. [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"

--- a/.github/workflows/sdk-ruby.yml
+++ b/.github/workflows/sdk-ruby.yml
@@ -227,6 +227,10 @@ jobs:
   old-engine-new-sdk:
     runs-on: ubicloud-standard-4
     timeout-minutes: 20
+    continue-on-error: true
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -368,6 +372,14 @@ jobs:
         with:
           name: ${{ env.HATCHET_CLIENT_NAMESPACE }}-api-logs
           path: /tmp/api.log
+
+      - name: Comment on PR
+        if: failure() && github.event_name == 'pull_request'
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body "⚠️ **Optional test failure**: The \`old-engine-new-sdk\` (Ruby) job failed on this PR. This check is non-mandatory and does not block merging, but may be worth investigating. [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Teardown
         if: always()

--- a/.github/workflows/sdk-ruby.yml
+++ b/.github/workflows/sdk-ruby.yml
@@ -230,6 +230,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/sdk-typescript.yml
+++ b/.github/workflows/sdk-typescript.yml
@@ -266,7 +266,6 @@ jobs:
   old-engine-new-sdk:
     runs-on: ubicloud-standard-4
     timeout-minutes: 20
-    continue-on-error: true
     permissions:
       contents: read
       pull-requests: write
@@ -344,6 +343,8 @@ jobs:
           echo "HATCHET_CLIENT_NAMESPACE=old-engine-new-sdk-ts-${SHORT_SHA}" >> $GITHUB_ENV
 
       - name: Run e2e tests
+        id: run-tests
+        continue-on-error: true
         env:
           HATCHET_CLIENT_TLS_STRATEGY: none
           HATCHET_CLIENT_WORKER_HEALTHCHECK_ENABLED: "false"
@@ -378,7 +379,7 @@ jobs:
           path: /tmp/api.log
 
       - name: Comment on PR
-        if: failure() && github.event_name == 'pull_request'
+        if: steps.run-tests.outcome == 'failure' && github.event_name == 'pull_request'
         run: |
           gh pr comment ${{ github.event.pull_request.number }} \
             --body "⚠️ **Optional test failure**: The \`old-engine-new-sdk\` (TypeScript) job failed on this PR. This check is non-mandatory and does not block merging, but may be worth investigating. [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"

--- a/.github/workflows/sdk-typescript.yml
+++ b/.github/workflows/sdk-typescript.yml
@@ -266,6 +266,10 @@ jobs:
   old-engine-new-sdk:
     runs-on: ubicloud-standard-4
     timeout-minutes: 20
+    continue-on-error: true
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -372,6 +376,14 @@ jobs:
         with:
           name: ${{ env.HATCHET_CLIENT_NAMESPACE }}-api-logs
           path: /tmp/api.log
+
+      - name: Comment on PR
+        if: failure() && github.event_name == 'pull_request'
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body "⚠️ **Optional test failure**: The \`old-engine-new-sdk\` (TypeScript) job failed on this PR. This check is non-mandatory and does not block merging, but may be worth investigating. [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Teardown
         if: always()

--- a/.github/workflows/sdk-typescript.yml
+++ b/.github/workflows/sdk-typescript.yml
@@ -269,6 +269,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -611,7 +611,7 @@ jobs:
           echo "Load test passed"
 
       - name: Upload load-online-migrate logs
-        if: failure()
+        if: steps.run-load-test.outcome == 'failure'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: load-online-migrate-logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -480,6 +480,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     env:
       DATABASE_URL: postgresql://hatchet:hatchet@127.0.0.1:5431/hatchet?sslmode=disable
       SERVER_GRPC_PORT: "7077"
@@ -640,6 +641,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     strategy:
       matrix:
         migrate-strategy: ["latest"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -477,7 +477,6 @@ jobs:
   load-online-migrate:
     runs-on: ubicloud-standard-8
     timeout-minutes: 30
-    continue-on-error: true
     permissions:
       contents: read
       pull-requests: write
@@ -551,6 +550,8 @@ jobs:
           exit 1
 
       - name: Run load test with migrations
+        id: run-load-test
+        continue-on-error: true
         run: |
           HATCHET_CLIENT_TOKEN="${{ env.HATCHET_CLIENT_TOKEN }}" \
           HATCHET_CLIENT_TLS_STRATEGY=none \
@@ -619,7 +620,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Comment on PR
-        if: failure() && github.event_name == 'pull_request'
+        if: steps.run-load-test.outcome == 'failure' && github.event_name == 'pull_request'
         run: |
           gh pr comment ${{ github.event.pull_request.number }} \
             --body "⚠️ **Optional test failure**: The \`load-online-migrate\` job failed on this PR. This check is non-mandatory and does not block merging, but may be worth investigating. [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
@@ -636,7 +637,6 @@ jobs:
   load-deadlock:
     runs-on: ubicloud-standard-8
     timeout-minutes: 30
-    continue-on-error: true
     permissions:
       contents: read
       pull-requests: write
@@ -718,6 +718,8 @@ jobs:
           git diff --name-only -- '*.go' || true
 
       - name: Test (deadlock-instrumented)
+        id: run-tests
+        continue-on-error: true
         run: |
           # Disable gzip compression for load tests to reduce CPU overhead
           # Compression adds overhead without benefit for 0kb payloads
@@ -733,7 +735,7 @@ jobs:
           TESTING_MATRIX_OPTIMISTIC_SCHEDULING: ${{ matrix.optimistic-scheduling }}
 
       - name: Comment on PR
-        if: failure() && github.event_name == 'pull_request'
+        if: steps.run-tests.outcome == 'failure' && github.event_name == 'pull_request'
         run: |
           gh pr comment ${{ github.event.pull_request.number }} \
             --body "⚠️ **Optional test failure**: The \`load-deadlock\` job failed on this PR (optimistic-scheduling=${{ matrix.optimistic-scheduling }}). This check is non-mandatory and does not block merging, but may be worth investigating. [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -477,6 +477,10 @@ jobs:
   load-online-migrate:
     runs-on: ubicloud-standard-8
     timeout-minutes: 30
+    continue-on-error: true
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       DATABASE_URL: postgresql://hatchet:hatchet@127.0.0.1:5431/hatchet?sslmode=disable
       SERVER_GRPC_PORT: "7077"
@@ -614,6 +618,14 @@ jobs:
             /tmp/loadtest.log
           if-no-files-found: ignore
 
+      - name: Comment on PR
+        if: failure() && github.event_name == 'pull_request'
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body "⚠️ **Optional test failure**: The \`load-online-migrate\` job failed on this PR. This check is non-mandatory and does not block merging, but may be worth investigating. [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Teardown
         if: always()
         run: |
@@ -624,6 +636,10 @@ jobs:
   load-deadlock:
     runs-on: ubicloud-standard-8
     timeout-minutes: 30
+    continue-on-error: true
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       matrix:
         migrate-strategy: ["latest"]
@@ -715,6 +731,14 @@ jobs:
           TESTING_MATRIX_RABBITMQ_ENABLED: ${{ matrix.rabbitmq-enabled }}
           TESTING_MATRIX_PG_VERSION: ${{ matrix.pg-version }}
           TESTING_MATRIX_OPTIMISTIC_SCHEDULING: ${{ matrix.optimistic-scheduling }}
+
+      - name: Comment on PR
+        if: failure() && github.event_name == 'pull_request'
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body "⚠️ **Optional test failure**: The \`load-deadlock\` job failed on this PR (optimistic-scheduling=${{ matrix.optimistic-scheduling }}). This check is non-mandatory and does not block merging, but may be worth investigating. [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   rampup:
     runs-on: ubicloud-standard-8


### PR DESCRIPTION
# Description

Instead of failing CI on known problematic tests `*-online-migrate`, `*-deadlock`, and `*-old-engine-new-sdk`, we run them in the "background" and post a comment on the PR if they fail, since there are too many known causes of failure for these tests that are unavoidable

## Type of change

- [x] CI (any automation pipeline changes)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)


<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Used Claude Code to implement the changes

</details>