### PR TITLE
chore: show appropriate message for `hatchet server start --disable-auth`

### DIFF
--- a/cmd/hatchet-cli/cli/server.go
+++ b/cmd/hatchet-cli/cli/server.go
@@ -89,7 +89,13 @@ func runServerStart(cmd *cobra.Command) {
 		cli.Logger.Fatalf("%v", err)
 	}
 
-	fmt.Println(serverStartedView(result.ProfileName, result.DashboardPort, result.GrpcPort, ""))
+	fmt.Println(serverStartedView(result.ProfileName, result.DashboardPort, result.GrpcPort, disableAuth, ""))
+
+	if disableAuth && result.Token != "" {
+		fmt.Println()
+		fmt.Println(styles.Muted.Render("Worker API token (set HATCHET_CLIENT_TOKEN to this value):"))
+		fmt.Println(result.Token)
+	}
 }
 
 var stopCmd = &cobra.Command{
@@ -182,7 +188,7 @@ func startLocalServer(cmd *cobra.Command, profileName string, opts ...docker.Hat
 }
 
 // serverStartedView renders the server started message
-func serverStartedView(profileName string, dashboardPort, grpcPort int, additionalMessage string) string {
+func serverStartedView(profileName string, dashboardPort, grpcPort int, disableAuth bool, additionalMessage string) string {
 	var lines []string
 
 	lines = append(lines, styles.SuccessMessage("Hatchet server started successfully!"))
@@ -193,7 +199,11 @@ func serverStartedView(profileName string, dashboardPort, grpcPort int, addition
 	lines = append(lines, styles.KeyValue("gRPC Port", fmt.Sprintf("%d", grpcPort)))
 	lines = append(lines, "")
 	lines = append(lines, styles.Success.Render(fmt.Sprintf("Visit the dashboard at http://localhost:%d to get started!", dashboardPort)))
-	lines = append(lines, styles.Muted.Render("Admin credentials: email 'admin@example.com', password 'Admin123!!'"))
+	if disableAuth {
+		lines = append(lines, styles.Muted.Render("Authentication is disabled — no credentials required."))
+	} else {
+		lines = append(lines, styles.Muted.Render("Admin credentials: email 'admin@example.com', password 'Admin123!!'"))
+	}
 
 	if additionalMessage != "" {
 		lines = append(lines, "")

--- a/cmd/hatchet-cli/cli/worker.go
+++ b/cmd/hatchet-cli/cli/worker.go
@@ -323,7 +323,7 @@ func startLocalServerAndCreateProfile(cmd *cobra.Command) string {
 	}
 
 	// Show success message
-	fmt.Println(serverStartedView(result.ProfileName, result.DashboardPort, result.GrpcPort, "Starting worker..."))
+	fmt.Println(serverStartedView(result.ProfileName, result.DashboardPort, result.GrpcPort, false, "Starting worker..."))
 
 	return result.ProfileName
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

When launching an auth disabled local server from the CLI we should print the embedded token and an appropriate message about auth being disabled.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Chore (changes which are not directly related to any business logic)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
