### PR TITLE
fix: hijack the multiplexed listener's LISTEN connection out of the pool

### DIFF
--- a/pkg/repository/multiplexer.go
+++ b/pkg/repository/multiplexer.go
@@ -62,7 +62,10 @@ func (m *multiplexedListener) startListening() {
 			if err != nil {
 				return nil, err
 			}
-			return poolConn.Conn(), nil
+			// Hijack removes the connection from the pool's accounting: pgxlisten
+			// owns it and closes it when the listener exits, so the pool can be
+			// closed cleanly and slots aren't leaked across listener reconnects.
+			return poolConn.Hijack(), nil
 		},
 		LogError: func(innerCtx context.Context, err error) {
 			m.l.Warn().Err(err).Msg("error in listener")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

This is required for https://github.com/hatchet-dev/hatchet/pull/4480

Fixes #3694 

Related: https://github.com/hatchet-dev/hatchet/pull/4214

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## What's Changed

Hijacks a connection on the connection pool for usage with `pg_listen`. 

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Tested (unit, integration, or manually with steps specified)
- [X] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [X] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude w/ Fable

</details>
