### PR TITLE
fix(engine): check nil uuid before creating event resource hint

### DIFF
--- a/pkg/repository/match.go
+++ b/pkg/repository/match.go
@@ -1304,7 +1304,7 @@ func getConditionParam(tenantId uuid.UUID, createdMatchId int64, condition Group
 		Data:            condition.Data,
 	}
 
-	if condition.EventResourceHint != nil {
+	if condition.EventResourceHint != nil && *condition.EventResourceHint != uuid.Nil.String() {
 		param.EventResourceHint = sqlchelpers.TextFromStr(*condition.EventResourceHint)
 	}
 

--- a/pkg/repository/match.go
+++ b/pkg/repository/match.go
@@ -1304,6 +1304,9 @@ func getConditionParam(tenantId uuid.UUID, createdMatchId int64, condition Group
 		Data:            condition.Data,
 	}
 
+	// fixme: checking that the EventResourceHint is not a zero-valued uuid is a workaround,
+	// but there's likely a bug somewhere upstream where it's set to that instead of being nil,
+	// which would be better to fix at the root
 	if condition.EventResourceHint != nil && *condition.EventResourceHint != uuid.Nil.String() {
 		param.EventResourceHint = sqlchelpers.TextFromStr(*condition.EventResourceHint)
 	}


### PR DESCRIPTION
# Description

Found one more zero uuid in the match conditions table, which is coming from UUIDs being converted to strings somewhere along the line. This is a bit of a band-aid, since the issue is clearly farther upstream (where the zero value is being created) but I didn't want to take the time to try to reproduce for now, so figured this was a fine fix. Left a comment too

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI use here

</details>
