### PR TITLE
fix: Increase batch scheduler max new items limit, exclude already buffered items in query, flush multiple times a tick

### DIFF
--- a/pkg/repository/scheduler.go
+++ b/pkg/repository/scheduler.go
@@ -115,7 +115,8 @@ type BatchQueueFactoryRepository interface {
 
 type BatchQueueRepository interface {
 	ListBatchResources(ctx context.Context) ([]*sqlcv1.ListDistinctBatchResourcesRow, error)
-	ListBatchedQueueItems(ctx context.Context, stepId uuid.UUID, limit int32) ([]*sqlcv1.V1BatchedQueueItem, error)
+
+	ListBatchedQueueItems(ctx context.Context, stepId uuid.UUID, excludeIds []int64, limit int32) ([]*sqlcv1.V1BatchedQueueItem, error)
 	ListExistingBatchedQueueItemIds(ctx context.Context, ids []int64) (map[int64]struct{}, error)
 	GetBatchedQueueItemsByIds(ctx context.Context, ids []int64) ([]*sqlcv1.V1BatchedQueueItem, error)
 	DeleteBatchedQueueItems(ctx context.Context, ids []int64) error

--- a/pkg/repository/scheduler_queue.go
+++ b/pkg/repository/scheduler_queue.go
@@ -990,7 +990,45 @@ func (b *batchQueueRepository) ListBatchedQueueItems(ctx context.Context, stepId
 		}
 	}
 
-	return b.queries.ListBatchedQueueItemsForStep(ctx, b.pool, params)
+	rows, err := b.queries.ListBatchedQueueItemsForStep(ctx, b.pool, params)
+	if err != nil {
+		return nil, err
+	}
+
+	// ListBatchedQueueItemsForStep selects from a CTE rather than the table directly (to keep the
+	// exclude-id filter from being planned against the priority index -- see the query comment),
+	// so sqlc can't trace its result back to the V1BatchedQueueItem model and generates a
+	// structurally-identical sibling type instead. Convert it back so callers keep using the one
+	// shared model.
+	items := make([]*sqlcv1.V1BatchedQueueItem, len(rows))
+	for i, row := range rows {
+		if row == nil {
+			continue
+		}
+		items[i] = &sqlcv1.V1BatchedQueueItem{
+			ID:                row.ID,
+			TenantID:          row.TenantID,
+			Queue:             row.Queue,
+			TaskID:            row.TaskID,
+			TaskInsertedAt:    row.TaskInsertedAt,
+			ExternalID:        row.ExternalID,
+			ActionID:          row.ActionID,
+			StepID:            row.StepID,
+			WorkflowID:        row.WorkflowID,
+			WorkflowRunID:     row.WorkflowRunID,
+			ScheduleTimeoutAt: row.ScheduleTimeoutAt,
+			StepTimeout:       row.StepTimeout,
+			Priority:          row.Priority,
+			Sticky:            row.Sticky,
+			DesiredWorkerID:   row.DesiredWorkerID,
+			RetryCount:        row.RetryCount,
+			BatchKey:          row.BatchKey,
+			InsertedAt:        row.InsertedAt,
+			PayloadSize:       row.PayloadSize,
+		}
+	}
+
+	return items, nil
 }
 
 func (b *batchQueueRepository) DeleteBatchedQueueItems(ctx context.Context, ids []int64) error {

--- a/pkg/repository/scheduler_queue.go
+++ b/pkg/repository/scheduler_queue.go
@@ -969,13 +969,18 @@ func (b *batchQueueRepository) ListBatchResources(ctx context.Context) ([]*sqlcv
 	return rows, nil
 }
 
-func (b *batchQueueRepository) ListBatchedQueueItems(ctx context.Context, stepId uuid.UUID, limit int32) ([]*sqlcv1.V1BatchedQueueItem, error) {
+func (b *batchQueueRepository) ListBatchedQueueItems(ctx context.Context, stepId uuid.UUID, excludeIds []int64, limit int32) ([]*sqlcv1.V1BatchedQueueItem, error) {
 	ctx, span := telemetry.NewSpan(ctx, "list-batched-queue-items")
 	defer span.End()
 
+	if excludeIds == nil {
+		excludeIds = []int64{}
+	}
+
 	params := sqlcv1.ListBatchedQueueItemsForStepParams{
-		Tenantid: b.tenantId,
-		Stepid:   stepId,
+		Tenantid:   b.tenantId,
+		Stepid:     stepId,
+		Excludeids: excludeIds,
 	}
 
 	if limit > 0 {

--- a/pkg/repository/scheduler_queue.go
+++ b/pkg/repository/scheduler_queue.go
@@ -997,35 +997,15 @@ func (b *batchQueueRepository) ListBatchedQueueItems(ctx context.Context, stepId
 
 	// ListBatchedQueueItemsForStep selects from a CTE rather than the table directly (to keep the
 	// exclude-id filter from being planned against the priority index -- see the query comment),
-	// so sqlc can't trace its result back to the V1BatchedQueueItem model and generates a
-	// structurally-identical sibling type instead. Convert it back so callers keep using the one
-	// shared model.
+	// so sqlc can't trace it back to the V1BatchedQueueItem model on its own; the query uses
+	// sqlc.embed() (aliasing the CTE to the table's own name) to embed it explicitly instead.
 	items := make([]*sqlcv1.V1BatchedQueueItem, len(rows))
 	for i, row := range rows {
 		if row == nil {
 			continue
 		}
-		items[i] = &sqlcv1.V1BatchedQueueItem{
-			ID:                row.ID,
-			TenantID:          row.TenantID,
-			Queue:             row.Queue,
-			TaskID:            row.TaskID,
-			TaskInsertedAt:    row.TaskInsertedAt,
-			ExternalID:        row.ExternalID,
-			ActionID:          row.ActionID,
-			StepID:            row.StepID,
-			WorkflowID:        row.WorkflowID,
-			WorkflowRunID:     row.WorkflowRunID,
-			ScheduleTimeoutAt: row.ScheduleTimeoutAt,
-			StepTimeout:       row.StepTimeout,
-			Priority:          row.Priority,
-			Sticky:            row.Sticky,
-			DesiredWorkerID:   row.DesiredWorkerID,
-			RetryCount:        row.RetryCount,
-			BatchKey:          row.BatchKey,
-			InsertedAt:        row.InsertedAt,
-			PayloadSize:       row.PayloadSize,
-		}
+		item := row.V1BatchedQueueItem
+		items[i] = &item
 	}
 
 	return items, nil

--- a/pkg/repository/sqlcv1/queue.sql
+++ b/pkg/repository/sqlcv1/queue.sql
@@ -727,28 +727,13 @@ WITH candidates AS (
     LIMIT
         COALESCE(sqlc.narg('limit')::integer, 1000) + COALESCE(array_length(@excludeIds::bigint[], 1), 0)
 )
+-- sqlc.embed() only resolves against a real catalog relation, not a CTE alias, so "candidates" is
+-- re-aliased to the table's own name here purely so embed() matches it back to the existing
+-- V1BatchedQueueItem model instead of sqlc minting a new, structurally-identical row type.
 SELECT
-    id,
-    tenant_id,
-    queue,
-    task_id,
-    task_inserted_at,
-    external_id,
-    action_id,
-    step_id,
-    workflow_id,
-    workflow_run_id,
-    schedule_timeout_at,
-    step_timeout,
-    priority,
-    sticky,
-    desired_worker_id,
-    retry_count,
-    batch_key,
-    inserted_at,
-    payload_size
+    sqlc.embed(v1_batched_queue_item)
 FROM
-    candidates
+    candidates AS v1_batched_queue_item
 WHERE
     id != ALL(@excludeIds::bigint[])
 ORDER BY

--- a/pkg/repository/sqlcv1/queue.sql
+++ b/pkg/repository/sqlcv1/queue.sql
@@ -689,6 +689,44 @@ WHERE (task_id, task_inserted_at) IN (
 );
 
 -- name: ListBatchedQueueItemsForStep :many
+-- The inner CTE only has sargable predicates (tenant_id/step_id equality) plus an ORDER BY/LIMIT
+-- matching the v1_batched_queue_item_step_priority_idx index, so it's guaranteed a plain bounded
+-- index scan regardless of how the exclude-id filter below gets planned. The inner LIMIT is
+-- oversized by exactly the exclude count so that even in the worst case -- every excluded id
+-- sits at the front of the priority/id ordering -- there's still room for a full page of
+-- genuinely new rows after filtering, without having to scan past the entire backlog.
+WITH candidates AS (
+    SELECT
+        id,
+        tenant_id,
+        queue,
+        task_id,
+        task_inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        schedule_timeout_at,
+        step_timeout,
+        priority,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        batch_key,
+        inserted_at,
+        payload_size
+    FROM
+        v1_batched_queue_item
+    WHERE
+        tenant_id = @tenantId::uuid
+        AND step_id = @stepId::uuid
+    ORDER BY
+        priority DESC,
+        id ASC
+    LIMIT
+        COALESCE(sqlc.narg('limit')::integer, 1000) + COALESCE(array_length(@excludeIds::bigint[], 1), 0)
+)
 SELECT
     id,
     tenant_id,
@@ -710,11 +748,9 @@ SELECT
     inserted_at,
     payload_size
 FROM
-    v1_batched_queue_item
+    candidates
 WHERE
-    tenant_id = @tenantId::uuid
-    AND step_id = @stepId::uuid
-    AND id != ALL(@excludeIds::bigint[])
+    id != ALL(@excludeIds::bigint[])
 ORDER BY
     priority DESC,
     id ASC

--- a/pkg/repository/sqlcv1/queue.sql
+++ b/pkg/repository/sqlcv1/queue.sql
@@ -714,6 +714,7 @@ FROM
 WHERE
     tenant_id = @tenantId::uuid
     AND step_id = @stepId::uuid
+    AND id != ALL(@excludeIds::bigint[])
 ORDER BY
     priority DESC,
     id ASC

--- a/pkg/repository/sqlcv1/queue.sql.go
+++ b/pkg/repository/sqlcv1/queue.sql.go
@@ -588,6 +588,38 @@ func (q *Queries) ListActionsForWorkersLegacyFallback(ctx context.Context, db DB
 }
 
 const listBatchedQueueItemsForStep = `-- name: ListBatchedQueueItemsForStep :many
+WITH candidates AS (
+    SELECT
+        id,
+        tenant_id,
+        queue,
+        task_id,
+        task_inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        schedule_timeout_at,
+        step_timeout,
+        priority,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        batch_key,
+        inserted_at,
+        payload_size
+    FROM
+        v1_batched_queue_item
+    WHERE
+        tenant_id = $3::uuid
+        AND step_id = $4::uuid
+    ORDER BY
+        priority DESC,
+        id ASC
+    LIMIT
+        COALESCE($2::integer, 1000) + COALESCE(array_length($1::bigint[], 1), 0)
+)
 SELECT
     id,
     tenant_id,
@@ -609,39 +641,65 @@ SELECT
     inserted_at,
     payload_size
 FROM
-    v1_batched_queue_item
+    candidates
 WHERE
-    tenant_id = $1::uuid
-    AND step_id = $2::uuid
-    AND id != ALL($3::bigint[])
+    id != ALL($1::bigint[])
 ORDER BY
     priority DESC,
     id ASC
 LIMIT
-    COALESCE($4::integer, 1000)
+    COALESCE($2::integer, 1000)
 `
 
 type ListBatchedQueueItemsForStepParams struct {
-	Tenantid   uuid.UUID   `json:"tenantid"`
-	Stepid     uuid.UUID   `json:"stepid"`
 	Excludeids []int64     `json:"excludeids"`
 	Limit      pgtype.Int4 `json:"limit"`
+	Tenantid   uuid.UUID   `json:"tenantid"`
+	Stepid     uuid.UUID   `json:"stepid"`
 }
 
-func (q *Queries) ListBatchedQueueItemsForStep(ctx context.Context, db DBTX, arg ListBatchedQueueItemsForStepParams) ([]*V1BatchedQueueItem, error) {
+type ListBatchedQueueItemsForStepRow struct {
+	ID                int64              `json:"id"`
+	TenantID          uuid.UUID          `json:"tenant_id"`
+	Queue             string             `json:"queue"`
+	TaskID            int64              `json:"task_id"`
+	TaskInsertedAt    pgtype.Timestamptz `json:"task_inserted_at"`
+	ExternalID        uuid.UUID          `json:"external_id"`
+	ActionID          string             `json:"action_id"`
+	StepID            uuid.UUID          `json:"step_id"`
+	WorkflowID        uuid.UUID          `json:"workflow_id"`
+	WorkflowRunID     uuid.UUID          `json:"workflow_run_id"`
+	ScheduleTimeoutAt pgtype.Timestamp   `json:"schedule_timeout_at"`
+	StepTimeout       pgtype.Text        `json:"step_timeout"`
+	Priority          int32              `json:"priority"`
+	Sticky            V1StickyStrategy   `json:"sticky"`
+	DesiredWorkerID   *uuid.UUID         `json:"desired_worker_id"`
+	RetryCount        int32              `json:"retry_count"`
+	BatchKey          string             `json:"batch_key"`
+	InsertedAt        pgtype.Timestamptz `json:"inserted_at"`
+	PayloadSize       int32              `json:"payload_size"`
+}
+
+// The inner CTE only has sargable predicates (tenant_id/step_id equality) plus an ORDER BY/LIMIT
+// matching the v1_batched_queue_item_step_priority_idx index, so it's guaranteed a plain bounded
+// index scan regardless of how the exclude-id filter below gets planned. The inner LIMIT is
+// oversized by exactly the exclude count so that even in the worst case -- every excluded id
+// sits at the front of the priority/id ordering -- there's still room for a full page of
+// genuinely new rows after filtering, without having to scan past the entire backlog.
+func (q *Queries) ListBatchedQueueItemsForStep(ctx context.Context, db DBTX, arg ListBatchedQueueItemsForStepParams) ([]*ListBatchedQueueItemsForStepRow, error) {
 	rows, err := db.Query(ctx, listBatchedQueueItemsForStep,
-		arg.Tenantid,
-		arg.Stepid,
 		arg.Excludeids,
 		arg.Limit,
+		arg.Tenantid,
+		arg.Stepid,
 	)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*V1BatchedQueueItem
+	var items []*ListBatchedQueueItemsForStepRow
 	for rows.Next() {
-		var i V1BatchedQueueItem
+		var i ListBatchedQueueItemsForStepRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.TenantID,

--- a/pkg/repository/sqlcv1/queue.sql.go
+++ b/pkg/repository/sqlcv1/queue.sql.go
@@ -621,27 +621,9 @@ WITH candidates AS (
         COALESCE($2::integer, 1000) + COALESCE(array_length($1::bigint[], 1), 0)
 )
 SELECT
-    id,
-    tenant_id,
-    queue,
-    task_id,
-    task_inserted_at,
-    external_id,
-    action_id,
-    step_id,
-    workflow_id,
-    workflow_run_id,
-    schedule_timeout_at,
-    step_timeout,
-    priority,
-    sticky,
-    desired_worker_id,
-    retry_count,
-    batch_key,
-    inserted_at,
-    payload_size
+    v1_batched_queue_item.id, v1_batched_queue_item.tenant_id, v1_batched_queue_item.queue, v1_batched_queue_item.task_id, v1_batched_queue_item.task_inserted_at, v1_batched_queue_item.external_id, v1_batched_queue_item.action_id, v1_batched_queue_item.step_id, v1_batched_queue_item.workflow_id, v1_batched_queue_item.workflow_run_id, v1_batched_queue_item.schedule_timeout_at, v1_batched_queue_item.step_timeout, v1_batched_queue_item.priority, v1_batched_queue_item.sticky, v1_batched_queue_item.desired_worker_id, v1_batched_queue_item.retry_count, v1_batched_queue_item.batch_key, v1_batched_queue_item.inserted_at, v1_batched_queue_item.payload_size
 FROM
-    candidates
+    candidates AS v1_batched_queue_item
 WHERE
     id != ALL($1::bigint[])
 ORDER BY
@@ -659,25 +641,7 @@ type ListBatchedQueueItemsForStepParams struct {
 }
 
 type ListBatchedQueueItemsForStepRow struct {
-	ID                int64              `json:"id"`
-	TenantID          uuid.UUID          `json:"tenant_id"`
-	Queue             string             `json:"queue"`
-	TaskID            int64              `json:"task_id"`
-	TaskInsertedAt    pgtype.Timestamptz `json:"task_inserted_at"`
-	ExternalID        uuid.UUID          `json:"external_id"`
-	ActionID          string             `json:"action_id"`
-	StepID            uuid.UUID          `json:"step_id"`
-	WorkflowID        uuid.UUID          `json:"workflow_id"`
-	WorkflowRunID     uuid.UUID          `json:"workflow_run_id"`
-	ScheduleTimeoutAt pgtype.Timestamp   `json:"schedule_timeout_at"`
-	StepTimeout       pgtype.Text        `json:"step_timeout"`
-	Priority          int32              `json:"priority"`
-	Sticky            V1StickyStrategy   `json:"sticky"`
-	DesiredWorkerID   *uuid.UUID         `json:"desired_worker_id"`
-	RetryCount        int32              `json:"retry_count"`
-	BatchKey          string             `json:"batch_key"`
-	InsertedAt        pgtype.Timestamptz `json:"inserted_at"`
-	PayloadSize       int32              `json:"payload_size"`
+	V1BatchedQueueItem V1BatchedQueueItem `json:"v1_batched_queue_item"`
 }
 
 // The inner CTE only has sargable predicates (tenant_id/step_id equality) plus an ORDER BY/LIMIT
@@ -686,6 +650,9 @@ type ListBatchedQueueItemsForStepRow struct {
 // oversized by exactly the exclude count so that even in the worst case -- every excluded id
 // sits at the front of the priority/id ordering -- there's still room for a full page of
 // genuinely new rows after filtering, without having to scan past the entire backlog.
+// sqlc.embed() only resolves against a real catalog relation, not a CTE alias, so "candidates" is
+// re-aliased to the table's own name here purely so embed() matches it back to the existing
+// V1BatchedQueueItem model instead of sqlc minting a new, structurally-identical row type.
 func (q *Queries) ListBatchedQueueItemsForStep(ctx context.Context, db DBTX, arg ListBatchedQueueItemsForStepParams) ([]*ListBatchedQueueItemsForStepRow, error) {
 	rows, err := db.Query(ctx, listBatchedQueueItemsForStep,
 		arg.Excludeids,
@@ -701,25 +668,25 @@ func (q *Queries) ListBatchedQueueItemsForStep(ctx context.Context, db DBTX, arg
 	for rows.Next() {
 		var i ListBatchedQueueItemsForStepRow
 		if err := rows.Scan(
-			&i.ID,
-			&i.TenantID,
-			&i.Queue,
-			&i.TaskID,
-			&i.TaskInsertedAt,
-			&i.ExternalID,
-			&i.ActionID,
-			&i.StepID,
-			&i.WorkflowID,
-			&i.WorkflowRunID,
-			&i.ScheduleTimeoutAt,
-			&i.StepTimeout,
-			&i.Priority,
-			&i.Sticky,
-			&i.DesiredWorkerID,
-			&i.RetryCount,
-			&i.BatchKey,
-			&i.InsertedAt,
-			&i.PayloadSize,
+			&i.V1BatchedQueueItem.ID,
+			&i.V1BatchedQueueItem.TenantID,
+			&i.V1BatchedQueueItem.Queue,
+			&i.V1BatchedQueueItem.TaskID,
+			&i.V1BatchedQueueItem.TaskInsertedAt,
+			&i.V1BatchedQueueItem.ExternalID,
+			&i.V1BatchedQueueItem.ActionID,
+			&i.V1BatchedQueueItem.StepID,
+			&i.V1BatchedQueueItem.WorkflowID,
+			&i.V1BatchedQueueItem.WorkflowRunID,
+			&i.V1BatchedQueueItem.ScheduleTimeoutAt,
+			&i.V1BatchedQueueItem.StepTimeout,
+			&i.V1BatchedQueueItem.Priority,
+			&i.V1BatchedQueueItem.Sticky,
+			&i.V1BatchedQueueItem.DesiredWorkerID,
+			&i.V1BatchedQueueItem.RetryCount,
+			&i.V1BatchedQueueItem.BatchKey,
+			&i.V1BatchedQueueItem.InsertedAt,
+			&i.V1BatchedQueueItem.PayloadSize,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/repository/sqlcv1/queue.sql.go
+++ b/pkg/repository/sqlcv1/queue.sql.go
@@ -613,21 +613,28 @@ FROM
 WHERE
     tenant_id = $1::uuid
     AND step_id = $2::uuid
+    AND id != ALL($3::bigint[])
 ORDER BY
     priority DESC,
     id ASC
 LIMIT
-    COALESCE($3::integer, 1000)
+    COALESCE($4::integer, 1000)
 `
 
 type ListBatchedQueueItemsForStepParams struct {
-	Tenantid uuid.UUID   `json:"tenantid"`
-	Stepid   uuid.UUID   `json:"stepid"`
-	Limit    pgtype.Int4 `json:"limit"`
+	Tenantid   uuid.UUID   `json:"tenantid"`
+	Stepid     uuid.UUID   `json:"stepid"`
+	Excludeids []int64     `json:"excludeids"`
+	Limit      pgtype.Int4 `json:"limit"`
 }
 
 func (q *Queries) ListBatchedQueueItemsForStep(ctx context.Context, db DBTX, arg ListBatchedQueueItemsForStepParams) ([]*V1BatchedQueueItem, error) {
-	rows, err := db.Query(ctx, listBatchedQueueItemsForStep, arg.Tenantid, arg.Stepid, arg.Limit)
+	rows, err := db.Query(ctx, listBatchedQueueItemsForStep,
+		arg.Tenantid,
+		arg.Stepid,
+		arg.Excludeids,
+		arg.Limit,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scheduling/v1/batch_scheduler.go
+++ b/pkg/scheduling/v1/batch_scheduler.go
@@ -138,6 +138,16 @@ type BatchScheduler struct {
 	l zerolog.Logger
 }
 
+// allBufferedIds collects the ids currently buffered in memory across every batch_key group for
+// this step, e.g. to exclude them from a re-fetch or to check them for staleness.
+func (b *BatchScheduler) allBufferedIds() []int64 {
+	ids := make([]int64, 0)
+	for _, group := range b.groups {
+		ids = append(ids, group.getBufferedIds()...)
+	}
+	return ids
+}
+
 // reconcileBuffers drops cancelled/deleted items out of every group's buffer, using a single
 // ListExistingBatchedQueueItemIds call across all groups rather than one call per group -- this
 // is the tenant-wide (well, step-wide) analog of what fetchNewItems already does for fetching.
@@ -149,10 +159,7 @@ func (b *BatchScheduler) reconcileBuffers(ctx context.Context) {
 		return
 	}
 
-	ids := make([]int64, 0)
-	for _, group := range b.groups {
-		ids = append(ids, group.getBufferedIds()...)
-	}
+	ids := b.allBufferedIds()
 
 	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "ids.checked", Value: len(ids)})
 
@@ -386,11 +393,18 @@ func (b *BatchScheduler) tick() error {
 			}
 		}
 
-		// flush for batch size
-		if b.batchSize > 0 && len(group.buffer) >= b.batchSize {
+		// flush for batch size -- loop rather than flushing once, since under sustained load a
+		// single tick can accumulate many multiples of batchSize in the buffer (bounded by
+		// batchFetchLimit). Guard against a tight spin if flush makes no progress, e.g. because
+		// no worker slots are available; the remaining full batches will be retried next tick.
+		for b.batchSize > 0 && len(group.buffer) >= b.batchSize {
+			before := len(group.buffer)
 			if err := b.flush(ctx, group, b.batchSize, v1repo.FlushReasonBatchSizeReached); err != nil {
 				span.RecordError(err)
 				return err
+			}
+			if len(group.buffer) >= before {
+				break
 			}
 		}
 
@@ -420,12 +434,12 @@ func (b *BatchScheduler) fetchNewItems(ctx context.Context) ([]*sqlcv1.V1Batched
 		return nil, ctx.Err()
 	}
 
-	limit := pgtype.Int4{
-		Int32: batchFetchLimit,
-		Valid: true,
-	}
-
-	items, err := b.repo.ListBatchedQueueItems(ctx, b.stepId, limit.Int32)
+	// Excluding ids already buffered lets the LIMIT window advance to rows we haven't seen yet,
+	// instead of re-fetching (and discarding) the same still-pending rows every tick. That
+	// matters most when one batch_key group's backlog alone fills the window -- without the
+	// exclusion, other batch_key groups for this step would never be fetched at all until the
+	// dominant group's rows drop out via flush/delete.
+	items, err := b.repo.ListBatchedQueueItems(ctx, b.stepId, b.allBufferedIds(), batchFetchLimit)
 	if err != nil {
 		span.RecordError(err)
 		return nil, err
@@ -465,23 +479,12 @@ func (b *BatchScheduler) fetchNewItems(ctx context.Context) ([]*sqlcv1.V1Batched
 			b.groups[batchKey] = group
 		}
 
-		// ListBatchedQueueItems has no cursor: it keeps returning the same still-pending rows on
-		// every call until they're actually flushed. Without this check, a group that doesn't flush
-		// on the very next tick (e.g. flushInterval > defaultBatchPollInterval) would have duplicates
-		alreadyBuffered := make(map[int64]struct{}, len(group.buffer))
-		for _, item := range group.buffer {
-			alreadyBuffered[item.ID] = struct{}{}
-		}
-
 		// newItems holds the full rows only long enough to emit "waiting" events and derive the
-		// slim bufferedItem records actually kept in group.buffer.
+		// slim bufferedItem records actually kept in group.buffer. ListBatchedQueueItems already
+		// excludes ids buffered by any group, so everything returned here is genuinely new.
 		newItems := make([]*sqlcv1.V1BatchedQueueItem, 0, len(groupItems))
 		for _, item := range groupItems {
 			if item == nil {
-				continue
-			}
-
-			if _, ok := alreadyBuffered[item.ID]; ok {
 				continue
 			}
 
@@ -574,7 +577,7 @@ func (b *BatchScheduler) maybeStopIfIdle() {
 	}
 
 	// Confirm there are no DB items left for this step at all.
-	rows, err := b.repo.ListBatchedQueueItems(b.ctx, b.stepId, 1)
+	rows, err := b.repo.ListBatchedQueueItems(b.ctx, b.stepId, nil, 1)
 	if err != nil {
 		b.l.Debug().Err(err).Msg("idle check failed to list batched queue items")
 		return

--- a/pkg/scheduling/v1/batch_scheduler.go
+++ b/pkg/scheduling/v1/batch_scheduler.go
@@ -18,7 +18,7 @@ import (
 )
 
 const defaultBatchPollInterval = 200 * time.Millisecond
-const batchFetchLimit int32 = 256
+const batchFetchLimit int32 = 20000 // ~72byte batch queue item size -> 1.44 mb worst case
 const defaultBatchIdleTTL = 30 * time.Second
 const maxBufferedPayloadBytes int32 = 4_000_000
 

--- a/pkg/scheduling/v1/batch_scheduler_test.go
+++ b/pkg/scheduling/v1/batch_scheduler_test.go
@@ -28,6 +28,7 @@ type fakeReserveCall struct {
 type fakeBatchRepo struct {
 	mu               sync.Mutex
 	listResponses    [][]*sqlcv1.V1BatchedQueueItem
+	listExcludeCalls [][]int64
 	itemsById        map[int64]*sqlcv1.V1BatchedQueueItem
 	moveCalls        [][]int64
 	commitCalls      [][]*v1repo.BatchAssignment
@@ -44,9 +45,11 @@ func (f *fakeBatchRepo) ListBatchResources(ctx context.Context) ([]*sqlcv1.ListD
 	return nil, nil
 }
 
-func (f *fakeBatchRepo) ListBatchedQueueItems(ctx context.Context, stepId uuid.UUID, limit int32) ([]*sqlcv1.V1BatchedQueueItem, error) {
+func (f *fakeBatchRepo) ListBatchedQueueItems(ctx context.Context, stepId uuid.UUID, excludeIds []int64, limit int32) ([]*sqlcv1.V1BatchedQueueItem, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+
+	f.listExcludeCalls = append(f.listExcludeCalls, append([]int64(nil), excludeIds...))
 
 	if len(f.listResponses) == 0 {
 		return nil, nil
@@ -66,7 +69,24 @@ func (f *fakeBatchRepo) ListBatchedQueueItems(ctx context.Context, stepId uuid.U
 		}
 	}
 
-	return resp, nil
+	// Mirrors the real query's "AND id != ALL(@excludeIds)" filter.
+	exclude := make(map[int64]struct{}, len(excludeIds))
+	for _, id := range excludeIds {
+		exclude[id] = struct{}{}
+	}
+
+	filtered := make([]*sqlcv1.V1BatchedQueueItem, 0, len(resp))
+	for _, item := range resp {
+		if item == nil {
+			continue
+		}
+		if _, ok := exclude[item.ID]; ok {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+
+	return filtered, nil
 }
 
 func (f *fakeBatchRepo) GetBatchedQueueItemsByIds(ctx context.Context, ids []int64) ([]*sqlcv1.V1BatchedQueueItem, error) {
@@ -841,11 +861,70 @@ func TestBatchSchedulerRespectsBatchSizeWithMultiplePendingItems(t *testing.T) {
 		return assignments, nil, nil
 	}
 
-	// Both items land in the buffer from a single fetch (e.g. two tasks submitted at once), so
-	// the batch-size flush on the very first tick must still only take one of them.
+	// Both items land in the buffer from a single fetch (e.g. two tasks submitted at once). With
+	// batchMaxSize=1, the batch-size flush should drain the whole buffer within the same tick
+	// instead of leaving a full batch's worth of items to wait for the next poll.
 	require.NoError(t, scheduler.tick())
 
-	require.Len(t, repo.commitCalls, 1, "expected exactly one flush on the first tick")
-	require.Len(t, repo.commitCalls[0], 1, "expected the flush to contain exactly one item, matching batchMaxSize=1")
-	require.Len(t, scheduler.groups[""].buffer, 1, "the second item should remain buffered for the next tick")
+	require.Len(t, repo.commitCalls, 2, "expected one flush per buffered item within the same tick")
+	require.Len(t, repo.commitCalls[0], 1, "expected each flush to contain exactly one item, matching batchMaxSize=1")
+	require.Len(t, repo.commitCalls[1], 1, "expected each flush to contain exactly one item, matching batchMaxSize=1")
+	require.Empty(t, scheduler.groups[""].buffer, "both items should have been flushed within the same tick")
+}
+
+// TestBatchSchedulerExcludesBufferedIdsFromRefetch is a regression test for ListBatchedQueueItems
+// having no cursor: every tick re-lists from the top of the (priority, id) order, so without a
+// server-side exclusion of already-buffered ids, a group that doesn't fully drain in one tick
+// would see the same still-pending rows come back on the next poll -- and, with a large enough
+// backlog in one batch_key, could crowd other batch_key groups for the step out of the LIMIT
+// window entirely. This verifies the scheduler passes the currently-buffered ids as the exclusion
+// list, and that a (simulated) DB response reflecting that exclusion doesn't produce duplicates.
+func TestBatchSchedulerExcludesBufferedIdsFromRefetch(t *testing.T) {
+	tenantId := uuid.MustParse("00000000-0000-0000-0000-000000000008")
+	stepId := uuid.MustParse("00000000-0000-0000-0000-000000000080")
+
+	repo := &fakeBatchRepo{
+		listResponses: [][]*sqlcv1.V1BatchedQueueItem{
+			{
+				{ID: 1, TenantID: tenantId, Queue: "default", TaskID: 401, TaskInsertedAt: pgtype.Timestamptz{Valid: true}, ActionID: "action", StepID: stepId, BatchKey: "a"},
+				{ID: 2, TenantID: tenantId, Queue: "default", TaskID: 402, TaskInsertedAt: pgtype.Timestamptz{Valid: true}, ActionID: "action", StepID: stepId, BatchKey: "a"},
+			},
+			{
+				// Simulates the real DB still holding ids 1 and 2 pending (unflushed) alongside a
+				// genuinely new row 5 -- the fake applies the same exclusion the real query would.
+				{ID: 1, TenantID: tenantId, Queue: "default", TaskID: 401, TaskInsertedAt: pgtype.Timestamptz{Valid: true}, ActionID: "action", StepID: stepId, BatchKey: "a"},
+				{ID: 2, TenantID: tenantId, Queue: "default", TaskID: 402, TaskInsertedAt: pgtype.Timestamptz{Valid: true}, ActionID: "action", StepID: stepId, BatchKey: "a"},
+				{ID: 5, TenantID: tenantId, Queue: "default", TaskID: 405, TaskInsertedAt: pgtype.Timestamptz{Valid: true}, ActionID: "action", StepID: stepId, BatchKey: "a"},
+			},
+		},
+	}
+
+	resource := &sqlcv1.ListDistinctBatchResourcesRow{
+		StepID:       stepId,
+		BatchKey:     "a",
+		BatchMaxSize: 100, // large enough that nothing flushes during this test
+	}
+
+	scheduler := newBatchScheduler(
+		newTestSharedConfig(repo),
+		tenantId,
+		resource,
+		nil,
+		nil,
+		func(*QueueResults) {},
+	)
+	require.NotNil(t, scheduler)
+	scheduler.ctx = context.Background()
+
+	require.NoError(t, scheduler.tick())
+	require.Len(t, repo.listExcludeCalls, 1)
+	require.Empty(t, repo.listExcludeCalls[0], "first tick has nothing buffered yet, so nothing to exclude")
+	require.Len(t, scheduler.groups["a"].buffer, 2)
+
+	require.NoError(t, scheduler.tick())
+	require.Len(t, repo.listExcludeCalls, 2)
+	require.ElementsMatch(t, []int64{1, 2}, repo.listExcludeCalls[1], "second tick should exclude ids already buffered from the first")
+
+	// Only the genuinely new row (5) should have been added; ids 1 and 2 shouldn't be duplicated.
+	require.ElementsMatch(t, []int64{1, 2, 5}, scheduler.groups["a"].getBufferedIds())
 }

--- a/pkg/scheduling/v1/lease_manager_test.go
+++ b/pkg/scheduling/v1/lease_manager_test.go
@@ -69,7 +69,7 @@ func (f *fakeBatchQueueRepo) ListBatchResources(context.Context) ([]*sqlcv1.List
 	return f.resources, nil
 }
 
-func (f *fakeBatchQueueRepo) ListBatchedQueueItems(context.Context, uuid.UUID, int32) ([]*sqlcv1.V1BatchedQueueItem, error) {
+func (f *fakeBatchQueueRepo) ListBatchedQueueItems(context.Context, uuid.UUID, []int64, int32) ([]*sqlcv1.V1BatchedQueueItem, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

A few fixes to help the batch scheduler deal with massive amounts of load. 
1. Increase the number of new items that can be fetched.
2. Exclude already fetched items so that large groups don't prevent the buffer from advancing
3. Flush multiple times a tick to clear large backlogs

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
