### PR TITLE
fix: skip no dag updates

### DIFF
--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -1725,7 +1725,7 @@ func (r *OLAPRepositoryImpl) prepareDAGStatusUpdateBatch(taskRows []*sqlcv1.Upda
 	dagInsertedAts := make([]pgtype.Timestamptz, 0)
 
 	for _, row := range taskRows {
-		if !row.DagID.Valid {
+		if !row.WasUpdated || !row.DagID.Valid {
 			continue
 		}
 

--- a/pkg/repository/olap_status_update_test.go
+++ b/pkg/repository/olap_status_update_test.go
@@ -257,6 +257,42 @@ func runReplayStatusScenario(
 	assertOLAPRunStatus(t, ctx, pool, f, "COMPLETED")
 }
 
+func TestPrepareDAGStatusUpdateBatchOnlyIncludesUpdatedTasks(t *testing.T) {
+	repo := &OLAPRepositoryImpl{}
+	tenantId := uuid.New()
+	dagInsertedAt := pgtype.Timestamptz{Time: time.Now().UTC(), Valid: true}
+
+	batch := repo.prepareDAGStatusUpdateBatch([]*sqlcv1.UpdateTaskStatusesFromMQRow{
+		{
+			TenantID:      tenantId,
+			DagID:         pgtype.Int8{Int64: 1, Valid: true},
+			DagInsertedAt: dagInsertedAt,
+			WasUpdated:    false,
+		},
+		{
+			TenantID:      tenantId,
+			DagID:         pgtype.Int8{Int64: 2, Valid: true},
+			DagInsertedAt: dagInsertedAt,
+			WasUpdated:    true,
+		},
+		{
+			TenantID:      tenantId,
+			DagID:         pgtype.Int8{Int64: 2, Valid: true},
+			DagInsertedAt: dagInsertedAt,
+			WasUpdated:    true,
+		},
+		{
+			TenantID:   tenantId,
+			DagID:      pgtype.Int8{},
+			WasUpdated: true,
+		},
+	})
+
+	assert.Equal(t, []uuid.UUID{tenantId}, batch.Tenantids)
+	assert.Equal(t, []int64{2}, batch.Dagids)
+	assert.Equal(t, []pgtype.Timestamptz{dagInsertedAt}, batch.Daginsertedats)
+}
+
 // TestOLAPStatusUpdate_ReplayOfCompletedTask is a regression test for runs
 // permanently stuck in RUNNING (or with a stale retry count) after a bulk
 // replay of completed tasks, when the replay's OLAP events are ingested


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
