### PR TITLE
perf: bulk write meter tenant resources

### DIFF
--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -137,7 +137,7 @@ func NewRepository(
 		slack:             newSlackRepository(shared),
 		sns:               newSNSRepository(shared),
 		tenantInvite:      newTenantInviteRepository(shared),
-		tenantLimit:       newTenantLimitRepository(shared, tenantLimitConfig, enforceLimits, cacheDuration),
+		tenantLimit:       shared.m,
 		tenantEntitlement: newTenantEntitlementRepository(shared),
 		tenantAlerting:    newTenantAlertingRepository(shared, cacheDuration),
 		tenant:            newTenantRepository(shared, cacheDuration),

--- a/pkg/repository/sqlcv1/tenant_limits.sql
+++ b/pkg/repository/sqlcv1/tenant_limits.sql
@@ -87,6 +87,45 @@ WHERE "tenantId" = @tenantId::uuid
     AND "resource" = sqlc.narg('resource')::"LimitResource"
 RETURNING *;
 
+-- name: BulkMeterTenantResources :many
+WITH input AS (
+    SELECT
+        unnest(@tenantIds::uuid[]) AS tenant_id,
+        unnest(cast(@resources::text[] AS "LimitResource"[])) AS resource,
+        unnest(@numResources::int[]) AS num_resources
+), to_update AS (
+    SELECT
+        trl.*,
+        i.num_resources
+    FROM
+        "TenantResourceLimit" trl
+    JOIN
+        input i ON i.tenant_id = trl."tenantId" AND i.resource = trl."resource"
+    ORDER BY
+        trl."tenantId", trl."resource"
+    FOR UPDATE
+)
+UPDATE "TenantResourceLimit" trl
+SET
+    "value" = CASE
+        WHEN (trl."customValueMeter" = true OR (trl."window" IS NOT NULL AND trl."window" != '' AND NOW() - trl."lastRefill" >= trl."window"::INTERVAL)) THEN
+            0
+        ELSE
+            trl."value" + tu.num_resources
+    END,
+    "lastRefill" = CASE
+        WHEN (trl."window" IS NOT NULL AND trl."window" != '' AND NOW() - trl."lastRefill" >= trl."window"::INTERVAL) THEN
+            CURRENT_TIMESTAMP
+        ELSE
+            trl."lastRefill"
+    END
+FROM
+    to_update tu
+WHERE
+    trl."tenantId" = tu."tenantId"
+    AND trl."resource" = tu."resource"
+RETURNING trl.*;
+
 -- name: CountTenantWorkers :one
 SELECT COUNT(distinct id) AS "count"
 FROM "Worker"

--- a/pkg/repository/sqlcv1/tenant_limits.sql.go
+++ b/pkg/repository/sqlcv1/tenant_limits.sql.go
@@ -12,6 +12,84 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const bulkMeterTenantResources = `-- name: BulkMeterTenantResources :many
+WITH input AS (
+    SELECT
+        unnest($1::uuid[]) AS tenant_id,
+        unnest(cast($2::text[] AS "LimitResource"[])) AS resource,
+        unnest($3::int[]) AS num_resources
+), to_update AS (
+    SELECT
+        trl.id, trl."createdAt", trl."updatedAt", trl.resource, trl."tenantId", trl."limitValue", trl."alarmValue", trl.value, trl."window", trl."lastRefill", trl."customValueMeter",
+        i.num_resources
+    FROM
+        "TenantResourceLimit" trl
+    JOIN
+        input i ON i.tenant_id = trl."tenantId" AND i.resource = trl."resource"
+    ORDER BY
+        trl."tenantId", trl."resource"
+    FOR UPDATE
+)
+UPDATE "TenantResourceLimit" trl
+SET
+    "value" = CASE
+        WHEN (trl."customValueMeter" = true OR (trl."window" IS NOT NULL AND trl."window" != '' AND NOW() - trl."lastRefill" >= trl."window"::INTERVAL)) THEN
+            0
+        ELSE
+            trl."value" + tu.num_resources
+    END,
+    "lastRefill" = CASE
+        WHEN (trl."window" IS NOT NULL AND trl."window" != '' AND NOW() - trl."lastRefill" >= trl."window"::INTERVAL) THEN
+            CURRENT_TIMESTAMP
+        ELSE
+            trl."lastRefill"
+    END
+FROM
+    to_update tu
+WHERE
+    trl."tenantId" = tu."tenantId"
+    AND trl."resource" = tu."resource"
+RETURNING trl.id, trl."createdAt", trl."updatedAt", trl.resource, trl."tenantId", trl."limitValue", trl."alarmValue", trl.value, trl."window", trl."lastRefill", trl."customValueMeter"
+`
+
+type BulkMeterTenantResourcesParams struct {
+	Tenantids    []uuid.UUID `json:"tenantids"`
+	Resources    []string    `json:"resources"`
+	Numresources []int32     `json:"numresources"`
+}
+
+func (q *Queries) BulkMeterTenantResources(ctx context.Context, db DBTX, arg BulkMeterTenantResourcesParams) ([]*TenantResourceLimit, error) {
+	rows, err := db.Query(ctx, bulkMeterTenantResources, arg.Tenantids, arg.Resources, arg.Numresources)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*TenantResourceLimit
+	for rows.Next() {
+		var i TenantResourceLimit
+		if err := rows.Scan(
+			&i.ID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.Resource,
+			&i.TenantId,
+			&i.LimitValue,
+			&i.AlarmValue,
+			&i.Value,
+			&i.Window,
+			&i.LastRefill,
+			&i.CustomValueMeter,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const countTenantWorkers = `-- name: CountTenantWorkers :one
 SELECT COUNT(distinct id) AS "count"
 FROM "Worker"

--- a/pkg/repository/tenant_limit.go
+++ b/pkg/repository/tenant_limit.go
@@ -50,6 +50,12 @@ type meterKey struct {
 	tenantId uuid.UUID
 }
 
+// cacheKey is the string form used for the canCreate result cache, which is
+// backed by a string-keyed TTL cache.
+func (k meterKey) cacheKey() string {
+	return fmt.Sprintf("%s:%s", k.resource, k.tenantId)
+}
+
 type meterSet map[meterKey]int32
 
 type tenantLimitRepository struct {
@@ -320,8 +326,8 @@ func (t *tenantLimitRepository) flushToDatabase(ctx context.Context) error {
 	for _, limit := range limits {
 		percent := calcPercent(limit.Value, limit.LimitValue)
 		if percent <= 50 || percent >= 100 {
-			key := fmt.Sprintf("%s:%s", limit.Resource, limit.TenantId)
-			t.c.Set(key, limit.Value < limit.LimitValue)
+			key := meterKey{tenantId: limit.TenantId, resource: limit.Resource}
+			t.c.Set(key.cacheKey(), limit.Value < limit.LimitValue)
 		}
 	}
 
@@ -329,7 +335,7 @@ func (t *tenantLimitRepository) flushToDatabase(ctx context.Context) error {
 }
 
 func (t *tenantLimitRepository) cachedCanCreate(ctx context.Context, dbtx sqlcv1.DBTX, resource sqlcv1.LimitResource, tenantId uuid.UUID, numberOfResources int32) (bool, int, error) {
-	var key = fmt.Sprintf("%s:%s", resource, tenantId)
+	key := meterKey{tenantId: tenantId, resource: resource}.cacheKey()
 
 	var canCreate *bool
 	var percent int

--- a/pkg/repository/tenant_limit.go
+++ b/pkg/repository/tenant_limit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -44,20 +45,40 @@ type TenantLimitRepository interface {
 	Stop()
 }
 
+type meterKey struct {
+	resource sqlcv1.LimitResource
+	tenantId uuid.UUID
+}
+
+type meterSet map[meterKey]int32
+
 type tenantLimitRepository struct {
 	c cache.Cacheable
 	*sharedRepository
 	config        limits.LimitConfigFile
 	enforceLimits bool
+
+	unflushedMu sync.RWMutex
+	unflushed   meterSet
+
+	cleanup func()
 }
 
 func newTenantLimitRepository(shared *sharedRepository, s limits.LimitConfigFile, enforceLimits bool, cacheDuration time.Duration) TenantLimitRepository {
-	return &tenantLimitRepository{
+	ctx, cancel := context.WithCancel(context.Background())
+
+	t := &tenantLimitRepository{
 		sharedRepository: shared,
 		config:           s,
 		enforceLimits:    enforceLimits,
 		c:                cache.New(cacheDuration),
+		unflushed:        make(meterSet),
+		cleanup:          cancel,
 	}
+
+	go t.loopFlush(ctx)
+
+	return t
 }
 
 func (t *tenantLimitRepository) ResolveAllTenantResourceLimits(ctx context.Context) error {
@@ -196,6 +217,11 @@ func (t *tenantLimitRepository) canCreate(ctx context.Context, dbtx sqlcv1.DBTX,
 		}
 	}
 
+	// include meters accepted but not yet flushed (same idea as rateLimiter.subtractUnflushed)
+	if !hasCustomValueMeter(resource) {
+		value += t.unflushedAmount(tenantId, resource)
+	}
+
 	// subtract 1 for backwards compatibility
 
 	if value+numberOfResources-1 >= limit.LimitValue {
@@ -209,25 +235,97 @@ func calcPercent(value int32, limit int32) int {
 	return int((float64(value) / float64(limit)) * 100)
 }
 
-func (t *tenantLimitRepository) saveMeter(ctx context.Context, resource sqlcv1.LimitResource, tenantId uuid.UUID, numberOfResources int32) (*sqlcv1.TenantResourceLimit, error) {
-	if !t.enforceLimits {
-		return nil, nil
+func (t *tenantLimitRepository) unflushedAmount(tenantId uuid.UUID, resource sqlcv1.LimitResource) int32 {
+	t.unflushedMu.RLock()
+	defer t.unflushedMu.RUnlock()
+
+	return t.unflushed[meterKey{tenantId: tenantId, resource: resource}]
+}
+
+func (t *tenantLimitRepository) addToUnflushed(resource sqlcv1.LimitResource, tenantId uuid.UUID, numberOfResources int32) {
+	if numberOfResources == 0 {
+		return
 	}
 
-	r, err := t.queries.MeterTenantResource(ctx, t.pool, sqlcv1.MeterTenantResourceParams{
-		Tenantid: tenantId,
-		Resource: sqlcv1.NullLimitResource{
-			LimitResource: resource,
-			Valid:         true,
-		},
-		Numresources: numberOfResources,
+	t.unflushedMu.Lock()
+	defer t.unflushedMu.Unlock()
+
+	t.unflushed[meterKey{tenantId: tenantId, resource: resource}] += numberOfResources
+}
+
+func (t *tenantLimitRepository) loopFlush(ctx context.Context) {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			err := t.flushToDatabase(ctx)
+
+			if err != nil {
+				t.l.Error().Ctx(ctx).Err(err).Msg("error flushing tenant resource meters")
+			}
+		}
+	}
+}
+
+// flushToDatabase writes coalesced meter deltas in a single bulk update. The
+// unflushed set is swapped out before the DB call so the hot paths (Meter
+// postcommit, canCreate) never block on a slow flush since mutex is global.
+func (t *tenantLimitRepository) flushToDatabase(ctx context.Context) error {
+	if !t.enforceLimits {
+		return nil
+	}
+
+	t.unflushedMu.Lock()
+
+	if len(t.unflushed) == 0 {
+		t.unflushedMu.Unlock()
+		return nil
+	}
+
+	updates := t.unflushed
+	t.unflushed = make(meterSet)
+	t.unflushedMu.Unlock()
+
+	tenantIds := make([]uuid.UUID, 0, len(updates))
+	resources := make([]string, 0, len(updates))
+	numResources := make([]int32, 0, len(updates))
+
+	for key, n := range updates {
+		tenantIds = append(tenantIds, key.tenantId)
+		resources = append(resources, string(key.resource))
+		numResources = append(numResources, n)
+	}
+
+	limits, err := t.queries.BulkMeterTenantResources(ctx, t.pool, sqlcv1.BulkMeterTenantResourcesParams{
+		Tenantids:    tenantIds,
+		Resources:    resources,
+		Numresources: numResources,
 	})
 
 	if err != nil {
-		return nil, err
+		// merge the deltas back so the next flush retries them
+		t.unflushedMu.Lock()
+		for key, n := range updates {
+			t.unflushed[key] += n
+		}
+		t.unflushedMu.Unlock()
+
+		return err
 	}
 
-	return r, nil
+	for _, limit := range limits {
+		percent := calcPercent(limit.Value, limit.LimitValue)
+		if percent <= 50 || percent >= 100 {
+			key := fmt.Sprintf("%s:%s", limit.Resource, limit.TenantId)
+			t.c.Set(key, limit.Value < limit.LimitValue)
+		}
+	}
+
+	return nil
 }
 
 func (t *tenantLimitRepository) cachedCanCreate(ctx context.Context, dbtx sqlcv1.DBTX, resource sqlcv1.LimitResource, tenantId uuid.UUID, numberOfResources int32) (bool, int, error) {
@@ -273,26 +371,11 @@ func (t *tenantLimitRepository) Meter(ctx context.Context, dbtx sqlcv1.DBTX, res
 
 			return nil
 		}, func() {
-			postCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Second)
-			defer cancel()
-
-			_, percent, err := t.cachedCanCreate(postCtx, nil, resource, tenantId, numberOfResources)
-
-			if err != nil {
-				t.l.Error().Ctx(postCtx).Err(err).Msg("could not check tenant limit")
+			if !t.enforceLimits || numberOfResources == 0 {
 				return
 			}
 
-			limit, err := t.saveMeter(postCtx, resource, tenantId, numberOfResources)
-
-			if limit != nil && (percent <= 50 || percent >= 100) {
-				var key = fmt.Sprintf("%s:%s", resource, tenantId)
-				t.c.Set(key, limit.Value < limit.LimitValue)
-			}
-
-			if err != nil {
-				t.l.Error().Ctx(postCtx).Err(err).Msg("could not meter resource")
-			}
+			t.addToUnflushed(resource, tenantId, numberOfResources)
 		}
 }
 
@@ -344,5 +427,17 @@ func (t *tenantLimitRepository) updateLimits(ctx context.Context, dbtx sqlcv1.DB
 var ErrResourceExhausted = fmt.Errorf("resource exhausted")
 
 func (t *tenantLimitRepository) Stop() {
+	if t.cleanup != nil {
+		t.cleanup()
+	}
+
+	// final flush (rateLimiter leaves this to the next process; metering should not drop counts)
+	flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := t.flushToDatabase(flushCtx); err != nil {
+		t.l.Error().Err(err).Msg("error flushing tenant resource meters on shutdown")
+	}
+
 	t.c.Stop()
 }


### PR DESCRIPTION
# Description

Metering tenant resource limits currently issues one `MeterTenantResource` UPDATE per task/event, which caused row-lock contention on `TenantResourceLimit` under high-throughput tenants and contributed to `task_processing_queue_v2` backlog. Meter deltas are now buffered in memory per `(tenant, resource)` and flushed to the database in a single bulk UPDATE once per second, following the same pattern as the scheduler's rate limiter.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- Add `BulkMeterTenantResources` query that coalesces meter deltas and updates all `TenantResourceLimit` rows in one statement, with deterministic lock ordering to avoid deadlocks between engine replicas
- Buffer meter deltas in `tenantLimitRepository` instead of writing per-meter; a background loop flushes every 1s (map is swapped out before the DB call so hot paths never block on a flush; deltas are merged back on flush error)
- `canCreate` includes buffered-but-unflushed deltas so control stays accurate between flushes
- `Stop()` cancels the flush loop and performs a final flush so counts aren't dropped on graceful shutdown
- Reuse the shared `TenantLimitRepository` instance in `NewRepository` so only one buffer/flusher exists per process

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Implementation and PR description written with Cursor agents (Grok and Claude), guided and reviewed by a human.

</details>