### PR TITLE
fix: cancel in progress has incorrect ordering with new in-memory index

### DIFF
--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -64,6 +64,7 @@ jobs:
       matrix:
         python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.14"]') || fromJSON('["3.10", "3.11", "3.12", "3.13", "3.14"]') }}
         optimistic-scheduling: ["true", "false"]
+        concurrency-in-memory-index: ["true", "false"]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -105,6 +106,7 @@ jobs:
           export SERVER_DEFAULT_ENGINE_VERSION=V1
           export SERVER_MSGQUEUE_RABBITMQ_URL="amqp://user:password@localhost:5672/"
           export SERVER_OPTIMISTIC_SCHEDULING_ENABLED=${{ matrix.optimistic-scheduling }}
+          export SERVER_CONCURRENCY_IN_MEMORY_INDEX_ENABLED=${{ matrix.concurrency-in-memory-index }}
           export SERVER_OBSERVABILITY_ENABLED=true
 
           go run ./cmd/hatchet-admin quickstart
@@ -161,14 +163,14 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.HATCHET_CLIENT_NAMESPACE }}-opt-${{ matrix.optimistic-scheduling }}-engine-logs
+          name: ${{ env.HATCHET_CLIENT_NAMESPACE }}-opt-${{ matrix.optimistic-scheduling }}-cimi-${{ matrix.concurrency-in-memory-index }}-engine-logs
           path: engine.log
 
       - name: Upload API logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.HATCHET_CLIENT_NAMESPACE }}-opt-${{ matrix.optimistic-scheduling }}-api-logs
+          name: ${{ env.HATCHET_CLIENT_NAMESPACE }}-opt-${{ matrix.optimistic-scheduling }}-cimi-${{ matrix.concurrency-in-memory-index }}-api-logs
           path: api.log
 
   publish:

--- a/examples/python/concurrency_cancel_in_progress_task_level/worker.py
+++ b/examples/python/concurrency_cancel_in_progress_task_level/worker.py
@@ -1,0 +1,56 @@
+import asyncio
+
+from pydantic import BaseModel
+
+from hatchet_sdk import (
+    ConcurrencyExpression,
+    ConcurrencyLimitStrategy,
+    Context,
+    Hatchet,
+)
+
+hatchet = Hatchet()
+
+
+class WorkflowInput(BaseModel):
+    group: str
+
+
+# The concurrency is declared on the TASK (step-level), not on the workflow. Step-level concurrency
+# is the only path served by the in-memory concurrency index, so this exercises that code path
+# rather than the legacy workflow-level DB path.
+concurrency_cancel_in_progress_task_level_workflow = hatchet.workflow(
+    name="ConcurrencyCancelInProgressTaskLevel",
+    input_validator=WorkflowInput,
+)
+
+
+# > Task-Level Cancel In Progress
+@concurrency_cancel_in_progress_task_level_workflow.task(
+    concurrency=[
+        ConcurrencyExpression(
+            expression="input.group",
+            max_runs=1,
+            limit_strategy=ConcurrencyLimitStrategy.CANCEL_IN_PROGRESS,
+        )
+    ],
+)
+async def task(input: WorkflowInput, ctx: Context) -> None:
+    # sleep long enough that a newer run arrives while this one is still running, so
+    # CANCEL_IN_PROGRESS has an in-progress run to preempt.
+    for _ in range(50):
+        await asyncio.sleep(0.10)
+
+
+
+
+def main() -> None:
+    worker = hatchet.worker(
+        "concurrency-cancel-in-progress-task-level-worker",
+        workflows=[concurrency_cancel_in_progress_task_level_workflow],
+    )
+    worker.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/concurrency_cancel_in_progress_task_level/worker.py
+++ b/examples/python/concurrency_cancel_in_progress_task_level/worker.py
@@ -36,8 +36,6 @@ concurrency_cancel_in_progress_task_level_workflow = hatchet.workflow(
     ],
 )
 async def task(input: WorkflowInput, ctx: Context) -> None:
-    # sleep long enough that a newer run arrives while this one is still running, so
-    # CANCEL_IN_PROGRESS has an in-progress run to preempt.
     for _ in range(50):
         await asyncio.sleep(0.10)
 

--- a/examples/python/concurrency_cancel_newest_task_level/worker.py
+++ b/examples/python/concurrency_cancel_newest_task_level/worker.py
@@ -1,0 +1,56 @@
+import asyncio
+
+from pydantic import BaseModel
+
+from hatchet_sdk import (
+    ConcurrencyExpression,
+    ConcurrencyLimitStrategy,
+    Context,
+    Hatchet,
+)
+
+hatchet = Hatchet()
+
+
+class WorkflowInput(BaseModel):
+    group: str
+
+
+# The concurrency is declared on the TASK (step-level), not on the workflow. Step-level concurrency
+# is the only path served by the in-memory concurrency index, so this exercises that code path
+# rather than the legacy workflow-level DB path.
+concurrency_cancel_newest_task_level_workflow = hatchet.workflow(
+    name="ConcurrencyCancelNewestTaskLevel",
+    input_validator=WorkflowInput,
+)
+
+
+# > Task-Level Cancel Newest
+@concurrency_cancel_newest_task_level_workflow.task(
+    concurrency=[
+        ConcurrencyExpression(
+            expression="input.group",
+            max_runs=1,
+            limit_strategy=ConcurrencyLimitStrategy.CANCEL_NEWEST,
+        )
+    ],
+)
+async def task(input: WorkflowInput, ctx: Context) -> None:
+    # sleep long enough that newer runs pile up while this one runs; CANCEL_NEWEST rejects them
+    # instead of preempting the running (oldest) run.
+    for _ in range(50):
+        await asyncio.sleep(0.10)
+
+
+
+
+def main() -> None:
+    worker = hatchet.worker(
+        "concurrency-cancel-newest-task-level-worker",
+        workflows=[concurrency_cancel_newest_task_level_workflow],
+    )
+    worker.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/worker.py
+++ b/examples/python/worker.py
@@ -12,7 +12,13 @@ from examples.cancellation.worker import cancellation_workflow
 from examples.concurrency_cancel_in_progress.worker import (
     concurrency_cancel_in_progress_workflow,
 )
+from examples.concurrency_cancel_in_progress_task_level.worker import (
+    concurrency_cancel_in_progress_task_level_workflow,
+)
 from examples.concurrency_cancel_newest.worker import concurrency_cancel_newest_workflow
+from examples.concurrency_cancel_newest_task_level.worker import (
+    concurrency_cancel_newest_task_level_workflow,
+)
 from examples.concurrency_limit.worker import concurrency_limit_workflow
 from examples.concurrency_limit_rr.worker import concurrency_limit_rr_workflow
 from examples.concurrency_multiple_keys.worker import concurrency_multiple_keys_workflow
@@ -144,6 +150,8 @@ def main() -> None:
             concurrency_workflow_level_workflow,
             concurrency_cancel_newest_workflow,
             concurrency_cancel_in_progress_workflow,
+            concurrency_cancel_newest_task_level_workflow,
+            concurrency_cancel_in_progress_task_level_workflow,
             di_workflow,
             payload_initial_cancel_bug_workflow,
             run_detail_test_workflow,

--- a/internal/services/scheduler/v1/scheduler.go
+++ b/internal/services/scheduler/v1/scheduler.go
@@ -723,6 +723,12 @@ func (s *Scheduler) notifyAfterConcurrency(ctx context.Context, tenantId uuid.UU
 
 	s.pool.NotifyQueues(ctx, tenantId, queues)
 
+	// The in-memory concurrency flush releases the task runtime in-transaction, so the
+	// MsgIDTaskCancelled handler below (handleTaskCancelled -> CancelTasks) can no longer resolve the
+	// worker for a task that was running when it got cancelled. Signal those workers' dispatchers
+	// directly using the worker id captured during the flush, mirroring sendTaskCancellationsToDispatcher.
+	s.signalWorkersToCancelInProgress(ctx, tenantId, res.Cancelled)
+
 	// handle cancellations
 	for _, cancelled := range res.Cancelled {
 		eventType := sqlcv1.V1EventTypeOlapCANCELLED
@@ -762,6 +768,74 @@ func (s *Scheduler) notifyAfterConcurrency(ctx context.Context, tenantId uuid.UU
 		if err != nil {
 			s.l.Error().Ctx(ctx).Err(err).Msg("could not send cancelled task")
 			continue
+		}
+	}
+}
+
+// signalWorkersToCancelInProgress tells the relevant dispatchers to cancel tasks that were running on
+// a worker when a concurrency strategy cancelled them. The in-memory concurrency flush releases the
+// task runtime in its transaction, so the MsgIDTaskCancelled handler (handleTaskCancelled) can't map
+// these tasks back to a worker; we do it here from the worker id captured during the flush. Tasks that
+// were only queued (no runtime) carry a nil worker id and are skipped - their cancellation still flows
+// through the MsgIDTaskCancelled handler. This mirrors sendTaskCancellationsToDispatcher in the tasks
+// controller.
+func (s *Scheduler) signalWorkersToCancelInProgress(ctx context.Context, tenantId uuid.UUID, cancelled []repov1.TaskWithCancelledReason) {
+	signals := make([]tasktypes.SignalTaskCancelledPayload, 0, len(cancelled))
+	workerIds := make([]uuid.UUID, 0, len(cancelled))
+
+	for _, c := range cancelled {
+		if c.WorkerId == uuid.Nil {
+			continue
+		}
+
+		signals = append(signals, tasktypes.SignalTaskCancelledPayload{
+			TaskId:     c.Id,
+			InsertedAt: c.InsertedAt,
+			RetryCount: c.RetryCount,
+			WorkerId:   c.WorkerId,
+		})
+		workerIds = append(workerIds, c.WorkerId)
+	}
+
+	if len(signals) == 0 {
+		return
+	}
+
+	workerIdToDispatcherId, _, err := s.repov1.Workers().GetDispatcherIdsForWorkers(ctx, tenantId, workerIds)
+
+	if err != nil {
+		s.l.Error().Ctx(ctx).Err(err).Msg("could not list dispatcher ids for cancelled in-progress tasks")
+		return
+	}
+
+	dispatcherIdsToPayloads := make(map[uuid.UUID][]tasktypes.SignalTaskCancelledPayload)
+
+	for _, sig := range signals {
+		dispatcherId, ok := workerIdToDispatcherId[sig.WorkerId]
+
+		if !ok {
+			continue
+		}
+
+		dispatcherIdsToPayloads[dispatcherId] = append(dispatcherIdsToPayloads[dispatcherId], sig)
+	}
+
+	for dispatcherId, payloads := range dispatcherIdsToPayloads {
+		msg, err := msgqueue.NewTenantMessage(
+			tenantId,
+			msgqueue.MsgIDTaskCancelled,
+			false,
+			true,
+			payloads...,
+		)
+
+		if err != nil {
+			s.l.Error().Ctx(ctx).Err(err).Msg("could not create task cancellation signal for dispatcher")
+			continue
+		}
+
+		if err := s.mq.SendMessage(ctx, msgqueue.QueueTypeFromDispatcherID(dispatcherId), msg); err != nil {
+			s.l.Error().Ctx(ctx).Err(err).Msg("could not send task cancellation signal to dispatcher")
 		}
 	}
 }

--- a/pkg/repository/scheduler_concurrency.go
+++ b/pkg/repository/scheduler_concurrency.go
@@ -36,6 +36,12 @@ type TaskWithCancelledReason struct {
 	TaskExternalId uuid.UUID
 
 	WorkflowRunId uuid.UUID
+
+	// WorkerId is the worker running the task at the moment it was cancelled, or uuid.Nil if the task
+	// was not running (queued). It's captured here because the concurrency flush releases the task
+	// runtime in-transaction, so the downstream MsgIDTaskCancelled handler can no longer resolve the
+	// worker; the scheduler uses it to signal the dispatcher directly for in-progress cancellations.
+	WorkerId uuid.UUID
 }
 
 // CancelledSlotInput identifies a concurrency slot to cancel along with the reason it's being
@@ -992,6 +998,10 @@ func (c *ConcurrencyRepositoryImpl) UpdateConcurrencySlotsTx(
 			CancelledReason: reason,
 			TaskExternalId:  released.ExternalID,
 			WorkflowRunId:   released.WorkflowRunID,
+			// releaseTasks deleted v1_task_runtime here, so the downstream MsgIDTaskCancelled handler
+			// can no longer resolve the worker for an in-progress cancellation. Capture the worker id
+			// now so the scheduler can signal the dispatcher directly (see notifyAfterConcurrency).
+			WorkerId: released.WorkerID,
 		})
 	}
 

--- a/pkg/scheduling/v1/concurrency/cancel_in_progress_test.go
+++ b/pkg/scheduling/v1/concurrency/cancel_in_progress_test.go
@@ -89,6 +89,82 @@ func TestCancelInProgress_RanksByPriority(t *testing.T) {
 	}
 }
 
+// Among equal-priority slots, CANCEL_IN_PROGRESS keeps the NEWEST maxRuns and cancels the oldest
+// (matching the legacy runCancelInProgress ORDER BY sort_id DESC). This is the case that actually
+// exercises the recency tiebreak - if it were inverted we would keep the oldest instead.
+func TestCancelInProgress_KeepsNewestAmongEqualPriority(t *testing.T) {
+	now := time.Now().UTC()
+	future := now.Add(time.Hour)
+
+	repo := &mockConcurrencyRepo{}
+	c := newCancelInProgressStrategy(repo, 2)
+
+	// same priority, same inserted_at; recency is distinguished by taskId (higher = newer).
+	msgs := []walMessage{
+		walInsert("a", 10, 5, now, future), // oldest
+		walInsert("a", 11, 5, now, future),
+		walInsert("a", 12, 5, now, future), // newest
+	}
+
+	if _, err := c.processWALMessages(context.Background(), nil, msgs); err != nil {
+		t.Fatalf("processWALMessages: %v", err)
+	}
+
+	// newest two (12, 11) run; oldest (10) cancelled
+	filled := filledIDs(repo.lastFilled)
+	if len(filled) != 2 || !containsID(filled, 12) || !containsID(filled, 11) {
+		t.Fatalf("filled = %v, want {11,12} (newest maxRuns)", filled)
+	}
+	cancelled := cancelledByReason(repo.lastCancelled, repository.CancelledReasonConcurrencyLimit)
+	if len(cancelled) != 1 || !containsID(cancelled, 10) {
+		t.Fatalf("cancelled = %v, want [10] (oldest)", cancelled)
+	}
+}
+
+// At capacity with equal priorities, a newer arrival preempts the OLDEST running task (in-progress
+// cancellation) - the defining CANCEL_IN_PROGRESS behaviour. Distinct from the priority-driven
+// preemption above; this pins the recency direction for running slots.
+func TestCancelInProgress_NewerArrivalPreemptsOldestRunning(t *testing.T) {
+	now := time.Now().UTC()
+	future := now.Add(time.Hour)
+
+	repo := &mockConcurrencyRepo{
+		indexRows: []*sqlcv1.ListConcurrencySlotsForIndexingRow{
+			indexRow("a", 1, 5, 0, now, future, true), // running, oldest
+			indexRow("a", 2, 5, 0, now, future, true), // running
+		},
+	}
+	c := newCancelInProgressStrategy(repo, 2)
+
+	if err := c.buildIndex(context.Background()); err != nil {
+		t.Fatalf("buildIndex: %v", err)
+	}
+
+	// a newer equal-priority slot arrives at a full group
+	msgs := []walMessage{walInsert("a", 3, 5, now, future)}
+
+	if _, err := c.processWALMessages(context.Background(), nil, msgs); err != nil {
+		t.Fatalf("processWALMessages: %v", err)
+	}
+
+	// newcomer (3) promoted; oldest runner (1) preempted
+	if got := filledIDs(repo.lastFilled); len(got) != 1 || got[0] != 3 {
+		t.Fatalf("filled = %v, want [3]", got)
+	}
+	cancelled := cancelledByReason(repo.lastCancelled, repository.CancelledReasonConcurrencyLimit)
+	if len(cancelled) != 1 || !containsID(cancelled, 1) {
+		t.Fatalf("cancelled = %v, want [1] (oldest running preempted)", cancelled)
+	}
+
+	sq := c.getOrCreateSubQueue("a")
+	if _, ok := sq.running.get(1); ok {
+		t.Fatalf("oldest task 1 should have been preempted")
+	}
+	if _, ok := sq.running.get(3); !ok {
+		t.Fatalf("newcomer 3 should be running")
+	}
+}
+
 // Queued slots past their scheduling timeout are cancelled as SCHEDULING_TIMED_OUT and excluded from
 // the run/cancel ranking, even if they would otherwise outrank the survivors.
 func TestCancelInProgress_TimedOutExcludedFromRanking(t *testing.T) {

--- a/pkg/scheduling/v1/concurrency/index.go
+++ b/pkg/scheduling/v1/concurrency/index.go
@@ -66,10 +66,11 @@ type inMemorySlotIndex struct {
 	byTaskID map[int64]slotLocation
 }
 
-// priorityCompare is the default slot ordering, shared by GROUP_ROUND_ROBIN and CANCEL_IN_PROGRESS:
-// higher priority first, then earlier taskInsertedAt, then lower taskId. It is a total order
-// (taskId is unique per slot), so it is tie-free. Cancel strategies that keep the opposite end (e.g.
-// CANCEL_NEWEST) pass reverseCompare(priorityCompare).
+// priorityCompare is the default slot ordering, shared by GROUP_ROUND_ROBIN and CANCEL_NEWEST:
+// higher priority first, then earlier taskInsertedAt, then lower taskId ("smaller" = should run).
+// Among equal-priority slots it keeps the OLDEST, which is what GROUP_ROUND_ROBIN (fill oldest
+// first) and CANCEL_NEWEST (keep oldest, cancel the newest) both want. It is a total order (taskId
+// is unique per slot), so it is tie-free.
 func priorityCompare(a, b slot) int {
 	if a.priority != b.priority {
 		return cmp.Compare(b.priority, a.priority)
@@ -78,6 +79,22 @@ func priorityCompare(a, b slot) int {
 		return cmp.Compare(a.taskInsertedAtNs, b.taskInsertedAtNs)
 	}
 	return cmp.Compare(a.taskId, b.taskId)
+}
+
+// cancelInProgressCompare is priorityCompare with the recency tiebreak reversed: higher priority
+// first, then LATER taskInsertedAt, then HIGHER taskId. Among equal-priority slots it keeps the
+// NEWEST, matching the legacy runCancelInProgress SQL (ORDER BY sort_id DESC) - CANCEL_IN_PROGRESS
+// keeps the most-recently-created runs and cancels older ones, including running tasks. Priority
+// stays primary (a higher-priority arrival still preempts), consistent with the in-memory
+// priority-aware design. It is a total order, so it is tie-free.
+func cancelInProgressCompare(a, b slot) int {
+	if a.priority != b.priority {
+		return cmp.Compare(b.priority, a.priority)
+	}
+	if a.taskInsertedAtNs != b.taskInsertedAtNs {
+		return cmp.Compare(b.taskInsertedAtNs, a.taskInsertedAtNs)
+	}
+	return cmp.Compare(b.taskId, a.taskId)
 }
 
 // reverseCompare flips a comparator's order while preserving ties, so an index built with it pops

--- a/pkg/scheduling/v1/concurrency/strategy.go
+++ b/pkg/scheduling/v1/concurrency/strategy.go
@@ -105,7 +105,7 @@ func NewConcurrencyStrategy(
 		strategy:  strategy,
 		repo:      repo,
 		l:         l,
-		compare:   priorityCompare,
+		compare:   comparatorForStrategy(strategy.Strategy),
 		outbox:    outbox,
 		topic:     getTopic(strategy),
 		built:     make(chan struct{}),
@@ -494,11 +494,22 @@ func (c *ConcurrencyStrategy) processWALMessages(ctx context.Context, tx pgx.Tx,
 // Timed-out queued slots are handled by the shared pipeline and are not passed here.
 type decideFn func(sq *subQueue) (toFill, toCancel []slot)
 
+// comparatorForStrategy selects the slot ordering for a strategy kind. GROUP_ROUND_ROBIN and
+// CANCEL_NEWEST keep the oldest among equal-priority slots (priorityCompare); CANCEL_IN_PROGRESS
+// keeps the newest (cancelInProgressCompare), so a newer arrival preempts an older run. "Smaller"
+// under the chosen comparator always means "should run".
+func comparatorForStrategy(kind sqlcv1.V1ConcurrencyStrategy) func(a, b slot) int {
+	if kind == sqlcv1.V1ConcurrencyStrategyCANCELINPROGRESS {
+		return cancelInProgressCompare
+	}
+	return priorityCompare
+}
+
 // decide selects the per-sub-queue decision function for this strategy's kind. All three fill free
-// capacity from the queued backlog in priorityCompare order; they differ in what happens to the
-// slots that don't fit: GROUP_ROUND_ROBIN leaves them queued, CANCEL_NEWEST cancels them (reject the
+// capacity from the queued backlog in comparator order; they differ in what happens to the slots
+// that don't fit: GROUP_ROUND_ROBIN leaves them queued, CANCEL_NEWEST cancels them (reject the
 // newest arrivals, never touch running work), and CANCEL_IN_PROGRESS cancels them too but may also
-// preempt a running slot when a higher-priority slot is waiting.
+// preempt a running slot when a higher-priority-or-newer slot is waiting.
 func (c *ConcurrencyStrategy) decide() decideFn {
 	switch c.strategy.Strategy {
 	case sqlcv1.V1ConcurrencyStrategyGROUPROUNDROBIN:

--- a/pkg/scheduling/v1/concurrency/strategy.go
+++ b/pkg/scheduling/v1/concurrency/strategy.go
@@ -147,7 +147,13 @@ func NewNoOpFlusher(
 				l.Error().Err(err).Msgf("failed to process messages for topic %s", topic)
 			}
 
-			time.Sleep(5 * time.Second)
+			// context-aware sleep so this goroutine exits promptly on shutdown rather than
+			// lingering in a fixed sleep (which otherwise trips goleak and delays teardown).
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(5 * time.Second):
+			}
 		}
 	}()
 }

--- a/pkg/scheduling/v1/concurrency/strategy_test.go
+++ b/pkg/scheduling/v1/concurrency/strategy_test.go
@@ -86,7 +86,7 @@ func newTestStrategyKind(repo repository.ConcurrencyRepository, maxConcurrency i
 		strategy:  &sqlcv1.V1StepConcurrency{MaxConcurrency: maxConcurrency, Strategy: kind},
 		repo:      repo,
 		l:         &l,
-		compare:   priorityCompare,
+		compare:   comparatorForStrategy(kind),
 		built:     make(chan struct{}),
 	}
 }

--- a/pkg/scheduling/v1/concurrency_integration_test.go
+++ b/pkg/scheduling/v1/concurrency_integration_test.go
@@ -245,9 +245,10 @@ func TestConcurrency_CancelInProgress(t *testing.T) {
 }
 
 // TestConcurrency_CancelInProgress_InMemory exercises the new outbox-backed in-memory index for
-// CANCEL_IN_PROGRESS: it keeps the best maxRuns slots under the comparator (priority, then
-// inserted_at, then taskId) running and cancels the rest with CONCURRENCY_LIMIT. With equal-priority
-// tasks this comes down to maxRuns running and the remainder cancelled.
+// CANCEL_IN_PROGRESS: it keeps the newest maxRuns slots (highest priority, then latest) running and
+// cancels the older ones with CONCURRENCY_LIMIT. With equal-priority tasks this comes down to the
+// newest maxRuns running and the older remainder cancelled. (Recency direction is pinned by the unit
+// tests in cancel_in_progress_test.go; this asserts the end-to-end counts.)
 func TestConcurrency_CancelInProgress_InMemory(t *testing.T) {
 	runWithDatabase(t, func(conf *database.Layer) error {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/sdks/python/examples/concurrency_cancel_in_progress_task_level/test_concurrency_cancel_in_progress_task_level.py
+++ b/sdks/python/examples/concurrency_cancel_in_progress_task_level/test_concurrency_cancel_in_progress_task_level.py
@@ -39,7 +39,9 @@ async def test_run(hatchet: Hatchet) -> None:
 
     runs = sorted(
         (
-            await hatchet.runs.aio_list(additional_metadata={"test_run_id": test_run_id})
+            await hatchet.runs.aio_list(
+                additional_metadata={"test_run_id": test_run_id}
+            )
         ).rows,
         key=lambda r: int((r.additional_metadata or {}).get("i", "0")),
     )

--- a/sdks/python/examples/concurrency_cancel_in_progress_task_level/test_concurrency_cancel_in_progress_task_level.py
+++ b/sdks/python/examples/concurrency_cancel_in_progress_task_level/test_concurrency_cancel_in_progress_task_level.py
@@ -38,7 +38,9 @@ async def test_run(hatchet: Hatchet) -> None:
     await asyncio.sleep(5)
 
     runs = sorted(
-        hatchet.runs.list(additional_metadata={"test_run_id": test_run_id}).rows,
+        (
+            await hatchet.runs.aio_list(additional_metadata={"test_run_id": test_run_id})
+        ).rows,
         key=lambda r: int((r.additional_metadata or {}).get("i", "0")),
     )
 

--- a/sdks/python/examples/concurrency_cancel_in_progress_task_level/test_concurrency_cancel_in_progress_task_level.py
+++ b/sdks/python/examples/concurrency_cancel_in_progress_task_level/test_concurrency_cancel_in_progress_task_level.py
@@ -1,0 +1,49 @@
+import asyncio
+from uuid import uuid4
+
+import pytest
+
+from examples.concurrency_cancel_in_progress_task_level.worker import (
+    WorkflowInput,
+    concurrency_cancel_in_progress_task_level_workflow,
+)
+from hatchet_sdk import Hatchet, V1TaskStatus, WorkflowRunRef
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_run(hatchet: Hatchet) -> None:
+    """Task-level (step-level) CANCEL_IN_PROGRESS must keep the NEWEST run and cancel the older
+    ones, including the currently-running one.
+    """
+    test_run_id = str(uuid4())
+    refs: list[WorkflowRunRef] = []
+
+    for i in range(10):
+        ref = await concurrency_cancel_in_progress_task_level_workflow.aio_run(
+            WorkflowInput(group="A"),
+            additional_metadata={"test_run_id": test_run_id, "i": str(i)},
+            wait_for_result=False,
+        )
+        refs.append(ref)
+        await asyncio.sleep(1)
+
+    for ref in refs:
+        print(f"Waiting for run {ref.workflow_run_id} to complete")
+        try:
+            await ref.aio_result()
+        except Exception:
+            continue
+
+    ## wait for the olap repo to catch up
+    await asyncio.sleep(5)
+
+    runs = sorted(
+        hatchet.runs.list(additional_metadata={"test_run_id": test_run_id}).rows,
+        key=lambda r: int((r.additional_metadata or {}).get("i", "0")),
+    )
+
+    assert len(runs) == 10
+    # the newest run (i == "9") wins and completes; every older run is cancelled.
+    assert (runs[-1].additional_metadata or {}).get("i") == "9"
+    assert runs[-1].status == V1TaskStatus.COMPLETED
+    assert all(r.status == V1TaskStatus.CANCELLED for r in runs[:-1])

--- a/sdks/python/examples/concurrency_cancel_in_progress_task_level/worker.py
+++ b/sdks/python/examples/concurrency_cancel_in_progress_task_level/worker.py
@@ -36,7 +36,7 @@ concurrency_cancel_in_progress_task_level_workflow = hatchet.workflow(
     ],
 )
 async def task(input: WorkflowInput, ctx: Context) -> None:
-    for _ in range(100):
+    for _ in range(50):
         await asyncio.sleep(0.10)
 
 

--- a/sdks/python/examples/concurrency_cancel_in_progress_task_level/worker.py
+++ b/sdks/python/examples/concurrency_cancel_in_progress_task_level/worker.py
@@ -1,0 +1,57 @@
+import asyncio
+
+from pydantic import BaseModel
+
+from hatchet_sdk import (
+    ConcurrencyExpression,
+    ConcurrencyLimitStrategy,
+    Context,
+    Hatchet,
+)
+
+hatchet = Hatchet()
+
+
+class WorkflowInput(BaseModel):
+    group: str
+
+
+# The concurrency is declared on the TASK (step-level), not on the workflow. Step-level concurrency
+# is the only path served by the in-memory concurrency index, so this exercises that code path
+# rather than the legacy workflow-level DB path.
+concurrency_cancel_in_progress_task_level_workflow = hatchet.workflow(
+    name="ConcurrencyCancelInProgressTaskLevel",
+    input_validator=WorkflowInput,
+)
+
+
+# > Task-Level Cancel In Progress
+@concurrency_cancel_in_progress_task_level_workflow.task(
+    concurrency=[
+        ConcurrencyExpression(
+            expression="input.group",
+            max_runs=1,
+            limit_strategy=ConcurrencyLimitStrategy.CANCEL_IN_PROGRESS,
+        )
+    ],
+)
+async def task(input: WorkflowInput, ctx: Context) -> None:
+    # sleep long enough that a newer run arrives while this one is still running, so
+    # CANCEL_IN_PROGRESS has an in-progress run to preempt.
+    for _ in range(50):
+        await asyncio.sleep(0.10)
+
+
+# !!
+
+
+def main() -> None:
+    worker = hatchet.worker(
+        "concurrency-cancel-in-progress-task-level-worker",
+        workflows=[concurrency_cancel_in_progress_task_level_workflow],
+    )
+    worker.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/sdks/python/examples/concurrency_cancel_in_progress_task_level/worker.py
+++ b/sdks/python/examples/concurrency_cancel_in_progress_task_level/worker.py
@@ -36,9 +36,7 @@ concurrency_cancel_in_progress_task_level_workflow = hatchet.workflow(
     ],
 )
 async def task(input: WorkflowInput, ctx: Context) -> None:
-    # sleep long enough that a newer run arrives while this one is still running, so
-    # CANCEL_IN_PROGRESS has an in-progress run to preempt.
-    for _ in range(50):
+    for _ in range(100):
         await asyncio.sleep(0.10)
 
 

--- a/sdks/python/examples/concurrency_cancel_newest_task_level/test_concurrency_cancel_newest_task_level.py
+++ b/sdks/python/examples/concurrency_cancel_newest_task_level/test_concurrency_cancel_newest_task_level.py
@@ -1,0 +1,64 @@
+import asyncio
+from uuid import uuid4
+
+import pytest
+
+from examples.concurrency_cancel_newest_task_level.worker import (
+    WorkflowInput,
+    concurrency_cancel_newest_task_level_workflow,
+)
+from hatchet_sdk import Hatchet, V1TaskStatus
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_run(hatchet: Hatchet) -> None:
+    """Task-level (step-level) CANCEL_NEWEST must keep the OLDEST run and cancel the newer ones,
+    never preempting the running run. This exercises the in-memory concurrency index (the only path
+    that serves step-level concurrency).
+
+    Together with the CANCEL_IN_PROGRESS task-level test this pins the two strategies as opposites:
+    CANCEL_IN_PROGRESS keeps the newest, CANCEL_NEWEST keeps the oldest.
+    """
+    test_run_id = str(uuid4())
+
+    # this run starts first and, as the oldest, must be the one that completes.
+    to_run = await concurrency_cancel_newest_task_level_workflow.aio_run(
+        WorkflowInput(group="A"),
+        additional_metadata={"test_run_id": test_run_id},
+        wait_for_result=False,
+    )
+    await asyncio.sleep(1)
+
+    # these arrive while the first run is in progress; CANCEL_NEWEST rejects them.
+    to_cancel = await concurrency_cancel_newest_task_level_workflow.aio_run_many(
+        [
+            concurrency_cancel_newest_task_level_workflow.create_bulk_run_item(
+                input=WorkflowInput(group="A"),
+                additional_metadata={"test_run_id": test_run_id},
+            )
+            for _ in range(10)
+        ],
+        wait_for_result=False,
+    )
+
+    await to_run.aio_result()
+
+    for ref in to_cancel:
+        try:
+            await ref.aio_result()
+        except Exception:
+            pass
+
+    ## wait for the olap repo to catch up
+    await asyncio.sleep(5)
+
+    successful_run = hatchet.runs.get(to_run.workflow_run_id)
+
+    assert successful_run.run.status == V1TaskStatus.COMPLETED
+    assert all(
+        r.status == V1TaskStatus.CANCELLED
+        for r in hatchet.runs.list(
+            additional_metadata={"test_run_id": test_run_id}
+        ).rows
+        if r.metadata.id != to_run.workflow_run_id
+    )

--- a/sdks/python/examples/concurrency_cancel_newest_task_level/test_concurrency_cancel_newest_task_level.py
+++ b/sdks/python/examples/concurrency_cancel_newest_task_level/test_concurrency_cancel_newest_task_level.py
@@ -7,7 +7,7 @@ from examples.concurrency_cancel_newest_task_level.worker import (
     WorkflowInput,
     concurrency_cancel_newest_task_level_workflow,
 )
-from hatchet_sdk import Hatchet, V1TaskStatus
+from hatchet_sdk import Hatchet, RunStatus
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -49,16 +49,12 @@ async def test_run(hatchet: Hatchet) -> None:
         except Exception:
             pass
 
-    ## wait for the olap repo to catch up
-    await asyncio.sleep(5)
+    # read the authoritative run details (rather than the eventually-consistent runs list) so we
+    # don't need to sleep waiting for the OLAP repo to catch up.
+    successful_run = await hatchet.runs.aio_get_details(to_run.workflow_run_id)
+    assert successful_run.status == RunStatus.COMPLETED
 
-    successful_run = hatchet.runs.get(to_run.workflow_run_id)
-
-    assert successful_run.run.status == V1TaskStatus.COMPLETED
-    assert all(
-        r.status == V1TaskStatus.CANCELLED
-        for r in hatchet.runs.list(
-            additional_metadata={"test_run_id": test_run_id}
-        ).rows
-        if r.metadata.id != to_run.workflow_run_id
-    )
+    cancelled_runs = [
+        await hatchet.runs.aio_get_details(ref.workflow_run_id) for ref in to_cancel
+    ]
+    assert all(r.status == RunStatus.CANCELLED for r in cancelled_runs)

--- a/sdks/python/examples/concurrency_cancel_newest_task_level/worker.py
+++ b/sdks/python/examples/concurrency_cancel_newest_task_level/worker.py
@@ -1,0 +1,57 @@
+import asyncio
+
+from pydantic import BaseModel
+
+from hatchet_sdk import (
+    ConcurrencyExpression,
+    ConcurrencyLimitStrategy,
+    Context,
+    Hatchet,
+)
+
+hatchet = Hatchet()
+
+
+class WorkflowInput(BaseModel):
+    group: str
+
+
+# The concurrency is declared on the TASK (step-level), not on the workflow. Step-level concurrency
+# is the only path served by the in-memory concurrency index, so this exercises that code path
+# rather than the legacy workflow-level DB path.
+concurrency_cancel_newest_task_level_workflow = hatchet.workflow(
+    name="ConcurrencyCancelNewestTaskLevel",
+    input_validator=WorkflowInput,
+)
+
+
+# > Task-Level Cancel Newest
+@concurrency_cancel_newest_task_level_workflow.task(
+    concurrency=[
+        ConcurrencyExpression(
+            expression="input.group",
+            max_runs=1,
+            limit_strategy=ConcurrencyLimitStrategy.CANCEL_NEWEST,
+        )
+    ],
+)
+async def task(input: WorkflowInput, ctx: Context) -> None:
+    # sleep long enough that newer runs pile up while this one runs; CANCEL_NEWEST rejects them
+    # instead of preempting the running (oldest) run.
+    for _ in range(50):
+        await asyncio.sleep(0.10)
+
+
+# !!
+
+
+def main() -> None:
+    worker = hatchet.worker(
+        "concurrency-cancel-newest-task-level-worker",
+        workflows=[concurrency_cancel_newest_task_level_workflow],
+    )
+    worker.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/sdks/python/examples/worker.py
+++ b/sdks/python/examples/worker.py
@@ -12,7 +12,13 @@ from examples.cancellation.worker import cancellation_workflow
 from examples.concurrency_cancel_in_progress.worker import (
     concurrency_cancel_in_progress_workflow,
 )
+from examples.concurrency_cancel_in_progress_task_level.worker import (
+    concurrency_cancel_in_progress_task_level_workflow,
+)
 from examples.concurrency_cancel_newest.worker import concurrency_cancel_newest_workflow
+from examples.concurrency_cancel_newest_task_level.worker import (
+    concurrency_cancel_newest_task_level_workflow,
+)
 from examples.concurrency_limit.worker import concurrency_limit_workflow
 from examples.concurrency_limit_rr.worker import concurrency_limit_rr_workflow
 from examples.concurrency_multiple_keys.worker import concurrency_multiple_keys_workflow
@@ -144,6 +150,8 @@ def main() -> None:
             concurrency_workflow_level_workflow,
             concurrency_cancel_newest_workflow,
             concurrency_cancel_in_progress_workflow,
+            concurrency_cancel_newest_task_level_workflow,
+            concurrency_cancel_in_progress_task_level_workflow,
             di_workflow,
             payload_initial_cancel_bug_workflow,
             run_detail_test_workflow,


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

When `SERVER_CONCURRENCY_IN_MEMORY_INDEX_ENABLED=true` is set (enabling the new experimental in-memory index), the cancel-in-progress concurrency strategy incorrectly acts like cancel-newest. This is due to the comparator method for the internal heap using the default `priorityCompare` instead of ranking newer slots as greater values in the heap, so they take precedence when popping out of the minHeap. 

Also adds a set of Python tests which use task-level concurrency for cancel-in-progress and cancel-newest, which correctly failed when setting `SERVER_CONCURRENCY_IN_MEMORY_INDEX_ENABLED`. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [X] New unit, integration and e2e tests to ensure we catch this path
- [X] Adding a new comparator for `CancelInProgress`

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Tested (unit, integration, or manually with steps specified)
- [X] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [X] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude w/ Fable

</details>
