### PR TITLE
fix(dashboard): add copy to run page on redirect from trigger

### DIFF
--- a/frontend/app/src/pages/error/components/resource-not-found.tsx
+++ b/frontend/app/src/pages/error/components/resource-not-found.tsx
@@ -51,7 +51,11 @@ export function ResourceNotFound({
       return;
     }
 
-    throw new Error('unhandled action');
+    navigate({
+      to: appRoutes.authenticatedRoute.to,
+      replace: true,
+    });
+    return;
   };
 
   return (

--- a/frontend/app/src/pages/error/components/resource-not-found.tsx
+++ b/frontend/app/src/pages/error/components/resource-not-found.tsx
@@ -4,8 +4,8 @@ import { Button } from '@/components/v1/ui/button';
 import { appRoutes } from '@/router';
 import { useLocation, useNavigate } from '@tanstack/react-router';
 import type { NavigateOptions } from '@tanstack/react-router';
-import { FileQuestion, Home, Undo2 } from 'lucide-react';
-import { ReactNode } from 'react';
+import { FileQuestion, Home, LucideIcon, Undo2 } from 'lucide-react';
+import { ReactNode, useState } from 'react';
 
 export function ResourceNotFound({
   resource,
@@ -16,11 +16,43 @@ export function ResourceNotFound({
   description?: ReactNode;
   primaryAction?: {
     label: string;
-    navigate: NavigateOptions;
+    navigate?: NavigateOptions;
+    icon?: LucideIcon;
+    actionOverride?: () => void;
   };
 }) {
   const navigate = useNavigate();
   const location = useLocation();
+  const Icon = primaryAction?.icon ?? Home;
+  const [spinning, setSpinning] = useState(false);
+
+  const handleButtonClick = () => {
+    if (!primaryAction) {
+      navigate({
+        to: appRoutes.authenticatedRoute.to,
+        replace: true,
+      });
+      return;
+    }
+
+    const override = primaryAction.actionOverride;
+    if (override) {
+      setSpinning(true);
+      override();
+      return;
+    }
+
+    if (primaryAction.navigate) {
+      navigate({
+        ...primaryAction.navigate,
+        replace: primaryAction.navigate.replace ?? true,
+      });
+
+      return;
+    }
+
+    throw new Error('unhandled action');
+  };
 
   return (
     <ErrorPageLayout
@@ -28,23 +60,21 @@ export function ResourceNotFound({
       title={`${resource} not found`}
       description={
         description ??
-        `The ${resource.toLowerCase()} you're looking for doesn’t exist.`
+        `The ${resource.toLowerCase()} you're looking for doesn't exist.`
       }
       actions={
         <>
           <Button
-            leftIcon={<Home className="h-4 w-4" />}
-            onClick={() =>
-              primaryAction
-                ? navigate({
-                    ...primaryAction.navigate,
-                    replace: primaryAction.navigate.replace ?? true,
-                  })
-                : navigate({
-                    to: appRoutes.authenticatedRoute.to,
-                    replace: true,
-                  })
+            leftIcon={
+              <Icon
+                className="h-4 w-4"
+                style={
+                  spinning ? { animation: 'spin 0.5s linear 1' } : undefined
+                }
+                onAnimationEnd={() => setSpinning(false)}
+              />
             }
+            onClick={handleButtonClick}
           >
             {primaryAction?.label ?? 'Dashboard'}
           </Button>

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/index.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/index.tsx
@@ -219,7 +219,8 @@ export default function Run() {
           description={
             <span className="mx-auto block max-w-96">
               The run was triggered successfully, but has not been replicated to
-              the analytics database yet.{' '}
+              the analytics database yet. Once it's replicated, it will show up
+              on this page.{' '}
               <strong className="text-foreground">
                 You do not need to re-trigger the run.
               </strong>

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/index.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/index.tsx
@@ -194,7 +194,7 @@ export default function Run() {
 
   if (
     taskRunQuery.isError &&
-    wasRedirectedFromTrigger &&
+    wasRedirectedFromTrigger === 'true' &&
     getErrorStatus(taskRunQuery.error) === 404
   ) {
     seenRedirect404.current = true;

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/index.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/index.tsx
@@ -217,10 +217,12 @@ export default function Run() {
         <ResourceNotFound
           resource="Run"
           description={
-            <span>
-              Your run was triggered successfully.{' '}
-              <strong>Do not re-trigger it.</strong> It may take a few seconds
-              to appear — this page will refresh automatically.
+            <span className="mx-auto block max-w-96">
+              The run was triggered successfully, but has not been replicated to
+              the analytics database yet.{' '}
+              <strong className="text-foreground">
+                You do not need to re-trigger the run.
+              </strong>
             </span>
           }
           primaryAction={{

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/index.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/index.tsx
@@ -41,11 +41,12 @@ import api, {
 import { preferredWorkflowRunViewAtom } from '@/lib/atoms';
 import { getErrorStatus, shouldRetryQueryError } from '@/lib/error-utils';
 import { ResourceNotFound } from '@/pages/error/components/resource-not-found';
-import { appRoutes } from '@/router';
+import { appRoutes, tenantRunRoute } from '@/router';
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
 import { isAxiosError } from 'axios';
 import { useAtom } from 'jotai';
+import { RefreshCcw } from 'lucide-react';
 import { useCallback, useMemo, useRef } from 'react';
 
 class StatusError extends Error {
@@ -135,6 +136,12 @@ async function fetchDAGRun(id: string) {
 export default function Run() {
   const params = useParams({ from: appRoutes.tenantRunRoute.to });
   const { run } = params;
+  const { wasRedirectedFromTrigger } = tenantRunRoute.useSearch();
+
+  // Once we've shown the redirect-404 page, stay on it during subsequent refetches
+  // instead of flashing back to the full-page spinner (which would unmount the component
+  // and reset the icon spin animation state).
+  const seenRedirect404 = useRef(false);
 
   const taskRunQuery = useQuery({
     queryKey: ['workflow-run', run],
@@ -185,15 +192,45 @@ export default function Run() {
     retry: (_failureCount, error) => shouldRetryQueryError(error),
   });
 
-  if (taskRunQuery.isLoading) {
+  if (
+    taskRunQuery.isError &&
+    wasRedirectedFromTrigger &&
+    getErrorStatus(taskRunQuery.error) === 404
+  ) {
+    seenRedirect404.current = true;
+  }
+
+  if (taskRunQuery.isLoading && !seenRedirect404.current) {
     return <Spinner />;
   }
 
-  if (taskRunQuery.isError) {
-    const status = getErrorStatus(taskRunQuery.error);
+  if (
+    taskRunQuery.isError ||
+    (seenRedirect404.current && taskRunQuery.isLoading)
+  ) {
+    const status = taskRunQuery.isError
+      ? getErrorStatus(taskRunQuery.error)
+      : 404;
 
-    // Treat malformed IDs (often 400) and missing resources (404) as not found.
-    if (status === 400 || status === 404) {
+    if (status === 404 && wasRedirectedFromTrigger) {
+      return (
+        <ResourceNotFound
+          resource="Run"
+          description={
+            <span>
+              Your run was triggered successfully.{' '}
+              <strong>Do not re-trigger it.</strong> It may take a few seconds
+              to appear — this page will refresh automatically.
+            </span>
+          }
+          primaryAction={{
+            label: 'Try refreshing',
+            icon: RefreshCcw,
+            actionOverride: () => taskRunQuery.refetch(),
+          }}
+        />
+      );
+    } else if (status === 400 || status === 404) {
       return (
         <ResourceNotFound
           resource="Run"
@@ -208,7 +245,9 @@ export default function Run() {
       );
     }
 
-    throw taskRunQuery.error;
+    if (taskRunQuery.isError) {
+      throw taskRunQuery.error;
+    }
   }
 
   const runData = taskRunQuery.data;

--- a/frontend/app/src/pages/main/v1/workflows/$workflow/components/trigger-workflow-form.tsx
+++ b/frontend/app/src/pages/main/v1/workflows/$workflow/components/trigger-workflow-form.tsx
@@ -179,7 +179,7 @@ export function TriggerWorkflowForm({
       navigate({
         to: appRoutes.tenantRunRoute.to,
         params: { tenant: tenantId, run: workflowRun.run.metadata.id },
-        search: (prev) => ({ ...prev, redirectedFromTrigger: true }),
+        search: (prev) => ({ ...prev, wasRedirectedFromTrigger: 'true' }),
       });
     },
     onError: handleApiError,

--- a/frontend/app/src/pages/main/v1/workflows/$workflow/components/trigger-workflow-form.tsx
+++ b/frontend/app/src/pages/main/v1/workflows/$workflow/components/trigger-workflow-form.tsx
@@ -179,6 +179,7 @@ export function TriggerWorkflowForm({
       navigate({
         to: appRoutes.tenantRunRoute.to,
         params: { tenant: tenantId, run: workflowRun.run.metadata.id },
+        search: (prev) => ({ ...prev, redirectedFromTrigger: true }),
       });
     },
     onError: handleApiError,

--- a/frontend/app/src/router.tsx
+++ b/frontend/app/src/router.tsx
@@ -613,7 +613,7 @@ const tenantRunsRoute = createRoute({
 });
 
 const runSearchSchema = z.object({
-  wasRedirectedFromTrigger: z.boolean().optional(),
+  wasRedirectedFromTrigger: z.enum(['true', 'false']).optional(), // hack to preserve typing elsewhere
 });
 
 export const tenantRunRoute = createRoute({

--- a/frontend/app/src/router.tsx
+++ b/frontend/app/src/router.tsx
@@ -22,6 +22,7 @@ import {
 import { Outlet } from '@tanstack/react-router';
 import { FC } from 'react';
 import { validate } from 'uuid';
+import { z } from 'zod';
 
 const rootRoute = createRootRoute({
   component: Root,
@@ -611,13 +612,18 @@ const tenantRunsRoute = createRoute({
   ),
 });
 
-const tenantRunRoute = createRoute({
+const runSearchSchema = z.object({
+  wasRedirectedFromTrigger: z.boolean().optional(),
+});
+
+export const tenantRunRoute = createRoute({
   getParentRoute: () => tenantRoute,
   path: 'runs/$run',
   component: lazyRouteComponent(
     () => import('./pages/main/v1/workflow-runs-v1/$run'),
     'default',
   ),
+  validateSearch: runSearchSchema,
 });
 
 const tenantTaskRunsRoute = createRoute({


### PR DESCRIPTION
# Description

Adds some copy to the run detail page when you get redirected there after triggering a run from the dashboard and getting a 404, saying to just wait a bit

<img width="701" height="565" alt="Screenshot 2026-07-14 at 2 05 31 PM" src="https://github.com/user-attachments/assets/baafa043-21a1-439c-af34-bc3aa5462b4d" />

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI use

</details>
