### PR TITLE
test(e2e): wait for durable terminal statuses

### DIFF
--- a/sdks/typescript/src/v1/examples/durable/durable.e2e.ts
+++ b/sdks/typescript/src/v1/examples/durable/durable.e2e.ts
@@ -309,12 +309,14 @@ describe('durable-e2e', () => {
     const child = await poll(() => hatchet.runs.get(result.child_run_external_id), {
       timeoutMs: 15_000,
       intervalMs: 500,
-      shouldStop: (r: any) => r?.run?.status != null,
+      shouldStop: (r: any) => r?.run?.status === V1TaskStatus.FAILED,
+      label: 'child run status=FAILED',
     });
     const parent = await poll(() => hatchet.runs.get(result.parent_run_external_id), {
       timeoutMs: 15_000,
       intervalMs: 500,
-      shouldStop: (r: any) => r?.run?.status != null,
+      shouldStop: (r: any) => r?.run?.status === V1TaskStatus.COMPLETED,
+      label: 'parent run status=COMPLETED',
     });
 
     expect((child as any).run?.status).toBe(V1TaskStatus.FAILED);


### PR DESCRIPTION
# Description

Stabilizes the TypeScript durable e2e test that checks a parent task catching a failed child run. The test now waits for the child run to reach `FAILED` and the parent run to reach `COMPLETED` instead of stopping on any non-null status such as `QUEUED` or `RUNNING`.

Refs #4204

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

- [x] Wait for the durable child run to reach `FAILED` before asserting.
- [x] Wait for the durable parent run to reach `COMPLETED` before asserting.
- [x] Add poll labels so timeout messages identify which run status was pending.

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted

## Testing

- `pnpm exec prettier src/v1/examples/durable/durable.e2e.ts --check`
- `pnpm exec eslint src/v1/examples/durable/durable.e2e.ts`
- `pnpm exec tsc --noEmit`
- Not run: database-backed `pnpm test:e2e`, per local DB safety constraints. CI should cover the TypeScript `test-e2e` and `old-engine-new-sdk` jobs.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Used Cursor agent and a Composer subagent to update the durable e2e polling predicates and run static TypeScript checks.

</details>