### PR TITLE
fix: reset pagination state when search params change

### DIFF
--- a/frontend/app/src/components/v1/molecules/data-table/data-table-pagination.tsx
+++ b/frontend/app/src/components/v1/molecules/data-table/data-table-pagination.tsx
@@ -74,7 +74,7 @@ export function DataTablePagination<TData>({
           </Select>
         </div>
         <div className="flex w-[100px] items-center justify-center text-sm font-medium">
-          Page {pagination.pageIndex + 1} of {table.getPageCount()}
+          Page {pagination.pageIndex + 1} of {Math.max(table.getPageCount(), 1)}
         </div>
         <div className="flex items-center space-x-1">
           <Button

--- a/frontend/app/src/hooks/use-pagination.tsx
+++ b/frontend/app/src/hooks/use-pagination.tsx
@@ -1,6 +1,6 @@
 import { useSearchParams } from '@/lib/router-helpers';
 import { PaginationState, Updater } from '@tanstack/react-table';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { DependencyList, useCallback, useEffect, useMemo, useRef } from 'react';
 
 type PaginationQueryShape = {
   i: number; // index
@@ -9,10 +9,9 @@ type PaginationQueryShape = {
 
 type UsePaginationProps = {
   key: string;
-  // When this value changes (by deep/serialized equality), the page index resets to 0.
-  // Pass the active filter values here so changing a filter doesn't leave the user
-  // stranded on a page that no longer has results.
-  resetPageOnChange?: unknown;
+  // if any dependency changes, we reset pagination to 0 so users don't get
+  // stuck on a page that no longer has results.
+  resetPageOnChange?: DependencyList;
 };
 
 const parsePaginationParam = (searchParams: URLSearchParams, key: string) => {

--- a/frontend/app/src/hooks/use-pagination.tsx
+++ b/frontend/app/src/hooks/use-pagination.tsx
@@ -1,6 +1,6 @@
 import { useSearchParams } from '@/lib/router-helpers';
 import { PaginationState, Updater } from '@tanstack/react-table';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 type PaginationQueryShape = {
   i: number; // index
@@ -9,6 +9,10 @@ type PaginationQueryShape = {
 
 type UsePaginationProps = {
   key: string;
+  // When this value changes (by deep/serialized equality), the page index resets to 0.
+  // Pass the active filter values here so changing a filter doesn't leave the user
+  // stranded on a page that no longer has results.
+  resetPageOnChange?: unknown;
 };
 
 const parsePaginationParam = (searchParams: URLSearchParams, key: string) => {
@@ -43,7 +47,10 @@ const parsePaginationParam = (searchParams: URLSearchParams, key: string) => {
   };
 };
 
-export const usePagination = ({ key }: UsePaginationProps) => {
+export const usePagination = ({
+  key,
+  resetPageOnChange,
+}: UsePaginationProps) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const paramKey = `pagination-${key}`;
 
@@ -51,6 +58,33 @@ export const usePagination = ({ key }: UsePaginationProps) => {
     () => parsePaginationParam(searchParams, paramKey),
     [searchParams, paramKey],
   );
+
+  const resetPageOnChangeKey = JSON.stringify(resetPageOnChange);
+  const prevResetPageOnChangeKey = useRef(resetPageOnChangeKey);
+
+  useEffect(() => {
+    if (prevResetPageOnChangeKey.current === resetPageOnChangeKey) {
+      return;
+    }
+
+    prevResetPageOnChangeKey.current = resetPageOnChangeKey;
+
+    if (pagination.pageIndex === 0) {
+      return;
+    }
+
+    setSearchParams((prev) => {
+      const currentPagination = parsePaginationParam(prev, paramKey);
+
+      return {
+        ...Object.fromEntries(prev.entries()),
+        [paramKey]: {
+          i: 0,
+          s: currentPagination.pageSize,
+        },
+      };
+    });
+  }, [resetPageOnChangeKey, pagination.pageIndex, setSearchParams, paramKey]);
 
   const offset = useMemo(() => {
     if (!pagination) {

--- a/frontend/app/src/hooks/use-pagination.tsx
+++ b/frontend/app/src/hooks/use-pagination.tsx
@@ -46,6 +46,33 @@ const parsePaginationParam = (searchParams: URLSearchParams, key: string) => {
   };
 };
 
+// Builds the updated search params for setting the `i` (pageIndex) and `s`
+// (pageSize) of the pagination param at `paramKey`, preserving all other params.
+const buildPaginationSearchParams = (
+  prev: URLSearchParams,
+  paramKey: string,
+  i: number,
+  s: number,
+) => ({
+  ...Object.fromEntries(prev.entries()),
+  [paramKey]: { i, s },
+});
+
+// JSON.stringify throws on values a DependencyList can legally contain but
+// JSON can't represent (BigInt, circular references). Fall back to a
+// best-effort string so a bad dependency value can't crash render.
+const serializeDeps = (deps?: DependencyList): string => {
+  if (!deps) {
+    return '';
+  }
+
+  try {
+    return JSON.stringify(deps);
+  } catch {
+    return deps.map((dep) => String(dep)).join('|');
+  }
+};
+
 export const usePagination = ({
   key,
   resetPageOnChange,
@@ -58,7 +85,7 @@ export const usePagination = ({
     [searchParams, paramKey],
   );
 
-  const resetPageOnChangeKey = JSON.stringify(resetPageOnChange);
+  const resetPageOnChangeKey = serializeDeps(resetPageOnChange);
   const prevResetPageOnChangeKey = useRef(resetPageOnChangeKey);
 
   useEffect(() => {
@@ -75,13 +102,12 @@ export const usePagination = ({
     setSearchParams((prev) => {
       const currentPagination = parsePaginationParam(prev, paramKey);
 
-      return {
-        ...Object.fromEntries(prev.entries()),
-        [paramKey]: {
-          i: 0,
-          s: currentPagination.pageSize,
-        },
-      };
+      return buildPaginationSearchParams(
+        prev,
+        paramKey,
+        0,
+        currentPagination.pageSize,
+      );
     });
   }, [resetPageOnChangeKey, pagination.pageIndex, setSearchParams, paramKey]);
 
@@ -105,18 +131,12 @@ export const usePagination = ({
     setSearchParams((prev) => {
       const currentPagination = parsePaginationParam(prev, paramKey);
 
-      const nextPagination = {
-        ...currentPagination,
-        pageIndex: currentPagination.pageIndex + 1,
-      };
-
-      return {
-        ...Object.fromEntries(prev.entries()),
-        [paramKey]: {
-          i: nextPagination.pageIndex,
-          s: nextPagination.pageSize,
-        },
-      };
+      return buildPaginationSearchParams(
+        prev,
+        paramKey,
+        currentPagination.pageIndex + 1,
+        currentPagination.pageSize,
+      );
     });
   }, [setSearchParams, paramKey]);
 
@@ -124,39 +144,21 @@ export const usePagination = ({
     setSearchParams((prev) => {
       const currentPagination = parsePaginationParam(prev, paramKey);
 
-      const prevPagination = {
-        ...currentPagination,
-        pageIndex: Math.max(0, currentPagination.pageIndex - 1),
-      };
-
-      return {
-        ...Object.fromEntries(prev.entries()),
-        [paramKey]: {
-          i: prevPagination.pageIndex,
-          s: prevPagination.pageSize,
-        },
-      };
+      return buildPaginationSearchParams(
+        prev,
+        paramKey,
+        Math.max(0, currentPagination.pageIndex - 1),
+        currentPagination.pageSize,
+      );
     });
   }, [setSearchParams, paramKey]);
 
   const setPageSize = useCallback(
     (pageSize: number) => {
-      setSearchParams((prev) => {
-        const currentPagination = parsePaginationParam(prev, paramKey);
-        const nextPagination = {
-          ...currentPagination,
-          pageIndex: 0, // Reset to first page when page size changes
-          pageSize,
-        };
-
-        return {
-          ...Object.fromEntries(prev.entries()),
-          [paramKey]: {
-            i: nextPagination.pageIndex,
-            s: nextPagination.pageSize,
-          },
-        };
-      });
+      setSearchParams((prev) =>
+        // Reset to first page when page size changes
+        buildPaginationSearchParams(prev, paramKey, 0, pageSize),
+      );
     },
     [setSearchParams, paramKey],
   );
@@ -169,13 +171,12 @@ export const usePagination = ({
         const newPagination =
           typeof updater === 'function' ? updater(currentPagination) : updater;
 
-        return {
-          ...Object.fromEntries(prev.entries()),
-          [paramKey]: {
-            i: newPagination.pageIndex,
-            s: newPagination.pageSize,
-          },
-        };
+        return buildPaginationSearchParams(
+          prev,
+          paramKey,
+          newPagination.pageIndex,
+          newPagination.pageSize,
+        );
       });
     },
     offset,

--- a/frontend/app/src/pages/main/v1/events/hooks/use-events.tsx
+++ b/frontend/app/src/pages/main/v1/events/hooks/use-events.tsx
@@ -35,10 +35,6 @@ const eventFilterSchema = z
 export const useEvents = ({ key }: UseEventsProps) => {
   const { tenantId } = useCurrentTenantId();
   const { refetchInterval } = useRefetchInterval();
-  const { limit, offset, pagination, setPagination, setPageSize } =
-    usePagination({
-      key,
-    });
 
   const paramKey = `events-${key}`;
   const {
@@ -61,6 +57,19 @@ export const useEvents = ({ key }: UseEventsProps) => {
     m: metadataKey,
     i: idKey,
   });
+
+  const { limit, offset, pagination, setPagination, setPageSize } =
+    usePagination({
+      key,
+      resetPageOnChange: [
+        selectedKeys,
+        selectedWorkflowIds,
+        selectedScopes,
+        selectedStatuses,
+        selectedMetadata,
+        selectedEventIds,
+      ],
+    });
 
   const { data, isLoading, refetch, error, isRefetching } = useQuery({
     queryKey: [

--- a/frontend/app/src/pages/main/v1/filters/hooks/use-filters.tsx
+++ b/frontend/app/src/pages/main/v1/filters/hooks/use-filters.tsx
@@ -60,10 +60,6 @@ export const useFilters = ({ key, scopeOverrides }: UseFiltersProps) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const { tenantId } = useCurrentTenantId();
   const { refetchInterval } = useRefetchInterval();
-  const { limit, offset, pagination, setPagination, setPageSize } =
-    usePagination({
-      key,
-    });
 
   const paramKey = `filters-${key}`;
 
@@ -82,6 +78,12 @@ export const useFilters = ({ key, scopeOverrides }: UseFiltersProps) => {
 
     return s;
   }, [searchParams, paramKey, scopeOverrides]);
+
+  const { limit, offset, pagination, setPagination, setPageSize } =
+    usePagination({
+      key,
+      resetPageOnChange: [selectedWorkflowIds, selectedScopes],
+    });
 
   const columnFilters = useMemo<ColumnFiltersState>(() => {
     const { w, s } = parseFilterParam(searchParams, paramKey);

--- a/frontend/app/src/pages/main/v1/rate-limits/hooks/use-rate-limits.tsx
+++ b/frontend/app/src/pages/main/v1/rate-limits/hooks/use-rate-limits.tsx
@@ -28,10 +28,6 @@ export type RateLimitWithMetadata = RateLimit & {
 
 export const useRateLimits = ({ key }: { key: string }) => {
   const { tenantId } = useCurrentTenantId();
-  const { limit, offset, pagination, setPagination, setPageSize } =
-    usePagination({
-      key,
-    });
   const { refetchInterval } = useRefetchInterval();
 
   const paramKey = `rate-limits-${key}`;
@@ -44,6 +40,12 @@ export const useRateLimits = ({ key }: { key: string }) => {
   } = useZodColumnFilters(rateLimitQuerySchema, paramKey, { s: keyKey });
 
   const [debouncedSearch] = useDebounce(search, 300);
+
+  const { limit, offset, pagination, setPagination, setPageSize } =
+    usePagination({
+      key,
+      resetPageOnChange: debouncedSearch,
+    });
 
   const { data, isLoading, error, isRefetching, refetch } = useQuery({
     ...queries.rate_limits.list(tenantId, {

--- a/frontend/app/src/pages/main/v1/rate-limits/hooks/use-rate-limits.tsx
+++ b/frontend/app/src/pages/main/v1/rate-limits/hooks/use-rate-limits.tsx
@@ -44,7 +44,7 @@ export const useRateLimits = ({ key }: { key: string }) => {
   const { limit, offset, pagination, setPagination, setPageSize } =
     usePagination({
       key,
-      resetPageOnChange: debouncedSearch,
+      resetPageOnChange: [debouncedSearch],
     });
 
   const { data, isLoading, error, isRefetching, refetch } = useQuery({

--- a/frontend/app/src/pages/main/v1/recurring/hooks/use-crons.tsx
+++ b/frontend/app/src/pages/main/v1/recurring/hooks/use-crons.tsx
@@ -34,10 +34,6 @@ export const useCrons = ({ key }: UseCronsProps) => {
   const { refetchInterval } = useRefetchInterval();
   const navigate = useNavigate();
   const { toast } = useToast();
-  const { limit, offset, pagination, setPagination, setPageSize } =
-    usePagination({
-      key,
-    });
 
   const paramKey = `crons-${key}`;
   const {
@@ -49,6 +45,12 @@ export const useCrons = ({ key }: UseCronsProps) => {
     w: workflowKey,
     m: metadataKey,
   });
+
+  const { limit, offset, pagination, setPagination, setPageSize } =
+    usePagination({
+      key,
+      resetPageOnChange: [selectedWorkflowIds, selectedMetadata],
+    });
 
   const { data, isLoading, refetch, error, isRefetching } = useQuery({
     ...queries.cronJobs.list(tenantId, {

--- a/frontend/app/src/pages/main/v1/scheduled-runs/hooks/use-scheduled-runs.tsx
+++ b/frontend/app/src/pages/main/v1/scheduled-runs/hooks/use-scheduled-runs.tsx
@@ -46,10 +46,6 @@ export const useScheduledRuns = ({
   const { refetchInterval } = useRefetchInterval();
   const navigate = useNavigate();
   const { toast } = useToast();
-  const { limit, offset, pagination, setPagination, setPageSize } =
-    usePagination({
-      key,
-    });
 
   const paramKey = `scheduled-runs-${key}`;
   const {
@@ -65,6 +61,19 @@ export const useScheduledRuns = ({
 
   // todo: allow multiple workflow ids here
   const effectiveWorkflowId = workflowId || selectedWorkflowIds[0];
+
+  const { limit, offset, pagination, setPagination, setPageSize } =
+    usePagination({
+      key,
+      resetPageOnChange: [
+        selectedWorkflowIds,
+        selectedStatuses,
+        selectedMetadata,
+        workflowId,
+        parentWorkflowRunId,
+        parentStepRunId,
+      ],
+    });
 
   const { data, isLoading, refetch, error, isRefetching } = useQuery({
     ...queries.scheduledRuns.list(tenantId, {

--- a/frontend/app/src/pages/main/v1/workers/index.tsx
+++ b/frontend/app/src/pages/main/v1/workers/index.tsx
@@ -29,10 +29,6 @@ export default function Workers() {
   const { tenantId } = useCurrentTenantId();
   const { refetchInterval } = useRefetchInterval();
   const paramKey = 'workers-table';
-  const { pagination, setPagination, limit, offset, setPageSize } =
-    usePagination({
-      key: paramKey,
-    });
   const [openLabelsPopover, setOpenLabelsPopover] = useState<string | null>(
     null,
   );
@@ -43,6 +39,12 @@ export default function Workers() {
     setColumnFilters,
     resetFilters,
   } = useZodColumnFilters(workersQuerySchema, paramKey, { s: statusKey });
+
+  const { pagination, setPagination, limit, offset, setPageSize } =
+    usePagination({
+      key: paramKey,
+      resetPageOnChange: statuses,
+    });
 
   const [columnVisibility, setColumnVisibility] =
     useLocalStorageState<VisibilityState>('hatchet:columns:workers', {});

--- a/frontend/app/src/pages/main/v1/workers/index.tsx
+++ b/frontend/app/src/pages/main/v1/workers/index.tsx
@@ -43,7 +43,7 @@ export default function Workers() {
   const { pagination, setPagination, limit, offset, setPageSize } =
     usePagination({
       key: paramKey,
-      resetPageOnChange: statuses,
+      resetPageOnChange: [statuses],
     });
 
   const [columnVisibility, setColumnVisibility] =

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-runs.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-runs.tsx
@@ -46,6 +46,18 @@ export const useRuns = ({
   const { refetchInterval } = useRefetchInterval();
   const { offset, pagination, setPageSize, setPagination } = usePagination({
     key: 'runs-table-' + key,
+    resetPageOnChange: [
+      createdAfter,
+      finishedBefore,
+      statuses,
+      runningFilter,
+      additionalMetadata,
+      workerId,
+      workflowIds,
+      parentTaskExternalId,
+      triggeringEventExternalId,
+      onlyTasks,
+    ],
   });
 
   const [initialRenderTime] = useState(

--- a/frontend/app/src/pages/main/v1/workflows/hooks/use-workflows.tsx
+++ b/frontend/app/src/pages/main/v1/workflows/hooks/use-workflows.tsx
@@ -22,10 +22,6 @@ const workflowQuerySchema = z
 export const useWorkflows = ({ key }: UseWorkflowsProps) => {
   const { tenantId } = useCurrentTenantId();
   const { refetchInterval } = useRefetchInterval();
-  const { pagination, setPagination, setPageSize, offset, limit } =
-    usePagination({
-      key,
-    });
 
   const paramKey = `workflows-${key}`;
 
@@ -37,6 +33,12 @@ export const useWorkflows = ({ key }: UseWorkflowsProps) => {
   } = useZodColumnFilters(workflowQuerySchema, paramKey, { s: nameKey });
 
   const [debouncedSearch] = useDebounce(search, 300);
+
+  const { pagination, setPagination, setPageSize, offset, limit } =
+    usePagination({
+      key,
+      resetPageOnChange: debouncedSearch,
+    });
 
   const setSearch = useCallback(
     (value: string) => {

--- a/frontend/app/src/pages/main/v1/workflows/hooks/use-workflows.tsx
+++ b/frontend/app/src/pages/main/v1/workflows/hooks/use-workflows.tsx
@@ -37,7 +37,7 @@ export const useWorkflows = ({ key }: UseWorkflowsProps) => {
   const { pagination, setPagination, setPageSize, offset, limit } =
     usePagination({
       key,
-      resetPageOnChange: debouncedSearch,
+      resetPageOnChange: [debouncedSearch],
     });
 
   const setSearch = useCallback(


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Fixes two pagination bugs:
1. When you're on a page and you change filters, the pagination doesn't reset, leaving users potentially stranded on a page.
2. Empty state says `page 1 of 0` which doesn't make any sense

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [X] Adds a prop param as a  `DependencyList` to `usePagination` which resets pages if any dep changes
- [X] One-liner for casing on min displayed page being `1` instead of `0`

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Tested (unit, integration, or manually with steps specified) - manual
- [X] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude for implementation

</details>
