### PR TITLE
feat: instrument the pub/sub layer with Prometheus histograms

### DIFF
--- a/frontend/docs/pages/self-hosting/prometheus-metrics.mdx
+++ b/frontend/docs/pages/self-hosting/prometheus-metrics.mdx
@@ -86,6 +86,21 @@ Restart your Hatchet server after setting these variables to apply the changes.
 | `hatchet_queued_to_assigned`              | Counter   | The total number of unique tasks that were queued and later assigned to a worker  |
 | `hatchet_queued_to_assigned_time_seconds` | Histogram | Buckets of time (in seconds) spent in the queue before being assigned to a worker |
 | `hatchet_reassigned_tasks`                | Counter   | The total number of tasks that were reassigned to a worker                        |
+| `hatchet_pubsub_publish_duration_seconds` | Histogram | Publisher-side blocking time of a pub/sub `Pub` call                              |
+| `hatchet_pubsub_transit_seconds`          | Histogram | Pub/sub publish-to-delivery latency, from the message's `published_at` stamp      |
+
+The two pub/sub histograms are labelled by `kind` (the pub/sub backend:
+`rabbitmq`, `postgres`, or `nats`) and `topic_kind`;
+`hatchet_pubsub_publish_duration_seconds` is additionally labelled by `result`.
+Two caveats when comparing backends:
+
+- Publish duration is how long `Pub` blocks the caller, not how long the broker
+  took to deliver. NATS buffers the write and returns immediately, while
+  RabbitMQ performs a synchronous channel write, so NATS will look faster here
+  without necessarily delivering any sooner.
+- Transit latency is a difference between two clocks, so it is subject to skew
+  between the publishing and subscribing pods. Messages published by engines
+  that predate the `published_at` stamp are not observed at all.
 
 #### Example PromQL Queries
 

--- a/internal/msgqueue/instrumented_pubsub.go
+++ b/internal/msgqueue/instrumented_pubsub.go
@@ -1,0 +1,55 @@
+package msgqueue
+
+import (
+	"context"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/pkg/integrations/metrics/prometheus"
+)
+
+// instrumentedPubSub decorates a PubSub with publish-duration and transit-latency
+// Prometheus histograms. It never mutates the caller's *Message.
+type instrumentedPubSub struct {
+	inner PubSub
+	kind  string
+}
+
+// NewInstrumentedPubSub wraps a PubSub so that Pub stamps PublishedAt and
+// observes publisher-side duration, and Sub observes transit latency for
+// stamped messages. kind is the backend label ("rabbitmq"|"postgres"|"nats").
+func NewInstrumentedPubSub(inner PubSub, kind string) PubSub {
+	return &instrumentedPubSub{inner: inner, kind: kind}
+}
+
+func (i *instrumentedPubSub) Pub(ctx context.Context, topic Topic, msg *Message) error {
+	start := time.Now()
+
+	cp := msg.Clone()
+	cp.PublishedAt = start
+	err := i.inner.Pub(ctx, topic, cp)
+	elapsed := time.Since(start).Seconds()
+
+	result := "ok"
+	if err != nil {
+		result = "error"
+	}
+
+	prometheus.PubSubPublishDuration.WithLabelValues(i.kind, string(topic.Kind()), result).Observe(elapsed)
+
+	return err
+}
+
+func (i *instrumentedPubSub) Sub(topic Topic, handler MsgHandler) (func() error, error) {
+	return i.inner.Sub(topic, func(msg *Message) error {
+		if !msg.PublishedAt.IsZero() {
+			transit := max(0, time.Since(msg.PublishedAt).Seconds())
+			prometheus.PubSubTransit.WithLabelValues(i.kind, string(topic.Kind())).Observe(transit)
+		}
+
+		return handler(msg)
+	})
+}
+
+func (i *instrumentedPubSub) IsReady() bool {
+	return i.inner.IsReady()
+}

--- a/internal/msgqueue/instrumented_pubsub_test.go
+++ b/internal/msgqueue/instrumented_pubsub_test.go
@@ -1,0 +1,95 @@
+package msgqueue
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	prommetrics "github.com/hatchet-dev/hatchet/pkg/integrations/metrics/prometheus"
+)
+
+type capturingPubSub struct {
+	received *Message
+	handler  MsgHandler
+}
+
+func (c *capturingPubSub) Pub(ctx context.Context, topic Topic, msg *Message) error {
+	c.received = msg
+	return nil
+}
+
+func (c *capturingPubSub) Sub(topic Topic, handler MsgHandler) (func() error, error) {
+	c.handler = handler
+	return func() error { return nil }, nil
+}
+
+func (c *capturingPubSub) IsReady() bool {
+	return true
+}
+
+func histogramSampleCount(t *testing.T, vec *prometheus.HistogramVec, labelValues ...string) uint64 {
+	t.Helper()
+
+	obs, err := vec.GetMetricWithLabelValues(labelValues...)
+	require.NoError(t, err)
+
+	m := &dto.Metric{}
+	require.NoError(t, obs.(prometheus.Metric).Write(m))
+
+	return m.GetHistogram().GetSampleCount()
+}
+
+func TestInstrumentedPubSubStampsPublishedAtWithoutMutatingCaller(t *testing.T) {
+	inner := &capturingPubSub{}
+	ps := NewInstrumentedPubSub(inner, "test-stamp")
+
+	caller := &Message{ID: "msg-1"}
+	err := ps.Pub(context.Background(), SchedulerPartitionTopic("p"), caller)
+	require.NoError(t, err)
+
+	assert.True(t, caller.PublishedAt.IsZero(), "caller message must not be mutated")
+	require.NotNil(t, inner.received)
+	assert.False(t, inner.received.PublishedAt.IsZero(), "inner backend must receive a stamped copy")
+	assert.NotSame(t, caller, inner.received)
+}
+
+func TestInstrumentedPubSubTransitObservesOnlyStampedMessages(t *testing.T) {
+	kind := "test-transit"
+	topicKind := string(TopicKindSchedulerPartition)
+
+	inner := &capturingPubSub{}
+	ps := NewInstrumentedPubSub(inner, kind)
+
+	var handled int
+	_, err := ps.Sub(SchedulerPartitionTopic("p"), func(msg *Message) error {
+		handled++
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, inner.handler)
+
+	require.NoError(t, inner.handler(&Message{ID: "unstamped"}))
+	assert.EqualValues(t, 0, histogramSampleCount(t, prommetrics.PubSubTransit, kind, topicKind))
+
+	require.NoError(t, inner.handler(&Message{ID: "stamped", PublishedAt: time.Now().Add(-5 * time.Millisecond)}))
+	assert.EqualValues(t, 1, histogramSampleCount(t, prommetrics.PubSubTransit, kind, topicKind))
+	assert.Equal(t, 2, handled)
+}
+
+func TestInstrumentedPubSubPublishDurationResultLabels(t *testing.T) {
+	topicKind := string(TopicKindSchedulerPartition)
+
+	okInner := &capturingPubSub{}
+	err := NewInstrumentedPubSub(okInner, "test-pub-ok").Pub(context.Background(), SchedulerPartitionTopic("p"), &Message{ID: "ok"})
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, histogramSampleCount(t, prommetrics.PubSubPublishDuration, "test-pub-ok", topicKind, "ok"))
+
+	err = NewInstrumentedPubSub(&erroringPubSub{}, "test-pub-error").Pub(context.Background(), SchedulerPartitionTopic("p"), &Message{ID: "err"})
+	assert.Error(t, err)
+	assert.EqualValues(t, 1, histogramSampleCount(t, prommetrics.PubSubPublishDuration, "test-pub-error", topicKind, "error"))
+}

--- a/internal/msgqueue/instrumented_pubsub_test.go
+++ b/internal/msgqueue/instrumented_pubsub_test.go
@@ -73,23 +73,27 @@ func TestInstrumentedPubSubTransitObservesOnlyStampedMessages(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, inner.handler)
 
+	before := histogramSampleCount(t, prommetrics.PubSubTransit, kind, topicKind)
+
 	require.NoError(t, inner.handler(&Message{ID: "unstamped"}))
-	assert.EqualValues(t, 0, histogramSampleCount(t, prommetrics.PubSubTransit, kind, topicKind))
+	assert.EqualValues(t, before, histogramSampleCount(t, prommetrics.PubSubTransit, kind, topicKind))
 
 	require.NoError(t, inner.handler(&Message{ID: "stamped", PublishedAt: time.Now().Add(-5 * time.Millisecond)}))
-	assert.EqualValues(t, 1, histogramSampleCount(t, prommetrics.PubSubTransit, kind, topicKind))
+	assert.EqualValues(t, before+1, histogramSampleCount(t, prommetrics.PubSubTransit, kind, topicKind))
 	assert.Equal(t, 2, handled)
 }
 
 func TestInstrumentedPubSubPublishDurationResultLabels(t *testing.T) {
 	topicKind := string(TopicKindSchedulerPartition)
 
+	beforeOK := histogramSampleCount(t, prommetrics.PubSubPublishDuration, "test-pub-ok", topicKind, "ok")
 	okInner := &capturingPubSub{}
 	err := NewInstrumentedPubSub(okInner, "test-pub-ok").Pub(context.Background(), SchedulerPartitionTopic("p"), &Message{ID: "ok"})
 	require.NoError(t, err)
-	assert.EqualValues(t, 1, histogramSampleCount(t, prommetrics.PubSubPublishDuration, "test-pub-ok", topicKind, "ok"))
+	assert.EqualValues(t, beforeOK+1, histogramSampleCount(t, prommetrics.PubSubPublishDuration, "test-pub-ok", topicKind, "ok"))
 
+	beforeErr := histogramSampleCount(t, prommetrics.PubSubPublishDuration, "test-pub-error", topicKind, "error")
 	err = NewInstrumentedPubSub(&erroringPubSub{}, "test-pub-error").Pub(context.Background(), SchedulerPartitionTopic("p"), &Message{ID: "err"})
 	assert.Error(t, err)
-	assert.EqualValues(t, 1, histogramSampleCount(t, prommetrics.PubSubPublishDuration, "test-pub-error", topicKind, "error"))
+	assert.EqualValues(t, beforeErr+1, histogramSampleCount(t, prommetrics.PubSubPublishDuration, "test-pub-error", topicKind, "error"))
 }

--- a/internal/msgqueue/msg.go
+++ b/internal/msgqueue/msg.go
@@ -3,6 +3,7 @@ package msgqueue
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -44,6 +45,11 @@ type Message struct {
 
 	// Compressed indicates whether the payloads are gzip compressed
 	Compressed bool `json:"compressed,omitempty"`
+
+	// PublishedAt is stamped by the instrumented pub/sub at publish time and is
+	// used to observe transit latency on delivery. Zero for durable-queue
+	// messages and messages from engines that predate the field.
+	PublishedAt time.Time `json:"published_at,omitzero"`
 }
 
 func NewTenantMessage[T any](tenantId uuid.UUID, id string, immediatelyExpire, persistent bool, payloads ...T) (*Message, error) {

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -956,8 +956,9 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 // DisableTenantPubs gate.
 func createPubSubV1(dc *database.Layer, cf *server.ServerConfigFile, l *zerolog.Logger) (cleanup func() error, ps msgqueue.PubSub, err error) {
 	pubsubKind, pubsubURL := resolvePubSubKindAndURL(cf)
+	kind := strings.ToLower(pubsubKind)
 
-	switch strings.ToLower(pubsubKind) {
+	switch kind {
 	case "postgres":
 		// never dc.Pool and never the pgbouncer URL: the pub/sub owns its pool,
 		// and LISTEN does not survive transaction pooling
@@ -1054,7 +1055,7 @@ func createPubSubV1(dc *database.Layer, cf *server.ServerConfigFile, l *zerolog.
 		return nil, nil, fmt.Errorf("invalid pubsub kind %q, must be 'rabbitmq', 'postgres', or 'nats'", pubsubKind)
 	}
 
-	return cleanup, msgqueue.NewGatedPubSub(ps, cf.Runtime.DisableTenantPubs), nil
+	return cleanup, msgqueue.NewGatedPubSub(msgqueue.NewInstrumentedPubSub(ps, kind), cf.Runtime.DisableTenantPubs), nil
 }
 
 // resolvePubSubKindAndURL resolves the pub/sub kind and rabbit URL, inheriting

--- a/pkg/integrations/metrics/prometheus/pubsub.go
+++ b/pkg/integrations/metrics/prometheus/pubsub.go
@@ -1,0 +1,29 @@
+package prometheus
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type PubSubHatchetMetric string
+
+const (
+	PubSubPublishDurationSeconds PubSubHatchetMetric = "hatchet_pubsub_publish_duration_seconds"
+	PubSubTransitSeconds         PubSubHatchetMetric = "hatchet_pubsub_transit_seconds"
+)
+
+var pubSubBuckets = []float64{0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5}
+
+var (
+	PubSubPublishDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    string(PubSubPublishDurationSeconds),
+		Help:    "Time for the pub/sub backend's Pub call to return; this is publisher-side blocking cost, not broker delivery latency, and is not comparable across backends that differ in whether the write is synchronous.",
+		Buckets: pubSubBuckets,
+	}, []string{"kind", "topic_kind", "result"})
+
+	PubSubTransit = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    string(PubSubTransitSeconds),
+		Help:    "Publish-to-delivery latency computed from the message's published_at stamp; subject to clock skew between publisher and subscriber pods; unstamped messages (older engines) are not observed.",
+		Buckets: pubSubBuckets,
+	}, []string{"kind", "topic_kind"})
+)


### PR DESCRIPTION
# Description

Wraps every backend's `msgqueue.PubSub` (the interface #4480 split from the durable queue) in a decorator recording two Prometheus histograms:

```
hatchet_pubsub_publish_duration_seconds{kind, topic_kind, result}
hatchet_pubsub_transit_seconds{kind, topic_kind}
```

The goal is to be able to compare the numbers in a mixed fleet. (And later on to potentially alert on them).

Two caveats (also documented):

- Publish duration is caller-blocking time, not broker latency. NATS buffers and returns immediately, RabbitMQ writes synchronously.
- Transit latency subtracts two clocks, so pod clock skew applies; in AWS this should be <1-2 ms, which is good enough to detect outliers or the long tail.

The envelope gets a new `published_at` field. Mixed fleets are safe both ways: older engines ignore the unknown JSON field, unstamped messages skip the transit observation, and `omitzero` keeps the field off durable messages. `Pub` timestampsa copy as callers reuse the same `*Message` for the durable queue. The decorator sits inside the tenant-pubs gate, so `DisableTenantPubs` drops aren't counted as publishes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## What's Changed

- `internal/msgqueue/instrumented_pubsub.go` — the decorator
- `pkg/integrations/metrics/prometheus/pubsub.go` — histogram definitions and buckets
- `internal/msgqueue/msg.go` — `published_at` envelope field
- `pkg/config/loader/loader.go` — wires the decorator for every backend
- `frontend/docs/pages/self-hosting/prometheus-metrics.mdx` — docs

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

```bash
go test ./internal/msgqueue/...   # incl. instrumented decorator unit tests
```

Unit tests cover no mutation of the caller's `Message`, transit observed only for stamped messages, and the `result` label on success and error paths.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Cursor agent implemented the instrumentation, tests, and docs from a reviewed plan.

</details>