### PR TITLE
fix: concurrency strategy cold starts

### DIFF
--- a/pkg/scheduling/v1/concurrency_integration_test.go
+++ b/pkg/scheduling/v1/concurrency_integration_test.go
@@ -215,6 +215,55 @@ func TestConcurrency_CancelInProgress(t *testing.T) {
 	})
 }
 
+func TestConcurrency_NotifyConcurrencyColdStartsTenantManager(t *testing.T) {
+	runWithDatabase(t, func(conf *database.Layer) error {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		requireSchedulerSchema(t, ctx, conf)
+
+		s := setupStepConcurrencyTest(t, ctx, conf, "concurrency-cold-start-test", "GROUP_ROUND_ROBIN", 1, 2)
+
+		l := zerolog.Nop()
+		schedulingPool, cleanup, err := v1.NewSchedulingPool(
+			conf.V1.Scheduler(),
+			&l,
+			100,
+			20,
+			5*time.Millisecond,
+			6*time.Millisecond,
+			50*time.Millisecond,
+			100*time.Millisecond,
+			5*time.Millisecond,
+			false,
+			1,
+			nil,
+		)
+		require.NoError(t, err)
+		defer func() { _ = cleanup() }()
+
+		resultsChan := schedulingPool.GetConcurrencyResultsCh()
+		schedulingPool.NotifyConcurrency(ctx, s.tenantId, []int64{s.strategy.ID})
+
+		deadline := time.NewTimer(2 * time.Second)
+		defer deadline.Stop()
+
+		for {
+			select {
+			case <-deadline.C:
+				t.Fatal("timed out waiting for concurrency result after cold-start notification")
+			case res := <-resultsChan:
+				if res.TenantId != s.tenantId || len(res.Queued) == 0 {
+					continue
+				}
+
+				require.Len(t, res.Queued, 1)
+				return nil
+			}
+		}
+	})
+}
+
 // --- Chained strategy regression test ---
 
 // TestConcurrency_ChainedStrategiesDoNotContaminate verifies that when two concurrency

--- a/pkg/scheduling/v1/lease_manager.go
+++ b/pkg/scheduling/v1/lease_manager.go
@@ -44,9 +44,9 @@ type LeaseManager struct {
 }
 
 func newLeaseManager(conf *sharedConfig, tenantId uuid.UUID) (*LeaseManager, notifierCh[*v1.ListActiveWorkersResult], notifierCh[string], notifierCh[*sqlcv1.V1StepConcurrency]) {
-	workersCh := make(notifierCh[*v1.ListActiveWorkersResult])
-	queuesCh := make(notifierCh[string])
-	concurrencyLeasesCh := make(notifierCh[*sqlcv1.V1StepConcurrency])
+	workersCh := make(notifierCh[*v1.ListActiveWorkersResult], 1)
+	queuesCh := make(notifierCh[string], 1)
+	concurrencyLeasesCh := make(notifierCh[*sqlcv1.V1StepConcurrency], 1)
 
 	return &LeaseManager{
 		lr:                  conf.repo.Lease(),

--- a/pkg/scheduling/v1/pool.go
+++ b/pkg/scheduling/v1/pool.go
@@ -200,7 +200,7 @@ func (p *SchedulingPool) NotifyQueues(ctx context.Context, tenantId uuid.UUID, q
 }
 
 func (p *SchedulingPool) NotifyConcurrency(ctx context.Context, tenantId uuid.UUID, strategyIds []int64) {
-	if tm := p.getTenantManager(tenantId, false); tm != nil {
+	if tm := p.getTenantManager(tenantId, true); tm != nil {
 		tm.notifyConcurrency(ctx, strategyIds)
 	}
 }
@@ -218,7 +218,7 @@ func (p *SchedulingPool) NotifyNewQueue(ctx context.Context, tenantId uuid.UUID,
 }
 
 func (p *SchedulingPool) NotifyNewConcurrencyStrategy(ctx context.Context, tenantId uuid.UUID, strategyId int64) {
-	if tm := p.getTenantManager(tenantId, false); tm != nil {
+	if tm := p.getTenantManager(tenantId, true); tm != nil {
 		tm.notifyNewConcurrencyStrategy(ctx, strategyId)
 	}
 }

--- a/pkg/scheduling/v1/pool.go
+++ b/pkg/scheduling/v1/pool.go
@@ -188,13 +188,13 @@ func (p *SchedulingPool) cleanupTenants(toCleanup []*tenantManager) {
 }
 
 func (p *SchedulingPool) Replenish(ctx context.Context, tenantId uuid.UUID) {
-	if tm := p.getTenantManager(tenantId, false); tm != nil {
+	if tm := p.getTenantManager(tenantId, true); tm != nil {
 		tm.replenish(ctx)
 	}
 }
 
 func (p *SchedulingPool) NotifyQueues(ctx context.Context, tenantId uuid.UUID, queueNames []string) {
-	if tm := p.getTenantManager(tenantId, false); tm != nil {
+	if tm := p.getTenantManager(tenantId, true); tm != nil {
 		tm.queue(ctx, queueNames)
 	}
 }
@@ -206,13 +206,13 @@ func (p *SchedulingPool) NotifyConcurrency(ctx context.Context, tenantId uuid.UU
 }
 
 func (p *SchedulingPool) NotifyNewWorker(ctx context.Context, tenantId uuid.UUID, workerId uuid.UUID) {
-	if tm := p.getTenantManager(tenantId, false); tm != nil {
+	if tm := p.getTenantManager(tenantId, true); tm != nil {
 		tm.notifyNewWorker(ctx, workerId)
 	}
 }
 
 func (p *SchedulingPool) NotifyNewQueue(ctx context.Context, tenantId uuid.UUID, queueName string) {
-	if tm := p.getTenantManager(tenantId, false); tm != nil {
+	if tm := p.getTenantManager(tenantId, true); tm != nil {
 		tm.notifyNewQueue(ctx, queueName)
 	}
 }

--- a/pkg/scheduling/v1/scheduler_integration_test.go
+++ b/pkg/scheduling/v1/scheduler_integration_test.go
@@ -226,7 +226,15 @@ func TestScheduler_NotifyQueuesColdStartsTenantManager(t *testing.T) {
 		taskParams.WorkflowVersionIds[0] = wfVersion.WorkflowVersion.ID
 		taskParams.WorkflowRunIds[0] = uuid.New()
 
-		tasks, err := sqlcv1.New().CreateTasks(ctx, conf.Pool, taskParams)
+		queries := sqlcv1.New()
+
+		err = queries.UpsertQueues(ctx, conf.Pool, sqlcv1.UpsertQueuesParams{
+			TenantID: tenantId,
+			Names:    []string{"default"},
+		})
+		require.NoError(t, err)
+
+		tasks, err := queries.CreateTasks(ctx, conf.Pool, taskParams)
 		require.NoError(t, err)
 		require.Len(t, tasks, 1)
 

--- a/pkg/scheduling/v1/scheduler_integration_test.go
+++ b/pkg/scheduling/v1/scheduler_integration_test.go
@@ -177,6 +177,95 @@ func requireNoSnapshotsForTenant(
 	}
 }
 
+func TestScheduler_NotifyQueuesColdStartsTenantManager(t *testing.T) {
+	runWithDatabase(t, func(conf *database.Layer) error {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		requireSchedulerSchema(t, ctx, conf)
+
+		action := "test:run"
+		tenantId, _, _ := createTenantDispatcherWorker(t, ctx, conf.V1, "scheduler-queue-cold-start", 1, []string{action})
+
+		desc := "queue cold-start workflow"
+		wfVersion, err := conf.V1.Workflows().PutWorkflowVersion(ctx, tenantId, &repo.CreateWorkflowVersionOpts{
+			Name:        "queue-cold-start-test",
+			Description: &desc,
+			Tasks: []repo.CreateStepOpts{
+				{
+					ReadableId: "my-task",
+					Action:     action,
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		shape, err := conf.V1.Workflows().GetWorkflowShape(ctx, wfVersion.WorkflowVersion.ID)
+		require.NoError(t, err)
+		require.Len(t, shape, 1)
+
+		taskParams := newCreateTasksParams(1)
+		taskParams.Tenantids[0] = tenantId
+		taskParams.Queues[0] = "default"
+		taskParams.Actionids[0] = action
+		taskParams.Stepids[0] = shape[0].Parentstepid
+		taskParams.Stepreadableids[0] = "my-task"
+		taskParams.Workflowids[0] = wfVersion.WorkflowVersion.WorkflowId
+		taskParams.Scheduletimeouts[0] = "5m"
+		taskParams.Priorities[0] = 1
+		taskParams.Stickies[0] = string(sqlcv1.V1StickyStrategyNONE)
+		taskParams.Externalids[0] = uuid.New()
+		taskParams.Displaynames[0] = "queue-cold-start-task"
+		taskParams.Inputs[0] = []byte(`{}`)
+		taskParams.Additionalmetadatas[0] = []byte(`{}`)
+		taskParams.InitialStates[0] = string(sqlcv1.V1TaskInitialStateQUEUED)
+		taskParams.WorkflowVersionIds[0] = wfVersion.WorkflowVersion.ID
+		taskParams.WorkflowRunIds[0] = uuid.New()
+
+		tasks, err := sqlcv1.New().CreateTasks(ctx, conf.Pool, taskParams)
+		require.NoError(t, err)
+		require.Len(t, tasks, 1)
+
+		l := zerolog.Nop()
+		pool, cleanup, err := schedv1.NewSchedulingPool(
+			conf.V1.Scheduler(),
+			&l,
+			100,
+			20,
+			5*time.Millisecond,
+			6*time.Millisecond,
+			50*time.Millisecond,
+			100*time.Millisecond,
+			5*time.Millisecond,
+			false,
+			1,
+			nil,
+		)
+		require.NoError(t, err)
+		defer func() { _ = cleanup() }()
+
+		resultsChan := pool.GetResultsCh()
+		pool.NotifyQueues(ctx, tenantId, []string{"default"})
+
+		deadline := time.NewTimer(2 * time.Second)
+		defer deadline.Stop()
+
+		for {
+			select {
+			case <-deadline.C:
+				t.Fatal("timed out waiting for queue assignment after cold-start notification")
+			case res := <-resultsChan:
+				if res.TenantId != tenantId || len(res.Assigned) == 0 {
+					continue
+				}
+
+				require.Len(t, res.Assigned, 1)
+				return nil
+			}
+		}
+	})
+}
+
 func TestScheduler_ReplenishIntegration_SingleActionUtilizationEqualsMaxRuns(t *testing.T) {
 	runWithDatabase(t, func(conf *database.Layer) error {
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/pkg/scheduling/v1/scheduler_integration_test.go
+++ b/pkg/scheduling/v1/scheduler_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
@@ -219,6 +220,9 @@ func TestScheduler_NotifyQueuesColdStartsTenantManager(t *testing.T) {
 		taskParams.Inputs[0] = []byte(`{}`)
 		taskParams.Additionalmetadatas[0] = []byte(`{}`)
 		taskParams.InitialStates[0] = string(sqlcv1.V1TaskInitialStateQUEUED)
+		taskParams.Concurrencyparentstrategyids[0] = []pgtype.Int8{}
+		taskParams.ConcurrencyStrategyIds[0] = []int64{}
+		taskParams.ConcurrencyKeys[0] = []string{}
 		taskParams.WorkflowVersionIds[0] = wfVersion.WorkflowVersion.ID
 		taskParams.WorkflowRunIds[0] = uuid.New()
 

--- a/pkg/scheduling/v1/tenant_manager.go
+++ b/pkg/scheduling/v1/tenant_manager.go
@@ -240,7 +240,6 @@ func (t *tenantManager) addQueuer(queueName string) {
 
 func (t *tenantManager) setConcurrencyStrategies(strategies []*sqlcv1.V1StepConcurrency) {
 	t.concurrencyMu.Lock()
-	defer t.concurrencyMu.Unlock()
 
 	strategiesSet := make(map[int64]*sqlcv1.V1StepConcurrency, len(strategies))
 
@@ -262,24 +261,37 @@ func (t *tenantManager) setConcurrencyStrategies(strategies []*sqlcv1.V1StepConc
 		}
 	}
 
+	newStrategies := make([]*ConcurrencyManager, 0, len(strategiesSet))
+
 	for _, strategy := range strategiesSet {
-		newArr = append(newArr, newConcurrencyManager(t.cf, t.tenantId, strategy, t.concurrencyResultsCh, t.concurrencyAdvisoryLock, t.concurrencyParentAdvisoryLock))
+		c := newConcurrencyManager(t.cf, t.tenantId, strategy, t.concurrencyResultsCh, t.concurrencyAdvisoryLock, t.concurrencyParentAdvisoryLock)
+		newArr = append(newArr, c)
+		newStrategies = append(newStrategies, c)
 	}
 
 	t.concurrencyStrategies = newArr
+	t.concurrencyMu.Unlock()
+
+	for _, c := range newStrategies {
+		c.notify(context.Background())
+	}
 }
 
 func (t *tenantManager) addConcurrencyStrategy(strategy *sqlcv1.V1StepConcurrency) {
 	t.concurrencyMu.Lock()
-	defer t.concurrencyMu.Unlock()
 
 	for _, c := range t.concurrencyStrategies {
 		if c.strategy.ID == strategy.ID {
+			t.concurrencyMu.Unlock()
 			return
 		}
 	}
 
-	t.concurrencyStrategies = append(t.concurrencyStrategies, newConcurrencyManager(t.cf, t.tenantId, strategy, t.concurrencyResultsCh, t.concurrencyAdvisoryLock, t.concurrencyParentAdvisoryLock))
+	c := newConcurrencyManager(t.cf, t.tenantId, strategy, t.concurrencyResultsCh, t.concurrencyAdvisoryLock, t.concurrencyParentAdvisoryLock)
+	t.concurrencyStrategies = append(t.concurrencyStrategies, c)
+	t.concurrencyMu.Unlock()
+
+	c.notify(context.Background())
 }
 
 func (t *tenantManager) replenish(ctx context.Context) {
@@ -297,6 +309,8 @@ func (t *tenantManager) notifyConcurrency(ctx context.Context, strategyIds []int
 		strategyIdsMap[id] = struct{}{}
 	}
 
+	notifiedStrategyIds := make(map[int64]struct{}, len(strategyIdsMap))
+
 	t.concurrencyMu.RLock()
 
 	for _, c := range t.concurrencyStrategies {
@@ -304,6 +318,7 @@ func (t *tenantManager) notifyConcurrency(ctx context.Context, strategyIds []int
 			continue
 		}
 
+		notifiedStrategyIds[c.strategy.ID] = struct{}{}
 		c.notify(ctx)
 
 		childStrategyIds := make([]int64, 0)
@@ -354,6 +369,14 @@ func (t *tenantManager) notifyConcurrency(ctx context.Context, strategyIds []int
 	}
 
 	t.concurrencyMu.RUnlock()
+
+	for strategyId := range strategyIdsMap {
+		if _, ok := notifiedStrategyIds[strategyId]; ok {
+			continue
+		}
+
+		t.notifyNewConcurrencyStrategy(ctx, strategyId)
+	}
 }
 
 func (t *tenantManager) notifyNewWorker(ctx context.Context, workerId uuid.UUID) {

--- a/pkg/scheduling/v1/tenant_manager.go
+++ b/pkg/scheduling/v1/tenant_manager.go
@@ -147,6 +147,15 @@ func (t *tenantManager) listenForWorkerLeases(ctx context.Context) {
 				t.queuersMu.RUnlock()
 			} else {
 				t.scheduler.setWorkers(msg.items)
+				t.replenish(ctx)
+
+				t.queuersMu.RLock()
+
+				for _, q := range t.queuers {
+					q.queue(ctx)
+				}
+
+				t.queuersMu.RUnlock()
 			}
 		}
 	}
@@ -188,7 +197,6 @@ func (t *tenantManager) listenForConcurrencyLeases(ctx context.Context) {
 
 func (t *tenantManager) setQueuers(queueNames []string) {
 	t.queuersMu.Lock()
-	defer t.queuersMu.Unlock()
 
 	queueNamesSet := make(map[string]struct{}, len(queueNames))
 
@@ -212,11 +220,20 @@ func (t *tenantManager) setQueuers(queueNames []string) {
 		}
 	}
 
+	newQueuers := make([]*Queuer, 0, len(queueNamesSet))
+
 	for queueName := range queueNamesSet {
-		newQueueArr = append(newQueueArr, newQueuer(t.cf, t.tenantId, queueName, t.scheduler, t.resultsCh))
+		q := newQueuer(t.cf, t.tenantId, queueName, t.scheduler, t.resultsCh)
+		newQueueArr = append(newQueueArr, q)
+		newQueuers = append(newQueuers, q)
 	}
 
 	t.queuers = newQueueArr
+	t.queuersMu.Unlock()
+
+	for _, q := range newQueuers {
+		q.queue(context.Background())
+	}
 }
 
 func (t *tenantManager) addQueuer(queueName string) {


### PR DESCRIPTION
# Description

Fixes cold-start scheduling latency when scheduler notifications arrive before tenant-scoped managers, queues, workers, or concurrency strategies have been warmed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

- [x] Cold-start tenant managers from scheduler notification paths instead of dropping queue, worker, replenish, and concurrency notifications.
- [x] Immediately wake newly discovered queues and concurrency strategies instead of waiting for the next polling tick.
- [x] Replenish worker slots and wake queues after full worker lease discovery.
- [x] Add integration regression coverage for queue and concurrency cold-start notifications.

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Used to audit scheduler polling paths, implement the cold-start fixes, and add regression tests.

</details>