### PR TITLE
fix(engine): handle int32 x-death count from RabbitMQ

### DIFF
--- a/internal/msgqueue/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/rabbitmq/rabbitmq.go
@@ -802,7 +802,7 @@ func (t *MessageQueueImpl) subscribe(
 
 				if exists {
 					// message was rejected before
-					deathCount := xDeath[0].(amqp.Table)["count"].(int64)
+					deathCount := xDeathCount(xDeath)
 
 					if deathCount > 5 {
 						t.l.Error().
@@ -945,6 +945,39 @@ func identity() string {
 	_, _ = fmt.Fprint(h, err)
 	_, _ = fmt.Fprint(h, os.Getpid())
 	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+// xDeathCount reads the retry count from RabbitMQ's x-death header.
+// AMQP encodes the count field as a signed 32-bit integer (type 'I'), but
+// some publishers may send int64; accept both to avoid panics in consumers.
+func xDeathCount(xDeath []interface{}) int64 {
+	if len(xDeath) == 0 {
+		return 0
+	}
+
+	table, ok := xDeath[0].(amqp.Table)
+	if !ok {
+		return 0
+	}
+
+	return amqpTableInt64(table["count"])
+}
+
+func amqpTableInt64(v interface{}) int64 {
+	switch n := v.(type) {
+	case int64:
+		return n
+	case int32:
+		return int64(n)
+	case int:
+		return int64(n)
+	case uint64:
+		return int64(n)
+	case uint32:
+		return int64(n)
+	default:
+		return 0
+	}
 }
 
 func getTmpDLQName(dlxName string) string {

--- a/internal/msgqueue/rabbitmq/x_death_test.go
+++ b/internal/msgqueue/rabbitmq/x_death_test.go
@@ -1,0 +1,59 @@
+package rabbitmq
+
+import (
+	"testing"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestXDeathCount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		xDeath []interface{}
+		want   int64
+	}{
+		{
+			name: "rabbitmq int32 count",
+			xDeath: []interface{}{
+				amqp.Table{"count": int32(3)},
+			},
+			want: 3,
+		},
+		{
+			name: "int64 count",
+			xDeath: []interface{}{
+				amqp.Table{"count": int64(7)},
+			},
+			want: 7,
+		},
+		{
+			name:   "empty x-death",
+			xDeath: []interface{}{},
+			want:   0,
+		},
+		{
+			name: "missing count",
+			xDeath: []interface{}{
+				amqp.Table{"reason": "rejected"},
+			},
+			want: 0,
+		},
+		{
+			name: "unexpected entry type",
+			xDeath: []interface{}{
+				"not-a-table",
+			},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, xDeathCount(tt.xDeath))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Fixes #4311

`hatchet-engine` panics when consuming dead-lettered RabbitMQ messages with `x-death` headers. RabbitMQ encodes the `count` field as `int32` per AMQP 0-9-1, but the consumer asserted `int64` directly, causing:

```
panic: interface conversion: interface {} is int32, not int64
```

Because the engine auto-subscribes to `*_dlq_proc` queues, a single dead-lettered message can crash-loop the engine.

This adds `xDeathCount()` to safely read the retry count from `x-death`, accepting `int32`, `int64`, and other common numeric types.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Add `xDeathCount()` / `amqpTableInt64()` helpers in `internal/msgqueue/rabbitmq/rabbitmq.go`
- [x] Add unit tests in `internal/msgqueue/rabbitmq/x_death_test.go`

## Checklist

Changes have been:

- [x] Tested (unit tests added; CI will run `task test`)
- [ ] Linted and formatted (CI will run `task lint` / `task fmt`)
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

```sh
go test ./internal/msgqueue/rabbitmq -run TestXDeathCount
```

---

<details open id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._
- **Details**: Cursor assisted with diagnosing a production incident, implementing the fix, writing unit tests, and drafting the PR description; changes were reviewed before submission.

</details>