### PR TITLE
fix: invert shouldRefill() condition in v1 scheduler rate limiter

### DIFF
--- a/pkg/scheduling/v1/rate_limit.go
+++ b/pkg/scheduling/v1/rate_limit.go
@@ -179,7 +179,7 @@ func (r *rateLimiter) shouldRefill() bool {
 		return false
 	}
 
-	return r.nextRefillAt.After(time.Now().UTC())
+	return !r.nextRefillAt.After(time.Now().UTC())
 }
 
 func (r *rateLimiter) copyDbRateLimits() rateLimitSet {

--- a/pkg/scheduling/v1/rate_limit_test.go
+++ b/pkg/scheduling/v1/rate_limit_test.go
@@ -218,6 +218,72 @@ func TestRateLimiter_FlushToDatabase(t *testing.T) {
 	assert.Empty(t, rateLimiter.unflushed)
 }
 
+func TestRateLimiter_ShouldRefill(t *testing.T) {
+	l := zerolog.Nop()
+
+	t.Run("nil nextRefillAt returns false", func(t *testing.T) {
+		r := &rateLimiter{
+			dbRateLimits: make(rateLimitSet),
+			unacked:      make(map[int64]rateLimitSet),
+			unflushed:    make(rateLimitSet),
+			l:            &l,
+		}
+		assert.False(t, r.shouldRefill())
+	})
+
+	t.Run("future nextRefillAt returns false", func(t *testing.T) {
+		future := time.Now().Add(time.Hour)
+		r := &rateLimiter{
+			nextRefillAt: &future,
+			dbRateLimits: make(rateLimitSet),
+			unacked:      make(map[int64]rateLimitSet),
+			unflushed:    make(rateLimitSet),
+			l:            &l,
+		}
+		assert.False(t, r.shouldRefill())
+	})
+
+	t.Run("past nextRefillAt returns true", func(t *testing.T) {
+		past := time.Now().Add(-time.Hour)
+		r := &rateLimiter{
+			nextRefillAt: &past,
+			dbRateLimits: make(rateLimitSet),
+			unacked:      make(map[int64]rateLimitSet),
+			unflushed:    make(rateLimitSet),
+			l:            &l,
+		}
+		assert.True(t, r.shouldRefill())
+	})
+}
+
+func TestRateLimiter_UseRefreshesFromDbOnExpiredWindow(t *testing.T) {
+	l := zerolog.Nop()
+
+	mockRateLimitRepo := &mockRateLimitRepo{}
+	mockRows := []*sqlcv1.ListRateLimitsForTenantWithMutateRow{
+		{Key: "key1", Value: 10},
+	}
+	past := time.Now().Add(-time.Second)
+	mockRateLimitRepo.On("UpdateRateLimits", context.Background(), mock.Anything, mock.Anything).Return(mockRows, &past, nil)
+
+	rateLimiter := &rateLimiter{
+		dbRateLimits: rateLimitSet{
+			"key1": {key: "key1", val: 0, nextRefillAt: &past},
+		},
+		nextRefillAt:   &past,
+		unacked:        make(map[int64]rateLimitSet),
+		unflushed:      make(rateLimitSet),
+		l:              &l,
+		rateLimitRepo:  mockRateLimitRepo,
+	}
+
+	// use() detects the expired window via shouldRefill(), triggers flushToDatabase,
+	// and the refreshed limits (val: 10) should allow the request
+	res := rateLimiter.use(context.Background(), 1, map[string]int32{"key1": 5})
+	assert.True(t, res.succeeded)
+	mockRateLimitRepo.AssertExpectations(t)
+}
+
 func BenchmarkRateLimiter(b *testing.B) {
 	l := zerolog.Nop()
 


### PR DESCRIPTION
## Description

`shouldRefill()` in the v1 scheduler rate limiter had its condition inverted. It returned `true` when `nextRefillAt` was still in the future (window still open, no refill needed) — the opposite of when a refill is actually due.

## The bug

`pkg/scheduling/v1/rate_limit.go:182`:
```go
return r.nextRefillAt.After(time.Now().UTC())
```

This returns `true` while the refill time is still in the future. Compare with the guard inside `flushToDatabase()` (line 292), which no-ops while `nextRefillAt.After(now)` and only does real work once the boundary has passed. The two are meant to agree; `shouldRefill()` got the negation wrong.

## Impact

Both failure modes land in `use()` at line 118:

1. **After a window rolls over**: `shouldRefill()` reports `false`, so `use()` never triggers the on-demand refresh. Tasks are evaluated against depleted counts from the previous window and rejected until the 1s `loopFlush` ticker fires. Up to ~1s of spurious rate-limit rejections per window rollover, per tenant.

2. **Before the window rolls over** (the common case): `shouldRefill()` reports `true`, so every `use()` call runs `flushToDatabase()`, which takes three write locks (`unflushedMu`, `dbRateLimitsMu`, `nextRefillAtMu`) and immediately returns doing nothing. `use()` sits on the per-task scheduling path — constant write-lock churn for zero work.

## Fix

```go
return !r.nextRefillAt.After(time.Now().UTC())
```

This aligns `shouldRefill()` with the `flushToDatabase()` guard: returns `true` when `now >= nextRefillAt` (refill is due), `false` while the window is still open.

Fixes #4346