### PR TITLE
feat: expose separate olap and core retention config

### DIFF
--- a/frontend/docs/pages/self-hosting/configuration-options.mdx
+++ b/frontend/docs/pages/self-hosting/configuration-options.mdx
@@ -203,6 +203,8 @@ Variables marked with ⚠️ are conditionally required when specific features a
 | Variable                                        | Description                     | Default Value |
 | ----------------------------------------------- | ------------------------------- | ------------- |
 | `SERVER_LIMITS_DEFAULT_TENANT_RETENTION_PERIOD` | Default tenant retention period | `720h`        |
+| `SERVER_LIMITS_CORE_PARTITION_RETENTION`        | Core partition retention period | Tenant default |
+| `SERVER_LIMITS_OLAP_PARTITION_RETENTION`        | OLAP partition retention period | Tenant default |
 | `SERVER_LIMITS_DEFAULT_WORKER_LIMIT`            | Default worker limit            | `4`           |
 | `SERVER_LIMITS_DEFAULT_WORKER_ALARM_LIMIT`      | Default worker alarm limit      | `2`           |
 | `SERVER_LIMITS_DEFAULT_EVENT_LIMIT`             | Default event limit             | `1000`        |

--- a/frontend/docs/pages/self-hosting/configuration-options.mdx
+++ b/frontend/docs/pages/self-hosting/configuration-options.mdx
@@ -200,25 +200,25 @@ Variables marked with ⚠️ are conditionally required when specific features a
 
 ## Limit Configuration
 
-| Variable                                        | Description                     | Default Value |
-| ----------------------------------------------- | ------------------------------- | ------------- |
-| `SERVER_LIMITS_DEFAULT_TENANT_RETENTION_PERIOD` | Default tenant retention period | `720h`        |
+| Variable                                        | Description                     | Default Value  |
+| ----------------------------------------------- | ------------------------------- | -------------- |
+| `SERVER_LIMITS_DEFAULT_TENANT_RETENTION_PERIOD` | Default tenant retention period | `720h`         |
 | `SERVER_LIMITS_CORE_PARTITION_RETENTION`        | Core partition retention period | Tenant default |
 | `SERVER_LIMITS_OLAP_PARTITION_RETENTION`        | OLAP partition retention period | Tenant default |
-| `SERVER_LIMITS_DEFAULT_WORKER_LIMIT`            | Default worker limit            | `4`           |
-| `SERVER_LIMITS_DEFAULT_WORKER_ALARM_LIMIT`      | Default worker alarm limit      | `2`           |
-| `SERVER_LIMITS_DEFAULT_EVENT_LIMIT`             | Default event limit             | `1000`        |
-| `SERVER_LIMITS_DEFAULT_EVENT_ALARM_LIMIT`       | Default event alarm limit       | `750`         |
-| `SERVER_LIMITS_DEFAULT_EVENT_WINDOW`            | Default event window            | `24h`         |
-| `SERVER_LIMITS_DEFAULT_CRON_LIMIT`              | Default cron limit              | `5`           |
-| `SERVER_LIMITS_DEFAULT_CRON_ALARM_LIMIT`        | Default cron alarm limit        | `2`           |
-| `SERVER_LIMITS_DEFAULT_SCHEDULE_LIMIT`          | Default schedule limit          | `1000`        |
-| `SERVER_LIMITS_DEFAULT_SCHEDULE_ALARM_LIMIT`    | Default schedule alarm limit    | `750`         |
-| `SERVER_LIMITS_DEFAULT_TASK_RUN_LIMIT`          | Default task run limit          | `2000`        |
-| `SERVER_LIMITS_DEFAULT_TASK_RUN_ALARM_LIMIT`    | Default task run alarm limit    | `1500`        |
-| `SERVER_LIMITS_DEFAULT_TASK_RUN_WINDOW`         | Default task run window         | `24h`         |
-| `SERVER_LIMITS_DEFAULT_WORKER_SLOT_LIMIT`       | Default worker slot limit       | `4000`        |
-| `SERVER_LIMITS_DEFAULT_WORKER_SLOT_ALARM_LIMIT` | Default worker slot alarm limit | `3000`        |
+| `SERVER_LIMITS_DEFAULT_WORKER_LIMIT`            | Default worker limit            | `4`            |
+| `SERVER_LIMITS_DEFAULT_WORKER_ALARM_LIMIT`      | Default worker alarm limit      | `2`            |
+| `SERVER_LIMITS_DEFAULT_EVENT_LIMIT`             | Default event limit             | `1000`         |
+| `SERVER_LIMITS_DEFAULT_EVENT_ALARM_LIMIT`       | Default event alarm limit       | `750`          |
+| `SERVER_LIMITS_DEFAULT_EVENT_WINDOW`            | Default event window            | `24h`          |
+| `SERVER_LIMITS_DEFAULT_CRON_LIMIT`              | Default cron limit              | `5`            |
+| `SERVER_LIMITS_DEFAULT_CRON_ALARM_LIMIT`        | Default cron alarm limit        | `2`            |
+| `SERVER_LIMITS_DEFAULT_SCHEDULE_LIMIT`          | Default schedule limit          | `1000`         |
+| `SERVER_LIMITS_DEFAULT_SCHEDULE_ALARM_LIMIT`    | Default schedule alarm limit    | `750`          |
+| `SERVER_LIMITS_DEFAULT_TASK_RUN_LIMIT`          | Default task run limit          | `2000`         |
+| `SERVER_LIMITS_DEFAULT_TASK_RUN_ALARM_LIMIT`    | Default task run alarm limit    | `1500`         |
+| `SERVER_LIMITS_DEFAULT_TASK_RUN_WINDOW`         | Default task run window         | `24h`          |
+| `SERVER_LIMITS_DEFAULT_WORKER_SLOT_LIMIT`       | Default worker slot limit       | `4000`         |
+| `SERVER_LIMITS_DEFAULT_WORKER_SLOT_ALARM_LIMIT` | Default worker slot alarm limit | `3000`         |
 
 ## Alerting Configuration
 

--- a/pkg/config/limits/limits.go
+++ b/pkg/config/limits/limits.go
@@ -4,6 +4,8 @@ import "time"
 
 type LimitConfigFile struct {
 	DefaultTenantRetentionPeriod string `mapstructure:"defaultTenantRetentionPeriod" json:"defaultTenantRetentionPeriod,omitempty" default:"720h"`
+	CorePartitionRetention       string `mapstructure:"corePartitionRetention" json:"corePartitionRetention,omitempty"`
+	OLAPPartitionRetention       string `mapstructure:"olapPartitionRetention" json:"olapPartitionRetention,omitempty"`
 
 	DefaultWorkflowRunLimit      int32         `mapstructure:"defaultWorkflowRunLimit" json:"defaultWorkflowRunLimit,omitempty" default:"2000"`
 	DefaultWorkflowRunAlarmLimit int32         `mapstructure:"defaultWorkflowRunAlarmLimit" json:"defaultWorkflowRunAlarmLimit,omitempty" default:"1600"`
@@ -31,4 +33,22 @@ type LimitConfigFile struct {
 
 	DefaultIncomingWebhookLimit      int32 `mapstructure:"defaultIncomingWebhookLimit" json:"defaultIncomingWebhookLimit,omitempty" default:"5"`
 	DefaultIncomingWebhookAlarmLimit int32 `mapstructure:"defaultIncomingWebhookAlarmLimit" json:"defaultIncomingWebhookALarmLimit,omitempty" default:"4"`
+}
+
+// CorePartitionRetentionOrDefault returns the core partition retention override or the tenant default.
+func (c LimitConfigFile) CorePartitionRetentionOrDefault() string {
+	if c.CorePartitionRetention != "" {
+		return c.CorePartitionRetention
+	}
+
+	return c.DefaultTenantRetentionPeriod
+}
+
+// OLAPPartitionRetentionOrDefault returns the OLAP partition retention override or the tenant default.
+func (c LimitConfigFile) OLAPPartitionRetentionOrDefault() string {
+	if c.OLAPPartitionRetention != "" {
+		return c.OLAPPartitionRetention
+	}
+
+	return c.DefaultTenantRetentionPeriod
 }

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -76,6 +76,16 @@ func LoadServerConfigFile(files ...[]byte) (*server.ServerConfigFile, error) {
 	return configFile, err
 }
 
+func parseRetentionDuration(name, value string) (time.Duration, error) {
+	retentionPeriod, err := time.ParseDuration(value)
+
+	if err != nil {
+		return 0, fmt.Errorf("could not parse %s %s: %w", name, value, err)
+	}
+
+	return retentionPeriod, nil
+}
+
 type ConfigLoader struct {
 	directory string
 }
@@ -314,10 +324,22 @@ func (c *ConfigLoader) InitDataLayer() (res *database.Layer, err error) {
 
 	ch := cache.New(cf.CacheDuration)
 
-	retentionPeriod, err := time.ParseDuration(scf.Runtime.Limits.DefaultTenantRetentionPeriod)
+	_, err = parseRetentionDuration("default tenant retention period", scf.Runtime.Limits.DefaultTenantRetentionPeriod)
 
 	if err != nil {
-		return nil, fmt.Errorf("could not parse retention period %s: %w", scf.Runtime.Limits.DefaultTenantRetentionPeriod, err)
+		return nil, err
+	}
+
+	corePartitionRetention, err := parseRetentionDuration("core partition retention", scf.Runtime.Limits.CorePartitionRetentionOrDefault())
+
+	if err != nil {
+		return nil, err
+	}
+
+	olapPartitionRetention, err := parseRetentionDuration("OLAP partition retention", scf.Runtime.Limits.OLAPPartitionRetentionOrDefault())
+
+	if err != nil {
+		return nil, err
 	}
 
 	taskLimits := repov1.TaskOperationLimits{
@@ -357,8 +379,8 @@ func (c *ConfigLoader) InitDataLayer() (res *database.Layer, err error) {
 		ddlPool,
 		&l,
 		cf.CacheDuration,
-		retentionPeriod,
-		retentionPeriod,
+		corePartitionRetention,
+		olapPartitionRetention,
 		scf.Runtime.MaxInternalRetryCount,
 		taskLimits,
 		payloadStoreOpts,

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -782,6 +782,8 @@ func BindAllEnv(v *viper.Viper) {
 
 	// limit options
 	_ = v.BindEnv("runtime.limits.defaultTenantRetentionPeriod", "SERVER_LIMITS_DEFAULT_TENANT_RETENTION_PERIOD")
+	_ = v.BindEnv("runtime.limits.corePartitionRetention", "SERVER_LIMITS_CORE_PARTITION_RETENTION")
+	_ = v.BindEnv("runtime.limits.olapPartitionRetention", "SERVER_LIMITS_OLAP_PARTITION_RETENTION")
 
 	_ = v.BindEnv("runtime.limits.defaultTaskRunLimit", "SERVER_LIMITS_DEFAULT_TASK_RUN_LIMIT")
 	_ = v.BindEnv("runtime.limits.defaultTaskRunAlarmLimit", "SERVER_LIMITS_DEFAULT_TASK_RUN_ALARM_LIMIT")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Adds separate configuration for core and OLAP partition retention so partition cleanup windows can be tuned independently from the tenant data retention default. When either new setting is unset, it falls back to `SERVER_LIMITS_DEFAULT_TENANT_RETENTION_PERIOD`.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## What's Changed

- [x] Added `SERVER_LIMITS_CORE_PARTITION_RETENTION` and `SERVER_LIMITS_OLAP_PARTITION_RETENTION`.
- [x] Wired core partition cleanup to use the core retention override with fallback to tenant retention.
- [x] Wired OLAP partition cleanup to use the OLAP retention override with fallback to tenant retention.
- [x] Documented the new configuration variables.

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Cursor agent was used to inspect the existing retention wiring, implement the config changes, update docs, and run focused validation.

</details>