### PR TITLE
fix(api): set the tenant group on tenant:create analytics events

### DIFF
--- a/api/v1/server/handlers/tenants/create.go
+++ b/api/v1/server/handlers/tenants/create.go
@@ -1,6 +1,7 @@
 package tenants
 
 import (
+	"context"
 	"errors"
 
 	"github.com/jackc/pgx/v5"
@@ -97,17 +98,23 @@ func (t *TenantService) TenantCreate(ctx echo.Context, request gen.TenantCreateR
 
 	ctx.Set("tenant", tenant)
 
+	t.dispatchTenantCreateAnalyticsEvent(ctx.Request().Context(), tenant)
+
+	return gen.TenantCreate200JSONResponse(
+		*transformers.ToTenant(tenant, t.config.Runtime.ServerURL),
+	), nil
+}
+
+func (t *TenantService) dispatchTenantCreateAnalyticsEvent(ctx context.Context, tenant *sqlcv1.Tenant) {
+	ctx = context.WithValue(ctx, analytics.TenantIDKey, tenant.ID)
+
 	t.config.Analytics.Enqueue(
-		ctx.Request().Context(),
+		ctx,
 		analytics.Tenant, analytics.Create,
-		tenantId.String(),
+		tenant.ID.String(),
 		map[string]interface{}{
 			"name": tenant.Name,
 			"slug": tenant.Slug,
 		},
 	)
-
-	return gen.TenantCreate200JSONResponse(
-		*transformers.ToTenant(tenant, t.config.Runtime.ServerURL),
-	), nil
 }

--- a/api/v1/server/handlers/tenants/create_test.go
+++ b/api/v1/server/handlers/tenants/create_test.go
@@ -1,0 +1,41 @@
+package tenants
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/hatchet-dev/hatchet/pkg/analytics"
+	"github.com/hatchet-dev/hatchet/pkg/config/server"
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
+)
+
+type enqueueRecorder struct {
+	analytics.NoOpAnalytics
+	ctx context.Context
+}
+
+func (r *enqueueRecorder) Enqueue(ctx context.Context, _ analytics.Resource, _ analytics.Action, _ string, _ analytics.Properties) {
+	r.ctx = ctx
+}
+
+func TestTenantCreateAnalyticsCarriesTenantID(t *testing.T) {
+	t.Parallel()
+
+	rec := &enqueueRecorder{}
+	svc := &TenantService{config: &server.ServerConfig{Analytics: rec}}
+
+	tenant := &sqlcv1.Tenant{ID: uuid.New(), Name: "acme", Slug: "acme"}
+
+	svc.dispatchTenantCreateAnalyticsEvent(context.Background(), tenant)
+
+	if rec.ctx == nil {
+		t.Fatal("expected an Enqueue call")
+	}
+
+	got := analytics.TenantIDFromContext(rec.ctx)
+	if got == nil || *got != tenant.ID {
+		t.Fatalf("expected tenant id %s on the analytics context, got %v", tenant.ID, got)
+	}
+}


### PR DESCRIPTION
# Description

The handler now puts the tenant id on the analytics context before the emit, so the event carries the tenant group like other tenant-scoped events.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- `tenants/create.go` moves the emission into a `dispatchTenantCreateAnalyticsEvent` method and sets `analytics.TenantIDKey` on the context before the emit. The event name and properties are unchanged.
- A new test asserts the context handed to Enqueue carries the created tenant's id.

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted

## Testing

The test builds the service with a fake Analytics implementation that records the Enqueue context, then asserts `TenantIDFromContext` returns the created tenant's id.


---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Claude Code (Opus 4.8) wrote the test.

</details>