### PR TITLE
chore: remove sdks from gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 **/examples/** linguist-detectable=false
 api-contracts/** linguist-detectable=false
 .github/** linguist-detectable=false
+sdks/** linguist-detectable=false
 
 # -------- generated ---------
 


### PR DESCRIPTION
I'd like to make it more obvious that Hatchet is a Go application. 