### PR TITLE
feat: enhancements to deliver more structured security updates

### DIFF
--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -547,11 +547,21 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 	cleanupSecurityCheck := func() {}
 
 	if cf.SecurityCheck.Enabled {
+		var oauthProviders []string
+		if cf.Auth.Google.Enabled {
+			oauthProviders = append(oauthProviders, "google")
+		}
+		if cf.Auth.Github.Enabled {
+			oauthProviders = append(oauthProviders, "github")
+		}
+
 		securityCheck := security.NewSecurityCheck(&security.DefaultSecurityCheck{
-			Enabled:  cf.SecurityCheck.Enabled,
-			Endpoint: cf.SecurityCheck.Endpoint,
-			Logger:   &l,
-			Version:  version,
+			Enabled:        cf.SecurityCheck.Enabled,
+			Endpoint:       cf.SecurityCheck.Endpoint,
+			Logger:         &l,
+			Version:        version,
+			MQKind:         cf.MessageQueue.Kind,
+			OAuthProviders: oauthProviders,
 		}, dc.V1.SecurityCheck())
 
 		securityCheckCtx, cancel := context.WithCancel(context.Background())

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -565,7 +565,10 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 		}, dc.V1.SecurityCheck())
 
 		securityCheckCtx, cancel := context.WithCancel(context.Background())
-		cleanupSecurityCheck = cancel
+		cleanupSecurityCheck = func() {
+			cancel()
+			securityCheck.Shutdown()
+		}
 
 		go securityCheck.Start(securityCheckCtx)
 	}

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -5,6 +5,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	v1 "github.com/hatchet-dev/hatchet/pkg/repository"
@@ -25,19 +29,46 @@ type DefaultSecurityCheck struct {
 	Logger   *zerolog.Logger
 	Version  string
 	Repo     v1.SecurityCheckRepository
+
+	MQKind         string
+	OAuthProviders []string
+
+	startTime time.Time
 }
 
 func NewSecurityCheck(opts *DefaultSecurityCheck, repo v1.SecurityCheckRepository) SecurityCheck {
 	return DefaultSecurityCheck{
-		Enabled:  opts.Enabled,
-		Endpoint: opts.Endpoint,
-		Logger:   opts.Logger,
-		Version:  opts.Version,
-		Repo:     repo,
+		Enabled:        opts.Enabled,
+		Endpoint:       opts.Endpoint,
+		Logger:         opts.Logger,
+		Version:        opts.Version,
+		Repo:           repo,
+		MQKind:         opts.MQKind,
+		OAuthProviders: opts.OAuthProviders,
+		startTime:      time.Now(),
 	}
 }
 
-// Start runs an initial check, then repeats every checkInterval until ctx is cancelled.
+func detectEnvironment() string {
+	switch {
+	case os.Getenv("GITHUB_ACTIONS") == "true":
+		return "github_actions"
+	case os.Getenv("CI") != "":
+		return "ci"
+	case os.Getenv("KUBERNETES_SERVICE_HOST") != "":
+		return "kubernetes"
+	case dockerEnv():
+		return "docker"
+	default:
+		return "unknown"
+	}
+}
+
+func dockerEnv() bool {
+	_, err := os.Stat("/.dockerenv")
+	return err == nil
+}
+
 func (a DefaultSecurityCheck) Start(ctx context.Context) {
 	if !a.Enabled {
 		return
@@ -80,7 +111,19 @@ func (a DefaultSecurityCheck) Check() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	reqURL := fmt.Sprintf("%s/check?version=%s&tag=%s", a.Endpoint, a.Version, ident)
+	params := url.Values{}
+	params.Set("version", a.Version)
+	params.Set("tag", ident)
+	params.Set("uptime_seconds", strconv.FormatInt(int64(time.Since(a.startTime).Seconds()), 10))
+	params.Set("environment", detectEnvironment())
+	if a.MQKind != "" {
+		params.Set("mq_kind", a.MQKind)
+	}
+	if len(a.OAuthProviders) > 0 {
+		params.Set("oauth_providers", strings.Join(a.OAuthProviders, ","))
+	}
+
+	reqURL := fmt.Sprintf("%s/check?%s", a.Endpoint, params.Encode())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		a.Logger.Debug().Msgf("Error creating security check request: %s", err)

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -21,6 +21,7 @@ const checkInterval = time.Hour
 type SecurityCheck interface {
 	Check()
 	Start(ctx context.Context)
+	Shutdown()
 }
 
 type DefaultSecurityCheck struct {
@@ -90,6 +91,14 @@ func (a DefaultSecurityCheck) Start(ctx context.Context) {
 }
 
 func (a DefaultSecurityCheck) Check() {
+	a.report(5 * time.Second)
+}
+
+func (a DefaultSecurityCheck) Shutdown() {
+	a.report(1 * time.Second)
+}
+
+func (a DefaultSecurityCheck) report(timeout time.Duration) {
 	if !a.Enabled {
 		return
 	}
@@ -108,7 +117,7 @@ func (a DefaultSecurityCheck) Check() {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	params := url.Values{}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

This PR adds the ability to make the security endpoint more aware of the environment the Hatchet instance is running on in order to provide more contextual security updates when applicable.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## What's Changed

- [x] Add uptime, mq_kind, and oauth_providers info
- [x] Try sending a security ping right before graceful shutdown

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
