### PR TITLE
fix: avoid nested RabbitMQ pub channel acquire on tenant register

### DIFF
--- a/internal/msgqueue/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/rabbitmq/rabbitmq.go
@@ -469,13 +469,8 @@ func (t *MessageQueueImpl) pubMessage(ctx context.Context, q msgqueue.Queue, msg
 
 	pubSpan.End()
 
-	// if this is a tenant msg, publish to the tenant exchange
 	if (!t.disableTenantExchangePubs || msg.ID == "task-stream-event") && msg.TenantID != uuid.Nil {
-		// determine if the tenant exchange exists
 		if _, ok := t.tenantIdCache.Get(msg.TenantID); !ok {
-			// Reuse the already-held publish channel. Calling RegisterTenant here would
-			// Acquire a second pub channel while this one is still checked out and can
-			// exhaust the pool under concurrent publish load (e.g. top-of-hour crons).
 			err = t.declareTenantExchange(ctx, pub, msg.TenantID)
 
 			if err != nil {

--- a/internal/msgqueue/rabbitmq/rabbitmq.go
+++ b/internal/msgqueue/rabbitmq/rabbitmq.go
@@ -473,8 +473,10 @@ func (t *MessageQueueImpl) pubMessage(ctx context.Context, q msgqueue.Queue, msg
 	if (!t.disableTenantExchangePubs || msg.ID == "task-stream-event") && msg.TenantID != uuid.Nil {
 		// determine if the tenant exchange exists
 		if _, ok := t.tenantIdCache.Get(msg.TenantID); !ok {
-			// register the tenant exchange
-			err = t.RegisterTenant(ctx, msg.TenantID)
+			// Reuse the already-held publish channel. Calling RegisterTenant here would
+			// Acquire a second pub channel while this one is still checked out and can
+			// exhaust the pool under concurrent publish load (e.g. top-of-hour crons).
+			err = t.declareTenantExchange(ctx, pub, msg.TenantID)
 
 			if err != nil {
 				t.l.Error().Ctx(ctx).Str("tenant_id", msg.TenantID.String()).Msgf("error registering tenant exchange: %v", err)
@@ -554,7 +556,6 @@ func (t *MessageQueueImpl) Subscribe(
 }
 
 func (t *MessageQueueImpl) RegisterTenant(ctx context.Context, tenantId uuid.UUID) error {
-	// create a new fanout exchange for the tenant
 	poolCh, err := t.pubChannels.Acquire(ctx)
 
 	if err != nil {
@@ -562,20 +563,26 @@ func (t *MessageQueueImpl) RegisterTenant(ctx context.Context, tenantId uuid.UUI
 		return err
 	}
 
-	sub := poolCh.Value()
+	ch := poolCh.Value()
 
-	if sub.IsClosed() {
+	if ch.IsClosed() {
 		poolCh.Destroy()
 		return fmt.Errorf("channel is closed")
 	}
 
 	defer poolCh.Release()
 
+	return t.declareTenantExchange(ctx, ch, tenantId)
+}
+
+// declareTenantExchange creates the tenant fanout exchange on an already-held channel
+// and records the tenant in the local cache. Callers that already hold a pub channel
+// (e.g. pubMessage) must use this instead of RegisterTenant to avoid a nested Acquire.
+func (t *MessageQueueImpl) declareTenantExchange(ctx context.Context, ch *amqp.Channel, tenantId uuid.UUID) error {
 	t.l.Debug().Ctx(ctx).Str("tenant_id", tenantId.String()).Msgf("registering tenant exchange: %s", tenantId)
 
-	// create a fanout exchange for the tenant. each consumer of the fanout exchange will get notified
-	// with the tenant events.
-	err = sub.ExchangeDeclare(
+	// each consumer of the fanout exchange will get notified with the tenant events
+	err := ch.ExchangeDeclare(
 		msgqueue.GetTenantExchangeName(tenantId),
 		"fanout",
 		true,  // durable


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Avoid nested RabbitMQ pub-channel acquires when registering a tenant exchange during publish. Under concurrent load (e.g. top-of-hour crons), holding one pooled channel and then acquiring a second exhausted the pool and timed out, dropping cron triggers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Declare tenant exchange on the already-held publish channel in `pubMessage`
- [x] Extract `declareTenantExchange` for shared use by `RegisterTenant` and `pubMessage`

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

- `go build ./internal/msgqueue/rabbitmq/`
- golangci-lint via pre-commit
- After deploy: confirm top-of-hour controllers no longer spike on `[RegisterTenant] cannot acquire channel` / `could not run cron workflow`

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Investigating production cron misses via o11y, identifying nested channel acquire, implementing fix and PR

</details>