### PR TITLE
fix: infinite modal loop

### DIFF
--- a/frontend/app/src/components/modals/domain-redirect-modal.tsx
+++ b/frontend/app/src/components/modals/domain-redirect-modal.tsx
@@ -15,13 +15,15 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
 
-type CloudMetadataQueryData = APICloudMetadata & { isCloudEnabled?: boolean };
+type CloudMetadataQueryData = APICloudMetadata & {
+  isLegacyCloudEnabled?: boolean;
+};
 
 function isCloudEnabledMetadata(data: unknown): data is CloudMetadataQueryData {
   return (
     typeof data === 'object' &&
     data !== null &&
-    (data as CloudMetadataQueryData).isCloudEnabled === true
+    (data as CloudMetadataQueryData).isLegacyCloudEnabled === true
   );
 }
 

--- a/frontend/app/src/components/modals/invite-modal.tsx
+++ b/frontend/app/src/components/modals/invite-modal.tsx
@@ -31,24 +31,11 @@ import { useEffect, useMemo, useState } from 'react';
 interface InviteModalProps {
   isOpen: boolean;
   onClose: () => void;
-  // Must match the flags used by whatever drives `isOpen` (e.g. the auto-open
-  // effect in authenticated.tsx). `usePendingInvites` keys its query on these,
-  // so a mismatch points the modal at a different cache entry than the opener —
-  // the modal then sees `inviteCount: 0` and stale-closes in a loop. When
-  // omitted, they fall back to the async `useCloud`/`useControlPlane` hooks,
-  // which start `false` while loading and can transiently diverge.
-  isCloudEnabled?: boolean;
-  isControlPlaneEnabled?: boolean;
 }
 
-export function InviteModal({
-  isOpen,
-  onClose,
-  isCloudEnabled,
-  isControlPlaneEnabled,
-}: InviteModalProps) {
+export function InviteModal({ isOpen, onClose }: InviteModalProps) {
   const { pendingInvitesQuery, invalidate: invalidatePendingInvites } =
-    usePendingInvites({ isCloudEnabled, isControlPlaneEnabled });
+    usePendingInvites();
   const { tenantMemberships } = useUserUniverse();
   const { setTenant } = useTenantDetails();
 

--- a/frontend/app/src/components/modals/invite-modal.tsx
+++ b/frontend/app/src/components/modals/invite-modal.tsx
@@ -31,11 +31,24 @@ import { useEffect, useMemo, useState } from 'react';
 interface InviteModalProps {
   isOpen: boolean;
   onClose: () => void;
+  // Must match the flags used by whatever drives `isOpen` (e.g. the auto-open
+  // effect in authenticated.tsx). `usePendingInvites` keys its query on these,
+  // so a mismatch points the modal at a different cache entry than the opener —
+  // the modal then sees `inviteCount: 0` and stale-closes in a loop. When
+  // omitted, they fall back to the async `useCloud`/`useControlPlane` hooks,
+  // which start `false` while loading and can transiently diverge.
+  isCloudEnabled?: boolean;
+  isControlPlaneEnabled?: boolean;
 }
 
-export function InviteModal({ isOpen, onClose }: InviteModalProps) {
+export function InviteModal({
+  isOpen,
+  onClose,
+  isCloudEnabled,
+  isControlPlaneEnabled,
+}: InviteModalProps) {
   const { pendingInvitesQuery, invalidate: invalidatePendingInvites } =
-    usePendingInvites();
+    usePendingInvites({ isCloudEnabled, isControlPlaneEnabled });
   const { tenantMemberships } = useUserUniverse();
   const { setTenant } = useTenantDetails();
 
@@ -73,12 +86,16 @@ export function InviteModal({ isOpen, onClose }: InviteModalProps) {
     }
   }, [isOpen, invalidatePendingInvites, reset]);
 
-  // Close immediately if opened with stale data that resolves to 0 invites
+  // Close immediately if opened with stale data that resolves to 0 invites.
+  // Gate on `!isFetching`: while a refetch is in flight react-query retains the
+  // previous (possibly stale count=0) data, and closing on it would fight
+  // whatever opened the modal — an open/close loop.
   useEffect(() => {
     if (
       isOpen &&
       phase === 'invites' &&
       pendingInvitesQuery.isSuccess &&
+      !pendingInvitesQuery.isFetching &&
       totalInviteCount === 0 &&
       processedIds.size === 0
     ) {
@@ -88,6 +105,7 @@ export function InviteModal({ isOpen, onClose }: InviteModalProps) {
     isOpen,
     phase,
     pendingInvitesQuery.isSuccess,
+    pendingInvitesQuery.isFetching,
     totalInviteCount,
     processedIds.size,
     onClose,

--- a/frontend/app/src/hooks/use-cloud.ts
+++ b/frontend/app/src/hooks/use-cloud.ts
@@ -1,29 +1,45 @@
 import useControlPlane from '@/hooks/use-control-plane';
-import { cloudApi } from '@/lib/api/api';
+import { cloudApi, fetchControlPlaneStatus } from '@/lib/api/api';
 import {
   APICloudMetadata,
   FeatureFlags,
 } from '@/lib/api/generated/cloud/data-contracts';
 import { useQuery } from '@tanstack/react-query';
 
-export const metadataIndicatesCloudEnabled = (cloudMeta: APICloudMetadata) => {
+export const metadataIndicatesLegacyCloudEnabled = (
+  cloudMeta: APICloudMetadata,
+) => {
   // @ts-expect-error errors is returned when this is oss
   return !!cloudMeta && !cloudMeta?.errors;
 };
 
+// Detects the legacy (non-control-plane) hosted-cloud backend. This is a
+// distinct concept from `useCloud().isCloudEnabled`, which is `true` under the
+// control plane too — see the note there. Callers that mean "is the legacy
+// cloud backend active?" (route loaders, cloud metadata consumers) read
+// `isLegacyCloudEnabled`; callers that mean "should cloud-style features be
+// available?" read `useCloud().isCloudEnabled`.
 export const getCloudMetadataQuery = {
   queryKey: ['cloud-metadata:get'],
   retry: false,
   queryFn: async () => {
+    // Under the control plane there is no legacy cloud backend: the control
+    // plane is the source of truth, so `/api/v1/cloud/metadata` (which 403s) is
+    // never hit.
+    const { isControlPlaneEnabled } = await fetchControlPlaneStatus();
+    if (isControlPlaneEnabled) {
+      return { isLegacyCloudEnabled: false } as const;
+    }
+
     try {
       const { data: meta } = await cloudApi.metadataGet();
-      const isCloudEnabled = metadataIndicatesCloudEnabled(meta);
-      if (isCloudEnabled) {
+      const isLegacyCloudEnabled = metadataIndicatesLegacyCloudEnabled(meta);
+      if (isLegacyCloudEnabled) {
         console.log('🪓☁️');
 
         return {
           ...meta,
-          isCloudEnabled,
+          isLegacyCloudEnabled,
         };
       }
 
@@ -36,7 +52,7 @@ export const getCloudMetadataQuery = {
     }
 
     return {
-      isCloudEnabled: false,
+      isLegacyCloudEnabled: false,
     } as const;
   },
   staleTime: 1000 * 60,
@@ -65,6 +81,11 @@ type UseCloudReturn =
       cloud: null;
     };
 
+// `isCloudEnabled` here is the *feature* sense: "should cloud-style features
+// (billing, GitHub linking, metrics) be available?". It is `true` under the
+// control plane, which provides those features, even though there is no legacy
+// cloud backend (`isLegacyCloudEnabled` is `false` then). Outside the control
+// plane the two coincide.
 export default function useCloud(tenantId?: string): UseCloudReturn {
   const cloudMetaQuery = useQuery(getCloudMetadataQuery);
   const { isControlPlaneEnabled, controlPlaneMeta } = useControlPlane();
@@ -73,7 +94,7 @@ export default function useCloud(tenantId?: string): UseCloudReturn {
     queryKey: ['feature-flags:list', tenantId],
     retry: false,
     enabled:
-      (isControlPlaneEnabled || cloudMetaQuery.data?.isCloudEnabled) &&
+      (isControlPlaneEnabled || cloudMetaQuery.data?.isLegacyCloudEnabled) &&
       !!tenantId,
     queryFn: async () => {
       try {
@@ -106,10 +127,10 @@ export default function useCloud(tenantId?: string): UseCloudReturn {
     };
   }
 
-  if (cloudMetaQuery.data && cloudMetaQuery.data.isCloudEnabled) {
+  if (cloudMetaQuery.data && cloudMetaQuery.data.isLegacyCloudEnabled) {
     return {
       cloud: cloudMetaQuery.data,
-      isCloudEnabled: cloudMetaQuery.data.isCloudEnabled,
+      isCloudEnabled: cloudMetaQuery.data.isLegacyCloudEnabled,
       isCloudLoaded: true,
       isCloudLoading: cloudMetaQuery.isLoading,
       featureFlags: featureFlagsQuery.data?.data || null,
@@ -121,6 +142,8 @@ export default function useCloud(tenantId?: string): UseCloudReturn {
     isCloudLoaded: cloudMetaQuery.isSuccess,
     isCloudLoading: cloudMetaQuery.isLoading,
     featureFlags: featureFlagsQuery.data?.data || null,
-    cloud: cloudMetaQuery?.data?.isCloudEnabled ? cloudMetaQuery.data : null,
+    cloud: cloudMetaQuery?.data?.isLegacyCloudEnabled
+      ? cloudMetaQuery.data
+      : null,
   };
 }

--- a/frontend/app/src/hooks/use-pending-invites.ts
+++ b/frontend/app/src/hooks/use-pending-invites.ts
@@ -24,11 +24,11 @@ export const pendingInvitesQuery = (
       isControlPlaneEnabled
         ? controlPlaneApi.userListTenantInvites()
         : api.userListTenantInvites(),
-      isCloudEnabled || isControlPlaneEnabled
-        ? isControlPlaneEnabled
-          ? controlPlaneApi.userListOrganizationInvites()
-          : cloudApi.userListOrganizationInvites()
-        : Promise.resolve({ data: { rows: [] } }),
+      isControlPlaneEnabled
+        ? controlPlaneApi.userListOrganizationInvites()
+        : isCloudEnabled
+          ? cloudApi.userListOrganizationInvites()
+          : Promise.resolve({ data: { rows: [] } }),
     ]);
 
     const tenantInvites: TenantInvite[] =
@@ -53,19 +53,13 @@ export const pendingInvitesQuery = (
   staleTime: 30_000,
 });
 
-export const usePendingInvites = (opts?: {
-  isCloudEnabled?: boolean;
-  isControlPlaneEnabled?: boolean;
-}) => {
+export const usePendingInvites = () => {
   const { isCloudEnabled, isCloudLoading } = useCloud();
   const { isControlPlaneEnabled } = useControlPlane();
   const queryClient = useQueryClient();
-  const resolvedIsCloudEnabled = opts?.isCloudEnabled ?? isCloudEnabled;
-  const resolvedIsControlPlaneEnabled =
-    opts?.isControlPlaneEnabled ?? isControlPlaneEnabled;
 
   const query = useQuery(
-    pendingInvitesQuery(resolvedIsCloudEnabled, resolvedIsControlPlaneEnabled),
+    pendingInvitesQuery(isCloudEnabled, isControlPlaneEnabled),
   );
 
   const invalidate = useCallback(() => {

--- a/frontend/app/src/pages/authenticated.tsx
+++ b/frontend/app/src/pages/authenticated.tsx
@@ -628,6 +628,8 @@ function AuthenticatedInner() {
         <InviteModal
           isOpen={inviteModalOpen}
           onClose={() => setInviteModalOpen(false)}
+          isCloudEnabled={loaderData.isCloudEnabled}
+          isControlPlaneEnabled={loaderData.isControlPlaneEnabled}
         />
       </SupportChat>
     </PostHogProvider>

--- a/frontend/app/src/pages/authenticated.tsx
+++ b/frontend/app/src/pages/authenticated.tsx
@@ -63,15 +63,17 @@ const DevtoolsFooter = import.meta.env.DEV
 export async function loader(_args: { request: Request }) {
   const { isControlPlaneEnabled } = await fetchControlPlaneStatus();
 
-  const { isCloudEnabled, ...meta } = isControlPlaneEnabled
-    ? { isCloudEnabled: false as const }
+  const { isLegacyCloudEnabled, ...meta } = isControlPlaneEnabled
+    ? { isLegacyCloudEnabled: false as const }
     : await queryClient.fetchQuery(getCloudMetadataQuery);
+
+  const isCloudEnabled = isControlPlaneEnabled || isLegacyCloudEnabled;
 
   await queryClient.fetchQuery(
     pendingInvitesQuery(isCloudEnabled, isControlPlaneEnabled),
   );
   return {
-    isCloudEnabled,
+    isLegacyCloudEnabled,
     isControlPlaneEnabled,
     inactivityLogoutMs:
       'inactivityLogoutMs' in meta ? (meta.inactivityLogoutMs ?? -1) : -1,
@@ -150,10 +152,7 @@ function AuthenticatedInner() {
     },
   });
 
-  const { pendingInvitesQuery } = usePendingInvites({
-    isCloudEnabled: loaderData.isCloudEnabled,
-    isControlPlaneEnabled: loaderData.isControlPlaneEnabled,
-  });
+  const { pendingInvitesQuery } = usePendingInvites();
 
   const {
     isCloudEnabled,
@@ -628,8 +627,6 @@ function AuthenticatedInner() {
         <InviteModal
           isOpen={inviteModalOpen}
           onClose={() => setInviteModalOpen(false)}
-          isCloudEnabled={loaderData.isCloudEnabled}
-          isControlPlaneEnabled={loaderData.isControlPlaneEnabled}
         />
       </SupportChat>
     </PostHogProvider>

--- a/frontend/app/src/pages/onboarding/invites/index.tsx
+++ b/frontend/app/src/pages/onboarding/invites/index.tsx
@@ -8,13 +8,17 @@ import { redirect, useNavigate } from '@tanstack/react-router';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function loader(_args: { request: Request }) {
-  const [{ isCloudEnabled }, { isControlPlaneEnabled }] = await Promise.all([
-    queryClient.fetchQuery(getCloudMetadataQuery),
-    fetchControlPlaneStatus(),
-  ]);
+  const [{ isLegacyCloudEnabled }, { isControlPlaneEnabled }] =
+    await Promise.all([
+      queryClient.fetchQuery(getCloudMetadataQuery),
+      fetchControlPlaneStatus(),
+    ]);
 
   const { inviteCount } = await queryClient.fetchQuery(
-    pendingInvitesQuery(isCloudEnabled, isControlPlaneEnabled),
+    pendingInvitesQuery(
+      isControlPlaneEnabled || isLegacyCloudEnabled,
+      isControlPlaneEnabled,
+    ),
   );
 
   if (inviteCount === 0) {

--- a/frontend/app/src/router.tsx
+++ b/frontend/app/src/router.tsx
@@ -359,13 +359,14 @@ const onboardingCreateTenantRoute = createRoute({
     'default',
   ),
   loader: async () => {
-    const [{ isCloudEnabled }, { isControlPlaneEnabled }] = await Promise.all([
-      queryClient.fetchQuery(getCloudMetadataQuery),
-      fetchControlPlaneStatus(),
-    ]);
+    const [{ isLegacyCloudEnabled }, { isControlPlaneEnabled }] =
+      await Promise.all([
+        queryClient.fetchQuery(getCloudMetadataQuery),
+        fetchControlPlaneStatus(),
+      ]);
     return queryClient.fetchQuery(
       userUniverseQuery({
-        isCloudEnabled,
+        isCloudEnabled: isControlPlaneEnabled || isLegacyCloudEnabled,
         isCloudLoaded: true,
         isControlPlaneEnabled,
       }),
@@ -416,11 +417,13 @@ const v1RedirectRoute = createRoute({
 });
 
 async function getOrganizationIdForTenantInRouter(tenantId: string) {
-  const [{ isCloudEnabled }, { isControlPlaneEnabled }] = await Promise.all([
-    queryClient.fetchQuery(getCloudMetadataQuery),
-    fetchControlPlaneStatus(),
-  ]);
+  const [{ isLegacyCloudEnabled }, { isControlPlaneEnabled }] =
+    await Promise.all([
+      queryClient.fetchQuery(getCloudMetadataQuery),
+      fetchControlPlaneStatus(),
+    ]);
 
+  const isCloudEnabled = isControlPlaneEnabled || isLegacyCloudEnabled;
   if (!isCloudEnabled) {
     return null;
   }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Fixes an infinite invite modal loop caused by colliding react-query cache keys. Also refactors the `isCloudEnabled` boolean to properly represent whether cloud features should be enabled, and uses `isLegacyCloudEnabled` to represent whether we should fallback to the cloudApi endpoints.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- Propagates cloud enabled flags through to `pendingInvites` so that cache keys match between the parent and invite modal. 
- Refactors `use-cloud` to properly disambiguate between whether we should enable cloud features (`isCloudEnabled`) versus use legacy cloud endpoints (`isLegacyCloudEnabled`)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Tested (unit, integration, or manually with steps specified) - manual repro and fix locally.
- [X] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [X] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude fable. 

</details>
