### PR TITLE
fix: memory leak in Python SDK worker logging

### DIFF
--- a/sdks/python/hatchet_sdk/worker/runner/utils/capture_logs.py
+++ b/sdks/python/hatchet_sdk/worker/runner/utils/capture_logs.py
@@ -4,7 +4,6 @@ import queue
 import threading
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from io import StringIO
 from typing import Any, Literal, ParamSpec, TypeVar
 
 from pydantic import BaseModel, Field
@@ -161,15 +160,13 @@ class AsyncLogSender:
         self._thread = None
 
 
-class LogForwardingHandler(logging.StreamHandler):  # type: ignore[type-arg]
-    def __init__(self, log_sender: AsyncLogSender, stream: StringIO):
-        super().__init__(stream)
+class LogForwardingHandler(logging.Handler): # type: ignore[type-arg]
+    def __init__(self, log_sender: AsyncLogSender):
+        super().__init__()
 
         self.log_sender = log_sender
 
     def emit(self, record: logging.LogRecord) -> None:
-        super().emit(record)
-
         log_entry = self.format(record)
         step_run_id = ctx_step_run_id.get()
         task_retry_count = ctx_task_retry_count.get()
@@ -192,8 +189,7 @@ def capture_logs(
 ) -> Callable[P, Awaitable[T]]:
     @functools.wraps(func)
     async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
-        log_stream = StringIO()
-        log_forwarder = LogForwardingHandler(log_sender, log_stream)
+        log_forwarder = LogForwardingHandler(log_sender)
         log_forwarder.setLevel(logger.level)
 
         if logger.handlers:
@@ -214,7 +210,6 @@ def capture_logs(
         finally:
             log_forwarder.flush()
             logger.removeHandler(log_forwarder)
-            log_stream.close()
 
         return result
 

--- a/sdks/python/tests/unit/test_capture_logs.py
+++ b/sdks/python/tests/unit/test_capture_logs.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from io import StringIO
 from types import SimpleNamespace
 from typing import cast
 
@@ -29,7 +28,7 @@ async def test_log_forwarding_handler_enqueues_correct_record() -> None:
     previous_level = target_logger.level
     target_logger.setLevel(logging.INFO)
 
-    handler = LogForwardingHandler(log_sender, StringIO())
+    handler = LogForwardingHandler(log_sender)
     target_logger.addHandler(handler)
 
     step_token = ctx_step_run_id.set("step-run-id")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### Root Cause

During worker startup, a `LogForwardingHandler` is added to the logging system.  
Initially, this handler extended `logging.StreamHandler`, which requires a stream object. However, it was initialized with `StringIO`, but this `StringIO` do nothing. StringIO was only present as a placeholder to instantiate StreamHandler and was never actually used.

The `StringIO` buffer is only closed when the worker shuts down. Under normal conditions, the worker runs indefinitely, while `StringIO.emit()` continuously appends data. This results in unbounded memory growth, effectively causing a memory leak.

### Fix

This PR replaces `logging.StreamHandler` with a direct subclass of `logging.Handler`.  
Since the handler only uses `format()` and never performs actual stream output, the `StringIO` dependency is entirely unnecessary and has been removed.


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
