### PR TITLE
fix: Tenant members should not be able to see API tokens nav menu item

### DIFF
--- a/frontend/app/src/pages/main/v1/index.tsx
+++ b/frontend/app/src/pages/main/v1/index.tsx
@@ -6,7 +6,7 @@ import { Loading } from '@/components/v1/ui/loading';
 import useCloud from '@/hooks/use-cloud';
 import { useOrganizations } from '@/hooks/use-organizations';
 import { useTenantDetails } from '@/hooks/use-tenant';
-import { queries } from '@/lib/api';
+import { queries, TenantMemberRole } from '@/lib/api';
 import {
   MembershipsContextType,
   UserContextType,
@@ -19,7 +19,7 @@ import { ReactNode, useEffect, useMemo } from 'react';
 export function MainShell({ children }: { children?: ReactNode }) {
   const ctx = useOutletContext<UserContextType & MembershipsContextType>();
   const { user, memberships } = ctx;
-  const { tenantId, isUserUniverseLoaded } = useTenantDetails();
+  const { tenantId, isUserUniverseLoaded, membership } = useTenantDetails();
   const { cloud, featureFlags, isCloudEnabled } = useCloud(tenantId);
   const managedWorkerEnabled = featureFlags?.['managed-worker'] === 'true';
   const { getOrganizationIdForTenant } = useOrganizations();
@@ -29,6 +29,9 @@ export function MainShell({ children }: { children?: ReactNode }) {
       ? (getOrganizationIdForTenant(tenantId) ?? undefined)
       : undefined
     : undefined;
+  const canManageApiTokens =
+    membership === TenantMemberRole.OWNER ||
+    membership === TenantMemberRole.ADMIN;
 
   useEffect(() => {
     if (!tenantId) {
@@ -47,8 +50,15 @@ export function MainShell({ children }: { children?: ReactNode }) {
         managedWorkerEnabled,
         isCloudEnabled,
         orgId,
+        canManageApiTokens,
       }),
-    [cloud?.canBill, managedWorkerEnabled, isCloudEnabled, orgId],
+    [
+      cloud?.canBill,
+      managedWorkerEnabled,
+      isCloudEnabled,
+      orgId,
+      canManageApiTokens,
+    ],
   );
 
   const childCtx = useContextFromParent({

--- a/frontend/app/src/pages/main/v1/side-nav-items.tsx
+++ b/frontend/app/src/pages/main/v1/side-nav-items.tsx
@@ -24,6 +24,7 @@ export function sideNavItems(opts: {
   managedWorkerEnabled?: boolean;
   isCloudEnabled?: boolean;
   orgId?: string;
+  canManageApiTokens?: boolean;
 }): SideNavSection[] {
   return [
     {
@@ -279,16 +280,20 @@ export function sideNavItems(opts: {
             />
           ),
         },
-        {
-          key: 'settings-api-tokens',
-          name: 'API Tokens',
-          to: appRoutes.tenantSettingsApiTokensRoute.to,
-          icon: ({ collapsed }: { collapsed: boolean }) => (
-            <RiKey2Line
-              className={collapsed ? 'size-5' : 'mr-2 size-4 shrink-0'}
-            />
-          ),
-        },
+        ...(opts.canManageApiTokens
+          ? [
+              {
+                key: 'settings-api-tokens',
+                name: 'API Tokens',
+                to: appRoutes.tenantSettingsApiTokensRoute.to,
+                icon: ({ collapsed }: { collapsed: boolean }) => (
+                  <RiKey2Line
+                    className={collapsed ? 'size-5' : 'mr-2 size-4 shrink-0'}
+                  />
+                ),
+              },
+            ]
+          : []),
         ...(opts.canBill && opts.orgId
           ? [
               {

--- a/frontend/app/src/pages/main/v1/tenant-settings/api-tokens/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/api-tokens/index.tsx
@@ -5,22 +5,56 @@ import { RevokeTokenForm } from './components/revoke-token-form';
 import { EmptyState } from '@/components/v1/molecules/empty-state/empty-state';
 import RelativeDate from '@/components/v1/molecules/relative-date';
 import { SimpleTable } from '@/components/v1/molecules/simple-table/simple-table';
+import { Alert, AlertDescription, AlertTitle } from '@/components/v1/ui/alert';
 import { Button } from '@/components/v1/ui/button';
 import { Dialog } from '@/components/v1/ui/dialog';
-import { useCurrentTenantId } from '@/hooks/use-tenant';
-import api, { APIToken, CreateAPITokenRequest, queries } from '@/lib/api';
+import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
+import api, {
+  APIToken,
+  CreateAPITokenRequest,
+  queries,
+  TenantMemberRole,
+} from '@/lib/api';
 import { useApiError } from '@/lib/hooks';
 import { useMutation, useQuery } from '@tanstack/react-query';
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import { useState, useMemo } from 'react';
 
 export default function APITokens() {
   const { tenantId } = useCurrentTenantId();
+  const { membership } = useTenantDetails();
+  const canManageApiTokens =
+    membership === TenantMemberRole.OWNER ||
+    membership === TenantMemberRole.ADMIN;
   const [showTokenDialog, setShowTokenDialog] = useState(false);
   const [revokeToken, setRevokeToken] = useState<APIToken | null>(null);
 
   const listTokensQuery = useQuery({
     ...queries.tokens.list(tenantId),
+    enabled: canManageApiTokens,
   });
+
+  if (!canManageApiTokens) {
+    return (
+      <div className="h-full w-full flex-grow">
+        <div className="mx-auto px-4 py-8 sm:px-6 lg:px-8">
+          <SettingsPageHeader
+            title="API token settings"
+            description="Create and revoke API tokens used by workers and external systems to authenticate with this tenant."
+          />
+          <Alert variant="warn">
+            <ExclamationTriangleIcon className="size-4" />
+            <AlertTitle className="font-semibold">
+              You do not have permission to manage API tokens.
+            </AlertTitle>
+            <AlertDescription>
+              Only tenant owners and admins can view or manage API tokens.
+            </AlertDescription>
+          </Alert>
+        </div>
+      </div>
+    );
+  }
 
   const tokenColumns = useMemo(
     () => [

--- a/frontend/app/src/pages/main/v1/tenant-settings/api-tokens/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/api-tokens/index.tsx
@@ -16,8 +16,8 @@ import api, {
   TenantMemberRole,
 } from '@/lib/api';
 import { useApiError } from '@/lib/hooks';
-import { useMutation, useQuery } from '@tanstack/react-query';
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useState, useMemo } from 'react';
 
 export default function APITokens() {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Tenant members are currently able to see the API tokens nav item, and navigate to the page, but the actual token creation API call fails because they don't have permissions. This fixes that, so they can't see it unless they're an `ADMIN` or `OWNER` role.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
