### PR TITLE
fix(engine): scheduled workflow idempotency insert conflict

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260717150345_v1_0_131.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260717150345_v1_0_131.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE v1_idempotency_key DROP CONSTRAINT v1_idempotency_key_pkey;
+ALTER TABLE v1_idempotency_key ADD CONSTRAINT v1_idempotency_key_pkey PRIMARY KEY USING INDEX v1_idempotency_key_unique_tenant_key;
+CREATE INDEX v1_idempotency_key_expires_at_idx ON v1_idempotency_key (tenant_id, expires_at);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE v1_idempotency_key DROP CONSTRAINT v1_idempotency_key_pkey;
+ALTER TABLE v1_idempotency_key ADD CONSTRAINT v1_idempotency_key_pkey PRIMARY KEY (tenant_id, expires_at, key);
+CREATE UNIQUE INDEX v1_idempotency_key_unique_tenant_key ON v1_idempotency_key (tenant_id, key);
+DROP INDEX v1_idempotency_key_expires_at_idx;
+-- +goose StatementEnd

--- a/internal/services/ticker/schedule_workflow_v1.go
+++ b/internal/services/ticker/schedule_workflow_v1.go
@@ -19,7 +19,9 @@ func (t *TickerImpl) RunScheduledWorkflowV1(ctx context.Context, tenantId uuid.U
 }
 
 func RunScheduledWorkflow(ctx context.Context, l *zerolog.Logger, mq msgqueue.MessageQueue, repo v1.Repository, tenantId uuid.UUID, opts v1.RunScheduledWorkflowV1Opts) (*uuid.UUID, error) {
-	claimed, err := repo.Idempotency().ClaimKey(ctx, tenantId, fmt.Sprintf("hatchet_internal_%s", opts.ID.String()), opts.TriggerAt.Add(30*time.Second), opts.ID)
+	externalId := uuid.New()
+
+	claimed, err := repo.Idempotency().ClaimKey(ctx, tenantId, fmt.Sprintf("hatchet_internal_%s", opts.ID.String()), opts.TriggerAt.Add(30*time.Second), externalId)
 
 	if err != nil {
 		return nil, fmt.Errorf("could not claim idempotency key for scheduled workflow: %w", err)
@@ -29,8 +31,6 @@ func RunScheduledWorkflow(ctx context.Context, l *zerolog.Logger, mq msgqueue.Me
 		l.Info().Ctx(ctx).Msgf("idempotency key for scheduled workflow %s already claimed, skipping", opts.ID.String())
 		return nil, nil
 	}
-
-	externalId := uuid.New()
 
 	msg, err := tasktypes.TriggerTaskMessage(
 		tenantId,

--- a/internal/services/ticker/schedule_workflow_v1_test.go
+++ b/internal/services/ticker/schedule_workflow_v1_test.go
@@ -1,0 +1,125 @@
+//go:build !e2e && !load && !rampup && !integration
+
+package ticker
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/hatchet-dev/hatchet/cmd/hatchet-migrate/migrate"
+	"github.com/hatchet-dev/hatchet/internal/msgqueue"
+	v1 "github.com/hatchet-dev/hatchet/pkg/repository"
+)
+
+func setupTickerTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	ctx := context.Background()
+
+	container, err := postgres.Run(ctx,
+		"postgres:15.6",
+		postgres.WithDatabase("hatchet"),
+		postgres.WithUsername("hatchet"),
+		postgres.WithPassword("hatchet"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(30*time.Second),
+		),
+	)
+	require.NoError(t, err)
+
+	connStr, err := container.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	t.Setenv("DATABASE_URL", connStr)
+	migrate.RunMigrations(ctx)
+
+	config, err := pgxpool.ParseConfig(connStr)
+	require.NoError(t, err)
+	config.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+		_, err := conn.Exec(ctx, "SET TIME ZONE 'UTC'")
+		return err
+	}
+
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		pool.Close()
+		container.Terminate(ctx)
+	})
+
+	return pool
+}
+
+type mockMQ struct{ sends atomic.Int64 }
+
+func (m *mockMQ) SendMessage(_ context.Context, _ msgqueue.Queue, _ *msgqueue.Message) error {
+	m.sends.Add(1)
+	return nil
+}
+func (m *mockMQ) Clone() (func() error, msgqueue.MessageQueue, error) { return nil, nil, nil }
+func (m *mockMQ) SetQOS(_ int)                                        {}
+func (m *mockMQ) Subscribe(_ msgqueue.Queue, _, _ msgqueue.AckHook) (func() error, error) {
+	return nil, nil
+}
+func (m *mockMQ) RegisterTenant(_ context.Context, _ uuid.UUID) error { return nil }
+func (m *mockMQ) IsReady() bool                                       { return true }
+
+type mockRepo struct {
+	v1.Repository
+	idempotency v1.IdempotencyRepository
+}
+
+func (r *mockRepo) Idempotency() v1.IdempotencyRepository            { return r.idempotency }
+func (r *mockRepo) WorkflowSchedules() v1.WorkflowScheduleRepository { return &noopSchedules{} }
+
+type noopSchedules struct{ v1.WorkflowScheduleRepository }
+
+func (n *noopSchedules) DeleteScheduledWorkflow(_ context.Context, _, _ uuid.UUID) error {
+	return nil
+}
+
+func TestRunScheduledWorkflow_ConcurrentCallersOnlyTriggerOnce(t *testing.T) {
+	pool := setupTickerTestPool(t)
+
+	logger := zerolog.Nop()
+	repo := &mockRepo{idempotency: v1.NewIdempotencyRepository(pool)}
+	mq := &mockMQ{}
+
+	tenantID := uuid.New()
+	opts := v1.RunScheduledWorkflowV1Opts{
+		ID:           uuid.New(),
+		WorkflowName: "test-workflow",
+		TriggerAt:    time.Now(),
+	}
+
+	const n = 20
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			RunScheduledWorkflow(context.Background(), &logger, mq, repo, tenantID, opts)
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, int64(1), mq.sends.Load(), "exactly one message should be sent across all concurrent callers")
+}

--- a/pkg/repository/idempotency.go
+++ b/pkg/repository/idempotency.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog"
 
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlchelpers"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
@@ -34,6 +36,17 @@ func newIdempotencyRepository(shared *sharedRepository) IdempotencyRepository {
 	return &idempotencyRepository{
 		sharedRepository: shared,
 	}
+}
+
+func NewIdempotencyRepository(pool *pgxpool.Pool) IdempotencyRepository {
+	logger := zerolog.Nop()
+	shared := &sharedRepository{
+		pool:    pool,
+		ddlPool: pool,
+		l:       &logger,
+		queries: sqlcv1.New(),
+	}
+	return newIdempotencyRepository(shared)
 }
 
 func (r *idempotencyRepository) EvictExpiredIdempotencyKeys(context context.Context, tenantId uuid.UUID) error {

--- a/pkg/repository/sqlcv1/idempotency-keys.sql
+++ b/pkg/repository/sqlcv1/idempotency-keys.sql
@@ -28,7 +28,7 @@ WITH inputs AS (
             FROM deduplicated_potential_claims
         )
     ORDER BY tenant_id, expires_at, key
-    FOR UPDATE SKIP LOCKED
+    FOR UPDATE
 ), claimable_keys AS (
     SELECT *
     FROM locked_existing_keys

--- a/pkg/repository/sqlcv1/idempotency-keys.sql.go
+++ b/pkg/repository/sqlcv1/idempotency-keys.sql.go
@@ -35,7 +35,7 @@ WITH inputs AS (
             FROM deduplicated_potential_claims
         )
     ORDER BY tenant_id, expires_at, key
-    FOR UPDATE SKIP LOCKED
+    FOR UPDATE
 ), claimable_keys AS (
     SELECT tenant_id, key, expires_at, claimed_by_external_id, inserted_at, updated_at
     FROM locked_existing_keys

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -2289,10 +2289,10 @@ CREATE TABLE v1_idempotency_key (
     inserted_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-    PRIMARY KEY (tenant_id, expires_at, key)
+    PRIMARY KEY (tenant_id, key)
 );
 
-CREATE UNIQUE INDEX v1_idempotency_key_unique_tenant_key ON v1_idempotency_key (tenant_id, key);
+CREATE INDEX v1_idempotency_key_expires_at_idx ON v1_idempotency_key (tenant_id, expires_at);
 
 -- v1_operation_interval_settings represents the interval settings for a specific tenant. "Operation" means
 -- any sort of tenant-specific polling-based operation on the engine, like timeouts, reassigns, etc.


### PR DESCRIPTION
# Description

Seeing some of these `2026-07-17T12:30:53.699Z ERR could not run scheduled workflow error="could not claim idempotency key for scheduled workflow: ERROR: duplicate key value violates unique constraint \"v1_idempotency_key_pkey\" (SQLSTATE 23505)" service=ticker` errors on cloud

Pretty sure the issue here is that we're attempting two concurrent inserts. I think the root of the problem was using `SKIP LOCKED` to see which rows to lock, since if a row was locked we'd end up trying to do another insert, which would then fail. Removed that. Then I also updated the schema to change the PK so we don't have overlapping indexes, which I think should also help

Then there was one other issue too, which was that we could spawn duplicate runs if this method was called multiple times since the `claimed_by_external_id` was set upstream (we were using `opts.Id`) and instead, we should use a unique id so the run's external id is the claimant, not the external id of the _schedule_.

Also added a regression test which asserts we only pub to the MQ once

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

No AI use

</details>
