### PR TITLE
feat: add event time bounds to aggregated analytics flushes

### DIFF
--- a/pkg/analytics/aggregating.go
+++ b/pkg/analytics/aggregating.go
@@ -31,9 +31,7 @@ type counterEntry struct {
 
 // The first marker is set once and the last marker only advances
 func (e *counterEntry) observe(nanos int64) {
-	if e.firstEventAtNanos.Load() == 0 {
-		e.firstEventAtNanos.CompareAndSwap(0, nanos)
-	}
+	e.firstEventAtNanos.CompareAndSwap(0, nanos)
 
 	for {
 		last := e.lastEventAtNanos.Load()
@@ -198,7 +196,7 @@ func (a *Aggregator) flush() {
 			// marker whose count was already flushed. A bucket's first
 			// event is never misplaced, because Count fills the markers
 			// before publishing a new bucket, so the earliest
-			// first_event_at in a bucket's lifetime is exact. Preventing
+			// firstEventAt in a bucket's lifetime is exact. Preventing
 			// the misplacement would require Count to take a lock.
 			firstNanos := e.firstEventAtNanos.Swap(0)
 			lastNanos := e.lastEventAtNanos.Swap(0)

--- a/pkg/analytics/aggregating.go
+++ b/pkg/analytics/aggregating.go
@@ -24,9 +24,33 @@ type counterEntry struct {
 	count   *atomic.Int64
 	props   Properties
 	tokenID *uuid.UUID
+	// First and last event times since the last flush. Zero means unset.
+	firstEventAtNanos atomic.Int64
+	lastEventAtNanos  atomic.Int64
 }
 
-type FlushFunc func(resource Resource, action Action, tenantID uuid.UUID, tokenID *uuid.UUID, count int64, properties Properties)
+// The first marker is set once and the last marker only advances
+func (e *counterEntry) observe(nanos int64) {
+	if e.firstEventAtNanos.Load() == 0 {
+		e.firstEventAtNanos.CompareAndSwap(0, nanos)
+	}
+
+	for {
+		last := e.lastEventAtNanos.Load()
+		if nanos <= last {
+			return
+		}
+		if e.lastEventAtNanos.CompareAndSwap(last, nanos) {
+			return
+		}
+	}
+}
+
+// FlushFunc receives one bucket's totals for the interval since the previous
+// flush: the number of events counted, and the times of the first and last
+// events. The times are zero when unknown and can disagree with the count by
+// one event at the interval boundary.
+type FlushFunc func(resource Resource, action Action, tenantID uuid.UUID, tokenID *uuid.UUID, count int64, firstEventAt, lastEventAt time.Time, properties Properties)
 
 // Aggregator batches Count calls into periodic flushes. It is intended to be
 // embedded inside an Analytics implementation (e.g. PosthogAnalytics) so that
@@ -42,6 +66,7 @@ type Aggregator struct {
 	keyCount atomic.Int64
 	flushMu  sync.Mutex
 	disabled bool
+	now      func() time.Time
 }
 
 func NewAggregator(l *zerolog.Logger, enabled bool, interval time.Duration, maxKeys int64, fn FlushFunc) *Aggregator {
@@ -59,14 +84,15 @@ func NewAggregator(l *zerolog.Logger, enabled bool, interval time.Duration, maxK
 		maxKeys:  maxKeys,
 		l:        l,
 		disabled: !enabled,
+		now:      time.Now,
 	}
 }
 
 // Count increments the aggregated counter for the given resource/action/tenant/token
 // and optional properties. Properties are hashed into the bucket key so that
 // different feature combinations (e.g. priority=1 vs priority=3) are counted
-// separately. This is the non-blocking hot path: sync.Map.Load + atomic.Add
-// on the common case.
+// separately. This is the non-blocking hot path: sync.Map.Load + atomic.Add +
+// the marker update on the common case.
 func (a *Aggregator) Count(resource Resource, action Action, tenantID uuid.UUID, tokenID *uuid.UUID, n int64, props ...Properties) {
 	if a.disabled {
 		return
@@ -90,8 +116,12 @@ func (a *Aggregator) Count(resource Resource, action Action, tenantID uuid.UUID,
 		PropsHash: hashProps(p),
 	}
 
+	nanos := a.now().UnixNano()
+
 	if v, ok := a.counters.Load(key); ok {
-		v.(*counterEntry).count.Add(n)
+		e := v.(*counterEntry)
+		e.count.Add(n)
+		e.observe(nanos)
 		return
 	}
 
@@ -103,8 +133,11 @@ func (a *Aggregator) Count(resource Resource, action Action, tenantID uuid.UUID,
 	c := &atomic.Int64{}
 	c.Add(n)
 	entry := &counterEntry{count: c, props: p, tokenID: tokenID}
+	entry.observe(nanos)
 	if existing, loaded := a.counters.LoadOrStore(key, entry); loaded {
-		existing.(*counterEntry).count.Add(n)
+		e := existing.(*counterEntry)
+		e.count.Add(n)
+		e.observe(nanos)
 	} else {
 		a.keyCount.Add(1)
 	}
@@ -156,7 +189,29 @@ func (a *Aggregator) flush() {
 		e := val.(*counterEntry)
 		count := e.count.Swap(0)
 		if count > 0 {
-			a.flushFn(k.Resource, k.Action, k.TenantID, e.tokenID, count, e.props)
+			// The count swap and the marker swaps are separate operations,
+			// so an event arriving during this flush can have its count
+			// taken by this flush and its time left for the next one, or
+			// the reverse. Each flush can misplace at most one event's time
+			// in each bucket. A flushed bucket can therefore carry a count
+			// with zero markers, and the delete branch below can discard a
+			// marker whose count was already flushed. A bucket's first
+			// event is never misplaced, because Count fills the markers
+			// before publishing a new bucket, so the earliest
+			// first_event_at in a bucket's lifetime is exact. Preventing
+			// the misplacement would require Count to take a lock.
+			firstNanos := e.firstEventAtNanos.Swap(0)
+			lastNanos := e.lastEventAtNanos.Swap(0)
+
+			var firstEventAt, lastEventAt time.Time
+			if firstNanos != 0 {
+				firstEventAt = time.Unix(0, firstNanos).UTC()
+			}
+			if lastNanos != 0 {
+				lastEventAt = time.Unix(0, lastNanos).UTC()
+			}
+
+			a.flushFn(k.Resource, k.Action, k.TenantID, e.tokenID, count, firstEventAt, lastEventAt, e.props)
 		} else {
 			a.counters.Delete(key)
 			a.keyCount.Add(-1)

--- a/pkg/analytics/aggregating_test.go
+++ b/pkg/analytics/aggregating_test.go
@@ -450,8 +450,8 @@ func TestFlush_CountWithoutMarkers(t *testing.T) {
 	tenantID := uuid.New()
 	agg.Count(Event, Create, tenantID, nil, 1)
 
-	// Construct the flush-boundary state where an event was counted in this
-	// window but its markers were consumed by the previous flush.
+	// Construct the boundary state where an event was counted in this
+	// interval but its markers were consumed by the previous flush.
 	agg.counters.Range(func(_, v any) bool {
 		e := v.(*counterEntry)
 		e.firstEventAtNanos.Store(0)

--- a/pkg/analytics/aggregating_test.go
+++ b/pkg/analytics/aggregating_test.go
@@ -14,12 +14,14 @@ import (
 var nopLogger = zerolog.Nop()
 
 type flushedEvent struct {
-	Resource   Resource
-	Action     Action
-	TenantID   uuid.UUID
-	TokenID    *uuid.UUID
-	Count      int64
-	Properties Properties
+	Resource     Resource
+	Action       Action
+	TenantID     uuid.UUID
+	TokenID      *uuid.UUID
+	Count        int64
+	FirstEventAt time.Time
+	LastEventAt  time.Time
+	Properties   Properties
 }
 
 type flushRecorder struct {
@@ -27,16 +29,18 @@ type flushRecorder struct {
 	events []flushedEvent
 }
 
-func (r *flushRecorder) record(resource Resource, action Action, tenantID uuid.UUID, tokenID *uuid.UUID, count int64, properties Properties) {
+func (r *flushRecorder) record(resource Resource, action Action, tenantID uuid.UUID, tokenID *uuid.UUID, count int64, firstEventAt, lastEventAt time.Time, properties Properties) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.events = append(r.events, flushedEvent{
-		Resource:   resource,
-		Action:     action,
-		TenantID:   tenantID,
-		TokenID:    tokenID,
-		Count:      count,
-		Properties: properties,
+		Resource:     resource,
+		Action:       action,
+		TenantID:     tenantID,
+		TokenID:      tokenID,
+		Count:        count,
+		FirstEventAt: firstEventAt,
+		LastEventAt:  lastEventAt,
+		Properties:   properties,
 	})
 }
 
@@ -321,6 +325,200 @@ func TestCount_FlagsPassedToFlush(t *testing.T) {
 	}
 	if e.Properties["has_scope"] != true {
 		t.Errorf("expected has_scope=true, got %v", e.Properties["has_scope"])
+	}
+}
+
+func TestFlush_FirstAndLastEventAt(t *testing.T) {
+	rec := &flushRecorder{}
+	agg := NewAggregator(&nopLogger, true, 10*time.Second, 0, rec.record)
+
+	now := time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC)
+	agg.now = func() time.Time { return now }
+
+	tenantID := uuid.New()
+	props := Properties{"has_priority": true}
+
+	agg.Count(Event, Create, tenantID, nil, 1, props)
+	now = now.Add(2 * time.Minute)
+	agg.Count(Event, Create, tenantID, nil, 1, props)
+	now = now.Add(3 * time.Minute)
+	agg.Count(Event, Create, tenantID, nil, 1, props)
+
+	agg.flush()
+
+	events := rec.getEvents()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 flushed event, got %d", len(events))
+	}
+
+	e := events[0]
+	if e.Count != 3 {
+		t.Errorf("expected count 3, got %d", e.Count)
+	}
+
+	wantFirst := time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC)
+	wantLast := time.Date(2026, 7, 3, 10, 5, 0, 0, time.UTC)
+	if !e.FirstEventAt.Equal(wantFirst) {
+		t.Errorf("expected first_event_at %v, got %v", wantFirst, e.FirstEventAt)
+	}
+	if !e.LastEventAt.Equal(wantLast) {
+		t.Errorf("expected last_event_at %v, got %v", wantLast, e.LastEventAt)
+	}
+	if e.Properties["has_priority"] != true {
+		t.Errorf("expected has_priority=true, got %v", e.Properties["has_priority"])
+	}
+}
+
+func TestFlush_MarkersResetBetweenWindows(t *testing.T) {
+	rec := &flushRecorder{}
+	agg := NewAggregator(&nopLogger, true, 10*time.Second, 0, rec.record)
+
+	now := time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC)
+	agg.now = func() time.Time { return now }
+
+	tenantID := uuid.New()
+	agg.Count(Event, Create, tenantID, nil, 1)
+	now = now.Add(time.Minute)
+	agg.Count(Event, Create, tenantID, nil, 1)
+	agg.flush()
+
+	now = now.Add(time.Hour)
+	agg.Count(Event, Create, tenantID, nil, 1)
+	agg.flush()
+
+	events := rec.getEvents()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 flushed events, got %d", len(events))
+	}
+
+	second := events[1]
+	wantSecond := time.Date(2026, 7, 3, 11, 1, 0, 0, time.UTC)
+	if !second.FirstEventAt.Equal(wantSecond) {
+		t.Errorf("expected second window first_event_at %v, got %v", wantSecond, second.FirstEventAt)
+	}
+	if !second.LastEventAt.Equal(wantSecond) {
+		t.Errorf("expected second window last_event_at %v, got %v", wantSecond, second.LastEventAt)
+	}
+	if second.Count != 1 {
+		t.Errorf("expected second window count 1, got %d", second.Count)
+	}
+}
+
+func TestFlush_MarkersPerPropertyBucket(t *testing.T) {
+	rec := &flushRecorder{}
+	agg := NewAggregator(&nopLogger, true, 10*time.Second, 0, rec.record)
+
+	now := time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC)
+	agg.now = func() time.Time { return now }
+
+	tenantID := uuid.New()
+	agg.Count(Event, Create, tenantID, nil, 1, Properties{"has_priority": true})
+	now = now.Add(30 * time.Minute)
+	agg.Count(Event, Create, tenantID, nil, 1, Properties{"has_scope": true})
+
+	agg.flush()
+
+	events := rec.getEvents()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 flushed buckets, got %d", len(events))
+	}
+
+	byProp := make(map[string]flushedEvent)
+	for _, e := range events {
+		if _, ok := e.Properties["has_priority"]; ok {
+			byProp["priority"] = e
+		}
+		if _, ok := e.Properties["has_scope"]; ok {
+			byProp["scope"] = e
+		}
+	}
+
+	wantPriority := time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC)
+	wantScope := time.Date(2026, 7, 3, 10, 30, 0, 0, time.UTC)
+	if !byProp["priority"].FirstEventAt.Equal(wantPriority) {
+		t.Errorf("expected priority bucket first_event_at %v, got %v", wantPriority, byProp["priority"].FirstEventAt)
+	}
+	if !byProp["scope"].FirstEventAt.Equal(wantScope) {
+		t.Errorf("expected scope bucket first_event_at %v, got %v", wantScope, byProp["scope"].FirstEventAt)
+	}
+}
+
+func TestFlush_CountWithoutMarkers(t *testing.T) {
+	rec := &flushRecorder{}
+	agg := NewAggregator(&nopLogger, true, 10*time.Second, 0, rec.record)
+
+	tenantID := uuid.New()
+	agg.Count(Event, Create, tenantID, nil, 1)
+
+	// Construct the flush-boundary state where an event was counted in this
+	// window but its markers were consumed by the previous flush.
+	agg.counters.Range(func(_, v any) bool {
+		e := v.(*counterEntry)
+		e.firstEventAtNanos.Store(0)
+		e.lastEventAtNanos.Store(0)
+		return true
+	})
+
+	agg.flush()
+
+	events := rec.getEvents()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 flushed event, got %d", len(events))
+	}
+	if events[0].Count != 1 {
+		t.Errorf("expected count 1, got %d", events[0].Count)
+	}
+	if !events[0].FirstEventAt.IsZero() {
+		t.Errorf("expected zero first_event_at, got %v", events[0].FirstEventAt)
+	}
+	if !events[0].LastEventAt.IsZero() {
+		t.Errorf("expected zero last_event_at, got %v", events[0].LastEventAt)
+	}
+}
+
+func TestFlush_ConcurrentCountsKeepMarkerInvariants(t *testing.T) {
+	rec := &flushRecorder{}
+	agg := NewAggregator(&nopLogger, true, time.Millisecond, 0, rec.record)
+	agg.Start()
+
+	tenantID := uuid.New()
+	start := time.Now().Add(-time.Millisecond)
+
+	const goroutines = 20
+	const countsPerGoroutine = 500
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < countsPerGoroutine; j++ {
+				agg.Count(Event, Create, tenantID, nil, 1)
+			}
+		}()
+	}
+	wg.Wait()
+	agg.Shutdown()
+
+	end := time.Now().Add(time.Millisecond)
+
+	events := rec.getEvents()
+	var total int64
+	for _, e := range events {
+		total += e.Count
+		if !e.FirstEventAt.IsZero() && !e.LastEventAt.IsZero() && e.LastEventAt.Before(e.FirstEventAt) {
+			t.Errorf("last_event_at %v before first_event_at %v", e.LastEventAt, e.FirstEventAt)
+		}
+		if !e.FirstEventAt.IsZero() && (e.FirstEventAt.Before(start) || e.FirstEventAt.After(end)) {
+			t.Errorf("first_event_at %v outside test window [%v, %v]", e.FirstEventAt, start, end)
+		}
+		if !e.LastEventAt.IsZero() && (e.LastEventAt.Before(start) || e.LastEventAt.After(end)) {
+			t.Errorf("last_event_at %v outside test window [%v, %v]", e.LastEventAt, start, end)
+		}
+	}
+
+	if total != goroutines*countsPerGoroutine {
+		t.Errorf("expected total count %d, got %d", goroutines*countsPerGoroutine, total)
 	}
 }
 

--- a/pkg/analytics/posthog/posthog.go
+++ b/pkg/analytics/posthog/posthog.go
@@ -154,10 +154,21 @@ func (p *PosthogAnalytics) Count(ctx context.Context, resource analytics.Resourc
 	p.aggregator.Count(resource, action, tid, tokenID, 1, merged)
 }
 
-func (p *PosthogAnalytics) flushCount(resource analytics.Resource, action analytics.Action, tenantID uuid.UUID, tokenID *uuid.UUID, count int64, properties analytics.Properties) {
+func (p *PosthogAnalytics) flushCount(resource analytics.Resource, action analytics.Action, tenantID uuid.UUID, tokenID *uuid.UUID, count int64, firstEventAt, lastEventAt time.Time, properties analytics.Properties) {
 	merged := analytics.Properties{"count": count}
 	for k, v := range properties {
 		merged[k] = v
+	}
+
+	// The event-time bounds always come from the aggregator, never from
+	// caller properties.
+	delete(merged, "first_event_at")
+	delete(merged, "last_event_at")
+	if !firstEventAt.IsZero() {
+		merged["first_event_at"] = firstEventAt
+	}
+	if !lastEventAt.IsZero() {
+		merged["last_event_at"] = lastEventAt
 	}
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, analytics.TenantIDKey, tenantID)

--- a/pkg/analytics/posthog/posthog.go
+++ b/pkg/analytics/posthog/posthog.go
@@ -161,14 +161,15 @@ func (p *PosthogAnalytics) flushCount(resource analytics.Resource, action analyt
 	}
 
 	// The event-time bounds always come from the aggregator, never from
-	// caller properties.
-	delete(merged, "first_event_at")
-	delete(merged, "last_event_at")
+	// caller properties. The aggregate_ prefix keeps them from colliding
+	// with caller-owned property names.
+	delete(merged, "aggregate_first_event_at")
+	delete(merged, "aggregate_last_event_at")
 	if !firstEventAt.IsZero() {
-		merged["first_event_at"] = firstEventAt
+		merged["aggregate_first_event_at"] = firstEventAt
 	}
 	if !lastEventAt.IsZero() {
-		merged["last_event_at"] = lastEventAt
+		merged["aggregate_last_event_at"] = lastEventAt
 	}
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, analytics.TenantIDKey, tenantID)

--- a/pkg/analytics/posthog/posthog_test.go
+++ b/pkg/analytics/posthog/posthog_test.go
@@ -49,20 +49,24 @@ func TestFlushCount_GeneratedEventTimesWin(t *testing.T) {
 	last := first.Add(time.Minute)
 
 	p.flushCount(analytics.Worker, analytics.Register, uuid.New(), nil, 5, first, last, analytics.Properties{
-		"first_event_at":   "spoofed",
-		"last_event_at":    "spoofed",
-		"runtime_language": "go",
+		"aggregate_first_event_at": "spoofed",
+		"aggregate_last_event_at":  "spoofed",
+		"first_event_at":           "caller-owned",
+		"runtime_language":         "go",
 	})
 
 	capture := captureFrom(t, fake)
-	if capture.Properties["first_event_at"] != first {
-		t.Errorf("expected generated first_event_at %v, got %v", first, capture.Properties["first_event_at"])
+	if capture.Properties["aggregate_first_event_at"] != first {
+		t.Errorf("expected generated aggregate_first_event_at %v, got %v", first, capture.Properties["aggregate_first_event_at"])
 	}
-	if capture.Properties["last_event_at"] != last {
-		t.Errorf("expected generated last_event_at %v, got %v", last, capture.Properties["last_event_at"])
+	if capture.Properties["aggregate_last_event_at"] != last {
+		t.Errorf("expected generated aggregate_last_event_at %v, got %v", last, capture.Properties["aggregate_last_event_at"])
 	}
 	if capture.Properties["count"] != int64(5) {
 		t.Errorf("expected count 5, got %v", capture.Properties["count"])
+	}
+	if capture.Properties["first_event_at"] != "caller-owned" {
+		t.Errorf("expected caller-owned first_event_at to pass through, got %v", capture.Properties["first_event_at"])
 	}
 	if capture.Properties["runtime_language"] != "go" {
 		t.Errorf("expected runtime_language to pass through, got %v", capture.Properties["runtime_language"])
@@ -74,15 +78,15 @@ func TestFlushCount_UnknownEventTimesOmitted(t *testing.T) {
 	p := newTestAnalytics(fake)
 
 	p.flushCount(analytics.Worker, analytics.Register, uuid.New(), nil, 1, time.Time{}, time.Time{}, analytics.Properties{
-		"first_event_at": "spoofed",
-		"last_event_at":  "spoofed",
+		"aggregate_first_event_at": "spoofed",
+		"aggregate_last_event_at":  "spoofed",
 	})
 
 	capture := captureFrom(t, fake)
-	if v, ok := capture.Properties["first_event_at"]; ok {
-		t.Errorf("expected no first_event_at, got %v", v)
+	if v, ok := capture.Properties["aggregate_first_event_at"]; ok {
+		t.Errorf("expected no aggregate_first_event_at, got %v", v)
 	}
-	if v, ok := capture.Properties["last_event_at"]; ok {
-		t.Errorf("expected no last_event_at, got %v", v)
+	if v, ok := capture.Properties["aggregate_last_event_at"]; ok {
+		t.Errorf("expected no aggregate_last_event_at, got %v", v)
 	}
 }

--- a/pkg/analytics/posthog/posthog_test.go
+++ b/pkg/analytics/posthog/posthog_test.go
@@ -1,0 +1,88 @@
+package posthog
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/posthog/posthog-go"
+	"github.com/rs/zerolog"
+
+	"github.com/hatchet-dev/hatchet/pkg/analytics"
+)
+
+// fakeClient embeds posthog.Client to satisfy the methods flushCount never
+// calls.
+type fakeClient struct {
+	posthog.Client
+	messages []posthog.Message
+}
+
+func (f *fakeClient) Enqueue(m posthog.Message) error {
+	f.messages = append(f.messages, m)
+	return nil
+}
+
+func newTestAnalytics(fake *fakeClient) *PosthogAnalytics {
+	l := zerolog.Nop()
+	var client posthog.Client = fake
+	return &PosthogAnalytics{client: &client, l: &l}
+}
+
+func captureFrom(t *testing.T, fake *fakeClient) posthog.Capture {
+	t.Helper()
+	if len(fake.messages) != 1 {
+		t.Fatalf("expected 1 enqueued message, got %d", len(fake.messages))
+	}
+	capture, ok := fake.messages[0].(posthog.Capture)
+	if !ok {
+		t.Fatalf("expected a posthog.Capture, got %T", fake.messages[0])
+	}
+	return capture
+}
+
+func TestFlushCount_GeneratedEventTimesWin(t *testing.T) {
+	fake := &fakeClient{}
+	p := newTestAnalytics(fake)
+
+	first := time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC)
+	last := first.Add(time.Minute)
+
+	p.flushCount(analytics.Worker, analytics.Register, uuid.New(), nil, 5, first, last, analytics.Properties{
+		"first_event_at":   "spoofed",
+		"last_event_at":    "spoofed",
+		"runtime_language": "go",
+	})
+
+	capture := captureFrom(t, fake)
+	if capture.Properties["first_event_at"] != first {
+		t.Errorf("expected generated first_event_at %v, got %v", first, capture.Properties["first_event_at"])
+	}
+	if capture.Properties["last_event_at"] != last {
+		t.Errorf("expected generated last_event_at %v, got %v", last, capture.Properties["last_event_at"])
+	}
+	if capture.Properties["count"] != int64(5) {
+		t.Errorf("expected count 5, got %v", capture.Properties["count"])
+	}
+	if capture.Properties["runtime_language"] != "go" {
+		t.Errorf("expected runtime_language to pass through, got %v", capture.Properties["runtime_language"])
+	}
+}
+
+func TestFlushCount_UnknownEventTimesOmitted(t *testing.T) {
+	fake := &fakeClient{}
+	p := newTestAnalytics(fake)
+
+	p.flushCount(analytics.Worker, analytics.Register, uuid.New(), nil, 1, time.Time{}, time.Time{}, analytics.Properties{
+		"first_event_at": "spoofed",
+		"last_event_at":  "spoofed",
+	})
+
+	capture := captureFrom(t, fake)
+	if v, ok := capture.Properties["first_event_at"]; ok {
+		t.Errorf("expected no first_event_at, got %v", v)
+	}
+	if v, ok := capture.Properties["last_event_at"]; ok {
+		t.Errorf("expected no last_event_at, got %v", v)
+	}
+}


### PR DESCRIPTION
# Description

Aggregated Count events are stamped with the flush time, so the real event times are lost. Track the first and last event time in each bucket and include them on the flushed event as first_event_at and last_event_at. The bounds can disagree with the count by one event at an interval boundary. Exact consistency would need a lock in Count, which runs for every event.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## What's Changed

- Each bucket records the first and last event time seen since its last flush. The flush resets them, so the values bracket one flush interval.
- FlushFunc gains firstEventAt and lastEventAt parameters.
- Flushed count events carry the times as first_event_at and last_event_at in UTC, omitted when unknown. Caller properties with those names are dropped, so the values always come from the aggregator.
- Immediate Enqueue events are unchanged.

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted

## Testing

`go test -count=1 -race ./pkg/analytics/...` passes. The new aggregator tests use an injected clock and direct flush calls, so the assertions are deterministic

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Claude Code (Opus 4.8) wrote the tests.

</details>