### PR TITLE
chore: only err RMQ retries when over 80% mark

### DIFF
--- a/internal/msgqueue/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/rabbitmq/rabbitmq.go
@@ -87,7 +87,7 @@ func defaultMessageQueueImplOpts() *MessageQueueImplOpts {
 		disableTenantExchangePubs: false,
 		deadLetterBackoff:         5 * time.Second,
 		enableMessageRejection:    false,
-		maxDeathCount:             5,
+		maxDeathCount:             1000,
 	}
 }
 

--- a/internal/msgqueue/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/rabbitmq/rabbitmq.go
@@ -804,8 +804,14 @@ func (t *MessageQueueImpl) subscribe(
 					// message was rejected before
 					deathCount := xDeath[0].(amqp.Table)["count"].(int64)
 
+					logger := t.l.Warn()
+					if deathCount > int64(float64(t.maxDeathCount)*0.8) {
+						// only log as error if we've exceeded 80% of the max death count
+						logger = t.l.Error()
+					}
+
 					if deathCount > 5 {
-						t.l.Error().
+						logger.
 							Int64("death_count", deathCount).
 							Str("message_id", msg.ID).
 							Str("tenant_id", msg.TenantID.String()).


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

We want to get rid of noisy errors. This PR adjusts how we error out RMQ errors.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (changes which are not directly related to any business logic)

## What's Changed

- [x] Adds conditional to only ERR when > 80% of max death count

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
