### PR TITLE
fix: need to prop `until` param for counts

### DIFF
--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
@@ -235,6 +235,7 @@ export const RunsProvider = ({
     workflow,
     parentTaskExternalId,
     createdAfter: filters.apiFilters.since,
+    createdBefore: filters.apiFilters.until,
     additionalMetadata: filters.apiFilters.additionalMetadata,
     showQueueMetrics,
   });

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-metrics.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-metrics.tsx
@@ -8,12 +8,14 @@ export const useMetrics = ({
   parentTaskExternalId,
   additionalMetadata,
   createdAfter,
+  createdBefore,
   showQueueMetrics,
 }: {
   workflow: string | undefined;
   parentTaskExternalId: string | undefined;
   additionalMetadata?: string[] | undefined;
   createdAfter?: string;
+  createdBefore?: string;
   showQueueMetrics: boolean;
 }) => {
   const { tenantId } = useCurrentTenantId();
@@ -30,6 +32,7 @@ export const useMetrics = ({
       since:
         createdAfter ||
         new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+      until: createdBefore,
       parent_task_external_id: parentTaskExternalId,
       workflow_ids: workflow ? [workflow] : [],
       additional_metadata: additionalMetadata,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Fixes a bug where the `createdBefore` parameter is not propagated to the `task-metrics` endpoint (which uses `until`). Basically fixes this bug, where counts are non-zero but the list endpoint and chart is empty:

<img width="1722" height="881" alt="image" src="https://github.com/user-attachments/assets/9523b72d-407c-432d-96e8-a4dc99ddb54b" />

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [X] Just prop `createdBefore` through to `use-metrics` 

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Tested (unit, integration, or manually with steps specified) - manual
- [X] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [X] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude for debugging and implementing

</details>
