### PR TITLE
fix(dashboard): event key placeholder / empty state

### DIFF
--- a/frontend/app/src/pages/main/v1/webhooks/index.tsx
+++ b/frontend/app/src/pages/main/v1/webhooks/index.tsx
@@ -372,6 +372,22 @@ const createSourceInlineDescription = (sourceName: V1WebhookSourceName) => {
   }
 };
 
+const createEventKeyPlaceholder = (sourceName: V1WebhookSourceName) => {
+  switch (sourceName) {
+    case V1WebhookSourceName.SLACK:
+      return 'input.type';
+    case V1WebhookSourceName.GENERIC:
+    case V1WebhookSourceName.GITHUB:
+    case V1WebhookSourceName.LINEAR:
+    case V1WebhookSourceName.STRIPE:
+    case V1WebhookSourceName.SVIX:
+      return 'input.id';
+    default:
+      const exhaustiveCheck: never = sourceName;
+      throw new Error(`Unhandled source name: ${exhaustiveCheck}`);
+  }
+};
+
 const SourceCaption = ({ sourceName }: { sourceName: V1WebhookSourceName }) => {
   switch (sourceName) {
     case V1WebhookSourceName.GITHUB:
@@ -415,7 +431,7 @@ const CreateWebhookModal = () => {
       sourceName: V1WebhookSourceName.GENERIC,
       authType: V1WebhookAuthType.BASIC,
       name: '',
-      eventKeyExpression: 'input.id',
+      eventKeyExpression: '',
       username: '',
       password: '',
       returnEventAsResponsePayload: true,
@@ -425,20 +441,7 @@ const CreateWebhookModal = () => {
   const sourceName = watch('sourceName');
   const authType = watch('authType');
   const webhookName = watch('name');
-  const eventKeyExpression = watch('eventKeyExpression');
   const returnEventAsResponsePayload = watch('returnEventAsResponsePayload');
-
-  /* Update default event key expression when source changes */
-  useEffect(() => {
-    if (sourceName === V1WebhookSourceName.SLACK && !eventKeyExpression) {
-      setValue('eventKeyExpression', 'input.type');
-    } else if (
-      sourceName === V1WebhookSourceName.GENERIC &&
-      !eventKeyExpression
-    ) {
-      setValue('eventKeyExpression', 'input.id');
-    }
-  }, [sourceName, eventKeyExpression, setValue]);
 
   const copyToClipboard = useCallback(async () => {
     if (webhookName) {
@@ -583,7 +586,7 @@ const CreateWebhookModal = () => {
             </Label>
             <Input
               id="eventKeyExpression"
-              placeholder="input.id"
+              placeholder={createEventKeyPlaceholder(sourceName)}
               {...register('eventKeyExpression')}
               className="h-10"
             />


### PR DESCRIPTION
# Description

The webhook modal was resetting the key expression to `input.id` if it was cleared, which was super annoying UX. Getting rid of the default in the form and instead just showing a placeholder.

<img width="791" height="938" alt="Screenshot 2026-07-13 at 2 23 49 PM" src="https://github.com/user-attachments/assets/40cbb670-e06b-4053-9cd9-8da869b6494c" />

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI use

</details>
