### PR TITLE
fix: rm another instance of `seenAt` being in the wrong place

### DIFF
--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -2078,15 +2078,13 @@ func (r *sharedRepository) prepareTriggerFromEvents(ctx context.Context, tx sqlc
 
 	eventExternalIdsToPayloads := make(map[uuid.UUID][]byte)
 
-	seenAt := time.Now().UTC() // TODO: propagate this to caller, and figure out how we should be setting this
-
 	eventKeys := make([]string, 0, len(opts))
 	uniqueEventKeys := make(map[string]struct{})
 
 	for _, opt := range opts {
 		createCoreEventsTenantIds = append(createCoreEventsTenantIds, tenantId)
 		createCoreEventsExternalIds = append(createCoreEventsExternalIds, opt.ExternalId)
-		createCoreEventsSeenAts = append(createCoreEventsSeenAts, sqlchelpers.TimestamptzFromTime(seenAt))
+		createCoreEventsSeenAts = append(createCoreEventsSeenAts, sqlchelpers.TimestamptzFromTime(opt.SeenAt))
 		createCoreEventsKeys = append(createCoreEventsKeys, opt.Key)
 		eventExternalIdsToPayloads[opt.ExternalId] = opt.Data
 		createCoreEventsAdditionalMetadatas = append(createCoreEventsAdditionalMetadatas, opt.AdditionalMetadata)


### PR DESCRIPTION
# Description

Follow up to https://github.com/hatchet-dev/hatchet/pull/4226

Using the `opt.SeenAt` correctly to fix one more set of possible duplicates

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)


<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI use here

</details>
