### PR TITLE
fix(cli): set limit on workflow list to avoid truncated results

### DIFF
--- a/cmd/hatchet-cli/cli/trigger.go
+++ b/cmd/hatchet-cli/cli/trigger.go
@@ -333,8 +333,10 @@ func runManualInteractive(profile *profileconfig.Profile, hatchetClient client.C
 	}
 
 	// Fetch workflows
-	fmt.Println(styles.InfoMessage("Fetching workflows..."))
-	response, err := hatchetClient.API().WorkflowListWithResponse(ctx, tenantUUID, &rest.WorkflowListParams{})
+	limit := 100
+response, err := hatchetClient.API().WorkflowListWithResponse(ctx, tenantUUID, &rest.WorkflowListParams{
+    Limit: &limit,
+})
 	if err != nil {
 		cli.Logger.Fatalf("could not fetch workflows: %v", err)
 	}
@@ -411,7 +413,10 @@ func runManualNonInteractive(profile *profileconfig.Profile, hatchetClient clien
 	}
 
 	// Fetch workflows
-	response, err := hatchetClient.API().WorkflowListWithResponse(ctx, tenantUUID, &rest.WorkflowListParams{})
+	limit := 100
+response, err := hatchetClient.API().WorkflowListWithResponse(ctx, tenantUUID, &rest.WorkflowListParams{
+    Limit: &limit,
+})
 	if err != nil {
 		cli.Logger.Fatalf("could not fetch workflows: %v", err)
 	}

--- a/cmd/hatchet-cli/cli/trigger.go
+++ b/cmd/hatchet-cli/cli/trigger.go
@@ -334,9 +334,9 @@ func runManualInteractive(profile *profileconfig.Profile, hatchetClient client.C
 
 	// Fetch workflows
 	limit := 100
-response, err := hatchetClient.API().WorkflowListWithResponse(ctx, tenantUUID, &rest.WorkflowListParams{
-    Limit: &limit,
-})
+	response, err := hatchetClient.API().WorkflowListWithResponse(ctx, tenantUUID, &rest.WorkflowListParams{
+		Limit: &limit,
+	})
 	if err != nil {
 		cli.Logger.Fatalf("could not fetch workflows: %v", err)
 	}
@@ -414,9 +414,9 @@ func runManualNonInteractive(profile *profileconfig.Profile, hatchetClient clien
 
 	// Fetch workflows
 	limit := 100
-response, err := hatchetClient.API().WorkflowListWithResponse(ctx, tenantUUID, &rest.WorkflowListParams{
-    Limit: &limit,
-})
+	response, err := hatchetClient.API().WorkflowListWithResponse(ctx, tenantUUID, &rest.WorkflowListParams{
+		Limit: &limit,
+	})
 	if err != nil {
 		cli.Logger.Fatalf("could not fetch workflows: %v", err)
 	}


### PR DESCRIPTION
# Description

The `hatchet trigger manual` command fetches the list of workflows to display via `WorkflowListWithResponse`, but calls it with empty `WorkflowListParams{}`. This means no `Limit` is set, so the API falls back to its default page size — meaning tenants with more workflows than that default only ever see the first page, and can't select or trigger any workflow beyond it.

This fix sets an explicit `Limit: 100` on both the interactive and non-interactive code paths, following the same pattern already used elsewhere in the CLI (e.g. `crons.go`, `rate_limits.go`, `scheduled.go`).

Fixes #4429

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- Added an explicit `Limit: 100` to `WorkflowListParams` in both `runManualInteractive` and `runManualNonInteractive` in `cmd/hatchet-cli/cli/trigger.go`, so `hatchet trigger manual` can list and trigger workflows beyond the API's default page size.

## Checklist

Changes have been:

- [x] Tested (manually — verified `go build ./cmd/hatchet-cli/...` succeeds and `golangci-lint` reports no new issues in the affected package)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable)
---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Claude was used to help investigate and diagnose the root cause of the bug (tracing from the issue report to the empty `WorkflowListParams{}` call), confirm the fix pattern by cross-referencing similar code elsewhere in the repo, and draft this PR description. All code changes were reviewed and applied by me.

</details>