### PR TITLE
fix(dashboard): make sure workflow settings page is scrollable

### DIFF
--- a/frontend/app/src/pages/main/v1/workflows/$workflow/components/workflow-general-settings.tsx
+++ b/frontend/app/src/pages/main/v1/workflows/$workflow/components/workflow-general-settings.tsx
@@ -164,7 +164,7 @@ function TriggerSettings({ workflow }: { workflow: WorkflowVersion }) {
 
       {workflow.triggers.crons && workflow.triggers.crons.length > 0 && (
         <FieldGroup label="Cron Schedules">
-          <div className="space-y-2">
+          <div className="max-h-72 space-y-2 overflow-y-auto pr-2">
             {workflow.triggers.crons.map((cronTrigger) => (
               <div key={cronTrigger.cron}>
                 <Badge

--- a/frontend/app/src/pages/main/v1/workflows/$workflow/index.tsx
+++ b/frontend/app/src/pages/main/v1/workflows/$workflow/index.tsx
@@ -164,7 +164,10 @@ export default function ExpandedWorkflow() {
           <TabsContent value="runs" className="min-h-0 flex-1">
             <RecentRunsList />
           </TabsContent>
-          <TabsContent value="settings" className="min-h-0 flex-1 pt-4 pb-8">
+          <TabsContent
+            value="settings"
+            className="min-h-0 flex-1 overflow-y-auto pt-4 pb-8"
+          >
             {workflowVersionQuery.isLoading || !workflowVersionQuery.data ? (
               <Loading />
             ) : (


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Right now the workflow settings page does not scroll. Also, when a workflow has too many crons, the other options cannot be accessed.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Adds ability for crons and the overall settings page to be scrollable.

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
