### PR TITLE
fix: early return if context is already cancelled

### DIFF
--- a/pkg/repository/sqlchelpers/tx.go
+++ b/pkg/repository/sqlchelpers/tx.go
@@ -144,6 +144,11 @@ func AcquireConnectionWithStatementTimeout(ctx context.Context, pool *pgxpool.Po
 }
 
 func DeferRollback(ctx context.Context, l *zerolog.Logger, rollback func(context.Context) error) {
+
+	if ctx.Done() != nil {
+		return
+	}
+
 	if err := rollback(ctx); err != nil {
 		if !errors.Is(err, pgx.ErrTxClosed) {
 			l.Error().Err(err).Msg("failed to rollback transaction")

--- a/pkg/repository/sqlchelpers/tx.go
+++ b/pkg/repository/sqlchelpers/tx.go
@@ -145,7 +145,7 @@ func AcquireConnectionWithStatementTimeout(ctx context.Context, pool *pgxpool.Po
 
 func DeferRollback(ctx context.Context, l *zerolog.Logger, rollback func(context.Context) error) {
 
-	if ctx.Done() != nil {
+	if ctx.Done() != nil && ctx.Done() {
 		return
 	}
 

--- a/pkg/repository/sqlchelpers/tx.go
+++ b/pkg/repository/sqlchelpers/tx.go
@@ -145,7 +145,7 @@ func AcquireConnectionWithStatementTimeout(ctx context.Context, pool *pgxpool.Po
 
 func DeferRollback(ctx context.Context, l *zerolog.Logger, rollback func(context.Context) error) {
 
-	if ctx.Done() != nil && ctx.Done() {
+	if ctx.Err() != nil {
 		return
 	}
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Avoid rollback attempts when the transaction context has already been canceled, reducing noisy rollback failure logs and stack traces during context cancellation paths.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Return early from `DeferRollback` when the provided context is already done.

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Cursor/GPT-5.5 assisted with drafting the PR description from the branch diff.

</details>