### PR TITLE
feat(cli): add use-case quickstart templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Highlights
 
 - Fixes timeouts in `UserSession` cleanup jobs by adding an index via a new `hatchet-migrate` migration.
+- `hatchet quickstart` supports use-case templates through a new `--use-case` flag. The first use case is `scheduled`, a Go template whose workflow runs on a cron schedule and can also be run on demand. The default quickstart behavior is unchanged. See the [quickstart CLI docs](https://docs.hatchet.run/cli/quickstarts).
 
 ## [0.90.13] - 2026-06-29
 

--- a/cmd/hatchet-cli/cli/internal/templater/selection.go
+++ b/cmd/hatchet-cli/cli/internal/templater/selection.go
@@ -1,0 +1,156 @@
+package templater
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"path"
+	"sort"
+	"strings"
+)
+
+// DefaultUseCase maps to the template tree root, which released CLI versions
+// already generate from.
+const DefaultUseCase = "simple"
+
+// The layout under useCasesDir is a contract with the hatchet-quickstarts module.
+const useCasesDir = "templates/use-cases"
+
+// Selection identifies one template to generate.
+type Selection struct {
+	UseCase        string
+	Language       string
+	PackageManager string
+}
+
+// languageOrder is the order languages appear in prompts and error messages.
+var languageOrder = []string{"python", "typescript", "go"}
+
+// Each language has one set of package managers, the same for every use case.
+var packageManagersByLanguage = map[string][]string{
+	"python":     {"poetry", "uv", "pip"},
+	"typescript": {"npm", "pnpm", "yarn", "bun"},
+	"go":         {"go"},
+}
+
+func (s Selection) normalizedUseCase() string {
+	if s.UseCase == "" {
+		return DefaultUseCase
+	}
+
+	return s.UseCase
+}
+
+func (s Selection) templateRoot() string {
+	useCase := s.normalizedUseCase()
+
+	if useCase == DefaultUseCase {
+		return "templates"
+	}
+
+	return path.Join(useCasesDir, useCase)
+}
+
+// UseCases returns the selectable use cases. The default comes first, then
+// the use cases found in the filesystem, sorted.
+func UseCases(fsys fs.FS) ([]string, error) {
+	useCases := []string{DefaultUseCase}
+
+	entries, err := fs.ReadDir(fsys, useCasesDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return useCases, nil
+		}
+
+		return nil, err
+	}
+
+	var discovered []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			discovered = append(discovered, entry.Name())
+		}
+	}
+
+	sort.Strings(discovered)
+
+	return append(useCases, discovered...), nil
+}
+
+// LanguagesFor returns the languages the use case supports, in the order of
+// languageOrder. A language is supported when its template tree exists under
+// the use case's root, meaning the language directory itself for go and the
+// shared subdirectory for python and typescript.
+func LanguagesFor(fsys fs.FS, useCase string) ([]string, error) {
+	root := Selection{UseCase: useCase}.templateRoot()
+
+	var languages []string
+
+	for _, language := range languageOrder {
+		dir := path.Join(root, language)
+		if language != "go" {
+			dir = path.Join(dir, "shared")
+		}
+
+		if _, err := fs.Stat(fsys, dir); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+
+			return nil, err
+		}
+
+		languages = append(languages, language)
+	}
+
+	return languages, nil
+}
+
+// PackageManagersFor returns the package managers the language supports.
+func PackageManagersFor(language string) []string {
+	return append([]string(nil), packageManagersByLanguage[language]...)
+}
+
+// Validate checks that the selection names an existing use case, a language
+// that use case supports, and a package manager that language supports.
+func Validate(fsys fs.FS, sel Selection) error {
+	useCase := sel.normalizedUseCase()
+
+	useCases, err := UseCases(fsys)
+	if err != nil {
+		return err
+	}
+
+	if !contains(useCases, useCase) {
+		return fmt.Errorf("unknown use case %q (available: %s)", useCase, strings.Join(useCases, ", "))
+	}
+
+	if !contains(languageOrder, sel.Language) {
+		return fmt.Errorf("invalid language: %s (must be one of: %s)", sel.Language, strings.Join(languageOrder, ", "))
+	}
+
+	languages, err := LanguagesFor(fsys, useCase)
+	if err != nil {
+		return err
+	}
+
+	if !contains(languages, sel.Language) {
+		return fmt.Errorf("use case %q does not support language %q (supported: %s)", useCase, sel.Language, strings.Join(languages, ", "))
+	}
+
+	if !contains(packageManagersByLanguage[sel.Language], sel.PackageManager) {
+		return fmt.Errorf("invalid package manager '%s' for language '%s' (must be one of: %s)", sel.PackageManager, sel.Language, strings.Join(packageManagersByLanguage[sel.Language], ", "))
+	}
+
+	return nil
+}
+
+func contains(values []string, value string) bool {
+	for _, v := range values {
+		if v == value {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cmd/hatchet-cli/cli/internal/templater/selection_test.go
+++ b/cmd/hatchet-cli/cli/internal/templater/selection_test.go
@@ -1,0 +1,161 @@
+package templater
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	quickstarts "github.com/hatchet-dev/hatchet-quickstarts"
+)
+
+func TestUseCases(t *testing.T) {
+	useCases, err := UseCases(quickstarts.TemplatesFS())
+	if err != nil {
+		t.Fatalf("UseCases returned an error: %v", err)
+	}
+
+	if len(useCases) == 0 || useCases[0] != DefaultUseCase {
+		t.Fatalf("expected %q first, got %v", DefaultUseCase, useCases)
+	}
+
+	found := false
+	for _, useCase := range useCases {
+		if useCase == "scheduled" {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatalf("expected use case %q in %v", "scheduled", useCases)
+	}
+}
+
+func TestLanguagesFor(t *testing.T) {
+	fsys := quickstarts.TemplatesFS()
+
+	simple, err := LanguagesFor(fsys, DefaultUseCase)
+	if err != nil {
+		t.Fatalf("LanguagesFor(simple) returned an error: %v", err)
+	}
+
+	if !reflect.DeepEqual(simple, []string{"python", "typescript", "go"}) {
+		t.Errorf("expected all three languages for simple, got %v", simple)
+	}
+
+	scheduled, err := LanguagesFor(fsys, "scheduled")
+	if err != nil {
+		t.Fatalf("LanguagesFor(scheduled) returned an error: %v", err)
+	}
+
+	if !reflect.DeepEqual(scheduled, []string{"go"}) {
+		t.Errorf("expected only go for scheduled, got %v", scheduled)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	fsys := quickstarts.TemplatesFS()
+
+	valid := []Selection{
+		{UseCase: "simple", Language: "python", PackageManager: "poetry"},
+		{UseCase: "", Language: "typescript", PackageManager: "pnpm"},
+		{UseCase: "scheduled", Language: "go", PackageManager: "go"},
+	}
+
+	for _, sel := range valid {
+		if err := Validate(fsys, sel); err != nil {
+			t.Errorf("expected %+v to validate, got: %v", sel, err)
+		}
+	}
+
+	invalid := []struct {
+		sel     Selection
+		wantErr string
+	}{
+		{Selection{UseCase: "nonexistent", Language: "go", PackageManager: "go"}, "unknown use case"},
+		{Selection{UseCase: "scheduled", Language: "python", PackageManager: "poetry"}, "does not support language"},
+		{Selection{UseCase: "simple", Language: "rust", PackageManager: "cargo"}, "invalid language"},
+		{Selection{UseCase: "simple", Language: "go", PackageManager: "npm"}, "invalid package manager"},
+	}
+
+	for _, tc := range invalid {
+		err := Validate(fsys, tc.sel)
+		if err == nil {
+			t.Errorf("expected %+v to fail validation", tc.sel)
+			continue
+		}
+
+		if !strings.Contains(err.Error(), tc.wantErr) {
+			t.Errorf("expected error for %+v to contain %q, got: %v", tc.sel, tc.wantErr, err)
+		}
+	}
+}
+
+func TestProcessMultiSourceScheduledGo(t *testing.T) {
+	dstDir := filepath.Join(t.TempDir(), "project")
+	sel := Selection{UseCase: "scheduled", Language: "go", PackageManager: "go"}
+	data := Data{Name: "test-project", PackageManager: "go"}
+
+	if err := ProcessMultiSource(quickstarts.TemplatesFS(), sel, dstDir, data); err != nil {
+		t.Fatalf("ProcessMultiSource failed: %v", err)
+	}
+
+	expected := []string{
+		"cmd/worker/main.go",
+		"cmd/run/main.go",
+		"client/client.go",
+		"workflows/scheduled_workflow.go",
+		"go.mod",
+		"hatchet.yaml",
+	}
+
+	for _, file := range expected {
+		if _, err := os.Stat(filepath.Join(dstDir, file)); err != nil {
+			t.Errorf("expected file %s: %v", file, err)
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(dstDir, "POST_QUICKSTART.md")); err == nil {
+		t.Error("POST_QUICKSTART.md must not be copied into the project")
+	}
+
+	goMod, err := os.ReadFile(filepath.Join(dstDir, "go.mod"))
+	if err != nil {
+		t.Fatalf("could not read generated go.mod: %v", err)
+	}
+
+	// The go templates use a fixed module path, so the project name is not in
+	// go.mod. Assert the hatchet SDK requirement instead.
+	if !strings.Contains(string(goMod), "github.com/hatchet-dev/hatchet ") {
+		t.Errorf("expected go.mod to require the hatchet SDK, got:\n%s", goMod)
+	}
+}
+
+func TestProcessMultiSourceSimpleGoUnchanged(t *testing.T) {
+	dstDir := filepath.Join(t.TempDir(), "project")
+	sel := Selection{UseCase: "", Language: "go", PackageManager: "go"}
+	data := Data{Name: "test-project", PackageManager: "go"}
+
+	if err := ProcessMultiSource(quickstarts.TemplatesFS(), sel, dstDir, data); err != nil {
+		t.Fatalf("ProcessMultiSource failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dstDir, "workflows/first_workflow.go")); err != nil {
+		t.Errorf("expected the default go template's workflow file: %v", err)
+	}
+}
+
+func TestProcessPostQuickstartMultiSourceScheduled(t *testing.T) {
+	sel := Selection{UseCase: "scheduled", Language: "go", PackageManager: "go"}
+	data := Data{Name: "test-project", PackageManager: "go"}
+
+	content, err := ProcessPostQuickstartMultiSource(quickstarts.TemplatesFS(), sel, data)
+	if err != nil {
+		t.Fatalf("ProcessPostQuickstartMultiSource failed: %v", err)
+	}
+
+	if !strings.Contains(content, "manual-run") {
+		t.Errorf("expected the scheduled post-quickstart content to mention the manual-run trigger, got:\n%s", content)
+	}
+}

--- a/cmd/hatchet-cli/cli/internal/templater/templater.go
+++ b/cmd/hatchet-cli/cli/internal/templater/templater.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -71,20 +72,24 @@ func Process(fsys fs.FS, srcDir, dstDir string, data Data) error {
 
 // ProcessMultiSource processes templates from multiple source directories (shared + package-manager-specific).
 // It first processes files from the shared directory, then overlays package-manager-specific files.
-// For languages that support multiple package managers (python, typescript), this function expects:
-//   - shared directory: templates/LANG/shared/
-//   - package manager directory: templates/LANG/PACKAGE_MANAGER/
+// The selection's use case picks the template root. The default use case reads
+// from templates/; any other use case reads from templates/use-cases/USE_CASE/.
+// Under that root, languages that support multiple package managers (python, typescript) expect:
+//   - shared directory: ROOT/LANG/shared/
+//   - package manager directory: ROOT/LANG/PACKAGE_MANAGER/
 //
 // For languages with a single package manager (go), it falls back to the language root directory.
-func ProcessMultiSource(fsys fs.FS, language, packageManager, dstDir string, data Data) error {
+func ProcessMultiSource(fsys fs.FS, sel Selection, dstDir string, data Data) error {
+	root := sel.templateRoot()
+
 	// For Go, use the old behavior (no shared directory)
-	if language == "go" {
-		return Process(fsys, "templates/go", dstDir, data)
+	if sel.Language == "go" {
+		return Process(fsys, path.Join(root, "go"), dstDir, data)
 	}
 
 	// For Python and TypeScript, process shared + package-manager-specific
-	sharedDir := filepath.Join("templates", language, "shared")
-	pkgMgrDir := filepath.Join("templates", language, packageManager)
+	sharedDir := path.Join(root, sel.Language, "shared")
+	pkgMgrDir := path.Join(root, sel.Language, sel.PackageManager)
 
 	// Process shared files first
 	if err := Process(fsys, sharedDir, dstDir, data); err != nil {
@@ -133,15 +138,18 @@ func ProcessPostQuickstart(fsys fs.FS, srcDir string, data Data) (string, error)
 }
 
 // ProcessPostQuickstartMultiSource reads and processes the POST_QUICKSTART.md file from the package-manager-specific directory.
-// For languages with multiple package managers, it looks in templates/LANG/PACKAGE_MANAGER/.
-// For Go, it looks in the templates/go/ directory.
+// The selection's use case picks the template root, as in ProcessMultiSource.
+// For languages with multiple package managers, it looks in ROOT/LANG/PACKAGE_MANAGER/.
+// For Go, it looks in the ROOT/go/ directory.
 // Returns the processed content as a string, or empty string if the file doesn't exist.
-func ProcessPostQuickstartMultiSource(fsys fs.FS, language, packageManager string, data Data) (string, error) {
+func ProcessPostQuickstartMultiSource(fsys fs.FS, sel Selection, data Data) (string, error) {
+	root := sel.templateRoot()
+
 	var srcDir string
-	if language == "go" {
-		srcDir = "templates/go"
+	if sel.Language == "go" {
+		srcDir = path.Join(root, "go")
 	} else {
-		srcDir = filepath.Join("templates", language, packageManager)
+		srcDir = path.Join(root, sel.Language, sel.PackageManager)
 	}
 
 	return ProcessPostQuickstart(fsys, srcDir, data)

--- a/cmd/hatchet-cli/cli/quickstart.go
+++ b/cmd/hatchet-cli/cli/quickstart.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"strings"
 
@@ -24,8 +25,12 @@ var quickstartCmd = &cobra.Command{
 Supports multiple package managers:
   Python: poetry, uv, pip
   TypeScript: npm, pnpm, yarn, bun
-  Go: go modules`,
-	Example: `  # Generate a project interactively (prompts for language, package manager, name, and directory)
+  Go: go modules
+
+Use-case templates are selected with --use-case. The default, simple, is a
+minimal worker with one workflow. Other use cases, such as scheduled, may
+support a subset of languages.`,
+	Example: `  # Generate a project interactively (prompts for use case, language, package manager, name, and directory)
   hatchet quickstart
 
   # Generate a Python project with Poetry
@@ -33,6 +38,9 @@ Supports multiple package managers:
 
   # Generate a TypeScript project with pnpm
   hatchet quickstart --language typescript --package-manager pnpm --project-name my-worker
+
+  # Generate the scheduled use case in Go
+  hatchet quickstart --use-case scheduled --language go
 
   # Generate a Python project with uv using short flags
   hatchet quickstart -l python -m uv -p my-worker -d ./my-worker`,
@@ -45,21 +53,28 @@ Supports multiple package managers:
 		}
 
 		// Get flag values
+		useCase, _ := cmd.Flags().GetString("use-case")
 		language, _ := cmd.Flags().GetString("language")
 		packageManager, _ := cmd.Flags().GetString("package-manager")
 		projectName, _ := cmd.Flags().GetString("project-name")
 		dir, _ := cmd.Flags().GetString("directory")
 
+		templatesFS := quickstarts.TemplatesFS()
+
 		// Use interactive forms only if flags not provided
-		if language == "" {
-			language = selectLanguageForm()
+		if useCase == "" {
+			// Commands that pass --language or --package-manager ran
+			// without prompts before use cases existed and must keep
+			// doing so. They get the simple template.
+			if cmd.Flags().Changed("language") || cmd.Flags().Changed("package-manager") {
+				useCase = templater.DefaultUseCase
+			} else {
+				useCase = selectUseCaseForm(templatesFS)
+			}
 		}
 
-		// Validate language
-		validLanguages := map[string]bool{"python": true, "typescript": true, "go": true}
-
-		if !validLanguages[language] {
-			cli.Logger.Fatalf("invalid language: %s (must be one of: python, typescript, go)", language)
+		if language == "" {
+			language = selectLanguageForm(templatesFS, useCase)
 		}
 
 		// Get package manager
@@ -67,19 +82,14 @@ Supports multiple package managers:
 			packageManager = selectPackageManagerForm(language)
 		}
 
-		// Validate package manager for the selected language
-		validPackageManagers := map[string]map[string]bool{
-			"python":     {"poetry": true, "uv": true, "pip": true},
-			"typescript": {"npm": true, "pnpm": true, "yarn": true, "bun": true},
-			"go":         {"go": true},
+		selection := templater.Selection{
+			UseCase:        useCase,
+			Language:       language,
+			PackageManager: packageManager,
 		}
 
-		if !validPackageManagers[language][packageManager] {
-			var validOptions []string
-			for pm := range validPackageManagers[language] {
-				validOptions = append(validOptions, pm)
-			}
-			cli.Logger.Fatalf("invalid package manager '%s' for language '%s' (must be one of: %s)", packageManager, language, strings.Join(validOptions, ", "))
+		if err := templater.Validate(templatesFS, selection); err != nil {
+			cli.Logger.Fatalf("%v", err)
 		}
 
 		if projectName == "" {
@@ -95,7 +105,7 @@ Supports multiple package managers:
 			}
 		}
 
-		postQuickstart, err := GenerateQuickstart(language, packageManager, projectName, dir)
+		postQuickstart, err := GenerateQuickstart(selection, projectName, dir)
 		if err != nil {
 			cli.Logger.Fatalf("could not generate quickstart: %v", err)
 		}
@@ -106,21 +116,21 @@ Supports multiple package managers:
 
 // GenerateQuickstart generates a quickstart project without interactive forms.
 // Returns the post-quickstart content that should be displayed to the user.
-func GenerateQuickstart(language, packageManager, projectName, dir string) (string, error) {
+func GenerateQuickstart(selection templater.Selection, projectName, dir string) (string, error) {
 	templateData := templater.Data{
 		Name:           projectName,
-		PackageManager: packageManager,
+		PackageManager: selection.PackageManager,
 	}
 
 	templatesFS := quickstarts.TemplatesFS()
 
-	err := templater.ProcessMultiSource(templatesFS, language, packageManager, dir, templateData)
+	err := templater.ProcessMultiSource(templatesFS, selection, dir, templateData)
 	if err != nil {
 		return "", fmt.Errorf("could not process templates: %w", err)
 	}
 
 	// Process POST_QUICKSTART.md if it exists
-	postQuickstart, err := templater.ProcessPostQuickstartMultiSource(templatesFS, language, packageManager, templateData)
+	postQuickstart, err := templater.ProcessPostQuickstartMultiSource(templatesFS, selection, templateData)
 	if err != nil {
 		return "", fmt.Errorf("could not process post-quickstart content: %w", err)
 	}
@@ -132,31 +142,87 @@ func init() {
 	rootCmd.AddCommand(quickstartCmd)
 
 	// Add flags for quickstart command
+	quickstartCmd.Flags().StringP("use-case", "u", "", "Use case template (default: simple)")
 	quickstartCmd.Flags().StringP("language", "l", "", "Programming language (python, typescript, go)")
 	quickstartCmd.Flags().StringP("package-manager", "m", "", "Package manager (poetry, uv, pip for Python; npm, pnpm, yarn, bun for TypeScript)")
 	quickstartCmd.Flags().StringP("project-name", "p", "", "Name of the project (default: hatchet-worker)")
 	quickstartCmd.Flags().StringP("directory", "d", "", "Directory to create the project in (default: ./{project-name})")
 }
 
-func selectLanguageForm() string {
+func selectUseCaseForm(templatesFS fs.FS) string {
+	useCases, err := templater.UseCases(templatesFS)
+	if err != nil {
+		cli.Logger.Fatalf("could not list use cases: %v", err)
+	}
+
+	if len(useCases) == 1 {
+		return useCases[0]
+	}
+
+	options := make([]huh.Option[string], 0, len(useCases))
+	for _, useCase := range useCases {
+		label := useCase
+		if useCase == templater.DefaultUseCase {
+			label = useCase + " (default)"
+		}
+		options = append(options, huh.NewOption(label, useCase))
+	}
+
+	useCase := ""
+
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Choose a use case").
+				Options(options...).
+				Value(&useCase),
+		),
+	).WithTheme(styles.HatchetTheme())
+
+	if err := form.Run(); err != nil {
+		cli.Logger.Fatalf("could not run quickstart form: %v", err)
+	}
+
+	return useCase
+}
+
+var languageLabels = map[string]string{
+	"python":     "Python",
+	"typescript": "Typescript",
+	"go":         "Go",
+}
+
+func selectLanguageForm(templatesFS fs.FS, useCase string) string {
+	languages, err := templater.LanguagesFor(templatesFS, useCase)
+	if err != nil {
+		cli.Logger.Fatalf("could not list languages for use case %q: %v", useCase, err)
+	}
+
+	if len(languages) == 0 {
+		cli.Logger.Fatalf("use case %q has no language templates", useCase)
+	}
+
+	if len(languages) == 1 {
+		return languages[0]
+	}
+
+	options := make([]huh.Option[string], 0, len(languages))
+	for _, lang := range languages {
+		options = append(options, huh.NewOption(languageLabels[lang], lang))
+	}
+
 	language := ""
 
 	form := huh.NewForm(
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title("Choose your language").
-				Options(
-					huh.NewOption("Python", "python"),
-					huh.NewOption("Typescript", "typescript"),
-					huh.NewOption("Go", "go"),
-				).
+				Options(options...).
 				Value(&language),
 		),
 	).WithTheme(styles.HatchetTheme())
 
-	err := form.Run()
-
-	if err != nil {
+	if err := form.Run(); err != nil {
 		cli.Logger.Fatalf("could not run quickstart form: %v", err)
 	}
 

--- a/cmd/hatchet-cli/cli/quickstart_e2e_test.go
+++ b/cmd/hatchet-cli/cli/quickstart_e2e_test.go
@@ -13,47 +13,63 @@ import (
 
 	cliconfig "github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/config/cli"
 	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/config/worker"
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/templater"
 	profileconfig "github.com/hatchet-dev/hatchet/pkg/config/cli"
 )
 
-// Test matrix of all language and package manager combinations
-var templateTests = []struct {
+type templateTestCase struct {
+	useCase        string
 	language       string
 	packageManager string
-}{
+	// trigger is the hatchet.yaml trigger name the test runs once the worker
+	// is up
+	trigger string
+}
+
+// Test matrix of all use case, language, and package manager combinations
+var templateTests = []templateTestCase{
 	// Python
-	{"python", "poetry"},
-	{"python", "uv"},
-	{"python", "pip"},
+	{"simple", "python", "poetry", "simple"},
+	{"simple", "python", "uv", "simple"},
+	{"simple", "python", "pip", "simple"},
 
 	// TypeScript
-	{"typescript", "npm"},
-	{"typescript", "pnpm"},
-	{"typescript", "yarn"},
-	{"typescript", "bun"},
+	{"simple", "typescript", "npm", "simple"},
+	{"simple", "typescript", "pnpm", "simple"},
+	{"simple", "typescript", "yarn", "simple"},
+	{"simple", "typescript", "bun", "simple"},
 
 	// Go
-	{"go", "go"},
+	{"simple", "go", "go", "simple"},
+
+	// Use cases
+	{"scheduled", "go", "go", "manual-run"},
 }
 
 func TestQuickstartTemplates(t *testing.T) {
 	for _, tt := range templateTests {
-		t.Run(fmt.Sprintf("%s_%s", tt.language, tt.packageManager), func(t *testing.T) {
-			testTemplate(t, tt.language, tt.packageManager)
+		t.Run(fmt.Sprintf("%s_%s_%s", tt.useCase, tt.language, tt.packageManager), func(t *testing.T) {
+			testTemplate(t, tt)
 		})
 	}
 }
 
-func testTemplate(t *testing.T, language, packageManager string) {
+func testTemplate(t *testing.T, tt templateTestCase) {
 	// 1. Create temp directory
 	tmpDir := t.TempDir()
 	projectDir := filepath.Join(tmpDir, "test-project")
 	projectName := "test-project"
 
-	t.Logf("Testing %s with %s in %s", language, packageManager, projectDir)
+	t.Logf("Testing %s %s with %s in %s", tt.useCase, tt.language, tt.packageManager, projectDir)
 
 	// 2. Generate quickstart project using the CLI implementation
-	_, err := GenerateQuickstart(language, packageManager, projectName, projectDir)
+	selection := templater.Selection{
+		UseCase:        tt.useCase,
+		Language:       tt.language,
+		PackageManager: tt.packageManager,
+	}
+
+	_, err := GenerateQuickstart(selection, projectName, projectDir)
 	if err != nil {
 		t.Fatalf("quickstart generation failed: %v", err)
 	}
@@ -61,7 +77,7 @@ func testTemplate(t *testing.T, language, packageManager string) {
 	t.Logf("Project generated successfully")
 
 	// 3. Verify project structure
-	if err := verifyProjectStructure(t, projectDir, language, packageManager); err != nil {
+	if err := verifyProjectStructure(t, projectDir, tt); err != nil {
 		t.Fatalf("Project structure verification failed: %v", err)
 	}
 
@@ -93,20 +109,20 @@ func testTemplate(t *testing.T, language, packageManager string) {
 
 	// 6. Start worker in dev mode using the CLI implementation and ensure it runs for 15 seconds without error
 	t.Log("Starting worker dev mode...")
-	if err := testWorkerDev(t, workerConfig, profile); err != nil {
+	if err := testWorkerDev(t, workerConfig, profile, tt.trigger); err != nil {
 		t.Fatalf("Worker dev test failed: %v", err)
 	}
 
 	// 7. Verify Dockerfile builds
 	t.Log("Verifying Dockerfile builds...")
-	if err := testDockerfileBuild(t, projectDir, language, packageManager); err != nil {
+	if err := testDockerfileBuild(t, projectDir, tt); err != nil {
 		t.Fatalf("Dockerfile build test failed: %v", err)
 	}
 
-	t.Logf("Successfully tested %s with %s", language, packageManager)
+	t.Logf("Successfully tested %s %s with %s", tt.useCase, tt.language, tt.packageManager)
 }
 
-func testWorkerDev(t *testing.T, workerConfig *worker.WorkerConfig, profile *profileconfig.Profile) error {
+func testWorkerDev(t *testing.T, workerConfig *worker.WorkerConfig, profile *profileconfig.Profile, triggerName string) error {
 	// Create a context with timeout (safety net)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
@@ -156,20 +172,20 @@ func testWorkerDev(t *testing.T, workerConfig *worker.WorkerConfig, profile *pro
 	default:
 	}
 
-	// Trigger the "simple" workflow if it exists in the config
+	// Trigger the named workflow if it exists in the config
 	if len(workerConfig.Triggers) > 0 {
-		var simpleTrigger *worker.Trigger
+		var trigger *worker.Trigger
 		for i := range workerConfig.Triggers {
-			if workerConfig.Triggers[i].Name == "simple" {
-				simpleTrigger = &workerConfig.Triggers[i]
+			if workerConfig.Triggers[i].Name == triggerName {
+				trigger = &workerConfig.Triggers[i]
 				break
 			}
 		}
 
-		if simpleTrigger != nil {
-			t.Logf("Triggering workflow using command: %s", simpleTrigger.Command)
+		if trigger != nil {
+			t.Logf("Triggering workflow using command: %s", trigger.Command)
 			triggerCtx, triggerCancel := context.WithTimeout(ctx, 30*time.Second)
-			err := executeTriggerCommand(triggerCtx, simpleTrigger.Command, profile)
+			err := executeTriggerCommand(triggerCtx, trigger.Command, profile)
 			triggerCancel()
 			if err != nil {
 				return fmt.Errorf("failed to trigger workflow: %w", err)
@@ -196,8 +212,8 @@ func testWorkerDev(t *testing.T, workerConfig *worker.WorkerConfig, profile *pro
 	return nil
 }
 
-func verifyProjectStructure(t *testing.T, projectDir, language, packageManager string) error {
-	t.Logf("Verifying project structure for %s/%s", language, packageManager)
+func verifyProjectStructure(t *testing.T, projectDir string, tt templateTestCase) error {
+	t.Logf("Verifying project structure for %s %s with %s", tt.useCase, tt.language, tt.packageManager)
 
 	// Common files that should exist
 	commonFiles := []string{
@@ -214,7 +230,7 @@ func verifyProjectStructure(t *testing.T, projectDir, language, packageManager s
 	}
 
 	// Language-specific files
-	switch language {
+	switch tt.language {
 	case "python":
 		pythonFiles := []string{
 			"src/hatchet_client.py",
@@ -230,7 +246,7 @@ func verifyProjectStructure(t *testing.T, projectDir, language, packageManager s
 		}
 
 		// Check for package manager specific files
-		switch packageManager {
+		switch tt.packageManager {
 		case "poetry":
 			if _, err := os.Stat(filepath.Join(projectDir, "pyproject.toml")); os.IsNotExist(err) {
 				return fmt.Errorf("expected pyproject.toml for poetry")
@@ -262,11 +278,16 @@ func verifyProjectStructure(t *testing.T, projectDir, language, packageManager s
 		}
 
 	case "go":
+		workflowFile := "workflows/first_workflow.go"
+		if tt.useCase == "scheduled" {
+			workflowFile = "workflows/scheduled_workflow.go"
+		}
+
 		goFiles := []string{
 			"cmd/worker/main.go",
 			"cmd/run/main.go",
 			"client/client.go",
-			"workflows/first_workflow.go",
+			workflowFile,
 			"go.mod",
 		}
 		for _, file := range goFiles {
@@ -280,18 +301,18 @@ func verifyProjectStructure(t *testing.T, projectDir, language, packageManager s
 	return nil
 }
 
-func testDockerfileBuild(t *testing.T, projectDir, language, packageManager string) error {
+func testDockerfileBuild(t *testing.T, projectDir string, tt templateTestCase) error {
 	// Verify Dockerfile exists
 	dockerfilePath := filepath.Join(projectDir, "Dockerfile")
 	if _, err := os.Stat(dockerfilePath); os.IsNotExist(err) {
 		return fmt.Errorf("Dockerfile does not exist at %s", dockerfilePath)
 	}
 
-	t.Logf("Building Dockerfile for %s/%s...", language, packageManager)
+	t.Logf("Building Dockerfile for %s %s with %s...", tt.useCase, tt.language, tt.packageManager)
 
 	// Build the Docker image
 	// Use a unique tag for each test to avoid conflicts
-	imageName := fmt.Sprintf("hatchet-test-%s-%s:latest", language, packageManager)
+	imageName := fmt.Sprintf("hatchet-test-%s-%s-%s:latest", tt.useCase, tt.language, tt.packageManager)
 
 	cmd := exec.Command("docker", "build", "-t", imageName, ".")
 	cmd.Dir = projectDir

--- a/frontend/docs/pages/reference/cli/_meta.js
+++ b/frontend/docs/pages/reference/cli/_meta.js
@@ -10,6 +10,7 @@ export default {
     type: "separator",
   },
   "running-hatchet-locally": "Running Hatchet Locally",
+  quickstarts: "Generating Quickstart Projects",
   "running-workers-locally": "Running Workers Locally",
   "triggering-workflows": "Triggering Workflows",
   "--tui": {

--- a/frontend/docs/pages/reference/cli/index.mdx
+++ b/frontend/docs/pages/reference/cli/index.mdx
@@ -12,7 +12,7 @@ The Hatchet CLI is a command-line tool with utilities for running workers locall
 
 ## Features
 
-- **Quickstarts**: the `hatchet quickstart` command sets up a local Hatchet instance with a sample project to help you get started quickly.
+- **Quickstarts**: the [`hatchet quickstart`](/cli/quickstarts) command generates a worker project from a template to help you get started quickly.
 
 - **Local worker reloading**: the [`hatchet worker dev`](/cli/running-workers-locally) command lets you run a worker locally with automatic reloading when code changes are detected.
 

--- a/frontend/docs/pages/reference/cli/quickstarts.mdx
+++ b/frontend/docs/pages/reference/cli/quickstarts.mdx
@@ -1,0 +1,69 @@
+# Generating Quickstart Projects
+
+The `hatchet quickstart` command generates a worker project with boilerplate code. Run it with no flags for an interactive setup, or pass flags to script it.
+
+```sh
+hatchet quickstart
+```
+
+The generated project contains a worker, a workflow, a trigger script, and a `hatchet.yaml` for [`hatchet worker dev`](/cli/running-workers-locally). The worker runs in your environment and connects to your Hatchet instance using the profile you have configured.
+
+## Use-case templates
+
+Templates are organized by use case. The default use case is `simple`, a worker with one workflow. Selecting a different one generates a project for that use case:
+
+```sh
+hatchet quickstart --use-case scheduled --language go
+```
+
+The `scheduled` use case is a Go project whose workflow runs on a cron schedule. With the worker running, its `manual-run` trigger runs the workflow once on demand:
+
+```sh
+hatchet trigger manual-run
+```
+
+The interactive flow only offers languages the selected use case supports, and commands that pass `--language` or `--package-manager` without `--use-case` generate the `simple` template.
+
+## Reference
+
+#### `hatchet quickstart`
+
+```txt
+Generate a quickstart Hatchet worker project with boilerplate code in your language of choice.
+
+Supports multiple package managers:
+  Python: poetry, uv, pip
+  TypeScript: npm, pnpm, yarn, bun
+  Go: go modules
+
+Use-case templates are selected with --use-case. The default, simple, is a
+minimal worker with one workflow. Other use cases, such as scheduled, may
+support a subset of languages.
+
+Usage:
+  hatchet quickstart [flags]
+
+Examples:
+  # Generate a project interactively (prompts for use case, language, package manager, name, and directory)
+  hatchet quickstart
+
+  # Generate a Python project with Poetry
+  hatchet quickstart --language python --package-manager poetry
+
+  # Generate a TypeScript project with pnpm
+  hatchet quickstart --language typescript --package-manager pnpm --project-name my-worker
+
+  # Generate the scheduled use case in Go
+  hatchet quickstart --use-case scheduled --language go
+
+  # Generate a Python project with uv using short flags
+  hatchet quickstart -l python -m uv -p my-worker -d ./my-worker
+
+Flags:
+  -d, --directory string         Directory to create the project in (default: ./{project-name})
+  -h, --help                     help for quickstart
+  -l, --language string          Programming language (python, typescript, go)
+  -m, --package-manager string   Package manager (poetry, uv, pip for Python; npm, pnpm, yarn, bun for TypeScript)
+  -p, --project-name string      Name of the project (default: hatchet-worker)
+  -u, --use-case string          Use case template (default: simple)
+```

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/gorilla/sessions v1.4.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru/v2 v2.0.7
-	github.com/hatchet-dev/hatchet-quickstarts v0.1.0
+	github.com/hatchet-dev/hatchet-quickstarts v0.2.0
 	github.com/hatchet-dev/pgoutbox v0.3.0
 	github.com/hatchet-dev/timediff v0.0.4
 	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6

--- a/go.sum
+++ b/go.sum
@@ -273,6 +273,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hatchet-dev/hatchet-quickstarts v0.1.0 h1:1NhP06WYnm7A+27W/dKj+NXJHZ/QFJLVaXqAiU6cAF8=
 github.com/hatchet-dev/hatchet-quickstarts v0.1.0/go.mod h1:kuGRjIxJUqfY6MR8x1oOrozo+G1Yo3q6A/GQqoDRp6M=
+github.com/hatchet-dev/hatchet-quickstarts v0.2.0 h1:CtZ0HMDIqLskH3aw4ohytFPDfUAIxZpqwLY+BqXmoeo=
+github.com/hatchet-dev/hatchet-quickstarts v0.2.0/go.mod h1:kuGRjIxJUqfY6MR8x1oOrozo+G1Yo3q6A/GQqoDRp6M=
 github.com/hatchet-dev/pgoutbox v0.3.0 h1:l3/1y1+mAGOVLVAEP13aU66RfpruOpOzSCTxi8AAV14=
 github.com/hatchet-dev/pgoutbox v0.3.0/go.mod h1:x7wEFajIrOJ+goWri49MjzlkdwLHMdr+dZkXjVCm9ho=
 github.com/hatchet-dev/timediff v0.0.4 h1:RfYX1ehoa/qxHKAGQBMAvmkPx+FRQfUV37tDy/G1pOY=


### PR DESCRIPTION
# Description

Adds a --use-case flag to hatchet quickstart and bumps hatchet-quickstarts to v0.2.0, which ships the first use case. The scheduled use case is a Go template whose workflow runs on a cron schedule and can be run once on demand through its manual-run trigger.

The interactive flow asks for the use case first and only offers the languages it supports. Commands that pass --language or --package-manager keep running without prompts and get the simple template. Use cases and their languages are discovered from the module filesystem, so a new use-case template in a supported language needs only a dependency bump here.

Part of #4107 (Phase 4).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## What's Changed

- [x] `--use-case` flag on `hatchet quickstart`, asked first in the interactive flow
- [x] Selection and validation layer in the templater, discovering use cases and their languages from the quickstarts module filesystem
- [x] hatchet-quickstarts dependency bumped to the tagged v0.2.0
- [x] Template source paths switched to slash-separated fs paths, which embedded filesystems require on every platform
- [x] Unit tests for selection, validation, and generation; e2e gains the scheduled Go case

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

Unit tests cover use-case discovery, which languages each use case supports, validation errors, and generation for the scheduled and default paths. The e2e cases simple_go_go and scheduled_go_go passed against a local `hatchet server start` instance, registering a worker, completing a triggered run, and building the Dockerfile.

## Related

- hatchet-dev/hatchet-quickstarts v0.2.0 has the scheduled template.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Claude Code (Fable 5) used for research, planning, writing tests and local validation.

</details>