### PR TITLE
fix: make sure we use partial index when creating scheduled and cron refs

### DIFF
--- a/pkg/repository/sqlcv1/workflow_schedules.sql
+++ b/pkg/repository/sqlcv1/workflow_schedules.sql
@@ -132,6 +132,7 @@ RETURNING t."id";
 WITH latest_version AS (
     SELECT "id" FROM "WorkflowVersion"
     WHERE "workflowId" = @workflowId::uuid
+        AND "deletedAt" IS NULL
     ORDER BY "order" DESC
     LIMIT 1
 ),

--- a/pkg/repository/sqlcv1/workflow_schedules.sql.go
+++ b/pkg/repository/sqlcv1/workflow_schedules.sql.go
@@ -216,6 +216,7 @@ const createWorkflowTriggerScheduledRefForWorkflow = `-- name: CreateWorkflowTri
 WITH latest_version AS (
     SELECT "id" FROM "WorkflowVersion"
     WHERE "workflowId" = $6::uuid
+        AND "deletedAt" IS NULL
     ORDER BY "order" DESC
     LIMIT 1
 ),

--- a/pkg/repository/sqlcv1/workflows.sql
+++ b/pkg/repository/sqlcv1/workflows.sql
@@ -657,6 +657,7 @@ WHERE "id" = @cronTriggerId::uuid
 WITH latest_version AS (
     SELECT "id" FROM "WorkflowVersion"
     WHERE "workflowId" = @workflowId::uuid
+        AND "deletedAt" IS NULL
     ORDER BY "order" DESC
     LIMIT 1
 ),

--- a/pkg/repository/sqlcv1/workflows.sql.go
+++ b/pkg/repository/sqlcv1/workflows.sql.go
@@ -770,6 +770,7 @@ const createWorkflowTriggerCronRefForWorkflow = `-- name: CreateWorkflowTriggerC
 WITH latest_version AS (
     SELECT "id" FROM "WorkflowVersion"
     WHERE "workflowId" = $7::uuid
+        AND "deletedAt" IS NULL
     ORDER BY "order" DESC
     LIMIT 1
 ),


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

When creating scheduled and cron refs we were not properly filtering for latest workflow version and hence not using the desired partial index `idx_workflow_version_workflow_id_order` which can lead to high CPU when there are millions of rows in the respective tables.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Add a clause `deletedAt IS NULL` to existing SQL CTEs when filtering for latest workflow versions.

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
