### PR TITLE
fix: don't join on v1_step_concurrency for outbox insert triggers

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260703125435_v1_0_124.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260703125435_v1_0_124.sql
@@ -1,0 +1,153 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- The outbox trigger functions joined v1_step_concurrency on id alone (unindexed, since the
+-- primary key leads with workflow_id), sequentially scanning it on every concurrency slot
+-- insert/update/delete. The slot row's own parent_strategy_id is populated from the same
+-- v1_step_concurrency row, so we can filter on it directly and skip the join.
+
+CREATE OR REPLACE FUNCTION after_v1_concurrency_slot_insert_outbox_function()
+RETURNS trigger AS $$
+BEGIN
+    INSERT INTO outbox.messages (topic, payload)
+    SELECT
+        'concurrency.' || nt.tenant_id::text || '.' || nt.strategy_id::text,
+        jsonb_build_object(
+            'operation', 'INSERT',
+            'key', nt.key,
+            'priority', nt.priority,
+            'taskId', nt.task_id,
+            'taskInsertedAt', nt.task_inserted_at,
+            'taskRetryCount', nt.task_retry_count,
+            'scheduleTimeoutAtMs', (EXTRACT(EPOCH FROM nt.schedule_timeout_at) * 1000)::bigint
+        )
+    FROM new_table nt
+    WHERE nt.parent_strategy_id IS NULL;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION after_v1_concurrency_slot_delete_outbox_function()
+RETURNS trigger AS $$
+BEGIN
+    INSERT INTO outbox.messages (topic, payload)
+    SELECT
+        'concurrency.' || dr.tenant_id::text || '.' || dr.strategy_id::text,
+        jsonb_build_object(
+            'operation', 'DELETE',
+            'key', dr.key,
+            'priority', dr.priority,
+            'taskId', dr.task_id,
+            'taskInsertedAt', dr.task_inserted_at,
+            'taskRetryCount', dr.task_retry_count,
+            'scheduleTimeoutAtMs', (EXTRACT(EPOCH FROM dr.schedule_timeout_at) * 1000)::bigint
+        )
+    FROM deleted_rows dr
+    WHERE dr.parent_strategy_id IS NULL;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION after_v1_concurrency_slot_update_outbox_function()
+RETURNS trigger AS $$
+BEGIN
+    INSERT INTO outbox.messages (topic, payload)
+    SELECT
+        'concurrency.' || nt.tenant_id::text || '.' || nt.strategy_id::text,
+        jsonb_build_object(
+            'operation', 'UPDATE',
+            'key', nt.key,
+            'priority', nt.priority,
+            'taskId', nt.task_id,
+            'taskInsertedAt', nt.task_inserted_at,
+            'taskRetryCount', nt.task_retry_count,
+            'scheduleTimeoutAtMs', (EXTRACT(EPOCH FROM nt.schedule_timeout_at) * 1000)::bigint,
+            'isFilled', nt.is_filled
+        )
+    FROM new_table nt
+    WHERE nt.parent_strategy_id IS NULL
+        AND nt.is_filled = FALSE;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+CREATE OR REPLACE FUNCTION after_v1_concurrency_slot_insert_outbox_function()
+RETURNS trigger AS $$
+BEGIN
+    INSERT INTO outbox.messages (topic, payload)
+    SELECT
+        'concurrency.' || nt.tenant_id::text || '.' || nt.strategy_id::text,
+        jsonb_build_object(
+            'operation', 'INSERT',
+            'key', nt.key,
+            'priority', nt.priority,
+            'taskId', nt.task_id,
+            'taskInsertedAt', nt.task_inserted_at,
+            'taskRetryCount', nt.task_retry_count,
+            'scheduleTimeoutAtMs', (EXTRACT(EPOCH FROM nt.schedule_timeout_at) * 1000)::bigint
+        )
+    FROM new_table nt
+    JOIN v1_step_concurrency sc ON sc.id = nt.strategy_id
+    WHERE sc.parent_strategy_id IS NULL;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION after_v1_concurrency_slot_delete_outbox_function()
+RETURNS trigger AS $$
+BEGIN
+    INSERT INTO outbox.messages (topic, payload)
+    SELECT
+        'concurrency.' || dr.tenant_id::text || '.' || dr.strategy_id::text,
+        jsonb_build_object(
+            'operation', 'DELETE',
+            'key', dr.key,
+            'priority', dr.priority,
+            'taskId', dr.task_id,
+            'taskInsertedAt', dr.task_inserted_at,
+            'taskRetryCount', dr.task_retry_count,
+            'scheduleTimeoutAtMs', (EXTRACT(EPOCH FROM dr.schedule_timeout_at) * 1000)::bigint
+        )
+    FROM deleted_rows dr
+    JOIN v1_step_concurrency sc ON sc.id = dr.strategy_id
+    WHERE sc.parent_strategy_id IS NULL;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION after_v1_concurrency_slot_update_outbox_function()
+RETURNS trigger AS $$
+BEGIN
+    INSERT INTO outbox.messages (topic, payload)
+    SELECT
+        'concurrency.' || nt.tenant_id::text || '.' || nt.strategy_id::text,
+        jsonb_build_object(
+            'operation', 'UPDATE',
+            'key', nt.key,
+            'priority', nt.priority,
+            'taskId', nt.task_id,
+            'taskInsertedAt', nt.task_inserted_at,
+            'taskRetryCount', nt.task_retry_count,
+            'scheduleTimeoutAtMs', (EXTRACT(EPOCH FROM nt.schedule_timeout_at) * 1000)::bigint,
+            'isFilled', nt.is_filled
+        )
+    FROM new_table nt
+    JOIN v1_step_concurrency sc ON sc.id = nt.strategy_id
+    WHERE sc.parent_strategy_id IS NULL
+        AND nt.is_filled = FALSE;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- +goose StatementEnd

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -2488,8 +2488,7 @@ BEGIN
             'scheduleTimeoutAtMs', (EXTRACT(EPOCH FROM nt.schedule_timeout_at) * 1000)::bigint
         )
     FROM new_table nt
-    JOIN v1_step_concurrency sc ON sc.id = nt.strategy_id
-    WHERE sc.parent_strategy_id IS NULL;
+    WHERE nt.parent_strategy_id IS NULL;
 
     RETURN NULL;
 END;
@@ -2517,8 +2516,7 @@ BEGIN
             'scheduleTimeoutAtMs', (EXTRACT(EPOCH FROM dr.schedule_timeout_at) * 1000)::bigint
         )
     FROM deleted_rows dr
-    JOIN v1_step_concurrency sc ON sc.id = dr.strategy_id
-    WHERE sc.parent_strategy_id IS NULL;
+    WHERE dr.parent_strategy_id IS NULL;
 
     RETURN NULL;
 END;
@@ -2547,8 +2545,7 @@ BEGIN
             'isFilled', nt.is_filled
         )
     FROM new_table nt
-    JOIN v1_step_concurrency sc ON sc.id = nt.strategy_id
-    WHERE sc.parent_strategy_id IS NULL
+    WHERE nt.parent_strategy_id IS NULL
         AND nt.is_filled = FALSE;
 
     RETURN NULL;


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Removes an unnecessary `JOIN` on `v1_step_concurrency` in each outbox trigger which was causing elevated latency on `CreateTasks`. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [X] Updated each trigger to just use the `parent_strategy_id` instead.

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Tested (unit, integration, or manually with steps specified)
- [X] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [X] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude for hotfix after diagnosis

</details>
