### PR TITLE
fix: Indicate env in load test slack messages

### DIFF
--- a/cmd/hatchet-loadtest/slack.go
+++ b/cmd/hatchet-loadtest/slack.go
@@ -15,11 +15,12 @@ import (
 )
 
 type SlackSender struct {
-	s3Client *s3.Client
-	s3Bucket string
-	Token    string
-	Channel  string
-	Thread   string
+	s3Client    *s3.Client
+	s3Bucket    string
+	Token       string
+	Channel     string
+	Thread      string
+	Environment string
 }
 
 func NewS3Client(ctx context.Context) (*s3.Client, error) {
@@ -45,17 +46,24 @@ func ShouldSendSlack() bool {
 func NewSlackSender(s3Bucket string) *SlackSender {
 	s3Client, _ := NewS3Client(context.Background())
 	return &SlackSender{
-		s3Client: s3Client,
-		s3Bucket: s3Bucket,
-		Token:    os.Getenv("SLACK_BOT_TOKEN"),
-		Thread:   os.Getenv("SLACK_THREAD_TS"),
-		Channel:  os.Getenv("SLACK_CHANNEL_ID"),
+		s3Client:    s3Client,
+		s3Bucket:    s3Bucket,
+		Token:       os.Getenv("SLACK_BOT_TOKEN"),
+		Thread:      os.Getenv("SLACK_THREAD_TS"),
+		Channel:     os.Getenv("SLACK_CHANNEL_ID"),
+		Environment: os.Getenv("HATCHET_LOADTEST_ENVIRONMENT"),
 	}
 }
 
 func (s *SlackSender) SendMessage(durationPlotUrl string, schedulingPlotUrl string, avgDuration time.Duration, avgScheduling time.Duration) error {
+	header := ":star:Load test results:star:"
+	if s.Environment != "" {
+		header = fmt.Sprintf(":star:Load test results (%s):star:", s.Environment)
+	}
+
 	text := fmt.Sprintf(
-		":star:Load test results:star:\nAverage task duration: %s\nAverage task scheduling: %s",
+		"%s\nAverage task duration: %s\nAverage task scheduling: %s",
+		header,
 		avgDuration.String(),
 		avgScheduling.String(),
 	)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Indicate the env because otherwise it's hard to distinguish when multiple environments are running at the same time. 

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
