### PR TITLE
chore: improve pgx applicaiton name

### DIFF
--- a/pkg/config/database/config.go
+++ b/pkg/config/database/config.go
@@ -39,6 +39,11 @@ type ConfigFile struct {
 	MaxConnLifetime time.Duration `mapstructure:"maxConnLifetime" json:"maxConnLifetime,omitempty" default:"15m"`
 	MaxConnIdleTime time.Duration `mapstructure:"maxConnIdleTime" json:"maxConnIdleTime,omitempty" default:"1m"`
 
+	// ApplicationNamePrefix is prepended to the pgx application_name as "<prefix>:<otel service name>"
+	// so connections in pg_stat_activity can be attributed to a deployment. In Kubernetes this is
+	// populated with the pod namespace via the downward API (K8S_POD_NAMESPACE).
+	ApplicationNamePrefix string `mapstructure:"applicationNamePrefix" json:"applicationNamePrefix,omitempty" default:""`
+
 	Seed SeedConfigFile `mapstructure:"seed" json:"seed,omitempty"`
 
 	Logger shared.LoggerConfigFile `mapstructure:"logger" json:"logger,omitempty"`
@@ -95,6 +100,7 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("minQueueConns", "DATABASE_MIN_QUEUE_CONNS")
 	_ = v.BindEnv("maxConnLifetime", "DATABASE_MAX_CONN_LIFETIME")
 	_ = v.BindEnv("maxConnIdleTime", "DATABASE_MAX_CONN_IDLE_TIME")
+	_ = v.BindEnv("applicationNamePrefix", "K8S_POD_NAMESPACE")
 
 	_ = v.BindEnv("pgbouncerUrl", "DATABASE_PGBOUNCER_URL")
 	_ = v.BindEnv("ddlPoolMaxConns", "DATABASE_DDL_POOL_MAX_CONNS")

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -210,10 +210,20 @@ func (c *ConfigLoader) InitDataLayer() (res *database.Layer, err error) {
 		l.Info().Msgf("main pool will connect through pgbouncer")
 	}
 
+	// application_name shows up in pg_stat_activity, letting us attribute connections
+	// and idle transactions to a specific service (and shard namespace) on shared
+	// postgres instances.
+	appName := scf.OpenTelemetry.ServiceName
+	if cf.ApplicationNamePrefix != "" {
+		appName = cf.ApplicationNamePrefix + ":" + appName
+	}
+
 	config, err := pgxpool.ParseConfig(mainPoolUrl)
 	if err != nil {
 		return nil, err
 	}
+
+	setPgxApplicationName(config, appName)
 
 	config.AfterConnect = pgxpoolConnAfterConnect
 
@@ -279,6 +289,8 @@ func (c *ConfigLoader) InitDataLayer() (res *database.Layer, err error) {
 			return nil, fmt.Errorf("could not parse read replica database url: %w", err)
 		}
 
+		setPgxApplicationName(readReplicaConfig, appName+":read-replica")
+
 		if cf.ReadReplicaMaxConns != 0 {
 			readReplicaConfig.MaxConns = int32(cf.ReadReplicaMaxConns) // nolint: gosec
 		}
@@ -314,6 +326,8 @@ func (c *ConfigLoader) InitDataLayer() (res *database.Layer, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not parse direct database url: %w", err)
 	}
+
+	setPgxApplicationName(ddlConfig, appName+":ddl")
 
 	ddlConfig.MaxConns = int32(cf.DDLPoolMaxConns) // nolint: gosec
 	ddlConfig.MinConns = int32(cf.DDLPoolMinConns) // nolint: gosec
@@ -1058,6 +1072,16 @@ func checkDatabaseTimezone(connConfig *pgx.ConnConfig, dbName string, dbLabel st
 
 	l.Info().Msgf("%s instance timezone verified: %s", dbLabel, dbTimezone)
 	return nil
+}
+
+// setPgxApplicationName sets application_name on the pool config unless the
+// connection string already provided one explicitly.
+func setPgxApplicationName(config *pgxpool.Config, appName string) {
+	if config.ConnConfig.RuntimeParams["application_name"] != "" {
+		return
+	}
+
+	config.ConnConfig.RuntimeParams["application_name"] = appName
 }
 
 func newOTelPgxTracer() *otelpgx.Tracer {


### PR DESCRIPTION
# Description

Sets the postgres `application_name` on all pgx pools created by the config loader (main, read-replica, and DDL pools) so that connections and idle transactions in `pg_stat_activity` can be attributed to a specific service and deployment on shared postgres instances.

Previously, all engine services (api, engine, controllers, scheduler, worker) connected with no `application_name`, making it impossible to pinpoint which service was consuming connections or holding idle transactions when investigating connection pressure on a shard's database.

The name is built as `<applicationNamePrefix>:<otel service name>` (e.g. `cloud-shard-4:hatchet_scheduler`), with `:read-replica` and `:ddl` suffixes to distinguish the secondary pools. The prefix is a new `applicationNamePrefix` field on the database config file, bound to the `K8S_POD_NAMESPACE` env var — which is already injected by the Helm chart via the downward API, so no infra changes are required. An `application_name` provided explicitly in the connection string takes precedence and is never overridden.

Connections can then be broken down with:

```sql
SELECT application_name, state, count(*)
FROM pg_stat_activity
GROUP BY 1, 2
ORDER BY 3 DESC;
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## What's Changed

- [x] Added `ApplicationNamePrefix` to `database.ConfigFile` (`applicationNamePrefix`), bound to `K8S_POD_NAMESPACE`
- [x] Set `application_name` on the main pool as `<prefix>:<otel service name>` in `InitDataLayer`
- [x] Set `application_name` on the read-replica pool with a `:read-replica` suffix
- [x] Set `application_name` on the DDL pool with a `:ddl` suffix
- [x] Added `setPgxApplicationName` helper that preserves an `application_name` already present in the connection string

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Implementation and PR description written with Cursor (Fable 5), reviewed by a human.

</details>