### PR TITLE
chore: bump hatchet-quickstarts to v0.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/gorilla/sessions v1.4.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru/v2 v2.0.7
-	github.com/hatchet-dev/hatchet-quickstarts v0.2.0
+	github.com/hatchet-dev/hatchet-quickstarts v0.2.1
 	github.com/hatchet-dev/pgoutbox v0.3.0
 	github.com/hatchet-dev/timediff v0.0.4
 	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
-github.com/hatchet-dev/hatchet-quickstarts v0.2.0 h1:CtZ0HMDIqLskH3aw4ohytFPDfUAIxZpqwLY+BqXmoeo=
-github.com/hatchet-dev/hatchet-quickstarts v0.2.0/go.mod h1:kuGRjIxJUqfY6MR8x1oOrozo+G1Yo3q6A/GQqoDRp6M=
+github.com/hatchet-dev/hatchet-quickstarts v0.2.1 h1:HqA02r13AHGPlhMvuUKPKU1GL4w+HGr7p34PfmlQMng=
+github.com/hatchet-dev/hatchet-quickstarts v0.2.1/go.mod h1:kuGRjIxJUqfY6MR8x1oOrozo+G1Yo3q6A/GQqoDRp6M=
 github.com/hatchet-dev/pgoutbox v0.3.0 h1:l3/1y1+mAGOVLVAEP13aU66RfpruOpOzSCTxi8AAV14=
 github.com/hatchet-dev/pgoutbox v0.3.0/go.mod h1:x7wEFajIrOJ+goWri49MjzlkdwLHMdr+dZkXjVCm9ho=
 github.com/hatchet-dev/timediff v0.0.4 h1:RfYX1ehoa/qxHKAGQBMAvmkPx+FRQfUV37tDy/G1pOY=


### PR DESCRIPTION
# Description

Bumping to v0.2.1 adds the following fixes:
- hatchet-dev/hatchet-quickstarts#13, which declares ts-node in the npm, pnpm, and yarn TypeScript templates and updates the TypeScript SDK to 1.26.1,
- hatchet-dev/hatchet-quickstarts#14, which replaces the retired clone instructions in the template READMEs with hatchet quickstart.

Refs #4107.

## Type of change

- [x] Chore (changes which are not directly related to any business logic)

## What's Changed

- Bump github.com/hatchet-dev/hatchet-quickstarts from v0.2.0 to v0.2.1 in go.mod and go.sum. No source changes.

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)

## Testing

Ran CLI unit tests and e2e under `-tags e2e_cli`. Also ran `go build` and `go vet` over `cmd/hatchet-cli`.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: N/A

</details>