### PR TITLE
fix: Loadtest--increase number of emit workers to support higher events numbers

### DIFF
--- a/cmd/hatchet-loadtest/do.go
+++ b/cmd/hatchet-loadtest/do.go
@@ -275,7 +275,7 @@ func do(config LoadTestConfig) error {
 		}()
 	}
 
-	emitted := emit(ctx, config.Namespace, config.Events, config.Duration, scheduled, config.PayloadSize)
+	emitted := emit(ctx, config.Namespace, config.Events, config.Duration, scheduled, config.PayloadSize, config.EmitWorkers)
 	close(scheduled)
 
 	executed := <-ch
@@ -286,6 +286,16 @@ func do(config LoadTestConfig) error {
 
 	var phases phaseAccumulator
 	if config.ExternalWorker {
+		// Give the engine config.Wait to finish (and the collector to observe) runs that
+		// were still in flight when emission stopped, before tearing down collection -
+		// cancelling immediately here would abort the collector mid-sweep for any run that
+		// completes right around this instant, silently dropping its timing sample instead
+		// of just not counting it (see the "context canceled" warnings this produces).
+		if config.Wait > 0 {
+			l.Info().Msgf("externalWorker: waiting %s for in-flight runs to complete before stopping timing collection...", config.Wait)
+			time.Sleep(config.Wait)
+		}
+
 		cancelTiming()
 		phases = <-phaseResultCh
 	}

--- a/cmd/hatchet-loadtest/emit.go
+++ b/cmd/hatchet-loadtest/emit.go
@@ -40,7 +40,29 @@ func parseSize(s string) int {
 	return num * multiplier
 }
 
-func emit(ctx context.Context, namespace string, amountPerSecond int, duration time.Duration, scheduled chan<- time.Duration, payloadArg string) int64 {
+// assumedPushLatency estimates the round-trip time of a single blocking Events().Push call to a
+// remote engine (observed ~17ms against staging-chonky). defaultEmitWorkers uses it to size the
+// pusher pool when the caller doesn't pin one explicitly via --emitWorkers.
+const assumedPushLatency = 20 * time.Millisecond
+
+// defaultEmitWorkers picks a pusher-pool size for amountPerSecond when emitWorkers isn't set
+// explicitly. Each pusher goroutine blocks on a synchronous network call per event, so
+// sustaining amountPerSecond requires roughly amountPerSecond*assumedPushLatency pushers in
+// flight at once - a fixed pool (the previous hardcoded 10) caps throughput at
+// numWorkers/pushLatency regardless of the requested rate. Clamped so a low rate doesn't spin
+// up an unnecessary number of goroutines and a typo'd huge rate doesn't ask for millions.
+func defaultEmitWorkers(amountPerSecond int) int {
+	n := int(float64(amountPerSecond) * assumedPushLatency.Seconds())
+	if n < 10 {
+		n = 10
+	}
+	if n > 1000 {
+		n = 1000
+	}
+	return n
+}
+
+func emit(ctx context.Context, namespace string, amountPerSecond int, duration time.Duration, scheduled chan<- time.Duration, payloadArg string, emitWorkers int) int64 {
 	c, err := v1.NewHatchetClient(
 		v1.Config{
 			Namespace: namespace,
@@ -63,7 +85,11 @@ func emit(ctx context.Context, namespace string, amountPerSecond int, duration t
 	jobCh := make(chan Event, amountPerSecond*2)
 
 	// Worker pool to handle event pushes.
-	numWorkers := 10
+	numWorkers := emitWorkers
+	if numWorkers <= 0 {
+		numWorkers = defaultEmitWorkers(amountPerSecond)
+	}
+	l.Info().Msgf("emitting with %d concurrent push workers (amountPerSecond=%d)", numWorkers, amountPerSecond)
 	var wg sync.WaitGroup
 	for i := 0; i < numWorkers; i++ {
 		wg.Add(1)

--- a/cmd/hatchet-loadtest/main.go
+++ b/cmd/hatchet-loadtest/main.go
@@ -21,6 +21,7 @@ var l zerolog.Logger
 type LoadTestConfig struct {
 	Namespace                string
 	Events                   int
+	EmitWorkers              int
 	Concurrency              int
 	Duration                 time.Duration
 	Wait                     time.Duration
@@ -77,6 +78,7 @@ func main() {
 	}
 
 	loadtest.Flags().IntVarP(&config.Events, "events", "e", 10, "events per second")
+	loadtest.Flags().IntVar(&config.EmitWorkers, "emitWorkers", 0, "emitWorkers specifies how many concurrent goroutines push events to the engine; each push is a blocking call, so this bounds sustained throughput regardless of --events. 0 auto-scales from --events (see emit.go's defaultEmitWorkers)")
 	loadtest.Flags().IntVarP(&config.Concurrency, "concurrency", "c", 0, "concurrency specifies the maximum events to run at the same time")
 	loadtest.Flags().DurationVarP(&config.Duration, "duration", "d", 10*time.Second, "duration specifies the total time to run the load test")
 	loadtest.Flags().DurationVarP(&config.Delay, "delay", "D", 0, "delay specifies the time to wait in each event to simulate slow tasks")


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Need more emitting workers so we aren't bottlenecked when producing > thousands of events.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
