### PR TITLE
chore(frontend): rename the SSO setup title to Single Sign-On

### DIFF
--- a/frontend/app/src/components/sso/sso-setup.tsx
+++ b/frontend/app/src/components/sso/sso-setup.tsx
@@ -118,7 +118,7 @@ function SsoFormHeader() {
   return (
     <DialogHeader>
       <DialogTitle>
-        Set up Enterprise SSO
+        Set up Single Sign-On
         {step === SsoSetupStep.Configuration &&
           ` - ${PROVIDER_CONFIG[provider].displayName}`}
       </DialogTitle>


### PR DESCRIPTION
# Description

The single sign-on setup modal labeled the feature "Enterprise SSO". A decision was made to rename to "Set up Single Sign-On" for the enterprise launch.

## Type of change

- [x] Chore (changes which are not directly related to any business logic)

## What's Changed

- Renamed the single sign-on setup modal heading from "Enterprise SSO" to "Single Sign-On".

## Checklist

Changes have been:

N/A. Linting was not necessary since the character length of the change is identical to what was there.

## Testing

In an organization's SSO settings, open Edit SSO Config and confirm the modal heading reads "Set up Single Sign-On".

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: N/A

</details>
