### PR TITLE
fix: prevent task stats concurrency overcounting

### DIFF
--- a/pkg/repository/sqlcv1/tasks.sql
+++ b/pkg/repository/sqlcv1/tasks.sql
@@ -1214,36 +1214,60 @@ WITH queued_tasks AS (
         sc.expression,
         sc.strategy,
         cs.key
-), running_tasks AS (
+), running_task_attempts AS (
     SELECT
+        t.id AS task_id,
         t.step_readable_id,
-        COALESCE(sc.expression, '') as expression,
-        COALESCE(sc.strategy, 'NONE'::v1_concurrency_strategy) as strategy,
-        COALESCE(cs.key, '') as key,
-        COUNT(*) as count,
-        MIN(t.inserted_at) AS oldest,
-        MIN(t.inserted_at) FILTER (WHERE t.retry_count = 0) AS oldest_excluding_retries
+        t.inserted_at AS task_inserted_at,
+        t.retry_count,
+        t.tenant_id,
+        t.workflow_id,
+        t.workflow_version_id,
+        t.step_id
     FROM
         v1_task_runtime tr
     JOIN
         v1_task t ON tr.task_id = t.id AND tr.task_inserted_at = t.inserted_at AND tr.retry_count = t.retry_count
-    LEFT JOIN
-        v1_concurrency_slot cs ON cs.task_id = t.id AND cs.task_inserted_at = t.inserted_at AND cs.task_retry_count = t.retry_count
-    LEFT JOIN
-        v1_step_concurrency sc ON sc.workflow_id = t.workflow_id AND sc.workflow_version_id = t.workflow_version_id AND sc.step_id = t.step_id
     WHERE
         t.tenant_id = @tenantId::uuid
         AND tr.tenant_id = @tenantId::uuid
         AND tr.worker_id IS NOT NULL
-        AND (t.concurrency_strategy_ids IS NULL OR array_length(t.concurrency_strategy_ids, 1) IS NULL OR sc.id = ANY(t.concurrency_strategy_ids))
+), running_totals AS (
+    SELECT
+        step_readable_id,
+        COUNT(*) as count,
+        MIN(task_inserted_at) AS oldest,
+        MIN(task_inserted_at) FILTER (WHERE retry_count = 0) AS oldest_excluding_retries
+    FROM
+        running_task_attempts
     GROUP BY
-        t.step_readable_id,
+        step_readable_id
+), running_concurrency AS (
+    SELECT
+        rta.step_readable_id,
+        sc.expression,
+        sc.strategy,
+        cs.key,
+        COUNT(DISTINCT (rta.task_id, rta.task_inserted_at, rta.retry_count)) as count
+    FROM
+        running_task_attempts rta
+    JOIN
+        v1_concurrency_slot cs ON cs.task_id = rta.task_id AND cs.task_inserted_at = rta.task_inserted_at AND cs.task_retry_count = rta.retry_count AND cs.workflow_id = rta.workflow_id AND cs.workflow_version_id = rta.workflow_version_id
+    JOIN
+        v1_step_concurrency sc ON sc.workflow_id = rta.workflow_id AND sc.workflow_version_id = rta.workflow_version_id AND sc.step_id = rta.step_id AND cs.strategy_id = sc.id
+    WHERE
+        cs.tenant_id = @tenantId::uuid
+        AND cs.tenant_id = rta.tenant_id
+        AND cs.is_filled = TRUE
+        AND sc.tenant_id = @tenantId::uuid
+    GROUP BY
+        rta.step_readable_id,
         sc.expression,
         sc.strategy,
         cs.key
 )
 SELECT
-    'queued' as task_status,
+    'queued' as row_kind,
     step_readable_id,
     queue,
     NULL::text as expression,
@@ -1257,7 +1281,7 @@ FROM queued_tasks
 UNION ALL
 
 SELECT
-    'queued' as task_status,
+    'queued' as row_kind,
     step_readable_id,
     queue,
     NULL::text as expression,
@@ -1271,7 +1295,7 @@ FROM retry_queued_tasks
 UNION ALL
 
 SELECT
-    'queued' as task_status,
+    'queued' as row_kind,
     step_readable_id,
     queue,
     NULL::text as expression,
@@ -1285,7 +1309,7 @@ FROM rate_limited_queued_tasks
 UNION ALL
 
 SELECT
-    'queued' as task_status,
+    'queued' as row_kind,
     step_readable_id,
     queue,
     expression,
@@ -1299,16 +1323,30 @@ FROM concurrency_queued_tasks
 UNION ALL
 
 SELECT
-    'running' as task_status,
+    'running_total' as row_kind,
+    step_readable_id,
+    ''::text as queue,
+    NULL::text as expression,
+    NULL::text as strategy,
+    NULL::text as key,
+    count,
+    oldest::TIMESTAMPTZ,
+    oldest_excluding_retries::TIMESTAMPTZ
+FROM running_totals
+
+UNION ALL
+
+SELECT
+    'running_concurrency' as row_kind,
     step_readable_id,
     ''::text as queue,
     expression,
     strategy::text,
     key,
     count,
-    oldest::TIMESTAMPTZ,
-    oldest_excluding_retries::TIMESTAMPTZ
-FROM running_tasks;
+    NULL::TIMESTAMPTZ as oldest,
+    NULL::TIMESTAMPTZ as oldest_excluding_retries
+FROM running_concurrency;
 
 -- name: FindOldestRunningTask :one
 SELECT

--- a/pkg/repository/sqlcv1/tasks.sql.go
+++ b/pkg/repository/sqlcv1/tasks.sql.go
@@ -980,36 +980,60 @@ WITH queued_tasks AS (
         sc.expression,
         sc.strategy,
         cs.key
-), running_tasks AS (
+), running_task_attempts AS (
     SELECT
+        t.id AS task_id,
         t.step_readable_id,
-        COALESCE(sc.expression, '') as expression,
-        COALESCE(sc.strategy, 'NONE'::v1_concurrency_strategy) as strategy,
-        COALESCE(cs.key, '') as key,
-        COUNT(*) as count,
-        MIN(t.inserted_at) AS oldest,
-        MIN(t.inserted_at) FILTER (WHERE t.retry_count = 0) AS oldest_excluding_retries
+        t.inserted_at AS task_inserted_at,
+        t.retry_count,
+        t.tenant_id,
+        t.workflow_id,
+        t.workflow_version_id,
+        t.step_id
     FROM
         v1_task_runtime tr
     JOIN
         v1_task t ON tr.task_id = t.id AND tr.task_inserted_at = t.inserted_at AND tr.retry_count = t.retry_count
-    LEFT JOIN
-        v1_concurrency_slot cs ON cs.task_id = t.id AND cs.task_inserted_at = t.inserted_at AND cs.task_retry_count = t.retry_count
-    LEFT JOIN
-        v1_step_concurrency sc ON sc.workflow_id = t.workflow_id AND sc.workflow_version_id = t.workflow_version_id AND sc.step_id = t.step_id
     WHERE
         t.tenant_id = $1::uuid
         AND tr.tenant_id = $1::uuid
         AND tr.worker_id IS NOT NULL
-        AND (t.concurrency_strategy_ids IS NULL OR array_length(t.concurrency_strategy_ids, 1) IS NULL OR sc.id = ANY(t.concurrency_strategy_ids))
+), running_totals AS (
+    SELECT
+        step_readable_id,
+        COUNT(*) as count,
+        MIN(task_inserted_at) AS oldest,
+        MIN(task_inserted_at) FILTER (WHERE retry_count = 0) AS oldest_excluding_retries
+    FROM
+        running_task_attempts
     GROUP BY
-        t.step_readable_id,
+        step_readable_id
+), running_concurrency AS (
+    SELECT
+        rta.step_readable_id,
+        sc.expression,
+        sc.strategy,
+        cs.key,
+        COUNT(DISTINCT (rta.task_id, rta.task_inserted_at, rta.retry_count)) as count
+    FROM
+        running_task_attempts rta
+    JOIN
+        v1_concurrency_slot cs ON cs.task_id = rta.task_id AND cs.task_inserted_at = rta.task_inserted_at AND cs.task_retry_count = rta.retry_count AND cs.workflow_id = rta.workflow_id AND cs.workflow_version_id = rta.workflow_version_id
+    JOIN
+        v1_step_concurrency sc ON sc.workflow_id = rta.workflow_id AND sc.workflow_version_id = rta.workflow_version_id AND sc.step_id = rta.step_id AND cs.strategy_id = sc.id
+    WHERE
+        cs.tenant_id = $1::uuid
+        AND cs.tenant_id = rta.tenant_id
+        AND cs.is_filled = TRUE
+        AND sc.tenant_id = $1::uuid
+    GROUP BY
+        rta.step_readable_id,
         sc.expression,
         sc.strategy,
         cs.key
 )
 SELECT
-    'queued' as task_status,
+    'queued' as row_kind,
     step_readable_id,
     queue,
     NULL::text as expression,
@@ -1023,7 +1047,7 @@ FROM queued_tasks
 UNION ALL
 
 SELECT
-    'queued' as task_status,
+    'queued' as row_kind,
     step_readable_id,
     queue,
     NULL::text as expression,
@@ -1037,7 +1061,7 @@ FROM retry_queued_tasks
 UNION ALL
 
 SELECT
-    'queued' as task_status,
+    'queued' as row_kind,
     step_readable_id,
     queue,
     NULL::text as expression,
@@ -1051,7 +1075,7 @@ FROM rate_limited_queued_tasks
 UNION ALL
 
 SELECT
-    'queued' as task_status,
+    'queued' as row_kind,
     step_readable_id,
     queue,
     expression,
@@ -1065,20 +1089,34 @@ FROM concurrency_queued_tasks
 UNION ALL
 
 SELECT
-    'running' as task_status,
+    'running_total' as row_kind,
+    step_readable_id,
+    ''::text as queue,
+    NULL::text as expression,
+    NULL::text as strategy,
+    NULL::text as key,
+    count,
+    oldest::TIMESTAMPTZ,
+    oldest_excluding_retries::TIMESTAMPTZ
+FROM running_totals
+
+UNION ALL
+
+SELECT
+    'running_concurrency' as row_kind,
     step_readable_id,
     ''::text as queue,
     expression,
     strategy::text,
     key,
     count,
-    oldest::TIMESTAMPTZ,
-    oldest_excluding_retries::TIMESTAMPTZ
-FROM running_tasks
+    NULL::TIMESTAMPTZ as oldest,
+    NULL::TIMESTAMPTZ as oldest_excluding_retries
+FROM running_concurrency
 `
 
 type GetTenantTaskStatsRow struct {
-	TaskStatus             string             `json:"task_status"`
+	RowKind                string             `json:"row_kind"`
 	StepReadableID         string             `json:"step_readable_id"`
 	Queue                  string             `json:"queue"`
 	Expression             pgtype.Text        `json:"expression"`
@@ -1099,7 +1137,7 @@ func (q *Queries) GetTenantTaskStats(ctx context.Context, db DBTX, tenantid uuid
 	for rows.Next() {
 		var i GetTenantTaskStatsRow
 		if err := rows.Scan(
-			&i.TaskStatus,
+			&i.RowKind,
 			&i.StepReadableID,
 			&i.Queue,
 			&i.Expression,

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -2757,27 +2757,6 @@ func (r *sharedRepository) replayTasks(
 	return res, nil
 }
 
-func sortConcurrencyStrategies(strats []*sqlcv1.V1StepConcurrency) {
-	sort.SliceStable(strats, func(i, j int) bool {
-		iStrat := strats[i]
-		jStrat := strats[j]
-
-		if iStrat.ParentStrategyID.Valid && jStrat.ParentStrategyID.Valid && iStrat.ParentStrategyID.Int64 != jStrat.ParentStrategyID.Int64 {
-			return iStrat.ParentStrategyID.Int64 < jStrat.ParentStrategyID.Int64
-		}
-
-		if iStrat.ParentStrategyID.Valid && !jStrat.ParentStrategyID.Valid {
-			return true
-		}
-
-		if !iStrat.ParentStrategyID.Valid && jStrat.ParentStrategyID.Valid {
-			return false
-		}
-
-		return iStrat.ID < jStrat.ID
-	})
-}
-
 func (r *sharedRepository) getConcurrencyExpressions(
 	ctx context.Context,
 	tx sqlcv1.DBTX,
@@ -2798,6 +2777,27 @@ func (r *sharedRepository) getConcurrencyExpressions(
 
 	cacheKey := func(stepId uuid.UUID) string {
 		return fmt.Sprintf("concurrency-strategies:%s:%s", tenantId, stepId)
+	}
+
+	sortStrategies := func(strats []*sqlcv1.V1StepConcurrency) {
+		sort.SliceStable(strats, func(i, j int) bool {
+			iStrat := strats[i]
+			jStrat := strats[j]
+
+			if iStrat.ParentStrategyID.Valid && jStrat.ParentStrategyID.Valid && iStrat.ParentStrategyID.Int64 != jStrat.ParentStrategyID.Int64 {
+				return iStrat.ParentStrategyID.Int64 < jStrat.ParentStrategyID.Int64
+			}
+
+			if iStrat.ParentStrategyID.Valid && !jStrat.ParentStrategyID.Valid {
+				return true
+			}
+
+			if !iStrat.ParentStrategyID.Valid && jStrat.ParentStrategyID.Valid {
+				return false
+			}
+
+			return iStrat.ID < jStrat.ID
+		})
 	}
 
 	stepIdToStrats := make(map[uuid.UUID][]*sqlcv1.V1StepConcurrency, len(stepIdsWithExpressions))
@@ -2841,7 +2841,7 @@ func (r *sharedRepository) getConcurrencyExpressions(
 		if stepStrats == nil {
 			stepStrats = []*sqlcv1.V1StepConcurrency{}
 		} else {
-			sortConcurrencyStrategies(stepStrats)
+			sortStrategies(stepStrats)
 		}
 
 		r.concurrencyStrategyCache.Set(cacheKey(stepId), stepStrats)

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -2757,6 +2757,27 @@ func (r *sharedRepository) replayTasks(
 	return res, nil
 }
 
+func sortConcurrencyStrategies(strats []*sqlcv1.V1StepConcurrency) {
+	sort.SliceStable(strats, func(i, j int) bool {
+		iStrat := strats[i]
+		jStrat := strats[j]
+
+		if iStrat.ParentStrategyID.Valid && jStrat.ParentStrategyID.Valid && iStrat.ParentStrategyID.Int64 != jStrat.ParentStrategyID.Int64 {
+			return iStrat.ParentStrategyID.Int64 < jStrat.ParentStrategyID.Int64
+		}
+
+		if iStrat.ParentStrategyID.Valid && !jStrat.ParentStrategyID.Valid {
+			return true
+		}
+
+		if !iStrat.ParentStrategyID.Valid && jStrat.ParentStrategyID.Valid {
+			return false
+		}
+
+		return iStrat.ID < jStrat.ID
+	})
+}
+
 func (r *sharedRepository) getConcurrencyExpressions(
 	ctx context.Context,
 	tx sqlcv1.DBTX,
@@ -2777,27 +2798,6 @@ func (r *sharedRepository) getConcurrencyExpressions(
 
 	cacheKey := func(stepId uuid.UUID) string {
 		return fmt.Sprintf("concurrency-strategies:%s:%s", tenantId, stepId)
-	}
-
-	sortStrategies := func(strats []*sqlcv1.V1StepConcurrency) {
-		sort.SliceStable(strats, func(i, j int) bool {
-			iStrat := strats[i]
-			jStrat := strats[j]
-
-			if iStrat.ParentStrategyID.Valid && jStrat.ParentStrategyID.Valid && iStrat.ParentStrategyID.Int64 != jStrat.ParentStrategyID.Int64 {
-				return iStrat.ParentStrategyID.Int64 < jStrat.ParentStrategyID.Int64
-			}
-
-			if iStrat.ParentStrategyID.Valid && !jStrat.ParentStrategyID.Valid {
-				return true
-			}
-
-			if !iStrat.ParentStrategyID.Valid && jStrat.ParentStrategyID.Valid {
-				return false
-			}
-
-			return iStrat.ID < jStrat.ID
-		})
 	}
 
 	stepIdToStrats := make(map[uuid.UUID][]*sqlcv1.V1StepConcurrency, len(stepIdsWithExpressions))
@@ -2841,7 +2841,7 @@ func (r *sharedRepository) getConcurrencyExpressions(
 		if stepStrats == nil {
 			stepStrats = []*sqlcv1.V1StepConcurrency{}
 		} else {
-			sortStrategies(stepStrats)
+			sortConcurrencyStrategies(stepStrats)
 		}
 
 		r.concurrencyStrategyCache.Set(cacheKey(stepId), stepStrats)
@@ -4166,6 +4166,12 @@ type ConcurrencyStat struct {
 	Keys       map[string]int64 `json:"keys"`
 }
 
+const (
+	taskStatsRowKindQueued             = "queued"
+	taskStatsRowKindRunningTotal       = "running_total"
+	taskStatsRowKindRunningConcurrency = "running_concurrency"
+)
+
 func (r *TaskRepositoryImpl) GetTaskStats(ctx context.Context, tenantId uuid.UUID) (map[string]TaskStat, error) {
 	rows, err := r.queries.GetTenantTaskStats(ctx, r.pool, tenantId)
 
@@ -4177,11 +4183,8 @@ func (r *TaskRepositoryImpl) GetTaskStats(ctx context.Context, tenantId uuid.UUI
 
 	for _, row := range rows {
 		stepReadableId := row.StepReadableID
-		taskStatus := row.TaskStatus
+		rowKind := row.RowKind
 		queue := row.Queue
-		expression := row.Expression.String
-		strategy := row.Strategy.String
-		key := row.Key.String
 		count := row.Count
 		oldest := row.Oldest
 		oldestExcludingRetries := row.OldestExcludingRetries
@@ -4192,17 +4195,17 @@ func (r *TaskRepositoryImpl) GetTaskStats(ctx context.Context, tenantId uuid.UUI
 			taskStat = result[stepReadableId]
 		}
 
-		var statusStat *TaskStatusStat
-
-		switch taskStatus {
-		case "queued":
+		switch rowKind {
+		case taskStatsRowKindQueued:
 			if taskStat.Queued == nil {
 				taskStat.Queued = &TaskStatusStat{
 					Queues: make(map[string]int64),
 				}
 				result[stepReadableId] = taskStat
 			}
-			statusStat = result[stepReadableId].Queued
+			statusStat := result[stepReadableId].Queued
+
+			statusStat.Total += count
 
 			if oldest.Valid && (statusStat.Oldest == nil || oldest.Time.Before(*statusStat.Oldest)) {
 				statusStat.Oldest = &oldest.Time
@@ -4211,12 +4214,21 @@ func (r *TaskRepositoryImpl) GetTaskStats(ctx context.Context, tenantId uuid.UUI
 			if oldestExcludingRetries.Valid && (statusStat.OldestExcludingRetries == nil || oldestExcludingRetries.Time.Before(*statusStat.OldestExcludingRetries)) {
 				statusStat.OldestExcludingRetries = &oldestExcludingRetries.Time
 			}
-		case "running":
-			if taskStat.Running == nil {
-				taskStat.Running = &TaskStatusStat{}
-				result[stepReadableId] = taskStat
+
+			if queue != "" {
+				if statusStat.Queues == nil {
+					statusStat.Queues = make(map[string]int64)
+				}
+				statusStat.Queues[queue] += count
 			}
-			statusStat = result[stepReadableId].Running
+
+			if isTaskStatsConcurrencyDetail(row.Expression, row.Strategy, row.Key) {
+				addTaskStatsConcurrencyEntry(statusStat, row.Expression.String, row.Strategy.String, row.Key.String, count)
+			}
+		case taskStatsRowKindRunningTotal:
+			statusStat := getOrCreateRunningTaskStatus(result, stepReadableId)
+
+			statusStat.Total += count
 
 			if oldest.Valid && (statusStat.Oldest == nil || oldest.Time.Before(*statusStat.Oldest)) {
 				statusStat.Oldest = &oldest.Time
@@ -4225,44 +4237,62 @@ func (r *TaskRepositoryImpl) GetTaskStats(ctx context.Context, tenantId uuid.UUI
 			if oldestExcludingRetries.Valid && (statusStat.OldestExcludingRetries == nil || oldestExcludingRetries.Time.Before(*statusStat.OldestExcludingRetries)) {
 				statusStat.OldestExcludingRetries = &oldestExcludingRetries.Time
 			}
-		}
+		case taskStatsRowKindRunningConcurrency:
+			statusStat := getOrCreateRunningTaskStatus(result, stepReadableId)
 
-		statusStat.Total += count
-
-		if taskStatus == "queued" && queue != "" {
-			if statusStat.Queues == nil {
-				statusStat.Queues = make(map[string]int64)
+			if isTaskStatsConcurrencyDetail(row.Expression, row.Strategy, row.Key) {
+				addTaskStatsConcurrencyEntry(statusStat, row.Expression.String, row.Strategy.String, row.Key.String, count)
 			}
-			statusStat.Queues[queue] += count
-		}
-
-		if expression != "" && key != "" && strategy != "NONE" {
-			var concurrencyEntry *ConcurrencyStat
-			for i := range statusStat.Concurrency {
-				if statusStat.Concurrency[i].Expression == expression && statusStat.Concurrency[i].Type == strategy {
-					concurrencyEntry = &statusStat.Concurrency[i]
-					break
-				}
-			}
-
-			if concurrencyEntry == nil {
-				newEntry := ConcurrencyStat{
-					Expression: expression,
-					Type:       strategy,
-					Keys:       make(map[string]int64),
-				}
-				statusStat.Concurrency = append(statusStat.Concurrency, newEntry)
-				concurrencyEntry = &statusStat.Concurrency[len(statusStat.Concurrency)-1]
-			}
-
-			if concurrencyEntry.Keys == nil {
-				concurrencyEntry.Keys = make(map[string]int64)
-			}
-			concurrencyEntry.Keys[key] += count
+		default:
+			return nil, fmt.Errorf("unknown task stats row kind: %q", rowKind)
 		}
 	}
 
 	return result, nil
+}
+
+func getOrCreateRunningTaskStatus(result map[string]TaskStat, stepReadableId string) *TaskStatusStat {
+	taskStat := result[stepReadableId]
+	if taskStat.Running == nil {
+		taskStat.Running = &TaskStatusStat{}
+		result[stepReadableId] = taskStat
+	}
+
+	return taskStat.Running
+}
+
+func isTaskStatsConcurrencyDetail(expression, strategy, key pgtype.Text) bool {
+	return expression.Valid &&
+		expression.String != "" &&
+		strategy.Valid &&
+		strategy.String != string(sqlcv1.V1ConcurrencyStrategyNONE) &&
+		key.Valid &&
+		key.String != ""
+}
+
+func addTaskStatsConcurrencyEntry(statusStat *TaskStatusStat, expression, strategy, key string, count int64) {
+	var concurrencyEntry *ConcurrencyStat
+	for i := range statusStat.Concurrency {
+		if statusStat.Concurrency[i].Expression == expression && statusStat.Concurrency[i].Type == strategy {
+			concurrencyEntry = &statusStat.Concurrency[i]
+			break
+		}
+	}
+
+	if concurrencyEntry == nil {
+		newEntry := ConcurrencyStat{
+			Expression: expression,
+			Type:       strategy,
+			Keys:       make(map[string]int64),
+		}
+		statusStat.Concurrency = append(statusStat.Concurrency, newEntry)
+		concurrencyEntry = &statusStat.Concurrency[len(statusStat.Concurrency)-1]
+	}
+
+	if concurrencyEntry.Keys == nil {
+		concurrencyEntry.Keys = make(map[string]int64)
+	}
+	concurrencyEntry.Keys[key] += count
 }
 
 func (r *TaskRepositoryImpl) FindOldestRunningTaskInsertedAt(ctx context.Context) (*time.Time, error) {

--- a/pkg/repository/task_stats_test.go
+++ b/pkg/repository/task_stats_test.go
@@ -8,530 +8,280 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/hatchet-dev/hatchet/pkg/repository/cache"
-	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 )
 
-type taskStatsEnv struct {
-	t               *testing.T
-	ctx             context.Context
-	repo            *TaskRepositoryImpl
-	wfRepo          *workflowRepository
-	queries         *sqlcv1.Queries
-	concurrencyRepo ConcurrencyRepository
-	tenantID        uuid.UUID
-	workerID        uuid.UUID
+const taskStatsGroupRoundRobin = "GROUP_ROUND_ROBIN"
+
+type taskStatsTestEnv struct {
+	t        *testing.T
+	ctx      context.Context
+	pool     *pgxpool.Pool
+	repo     *TaskRepositoryImpl
+	tenantID uuid.UUID
+	workerID uuid.UUID
 }
 
-type taskStatsWorkflow struct {
-	workflowID        uuid.UUID
-	workflowVersionID uuid.UUID
-	stepID            uuid.UUID
-	strategies        []*sqlcv1.V1StepConcurrency
+type taskStatsStrategySeed struct {
+	expression string
+	key        string
+	parent     bool
+	filled     bool
 }
 
-type taskStatsTask struct {
-	id            int64
-	insertedAt    pgtype.Timestamptz
-	retryCount    int32
-	workflowRunID uuid.UUID
-}
-
-func newTaskStatsEnv(t *testing.T, pool *pgxpool.Pool) *taskStatsEnv {
+func newTaskStatsTestEnv(t *testing.T, pool *pgxpool.Pool) *taskStatsTestEnv {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	t.Cleanup(cancel)
 
-	tenantID := uuid.New()
-	workerID := uuid.New()
-	suffix := tenantID.String()
+	env := &taskStatsTestEnv{
+		t:        t,
+		ctx:      ctx,
+		pool:     pool,
+		repo:     createTaskRepository(pool),
+		tenantID: uuid.New(),
+		workerID: uuid.New(),
+	}
 
 	_, err := pool.Exec(ctx, `
 		INSERT INTO "Tenant" ("id", "name", "slug", "createdAt", "updatedAt")
 		VALUES ($1, 'task-stats-tenant', $2, NOW(), NOW())
-	`, tenantID, "task-stats-"+suffix)
+	`, env.tenantID, "task-stats-"+env.tenantID.String())
 	require.NoError(t, err)
 
 	_, err = pool.Exec(ctx, `
 		INSERT INTO "Worker" ("id", "tenantId", "name", "lastHeartbeatAt", "createdAt", "updatedAt")
 		VALUES ($1, $2, 'task-stats-worker', NOW(), NOW(), NOW())
-	`, workerID, tenantID)
+	`, env.workerID, env.tenantID)
 	require.NoError(t, err)
 
-	repo := createTaskRepository(pool)
-	repo.queueCache = cache.New(5 * time.Minute)
-	t.Cleanup(repo.queueCache.Stop)
-
-	wfRepo := newWorkflowTestRepository(pool)
-	t.Cleanup(wfRepo.queueCache.Stop)
-
-	return &taskStatsEnv{
-		t:               t,
-		ctx:             ctx,
-		repo:            repo,
-		wfRepo:          wfRepo,
-		queries:         sqlcv1.New(),
-		concurrencyRepo: newConcurrencyRepository(repo.sharedRepository),
-		tenantID:        tenantID,
-		workerID:        workerID,
-	}
+	return env
 }
 
-func (e *taskStatsEnv) registerWorkflow(
-	name string,
-	workflowConcurrency []CreateConcurrencyOpts,
-	stepConcurrency []CreateConcurrencyOpts,
-) taskStatsWorkflow {
+func (e *taskStatsTestEnv) seedTask(stepReadableID string, running bool, seeds ...taskStatsStrategySeed) {
 	e.t.Helper()
 
-	desc := name
-	version, err := e.wfRepo.PutWorkflowVersion(e.ctx, e.tenantID, &CreateWorkflowVersionOpts{
-		Name:        name,
-		Description: &desc,
-		Concurrency: workflowConcurrency,
-		Tasks: []CreateStepOpts{
-			{
-				ReadableId:  "my-task",
-				Action:      "test:run",
-				Concurrency: stepConcurrency,
-			},
-		},
-	})
-	require.NoError(e.t, err)
-
-	workflowID := version.WorkflowVersion.WorkflowId
-	workflowVersionID := version.WorkflowVersion.ID
-
-	var stepID uuid.UUID
-	err = e.repo.pool.QueryRow(e.ctx, `
-		SELECT s."id"
-		FROM "Step" s
-		JOIN "Job" j ON s."jobId" = j."id"
-		WHERE j."workflowVersionId" = $1 AND s."readableId" = 'my-task'
-	`, workflowVersionID).Scan(&stepID)
-	require.NoError(e.t, err)
-
-	strategies, err := e.queries.ListActiveConcurrencyStrategies(e.ctx, e.repo.pool, e.tenantID)
-	require.NoError(e.t, err)
-
-	filtered := make([]*sqlcv1.V1StepConcurrency, 0, len(strategies))
-	for _, strategy := range strategies {
-		if strategy.WorkflowID == workflowID && strategy.WorkflowVersionID == workflowVersionID && strategy.StepID == stepID {
-			filtered = append(filtered, strategy)
-		}
-	}
-	sortConcurrencyStrategies(filtered)
-
-	return taskStatsWorkflow{
-		workflowID:        workflowID,
-		workflowVersionID: workflowVersionID,
-		stepID:            stepID,
-		strategies:        filtered,
-	}
-}
-
-func (e *taskStatsEnv) createTask(workflow taskStatsWorkflow, keysByExpression map[string]string) taskStatsTask {
-	e.t.Helper()
-
-	strategyIDs := make([]int64, len(workflow.strategies))
-	parentStrategyIDs := make([]pgtype.Int8, len(workflow.strategies))
-	concurrencyKeys := make([]string, len(workflow.strategies))
-
-	for i, strategy := range workflow.strategies {
-		key, ok := keysByExpression[strategy.Expression]
-		require.True(e.t, ok, "missing concurrency key for expression %q", strategy.Expression)
-
-		strategyIDs[i] = strategy.ID
-		parentStrategyIDs[i] = strategy.ParentStrategyID
-		concurrencyKeys[i] = key
-	}
-
+	workflowID := uuid.New()
+	workflowVersionID := uuid.New()
 	workflowRunID := uuid.New()
-	tasks, err := e.queries.CreateTasks(e.ctx, e.repo.pool, sqlcv1.CreateTasksParams{
-		Tenantids:                    []uuid.UUID{e.tenantID},
-		Queues:                       []string{"default"},
-		Actionids:                    []string{"test:run"},
-		Stepids:                      []uuid.UUID{workflow.stepID},
-		Stepreadableids:              []string{"my-task"},
-		Workflowids:                  []uuid.UUID{workflow.workflowID},
-		Scheduletimeouts:             []string{"5m"},
-		Steptimeouts:                 []string{"30s"},
-		Priorities:                   []int32{1},
-		Stickies:                     []string{string(sqlcv1.V1StickyStrategyNONE)},
-		Externalids:                  []uuid.UUID{uuid.New()},
-		Displaynames:                 []string{"task-stats-task"},
-		Inputs:                       [][]byte{[]byte(`{}`)},
-		Retrycounts:                  []int32{0},
-		Additionalmetadatas:          [][]byte{[]byte(`{}`)},
-		InitialStates:                []string{string(sqlcv1.V1TaskInitialStateQUEUED)},
-		Concurrencyparentstrategyids: [][]pgtype.Int8{parentStrategyIDs},
-		ConcurrencyStrategyIds:       [][]int64{strategyIDs},
-		ConcurrencyKeys:              [][]string{concurrencyKeys},
-		WorkflowVersionIds:           []uuid.UUID{workflow.workflowVersionID},
-		WorkflowRunIds:               []uuid.UUID{workflowRunID},
-	})
-	require.NoError(e.t, err)
-	require.Len(e.t, tasks, 1)
+	stepID := uuid.New()
+	externalID := uuid.New()
 
-	return taskStatsTask{
-		id:            tasks[0].ID,
-		insertedAt:    tasks[0].InsertedAt,
-		retryCount:    tasks[0].RetryCount,
-		workflowRunID: workflowRunID,
-	}
-}
+	strategyIDs := make([]int64, len(seeds))
+	parentStrategyIDs := make([]any, len(seeds))
+	keys := make([]string, len(seeds))
 
-func (e *taskStatsEnv) advanceConcurrency(workflow taskStatsWorkflow) {
-	e.t.Helper()
+	for i, seed := range seeds {
+		if seed.parent {
+			var parentStrategyID int64
+			err := e.pool.QueryRow(e.ctx, `
+				INSERT INTO v1_workflow_concurrency (
+					workflow_id,
+					workflow_version_id,
+					strategy,
+					expression,
+					tenant_id,
+					max_concurrency
+				)
+				VALUES ($1, $2, $3, $4, $5, 5)
+				RETURNING id
+			`, workflowID, workflowVersionID, taskStatsGroupRoundRobin, seed.expression, e.tenantID).Scan(&parentStrategyID)
+			require.NoError(e.t, err)
+			parentStrategyIDs[i] = parentStrategyID
+		}
 
-	for _, strategy := range workflow.strategies {
-		result, err := e.concurrencyRepo.RunConcurrencyStrategy(e.ctx, e.tenantID, strategy)
+		err := e.pool.QueryRow(e.ctx, `
+			INSERT INTO v1_step_concurrency (
+				parent_strategy_id,
+				workflow_id,
+				workflow_version_id,
+				step_id,
+				strategy,
+				expression,
+				tenant_id,
+				max_concurrency
+			)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, 5)
+			RETURNING id
+		`, parentStrategyIDs[i], workflowID, workflowVersionID, stepID, taskStatsGroupRoundRobin, seed.expression, e.tenantID).Scan(&strategyIDs[i])
 		require.NoError(e.t, err)
-		require.NotNil(e.t, result)
-		require.False(e.t, result.FailedAdvisoryLock)
-		require.Empty(e.t, result.Cancelled)
+
+		if parentStrategyIDs[i] != nil {
+			_, err = e.pool.Exec(e.ctx, `
+				UPDATE v1_workflow_concurrency
+				SET child_strategy_ids = ARRAY[$1]::bigint[]
+				WHERE workflow_id = $2
+					AND workflow_version_id = $3
+					AND id = $4
+			`, strategyIDs[i], workflowID, workflowVersionID, parentStrategyIDs[i])
+			require.NoError(e.t, err)
+		}
+
+		keys[i] = seed.key
+	}
+
+	var taskID int64
+	var taskInsertedAt time.Time
+	err := e.pool.QueryRow(e.ctx, `
+		INSERT INTO v1_task (
+			tenant_id,
+			queue,
+			action_id,
+			step_id,
+			step_readable_id,
+			workflow_id,
+			workflow_version_id,
+			workflow_run_id,
+			schedule_timeout,
+			step_timeout,
+			sticky,
+			external_id,
+			display_name,
+			input,
+			step_index
+		)
+		VALUES ($1, 'default', 'test:run', $2, $3, $4, $5, $6, '5m', '30s', 'NONE', $7, 'task-stats-task', '{}', 0)
+		RETURNING id, inserted_at
+	`, e.tenantID, stepID, stepReadableID, workflowID, workflowVersionID, workflowRunID, externalID).Scan(&taskID, &taskInsertedAt)
+	require.NoError(e.t, err)
+
+	if len(strategyIDs) > 0 {
+		_, err = e.pool.Exec(e.ctx, `
+			UPDATE v1_task
+			SET concurrency_strategy_ids = $1,
+				concurrency_keys = $2
+			WHERE id = $3 AND inserted_at = $4
+		`, strategyIDs, keys, taskID, taskInsertedAt)
+		require.NoError(e.t, err)
+	}
+
+	if running || len(strategyIDs) > 0 {
+		_, err = e.pool.Exec(e.ctx, `
+			DELETE FROM v1_queue_item
+			WHERE task_id = $1 AND task_inserted_at = $2 AND retry_count = 0
+		`, taskID, taskInsertedAt)
+		require.NoError(e.t, err)
+	}
+
+	for i, seed := range seeds {
+		_, err = e.pool.Exec(e.ctx, `
+			INSERT INTO v1_concurrency_slot (
+				task_id,
+				task_inserted_at,
+				task_retry_count,
+				external_id,
+				tenant_id,
+				workflow_id,
+				workflow_version_id,
+				workflow_run_id,
+				strategy_id,
+				parent_strategy_id,
+				priority,
+				key,
+				is_filled,
+				queue_to_notify,
+				schedule_timeout_at
+			)
+			VALUES ($1, $2, 0, $3, $4, $5, $6, $7, $8, $9, 1, $10, $11, 'default', NOW() + INTERVAL '5 minutes')
+		`, taskID, taskInsertedAt, externalID, e.tenantID, workflowID, workflowVersionID, workflowRunID, strategyIDs[i], parentStrategyIDs[i], seed.key, seed.filled)
+		require.NoError(e.t, err)
+	}
+
+	if running {
+		_, err = e.pool.Exec(e.ctx, `
+			INSERT INTO v1_task_runtime (
+				task_id,
+				task_inserted_at,
+				retry_count,
+				worker_id,
+				tenant_id,
+				timeout_at
+			)
+			VALUES ($1, $2, 0, $3, $4, NOW() + INTERVAL '30 seconds')
+		`, taskID, taskInsertedAt, e.workerID, e.tenantID)
+		require.NoError(e.t, err)
 	}
 }
 
-func (e *taskStatsEnv) assign(task taskStatsTask) {
-	e.t.Helper()
-
-	tx, err := e.repo.pool.Begin(e.ctx)
-	require.NoError(e.t, err)
-	defer func() { _ = tx.Rollback(e.ctx) }()
-
-	var queueItemID int64
-	err = tx.QueryRow(e.ctx, `
-		SELECT id
-		FROM v1_queue_item
-		WHERE tenant_id = $1
-			AND task_id = $2
-			AND task_inserted_at = $3
-			AND retry_count = $4
-	`, e.tenantID, task.id, task.insertedAt, task.retryCount).Scan(&queueItemID)
-	require.NoError(e.t, err)
-
-	deletedQueueItems, err := e.queries.BulkQueueItems(e.ctx, tx, []int64{queueItemID})
-	require.NoError(e.t, err)
-	require.Equal(e.t, []int64{queueItemID}, deletedQueueItems)
-
-	assigned, err := e.queries.UpdateTasksToAssigned(e.ctx, tx, sqlcv1.UpdateTasksToAssignedParams{
-		Taskids:           []int64{task.id},
-		Taskinsertedats:   []pgtype.Timestamptz{task.insertedAt},
-		Mintaskinsertedat: task.insertedAt,
-		Workerids:         []uuid.UUID{e.workerID},
-		Tenantid:          e.tenantID,
-	})
-	require.NoError(e.t, err)
-	require.Len(e.t, assigned, 1)
-
-	require.NoError(e.t, tx.Commit(e.ctx))
-}
-
-func (e *taskStatsEnv) advanceAndAssign(task taskStatsTask, workflow taskStatsWorkflow) {
-	e.t.Helper()
-
-	e.advanceConcurrency(workflow)
-	e.assign(task)
-}
-
-func (e *taskStatsEnv) retryAndAssign(task taskStatsTask, workflow taskStatsWorkflow) taskStatsTask {
-	e.t.Helper()
-
-	tx, err := e.repo.pool.Begin(e.ctx)
-	require.NoError(e.t, err)
-	defer func() { _ = tx.Rollback(e.ctx) }()
-
-	retried, err := e.queries.FailTaskInternalFailure(e.ctx, tx, sqlcv1.FailTaskInternalFailureParams{
-		Maxinternalretries: 3,
-		Taskids:            []int64{task.id},
-		Taskinsertedats:    []pgtype.Timestamptz{task.insertedAt},
-		Taskretrycounts:    []int32{task.retryCount},
-		Tenantid:           e.tenantID,
-	})
-	require.NoError(e.t, err)
-	require.Len(e.t, retried, 1)
-
-	released, err := e.repo.releaseTasks(e.ctx, tx, e.tenantID, []TaskIdInsertedAtRetryCount{{
-		Id:         task.id,
-		InsertedAt: task.insertedAt,
-		RetryCount: task.retryCount,
-	}})
-	require.NoError(e.t, err)
-	require.Len(e.t, released, 1)
-	require.NoError(e.t, tx.Commit(e.ctx))
-
-	next := taskStatsTask{
-		id:            retried[0].ID,
-		insertedAt:    retried[0].InsertedAt,
-		retryCount:    retried[0].RetryCount,
-		workflowRunID: task.workflowRunID,
-	}
-	e.advanceAndAssign(next, workflow)
-
-	return next
-}
-
-func (e *taskStatsEnv) clearAssignedWorker(task taskStatsTask) {
-	e.t.Helper()
-
-	// Production release paths delete the runtime, so clear the assigned worker in place to
-	// exercise the legacy NULL-worker state without reintroducing a queue item.
-	tag, err := e.repo.pool.Exec(e.ctx, `
-		UPDATE v1_task_runtime
-		SET worker_id = NULL
-		WHERE task_id = $1
-			AND task_inserted_at = $2
-			AND retry_count = $3
-			AND tenant_id = $4
-	`, task.id, task.insertedAt, task.retryCount, e.tenantID)
-	require.NoError(e.t, err)
-	require.Equal(e.t, int64(1), tag.RowsAffected())
-
-	var queueItems int
-	err = e.repo.pool.QueryRow(e.ctx, `
-		SELECT COUNT(*)
-		FROM v1_queue_item
-		WHERE tenant_id = $1
-			AND task_id = $2
-			AND task_inserted_at = $3
-			AND retry_count = $4
-	`, e.tenantID, task.id, task.insertedAt, task.retryCount).Scan(&queueItems)
-	require.NoError(e.t, err)
-	require.Zero(e.t, queueItems)
-}
-
-func (e *taskStatsEnv) stats() map[string]TaskStat {
+func (e *taskStatsTestEnv) taskStats(stepReadableID string) TaskStat {
 	e.t.Helper()
 
 	stats, err := e.repo.GetTaskStats(e.ctx, e.tenantID)
 	require.NoError(e.t, err)
-	return stats
-}
-
-func concurrencyKeyCount(status *TaskStatusStat, expression, strategyType, key string) int64 {
-	if status == nil {
-		return 0
-	}
-
-	for _, entry := range status.Concurrency {
-		if entry.Expression == expression && entry.Type == strategyType {
-			return entry.Keys[key]
-		}
-	}
-
-	return 0
+	return stats[stepReadableID]
 }
 
 func TestGetTaskStats(t *testing.T) {
 	pool, cleanup := setupPostgresWithMigration(t)
 	defer cleanup()
 
-	groupRoundRobin := "GROUP_ROUND_ROBIN"
-	maxRuns := int32(5)
-	concurrency := func(expression string) CreateConcurrencyOpts {
-		return CreateConcurrencyOpts{
-			MaxRuns:       &maxRuns,
-			LimitStrategy: &groupRoundRobin,
-			Expression:    expression,
-		}
-	}
+	t.Run("duplicate strategies count one running attempt", func(t *testing.T) {
+		env := newTaskStatsTestEnv(t, pool)
+		env.seedTask("duplicate-strategies", true,
+			taskStatsStrategySeed{expression: "input.my_id", key: "shared-key", parent: true, filled: true},
+			taskStatsStrategySeed{expression: "input.my_id", key: "shared-key", filled: true},
+		)
+
+		running := env.taskStats("duplicate-strategies").Running
+		require.NotNil(t, running)
+		require.Equal(t, int64(1), running.Total)
+		require.Equal(t, []ConcurrencyStat{{
+			Expression: "input.my_id",
+			Type:       taskStatsGroupRoundRobin,
+			Keys:       map[string]int64{"shared-key": 1},
+		}}, running.Concurrency)
+	})
+
+	t.Run("distinct strategies do not inflate running total", func(t *testing.T) {
+		env := newTaskStatsTestEnv(t, pool)
+		env.seedTask("distinct-strategies", true,
+			taskStatsStrategySeed{expression: "input.key_a", key: "key-a", filled: true},
+			taskStatsStrategySeed{expression: "input.key_b", key: "key-b", filled: true},
+		)
+
+		running := env.taskStats("distinct-strategies").Running
+		require.NotNil(t, running)
+		require.Equal(t, int64(1), running.Total)
+		require.ElementsMatch(t, []ConcurrencyStat{
+			{
+				Expression: "input.key_a",
+				Type:       taskStatsGroupRoundRobin,
+				Keys:       map[string]int64{"key-a": 1},
+			},
+			{
+				Expression: "input.key_b",
+				Type:       taskStatsGroupRoundRobin,
+				Keys:       map[string]int64{"key-b": 1},
+			},
+		}, running.Concurrency)
+	})
 
 	t.Run("running task without concurrency", func(t *testing.T) {
-		env := newTaskStatsEnv(t, pool)
-		workflow := env.registerWorkflow("no-concurrency", nil, nil)
-		task := env.createTask(workflow, nil)
-		env.advanceAndAssign(task, workflow)
+		env := newTaskStatsTestEnv(t, pool)
+		env.seedTask("no-concurrency", true)
 
-		running := env.stats()["my-task"].Running
+		running := env.taskStats("no-concurrency").Running
 		require.NotNil(t, running)
-		assert.Equal(t, int64(1), running.Total)
-		assert.Empty(t, running.Concurrency)
+		require.Equal(t, int64(1), running.Total)
+		require.Empty(t, running.Concurrency)
 	})
 
-	t.Run("one filled strategy", func(t *testing.T) {
-		env := newTaskStatsEnv(t, pool)
-		workflow := env.registerWorkflow("one-strategy", nil, []CreateConcurrencyOpts{concurrency("input.my_id")})
-		require.Len(t, workflow.strategies, 1)
-		task := env.createTask(workflow, map[string]string{"input.my_id": "shared-key"})
-		env.advanceAndAssign(task, workflow)
+	t.Run("queued concurrency aggregation is unchanged", func(t *testing.T) {
+		env := newTaskStatsTestEnv(t, pool)
+		env.seedTask("queued-concurrency", false,
+			taskStatsStrategySeed{expression: "input.my_id", key: "queued-key"},
+		)
 
-		running := env.stats()["my-task"].Running
-		require.NotNil(t, running)
-		assert.Equal(t, int64(1), running.Total)
-		assert.Equal(t, int64(1), concurrencyKeyCount(running, "input.my_id", groupRoundRobin, "shared-key"))
-	})
-
-	t.Run("duplicate workflow-child and direct strategies collapse", func(t *testing.T) {
-		env := newTaskStatsEnv(t, pool)
-		duplicate := []CreateConcurrencyOpts{concurrency("input.my_id")}
-		workflow := env.registerWorkflow("duplicate-strategies", duplicate, duplicate)
-		require.Len(t, workflow.strategies, 2)
-		require.True(t, workflow.strategies[0].ParentStrategyID.Valid)
-		require.False(t, workflow.strategies[1].ParentStrategyID.Valid)
-		task := env.createTask(workflow, map[string]string{"input.my_id": "shared-key"})
-		env.advanceConcurrency(workflow)
-
-		var filledParentSlots int
-		err := pool.QueryRow(env.ctx, `
-			SELECT COUNT(*)
-			FROM v1_workflow_concurrency_slot
-			WHERE tenant_id = $1
-				AND workflow_version_id = $2
-				AND workflow_run_id = $3
-				AND strategy_id = $4
-				AND is_filled = TRUE
-		`, env.tenantID, workflow.workflowVersionID, task.workflowRunID, workflow.strategies[0].ParentStrategyID.Int64).Scan(&filledParentSlots)
-		require.NoError(t, err)
-		require.Equal(t, 1, filledParentSlots)
-
-		var filledSlots int
-		var filledStrategyIDs int
-		err = pool.QueryRow(env.ctx, `
-			SELECT COUNT(*), COUNT(DISTINCT strategy_id)
-			FROM v1_concurrency_slot
-			WHERE task_id = $1
-				AND task_inserted_at = $2
-				AND task_retry_count = $3
-				AND strategy_id = ANY($4::bigint[])
-				AND is_filled = TRUE
-		`, task.id, task.insertedAt, task.retryCount, []int64{
-			workflow.strategies[0].ID,
-			workflow.strategies[1].ID,
-		}).Scan(&filledSlots, &filledStrategyIDs)
-		require.NoError(t, err)
-		require.Equal(t, 2, filledSlots)
-		require.Equal(t, 2, filledStrategyIDs)
-
-		env.assign(task)
-
-		running := env.stats()["my-task"].Running
-		require.NotNil(t, running)
-		assert.Equal(t, int64(1), running.Total)
-		assert.Equal(t, int64(1), concurrencyKeyCount(running, "input.my_id", groupRoundRobin, "shared-key"))
-	})
-
-	t.Run("distinct strategies each include the attempt", func(t *testing.T) {
-		env := newTaskStatsEnv(t, pool)
-		workflow := env.registerWorkflow("distinct-strategies", nil, []CreateConcurrencyOpts{
-			concurrency("input.key_a"),
-			concurrency("input.key_b"),
-		})
-		require.Len(t, workflow.strategies, 2)
-		task := env.createTask(workflow, map[string]string{
-			"input.key_a": "key-a",
-			"input.key_b": "key-b",
-		})
-		env.advanceAndAssign(task, workflow)
-
-		running := env.stats()["my-task"].Running
-		require.NotNil(t, running)
-		assert.Equal(t, int64(1), running.Total)
-		assert.Equal(t, int64(1), concurrencyKeyCount(running, "input.key_a", groupRoundRobin, "key-a"))
-		assert.Equal(t, int64(1), concurrencyKeyCount(running, "input.key_b", groupRoundRobin, "key-b"))
-	})
-
-	t.Run("same key counts distinct attempts", func(t *testing.T) {
-		env := newTaskStatsEnv(t, pool)
-		workflow := env.registerWorkflow("same-key", nil, []CreateConcurrencyOpts{concurrency("input.my_id")})
-
-		for range 3 {
-			task := env.createTask(workflow, map[string]string{"input.my_id": "shared-key"})
-			env.advanceAndAssign(task, workflow)
-		}
-
-		running := env.stats()["my-task"].Running
-		require.NotNil(t, running)
-		assert.Equal(t, int64(3), running.Total)
-		assert.Equal(t, int64(3), concurrencyKeyCount(running, "input.my_id", groupRoundRobin, "shared-key"))
-	})
-
-	t.Run("canonical retry transition keeps current attempt only", func(t *testing.T) {
-		env := newTaskStatsEnv(t, pool)
-		workflow := env.registerWorkflow("retry", nil, nil)
-		task := env.createTask(workflow, nil)
-		env.advanceAndAssign(task, workflow)
-
-		retried := env.retryAndAssign(task, workflow)
-		require.Equal(t, task.id, retried.id)
-		require.Equal(t, int32(1), retried.retryCount)
-
-		running := env.stats()["my-task"].Running
-		require.NotNil(t, running)
-		assert.Equal(t, int64(1), running.Total)
-		assert.Nil(t, running.OldestExcludingRetries)
-	})
-
-	t.Run("assigned runtime with cleared worker is not running", func(t *testing.T) {
-		env := newTaskStatsEnv(t, pool)
-		workflow := env.registerWorkflow("null-worker", nil, nil)
-		task := env.createTask(workflow, nil)
-		env.advanceAndAssign(task, workflow)
-		env.clearAssignedWorker(task)
-
-		assert.Nil(t, env.stats()["my-task"].Running)
-	})
-
-	t.Run("missing runtime is not running", func(t *testing.T) {
-		env := newTaskStatsEnv(t, pool)
-		workflow := env.registerWorkflow("missing-runtime", nil, nil)
-		env.createTask(workflow, nil)
-
-		assert.Nil(t, env.stats()["my-task"].Running)
-	})
-
-	t.Run("unfilled is queued and filled assignment is running", func(t *testing.T) {
-		env := newTaskStatsEnv(t, pool)
-		workflow := env.registerWorkflow("slot-lifecycle", nil, []CreateConcurrencyOpts{concurrency("input.my_id")})
-		task := env.createTask(workflow, map[string]string{"input.my_id": "slot-key"})
-
-		queuedStats := env.stats()["my-task"]
-		require.NotNil(t, queuedStats.Queued)
-		assert.Equal(t, int64(1), queuedStats.Queued.Total)
-		assert.Equal(t, int64(1), concurrencyKeyCount(queuedStats.Queued, "input.my_id", groupRoundRobin, "slot-key"))
-		assert.Nil(t, queuedStats.Running)
-
-		env.advanceAndAssign(task, workflow)
-
-		runningStats := env.stats()["my-task"]
-		require.NotNil(t, runningStats.Running)
-		assert.Equal(t, int64(1), runningStats.Running.Total)
-		assert.Equal(t, int64(1), concurrencyKeyCount(runningStats.Running, "input.my_id", groupRoundRobin, "slot-key"))
-	})
-
-	t.Run("oldest comes from assigned attempts", func(t *testing.T) {
-		env := newTaskStatsEnv(t, pool)
-		workflow := env.registerWorkflow("oldest", nil, nil)
-
-		older := env.createTask(workflow, nil)
-		env.advanceAndAssign(older, workflow)
-		time.Sleep(2 * time.Millisecond)
-		newer := env.createTask(workflow, nil)
-		env.advanceAndAssign(newer, workflow)
-		require.True(t, older.insertedAt.Time.Before(newer.insertedAt.Time))
-
-		running := env.stats()["my-task"].Running
-		require.NotNil(t, running)
-		require.NotNil(t, running.Oldest)
-		assert.True(t, running.Oldest.Equal(older.insertedAt.Time))
-		require.NotNil(t, running.OldestExcludingRetries)
-		assert.True(t, running.OldestExcludingRetries.Equal(older.insertedAt.Time))
-	})
-
-	t.Run("queued concurrency aggregation remains unchanged", func(t *testing.T) {
-		env := newTaskStatsEnv(t, pool)
-		workflow := env.registerWorkflow("queued-concurrency", nil, []CreateConcurrencyOpts{concurrency("input.my_id")})
-		env.createTask(workflow, map[string]string{"input.my_id": "queued-key"})
-
-		queued := env.stats()["my-task"].Queued
-		require.NotNil(t, queued)
-		assert.Equal(t, int64(1), queued.Total)
-		assert.Equal(t, int64(1), concurrencyKeyCount(queued, "input.my_id", groupRoundRobin, "queued-key"))
+		stat := env.taskStats("queued-concurrency")
+		require.Nil(t, stat.Running)
+		require.NotNil(t, stat.Queued)
+		require.Equal(t, int64(1), stat.Queued.Total)
+		require.Equal(t, []ConcurrencyStat{{
+			Expression: "input.my_id",
+			Type:       taskStatsGroupRoundRobin,
+			Keys:       map[string]int64{"queued-key": 1},
+		}}, stat.Queued.Concurrency)
 	})
 }

--- a/pkg/repository/task_stats_test.go
+++ b/pkg/repository/task_stats_test.go
@@ -1,0 +1,537 @@
+//go:build !e2e && !load && !rampup && !integration
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hatchet-dev/hatchet/pkg/repository/cache"
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
+)
+
+type taskStatsEnv struct {
+	t               *testing.T
+	ctx             context.Context
+	repo            *TaskRepositoryImpl
+	wfRepo          *workflowRepository
+	queries         *sqlcv1.Queries
+	concurrencyRepo ConcurrencyRepository
+	tenantID        uuid.UUID
+	workerID        uuid.UUID
+}
+
+type taskStatsWorkflow struct {
+	workflowID        uuid.UUID
+	workflowVersionID uuid.UUID
+	stepID            uuid.UUID
+	strategies        []*sqlcv1.V1StepConcurrency
+}
+
+type taskStatsTask struct {
+	id            int64
+	insertedAt    pgtype.Timestamptz
+	retryCount    int32
+	workflowRunID uuid.UUID
+}
+
+func newTaskStatsEnv(t *testing.T, pool *pgxpool.Pool) *taskStatsEnv {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	t.Cleanup(cancel)
+
+	tenantID := uuid.New()
+	workerID := uuid.New()
+	suffix := tenantID.String()
+
+	_, err := pool.Exec(ctx, `
+		INSERT INTO "Tenant" ("id", "name", "slug", "createdAt", "updatedAt")
+		VALUES ($1, 'task-stats-tenant', $2, NOW(), NOW())
+	`, tenantID, "task-stats-"+suffix)
+	require.NoError(t, err)
+
+	_, err = pool.Exec(ctx, `
+		INSERT INTO "Worker" ("id", "tenantId", "name", "lastHeartbeatAt", "createdAt", "updatedAt")
+		VALUES ($1, $2, 'task-stats-worker', NOW(), NOW(), NOW())
+	`, workerID, tenantID)
+	require.NoError(t, err)
+
+	repo := createTaskRepository(pool)
+	repo.queueCache = cache.New(5 * time.Minute)
+	t.Cleanup(repo.queueCache.Stop)
+
+	wfRepo := newWorkflowTestRepository(pool)
+	t.Cleanup(wfRepo.queueCache.Stop)
+
+	return &taskStatsEnv{
+		t:               t,
+		ctx:             ctx,
+		repo:            repo,
+		wfRepo:          wfRepo,
+		queries:         sqlcv1.New(),
+		concurrencyRepo: newConcurrencyRepository(repo.sharedRepository),
+		tenantID:        tenantID,
+		workerID:        workerID,
+	}
+}
+
+func (e *taskStatsEnv) registerWorkflow(
+	name string,
+	workflowConcurrency []CreateConcurrencyOpts,
+	stepConcurrency []CreateConcurrencyOpts,
+) taskStatsWorkflow {
+	e.t.Helper()
+
+	desc := name
+	version, err := e.wfRepo.PutWorkflowVersion(e.ctx, e.tenantID, &CreateWorkflowVersionOpts{
+		Name:        name,
+		Description: &desc,
+		Concurrency: workflowConcurrency,
+		Tasks: []CreateStepOpts{
+			{
+				ReadableId:  "my-task",
+				Action:      "test:run",
+				Concurrency: stepConcurrency,
+			},
+		},
+	})
+	require.NoError(e.t, err)
+
+	workflowID := version.WorkflowVersion.WorkflowId
+	workflowVersionID := version.WorkflowVersion.ID
+
+	var stepID uuid.UUID
+	err = e.repo.pool.QueryRow(e.ctx, `
+		SELECT s."id"
+		FROM "Step" s
+		JOIN "Job" j ON s."jobId" = j."id"
+		WHERE j."workflowVersionId" = $1 AND s."readableId" = 'my-task'
+	`, workflowVersionID).Scan(&stepID)
+	require.NoError(e.t, err)
+
+	strategies, err := e.queries.ListActiveConcurrencyStrategies(e.ctx, e.repo.pool, e.tenantID)
+	require.NoError(e.t, err)
+
+	filtered := make([]*sqlcv1.V1StepConcurrency, 0, len(strategies))
+	for _, strategy := range strategies {
+		if strategy.WorkflowID == workflowID && strategy.WorkflowVersionID == workflowVersionID && strategy.StepID == stepID {
+			filtered = append(filtered, strategy)
+		}
+	}
+	sortConcurrencyStrategies(filtered)
+
+	return taskStatsWorkflow{
+		workflowID:        workflowID,
+		workflowVersionID: workflowVersionID,
+		stepID:            stepID,
+		strategies:        filtered,
+	}
+}
+
+func (e *taskStatsEnv) createTask(workflow taskStatsWorkflow, keysByExpression map[string]string) taskStatsTask {
+	e.t.Helper()
+
+	strategyIDs := make([]int64, len(workflow.strategies))
+	parentStrategyIDs := make([]pgtype.Int8, len(workflow.strategies))
+	concurrencyKeys := make([]string, len(workflow.strategies))
+
+	for i, strategy := range workflow.strategies {
+		key, ok := keysByExpression[strategy.Expression]
+		require.True(e.t, ok, "missing concurrency key for expression %q", strategy.Expression)
+
+		strategyIDs[i] = strategy.ID
+		parentStrategyIDs[i] = strategy.ParentStrategyID
+		concurrencyKeys[i] = key
+	}
+
+	workflowRunID := uuid.New()
+	tasks, err := e.queries.CreateTasks(e.ctx, e.repo.pool, sqlcv1.CreateTasksParams{
+		Tenantids:                    []uuid.UUID{e.tenantID},
+		Queues:                       []string{"default"},
+		Actionids:                    []string{"test:run"},
+		Stepids:                      []uuid.UUID{workflow.stepID},
+		Stepreadableids:              []string{"my-task"},
+		Workflowids:                  []uuid.UUID{workflow.workflowID},
+		Scheduletimeouts:             []string{"5m"},
+		Steptimeouts:                 []string{"30s"},
+		Priorities:                   []int32{1},
+		Stickies:                     []string{string(sqlcv1.V1StickyStrategyNONE)},
+		Externalids:                  []uuid.UUID{uuid.New()},
+		Displaynames:                 []string{"task-stats-task"},
+		Inputs:                       [][]byte{[]byte(`{}`)},
+		Retrycounts:                  []int32{0},
+		Additionalmetadatas:          [][]byte{[]byte(`{}`)},
+		InitialStates:                []string{string(sqlcv1.V1TaskInitialStateQUEUED)},
+		Concurrencyparentstrategyids: [][]pgtype.Int8{parentStrategyIDs},
+		ConcurrencyStrategyIds:       [][]int64{strategyIDs},
+		ConcurrencyKeys:              [][]string{concurrencyKeys},
+		WorkflowVersionIds:           []uuid.UUID{workflow.workflowVersionID},
+		WorkflowRunIds:               []uuid.UUID{workflowRunID},
+	})
+	require.NoError(e.t, err)
+	require.Len(e.t, tasks, 1)
+
+	return taskStatsTask{
+		id:            tasks[0].ID,
+		insertedAt:    tasks[0].InsertedAt,
+		retryCount:    tasks[0].RetryCount,
+		workflowRunID: workflowRunID,
+	}
+}
+
+func (e *taskStatsEnv) advanceConcurrency(workflow taskStatsWorkflow) {
+	e.t.Helper()
+
+	for _, strategy := range workflow.strategies {
+		result, err := e.concurrencyRepo.RunConcurrencyStrategy(e.ctx, e.tenantID, strategy)
+		require.NoError(e.t, err)
+		require.NotNil(e.t, result)
+		require.False(e.t, result.FailedAdvisoryLock)
+		require.Empty(e.t, result.Cancelled)
+	}
+}
+
+func (e *taskStatsEnv) assign(task taskStatsTask) {
+	e.t.Helper()
+
+	tx, err := e.repo.pool.Begin(e.ctx)
+	require.NoError(e.t, err)
+	defer func() { _ = tx.Rollback(e.ctx) }()
+
+	var queueItemID int64
+	err = tx.QueryRow(e.ctx, `
+		SELECT id
+		FROM v1_queue_item
+		WHERE tenant_id = $1
+			AND task_id = $2
+			AND task_inserted_at = $3
+			AND retry_count = $4
+	`, e.tenantID, task.id, task.insertedAt, task.retryCount).Scan(&queueItemID)
+	require.NoError(e.t, err)
+
+	deletedQueueItems, err := e.queries.BulkQueueItems(e.ctx, tx, []int64{queueItemID})
+	require.NoError(e.t, err)
+	require.Equal(e.t, []int64{queueItemID}, deletedQueueItems)
+
+	assigned, err := e.queries.UpdateTasksToAssigned(e.ctx, tx, sqlcv1.UpdateTasksToAssignedParams{
+		Taskids:           []int64{task.id},
+		Taskinsertedats:   []pgtype.Timestamptz{task.insertedAt},
+		Mintaskinsertedat: task.insertedAt,
+		Workerids:         []uuid.UUID{e.workerID},
+		Tenantid:          e.tenantID,
+	})
+	require.NoError(e.t, err)
+	require.Len(e.t, assigned, 1)
+
+	require.NoError(e.t, tx.Commit(e.ctx))
+}
+
+func (e *taskStatsEnv) advanceAndAssign(task taskStatsTask, workflow taskStatsWorkflow) {
+	e.t.Helper()
+
+	e.advanceConcurrency(workflow)
+	e.assign(task)
+}
+
+func (e *taskStatsEnv) retryAndAssign(task taskStatsTask, workflow taskStatsWorkflow) taskStatsTask {
+	e.t.Helper()
+
+	tx, err := e.repo.pool.Begin(e.ctx)
+	require.NoError(e.t, err)
+	defer func() { _ = tx.Rollback(e.ctx) }()
+
+	retried, err := e.queries.FailTaskInternalFailure(e.ctx, tx, sqlcv1.FailTaskInternalFailureParams{
+		Maxinternalretries: 3,
+		Taskids:            []int64{task.id},
+		Taskinsertedats:    []pgtype.Timestamptz{task.insertedAt},
+		Taskretrycounts:    []int32{task.retryCount},
+		Tenantid:           e.tenantID,
+	})
+	require.NoError(e.t, err)
+	require.Len(e.t, retried, 1)
+
+	released, err := e.repo.releaseTasks(e.ctx, tx, e.tenantID, []TaskIdInsertedAtRetryCount{{
+		Id:         task.id,
+		InsertedAt: task.insertedAt,
+		RetryCount: task.retryCount,
+	}})
+	require.NoError(e.t, err)
+	require.Len(e.t, released, 1)
+	require.NoError(e.t, tx.Commit(e.ctx))
+
+	next := taskStatsTask{
+		id:            retried[0].ID,
+		insertedAt:    retried[0].InsertedAt,
+		retryCount:    retried[0].RetryCount,
+		workflowRunID: task.workflowRunID,
+	}
+	e.advanceAndAssign(next, workflow)
+
+	return next
+}
+
+func (e *taskStatsEnv) clearAssignedWorker(task taskStatsTask) {
+	e.t.Helper()
+
+	// Production release paths delete the runtime, so clear the assigned worker in place to
+	// exercise the legacy NULL-worker state without reintroducing a queue item.
+	tag, err := e.repo.pool.Exec(e.ctx, `
+		UPDATE v1_task_runtime
+		SET worker_id = NULL
+		WHERE task_id = $1
+			AND task_inserted_at = $2
+			AND retry_count = $3
+			AND tenant_id = $4
+	`, task.id, task.insertedAt, task.retryCount, e.tenantID)
+	require.NoError(e.t, err)
+	require.Equal(e.t, int64(1), tag.RowsAffected())
+
+	var queueItems int
+	err = e.repo.pool.QueryRow(e.ctx, `
+		SELECT COUNT(*)
+		FROM v1_queue_item
+		WHERE tenant_id = $1
+			AND task_id = $2
+			AND task_inserted_at = $3
+			AND retry_count = $4
+	`, e.tenantID, task.id, task.insertedAt, task.retryCount).Scan(&queueItems)
+	require.NoError(e.t, err)
+	require.Zero(e.t, queueItems)
+}
+
+func (e *taskStatsEnv) stats() map[string]TaskStat {
+	e.t.Helper()
+
+	stats, err := e.repo.GetTaskStats(e.ctx, e.tenantID)
+	require.NoError(e.t, err)
+	return stats
+}
+
+func concurrencyKeyCount(status *TaskStatusStat, expression, strategyType, key string) int64 {
+	if status == nil {
+		return 0
+	}
+
+	for _, entry := range status.Concurrency {
+		if entry.Expression == expression && entry.Type == strategyType {
+			return entry.Keys[key]
+		}
+	}
+
+	return 0
+}
+
+func TestGetTaskStats(t *testing.T) {
+	pool, cleanup := setupPostgresWithMigration(t)
+	defer cleanup()
+
+	groupRoundRobin := "GROUP_ROUND_ROBIN"
+	maxRuns := int32(5)
+	concurrency := func(expression string) CreateConcurrencyOpts {
+		return CreateConcurrencyOpts{
+			MaxRuns:       &maxRuns,
+			LimitStrategy: &groupRoundRobin,
+			Expression:    expression,
+		}
+	}
+
+	t.Run("running task without concurrency", func(t *testing.T) {
+		env := newTaskStatsEnv(t, pool)
+		workflow := env.registerWorkflow("no-concurrency", nil, nil)
+		task := env.createTask(workflow, nil)
+		env.advanceAndAssign(task, workflow)
+
+		running := env.stats()["my-task"].Running
+		require.NotNil(t, running)
+		assert.Equal(t, int64(1), running.Total)
+		assert.Empty(t, running.Concurrency)
+	})
+
+	t.Run("one filled strategy", func(t *testing.T) {
+		env := newTaskStatsEnv(t, pool)
+		workflow := env.registerWorkflow("one-strategy", nil, []CreateConcurrencyOpts{concurrency("input.my_id")})
+		require.Len(t, workflow.strategies, 1)
+		task := env.createTask(workflow, map[string]string{"input.my_id": "shared-key"})
+		env.advanceAndAssign(task, workflow)
+
+		running := env.stats()["my-task"].Running
+		require.NotNil(t, running)
+		assert.Equal(t, int64(1), running.Total)
+		assert.Equal(t, int64(1), concurrencyKeyCount(running, "input.my_id", groupRoundRobin, "shared-key"))
+	})
+
+	t.Run("duplicate workflow-child and direct strategies collapse", func(t *testing.T) {
+		env := newTaskStatsEnv(t, pool)
+		duplicate := []CreateConcurrencyOpts{concurrency("input.my_id")}
+		workflow := env.registerWorkflow("duplicate-strategies", duplicate, duplicate)
+		require.Len(t, workflow.strategies, 2)
+		require.True(t, workflow.strategies[0].ParentStrategyID.Valid)
+		require.False(t, workflow.strategies[1].ParentStrategyID.Valid)
+		task := env.createTask(workflow, map[string]string{"input.my_id": "shared-key"})
+		env.advanceConcurrency(workflow)
+
+		var filledParentSlots int
+		err := pool.QueryRow(env.ctx, `
+			SELECT COUNT(*)
+			FROM v1_workflow_concurrency_slot
+			WHERE tenant_id = $1
+				AND workflow_version_id = $2
+				AND workflow_run_id = $3
+				AND strategy_id = $4
+				AND is_filled = TRUE
+		`, env.tenantID, workflow.workflowVersionID, task.workflowRunID, workflow.strategies[0].ParentStrategyID.Int64).Scan(&filledParentSlots)
+		require.NoError(t, err)
+		require.Equal(t, 1, filledParentSlots)
+
+		var filledSlots int
+		var filledStrategyIDs int
+		err = pool.QueryRow(env.ctx, `
+			SELECT COUNT(*), COUNT(DISTINCT strategy_id)
+			FROM v1_concurrency_slot
+			WHERE task_id = $1
+				AND task_inserted_at = $2
+				AND task_retry_count = $3
+				AND strategy_id = ANY($4::bigint[])
+				AND is_filled = TRUE
+		`, task.id, task.insertedAt, task.retryCount, []int64{
+			workflow.strategies[0].ID,
+			workflow.strategies[1].ID,
+		}).Scan(&filledSlots, &filledStrategyIDs)
+		require.NoError(t, err)
+		require.Equal(t, 2, filledSlots)
+		require.Equal(t, 2, filledStrategyIDs)
+
+		env.assign(task)
+
+		running := env.stats()["my-task"].Running
+		require.NotNil(t, running)
+		assert.Equal(t, int64(1), running.Total)
+		assert.Equal(t, int64(1), concurrencyKeyCount(running, "input.my_id", groupRoundRobin, "shared-key"))
+	})
+
+	t.Run("distinct strategies each include the attempt", func(t *testing.T) {
+		env := newTaskStatsEnv(t, pool)
+		workflow := env.registerWorkflow("distinct-strategies", nil, []CreateConcurrencyOpts{
+			concurrency("input.key_a"),
+			concurrency("input.key_b"),
+		})
+		require.Len(t, workflow.strategies, 2)
+		task := env.createTask(workflow, map[string]string{
+			"input.key_a": "key-a",
+			"input.key_b": "key-b",
+		})
+		env.advanceAndAssign(task, workflow)
+
+		running := env.stats()["my-task"].Running
+		require.NotNil(t, running)
+		assert.Equal(t, int64(1), running.Total)
+		assert.Equal(t, int64(1), concurrencyKeyCount(running, "input.key_a", groupRoundRobin, "key-a"))
+		assert.Equal(t, int64(1), concurrencyKeyCount(running, "input.key_b", groupRoundRobin, "key-b"))
+	})
+
+	t.Run("same key counts distinct attempts", func(t *testing.T) {
+		env := newTaskStatsEnv(t, pool)
+		workflow := env.registerWorkflow("same-key", nil, []CreateConcurrencyOpts{concurrency("input.my_id")})
+
+		for range 3 {
+			task := env.createTask(workflow, map[string]string{"input.my_id": "shared-key"})
+			env.advanceAndAssign(task, workflow)
+		}
+
+		running := env.stats()["my-task"].Running
+		require.NotNil(t, running)
+		assert.Equal(t, int64(3), running.Total)
+		assert.Equal(t, int64(3), concurrencyKeyCount(running, "input.my_id", groupRoundRobin, "shared-key"))
+	})
+
+	t.Run("canonical retry transition keeps current attempt only", func(t *testing.T) {
+		env := newTaskStatsEnv(t, pool)
+		workflow := env.registerWorkflow("retry", nil, nil)
+		task := env.createTask(workflow, nil)
+		env.advanceAndAssign(task, workflow)
+
+		retried := env.retryAndAssign(task, workflow)
+		require.Equal(t, task.id, retried.id)
+		require.Equal(t, int32(1), retried.retryCount)
+
+		running := env.stats()["my-task"].Running
+		require.NotNil(t, running)
+		assert.Equal(t, int64(1), running.Total)
+		assert.Nil(t, running.OldestExcludingRetries)
+	})
+
+	t.Run("assigned runtime with cleared worker is not running", func(t *testing.T) {
+		env := newTaskStatsEnv(t, pool)
+		workflow := env.registerWorkflow("null-worker", nil, nil)
+		task := env.createTask(workflow, nil)
+		env.advanceAndAssign(task, workflow)
+		env.clearAssignedWorker(task)
+
+		assert.Nil(t, env.stats()["my-task"].Running)
+	})
+
+	t.Run("missing runtime is not running", func(t *testing.T) {
+		env := newTaskStatsEnv(t, pool)
+		workflow := env.registerWorkflow("missing-runtime", nil, nil)
+		env.createTask(workflow, nil)
+
+		assert.Nil(t, env.stats()["my-task"].Running)
+	})
+
+	t.Run("unfilled is queued and filled assignment is running", func(t *testing.T) {
+		env := newTaskStatsEnv(t, pool)
+		workflow := env.registerWorkflow("slot-lifecycle", nil, []CreateConcurrencyOpts{concurrency("input.my_id")})
+		task := env.createTask(workflow, map[string]string{"input.my_id": "slot-key"})
+
+		queuedStats := env.stats()["my-task"]
+		require.NotNil(t, queuedStats.Queued)
+		assert.Equal(t, int64(1), queuedStats.Queued.Total)
+		assert.Equal(t, int64(1), concurrencyKeyCount(queuedStats.Queued, "input.my_id", groupRoundRobin, "slot-key"))
+		assert.Nil(t, queuedStats.Running)
+
+		env.advanceAndAssign(task, workflow)
+
+		runningStats := env.stats()["my-task"]
+		require.NotNil(t, runningStats.Running)
+		assert.Equal(t, int64(1), runningStats.Running.Total)
+		assert.Equal(t, int64(1), concurrencyKeyCount(runningStats.Running, "input.my_id", groupRoundRobin, "slot-key"))
+	})
+
+	t.Run("oldest comes from assigned attempts", func(t *testing.T) {
+		env := newTaskStatsEnv(t, pool)
+		workflow := env.registerWorkflow("oldest", nil, nil)
+
+		older := env.createTask(workflow, nil)
+		env.advanceAndAssign(older, workflow)
+		time.Sleep(2 * time.Millisecond)
+		newer := env.createTask(workflow, nil)
+		env.advanceAndAssign(newer, workflow)
+		require.True(t, older.insertedAt.Time.Before(newer.insertedAt.Time))
+
+		running := env.stats()["my-task"].Running
+		require.NotNil(t, running)
+		require.NotNil(t, running.Oldest)
+		assert.True(t, running.Oldest.Equal(older.insertedAt.Time))
+		require.NotNil(t, running.OldestExcludingRetries)
+		assert.True(t, running.OldestExcludingRetries.Equal(older.insertedAt.Time))
+	})
+
+	t.Run("queued concurrency aggregation remains unchanged", func(t *testing.T) {
+		env := newTaskStatsEnv(t, pool)
+		workflow := env.registerWorkflow("queued-concurrency", nil, []CreateConcurrencyOpts{concurrency("input.my_id")})
+		env.createTask(workflow, map[string]string{"input.my_id": "queued-key"})
+
+		queued := env.stats()["my-task"].Queued
+		require.NotNil(t, queued)
+		assert.Equal(t, int64(1), queued.Total)
+		assert.Equal(t, int64(1), concurrencyKeyCount(queued, "input.my_id", groupRoundRobin, "queued-key"))
+	})
+}


### PR DESCRIPTION
# Description

`GET /api/v1/tenants/{tenant}/task-stats` overcounts running tasks when a task has multiple concurrency strategies. The old `running_tasks` CTE joined each assigned attempt (`v1_task_runtime`) to all of its concurrency slots and, independently, to all of the step's strategies — without correlating slot to strategy. One assigned attempt with 2 filled slots and 2 strategies produced 1 × 2 × 2 = 4 rows, reporting `running.total = 4` instead of 1.

Fixes #4394

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- Split the running side of `GetTenantTaskStats` into two row kinds:
  - `running_total` counts assigned attempts (`v1_task_runtime` rows with a worker) with no joins to concurrency tables, so an attempt contributes exactly once regardless of how many strategies govern it. `oldest` / `oldest_excluding_retries` come from these rows, unchanged in semantics.
  - `running_concurrency` joins each slot to its actual strategy (`cs.strategy_id = sc.id`, `is_filled = TRUE`) and counts `COUNT(DISTINCT (task_id, inserted_at, retry_count))` per visible `(step, expression, strategy, key)` group, so equivalent slots from serial/chained strategies don't inflate the key counts.
- `GetTaskStats` in `pkg/repository/task.go` merges the two row kinds into the existing `running` shape; queued aggregation is untouched.
- New regression test `pkg/repository/task_stats_test.go` seeds the exact shape from the issue (one assigned attempt, two filled slots, direct + workflow-child strategies) and asserts `running.total = 1`, plus cases for distinct strategies, running without concurrency, and unchanged queued aggregation.

## Testing

- `TestGetTaskStats` runs against a Testcontainers Postgres with real migrations (same harness as the other `pkg/repository` tests) and is part of the default `go test ./...` suite, i.e. the `unit` CI job on this PR. The overcounting case (`duplicate strategies count one running attempt`) reproduces the 1 × 2 × 2 shape from #4394.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Cursor (GPT) was used to iterate on the fix, the regression tests, and this PR description.

</details>
