### PR TITLE
fix: `loopReplenish` lock contention with `tryAssignBatch`

### DIFF
--- a/pkg/scheduling/v1/scheduler.go
+++ b/pkg/scheduling/v1/scheduler.go
@@ -514,7 +514,7 @@ func (s *Scheduler) replenish(ctx context.Context, mustReplenish bool) error {
 }
 
 func (s *Scheduler) loopReplenish(ctx context.Context) {
-	ticker := time.NewTicker(1 * time.Second)
+	ticker := randomticker.NewRandomTicker(1000*time.Millisecond, 1500*time.Millisecond)
 	defer ticker.Stop()
 
 	for {

--- a/pkg/scheduling/v1/scheduler_test.go
+++ b/pkg/scheduling/v1/scheduler_test.go
@@ -5,6 +5,7 @@ package v1
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -555,6 +556,75 @@ func TestScheduler_Replenish_DoesNotLockUnackedMuBeforeActionLocks(t *testing.T)
 	case <-time.After(2 * time.Second):
 		t.Fatalf("timed out waiting for replenish to complete (possible deadlock)")
 	}
+}
+
+func TestScheduler_TryAssign_NotStarvedByRepeatedReplenishTimeouts(t *testing.T) {
+	tenantId := uuid.New()
+	workerId := uuid.New()
+
+	ar := &mockAssignmentRepo{
+		listActionsForWorkersFn: func(ctx context.Context, tenantId uuid.UUID, workerIds []uuid.UUID) ([]*sqlcv1.ListActionsForWorkersRow, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	s := newTestScheduler(t, tenantId, ar)
+	s.setWorkers([]*repo.ListActiveWorkersResult{testWorker(workerId)})
+
+	const (
+		assignBudget = 2100 * time.Millisecond // no more than one lost replenish cycle
+		numProbers   = 64
+		probeFor     = 10 * time.Second
+	)
+	qis := []*sqlcv1.V1QueueItem{testQI(tenantId, "missing", 1)}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	loopDone := make(chan struct{})
+	go func() {
+		defer close(loopDone)
+		s.loopReplenish(ctx)
+	}()
+	time.Sleep(1100 * time.Millisecond)
+
+	// A single sequential prober always loses the race to reacquire actionsMu against
+	// an immediately-relocking writer, so it only ever observes one lost cycle. Many
+	// concurrent probers, as in production with many actions/queue items in flight,
+	// give some of them a chance to lose the race across multiple consecutive cycles.
+	probeCtx, stopProbing := context.WithTimeout(context.Background(), probeFor)
+	defer stopProbing()
+
+	var (
+		mu         sync.Mutex
+		maxLatency time.Duration
+		wg         sync.WaitGroup
+	)
+
+	for i := 0; i < numProbers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for probeCtx.Err() == nil {
+				start := time.Now()
+				_, _, _ = s.tryAssignBatch(context.Background(), "missing", qis, 0, nil, nil, nil, nil)
+				d := time.Since(start)
+
+				mu.Lock()
+				if d > maxLatency {
+					maxLatency = d
+				}
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	cancel()
+	<-loopDone
+
+	t.Logf("max latency observed: %s", maxLatency)
+	require.LessOrEqual(t, maxLatency, assignBudget,
+		"tryAssignBatch was starved by repeated replenish timeouts: max latency %s", maxLatency)
 }
 
 func TestScheduler_TryAssignBatch_AssignsUntilExhausted(t *testing.T) {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

`loopReplenish` had a fixed 1 second loop interval, with a 2 second timeout in case of query timeout. This was causing issues because `loopQueue` also has a 1 second fixed loop interval, which calls `tryAssign` which calls `tryAssignBatch`, which would cause heavy lock contention under load, leading to `loopReplenish` often winning the race and causing consecutive 2 second delays for `tryAssignBatch`. This PR fixes that by making `loopReplenish` have a randomized loop interval between 1 and 1.5 seconds.


Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

Claude, generating test.

</details>
