### PR TITLE
fix: update trigger for runs status and update schema for consistency

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260714120000_v1_0_126.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260714120000_v1_0_126.sql
@@ -1,0 +1,57 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Rewrite v1_runs_olap_status_update_function from UPDATE ... FROM to an upsert.
+--
+-- We use INSERT INTO rather than UPDATE for ensuring this query is fast on TimescaleDB,
+-- which does not have effective runtime partition pruning on UPDATE and would involve scanning
+-- every partition in v1_statuses_olap.
+CREATE OR REPLACE FUNCTION v1_runs_olap_status_update_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    INSERT INTO v1_statuses_olap (
+        external_id,
+        inserted_at,
+        tenant_id,
+        workflow_id,
+        kind,
+        readable_status
+    )
+    SELECT
+        external_id,
+        inserted_at,
+        tenant_id,
+        workflow_id,
+        kind,
+        readable_status
+    FROM new_rows
+    ON CONFLICT (external_id, inserted_at) DO UPDATE
+    SET readable_status = EXCLUDED.readable_status
+    WHERE v1_statuses_olap.readable_status IS DISTINCT FROM EXCLUDED.readable_status;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION v1_runs_olap_status_update_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    UPDATE
+        v1_statuses_olap s
+    SET
+        readable_status = n.readable_status
+    FROM new_rows n
+    WHERE
+        s.external_id = n.external_id
+        AND s.inserted_at = n.inserted_at;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20260714120000_v1_0_126.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260714120000_v1_0_126.sql
@@ -17,7 +17,11 @@ BEGIN
         kind,
         readable_status
     )
-    SELECT
+    -- DISTINCT ON: nothing constraint-enforces (external_id, inserted_at)
+    -- uniqueness across new_rows, and ON CONFLICT DO UPDATE errors if a single
+    -- statement affects the same row twice. On duplicates, keep the
+    -- highest-priority status.
+    SELECT DISTINCT ON (external_id, inserted_at)
         external_id,
         inserted_at,
         tenant_id,
@@ -25,6 +29,7 @@ BEGIN
         kind,
         readable_status
     FROM new_rows
+    ORDER BY external_id, inserted_at, v1_status_to_priority(readable_status) DESC
     ON CONFLICT (external_id, inserted_at) DO UPDATE
     SET readable_status = EXCLUDED.readable_status
     WHERE v1_statuses_olap.readable_status IS DISTINCT FROM EXCLUDED.readable_status;

--- a/sql/schema/v1-olap.sql
+++ b/sql/schema/v1-olap.sql
@@ -865,7 +865,11 @@ BEGIN
         kind,
         readable_status
     )
-    SELECT
+    -- DISTINCT ON: nothing constraint-enforces (external_id, inserted_at)
+    -- uniqueness across new_rows, and ON CONFLICT DO UPDATE errors if a single
+    -- statement affects the same row twice. On duplicates, keep the
+    -- highest-priority status.
+    SELECT DISTINCT ON (external_id, inserted_at)
         external_id,
         inserted_at,
         tenant_id,
@@ -873,6 +877,7 @@ BEGIN
         kind,
         readable_status
     FROM new_rows
+    ORDER BY external_id, inserted_at, v1_status_to_priority(readable_status) DESC
     ON CONFLICT (external_id, inserted_at) DO UPDATE
     SET readable_status = EXCLUDED.readable_status
     WHERE v1_statuses_olap.readable_status IS DISTINCT FROM EXCLUDED.readable_status;

--- a/sql/schema/v1-olap.sql
+++ b/sql/schema/v1-olap.sql
@@ -251,7 +251,6 @@ CREATE INDEX v1_dags_olap_workflow_id_idx ON v1_dags_olap (tenant_id, workflow_i
 CREATE TYPE v1_run_kind AS ENUM ('TASK', 'DAG');
 
 -- v1_runs_olap represents an invocation of a workflow. it can either refer to a DAG or a task.
--- we partition this table on status to allow for efficient querying of tasks in different states.
 CREATE TABLE v1_runs_olap (
     tenant_id UUID NOT NULL,
     id BIGINT NOT NULL,
@@ -264,7 +263,7 @@ CREATE TABLE v1_runs_olap (
     additional_metadata JSONB,
     parent_task_external_id UUID,
 
-    PRIMARY KEY (inserted_at, id, readable_status, kind)
+    PRIMARY KEY (inserted_at, id)
 ) PARTITION BY RANGE(inserted_at);
 
 CREATE INDEX ix_v1_runs_olap_parent_task_external_id ON v1_runs_olap (parent_task_external_id) WHERE parent_task_external_id IS NOT NULL;
@@ -851,18 +850,32 @@ REFERENCING NEW TABLE AS new_rows
 FOR EACH STATEMENT
 EXECUTE FUNCTION v1_runs_olap_insert_function();
 
+-- We use INSERT INTO rather than UPDATE for ensuring this query is fast on TimescaleDB,
+-- which does not have effective runtime partition pruning on UPDATE and would involve scanning
+-- every partition in v1_statuses_olap.
 CREATE OR REPLACE FUNCTION v1_runs_olap_status_update_function()
 RETURNS TRIGGER AS
 $$
 BEGIN
-    UPDATE
-        v1_statuses_olap s
-    SET
-        readable_status = n.readable_status
-    FROM new_rows n
-    WHERE
-        s.external_id = n.external_id
-        AND s.inserted_at = n.inserted_at;
+    INSERT INTO v1_statuses_olap (
+        external_id,
+        inserted_at,
+        tenant_id,
+        workflow_id,
+        kind,
+        readable_status
+    )
+    SELECT
+        external_id,
+        inserted_at,
+        tenant_id,
+        workflow_id,
+        kind,
+        readable_status
+    FROM new_rows
+    ON CONFLICT (external_id, inserted_at) DO UPDATE
+    SET readable_status = EXCLUDED.readable_status
+    WHERE v1_statuses_olap.readable_status IS DISTINCT FROM EXCLUDED.readable_status;
 
     RETURN NULL;
 END;


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Updates the trigger on `v1_runs_status` so that it updates the corresponding `v1_statuses_olap` table using an `INSERT INTO...ON CONFLICT` instead of an `UPDATE`. 

Note the following p99 reduction in latency (milliseconds) on `UpdateTaskStatusesFromMQ` after this fix was applied:

<img width="1470" height="508" alt="image" src="https://github.com/user-attachments/assets/635af7f6-cc02-4b26-9f0c-cb2195220a67" />

This particular database runs TimescaleDB and `v1_statuses_olap` is a hypertable. When running query plans simulating this trigger, we saw that every chunk of the hypertable was being index scanned when calling the `UPDATE`. This seems internal to Timescale's partitioning implementation; we don't see the same thing on updates of our partitioned tables.  

This was ultimately the cause of extremely heavy `LWLock:BufferContent` (called `lwlock:buffer_content` in some systems) due to the index scan touching every partition across 30 days of retention. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Refactor (non-breaking changes to code which doesn't change any behaviour)

## What's Changed

- [X] Updates the `v1_runs_olap_status_update_function` to use `INSERT INTO...ON CONFLICT` instead of `UPDATE` 

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Tested (unit, integration, or manually with steps specified)
- [X] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [X] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude Fable for implementation

</details>
