### PR TITLE
fix: map context cancellation errors to grpc codes instead of erroring

### DIFF
--- a/internal/services/grpc/middleware/error.go
+++ b/internal/services/grpc/middleware/error.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	goerrors "errors"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -11,6 +12,23 @@ import (
 
 	"github.com/hatchet-dev/hatchet/pkg/errors"
 )
+
+// contextErrorStatus maps wrapped context cancellation/deadline errors to their
+// canonical gRPC codes, returning nil if the error is not context-related.
+// These are triggered by clients disconnecting mid-request (e.g. a worker
+// cancelling Unsubscribe during shutdown) and should not be treated as
+// internal errors or alerted on.
+func contextErrorStatus(err error) error {
+	if goerrors.Is(err, context.Canceled) {
+		return status.Error(codes.Canceled, "request was canceled")
+	}
+
+	if goerrors.Is(err, context.DeadlineExceeded) {
+		return status.Error(codes.DeadlineExceeded, "request deadline exceeded")
+	}
+
+	return nil
+}
 
 type ErrorInterceptor struct {
 	a errors.Alerter
@@ -31,6 +49,10 @@ func (e *ErrorInterceptor) ErrorUnaryServerInterceptor() grpc.UnaryServerInterce
 
 		// if this is not a grpc error already, convert it to an internal grpc error
 		if err != nil && status.Code(err) == codes.Unknown {
+			if statusErr := contextErrorStatus(err); statusErr != nil {
+				return res, statusErr
+			}
+
 			e.l.Err(err).Ctx(ctx).Msg("")
 			e.a.SendAlert(context.Background(), err, nil)
 
@@ -48,6 +70,10 @@ func (e *ErrorInterceptor) ErrorStreamServerInterceptor() grpc.StreamServerInter
 
 		// if this is not a grpc error already, convert it to an internal grpc error
 		if err != nil && status.Code(err) == codes.Unknown {
+			if statusErr := contextErrorStatus(err); statusErr != nil {
+				return statusErr
+			}
+
 			e.l.Err(err).Ctx(stream.Context()).Msg("")
 			e.a.SendAlert(context.Background(), err, nil)
 


### PR DESCRIPTION
# Description

Client-canceled requests (e.g. a worker cancelling `Unsubscribe` during shutdown) surface as wrapped `context.Canceled` errors with gRPC code `Unknown`, causing the error interceptor to fire alerts for what is benign noise. The unary and stream error interceptors now detect wrapped `context.Canceled` / `context.DeadlineExceeded` errors via `errors.Is` and return proper `codes.Canceled` / `codes.DeadlineExceeded` statuses without alerting. Real internal errors still alert as before.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Map wrapped context cancellation/deadline errors to canonical gRPC codes in the error interceptors instead of alerting Sentry

## Checklist

Changes have been:

- [x] Tested (builds, `go vet` clean; verified against the ENGINE-AZ stack trace)
- [x] Linted and formatted

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Cursor agent diagnosed the Sentry issue and wrote the fix and this description.

</details>