### PR TITLE
fix(api): return 5xx if webhook lookup errors

### DIFF
--- a/api/v1/server/handlers/v1/webhooks/receive.go
+++ b/api/v1/server/handlers/v1/webhooks/receive.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/labstack/echo/v4"
 
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
@@ -48,7 +49,11 @@ func (w *V1WebhooksService) V1WebhookReceive(ctx echo.Context, request gen.V1Web
 
 	webhook, err := w.config.V1.Webhooks().GetWebhook(ctx.Request().Context(), tenantId, webhookName)
 
-	if err != nil || webhook == nil {
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("failed to look up webhook")
+	}
+
+	if webhook == nil || errors.Is(err, pgx.ErrNoRows) {
 		return gen.V1WebhookReceive400JSONResponse{
 			Errors: []gen.APIError{
 				{


### PR DESCRIPTION
# Description

Returns a 500 if we get an error looking up the webhook for whatever reason (e.g. a timeout)

Fixes # (issue)

https://discord.com/channels/1088927970518909068/1523625740330078369/1523625740330078369

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)


<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI use

</details>
