### PR TITLE
feat: ping the security endpoint every hour

### DIFF
--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -544,6 +544,8 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 		alerter = errors.NoOpAlerter{}
 	}
 
+	cleanupSecurityCheck := func() {}
+
 	if cf.SecurityCheck.Enabled {
 		securityCheck := security.NewSecurityCheck(&security.DefaultSecurityCheck{
 			Enabled:  cf.SecurityCheck.Enabled,
@@ -552,7 +554,10 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 			Version:  version,
 		}, dc.V1.SecurityCheck())
 
-		go securityCheck.Check()
+		securityCheckCtx, cancel := context.WithCancel(context.Background())
+		cleanupSecurityCheck = cancel
+
+		go securityCheck.Start(securityCheckCtx)
 	}
 
 	var analyticsEmitter analytics.Analytics
@@ -789,6 +794,8 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 
 	cleanup = func() error {
 		log.Printf("cleaning up server config")
+
+		cleanupSecurityCheck()
 
 		cleanupConcurrencyOutbox()
 

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -12,8 +12,11 @@ import (
 	"github.com/rs/zerolog"
 )
 
+const checkInterval = time.Hour
+
 type SecurityCheck interface {
 	Check()
+	Start(ctx context.Context)
 }
 
 type DefaultSecurityCheck struct {
@@ -31,6 +34,27 @@ func NewSecurityCheck(opts *DefaultSecurityCheck, repo v1.SecurityCheckRepositor
 		Logger:   opts.Logger,
 		Version:  opts.Version,
 		Repo:     repo,
+	}
+}
+
+// Start runs an initial check, then repeats every checkInterval until ctx is cancelled.
+func (a DefaultSecurityCheck) Start(ctx context.Context) {
+	if !a.Enabled {
+		return
+	}
+
+	a.Check()
+
+	ticker := time.NewTicker(checkInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			a.Check()
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

This adds a ticker based ping to the security endpoint every hour.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## What's Changed

- [x] Add ticker based ping to the security endpoint each hour

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
