### PR TITLE
feat: `SyncListUsers` for getting users from a shard

### DIFF
--- a/pkg/repository/sqlcv1/sync.sql
+++ b/pkg/repository/sqlcv1/sync.sql
@@ -59,6 +59,15 @@ SET
     "slug" = @slug::text
 WHERE "id" = @id::uuid;
 
+-- name: SyncListUsers :many
+SELECT
+    "id",
+    "email"
+FROM
+    "User"
+WHERE
+    "deletedAt" IS NULL;
+
 -- name: SyncUpsertUser :one
 INSERT INTO "User" (
     "id",

--- a/pkg/repository/sqlcv1/sync.sql.go
+++ b/pkg/repository/sqlcv1/sync.sql.go
@@ -12,6 +12,41 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const syncListUsers = `-- name: SyncListUsers :many
+SELECT
+    "id",
+    "email"
+FROM
+    "User"
+WHERE
+    "deletedAt" IS NULL
+`
+
+type SyncListUsersRow struct {
+	ID    uuid.UUID `json:"id"`
+	Email string    `json:"email"`
+}
+
+func (q *Queries) SyncListUsers(ctx context.Context, db DBTX) ([]*SyncListUsersRow, error) {
+	rows, err := db.Query(ctx, syncListUsers)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*SyncListUsersRow
+	for rows.Next() {
+		var i SyncListUsersRow
+		if err := rows.Scan(&i.ID, &i.Email); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const syncSoftDeleteTenant = `-- name: SyncSoftDeleteTenant :exec
 UPDATE "Tenant"
 SET

--- a/pkg/repository/sync.go
+++ b/pkg/repository/sync.go
@@ -32,6 +32,7 @@ type SyncRepository interface {
 	SyncSoftDeleteTenant(ctx context.Context, db sqlcv1.DBTX, arg sqlcv1.SyncSoftDeleteTenantParams) error
 
 	SyncUpsertUser(ctx context.Context, db sqlcv1.DBTX, arg sqlcv1.SyncUpsertUserParams) (*sqlcv1.User, error)
+	SyncListUsers(ctx context.Context, db sqlcv1.DBTX) ([]*sqlcv1.SyncListUsersRow, error)
 
 	SyncUpsertTenantInvite(ctx context.Context, db sqlcv1.DBTX, arg sqlcv1.SyncUpsertTenantInviteParams) (*sqlcv1.TenantInviteLink, error)
 	SyncUpdateTenantInvite(ctx context.Context, db sqlcv1.DBTX, arg sqlcv1.SyncUpdateTenantInviteParams) (*sqlcv1.TenantInviteLink, error)
@@ -76,6 +77,10 @@ func (r *syncRepository) SyncSoftDeleteTenant(ctx context.Context, db sqlcv1.DBT
 
 func (r *syncRepository) SyncUpsertUser(ctx context.Context, db sqlcv1.DBTX, arg sqlcv1.SyncUpsertUserParams) (*sqlcv1.User, error) {
 	return r.queries.SyncUpsertUser(ctx, db, arg)
+}
+
+func (r *syncRepository) SyncListUsers(ctx context.Context, db sqlcv1.DBTX) ([]*sqlcv1.SyncListUsersRow, error) {
+	return r.queries.SyncListUsers(ctx, db)
 }
 
 func (r *syncRepository) SyncUpsertTenantInvite(ctx context.Context, db sqlcv1.DBTX, arg sqlcv1.SyncUpsertTenantInviteParams) (*sqlcv1.TenantInviteLink, error) {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Adds a new repository method for internal use called `SyncListUsers`, listing every user in a shard for validation.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)