### PR TITLE
fix: trace row labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Highlights
 
 - Tasks can declare a slot cost, so a task that needs more memory or CPU consumes more than one worker slot. See [Task Slot Cost](https://docs.hatchet.run/v1/advanced-assignment/slot-cost).
+- The run trace view now labels rows with workflow, task, and event names instead of internal span names such as `hatchet.engine.workflow_run`, and marks each retry attempt with its number.
 
 ## [0.94.10] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Highlights
 
 - Tasks can declare a slot cost, so a task that needs more memory or CPU consumes more than one worker slot. See [Task Slot Cost](https://docs.hatchet.run/v1/advanced-assignment/slot-cost).
-- The run trace view now labels rows with workflow, task, and event names instead of internal span names such as `hatchet.engine.workflow_run`, and marks each retry attempt with its number.
+- Engine rows in the run trace view now carry a badge with their workflow, task, or event name, and the retry number on retried tasks, so repeated spans such as `hatchet.engine.workflow_run` are distinguishable at a glance.
 
 ## [0.94.10] - 2026-07-14
 

--- a/frontend/app/src/components/v1/agent-prism/convert-otel-spans-to-agent-prism-span-tree.ts
+++ b/frontend/app/src/components/v1/agent-prism/convert-otel-spans-to-agent-prism-span-tree.ts
@@ -28,6 +28,7 @@ export const ATTR = {
   WORKFLOW_NAME: 'hatchet.workflow_name',
   WORKFLOW_RUN_ID: 'hatchet.workflow_run_id',
   TASK_NAME: 'hatchet.task_name',
+  RETRY_COUNT: 'hatchet.retry_count',
   INSTRUMENTOR: 'instrumentor',
   EVENT_KEY: 'hatchet.event_key',
   EVENT_ID: 'hatchet.event_id',

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/timeline/span-bar.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/timeline/span-bar.tsx
@@ -1,6 +1,6 @@
 import {
   getBarColor,
-  hasErrorInTree,
+  isSpanError,
   isQueuedOnlyRoot,
 } from '../utils/span-tree-utils';
 import {
@@ -101,7 +101,7 @@ export const SpanBar = memo(function SpanBar({
               'animate-pulse',
             row.span.inProgress || isQueuedOnlyRoot(row.span)
               ? 'border-yellow-500 bg-yellow-500/10'
-              : hasErrorInTree(row.span)
+              : isSpanError(row.span)
                 ? 'border-red-500 bg-red-500/10'
                 : 'border-green-500 bg-green-500/10',
           )}

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/timeline/trace-timeline-labels.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/timeline/trace-timeline-labels.tsx
@@ -1,6 +1,6 @@
 import {
   getSpanAttributeLabel,
-  getSpanDisplayLabel,
+  getSpanIdentityParts,
   isEngineSpan,
 } from '../utils/span-tree-utils';
 import {
@@ -238,12 +238,12 @@ export const TimelineLabels = memo(function TimelineLabels({
         }
 
         const isSelected = selectedSpan?.spanId === row.span.spanId;
-        const displayName = getSpanDisplayLabel(row.span);
-        // On step-run rows the badge would repeat the primary label, so show it
-        // only when it differs.
-        const attributeLabel = getSpanAttributeLabel(row.span);
-        const showAttributeLabel =
-          !!attributeLabel && attributeLabel !== displayName;
+        const displayName = row.span.spanName;
+        const identity = getSpanIdentityParts(row.span);
+        const contextLabel = identity
+          ? undefined
+          : getSpanAttributeLabel(row.span);
+        const showContextLabel = !!contextLabel && contextLabel !== displayName;
 
         return (
           <LabelRow
@@ -292,15 +292,36 @@ export const TimelineLabels = memo(function TimelineLabels({
                 <TooltipContent>{displayName}</TooltipContent>
               </Tooltip>
             </TooltipProvider>
-            {showAttributeLabel && (
+            {identity && (
+              <TooltipProvider delayDuration={0}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="ml-1.5 flex min-w-0 items-center gap-1 rounded bg-muted px-1 py-0.5 font-mono text-[10px] text-foreground">
+                      <span className="truncate">{identity.label}</span>
+                      {identity.discriminator && (
+                        <span className="shrink-0">
+                          {identity.discriminator}
+                        </span>
+                      )}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {identity.discriminator
+                      ? `${identity.label} ${identity.discriminator}`
+                      : identity.label}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+            {showContextLabel && (
               <TooltipProvider delayDuration={0}>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span className="ml-1.5 truncate rounded bg-muted px-1 py-0.5 font-mono text-[10px] text-muted-foreground">
-                      {attributeLabel}
+                      {contextLabel}
                     </span>
                   </TooltipTrigger>
-                  <TooltipContent>{attributeLabel}</TooltipContent>
+                  <TooltipContent>{contextLabel}</TooltipContent>
                 </Tooltip>
               </TooltipProvider>
             )}

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/timeline/trace-timeline-labels.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/timeline/trace-timeline-labels.tsx
@@ -1,4 +1,8 @@
-import { getSpanAttributeLabel, isEngineSpan } from '../utils/span-tree-utils';
+import {
+  getSpanAttributeLabel,
+  getSpanDisplayLabel,
+  isEngineSpan,
+} from '../utils/span-tree-utils';
 import {
   ROW_HEIGHT,
   CONNECTOR_WIDTH,
@@ -234,8 +238,12 @@ export const TimelineLabels = memo(function TimelineLabels({
         }
 
         const isSelected = selectedSpan?.spanId === row.span.spanId;
-        const displayName = row.span.spanName;
+        const displayName = getSpanDisplayLabel(row.span);
+        // On step-run rows the badge would repeat the primary label, so show it
+        // only when it differs.
         const attributeLabel = getSpanAttributeLabel(row.span);
+        const showAttributeLabel =
+          !!attributeLabel && attributeLabel !== displayName;
 
         return (
           <LabelRow
@@ -284,7 +292,7 @@ export const TimelineLabels = memo(function TimelineLabels({
                 <TooltipContent>{displayName}</TooltipContent>
               </Tooltip>
             </TooltipProvider>
-            {attributeLabel && (
+            {showAttributeLabel && (
               <TooltipProvider delayDuration={0}>
                 <Tooltip>
                   <TooltipTrigger asChild>

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/timeline/trace-timeline-tooltips.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/timeline/trace-timeline-tooltips.tsx
@@ -1,6 +1,7 @@
 import { formatDuration, formatTimestamp } from '../utils/format-utils';
 import {
   getSpanColor,
+  getSpanDisplayLabel,
   effectiveStatusLabel,
   isEngineSpan,
   isQueuedEngineSpan,
@@ -63,7 +64,7 @@ export function SpanTooltip({
     ? Math.max(0, now - startMs)
     : span.durationNs / 1_000_000;
 
-  const displayName = span.spanName;
+  const displayName = getSpanDisplayLabel(span);
   const started = formatTimestamp(span.createdAt, { ms: true });
   const q = span.queuedPhase;
 

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/timeline/trace-timeline-tooltips.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/timeline/trace-timeline-tooltips.tsx
@@ -1,7 +1,7 @@
 import { formatDuration, formatTimestamp } from '../utils/format-utils';
 import {
   getSpanColor,
-  getSpanDisplayLabel,
+  getSpanIdentityLabel,
   effectiveStatusLabel,
   isEngineSpan,
   isQueuedEngineSpan,
@@ -64,7 +64,7 @@ export function SpanTooltip({
     ? Math.max(0, now - startMs)
     : span.durationNs / 1_000_000;
 
-  const displayName = getSpanDisplayLabel(span);
+  const identityLabel = getSpanIdentityLabel(span);
   const started = formatTimestamp(span.createdAt, { ms: true });
   const q = span.queuedPhase;
 
@@ -75,11 +75,7 @@ export function SpanTooltip({
   }
 
   return (
-    <TooltipShell
-      title={displayName}
-      subtitle={displayName !== span.spanName ? span.spanName : undefined}
-      style={style}
-    >
+    <TooltipShell title={span.spanName} subtitle={identityLabel} style={style}>
       {q ? (
         <>
           <span className="text-muted-foreground">Queue Time</span>

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/timeline/trace-timeline-utils.ts
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/timeline/trace-timeline-utils.ts
@@ -1,4 +1,8 @@
-import { getStableKey, hasErrorInTree } from '../utils/span-tree-utils';
+import {
+  getSpanGroupLabel,
+  getStableKey,
+  hasErrorInTree,
+} from '../utils/span-tree-utils';
 import type { OtelSpanTree } from '@/components/v1/agent-prism/span-tree-type';
 
 const GROUP_THRESHOLD = 5;
@@ -124,7 +128,7 @@ export function groupSiblings(
         kind: 'group' as const,
         group: {
           groupId: `__group_${parentSpanId || 'root'}_${name}`,
-          groupName: name,
+          groupName: getSpanGroupLabel(name),
           spans: sorted,
           errorCount: errors.length,
           totalCount: sorted.length,

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/timeline/trace-timeline-utils.ts
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/timeline/trace-timeline-utils.ts
@@ -1,8 +1,4 @@
-import {
-  getSpanGroupLabel,
-  getStableKey,
-  hasErrorInTree,
-} from '../utils/span-tree-utils';
+import { getStableKey, hasErrorInTree } from '../utils/span-tree-utils';
 import type { OtelSpanTree } from '@/components/v1/agent-prism/span-tree-type';
 
 const GROUP_THRESHOLD = 5;
@@ -128,7 +124,7 @@ export function groupSiblings(
         kind: 'group' as const,
         group: {
           groupId: `__group_${parentSpanId || 'root'}_${name}`,
-          groupName: getSpanGroupLabel(name),
+          groupName: name,
           spans: sorted,
           errorCount: errors.length,
           totalCount: sorted.length,

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/utils/span-tree-utils.test.ts
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/utils/span-tree-utils.test.ts
@@ -1,7 +1,7 @@
 import {
   getSpanAttributeLabel,
-  getSpanDisplayLabel,
-  getSpanGroupLabel,
+  getSpanIdentityLabel,
+  getSpanIdentityParts,
   isSpanError,
 } from './span-tree-utils';
 import type { OtelSpanTree } from '@/components/v1/agent-prism/span-tree-type';
@@ -25,51 +25,48 @@ function node(
   };
 }
 
-describe('getSpanDisplayLabel', () => {
-  test('workflow-run spans that share a display name stay distinguishable by run id', () => {
-    const shared = 'repro-child-1784075658981';
-    const a = node('hatchet.engine.workflow_run', {
-      'hatchet.workflow_name': shared,
+describe('getSpanIdentityParts', () => {
+  test('a workflow-run span gets the workflow name with a short run id discriminator', () => {
+    const span = node('hatchet.engine.workflow_run', {
+      'hatchet.workflow_name': 'repro-child-1784075658981',
       'hatchet.workflow_run_id': '11111111-aaaa-bbbb-cccc-222222222222',
     });
-    const b = node('hatchet.engine.workflow_run', {
-      'hatchet.workflow_name': shared,
-      'hatchet.workflow_run_id': '33333333-dddd-eeee-ffff-444444444444',
-    });
 
-    assert.notStrictEqual(getSpanDisplayLabel(a), getSpanDisplayLabel(b));
-    assert.strictEqual(getSpanDisplayLabel(a), `${shared} (11111111)`);
-    assert.strictEqual(getSpanDisplayLabel(b), `${shared} (33333333)`);
+    assert.deepStrictEqual(getSpanIdentityParts(span), {
+      label: 'repro-child-1784075658981',
+      discriminator: '(11111111)',
+    });
   });
 
-  test('a retried step-run row shows the task name with the retry number', () => {
+  test('a retried step-run span gets a retry discriminator, the base attempt none', () => {
     const base = node('hatchet.engine.start_step_run', {
       'hatchet.task_name': 'retry-repro',
       'hatchet.retry_count': '0',
-    });
-    const retry1 = node('hatchet.engine.start_step_run', {
-      'hatchet.task_name': 'retry-repro',
-      'hatchet.retry_count': '1',
     });
     const retry2 = node('hatchet.engine.start_step_run', {
       'hatchet.task_name': 'retry-repro',
       'hatchet.retry_count': '2',
     });
 
-    assert.strictEqual(getSpanDisplayLabel(base), 'retry-repro');
-    assert.strictEqual(getSpanDisplayLabel(retry1), 'retry-repro (retry 1)');
-    assert.strictEqual(getSpanDisplayLabel(retry2), 'retry-repro (retry 2)');
+    assert.deepStrictEqual(getSpanIdentityParts(base), {
+      label: 'retry-repro',
+      discriminator: undefined,
+    });
+    assert.deepStrictEqual(getSpanIdentityParts(retry2), {
+      label: 'retry-repro',
+      discriminator: '(retry 2)',
+    });
   });
 
-  test('step-run span without a task name falls back to the step name', () => {
+  test('a step-run span without a task name falls back to the step name', () => {
     const span = node('hatchet.start_step_run', {
       'hatchet.step_name': 'send-email',
     });
 
-    assert.strictEqual(getSpanDisplayLabel(span), 'send-email');
+    assert.strictEqual(getSpanIdentityParts(span)?.label, 'send-email');
   });
 
-  test('engine event rows show the event key with a short event id', () => {
+  test('engine event spans get the event key with a short event id discriminator', () => {
     const received = node('hatchet.engine.event', {
       'hatchet.event_key': 'user:created',
       'hatchet.event_id': 'aaaaaaaa-1111-2222-3333-444444444444',
@@ -79,52 +76,48 @@ describe('getSpanDisplayLabel', () => {
       'hatchet.event_id': '11111111-aaaa-bbbb-cccc-222222222222',
     });
 
-    assert.strictEqual(
-      getSpanDisplayLabel(received),
-      'user:created (aaaaaaaa)',
-    );
-    assert.strictEqual(getSpanDisplayLabel(emitted), 'order:placed (11111111)');
+    assert.deepStrictEqual(getSpanIdentityParts(received), {
+      label: 'user:created',
+      discriminator: '(aaaaaaaa)',
+    });
+    assert.deepStrictEqual(getSpanIdentityParts(emitted), {
+      label: 'order:placed',
+      discriminator: '(11111111)',
+    });
   });
 
-  test('application/custom spans keep their own span name', () => {
+  test('application/custom spans have no identity, even with task context attributes', () => {
     const span = node('inventory.check-availability', {
-      'my.custom.attr': 'value',
+      'hatchet.task_name': 'process-message',
+      'hatchet.step_name': 'process-message',
     });
 
-    assert.strictEqual(
-      getSpanDisplayLabel(span),
-      'inventory.check-availability',
-    );
+    assert.strictEqual(getSpanIdentityParts(span), undefined);
   });
 });
 
-describe('getSpanGroupLabel', () => {
-  test('workflow-run groups read as "workflow runs"', () => {
-    assert.strictEqual(
-      getSpanGroupLabel('hatchet.engine.workflow_run'),
-      'workflow runs',
-    );
-  });
+describe('getSpanIdentityLabel', () => {
+  test('joins the label and discriminator for tooltip text', () => {
+    const withDiscriminator = node('hatchet.engine.workflow_run', {
+      'hatchet.workflow_name': 'repro-parent',
+      'hatchet.workflow_run_id': '11111111-aaaa-bbbb-cccc-222222222222',
+    });
+    const withoutDiscriminator = node('hatchet.engine.start_step_run', {
+      'hatchet.task_name': 'retry-repro',
+      'hatchet.retry_count': '0',
+    });
 
-  test('step-run groups read as "tasks", engine and sdk alike', () => {
     assert.strictEqual(
-      getSpanGroupLabel('hatchet.engine.start_step_run'),
-      'tasks',
+      getSpanIdentityLabel(withDiscriminator),
+      'repro-parent (11111111)',
     );
-    assert.strictEqual(getSpanGroupLabel('hatchet.start_step_run'), 'tasks');
-  });
-
-  test('emitted-event groups read as "emitted events"', () => {
     assert.strictEqual(
-      getSpanGroupLabel('hatchet.engine.event_emitted'),
-      'emitted events',
+      getSpanIdentityLabel(withoutDiscriminator),
+      'retry-repro',
     );
-  });
-
-  test('unknown span names keep their own name', () => {
     assert.strictEqual(
-      getSpanGroupLabel('inventory.check-availability'),
-      'inventory.check-availability',
+      getSpanIdentityLabel(node('inventory.check-availability')),
+      undefined,
     );
   });
 });

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/utils/span-tree-utils.test.ts
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/utils/span-tree-utils.test.ts
@@ -2,6 +2,7 @@ import {
   getSpanAttributeLabel,
   getSpanDisplayLabel,
   getSpanGroupLabel,
+  isSpanError,
 } from './span-tree-utils';
 import type { OtelSpanTree } from '@/components/v1/agent-prism/span-tree-type';
 import * as assert from 'node:assert';
@@ -41,14 +42,23 @@ describe('getSpanDisplayLabel', () => {
     assert.strictEqual(getSpanDisplayLabel(b), `${shared} (33333333)`);
   });
 
-  test('engine step-run span shows the task name', () => {
-    const span = node('hatchet.engine.start_step_run', {
-      'hatchet.span_source': 'engine',
-      'hatchet.task_name': 'process-message',
-      'hatchet.step_name': 'process-message',
+  test('a retried step-run row shows the task name with the retry number', () => {
+    const base = node('hatchet.engine.start_step_run', {
+      'hatchet.task_name': 'retry-repro',
+      'hatchet.retry_count': '0',
+    });
+    const retry1 = node('hatchet.engine.start_step_run', {
+      'hatchet.task_name': 'retry-repro',
+      'hatchet.retry_count': '1',
+    });
+    const retry2 = node('hatchet.engine.start_step_run', {
+      'hatchet.task_name': 'retry-repro',
+      'hatchet.retry_count': '2',
     });
 
-    assert.strictEqual(getSpanDisplayLabel(span), 'process-message');
+    assert.strictEqual(getSpanDisplayLabel(base), 'retry-repro');
+    assert.strictEqual(getSpanDisplayLabel(retry1), 'retry-repro (retry 1)');
+    assert.strictEqual(getSpanDisplayLabel(retry2), 'retry-repro (retry 2)');
   });
 
   test('step-run span without a task name falls back to the step name', () => {
@@ -110,5 +120,41 @@ describe('getSpanAttributeLabel', () => {
     });
 
     assert.strictEqual(getSpanAttributeLabel(span), undefined);
+  });
+});
+
+describe('isSpanError', () => {
+  const errored = (spanName: string): OtelSpanTree => ({
+    ...node(spanName),
+    statusCode: 'ERROR' as OtelSpanTree['statusCode'],
+  });
+
+  test('an engine span with status OK is not an error even if a child failed', () => {
+    const span: OtelSpanTree = {
+      ...node('hatchet.engine.start_step_run', {
+        'hatchet.span_source': 'engine',
+      }),
+      children: [errored('hatchet.engine.start_step_run')],
+    };
+
+    assert.strictEqual(isSpanError(span), false);
+  });
+
+  test('an engine span with status ERROR is an error', () => {
+    const span: OtelSpanTree = {
+      ...errored('hatchet.engine.start_step_run'),
+      spanAttributes: { 'hatchet.span_source': 'engine' },
+    };
+
+    assert.strictEqual(isSpanError(span), true);
+  });
+
+  test('a non-engine span inherits an error from its subtree', () => {
+    const span: OtelSpanTree = {
+      ...node('inventory.check-availability'),
+      children: [errored('db.query')],
+    };
+
+    assert.strictEqual(isSpanError(span), true);
   });
 });

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/utils/span-tree-utils.test.ts
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/utils/span-tree-utils.test.ts
@@ -1,0 +1,114 @@
+import {
+  getSpanAttributeLabel,
+  getSpanDisplayLabel,
+  getSpanGroupLabel,
+} from './span-tree-utils';
+import type { OtelSpanTree } from '@/components/v1/agent-prism/span-tree-type';
+import * as assert from 'node:assert';
+import { describe, test } from 'node:test';
+
+function node(
+  spanName: string,
+  spanAttributes: Record<string, string> = {},
+): OtelSpanTree {
+  return {
+    spanId: 'span-1',
+    parentSpanId: undefined,
+    spanName,
+    statusCode: 'OK' as OtelSpanTree['statusCode'],
+    statusMessage: undefined,
+    durationNs: 1_000_000,
+    createdAt: '2025-01-01T00:00:00.000Z',
+    spanAttributes,
+    children: [],
+  };
+}
+
+describe('getSpanDisplayLabel', () => {
+  test('workflow-run spans that share a display name stay distinguishable by run id', () => {
+    const shared = 'repro-child-1784075658981';
+    const a = node('hatchet.engine.workflow_run', {
+      'hatchet.workflow_name': shared,
+      'hatchet.workflow_run_id': '11111111-aaaa-bbbb-cccc-222222222222',
+    });
+    const b = node('hatchet.engine.workflow_run', {
+      'hatchet.workflow_name': shared,
+      'hatchet.workflow_run_id': '33333333-dddd-eeee-ffff-444444444444',
+    });
+
+    assert.notStrictEqual(getSpanDisplayLabel(a), getSpanDisplayLabel(b));
+    assert.strictEqual(getSpanDisplayLabel(a), `${shared} (11111111)`);
+    assert.strictEqual(getSpanDisplayLabel(b), `${shared} (33333333)`);
+  });
+
+  test('engine step-run span shows the task name', () => {
+    const span = node('hatchet.engine.start_step_run', {
+      'hatchet.span_source': 'engine',
+      'hatchet.task_name': 'process-message',
+      'hatchet.step_name': 'process-message',
+    });
+
+    assert.strictEqual(getSpanDisplayLabel(span), 'process-message');
+  });
+
+  test('step-run span without a task name falls back to the step name', () => {
+    const span = node('hatchet.start_step_run', {
+      'hatchet.step_name': 'send-email',
+    });
+
+    assert.strictEqual(getSpanDisplayLabel(span), 'send-email');
+  });
+
+  test('application/custom spans keep their own span name', () => {
+    const span = node('inventory.check-availability', {
+      'my.custom.attr': 'value',
+    });
+
+    assert.strictEqual(
+      getSpanDisplayLabel(span),
+      'inventory.check-availability',
+    );
+  });
+});
+
+describe('getSpanGroupLabel', () => {
+  test('workflow-run groups read as "workflow runs"', () => {
+    assert.strictEqual(
+      getSpanGroupLabel('hatchet.engine.workflow_run'),
+      'workflow runs',
+    );
+  });
+
+  test('step-run groups read as "tasks", engine and sdk alike', () => {
+    assert.strictEqual(
+      getSpanGroupLabel('hatchet.engine.start_step_run'),
+      'tasks',
+    );
+    assert.strictEqual(getSpanGroupLabel('hatchet.start_step_run'), 'tasks');
+  });
+
+  test('unknown span names keep their own name', () => {
+    assert.strictEqual(
+      getSpanGroupLabel('inventory.check-availability'),
+      'inventory.check-availability',
+    );
+  });
+});
+
+describe('getSpanAttributeLabel', () => {
+  test('a custom span carries the propagated task/step name', () => {
+    const span = node('inventory.check-availability', {
+      'hatchet.step_name': 'process-message',
+    });
+
+    assert.strictEqual(getSpanAttributeLabel(span), 'process-message');
+  });
+
+  test('is undefined when no task or step name is present', () => {
+    const span = node('hatchet.engine.workflow_run', {
+      'hatchet.workflow_name': 'repro-parent',
+    });
+
+    assert.strictEqual(getSpanAttributeLabel(span), undefined);
+  });
+});

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/utils/span-tree-utils.test.ts
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/utils/span-tree-utils.test.ts
@@ -69,6 +69,23 @@ describe('getSpanDisplayLabel', () => {
     assert.strictEqual(getSpanDisplayLabel(span), 'send-email');
   });
 
+  test('engine event rows show the event key with a short event id', () => {
+    const received = node('hatchet.engine.event', {
+      'hatchet.event_key': 'user:created',
+      'hatchet.event_id': 'aaaaaaaa-1111-2222-3333-444444444444',
+    });
+    const emitted = node('hatchet.engine.event_emitted', {
+      'hatchet.event_key': 'order:placed',
+      'hatchet.event_id': '11111111-aaaa-bbbb-cccc-222222222222',
+    });
+
+    assert.strictEqual(
+      getSpanDisplayLabel(received),
+      'user:created (aaaaaaaa)',
+    );
+    assert.strictEqual(getSpanDisplayLabel(emitted), 'order:placed (11111111)');
+  });
+
   test('application/custom spans keep their own span name', () => {
     const span = node('inventory.check-availability', {
       'my.custom.attr': 'value',
@@ -95,6 +112,13 @@ describe('getSpanGroupLabel', () => {
       'tasks',
     );
     assert.strictEqual(getSpanGroupLabel('hatchet.start_step_run'), 'tasks');
+  });
+
+  test('emitted-event groups read as "emitted events"', () => {
+    assert.strictEqual(
+      getSpanGroupLabel('hatchet.engine.event_emitted'),
+      'emitted events',
+    );
   });
 
   test('unknown span names keep their own name', () => {

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/utils/span-tree-utils.ts
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/utils/span-tree-utils.ts
@@ -80,6 +80,8 @@ export function getSpanAttributeLabel(span: OtelSpanTree): string | undefined {
  * A workflow-run label gets a short run id appended because run display names are
  * not unique across concurrent runs. A retried task renders one row per attempt
  * with the same task name, so the retry number is appended to tell them apart.
+ * An event row shows its event key, with a short event id appended because a
+ * single task can emit the same event key more than once.
  * The raw span name stays visible in the detail panel and the tooltip subtitle.
  */
 export function getSpanDisplayLabel(span: OtelSpanTree): string {
@@ -101,6 +103,17 @@ export function getSpanDisplayLabel(span: OtelSpanTree): string {
     }
   }
 
+  if (
+    span.spanName === SPAN.ENGINE_EVENT ||
+    span.spanName === SPAN.ENGINE_EVENT_EMITTED
+  ) {
+    const eventKey = span.spanAttributes?.[ATTR.EVENT_KEY];
+    if (eventKey) {
+      const shortId = span.spanAttributes?.[ATTR.EVENT_ID]?.split('-')[0];
+      return shortId ? `${eventKey} (${shortId})` : eventKey;
+    }
+  }
+
   return span.spanName;
 }
 
@@ -115,6 +128,8 @@ export function getSpanGroupLabel(spanName: string): string {
     case SPAN.ENGINE_START_STEP_RUN:
     case SPAN.START_STEP_RUN:
       return 'tasks';
+    case SPAN.ENGINE_EVENT_EMITTED:
+      return 'emitted events';
     default:
       return spanName;
   }

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/utils/span-tree-utils.ts
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/utils/span-tree-utils.ts
@@ -76,22 +76,35 @@ export function getSpanAttributeLabel(span: OtelSpanTree): string | undefined {
   );
 }
 
+export type SpanIdentity = {
+  label: string;
+  /**
+   * Distinguishes same-named sibling rows and stays visible when the label
+   * truncates.
+   */
+  discriminator?: string;
+};
+
 /**
- * A workflow-run label gets a short run id appended because run display names are
- * not unique across concurrent runs. A retried task renders one row per attempt
- * with the same task name, so the retry number is appended to tell them apart.
- * An event row shows its event key, with a short event id appended because a
- * single task can emit the same event key more than once.
- * The raw span name stays visible in the detail panel and the tooltip subtitle.
+ * The Hatchet identity behind a span, shown as a badge next to the span name.
+ * Returns undefined for spans with no Hatchet identity, such as application
+ * spans.
  */
-export function getSpanDisplayLabel(span: OtelSpanTree): string {
+export function getSpanIdentityParts(
+  span: OtelSpanTree,
+): SpanIdentity | undefined {
   if (isStartStepRunSpan(span)) {
     const name =
       span.spanAttributes?.[ATTR.TASK_NAME] ??
-      span.spanAttributes?.[ATTR.STEP_NAME] ??
-      span.spanName;
-    const retryCount = Number(span.spanAttributes?.[ATTR.RETRY_COUNT]);
-    return retryCount > 0 ? `${name} (retry ${retryCount})` : name;
+      span.spanAttributes?.[ATTR.STEP_NAME];
+    if (name) {
+      const retryCount = Number(span.spanAttributes?.[ATTR.RETRY_COUNT]);
+      return {
+        label: name,
+        discriminator: retryCount > 0 ? `(retry ${retryCount})` : undefined,
+      };
+    }
+    return undefined;
   }
 
   if (span.spanName === SPAN.ENGINE_WORKFLOW_RUN) {
@@ -99,8 +112,12 @@ export function getSpanDisplayLabel(span: OtelSpanTree): string {
     if (workflowName) {
       const shortId =
         span.spanAttributes?.[ATTR.WORKFLOW_RUN_ID]?.split('-')[0];
-      return shortId ? `${workflowName} (${shortId})` : workflowName;
+      return {
+        label: workflowName,
+        discriminator: shortId ? `(${shortId})` : undefined,
+      };
     }
+    return undefined;
   }
 
   if (
@@ -110,29 +127,25 @@ export function getSpanDisplayLabel(span: OtelSpanTree): string {
     const eventKey = span.spanAttributes?.[ATTR.EVENT_KEY];
     if (eventKey) {
       const shortId = span.spanAttributes?.[ATTR.EVENT_ID]?.split('-')[0];
-      return shortId ? `${eventKey} (${shortId})` : eventKey;
+      return {
+        label: eventKey,
+        discriminator: shortId ? `(${shortId})` : undefined,
+      };
     }
+    return undefined;
   }
 
-  return span.spanName;
+  return undefined;
 }
 
-/**
- * Groups stay keyed by the raw span name, so this changes only the header text,
- * not how spans are grouped.
- */
-export function getSpanGroupLabel(spanName: string): string {
-  switch (spanName) {
-    case SPAN.ENGINE_WORKFLOW_RUN:
-      return 'workflow runs';
-    case SPAN.ENGINE_START_STEP_RUN:
-    case SPAN.START_STEP_RUN:
-      return 'tasks';
-    case SPAN.ENGINE_EVENT_EMITTED:
-      return 'emitted events';
-    default:
-      return spanName;
+export function getSpanIdentityLabel(span: OtelSpanTree): string | undefined {
+  const identity = getSpanIdentityParts(span);
+  if (!identity) {
+    return undefined;
   }
+  return identity.discriminator
+    ? `${identity.label} ${identity.discriminator}`
+    : identity.label;
 }
 
 export function getStableKey(span: OtelSpanTree): string {

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/utils/span-tree-utils.ts
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/utils/span-tree-utils.ts
@@ -1,4 +1,8 @@
-import { isStartStepRunSpan } from '@/components/v1/agent-prism/convert-otel-spans-to-agent-prism-span-tree';
+import {
+  isStartStepRunSpan,
+  SPAN,
+  ATTR,
+} from '@/components/v1/agent-prism/convert-otel-spans-to-agent-prism-span-tree';
 import type { OtelSpanTree } from '@/components/v1/agent-prism/span-tree-type';
 import { OtelStatusCode } from '@/lib/api/generated/data-contracts';
 
@@ -54,11 +58,58 @@ export function isQueuedOnly(span: OtelSpanTree): boolean {
   return !!span.queuedPhase && span.durationNs <= 0 && !span.inProgress;
 }
 
+/**
+ * The SDK instrumentor copies the task run's `hatchet.*` attributes onto every
+ * span created inside a task, so a custom span carries the name of the task it
+ * ran in.
+ */
 export function getSpanAttributeLabel(span: OtelSpanTree): string | undefined {
   return (
-    span.spanAttributes?.['hatchet.task_name'] ??
-    span.spanAttributes?.['hatchet.step_name']
+    span.spanAttributes?.[ATTR.TASK_NAME] ??
+    span.spanAttributes?.[ATTR.STEP_NAME]
   );
+}
+
+/**
+ * The short run id is appended to a workflow-run label because run display names
+ * are not unique across concurrent runs. The raw span name stays visible in the
+ * detail panel and the tooltip subtitle.
+ */
+export function getSpanDisplayLabel(span: OtelSpanTree): string {
+  if (isStartStepRunSpan(span)) {
+    return (
+      span.spanAttributes?.[ATTR.TASK_NAME] ??
+      span.spanAttributes?.[ATTR.STEP_NAME] ??
+      span.spanName
+    );
+  }
+
+  if (span.spanName === SPAN.ENGINE_WORKFLOW_RUN) {
+    const workflowName = span.spanAttributes?.[ATTR.WORKFLOW_NAME];
+    if (workflowName) {
+      const shortId =
+        span.spanAttributes?.[ATTR.WORKFLOW_RUN_ID]?.split('-')[0];
+      return shortId ? `${workflowName} (${shortId})` : workflowName;
+    }
+  }
+
+  return span.spanName;
+}
+
+/**
+ * Groups stay keyed by the raw span name, so this changes only the header text,
+ * not how spans are grouped.
+ */
+export function getSpanGroupLabel(spanName: string): string {
+  switch (spanName) {
+    case SPAN.ENGINE_WORKFLOW_RUN:
+      return 'workflow runs';
+    case SPAN.ENGINE_START_STEP_RUN:
+    case SPAN.START_STEP_RUN:
+      return 'tasks';
+    default:
+      return spanName;
+  }
 }
 
 export function getStableKey(span: OtelSpanTree): string {

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/utils/span-tree-utils.ts
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/step-run-detail/observability/utils/span-tree-utils.ts
@@ -20,6 +20,12 @@ export function isEngineSpan(span: OtelSpanTree): boolean {
   return span.spanAttributes?.['hatchet.span_source'] === 'engine';
 }
 
+export function isSpanError(span: OtelSpanTree): boolean {
+  return isEngineSpan(span)
+    ? span.statusCode === OtelStatusCode.ERROR
+    : hasErrorInTree(span);
+}
+
 export function hasOnlyEngineSpans(trees: OtelSpanTree[]): boolean {
   const stack = [...trees];
   let realSpanCount = 0;
@@ -71,17 +77,19 @@ export function getSpanAttributeLabel(span: OtelSpanTree): string | undefined {
 }
 
 /**
- * The short run id is appended to a workflow-run label because run display names
- * are not unique across concurrent runs. The raw span name stays visible in the
- * detail panel and the tooltip subtitle.
+ * A workflow-run label gets a short run id appended because run display names are
+ * not unique across concurrent runs. A retried task renders one row per attempt
+ * with the same task name, so the retry number is appended to tell them apart.
+ * The raw span name stays visible in the detail panel and the tooltip subtitle.
  */
 export function getSpanDisplayLabel(span: OtelSpanTree): string {
   if (isStartStepRunSpan(span)) {
-    return (
+    const name =
       span.spanAttributes?.[ATTR.TASK_NAME] ??
       span.spanAttributes?.[ATTR.STEP_NAME] ??
-      span.spanName
-    );
+      span.spanName;
+    const retryCount = Number(span.spanAttributes?.[ATTR.RETRY_COUNT]);
+    return retryCount > 0 ? `${name} (retry ${retryCount})` : name;
   }
 
   if (span.spanName === SPAN.ENGINE_WORKFLOW_RUN) {
@@ -170,13 +178,5 @@ export function getBarColor(span: OtelSpanTree): string {
   if (isQueuedOnlyRoot(span) || isQueuedOnly(span)) {
     return 'bg-yellow-500';
   }
-  if (isEngineSpan(span)) {
-    return span.statusCode === OtelStatusCode.ERROR
-      ? 'bg-red-500'
-      : 'bg-green-500';
-  }
-  if (hasErrorInTree(span)) {
-    return 'bg-red-500';
-  }
-  return 'bg-green-500';
+  return isSpanError(span) ? 'bg-red-500' : 'bg-green-500';
 }


### PR DESCRIPTION
# Description

The run trace view labeled engine-generated rows only by their span names, such as `hatchet.engine.workflow_run`, so repeated rows were indistinguishable. A user reported this in Discord. The span name stays the primary label, consistent with how trace tools label spans, and each engine row gains a badge with its Hatchet identity. The PR also fixes a queued-bar color bug on retried tasks.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Engine trace rows show their workflow, task, or event identity in a badge next to the span name; the short run id, event id, or retry number stays visible when the name truncates.
- [x] Tooltips title the span name and show the identity as the subtitle.
- [x] A successful retry no longer shows its queued bar as an error.
- [x] Added unit tests for the identity and error-state helpers.

## Checklist

Changes have been:

- [x] Tested (unit tests, plus manual verification in a local dashboard)
- [x] Linted and formatted
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Claude Opus 4.8 (Claude Code) was used for the investigation and writing the unit tests.

</details>

# Before

<img width="1710" height="654" alt="shot-20260716-121410" src="https://github.com/user-attachments/assets/542a95f0-b021-48fb-9f2d-6366d88145f4" />

<img width="1725" height="756" alt="shot-20260716-121632" src="https://github.com/user-attachments/assets/472fb821-78b7-4b3f-befa-cae613a775d6" />


# After

<img width="1538" height="632" alt="shot-20260716-121516" src="https://github.com/user-attachments/assets/e2b5a297-d1b7-4d6a-b4de-0ed7cf27eb51" />

<img width="1714" height="749" alt="shot-20260716-122114" src="https://github.com/user-attachments/assets/d3aad1c1-9c51-4188-add0-7e7bc64ebfe5" />

