### PR TITLE
fix: metering bugs (deadlock, phantom context canceled), deadlocks, and index on StepExpression

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260701180304_v1_0_121.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260701180304_v1_0_121.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "StepExpression_stepId_idx" ON "StepExpression" ("stepId");
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX CONCURRENTLY IF EXISTS "StepExpression_stepId_idx";
+-- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20260701180304_v1_0_121.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260701180304_v1_0_121.sql
@@ -1,3 +1,5 @@
+-- +goose NO TRANSACTION
+
 -- +goose Up
 -- +goose StatementBegin
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "StepExpression_stepId_idx" ON "StepExpression" ("stepId");

--- a/pkg/repository/dispatcher.go
+++ b/pkg/repository/dispatcher.go
@@ -26,8 +26,6 @@ type DispatcherRepository interface {
 	UpdateDispatcher(ctx context.Context, dispatcherId uuid.UUID, opts *UpdateDispatcherOpts) (*sqlcv1.Dispatcher, error)
 
 	Delete(ctx context.Context, dispatcherId uuid.UUID) error
-
-	UpdateStaleDispatchers(ctx context.Context, onStale func(dispatcherId uuid.UUID, getValidDispatcherId func() string) error) error
 }
 
 type dispatcherRepository struct {
@@ -62,49 +60,4 @@ func (d *dispatcherRepository) UpdateDispatcher(ctx context.Context, dispatcherI
 func (d *dispatcherRepository) Delete(ctx context.Context, dispatcherId uuid.UUID) error {
 	_, err := d.queries.DeleteDispatcher(ctx, d.pool, dispatcherId)
 	return err
-}
-
-func (d *dispatcherRepository) UpdateStaleDispatchers(ctx context.Context, onStale func(dispatcherId uuid.UUID, getValidDispatcherId func() string) error) error {
-	tx, err := d.pool.Begin(ctx)
-
-	if err != nil {
-		return err
-	}
-
-	defer sqlchelpers.DeferRollback(context.Background(), d.l, tx.Rollback)
-
-	staleDispatchers, err := d.queries.ListStaleDispatchers(context.Background(), tx)
-
-	if err != nil {
-		return err
-	}
-
-	activeDispatchers, err := d.queries.ListActiveDispatchers(context.Background(), tx)
-
-	if err != nil {
-		return err
-	}
-
-	dispatchersToDelete := make([]uuid.UUID, 0)
-
-	for i, dispatcher := range staleDispatchers {
-		err := onStale(dispatcher.Dispatcher.ID, func() string {
-			// assign tickers in round-robin fashion
-			return activeDispatchers[i%len(activeDispatchers)].Dispatcher.ID.String()
-		})
-
-		if err != nil {
-			return err
-		}
-
-		dispatchersToDelete = append(dispatchersToDelete, dispatcher.Dispatcher.ID)
-	}
-
-	_, err = d.queries.SetDispatchersInactive(context.Background(), tx, dispatchersToDelete)
-
-	if err != nil {
-		return err
-	}
-
-	return tx.Commit(context.Background())
 }

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -874,26 +874,23 @@ func (r *OLAPRepositoryImpl) ListTasks(ctx context.Context, tenantId uuid.UUID, 
 	}
 
 	var (
-		rows     []*sqlcv1.ListTasksOlapRow
-		count    int64
-		countErr error
+		rows  []*sqlcv1.ListTasksOlapRow
+		count int64
 	)
 
 	// A pgx.Tx must not be used concurrently, so we run the count query against the pool.
 	g, gctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		var err error
-		rows, err = r.queries.ListTasksOlap(gctx, tx, params)
-		return err
-	})
-
-	g.Go(func() error {
+		var countErr error
 		count, countErr = r.queries.CountTasks(gctx, r.readPool, countParams)
-		return nil
+
+		return countErr
 	})
 
-	if err := g.Wait(); err != nil {
+	rows, err = r.queries.ListTasksOlap(gctx, tx, params)
+
+	if err != nil {
 		return nil, 0, err
 	}
 
@@ -966,11 +963,11 @@ func (r *OLAPRepositoryImpl) ListTasks(ctx context.Context, tenantId uuid.UUID, 
 		})
 	}
 
-	if countErr != nil {
-		count = int64(len(tasksWithData))
+	if err := commit(ctx); err != nil {
+		return nil, 0, err
 	}
 
-	if err := commit(ctx); err != nil {
+	if err := g.Wait(); err != nil {
 		return nil, 0, err
 	}
 
@@ -1236,14 +1233,14 @@ func (r *OLAPRepositoryImpl) ListWorkflowRuns(ctx context.Context, tenantId uuid
 	var (
 		workflowRunIds []*sqlcv1.FetchWorkflowRunIdsRow
 		count          int64
-		countErr       error
 	)
 
 	// A pgx.Tx must not be used concurrently; run count on the pool in the background while we do tx work.
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
+		var countErr error
 		count, countErr = r.queries.CountWorkflowRuns(gctx, r.readPool, countParams)
-		return nil
+		return countErr
 	})
 
 	workflowRunIds, err = r.queries.FetchWorkflowRunIds(ctx, tx, params)
@@ -1330,11 +1327,6 @@ func (r *OLAPRepositoryImpl) ListWorkflowRuns(ctx context.Context, tenantId uuid
 	// Join the count goroutine before returning.
 	if err := g.Wait(); err != nil {
 		return nil, 0, err
-	}
-
-	if countErr != nil {
-		r.l.Error().Ctx(ctx).Msgf("error counting workflow runs: %v", countErr)
-		count = int64(len(workflowRunIds))
 	}
 
 	externalIdToPayload := make(map[uuid.UUID][]byte)

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -878,17 +878,13 @@ func (r *OLAPRepositoryImpl) ListTasks(ctx context.Context, tenantId uuid.UUID, 
 		count int64
 	)
 
-	// A pgx.Tx must not be used concurrently, so we run the count query against the pool.
-	g, gctx := errgroup.WithContext(ctx)
+	rows, err = r.queries.ListTasksOlap(ctx, tx, params)
 
-	g.Go(func() error {
-		var countErr error
-		count, countErr = r.queries.CountTasks(gctx, r.readPool, countParams)
+	if err != nil {
+		return nil, 0, err
+	}
 
-		return countErr
-	})
-
-	rows, err = r.queries.ListTasksOlap(gctx, tx, params)
+	count, err = r.queries.CountTasks(ctx, tx, countParams)
 
 	if err != nil {
 		return nil, 0, err
@@ -964,10 +960,6 @@ func (r *OLAPRepositoryImpl) ListTasks(ctx context.Context, tenantId uuid.UUID, 
 	}
 
 	if err := commit(ctx); err != nil {
-		return nil, 0, err
-	}
-
-	if err := g.Wait(); err != nil {
 		return nil, 0, err
 	}
 
@@ -1235,15 +1227,12 @@ func (r *OLAPRepositoryImpl) ListWorkflowRuns(ctx context.Context, tenantId uuid
 		count          int64
 	)
 
-	// A pgx.Tx must not be used concurrently; run count on the pool in the background while we do tx work.
-	g, gctx := errgroup.WithContext(ctx)
-	g.Go(func() error {
-		var countErr error
-		count, countErr = r.queries.CountWorkflowRuns(gctx, r.readPool, countParams)
-		return countErr
-	})
-
 	workflowRunIds, err = r.queries.FetchWorkflowRunIds(ctx, tx, params)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	count, err = r.queries.CountWorkflowRuns(ctx, tx, countParams)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -1321,11 +1310,6 @@ func (r *OLAPRepositoryImpl) ListWorkflowRuns(ctx context.Context, tenantId uuid
 	}
 
 	if err := commit(ctx); err != nil {
-		return nil, 0, err
-	}
-
-	// Join the count goroutine before returning.
-	if err := g.Wait(); err != nil {
 		return nil, 0, err
 	}
 

--- a/pkg/repository/scheduler_optimistic.go
+++ b/pkg/repository/scheduler_optimistic.go
@@ -27,7 +27,7 @@ func (r *optimisticSchedulingRepositoryImpl) StartTx(ctx context.Context) (*Opti
 }
 
 func (r *optimisticSchedulingRepositoryImpl) TriggerFromEvents(ctx context.Context, tx *OptimisticTx, tenantId uuid.UUID, opts []EventTriggerOpts) ([]*sqlcv1.V1QueueItem, *TriggerFromEventsResult, error) {
-	pre, post := r.m.Meter(ctx, sqlcv1.LimitResourceEVENT, tenantId, int32(len(opts))) // nolint: gosec
+	pre, post := r.m.Meter(ctx, tx.tx, sqlcv1.LimitResourceEVENT, tenantId, int32(len(opts))) // nolint: gosec
 
 	if err := pre(); err != nil {
 		return nil, nil, err

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -3445,13 +3445,13 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 	stepsToAdditionalMatches := make(map[uuid.UUID][]*sqlcv1.V1StepMatchCondition)
 
 	if len(stepIdsInDAGs) > 0 {
-		additionalMatches, err := r.queries.ListStepMatchConditions(ctx, r.pool, sqlcv1.ListStepMatchConditionsParams{
+		additionalMatches, listErr := r.queries.ListStepMatchConditions(ctx, tx, sqlcv1.ListStepMatchConditionsParams{
 			Stepids:  listutils.Uniq(stepIdsInDAGs),
 			Tenantid: tenantId,
 		})
 
-		if err != nil {
-			return nil, fmt.Errorf("failed to list step match conditions: %w", err)
+		if listErr != nil {
+			return nil, fmt.Errorf("failed to list step match conditions: %w", listErr)
 		}
 
 		for _, match := range additionalMatches {

--- a/pkg/repository/tenant_limit.go
+++ b/pkg/repository/tenant_limit.go
@@ -39,7 +39,7 @@ type TenantLimitRepository interface {
 
 	DefaultLimits() []Limit
 
-	Meter(ctx context.Context, resource sqlcv1.LimitResource, tenantId uuid.UUID, numberOfResources int32) (precommit func() error, postcommit func())
+	Meter(ctx context.Context, dbtx sqlcv1.DBTX, resource sqlcv1.LimitResource, tenantId uuid.UUID, numberOfResources int32) (precommit func() error, postcommit func())
 
 	Stop()
 }
@@ -150,11 +150,19 @@ func (t *tenantLimitRepository) GetLimits(ctx context.Context, tenantId uuid.UUI
 }
 
 func (t *tenantLimitRepository) CanCreate(ctx context.Context, resource sqlcv1.LimitResource, tenantId uuid.UUID, numberOfResources int32) (bool, int, error) {
+	return t.canCreate(ctx, nil, resource, tenantId, numberOfResources)
+}
+
+func (t *tenantLimitRepository) canCreate(ctx context.Context, dbtx sqlcv1.DBTX, resource sqlcv1.LimitResource, tenantId uuid.UUID, numberOfResources int32) (bool, int, error) {
 	if !t.enforceLimits {
 		return true, 0, nil
 	}
 
-	limit, err := t.queries.GetTenantResourceLimit(ctx, t.pool, sqlcv1.GetTenantResourceLimitParams{
+	if dbtx == nil {
+		dbtx = t.pool
+	}
+
+	limit, err := t.queries.GetTenantResourceLimit(ctx, dbtx, sqlcv1.GetTenantResourceLimitParams{
 		Tenantid: tenantId,
 		Resource: sqlcv1.NullLimitResource{
 			LimitResource: resource,
@@ -165,7 +173,7 @@ func (t *tenantLimitRepository) CanCreate(ctx context.Context, resource sqlcv1.L
 	if err != nil && errors.Is(err, pgx.ErrNoRows) {
 		t.l.Warn().Ctx(ctx).Msgf("no %s tenant limit found, creating default limit", string(resource))
 
-		err = t.UpdateLimits(ctx, tenantId, t.DefaultLimits())
+		err = t.updateLimits(ctx, dbtx, tenantId, t.DefaultLimits())
 
 		if err != nil {
 			return false, 0, err
@@ -180,7 +188,7 @@ func (t *tenantLimitRepository) CanCreate(ctx context.Context, resource sqlcv1.L
 
 	// patch custom worker limits aggregate methods
 	if resource == sqlcv1.LimitResourceWORKER {
-		count, err := t.queries.CountTenantWorkers(ctx, t.pool, tenantId)
+		count, err := t.queries.CountTenantWorkers(ctx, dbtx, tenantId)
 		value = int32(count) // nolint: gosec
 
 		if err != nil {
@@ -222,7 +230,7 @@ func (t *tenantLimitRepository) saveMeter(ctx context.Context, resource sqlcv1.L
 	return r, nil
 }
 
-func (t *tenantLimitRepository) cachedCanCreate(ctx context.Context, resource sqlcv1.LimitResource, tenantId uuid.UUID, numberOfResources int32) (bool, int, error) {
+func (t *tenantLimitRepository) cachedCanCreate(ctx context.Context, dbtx sqlcv1.DBTX, resource sqlcv1.LimitResource, tenantId uuid.UUID, numberOfResources int32) (bool, int, error) {
 	var key = fmt.Sprintf("%s:%s", resource, tenantId)
 
 	var canCreate *bool
@@ -234,7 +242,7 @@ func (t *tenantLimitRepository) cachedCanCreate(ctx context.Context, resource sq
 	}
 
 	if canCreate == nil {
-		c, p, err := t.CanCreate(ctx, resource, tenantId, numberOfResources)
+		c, p, err := t.canCreate(ctx, dbtx, resource, tenantId, numberOfResources)
 
 		if err != nil {
 			return false, 0, fmt.Errorf("could not check tenant limit: %w", err)
@@ -251,9 +259,9 @@ func (t *tenantLimitRepository) cachedCanCreate(ctx context.Context, resource sq
 	return *canCreate, percent, nil
 }
 
-func (t *tenantLimitRepository) Meter(ctx context.Context, resource sqlcv1.LimitResource, tenantId uuid.UUID, numberOfResources int32) (precommit func() error, postcommit func()) {
+func (t *tenantLimitRepository) Meter(ctx context.Context, dbtx sqlcv1.DBTX, resource sqlcv1.LimitResource, tenantId uuid.UUID, numberOfResources int32) (precommit func() error, postcommit func()) {
 	return func() error {
-			canCreate, _, err := t.cachedCanCreate(ctx, resource, tenantId, numberOfResources)
+			canCreate, _, err := t.cachedCanCreate(ctx, dbtx, resource, tenantId, numberOfResources)
 
 			if err != nil {
 				return fmt.Errorf("could not check tenant limit: %w", err)
@@ -265,14 +273,17 @@ func (t *tenantLimitRepository) Meter(ctx context.Context, resource sqlcv1.Limit
 
 			return nil
 		}, func() {
-			_, percent, err := t.cachedCanCreate(ctx, resource, tenantId, numberOfResources)
+			postCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Second)
+			defer cancel()
+
+			_, percent, err := t.cachedCanCreate(postCtx, nil, resource, tenantId, numberOfResources)
 
 			if err != nil {
-				t.l.Error().Ctx(ctx).Err(err).Msg("could not check tenant limit")
+				t.l.Error().Ctx(postCtx).Err(err).Msg("could not check tenant limit")
 				return
 			}
 
-			limit, err := t.saveMeter(ctx, resource, tenantId, numberOfResources)
+			limit, err := t.saveMeter(postCtx, resource, tenantId, numberOfResources)
 
 			if limit != nil && (percent <= 50 || percent >= 100) {
 				var key = fmt.Sprintf("%s:%s", resource, tenantId)
@@ -280,14 +291,22 @@ func (t *tenantLimitRepository) Meter(ctx context.Context, resource sqlcv1.Limit
 			}
 
 			if err != nil {
-				t.l.Error().Ctx(ctx).Err(err).Msg("could not meter resource")
+				t.l.Error().Ctx(postCtx).Err(err).Msg("could not meter resource")
 			}
 		}
 }
 
 func (t *tenantLimitRepository) UpdateLimits(ctx context.Context, tenantId uuid.UUID, limits []Limit) error {
+	return t.updateLimits(ctx, nil, tenantId, limits)
+}
+
+func (t *tenantLimitRepository) updateLimits(ctx context.Context, dbtx sqlcv1.DBTX, tenantId uuid.UUID, limits []Limit) error {
 	if len(limits) == 0 {
 		return nil
+	}
+
+	if dbtx == nil {
+		dbtx = t.pool
 	}
 
 	resources := make([]string, len(limits))
@@ -312,7 +331,7 @@ func (t *tenantLimitRepository) UpdateLimits(ctx context.Context, tenantId uuid.
 		}
 	}
 
-	return t.queries.UpsertTenantResourceLimits(ctx, t.pool, sqlcv1.UpsertTenantResourceLimitsParams{
+	return t.queries.UpsertTenantResourceLimits(ctx, dbtx, sqlcv1.UpsertTenantResourceLimitsParams{
 		Tenantid:          tenantId,
 		Resources:         resources,
 		Limitvalues:       limitValues,

--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -275,7 +275,7 @@ type WorkflowAndScope struct {
 }
 
 func (r *TriggerRepositoryImpl) TriggerFromEvents(ctx context.Context, tenantId uuid.UUID, opts []EventTriggerOpts) (*TriggerFromEventsResult, error) {
-	pre, post := r.m.Meter(ctx, sqlcv1.LimitResourceEVENT, tenantId, int32(len(opts))) // nolint: gosec
+	pre, post := r.m.Meter(ctx, nil, sqlcv1.LimitResourceEVENT, tenantId, int32(len(opts))) // nolint: gosec
 
 	if err := pre(); err != nil {
 		return nil, err
@@ -662,7 +662,7 @@ func (r *sharedRepository) triggerWorkflows(
 		countTasks += len(steps)
 	}
 
-	preTask, postTask := r.m.Meter(ctx, sqlcv1.LimitResourceTASKRUN, tenantId, int32(countTasks)) // nolint: gosec
+	preTask, postTask := r.m.Meter(ctx, preflightTx, sqlcv1.LimitResourceTASKRUN, tenantId, int32(countTasks)) // nolint: gosec
 
 	if err := preTask(); err != nil {
 		return nil, nil, err

--- a/pkg/repository/worker.go
+++ b/pkg/repository/worker.go
@@ -508,7 +508,7 @@ func hashActions(actions []string) []byte {
 }
 
 func (w *workerRepository) CreateNewWorker(ctx context.Context, tenantId uuid.UUID, opts *CreateWorkerOpts) (*sqlcv1.Worker, error) {
-	preWorker, postWorker := w.m.Meter(ctx, sqlcv1.LimitResourceWORKER, tenantId, 1)
+	preWorker, postWorker := w.m.Meter(ctx, nil, sqlcv1.LimitResourceWORKER, tenantId, 1)
 
 	if err := preWorker(); err != nil {
 		return nil, err
@@ -521,7 +521,7 @@ func (w *workerRepository) CreateNewWorker(ctx context.Context, tenantId uuid.UU
 		slots += units
 	}
 
-	preWorkerSlot, postWorkerSlot := w.m.Meter(ctx, sqlcv1.LimitResourceWORKERSLOT, tenantId, slots)
+	preWorkerSlot, postWorkerSlot := w.m.Meter(ctx, nil, sqlcv1.LimitResourceWORKERSLOT, tenantId, slots)
 
 	if err := preWorkerSlot(); err != nil {
 		return nil, err

--- a/sql/schema/v0.sql
+++ b/sql/schema/v0.sql
@@ -485,6 +485,8 @@ CREATE TABLE "StepExpression" (
     CONSTRAINT "StepExpression_pkey" PRIMARY KEY ("key","stepId","kind")
 );
 
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "StepExpression_stepId_idx" ON "StepExpression" ("stepId");
+
 -- CreateTable
 CREATE TABLE "StepRateLimit" (
     "units" INTEGER NOT NULL,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Fixes several engine-side bugs:
1. On the workflow trigger path, we risk deadlocking when we call `Meter` without a cached result, since we acquire a new connection from the pool if we miss the cache.
2. On `ReplayTasks`, `ListStepMatchConditions` was not using the existing tx
3. On the OLAP side, `ListTasks` was incorrectly running two goroutines, one which acquired a new connection from the `readPool` and the other which used the existing tx, and then waiting for the goroutines inside of the existing tx, which is a deadlock risk. This changes the behavior to match `ListWorkflowRuns`, and also changes the behavior of both methods so that failing to count results in an error.
4. Adds an index to `StepExpression` so that we can directly look these up by `stepId`, which was causing unexpectedly high triggering times.
5. Constructs a separate context for the postcommit hook after metering to avoid phantom `context canceled` statements appearing in the logs.  

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## What's Changed

See above. 

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Tested (unit, integration, or manually with steps specified)
- [X] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [X] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude for debugging and light implementation (particularly on the postcommit hooks)

</details>
