### PR TITLE
refactor(engine): clean up a handful of empty raw json blobs we don't need anymore

### DIFF
--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -797,7 +797,6 @@ func (tc *OLAPControllerImpl) handleCreateEventTriggers(ctx context.Context, ten
 		Externalids:            externalIds,
 		Seenats:                seenAts,
 		Keys:                   keys,
-		Payloads:               payloadstoInsert,
 		Additionalmetadatas:    additionalMetadatas,
 		Scopes:                 scopes,
 		TriggeringWebhookNames: triggeringWebhookNames,
@@ -805,7 +804,10 @@ func (tc *OLAPControllerImpl) handleCreateEventTriggers(ctx context.Context, ten
 
 	if err := tc.repo.OLAP().BulkCreateEventsAndTriggers(
 		ctx,
-		bulkCreateEventParams,
+		v1.BulkCreateEventsAndTriggersParams{
+			BulkCreateEventsOLAPParams: &bulkCreateEventParams,
+			Payloads:                   payloadstoInsert,
+		},
 		bulkCreateTriggersParams,
 	); err != nil {
 		return err

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -312,7 +312,7 @@ type OLAPRepository interface {
 	GetTaskTimings(ctx context.Context, tenantId, workflowRunId uuid.UUID, depth int32) ([]*sqlcv1.PopulateTaskRunDataRow, map[uuid.UUID]int32, error)
 
 	// Events queries
-	BulkCreateEventsAndTriggers(ctx context.Context, events sqlcv1.BulkCreateEventsOLAPParams, triggers []EventTriggersFromExternalId) error
+	BulkCreateEventsAndTriggers(ctx context.Context, events BulkCreateEventsAndTriggersParams, triggers []EventTriggersFromExternalId) error
 	ListEvents(ctx context.Context, opts sqlcv1.ListEventsParams) ([]*EventWithPayload, *int64, error)
 	GetEvent(ctx context.Context, externalId uuid.UUID) (*sqlcv1.V1EventsOlap, error)
 	GetEventWithPayload(ctx context.Context, externalId, tenantId uuid.UUID) (*EventWithPayload, error)
@@ -2306,8 +2306,6 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId uuid.U
 			payload = task.Input
 		}
 
-		payloadToWriteToTask := []byte("{}")
-
 		params.Tenantids = append(params.Tenantids, task.TenantID)
 		params.Ids = append(params.Ids, task.ID)
 		params.Insertedats = append(params.Insertedats, task.InsertedAt)
@@ -2328,7 +2326,6 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId uuid.U
 		params.Daginsertedats = append(params.Daginsertedats, task.DagInsertedAt)
 		params.Parenttaskexternalids = append(params.Parenttaskexternalids, task.ParentTaskExternalID)
 		params.Workflowrunids = append(params.Workflowrunids, task.WorkflowRunID)
-		params.Inputs = append(params.Inputs, payloadToWriteToTask)
 		params.Isdurables = append(params.Isdurables, task.IsDurable.Bool)
 		params.IdempotencyKeys = append(params.IdempotencyKeys, task.IdempotencyKey)
 
@@ -2438,8 +2435,6 @@ func (r *OLAPRepositoryImpl) writeDAGBatch(ctx context.Context, tenantId uuid.UU
 			continue
 		}
 
-		input := []byte("{}")
-
 		params.Tenantids = append(params.Tenantids, dag.TenantID)
 		params.Ids = append(params.Ids, dag.ID)
 		params.Insertedats = append(params.Insertedats, dag.InsertedAt)
@@ -2447,7 +2442,6 @@ func (r *OLAPRepositoryImpl) writeDAGBatch(ctx context.Context, tenantId uuid.UU
 		params.Displaynames = append(params.Displaynames, dag.DisplayName)
 		params.Workflowids = append(params.Workflowids, dag.WorkflowID)
 		params.Workflowversionids = append(params.Workflowversionids, dag.WorkflowVersionID)
-		params.Inputs = append(params.Inputs, input)
 		params.Additionalmetadatas = append(params.Additionalmetadatas, dag.AdditionalMetadata)
 		params.Parenttaskexternalids = append(params.Parenttaskexternalids, dag.ParentTaskExternalID)
 		params.Totaltasks = append(params.Totaltasks, int32(dag.TotalTasks)) // nolint: gosec
@@ -2628,7 +2622,12 @@ type EventTriggersFromExternalId struct {
 	FilterId        *uuid.UUID         `json:"filter_id"`
 }
 
-func (r *OLAPRepositoryImpl) BulkCreateEventsAndTriggers(ctx context.Context, events sqlcv1.BulkCreateEventsOLAPParams, triggers []EventTriggersFromExternalId) error {
+type BulkCreateEventsAndTriggersParams struct {
+	*sqlcv1.BulkCreateEventsOLAPParams
+	Payloads [][]byte
+}
+
+func (r *OLAPRepositoryImpl) BulkCreateEventsAndTriggers(ctx context.Context, events BulkCreateEventsAndTriggersParams, triggers []EventTriggersFromExternalId) error {
 	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
@@ -2644,15 +2643,7 @@ func (r *OLAPRepositoryImpl) BulkCreateEventsAndTriggers(ctx context.Context, ev
 		eventExternalIdToPayload[eventsToInsert.Externalids[i]] = payload
 	}
 
-	payloads := make([][]byte, len(eventsToInsert.Payloads))
-
-	for i := range eventsToInsert.Payloads {
-		payloads[i] = []byte("{}")
-	}
-
-	eventsToInsert.Payloads = payloads
-
-	insertedEvents, err := r.queries.BulkCreateEventsOLAP(ctx, tx, eventsToInsert)
+	insertedEvents, err := r.queries.BulkCreateEventsOLAP(ctx, tx, *eventsToInsert.BulkCreateEventsOLAPParams)
 
 	if err != nil {
 		return fmt.Errorf("error creating events: %v", err)

--- a/pkg/repository/sqlcv1/olap-overwrite.go
+++ b/pkg/repository/sqlcv1/olap-overwrite.go
@@ -937,12 +937,11 @@ WITH to_insert AS (
         UNNEST($2::UUID[]) AS external_id,
         UNNEST($3::TIMESTAMPTZ[]) AS seen_at,
         UNNEST($4::TEXT[]) AS key,
-        UNNEST($5::JSONB[]) AS payload,
-        UNNEST($6::JSONB[]) AS additional_metadata,
+        UNNEST($5::JSONB[]) AS additional_metadata,
         -- Scopes are nullable
-        UNNEST($7::TEXT[]) AS scope,
+        UNNEST($6::TEXT[]) AS scope,
         -- Webhook names are nullable
-        UNNEST($8::TEXT[]) AS triggering_webhook_name
+        UNNEST($7::TEXT[]) AS triggering_webhook_name
 
 )
 INSERT INTO v1_events_olap (
@@ -955,7 +954,7 @@ INSERT INTO v1_events_olap (
     scope,
 	triggering_webhook_name
 )
-SELECT tenant_id, external_id, seen_at, key, payload, additional_metadata, scope, triggering_webhook_name
+SELECT tenant_id, external_id, seen_at, key, '{}'::JSONB AS payload, additional_metadata, scope, triggering_webhook_name
 FROM to_insert
 RETURNING tenant_id, id, external_id, seen_at, key, payload, additional_metadata, scope, triggering_webhook_name
 `
@@ -965,7 +964,6 @@ type BulkCreateEventsOLAPParams struct {
 	Externalids            []uuid.UUID          `json:"externalids"`
 	Seenats                []pgtype.Timestamptz `json:"seenats"`
 	Keys                   []string             `json:"keys"`
-	Payloads               [][]byte             `json:"payloads"`
 	Additionalmetadatas    [][]byte             `json:"additionalmetadatas"`
 	Scopes                 []pgtype.Text        `json:"scopes"`
 	TriggeringWebhookNames []pgtype.Text        `json:"triggeringWebhookName"`
@@ -977,7 +975,6 @@ func (q *Queries) BulkCreateEventsOLAP(ctx context.Context, db DBTX, arg BulkCre
 		arg.Externalids,
 		arg.Seenats,
 		arg.Keys,
-		arg.Payloads,
 		arg.Additionalmetadatas,
 		arg.Scopes,
 		arg.TriggeringWebhookNames,
@@ -1079,13 +1076,12 @@ WITH inputs AS (
         UNNEST($14::UUID[]) AS desired_worker_id,
         UNNEST($15::UUID[]) AS external_id,
         UNNEST($16::TEXT[]) AS display_name,
-        UNNEST($17::JSONB[]) AS input,
-        UNNEST($18::JSONB[]) AS additional_metadata,
-        UNNEST($19::BIGINT[]) AS dag_id,
-        UNNEST($20::TIMESTAMPTZ[]) AS dag_inserted_at,
-        UNNEST($21::UUID[]) AS parent_task_external_id,
-        UNNEST($22::BOOLEAN[]) AS is_durable,
-		UNNEST($23::TEXT[]) AS idempotency_key
+        UNNEST($17::JSONB[]) AS additional_metadata,
+        UNNEST($18::BIGINT[]) AS dag_id,
+        UNNEST($19::TIMESTAMPTZ[]) AS dag_inserted_at,
+        UNNEST($20::UUID[]) AS parent_task_external_id,
+        UNNEST($21::BOOLEAN[]) AS is_durable,
+		UNNEST($22::TEXT[]) AS idempotency_key
 )
 INSERT INTO v1_tasks_olap (
     tenant_id,
@@ -1129,7 +1125,7 @@ SELECT
     desired_worker_id,
     external_id,
     display_name,
-    input,
+    '{}'::JSONB AS input,
     additional_metadata,
     dag_id,
     dag_inserted_at,
@@ -1157,7 +1153,6 @@ type CreateTasksOLAPParams struct {
 	Desiredworkerids      []*uuid.UUID         `json:"desiredworkerids"`
 	Externalids           []uuid.UUID          `json:"externalids"`
 	Displaynames          []string             `json:"displaynames"`
-	Inputs                [][]byte             `json:"inputs"`
 	Additionalmetadatas   [][]byte             `json:"additionalmetadatas"`
 	Dagids                []pgtype.Int8        `json:"dagids"`
 	Daginsertedats        []pgtype.Timestamptz `json:"daginsertedats"`
@@ -1184,7 +1179,6 @@ func (q *Queries) CreateTasksOLAP(ctx context.Context, db DBTX, arg CreateTasksO
 		arg.Desiredworkerids,
 		arg.Externalids,
 		arg.Displaynames,
-		arg.Inputs,
 		arg.Additionalmetadatas,
 		arg.Dagids,
 		arg.Daginsertedats,
@@ -1205,11 +1199,10 @@ WITH inputs AS (
         UNNEST($5::TEXT[]) AS display_name,
         UNNEST($6::UUID[]) AS workflow_id,
         UNNEST($7::UUID[]) AS workflow_version_id,
-        UNNEST($8::JSONB[]) AS input,
-        UNNEST($9::JSONB[]) AS additional_metadata,
-        UNNEST($10::UUID[]) AS parent_task_external_id,
-        UNNEST($11::INTEGER[]) AS total_tasks,
-		UNNEST($12::TEXT[]) AS idempotency_key
+        UNNEST($8::JSONB[]) AS additional_metadata,
+        UNNEST($9::UUID[]) AS parent_task_external_id,
+        UNNEST($10::INTEGER[]) AS total_tasks,
+		UNNEST($11::TEXT[]) AS idempotency_key
 ), dag_task_counts AS (
     SELECT
         i.id,
@@ -1265,7 +1258,7 @@ SELECT
     i.display_name,
     i.workflow_id,
     i.workflow_version_id,
-    i.input,
+    '{}'::JSONB AS input,
     i.additional_metadata,
     i.parent_task_external_id,
     i.total_tasks,
@@ -1289,7 +1282,6 @@ type CreateDAGsOLAPOverwriteParams struct {
 	Displaynames          []string             `json:"displaynames"`
 	Workflowids           []uuid.UUID          `json:"workflowids"`
 	Workflowversionids    []uuid.UUID          `json:"workflowversionids"`
-	Inputs                [][]byte             `json:"inputs"`
 	Additionalmetadatas   [][]byte             `json:"additionalmetadatas"`
 	Parenttaskexternalids []*uuid.UUID         `json:"parenttaskexternalids"`
 	Totaltasks            []int32              `json:"totaltasks"`
@@ -1305,7 +1297,6 @@ func (q *Queries) CreateDAGsOLAP(ctx context.Context, db DBTX, arg CreateDAGsOLA
 		arg.Displaynames,
 		arg.Workflowids,
 		arg.Workflowversionids,
-		arg.Inputs,
 		arg.Additionalmetadatas,
 		arg.Parenttaskexternalids,
 		arg.Totaltasks,

--- a/pkg/repository/sqlcv1/tasks-overwrite.go
+++ b/pkg/repository/sqlcv1/tasks-overwrite.go
@@ -24,32 +24,31 @@ WITH input AS (
         unnest($11::uuid[]) AS desired_worker_id,
         unnest($12::uuid[]) AS external_id,
         unnest($13::text[]) AS display_name,
-        unnest($14::jsonb[]) AS input,
-        unnest($15::integer[]) AS retry_count,
-        unnest($16::jsonb[]) AS additional_metadata,
-        unnest(cast($17::text[] as v1_task_initial_state[])) AS initial_state,
+        unnest($14::integer[]) AS retry_count,
+        unnest($15::jsonb[]) AS additional_metadata,
+        unnest(cast($16::text[] as v1_task_initial_state[])) AS initial_state,
         -- NOTE: these are nullable, so sqlc doesn't support casting to a type
-        unnest($18::bigint[]) AS dag_id,
-        unnest($19::timestamptz[]) AS dag_inserted_at,
-        unnest_nd_1d($20::bigint[][]) AS concurrency_parent_strategy_ids,
-        unnest_nd_1d($21::bigint[][]) AS concurrency_strategy_ids,
-        unnest_nd_1d($22::text[][]) AS concurrency_keys,
-        unnest($23::text[]) AS initial_state_reason,
-        unnest($24::uuid[]) AS parent_task_external_id,
-        unnest($25::bigint[]) AS parent_task_id,
-        unnest($26::timestamptz[]) AS parent_task_inserted_at,
-        unnest($27::integer[]) AS child_index,
-        unnest($28::text[]) AS child_key,
-        unnest($29::bigint[]) AS step_index,
-        unnest($30::double precision[]) AS retry_backoff_factor,
-        unnest($31::integer[]) AS retry_max_backoff,
-        unnest($32::uuid[]) AS workflow_version_id,
-        unnest($33::uuid[]) AS workflow_run_id,
-        unnest($34::boolean[]) AS is_durable,
-		unnest($35::jsonb[]) AS desired_worker_label,
-		unnest($36::uuid[]) AS triggering_event_external_id,
-		unnest($37::text[]) AS triggering_event_key,
-		unnest($38::text[]) AS idempotency_key
+        unnest($17::bigint[]) AS dag_id,
+        unnest($18::timestamptz[]) AS dag_inserted_at,
+        unnest_nd_1d($19::bigint[][]) AS concurrency_parent_strategy_ids,
+        unnest_nd_1d($20::bigint[][]) AS concurrency_strategy_ids,
+        unnest_nd_1d($21::text[][]) AS concurrency_keys,
+        unnest($22::text[]) AS initial_state_reason,
+        unnest($23::uuid[]) AS parent_task_external_id,
+        unnest($24::bigint[]) AS parent_task_id,
+        unnest($25::timestamptz[]) AS parent_task_inserted_at,
+        unnest($26::integer[]) AS child_index,
+        unnest($27::text[]) AS child_key,
+        unnest($28::bigint[]) AS step_index,
+        unnest($29::double precision[]) AS retry_backoff_factor,
+        unnest($30::integer[]) AS retry_max_backoff,
+        unnest($31::uuid[]) AS workflow_version_id,
+        unnest($32::uuid[]) AS workflow_run_id,
+        unnest($33::boolean[]) AS is_durable,
+		unnest($34::jsonb[]) AS desired_worker_label,
+		unnest($35::uuid[]) AS triggering_event_external_id,
+		unnest($36::text[]) AS triggering_event_key,
+		unnest($37::text[]) AS idempotency_key
 )
 INSERT INTO v1_task (
     tenant_id,
@@ -105,7 +104,7 @@ SELECT
     i.desired_worker_id,
     i.external_id,
     i.display_name,
-    i.input,
+    '{}'::JSONB AS input,
     i.retry_count,
     i.additional_metadata,
 	i.initial_state,
@@ -150,7 +149,6 @@ type CreateTasksParams struct {
 	Desiredworkerids    []*uuid.UUID         `json:"desiredworkerids"`
 	Externalids         []uuid.UUID          `json:"externalids"`
 	Displaynames        []string             `json:"displaynames"`
-	Inputs              [][]byte             `json:"inputs"`
 	Retrycounts         []int32              `json:"retrycounts"`
 	Additionalmetadatas [][]byte             `json:"additionalmetadatas"`
 	InitialStates       []string             `json:"initialstates"`
@@ -208,7 +206,6 @@ func (q *Queries) CreateTasks(ctx context.Context, db DBTX, arg CreateTasksParam
 		arg.Desiredworkerids,
 		arg.Externalids,
 		arg.Displaynames,
-		arg.Inputs,
 		arg.Retrycounts,
 		arg.Additionalmetadatas,
 		arg.InitialStates,

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -2274,7 +2274,6 @@ func (r *sharedRepository) insertTasks(
 				RetryMaxBackoff:              make([]pgtype.Int4, 0),
 				WorkflowVersionIds:           make([]uuid.UUID, 0),
 				WorkflowRunIds:               make([]uuid.UUID, 0),
-				Inputs:                       make([][]byte, 0),
 				IsDurables:                   make([]bool, 0),
 				DesiredWorkerLabels:          make([][]byte, 0),
 				TriggeringEventExternalIds:   make([]*uuid.UUID, 0),
@@ -2339,8 +2338,6 @@ func (r *sharedRepository) insertTasks(
 		}
 
 		params.IdempotencyKeys = append(params.IdempotencyKeys, idempotencyKey)
-
-		params.Inputs = append(params.Inputs, []byte("{}"))
 
 		stepIdsToParams[task.StepId] = params
 	}

--- a/pkg/scheduling/v1/concurrency_integration_test.go
+++ b/pkg/scheduling/v1/concurrency_integration_test.go
@@ -113,7 +113,6 @@ func createConcurrencyTasks(t *testing.T, ctx context.Context, conf *database.La
 		taskParams.Stickies[i] = string(sqlcv1.V1StickyStrategyNONE)
 		taskParams.Externalids[i] = uuid.New()
 		taskParams.Displaynames[i] = fmt.Sprintf("task-%d", i)
-		taskParams.Inputs[i] = []byte(`{"my_id": "test-key"}`)
 		taskParams.Additionalmetadatas[i] = []byte(`{}`)
 		taskParams.InitialStates[i] = string(sqlcv1.V1TaskInitialStateQUEUED)
 		taskParams.Concurrencyparentstrategyids[i] = []pgtype.Int8{{}}
@@ -162,7 +161,6 @@ func newCreateTasksParams(n int) sqlcv1.CreateTasksParams {
 		Desiredworkerids:             make([]*uuid.UUID, n),
 		Externalids:                  make([]uuid.UUID, n),
 		Displaynames:                 make([]string, n),
-		Inputs:                       make([][]byte, n),
 		Retrycounts:                  make([]int32, n),
 		Additionalmetadatas:          make([][]byte, n),
 		InitialStates:                make([]string, n),
@@ -417,7 +415,6 @@ func TestConcurrency_ChainedStrategiesDoNotContaminate(t *testing.T) {
 			taskParams.Stickies[i] = string(sqlcv1.V1StickyStrategyNONE)
 			taskParams.Externalids[i] = uuid.New()
 			taskParams.Displaynames[i] = fmt.Sprintf("task-%d", i)
-			taskParams.Inputs[i] = []byte(`{"my_id": "test-key"}`)
 			taskParams.Additionalmetadatas[i] = []byte(`{}`)
 			taskParams.InitialStates[i] = string(sqlcv1.V1TaskInitialStateQUEUED)
 			taskParams.Concurrencyparentstrategyids[i] = []pgtype.Int8{strat1.ParentStrategyID, strat2.ParentStrategyID}
@@ -682,7 +679,6 @@ func TestConcurrency_ColdStrategyScheduledPromptly(t *testing.T) {
 		taskParams.Stickies[0] = string(sqlcv1.V1StickyStrategyNONE)
 		taskParams.Externalids[0] = uuid.New()
 		taskParams.Displaynames[0] = "cold-task"
-		taskParams.Inputs[0] = []byte(`{"my_id": "thread-1"}`)
 		taskParams.Additionalmetadatas[0] = []byte(`{}`)
 		taskParams.InitialStates[0] = string(sqlcv1.V1TaskInitialStateQUEUED)
 		taskParams.Concurrencyparentstrategyids[0] = []pgtype.Int8{{}}


### PR DESCRIPTION
# Description

Building on the work from last week / this week - removing some instances of `[]byte("{}")` that we can drop now by just getting rid of the `input` opt on the various write paths

## Type of change

- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI

</details>
