### PR TITLE
fix: evaluate rate limit CEL expressions with parent outputs

### DIFF
--- a/internal/cel/cel.go
+++ b/internal/cel/cel.go
@@ -218,7 +218,7 @@ func (p *CELParser) ParseStepRun(stepRunExpr string) (cel.Program, error) {
 }
 
 func (p *CELParser) ParseAndEvalStepRun(stepRunExpr string, in Input) (*StepRunOut, error) {
-	prg, err := p.ParseWorkflowString(stepRunExpr)
+	prg, err := p.ParseStepRun(stepRunExpr)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cel/cel_test.go
+++ b/internal/cel/cel_test.go
@@ -185,7 +185,7 @@ func TestCELParserStepRunExpressionWithParents(t *testing.T) {
 		`parents.step1.group`,
 		cel.NewInput(
 			cel.WithParents(map[string]map[string]interface{}{
-				"step1": {"group": "tenant-a"},
+				"step1": {"group": "parent-group-a"},
 			}),
 		),
 	)
@@ -193,5 +193,5 @@ func TestCELParserStepRunExpressionWithParents(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, cel.StepRunOutTypeString, result.Type)
 	assert.NotNil(t, result.String)
-	assert.Equal(t, "tenant-a", *result.String)
+	assert.Equal(t, "parent-group-a", *result.String)
 }

--- a/internal/cel/cel_test.go
+++ b/internal/cel/cel_test.go
@@ -177,3 +177,21 @@ func TestCELParserEventExpression(t *testing.T) {
 		})
 	}
 }
+
+func TestCELParserStepRunExpressionWithParents(t *testing.T) {
+	parser := cel.NewCELParser()
+
+	result, err := parser.ParseAndEvalStepRun(
+		`parents.step1.group`,
+		cel.NewInput(
+			cel.WithParents(map[string]map[string]interface{}{
+				"step1": {"group": "tenant-a"},
+			}),
+		),
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, cel.StepRunOutTypeString, result.Type)
+	assert.NotNil(t, result.String)
+	assert.Equal(t, "tenant-a", *result.String)
+}

--- a/pkg/repository/input.go
+++ b/pkg/repository/input.go
@@ -88,6 +88,36 @@ func (t *TaskInput) Bytes() []byte {
 	return out
 }
 
+// toParentsData returns just the completed parent outputs from a task's trigger
+// data, keyed by step readable id. CEL expressions only reference `parents`, so
+// this avoids building a full V1StepRunData (and its triggers) to read one field.
+func (s *sharedRepository) toParentsData(t *TaskInput) map[string]map[string]interface{} {
+	parents := make(map[string]map[string]interface{})
+
+	if t == nil || t.TriggerData == nil {
+		return parents
+	}
+
+	for _, stepReadableId := range t.TriggerData.DataKeys() {
+		data := t.TriggerData.DataValueAsTaskOutputEvent(stepReadableId)
+
+		if data == nil || !data.IsCompleted() {
+			continue
+		}
+
+		dataMap := make(map[string]interface{})
+
+		if err := json.Unmarshal(data.Output, &dataMap); err != nil {
+			s.l.Warn().Err(err).Msg("failed to unmarshal parent output for CEL evaluation")
+			continue
+		}
+
+		parents[stepReadableId] = dataMap
+	}
+
+	return parents
+}
+
 func (s *sharedRepository) ToV1StepRunData(t *TaskInput) *V1StepRunData {
 	if t == nil {
 		return nil

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -2292,7 +2292,7 @@ func (r *sharedRepository) insertTasks(
 						cel.WithInput(task.Input.Input),
 						cel.WithAdditionalMetadata(additionalMeta),
 						cel.WithWorkflowRunID(task.ExternalId),
-						cel.WithParents(task.Input.TriggerData),
+						cel.WithParents(r.ToV1StepRunData(task.Input).Parents),
 					))
 
 					if err != nil {
@@ -2364,7 +2364,7 @@ func (r *sharedRepository) insertTasks(
 						cel.WithInput(task.Input.Input),
 						cel.WithAdditionalMetadata(additionalMeta),
 						cel.WithWorkflowRunID(task.ExternalId),
-						cel.WithParents(task.Input.TriggerData),
+						cel.WithParents(r.ToV1StepRunData(task.Input).Parents),
 					))
 
 					if err != nil {
@@ -2769,7 +2769,7 @@ func (r *sharedRepository) replayTasks(
 						cel.WithInput(task.Input.Input),
 						cel.WithAdditionalMetadata(additionalMeta),
 						cel.WithWorkflowRunID(task.ExternalId),
-						cel.WithParents(task.Input.TriggerData),
+						cel.WithParents(r.ToV1StepRunData(task.Input).Parents),
 					))
 
 					if err != nil {

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -2436,7 +2436,7 @@ func (r *sharedRepository) insertTasks(
 						cel.WithInput(task.Input.Input),
 						cel.WithAdditionalMetadata(additionalMeta),
 						cel.WithWorkflowRunID(task.ExternalId),
-						cel.WithParents(task.Input.TriggerData),
+						cel.WithParents(r.ToV1StepRunData(task.Input).Parents),
 					))
 
 					if err != nil {
@@ -2508,7 +2508,7 @@ func (r *sharedRepository) insertTasks(
 						cel.WithInput(task.Input.Input),
 						cel.WithAdditionalMetadata(additionalMeta),
 						cel.WithWorkflowRunID(task.ExternalId),
-						cel.WithParents(task.Input.TriggerData),
+						cel.WithParents(r.ToV1StepRunData(task.Input).Parents),
 					))
 
 					if err != nil {
@@ -2908,7 +2908,7 @@ func (r *sharedRepository) replayTasks(
 						cel.WithInput(task.Input.Input),
 						cel.WithAdditionalMetadata(additionalMeta),
 						cel.WithWorkflowRunID(task.ExternalId),
-						cel.WithParents(task.Input.TriggerData),
+						cel.WithParents(r.ToV1StepRunData(task.Input).Parents),
 					))
 
 					if err != nil {

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -2436,7 +2436,7 @@ func (r *sharedRepository) insertTasks(
 						cel.WithInput(task.Input.Input),
 						cel.WithAdditionalMetadata(additionalMeta),
 						cel.WithWorkflowRunID(task.ExternalId),
-						cel.WithParents(r.ToV1StepRunData(task.Input).Parents),
+						cel.WithParents(r.toParentsData(task.Input)),
 					))
 
 					if err != nil {
@@ -2508,7 +2508,7 @@ func (r *sharedRepository) insertTasks(
 						cel.WithInput(task.Input.Input),
 						cel.WithAdditionalMetadata(additionalMeta),
 						cel.WithWorkflowRunID(task.ExternalId),
-						cel.WithParents(r.ToV1StepRunData(task.Input).Parents),
+						cel.WithParents(r.toParentsData(task.Input)),
 					))
 
 					if err != nil {
@@ -2908,7 +2908,7 @@ func (r *sharedRepository) replayTasks(
 						cel.WithInput(task.Input.Input),
 						cel.WithAdditionalMetadata(additionalMeta),
 						cel.WithWorkflowRunID(task.ExternalId),
-						cel.WithParents(r.ToV1StepRunData(task.Input).Parents),
+						cel.WithParents(r.toParentsData(task.Input)),
 					))
 
 					if err != nil {


### PR DESCRIPTION
## Summary
- compile step expressions with the step-run CEL environment
- bind parent task outputs as the documented parents map during task creation and replay
- cover parent output access in step-run CEL evaluation

## Test plan
- [x] `go test ./internal/cel`

Fixes #4380
