### PR TITLE
fix: Namespace on external not matching expected in load test

### DIFF
--- a/cmd/hatchet-loadtest/do.go
+++ b/cmd/hatchet-loadtest/do.go
@@ -81,15 +81,15 @@ type avgResult struct {
 // worker is expected to have registered, matching the exact naming scheme
 // run.go itself would use for the same config (see run.go's EventFanout
 // loop: "load-test-0", "load-test-1", ...).
-func expectedWorkflowNames(config LoadTestConfig) []string {
-	fanout := config.EventFanout
+
+func expectedWorkflowNames(namespace string, fanout int) []string {
 	if fanout <= 0 {
 		fanout = 1
 	}
 
 	names := make([]string, 0, fanout)
 	for i := 0; i < fanout; i++ {
-		names = append(names, applyNamespace(fmt.Sprintf("load-test-%d", i), config.Namespace))
+		names = append(names, applyNamespace(fmt.Sprintf("load-test-%d", i), namespace))
 	}
 	return names
 }
@@ -198,7 +198,7 @@ func do(config LoadTestConfig) error {
 			}
 			timingClient = hc
 
-			names := expectedWorkflowNames(config)
+			names := expectedWorkflowNames(hc.V0().Namespace(), config.EventFanout)
 
 			l.Info().Msgf("externalWorker: resolving workflow(s) %v (make sure a separately-running SDK worker, e.g. cmd/hatchet-loadtest/go, is already up and has registered them)...", names)
 
@@ -299,7 +299,7 @@ func do(config LoadTestConfig) error {
 		)
 
 		if phases.execution.count == 0 {
-			return fmt.Errorf("❌ no timing samples observed - check that the external SDK worker actually executed tasks for workflow(s) %v", expectedWorkflowNames(config))
+			return fmt.Errorf("❌ no timing samples observed - check that the external SDK worker actually executed tasks for workflow(s) %v", expectedWorkflowNames(timingClient.V0().Namespace(), config.EventFanout))
 		}
 
 		if expected != phases.execution.count {


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Fixes bug that was causing load tests to fail when running with namespaces.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
