### PR TITLE
fix(api): re-enable rate limiting for incoming webhook requests

### DIFF
--- a/api-contracts/openapi/paths/v1/webhooks/webhook.yaml
+++ b/api-contracts/openapi/paths/v1/webhooks/webhook.yaml
@@ -90,11 +90,11 @@ V1WebhookGetDeleteReceiveUpdate:
     tags:
       - Webhook
   post:
+    # !!! IMPORTANT: we directly reference this path in the webhook rate limiter in `webhook_rate_limit.go`
+    # changing this path will break the rate limiter. !!!
     x-resources: ["tenant", "v1-webhook"]
     description: Post an incoming webhook message
     operationId: v1-webhook:receive
-    # !!! IMPORTANT: we directly reference this path in the webhook rate limiter in `webhook_rate_limit.go`
-    # changing this path will break the rate limiter. !!!
     security: []
     parameters:
       - description: The tenant id

--- a/api-contracts/openapi/paths/v1/webhooks/webhook.yaml
+++ b/api-contracts/openapi/paths/v1/webhooks/webhook.yaml
@@ -93,6 +93,8 @@ V1WebhookGetDeleteReceiveUpdate:
     x-resources: ["tenant", "v1-webhook"]
     description: Post an incoming webhook message
     operationId: v1-webhook:receive
+    # !!! IMPORTANT: we directly reference this path in the webhook rate limiter in `webhook_rate_limit.go`
+    # changing this path will break the rate limiter. !!!
     security: []
     parameters:
       - description: The tenant id

--- a/api/v1/server/middleware/webhook_rate_limit.go
+++ b/api/v1/server/middleware/webhook_rate_limit.go
@@ -1,0 +1,43 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"github.com/rs/zerolog"
+	"golang.org/x/time/rate"
+)
+
+func WebhookRateLimitMiddleware(rateLimit rate.Limit, burst int, l *zerolog.Logger) echo.MiddlewareFunc {
+	config := middleware.RateLimiterConfig{
+		Skipper: func(c echo.Context) bool {
+			method := c.Request().Method
+
+			if method != http.MethodPost {
+				return true
+			}
+
+			tenantId := c.Param("tenant")
+			webhookName := c.Param("v1-webhook")
+
+			if tenantId == "" || webhookName == "" {
+				return true
+			}
+
+			return c.Request().URL.Path != fmt.Sprintf("/api/v1/stable/tenants/%s/webhooks/%s", tenantId, webhookName)
+		},
+
+		Store: middleware.NewRateLimiterMemoryStoreWithConfig(
+			middleware.RateLimiterMemoryStoreConfig{
+				Rate:      rateLimit,
+				Burst:     burst,
+				ExpiresIn: 10 * time.Minute,
+			},
+		),
+	}
+
+	return middleware.RateLimiterWithConfig(config)
+}

--- a/api/v1/server/middleware/webhook_rate_limit.go
+++ b/api/v1/server/middleware/webhook_rate_limit.go
@@ -37,6 +37,22 @@ func WebhookRateLimitMiddleware(rateLimit rate.Limit, burst int, l *zerolog.Logg
 				ExpiresIn: 10 * time.Minute,
 			},
 		),
+
+		IdentifierExtractor: func(c echo.Context) (string, error) {
+			tenantId := c.Param("tenant")
+			webhookName := c.Param("v1-webhook")
+			method := c.Request().Method
+
+			if method != http.MethodPost {
+				return "", fmt.Errorf("method not allowed for rate limiting: %s", method)
+			}
+
+			if tenantId == "" || webhookName == "" {
+				return "", fmt.Errorf("missing tenant or webhook name in request path")
+			}
+
+			return fmt.Sprintf("%s-%s", tenantId, webhookName), nil
+		},
 	}
 
 	return middleware.RateLimiterWithConfig(config)

--- a/api/v1/server/middleware/webhook_rate_limit.go
+++ b/api/v1/server/middleware/webhook_rate_limit.go
@@ -41,14 +41,9 @@ func WebhookRateLimitMiddleware(rateLimit rate.Limit, burst int, l *zerolog.Logg
 		IdentifierExtractor: func(c echo.Context) (string, error) {
 			tenantId := c.Param("tenant")
 			webhookName := c.Param("v1-webhook")
-			method := c.Request().Method
-
-			if method != http.MethodPost {
-				return "", fmt.Errorf("method not allowed for rate limiting: %s", method)
-			}
 
 			if tenantId == "" || webhookName == "" {
-				return "", fmt.Errorf("missing tenant or webhook name in request path")
+				return c.RealIP(), nil
 			}
 
 			return fmt.Sprintf("%s-%s", tenantId, webhookName), nil

--- a/api/v1/server/run/run.go
+++ b/api/v1/server/run/run.go
@@ -14,6 +14,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/rs/zerolog"
+	"golang.org/x/time/rate"
 
 	"github.com/hatchet-dev/hatchet/api/v1/server/authn"
 	"github.com/hatchet-dev/hatchet/api/v1/server/authz"
@@ -752,6 +753,11 @@ func (t *APIServer) registerSpec(g *echo.Group, spec *openapi3.T) (*populator.Po
 	})
 
 	rateLimitMW := ratelimit.NewRateLimitMiddleware(t.config, spec)
+	webhookRateLimitMW := hatchetmiddleware.WebhookRateLimitMiddleware(
+		rate.Limit(t.config.Runtime.WebhookRateLimit),
+		t.config.Runtime.WebhookRateLimitBurst,
+		t.config.Logger,
+	)
 	otelMW := telemetry.NewOTelMiddleware(t.config)
 
 	// register echo middleware
@@ -759,6 +765,7 @@ func (t *APIServer) registerSpec(g *echo.Group, spec *openapi3.T) (*populator.Po
 		loggerMiddleware,
 		middleware.Recover(),
 		rateLimitMW.Middleware(),
+		webhookRateLimitMW,
 		otelMW.Middleware(),
 		otelMW.ErrorStatusMiddleware(),
 		allHatchetMiddleware,

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -755,6 +755,8 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("runtime.grpcWorkerMaxLockAcquisitionTime", "SERVER_GRPC_WORKER_MAX_LOCK_ACQUISITION_TIME")
 	_ = v.BindEnv("runtime.grpcStaticStreamWindowSize", "SERVER_GRPC_STATIC_STREAM_WINDOW_SIZE")
 	_ = v.BindEnv("runtime.grpcRateLimit", "SERVER_GRPC_RATE_LIMIT")
+	_ = v.BindEnv("runtime.webhookRateLimit", "SERVER_INCOMING_WEBHOOK_RATE_LIMIT")
+	_ = v.BindEnv("runtime.webhookRateLimitBurst", "SERVER_INCOMING_WEBHOOK_RATE_LIMIT_BURST")
 	_ = v.BindEnv("runtime.grpcShutdownTimeout", "SERVER_GRPC_SHUTDOWN_TIMEOUT")
 	_ = v.BindEnv("runtime.schedulerConcurrencyRateLimit", "SCHEDULER_CONCURRENCY_RATE_LIMIT")
 	_ = v.BindEnv("runtime.schedulerConcurrencyPollingMinInterval", "SCHEDULER_CONCURRENCY_POLLING_MIN_INTERVAL")

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -259,6 +259,12 @@ type ConfigFileRuntime struct {
 	APIRateLimit       int           `mapstructure:"apiRateLimit" json:"apiRateLimit,omitempty" default:"10"`
 	APIRateLimitWindow time.Duration `mapstructure:"apiRateLimitWindow" json:"apiRateLimitWindow,omitempty" default:"300s"`
 
+	// WebhookRateLimit is the rate limit for webhook endpoints per second, per webhook
+	WebhookRateLimit float64 `mapstructure:"webhookRateLimit" json:"webhookRateLimit,omitempty" default:"50"`
+
+	// WebhookRateLimitBurst is the burst size for webhook rate limiting
+	WebhookRateLimitBurst int `mapstructure:"webhookRateLimitBurst" json:"webhookRateLimitBurst,omitempty" default:"100"`
+
 	// DisableTenantPubs controls whether tenant pubsub is disabled
 	DisableTenantPubs bool `mapstructure:"disableTenantPubs" json:"disableTenantPubs,omitempty"`
 


### PR DESCRIPTION
# Description

[This commit](https://github.com/hatchet-dev/hatchet/pull/1893/changes/121b2d9897b411ad95e62435dafa4046b92e9a80#diff-97b387589242cdf48a7b66f4daa27066a206a9dcd8659d8587740c904aaa1ce7L68) seemingly removed rate limiting for incoming webhooks, which we need to keep (and also allow bursting, and separate configuration from the broader rate limiting setup on the API since we're using them for ingestion). This just adds back the original logic. Tested locally to confirm I could get 429s when I bursted to 100 / 150 RPS using this script:

```bash
while true; do
  for i in {1..50}; do
    (
      curl -s \
        -X POST \
        https://app.dev.hatchet-tools.com/api/v1/stable/tenants/2de05c02-94a8-4ced-912b-1b4ab33b059c/webhooks/test-webhook \
        -H "x-api-key: testkey" \
        -H "Content-Type: application/json" \
        -d '{}' \
        -w "HTTP %{http_code}\n"
    ) &
  done

  wait
  sleep 1
done
```

which results in:

```
HTTP 204
HTTP 204
HTTP 204
HTTP 204
...
```

when `50` is the upper bound,

```
HTTP 204
HTTP 204
HTTP 204
{"message":"rate limit exceeded"}
HTTP 429
HTTP 204
HTTP 204
HTTP 204
{"message":"rate limit exceeded"}
HTTP 429
{"message":"rate limit exceeded"}
```

when it's `100`, and

```
HTTP 429
{"message":"rate limit exceeded"}
HTTP 429
{"message":"rate limit exceeded"}
HTTP 429
{"message":"rate limit exceeded"}
HTTP 429
{"message":"rate limit exceeded"}
HTTP 429
```

when it's `150` (since we can burst up to 100)

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI use

</details>
