### PR TITLE
chore: drop external payload not found errors

### DIFF
--- a/internal/msgqueue/rabbitmq/permanent_preack_test.go
+++ b/internal/msgqueue/rabbitmq/permanent_preack_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/hatchet-dev/hatchet/pkg/repository"
 )
 
 func TestIsPermanentPreAckError_PgError22P02(t *testing.T) {
@@ -22,6 +24,22 @@ func TestIsPermanentPreAckError_StringFallback(t *testing.T) {
 	err := errors.New("ERROR: invalid input syntax for type json (SQLSTATE 22P02)")
 	if !isPermanentPreAckError(err) {
 		t.Fatalf("expected true for sqlstate 22P02 string fallback")
+	}
+}
+
+func TestIsPermanentPreAckError_ExternalPayloadNotFound(t *testing.T) {
+	err := fmt.Errorf("wrap: %w", &repository.ExternalPayloadNotFoundError{
+		Kind: repository.ExternalPayloadNotFoundKindIndexFile,
+		Key:  "index/2026-06-11/example.index",
+		Err:  errors.New("key not found"),
+	})
+
+	if !isPermanentPreAckError(err) {
+		t.Fatalf("expected true for external payload not found error")
+	}
+
+	if got := permanentPreAckErrorReason(err); got != "external_payload_not_found" {
+		t.Fatalf("expected external payload reason, got %q", got)
 	}
 }
 

--- a/internal/msgqueue/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/rabbitmq/rabbitmq.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hatchet-dev/hatchet/internal/queueutils"
 	"github.com/hatchet-dev/hatchet/pkg/logger"
 	"github.com/hatchet-dev/hatchet/pkg/random"
+	"github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/telemetry"
 )
 
@@ -832,11 +833,13 @@ func (t *MessageQueueImpl) subscribe(
 
 				if err := preAck(msg); err != nil {
 					if isPermanentPreAckError(err) {
-						t.l.Error().
+						event := t.l.Error().
 							Err(err).
 							Str("message_id", msg.ID).
 							Str("tenant_id", msg.TenantID.String()).
-							Int("num_payloads", len(msg.Payloads)).
+							Int("num_payloads", len(msg.Payloads))
+
+						addPermanentPreAckErrorFields(event, err).
 							Msg("dropping message due to permanent pre-ack error")
 
 						if ackErr := rabbitMsg.Ack(false); ackErr != nil {
@@ -912,28 +915,49 @@ func (t *MessageQueueImpl) subscribe(
 }
 
 func isPermanentPreAckError(err error) bool {
+	return permanentPreAckErrorReason(err) != ""
+}
+
+func permanentPreAckErrorReason(err error) string {
 	if err == nil {
-		return false
+		return ""
+	}
+
+	if errors.Is(err, repository.ErrExternalPayloadNotFound) {
+		return "external_payload_not_found"
 	}
 
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) {
 		// invalid input syntax for type json / jsonb
 		if pgErr.Code == pgerrcode.InvalidTextRepresentation {
-			return true
+			return "invalid_json"
 		}
 	}
 
 	// Fallback: some error paths may lose pg error type info.
 	errStr := err.Error()
 	if strings.Contains(errStr, fmt.Sprintf("SQLSTATE %s", pgerrcode.InvalidTextRepresentation)) {
-		return true
+		return "invalid_json"
 	}
 	if strings.Contains(errStr, "invalid input syntax for type json") {
-		return true
+		return "invalid_json"
 	}
 
-	return false
+	return ""
+}
+
+func addPermanentPreAckErrorFields(event *zerolog.Event, err error) *zerolog.Event {
+	event.Str("permanent_pre_ack_reason", permanentPreAckErrorReason(err))
+
+	var payloadErr *repository.ExternalPayloadNotFoundError
+	if errors.As(err, &payloadErr) {
+		event.
+			Str("external_payload_kind", string(payloadErr.Kind)).
+			Str("external_payload_key", payloadErr.Key)
+	}
+
+	return event
 }
 
 // identity returns the same host/process unique string for the lifetime of

--- a/internal/msgqueue/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/rabbitmq/rabbitmq.go
@@ -4,18 +4,14 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"slices"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
 	lru "github.com/hashicorp/golang-lru/v2"
-	"github.com/jackc/pgerrcode"
-	"github.com/jackc/pgx/v5/pgconn"
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/attribute"
@@ -25,7 +21,6 @@ import (
 	"github.com/hatchet-dev/hatchet/internal/queueutils"
 	"github.com/hatchet-dev/hatchet/pkg/logger"
 	"github.com/hatchet-dev/hatchet/pkg/random"
-	"github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/telemetry"
 )
 
@@ -832,23 +827,6 @@ func (t *MessageQueueImpl) subscribe(
 				t.l.Debug().Msgf("(session: %d) got msg", session)
 
 				if err := preAck(msg); err != nil {
-					if isPermanentPreAckError(err) {
-						event := t.l.Error().
-							Err(err).
-							Str("message_id", msg.ID).
-							Str("tenant_id", msg.TenantID.String()).
-							Int("num_payloads", len(msg.Payloads))
-
-						addPermanentPreAckErrorFields(event, err).
-							Msg("dropping message due to permanent pre-ack error")
-
-						if ackErr := rabbitMsg.Ack(false); ackErr != nil {
-							t.l.Error().Err(ackErr).Msg("error acknowledging message after permanent pre-ack error")
-						}
-
-						return
-					}
-
 					t.l.Error().Msgf("error in pre-ack on msg %s: %v", msg.ID, err)
 
 					// nack the message
@@ -912,52 +890,6 @@ func (t *MessageQueueImpl) subscribe(
 	}
 
 	return cleanup, nil
-}
-
-func isPermanentPreAckError(err error) bool {
-	return permanentPreAckErrorReason(err) != ""
-}
-
-func permanentPreAckErrorReason(err error) string {
-	if err == nil {
-		return ""
-	}
-
-	if errors.Is(err, repository.ErrExternalPayloadNotFound) {
-		return "external_payload_not_found"
-	}
-
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) {
-		// invalid input syntax for type json / jsonb
-		if pgErr.Code == pgerrcode.InvalidTextRepresentation {
-			return "invalid_json"
-		}
-	}
-
-	// Fallback: some error paths may lose pg error type info.
-	errStr := err.Error()
-	if strings.Contains(errStr, fmt.Sprintf("SQLSTATE %s", pgerrcode.InvalidTextRepresentation)) {
-		return "invalid_json"
-	}
-	if strings.Contains(errStr, "invalid input syntax for type json") {
-		return "invalid_json"
-	}
-
-	return ""
-}
-
-func addPermanentPreAckErrorFields(event *zerolog.Event, err error) *zerolog.Event {
-	event.Str("permanent_pre_ack_reason", permanentPreAckErrorReason(err))
-
-	var payloadErr *repository.ExternalPayloadNotFoundError
-	if errors.As(err, &payloadErr) {
-		event.
-			Str("external_payload_kind", string(payloadErr.Kind)).
-			Str("external_payload_key", payloadErr.Key)
-	}
-
-	return event
 }
 
 // identity returns the same host/process unique string for the lifetime of

--- a/internal/queueutils/permanent_errors.go
+++ b/internal/queueutils/permanent_errors.go
@@ -1,0 +1,43 @@
+package queueutils
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/hatchet-dev/hatchet/pkg/repository"
+)
+
+// PermanentConsumerErrorReason returns a stable reason for consumer errors that should be shed instead of retried.
+func PermanentConsumerErrorReason(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	if errors.Is(err, repository.ErrExternalPayloadNotFound) {
+		return "external_payload_not_found"
+	}
+
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.InvalidTextRepresentation {
+		return "invalid_json"
+	}
+
+	errStr := err.Error()
+	if strings.Contains(errStr, fmt.Sprintf("SQLSTATE %s", pgerrcode.InvalidTextRepresentation)) {
+		return "invalid_json"
+	}
+	if strings.Contains(errStr, "invalid input syntax for type json") {
+		return "invalid_json"
+	}
+
+	return ""
+}
+
+// IsPermanentConsumerError returns true when a consumer can drop the offending payload from a buffered batch.
+func IsPermanentConsumerError(err error) bool {
+	return PermanentConsumerErrorReason(err) != ""
+}

--- a/internal/queueutils/permanent_errors_test.go
+++ b/internal/queueutils/permanent_errors_test.go
@@ -1,4 +1,4 @@
-package rabbitmq
+package queueutils
 
 import (
 	"errors"
@@ -11,41 +11,41 @@ import (
 	"github.com/hatchet-dev/hatchet/pkg/repository"
 )
 
-func TestIsPermanentPreAckError_PgError22P02(t *testing.T) {
+func TestIsPermanentConsumerError_PgError22P02(t *testing.T) {
 	pgErr := &pgconn.PgError{Code: pgerrcode.InvalidTextRepresentation, Message: "invalid input syntax for type json"}
 	wrapped := fmt.Errorf("wrap: %w", pgErr)
 
-	if !isPermanentPreAckError(wrapped) {
+	if !IsPermanentConsumerError(wrapped) {
 		t.Fatalf("expected true for wrapped pg error 22P02")
 	}
 }
 
-func TestIsPermanentPreAckError_StringFallback(t *testing.T) {
+func TestIsPermanentConsumerError_StringFallback(t *testing.T) {
 	err := errors.New("ERROR: invalid input syntax for type json (SQLSTATE 22P02)")
-	if !isPermanentPreAckError(err) {
+	if !IsPermanentConsumerError(err) {
 		t.Fatalf("expected true for sqlstate 22P02 string fallback")
 	}
 }
 
-func TestIsPermanentPreAckError_ExternalPayloadNotFound(t *testing.T) {
+func TestIsPermanentConsumerError_ExternalPayloadNotFound(t *testing.T) {
 	err := fmt.Errorf("wrap: %w", &repository.ExternalPayloadNotFoundError{
 		Kind: repository.ExternalPayloadNotFoundKindIndexFile,
 		Key:  "index/2026-06-11/example.index",
 		Err:  errors.New("key not found"),
 	})
 
-	if !isPermanentPreAckError(err) {
+	if !IsPermanentConsumerError(err) {
 		t.Fatalf("expected true for external payload not found error")
 	}
 
-	if got := permanentPreAckErrorReason(err); got != "external_payload_not_found" {
+	if got := PermanentConsumerErrorReason(err); got != "external_payload_not_found" {
 		t.Fatalf("expected external payload reason, got %q", got)
 	}
 }
 
-func TestIsPermanentPreAckError_OtherError(t *testing.T) {
+func TestIsPermanentConsumerError_OtherError(t *testing.T) {
 	err := errors.New("some transient error")
-	if isPermanentPreAckError(err) {
+	if IsPermanentConsumerError(err) {
 		t.Fatalf("expected false for non-permanent error")
 	}
 }

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -588,6 +588,26 @@ func (tc *OLAPControllerImpl) handleCreatedTask(ctx context.Context, tenantId uu
 		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTasks(ctx, tenantId, extractCreatedTaskData(createTaskOpts))
 
 		if err != nil {
+			if queueutils.IsPermanentConsumerError(err) {
+				tc.l.Error().
+					Ctx(ctx).
+					Err(err).
+					Str("permanent_consumer_error_reason", queueutils.PermanentConsumerErrorReason(err)).
+					Int("num_payloads", len(createTaskOpts)).
+					Msg("shedding created task batch after permanent consumer error")
+
+				createTaskOpts, err = tc.shedPermanentCreatedTaskErrors(ctx, tenantId, createTaskOpts)
+				if err != nil {
+					return fmt.Errorf("failed to shed permanent created task errors: %w", err)
+				}
+
+				if len(createTaskOpts) > 0 && attempts < maxLockAttempts {
+					tc.sleepWithBackoff(attempts)
+				}
+
+				continue
+			}
+
 			return fmt.Errorf("failed to create tasks: %w", err)
 		}
 
@@ -683,6 +703,26 @@ func (tc *OLAPControllerImpl) handleCreatedDAG(ctx context.Context, tenantId uui
 		workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateDAGs(ctx, tenantId, extractCreatedDAGData(createDAGOpts))
 
 		if err != nil {
+			if queueutils.IsPermanentConsumerError(err) {
+				tc.l.Error().
+					Ctx(ctx).
+					Err(err).
+					Str("permanent_consumer_error_reason", queueutils.PermanentConsumerErrorReason(err)).
+					Int("num_payloads", len(createDAGOpts)).
+					Msg("shedding created DAG batch after permanent consumer error")
+
+				createDAGOpts, err = tc.shedPermanentCreatedDAGErrors(ctx, tenantId, createDAGOpts)
+				if err != nil {
+					return fmt.Errorf("failed to shed permanent created DAG errors: %w", err)
+				}
+
+				if len(createDAGOpts) > 0 && attempts < maxLockAttempts {
+					tc.sleepWithBackoff(attempts)
+				}
+
+				continue
+			}
+
 			return fmt.Errorf("failed to create DAGs: %w", err)
 		}
 
@@ -921,6 +961,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 	timestamps := make([]pgtype.Timestamptz, 0)
 	eventExternalIds := make([]uuid.UUID, 0)
 	msgIxToSpanEvent := make(map[int]engineSpanEvent)
+	externalIdToSpanEvent := make(map[uuid.UUID]engineSpanEvent)
 
 	for ix, msg := range msgs {
 		taskMeta := taskIdsToMetas[msg.TaskId]
@@ -950,7 +991,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		eventExternalIdToWorkflowRunId[externalId] = taskMeta.WorkflowRunID
 		externalIdToMsg[externalId] = msg
 
-		msgIxToSpanEvent[ix] = engineSpanEvent{
+		spanEvent := engineSpanEvent{
 			taskID:             msg.TaskId,
 			insertedAt:         taskMeta.InsertedAt.Time,
 			taskInsertedAt:     taskMeta.InsertedAt.Time,
@@ -968,6 +1009,8 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 			workflowVersionID:  taskMeta.WorkflowVersionID,
 			stepID:             taskMeta.StepID,
 		}
+		msgIxToSpanEvent[ix] = spanEvent
+		externalIdToSpanEvent[externalId] = spanEvent
 
 		if msg.WorkerId != nil {
 			workerIds = append(workerIds, *msg.WorkerId)
@@ -1085,6 +1128,26 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTaskEvents(ctx, tenantId, opts, eventExternalIdToWorkflowRunId)
 
 		if err != nil {
+			if queueutils.IsPermanentConsumerError(err) {
+				tc.l.Error().
+					Ctx(ctx).
+					Err(err).
+					Str("permanent_consumer_error_reason", queueutils.PermanentConsumerErrorReason(err)).
+					Int("num_payloads", len(opts)).
+					Msg("shedding monitoring event batch after permanent consumer error")
+
+				opts, err = tc.shedPermanentMonitoringEventErrors(ctx, tenantId, opts, eventExternalIdToWorkflowRunId, externalIdToMsg, externalIdToSpanEvent, processedRunIDs)
+				if err != nil {
+					return fmt.Errorf("failed to shed permanent monitoring event errors: %w", err)
+				}
+
+				if len(opts) > 0 && attempts < maxLockAttempts {
+					tc.sleepWithBackoff(attempts)
+				}
+
+				continue
+			}
+
 			return fmt.Errorf("failed to create task events: %w", err)
 		}
 
@@ -1150,6 +1213,137 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 	)
 
 	return nil
+}
+
+func (tc *OLAPControllerImpl) shedPermanentCreatedTaskErrors(ctx context.Context, tenantId uuid.UUID, createTaskOpts []*tasktypes.CreatedTaskPayload) ([]*tasktypes.CreatedTaskPayload, error) {
+	remainingOpts := make([]*tasktypes.CreatedTaskPayload, 0)
+
+	for _, opt := range createTaskOpts {
+		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTasks(ctx, tenantId, []*v1.V1TaskWithPayload{opt.V1TaskWithPayload})
+		if err != nil {
+			if queueutils.IsPermanentConsumerError(err) {
+				tc.l.Error().
+					Ctx(ctx).
+					Err(err).
+					Str("permanent_consumer_error_reason", queueutils.PermanentConsumerErrorReason(err)).
+					Int64("task_id", opt.ID).
+					Str("task_external_id", opt.ExternalID.String()).
+					Str("workflow_run_id", opt.WorkflowRunID.String()).
+					Msg("dropping created task after permanent consumer error")
+				continue
+			}
+
+			return nil, err
+		}
+
+		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[opt.WorkflowRunID]; notAcquired {
+			remainingOpts = append(remainingOpts, opt)
+			continue
+		}
+
+		if result != nil {
+			if err := tc.notifyStatusUpdates(ctx, result); err != nil {
+				return nil, err
+			}
+		}
+
+		tc.emitStandaloneTaskRootSpans(ctx, tenantId, []*v1.V1TaskWithPayload{opt.V1TaskWithPayload})
+	}
+
+	return remainingOpts, nil
+}
+
+func (tc *OLAPControllerImpl) shedPermanentCreatedDAGErrors(ctx context.Context, tenantId uuid.UUID, createDAGOpts []*tasktypes.CreatedDAGPayload) ([]*tasktypes.CreatedDAGPayload, error) {
+	remainingOpts := make([]*tasktypes.CreatedDAGPayload, 0)
+
+	for _, opt := range createDAGOpts {
+		workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateDAGs(ctx, tenantId, []*v1.DAGWithData{opt.DAGWithData})
+		if err != nil {
+			if queueutils.IsPermanentConsumerError(err) {
+				tc.l.Error().
+					Ctx(ctx).
+					Err(err).
+					Str("permanent_consumer_error_reason", queueutils.PermanentConsumerErrorReason(err)).
+					Int64("dag_id", opt.ID).
+					Str("dag_external_id", opt.ExternalID.String()).
+					Msg("dropping created DAG after permanent consumer error")
+				continue
+			}
+
+			return nil, err
+		}
+
+		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[opt.ExternalID]; notAcquired {
+			remainingOpts = append(remainingOpts, opt)
+			continue
+		}
+
+		tc.emitWorkflowRunRootSpans(ctx, tenantId, []*v1.DAGWithData{opt.DAGWithData})
+	}
+
+	return remainingOpts, nil
+}
+
+func (tc *OLAPControllerImpl) shedPermanentMonitoringEventErrors(
+	ctx context.Context,
+	tenantId uuid.UUID,
+	opts []sqlcv1.CreateTaskEventsOLAPParams,
+	eventExternalIdToWorkflowRunId map[uuid.UUID]uuid.UUID,
+	externalIdToMsg map[uuid.UUID]*tasktypes.CreateMonitoringEventPayload,
+	externalIdToSpanEvent map[uuid.UUID]engineSpanEvent,
+	processedRunIDs map[uuid.UUID]bool,
+) ([]sqlcv1.CreateTaskEventsOLAPParams, error) {
+	remainingOpts := make([]sqlcv1.CreateTaskEventsOLAPParams, 0)
+
+	for _, opt := range opts {
+		workflowRunId, ok := eventExternalIdToWorkflowRunId[opt.ExternalID]
+		if !ok {
+			tc.l.Error().Ctx(ctx).Str("event_external_id", opt.ExternalID.String()).Msg("could not find workflow run id for monitoring event")
+			continue
+		}
+
+		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTaskEvents(ctx, tenantId, []sqlcv1.CreateTaskEventsOLAPParams{opt}, map[uuid.UUID]uuid.UUID{
+			opt.ExternalID: workflowRunId,
+		})
+		if err != nil {
+			if queueutils.IsPermanentConsumerError(err) {
+				event := tc.l.Error().
+					Ctx(ctx).
+					Err(err).
+					Str("permanent_consumer_error_reason", queueutils.PermanentConsumerErrorReason(err)).
+					Str("event_external_id", opt.ExternalID.String()).
+					Str("event_type", string(opt.EventType))
+
+				if msg, ok := externalIdToMsg[opt.ExternalID]; ok {
+					event.Int64("task_id", msg.TaskId)
+				}
+
+				event.Msg("dropping monitoring event after permanent consumer error")
+				continue
+			}
+
+			return nil, err
+		}
+
+		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[workflowRunId]; notAcquired {
+			remainingOpts = append(remainingOpts, opt)
+			continue
+		}
+
+		if result != nil {
+			if err := tc.notifyStatusUpdates(ctx, result); err != nil {
+				return nil, err
+			}
+		}
+
+		if spanEvent, ok := externalIdToSpanEvent[opt.ExternalID]; ok {
+			tc.synthesizeEngineSpans(ctx, tenantId, []engineSpanEvent{spanEvent})
+		}
+
+		processedRunIDs[workflowRunId] = true
+	}
+
+	return remainingOpts, nil
 }
 
 func (tc *OLAPControllerImpl) republishCreatedTasks(ctx context.Context, tenantId uuid.UUID, tasks []*tasktypes.CreatedTaskPayload) error {

--- a/pkg/repository/payloadstore.go
+++ b/pkg/repository/payloadstore.go
@@ -89,6 +89,42 @@ type PayloadLocation string
 type ExternalPayloadLocationKey string
 type ExternalIndexFileLocationKey string
 
+var ErrExternalPayloadNotFound = errors.New("external payload not found")
+
+type ExternalPayloadNotFoundKind string
+
+const (
+	ExternalPayloadNotFoundKindIndexFile ExternalPayloadNotFoundKind = "index_file"
+)
+
+type ExternalPayloadNotFoundError struct {
+	Err  error
+	Kind ExternalPayloadNotFoundKind
+	Key  string
+}
+
+func (e *ExternalPayloadNotFoundError) Error() string {
+	msg := ErrExternalPayloadNotFound.Error()
+	if e.Kind != "" {
+		msg = fmt.Sprintf("%s: %s", msg, e.Kind)
+	}
+	if e.Key != "" {
+		msg = fmt.Sprintf("%s %s", msg, e.Key)
+	}
+	if e.Err != nil {
+		msg = fmt.Sprintf("%s: %v", msg, e.Err)
+	}
+	return msg
+}
+
+func (e *ExternalPayloadNotFoundError) Unwrap() error {
+	return e.Err
+}
+
+func (e *ExternalPayloadNotFoundError) Is(target error) bool {
+	return target == ErrExternalPayloadNotFound
+}
+
 type CreateIndexBlockOpts struct {
 	PartitionDate             PartitionDate
 	BlockLowerExternalIdBound uuid.UUID


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Adds a terminal external payload not found error and teaches RabbitMQ pre-ack handling to drop those messages instead of retrying indefinitely. This prevents missing S3 offloaded payload index files from generating noisy retry storms, while keeping other S3 failures retryable.

The permanent drop log is enriched with structured fields like `permanent_pre_ack_reason=external_payload_not_found`, `external_payload_kind`, and `external_payload_key` for filtering and alerting.

Fixes #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

- [x] Add a shared `ErrExternalPayloadNotFound` typed error for terminal external payload misses.
- [x] Treat external payload not found errors as permanent RabbitMQ pre-ack failures.
- [x] Add structured permanent drop reason fields to RabbitMQ logs.
- [x] Map S3 `NoSuchKey` index file fetch errors to the terminal payload error.
- [x] Add focused tests for permanent pre-ack classification and S3 index file error classification.

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

- `go test ./internal/msgqueue/rabbitmq -run 'TestIsPermanentPreAckError' -count=1`
- `go test ./pkg/repository -run '^$' -count=1`
- `GOWORK=<temp local workspace> go test github.com/hatchet-dev/hatchet-cloud/internal/repository -run 'Test(FetchWithFallback|IndexFileFetchError)' -count=1`

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Cursor agent was used to inspect the retry/error paths, implement the targeted code changes, add focused tests, and run validation commands.

</details>