### PR TITLE
fix: always run rollback in DeferRollback to avoid leaking pool conne…

### DIFF
--- a/pkg/repository/sqlchelpers/tx.go
+++ b/pkg/repository/sqlchelpers/tx.go
@@ -98,12 +98,14 @@ func PrepareTxWithStatementTimeout(ctx context.Context, pool *pgxpool.Pool, l *z
 	_, err = tx.Exec(ctx, fmt.Sprintf("SET statement_timeout=%d", timeoutMs))
 
 	if err != nil {
+		rollback()
 		return nil, nil, nil, err
 	}
 
 	_, err = tx.Exec(ctx, fmt.Sprintf("SET idle_in_transaction_session_timeout=%d", timeoutMs))
 
 	if err != nil {
+		rollback()
 		return nil, nil, nil, err
 	}
 
@@ -174,12 +176,16 @@ func AcquireConnectionWithStatementTimeout(ctx context.Context, pool *pgxpool.Po
 }
 
 func DeferRollback(ctx context.Context, l *zerolog.Logger, rollback func(context.Context) error) {
-
-	if ctx.Err() != nil {
-		return
-	}
-
+	// NOTE: rollback must always run, even if the caller's context has been cancelled, because
+	// pgxpool only releases the connection back to the pool via Rollback/Commit. Skipping the
+	// rollback on a cancelled context permanently leaks the connection from the pool.
 	if err := rollback(ctx); err != nil {
+		// a cancelled context makes the rollback fail, but pgxpool still destroys and releases
+		// the connection, so there's nothing actionable to log
+		if ctx.Err() != nil {
+			return
+		}
+
 		if !errors.Is(err, pgx.ErrTxClosed) {
 			l.Error().Err(err).Msg("failed to rollback transaction")
 

--- a/pkg/repository/sqlchelpers/tx_test.go
+++ b/pkg/repository/sqlchelpers/tx_test.go
@@ -1,0 +1,43 @@
+package sqlchelpers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestDeferRollbackRunsWhenContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	l := zerolog.Nop()
+
+	called := false
+	rollback := func(rollbackCtx context.Context) error {
+		called = true
+		return rollbackCtx.Err()
+	}
+
+	DeferRollback(ctx, &l, rollback)
+
+	if !called {
+		t.Fatal("rollback was not called for a cancelled context; this leaks the pooled connection since pgxpool only releases connections via Rollback/Commit")
+	}
+}
+
+func TestDeferRollbackRunsWithLiveContext(t *testing.T) {
+	l := zerolog.Nop()
+
+	called := false
+	rollback := func(rollbackCtx context.Context) error {
+		called = true
+		return nil
+	}
+
+	DeferRollback(context.Background(), &l, rollback)
+
+	if !called {
+		t.Fatal("rollback was not called")
+	}
+}


### PR DESCRIPTION
# Description

The early return added in #4303 skipped tx.Rollback when the request context was already cancelled. In pgxpool, Rollback/Commit are the only paths that release the connection back to the pool, so every cancelled request that died mid-transaction permanently leaked a pool slot until the process restarted. Rollback now always runs, and we only swallow the error log when the context was cancelled. Also roll back the tx in PrepareTxWithStatementTimeout when the initial SET statements fail.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Always rolls back

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Cursor was used to investigate and write the test.

</details>
