### PR TITLE
test(sdk/python): stabilize bulk replay polling

### DIFF
--- a/sdks/python/examples/bulk_operations/test_bulk_replay.py
+++ b/sdks/python/examples/bulk_operations/test_bulk_replay.py
@@ -1,5 +1,4 @@
-import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from uuid import uuid4
 
 import pytest
@@ -12,99 +11,142 @@ from examples.bulk_operations.worker import (
     bulk_replay_test_3,
 )
 from hatchet_sdk import BulkCancelReplayOpts, Hatchet, RunFilter
-from hatchet_sdk.clients.rest.models.v1_task_summary_list import V1TaskSummaryList
-from hatchet_sdk.clients.rest.models.v1_task_summary import V1TaskSummary
 from hatchet_sdk.clients.rest.models.v1_task_status import V1TaskStatus
+from hatchet_sdk.clients.rest.models.v1_task_summary import V1TaskSummary
+from hatchet_sdk.clients.rest.models.v1_task_summary_list import V1TaskSummaryList
 
 
 @pytest.mark.asyncio(loop_scope="session")
 async def test_bulk_replay(hatchet: Hatchet) -> None:
     test_run_id = str(uuid4())
     n = 100
+    expected_total = n + 1 + (n // 2 - 1) + (n // 2 - 2)
     test_start = datetime.now(tz=timezone.utc)
-    with pytest.raises(Exception):
-        await bulk_replay_test_1.aio_run_many(
-            [
-                bulk_replay_test_1.create_bulk_run_item(
-                    additional_metadata={
-                        "test_run_id": test_run_id,
-                    },
-                )
-                for _ in range(n + 1)
-            ]
-        )
-
-    with pytest.raises(Exception):
-        await bulk_replay_test_2.aio_run_many(
-            [
-                bulk_replay_test_2.create_bulk_run_item(
-                    additional_metadata={
-                        "test_run_id": test_run_id,
-                    },
-                )
-                for _ in range((n // 2) - 1)
-            ]
-        )
-
-    with pytest.raises(Exception):
-        await bulk_replay_test_3.aio_run_many(
-            [
-                bulk_replay_test_3.create_bulk_run_item(
-                    additional_metadata={
-                        "test_run_id": test_run_id,
-                    },
-                )
-                for _ in range((n // 2) - 2)
-            ]
-        )
 
     workflow_ids = [
         bulk_replay_test_1.id,
         bulk_replay_test_2.id,
         bulk_replay_test_3.id,
     ]
+    additional_metadata = {"test_run_id": test_run_id}
 
-    ## Should result in two batches of replays
+    async def list_filtered_runs() -> V1TaskSummaryList:
+        return await hatchet.runs.aio_list(
+            workflow_ids=workflow_ids,
+            since=test_start,
+            additional_metadata=additional_metadata,
+            limit=1000,
+        )
+
+    def summarize_statuses(rows: list[V1TaskSummary]) -> str:
+        counts: dict[str, int] = {}
+        for row in rows:
+            status = str(row.status)
+            counts[status] = counts.get(status, 0) + 1
+        return ", ".join(
+            f"{status}={count}" for status, count in sorted(counts.items())
+        )
+
+    await bulk_replay_test_1.aio_run_many(
+        [
+            bulk_replay_test_1.create_bulk_run_item(
+                additional_metadata=additional_metadata,
+            )
+            for _ in range(n + 1)
+        ],
+        wait_for_result=False,
+    )
+
+    await bulk_replay_test_2.aio_run_many(
+        [
+            bulk_replay_test_2.create_bulk_run_item(
+                additional_metadata=additional_metadata,
+            )
+            for _ in range((n // 2) - 1)
+        ],
+        wait_for_result=False,
+    )
+
+    await bulk_replay_test_3.aio_run_many(
+        [
+            bulk_replay_test_3.create_bulk_run_item(
+                additional_metadata=additional_metadata,
+            )
+            for _ in range((n // 2) - 2)
+        ],
+        wait_for_result=False,
+    )
+
+    @tenacity.retry(
+        stop=stop_after_attempt(10), wait=wait_exponential(multiplier=1, min=4, max=10)
+    )
+    async def wait_for_all_failed() -> V1TaskSummaryList:
+        runs = await list_filtered_runs()
+        rows = runs.rows or []
+
+        if len(rows) != expected_total:
+            raise AssertionError(
+                f"Expected {expected_total} runs before replay, got {len(rows)} "
+                f"(statuses: {summarize_statuses(rows)})"
+            )
+
+        failed_count = sum(1 for row in rows if row.status == V1TaskStatus.FAILED)
+        if failed_count != expected_total:
+            raise AssertionError(
+                f"Expected all {expected_total} runs to be FAILED before replay, "
+                f"but {failed_count}/{expected_total} are FAILED "
+                f"(statuses: {summarize_statuses(rows)})"
+            )
+
+        return runs
+
+    await wait_for_all_failed()
+
     await hatchet.runs.aio_bulk_replay(
         opts=BulkCancelReplayOpts(
             filters=RunFilter(
                 workflow_ids=workflow_ids,
                 since=test_start,
-                additional_metadata={"test_run_id": test_run_id},
+                additional_metadata=additional_metadata,
             )
         )
     )
-
-    await asyncio.sleep(20)
 
     @tenacity.retry(
         stop=stop_after_attempt(10), wait=wait_exponential(multiplier=1, min=4, max=10)
     )
-    async def get_runs() -> V1TaskSummaryList:
-        runs = await hatchet.runs.aio_list(
-            workflow_ids=workflow_ids,
-            since=test_start,
-            additional_metadata={"test_run_id": test_run_id},
-            limit=1000,
-        )
+    async def wait_for_replayed_completed() -> V1TaskSummaryList:
+        runs = await list_filtered_runs()
+        rows = runs.rows or []
 
-        def predicate(r: V1TaskSummary) -> bool:
-            return (
-                r.status == V1TaskStatus.COMPLETED  # type: ignore[return-value]
-                and r.retry_count
-                and r.retry_count >= 1
-                and r.attempt
-                and r.attempt >= 2
+        if len(rows) != expected_total:
+            raise AssertionError(
+                f"Expected {expected_total} runs after replay, got {len(rows)} "
+                f"(statuses: {summarize_statuses(rows)})"
             )
 
-        for r in runs.rows:
-            if not predicate(r):
-                raise Exception
+        ready_count = sum(
+            1
+            for row in rows
+            if row.status == V1TaskStatus.COMPLETED
+            and row.retry_count is not None
+            and row.retry_count >= 1
+            and row.attempt is not None
+            and row.attempt >= 2
+        )
+        if ready_count != expected_total:
+            raise AssertionError(
+                f"Expected all {expected_total} runs to be COMPLETED with "
+                f"retry_count>=1 and attempt>=2 after replay, but only "
+                f"{ready_count}/{expected_total} are ready "
+                f"(statuses: {summarize_statuses(rows)})"
+            )
+
         return runs
 
-    runs = await get_runs()
+    runs = await wait_for_replayed_completed()
 
-    assert len(runs.rows) == n + 1 + (n // 2 - 1) + (n // 2 - 2)
+    assert len(runs.rows) == expected_total
 
     for run in runs.rows:
         assert run.status == V1TaskStatus.COMPLETED


### PR DESCRIPTION
# Description

Stabilizes the Python bulk replay e2e test by submitting the initial bulk runs without waiting for the first failure, waiting until all matching runs are visible and failed, and only then replaying them. This should reduce `examples/bulk_operations/test_bulk_replay.py::test_bulk_replay` flakes in the Python `test` matrix and `old-engine-new-sdk` jobs.

Refs #4204

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

- [x] Submit bulk replay test runs with `wait_for_result=False`.
- [x] Poll for all expected initial runs to reach `FAILED` before replaying.
- [x] Poll for all replayed runs to reach `COMPLETED` with retry metadata.
- [x] Replace the fixed sleep and bare retry exception with actionable polling failure messages.

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted

## Testing

- `poetry run black examples/bulk_operations/test_bulk_replay.py --check`
- `poetry run ruff check examples/bulk_operations/test_bulk_replay.py`
- Not run: database-backed pytest/e2e, per local DB safety constraints. CI should cover the Python `test` and `old-engine-new-sdk` jobs.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Used Cursor agent and a Composer subagent to investigate CI flakes, update the Python bulk replay test polling, and run static checks.

</details>