### PR TITLE
chore: no need to error out when s3 bulk payloads return 404

### DIFF
--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -8,6 +8,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/go-co-op/gocron/v2"
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
@@ -639,6 +642,31 @@ type V1TaskWithPayloadAndInvocationCount struct {
 	InvocationCount *int32 // only used for durable tasks
 }
 
+// isS3NotFoundErr reports whether err (or any error it wraps) is an S3
+// "not found" response, i.e. a 404 / NoSuchKey. These are expected when a
+// payload was never written or has already been cleaned up.
+func isS3NotFoundErr(err error) bool {
+	var nsk *types.NoSuchKey
+	if errors.As(err, &nsk) {
+		return true
+	}
+
+	var respErr *smithyhttp.ResponseError
+	if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
+		return true
+	}
+
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "NoSuchKey", "NotFound":
+			return true
+		}
+	}
+
+	return false
+}
+
 func (d *DispatcherImpl) populateTaskData(
 	ctx context.Context,
 	requeue func(task *sqlcv1.V1Task),
@@ -716,7 +744,15 @@ func (d *DispatcherImpl) populateTaskData(
 			requeue(task)
 		}
 
-		d.l.Error().Ctx(ctx).Err(err).Msgf("could not bulk retrieve inputs for %d tasks", len(bulkDatas))
+		// An S3 "not found" (404 / NoSuchKey) for a payload is an expected condition
+		// (e.g. the payload was never written or has been cleaned up), not an operational
+		// error, so we log it at warn level to avoid noisy error alerts.
+		evt := d.l.Error()
+		if isS3NotFoundErr(err) {
+			evt = d.l.Warn()
+		}
+
+		evt.Ctx(ctx).Err(err).Msgf("could not bulk retrieve inputs for %d tasks", len(bulkDatas))
 		return nil, err
 	}
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Instead of treating expired and nvalid S3 keys as errors, let us only WRN for these for bulk payload processing.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (changes which are not directly related to any business logic)

## What's Changed

- [x] Helper to check for S3 404 or NoSuckKey error

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
