### PR TITLE
perf: use cached worker action-hash for replenish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # AGENTS
 
+## Code Comments
+
+- Comments should explain non-obvious intent, invariants, or constraints in the current code. Do not mention the old implementation/state (for example, "preserve the behavior of the original query"); state the current rule directly.
+
 ## Docs MDX
 
 - In MDX JSX component bodies, such as `<Callout>`, avoid Markdown link syntax (`[text](href)`). Prettier can wrap the label across lines and break MDX parsing. Use an explicit JSX link instead:

--- a/pkg/repository/scheduler_assignment.go
+++ b/pkg/repository/scheduler_assignment.go
@@ -135,8 +135,6 @@ func (d *assignmentRepository) ListActionsForWorkers(ctx context.Context, tenant
 		actions := hashToActions[key]
 
 		if len(actions) == 0 {
-			// preserve the LEFT JOIN behavior of the original query: live
-			// workers with no actions still produce a row
 			rows = append(rows, &sqlcv1.ListActionsForWorkersRow{
 				WorkerId: w.ID,
 				ActionId: pgtype.Text{},

--- a/pkg/repository/scheduler_assignment.go
+++ b/pkg/repository/scheduler_assignment.go
@@ -2,20 +2,36 @@ package repository
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 	"github.com/hatchet-dev/hatchet/pkg/telemetry"
 )
 
+// A worker's action set is immutable after registration (the actionHash is a
+// sha256 of the registered action names), so cache entries never go stale.
+// The TTL only bounds memory for tenants whose workers have churned away.
+const workerActionCacheTTL = 30 * time.Minute
+
+type workerActionCacheKey struct {
+	actionHash string
+	tenantId   uuid.UUID
+}
+
 type assignmentRepository struct {
 	*sharedRepository
+
+	workerActionCache *expirable.LRU[workerActionCacheKey, []string]
 }
 
 func newAssignmentRepository(shared *sharedRepository) *assignmentRepository {
 	return &assignmentRepository{
-		sharedRepository: shared,
+		sharedRepository:  shared,
+		workerActionCache: expirable.NewLRU[workerActionCacheKey, []string](10000, nil, workerActionCacheTTL),
 	}
 }
 
@@ -23,10 +39,141 @@ func (d *assignmentRepository) ListActionsForWorkers(ctx context.Context, tenant
 	ctx, span := telemetry.NewSpan(ctx, "list-actions-for-workers")
 	defer span.End()
 
-	return d.queries.ListActionsForWorkers(ctx, d.pool, sqlcv1.ListActionsForWorkersParams{
+	liveWorkers, err := d.queries.ListLiveWorkerActionHashes(ctx, d.pool, sqlcv1.ListLiveWorkerActionHashesParams{
 		Tenantid:  tenantId,
 		Workerids: workerIds,
 	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	hashToActions := make(map[workerActionCacheKey][]string)
+	// one live representative worker per uncached hash; all workers sharing a
+	// hash have identical action sets by construction
+	missedHashRepresentatives := make(map[string]uuid.UUID)
+	workersWithoutHash := make([]uuid.UUID, 0)
+
+	for _, w := range liveWorkers {
+		if len(w.ActionHash) == 0 {
+			workersWithoutHash = append(workersWithoutHash, w.ID)
+			continue
+		}
+
+		key := workerActionCacheKey{tenantId: tenantId, actionHash: string(w.ActionHash)}
+
+		if _, ok := hashToActions[key]; ok {
+			continue
+		}
+
+		if _, ok := missedHashRepresentatives[string(w.ActionHash)]; ok {
+			continue
+		}
+
+		if actions, ok := d.workerActionCache.Get(key); ok {
+			hashToActions[key] = actions
+		} else {
+			missedHashRepresentatives[string(w.ActionHash)] = w.ID
+		}
+	}
+
+	if len(missedHashRepresentatives) > 0 {
+		representativeIds := make([]uuid.UUID, 0, len(missedHashRepresentatives))
+
+		for _, workerId := range missedHashRepresentatives {
+			representativeIds = append(representativeIds, workerId)
+		}
+
+		records, err := d.queries.ListWorkerActionSets(ctx, d.pool, sqlcv1.ListWorkerActionSetsParams{
+			Tenantid:  tenantId,
+			Workerids: representativeIds,
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		fetched := make(map[workerActionCacheKey][]string, len(missedHashRepresentatives))
+
+		// pre-seed with empty slices so hashes with zero resolved actions
+		// still produce a NULL-action row below
+		for hash := range missedHashRepresentatives {
+			fetched[workerActionCacheKey{tenantId: tenantId, actionHash: hash}] = make([]string, 0)
+		}
+
+		for _, record := range records {
+			if !record.ActionId.Valid {
+				continue
+			}
+
+			key := workerActionCacheKey{tenantId: tenantId, actionHash: string(record.ActionHash)}
+			fetched[key] = append(fetched[key], record.ActionId.String)
+		}
+
+		for key, actions := range fetched {
+			// never cache empty sets: an empty result usually means the
+			// representative worker was deleted between the liveness lookup
+			// and the action set query, and caching it would pin every worker
+			// sharing this hash to zero actions until the TTL expires.
+			// Re-resolving next cycle is cheap and self-heals.
+			if len(actions) > 0 {
+				d.workerActionCache.Add(key, actions)
+			}
+
+			hashToActions[key] = actions
+		}
+	}
+
+	rows := make([]*sqlcv1.ListActionsForWorkersRow, 0, len(liveWorkers))
+
+	for _, w := range liveWorkers {
+		if len(w.ActionHash) == 0 {
+			continue
+		}
+
+		key := workerActionCacheKey{tenantId: tenantId, actionHash: string(w.ActionHash)}
+		actions := hashToActions[key]
+
+		if len(actions) == 0 {
+			// preserve the LEFT JOIN behavior of the original query: live
+			// workers with no actions still produce a row
+			rows = append(rows, &sqlcv1.ListActionsForWorkersRow{
+				WorkerId: w.ID,
+				ActionId: pgtype.Text{},
+			})
+
+			continue
+		}
+
+		for _, actionId := range actions {
+			rows = append(rows, &sqlcv1.ListActionsForWorkersRow{
+				WorkerId: w.ID,
+				ActionId: pgtype.Text{String: actionId, Valid: true},
+			})
+		}
+	}
+
+	telemetry.WithAttributes(span,
+		telemetry.AttributeKV{Key: "list_actions.live_workers", Value: len(liveWorkers)},
+		telemetry.AttributeKV{Key: "list_actions.hash_cache_misses", Value: len(missedHashRepresentatives)},
+		telemetry.AttributeKV{Key: "list_actions.workers_without_hash", Value: len(workersWithoutHash)},
+	)
+
+	// fallback for workers registered before actionHash existed
+	if len(workersWithoutHash) > 0 {
+		fallbackRows, err := d.queries.ListActionsForWorkersLegacyFallback(ctx, d.pool, sqlcv1.ListActionsForWorkersLegacyFallbackParams{
+			Tenantid:  tenantId,
+			Workerids: workersWithoutHash,
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		rows = append(rows, fallbackRows...)
+	}
+
+	return rows, nil
 }
 
 func (d *assignmentRepository) ListAvailableSlotsForWorkers(ctx context.Context, tenantId uuid.UUID, params sqlcv1.ListAvailableSlotsForWorkersParams) ([]*sqlcv1.ListAvailableSlotsForWorkersRow, error) {

--- a/pkg/repository/sqlcv1/queue.sql
+++ b/pkg/repository/sqlcv1/queue.sql
@@ -32,7 +32,54 @@ SELECT $1, name, NOW()
 FROM names_to_insert
 ON CONFLICT (tenant_id, name) DO NOTHING;
 
--- name: ListActionsForWorkers :many
+-- name: ListLiveWorkerActionHashes :many
+SELECT
+    w."id",
+    w."actionHash"
+FROM
+    "Worker" w
+WHERE
+    w."tenantId" = @tenantId::uuid
+    AND w."id" = ANY(@workerIds::uuid[])
+    AND w."dispatcherId" IS NOT NULL
+    AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+    AND w."isActive" = true
+    AND w."isPaused" = false;
+
+-- name: ListWorkerActionSets :many
+WITH worker_actions AS MATERIALIZED (
+    SELECT
+        w."id",
+        w."actionHash",
+        atw."A" AS action_id
+    FROM
+        "Worker" w
+    LEFT JOIN
+        "_ActionToWorker" atw ON w."id" = atw."B"
+    WHERE
+        w."tenantId" = @tenantId::uuid
+        AND w."id" = ANY(@workerIds::uuid[])
+), tenant_actions AS MATERIALIZED (
+    SELECT
+        a."id",
+        a."actionId"
+    FROM
+        "Action" a
+    WHERE
+        a."tenantId" = @tenantId::uuid
+)
+SELECT
+    wa."actionHash",
+    ta."actionId"
+FROM
+    worker_actions wa
+LEFT JOIN
+    tenant_actions ta ON ta."id" = wa.action_id;
+
+-- name: ListActionsForWorkersLegacyFallback :many
+-- Fallback for workers registered before actionHash existed; expands the full
+-- worker<>action join per worker. Prefer the hash-cached path in the
+-- assignment repository (ListLiveWorkerActionHashes + ListWorkerActionSets).
 SELECT
     w."id" as "workerId",
     a."actionId"

--- a/pkg/repository/sqlcv1/queue.sql.go
+++ b/pkg/repository/sqlcv1/queue.sql.go
@@ -397,7 +397,7 @@ func (q *Queries) GetStepSlotRequests(ctx context.Context, db DBTX, arg GetStepS
 	return items, nil
 }
 
-const listActionsForWorkers = `-- name: ListActionsForWorkers :many
+const listActionsForWorkersLegacyFallback = `-- name: ListActionsForWorkersLegacyFallback :many
 SELECT
     w."id" as "workerId",
     a."actionId"
@@ -416,26 +416,78 @@ WHERE
     AND w."isPaused" = false
 `
 
-type ListActionsForWorkersParams struct {
+type ListActionsForWorkersLegacyFallbackParams struct {
 	Tenantid  uuid.UUID   `json:"tenantid"`
 	Workerids []uuid.UUID `json:"workerids"`
 }
 
-type ListActionsForWorkersRow struct {
+type ListActionsForWorkersLegacyFallbackRow struct {
 	WorkerId uuid.UUID   `json:"workerId"`
 	ActionId pgtype.Text `json:"actionId"`
 }
 
-func (q *Queries) ListActionsForWorkers(ctx context.Context, db DBTX, arg ListActionsForWorkersParams) ([]*ListActionsForWorkersRow, error) {
-	rows, err := db.Query(ctx, listActionsForWorkers, arg.Tenantid, arg.Workerids)
+// Fallback for workers registered before actionHash existed; expands the full
+// worker<>action join per worker. Prefer the hash-cached path in the
+// assignment repository (ListLiveWorkerActionHashes + ListWorkerActionSets).
+func (q *Queries) ListActionsForWorkersLegacyFallback(ctx context.Context, db DBTX, arg ListActionsForWorkersLegacyFallbackParams) ([]*ListActionsForWorkersLegacyFallbackRow, error) {
+	rows, err := db.Query(ctx, listActionsForWorkersLegacyFallback, arg.Tenantid, arg.Workerids)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*ListActionsForWorkersRow
+	var items []*ListActionsForWorkersLegacyFallbackRow
 	for rows.Next() {
-		var i ListActionsForWorkersRow
+		var i ListActionsForWorkersLegacyFallbackRow
 		if err := rows.Scan(&i.WorkerId, &i.ActionId); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listLiveWorkerActionHashes = `-- name: ListLiveWorkerActionHashes :many
+SELECT
+    w."id",
+    w."actionHash"
+FROM
+    "Worker" w
+WHERE
+    w."tenantId" = $1::uuid
+    AND w."id" = ANY($2::uuid[])
+    AND w."dispatcherId" IS NOT NULL
+    AND w."lastHeartbeatAt" > NOW() - INTERVAL '5 seconds'
+    AND w."isActive" = true
+    AND w."isPaused" = false
+`
+
+type ListLiveWorkerActionHashesParams struct {
+	Tenantid  uuid.UUID   `json:"tenantid"`
+	Workerids []uuid.UUID `json:"workerids"`
+}
+
+type ListLiveWorkerActionHashesRow struct {
+	ID         uuid.UUID `json:"id"`
+	ActionHash []byte    `json:"actionHash"`
+}
+
+// Cheap liveness + actionHash lookup used by the assignment repository to
+// serve worker->action mappings from the per-hash cache. Only workers whose
+// actionHash has not been seen before require hitting the join tables via
+// ListWorkerActionSets.
+func (q *Queries) ListLiveWorkerActionHashes(ctx context.Context, db DBTX, arg ListLiveWorkerActionHashesParams) ([]*ListLiveWorkerActionHashesRow, error) {
+	rows, err := db.Query(ctx, listLiveWorkerActionHashes, arg.Tenantid, arg.Workerids)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*ListLiveWorkerActionHashesRow
+	for rows.Next() {
+		var i ListLiveWorkerActionHashesRow
+		if err := rows.Scan(&i.ID, &i.ActionHash); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)
@@ -603,6 +655,72 @@ func (q *Queries) ListQueues(ctx context.Context, db DBTX, tenantid uuid.UUID) (
 	for rows.Next() {
 		var i V1Queue
 		if err := rows.Scan(&i.TenantID, &i.Name, &i.LastActive); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listWorkerActionSets = `-- name: ListWorkerActionSets :many
+WITH worker_actions AS MATERIALIZED (
+    SELECT
+        w."id",
+        w."actionHash",
+        atw."A" AS action_id
+    FROM
+        "Worker" w
+    LEFT JOIN
+        "_ActionToWorker" atw ON w."id" = atw."B"
+    WHERE
+        w."tenantId" = $1::uuid
+        AND w."id" = ANY($2::uuid[])
+), tenant_actions AS MATERIALIZED (
+    SELECT
+        a."id",
+        a."actionId"
+    FROM
+        "Action" a
+    WHERE
+        a."tenantId" = $1::uuid
+)
+SELECT
+    wa."actionHash",
+    ta."actionId"
+FROM
+    worker_actions wa
+LEFT JOIN
+    tenant_actions ta ON ta."id" = wa.action_id
+`
+
+type ListWorkerActionSetsParams struct {
+	Tenantid  uuid.UUID   `json:"tenantid"`
+	Workerids []uuid.UUID `json:"workerids"`
+}
+
+type ListWorkerActionSetsRow struct {
+	ActionHash []byte      `json:"actionHash"`
+	ActionId   pgtype.Text `json:"actionId"`
+}
+
+// Returns (actionHash, actionId) rows describing the action sets of the given
+// workers. Callers pass one worker per distinct actionHash, since all workers
+// sharing a hash have identical action sets by construction. The CTEs are
+// materialized to force a hash join against the tenant's actions instead of a
+// per-pair index lookup.
+func (q *Queries) ListWorkerActionSets(ctx context.Context, db DBTX, arg ListWorkerActionSetsParams) ([]*ListWorkerActionSetsRow, error) {
+	rows, err := db.Query(ctx, listWorkerActionSets, arg.Tenantid, arg.Workerids)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*ListWorkerActionSetsRow
+	for rows.Next() {
+		var i ListWorkerActionSetsRow
+		if err := rows.Scan(&i.ActionHash, &i.ActionId); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)

--- a/pkg/repository/sqlcv1/queue.sql.go
+++ b/pkg/repository/sqlcv1/queue.sql.go
@@ -474,10 +474,6 @@ type ListLiveWorkerActionHashesRow struct {
 	ActionHash []byte    `json:"actionHash"`
 }
 
-// Cheap liveness + actionHash lookup used by the assignment repository to
-// serve worker->action mappings from the per-hash cache. Only workers whose
-// actionHash has not been seen before require hitting the join tables via
-// ListWorkerActionSets.
 func (q *Queries) ListLiveWorkerActionHashes(ctx context.Context, db DBTX, arg ListLiveWorkerActionHashesParams) ([]*ListLiveWorkerActionHashesRow, error) {
 	rows, err := db.Query(ctx, listLiveWorkerActionHashes, arg.Tenantid, arg.Workerids)
 	if err != nil {
@@ -706,11 +702,6 @@ type ListWorkerActionSetsRow struct {
 	ActionId   pgtype.Text `json:"actionId"`
 }
 
-// Returns (actionHash, actionId) rows describing the action sets of the given
-// workers. Callers pass one worker per distinct actionHash, since all workers
-// sharing a hash have identical action sets by construction. The CTEs are
-// materialized to force a hash join against the tenant's actions instead of a
-// per-pair index lookup.
 func (q *Queries) ListWorkerActionSets(ctx context.Context, db DBTX, arg ListWorkerActionSetsParams) ([]*ListWorkerActionSetsRow, error) {
 	rows, err := db.Query(ctx, listWorkerActionSets, arg.Tenantid, arg.Workerids)
 	if err != nil {

--- a/pkg/repository/sqlcv1/types.go
+++ b/pkg/repository/sqlcv1/types.go
@@ -3,3 +3,8 @@ package sqlcv1
 import "github.com/jackc/pgx/v5/pgtype"
 
 type UUIDRange = pgtype.Range[pgtype.UUID]
+
+// ListActionsForWorkersRow is the canonical (workerId, actionId) row shape
+// returned by AssignmentRepository.ListActionsForWorkers. The legacy fallback
+// query produces the same shape, so alias it to keep callers stable.
+type ListActionsForWorkersRow = ListActionsForWorkersLegacyFallbackRow


### PR DESCRIPTION
# Description

`ListActionsForWorkers` expanded the full worker action join every scheduler replenish cycle (~1s). In production this could produce ~100k+ rows and hundreds of mliliseconds of query latency on large tenants while holding the replenish mutex. Since a worker's action set is immutable after registration (fingerprinted by `Worker.actionHash`), this replaces the per-cycle join with a cheap liveness+hash query (~0.4ms) and an in-process LRU cache of `(tenantId, actionHash) → action names`, only hitting the join tables for legacy worker registrations.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Add `ListLiveWorkerActionHashes` (liveness + hash, no joins) as the per-cycle query, and `ListWorkerActionSets` to resolve action sets for one representative worker per uncached hash (materialized CTEs force a hash join over per-pair index lookups)
- [x] Cache resolved action sets in a 10k-entry, 30-min-TTL LRU on the assignment repository, keyed by tenant + action hash; empty results are never cached so a representative worker deleted mid-cycle self-heals next cycle
- [x] Rename the original query to `ListActionsForWorkersLegacyFallback`, used only for workers registered before `actionHash` existed; alias the row type in `types.go` so the `AssignmentRepository` interface and all callers are unchanged
- [x] Add span attributes for live worker count, hash cache misses, and no-hash workers

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

- `EXPLAIN ANALYZE` on the affected production shard: per-cycle cost drops from ~228ms / 334k buffer hits to ~0.4ms / 349 buffer hits (cache warm); worst-case cold-cache resolution is ~25ms
- `go test ./pkg/scheduling/v1/ ./pkg/repository