### PR TITLE
feat: change org member roles, tenant tag improvements

### DIFF
--- a/api/v1/server/authn/middleware.go
+++ b/api/v1/server/authn/middleware.go
@@ -252,7 +252,11 @@ func (a *AuthN) handleBearerAuth(c echo.Context) error {
 		// we permit exchange token auth if the token is valid and represents a user if the endpoint is not tenant-scoped, because
 		// this is effectively a PAT without the tenant scoping
 		if isTenantScoped && *tenantId != queriedTenant.ID {
-			a.l.Error().Msgf("tenant id in token does not match tenant id in context")
+			a.l.Error().
+				Str("tenant_id", tenantId.String()).
+				Str("queried_tenant_id", queriedTenant.ID.String()).
+				Str("user_id", userId.String()).
+				Msgf("tenant id in token does not match tenant id in context")
 
 			return forbidden
 		}

--- a/frontend/app/src/lib/api/generated/control-plane/Api.ts
+++ b/frontend/app/src/lib/api/generated/control-plane/Api.ts
@@ -40,6 +40,7 @@ import {
   OrganizationEntitlements,
   OrganizationForUserList,
   OrganizationInviteList,
+  OrganizationMember,
   OrganizationPaymentMethodList,
   OrganizationTenant,
   OrganizationTenantResourceLimitsList,
@@ -56,6 +57,7 @@ import {
   TenantInviteList,
   TenantMember,
   TenantMemberList,
+  UpdateOrganizationMemberRequest,
   UpdateOrganizationRequest,
   UpdateOrganizationSubscriptionRequest,
   UpdateOrganizationSubscriptionResponse,
@@ -586,6 +588,29 @@ export class Api<
       path: `/api/v1/control-plane/organization-tenants/${tenant}/api-tokens/${apiToken}`,
       method: "DELETE",
       secure: true,
+      ...params,
+    });
+  /**
+   * @description Update an organization member's role
+   *
+   * @tags Management
+   * @name OrganizationMemberUpdate
+   * @summary Update Organization Member Role
+   * @request PATCH:/api/v1/control-plane/organization-members/{organization-member}
+   * @secure
+   */
+  organizationMemberUpdate = (
+    organizationMember: string,
+    data: UpdateOrganizationMemberRequest,
+    params: RequestParams = {},
+  ) =>
+    this.request<OrganizationMember, APIError>({
+      path: `/api/v1/control-plane/organization-members/${organizationMember}`,
+      method: "PATCH",
+      body: data,
+      secure: true,
+      type: ContentType.Json,
+      format: "json",
       ...params,
     });
   /**

--- a/frontend/app/src/lib/api/generated/control-plane/data-contracts.ts
+++ b/frontend/app/src/lib/api/generated/control-plane/data-contracts.ts
@@ -237,6 +237,11 @@ export interface RemoveOrganizationMembersRequest {
   emails: string[];
 }
 
+export interface UpdateOrganizationMemberRequest {
+  /** The new role for the member in the organization */
+  role: OrganizationMemberRoleType;
+}
+
 export interface OrganizationTenant {
   /**
    * ID of the tenant

--- a/frontend/app/src/lib/api/organization-wrapper.ts
+++ b/frontend/app/src/lib/api/organization-wrapper.ts
@@ -4,6 +4,8 @@ import type { CreateNewTenantForOrganizationRequest as CloudCreateNewTenantForOr
 import type {
   CreateNewTenantForOrganizationRequest as ControlPlaneCreateNewTenantForOrganizationRequest,
   CreateOrganizationInviteRequest as ControlPlaneCreateOrganizationInviteRequest,
+  OrganizationMemberRoleType as ControlPlaneOrganizationMemberRoleType,
+  UpdateOrganizationMemberRequest as ControlPlaneUpdateOrganizationMemberRequest,
 } from '@/lib/api/generated/control-plane/data-contracts';
 import { useMemo } from 'react';
 
@@ -20,6 +22,13 @@ type OrganizationCreateTenantRequest =
 type OrganizationMemberDeleteRequest = Parameters<
   typeof cloudApi.organizationMemberDelete
 >[1];
+// Control-plane-only: the legacy cloud management API is deprecated and does
+// not support member role changes. The role is typed as the shared string
+// values so callers holding the cloud client's (nominally distinct) role enum
+// compile against it.
+type OrganizationMemberUpdateRequest = {
+  role: `${ControlPlaneOrganizationMemberRoleType}`;
+};
 type ManagementTokenCreateRequest = Parameters<
   typeof cloudApi.managementTokenCreate
 >[1];
@@ -216,6 +225,22 @@ export function useOrganizationApi() {
                   data,
                 )
               : cloudApi.organizationMemberDelete(organizationMember, data))
+          ).data,
+      }),
+
+      // Control-plane-only: the legacy cloud management API is deprecated and
+      // does not support member role changes.
+      organizationMemberUpdateMutation: (organizationMember: string) => ({
+        mutationKey: [
+          'organization-member:update',
+          organizationMember,
+        ] as const,
+        mutationFn: async (data: OrganizationMemberUpdateRequest) =>
+          (
+            await controlPlaneApi.organizationMemberUpdate(
+              organizationMember,
+              data as ControlPlaneUpdateOrganizationMemberRequest,
+            )
           ).data,
       }),
 

--- a/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/organization/index.tsx
@@ -74,6 +74,7 @@ import { CreateTokenModal } from '@/pages/organizations/$organization/components
 import { DeleteMemberModal } from '@/pages/organizations/$organization/components/delete-member-modal';
 import { DeleteTenantModal } from '@/pages/organizations/$organization/components/delete-tenant-modal';
 import { DeleteTokenModal } from '@/pages/organizations/$organization/components/delete-token-modal';
+import { EditMemberRoleModal } from '@/pages/organizations/$organization/components/edit-member-role-modal';
 import { EditTenantTagsModal } from '@/pages/organizations/$organization/components/edit-tenant-tags-modal';
 import { useUserUniverse } from '@/providers/user-universe';
 import { appRoutes } from '@/router';
@@ -266,6 +267,8 @@ export function CloudOrganizationSettings({
   const schemes = meta?.auth?.schemes || [];
   const canManageSso = isOrganizationOwner && schemes.includes('sso');
   const [memberToDelete, setMemberToDelete] =
+    useState<OrganizationMember | null>(null);
+  const [memberToEditRole, setMemberToEditRole] =
     useState<OrganizationMember | null>(null);
   const [tenantToEditTags, setTenantToEditTags] =
     useState<OrganizationTenantWithRegion | null>(null);
@@ -467,6 +470,10 @@ export function CloudOrganizationSettings({
       i.status === OrganizationInviteStatus.EXPIRED,
   );
 
+  const organizationOwnerCount = (organization?.members ?? []).filter(
+    (m) => m.role === 'OWNER',
+  ).length;
+
   const memberColumns = [
     {
       columnLabel: 'Email',
@@ -488,6 +495,11 @@ export function CloudOrganizationSettings({
                 organizationId={orgId}
                 currentUserEmail={currentUser?.email}
                 onDelete={setMemberToDelete}
+                // Role changes are control-plane-only; the legacy cloud
+                // management API is deprecated and has no update endpoint.
+                onChangeRole={
+                  isControlPlaneEnabled ? setMemberToEditRole : undefined
+                }
               />
             ),
           },
@@ -538,22 +550,26 @@ export function CloudOrganizationSettings({
       ? [
           {
             columnLabel: 'Actions',
-            cellRenderer: (row: OrganizationInviteWithTenants) =>
-              row.status === OrganizationInviteStatus.PENDING ? (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
-                      <EllipsisVerticalIcon className="size-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem onClick={() => setInviteToCancel(row)}>
-                      <TrashIcon className="mr-2 size-4" />
-                      Cancel Invitation
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              ) : null,
+            // Both pending and expired invites are listed, and both can be
+            // removed (the delete works regardless of status) — an expired
+            // invite left in the list otherwise has no way to be cleared.
+            cellRenderer: (row: OrganizationInviteWithTenants) => (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
+                    <EllipsisVerticalIcon className="size-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={() => setInviteToCancel(row)}>
+                    <TrashIcon className="mr-2 size-4" />
+                    {row.status === OrganizationInviteStatus.PENDING
+                      ? 'Cancel Invitation'
+                      : 'Remove'}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ),
           },
         ]
       : []),
@@ -1266,6 +1282,23 @@ export function CloudOrganizationSettings({
         />
       )}
 
+      {isOrganizationOwner && isControlPlaneEnabled && memberToEditRole && (
+        <EditMemberRoleModal
+          open={!!memberToEditRole}
+          onOpenChange={(open) => !open && setMemberToEditRole(null)}
+          member={memberToEditRole}
+          organizationName={organizationName}
+          isLastOwner={
+            memberToEditRole.role === 'OWNER' && organizationOwnerCount <= 1
+          }
+          onSuccess={() =>
+            queryClient.invalidateQueries({
+              queryKey: ['organization:get', orgId],
+            })
+          }
+        />
+      )}
+
       {isOrganizationOwner && (
         <CreateTokenModal
           open={showCreateTokenModal}
@@ -1684,11 +1717,13 @@ function MemberActions({
   organizationId,
   currentUserEmail,
   onDelete,
+  onChangeRole,
 }: {
   row: OrganizationMember;
   organizationId: string;
   currentUserEmail?: string;
   onDelete: (member: OrganizationMember) => void;
+  onChangeRole?: (member: OrganizationMember) => void;
 }) {
   const isSelf = currentUserEmail === row.email;
 
@@ -1711,6 +1746,12 @@ function MemberActions({
           <PlusIcon className="mr-2 size-4" />
           Add to tenant
         </DropdownMenuItem>
+        {onChangeRole && (
+          <DropdownMenuItem onClick={() => onChangeRole(row)}>
+            <PencilSquareIcon className="mr-2 size-4" />
+            Change role
+          </DropdownMenuItem>
+        )}
         {isSelf ? (
           <TooltipProvider>
             <Tooltip>

--- a/frontend/app/src/pages/main/v1/tenant-settings/overview/index.tsx
+++ b/frontend/app/src/pages/main/v1/tenant-settings/overview/index.tsx
@@ -5,13 +5,18 @@ import { TenantSwitcher } from '@/components/v1/molecules/nav-bar/tenant-switche
 import { Button } from '@/components/v1/ui/button';
 import { Spinner } from '@/components/v1/ui/loading';
 import { Switch } from '@/components/v1/ui/switch';
+import useControlPlane from '@/hooks/use-control-plane';
 import { useOrganizations } from '@/hooks/use-organizations';
 import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
 import api, { UpdateTenantRequest } from '@/lib/api';
+import { useOrganizationApi } from '@/lib/api/organization-wrapper';
 import { useApiError } from '@/lib/hooks';
 import { MembershipsContextType } from '@/lib/outlet';
 import { useOutletContext } from '@/lib/router-helpers';
-import { useMutation } from '@tanstack/react-query';
+import { type OrganizationTenantWithRegion } from '@/pages/main/v1/tenant-settings/organization';
+import { TagBadge } from '@/pages/main/v1/tenant-settings/organization/components/tag-badge';
+import { EditTenantTagsModal } from '@/pages/organizations/$organization/components/edit-tenant-tags-modal';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
 
 export default function TenantSettings() {
@@ -33,6 +38,7 @@ export default function TenantSettings() {
           </SettingRow>
           <TenantApiUrl />
           <TenantRegion />
+          <TenantTags />
           <SettingRow
             label="Analytics Opt-Out"
             description="Disable usage analytics collection for this tenant."
@@ -108,6 +114,97 @@ const TenantRegion: React.FC = () => {
       description="The control-plane region this tenant is deployed to."
     >
       <ReadOnlyValue value={tenant.region} />
+    </SettingRow>
+  );
+};
+
+// Tenant tags are a control-plane, org-owner concept (they drive which org
+// members can access the tenant). Org owners can edit them here — on the
+// tenant's own General tab — in addition to the org-wide Tenants list.
+const TenantTags: React.FC = () => {
+  const { tenant, organizationId } = useTenantDetails();
+  const { tenantId } = useCurrentTenantId();
+  const { isControlPlaneEnabled } = useControlPlane();
+  const { organizations } = useOrganizations();
+  const orgApi = useOrganizationApi();
+  const queryClient = useQueryClient();
+  const [isEditing, setIsEditing] = useState(false);
+
+  const isOrganizationOwner =
+    organizations.find((o) => o.metadata.id === organizationId)?.isOwner ??
+    false;
+  const canEditTags =
+    isControlPlaneEnabled && isOrganizationOwner && !!organizationId;
+
+  const organizationQuery = useQuery({
+    ...orgApi.organizationGetQuery(organizationId!),
+    enabled: canEditTags,
+  });
+  // Widen the tag picker with tags defined on user groups but not yet applied
+  // to any tenant — matches the org-side editor's suggestions.
+  const userGroupsQuery = useQuery({
+    ...orgApi.userGroupsListQuery(organizationId!),
+    enabled: canEditTags,
+  });
+
+  if (!canEditTags) {
+    return null;
+  }
+
+  // Cloud's OrganizationTenant type omits `tags`; the control-plane data has
+  // it. Same graft the org-wide Tenants list uses.
+  const tenants: OrganizationTenantWithRegion[] =
+    organizationQuery.data?.tenants ?? [];
+  const tags = tenants.find((t) => t.id === tenantId)?.tags ?? [];
+
+  const tagSet = new Set<string>();
+  for (const t of tenants) {
+    t.tags?.forEach((tag) => tagSet.add(tag));
+  }
+  for (const group of userGroupsQuery.data ?? []) {
+    group.tags?.forEach((tag) => tagSet.add(tag));
+  }
+  const allTenantTags = Array.from(tagSet).sort();
+
+  return (
+    <SettingRow
+      label="Tags"
+      description="Tags control which organization members can access this tenant."
+    >
+      <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-1">
+          {tags.length > 0 ? (
+            tags.map((tag) => <TagBadge key={tag} tag={tag} />)
+          ) : (
+            <span className="text-sm text-muted-foreground">No tags</span>
+          )}
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="shrink-0"
+          onClick={() => setIsEditing(true)}
+        >
+          Edit tags
+        </Button>
+      </div>
+
+      {isEditing && (
+        <EditTenantTagsModal
+          open={isEditing}
+          onOpenChange={(open) => !open && setIsEditing(false)}
+          organizationId={organizationId!}
+          tenantId={tenantId}
+          tenantName={tenant?.name || tenantId}
+          initialTags={tags}
+          allTenantTags={allTenantTags}
+          onSuccess={() =>
+            queryClient.invalidateQueries({
+              queryKey: ['organization:get', organizationId],
+            })
+          }
+        />
+      )}
     </SettingRow>
   );
 };

--- a/frontend/app/src/pages/organizations/$organization/components/edit-member-role-modal.tsx
+++ b/frontend/app/src/pages/organizations/$organization/components/edit-member-role-modal.tsx
@@ -1,0 +1,133 @@
+import { Button } from '@/components/v1/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/v1/ui/dialog';
+import { InlineError } from '@/components/v1/ui/inline-error';
+import { Input } from '@/components/v1/ui/input';
+import { Label } from '@/components/v1/ui/label';
+import { Spinner } from '@/components/v1/ui/loading';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/v1/ui/select';
+import {
+  OrganizationMember,
+  OrganizationMemberRoleType,
+} from '@/lib/api/generated/cloud/data-contracts';
+import { useOrganizationApi } from '@/lib/api/organization-wrapper';
+import { useApiError } from '@/lib/hooks';
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { useState } from 'react';
+
+interface EditMemberRoleModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  member: OrganizationMember;
+  organizationName: string;
+  /** When the member is the org's only owner, demotion is blocked client-side
+   * (the server enforces this too). */
+  isLastOwner: boolean;
+  onSuccess: () => void;
+}
+
+export function EditMemberRoleModal({
+  open,
+  onOpenChange,
+  member,
+  organizationName,
+  isLastOwner,
+  onSuccess,
+}: EditMemberRoleModalProps) {
+  const [role, setRole] = useState<OrganizationMemberRoleType>(member.role);
+  const [formErrors, setFormErrors] = useState<string[]>([]);
+  const { handleApiError } = useApiError({ setErrors: setFormErrors });
+  const orgApi = useOrganizationApi();
+
+  const memberUpdate = orgApi.organizationMemberUpdateMutation(
+    member.metadata.id,
+  );
+  const updateMutation = useMutation({
+    ...memberUpdate,
+    onSuccess: () => {
+      onSuccess();
+      onOpenChange(false);
+    },
+    // Keep the dialog open so the inline error is visible (a toast would
+    // render behind the overlay).
+    onError: (error: AxiosError) => handleApiError(error),
+  });
+
+  const handleSubmit = () => {
+    setFormErrors([]);
+    updateMutation.mutate({ role });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-fit min-w-[500px] max-w-[80%]">
+        <DialogHeader>
+          <DialogTitle>Change member role</DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-4">
+          <InlineError errors={formErrors} />
+          <p className="text-sm text-muted-foreground">
+            Change the role of this member in {organizationName}.
+          </p>
+          <div className="grid gap-2">
+            <Label htmlFor="member-email">Email</Label>
+            <Input
+              readOnly
+              id="member-email"
+              type="email"
+              value={member.email}
+              disabled={true}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="member-role">Role</Label>
+            <Select
+              value={role}
+              onValueChange={(value) =>
+                setRole(value as OrganizationMemberRoleType)
+              }
+            >
+              <SelectTrigger className="w-[180px]">
+                <SelectValue id="member-role" placeholder="Role..." />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={OrganizationMemberRoleType.OWNER}>
+                  Owner
+                </SelectItem>
+                <SelectItem
+                  value={OrganizationMemberRoleType.MEMBER}
+                  disabled={isLastOwner}
+                >
+                  Member
+                </SelectItem>
+              </SelectContent>
+            </Select>
+            {isLastOwner && (
+              <p className="text-xs text-muted-foreground">
+                An organization must have at least one owner.
+              </p>
+            )}
+          </div>
+          <Button
+            onClick={handleSubmit}
+            disabled={updateMutation.isPending || role === member.role}
+          >
+            {updateMutation.isPending && <Spinner />}
+            Update member
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Two improvements to the settings pages:
1. Allows organization member roles to be modified by owners
2. Places tenant tags in the tenant's settings page so it's easier to discover how to edit them.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## What's Changed

Org member modal:

<img width="1728" height="951" alt="image" src="https://github.com/user-attachments/assets/2789f3a6-3f0a-41f8-a134-acb267bd014a" />

Tags:

<img width="1728" height="953" alt="image" src="https://github.com/user-attachments/assets/9a871bbd-a4d9-4043-9c75-30ec731d0d1e" />

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Tested (unit, integration, or manually with steps specified) - manually
- [X] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [X] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude Fable

</details>
