### PR TITLE
fix: ReserveTaskBatchRun does not need to lock v1_task_runtime

### DIFF
--- a/pkg/repository/sqlcv1/tasks.sql
+++ b/pkg/repository/sqlcv1/tasks.sql
@@ -1148,7 +1148,7 @@ WITH locked AS (
         br.tenant_id = @tenantId::uuid
         AND br.step_id = @stepId::uuid
         AND br.batch_key = @batchKey::text
-    FOR UPDATE
+    FOR UPDATE OF br
 ), existing AS (
     SELECT COUNT(DISTINCT batch_id) AS cnt FROM locked
 ), inserted AS (

--- a/pkg/repository/sqlcv1/tasks.sql.go
+++ b/pkg/repository/sqlcv1/tasks.sql.go
@@ -2966,7 +2966,7 @@ WITH locked AS (
         br.tenant_id = $1::uuid
         AND br.step_id = $2::uuid
         AND br.batch_key = $3::text
-    FOR UPDATE
+    FOR UPDATE OF br
 ), existing AS (
     SELECT COUNT(DISTINCT batch_id) AS cnt FROM locked
 ), inserted AS (


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

This can sometimes deadlock with other queries that also write to v1_task_runtime. However,
we don't need a write-lock on v1_task_runtime, so rather than use ORDER BY, use UPDATE OF.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
