### PR TITLE
fix(dashboard): pass plural workflow ids to metrics

### DIFF
--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
@@ -232,7 +232,8 @@ export const RunsProvider = ({
     isStatusCountsRefetching,
     isQueueMetricsLoading,
   } = useMetrics({
-    workflow,
+    workflowIds:
+      filters.apiFilters.workflowIds || (workflow ? [workflow] : undefined),
     parentTaskExternalId,
     createdAfter: filters.apiFilters.since,
     createdBefore: filters.apiFilters.until,

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-metrics.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-metrics.tsx
@@ -4,14 +4,14 @@ import { queries } from '@/lib/api';
 import { useQuery } from '@tanstack/react-query';
 
 export const useMetrics = ({
-  workflow,
+  workflowIds,
   parentTaskExternalId,
   additionalMetadata,
   createdAfter,
   createdBefore,
   showQueueMetrics,
 }: {
-  workflow: string | undefined;
+  workflowIds: string[] | undefined;
   parentTaskExternalId: string | undefined;
   additionalMetadata?: string[] | undefined;
   createdAfter?: string;
@@ -34,7 +34,7 @@ export const useMetrics = ({
         new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
       until: createdBefore,
       parent_task_external_id: parentTaskExternalId,
-      workflow_ids: workflow ? [workflow] : [],
+      workflow_ids: workflowIds ?? [],
       additional_metadata: additionalMetadata,
     }),
     placeholderData: (prev) => prev,


### PR DESCRIPTION
# Description

Pass the whole list of selected workflow ids to the metrics endpoint, not just one of them. Before, we weren't passing the whole list, which resulted in incorrect counts

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI use

</details>
