### PR TITLE
fix: avoid logging potentially sensitive request data

### DIFF
--- a/api/v1/server/handlers/v1/webhooks/receive.go
+++ b/api/v1/server/handlers/v1/webhooks/receive.go
@@ -144,12 +144,8 @@ func (w *V1WebhooksService) V1WebhookReceive(ctx echo.Context, request gen.V1Web
 					/* url.ParseQuery automatically URL-decodes the payload parameter value */
 					err := json.Unmarshal([]byte(payloadValue), &payloadMap)
 					if err != nil {
-						payloadPreview := payloadValue
-						if len(payloadPreview) > 200 {
-							payloadPreview = payloadPreview[:200] + "..."
-						}
 						errorMsg := "Failed to unmarshal payload parameter as JSON"
-						w.config.Logger.Info().Err(err).Str("webhook", webhookName).Str("tenant", tenantId.String()).Int("payload_length", len(payloadValue)).Str("payload_preview", payloadPreview).Msg(errorMsg)
+						w.config.Logger.Info().Err(err).Str("webhook", webhookName).Str("tenant", tenantId.String()).Int("payload_length", len(payloadValue)).Msg(errorMsg)
 						return gen.V1WebhookReceive400JSONResponse{
 							Errors: []gen.APIError{
 								{
@@ -186,12 +182,8 @@ func (w *V1WebhooksService) V1WebhookReceive(ctx echo.Context, request gen.V1Web
 		} else {
 			err := json.Unmarshal(rawBody, &payloadMap)
 			if err != nil {
-				bodyPreview := string(rawBody)
-				if len(bodyPreview) > 200 {
-					bodyPreview = bodyPreview[:200] + "..."
-				}
 				errorMsg := "Failed to unmarshal request body as JSON"
-				w.config.Logger.Info().Err(err).Str("webhook", webhookName).Str("tenant", tenantId.String()).Str("content_type", contentType).Int("body_length", len(rawBody)).Str("body_preview", bodyPreview).Msg(errorMsg)
+				w.config.Logger.Info().Err(err).Str("webhook", webhookName).Str("tenant", tenantId.String()).Str("content_type", contentType).Int("body_length", len(rawBody)).Msg(errorMsg)
 				return gen.V1WebhookReceive400JSONResponse{
 					Errors: []gen.APIError{
 						{

--- a/api/v1/server/run/run.go
+++ b/api/v1/server/run/run.go
@@ -709,7 +709,6 @@ func (t *APIServer) registerSpec(g *echo.Group, spec *openapi3.T) (*populator.Po
 	}
 
 	loggerMiddleware := middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
-		LogURI:       true,
 		LogStatus:    true,
 		LogError:     true,
 		LogLatency:   true,
@@ -742,7 +741,7 @@ func (t *APIServer) registerSpec(g *echo.Group, spec *openapi3.T) (*populator.Po
 				Dur("latency", v.Latency).
 				Int("status", statusCode).
 				Str("method", v.Method).
-				Str("uri", v.URI).
+				Str("uri", v.URIPath).
 				Str("user_agent", v.UserAgent).
 				Str("remote_ip", v.RemoteIP).
 				Str("host", v.Host).

--- a/pkg/repository/match.go
+++ b/pkg/repository/match.go
@@ -1025,7 +1025,7 @@ func (m *sharedRepository) processCELExpressions(ctx context.Context, events []C
 				err := json.Unmarshal(event.Data, &inputData)
 
 				if err != nil {
-					m.l.Warn().Ctx(ctx).Err(err).Msgf("failed to unmarshal user event data %s", string(event.Data))
+					m.l.Warn().Ctx(ctx).Err(err).Msgf("failed to unmarshal user event data. id: %s, key: %s", event.ID, event.Key)
 					continue
 				}
 			}


### PR DESCRIPTION
Avoid logging request query strings and malformed payload contents.

See in-line comments for details
