### PR TITLE
feat(sdks/go): add retry foundation for REST reads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS
+
+## Docs MDX
+
+- In MDX JSX component bodies, such as `<Callout>`, avoid Markdown link syntax (`[text](href)`). Prettier can wrap the label across lines and break MDX parsing. Use an explicit JSX link instead:
+
+```mdx
+<Callout type="info">
+  See the{" "}
+  <a href="/v1/retry-policies#go-sdk-client-retry-behavior">
+    Go SDK client retry behavior section
+  </a>
+</Callout>
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Added
+
+- Add Go SDK client retry controls, gRPC full-jitter retry backoff, and bounded REST read retries for transient API failures by @igor-kupczynski in [#4240](https://github.com/hatchet-dev/hatchet/pull/4240)
+
 ## [0.89.0] - 2026-06-09
 
 Hatchet v0.89.0 introduces a range of updates to the platform, consisting largely of performance improvements and bug fixes to the engine, alongside several user-experience changes to the dashboard.

--- a/frontend/docs/pages/v1/error-handling/retry-policies.mdx
+++ b/frontend/docs/pages/v1/error-handling/retry-policies.mdx
@@ -113,6 +113,14 @@ The Hatchet SDKs each expose a `NonRetryable` exception, which allows you to byp
 
 In these cases, even though `retries` is set to a non-zero number (meaning the task would ordinarily retry), Hatchet will not retry.
 
+<Callout type="info">
+  For SDK client retry behavior (automatic retries on REST and gRPC API calls),
+  see the{" "}
+  <a href="/v1/retry-policies#go-sdk-client-retry-behavior">
+    Go SDK client retry behavior section
+  </a>
+</Callout>
+
 ## Conclusion
 
 Hatchet's task-level retry feature is a simple and effective way to handle transient failures in your tasks, improving the reliability and resilience of your tasks. By specifying the number of retries for each task, you can ensure that your tasks can recover from temporary issues without requiring complex error handling logic.

--- a/frontend/docs/pages/v1/retry-policies.mdx
+++ b/frontend/docs/pages/v1/retry-policies.mdx
@@ -212,6 +212,79 @@ You can add non-idempotent methods to `retry_transport_methods`, but only do so 
 
 Python SDK client retries use exponential backoff with jitter. Fine-grained backoff timing is not currently configurable through `TenacityConfig`.
 
+## Go SDK Client Retry Behavior
+
+The retry behavior described above is for task execution inside Hatchet. The Go SDK also retries some REST and gRPC calls that the SDK itself makes to Hatchet.
+
+These SDK client retries are configured separately from task retries. They do not control whether Hatchet retries a task after it fails in a worker.
+
+<Callout type="info">
+  Task retries and SDK client retries are separate mechanisms. Task retries
+  control whether Hatchet retries a task after task failure. SDK client retries
+  control whether the Go SDK retries certain API calls to Hatchet.
+</Callout>
+
+### Default Go client retry behavior
+
+By default, the Go SDK retries certain client calls with exponential backoff. REST reads use up to 5 total attempts: the initial attempt plus up to 4 retries. gRPC calls keep the existing 5 attempt retry limit.
+
+REST read retries use bounded jittered backoff. When the caller request context has no deadline, each REST attempt uses a response-header timeout without cutting off response body reads. If the caller context already has a deadline, that deadline governs the whole request.
+
+**REST API calls (bodyless `GET` and `HEAD` only)**
+
+| Error Type                                            | Retried by Default |
+| ----------------------------------------------------- | ------------------ |
+| HTTP 502, 503, 504 (gateway errors)                   | Yes                |
+| HTTP 404 (not found)                                  | No                 |
+| HTTP 429 (too many requests)                          | Yes                |
+| HTTP 400, 401, 403, 409, 422 (client errors)          | No                 |
+| Transport errors (timeout, connection, TLS, protocol) | Yes                |
+
+For HTTP 429 responses on idempotent reads, the Go SDK honors a valid `Retry-After` header when it fits the client retry cap. When `Retry-After` is missing, invalid, or oversized, it falls back to the same bounded jittered backoff used for other retriable errors.
+
+<Callout type="info">
+  Unlike the Python SDK, the Go SDK does not retry HTTP 404 responses on REST
+  reads in this release. Python retries some 404 reads to account for
+  replication lag between the core database and the OLAP database.
+</Callout>
+
+**gRPC calls**
+
+| Status Code                                              | Retried |
+| -------------------------------------------------------- | ------- |
+| `UNAVAILABLE`, `DEADLINE_EXCEEDED`, `INTERNAL`           | Yes     |
+| `RESOURCE_EXHAUSTED`                                     | Yes     |
+| `FAILED_PRECONDITION`                                    | No      |
+| `UNIMPLEMENTED`, `NOT_FOUND`, `INVALID_ARGUMENT`         | No      |
+| `ALREADY_EXISTS`, `UNAUTHENTICATED`, `PERMISSION_DENIED` | No      |
+
+<Callout type="info">
+  `FAILED_PRECONDITION` is not retried because Hatchet uses it for non-transient
+  control-plane signals such as inactive listeners. The unary interceptor still
+  retries all unary RPCs, including writes, in this release.
+</Callout>
+
+### Configuring Go SDK client retries
+
+Use environment variables to disable SDK client retries:
+
+| Environment Variable           | Description                                                                                                                               |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `HATCHET_CLIENT_NO_RETRY`      | Disables both REST and gRPC SDK client retries when set to a truthy value.                                                                |
+| `HATCHET_CLIENT_NO_GRPC_RETRY` | Legacy gRPC-only retry control. Disables gRPC SDK retries only. REST read retries remain enabled unless `HATCHET_CLIENT_NO_RETRY` is set. |
+
+If both variables are set, all SDK client retries are disabled.
+
+### Idempotency considerations
+
+<Callout type="warning">
+  Go SDK REST retries apply only to bodyless `GET` and `HEAD` requests. `POST`,
+  `PUT`, `PATCH`, and `DELETE` requests are never retried by the SDK client in
+  this release. Bodied requests are excluded because Go `http.Request` bodies
+  are one-shot unless `GetBody` is set or the SDK buffers and rebuilds the body.
+  The generated REST clients do not set `GetBody`.
+</Callout>
+
 ## Conclusion
 
 Hatchet's task-level retry feature is a simple and effective way to handle transient failures in your tasks, improving the reliability and resilience of your tasks. By specifying the number of retries for each task, you can ensure that your tasks can recover from temporary issues without requiring complex error handling logic.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -9,18 +9,16 @@ import (
 	"net/http"
 	"time"
 
-	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry"
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	_ "google.golang.org/grpc/encoding/gzip" // Register gzip compression codec
 	"google.golang.org/grpc/keepalive"
-	"google.golang.org/grpc/status"
 
 	"github.com/hatchet-dev/hatchet/pkg/client/loader"
 	"github.com/hatchet-dev/hatchet/pkg/client/rest"
+	"github.com/hatchet-dev/hatchet/pkg/client/retry"
 
 	cloudrest "github.com/hatchet-dev/hatchet/pkg/client/cloud/rest"
 
@@ -91,6 +89,7 @@ type ClientOpts struct {
 	token       string
 	namespace   string
 	noGrpcRetry bool
+	noRetry     bool
 	sharedMeta  map[string]string
 
 	cloudRegisterID *string
@@ -145,6 +144,7 @@ func defaultClientOpts(token *string, cf *client.ClientConfigFile) *ClientOpts {
 		cloudRegisterID:        clientConfig.CloudRegisterID,
 		runnableActions:        clientConfig.RunnableActions,
 		noGrpcRetry:            clientConfig.NoGrpcRetry,
+		noRetry:                clientConfig.NoRetry,
 		sharedMeta:             make(map[string]string),
 		presetWorkerLabels:     clientConfig.PresetWorkerLabels,
 		disableGzipCompression: clientConfig.DisableGzipCompression,
@@ -316,30 +316,9 @@ func newFromOpts(opts *ClientOpts) (Client, error) {
 		opts.l.Info().Msg("gzip compression disabled for gRPC client")
 	}
 
-	if !opts.noGrpcRetry {
-		retryOnCodes := []codes.Code{
-			codes.ResourceExhausted,
-			codes.DeadlineExceeded,
-			codes.FailedPrecondition,
-			codes.Internal,
-			codes.Unavailable,
-		}
-
-		retryOpts := []grpc_retry.CallOption{
-
-			grpc_retry.WithBackoff(grpc_retry.BackoffExponentialWithJitter(5*time.Second, 0.10)),
-			grpc_retry.WithMax(5),
-			grpc_retry.WithPerRetryTimeout(30 * time.Second),
-			grpc_retry.WithCodes(retryOnCodes...),
-			grpc_retry.WithOnRetryCallback(grpc_retry.OnRetryCallback(func(ctx context.Context, attempt uint, err error) {
-				if contains(retryOnCodes, status.Code(err)) {
-					opts.l.Debug().Msgf("grpc_retry attempt: %d, backoff for %v", attempt, err)
-				}
-			})),
-		}
-		grpcOpts = append(grpcOpts, grpc.WithChainStreamInterceptor(grpc_retry.StreamClientInterceptor(retryOpts...)))
-		grpcOpts = append(grpcOpts, grpc.WithChainUnaryInterceptor(grpc_retry.UnaryClientInterceptor(retryOpts...)))
-	}
+	grpcRetryEnabled := !opts.noRetry && !opts.noGrpcRetry
+	restRetryEnabled := !opts.noRetry
+	grpcOpts = append(grpcOpts, retry.GRPCDialOptions(opts.l, grpcRetryEnabled)...)
 
 	conn, err := grpc.NewClient(
 		opts.hostPort,
@@ -364,19 +343,26 @@ func newFromOpts(opts *ClientOpts) (Client, error) {
 	dispatcher := newDispatcher(conn, shared, opts.presetWorkerLabels)
 	event := newEvent(conn, shared)
 
-	rest, err := rest.NewClientWithResponses(opts.serverURL, rest.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
+	authEditor := func(ctx context.Context, req *http.Request) error {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", opts.token))
 		return nil
-	}))
+	}
+
+	restOpts := []rest.ClientOption{rest.WithRequestEditorFn(authEditor)}
+	cloudRestOpts := []cloudrest.ClientOption{cloudrest.WithRequestEditorFn(authEditor)}
+	if restRetryEnabled {
+		restDoer := retry.NewRestDoer(&http.Client{})
+		restOpts = append(restOpts, rest.WithHTTPClient(restDoer))
+		cloudRestOpts = append(cloudRestOpts, cloudrest.WithHTTPClient(restDoer))
+	}
+
+	rest, err := rest.NewClientWithResponses(opts.serverURL, restOpts...)
 
 	if err != nil {
 		return nil, fmt.Errorf("could not create rest client: %w", err)
 	}
 
-	cloudrest, err := cloudrest.NewClientWithResponses(opts.serverURL, cloudrest.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", opts.token))
-		return nil
-	}))
+	cloudrest, err := cloudrest.NewClientWithResponses(opts.serverURL, cloudRestOpts...)
 
 	if err != nil {
 		return nil, fmt.Errorf("could not create cloud REST client: %w", err)
@@ -482,13 +468,4 @@ func initWorkflows(fl filesLoaderFunc, adminClient AdminClient) error {
 	}
 
 	return nil
-}
-
-func contains(codes []codes.Code, code codes.Code) bool {
-	for _, c := range codes {
-		if c == code {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -351,7 +351,10 @@ func newFromOpts(opts *ClientOpts) (Client, error) {
 	restOpts := []rest.ClientOption{rest.WithRequestEditorFn(authEditor)}
 	cloudRestOpts := []cloudrest.ClientOption{cloudrest.WithRequestEditorFn(authEditor)}
 	if restRetryEnabled {
-		restDoer := retry.NewRestDoer(&http.Client{})
+		restDoer, retryErr := retry.NewRestDoer(&http.Client{})
+		if retryErr != nil {
+			return nil, fmt.Errorf("could not create rest retry doer: %w", retryErr)
+		}
 		restOpts = append(restOpts, rest.WithHTTPClient(restDoer))
 		cloudRestOpts = append(cloudRestOpts, cloudrest.WithHTTPClient(restDoer))
 	}

--- a/pkg/client/loader/loader.go
+++ b/pkg/client/loader/loader.go
@@ -149,6 +149,7 @@ func GetClientConfigFromConfigFile(tokenOverride *string, cf *client.ClientConfi
 		CloudRegisterID:        cf.CloudRegisterID,
 		RunnableActions:        rawRunnableActions,
 		NoGrpcRetry:            cf.NoGrpcRetry,
+		NoRetry:                cf.NoRetry,
 		PresetWorkerLabels:     presetLabels,
 		DisableGzipCompression: cf.DisableGzipCompression,
 	}, nil

--- a/pkg/client/retry/backoff.go
+++ b/pkg/client/retry/backoff.go
@@ -10,10 +10,10 @@ import (
 )
 
 const (
-	// gRPC retry timing keeps the existing 5s exponential shape, but uses
-	// full jitter so clients spread retry pressure across the whole delay window.
-	// Consecutive retry delay windows are 0-5s, 0-10s, 0-20s, 0-40s,
-	// then capped at 0-80s.
+	// gRPC retry backoff uses full jitter over exponential windows so clients
+	// spread retry pressure. After the initial RPC fails, middleware invokes
+	// backoff with attempt=1 for the first retry; delay windows are 0-5s,
+	// 0-10s, 0-20s, 0-40s, then capped at 0-80s.
 	grpcMaxRetries    = 5
 	grpcBaseDelay     = 5 * time.Second
 	grpcBackoffFactor = 2.0

--- a/pkg/client/retry/backoff.go
+++ b/pkg/client/retry/backoff.go
@@ -1,0 +1,125 @@
+package retry
+
+import (
+	"context"
+	"math"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const (
+	// gRPC retry timing keeps the existing 5s exponential shape, but uses
+	// full jitter so clients spread retry pressure across the whole delay window.
+	// Consecutive retry delay windows are 0-5s, 0-10s, 0-20s, 0-40s,
+	// then capped at 0-80s.
+	grpcMaxRetries    = 5
+	grpcBaseDelay     = 5 * time.Second
+	grpcBackoffFactor = 2.0
+	grpcMaxDelay      = 80 * time.Second
+
+	// REST retry timing defaults keep SDK calls responsive while still covering
+	// short gateway and rate-limit blips. With 5 total attempts, retry delay
+	// windows are 0-250ms, 0-500ms, 0-1s, and 0-2s, unless a valid Retry-After
+	// header supplies the delay for an HTTP 429 response.
+	restMaxAttempts       = 5
+	restBaseDelay         = 250 * time.Millisecond
+	restBackoffFactor     = 2.0
+	restMaxDelay          = 5 * time.Second
+	restMaxRetryAfter     = 5 * time.Second
+	restPerAttemptTimeout = 30 * time.Second
+
+	// restDiscardDrainLimitBytes is a heuristic cap, not a protocol threshold.
+	// Draining small intermediate retry responses lets net/http reuse the TCP
+	// connection after Close. The cap is large enough for typical API error
+	// bodies, but small enough that an unexpectedly large or slow discarded body
+	// does not delay the next retry for long.
+	restDiscardDrainLimitBytes = 64 * 1024
+)
+
+type clock struct {
+	now    func() time.Time
+	sleep  func(context.Context, time.Duration) error
+	jitter func(int64) int64
+}
+
+func defaultClock() clock {
+	return clock{
+		now:    time.Now,
+		sleep:  sleepContext,
+		jitter: rand.Int64N,
+	}
+}
+
+func sleepContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func fullJitterDelay(attempt int, base time.Duration, factor float64, maxDelay time.Duration, jitter func(int64) int64) time.Duration {
+	if attempt < 0 {
+		attempt = 0
+	}
+
+	delayLimit := float64(base) * math.Pow(factor, float64(attempt))
+	if delayLimit > float64(maxDelay) {
+		delayLimit = float64(maxDelay)
+	}
+	if delayLimit <= 0 {
+		return 0
+	}
+
+	return time.Duration(jitter(int64(delayLimit) + 1))
+}
+
+// parseRetryAfter parses an HTTP Retry-After header value.
+// It supports delta-seconds and HTTP-date forms. Past HTTP-date values yield zero delay.
+// Returns ok=false when the header is missing, invalid, negative, or exceeds max.
+func parseRetryAfter(header string, now time.Time, maxDelay time.Duration) (time.Duration, bool) {
+	if header == "" {
+		return 0, false
+	}
+
+	if seconds, err := strconv.Atoi(header); err == nil {
+		if seconds < 0 {
+			return 0, false
+		}
+
+		delay := time.Duration(seconds) * time.Second
+		if delay > maxDelay {
+			return 0, false
+		}
+
+		return delay, true
+	}
+
+	retryAt, err := http.ParseTime(header)
+	if err != nil {
+		return 0, false
+	}
+
+	delay := retryAt.Sub(now)
+	if delay < 0 {
+		delay = 0
+	}
+	if delay > maxDelay {
+		return 0, false
+	}
+
+	return delay, true
+}

--- a/pkg/client/retry/backoff_test.go
+++ b/pkg/client/retry/backoff_test.go
@@ -1,0 +1,86 @@
+package retry
+
+import (
+	"context"
+	"math/rand/v2"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFullJitterDelayDeterministic(t *testing.T) {
+	t.Parallel()
+
+	r := rand.New(rand.NewPCG(1, 1))
+	delay := fullJitterDelay(2, restBaseDelay, restBackoffFactor, restMaxDelay, r.Int64N)
+	assert.GreaterOrEqual(t, delay, time.Duration(0))
+	assert.LessOrEqual(t, delay, restMaxDelay)
+}
+
+func TestParseRetryAfterDeltaSeconds(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(0, 0).UTC()
+
+	delay, ok := parseRetryAfter("2", now, restMaxRetryAfter)
+	require.True(t, ok)
+	assert.Equal(t, 2*time.Second, delay)
+}
+
+func TestParseRetryAfterHTTPDate(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(0, 0).UTC()
+	retryAt := now.Add(2 * time.Second).UTC().Format(http.TimeFormat)
+
+	delay, ok := parseRetryAfter(retryAt, now, restMaxRetryAfter)
+	require.True(t, ok)
+	assert.Equal(t, 2*time.Second, delay)
+}
+
+func TestParseRetryAfterPastHTTPDate(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(100, 0).UTC()
+	past := now.Add(-5 * time.Second).UTC().Format(http.TimeFormat)
+
+	delay, ok := parseRetryAfter(past, now, restMaxRetryAfter)
+	require.True(t, ok)
+	assert.Equal(t, time.Duration(0), delay)
+}
+
+func TestParseRetryAfterInvalidAndOversized(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(0, 0).UTC()
+
+	_, ok := parseRetryAfter("not-a-date", now, restMaxRetryAfter)
+	assert.False(t, ok)
+
+	_, ok = parseRetryAfter("10", now, restMaxRetryAfter)
+	assert.False(t, ok)
+
+	_, ok = parseRetryAfter("-1", now, restMaxRetryAfter)
+	assert.False(t, ok)
+}
+
+func TestSleepContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := sleepContext(ctx, time.Second)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestSleepContextZeroDelay(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	err := sleepContext(ctx, 0)
+	assert.NoError(t, err)
+}

--- a/pkg/client/retry/grpc.go
+++ b/pkg/client/retry/grpc.go
@@ -1,0 +1,52 @@
+package retry
+
+import (
+	"context"
+	"math/rand/v2"
+	"time"
+
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry"
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+func grpcRetryableCodes() []codes.Code {
+	return []codes.Code{
+		codes.ResourceExhausted,
+		codes.DeadlineExceeded,
+		codes.Internal,
+		codes.Unavailable,
+	}
+}
+
+// GRPCDialOptions returns gRPC dial options that install unary and stream retry interceptors.
+// When enabled is false, it returns nil.
+func GRPCDialOptions(l *zerolog.Logger, enabled bool) []grpc.DialOption {
+	if !enabled {
+		return nil
+	}
+
+	retryOnCodes := grpcRetryableCodes()
+
+	retryOpts := []grpc_retry.CallOption{
+		grpc_retry.WithBackoff(grpcFullJitterBackoff(rand.Int64N)),
+		grpc_retry.WithMax(grpcMaxRetries),
+		grpc_retry.WithPerRetryTimeout(30 * time.Second),
+		grpc_retry.WithCodes(retryOnCodes...),
+		grpc_retry.WithOnRetryCallback(grpc_retry.OnRetryCallback(func(ctx context.Context, attempt uint, err error) {
+			l.Debug().Msgf("grpc_retry attempt: %d, backoff for %v", attempt, err)
+		})),
+	}
+
+	return []grpc.DialOption{
+		grpc.WithChainStreamInterceptor(grpc_retry.StreamClientInterceptor(retryOpts...)),
+		grpc.WithChainUnaryInterceptor(grpc_retry.UnaryClientInterceptor(retryOpts...)),
+	}
+}
+
+func grpcFullJitterBackoff(jitter func(int64) int64) grpc_retry.BackoffFunc {
+	return func(_ context.Context, attempt uint) time.Duration {
+		return fullJitterDelay(int(attempt), grpcBaseDelay, grpcBackoffFactor, grpcMaxDelay, jitter)
+	}
+}

--- a/pkg/client/retry/grpc.go
+++ b/pkg/client/retry/grpc.go
@@ -47,6 +47,8 @@ func GRPCDialOptions(l *zerolog.Logger, enabled bool) []grpc.DialOption {
 
 func grpcFullJitterBackoff(jitter func(int64) int64) grpc_retry.BackoffFunc {
 	return func(_ context.Context, attempt uint) time.Duration {
-		return fullJitterDelay(int(attempt), grpcBaseDelay, grpcBackoffFactor, grpcMaxDelay, jitter)
+		// go-grpc-middleware passes attempt=1 for the first retry backoff.
+		zeroBasedAttempt := int(attempt) - 1
+		return fullJitterDelay(zeroBasedAttempt, grpcBaseDelay, grpcBackoffFactor, grpcMaxDelay, jitter)
 	}
 }

--- a/pkg/client/retry/grpc_test.go
+++ b/pkg/client/retry/grpc_test.go
@@ -1,0 +1,33 @@
+package retry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+)
+
+func TestGRPCRetryableCodesExcludeFailedPrecondition(t *testing.T) {
+	t.Parallel()
+
+	retryable := grpcRetryableCodes()
+	assert.Contains(t, retryable, codes.ResourceExhausted)
+	assert.Contains(t, retryable, codes.DeadlineExceeded)
+	assert.Contains(t, retryable, codes.Internal)
+	assert.Contains(t, retryable, codes.Unavailable)
+	assert.NotContains(t, retryable, codes.FailedPrecondition)
+}
+
+func TestGRPCFullJitterBackoff(t *testing.T) {
+	t.Parallel()
+
+	backoff := grpcFullJitterBackoff(func(maxExclusive int64) int64 {
+		return maxExclusive - 1
+	})
+
+	assert.Equal(t, 5*time.Second, backoff(context.Background(), 0))
+	assert.Equal(t, 10*time.Second, backoff(context.Background(), 1))
+	assert.Equal(t, grpcMaxDelay, backoff(context.Background(), 99))
+}

--- a/pkg/client/retry/grpc_test.go
+++ b/pkg/client/retry/grpc_test.go
@@ -27,7 +27,7 @@ func TestGRPCFullJitterBackoff(t *testing.T) {
 		return maxExclusive - 1
 	})
 
-	assert.Equal(t, 5*time.Second, backoff(context.Background(), 0))
-	assert.Equal(t, 10*time.Second, backoff(context.Background(), 1))
+	assert.Equal(t, 5*time.Second, backoff(context.Background(), 1))
+	assert.Equal(t, 10*time.Second, backoff(context.Background(), 2))
 	assert.Equal(t, grpcMaxDelay, backoff(context.Background(), 99))
 }

--- a/pkg/client/retry/rest.go
+++ b/pkg/client/retry/rest.go
@@ -1,0 +1,202 @@
+package retry
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"time"
+)
+
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// RestDoer retries eligible bodyless GET and HEAD requests.
+type RestDoer struct {
+	inner              httpDoer
+	headerTimeoutInner httpDoer
+	clock              clock
+}
+
+type restDoerOption func(*RestDoer)
+
+func withRestClock(c clock) restDoerOption {
+	return func(d *RestDoer) {
+		d.clock = c
+	}
+}
+
+func withHeaderTimeout(timeout time.Duration) restDoerOption {
+	return func(d *RestDoer) {
+		d.headerTimeoutInner = withResponseHeaderTimeout(d.inner, timeout)
+	}
+}
+
+// NewRestDoer wraps inner with REST read retry behavior.
+func NewRestDoer(inner httpDoer, opts ...restDoerOption) *RestDoer {
+	if inner == nil {
+		inner = &http.Client{}
+	}
+
+	d := &RestDoer{
+		inner:              inner,
+		headerTimeoutInner: withResponseHeaderTimeout(inner, restPerAttemptTimeout),
+		clock:              defaultClock(),
+	}
+
+	for _, opt := range opts {
+		opt(d)
+	}
+
+	return d
+}
+
+func (d *RestDoer) Do(req *http.Request) (*http.Response, error) {
+	if req == nil {
+		return d.inner.Do(req)
+	}
+
+	if err := req.Context().Err(); err != nil {
+		return nil, err
+	}
+
+	if !isRequestEligibleForRetry(req) {
+		return d.inner.Do(req)
+	}
+
+	ctx := req.Context()
+	original := req.Clone(ctx)
+
+	var lastTransportErr error
+
+	for attempt := range restMaxAttempts {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		attemptReq := original.Clone(ctx)
+		resp, err := d.doAttempt(ctx, attemptReq)
+		if err != nil {
+			lastTransportErr = err
+
+			if attempt == restMaxAttempts-1 || ctx.Err() != nil {
+				if ctx.Err() != nil {
+					return nil, ctx.Err()
+				}
+				return nil, err
+			}
+
+			delay := d.restBackoffDelay(attempt, nil)
+			if err := d.clock.sleep(ctx, delay); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		if !isResponseStatusCodeEligibleForRetry(resp.StatusCode) || attempt == restMaxAttempts-1 {
+			return resp, nil
+		}
+
+		discardResponse(resp)
+
+		delay := d.restBackoffDelay(attempt, resp)
+		if err := d.clock.sleep(ctx, delay); err != nil {
+			return nil, err
+		}
+	}
+
+	if lastTransportErr != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, lastTransportErr
+	}
+
+	return nil, ctx.Err()
+}
+
+func (d *RestDoer) doAttempt(ctx context.Context, req *http.Request) (*http.Response, error) {
+	if _, hasDeadline := ctx.Deadline(); hasDeadline {
+		return d.inner.Do(req)
+	}
+
+	return d.headerTimeoutInner.Do(req)
+}
+
+func isRequestEligibleForRetry(req *http.Request) bool {
+	if req == nil {
+		return false
+	}
+
+	if req.Method != http.MethodGet && req.Method != http.MethodHead {
+		return false
+	}
+
+	if req.Body != nil && req.Body != http.NoBody {
+		return false
+	}
+
+	return true
+}
+
+func isResponseStatusCodeEligibleForRetry(statusCode int) bool {
+	switch statusCode {
+	case http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+		http.StatusTooManyRequests:
+		return true
+	default:
+		return false
+	}
+}
+
+func (d *RestDoer) restBackoffDelay(attempt int, resp *http.Response) time.Duration {
+	if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
+		if delay, ok := parseRetryAfter(resp.Header.Get("Retry-After"), d.clock.now(), restMaxRetryAfter); ok {
+			return delay
+		}
+	}
+
+	return fullJitterDelay(attempt, restBaseDelay, restBackoffFactor, restMaxDelay, d.clock.jitter)
+}
+
+func discardResponse(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+
+	_, _ = io.CopyN(io.Discard, resp.Body, restDiscardDrainLimitBytes)
+	_ = resp.Body.Close()
+}
+
+func withResponseHeaderTimeout(inner httpDoer, timeout time.Duration) httpDoer {
+	client, ok := inner.(*http.Client)
+	if !ok {
+		return inner
+	}
+
+	return clientWithResponseHeaderTimeout(client, timeout)
+}
+
+func clientWithResponseHeaderTimeout(client *http.Client, timeout time.Duration) *http.Client {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	cloned := *client
+	transport := cloned.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+
+	t, ok := transport.(*http.Transport)
+	if !ok {
+		return client
+	}
+
+	tc := t.Clone()
+	tc.ResponseHeaderTimeout = timeout
+	cloned.Transport = tc
+	return &cloned
+}

--- a/pkg/client/retry/rest.go
+++ b/pkg/client/retry/rest.go
@@ -2,10 +2,21 @@ package retry
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
 )
+
+var errInvalidRestMaxAttempts = errors.New("rest max attempts must be at least 1")
+
+func validateRestMaxAttempts(maxAttempts int) error {
+	if maxAttempts < 1 {
+		return fmt.Errorf("%w: got %d", errInvalidRestMaxAttempts, maxAttempts)
+	}
+	return nil
+}
 
 type httpDoer interface {
 	Do(req *http.Request) (*http.Response, error)
@@ -16,6 +27,7 @@ type RestDoer struct {
 	inner              httpDoer
 	headerTimeoutInner httpDoer
 	clock              clock
+	maxAttempts        int
 }
 
 type restDoerOption func(*RestDoer)
@@ -33,7 +45,11 @@ func withHeaderTimeout(timeout time.Duration) restDoerOption {
 }
 
 // NewRestDoer wraps inner with REST read retry behavior.
-func NewRestDoer(inner httpDoer, opts ...restDoerOption) *RestDoer {
+func NewRestDoer(inner httpDoer, opts ...restDoerOption) (*RestDoer, error) {
+	if err := validateRestMaxAttempts(restMaxAttempts); err != nil {
+		return nil, err
+	}
+
 	if inner == nil {
 		inner = &http.Client{}
 	}
@@ -42,13 +58,14 @@ func NewRestDoer(inner httpDoer, opts ...restDoerOption) *RestDoer {
 		inner:              inner,
 		headerTimeoutInner: withResponseHeaderTimeout(inner, restPerAttemptTimeout),
 		clock:              defaultClock(),
+		maxAttempts:        restMaxAttempts,
 	}
 
 	for _, opt := range opts {
 		opt(d)
 	}
 
-	return d
+	return d, nil
 }
 
 func (d *RestDoer) Do(req *http.Request) (*http.Response, error) {
@@ -69,7 +86,7 @@ func (d *RestDoer) Do(req *http.Request) (*http.Response, error) {
 
 	var lastTransportErr error
 
-	for attempt := range restMaxAttempts {
+	for attempt := range d.maxAttempts {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
@@ -79,7 +96,7 @@ func (d *RestDoer) Do(req *http.Request) (*http.Response, error) {
 		if err != nil {
 			lastTransportErr = err
 
-			if attempt == restMaxAttempts-1 || ctx.Err() != nil {
+			if attempt == d.maxAttempts-1 || ctx.Err() != nil {
 				if ctx.Err() != nil {
 					return nil, ctx.Err()
 				}
@@ -93,7 +110,7 @@ func (d *RestDoer) Do(req *http.Request) (*http.Response, error) {
 			continue
 		}
 
-		if !isResponseStatusCodeEligibleForRetry(resp.StatusCode) || attempt == restMaxAttempts-1 {
+		if !isResponseStatusCodeEligibleForRetry(resp.StatusCode) || attempt == d.maxAttempts-1 {
 			return resp, nil
 		}
 

--- a/pkg/client/retry/rest_test.go
+++ b/pkg/client/retry/rest_test.go
@@ -50,7 +50,9 @@ func (c *countingDoer) Do(req *http.Request) (*http.Response, error) {
 	}, nil
 }
 
-func newTestRestDoer(inner httpDoer) (*RestDoer, chan time.Duration) {
+func newTestRestDoer(t *testing.T, inner httpDoer) (*RestDoer, chan time.Duration) {
+	t.Helper()
+
 	slept := make(chan time.Duration, 8)
 	sleep := func(ctx context.Context, d time.Duration) error {
 		select {
@@ -60,11 +62,14 @@ func newTestRestDoer(inner httpDoer) (*RestDoer, chan time.Duration) {
 		return sleepContext(ctx, 0)
 	}
 
-	return NewRestDoer(inner, withRestClock(clock{
+	doer, err := NewRestDoer(inner, withRestClock(clock{
 		now:    time.Now,
 		sleep:  sleep,
 		jitter: rand.New(rand.NewPCG(1, 1)).Int64N,
-	})), slept
+	}))
+	require.NoError(t, err)
+
+	return doer, slept
 }
 
 func TestRestDoerRetriesGatewayStatuses(t *testing.T) {
@@ -75,7 +80,7 @@ func TestRestDoerRetriesGatewayStatuses(t *testing.T) {
 			t.Parallel()
 
 			inner := &countingDoer{statuses: []int{status, status, http.StatusOK}}
-			doer, _ := newTestRestDoer(inner)
+			doer, _ := newTestRestDoer(t, inner)
 
 			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/path?q=1", nil)
 			require.NoError(t, err)
@@ -111,7 +116,7 @@ func TestRestDoerRetriesTransportErrors(t *testing.T) {
 		}, nil
 	}}
 
-	doer, _ := newTestRestDoer(inner)
+	doer, _ := newTestRestDoer(t, inner)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", nil)
 	require.NoError(t, err)
 
@@ -137,7 +142,7 @@ func TestRestDoerDoesNotRetryRequestsOutsideBodylessReads(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			inner := &countingDoer{statuses: []int{http.StatusBadGateway}}
-			doer, _ := newTestRestDoer(inner)
+			doer, _ := newTestRestDoer(t, inner)
 
 			req, err := http.NewRequestWithContext(context.Background(), tc.method, "http://example.com", tc.body)
 			require.NoError(t, err)
@@ -175,7 +180,7 @@ func TestRestDoerPreservesRequestClone(t *testing.T) {
 		}, nil
 	}}
 
-	doer, _ := newTestRestDoer(inner)
+	doer, _ := newTestRestDoer(t, inner)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/items?x=1", nil)
 	require.NoError(t, err)
 	req.Header.Set("Authorization", "Bearer abc")
@@ -194,7 +199,7 @@ func TestRestDoerStopsOnContextCancellation(t *testing.T) {
 	cancel()
 
 	inner := &countingDoer{statuses: []int{http.StatusServiceUnavailable}}
-	doer, _ := newTestRestDoer(inner)
+	doer, _ := newTestRestDoer(t, inner)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", nil)
 	require.NoError(t, err)
 
@@ -212,7 +217,7 @@ func TestRestDoer429RetryAfterDeltaSeconds(t *testing.T) {
 		statuses: []int{http.StatusTooManyRequests, http.StatusOK},
 		headers:  []http.Header{header},
 	}
-	doer, slept := newTestRestDoer(inner)
+	doer, slept := newTestRestDoer(t, inner)
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", nil)
 	require.NoError(t, err)
@@ -254,7 +259,7 @@ func TestRestDoer429InvalidRetryAfterStillRetries(t *testing.T) {
 		}, nil
 	}}
 
-	doer, _ := newTestRestDoer(inner)
+	doer, _ := newTestRestDoer(t, inner)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", nil)
 	require.NoError(t, err)
 
@@ -276,7 +281,8 @@ func TestRestDoerCallerDeadlineOverridesHeaderTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	doer := NewRestDoer(server.Client(), withHeaderTimeout(time.Millisecond))
+	doer, err := NewRestDoer(server.Client(), withHeaderTimeout(time.Millisecond))
+	require.NoError(t, err)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
 	require.NoError(t, err)
 
@@ -300,7 +306,8 @@ func TestRestDoerFinalBodyReadablePastHeaderTimeout(t *testing.T) {
 	}))
 	defer server.Close()
 
-	doer := NewRestDoer(server.Client(), withHeaderTimeout(50*time.Millisecond))
+	doer, err := NewRestDoer(server.Client(), withHeaderTimeout(50*time.Millisecond))
+	require.NoError(t, err)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
 	require.NoError(t, err)
 
@@ -317,7 +324,7 @@ func TestRestDoerDoesNotRetry404(t *testing.T) {
 	t.Parallel()
 
 	inner := &countingDoer{statuses: []int{http.StatusNotFound}}
-	doer, _ := newTestRestDoer(inner)
+	doer, _ := newTestRestDoer(t, inner)
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", nil)
 	require.NoError(t, err)
@@ -326,4 +333,45 @@ func TestRestDoerDoesNotRetry404(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	assert.Equal(t, 1, int(inner.attempts.Load()))
+}
+
+func TestValidateRestMaxAttempts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   int
+		wantErr error
+	}{
+		{
+			name:  "one is valid",
+			input: 1,
+		},
+		{
+			name:  "five is valid",
+			input: 5,
+		},
+		{
+			name:    "zero is invalid",
+			input:   0,
+			wantErr: errInvalidRestMaxAttempts,
+		},
+		{
+			name:    "negative is invalid",
+			input:   -1,
+			wantErr: errInvalidRestMaxAttempts,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRestMaxAttempts(tt.input)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/pkg/client/retry/rest_test.go
+++ b/pkg/client/retry/rest_test.go
@@ -1,0 +1,329 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockDoer struct {
+	fn func(req *http.Request, attempt int) (*http.Response, error)
+}
+
+func (m *mockDoer) Do(req *http.Request) (*http.Response, error) {
+	return m.fn(req, 0)
+}
+
+type countingDoer struct {
+	attempts atomic.Int32
+	statuses []int
+	headers  []http.Header
+}
+
+func (c *countingDoer) Do(req *http.Request) (*http.Response, error) {
+	attempt := int(c.attempts.Add(1)) - 1
+	status := http.StatusOK
+	if attempt < len(c.statuses) {
+		status = c.statuses[attempt]
+	}
+
+	header := make(http.Header)
+	if attempt < len(c.headers) && c.headers[attempt] != nil {
+		header = c.headers[attempt].Clone()
+	}
+
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader("ok")),
+		Header:     header,
+		Request:    req,
+	}, nil
+}
+
+func newTestRestDoer(inner httpDoer) (*RestDoer, chan time.Duration) {
+	slept := make(chan time.Duration, 8)
+	sleep := func(ctx context.Context, d time.Duration) error {
+		select {
+		case slept <- d:
+		default:
+		}
+		return sleepContext(ctx, 0)
+	}
+
+	return NewRestDoer(inner, withRestClock(clock{
+		now:    time.Now,
+		sleep:  sleep,
+		jitter: rand.New(rand.NewPCG(1, 1)).Int64N,
+	})), slept
+}
+
+func TestRestDoerRetriesGatewayStatuses(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []int{http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			t.Parallel()
+
+			inner := &countingDoer{statuses: []int{status, status, http.StatusOK}}
+			doer, _ := newTestRestDoer(inner)
+
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/path?q=1", nil)
+			require.NoError(t, err)
+			req.Header.Set("Authorization", "Bearer token")
+
+			resp, err := doer.Do(req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, 3, int(inner.attempts.Load()))
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.Equal(t, "ok", string(body))
+			require.NoError(t, resp.Body.Close())
+		})
+	}
+}
+
+func TestRestDoerRetriesTransportErrors(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	inner := &mockDoer{fn: func(req *http.Request, _ int) (*http.Response, error) {
+		if attempts.Add(1) < 3 {
+			return nil, errors.New("connection reset")
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	}}
+
+	doer, _ := newTestRestDoer(inner)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+
+	resp, err := doer.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, int32(3), attempts.Load())
+}
+
+func TestRestDoerDoesNotRetryRequestsOutsideBodylessReads(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		method string
+		body   io.ReadCloser
+	}{
+		{name: "post", method: http.MethodPost, body: nil},
+		{name: "delete", method: http.MethodDelete, body: nil},
+		{name: "get with body", method: http.MethodGet, body: io.NopCloser(strings.NewReader("x"))},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inner := &countingDoer{statuses: []int{http.StatusBadGateway}}
+			doer, _ := newTestRestDoer(inner)
+
+			req, err := http.NewRequestWithContext(context.Background(), tc.method, "http://example.com", tc.body)
+			require.NoError(t, err)
+
+			resp, err := doer.Do(req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
+			assert.Equal(t, 1, int(inner.attempts.Load()))
+		})
+	}
+}
+
+func TestRestDoerPreservesRequestClone(t *testing.T) {
+	t.Parallel()
+
+	var seenURLs []string
+	var seenAuth []string
+	inner := &mockDoer{fn: func(req *http.Request, _ int) (*http.Response, error) {
+		seenURLs = append(seenURLs, req.URL.String())
+		seenAuth = append(seenAuth, req.Header.Get("Authorization"))
+		if len(seenURLs) < 2 {
+			return &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Body:       io.NopCloser(strings.NewReader("retry")),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	}}
+
+	doer, _ := newTestRestDoer(inner)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/items?x=1", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer abc")
+
+	_, err = doer.Do(req)
+	require.NoError(t, err)
+	require.Len(t, seenURLs, 2)
+	assert.Equal(t, "/items?x=1", seenURLs[0][strings.Index(seenURLs[0], "/items"):])
+	assert.Equal(t, []string{"Bearer abc", "Bearer abc"}, seenAuth)
+}
+
+func TestRestDoerStopsOnContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	inner := &countingDoer{statuses: []int{http.StatusServiceUnavailable}}
+	doer, _ := newTestRestDoer(inner)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+
+	_, err = doer.Do(req)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 0, int(inner.attempts.Load()))
+}
+
+func TestRestDoer429RetryAfterDeltaSeconds(t *testing.T) {
+	t.Parallel()
+
+	header := make(http.Header)
+	header.Set("Retry-After", "2")
+	inner := &countingDoer{
+		statuses: []int{http.StatusTooManyRequests, http.StatusOK},
+		headers:  []http.Header{header},
+	}
+	doer, slept := newTestRestDoer(inner)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+
+	resp, err := doer.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	select {
+	case delay := <-slept:
+		assert.Equal(t, 2*time.Second, delay)
+	case <-time.After(time.Second):
+		t.Fatal("expected retry sleep delay")
+	}
+}
+
+func TestRestDoer429InvalidRetryAfterStillRetries(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	inner := &mockDoer{fn: func(req *http.Request, _ int) (*http.Response, error) {
+		attempt := int(attempts.Add(1))
+		if attempt < 2 {
+			header := make(http.Header)
+			header.Set("Retry-After", "invalid")
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Body:       io.NopCloser(strings.NewReader("retry")),
+				Header:     header,
+				Request:    req,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	}}
+
+	doer, _ := newTestRestDoer(inner)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+
+	resp, err := doer.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(2), attempts.Load())
+}
+
+func TestRestDoerCallerDeadlineOverridesHeaderTimeout(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(20 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	doer := NewRestDoer(server.Client(), withHeaderTimeout(time.Millisecond))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := doer.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestRestDoerFinalBodyReadablePastHeaderTimeout(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte("slow-body")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		time.Sleep(150 * time.Millisecond)
+		_, _ = w.Write(payload)
+	}))
+	defer server.Close()
+
+	doer := NewRestDoer(server.Client(), withHeaderTimeout(50*time.Millisecond))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := doer.Do(req)
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, payload, body)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestRestDoerDoesNotRetry404(t *testing.T) {
+	t.Parallel()
+
+	inner := &countingDoer{statuses: []int{http.StatusNotFound}}
+	doer, _ := newTestRestDoer(inner)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+
+	resp, err := doer.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, 1, int(inner.attempts.Load()))
+}

--- a/pkg/config/client/client.go
+++ b/pkg/config/client/client.go
@@ -29,6 +29,8 @@ type ClientConfigFile struct {
 
 	NoGrpcRetry bool `mapstructure:"noGrpcRetry" json:"noGrpcRetry,omitempty"`
 
+	NoRetry bool `mapstructure:"noRetry" json:"noRetry,omitempty"`
+
 	CloudRegisterID *string `mapstructure:"cloudRegisterID" json:"cloudRegisterID,omitempty"`
 
 	RawRunnableActions []string `mapstructure:"runnableActions" json:"runnableActions,omitempty"`
@@ -48,6 +50,7 @@ type ClientConfig struct {
 	TenantId    string
 	Token       string
 	NoGrpcRetry bool
+	NoRetry     bool
 
 	ServerURL            string
 	GRPCBroadcastAddress string
@@ -84,6 +87,7 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("cloudRegisterID", "HATCHET_CLOUD_REGISTER_ID")
 	_ = v.BindEnv("runnableActions", "HATCHET_CLOUD_ACTIONS")
 	_ = v.BindEnv("noGrpcRetry", "HATCHET_CLIENT_NO_GRPC_RETRY")
+	_ = v.BindEnv("noRetry", "HATCHET_CLIENT_NO_RETRY")
 	_ = v.BindEnv("autoscalingTarget", "HATCHET_CLIENT_AUTOSCALING_TARGET")
 	_ = v.BindEnv("disableGzipCompression", "HATCHET_CLIENT_DISABLE_GZIP_COMPRESSION")
 

--- a/pkg/config/client/client_test.go
+++ b/pkg/config/client/client_test.go
@@ -1,0 +1,67 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBindAllEnvNoRetry(t *testing.T) {
+	t.Setenv("HATCHET_CLIENT_NO_RETRY", "true")
+	t.Setenv("HATCHET_CLIENT_NO_GRPC_RETRY", "true")
+
+	v := viper.New()
+	BindAllEnv(v)
+
+	assert.Equal(t, "true", v.GetString("noRetry"))
+	assert.Equal(t, "true", v.GetString("noGrpcRetry"))
+}
+
+func TestClientConfigFileNoRetryYAML(t *testing.T) {
+	t.Parallel()
+
+	v := viper.New()
+	BindAllEnv(v)
+	require.NoError(t, v.MergeConfigMap(map[string]interface{}{
+		"noRetry":     true,
+		"noGrpcRetry": true,
+	}))
+
+	cf := &ClientConfigFile{}
+	require.NoError(t, v.Unmarshal(cf))
+
+	assert.True(t, cf.NoRetry)
+	assert.True(t, cf.NoGrpcRetry)
+}
+
+func TestRetryControlSemantics(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		noRetry     bool
+		noGrpcRetry bool
+		grpcRetry   bool
+		restRetry   bool
+	}{
+		{name: "defaults", grpcRetry: true, restRetry: true},
+		{name: "no grpc only", noGrpcRetry: true, grpcRetry: false, restRetry: true},
+		{name: "no retry all", noRetry: true, grpcRetry: false, restRetry: false},
+		{name: "both set", noRetry: true, noGrpcRetry: true, grpcRetry: false, restRetry: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cf := &ClientConfigFile{NoRetry: tc.noRetry, NoGrpcRetry: tc.noGrpcRetry}
+			grpcRetry := !cf.NoRetry && !cf.NoGrpcRetry
+			restRetry := !cf.NoRetry
+
+			assert.Equal(t, tc.grpcRetry, grpcRetry)
+			assert.Equal(t, tc.restRetry, restRetry)
+		})
+	}
+}

--- a/pkg/v1/config.go
+++ b/pkg/v1/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	ServerURL          string
 	Namespace          string
 	NoGrpcRetry        bool
+	NoRetry            bool
 	CloudRegisterID    string
 	RawRunnableActions []string
 	AutoscalingTarget  string
@@ -44,6 +45,7 @@ func mapConfigToCF(opts Config) *v0Config.ClientConfigFile {
 	cf.ServerURL = opts.ServerURL
 	cf.Namespace = opts.Namespace
 	cf.NoGrpcRetry = opts.NoGrpcRetry
+	cf.NoRetry = opts.NoRetry
 	cf.CloudRegisterID = &opts.CloudRegisterID
 	cf.RawRunnableActions = opts.RawRunnableActions
 	cf.AutoscalingTarget = opts.AutoscalingTarget


### PR DESCRIPTION
# Description

Adds the first scoped Go SDK retry change from #4228: shared retry helpers, REST retries for bodyless reads, gRPC retry construction cleanup with full-jitter backoff, and retry controls to disable SDK client retries.

Refs #4228

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [x] Test changes (add, refactor, improve or change a test)
- [x] This change requires a documentation update

## What's Changed

- Adds shared retry/backoff helpers to GoSDK (in `pkg/client/retry/`)
- REST
  - The main thing to review is `pkg/client/retry/rest.go` --> `func (d *RestDoer) Do(req *http.Request) (*http.Response, error)`
  - The rest client uses this _doer_
  - The retry behavior: 5 attempts with jitter: `0-250ms, 0-500ms, 0-1s, 0-2s`
  - Eligible for retry: bodyless `GET`/`HEAD`  (it's not possibly to retry a request with body as that body can be consumed only once; we'd need to manually manage save/cacheing it and forgo splicing)
- gRPC
  - The main thing to review is `pkg/client/retry/grpc.go` --> `func GRPCDialOptions(l *zerolog.Logger, enabled bool) []grpc.DialOption`
  - Most of the gRPC retry behavior stays the same for this PR, the only changes are:
  - Change: the retry now uses jitter: `0-5s, 0-10s, 0-20s, 0-40s`
  - Change: `FailedPrecondition` won't be retried (see below)

## Scope and limitations

### REST body replay

Bodied REST requests (`POST`, `PUT`, `PATCH`, and other methods with a body) are excluded from retry scope. In Go, an `http.Request` body is a one-shot `io.ReadCloser` unless `GetBody` is populated or the retry layer buffers and reconstructs the body. The generated REST clients do not set `req.GetBody`, so retrying bodied calls would require body replay plumbing and per-endpoint idempotency review. This PR limits REST retries to bodyless `GET`/`HEAD` reads.

### FailedPrecondition audit

Server-side audit of current `codes.FailedPrecondition` producers:

- The only production server return is `DispatcherImpl.Heartbeat` in `internal/services/dispatcher/server.go`, when a worker has a prior `ListenV2` listener session but `IsActive` is false.
- The only user-facing Go SDK path that observes it is the worker background heartbeat loop in `pkg/client/dispatcher.go`.
- Retrying that error does not reopen the listener stream; it only blocks the heartbeat goroutine behind gRPC retry backoff while listener reconnect remains driven separately by `ListenV2.Recv` errors.

Dropping `FailedPrecondition` from retryable gRPC codes is therefore a low-risk semantic cleanup: it is a rejected heartbeat / inactive-listener signal, not a transient transport fault.

### Duplicate gRPC write execution

This PR does **not** reduce duplicate-write risk from gRPC retries. The unary interceptor still retries all unary RPCs, including writes, with no method-level classification. That behavior change is deferred to a later semantic retry-policy PR.

### Retry controls

- `HATCHET_CLIENT_NO_RETRY` disables both REST read retries and gRPC SDK client retries.
- `HATCHET_CLIENT_NO_GRPC_RETRY` remains the existing gRPC-only retry control and continues to disable only the gRPC retry interceptor.

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

Latest verification:

- `task fmt-go`
- `task fmt-docs`
- `go test ./pkg/client/retry ./pkg/client ./pkg/config/client`
- pre-commit hooks on committed changes, including `golangci-lint`

## Related

This PR intentionally does not add gRPC method-level retry classification, REST write retries, or stream/listener reconnect normalization. Those are planned follow-ups from #4228.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Cursor agents were used to review the implementation, refine docs copy, identify simplification opportunities, and prepare this PR description. The final changes were checked with focused Go tests, docs formatting, and pre-commit hooks.

</details>