### PR TITLE
fix(frontend): harden exchange-token routing against transient control-plane failures

### DIFF
--- a/frontend/app/src/lib/api/api.ts
+++ b/frontend/app/src/lib/api/api.ts
@@ -6,6 +6,7 @@ import {
 import { Api } from './generated/Api';
 import { Api as CloudApi } from './generated/cloud/Api';
 import { Api as ControlPlaneApi } from './generated/control-plane/Api';
+import { isRetryableRequestError } from '@/lib/query-retry';
 import queryClient from '@/query-client';
 import { InternalAxiosRequestConfig } from 'axios';
 import qs from 'qs';
@@ -157,15 +158,22 @@ export const controlPlaneMetaQuery = {
         return lastKnown;
       }
 
-      // First load: a 4xx (404 on OSS deployments without a control plane)
-      // is a definitive "no control plane" answer.
+      // First load: a non-retryable 4xx (404 on OSS deployments without a
+      // control plane) is a definitive "no control plane" answer. Retryable
+      // statuses (408/429) are transient and must not be cached as one.
       const status = getApiErrorStatus(err);
-      if (status && status >= 400 && status < 500) {
+      if (
+        status &&
+        status >= 400 &&
+        status < 500 &&
+        !isRetryableRequestError(err)
+      ) {
         return null;
       }
 
-      // First load with a transient error (network, timeout, 5xx): fail so
-      // React Query retries, rather than caching "disabled" for staleTime.
+      // First load with a transient error (network, timeout, 408/429, 5xx):
+      // fail so React Query retries, rather than caching "disabled" for
+      // staleTime.
       throw err;
     }
   },

--- a/frontend/app/src/lib/api/api.ts
+++ b/frontend/app/src/lib/api/api.ts
@@ -1,5 +1,8 @@
 import { inferControlPlaneEnabled } from './control-plane-status';
-import { exchangeTokenQueryOptions } from './exchange-token';
+import {
+  ExchangeTokenFetchError,
+  exchangeTokenQueryOptions,
+} from './exchange-token';
 import { Api } from './generated/Api';
 import { Api as CloudApi } from './generated/cloud/Api';
 import { Api as ControlPlaneApi } from './generated/control-plane/Api';
@@ -60,8 +63,14 @@ export const cloudApi = new CloudApi({
   paramsSerializer: (params) => qs.stringify(params, { arrayFormat: 'repeat' }),
 });
 
+// Control-plane calls are all fast CRUD, but they cross regions for users on
+// non-US shards; bound them well below the browser's own limit (~60s in
+// Safari) so a stuck request fails into the retry path quickly.
+const CONTROL_PLANE_REQUEST_TIMEOUT_MS = 15_000;
+
 export const controlPlaneApi = new ControlPlaneApi({
   paramsSerializer: (params) => qs.stringify(params, { arrayFormat: 'repeat' }),
+  timeout: CONTROL_PLANE_REQUEST_TIMEOUT_MS,
 });
 
 api.instance.interceptors.request.use(exchangeTokenInterceptor);
@@ -117,21 +126,52 @@ export function resolveExchangeTokenTenantId(
   return config.xTenantId ?? readTenantIdFromLocation() ?? readStoredTenantId();
 }
 
+const CONTROL_PLANE_META_QUERY_KEY = ['control-plane-metadata:get'] as const;
+
+type ControlPlaneMetaResponse = Awaited<
+  ReturnType<typeof controlPlaneApi.metadataGet>
+>;
+
 /**
  * Shared query config for control-plane metadata.
  * Exported so loaders and the hook can reuse the same key/fn/staleTime,
  * keeping a single React Query cache entry as the source of truth.
  */
 export const controlPlaneMetaQuery = {
-  queryKey: ['control-plane-metadata:get'] as const,
-  queryFn: async () => {
+  queryKey: CONTROL_PLANE_META_QUERY_KEY,
+  queryFn: async (): Promise<ControlPlaneMetaResponse | null> => {
     try {
       return await controlPlaneApi.metadataGet();
-    } catch {
-      return null;
+    } catch (err) {
+      // The control plane doesn't appear or disappear at runtime; once we
+      // have an answer (including a definitive null), keep serving it so a
+      // transient failure can't flip the app into "control plane disabled"
+      // mode. That would make the exchange-token interceptor skip routing
+      // tenant requests to the shard apiUrl, sending them to the
+      // control-plane host where those routes don't exist (hard 404s).
+      const lastKnown =
+        queryClient.getQueryData<ControlPlaneMetaResponse | null>(
+          CONTROL_PLANE_META_QUERY_KEY,
+        );
+      if (lastKnown !== undefined) {
+        return lastKnown;
+      }
+
+      // First load: a 4xx (404 on OSS deployments without a control plane)
+      // is a definitive "no control plane" answer.
+      const status = getApiErrorStatus(err);
+      if (status && status >= 400 && status < 500) {
+        return null;
+      }
+
+      // First load with a transient error (network, timeout, 5xx): fail so
+      // React Query retries, rather than caching "disabled" for staleTime.
+      throw err;
     }
   },
-  staleTime: 1000 * 60,
+  // Whether the control plane exists doesn't change at runtime, so a longer
+  // staleTime just avoids blocking a request on a metadata round trip.
+  staleTime: 1000 * 60 * 5,
 };
 
 /**
@@ -155,8 +195,9 @@ async function resolveControlPlaneEnabled(): Promise<boolean> {
  * transparently authenticated with an exchange token and routed to the OSS apiUrl.
  *
  * If the exchange token cannot be obtained (e.g. network error), the request
- * proceeds unchanged and will likely fail with a 401, which React Query will
- * surface to the UI normally.
+ * is rejected with the token error. Proceeding unchanged would send the
+ * request to the control-plane host, where OSS routes don't exist, and the
+ * resulting 404 is both misleading and never retried by React Query.
  */
 export async function exchangeTokenInterceptor(
   config: InternalAxiosRequestConfig,
@@ -197,6 +238,7 @@ export async function exchangeTokenInterceptor(
       tenantId,
       err,
     });
+    throw new ExchangeTokenFetchError(tenantId, err);
   }
 
   return config;

--- a/frontend/app/src/lib/api/exchange-token.ts
+++ b/frontend/app/src/lib/api/exchange-token.ts
@@ -1,11 +1,49 @@
 import { TenantExchangeToken } from '@/lib/api/generated/control-plane/data-contracts';
+import { isRetryableRequestError, NonRetryableError } from '@/lib/query-retry';
 import { Query } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
 
 // Refresh the token 60 seconds before it actually expires.
 const EXPIRY_BUFFER_MS = 60_000;
 const RETRY_BASE_DELAY_MS = 1_000;
 const RETRY_MAX_DELAY_MS = 10_000;
 export const EXCHANGE_TOKEN_QUERY_KEY_PREFIX = 'exchange-token';
+
+/**
+ * Thrown by the exchange-token interceptor when the token could not be
+ * fetched. Extends NonRetryableError because the token layer has its own
+ * retry budget — retrying the outer request would just restart the whole
+ * token retry sequence.
+ */
+export class ExchangeTokenFetchError extends NonRetryableError {
+  readonly cause: unknown;
+
+  // Mirrors the underlying HTTP status (if any) so getApiErrorStatus works.
+  readonly status?: number;
+
+  constructor(tenantId: string, cause: unknown) {
+    super(`failed to fetch exchange token for tenant ${tenantId}`);
+    this.name = 'ExchangeTokenFetchError';
+    this.cause = cause;
+    if (isAxiosError(cause)) {
+      this.status = cause.response?.status;
+    }
+  }
+}
+
+function shouldRetryTokenFetch(failureCount: number, error: unknown) {
+  if (failureCount >= 5) {
+    return false;
+  }
+
+  // Unlike other 4xx, 404 gets a couple of quick retries: the token endpoint
+  // has been observed to intermittently 404 in production.
+  if (isAxiosError(error) && error.response?.status === 404) {
+    return failureCount < 2;
+  }
+
+  return isRetryableRequestError(error);
+}
 
 export function exchangeTokenQueryKey(tenantId: string) {
   return [EXCHANGE_TOKEN_QUERY_KEY_PREFIX, tenantId] as const;
@@ -34,10 +72,14 @@ export function exchangeTokenQueryOptions(
         return 0;
       }
       const expiry = new Date(data.expiresAt).getTime();
-      return Math.max(0, expiry - Date.now() - EXPIRY_BUFFER_MS);
+      // staleTime is a duration measured from dataUpdatedAt, so it must be
+      // computed relative to that timestamp. Subtracting Date.now() here
+      // would double-count elapsed time and mark tokens stale at half their
+      // intended lifetime.
+      return Math.max(0, expiry - query.state.dataUpdatedAt - EXPIRY_BUFFER_MS);
     },
     gcTime: 60 * 60 * 1000,
-    retry: 5,
+    retry: shouldRetryTokenFetch,
     retryDelay: (attemptIndex: number) =>
       Math.min(RETRY_BASE_DELAY_MS * 2 ** attemptIndex, RETRY_MAX_DELAY_MS),
   };

--- a/frontend/app/src/lib/query-retry.ts
+++ b/frontend/app/src/lib/query-retry.ts
@@ -1,32 +1,45 @@
 import { isAxiosError } from 'axios';
 
 /**
- * Default TanStack Query retry policy:
- * - Don't retry most 4xx (auth/validation/permission) errors
- * - Do retry rate limiting / timeouts (429/408)
- * - Cap retries to avoid infinite loops when custom retry functions are used
+ * Base class for errors that `defaultQueryRetry` must not retry, e.g. because
+ * the layer that threw them already exhausted its own retry budget.
  */
-export function defaultQueryRetry(failureCount: number, error: unknown) {
-  // Cap retries (TanStack default is 3); we keep the same upper bound.
-  const withinRetryBudget = failureCount < 3;
-  if (!withinRetryBudget) {
-    return false;
-  }
+export class NonRetryableError extends Error {}
 
+/**
+ * Whether a failed HTTP request is worth retrying:
+ * - No response (network error, CORS, timeout): retry
+ * - Most 4xx (auth/validation/permission) won't be fixed by retrying; 408/429 will
+ * - 5xx and unknown errors: retry
+ */
+export function isRetryableRequestError(error: unknown): boolean {
   if (isAxiosError(error)) {
     const status = error.response?.status;
 
-    // If we didn't get a response (network error, CORS, etc), retry.
     if (!status) {
       return true;
     }
 
-    // Don't retry most client errors (auth/forbidden/validation/etc).
     if (status >= 400 && status < 500) {
       return status === 408 || status === 429;
     }
   }
 
-  // Retry everything else (5xx, unknown errors) within the budget.
   return true;
+}
+
+/**
+ * Default TanStack Query retry policy: retry retryable request errors, capped
+ * at the same upper bound as the TanStack default (3).
+ */
+export function defaultQueryRetry(failureCount: number, error: unknown) {
+  if (error instanceof NonRetryableError) {
+    return false;
+  }
+
+  if (failureCount >= 3) {
+    return false;
+  }
+
+  return isRetryableRequestError(error);
 }

--- a/frontend/app/src/query-client.tsx
+++ b/frontend/app/src/query-client.tsx
@@ -38,24 +38,42 @@ function setupExchangeTokenRefreshTriggers() {
       const shouldForceRefresh = forceRefresh;
       forceRefresh = false;
 
+      // cancelRefetch: false — a token fetch mid-retry-backoff must not be
+      // cancelled and restarted from attempt one by the next trigger.
       if (shouldForceRefresh) {
-        void queryClient.invalidateQueries({
-          queryKey: [EXCHANGE_TOKEN_QUERY_KEY_PREFIX],
-          refetchType: 'all',
-        });
+        void queryClient.invalidateQueries(
+          {
+            queryKey: [EXCHANGE_TOKEN_QUERY_KEY_PREFIX],
+            refetchType: 'all',
+          },
+          { cancelRefetch: false },
+        );
         return;
       }
 
-      void queryClient.refetchQueries({
-        queryKey: [EXCHANGE_TOKEN_QUERY_KEY_PREFIX],
-        stale: true,
-        type: 'all',
-      });
+      void queryClient.refetchQueries(
+        {
+          queryKey: [EXCHANGE_TOKEN_QUERY_KEY_PREFIX],
+          stale: true,
+          type: 'all',
+        },
+        { cancelRefetch: false },
+      );
     }, 250);
   };
 
   const refreshStaleExchangeTokens = () => refreshExchangeTokens(false);
   const forceRefreshExchangeTokens = () => refreshExchangeTokens(true);
+
+  // Tokens go stale 60s before expiry; polling well inside that window means
+  // renewal happens in the background instead of blocking an interactive
+  // request on a cross-region control-plane round trip. Hidden tabs skip the
+  // poll — the visibilitychange handler below refreshes on return instead.
+  window.setInterval(() => {
+    if (document.visibilityState === 'visible') {
+      refreshStaleExchangeTokens();
+    }
+  }, 30_000);
 
   window.addEventListener('focus', refreshStaleExchangeTokens);
   document.addEventListener('visibilitychange', () => {

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -44,6 +44,23 @@ export default defineConfig({
       '/api/v1/control-plane': {
         target: controlPlaneApiProxyTarget,
         changeOrigin: true,
+        // With no control plane running (OSS dev/e2e), a dead upstream would
+        // surface as a 500, which the frontend treats as a transient error
+        // and retries. Production OSS returns 404 for unregistered
+        // control-plane routes, so mimic that: unreachable upstream means
+        // "no control plane".
+        configure: (proxy) => {
+          proxy.on('error', (_err, _req, res) => {
+            if ('writeHead' in res && !res.headersSent) {
+              res.writeHead(404, { 'Content-Type': 'application/json' });
+              res.end(
+                JSON.stringify({
+                  errors: [{ description: 'control plane not available' }],
+                }),
+              );
+            }
+          });
+        },
       },
       // The frontend uses relative `/api/v1/...` paths, so proxy `/api` to the API server.
       '/api': {


### PR DESCRIPTION
# Description

When the app runs with a control plane (Hatchet Cloud), every tenant-scoped API request is transparently authenticated by an axios interceptor: it fetches a short-lived exchange token from the control plane and rewrites the request's `baseURL` to the tenant shard's API. For users whose shard is in a different region than the control plane, those token/metadata calls are cross-region.

I've observed two failure paths which are worth fixing for a better UX:

1. The "is the control plane enabled?" metadata query caught all errors and returned `null`, which React Query cached as a **successful** "no control plane" answer. For the next 60s the interceptor skipped routing/auth entirely, so requests meant for the tenant shard went to the frontend's own origin — where those routes don't exist — producing 404s that are never retried (4xx).
2. Exchange-token fetch failures were swallowed (`console.error` only) and the request proceeded unauthenticated to the wrong host: same misleading 404.

On top of that, token renewal happened synchronously on the request path (blocking an interactive request on a cross-region round trip every few minutes), there was no client timeout below the browser's ~60s default, and a `staleTime` calculation bug made tokens go stale at half their intended lifetime, doubling renewal traffic.

### Before / after

```mermaid
sequenceDiagram
    participant UI as Browser UI
    participant INT as axios interceptor
    participant RQ as React Query cache
    participant CP as Control plane
    participant SH as Tenant shard

    UI->>INT: tenant API request
    INT->>RQ: control plane enabled? exchange token?
    RQ->>CP: metadata / token fetch (cross-region)
    CP--xRQ: transient failure

    rect rgb(255, 235, 235)
        Note over UI,SH: BEFORE — silent fallbacks
        RQ-->>INT: error swallowed, "control plane disabled" cached 60s
        INT->>CP: request proceeds unrouted + unauthenticated (wrong host)
        CP-->>UI: 404 — a 4xx is never retried, page hard-fails until the cache expires
    end

    rect rgb(235, 245, 235)
        Note over UI,SH: AFTER — fail loudly, recover fast
        RQ-->>INT: last known good answer (or retry transient errors on first load)
        alt token fresh (renewed by 30s background timer)
            INT->>SH: routed to shard with Bearer token
            SH-->>UI: 200
        else control plane genuinely unreachable
            RQ-->>INT: bounded retries exhausted (15s timeout per attempt)
            INT--xUI: request rejected with typed error — no misroute, no retry storm
        end
    end
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

**More robust handling of control plane blips**
- Metadata query: a failed fetch no longer counts as "control plane disabled"; keep the last known answer instead as this never changes.
- Token fetch failed → reject the request with a clear error. Before: silently sent it, unauthenticated, to the wrong host.

**Improve retries**
- 15s timeout on all control-plane calls (was: browser default, ~60s) (`api.ts`)
- Token fetch: retry network/5xx/404 errors, fail fast on other 4xx

**Keep token renewal off the hot path**
- Background timer renews tokens before they expire, so user requests never wait on a cross-region round trip (`query-client.tsx`)
- Bugfix: a `staleTime` math error expired tokens at half their lifetime → 2× the renewal traffic (`exchange-token.ts`)

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)


---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Cursor agent (Claude) was used to investigate the incident, implement the fix, and run adversarial correctness and code-quality reviews. All changes were verified with typecheck, unit tests, and lint; final review by a human.

</details>