### PR TITLE
fix: non tty profile selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Tasks can declare a slot cost, so a task that needs more memory or CPU consumes more than one worker slot. See [Task Slot Cost](https://docs.hatchet.run/v1/advanced-assignment/slot-cost).
 - Engine rows in the run trace view now carry a badge with their workflow, task, or event name, and the retry number on retried tasks, so repeated spans such as `hatchet.engine.workflow_run` are distinguishable at a glance.
+- CLI commands that take `--profile` now use the configured default or only profile without prompting, and `hatchet server start` sets its new profile as the default when none is configured. In sessions without a terminal, such as CI, a selection that would still need a prompt fails with an error that explains how to proceed.
 
 ## [0.94.10] - 2026-07-14
 

--- a/cmd/hatchet-cli/cli/internal/config/cli/profile.go
+++ b/cmd/hatchet-cli/cli/internal/config/cli/profile.go
@@ -322,6 +322,20 @@ func SetDefaultProfile(name string) error {
 	return saveConfig()
 }
 
+// SetDefaultProfileIfUnset makes name the default profile when none is configured and
+// reports whether it did.
+func SetDefaultProfileIfUnset(name string) (bool, error) {
+	if GetDefaultProfile() != "" {
+		return false, nil
+	}
+
+	if err := SetDefaultProfile(name); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
 // ClearDefaultProfile clears the default profile setting
 func ClearDefaultProfile() error {
 	unlock, err := acquireLock()

--- a/cmd/hatchet-cli/cli/internal/config/cli/profile_test.go
+++ b/cmd/hatchet-cli/cli/internal/config/cli/profile_test.go
@@ -912,6 +912,37 @@ func TestSetDefaultProfile_NilConfig(t *testing.T) {
 	assert.Contains(t, err.Error(), "config not initialized")
 }
 
+func TestSetDefaultProfileIfUnset(t *testing.T) {
+	_, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	err := AddProfile("local", makeTestProfile("local", "token-123"))
+	require.NoError(t, err)
+
+	set, err := SetDefaultProfileIfUnset("local")
+	require.NoError(t, err)
+	assert.True(t, set)
+	assert.Equal(t, "local", GetDefaultProfile())
+}
+
+func TestSetDefaultProfileIfUnset_ExistingDefaultKept(t *testing.T) {
+	_, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	err := AddProfile("prod", makeTestProfile("prod", "token-123"))
+	require.NoError(t, err)
+	err = AddProfile("local", makeTestProfile("local", "token-456"))
+	require.NoError(t, err)
+
+	err = SetDefaultProfile("prod")
+	require.NoError(t, err)
+
+	set, err := SetDefaultProfileIfUnset("local")
+	require.NoError(t, err)
+	assert.False(t, set)
+	assert.Equal(t, "prod", GetDefaultProfile())
+}
+
 func TestClearDefaultProfile(t *testing.T) {
 	_, cleanup := setupTestConfig(t)
 	defer cleanup()

--- a/cmd/hatchet-cli/cli/profile.go
+++ b/cmd/hatchet-cli/cli/profile.go
@@ -590,13 +590,8 @@ func selectProfileForm(useDefault bool) string {
 	}
 	sort.Strings(names)
 
-	// If useDefault is true, try to return the default profile without showing the form
-	if useDefault {
-		defaultProfile := cli.GetDefaultProfile()
-		// Verify the default profile is still in the list
-		if defaultProfile != "" && slices.Contains(names, defaultProfile) {
-			return defaultProfile
-		}
+	if name, ok := resolveProfileWithoutForm(names, cli.GetDefaultProfile(), useDefault); ok {
+		return name
 	}
 
 	// Create options in sorted order
@@ -621,10 +616,42 @@ func selectProfileForm(useDefault bool) string {
 	err := form.Run()
 
 	if err != nil {
-		cli.Logger.Fatalf("could not run profile remove form: %v", err)
+		cli.Logger.Fatalf("%s", profileSelectionFailureMessage(err, names))
 	}
 
 	return selectedName
+}
+
+// resolveProfileWithoutForm picks the profile when the form can be skipped: the still-valid
+// default, or the only profile when useDefault is set. Management commands keep the form even
+// with a single profile because they act immediately on the returned name.
+func resolveProfileWithoutForm(names []string, defaultProfile string, useDefault bool) (string, bool) {
+	if !useDefault {
+		return "", false
+	}
+
+	if defaultProfile != "" && slices.Contains(names, defaultProfile) {
+		return defaultProfile, true
+	}
+
+	if len(names) == 1 {
+		return names[0], true
+	}
+
+	return "", false
+}
+
+// Form failures here usually mean a session without a TTY, where the form library cannot
+// open /dev/tty.
+func profileSelectionFailureMessage(err error, names []string) string {
+	return fmt.Sprintf(
+		"could not run profile selection form: %v\n"+
+			"In a non-interactive session, pass the profile explicitly where the command supports it "+
+			"(for example --profile <name> or a profile name argument), or set a default with "+
+			"'hatchet profile set-default <name>'. Available profiles: %s",
+		err,
+		strings.Join(names, ", "),
+	)
 }
 
 // profileView renders a profile view with details

--- a/cmd/hatchet-cli/cli/profile_selection_test.go
+++ b/cmd/hatchet-cli/cli/profile_selection_test.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveProfileWithoutForm(t *testing.T) {
+	tests := []struct {
+		name           string
+		names          []string
+		defaultProfile string
+		useDefault     bool
+		wantName       string
+		wantOK         bool
+	}{
+		{
+			name:           "default set and valid",
+			names:          []string{"local", "prod"},
+			defaultProfile: "prod",
+			useDefault:     true,
+			wantName:       "prod",
+			wantOK:         true,
+		},
+		{
+			name:           "single profile, no default",
+			names:          []string{"local"},
+			defaultProfile: "",
+			useDefault:     true,
+			wantName:       "local",
+			wantOK:         true,
+		},
+		{
+			name:           "single profile, stale default",
+			names:          []string{"local"},
+			defaultProfile: "removed-profile",
+			useDefault:     true,
+			wantName:       "local",
+			wantOK:         true,
+		},
+		{
+			name:           "multiple profiles, no default",
+			names:          []string{"local", "prod"},
+			defaultProfile: "",
+			useDefault:     true,
+			wantName:       "",
+			wantOK:         false,
+		},
+		{
+			name:           "single profile but management command",
+			names:          []string{"local"},
+			defaultProfile: "",
+			useDefault:     false,
+			wantName:       "",
+			wantOK:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, ok := resolveProfileWithoutForm(tt.names, tt.defaultProfile, tt.useDefault)
+			assert.Equal(t, tt.wantName, name)
+			assert.Equal(t, tt.wantOK, ok)
+		})
+	}
+}
+
+// The fixture mirrors huh's no-TTY error. The message once misreported this failure as a
+// "profile remove form" error, hence the exclusion.
+func TestProfileSelectionFailureMessage(t *testing.T) {
+	formErr := errors.New("huh: could not open a new TTY: open /dev/tty: no such device or address")
+
+	msg := profileSelectionFailureMessage(formErr, []string{"local", "prod"})
+
+	assert.Contains(t, msg, "profile selection form")
+	assert.Contains(t, msg, "--profile")
+	assert.Contains(t, msg, "hatchet profile set-default")
+	assert.Contains(t, msg, "local, prod")
+	assert.Contains(t, msg, "/dev/tty")
+	assert.NotContains(t, msg, "remove")
+}

--- a/cmd/hatchet-cli/cli/server.go
+++ b/cmd/hatchet-cli/cli/server.go
@@ -89,7 +89,12 @@ func runServerStart(cmd *cobra.Command) {
 		cli.Logger.Fatalf("%v", err)
 	}
 
-	fmt.Println(serverStartedView(result.ProfileName, result.DashboardPort, result.GrpcPort, disableAuth, ""))
+	additionalMessage := ""
+	if result.DefaultSet {
+		additionalMessage = fmt.Sprintf("Profile '%s' set as the default profile", result.ProfileName)
+	}
+
+	fmt.Println(serverStartedView(result.ProfileName, result.DashboardPort, result.GrpcPort, disableAuth, additionalMessage))
 
 	if disableAuth && result.Token != "" {
 		fmt.Println()
@@ -140,6 +145,7 @@ type ServerStartResult struct {
 	Token         string
 	DashboardPort int
 	GrpcPort      int
+	DefaultSet    bool
 }
 
 // startLocalServer starts a local Hatchet server and returns connection details
@@ -179,11 +185,19 @@ func startLocalServer(cmd *cobra.Command, profileName string, opts ...docker.Hat
 		return nil, fmt.Errorf("could not add profile: %w", err)
 	}
 
+	// A non-interactive session cannot answer the profile-selection form, so the profile
+	// created here becomes the default unless the user already chose one.
+	defaultSet, err := cli.SetDefaultProfileIfUnset(profileName)
+	if err != nil {
+		return nil, fmt.Errorf("could not set default profile: %w", err)
+	}
+
 	return &ServerStartResult{
 		ProfileName:   profileName,
 		Token:         token,
 		DashboardPort: actualDashboardPort,
 		GrpcPort:      actualGrpcPort,
+		DefaultSet:    defaultSet,
 	}, nil
 }
 

--- a/cmd/hatchet-cli/cli/trigger.go
+++ b/cmd/hatchet-cli/cli/trigger.go
@@ -73,7 +73,7 @@ func init() {
 	rootCmd.AddCommand(triggerCmd)
 
 	// Add flags for trigger command
-	triggerCmd.Flags().StringP("profile", "p", "", "Profile to use for connecting to Hatchet (default: prompts for selection)")
+	triggerCmd.Flags().StringP("profile", "p", "", "Profile to use for connecting to Hatchet (default: the configured default or only profile, otherwise prompts)")
 	triggerCmd.Flags().StringP("workflow", "w", "", "Workflow name for manual triggering (non-interactive mode)")
 	triggerCmd.Flags().StringP("json", "j", "", "Path to JSON input file for manual triggering (non-interactive mode)")
 	triggerCmd.Flags().StringP("output", "o", "", "Output format: json (prints run ID as JSON, skips TUI prompt)")

--- a/cmd/hatchet-cli/cli/tui.go
+++ b/cmd/hatchet-cli/cli/tui.go
@@ -24,7 +24,7 @@ var tuiCmd = &cobra.Command{
 	Aliases: []string{"terminal-ui"},
 	Short:   "Start the Hatchet terminal UI",
 	Long:    `Start an interactive terminal UI for viewing and managing Hatchet tasks.`,
-	Example: `  # Start TUI (prompts for profile selection)
+	Example: `  # Start TUI (uses the default or only profile, otherwise prompts)
   hatchet tui
 
   # Start TUI with a specific profile
@@ -85,7 +85,7 @@ var tuiCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(tuiCmd)
-	tuiCmd.Flags().StringP("profile", "p", "", "Profile to use for connecting to Hatchet (default: prompts for selection)")
+	tuiCmd.Flags().StringP("profile", "p", "", "Profile to use for connecting to Hatchet (default: the configured default or only profile, otherwise prompts)")
 	tuiCmd.Flags().StringP("run", "r", "", "Navigate to a specific workflow run by ID")
 }
 

--- a/cmd/hatchet-cli/cli/worker.go
+++ b/cmd/hatchet-cli/cli/worker.go
@@ -48,7 +48,7 @@ var devCmd = &cobra.Command{
 	Use:   "dev",
 	Short: "Start a development environment for the Hatchet worker",
 	Long:  `Start a Hatchet worker in development mode with automatic reloading on file changes. This command connects to your Hatchet instance using a profile and runs your worker with the configuration specified in hatchet.yaml.`,
-	Example: `  # Start worker in dev mode (prompts for profile selection)
+	Example: `  # Start worker in dev mode (uses the default or only profile, otherwise prompts)
   hatchet worker dev
 
   # Start worker with a specific profile
@@ -188,14 +188,14 @@ func init() {
 	workerCmd.AddCommand(workerListCmd, workerGetCmd)
 
 	// Add flags for dev command
-	devCmd.Flags().StringP("profile", "p", "", "Profile to use for connecting to Hatchet (default: prompts for selection)")
+	devCmd.Flags().StringP("profile", "p", "", "Profile to use for connecting to Hatchet (default: the configured default or only profile, otherwise prompts)")
 	devCmd.Flags().Bool("no-reload", false, "Disable automatic reloading on file changes")
 	devCmd.Flags().StringP("run-cmd", "r", "", "Override the run command from hatchet.yaml")
 
 	// Add flags for list/get commands
-	workerListCmd.Flags().StringP("profile", "p", "", "Profile to use for connecting to Hatchet (default: prompts for selection)")
+	workerListCmd.Flags().StringP("profile", "p", "", "Profile to use for connecting to Hatchet (default: the configured default or only profile, otherwise prompts)")
 	workerListCmd.Flags().StringP("output", "o", "", "Output format: json (skips interactive TUI)")
-	workerGetCmd.Flags().StringP("profile", "p", "", "Profile to use for connecting to Hatchet (default: prompts for selection)")
+	workerGetCmd.Flags().StringP("profile", "p", "", "Profile to use for connecting to Hatchet (default: the configured default or only profile, otherwise prompts)")
 	workerGetCmd.Flags().StringP("output", "o", "", "Output format: json (skips interactive TUI)")
 }
 

--- a/frontend/docs/pages/reference/cli/profiles.mdx
+++ b/frontend/docs/pages/reference/cli/profiles.mdx
@@ -1,3 +1,5 @@
+import { Callout } from "nextra/components";
+
 # Profiles
 
 The Hatchet CLI supports managing multiple Hatchet instances and tenants using named profiles. This feature makes it easy to switch between different environments, such as development, staging, and production.
@@ -30,6 +32,8 @@ This will display all configured profiles, with the default profile marked with 
 
 You can set a profile as the default using the `hatchet profile set-default` command. The default profile will be automatically used when no profile is specified with the `--profile` flag.
 
+When no default is configured, `hatchet server start` sets the profile it creates as the default. Commands that take the `--profile` flag also use the only configured profile without prompting.
+
 ```sh
 # Set default profile interactively (prompts for selection)
 hatchet profile set-default
@@ -58,6 +62,12 @@ To use a specific profile for your Hatchet CLI commands, you can specify the pro
 ```sh
 hatchet worker dev --profile [name]
 ```
+
+<Callout type="info">
+  In a session without a terminal, such as CI, commands cannot prompt for a
+  profile and fail with an error if they try. Pass `--profile` or set a default
+  profile first.
+</Callout>
 
 ## Updating a Profile
 


### PR DESCRIPTION
# Description

CLI commands that resolve a profile opened an interactive select form whenever no default profile was set, even with only one profile configured. In a session without a TTY the form cannot open `/dev/tty`, and the CLI dies with an error that does not explain the issue. This issue aplies to any non-interactive environments, such as CI, containers, and coding agents.

Profile resolution now works without a terminal, if a selection still needs a prompt the error explains how to proceed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Commands that take `--profile` use the configured default or only profile without prompting
- [x] `hatchet server start` sets its new profile as the default when none is configured
- [x] A failed selection form reports the `--profile` and `set-default` options to resolve the issue
- [x] CLI help text, the profiles reference page, and the changelog have been updated

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

Unit tests cover profile resolution, the failure message, and the set-default-if-unset behavior. Manually reproduced the crash and verified the fix by running the built CLI under `setsid` with `TERM=xterm` and no `/dev/tty`, across single-profile, multi-profile, and default-set states.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Claude Code (Claude Fable 5) performed the investigation and implemented the tests.

</details>