### PR TITLE
feat(dashboard): discoverable theme toggle + system default

### DIFF
--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -15,6 +15,27 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hatchet</title>
+    <!-- Apply theme before paint: default system (prefers-color-scheme), or stored choice -->
+    <script>
+      (function () {
+        try {
+          var key = 'vite-ui-theme';
+          var stored = localStorage.getItem(key);
+          var theme =
+            stored === 'light' || stored === 'dark' || stored === 'system'
+              ? stored
+              : 'system';
+          var resolved =
+            theme === 'system'
+              ? window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? 'dark'
+                : 'light'
+              : theme;
+          document.documentElement.classList.add(resolved);
+          document.documentElement.style.colorScheme = resolved;
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/app/src/components/hooks/use-theme.tsx
+++ b/frontend/app/src/components/hooks/use-theme.tsx
@@ -16,6 +16,8 @@ type ThemeProviderState = {
   currentlyVisibleTheme: DisplayableTheme;
 };
 
+const SELECTABLE_THEMES: SelectableTheme[] = ['light', 'dark', 'system'];
+
 const initialState: ThemeProviderState = {
   theme: 'system',
   setTheme: () => null,
@@ -24,6 +26,10 @@ const initialState: ThemeProviderState = {
 };
 
 const ThemeProviderContext = createContext<ThemeProviderState>(initialState);
+
+export const isSelectableTheme = (value: unknown): value is SelectableTheme =>
+  typeof value === 'string' &&
+  SELECTABLE_THEMES.includes(value as SelectableTheme);
 
 const getThemeToDisplay = (theme: SelectableTheme): DisplayableTheme => {
   if (theme === 'system') {
@@ -34,14 +40,29 @@ const getThemeToDisplay = (theme: SelectableTheme): DisplayableTheme => {
   return theme;
 };
 
+const readStoredTheme = (
+  storageKey: string,
+  defaultTheme: SelectableTheme,
+): SelectableTheme => {
+  try {
+    const stored = localStorage.getItem(storageKey);
+    if (isSelectableTheme(stored)) {
+      return stored;
+    }
+  } catch {
+    // localStorage can throw in private mode / restricted iframes
+  }
+  return defaultTheme;
+};
+
 export function ThemeProvider({
   children,
   defaultTheme = 'system',
   storageKey = 'vite-ui-theme',
   ...props
 }: ThemeProviderProps) {
-  const [theme, setTheme] = useState<SelectableTheme>(
-    () => (localStorage.getItem(storageKey) as SelectableTheme) || defaultTheme,
+  const [theme, setTheme] = useState<SelectableTheme>(() =>
+    readStoredTheme(storageKey, defaultTheme),
   );
 
   const [currentlyVisibleTheme, setCurrentlyVisibleTheme] =
@@ -55,8 +76,10 @@ export function ThemeProvider({
     const themeToDisplay = getThemeToDisplay(theme);
     setCurrentlyVisibleTheme(themeToDisplay);
     root.classList.add(themeToDisplay);
+    root.style.colorScheme = themeToDisplay;
   }, [theme]);
 
+  // Follow OS theme changes while preference is "system"
   useEffect(() => {
     if (theme !== 'system') {
       return;
@@ -70,19 +93,27 @@ export function ThemeProvider({
       const root = window.document.documentElement;
       root.classList.remove('light', 'dark');
       root.classList.add(themeToDisplay);
+      root.style.colorScheme = themeToDisplay;
     };
 
     mediaQuery.addEventListener('change', handleChange);
     return () => mediaQuery.removeEventListener('change', handleChange);
   }, [theme]);
 
-  const setThemeAndLocal = (theme: SelectableTheme) => {
-    localStorage.setItem(storageKey, theme);
-    setTheme(theme);
+  const setThemeAndLocal = (nextTheme: SelectableTheme) => {
+    try {
+      localStorage.setItem(storageKey, nextTheme);
+    } catch {
+      // ignore persistence failures; still update in-memory theme
+    }
+    setTheme(nextTheme);
   };
 
   const toggleTheme = () => {
-    setThemeAndLocal(theme === 'dark' ? 'light' : 'dark');
+    // Cycle based on what the user actually sees (handles "system" correctly).
+    setThemeAndLocal(
+      getThemeToDisplay(theme) === 'dark' ? 'light' : 'dark',
+    );
   };
 
   const value = {

--- a/frontend/app/src/components/hooks/use-theme.tsx
+++ b/frontend/app/src/components/hooks/use-theme.tsx
@@ -111,9 +111,7 @@ export function ThemeProvider({
 
   const toggleTheme = () => {
     // Cycle based on what the user actually sees (handles "system" correctly).
-    setThemeAndLocal(
-      getThemeToDisplay(theme) === 'dark' ? 'light' : 'dark',
-    );
+    setThemeAndLocal(getThemeToDisplay(theme) === 'dark' ? 'light' : 'dark');
   };
 
   const value = {

--- a/frontend/app/src/components/v1/nav/top-nav.tsx
+++ b/frontend/app/src/components/v1/nav/top-nav.tsx
@@ -1,5 +1,4 @@
 import { useSidebar } from '@/components/hooks/use-sidebar';
-import { useTheme } from '@/components/hooks/use-theme';
 import { OrganizationSelector } from '@/components/v1/molecules/nav-bar/organization-selector';
 import { TenantSwitcher } from '@/components/v1/molecules/nav-bar/tenant-switcher';
 import { Notifications } from '@/components/v1/nav/notifications';
@@ -18,12 +17,10 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/components/v1/ui/dropdown-menu';
 import { HatchetLogo } from '@/components/v1/ui/hatchet-logo';
+import { ThemeToggle } from '@/components/v1/ui/theme-toggle';
 import useAuthDisabled from '@/hooks/use-auth-disabled';
 import { useBreadcrumbs } from '@/hooks/use-breadcrumbs';
 import useCloud from '@/hooks/use-cloud';
@@ -39,16 +36,7 @@ import {
   useNavigate,
   useParams,
 } from '@tanstack/react-router';
-import {
-  Check,
-  ChevronDown,
-  LogOut,
-  Menu,
-  Monitor,
-  Moon,
-  Sun,
-  UserCircle2,
-} from 'lucide-react';
+import { ChevronDown, LogOut, Menu, UserCircle2 } from 'lucide-react';
 import React from 'react';
 
 interface TopNavProps {
@@ -56,16 +44,9 @@ interface TopNavProps {
   tenantMemberships: TenantMember[];
 }
 
-const THEME_OPTIONS = [
-  { value: 'light' as const, label: 'Light', icon: Sun },
-  { value: 'dark' as const, label: 'Dark', icon: Moon },
-  { value: 'system' as const, label: 'System', icon: Monitor },
-];
-
 function AccountDropdown({ user }: { user?: User }) {
   const [open, setOpen] = React.useState(false);
   const { logoutMutation } = useUserUniverse();
-  const { theme, setTheme } = useTheme();
   const authDisabled = useAuthDisabled();
 
   if (!user) {
@@ -73,9 +54,6 @@ function AccountDropdown({ user }: { user?: User }) {
   }
 
   const displayName = user.name || user.email;
-  const activeThemeOption =
-    THEME_OPTIONS.find((option) => option.value === theme) ?? THEME_OPTIONS[2];
-  const ThemeIcon = activeThemeOption.icon;
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
@@ -103,27 +81,6 @@ function AccountDropdown({ user }: { user?: User }) {
           </p>
           <p className="truncate text-xs text-muted-foreground">{user.email}</p>
         </div>
-        <DropdownMenuSeparator />
-        <DropdownMenuSub>
-          <DropdownMenuSubTrigger className="cursor-pointer">
-            <ThemeIcon className="mr-2 size-4" />
-            Theme: {activeThemeOption.label}
-          </DropdownMenuSubTrigger>
-          <DropdownMenuSubContent>
-            {THEME_OPTIONS.map((option) => (
-              <DropdownMenuItem
-                key={option.value}
-                variant="interactive"
-                className="cursor-pointer"
-                onClick={() => setTheme(option.value)}
-              >
-                <option.icon className="mr-2 size-4" />
-                {option.label}
-                {theme === option.value && <Check className="ml-auto size-4" />}
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuSubContent>
-        </DropdownMenuSub>
         {!authDisabled && (
           <>
             <DropdownMenuSeparator />
@@ -219,6 +176,7 @@ export default function TopNav({ user, tenantMemberships }: TopNavProps) {
         </div>
 
         <div className="flex ml-auto items-center justify-end gap-2">
+          <ThemeToggle />
           <Notifications />
           {showTenantSwitcher &&
             (isCloudEnabled ? (
@@ -295,6 +253,7 @@ export default function TopNav({ user, tenantMemberships }: TopNavProps) {
         </div>
 
         <div className="flex items-center justify-end gap-2 pr-4">
+          <ThemeToggle />
           <Notifications />
           {showTenantSwitcher &&
             (isCloudEnabled ? (

--- a/frontend/app/src/components/v1/ui/theme-toggle.tsx
+++ b/frontend/app/src/components/v1/ui/theme-toggle.tsx
@@ -1,0 +1,79 @@
+import { useTheme } from '@/components/hooks/use-theme';
+import { Button } from '@/components/v1/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/v1/ui/dropdown-menu';
+import { cn } from '@/lib/utils';
+import { Check, Monitor, Moon, Sun } from 'lucide-react';
+import * as React from 'react';
+
+export const THEME_OPTIONS = [
+  { value: 'light' as const, label: 'Light', icon: Sun },
+  { value: 'dark' as const, label: 'Dark', icon: Moon },
+  { value: 'system' as const, label: 'System', icon: Monitor },
+];
+
+type ThemeToggleProps = {
+  className?: string;
+  align?: 'start' | 'center' | 'end';
+  /** Accessible label for the trigger button. */
+  'aria-label'?: string;
+};
+
+/**
+ * Compact theme switcher (Light / Dark / System).
+ * Visible from auth pages and the main top nav so light mode is easy to find.
+ */
+export function ThemeToggle({
+  className,
+  align = 'end',
+  'aria-label': ariaLabel = 'Change color theme',
+}: ThemeToggleProps) {
+  const [open, setOpen] = React.useState(false);
+  const { theme, setTheme, currentlyVisibleTheme } = useTheme();
+
+  // Prefer showing System icon when following OS; otherwise show resolved light/dark.
+  const TriggerIcon =
+    theme === 'system'
+      ? Monitor
+      : currentlyVisibleTheme === 'dark'
+        ? Moon
+        : Sun;
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          aria-label={ariaLabel}
+          className={cn(
+            'bg-muted/20 shadow-none hover:bg-muted/30',
+            open && 'bg-muted/30',
+            className,
+          )}
+        >
+          <TriggerIcon className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align={align} className="w-40">
+        {THEME_OPTIONS.map((option) => (
+          <DropdownMenuItem
+            key={option.value}
+            variant="interactive"
+            className="cursor-pointer"
+            onClick={() => setTheme(option.value)}
+          >
+            <option.icon className="mr-2 size-4" />
+            {option.label}
+            {theme === option.value && <Check className="ml-auto size-4" />}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/frontend/app/src/pages/auth/components/auth-layout.tsx
+++ b/frontend/app/src/pages/auth/components/auth-layout.tsx
@@ -1,4 +1,5 @@
 import { HeroPanel } from './hero-panel';
+import { ThemeToggle } from '@/components/v1/ui/theme-toggle';
 import { CSSProperties, PropsWithChildren } from 'react';
 
 export function AuthLayout({ children }: PropsWithChildren) {
@@ -31,7 +32,10 @@ export function AuthLayout({ children }: PropsWithChildren) {
         <HeroPanel />
       </div>
 
-      <div className="w-full overflow-y-auto">
+      <div className="relative w-full overflow-y-auto">
+        <div className="absolute right-4 top-4 z-10 sm:right-6 sm:top-6">
+          <ThemeToggle />
+        </div>
         <div className="flex min-h-screen w-full items-center justify-center px-4 py-10 lg:justify-start lg:px-12 lg:py-12">
           <div className="w-full max-w-lg">
             <div className="flex w-full flex-col justify-center space-y-6">

--- a/frontend/app/src/pages/root.tsx
+++ b/frontend/app/src/pages/root.tsx
@@ -11,7 +11,7 @@ import { PropsWithChildren } from 'react';
 
 function Root({ children }: PropsWithChildren) {
   return (
-    <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
+    <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
       <UserUniverseProvider>
         <AppContextProvider>
           <SidePanelProvider>


### PR DESCRIPTION
## Summary
- Add a shared `ThemeToggle` (Light / Dark / System) on the **login/register** layout and in the **top nav**, so light mode is easy to find.
- Default theme preference is **system** (`prefers-color-scheme`), with a pre-paint script to avoid FOUC and live updates when the OS theme changes.
- Remove the nested theme submenu from the account menu (toggle is the single control after login).

## Test plan
- [x] Run dashboard against local Hatchet Lite (`VITE_API_PROXY_TARGET=http://127.0.0.1:8888 pnpm dev`)
- [x] Login page shows theme control top-right; Light / Dark / System work
- [x] After login, top-nav theme control works; account menu has no Theme entry
- [x] With no `localStorage` (or `vite-ui-theme=system`), UI follows OS light/dark
- [x] Switching OS preference while on System updates the UI