### PR TITLE
fix: process concurrency slot updates in in-memory concurrency index

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260701211847_v1_0_122.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260701211847_v1_0_122.sql
@@ -1,0 +1,39 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION after_v1_concurrency_slot_update_outbox_function()
+RETURNS trigger AS $$
+BEGIN
+    INSERT INTO outbox.messages (topic, payload)
+    SELECT
+        'concurrency.' || nt.tenant_id::text || '.' || nt.strategy_id::text,
+        jsonb_build_object(
+            'operation', 'UPDATE',
+            'key', nt.key,
+            'priority', nt.priority,
+            'taskId', nt.task_id,
+            'taskInsertedAt', nt.task_inserted_at,
+            'taskRetryCount', nt.task_retry_count,
+            'scheduleTimeoutAtMs', (EXTRACT(EPOCH FROM nt.schedule_timeout_at) * 1000)::bigint,
+            'isFilled', nt.is_filled
+        )
+    FROM new_table nt
+    JOIN v1_step_concurrency sc ON sc.id = nt.strategy_id
+    WHERE sc.parent_strategy_id IS NULL
+        AND nt.is_filled = FALSE;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER after_v1_concurrency_slot_update_outbox
+AFTER UPDATE ON v1_concurrency_slot
+REFERENCING NEW TABLE AS new_table
+FOR EACH STATEMENT
+EXECUTE FUNCTION after_v1_concurrency_slot_update_outbox_function();
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS after_v1_concurrency_slot_update_outbox ON v1_concurrency_slot;
+DROP FUNCTION IF EXISTS after_v1_concurrency_slot_update_outbox_function();
+-- +goose StatementEnd

--- a/pkg/scheduling/v1/concurrency/strategy.go
+++ b/pkg/scheduling/v1/concurrency/strategy.go
@@ -595,7 +595,7 @@ func applyWAL(sq *subQueue, msgs []walMessage) []slot {
 
 	for _, msg := range msgs {
 		switch msg.Operation {
-		case "INSERT", "UPDATE":
+		case "INSERT":
 			if currentRunningSlot, exists := sq.running.get(msg.TaskId); exists {
 				// compare the current running slot's retry count with the message's retry count; the greater wins
 				if currentRunningSlot.taskRetryCount < msg.TaskRetryCount {
@@ -603,11 +603,7 @@ func applyWAL(sq *subQueue, msgs []walMessage) []slot {
 					sq.running.delete(msg.TaskId)
 
 					// place the new slot in the queued index, so it goes through the regular promotion pipeline
-					if !msg.IsFilled {
-						sq.queued.insert(walMessageToSlot(msg))
-					} else {
-						sq.running.insert(walMessageToSlot(msg))
-					}
+					sq.queued.insert(walMessageToSlot(msg))
 				} else if currentRunningSlot.taskRetryCount != msg.TaskRetryCount {
 					superseded = append(superseded, walMessageToSlot(msg))
 				}
@@ -622,6 +618,19 @@ func applyWAL(sq *subQueue, msgs []walMessage) []slot {
 				}
 			} else {
 				sq.queued.insert(walMessageToSlot(msg))
+			}
+		case "UPDATE":
+			// UPDATE never represents a duplicate row - it's the same physical v1_concurrency_slot row
+			// being resynced in place (a retry-reset: task_retry_count/schedule_timeout_at/priority
+			// changed, is_filled reset to FALSE). Unlike INSERT, nothing is ever superseded/cancelled
+			// here - just move the slot into whichever index matches msg.IsFilled.
+			newSlot := walMessageToSlot(msg)
+			if msg.IsFilled {
+				sq.queued.delete(msg.TaskId)
+				sq.running.insert(newSlot)
+			} else {
+				sq.running.delete(msg.TaskId)
+				sq.queued.insert(newSlot)
 			}
 		case "DELETE":
 			// note: since we're processing a DELETE, it's already been removed from the database, we're just

--- a/pkg/scheduling/v1/concurrency/strategy.go
+++ b/pkg/scheduling/v1/concurrency/strategy.go
@@ -407,6 +407,9 @@ type walMessage struct {
 	ScheduleTimeoutAtMs int64     `json:"scheduleTimeoutAtMs"`
 	Priority            int32     `json:"priority"`
 	TaskRetryCount      int32     `json:"taskRetryCount"`
+
+	// only populated by UPDATE messages
+	IsFilled bool `json:"isFilled"`
 }
 
 func (c *ConcurrencyStrategy) buildIndex(ctx context.Context) error {
@@ -592,13 +595,19 @@ func applyWAL(sq *subQueue, msgs []walMessage) []slot {
 
 	for _, msg := range msgs {
 		switch msg.Operation {
-		case "INSERT":
+		case "INSERT", "UPDATE":
 			if currentRunningSlot, exists := sq.running.get(msg.TaskId); exists {
 				// compare the current running slot's retry count with the message's retry count; the greater wins
 				if currentRunningSlot.taskRetryCount < msg.TaskRetryCount {
 					superseded = append(superseded, currentRunningSlot)
 					sq.running.delete(msg.TaskId)
-					sq.running.insert(walMessageToSlot(msg))
+
+					// place the new slot in the queued index, so it goes through the regular promotion pipeline
+					if !msg.IsFilled {
+						sq.queued.insert(walMessageToSlot(msg))
+					} else {
+						sq.running.insert(walMessageToSlot(msg))
+					}
 				} else if currentRunningSlot.taskRetryCount != msg.TaskRetryCount {
 					superseded = append(superseded, walMessageToSlot(msg))
 				}

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -2526,3 +2526,34 @@ AFTER DELETE ON v1_concurrency_slot
 REFERENCING OLD TABLE AS deleted_rows
 FOR EACH STATEMENT
 EXECUTE FUNCTION after_v1_concurrency_slot_delete_outbox_function();
+
+CREATE OR REPLACE FUNCTION after_v1_concurrency_slot_update_outbox_function()
+RETURNS trigger AS $$
+BEGIN
+    INSERT INTO outbox.messages (topic, payload)
+    SELECT
+        'concurrency.' || nt.tenant_id::text || '.' || nt.strategy_id::text,
+        jsonb_build_object(
+            'operation', 'UPDATE',
+            'key', nt.key,
+            'priority', nt.priority,
+            'taskId', nt.task_id,
+            'taskInsertedAt', nt.task_inserted_at,
+            'taskRetryCount', nt.task_retry_count,
+            'scheduleTimeoutAtMs', (EXTRACT(EPOCH FROM nt.schedule_timeout_at) * 1000)::bigint,
+            'isFilled', nt.is_filled
+        )
+    FROM new_table nt
+    JOIN v1_step_concurrency sc ON sc.id = nt.strategy_id
+    WHERE sc.parent_strategy_id IS NULL
+        AND nt.is_filled = FALSE;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER after_v1_concurrency_slot_update_outbox
+AFTER UPDATE ON v1_concurrency_slot
+REFERENCING NEW TABLE AS new_table
+FOR EACH STATEMENT
+EXECUTE FUNCTION after_v1_concurrency_slot_update_outbox_function();


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Fixes an issue where reassignments or timeouts would lead to stuck concurrency slots in the new (feature-flagged) in-memory index.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [X] New trigger on concurrency updates, which is gated on `is_filled = FALSE` so that we don't double-process each update coming from the concurrency queue. 
- [X] Small update to the strategy to process these UPDATE messages

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Tested (unit, integration, or manually with steps specified) - manual with repro
- [X] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [X] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude for implementation, manually tested 

</details>
