### PR TITLE
fix: tenant switcher tool tip for long tenant names

### DIFF
--- a/frontend/app/src/components/v1/molecules/nav-bar/organization-selector.tsx
+++ b/frontend/app/src/components/v1/molecules/nav-bar/organization-selector.tsx
@@ -7,7 +7,12 @@ import {
   CommandItem,
   CommandList,
 } from '@/components/v1/ui/command';
-import { TooltipProvider } from '@/components/v1/ui/tooltip';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/v1/ui/tooltip';
 import { useOrganizations } from '@/hooks/use-organizations';
 import { useTenantDetails } from '@/hooks/use-tenant';
 import { Tenant, TenantMember } from '@/lib/api';
@@ -165,9 +170,19 @@ function OrganizationGroup({
                   <div className="flex h-5 w-5 shrink-0 items-center justify-center">
                     <div className="h-2 w-2 rounded-full bg-green-500" />
                   </div>
-                  <span className="min-w-0 flex-1 truncate text-muted-foreground">
-                    {membership.tenant?.name}
-                  </span>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="min-w-0 flex-1 truncate text-left text-muted-foreground">
+                        {membership.tenant?.name}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent
+                      side="right"
+                      className="max-w-[min(24rem,calc(100vw-2rem))] break-words"
+                    >
+                      {membership.tenant?.name}
+                    </TooltipContent>
+                  </Tooltip>
                   <TenantRegionBadge region={membership.tenant?.region} />
                 </div>
                 <CheckIcon

--- a/frontend/app/src/components/v1/molecules/nav-bar/tenant-switcher.tsx
+++ b/frontend/app/src/components/v1/molecules/nav-bar/tenant-switcher.tsx
@@ -8,6 +8,12 @@ import {
   CommandSeparator,
 } from '@/components/v1/ui/command';
 import { Spinner } from '@/components/v1/ui/loading.tsx';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/v1/ui/tooltip';
 import { useOrganizations } from '@/hooks/use-organizations';
 import { useTenantDetails } from '@/hooks/use-tenant';
 import { TenantMember } from '@/lib/api';
@@ -70,100 +76,112 @@ export function TenantSwitcher({
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          size="sm"
-          role="combobox"
-          aria-expanded={open}
-          aria-label="Select a tenant"
-          className={cn(
-            'min-w-0 justify-between gap-2 bg-muted/20 shadow-none hover:bg-muted/30',
-            open && 'bg-muted/30',
-            className,
-          )}
-          disabled={!isUserUniverseLoaded || memberships.length === 0}
-        >
-          <div className="flex min-w-0 flex-1 items-center gap-2 text-left">
-            <BuildingOffice2Icon className="size-4 shrink-0" />
-            <span className="min-w-0 flex-1 truncate">{tenant.name}</span>
-            <TenantRegionBadge region={tenant.region} />
-          </div>
-          {!isUserUniverseLoaded ? (
-            <Spinner className="mr-0" />
-          ) : (
-            <CaretSortIcon className="size-4 shrink-0 opacity-50" />
-          )}
-        </Button>
-      </PopoverTrigger>
-      {/* Portal so the popover can render above the mobile sidebar overlay (header is z-50). */}
-      <PopoverPortal>
-        <PopoverContent
-          side="bottom"
-          align="start"
-          sideOffset={8}
-          // Must render above the mobile sidebar overlay (`side-nav` uses z-[100]).
-          className="z-[200] w-[min(18rem,100vw)] max-w-[calc(100vw-2rem)] p-0"
-        >
-          <Command className="">
-            <CommandList data-cy="tenant-switcher-list">
-              <CommandEmpty>No tenants found.</CommandEmpty>
-              {memberships.map((membership) => (
-                <CommandItem
-                  key={membership.metadata.id}
-                  onSelect={() => {
-                    invariant(membership.tenant);
-                    setCurrTenant(membership.tenant);
-                    setOpen(false);
-                  }}
-                  value={membership.tenant?.slug}
-                  data-cy={
-                    membership.tenant?.slug
-                      ? `tenant-switcher-item-${membership.tenant.slug}`
-                      : undefined
-                  }
-                  className="cursor-pointer text-sm"
-                >
-                  <div className="flex min-w-0 flex-1 items-center gap-2">
-                    <BuildingOffice2Icon className="size-4 shrink-0" />
-                    <span className="min-w-0 flex-1 truncate">
-                      {membership.tenant?.name}
-                    </span>
-                    <TenantRegionBadge region={membership.tenant?.region} />
-                  </div>
-                  <CheckIcon
-                    className={cn(
-                      'ml-2 size-4 shrink-0',
-                      tenant?.slug === membership.tenant?.slug
-                        ? 'opacity-100'
-                        : 'opacity-0',
-                    )}
-                  />
-                </CommandItem>
-              ))}
-            </CommandList>
-            {meta?.allowCreateTenant && !hasOrganizations && (
-              <>
-                <CommandSeparator />
-                <CommandList>
+    <TooltipProvider delayDuration={200}>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            role="combobox"
+            aria-expanded={open}
+            aria-label="Select a tenant"
+            className={cn(
+              'min-w-0 justify-between gap-2 bg-muted/20 shadow-none hover:bg-muted/30',
+              open && 'bg-muted/30',
+              className,
+            )}
+            disabled={!isUserUniverseLoaded || memberships.length === 0}
+          >
+            <div className="flex min-w-0 flex-1 items-center gap-2 text-left">
+              <BuildingOffice2Icon className="size-4 shrink-0" />
+              <span className="min-w-0 flex-1 truncate">{tenant.name}</span>
+              <TenantRegionBadge region={tenant.region} />
+            </div>
+            {!isUserUniverseLoaded ? (
+              <Spinner className="mr-0" />
+            ) : (
+              <CaretSortIcon className="size-4 shrink-0 opacity-50" />
+            )}
+          </Button>
+        </PopoverTrigger>
+        {/* Portal so the popover can render above the mobile sidebar overlay (header is z-50). */}
+        <PopoverPortal>
+          <PopoverContent
+            side="bottom"
+            align="start"
+            sideOffset={8}
+            // Must render above the mobile sidebar overlay (`side-nav` uses z-[100]).
+            className="z-[200] w-[min(18rem,100vw)] max-w-[calc(100vw-2rem)] p-0"
+          >
+            <Command className="">
+              <CommandList data-cy="tenant-switcher-list">
+                <CommandEmpty>No tenants found.</CommandEmpty>
+                {memberships.map((membership) => (
                   <CommandItem
-                    className="cursor-pointer text-sm"
-                    data-cy="new-tenant"
+                    key={membership.metadata.id}
                     onSelect={() => {
-                      globalEmitter.emit('create-new-tenant', {});
+                      invariant(membership.tenant);
+                      setCurrTenant(membership.tenant);
                       setOpen(false);
                     }}
+                    value={membership.tenant?.slug}
+                    data-cy={
+                      membership.tenant?.slug
+                        ? `tenant-switcher-item-${membership.tenant.slug}`
+                        : undefined
+                    }
+                    className="cursor-pointer text-sm"
                   >
-                    <PlusCircledIcon className="mr-2 size-4" />
-                    New Tenant
+                    <div className="flex min-w-0 flex-1 items-center gap-2">
+                      <BuildingOffice2Icon className="size-4 shrink-0" />
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="min-w-0 flex-1 truncate text-left">
+                            {membership.tenant?.name}
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent
+                          side="right"
+                          className="max-w-[min(24rem,calc(100vw-2rem))] break-words"
+                        >
+                          {membership.tenant?.name}
+                        </TooltipContent>
+                      </Tooltip>
+                      <TenantRegionBadge region={membership.tenant?.region} />
+                    </div>
+                    <CheckIcon
+                      className={cn(
+                        'ml-2 size-4 shrink-0',
+                        tenant?.slug === membership.tenant?.slug
+                          ? 'opacity-100'
+                          : 'opacity-0',
+                      )}
+                    />
                   </CommandItem>
-                </CommandList>
-              </>
-            )}
-          </Command>
-        </PopoverContent>
-      </PopoverPortal>
-    </Popover>
+                ))}
+              </CommandList>
+              {meta?.allowCreateTenant && !hasOrganizations && (
+                <>
+                  <CommandSeparator />
+                  <CommandList>
+                    <CommandItem
+                      className="cursor-pointer text-sm"
+                      data-cy="new-tenant"
+                      onSelect={() => {
+                        globalEmitter.emit('create-new-tenant', {});
+                        setOpen(false);
+                      }}
+                    >
+                      <PlusCircledIcon className="mr-2 size-4" />
+                      New Tenant
+                    </CommandItem>
+                  </CommandList>
+                </>
+              )}
+            </Command>
+          </PopoverContent>
+        </PopoverPortal>
+      </Popover>
+    </TooltipProvider>
   );
 }


### PR DESCRIPTION
# Description

Long tenant names were unreadable in the tenant switcher, this adds a tool tip until we properly redesign this component.

<img width="943" height="452" alt="image" src="https://github.com/user-attachments/assets/2fbf03eb-5423-4ff7-9c03-9533c0b5ea15" />

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Adds tool tip in the tenant picker

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Added the tool tip

</details>
