### PR TITLE
fix: set idle in transaction session timeout

### DIFF
--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -181,6 +181,11 @@ func (c *ConfigLoader) InitDataLayer() (res *database.Layer, err error) {
 		}
 
 		_, err = conn.Exec(ctx, "SET statement_timeout=30000")
+		if err != nil {
+			return err
+		}
+
+		_, err = conn.Exec(ctx, "SET idle_in_transaction_session_timeout=30000")
 
 		return err
 	}

--- a/pkg/repository/sqlchelpers/tx.go
+++ b/pkg/repository/sqlchelpers/tx.go
@@ -75,8 +75,14 @@ func PrepareTxWithStatementTimeout(ctx context.Context, pool *pgxpool.Pool, l *z
 	}
 
 	commit := func(ctx context.Context) error {
-		// reset statement timeout
+		// reset statement and idle-in-transaction timeouts
 		_, err = tx.Exec(ctx, "SET statement_timeout=30000")
+
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.Exec(ctx, "SET idle_in_transaction_session_timeout=30000")
 
 		if err != nil {
 			return err
@@ -90,6 +96,12 @@ func PrepareTxWithStatementTimeout(ctx context.Context, pool *pgxpool.Pool, l *z
 	}
 
 	_, err = tx.Exec(ctx, fmt.Sprintf("SET statement_timeout=%d", timeoutMs))
+
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET idle_in_transaction_session_timeout=%d", timeoutMs))
 
 	if err != nil {
 		return nil, nil, nil, err
@@ -126,7 +138,7 @@ func AcquireConnectionWithStatementTimeout(ctx context.Context, pool *pgxpool.Po
 	}
 
 	release := func() {
-		// reset statement timeout with a separate ctx; we don't want to use the original ctx here in case it has been cancelled
+		// reset timeouts with a separate ctx; we don't want to use the original ctx here in case it has been cancelled
 		resetCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		_, err = conn.Exec(resetCtx, "SET statement_timeout=30000")
@@ -135,10 +147,23 @@ func AcquireConnectionWithStatementTimeout(ctx context.Context, pool *pgxpool.Po
 			l.Error().Err(err).Msg("failed to reset statement timeout on released connection")
 		}
 
+		_, err = conn.Exec(resetCtx, "SET idle_in_transaction_session_timeout=30000")
+
+		if err != nil {
+			l.Error().Err(err).Msg("failed to reset idle in transaction timeout on released connection")
+		}
+
 		conn.Release()
 	}
 
 	_, err = conn.Exec(ctx, fmt.Sprintf("SET statement_timeout=%d", timeoutMs))
+
+	if err != nil {
+		release()
+		return nil, nil, err
+	}
+
+	_, err = conn.Exec(ctx, fmt.Sprintf("SET idle_in_transaction_session_timeout=%d", timeoutMs))
 
 	if err != nil {
 		release()

--- a/pkg/repository/tenant.go
+++ b/pkg/repository/tenant.go
@@ -664,8 +664,14 @@ func (r *tenantRepository) UpdateControllerPartitionHeartbeat(ctx context.Contex
 
 	defer sqlchelpers.DeferRollback(ctx, r.l, tx.Rollback)
 
-	// set tx timeout to 5 seconds to avoid deadlocks
+	// set tx timeouts to 5 seconds to avoid deadlocks
 	_, err = tx.Exec(ctx, "SET statement_timeout=5000")
+
+	if err != nil {
+		return "", err
+	}
+
+	_, err = tx.Exec(ctx, "SET idle_in_transaction_session_timeout=5000")
 
 	if err != nil {
 		return "", err
@@ -702,8 +708,14 @@ func (r *tenantRepository) UpdateWorkerPartitionHeartbeat(ctx context.Context, p
 
 	defer sqlchelpers.DeferRollback(ctx, r.l, tx.Rollback)
 
-	// set tx timeout to 5 seconds to avoid deadlocks
+	// set tx timeouts to 5 seconds to avoid deadlocks
 	_, err = tx.Exec(ctx, "SET statement_timeout=5000")
+
+	if err != nil {
+		return "", err
+	}
+
+	_, err = tx.Exec(ctx, "SET idle_in_transaction_session_timeout=5000")
 
 	if err != nil {
 		return "", err
@@ -815,8 +827,14 @@ func (r *tenantRepository) UpdateSchedulerPartitionHeartbeat(ctx context.Context
 
 	defer sqlchelpers.DeferRollback(ctx, r.l, tx.Rollback)
 
-	// set tx timeout to 5 seconds to avoid deadlocks
+	// set tx timeouts to 5 seconds to avoid deadlocks
 	_, err = tx.Exec(ctx, "SET statement_timeout=5000")
+
+	if err != nil {
+		return "", err
+	}
+
+	_, err = tx.Exec(ctx, "SET idle_in_transaction_session_timeout=5000")
 
 	if err != nil {
 		return "", err


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Sets `idle_in_transaction_session_timeout` anywhere we set a PostgreSQL `statement_timeout`, so transactions and pooled connections have consistent idle-in-transaction safeguards. This protects against a potential case on sigkill while queries are in an idle in transaction state.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Pair `idle_in_transaction_session_timeout` with `statement_timeout` in SQL helper transaction and connection timeout paths
- [x] Set idle-in-transaction timeout during database pool connection initialization
- [x] Set idle-in-transaction timeout for tenant partition heartbeat transactions

## Checklist

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)


---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Cursor GPT-5.5 was used to inspect timeout call sites, implement the changes, and draft this PR description.

</details>