### PR TITLE
fix: reject TS workflow result failures as Error

### DIFF
--- a/sdks/typescript/src/util/workflow-run-ref.test.ts
+++ b/sdks/typescript/src/util/workflow-run-ref.test.ts
@@ -1,0 +1,35 @@
+import {
+  RunListenerClient,
+  StepRunEvent,
+} from '@hatchet/clients/listeners/run-listener/child-listener-client';
+import { WorkflowRunEventType } from '../protoc/dispatcher';
+import WorkflowRunRef from './workflow-run-ref';
+
+describe('WorkflowRunRef', () => {
+  it('rejects failed runs with an Error containing only failed step messages', async () => {
+    const finishedEvent = {
+      eventType: WorkflowRunEventType.WORKFLOW_RUN_EVENT_TYPE_FINISHED,
+      results: [
+        { taskName: 'successful-step', error: undefined, output: '{}' },
+        { taskName: 'failed-step', error: 'step failed', output: '{}' },
+      ],
+    } as unknown as StepRunEvent;
+    const client = {
+      get: jest.fn().mockResolvedValue({
+        stream: async function* () {
+          yield finishedEvent;
+        },
+      }),
+    } as unknown as RunListenerClient;
+    const workflowRun = new WorkflowRunRef('workflow-run-id', client);
+
+    expect.assertions(2);
+
+    try {
+      await workflowRun.result();
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe('step failed');
+    }
+  });
+});

--- a/sdks/typescript/src/util/workflow-run-ref.ts
+++ b/sdks/typescript/src/util/workflow-run-ref.ts
@@ -121,7 +121,7 @@ export default class WorkflowRunRef<T> {
                 .filter((r) => r.error !== undefined && r.error !== '')
                 .map((r) => r.error);
 
-              reject(errors);
+              reject(new Error(errors.join('; ')));
               return;
             }
 


### PR DESCRIPTION
## Summary
- reject failed TypeScript SDK workflow results with a standard `Error`
- retain only failed-step messages in the error text
- add regression coverage for mixed successful and failed steps

Closes #4487

## Test plan
- [x] `pnpm test:unit -- src/util/workflow-run-ref.test.ts`
- [x] `pnpm exec prettier --check src/util/workflow-run-ref.ts src/util/workflow-run-ref.test.ts`
- [x] `pnpm exec tsc --noEmit`
