### PR TITLE
fix: jitter queue polls with inactive backoff

### DIFF
--- a/pkg/scheduling/v1/queuer.go
+++ b/pkg/scheduling/v1/queuer.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"context"
 	"encoding/json"
+	"math/rand/v2"
 	"sort"
 	"sync"
 	"time"
@@ -14,6 +15,19 @@ import (
 	v1 "github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 	"github.com/hatchet-dev/hatchet/pkg/telemetry"
+)
+
+const (
+	// queuePollInterval is the base polling interval for a queue loop.
+	queuePollInterval = 1 * time.Second
+
+	// emptyPollsBeforeBackoff is the number of consecutive polls which return no queue items
+	// before the loop starts backing off. Enqueues wake the loop immediately via notifyQueueCh,
+	// so backing off only delays polls of queues with no work.
+	emptyPollsBeforeBackoff = 3
+
+	// maxQueuePollInterval caps the backed-off polling interval.
+	maxQueuePollInterval = 30 * time.Second
 )
 
 type Queuer struct {
@@ -49,6 +63,36 @@ type Queuer struct {
 	unassignedMu mutex
 
 	hasRateLimits bool
+
+	// consecutiveEmptyPolls counts loop iterations whose refill returned no items. It is only
+	// accessed from the loopQueue goroutine.
+	consecutiveEmptyPolls int
+}
+
+// nextPollInterval returns the duration until the next poll of the queue. The interval doubles
+// for every consecutive empty poll beyond emptyPollsBeforeBackoff (capped at
+// maxQueuePollInterval), and always includes up to 50% random jitter. Jitter prevents queue
+// loops created in the same batch (e.g. on lease acquisition or after a cron sweep touches many
+// queues at once) from staying phase-locked and stampeding the connection pool in bursts.
+func (q *Queuer) nextPollInterval() time.Duration {
+	interval := queuePollInterval
+
+	if q.consecutiveEmptyPolls > emptyPollsBeforeBackoff {
+		shift := q.consecutiveEmptyPolls - emptyPollsBeforeBackoff
+
+		// 2^5 = 32x already exceeds any reasonable cap; avoid overflow on long idle streaks
+		if shift > 5 {
+			shift = 5
+		}
+
+		interval = queuePollInterval << shift
+
+		if interval > maxQueuePollInterval {
+			interval = maxQueuePollInterval
+		}
+	}
+
+	return interval + rand.N(interval/2) //nolint:gosec
 }
 
 func newQueuer(conf *sharedConfig, tenantId uuid.UUID, queueName string, s *Scheduler, resultsCh chan<- *QueueResults) *Queuer {
@@ -131,7 +175,19 @@ func (q *Queuer) queue(ctx context.Context) {
 }
 
 func (q *Queuer) loopQueue(ctx context.Context) {
-	ticker := time.NewTicker(1 * time.Second)
+	timer := time.NewTimer(q.nextPollInterval())
+	defer timer.Stop()
+
+	resetTimer := func() {
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+
+		timer.Reset(q.nextPollInterval())
+	}
 
 	q.l.Debug().Ctx(ctx).Int("limit", q.limit).Msg("starting queue loop")
 
@@ -141,9 +197,13 @@ func (q *Queuer) loopQueue(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
+		case <-timer.C:
 		case carrier = <-q.notifyQueueCh:
 		}
+
+		// re-arm immediately so early `continue` paths below can't stall the loop; re-armed
+		// again after the refill once the empty-poll streak is known
+		resetTimer()
 
 		q.l.Debug().Ctx(ctx).Msg("queue loop tick")
 
@@ -181,6 +241,15 @@ func (q *Queuer) loopQueue(ctx context.Context) {
 		}
 
 		q.l.Debug().Ctx(ctx).Int("refilled_items", len(qis)).Msg("refilled queue")
+
+		if len(qis) == 0 {
+			q.consecutiveEmptyPolls++
+		} else {
+			q.consecutiveEmptyPolls = 0
+		}
+
+		// re-arm with the interval reflecting the latest empty-poll streak
+		resetTimer()
 
 		// NOTE: we don't terminate early out of this loop because calling `tryAssign` is necessary
 		// for calling the scheduling extensions.


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

The scheduler runs one `loopQueue` goroutine per queue, each polling the database on a fixed 1-second `time.Ticker`. This causes two production problems for tenants with large numbers of mostly-idle queues (observed on a tenant with ~2,500 queues kept alive by dynamically-registered workflow names and hourly cron sweeps):

1. **Phase-locked polling bursts.** Queuers are created in a single batch when queue leases are acquired, so all tickers start (and stay) aligned to within milliseconds. Every second, thousands of `ListQueueItemsForQueue` calls hit the connection pool simultaneously. With a 20-connection pool serving ~2ms queries, each burst takes hundreds of ms to drain — internal traces showed a sustained `pool.acquire` p50 of ~600ms (p99 1.5–2s) even though average pool utilization was only ~25%, and other services sharing the pool hit `context canceled` errors waiting for connections.
2. **Idle queues cost as much as active ones.** A queue with no items still issues a refill query every second, for 24 hours after its last activity.

This PR changes `loopQueue` to:

- **Jitter every poll interval** by up to 50%, re-drawn on each re-arm, so loops created together (or re-synchronized by an event that notifies many queues at once, e.g. a cron sweep) don't stay phase-locked.
- **Back off idle queues**: after 3 consecutive polls that refill zero items, the interval doubles per empty poll, capped at 30s. Any non-empty refill resets to the 1s base.

This is safe for scheduling latency because enqueues wake the loop immediately via `notifyQueueCh` (the buffered channel + `TryLock` in `queue()` guarantees a notify is never lost while the loop is sleeping), and queues holding unassignable items never back off since their refill returns items. Backoff only delays polls of queues with no work.

**Why `time.Timer` + `Reset` instead of `time.Ticker`:** the interval is now dynamic (jittered per-cycle and stretched by backoff), and a ticker's period can only be changed via `Ticker.Reset`, which restarts the period from the moment of the call — making per-cycle randomization equivalent to managing a timer anyway, but with less explicit semantics. A self-reset timer makes the re-arm points explicit: once immediately after wake-up (so early `continue` paths on error can never leave the loop with no pending wake-up), and once after the refill when the empty-poll streak is known. The existing `randomticker` package (used by the concurrency manager) was considered but rejected because it spawns a dedicated goroutine per ticker — one timer per queuer avoids adding thousands of goroutines — and it doesn't support backoff. Both `Timer` and `Ticker` are a single `runtime.timer` re-inserted into the timer heap per fire, so there is no added runtime overhead; net timer traffic drops ~30x for idle queues.

For the motivating tenant, steady-state poll traffic drops from ~2,500 synchronized acquires/sec to roughly 80/sec spread evenly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Replace the fixed 1s `time.Ticker` in `Queuer.loopQueue` with a self-resetting `time.Timer` driven by `nextPollInterval()`
- [x] Add up-to-50% random jitter (via `math/rand/v2`) to every poll interval to de-correlate queue loops
- [x] Add exponential idle backoff: after 3 consecutive empty refills, double the poll interval per empty poll, capped at 30s; reset on any non-empty refill
- [x] Track `consecutiveEmptyPolls` on `Queuer` (single-goroutine access, no locking needed)
- [x] Re-arm the timer both after wake-up (liveness on error paths) and after refill (fresh backoff state)

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

- `go test ./pkg/scheduling/...` passes (including scheduler and concurrency integration tests)
- `go vet ./pkg/scheduling/v1/` clean
- Root cause and expected impact quantified against production traces (`pool.acquire` span latency) and `pg_stat_statements` for the affected tenant; the `pool.acquire` p50 for the scheduler service is the metric to validate post-deploy

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Claude (Cursor agent) was used to investigate the production incident (trace/DB analysis), author the code change, and write this PR description.

</details>
