### PR TITLE
fix: Skip s3 tests with local stack if docker is not available in environment

### DIFF
--- a/sdks/python/examples/aws/s3/test_worker.py
+++ b/sdks/python/examples/aws/s3/test_worker.py
@@ -16,9 +16,12 @@ def _docker_available() -> bool:
     if shutil.which("docker") is None:
         return False
     try:
-        return subprocess.run(
-            ["docker", "info"], capture_output=True, timeout=5
-        ).returncode == 0
+        return (
+            subprocess.run(
+                ["docker", "info"], capture_output=True, timeout=5
+            ).returncode
+            == 0
+        )
     except Exception:
         return False
 

--- a/sdks/python/examples/aws/s3/test_worker.py
+++ b/sdks/python/examples/aws/s3/test_worker.py
@@ -1,4 +1,6 @@
 import os
+import shutil
+import subprocess
 import time
 from pathlib import Path
 from subprocess import Popen, run
@@ -8,6 +10,23 @@ from typing import Any, Callable
 import pytest
 
 from examples.aws.s3.worker import fetch_buckets_workflow
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        return subprocess.run(
+            ["docker", "info"], capture_output=True, timeout=5
+        ).returncode == 0
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _docker_available(),
+    reason="Docker daemon is not available",
+)
 
 # Set variables running worker against LocalStack instance
 os.environ.setdefault("AWS_ENDPOINT_URL", "http://localhost:4566")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

This test requires docker for localstack, should be skipped if docker isn't available.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [x] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
