### PR TITLE
docs(self-hosting): add internal OpenTelemetry traces guide

### DIFF
--- a/frontend/docs/pages/self-hosting/_meta.js
+++ b/frontend/docs/pages/self-hosting/_meta.js
@@ -27,6 +27,12 @@ export default {
       toc: true,
     },
   },
+  opentelemetry: {
+    title: "Internal OpenTelemetry Traces",
+    theme: {
+      toc: true,
+    },
+  },
   "worker-configuration-options": "Worker Configuration Options",
   "upgrading-downgrading": "Upgrading and Downgrading",
   "downgrading-db-schema-manually": "Downgrading DB Schema Manually",

--- a/frontend/docs/pages/self-hosting/configuration-options.mdx
+++ b/frontend/docs/pages/self-hosting/configuration-options.mdx
@@ -319,6 +319,8 @@ Variables marked with ⚠️ are conditionally required when specific features a
 
 ## OpenTelemetry Configuration
 
+For how to enable and use internal trace export with these settings, see [Internal OpenTelemetry traces](/self-hosting/opentelemetry).
+
 | Variable                                 | Description                                                                                                                            | Default Value |
 | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
 | `SERVER_OTEL_SERVICE_NAME`               | Service name for OpenTelemetry                                                                                                         |               |

--- a/frontend/docs/pages/self-hosting/opentelemetry.mdx
+++ b/frontend/docs/pages/self-hosting/opentelemetry.mdx
@@ -1,0 +1,44 @@
+# Internal OpenTelemetry traces
+
+This page describes how to export traces emitted by Hatchet's own services, including the engine and the API server, to an OpenTelemetry collector, for visibility into a self-hosted Hatchet instance. This is different from the [OpenTelemetry](/v1/opentelemetry) page in the guide, which covers tracing your own application, task, and workflow code that runs on your workers. Internal trace export is off by default, and is enabled only when you set a collector URL.
+
+## Enable trace export
+
+Set a collector URL on the Hatchet service you want to trace. Export uses OTLP over gRPC, so the URL is a host and port with no scheme:
+
+```bash
+SERVER_OTEL_COLLECTOR_URL=<otel-collector-host>:4317
+SERVER_OTEL_SERVICE_NAME=hatchet-engine
+```
+
+By default the connection uses TLS. For a collector that does not terminate TLS, set `SERVER_OTEL_INSECURE=true`. If your collector requires authentication, set `SERVER_OTEL_COLLECTOR_AUTH` to the value Hatchet should send in the `Authorization` header. To export only a fraction of traces, set `SERVER_OTEL_TRACE_ID_RATIO` to a value between `0` and `1`. This is OpenTelemetry head sampling, and is unrelated to [Trace Sampling](/self-hosting/sampling), which samples dashboard results stored in the database.
+
+The engine and the API server are configured independently. Set these variables on each service you want to export from, and set a distinct `SERVER_OTEL_SERVICE_NAME` on each if you want to tell them apart in your collector.
+
+## Kubernetes and Helm
+
+The Helm charts do not expose dedicated OpenTelemetry values. Set the `SERVER_OTEL_*` variables through the generic environment passthrough described in [Configuring the Helm Chart](/self-hosting/kubernetes-helm-configuration). For the `hatchet-stack` and `hatchet-ha` charts this is `sharedConfig.env`:
+
+```yaml
+sharedConfig:
+  env:
+    SERVER_OTEL_COLLECTOR_URL: "<otel-collector-host>:4317"
+```
+
+Values under `sharedConfig.env` apply to all backend services, so a `SERVER_OTEL_SERVICE_NAME` set here is shared by every service. To give the engine and API server distinct service names, set `SERVER_OTEL_SERVICE_NAME` on the individual service deployments instead.
+
+## What Hatchet emits
+
+When export is enabled, the engine and the API server initialize tracing and can emit spans, including spans for database queries traced through `otelpgx`. Spans are namespaced under `hatchet.run/`. Each exporting service sets the `service.name` resource attribute, from `SERVER_OTEL_SERVICE_NAME`, along with `library.language=go`, and adds `k8s.pod.name` and `k8s.namespace.name` when `K8S_POD_NAME` and `K8S_POD_NAMESPACE` are set.
+
+## Configuration reference
+
+These variables are also listed on the [engine configuration options](/self-hosting/configuration-options) page, with the configuration file key shown in parentheses. A related setting, `SERVER_OTEL_METRICS_ENABLED` (`otel.metricsEnabled`), enables OpenTelemetry metrics export over the same collector URL.
+
+| Variable (config key)                               | Description                                                         | Default  |
+| --------------------------------------------------- | ------------------------------------------------------------------- | -------- |
+| `SERVER_OTEL_COLLECTOR_URL` (`otel.collectorURL`)   | OTLP gRPC collector endpoint as `host:port`. Empty disables export. | empty    |
+| `SERVER_OTEL_SERVICE_NAME` (`otel.serviceName`)     | Value of the `service.name` resource attribute.                     | `server` |
+| `SERVER_OTEL_TRACE_ID_RATIO` (`otel.traceIdRatio`)  | Head sampling ratio between `0` and `1`.                            | `1`      |
+| `SERVER_OTEL_INSECURE` (`otel.insecure`)            | Use a plaintext connection instead of TLS.                          | `false`  |
+| `SERVER_OTEL_COLLECTOR_AUTH` (`otel.collectorAuth`) | Value sent in the `Authorization` header to the collector.          | empty    |

--- a/frontend/docs/pages/v1/opentelemetry.mdx
+++ b/frontend/docs/pages/v1/opentelemetry.mdx
@@ -5,6 +5,12 @@ import UniversalTabs from "@/components/UniversalTabs";
 
 Hatchet supports exporting traces from your tasks to an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) to improve visibility into your Hatchet tasks.
 
+<Callout type="info">
+  This page is about tracing your application, task, and workflow code. To
+  export traces emitted by Hatchet's own services on a self-hosted instance, see
+  [Internal OpenTelemetry traces](/self-hosting/opentelemetry).
+</Callout>
+
 ## Setup
 
 <UniversalTabs items={["Python", "TypeScript", "Go", "Ruby"]}>


### PR DESCRIPTION
# Description

This adds a self-hosting documentation page describing how to export the traces that Hatchet's own services emit, the engine and the API server, to an OpenTelemetry collector using the existing `SERVER_OTEL_*` settings.

Fixes # N/A

## Type of change

- [x] Documentation change (pure documentation change)

## What's Changed

- [x] Add `frontend/docs/pages/self-hosting/opentelemetry.mdx`, a self-hosting how-to for exporting Hatchet's internal traces via `SERVER_OTEL_*`
- [x] Add the page to the self-hosting navigation in `frontend/docs/pages/self-hosting/_meta.js` as "Internal OpenTelemetry Traces" in the "Managing Hatchet" group
- [x] Add a cross-link from `frontend/docs/pages/v1/opentelemetry.mdx` pointing to the new page for Hatchet's own traces
- [x] Add a cross-link from the OpenTelemetry section of `frontend/docs/pages/self-hosting/configuration-options.mdx` to the new page

## Checklist

Changes have been:

- [x] Documented (where applicable)

## Testing

This is a documentation-only change. 

I ran the linter and built the docs locally:
- pnpm linst:fix
- pnpm dev

I manually verified the links by clicking on each one in the rendered local docs.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Claude was used to validate full coverage of `SERVER_OTEL_*`. I also had claude proof read for grammar issues and broken links.

</details>