### PR TITLE
chore: deduplicate code around logging before republishing for retry exhaustion

### DIFF
--- a/internal/listutils/helpers.go
+++ b/internal/listutils/helpers.go
@@ -32,3 +32,13 @@ func All[T comparable](statuses []T, target T) bool {
 	}
 	return true
 }
+
+func MaxOf[T any](xs []T, fn func(T) int) int {
+	m := 0
+	for _, x := range xs {
+		if c := fn(x); c > m {
+			m = c
+		}
+	}
+	return m
+}

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hatchet-dev/hatchet/internal/datautils"
 	"github.com/hatchet-dev/hatchet/internal/integrations/alerting"
+	"github.com/hatchet-dev/hatchet/internal/listutils"
 	"github.com/hatchet-dev/hatchet/internal/msgqueue"
 	"github.com/hatchet-dev/hatchet/internal/queueutils"
 	"github.com/hatchet-dev/hatchet/internal/services/partition"
@@ -48,18 +49,6 @@ const (
 	// escalates from warn to error level.
 	requeueErrorLogThreshold = 50
 )
-
-// maxRequeueCountOf returns the largest requeue count across items, used to decide
-// the log level when republishing items whose locks could not be acquired.
-func maxRequeueCountOf[T any](items []T, requeueCount func(T) int) int {
-	maxCount := 0
-	for _, item := range items {
-		if c := requeueCount(item); c > maxCount {
-			maxCount = c
-		}
-	}
-	return maxCount
-}
 
 // logRepublish emits the standard "failed to acquire locks" log line, escalating to
 // error level once items have been requeued many times.
@@ -589,7 +578,7 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 	attempts := 0
 	for len(createTaskOpts) > 0 {
 		if attempts >= maxLockAttempts {
-			maxRequeueCount := maxRequeueCountOf(createTaskOpts, func(o *tasktypes.CreatedTaskPayload) int { return o.RequeueCount })
+			maxRequeueCount := listutils.MaxOf(createTaskOpts, func(o *tasktypes.CreatedTaskPayload) int { return o.RequeueCount })
 			tc.logRepublish(ctx, "tasks", len(createTaskOpts), attempts, maxRequeueCount)
 			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
 		}
@@ -684,7 +673,7 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 	attempts := 0
 	for len(createDAGOpts) > 0 {
 		if attempts >= maxLockAttempts {
-			maxRequeueCount := maxRequeueCountOf(createDAGOpts, func(o *tasktypes.CreatedDAGPayload) int { return o.RequeueCount })
+			maxRequeueCount := listutils.MaxOf(createDAGOpts, func(o *tasktypes.CreatedDAGPayload) int { return o.RequeueCount })
 			tc.logRepublish(ctx, "DAGs", len(createDAGOpts), attempts, maxRequeueCount)
 			return tc.republishCreatedDAGs(ctx, tenantId, createDAGOpts)
 		}

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -39,6 +39,44 @@ type OLAPController interface {
 	Start(ctx context.Context) error
 }
 
+const (
+	// maxLockAttempts is the number of times we retry acquiring locks before
+	// republishing the remaining items to the message queue.
+	maxLockAttempts = 10
+
+	// requeueErrorLogThreshold is the requeue count at which republish logging
+	// escalates from warn to error level.
+	requeueErrorLogThreshold = 50
+)
+
+// maxRequeueCountOf returns the largest requeue count across items, used to decide
+// the log level when republishing items whose locks could not be acquired.
+func maxRequeueCountOf[T any](items []T, requeueCount func(T) int) int {
+	maxCount := 0
+	for _, item := range items {
+		if c := requeueCount(item); c > maxCount {
+			maxCount = c
+		}
+	}
+	return maxCount
+}
+
+// logRepublish emits the standard "failed to acquire locks" log line, escalating to
+// error level once items have been requeued many times.
+func (tc *OLAPControllerImpl) logRepublish(ctx context.Context, entity string, count, attempts, maxRequeueCount int) {
+	logger := tc.l.Warn()
+
+	if maxRequeueCount >= requeueErrorLogThreshold {
+		logger = tc.l.Error()
+	}
+
+	logger.Ctx(ctx).
+		Int("count", count).
+		Int("attempts", attempts).
+		Int("requeue_count", maxRequeueCount).
+		Msgf("failed to acquire locks for %s, republishing to MQ", entity)
+}
+
 type OLAPControllerImpl struct {
 	mq                           msgqueue.MessageQueue
 	l                            *zerolog.Logger
@@ -550,15 +588,9 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 
 	attempts := 0
 	for len(createTaskOpts) > 0 {
-		if attempts >= 10 {
-			maxRequeueCount := 0
-			for _, opt := range createTaskOpts {
-				if opt.RequeueCount > maxRequeueCount {
-					maxRequeueCount = opt.RequeueCount
-				}
-			}
-
-			tc.l.Error().Ctx(ctx).Int("count", len(createTaskOpts)).Int("attempts", attempts).Int("requeue_count", maxRequeueCount).Msg("failed to acquire locks for tasks, republishing to MQ")
+		if attempts >= maxLockAttempts {
+			maxRequeueCount := maxRequeueCountOf(createTaskOpts, func(o *tasktypes.CreatedTaskPayload) int { return o.RequeueCount })
+			tc.logRepublish(ctx, "tasks", len(createTaskOpts), attempts, maxRequeueCount)
 			return tc.republishCreatedTasks(ctx, tenantId, createTaskOpts)
 		}
 
@@ -588,7 +620,7 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 		createTaskOpts = failedOpts
 		tc.emitStandaloneTaskRootSpans(ctx, tenantId, extractCreatedTaskData(succeededOpts))
 
-		if len(failedOpts) > 0 && attempts < 10 {
+		if len(failedOpts) > 0 && attempts < maxLockAttempts {
 			tc.sleepWithBackoff(attempts)
 		}
 	}
@@ -651,15 +683,9 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 
 	attempts := 0
 	for len(createDAGOpts) > 0 {
-		if attempts >= 10 {
-			maxRequeueCount := 0
-			for _, opt := range createDAGOpts {
-				if opt.RequeueCount > maxRequeueCount {
-					maxRequeueCount = opt.RequeueCount
-				}
-			}
-
-			tc.l.Error().Ctx(ctx).Int("count", len(createDAGOpts)).Int("attempts", attempts).Int("requeue_count", maxRequeueCount).Msg("failed to acquire locks for DAGs, republishing to MQ")
+		if attempts >= maxLockAttempts {
+			maxRequeueCount := maxRequeueCountOf(createDAGOpts, func(o *tasktypes.CreatedDAGPayload) int { return o.RequeueCount })
+			tc.logRepublish(ctx, "DAGs", len(createDAGOpts), attempts, maxRequeueCount)
 			return tc.republishCreatedDAGs(ctx, tenantId, createDAGOpts)
 		}
 
@@ -685,7 +711,7 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 		createDAGOpts = failedOpts
 		tc.emitWorkflowRunRootSpans(ctx, tenantId, extractCreatedDAGData(succeededOpts))
 
-		if len(failedOpts) > 0 && attempts < 10 {
+		if len(failedOpts) > 0 && attempts < maxLockAttempts {
 			tc.sleepWithBackoff(attempts)
 		}
 	}
@@ -1053,7 +1079,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 
 	attempts := 0
 	for len(opts) > 0 {
-		if attempts >= 10 {
+		if attempts >= maxLockAttempts {
 			maxRequeueCount := 0
 			for _, msg := range externalIdToMsg {
 				if msg.RequeueCount > maxRequeueCount {
@@ -1061,7 +1087,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 				}
 			}
 
-			tc.l.Error().Ctx(ctx).Int("count", len(opts)).Int("attempts", attempts).Int("requeue_count", maxRequeueCount).Msg("failed to acquire locks for monitoring events, republishing to MQ")
+			tc.logRepublish(ctx, "monitoring events", len(opts), attempts, maxRequeueCount)
 			return tc.republishMonitoringEvents(ctx, tenantId, opts, externalIdToMsg)
 		}
 
@@ -1125,7 +1151,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 			tc.synthesizeEngineSpans(ctx, tenantId, spanEventsForSuccessfullyLockedRuns)
 		}
 
-		if len(remainingOpts) > 0 && attempts < 10 {
+		if len(remainingOpts) > 0 && attempts < maxLockAttempts {
 			tc.sleepWithBackoff(attempts)
 		}
 	}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

This PR adds helpers to deduplicate some code around MQ retry due to retry exhaustion as well as adds a threshold to bump log level from WRN to ERR.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (changes which are not directly related to any business logic)

## What's Changed

- [x] Added helper methods for code deduplication
- [x] Added retry count based log level

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
