### PR TITLE
feat: add non-root user to Docker images for PSA restricted compliance

### DIFF
--- a/build/package/dashboard.dockerfile
+++ b/build/package/dashboard.dockerfile
@@ -33,10 +33,7 @@ COPY --from=frontend-build /app/dist /usr/share/nginx/html
 # Make entrypoint script executable
 RUN chmod +x ./entrypoint.sh
 
-# Create non-root user for Kubernetes Pod Security Standards compliance.
-# Image defaults to root for backward compatibility (nginx requires root for port 80).
-# For non-root nginx, consider nginxinc/nginx-unprivileged:alpine in a future major version.
-RUN addgroup -S hatchet && adduser -S -G hatchet -H -s /sbin/nologin -u 1000 hatchet
+# TODO: switch to nginx-unprivileged to enable non-root operation
 
 EXPOSE 80
 

--- a/build/package/dashboard.dockerfile
+++ b/build/package/dashboard.dockerfile
@@ -33,6 +33,11 @@ COPY --from=frontend-build /app/dist /usr/share/nginx/html
 # Make entrypoint script executable
 RUN chmod +x ./entrypoint.sh
 
+# Create non-root user for Kubernetes Pod Security Standards compliance.
+# Image defaults to root for backward compatibility (nginx requires root for port 80).
+# For non-root nginx, consider nginxinc/nginx-unprivileged:alpine in a future major version.
+RUN addgroup -S hatchet && adduser -S -G hatchet -H -s /sbin/nologin -u 1000 hatchet
+
 EXPOSE 80
 
 # Run the entrypoint script

--- a/build/package/frontend.dockerfile
+++ b/build/package/frontend.dockerfile
@@ -31,6 +31,12 @@ WORKDIR /app
 COPY --from=build /app/dist ./dist
 COPY --from=staticfileserver /app/hatchet-staticfileserver ./hatchet-staticfileserver
 
+# Create non-root user for Kubernetes Pod Security Standards compliance.
+# Image defaults to root for backward compatibility. To run as non-root,
+# set securityContext.runAsUser: 1000 in your Kubernetes pod spec or
+# pass --user 1000 to docker run.
+RUN addgroup -S hatchet && adduser -S -G hatchet -H -s /sbin/nologin -u 1000 hatchet
+
 EXPOSE 80
 
 CMD ["/app/hatchet-staticfileserver", "-static-asset-dir", "/app/dist"]

--- a/build/package/frontend.dockerfile
+++ b/build/package/frontend.dockerfile
@@ -28,14 +28,14 @@ FROM alpine:3.21
 
 WORKDIR /app
 
-COPY --from=build /app/dist ./dist
-COPY --from=staticfileserver /app/hatchet-staticfileserver ./hatchet-staticfileserver
-
 # Create non-root user for Kubernetes Pod Security Standards compliance.
 # Image defaults to root for backward compatibility. To run as non-root,
 # set securityContext.runAsUser: 1000 in your Kubernetes pod spec or
 # pass --user 1000 to docker run.
 RUN addgroup -S hatchet && adduser -S -G hatchet -H -s /sbin/nologin -u 1000 hatchet
+
+COPY --from=build /app/dist ./dist
+COPY --chown=hatchet:hatchet --from=staticfileserver /app/hatchet-staticfileserver ./hatchet-staticfileserver
 
 EXPOSE 80
 

--- a/build/package/servers.dockerfile
+++ b/build/package/servers.dockerfile
@@ -79,18 +79,18 @@ WORKDIR /hatchet
 # openssl and bash needed for admin build
 RUN apk update && apk add --no-cache openssl bash ca-certificates tzdata
 
-COPY --from=build-go /hatchet/bin/hatchet-${SERVER_TARGET} /hatchet/
-
-# NOTE: this is just here for backwards compatibility with old migrate images which require the atlas-apply.sh script.
-# This script is just a wrapped for `/hatchet/hatchet-migrate`.
-COPY /hack/db/atlas-apply.sh ./atlas-apply.sh
-RUN chmod +x ./atlas-apply.sh
-
 # Create non-root user for Kubernetes Pod Security Standards compliance.
 # Image defaults to root for backward compatibility. To run as non-root,
 # set securityContext.runAsUser: 1000 in your Kubernetes pod spec or
 # pass --user 1000 to docker run.
 RUN addgroup -S hatchet && adduser -S -G hatchet -H -s /sbin/nologin -u 1000 hatchet
+
+COPY --chown=hatchet:hatchet --from=build-go /hatchet/bin/hatchet-${SERVER_TARGET} /hatchet/
+
+# NOTE: this is just here for backwards compatibility with old migrate images which require the atlas-apply.sh script.
+# This script is just a wrapped for `/hatchet/hatchet-migrate`.
+COPY --chown=hatchet:hatchet /hack/db/atlas-apply.sh ./atlas-apply.sh
+RUN chmod +x ./atlas-apply.sh
 
 EXPOSE 8080
 

--- a/build/package/servers.dockerfile
+++ b/build/package/servers.dockerfile
@@ -86,6 +86,12 @@ COPY --from=build-go /hatchet/bin/hatchet-${SERVER_TARGET} /hatchet/
 COPY /hack/db/atlas-apply.sh ./atlas-apply.sh
 RUN chmod +x ./atlas-apply.sh
 
+# Create non-root user for Kubernetes Pod Security Standards compliance.
+# Image defaults to root for backward compatibility. To run as non-root,
+# set securityContext.runAsUser: 1000 in your Kubernetes pod spec or
+# pass --user 1000 to docker run.
+RUN addgroup -S hatchet && adduser -S -G hatchet -H -s /sbin/nologin -u 1000 hatchet
+
 EXPOSE 8080
 
 CMD ["/bin/sh", "-c", "/hatchet/hatchet-${SERVER_TARGET}"]

--- a/frontend/docs/pages/self-hosting/kubernetes-helm-configuration.mdx
+++ b/frontend/docs/pages/self-hosting/kubernetes-helm-configuration.mdx
@@ -153,4 +153,4 @@ containerSecurityContext:
 shareProcessNamespace: false
 ```
 
-This requires Hatchet Docker images that include a non-root user (UID 1000). See [hatchet-dev/hatchet#3356](https://github.com/hatchet-dev/hatchet/pull/3356) for the image changes.
+This requires Hatchet Docker images that include a non-root user (UID 1000), available from version `v0.80.0` onwards.

--- a/frontend/docs/pages/self-hosting/kubernetes-helm-configuration.mdx
+++ b/frontend/docs/pages/self-hosting/kubernetes-helm-configuration.mdx
@@ -123,7 +123,7 @@ sharedConfig:
     DEFAULT_TENANT_NAME: "Default"
     DEFAULT_TENANT_SLUG: "default"
     DEFAULT_TENANT_ID: "707d0855-80ab-4e1f-a156-f1c4546cbf52"
-````
+```
 
 ## Pod Security Standards
 

--- a/frontend/docs/pages/self-hosting/kubernetes-helm-configuration.mdx
+++ b/frontend/docs/pages/self-hosting/kubernetes-helm-configuration.mdx
@@ -153,4 +153,4 @@ containerSecurityContext:
 shareProcessNamespace: false
 ```
 
-This requires Hatchet Docker images that include a non-root user (UID 1000), available from version `v0.80.0` onwards.
+This requires Hatchet Docker images that include a non-root user (UID 1000).

--- a/frontend/docs/pages/self-hosting/kubernetes-helm-configuration.mdx
+++ b/frontend/docs/pages/self-hosting/kubernetes-helm-configuration.mdx
@@ -123,4 +123,34 @@ sharedConfig:
     DEFAULT_TENANT_NAME: "Default"
     DEFAULT_TENANT_SLUG: "default"
     DEFAULT_TENANT_ID: "707d0855-80ab-4e1f-a156-f1c4546cbf52"
+````
+
+## Pod Security Standards
+
+The Helm charts support Kubernetes [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) (PSS) at the `restricted` level. By default, no security context is applied for backward compatibility. To enable PSA restricted compliance, set the following values:
+
+```yaml
+# Pod-level security context
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container-level security context
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+# Disable shared process namespace (required for PSA restricted)
+shareProcessNamespace: false
 ```
+
+This requires Hatchet Docker images that include a non-root user (UID 1000). See [hatchet-dev/hatchet#3356](https://github.com/hatchet-dev/hatchet/pull/3356) for the image changes.


### PR DESCRIPTION
# Description

Adds a `hatchet` system user (UID 1000) to the servers and frontend Dockerfiles with explicit file ownership via `COPY --chown`, enabling Kubernetes deployments to opt into non-root execution.

Images continue to run as root by default — no breaking changes for existing users.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## What's Changed

### Dockerfiles
- `build/package/servers.dockerfile`: Create `hatchet` user (UID 1000), `COPY --chown=hatchet:hatchet` for binary and `atlas-apply.sh`
- `build/package/frontend.dockerfile`: Create `hatchet` user (UID 1000), `COPY --chown=hatchet:hatchet` for `hatchet-staticfileserver` binary
- `build/package/dashboard.dockerfile`: No non-root support (nginx requires root for port 80). Added TODO comment for future `nginx-unprivileged` migration.

### Documentation
- Added Pod Security Standards configuration section to `frontend/docs/pages/self-hosting/kubernetes-helm-configuration.mdx`

### Why `COPY --chown`?
Makes file ownership explicit rather than relying on Alpine's default umask. When running as UID 1000, binaries owned by `hatchet:hatchet` are unambiguously accessible.

## Usage

After this change, users can run Hatchet as non-root:

```yaml
podSecurityContext:
  runAsNonRoot: true
  runAsUser: 1000
  runAsGroup: 1000
  fsGroup: 1000
```

No action needed for existing deployments — they continue to run as root.

### Companion PR

[hatchet-dev/hatchet-charts#45](https://github.com/hatchet-dev/hatchet-charts/pull/45) adds securityContext templating to the Helm charts.

## Testing

- `task fmt` — all pass
- `task test` — all unit tests pass
- `task test-integration` — all integration tests pass
- All 3 Docker images build successfully
- Verified on servers and frontend images:
  - User `hatchet` exists (UID 1000)
  - Binary files owned by `hatchet:hatchet`
  - Containers run correctly as `--user 1000:1000`
  - Binaries start successfully as non-root