### PR TITLE
fix(api): use the `AND` operator with the gin index when there's only one k-v pair set

### DIFF
--- a/api/v1/server/handlers/v1/workflow-runs/list.go
+++ b/api/v1/server/handlers/v1/workflow-runs/list.go
@@ -133,19 +133,20 @@ func (t *V1WorkflowRunsService) WithDags(ctx context.Context, request gen.V1Work
 	}
 
 	opts := v1.ListWorkflowRunOpts{
-		CreatedAfter:               since,
-		Statuses:                   statuses,
-		WorkflowIds:                workflowIds,
-		Limit:                      limit,
-		Offset:                     offset,
-		IncludePayloads:            includePayloads,
-		UseGinIndex:                useGinIndex,
-		AdditionalMetadataOperator: additionalMetadataOperator(request.Params.AdditionalMetadataOperator),
+		CreatedAfter:    since,
+		Statuses:        statuses,
+		WorkflowIds:     workflowIds,
+		Limit:           limit,
+		Offset:          offset,
+		IncludePayloads: includePayloads,
+		UseGinIndex:     useGinIndex,
 	}
 
 	additionalMetadataFilters := make(map[string]interface{})
+	numAdditionalMetaFilters := 1
 
 	if request.Params.AdditionalMetadata != nil {
+		numAdditionalMetaFilters = len(*request.Params.AdditionalMetadata)
 		for _, v := range *request.Params.AdditionalMetadata {
 			kv_pairs := strings.SplitN(v, ":", 2)
 			if len(kv_pairs) == 2 {
@@ -155,6 +156,8 @@ func (t *V1WorkflowRunsService) WithDags(ctx context.Context, request gen.V1Work
 
 		opts.AdditionalMetadata = additionalMetadataFilters
 	}
+
+	opts.AdditionalMetadataOperator = additionalMetadataOperator(request.Params.AdditionalMetadataOperator, numAdditionalMetaFilters)
 
 	if request.Params.Until != nil {
 		opts.FinishedBefore = request.Params.Until
@@ -282,20 +285,21 @@ func (t *V1WorkflowRunsService) OnlyTasks(ctx context.Context, request gen.V1Wor
 	}
 
 	opts := v1.ListTaskRunOpts{
-		CreatedAfter:               since,
-		Statuses:                   statuses,
-		WorkflowIds:                workflowIds,
-		Limit:                      limit,
-		Offset:                     offset,
-		WorkerId:                   request.Params.WorkerId,
-		IncludePayloads:            includePayloads,
-		UseGinIndex:                useGinIndex,
-		AdditionalMetadataOperator: additionalMetadataOperator(request.Params.AdditionalMetadataOperator),
+		CreatedAfter:    since,
+		Statuses:        statuses,
+		WorkflowIds:     workflowIds,
+		Limit:           limit,
+		Offset:          offset,
+		WorkerId:        request.Params.WorkerId,
+		IncludePayloads: includePayloads,
+		UseGinIndex:     useGinIndex,
 	}
 
 	additionalMetadataFilters := make(map[string]interface{})
+	numAdditionalMetaFilters := 1
 
 	if request.Params.AdditionalMetadata != nil {
+		numAdditionalMetaFilters = len(*request.Params.AdditionalMetadata)
 		for _, v := range *request.Params.AdditionalMetadata {
 			kv_pairs := strings.SplitN(v, ":", 2)
 			if len(kv_pairs) == 2 {
@@ -305,6 +309,8 @@ func (t *V1WorkflowRunsService) OnlyTasks(ctx context.Context, request gen.V1Wor
 
 		opts.AdditionalMetadata = additionalMetadataFilters
 	}
+
+	opts.AdditionalMetadataOperator = additionalMetadataOperator(request.Params.AdditionalMetadataOperator, numAdditionalMetaFilters)
 
 	if request.Params.Until != nil {
 		opts.FinishedBefore = request.Params.Until
@@ -371,7 +377,8 @@ func (t *V1WorkflowRunsService) V1WorkflowRunList(ctx echo.Context, request gen.
 			return nil, err
 		}
 
-		useGinIndex = enabled
+		// if there's only one filter, we should always use the `AND` path with the index, since it's the most performant and all methods are equivalent in that case
+		useGinIndex = enabled || len(*request.Params.AdditionalMetadata) == 1
 	}
 
 	if request.Params.OnlyTasks {
@@ -383,7 +390,12 @@ func (t *V1WorkflowRunsService) V1WorkflowRunList(ctx echo.Context, request gen.
 
 // additionalMetadataOperator maps the optional additional_metadata_operator query
 // param to the repository operator, defaulting to OR
-func additionalMetadataOperator(param *gen.V1AdditionalMetadataOperator) v1.AdditionalMetadataOperator {
+func additionalMetadataOperator(param *gen.V1AdditionalMetadataOperator, numFilters int) v1.AdditionalMetadataOperator {
+	// if we only have one filter, always use the `AND` since it's the most performant way, and both methods are equivalent
+	if numFilters <= 1 {
+		return v1.AdditionalMetadataOperatorAnd
+	}
+
 	if param != nil && *param == gen.AND {
 		return v1.AdditionalMetadataOperatorAnd
 	}

--- a/api/v1/server/handlers/v1/workflow-runs/list.go
+++ b/api/v1/server/handlers/v1/workflow-runs/list.go
@@ -143,10 +143,8 @@ func (t *V1WorkflowRunsService) WithDags(ctx context.Context, request gen.V1Work
 	}
 
 	additionalMetadataFilters := make(map[string]interface{})
-	numAdditionalMetaFilters := 1
 
 	if request.Params.AdditionalMetadata != nil {
-		numAdditionalMetaFilters = len(*request.Params.AdditionalMetadata)
 		for _, v := range *request.Params.AdditionalMetadata {
 			kv_pairs := strings.SplitN(v, ":", 2)
 			if len(kv_pairs) == 2 {
@@ -157,7 +155,7 @@ func (t *V1WorkflowRunsService) WithDags(ctx context.Context, request gen.V1Work
 		opts.AdditionalMetadata = additionalMetadataFilters
 	}
 
-	opts.AdditionalMetadataOperator = additionalMetadataOperator(request.Params.AdditionalMetadataOperator, numAdditionalMetaFilters)
+	opts.AdditionalMetadataOperator = additionalMetadataOperator(request.Params.AdditionalMetadataOperator, len(opts.AdditionalMetadata))
 
 	if request.Params.Until != nil {
 		opts.FinishedBefore = request.Params.Until
@@ -296,10 +294,8 @@ func (t *V1WorkflowRunsService) OnlyTasks(ctx context.Context, request gen.V1Wor
 	}
 
 	additionalMetadataFilters := make(map[string]interface{})
-	numAdditionalMetaFilters := 1
 
 	if request.Params.AdditionalMetadata != nil {
-		numAdditionalMetaFilters = len(*request.Params.AdditionalMetadata)
 		for _, v := range *request.Params.AdditionalMetadata {
 			kv_pairs := strings.SplitN(v, ":", 2)
 			if len(kv_pairs) == 2 {
@@ -310,7 +306,7 @@ func (t *V1WorkflowRunsService) OnlyTasks(ctx context.Context, request gen.V1Wor
 		opts.AdditionalMetadata = additionalMetadataFilters
 	}
 
-	opts.AdditionalMetadataOperator = additionalMetadataOperator(request.Params.AdditionalMetadataOperator, numAdditionalMetaFilters)
+	opts.AdditionalMetadataOperator = additionalMetadataOperator(request.Params.AdditionalMetadataOperator, len(opts.AdditionalMetadata))
 
 	if request.Params.Until != nil {
 		opts.FinishedBefore = request.Params.Until


### PR DESCRIPTION
# Description

Improves the performance of the run list API(s) when only one k-v pair for the additional meta filter is provided by always using the `AND` query in that case, since it'll use the index and is the fastest option

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI use

</details>
