### PR TITLE
fix: remove SAML from the enterprise plan card

### DIFF
--- a/frontend/app/src/components/v1/cloud/billing/plan-selector.tsx
+++ b/frontend/app/src/components/v1/cloud/billing/plan-selector.tsx
@@ -161,7 +161,7 @@ export function PlanSelector({
           '100M+ runs per month',
           'Custom SLAs & uptime guarantees',
           'Dedicated support & onboarding',
-          'SSO / SAML & audit logging',
+          'SSO & audit logging',
           'Bring your own cloud',
         ]}
         onSelect={() => window.open(enterpriseContactUrl, '_blank')}


### PR DESCRIPTION
# Description

The Enterprise plan card on the Billing and Usage page lists "SSO / SAML & audit logging". Hatchet SSO connects OIDC identity providers. SAML is not supported, so this change shortens the entry to "SSO & audit logging". The plan cards are what customers read when choosing a plan, and they must list only supported capabilities.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- Replaced "SSO / SAML & audit logging" with "SSO & audit logging" in the Enterprise plan card in frontend/app/src/components/v1/cloud/billing/plan-selector.tsx.

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

Searched the repository for remaining SAML references and found none.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: N/A

</details>
