### PR TITLE
fix(engine): raise non-determinism error on incorrect skip entry ordering

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
-          version: "29.3"
+          version: "29.6"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Task

--- a/examples/python/bug_tests/durable_spawn_index_collision/worker.py
+++ b/examples/python/bug_tests/durable_spawn_index_collision/worker.py
@@ -1,0 +1,52 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+from hatchet_sdk import Context, DurableContext, EmptyModel, Hatchet
+from hatchet_sdk.runnables.contextvars import ctx_action_key, workflow_spawn_indices
+
+hatchet = Hatchet()
+
+
+class SpawnIndexCollisionInput(BaseModel):
+    scenario: Literal["collision", "self_dedupe"]
+
+
+class OutputA(BaseModel):
+    which_child: Literal["a"]
+
+
+class OutputB(BaseModel):
+    which_child: Literal["b"]
+
+
+@hatchet.task()
+async def spawn_index_child_a(_i: EmptyModel, ctx: Context) -> OutputA:
+    return OutputA(which_child="a")
+
+
+@hatchet.task()
+async def spawn_index_child_b(_i: EmptyModel, ctx: Context) -> OutputB:
+    return OutputB(which_child="b")
+
+
+@hatchet.durable_task(input_validator=SpawnIndexCollisionInput)
+async def durable_spawn_index_collision(
+    input: SpawnIndexCollisionInput, ctx: DurableContext
+) -> dict[str, Any]:
+    first = await spawn_index_child_a.aio_run()  # child_index 0
+    await spawn_index_child_b.aio_run()  # child_index 1
+
+    key = ctx_action_key.get()
+    assert key is not None
+
+    if input.scenario == "collision":
+        # next spawn claims index 1, which is bound to child B
+        workflow_spawn_indices[key] -= 1
+    else:
+        # next spawn claims index 0, child A's own binding
+        workflow_spawn_indices[key] -= 2
+
+    respawned = await spawn_index_child_a.aio_run()
+
+    return {"first": first, "respawned": respawned}

--- a/examples/python/worker.py
+++ b/examples/python/worker.py
@@ -103,6 +103,11 @@ from examples.bug_tests.durable_child_key_duplicate_child.worker import (
     durable_parent_child_key_bug,
     child_child_key_bug,
 )
+from examples.bug_tests.durable_spawn_index_collision.worker import (
+    durable_spawn_index_collision,
+    spawn_index_child_a,
+    spawn_index_child_b,
+)
 from hatchet_sdk import Hatchet
 
 hatchet = Hatchet()
@@ -195,6 +200,9 @@ def main() -> None:
             welcome_email,
             durable_parent_child_key_bug,
             child_child_key_bug,
+            durable_spawn_index_collision,
+            spawn_index_child_a,
+            spawn_index_child_b,
             durable_child_key_dedup_replay,
             durable_spawn_many_dags,
             error_raising_durable_parent,

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -912,8 +912,26 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 		}
 
 		for _, o := range skipOpts {
-			if _, ok := childTaskExternalIdToSkipEntry[o.ChildTaskExternalId]; !ok {
+			e, ok := childTaskExternalIdToSkipEntry[o.ChildTaskExternalId]
+
+			if !ok {
 				return nil, fmt.Errorf("expected to find log entry for skipped child task external id %s", o.ChildTaskExternalId)
+			}
+
+			if len(o.IdempotencyKey) > 0 && !bytes.Equal(o.IdempotencyKey, e.IdempotencyKey) {
+				return nil, &NonDeterminismError{
+					BranchId:                e.BranchID,
+					NodeId:                  e.NodeID,
+					TaskExternalId:          opts.DurableTaskExternalId,
+					ExpectedIdempotencyKey:  e.IdempotencyKey,
+					ActualIdempotencyKey:    o.IdempotencyKey,
+					ExpectedKind:            e.Kind,
+					ActualKind:              o.Kind,
+					ExistingEntryId:         e.ID,
+					ExistingEntryInsertedAt: e.InsertedAt,
+					ExistingEntryTenantId:   e.TenantID,
+					ExistingEntryExternalId: e.ExternalID,
+				}
 			}
 		}
 	}
@@ -1075,9 +1093,15 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 			externalIdToTriggerOpts[triggerOpts.ExternalId] = triggerOpts
 
 			if triggerOpts.ShouldSkip {
+				idempotencyKey, keyErr := r.createIdempotencyKey(sqlcv1.V1DurableEventLogKindRUN, triggerOpts, nil)
+				if keyErr != nil {
+					return nil, fmt.Errorf("failed to create idempotency key: %w", keyErr)
+				}
+
 				innerOpts[i] = GetOrCreateLogEntryOpt{
 					Kind:                sqlcv1.V1DurableEventLogKindRUN,
 					ChildTaskExternalId: triggerOpts.ExternalId,
+					IdempotencyKey:      idempotencyKey,
 					ShouldSkip:          true,
 				}
 				continue

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -1093,9 +1093,16 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 			externalIdToTriggerOpts[triggerOpts.ExternalId] = triggerOpts
 
 			if triggerOpts.ShouldSkip {
-				idempotencyKey, keyErr := r.createIdempotencyKey(sqlcv1.V1DurableEventLogKindRUN, triggerOpts, nil)
-				if keyErr != nil {
-					return nil, fmt.Errorf("failed to create idempotency key: %w", keyErr)
+				// only index-based dedupe is validated against the existing entry's
+				// idempotency key: an explicit child_key intentionally reuses the
+				// cached child even when the inputs differ
+				var idempotencyKey []byte
+				if triggerOpts.ChildKey == nil {
+					key, keyErr := r.createIdempotencyKey(sqlcv1.V1DurableEventLogKindRUN, triggerOpts, nil)
+					if keyErr != nil {
+						return nil, fmt.Errorf("failed to create idempotency key: %w", keyErr)
+					}
+					idempotencyKey = key
 				}
 
 				innerOpts[i] = GetOrCreateLogEntryOpt{

--- a/sdks/python/examples/bug_tests/durable_spawn_index_collision/test_durable_spawn_index_collision.py
+++ b/sdks/python/examples/bug_tests/durable_spawn_index_collision/test_durable_spawn_index_collision.py
@@ -1,0 +1,38 @@
+import pytest
+
+from examples.bug_tests.durable_spawn_index_collision.worker import (
+    SpawnIndexCollisionInput,
+    durable_spawn_index_collision,
+)
+from hatchet_sdk import Hatchet, V1TaskStatus
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_spawn_index_collision_fails_loudly(hatchet: Hatchet) -> None:
+    ref = await durable_spawn_index_collision.aio_run(
+        input=SpawnIndexCollisionInput(scenario="collision"), wait_for_result=False
+    )
+
+    with pytest.raises(Exception, match="[nN]on-determinism"):
+        await ref.aio_result()
+
+    runs = await hatchet.runs.aio_list(parent_task_external_id=ref.workflow_run_id)
+
+    assert len(runs.rows) == 2, "the colliding spawn must not create a third child"
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_spawn_index_self_dedupe_returns_cached_result(hatchet: Hatchet) -> None:
+    ref = await durable_spawn_index_collision.aio_run(
+        input=SpawnIndexCollisionInput(scenario="self_dedupe"), wait_for_result=False
+    )
+
+    result = await ref.aio_result()
+
+    assert result["first"] == {"which_child": "a"}
+    assert result["respawned"] == {"which_child": "a"}
+
+    runs = await hatchet.runs.aio_list(parent_task_external_id=ref.workflow_run_id)
+
+    assert len(runs.rows) == 2, "the deduped spawn must not create a third child"
+    assert all(run.status == V1TaskStatus.COMPLETED for run in runs.rows)

--- a/sdks/python/examples/bug_tests/durable_spawn_index_collision/worker.py
+++ b/sdks/python/examples/bug_tests/durable_spawn_index_collision/worker.py
@@ -1,0 +1,52 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+from hatchet_sdk import Context, DurableContext, EmptyModel, Hatchet
+from hatchet_sdk.runnables.contextvars import ctx_action_key, workflow_spawn_indices
+
+hatchet = Hatchet()
+
+
+class SpawnIndexCollisionInput(BaseModel):
+    scenario: Literal["collision", "self_dedupe"]
+
+
+class OutputA(BaseModel):
+    which_child: Literal["a"]
+
+
+class OutputB(BaseModel):
+    which_child: Literal["b"]
+
+
+@hatchet.task()
+async def spawn_index_child_a(_i: EmptyModel, ctx: Context) -> OutputA:
+    return OutputA(which_child="a")
+
+
+@hatchet.task()
+async def spawn_index_child_b(_i: EmptyModel, ctx: Context) -> OutputB:
+    return OutputB(which_child="b")
+
+
+@hatchet.durable_task(input_validator=SpawnIndexCollisionInput)
+async def durable_spawn_index_collision(
+    input: SpawnIndexCollisionInput, ctx: DurableContext
+) -> dict[str, Any]:
+    first = await spawn_index_child_a.aio_run()  # child_index 0
+    await spawn_index_child_b.aio_run()  # child_index 1
+
+    key = ctx_action_key.get()
+    assert key is not None
+
+    if input.scenario == "collision":
+        # next spawn claims index 1, which is bound to child B
+        workflow_spawn_indices[key] -= 1
+    else:
+        # next spawn claims index 0, child A's own binding
+        workflow_spawn_indices[key] -= 2
+
+    respawned = await spawn_index_child_a.aio_run()
+
+    return {"first": first, "respawned": respawned}

--- a/sdks/python/examples/worker.py
+++ b/sdks/python/examples/worker.py
@@ -103,6 +103,11 @@ from examples.bug_tests.durable_child_key_duplicate_child.worker import (
     durable_parent_child_key_bug,
     child_child_key_bug,
 )
+from examples.bug_tests.durable_spawn_index_collision.worker import (
+    durable_spawn_index_collision,
+    spawn_index_child_a,
+    spawn_index_child_b,
+)
 from hatchet_sdk import Hatchet
 
 hatchet = Hatchet()
@@ -195,6 +200,9 @@ def main() -> None:
             welcome_email,
             durable_parent_child_key_bug,
             child_child_key_bug,
+            durable_spawn_index_collision,
+            spawn_index_child_a,
+            spawn_index_child_b,
             durable_child_key_dedup_replay,
             durable_spawn_many_dags,
             error_raising_durable_parent,


### PR DESCRIPTION
# Description

Fixes a bug where if we somehow get out-of-order skip entries (from incorrect / jumbled child keys or child indices set on the sdks), we'd potentially return the wrong payload to the caller since we're keyed on the node id. Instead, we check the idempotency key associated with the incoming trigger opts and raise non-determinism, since this is at least a clearer error message.

the underlying bug (sending the wrong index) should have been fixed already in #4368

also added a test that reproduces the bug on main (which shows the same error as the one in the original report):

```python
pydantic_core._pydantic_core.ValidationError: 1 validation error for OutputA
which_child
Input should be 'a' [type=literal_error, input_value='b', input_type=str]
For further information visit https://errors.pydantic.dev/2.13/v/literal_error
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Fable helped diagnose the issue

</details>
