### PR TITLE
fix(engine): populate external ids for durable task children inside of the existing trigger tx

### DIFF
--- a/internal/services/dispatcher/server_v1.go
+++ b/internal/services/dispatcher/server_v1.go
@@ -669,10 +669,6 @@ func (d *DispatcherServiceImpl) handleTriggerRuns(
 		})
 	}
 
-	if populateErr := d.repo.Triggers().PopulateExternalIdsForWorkflow(ctx, invocation.tenantId, triggerOpts); populateErr != nil {
-		return status.Errorf(codes.Internal, "failed to populate external ids for workflow: %v", populateErr)
-	}
-
 	ingestionResult, err := d.repo.DurableEvents().IngestDurableTaskEvent(ctx, v1.IngestDurableTaskEventOpts{
 		BaseIngestEventOpts: &v1.BaseIngestEventOpts{
 			TenantId:        invocation.tenantId,

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -1064,6 +1064,10 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 
 	switch opts.Kind {
 	case sqlcv1.V1DurableEventLogKindRUN:
+		if populateErr := r.populateExternalIdsForWorkflow(ctx, tx, tenantId, opts.TriggerRuns.TriggerOpts); populateErr != nil {
+			return nil, fmt.Errorf("failed to populate external ids for workflow: %w", populateErr)
+		}
+
 		innerOpts := make([]GetOrCreateLogEntryOpt, len(opts.TriggerRuns.TriggerOpts))
 
 		nonSkipOffset := int64(0)

--- a/pkg/repository/ids.go
+++ b/pkg/repository/ids.go
@@ -85,6 +85,22 @@ func (c *ChildWorkflowSignalCreatedData) Bytes() []byte {
 // GenerateExternalIdsForWorkflow generates external ids and additional looks up child workflows and whether they
 // already exist.
 func (s *sharedRepository) PopulateExternalIdsForWorkflow(ctx context.Context, tenantId uuid.UUID, opts []*WorkflowNameTriggerOpts) error {
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, s.pool, s.l)
+
+	if err != nil {
+		return err
+	}
+
+	defer rollback()
+
+	if err := s.populateExternalIdsForWorkflow(ctx, tx, tenantId, opts); err != nil {
+		return err
+	}
+
+	return commit(ctx)
+}
+
+func (s *sharedRepository) populateExternalIdsForWorkflow(ctx context.Context, tx sqlcv1.DBTX, tenantId uuid.UUID, opts []*WorkflowNameTriggerOpts) error {
 	// get child workflow data first
 	optsWithParents := make([]*WorkflowNameTriggerOpts, 0, len(opts))
 
@@ -99,7 +115,7 @@ func (s *sharedRepository) PopulateExternalIdsForWorkflow(ctx context.Context, t
 	}
 
 	if len(optsWithParents) > 0 {
-		err := s.generateExternalIdsForChildWorkflows(ctx, tenantId, optsWithParents)
+		err := s.generateExternalIdsForChildWorkflows(ctx, tx, tenantId, optsWithParents)
 
 		if err != nil {
 			return err
@@ -109,15 +125,7 @@ func (s *sharedRepository) PopulateExternalIdsForWorkflow(ctx context.Context, t
 	return nil
 }
 
-func (s *sharedRepository) generateExternalIdsForChildWorkflows(ctx context.Context, tenantId uuid.UUID, opts []*WorkflowNameTriggerOpts) error {
-	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, s.pool, s.l)
-
-	if err != nil {
-		return err
-	}
-
-	defer rollback()
-
+func (s *sharedRepository) generateExternalIdsForChildWorkflows(ctx context.Context, tx sqlcv1.DBTX, tenantId uuid.UUID, opts []*WorkflowNameTriggerOpts) error {
 	externalIds := make([]uuid.UUID, 0, len(opts))
 	spawnKeyToOpt := make(map[string]*WorkflowNameTriggerOpts)
 
@@ -259,10 +267,6 @@ func (s *sharedRepository) generateExternalIdsForChildWorkflows(ctx context.Cont
 	)
 
 	if err != nil {
-		return err
-	}
-
-	if err := commit(ctx); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
# Description

Fixes an issue where we'd populate external ids (which also had the side effect of creating task events) in one tx, commit, and then begin a second tx to spawn the children. this meant that if we populated, committed, and then the second tx failed, we wouldn't roll back, and we'd get into a stuck state where we'd just hang because there would be a ghost id in the list of runs to skip, which would result in:

```
failed to get or create event log entries: expected to find log entry for skipped child task external id
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Used Claude Code to help diagnose / narrow down the problem, wrote the fix myself

</details>
