### PR TITLE
chore: shrink Docker image sizes

### DIFF
--- a/build/package/frontend.dockerfile
+++ b/build/package/frontend.dockerfile
@@ -15,6 +15,8 @@ FROM golang:1.26-alpine AS staticfileserver
 
 WORKDIR /app
 
+ENV CGO_ENABLED=0
+
 COPY go.mod go.sum ./
 COPY ./cmd/hatchet-staticfileserver/ ./cmd/hatchet-staticfileserver/
 

--- a/build/package/lite.dockerfile
+++ b/build/package/lite.dockerfile
@@ -25,7 +25,7 @@ RUN npm run build
 FROM alpine AS deployment
 
 # install bash via apk
-RUN apk update && apk add --no-cache bash gcc musl-dev openssl bash ca-certificates curl postgresql-client tzdata
+RUN apk update && apk add --no-cache bash openssl ca-certificates curl postgresql-client tzdata
 
 COPY --from=lite-binary-base /hatchet/hatchet-lite ./hatchet-lite
 COPY --from=admin-binary-base /hatchet/hatchet-admin ./hatchet-admin

--- a/build/package/loadtest.dockerfile
+++ b/build/package/loadtest.dockerfile
@@ -3,6 +3,8 @@
 FROM golang:1.26-alpine as base
 WORKDIR /hatchet
 
+ENV CGO_ENABLED=0
+
 COPY go.mod go.sum ./
 
 RUN go mod download
@@ -25,7 +27,7 @@ FROM alpine AS deployment
 WORKDIR /hatchet
 
 # openssl and bash needed for admin build
-RUN apk update && apk add --no-cache gcc musl-dev openssl bash ca-certificates tzdata
+RUN apk update && apk add --no-cache openssl bash ca-certificates tzdata
 
 COPY --from=build-go /hatchet/bin/hatchet-load-test /hatchet/
 

--- a/build/package/servers.dockerfile
+++ b/build/package/servers.dockerfile
@@ -3,7 +3,9 @@
 FROM golang:1.26-alpine as base
 WORKDIR /hatchet
 
-RUN apk update && apk add --no-cache gcc musl-dev git protoc protobuf-dev
+ENV CGO_ENABLED=0
+
+RUN apk update && apk add --no-cache git protoc protobuf-dev
 
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
@@ -72,7 +74,7 @@ ENV SERVER_TARGET=${SERVER_TARGET}
 WORKDIR /hatchet
 
 # openssl and bash needed for admin build
-RUN apk update && apk add --no-cache gcc musl-dev openssl bash ca-certificates tzdata
+RUN apk update && apk add --no-cache openssl bash ca-certificates tzdata
 
 COPY --from=build-go /hatchet/bin/hatchet-${SERVER_TARGET} /hatchet/
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

Our Docker images are bigger in size than expected. The rootfs of almost all images contain a full gcc toolchain with the muslc library which are useless.

Stats table against `latest` as of July 7, 2026:
| Image | Old rootfs | New rootfs | Saved |
|---|--:|--:|--:|
| engine | 260 MB | 59 MB | 201 MB (77%) |
| api | 262 MB | 60 MB | 201 MB (77%) |
| admin | 280 MB | 78 MB | 202 MB (72%) |
| migrate | 228 MB | 28 MB | 199 MB (87%) |
| lite | 370 MB | 164 MB | 205 MB (56%) |

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (changes which are not directly related to any business logic)

## What's Changed

- [x] Removes gcc and muslc from respective images

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
