### PR TITLE
fix(sdks/python): handle empty CREATE payload in durable waits

### DIFF
--- a/sdks/python/hatchet_sdk/context/context.py
+++ b/sdks/python/hatchet_sdk/context/context.py
@@ -98,6 +98,27 @@ def _compute_memo_key(task_run_external_id: str, *args: Any, **kwargs: Any) -> b
     return h.digest()
 
 
+def _first_wait_match_or_none(result: dict[str, Any]) -> dict[str, Any] | None:
+    """
+    Extract the first match from a durable wait result's `CREATE` dict, if present.
+
+    The engine returns an object shaped like `{"CREATE": {"signal_key_1": [{"id": ...}]}}`.
+    A durable wait can legitimately complete with an empty payload (e.g. `aio_wait_for`
+    already falls back to `{}` when the proto payload is empty), in which case `CREATE`
+    may be missing, `{}`, or map to an empty match list. Treat all of those as "no match"
+    instead of letting `next(iter(...))`/list-indexing raise on an empty collection.
+    """
+    matches: dict[str, list[dict[str, Any]]] = result.get("CREATE", {})
+    if not matches:
+        return None
+
+    _, raw_matches = next(iter(matches.items()))
+    if not raw_matches:
+        return None
+
+    return raw_matches[0]
+
+
 class Context:
     def __init__(
         self,
@@ -911,10 +932,10 @@ class DurableContext(Context):
         ## the engine returns an object like this:
         ## {"CREATE": {"signal_key_1": [{"id": ...}]}}
         ## since we have a single match we're looking for, we know that
-        ## the list of matches will only have one item, so we can extract and parse it
-        matches: dict[str, list[dict[str, Any]]] = res.get("CREATE", {})
-        _, raw_matches = next(iter(matches.items()))
-        sleep = raw_matches[0]
+        ## the list of matches will only have one item, so we can extract and parse it.
+        ## An empty payload is a legitimate response (see `_first_wait_match_or_none`),
+        ## so fall back to an empty dict rather than raising.
+        sleep = _first_wait_match_or_none(res) or {}
 
         return SleepResult(
             duration=expr_to_timedelta(
@@ -997,10 +1018,10 @@ class DurableContext(Context):
         ## the engine returns an object like this:
         ## {"CREATE": {"signal_key_1": [{"id": ...}]}}
         ## since we have a single match we're looking for, we know that
-        ## the list of matches will only have one item, so we can extract and parse it
-        matches: dict[str, list[dict[str, Any]]] = result.get("CREATE", {})
-        _, raw_matches = next(iter(matches.items()))
-        raw_payload = raw_matches[0]
+        ## the list of matches will only have one item, so we can extract and parse it.
+        ## An empty payload is a legitimate response (see `_first_wait_match_or_none`),
+        ## so fall back to an empty dict rather than raising.
+        raw_payload = _first_wait_match_or_none(result) or {}
 
         if payload_validator is not None:
             adapter = TypeAdapter(payload_validator)

--- a/sdks/python/hatchet_sdk/context/context.py
+++ b/sdks/python/hatchet_sdk/context/context.py
@@ -98,23 +98,23 @@ def _compute_memo_key(task_run_external_id: str, *args: Any, **kwargs: Any) -> b
     return h.digest()
 
 
-def _first_wait_match_or_none(result: dict[str, Any]) -> dict[str, Any] | None:
+def _first_wait_match(result: dict[str, Any]) -> dict[str, Any]:
     """
     Extract the first match from a durable wait result's `CREATE` dict, if present.
 
     The engine returns an object shaped like `{"CREATE": {"signal_key_1": [{"id": ...}]}}`.
     A durable wait can legitimately complete with an empty payload (e.g. `aio_wait_for`
     already falls back to `{}` when the proto payload is empty), in which case `CREATE`
-    may be missing, `{}`, or map to an empty match list. Treat all of those as "no match"
-    instead of letting `next(iter(...))`/list-indexing raise on an empty collection.
+    may be missing, `{}`, or map to an empty match list. Treat all of those as an empty
+    payload instead of letting `next(iter(...))`/list-indexing raise on an empty collection.
     """
     matches: dict[str, list[dict[str, Any]]] = result.get("CREATE", {})
     if not matches:
-        return None
+        return {}
 
     _, raw_matches = next(iter(matches.items()))
     if not raw_matches:
-        return None
+        return {}
 
     return raw_matches[0]
 
@@ -933,9 +933,9 @@ class DurableContext(Context):
         ## {"CREATE": {"signal_key_1": [{"id": ...}]}}
         ## since we have a single match we're looking for, we know that
         ## the list of matches will only have one item, so we can extract and parse it.
-        ## An empty payload is a legitimate response (see `_first_wait_match_or_none`),
-        ## so fall back to an empty dict rather than raising.
-        sleep = _first_wait_match_or_none(res) or {}
+        ## An empty payload is a legitimate response; `_first_wait_match` returns
+        ## `{}` rather than raising in that case.
+        sleep = _first_wait_match(res)
 
         return SleepResult(
             duration=expr_to_timedelta(
@@ -1019,9 +1019,9 @@ class DurableContext(Context):
         ## {"CREATE": {"signal_key_1": [{"id": ...}]}}
         ## since we have a single match we're looking for, we know that
         ## the list of matches will only have one item, so we can extract and parse it.
-        ## An empty payload is a legitimate response (see `_first_wait_match_or_none`),
-        ## so fall back to an empty dict rather than raising.
-        raw_payload = _first_wait_match_or_none(result) or {}
+        ## An empty payload is a legitimate response; `_first_wait_match` returns
+        ## `{}` rather than raising in that case.
+        raw_payload = _first_wait_match(result)
 
         if payload_validator is not None:
             adapter = TypeAdapter(payload_validator)

--- a/sdks/python/tests/unit/test_durable_wait_empty_payload.py
+++ b/sdks/python/tests/unit/test_durable_wait_empty_payload.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from hatchet_sdk.context.context import DurableContext, _first_wait_match_or_none
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        {},
+        {"CREATE": {}},
+        {"CREATE": {"signal_key_1": []}},
+    ],
+)
+def test_first_wait_match_or_none_returns_none_for_empty_payloads(
+    result: dict[str, Any],
+) -> None:
+    assert _first_wait_match_or_none(result) is None
+
+
+def test_first_wait_match_or_none_extracts_first_match() -> None:
+    result = {"CREATE": {"signal_key_1": [{"id": "abc", "sleep_duration": "5s"}]}}
+
+    assert _first_wait_match_or_none(result) == {"id": "abc", "sleep_duration": "5s"}
+
+
+def _context_with_wait_for(aio_wait_for_result: dict[str, Any]) -> DurableContext:
+    ctx = DurableContext.__new__(DurableContext)
+    ctx._wait_index = 0
+    ctx.aio_wait_for = AsyncMock(return_value=aio_wait_for_result)  # type: ignore[method-assign]
+
+    return ctx
+
+
+async def test_aio_sleep_for_does_not_crash_on_empty_payload() -> None:
+    """
+    Regression test for issue #4349: a durable wait that completes with an
+    empty CREATE payload used to raise `RuntimeError: coroutine raised
+    StopIteration` (PEP 479) instead of falling back gracefully.
+    """
+    ctx = _context_with_wait_for({"CREATE": {}})
+
+    result = await ctx.aio_sleep_for(timedelta(seconds=5))
+
+    assert result.duration == timedelta(seconds=5)
+
+
+async def test_aio_wait_for_event_does_not_crash_on_empty_payload() -> None:
+    ctx = _context_with_wait_for({"CREATE": {}})
+    ctx.aio_now = AsyncMock()  # type: ignore[method-assign]
+
+    result = await ctx.aio_wait_for_event("some-event")
+
+    assert result == {}
+
+
+async def test_aio_wait_for_event_extracts_payload_when_present() -> None:
+    ctx = _context_with_wait_for({"CREATE": {"event:some-event-0": [{"foo": "bar"}]}})
+    ctx.aio_now = AsyncMock()  # type: ignore[method-assign]
+
+    result = await ctx.aio_wait_for_event("some-event")
+
+    assert result == cast(dict[str, Any], {"foo": "bar"})

--- a/sdks/python/tests/unit/test_durable_wait_empty_payload.py
+++ b/sdks/python/tests/unit/test_durable_wait_empty_payload.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from hatchet_sdk.context.context import DurableContext, _first_wait_match_or_none
+from hatchet_sdk.context.context import DurableContext, _first_wait_match
 
 
 @pytest.mark.parametrize(
@@ -17,16 +17,16 @@ from hatchet_sdk.context.context import DurableContext, _first_wait_match_or_non
         {"CREATE": {"signal_key_1": []}},
     ],
 )
-def test_first_wait_match_or_none_returns_none_for_empty_payloads(
+def test_first_wait_match_returns_empty_dict_for_empty_payloads(
     result: dict[str, Any],
 ) -> None:
-    assert _first_wait_match_or_none(result) is None
+    assert _first_wait_match(result) == {}
 
 
-def test_first_wait_match_or_none_extracts_first_match() -> None:
+def test_first_wait_match_extracts_first_match() -> None:
     result = {"CREATE": {"signal_key_1": [{"id": "abc", "sleep_duration": "5s"}]}}
 
-    assert _first_wait_match_or_none(result) == {"id": "abc", "sleep_duration": "5s"}
+    assert _first_wait_match(result) == {"id": "abc", "sleep_duration": "5s"}
 
 
 def _context_with_wait_for(aio_wait_for_result: dict[str, Any]) -> DurableContext:


### PR DESCRIPTION
## Summary

Fixes #4349 — `aio_sleep_for` and `aio_wait_for_event` on `DurableContext` crash with `RuntimeError: coroutine raised StopIteration` (PEP 479) when a durable wait completes with an empty `CREATE` payload, instead of falling back gracefully.

## Root cause

Both methods extracted the first match via:

```python
matches: dict[str, list[dict[str, Any]]] = res.get("CREATE", {})
_, raw_matches = next(iter(matches.items()))
sleep = raw_matches[0]
```

`next(iter(matches.items()))` raises `StopIteration` when `matches` is empty (e.g. `CREATE` missing, `{}`, or a key mapping to an empty list) — and since this executes inside a coroutine, Python 3.7+'s PEP 479 turns that `StopIteration` into a `RuntimeError` instead of letting it propagate as a normal exception. `aio_wait_for` already treats an empty proto payload as valid and falls back to `{}`, so a durable wait genuinely can complete with no payload — this wasn't an edge case, it was a reachable path that just crashed instead of degrading gracefully.

## Fix

Added a shared helper, `_first_wait_match_or_none`, used by both `aio_sleep_for` and `aio_wait_for_event`, that returns `None` for any empty-payload shape (missing `CREATE`, empty dict, or empty match list) instead of raising. Both call sites now do `_first_wait_match_or_none(res) or {}`.

## Testing

- Added `tests/unit/test_durable_wait_empty_payload.py`: parametrized tests for `_first_wait_match_or_none` covering empty/missing payload shapes and normal match extraction, plus async tests constructing `DurableContext` with a mocked `aio_wait_for` to verify `aio_sleep_for`/`aio_wait_for_event` no longer crash and still correctly extract a payload when one is present.
- `poetry run python -m pytest tests/unit/test_durable_wait_empty_payload.py` — 7 passed.
- `poetry run ruff check` / `poetry run ruff format --check` — clean.
- `poetry run mypy` — no issues.
- Rebased onto current `upstream/main`; confirmed no upstream commits touched `context.py` since this branch was created, so no merge risk.

Pre-existing, unrelated: 6 tests in `test_shutdown_ordering.py` fail locally on Windows (`loop.add_signal_handler` raises `NotImplementedError` — `SIGINT` handler registration isn't supported by Windows' asyncio event loop). Verified via `git stash` that this reproduces identically on unmodified `upstream/main`, so it's a pre-existing platform limitation, not a regression from this change.

## Disclosure

Prepared with AI assistance (Claude Code). I read the surrounding `Context`/`DurableContext` code and the PEP 479 mechanics before making the change, wrote the fix and its regression tests, and verified ruff/mypy/pytest all pass locally, including confirming the pre-existing Windows-only test failures are unrelated and reproduce on a clean `upstream/main` checkout.