### PR TITLE
chore: make sure we are only building stripped go binaries for Docker containers

### DIFF
--- a/build/package/frontend.dockerfile
+++ b/build/package/frontend.dockerfile
@@ -20,7 +20,7 @@ ENV CGO_ENABLED=0
 COPY go.mod go.sum ./
 COPY ./cmd/hatchet-staticfileserver/ ./cmd/hatchet-staticfileserver/
 
-RUN go build -o hatchet-staticfileserver ./cmd/hatchet-staticfileserver/main.go
+RUN go build -ldflags="-w -s" -a -o hatchet-staticfileserver ./cmd/hatchet-staticfileserver/main.go
 RUN chmod +x ./hatchet-staticfileserver
 
 # Stage 3: Run the static fileserver

--- a/build/package/loadtest.dockerfile
+++ b/build/package/loadtest.dockerfile
@@ -18,7 +18,7 @@ COPY /cmd/hatchet-loadtest ./cli
 # --------------------
 FROM base AS build-go
 
-RUN go build -a -o ./bin/hatchet-load-test ./cli
+RUN go build -ldflags="-w -s" -a -o ./bin/hatchet-load-test ./cli
 
 # Deployment environment
 # ----------------------


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Make sure we always strip symbols and debug information when building Go binaries.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (changes which are not directly related to any business logic)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
