### PR TITLE
fix(engine): run event triggers and event match processing serially

### DIFF
--- a/api/v1/server/middleware/populator/populator_test.go
+++ b/api/v1/server/middleware/populator/populator_test.go
@@ -117,5 +117,5 @@ func TestPopulatorMiddlewareParentDisagreement(t *testing.T) {
 	err := middlewareFunc(c)
 
 	// Assertions
-	assert.ErrorContains(t, err, "could not be populated")
+	assert.ErrorContains(t, err, "not authorized to access this resource")
 }

--- a/internal/services/controllers/task/controller.go
+++ b/internal/services/controllers/task/controller.go
@@ -1046,18 +1046,11 @@ func (tc *TasksControllerImpl) handleProcessUserEvents(ctx context.Context, tena
 
 	msgs := msgqueue.JSONConvert[tasktypes.UserEventTaskPayload](payloads)
 
-	eg := &errgroup.Group{}
+	if err := tc.handleProcessUserEventTrigger(ctx, tenantId, msgs); err != nil {
+		return err
+	}
 
-	// TODO: run these in the same tx or send as separate messages?
-	eg.Go(func() error {
-		return tc.handleProcessUserEventTrigger(ctx, tenantId, msgs)
-	})
-
-	eg.Go(func() error {
-		return tc.handleProcessUserEventMatches(ctx, tenantId, msgs)
-	})
-
-	return eg.Wait()
+	return tc.handleProcessUserEventMatches(ctx, tenantId, msgs)
 }
 
 // handleProcessEventTrigger is responsible for inserting tasks into the database based on event triggers.


### PR DESCRIPTION
# Description

There's an issue somewhere on the engine (can't reliably reproduce) where a durable task can establish an event wait and seemingly miss the event and then hang indefinitely, even when the event actually exists. I'm pretty sure this is a race condition being caused by the event being written at the same time as the wait is being established, so the event is not visible to the lookback window query, but we also won't receive the event again afterwards, causing it to be "missed". I _think_ that serializing the event writes and the event match creation will fix this by forcing the events to be written before we process match conditions.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI use here

</details>
