### PR TITLE
fix(sdks/go): recover durable waits after reconnect

### DIFF
--- a/pkg/client/durable_task_listener.go
+++ b/pkg/client/durable_task_listener.go
@@ -17,9 +17,13 @@ import (
 )
 
 const (
-	defaultReconnectInterval = 2 * time.Second
-	evictionAckTimeout       = 30 * time.Second
+	defaultReconnectInterval    = 2 * time.Second
+	defaultWorkerStatusInterval = time.Second
+	defaultCompletionBufferTTL  = 10 * time.Second
+	evictionAckTimeout          = 30 * time.Second
 )
+
+var errDurableTaskListenerStopped = errors.New("durable task listener stopped")
 
 // DurableTaskCallback is called when a response is received for a durable task.
 type DurableTaskCallback func(resp *v1.DurableTaskResponse) error
@@ -60,6 +64,16 @@ type TriggerRunAckEntry struct {
 	BranchID      int64
 }
 
+type bufferedCompletion struct {
+	resp      *v1.DurableTaskResponse
+	expiresAt time.Time
+}
+
+type durableTaskStreamResult struct {
+	err      error
+	terminal bool
+}
+
 // NonDeterminismError is returned by the engine when a durable task replay detects
 // a non-deterministic mutation (e.g. branching differently from the prior run).
 type NonDeterminismError struct {
@@ -87,18 +101,21 @@ type DurableTaskListener struct {
 	l                     zerolog.Logger
 	connectFn             func(ctx context.Context) (v1.V1Dispatcher_DurableTaskClient, error)
 	cancel                context.CancelFunc
+	done                  chan struct{}
 	requestQueue          chan *v1.DurableTaskRequest
-	bufferedCompletions   map[PendingCallbackKey]*v1.DurableTaskResponse
+	statusChanged         chan struct{}
+	bufferedCompletions   map[PendingCallbackKey]bufferedCompletion
 	pendingEventAcks      map[PendingAckKey]chan EventAckResult
 	pendingCallbacks      map[PendingCallbackKey]chan CallbackResult
+	callbackTerminalErr   error
 	workerID              string
 	streamSeq             int
 	reconnectInterval     time.Duration
 	evictionAckTTL        time.Duration
 	onServerEvictMu       sync.RWMutex
 	streamMu              sync.Mutex
-	bufferedCompletionsMu sync.Mutex
-	pendingCallbacksMu    sync.Mutex
+	callbackStateMu       sync.Mutex
+	callbacksTerminal     bool
 	pendingEvictionAcksMu sync.Mutex
 	pendingEventAcksMu    sync.Mutex
 	mu                    sync.Mutex
@@ -143,8 +160,9 @@ func NewDurableTaskListener(
 		pendingEventAcks:    make(map[PendingAckKey]chan EventAckResult),
 		pendingEvictionAcks: make(map[PendingAckKey]chan error),
 		pendingCallbacks:    make(map[PendingCallbackKey]chan CallbackResult),
-		bufferedCompletions: make(map[PendingCallbackKey]*v1.DurableTaskResponse),
+		bufferedCompletions: make(map[PendingCallbackKey]bufferedCompletion),
 		requestQueue:        make(chan *v1.DurableTaskRequest, 100),
+		statusChanged:       make(chan struct{}, 1),
 	}
 
 	for _, opt := range opts {
@@ -164,29 +182,67 @@ func (l *DurableTaskListener) SetServerEvictCallback(cb ServerEvictCallback) {
 
 // Start begins the listener loop.
 func (l *DurableTaskListener) Start(ctx context.Context) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
+	for {
+		l.mu.Lock()
+		if l.running {
+			l.mu.Unlock()
+			return
+		}
+		previousDone := l.done
+		l.mu.Unlock()
 
-	if l.running {
+		if previousDone != nil {
+			// A restarted listener cannot share callback state with senders or
+			// receivers from the preceding stream generation.
+			select {
+			case <-ctx.Done():
+				return
+			case <-previousDone:
+				continue
+			}
+		}
+
+		l.callbackStateMu.Lock()
+		l.mu.Lock()
+		if l.running || l.done != nil {
+			l.mu.Unlock()
+			l.callbackStateMu.Unlock()
+			continue
+		}
+
+		l.callbacksTerminal = false
+		l.callbackTerminalErr = nil
+		listenerCtx, cancel := context.WithCancel(ctx)
+		done := make(chan struct{})
+		l.cancel = cancel
+		l.done = done
+		l.running = true
+		l.mu.Unlock()
+		l.callbackStateMu.Unlock()
+
+		go l.receiveLoop(listenerCtx, done)
 		return
 	}
-
-	listenerCtx, cancel := context.WithCancel(ctx)
-	l.cancel = cancel
-	l.running = true
-	go l.receiveLoop(listenerCtx)
 }
 
 // Stop halts the listener.
 func (l *DurableTaskListener) Stop() {
+	// The callback-state lock makes terminal shutdown atomic with callback
+	// registration, completion buffering, and delivery.
+	l.callbackStateMu.Lock()
 	l.mu.Lock()
-	defer l.mu.Unlock()
-
 	l.running = false
-	if l.cancel != nil {
-		l.cancel()
-		l.cancel = nil
+	cancel := l.cancel
+	l.cancel = nil
+	l.mu.Unlock()
+	l.terminateCallbackStateLocked(errDurableTaskListenerStopped)
+	l.callbackStateMu.Unlock()
+
+	if cancel != nil {
+		cancel()
 	}
+
+	l.failPendingAcks(errDurableTaskListenerStopped)
 }
 
 // IsRunning returns whether the listener loop is active.
@@ -232,21 +288,28 @@ func (l *DurableTaskListener) AddPendingEvictionAck(key PendingAckKey) chan erro
 func (l *DurableTaskListener) AddPendingCallback(key PendingCallbackKey) chan CallbackResult {
 	ch := make(chan CallbackResult, 1)
 
-	l.bufferedCompletionsMu.Lock()
-	buffered, hasBuffered := l.bufferedCompletions[key]
-	if hasBuffered {
-		delete(l.bufferedCompletions, key)
-	}
-	l.bufferedCompletionsMu.Unlock()
-
-	if hasBuffered {
-		ch <- CallbackResult{Resp: buffered}
+	l.callbackStateMu.Lock()
+	if l.callbacksTerminal {
+		ch <- CallbackResult{Err: l.callbackTerminalErr}
+		l.callbackStateMu.Unlock()
 		return ch
 	}
 
-	l.pendingCallbacksMu.Lock()
-	defer l.pendingCallbacksMu.Unlock()
-	l.pendingCallbacks[key] = ch
+	l.pruneExpiredCompletionsLocked(time.Now())
+	buffered, hasBuffered := l.bufferedCompletions[key]
+	if hasBuffered {
+		delete(l.bufferedCompletions, key)
+		ch <- CallbackResult{Resp: buffered.resp}
+	} else {
+		l.pendingCallbacks[key] = ch
+	}
+	l.callbackStateMu.Unlock()
+
+	if hasBuffered {
+		return ch
+	}
+
+	l.signalStatusChanged()
 	return ch
 }
 
@@ -259,8 +322,8 @@ func (l *DurableTaskListener) PendingEventAckCount() int {
 
 // PendingCallbackCount returns the number of pending callbacks.
 func (l *DurableTaskListener) PendingCallbackCount() int {
-	l.pendingCallbacksMu.Lock()
-	defer l.pendingCallbacksMu.Unlock()
+	l.callbackStateMu.Lock()
+	defer l.callbackStateMu.Unlock()
 	return len(l.pendingCallbacks)
 }
 
@@ -273,8 +336,9 @@ func (l *DurableTaskListener) PendingEvictionAckCount() int {
 
 // BufferedCompletionCount returns the number of completions buffered for late consumers.
 func (l *DurableTaskListener) BufferedCompletionCount() int {
-	l.bufferedCompletionsMu.Lock()
-	defer l.bufferedCompletionsMu.Unlock()
+	l.callbackStateMu.Lock()
+	defer l.callbackStateMu.Unlock()
+	l.pruneExpiredCompletionsLocked(time.Now())
 	return len(l.bufferedCompletions)
 }
 
@@ -284,7 +348,7 @@ func (l *DurableTaskListener) BufferedCompletionCount() int {
 func (l *DurableTaskListener) CleanupTaskState(taskExternalID string, invocationCount int32) {
 	cancelErr := fmt.Errorf("state cleaned up after eviction of task %s invocation %d", taskExternalID, invocationCount)
 
-	l.pendingCallbacksMu.Lock()
+	l.callbackStateMu.Lock()
 	for k, ch := range l.pendingCallbacks {
 		if k.TaskID == taskExternalID && k.SignalKey <= int64(invocationCount) {
 			delete(l.pendingCallbacks, k)
@@ -294,77 +358,58 @@ func (l *DurableTaskListener) CleanupTaskState(taskExternalID string, invocation
 			}
 		}
 	}
-	l.pendingCallbacksMu.Unlock()
-
-	l.pendingEventAcksMu.Lock()
-	for k, ch := range l.pendingEventAcks {
-		if k.TaskID == taskExternalID && k.SignalKey <= int64(invocationCount) {
-			delete(l.pendingEventAcks, k)
-			select {
-			case ch <- EventAckResult{Err: cancelErr}:
-			default:
-			}
-		}
-	}
-	l.pendingEventAcksMu.Unlock()
-
-	l.bufferedCompletionsMu.Lock()
 	for k := range l.bufferedCompletions {
 		if k.TaskID == taskExternalID && k.SignalKey <= int64(invocationCount) {
 			delete(l.bufferedCompletions, k)
 		}
 	}
-	l.bufferedCompletionsMu.Unlock()
+	l.callbackStateMu.Unlock()
+
+	l.pendingEventAcksMu.Lock()
+	eventAcks := make([]chan EventAckResult, 0)
+	for k, ch := range l.pendingEventAcks {
+		if k.TaskID == taskExternalID && k.SignalKey <= int64(invocationCount) {
+			delete(l.pendingEventAcks, k)
+			eventAcks = append(eventAcks, ch)
+		}
+	}
+	l.pendingEventAcksMu.Unlock()
+
+	for _, ch := range eventAcks {
+		select {
+		case ch <- EventAckResult{Err: cancelErr}:
+		default:
+		}
+	}
 }
 
-func (l *DurableTaskListener) receiveLoop(ctx context.Context) {
+func (l *DurableTaskListener) receiveLoop(ctx context.Context, done chan struct{}) {
 	defer func() {
+		l.failPendingAcks(errDurableTaskListenerStopped)
+		l.terminateCallbackState(errDurableTaskListenerStopped)
+
 		l.mu.Lock()
 		l.running = false
+		if l.done == done {
+			l.done = nil
+		}
+		close(done)
 		l.mu.Unlock()
-		l.failPendingAcks(errors.New("durable task listener stopped"))
 	}()
 
 	for {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
-
-		stream, err := l.connect(ctx)
-		if err != nil {
-			if isCancelled(ctx) {
-				return
-			}
-			l.l.Error().Err(err).Msg("DurableTaskListener: connection failed, retrying")
-			if sleepErr := retry.Sleep(ctx, l.reconnectInterval); sleepErr != nil {
-				return
-			}
-			continue
-		}
-
-		l.streamMu.Lock()
-		l.streamSeq++
-		l.streamMu.Unlock()
-
-		err = l.handleStream(ctx, stream)
-		if err != nil {
-			if isCancelled(ctx) || isGRPCCancelled(err) {
-				return
-			}
-			l.failPendingAcks(fmt.Errorf("connection reset: %w", err))
-			l.l.Warn().Err(err).Msg("DurableTaskListener: stream ended, reconnecting")
-			if sleepErr := retry.Sleep(ctx, l.reconnectInterval); sleepErr != nil {
-				return
-			}
-			continue
-		}
-
-		l.failPendingAcks(errors.New("connection reset: stream ended"))
-		if isCancelled(ctx) {
+		result := l.handleStream(ctx)
+		if result.terminal {
 			return
 		}
+
+		resetErr := errors.New("connection reset: stream ended")
+		if result.err != nil {
+			resetErr = fmt.Errorf("connection reset: %w", result.err)
+			l.l.Warn().Err(result.err).Msg("DurableTaskListener: stream ended, reconnecting")
+		}
+		l.failPendingAcks(resetErr)
+
 		if sleepErr := retry.Sleep(ctx, l.reconnectInterval); sleepErr != nil {
 			return
 		}
@@ -375,7 +420,21 @@ func (l *DurableTaskListener) connect(ctx context.Context) (v1.V1Dispatcher_Dura
 	return l.connectFn(ctx)
 }
 
-func (l *DurableTaskListener) handleStream(ctx context.Context, stream v1.V1Dispatcher_DurableTaskClient) error {
+func (l *DurableTaskListener) handleStream(ctx context.Context) durableTaskStreamResult {
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	stream, err := l.connect(streamCtx)
+	if err != nil {
+		cancelStream()
+		return durableTaskStreamResult{
+			err:      err,
+			terminal: ctx.Err() != nil,
+		}
+	}
+
+	l.streamMu.Lock()
+	l.streamSeq++
+	l.streamMu.Unlock()
+
 	if err := stream.Send(&v1.DurableTaskRequest{
 		Message: &v1.DurableTaskRequest_RegisterWorker{
 			RegisterWorker: &v1.DurableTaskRequestRegisterWorker{
@@ -383,46 +442,98 @@ func (l *DurableTaskListener) handleStream(ctx context.Context, stream v1.V1Disp
 			},
 		},
 	}); err != nil {
-		return fmt.Errorf("failed to register worker on durable task stream: %w", err)
+		cancelStream()
+		return durableTaskStreamResult{
+			err:      fmt.Errorf("failed to register worker on durable task stream: %w", err),
+			terminal: ctx.Err() != nil,
+		}
 	}
 
 	l.l.Debug().Str("worker_id", l.workerID).Msg("DurableTaskListener: registered worker on stream")
 
-	streamCtx, cancelStream := context.WithCancel(ctx)
-	defer cancelStream()
+	sendFailed := make(chan error, 1)
+	senderStopped := make(chan struct{})
+	go l.sendStreamRequests(streamCtx, cancelStream, stream, sendFailed, senderStopped)
 
-	sendDone := make(chan error, 1)
-	go func() {
-		for {
-			select {
-			case <-streamCtx.Done():
-				sendDone <- streamCtx.Err()
-				return
-			case req := <-l.requestQueue:
-				if err := stream.Send(req); err != nil {
-					sendDone <- err
-					return
-				}
-			}
-		}
+	defer func() {
+		cancelStream()
+		<-senderStopped
 	}()
 
 	for {
-		select {
-		case err := <-sendDone:
-			return err
-		default:
-		}
-
 		resp, err := stream.Recv()
 		if err != nil {
-			if errors.Is(err, io.EOF) {
-				return nil
+			select {
+			case sendErr := <-sendFailed:
+				return durableTaskStreamResult{
+					err:      sendErr,
+					terminal: ctx.Err() != nil,
+				}
+			default:
 			}
-			return err
+			if ctx.Err() != nil {
+				return durableTaskStreamResult{err: ctx.Err(), terminal: true}
+			}
+			if errors.Is(err, io.EOF) {
+				return durableTaskStreamResult{}
+			}
+			return durableTaskStreamResult{
+				err:      err,
+				terminal: isGRPCCancelled(err),
+			}
 		}
 
 		l.dispatchResponse(resp)
+	}
+}
+
+func (l *DurableTaskListener) sendStreamRequests(
+	ctx context.Context,
+	cancelStream context.CancelFunc,
+	stream v1.V1Dispatcher_DurableTaskClient,
+	sendFailed chan<- error,
+	stopped chan<- struct{},
+) {
+	defer close(stopped)
+
+	ticker := time.NewTicker(defaultWorkerStatusInterval)
+	defer ticker.Stop()
+
+	select {
+	case <-l.statusChanged:
+	default:
+	}
+	if err := l.sendWorkerStatus(stream); err != nil {
+		sendFailed <- err
+		cancelStream()
+		return
+	}
+
+	// The capacity-one status signal stays ready until consumed, so Go's select
+	// can service either source without allowing status bursts into the mutation queue.
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case req := <-l.requestQueue:
+			if err := stream.Send(req); err != nil {
+				sendFailed <- err
+				cancelStream()
+				return
+			}
+		case <-l.statusChanged:
+			if err := l.sendWorkerStatus(stream); err != nil {
+				sendFailed <- err
+				cancelStream()
+				return
+			}
+		case <-ticker.C:
+			if err := l.sendWorkerStatus(stream); err != nil {
+				sendFailed <- err
+				cancelStream()
+				return
+			}
+		}
 	}
 }
 
@@ -473,11 +584,12 @@ func (l *DurableTaskListener) removePendingEventAck(key PendingAckKey) {
 }
 
 func (l *DurableTaskListener) removePendingCallback(key PendingCallbackKey) {
-	l.pendingCallbacksMu.Lock()
-	defer l.pendingCallbacksMu.Unlock()
+	l.callbackStateMu.Lock()
+	defer l.callbackStateMu.Unlock()
 	delete(l.pendingCallbacks, key)
 }
 
+// SendTriggerRunsRequest sends child workflow requests and waits for their event-log ack.
 func (l *DurableTaskListener) SendTriggerRunsRequest(
 	ctx context.Context,
 	taskExternalID string,
@@ -572,11 +684,7 @@ func (l *DurableTaskListener) WaitForCallback(
 }
 
 // SendWaitForRequest registers a durable wait-for on the engine over the bidi DurableTask
-// stream. It mirrors the Python SDK's `listener.send_event(WaitForEvent(...))` + wait-for-callback
-// flow: the listener first sends a WaitFor request and blocks for the WaitForAck (which carries
-// the server-assigned node_id/branch_id), then blocks until the corresponding EntryCompleted
-// response arrives (or ctx is cancelled). The returned payload is the raw JSON result bytes
-// which the caller can unmarshal with the same shape as the legacy RegisterDurableEvent path.
+// stream. It waits for the server-assigned event-log ref before waiting for completion.
 func (l *DurableTaskListener) SendWaitForRequest(
 	ctx context.Context,
 	taskExternalID string,
@@ -639,7 +747,6 @@ type MemoAckResult struct {
 
 // SendMemoRequest sends a memo lookup over the bidi DurableTask stream and blocks
 // until the engine acks with the cached payload (if any) and the log entry ref.
-// Mirrors the Python SDK's MemoEvent send_event flow.
 func (l *DurableTaskListener) SendMemoRequest(
 	ctx context.Context,
 	taskExternalID string,
@@ -747,24 +854,25 @@ func (l *DurableTaskListener) dispatchResponse(resp *v1.DurableTaskResponse) {
 			NodeID:    ref.GetNodeId(),
 		}
 
-		l.pendingCallbacksMu.Lock()
+		l.callbackStateMu.Lock()
+		if l.callbacksTerminal {
+			l.callbackStateMu.Unlock()
+			return
+		}
+		l.pruneExpiredCompletionsLocked(time.Now())
 		ch, ok := l.pendingCallbacks[key]
 		if ok {
 			delete(l.pendingCallbacks, key)
-		}
-		l.pendingCallbacksMu.Unlock()
-
-		if ok {
+			// Callback channels are buffered, so publishing while locked cannot
+			// block and ensures Stop cannot return before this delivery.
 			select {
 			case ch <- CallbackResult{Resp: resp}:
 			default:
 			}
-			return
+		} else {
+			l.cacheCompletionLocked(key, resp)
 		}
-
-		l.bufferedCompletionsMu.Lock()
-		l.bufferedCompletions[key] = resp
-		l.bufferedCompletionsMu.Unlock()
+		l.callbackStateMu.Unlock()
 	case *v1.DurableTaskResponse_Error:
 		l.dispatchError(msg.Error)
 	case *v1.DurableTaskResponse_ServerEvict:
@@ -831,14 +939,17 @@ func (l *DurableTaskListener) dispatchError(errResp *v1.DurableTaskErrorResponse
 	}
 
 	l.pendingEventAcksMu.Lock()
-	if ch, ok := l.pendingEventAcks[ackKey]; ok {
+	eventAckCh, hasEventAck := l.pendingEventAcks[ackKey]
+	if hasEventAck {
 		delete(l.pendingEventAcks, ackKey)
+	}
+	l.pendingEventAcksMu.Unlock()
+	if hasEventAck {
 		select {
-		case ch <- EventAckResult{Err: err}:
+		case eventAckCh <- EventAckResult{Err: err}:
 		default:
 		}
 	}
-	l.pendingEventAcksMu.Unlock()
 
 	cbKey := PendingCallbackKey{
 		TaskID:    ref.GetDurableTaskExternalId(),
@@ -847,25 +958,95 @@ func (l *DurableTaskListener) dispatchError(errResp *v1.DurableTaskErrorResponse
 		NodeID:    ref.GetNodeId(),
 	}
 
-	l.pendingCallbacksMu.Lock()
-	if ch, ok := l.pendingCallbacks[cbKey]; ok {
-		delete(l.pendingCallbacks, cbKey)
-		select {
-		case ch <- CallbackResult{Err: err}:
-		default:
+	l.callbackStateMu.Lock()
+	if !l.callbacksTerminal {
+		callbackCh, hasCallback := l.pendingCallbacks[cbKey]
+		if hasCallback {
+			delete(l.pendingCallbacks, cbKey)
+			select {
+			case callbackCh <- CallbackResult{Err: err}:
+			default:
+			}
 		}
 	}
-	l.pendingCallbacksMu.Unlock()
+	l.callbackStateMu.Unlock()
 
 	l.pendingEvictionAcksMu.Lock()
-	if ch, ok := l.pendingEvictionAcks[ackKey]; ok {
+	evictionAckCh, hasEvictionAck := l.pendingEvictionAcks[ackKey]
+	if hasEvictionAck {
 		delete(l.pendingEvictionAcks, ackKey)
+	}
+	l.pendingEvictionAcksMu.Unlock()
+	if hasEvictionAck {
 		select {
-		case ch <- err:
+		case evictionAckCh <- err:
 		default:
 		}
 	}
-	l.pendingEvictionAcksMu.Unlock()
+}
+
+func (l *DurableTaskListener) signalStatusChanged() {
+	// The signal carries no snapshot; the stream sender reads current callback
+	// state immediately before Send and coalesces any registration burst.
+	select {
+	case l.statusChanged <- struct{}{}:
+	default:
+	}
+}
+
+func (l *DurableTaskListener) sendWorkerStatus(stream v1.V1Dispatcher_DurableTaskClient) error {
+	req := l.workerStatusRequest()
+	if req == nil {
+		return nil
+	}
+	return stream.Send(req)
+}
+
+func (l *DurableTaskListener) workerStatusRequest() *v1.DurableTaskRequest {
+	l.callbackStateMu.Lock()
+	if l.callbacksTerminal || len(l.pendingCallbacks) == 0 {
+		l.callbackStateMu.Unlock()
+		return nil
+	}
+
+	waitingEntries := make([]*v1.DurableTaskAwaitedCompletedEntry, 0, len(l.pendingCallbacks))
+	for key := range l.pendingCallbacks {
+		waitingEntries = append(waitingEntries, &v1.DurableTaskAwaitedCompletedEntry{
+			DurableTaskExternalId: key.TaskID,
+			InvocationCount:       int32(key.SignalKey), //nolint:gosec
+			BranchId:              key.BranchID,
+			NodeId:                key.NodeID,
+		})
+	}
+	l.callbackStateMu.Unlock()
+
+	return &v1.DurableTaskRequest{
+		Message: &v1.DurableTaskRequest_WorkerStatus{
+			WorkerStatus: &v1.DurableTaskWorkerStatusRequest{
+				WorkerId:       l.workerID,
+				WaitingEntries: waitingEntries,
+			},
+		},
+	}
+}
+
+func (l *DurableTaskListener) cacheCompletionLocked(
+	key PendingCallbackKey,
+	resp *v1.DurableTaskResponse,
+) {
+	expiresAt := time.Now().Add(defaultCompletionBufferTTL)
+	l.bufferedCompletions[key] = bufferedCompletion{
+		resp:      resp,
+		expiresAt: expiresAt,
+	}
+}
+
+func (l *DurableTaskListener) pruneExpiredCompletionsLocked(now time.Time) {
+	for key, buffered := range l.bufferedCompletions {
+		if !buffered.expiresAt.After(now) {
+			delete(l.bufferedCompletions, key)
+		}
+	}
 }
 
 // failPendingAcks fails all pending event acks and eviction acks on disconnect.
@@ -897,8 +1078,27 @@ func (l *DurableTaskListener) failPendingAcks(err error) {
 	}
 }
 
-func isCancelled(ctx context.Context) bool {
-	return ctx.Err() != nil
+func (l *DurableTaskListener) terminateCallbackState(err error) {
+	l.callbackStateMu.Lock()
+	defer l.callbackStateMu.Unlock()
+	l.terminateCallbackStateLocked(err)
+}
+
+func (l *DurableTaskListener) terminateCallbackStateLocked(err error) {
+	l.callbacksTerminal = true
+	l.callbackTerminalErr = err
+	callbacks := l.pendingCallbacks
+	l.pendingCallbacks = make(map[PendingCallbackKey]chan CallbackResult)
+	l.bufferedCompletions = make(map[PendingCallbackKey]bufferedCompletion)
+
+	// Keep delivery inside the terminal transition so no detached waiter can
+	// receive its shutdown result after Stop returns.
+	for _, ch := range callbacks {
+		select {
+		case ch <- CallbackResult{Err: err}:
+		default:
+		}
+	}
 }
 
 func isGRPCCancelled(err error) bool {

--- a/pkg/client/durable_task_listener.go
+++ b/pkg/client/durable_task_listener.go
@@ -70,8 +70,9 @@ type bufferedCompletion struct {
 }
 
 type durableTaskStreamResult struct {
-	err      error
-	terminal bool
+	err       error
+	connected bool
+	terminal  bool
 }
 
 // NonDeterminismError is returned by the engine when a durable task replay detects
@@ -403,12 +404,16 @@ func (l *DurableTaskListener) receiveLoop(ctx context.Context, done chan struct{
 			return
 		}
 
-		resetErr := errors.New("connection reset: stream ended")
+		if result.connected {
+			resetErr := errors.New("connection reset: stream ended")
+			if result.err != nil {
+				resetErr = fmt.Errorf("connection reset: %w", result.err)
+			}
+			l.failPendingAcks(resetErr)
+		}
 		if result.err != nil {
-			resetErr = fmt.Errorf("connection reset: %w", result.err)
 			l.l.Warn().Err(result.err).Msg("DurableTaskListener: stream ended, reconnecting")
 		}
-		l.failPendingAcks(resetErr)
 
 		if sleepErr := retry.Sleep(ctx, l.reconnectInterval); sleepErr != nil {
 			return
@@ -444,8 +449,9 @@ func (l *DurableTaskListener) handleStream(ctx context.Context) durableTaskStrea
 	}); err != nil {
 		cancelStream()
 		return durableTaskStreamResult{
-			err:      fmt.Errorf("failed to register worker on durable task stream: %w", err),
-			terminal: ctx.Err() != nil,
+			err:       fmt.Errorf("failed to register worker on durable task stream: %w", err),
+			connected: true,
+			terminal:  ctx.Err() != nil,
 		}
 	}
 
@@ -466,20 +472,22 @@ func (l *DurableTaskListener) handleStream(ctx context.Context) durableTaskStrea
 			select {
 			case sendErr := <-sendFailed:
 				return durableTaskStreamResult{
-					err:      sendErr,
-					terminal: ctx.Err() != nil,
+					err:       sendErr,
+					connected: true,
+					terminal:  ctx.Err() != nil,
 				}
 			default:
 			}
 			if ctx.Err() != nil {
-				return durableTaskStreamResult{err: ctx.Err(), terminal: true}
+				return durableTaskStreamResult{err: ctx.Err(), connected: true, terminal: true}
 			}
 			if errors.Is(err, io.EOF) {
-				return durableTaskStreamResult{}
+				return durableTaskStreamResult{connected: true}
 			}
 			return durableTaskStreamResult{
-				err:      err,
-				terminal: isGRPCCancelled(err),
+				err:       err,
+				connected: true,
+				terminal:  isGRPCCancelled(err),
 			}
 		}
 

--- a/pkg/client/durable_task_listener_test.go
+++ b/pkg/client/durable_task_listener_test.go
@@ -259,6 +259,72 @@ func TestFailPendingAcksClearsEventAcks(t *testing.T) {
 	assert.Equal(t, 0, h.listener.PendingEventAckCount())
 }
 
+func TestConnectFailurePreservesPendingAcksAndQueuedRequests(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	l := zerolog.Nop()
+	stream := newMockStream(ctx)
+	firstDialFailed := make(chan struct{})
+	attempts := 0
+	listener := NewDurableTaskListener(
+		"test-worker",
+		func(ctx context.Context) (v1.V1Dispatcher_DurableTaskClient, error) {
+			attempts++
+			if attempts == 1 {
+				close(firstDialFailed)
+				return nil, status.Error(codes.Unavailable, "down")
+			}
+			return stream, nil
+		},
+		&l,
+		WithReconnectInterval(100*time.Millisecond),
+	)
+
+	key := PendingAckKey{TaskID: "task1", SignalKey: 1}
+	ackCh := listener.AddPendingEventAck(key)
+	listener.SendRequest(&v1.DurableTaskRequest{
+		Message: &v1.DurableTaskRequest_TriggerRuns{
+			TriggerRuns: &v1.DurableTaskTriggerRunsRequest{
+				DurableTaskExternalId: key.TaskID,
+				InvocationCount:       int32(key.SignalKey),
+			},
+		},
+	})
+
+	listener.Start(ctx)
+	defer listener.Stop()
+	<-firstDialFailed
+
+	select {
+	case result := <-ackCh:
+		t.Fatalf("pending ack failed before its request was sent: %v", result.Err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	require.NotNil(t, awaitRequest(t, stream).GetRegisterWorker())
+	sent := awaitRequest(t, stream).GetTriggerRuns()
+	require.NotNil(t, sent)
+	assert.Equal(t, key.TaskID, sent.GetDurableTaskExternalId())
+	assert.Equal(t, int32(key.SignalKey), sent.GetInvocationCount())
+
+	stream.recvCh <- &v1.DurableTaskResponse{
+		Message: &v1.DurableTaskResponse_TriggerRunsAck{
+			TriggerRunsAck: &v1.DurableTaskEventTriggerRunsAckResponse{
+				DurableTaskExternalId: key.TaskID,
+				InvocationCount:       int32(key.SignalKey),
+			},
+		},
+	}
+
+	select {
+	case result := <-ackCh:
+		require.NoError(t, result.Err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for ack after reconnect")
+	}
+}
+
 // --- Pending callbacks survive disconnect ---
 
 func TestPendingCallbacksSurviveDisconnect(t *testing.T) {

--- a/pkg/client/durable_task_listener_test.go
+++ b/pkg/client/durable_task_listener_test.go
@@ -295,15 +295,18 @@ func TestPendingCallbackRecoveredFromWorkerStatusAfterReconnect(t *testing.T) {
 	first := h.addHangingStream(ctx)
 	second := h.addHangingStream(ctx)
 	key := PendingCallbackKey{TaskID: "task1", SignalKey: 2, BranchID: 3, NodeID: 4}
+	// Pending callbacks must survive stream generation so waits can be reconciled after reconnect.
 	callbackCh := h.listener.AddPendingCallback(key)
 
 	h.listener.Start(ctx)
 	defer h.listener.Stop()
 
 	require.NotNil(t, awaitRequest(t, first).GetRegisterWorker())
+	// EOF drops the old stream's direct-delivery mapping; the wait must not be lost with it.
 	close(first.recvCh)
 
 	require.NotNil(t, awaitRequest(t, second).GetRegisterWorker())
+	// Replacement stream reports the exact wait key so the engine can replay a persisted completion.
 	statusReq := awaitRequest(t, second).GetWorkerStatus()
 	require.NotNil(t, statusReq)
 	require.Len(t, statusReq.GetWaitingEntries(), 1)
@@ -313,6 +316,7 @@ func TestPendingCallbackRecoveredFromWorkerStatusAfterReconnect(t *testing.T) {
 	assert.Equal(t, key.BranchID, waiting.GetBranchId())
 	assert.Equal(t, key.NodeID, waiting.GetNodeId())
 
+	// Injected EntryCompleted models the engine recovery path after WorkerStatus reconciliation.
 	second.recvCh <- &v1.DurableTaskResponse{
 		Message: &v1.DurableTaskResponse_EntryCompleted{
 			EntryCompleted: &v1.DurableTaskEventLogEntryCompletedResponse{

--- a/pkg/client/durable_task_listener_test.go
+++ b/pkg/client/durable_task_listener_test.go
@@ -119,6 +119,18 @@ func (h *testHarness) getCallCount() int {
 	return h.callCount
 }
 
+func awaitRequest(t *testing.T, stream *mockDurableTaskStream) *v1.DurableTaskRequest {
+	t.Helper()
+
+	select {
+	case req := <-stream.sendCh:
+		return req
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for durable task request")
+		return nil
+	}
+}
+
 // --- Reconnection on stream EOF ---
 
 func TestOpensNewStreamAfterEOF(t *testing.T) {
@@ -273,6 +285,55 @@ func TestPendingCallbacksSurviveDisconnect(t *testing.T) {
 	}
 
 	assert.Equal(t, 1, h.listener.PendingCallbackCount())
+}
+
+func TestPendingCallbackRecoveredFromWorkerStatusAfterReconnect(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h := newTestHarness()
+	first := h.addHangingStream(ctx)
+	second := h.addHangingStream(ctx)
+	key := PendingCallbackKey{TaskID: "task1", SignalKey: 2, BranchID: 3, NodeID: 4}
+	callbackCh := h.listener.AddPendingCallback(key)
+
+	h.listener.Start(ctx)
+	defer h.listener.Stop()
+
+	require.NotNil(t, awaitRequest(t, first).GetRegisterWorker())
+	close(first.recvCh)
+
+	require.NotNil(t, awaitRequest(t, second).GetRegisterWorker())
+	statusReq := awaitRequest(t, second).GetWorkerStatus()
+	require.NotNil(t, statusReq)
+	require.Len(t, statusReq.GetWaitingEntries(), 1)
+	waiting := statusReq.GetWaitingEntries()[0]
+	assert.Equal(t, key.TaskID, waiting.GetDurableTaskExternalId())
+	assert.Equal(t, int32(key.SignalKey), waiting.GetInvocationCount())
+	assert.Equal(t, key.BranchID, waiting.GetBranchId())
+	assert.Equal(t, key.NodeID, waiting.GetNodeId())
+
+	second.recvCh <- &v1.DurableTaskResponse{
+		Message: &v1.DurableTaskResponse_EntryCompleted{
+			EntryCompleted: &v1.DurableTaskEventLogEntryCompletedResponse{
+				Ref: &v1.DurableEventLogEntryRef{
+					DurableTaskExternalId: waiting.GetDurableTaskExternalId(),
+					InvocationCount:       waiting.GetInvocationCount(),
+					BranchId:              waiting.GetBranchId(),
+					NodeId:                waiting.GetNodeId(),
+				},
+				Payload: []byte("recovered"),
+			},
+		},
+	}
+
+	select {
+	case result := <-callbackCh:
+		require.NoError(t, result.Err)
+		assert.Equal(t, []byte("recovered"), result.Resp.GetEntryCompleted().GetPayload())
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for completion recovered after reconnect")
+	}
 }
 
 // --- Pending eviction acks cleared on disconnect ---


### PR DESCRIPTION
# Description

Go durable waits now report pending callbacks after reconnect and periodically so persisted completions can be replayed.

Why:
- Stream interruptions previously lost callback routing, leaving completed durable waits stuck.
- Periodic status reconciliation allows the engine to rediscover and redeliver completed entries.

How:
- Track outstanding durable callback waits and report them through `WorkerStatus` after connecting.
- Resend current waiting entries whenever callback state changes and every second.
- Preserve pending callbacks across reconnects and reconcile them with engine responses.
- Atomically deliver or briefly buffer early completions, with race-safe shutdown handling.



### similarity to other SDKs

Python
* https://github.com/hatchet-dev/hatchet/blob/522678b8d588429f687216d080380640d487a9b7/sdks/python/hatchet_sdk/clients/listeners/durable_event_listener.py#L293-L316

TypeScript
* https://github.com/hatchet-dev/hatchet/blob/522678b8d588429f687216d080380640d487a9b7/sdks/typescript/src/clients/listeners/durable-listener/durable-listener-client.ts#L384-L404

Fixes #4445

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

- [x] Report pending callback waiting entries after reconnect and while waits remain pending.
- [x] Add one deterministic reconnect regression test.

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

- `go test -race ./pkg/client -count=1`
- `go test ./sdks/go/... -count=1`
- `gofmt -d pkg/client/durable_task_listener.go pkg/client/durable_task_listener_test.go`
- `git diff --check -- pkg/client/durable_task_listener.go pkg/client/durable_task_listener_test.go`

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Cursor with GPT-5.6 Sol was used to develop and test the implementation and draft this pull request.

</details>