### PR TITLE
test(dispatcher): guard tenant-stream msg IDs against drift

### DIFF
--- a/internal/msgqueue/pubsub.go
+++ b/internal/msgqueue/pubsub.go
@@ -3,6 +3,8 @@ package msgqueue
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
@@ -80,9 +82,12 @@ type PubSub interface {
 }
 
 // tenantStreamMsgIDs enumerates the message IDs the dispatcher's gRPC streams
-// consume from tenant topics (see msgsToWorkflowEvent and
-// isMatchingWorkflowRunV1 in the dispatcher). Publishing any other ID to a
+// consume from tenant topics (see workflowEventConverters and
+// workflowRunMatchers in the dispatcher). Publishing any other ID to a
 // tenant topic is pure waste: the streams are the only consumers.
+//
+// Guarded against drift by TestTenantStreamMsgIDsInSync in the dispatcher
+// package: an ID consumed there but missing here is silently never published.
 var tenantStreamMsgIDs = map[string]struct{}{
 	MsgIDCreatedTask:                  {},
 	MsgIDTaskCompleted:                {},
@@ -91,6 +96,13 @@ var tenantStreamMsgIDs = map[string]struct{}{
 	MsgIDTaskStreamEvent:              {},
 	MsgIDWorkflowRunFinished:          {},
 	MsgIDWorkflowRunFinishedCandidate: {},
+}
+
+// TenantStreamMsgIDs returns the message IDs PubTenantMessage publishes to
+// tenant-stream topics, sorted. It exists so the dispatcher can assert its
+// stream consumers stay in sync with this allowlist.
+func TenantStreamMsgIDs() []string {
+	return slices.Sorted(maps.Keys(tenantStreamMsgIDs))
 }
 
 // PubTenantMessage writes a tenant-scoped message to its destinations: a

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -2350,14 +2350,17 @@ func (s *DispatcherImpl) listWorkflowRuns(ctx context.Context, tenantId uuid.UUI
 	return res, nil
 }
 
-func (s *DispatcherImpl) msgsToWorkflowEvent(msgId string, payloads [][]byte, filter func(tasks []*contracts.WorkflowEvent) ([]*contracts.WorkflowEvent, error), hangupFunc func(tasks []*contracts.WorkflowEvent) ([]*contracts.WorkflowEvent, error)) ([]*contracts.WorkflowEvent, error) {
-	workflowEvents := []*contracts.WorkflowEvent{}
+// workflowEventConverters maps each message ID the dispatcher's workflow event
+// streams consume off the tenant stream to its contracts.WorkflowEvent
+// converter. Together with workflowRunMatchers, its keys are the source of
+// truth for the message IDs the streams consume: msgqueue's tenant-stream
+// publish allowlist is asserted against them in TestTenantStreamMsgIDsInSync.
+var workflowEventConverters = map[string]func(payloads [][]byte) []*contracts.WorkflowEvent{
+	msgqueue.MsgIDCreatedTask: func(payloads [][]byte) []*contracts.WorkflowEvent {
+		converted := msgqueue.JSONConvert[tasktypes.CreatedTaskPayload](payloads)
+		workflowEvents := []*contracts.WorkflowEvent{}
 
-	switch msgId {
-	case "created-task":
-		payloads := msgqueue.JSONConvert[tasktypes.CreatedTaskPayload](payloads)
-
-		for _, payload := range payloads {
+		for _, payload := range converted {
 			workflowEvents = append(workflowEvents, &contracts.WorkflowEvent{
 				WorkflowRunId:  payload.WorkflowRunID.String(),
 				ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
@@ -2367,10 +2370,14 @@ func (s *DispatcherImpl) msgsToWorkflowEvent(msgId string, payloads [][]byte, fi
 				RetryCount:     &payload.RetryCount,
 			})
 		}
-	case "task-completed":
-		payloads := msgqueue.JSONConvert[tasktypes.CompletedTaskPayload](payloads)
 
-		for _, payload := range payloads {
+		return workflowEvents
+	},
+	msgqueue.MsgIDTaskCompleted: func(payloads [][]byte) []*contracts.WorkflowEvent {
+		converted := msgqueue.JSONConvert[tasktypes.CompletedTaskPayload](payloads)
+		workflowEvents := []*contracts.WorkflowEvent{}
+
+		for _, payload := range converted {
 			workflowEvents = append(workflowEvents, &contracts.WorkflowEvent{
 				WorkflowRunId:  payload.WorkflowRunId.String(),
 				ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
@@ -2381,10 +2388,14 @@ func (s *DispatcherImpl) msgsToWorkflowEvent(msgId string, payloads [][]byte, fi
 				EventPayload:   string(payload.Output),
 			})
 		}
-	case "task-failed":
-		payloads := msgqueue.JSONConvert[tasktypes.FailedTaskPayload](payloads)
 
-		for _, payload := range payloads {
+		return workflowEvents
+	},
+	msgqueue.MsgIDTaskFailed: func(payloads [][]byte) []*contracts.WorkflowEvent {
+		converted := msgqueue.JSONConvert[tasktypes.FailedTaskPayload](payloads)
+		workflowEvents := []*contracts.WorkflowEvent{}
+
+		for _, payload := range converted {
 			workflowEvents = append(workflowEvents, &contracts.WorkflowEvent{
 				WorkflowRunId:  payload.WorkflowRunId.String(),
 				ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
@@ -2395,10 +2406,14 @@ func (s *DispatcherImpl) msgsToWorkflowEvent(msgId string, payloads [][]byte, fi
 				EventPayload:   payload.ErrorMsg,
 			})
 		}
-	case "task-cancelled":
-		payloads := msgqueue.JSONConvert[tasktypes.CancelledTaskPayload](payloads)
 
-		for _, payload := range payloads {
+		return workflowEvents
+	},
+	msgqueue.MsgIDTaskCancelled: func(payloads [][]byte) []*contracts.WorkflowEvent {
+		converted := msgqueue.JSONConvert[tasktypes.CancelledTaskPayload](payloads)
+		workflowEvents := []*contracts.WorkflowEvent{}
+
+		for _, payload := range converted {
 			workflowEvents = append(workflowEvents, &contracts.WorkflowEvent{
 				WorkflowRunId:  payload.WorkflowRunId.String(),
 				ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
@@ -2408,10 +2423,14 @@ func (s *DispatcherImpl) msgsToWorkflowEvent(msgId string, payloads [][]byte, fi
 				RetryCount:     &payload.RetryCount,
 			})
 		}
-	case "task-stream-event":
-		payloads := msgqueue.JSONConvert[tasktypes.StreamEventPayload](payloads)
 
-		for _, payload := range payloads {
+		return workflowEvents
+	},
+	msgqueue.MsgIDTaskStreamEvent: func(payloads [][]byte) []*contracts.WorkflowEvent {
+		converted := msgqueue.JSONConvert[tasktypes.StreamEventPayload](payloads)
+		workflowEvents := []*contracts.WorkflowEvent{}
+
+		for _, payload := range converted {
 			workflowEvents = append(workflowEvents, &contracts.WorkflowEvent{
 				WorkflowRunId:  payload.WorkflowRunId.String(),
 				ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
@@ -2422,10 +2441,14 @@ func (s *DispatcherImpl) msgsToWorkflowEvent(msgId string, payloads [][]byte, fi
 				EventIndex:     payload.EventIndex,
 			})
 		}
-	case "workflow-run-finished":
-		payloads := msgqueue.JSONConvert[tasktypes.NotifyFinalizedPayload](payloads)
 
-		for _, payload := range payloads {
+		return workflowEvents
+	},
+	msgqueue.MsgIDWorkflowRunFinished: func(payloads [][]byte) []*contracts.WorkflowEvent {
+		converted := msgqueue.JSONConvert[tasktypes.NotifyFinalizedPayload](payloads)
+		workflowEvents := []*contracts.WorkflowEvent{}
+
+		for _, payload := range converted {
 			eventType := contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED
 
 			switch payload.Status {
@@ -2445,6 +2468,16 @@ func (s *DispatcherImpl) msgsToWorkflowEvent(msgId string, payloads [][]byte, fi
 				EventTimestamp: timestamppb.New(time.Now()),
 			})
 		}
+
+		return workflowEvents
+	},
+}
+
+func (s *DispatcherImpl) msgsToWorkflowEvent(msgId string, payloads [][]byte, filter func(tasks []*contracts.WorkflowEvent) ([]*contracts.WorkflowEvent, error), hangupFunc func(tasks []*contracts.WorkflowEvent) ([]*contracts.WorkflowEvent, error)) ([]*contracts.WorkflowEvent, error) {
+	workflowEvents := []*contracts.WorkflowEvent{}
+
+	if convert, ok := workflowEventConverters[msgId]; ok {
+		workflowEvents = convert(payloads)
 	}
 
 	matches, err := filter(workflowEvents)
@@ -2474,39 +2507,51 @@ func (s *DispatcherImpl) msgsToWorkflowEvent(msgId string, payloads [][]byte, fi
 	return matches, nil
 }
 
-func (s *DispatcherImpl) isMatchingWorkflowRunV1(msg *msgqueue.Message, acks *workflowRunAcks) ([]uuid.UUID, bool) {
-	switch msg.ID {
-	case "workflow-run-finished":
-		payloads := msgqueue.JSONConvert[tasktypes.NotifyFinalizedPayload](msg.Payloads)
+// workflowRunMatchers maps each message ID the dispatcher's workflow run
+// subscriptions consume off the tenant stream to a matcher returning the
+// subscribed workflow run IDs the message finalizes (or nominates as
+// candidates). See the comment on workflowEventConverters: the keys of both
+// maps together are asserted against msgqueue's tenant-stream publish
+// allowlist in TestTenantStreamMsgIDsInSync.
+var workflowRunMatchers = map[string]func(payloads [][]byte, acks *workflowRunAcks) []uuid.UUID{
+	msgqueue.MsgIDWorkflowRunFinished: func(payloads [][]byte, acks *workflowRunAcks) []uuid.UUID {
+		converted := msgqueue.JSONConvert[tasktypes.NotifyFinalizedPayload](payloads)
 		res := make([]uuid.UUID, 0)
 
-		for _, payload := range payloads {
+		for _, payload := range converted {
 			if acks.hasWorkflowRun(payload.ExternalId) {
 				res = append(res, payload.ExternalId)
 			}
 		}
 
-		if len(res) == 0 {
-			return nil, false
-		}
-
-		return res, true
-	case "workflow-run-finished-candidate":
-		payloads := msgqueue.JSONConvert[tasktypes.CandidateFinalizedPayload](msg.Payloads)
+		return res
+	},
+	msgqueue.MsgIDWorkflowRunFinishedCandidate: func(payloads [][]byte, acks *workflowRunAcks) []uuid.UUID {
+		converted := msgqueue.JSONConvert[tasktypes.CandidateFinalizedPayload](payloads)
 		res := make([]uuid.UUID, 0)
 
-		for _, payload := range payloads {
+		for _, payload := range converted {
 			if acks.hasWorkflowRun(payload.WorkflowRunId) {
 				res = append(res, payload.WorkflowRunId)
 			}
 		}
 
-		if len(res) == 0 {
-			return nil, false
-		}
+		return res
+	},
+}
 
-		return res, true
-	default:
+func (s *DispatcherImpl) isMatchingWorkflowRunV1(msg *msgqueue.Message, acks *workflowRunAcks) ([]uuid.UUID, bool) {
+	match, ok := workflowRunMatchers[msg.ID]
+
+	if !ok {
 		return nil, false
 	}
+
+	res := match(msg.Payloads, acks)
+
+	if len(res) == 0 {
+		return nil, false
+	}
+
+	return res, true
 }

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -1124,7 +1124,7 @@ func (s *DispatcherImpl) subscribeToWorkflowRunsV1(server contracts.Dispatcher_S
 		wg.Add(1)
 		defer wg.Done()
 
-		if matchedWorkflowRunIds, ok := s.isMatchingWorkflowRunV1(msg, acks); ok {
+		if matchedWorkflowRunIds, ok := isMatchingWorkflowRunV1(msg, acks); ok {
 			if err := iter(matchedWorkflowRunIds); err != nil {
 				s.l.Error().Ctx(ctx).Err(err).Msg("could not iterate over workflow runs")
 			}
@@ -2049,7 +2049,7 @@ func (s *DispatcherImpl) subscribeToWorkflowEventsByWorkflowRunIdV1(workflowRunI
 		wg.Add(1)
 		defer wg.Done()
 
-		events, err := s.msgsToWorkflowEvent(
+		events, err := msgsToWorkflowEvent(
 			msgId,
 			payloads,
 			func(events []*contracts.WorkflowEvent) ([]*contracts.WorkflowEvent, error) {
@@ -2175,7 +2175,7 @@ func (s *DispatcherImpl) subscribeToWorkflowEventsByAdditionalMetaV1(key string,
 		wg.Add(1)
 		defer wg.Done()
 
-		events, err := s.msgsToWorkflowEvent(
+		events, err := msgsToWorkflowEvent(
 			msgId,
 			payloads,
 			func(events []*contracts.WorkflowEvent) ([]*contracts.WorkflowEvent, error) {
@@ -2348,210 +2348,4 @@ func (s *DispatcherImpl) listWorkflowRuns(ctx context.Context, tenantId uuid.UUI
 	}
 
 	return res, nil
-}
-
-// workflowEventConverters maps each message ID the dispatcher's workflow event
-// streams consume off the tenant stream to its contracts.WorkflowEvent
-// converter. Together with workflowRunMatchers, its keys are the source of
-// truth for the message IDs the streams consume: msgqueue's tenant-stream
-// publish allowlist is asserted against them in TestTenantStreamMsgIDsInSync.
-var workflowEventConverters = map[string]func(payloads [][]byte) []*contracts.WorkflowEvent{
-	msgqueue.MsgIDCreatedTask: func(payloads [][]byte) []*contracts.WorkflowEvent {
-		converted := msgqueue.JSONConvert[tasktypes.CreatedTaskPayload](payloads)
-		workflowEvents := []*contracts.WorkflowEvent{}
-
-		for _, payload := range converted {
-			workflowEvents = append(workflowEvents, &contracts.WorkflowEvent{
-				WorkflowRunId:  payload.WorkflowRunID.String(),
-				ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
-				ResourceId:     payload.ExternalID.String(),
-				EventType:      contracts.ResourceEventType_RESOURCE_EVENT_TYPE_STARTED,
-				EventTimestamp: timestamppb.New(payload.InsertedAt.Time),
-				RetryCount:     &payload.RetryCount,
-			})
-		}
-
-		return workflowEvents
-	},
-	msgqueue.MsgIDTaskCompleted: func(payloads [][]byte) []*contracts.WorkflowEvent {
-		converted := msgqueue.JSONConvert[tasktypes.CompletedTaskPayload](payloads)
-		workflowEvents := []*contracts.WorkflowEvent{}
-
-		for _, payload := range converted {
-			workflowEvents = append(workflowEvents, &contracts.WorkflowEvent{
-				WorkflowRunId:  payload.WorkflowRunId.String(),
-				ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
-				ResourceId:     payload.ExternalId.String(),
-				EventType:      contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED,
-				EventTimestamp: timestamppb.New(time.Now()),
-				RetryCount:     &payload.RetryCount,
-				EventPayload:   string(payload.Output),
-			})
-		}
-
-		return workflowEvents
-	},
-	msgqueue.MsgIDTaskFailed: func(payloads [][]byte) []*contracts.WorkflowEvent {
-		converted := msgqueue.JSONConvert[tasktypes.FailedTaskPayload](payloads)
-		workflowEvents := []*contracts.WorkflowEvent{}
-
-		for _, payload := range converted {
-			workflowEvents = append(workflowEvents, &contracts.WorkflowEvent{
-				WorkflowRunId:  payload.WorkflowRunId.String(),
-				ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
-				ResourceId:     payload.ExternalId.String(),
-				EventType:      contracts.ResourceEventType_RESOURCE_EVENT_TYPE_FAILED,
-				EventTimestamp: timestamppb.New(time.Now()),
-				RetryCount:     &payload.RetryCount,
-				EventPayload:   payload.ErrorMsg,
-			})
-		}
-
-		return workflowEvents
-	},
-	msgqueue.MsgIDTaskCancelled: func(payloads [][]byte) []*contracts.WorkflowEvent {
-		converted := msgqueue.JSONConvert[tasktypes.CancelledTaskPayload](payloads)
-		workflowEvents := []*contracts.WorkflowEvent{}
-
-		for _, payload := range converted {
-			workflowEvents = append(workflowEvents, &contracts.WorkflowEvent{
-				WorkflowRunId:  payload.WorkflowRunId.String(),
-				ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
-				ResourceId:     payload.ExternalId.String(),
-				EventType:      contracts.ResourceEventType_RESOURCE_EVENT_TYPE_CANCELLED,
-				EventTimestamp: timestamppb.New(time.Now()),
-				RetryCount:     &payload.RetryCount,
-			})
-		}
-
-		return workflowEvents
-	},
-	msgqueue.MsgIDTaskStreamEvent: func(payloads [][]byte) []*contracts.WorkflowEvent {
-		converted := msgqueue.JSONConvert[tasktypes.StreamEventPayload](payloads)
-		workflowEvents := []*contracts.WorkflowEvent{}
-
-		for _, payload := range converted {
-			workflowEvents = append(workflowEvents, &contracts.WorkflowEvent{
-				WorkflowRunId:  payload.WorkflowRunId.String(),
-				ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
-				ResourceId:     payload.TaskRunId.String(),
-				EventType:      contracts.ResourceEventType_RESOURCE_EVENT_TYPE_STREAM,
-				EventTimestamp: timestamppb.New(payload.CreatedAt),
-				EventPayload:   string(payload.Payload),
-				EventIndex:     payload.EventIndex,
-			})
-		}
-
-		return workflowEvents
-	},
-	msgqueue.MsgIDWorkflowRunFinished: func(payloads [][]byte) []*contracts.WorkflowEvent {
-		converted := msgqueue.JSONConvert[tasktypes.NotifyFinalizedPayload](payloads)
-		workflowEvents := []*contracts.WorkflowEvent{}
-
-		for _, payload := range converted {
-			eventType := contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED
-
-			switch payload.Status {
-			case sqlcv1.V1ReadableStatusOlapCANCELLED:
-				eventType = contracts.ResourceEventType_RESOURCE_EVENT_TYPE_CANCELLED
-			case sqlcv1.V1ReadableStatusOlapFAILED:
-				eventType = contracts.ResourceEventType_RESOURCE_EVENT_TYPE_FAILED
-			case sqlcv1.V1ReadableStatusOlapCOMPLETED:
-				eventType = contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED
-			}
-
-			workflowEvents = append(workflowEvents, &contracts.WorkflowEvent{
-				WorkflowRunId:  payload.ExternalId.String(),
-				ResourceType:   contracts.ResourceType_RESOURCE_TYPE_WORKFLOW_RUN,
-				ResourceId:     payload.ExternalId.String(),
-				EventType:      eventType,
-				EventTimestamp: timestamppb.New(time.Now()),
-			})
-		}
-
-		return workflowEvents
-	},
-}
-
-func (s *DispatcherImpl) msgsToWorkflowEvent(msgId string, payloads [][]byte, filter func(tasks []*contracts.WorkflowEvent) ([]*contracts.WorkflowEvent, error), hangupFunc func(tasks []*contracts.WorkflowEvent) ([]*contracts.WorkflowEvent, error)) ([]*contracts.WorkflowEvent, error) {
-	workflowEvents := []*contracts.WorkflowEvent{}
-
-	if convert, ok := workflowEventConverters[msgId]; ok {
-		workflowEvents = convert(payloads)
-	}
-
-	matches, err := filter(workflowEvents)
-
-	if err != nil {
-		return nil, err
-	}
-
-	matches, err = hangupFunc(matches)
-
-	if err != nil {
-		return nil, err
-	}
-
-	// order matches
-	slices.SortFunc(matches, func(a, b *contracts.WorkflowEvent) int {
-		// anything with a hangup should be last
-		if a.Hangup && !b.Hangup {
-			return 1
-		} else if !a.Hangup && b.Hangup {
-			return -1
-		}
-
-		return sortByEventIndex(a, b)
-	})
-
-	return matches, nil
-}
-
-// workflowRunMatchers maps each message ID the dispatcher's workflow run
-// subscriptions consume off the tenant stream to a matcher returning the
-// subscribed workflow run IDs the message finalizes (or nominates as
-// candidates). See the comment on workflowEventConverters: the keys of both
-// maps together are asserted against msgqueue's tenant-stream publish
-// allowlist in TestTenantStreamMsgIDsInSync.
-var workflowRunMatchers = map[string]func(payloads [][]byte, acks *workflowRunAcks) []uuid.UUID{
-	msgqueue.MsgIDWorkflowRunFinished: func(payloads [][]byte, acks *workflowRunAcks) []uuid.UUID {
-		converted := msgqueue.JSONConvert[tasktypes.NotifyFinalizedPayload](payloads)
-		res := make([]uuid.UUID, 0)
-
-		for _, payload := range converted {
-			if acks.hasWorkflowRun(payload.ExternalId) {
-				res = append(res, payload.ExternalId)
-			}
-		}
-
-		return res
-	},
-	msgqueue.MsgIDWorkflowRunFinishedCandidate: func(payloads [][]byte, acks *workflowRunAcks) []uuid.UUID {
-		converted := msgqueue.JSONConvert[tasktypes.CandidateFinalizedPayload](payloads)
-		res := make([]uuid.UUID, 0)
-
-		for _, payload := range converted {
-			if acks.hasWorkflowRun(payload.WorkflowRunId) {
-				res = append(res, payload.WorkflowRunId)
-			}
-		}
-
-		return res
-	},
-}
-
-func (s *DispatcherImpl) isMatchingWorkflowRunV1(msg *msgqueue.Message, acks *workflowRunAcks) ([]uuid.UUID, bool) {
-	match, ok := workflowRunMatchers[msg.ID]
-
-	if !ok {
-		return nil, false
-	}
-
-	res := match(msg.Payloads, acks)
-
-	if len(res) == 0 {
-		return nil, false
-	}
-
-	return res, true
 }

--- a/internal/services/dispatcher/tenant_stream_events.go
+++ b/internal/services/dispatcher/tenant_stream_events.go
@@ -1,0 +1,195 @@
+package dispatcher
+
+import (
+	"slices"
+	"time"
+
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/hatchet-dev/hatchet/internal/msgqueue"
+	"github.com/hatchet-dev/hatchet/internal/services/dispatcher/contracts"
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
+
+	tasktypes "github.com/hatchet-dev/hatchet/internal/services/shared/tasktypes/v1"
+)
+
+// eventConverter adapts a per-payload field mapping into a converter over raw
+// tenant-stream payloads: each payload is decoded as T and mapped to a
+// contracts.WorkflowEvent.
+func eventConverter[T any](toEvent func(payload *T) *contracts.WorkflowEvent) func(payloads [][]byte) []*contracts.WorkflowEvent {
+	return func(payloads [][]byte) []*contracts.WorkflowEvent {
+		converted := msgqueue.JSONConvert[T](payloads)
+		workflowEvents := []*contracts.WorkflowEvent{}
+
+		for _, payload := range converted {
+			workflowEvents = append(workflowEvents, toEvent(payload))
+		}
+
+		return workflowEvents
+	}
+}
+
+// workflowEventConverters maps each message ID the dispatcher's workflow event
+// streams consume off the tenant stream to its contracts.WorkflowEvent
+// converter. Together with workflowRunMatchers, its keys are the source of
+// truth for the message IDs the streams consume: msgqueue's tenant-stream
+// publish allowlist is asserted against them in TestTenantStreamMsgIDsInSync.
+var workflowEventConverters = map[string]func(payloads [][]byte) []*contracts.WorkflowEvent{
+	msgqueue.MsgIDCreatedTask: eventConverter(func(payload *tasktypes.CreatedTaskPayload) *contracts.WorkflowEvent {
+		return &contracts.WorkflowEvent{
+			WorkflowRunId:  payload.WorkflowRunID.String(),
+			ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
+			ResourceId:     payload.ExternalID.String(),
+			EventType:      contracts.ResourceEventType_RESOURCE_EVENT_TYPE_STARTED,
+			EventTimestamp: timestamppb.New(payload.InsertedAt.Time),
+			RetryCount:     &payload.RetryCount,
+		}
+	}),
+	msgqueue.MsgIDTaskCompleted: eventConverter(func(payload *tasktypes.CompletedTaskPayload) *contracts.WorkflowEvent {
+		return &contracts.WorkflowEvent{
+			WorkflowRunId:  payload.WorkflowRunId.String(),
+			ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
+			ResourceId:     payload.ExternalId.String(),
+			EventType:      contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED,
+			EventTimestamp: timestamppb.New(time.Now()),
+			RetryCount:     &payload.RetryCount,
+			EventPayload:   string(payload.Output),
+		}
+	}),
+	msgqueue.MsgIDTaskFailed: eventConverter(func(payload *tasktypes.FailedTaskPayload) *contracts.WorkflowEvent {
+		return &contracts.WorkflowEvent{
+			WorkflowRunId:  payload.WorkflowRunId.String(),
+			ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
+			ResourceId:     payload.ExternalId.String(),
+			EventType:      contracts.ResourceEventType_RESOURCE_EVENT_TYPE_FAILED,
+			EventTimestamp: timestamppb.New(time.Now()),
+			RetryCount:     &payload.RetryCount,
+			EventPayload:   payload.ErrorMsg,
+		}
+	}),
+	msgqueue.MsgIDTaskCancelled: eventConverter(func(payload *tasktypes.CancelledTaskPayload) *contracts.WorkflowEvent {
+		return &contracts.WorkflowEvent{
+			WorkflowRunId:  payload.WorkflowRunId.String(),
+			ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
+			ResourceId:     payload.ExternalId.String(),
+			EventType:      contracts.ResourceEventType_RESOURCE_EVENT_TYPE_CANCELLED,
+			EventTimestamp: timestamppb.New(time.Now()),
+			RetryCount:     &payload.RetryCount,
+		}
+	}),
+	msgqueue.MsgIDTaskStreamEvent: eventConverter(func(payload *tasktypes.StreamEventPayload) *contracts.WorkflowEvent {
+		return &contracts.WorkflowEvent{
+			WorkflowRunId:  payload.WorkflowRunId.String(),
+			ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
+			ResourceId:     payload.TaskRunId.String(),
+			EventType:      contracts.ResourceEventType_RESOURCE_EVENT_TYPE_STREAM,
+			EventTimestamp: timestamppb.New(payload.CreatedAt),
+			EventPayload:   string(payload.Payload),
+			EventIndex:     payload.EventIndex,
+		}
+	}),
+	msgqueue.MsgIDWorkflowRunFinished: eventConverter(func(payload *tasktypes.NotifyFinalizedPayload) *contracts.WorkflowEvent {
+		eventType := contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED
+
+		switch payload.Status {
+		case sqlcv1.V1ReadableStatusOlapCANCELLED:
+			eventType = contracts.ResourceEventType_RESOURCE_EVENT_TYPE_CANCELLED
+		case sqlcv1.V1ReadableStatusOlapFAILED:
+			eventType = contracts.ResourceEventType_RESOURCE_EVENT_TYPE_FAILED
+		case sqlcv1.V1ReadableStatusOlapCOMPLETED:
+			eventType = contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED
+		}
+
+		return &contracts.WorkflowEvent{
+			WorkflowRunId:  payload.ExternalId.String(),
+			ResourceType:   contracts.ResourceType_RESOURCE_TYPE_WORKFLOW_RUN,
+			ResourceId:     payload.ExternalId.String(),
+			EventType:      eventType,
+			EventTimestamp: timestamppb.New(time.Now()),
+		}
+	}),
+}
+
+func msgsToWorkflowEvent(msgId string, payloads [][]byte, filter func(tasks []*contracts.WorkflowEvent) ([]*contracts.WorkflowEvent, error), hangupFunc func(tasks []*contracts.WorkflowEvent) ([]*contracts.WorkflowEvent, error)) ([]*contracts.WorkflowEvent, error) {
+	workflowEvents := []*contracts.WorkflowEvent{}
+
+	if convert, ok := workflowEventConverters[msgId]; ok {
+		workflowEvents = convert(payloads)
+	}
+
+	matches, err := filter(workflowEvents)
+
+	if err != nil {
+		return nil, err
+	}
+
+	matches, err = hangupFunc(matches)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// order matches
+	slices.SortFunc(matches, func(a, b *contracts.WorkflowEvent) int {
+		// anything with a hangup should be last
+		if a.Hangup && !b.Hangup {
+			return 1
+		} else if !a.Hangup && b.Hangup {
+			return -1
+		}
+
+		return sortByEventIndex(a, b)
+	})
+
+	return matches, nil
+}
+
+// runMatcher adapts a per-payload run ID extractor into a matcher over raw
+// tenant-stream payloads: each payload is decoded as T, and the run IDs the
+// given acks are subscribed to are collected.
+func runMatcher[T any](runID func(payload *T) uuid.UUID) func(payloads [][]byte, acks *workflowRunAcks) []uuid.UUID {
+	return func(payloads [][]byte, acks *workflowRunAcks) []uuid.UUID {
+		converted := msgqueue.JSONConvert[T](payloads)
+		res := make([]uuid.UUID, 0)
+
+		for _, payload := range converted {
+			if id := runID(payload); acks.hasWorkflowRun(id) {
+				res = append(res, id)
+			}
+		}
+
+		return res
+	}
+}
+
+// workflowRunMatchers maps each message ID the dispatcher's workflow run
+// subscriptions consume off the tenant stream to a matcher returning the
+// subscribed workflow run IDs the message finalizes (or nominates as
+// candidates). See the comment on workflowEventConverters: the keys of both
+// maps together are asserted against msgqueue's tenant-stream publish
+// allowlist in TestTenantStreamMsgIDsInSync.
+var workflowRunMatchers = map[string]func(payloads [][]byte, acks *workflowRunAcks) []uuid.UUID{
+	msgqueue.MsgIDWorkflowRunFinished: runMatcher(func(payload *tasktypes.NotifyFinalizedPayload) uuid.UUID {
+		return payload.ExternalId
+	}),
+	msgqueue.MsgIDWorkflowRunFinishedCandidate: runMatcher(func(payload *tasktypes.CandidateFinalizedPayload) uuid.UUID {
+		return payload.WorkflowRunId
+	}),
+}
+
+func isMatchingWorkflowRunV1(msg *msgqueue.Message, acks *workflowRunAcks) ([]uuid.UUID, bool) {
+	match, ok := workflowRunMatchers[msg.ID]
+
+	if !ok {
+		return nil, false
+	}
+
+	res := match(msg.Payloads, acks)
+
+	if len(res) == 0 {
+		return nil, false
+	}
+
+	return res, true
+}

--- a/internal/services/dispatcher/tenant_stream_msg_ids_test.go
+++ b/internal/services/dispatcher/tenant_stream_msg_ids_test.go
@@ -1,0 +1,55 @@
+//go:build !e2e && !load && !rampup && !integration
+
+package dispatcher
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/hatchet-dev/hatchet/internal/msgqueue"
+)
+
+// TestTenantStreamMsgIDsInSync guards against drift between msgqueue's
+// tenant-stream publish allowlist (tenantStreamMsgIDs, which gates what
+// PubTenantMessage publishes to tenant topics) and the message IDs the
+// dispatcher's gRPC streams actually consume (the keys of
+// workflowEventConverters and workflowRunMatchers).
+//
+// The failure mode this prevents is silent: before the pub/sub split, every
+// durable send was implicitly mirrored to the tenant stream, and making the
+// mirror explicit nearly dropped task-cancelled on the API cancellation path
+// (caught in review of #4480). A consumed ID missing from the allowlist means
+// subscribers never see those events; an allowlisted ID with no consumer means
+// every publish is wasted.
+func TestTenantStreamMsgIDsInSync(t *testing.T) {
+	consumed := make(map[string]struct{}, len(workflowEventConverters)+len(workflowRunMatchers))
+
+	for id := range workflowEventConverters {
+		consumed[id] = struct{}{}
+	}
+
+	for id := range workflowRunMatchers {
+		consumed[id] = struct{}{}
+	}
+
+	published := msgqueue.TenantStreamMsgIDs()
+
+	for _, id := range slices.Sorted(maps.Keys(consumed)) {
+		if !slices.Contains(published, id) {
+			t.Errorf(
+				"the dispatcher's streams consume %q, but msgqueue's tenantStreamMsgIDs allowlist does not include it, so PubTenantMessage never publishes it and subscribers silently miss those events. Add %q to tenantStreamMsgIDs in internal/msgqueue/pubsub.go and make sure every producer of it routes through PubTenantMessage.",
+				id, id,
+			)
+		}
+	}
+
+	for _, id := range published {
+		if _, ok := consumed[id]; !ok {
+			t.Errorf(
+				"msgqueue's tenantStreamMsgIDs allowlist includes %q, but the dispatcher's streams do not consume it, so every publish of it is wasted. Either remove %q from tenantStreamMsgIDs in internal/msgqueue/pubsub.go, or add a handler for it to workflowEventConverters or workflowRunMatchers in internal/services/dispatcher/server.go.",
+				id, id,
+			)
+		}
+	}
+}


### PR DESCRIPTION
# Description

Follow-up to #4480, which turned the implicit durable-send mirror to tenant streams into an explicit publish allowlist (`msgqueue.tenantStreamMsgIDs`). During that review the `task-cancelled` API cancellation path nearly fell out of the allowlist silently — nothing kept it in sync with what the dispatcher's streams actually consume, in either direction (a consumed ID missing from the allowlist is never published; an allowlisted ID nobody consumes is wasted publishes).

- **Guard**: `TestTenantStreamMsgIDsInSync` asserts set equality between `msgqueue.TenantStreamMsgIDs()` (new accessor) and the message IDs the dispatcher's streams consume, with failure messages saying exactly what to update on which side.
- **How**: the dispatcher's stream switches became introspectable maps — `workflowEventConverters` and `workflowRunMatchers` — extracted together with `msgsToWorkflowEvent` / `isMatchingWorkflowRunV1` (now receiver-less free functions) into `tenant_stream_events.go`, next to the test. The repeated decode/loop/append scaffolding is collapsed into two small generic adapters (`eventConverter`, `runMatcher`), so each map entry is just its payload type and field mapping.
- **Zero behavior change**: logic is moved verbatim; map misses and empty match results return exactly what they did before. Net −11 lines (`server.go` −206).

```mermaid
flowchart LR
    P[producers<br/>PubTenantMessage] -->|gated by<br/>tenantStreamMsgIDs| S[tenant stream]
    S --> C[workflowEventConverters]
    S --> M[workflowRunMatchers]
    T[TestTenantStreamMsgIDsInSync] -. asserts allowlist == consumer keys .- C
    T -.- M
```

## Type of change

- [x] New tests (plus a no-behavior-change refactor making the consumed ID set introspectable)

## Checklist

Changes have been:

- [x] Tested (unit): `go test ./internal/msgqueue/ ./internal/services/dispatcher/` passes; the drift test verified to fail with an actionable message when an ID is removed from either side
- [x] Linted and formatted

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Claude w/ Fable

</details>