### PR TITLE
fix: redact RabbitMQ URL in dial failure logs

### DIFF
--- a/internal/msgqueue/rabbitmq/channel_pool.go
+++ b/internal/msgqueue/rabbitmq/channel_pool.go
@@ -2,6 +2,7 @@ package rabbitmq
 
 import (
 	"context"
+	"net/url"
 	"sync"
 	"time"
 
@@ -23,11 +24,22 @@ type channelPool struct {
 	connMu sync.Mutex
 }
 
+// redactURL masks the password in a connection URL (as url.URL.Redacted does).
+// If the URL cannot be parsed, a placeholder is returned instead.
+func redactURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || (raw != "" && u.Host == "") {
+		return "<unparseable url>"
+	}
+
+	return u.Redacted()
+}
+
 func (p *channelPool) newConnection() error {
 	conn, err := amqp.Dial(p.url)
 
 	if err != nil {
-		p.l.Error().Msgf("cannot (re)dial: %v: %q", err, p.url)
+		p.l.Error().Msgf("cannot (re)dial: %v: %q", err, redactURL(p.url))
 		return err
 	}
 
@@ -104,7 +116,7 @@ func newChannelPool(ctx context.Context, l *zerolog.Logger, url string, maxChann
 				err := p.newConnection()
 
 				if err != nil {
-					l.Error().Msgf("cannot (re)dial: %v: %q", err, p.url)
+					l.Error().Msgf("cannot (re)dial: %v: %q", err, redactURL(p.url))
 					queueutils.SleepWithExponentialBackoff(10*time.Millisecond, 5*time.Second, retries)
 					retries++
 					continue

--- a/internal/msgqueue/rabbitmq/channel_pool_test.go
+++ b/internal/msgqueue/rabbitmq/channel_pool_test.go
@@ -1,0 +1,54 @@
+package rabbitmq
+
+import "testing"
+
+func TestRedactURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "username and password",
+			in:   "amqp://user:s3cret@rabbitmq-blue:5672/",
+			want: "amqp://user:xxxxx@rabbitmq-blue:5672/",
+		},
+		{
+			name: "username only",
+			in:   "amqp://user@rabbitmq:5672/vhost",
+			want: "amqp://user@rabbitmq:5672/vhost",
+		},
+		{
+			name: "no credentials",
+			in:   "amqp://rabbitmq:5672/",
+			want: "amqp://rabbitmq:5672/",
+		},
+		{
+			name: "unparseable",
+			in:   "amqp://user:pass@rabbit:5672/\x7f%zz",
+			want: "<unparseable url>",
+		},
+		{
+			// A scheme-less string parses without a host, and Redacted would
+			// return the credentials verbatim, so it must be masked entirely.
+			name: "scheme-less with credentials",
+			in:   "user:pass@rabbit:5672/vhost",
+			want: "<unparseable url>",
+		},
+		{
+			name: "empty",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := redactURL(tt.in)
+
+			if got != tt.want {
+				t.Errorf("redactURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- The `cannot (re)dial` error logs in `internal/msgqueue/rabbitmq/channel_pool.go` printed the raw RabbitMQ connection URL, potentially leaking the username and password into logs (and any log aggregation) whenever a dial failed — e.g. during credential rotation.
- Added a small `redactURL` helper (stdlib `net/url` + `URL.Redacted()`) that masks the password as `xxxxx`; unparseable URLs log `<unparseable url>` instead of the raw value. The redacted URL is computed once in `newChannelPool` and used at both log sites, keeping host/port visible for debugging.