### PR TITLE
fix: organization create patches

### DIFF
--- a/frontend/app/src/components/forms/new-organization-input-form.tsx
+++ b/frontend/app/src/components/forms/new-organization-input-form.tsx
@@ -2,6 +2,7 @@ import { RegionSelect } from '@/components/forms/region-select';
 import { Button } from '@/components/v1/ui/button';
 import { Input } from '@/components/v1/ui/input';
 import { Label } from '@/components/v1/ui/label';
+import { Spinner } from '@/components/v1/ui/loading';
 import { OrganizationAvailableShard } from '@/lib/api/generated/control-plane/data-contracts';
 import { shardDeploymentKey } from '@/lib/shard-deployment-key';
 import { ArrowRightIcon } from '@radix-ui/react-icons';
@@ -107,13 +108,10 @@ export function NewOrganizationInputForm({
       )}
 
       <div className="grid gap-2">
-        <Label htmlFor="tenant-name">Name of First Tenant</Label>
+        <Label htmlFor="tenant-name">First Tenant Name</Label>
         <p className="text-sm text-muted-foreground">
-          An isolated environment for your tasks, workflows, workers, and
-          events.
-          <br />
-          Most teams start with development and add a tenant for each engineer,
-          staging, or production environment later.
+          A tenant is an isolated environment for your tasks, workflows,
+          workers, and events.
         </p>
         <Input
           id="tenant-name"
@@ -134,8 +132,17 @@ export function NewOrganizationInputForm({
         className="w-full"
         disabled={isSaving || cannotSubmitRegion}
       >
-        {isSaving ? 'Getting started...' : 'Get started'}
-        {!isSaving && <ArrowRightIcon className="ml-2 size-4" />}
+        {isSaving ? (
+          <>
+            <Spinner />
+            Getting started...
+          </>
+        ) : (
+          <>
+            Get started
+            <ArrowRightIcon className="ml-2 size-4" />
+          </>
+        )}
       </Button>
     </form>
   );

--- a/frontend/app/src/components/forms/new-organization-saver-form.tsx
+++ b/frontend/app/src/components/forms/new-organization-saver-form.tsx
@@ -19,10 +19,12 @@ import invariant from 'tiny-invariant';
 interface NewOrganizationSaverFormProps {
   defaultOrganizationName?: string;
   defaultTenantName?: string;
+  // May return the navigation promise so the mutation stays pending (and the
+  // form stays in its saving state) until the destination page commits.
   afterSave: (data: {
     organization: Organization;
     tenant: OrganizationTenant;
-  }) => void;
+  }) => void | Promise<void>;
 }
 
 const useSaveOrganization = ({
@@ -68,7 +70,10 @@ const useSaveOrganization = ({
         tenant_type: 'cloud',
         is_cloud: true,
       });
-      afterSave(data);
+      // Keep the mutation pending until any navigation in afterSave commits;
+      // otherwise the form flashes back to its idle state while the target
+      // route's loader is still running.
+      await afterSave(data);
     },
     onError: handleApiError,
   });
@@ -103,7 +108,11 @@ export function NewOrganizationSaverForm({
     <NewOrganizationInputForm
       defaultOrganizationName={defaultOrganizationName}
       defaultTenantName={defaultTenantName}
-      isSaving={saveOrganizationMutation.isPending}
+      isSaving={
+        // Stay in the saving state after success too: the component only
+        // unmounts once the post-save navigation commits.
+        saveOrganizationMutation.isPending || saveOrganizationMutation.isSuccess
+      }
       onSubmit={saveOrganizationMutation.mutate}
       showRegionSelect={isControlPlaneEnabled}
       availableShards={shardsQuery.data?.rows}

--- a/frontend/app/src/components/forms/region-select.tsx
+++ b/frontend/app/src/components/forms/region-select.tsx
@@ -35,7 +35,7 @@ export function RegionSelect({
     <div className="grid gap-2">
       <Label htmlFor={id}>Region</Label>
       <p className="text-sm text-muted-foreground">
-        Choose where your first tenant is deployed.
+        Choose where this tenant is deployed.
       </p>
       <Select
         value={value}

--- a/frontend/app/src/components/forms/region-select.tsx
+++ b/frontend/app/src/components/forms/region-select.tsx
@@ -1,5 +1,3 @@
-import { usePylon } from '@/components/support-chat';
-import { Button } from '@/components/v1/ui/button';
 import { Label } from '@/components/v1/ui/label';
 import {
   Select,
@@ -9,7 +7,6 @@ import {
   SelectValue,
 } from '@/components/v1/ui/select';
 import { OrganizationAvailableShard } from '@/lib/api/generated/control-plane/data-contracts';
-import { OFFICE_HOURS_URL } from '@/lib/external-links';
 import {
   formatShardDeploymentKey,
   shardDeploymentKey,
@@ -32,14 +29,13 @@ export function RegionSelect({
   disabled = false,
   id = 'deployment-region',
 }: RegionSelectProps) {
-  const pylon = usePylon();
   const selectDisabled = disabled || isLoading || shards.length <= 1;
 
   return (
     <div className="grid gap-2">
       <Label htmlFor={id}>Region</Label>
       <p className="text-sm text-muted-foreground">
-        Choose where this tenant&apos;s control plane and data are deployed.
+        Choose where your first tenant is deployed.
       </p>
       <Select
         value={value}
@@ -63,31 +59,6 @@ export function RegionSelect({
           })}
         </SelectContent>
       </Select>
-      <p className="text-sm text-muted-foreground">
-        Don&apos;t see your region? Reach out via{' '}
-        {pylon.enabled ? (
-          <>
-            <Button
-              type="button"
-              variant="link"
-              className="h-auto p-0 text-sm font-normal"
-              onClick={() => pylon.show()}
-            >
-              Open support chat
-            </Button>
-            , or{' '}
-          </>
-        ) : null}
-        <a
-          href={OFFICE_HOURS_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-primary underline-offset-4 hover:underline"
-        >
-          Schedule office hours
-        </a>
-        .
-      </p>
     </div>
   );
 }

--- a/frontend/app/src/lib/redirect.ts
+++ b/frontend/app/src/lib/redirect.ts
@@ -10,10 +10,9 @@ export function useRedirectOrNavigate() {
       const redirectTo = sessionStorage.getItem(REDIRECT_TARGET_KEY);
       if (redirectTo) {
         sessionStorage.removeItem(REDIRECT_TARGET_KEY);
-        navigate({ to: redirectTo, replace: true } as never);
-      } else {
-        navigate(fallbackOpts as never);
+        return navigate({ to: redirectTo, replace: true } as never);
       }
+      return navigate(fallbackOpts as never);
     },
     [navigate],
   );

--- a/frontend/app/src/pages/onboarding/create-organization/index.tsx
+++ b/frontend/app/src/pages/onboarding/create-organization/index.tsx
@@ -72,7 +72,11 @@ export default function CreateOrganization() {
           defaultOrganizationName={user ? deriveDefaultOrgName(user) : ''}
           defaultTenantName="development"
           afterSave={({ tenant }) => {
-            queryClient.prefetchQuery(queries.controlPlane.subscriptionPlans());
+            void queryClient
+              .prefetchQuery(queries.controlPlane.subscriptionPlans())
+              .catch(() => {
+                // Ignore prefetch errors; subscription plans will be fetched on demand if needed.
+              });
             return redirectOrNavigate({
               to: appRoutes.tenantOverviewRoute.to,
               params: { tenant: tenant.id },

--- a/frontend/app/src/pages/onboarding/create-organization/index.tsx
+++ b/frontend/app/src/pages/onboarding/create-organization/index.tsx
@@ -73,7 +73,7 @@ export default function CreateOrganization() {
           defaultTenantName="development"
           afterSave={({ tenant }) => {
             queryClient.prefetchQuery(queries.controlPlane.subscriptionPlans());
-            redirectOrNavigate({
+            return redirectOrNavigate({
               to: appRoutes.tenantOverviewRoute.to,
               params: { tenant: tenant.id },
               replace: true,

--- a/frontend/app/src/pages/organizations/new/index.tsx
+++ b/frontend/app/src/pages/organizations/new/index.tsx
@@ -27,12 +27,12 @@ export default function OrganizationsNew() {
 
         <div className="flex justify-center">
           <NewOrganizationSaverForm
-            afterSave={({ organization, tenant }) => {
+            afterSave={({ tenant }) =>
               navigate({
                 to: appRoutes.tenantOverviewRoute.to,
                 params: { tenant: tenant.id },
-              });
-            }}
+              })
+            }
           />
         </div>
       </div>


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Patches some issues observed on a slow network with organization creation. We flash an empty input form after creation, and we don't show a loading state which makes it difficult to reason about org creation. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [X] Awaits the `useNavigate` callback so that we don't re-render the org creation form too early
- [X] Fixes some minor wording / noise on the form

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Tested (unit, integration, or manually with steps specified) - manually
- [X] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [X] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude Fable

</details>
