### PR TITLE
fix: prevent missing limits from overwriting existing limits

### DIFF
--- a/pkg/repository/sqlcv1/tenant_limits.sql
+++ b/pkg/repository/sqlcv1/tenant_limits.sql
@@ -68,6 +68,38 @@ ON CONFLICT ("tenantId", "resource") DO UPDATE SET
     "alarmValue" = EXCLUDED."alarmValue",
     "updatedAt" = CURRENT_TIMESTAMP;
 
+-- name: InsertTenantResourceLimitsIfNotExists :exec
+-- Insert-only defaults for first-use of a resource. Must not overwrite paid/custom limits.
+WITH input_values AS (
+    SELECT
+        "resource",
+        "limitValue",
+        "alarmValue",
+        "window",
+        "customValueMeter"
+    FROM (
+        SELECT
+            unnest(cast(@resources::text[] AS "LimitResource"[])) AS "resource",
+            unnest(@limitValues::int[]) AS "limitValue",
+            unnest(@alarmValues::int[]) AS "alarmValue",
+            unnest(@windows::text[]) AS "window",
+            unnest(@customValueMeters::boolean[]) AS "customValueMeter"
+    ) AS subquery
+)
+INSERT INTO "TenantResourceLimit" ("id", "tenantId", "resource", "value", "limitValue", "alarmValue", "window", "customValueMeter", "lastRefill")
+SELECT
+    gen_random_uuid(),
+    @tenantId::uuid,
+    iv."resource",
+    0,
+    iv."limitValue",
+    NULLIF(iv."alarmValue", 0),
+    NULLIF(iv."window", ''),
+    iv."customValueMeter",
+    CURRENT_TIMESTAMP
+FROM input_values iv
+ON CONFLICT ("tenantId", "resource") DO NOTHING;
+
 -- name: MeterTenantResource :one
 UPDATE "TenantResourceLimit"
 SET

--- a/pkg/repository/sqlcv1/tenant_limits.sql.go
+++ b/pkg/repository/sqlcv1/tenant_limits.sql.go
@@ -163,6 +163,60 @@ func (q *Queries) GetTenantResourceLimit(ctx context.Context, db DBTX, arg GetTe
 	return &i, err
 }
 
+const insertTenantResourceLimitsIfNotExists = `-- name: InsertTenantResourceLimitsIfNotExists :exec
+WITH input_values AS (
+    SELECT
+        "resource",
+        "limitValue",
+        "alarmValue",
+        "window",
+        "customValueMeter"
+    FROM (
+        SELECT
+            unnest(cast($2::text[] AS "LimitResource"[])) AS "resource",
+            unnest($3::int[]) AS "limitValue",
+            unnest($4::int[]) AS "alarmValue",
+            unnest($5::text[]) AS "window",
+            unnest($6::boolean[]) AS "customValueMeter"
+    ) AS subquery
+)
+INSERT INTO "TenantResourceLimit" ("id", "tenantId", "resource", "value", "limitValue", "alarmValue", "window", "customValueMeter", "lastRefill")
+SELECT
+    gen_random_uuid(),
+    $1::uuid,
+    iv."resource",
+    0,
+    iv."limitValue",
+    NULLIF(iv."alarmValue", 0),
+    NULLIF(iv."window", ''),
+    iv."customValueMeter",
+    CURRENT_TIMESTAMP
+FROM input_values iv
+ON CONFLICT ("tenantId", "resource") DO NOTHING
+`
+
+type InsertTenantResourceLimitsIfNotExistsParams struct {
+	Tenantid          uuid.UUID `json:"tenantid"`
+	Resources         []string  `json:"resources"`
+	Limitvalues       []int32   `json:"limitvalues"`
+	Alarmvalues       []int32   `json:"alarmvalues"`
+	Windows           []string  `json:"windows"`
+	Customvaluemeters []bool    `json:"customvaluemeters"`
+}
+
+// Insert-only defaults for first-use of a resource. Must not overwrite paid/custom limits.
+func (q *Queries) InsertTenantResourceLimitsIfNotExists(ctx context.Context, db DBTX, arg InsertTenantResourceLimitsIfNotExistsParams) error {
+	_, err := db.Exec(ctx, insertTenantResourceLimitsIfNotExists,
+		arg.Tenantid,
+		arg.Resources,
+		arg.Limitvalues,
+		arg.Alarmvalues,
+		arg.Windows,
+		arg.Customvaluemeters,
+	)
+	return err
+}
+
 const listTenantResourceLimits = `-- name: ListTenantResourceLimits :many
 SELECT id, "createdAt", "updatedAt", resource, "tenantId", "limitValue", "alarmValue", value, "window", "lastRefill", "customValueMeter" FROM "TenantResourceLimit"
 WHERE "tenantId" = $1::uuid

--- a/pkg/repository/tenant_limit.go
+++ b/pkg/repository/tenant_limit.go
@@ -200,13 +200,22 @@ func (t *tenantLimitRepository) canCreate(ctx context.Context, dbtx sqlcv1.DBTX,
 	if err != nil && errors.Is(err, pgx.ErrNoRows) {
 		t.l.Warn().Ctx(ctx).Msgf("no %s tenant limit found, creating default limit", string(resource))
 
-		err = t.updateLimits(ctx, dbtx, tenantId, t.DefaultLimits())
-
+		// Insert-only so concurrent first-use and existing paid/custom limits are not overwritten.
+		err = t.insertDefaultLimitsIfMissing(ctx, dbtx, tenantId)
 		if err != nil {
 			return false, 0, err
 		}
 
-		return true, 0, nil
+		limit, err = t.queries.GetTenantResourceLimit(ctx, dbtx, sqlcv1.GetTenantResourceLimitParams{
+			Tenantid: tenantId,
+			Resource: sqlcv1.NullLimitResource{
+				LimitResource: resource,
+				Valid:         true,
+			},
+		})
+		if err != nil {
+			return false, 0, err
+		}
 	} else if err != nil {
 		return false, 0, err
 	}
@@ -389,20 +398,14 @@ func (t *tenantLimitRepository) UpdateLimits(ctx context.Context, tenantId uuid.
 	return t.updateLimits(ctx, nil, tenantId, limits)
 }
 
-func (t *tenantLimitRepository) updateLimits(ctx context.Context, dbtx sqlcv1.DBTX, tenantId uuid.UUID, limits []Limit) error {
-	if len(limits) == 0 {
-		return nil
-	}
-
-	if dbtx == nil {
-		dbtx = t.pool
-	}
-
-	resources := make([]string, len(limits))
-	limitValues := make([]int32, len(limits))
-	alarmValues := make([]int32, len(limits))
-	windows := make([]string, len(limits))
-	customValueMeters := make([]bool, len(limits))
+// prepareTenantResourceLimitParams builds the shared SQL array params used by both
+// overwrite (upsert) and insert-only paths.
+func prepareTenantResourceLimitParams(limits []Limit) (resources []string, limitValues, alarmValues []int32, windows []string, customValueMeters []bool) {
+	resources = make([]string, len(limits))
+	limitValues = make([]int32, len(limits))
+	alarmValues = make([]int32, len(limits))
+	windows = make([]string, len(limits))
+	customValueMeters = make([]bool, len(limits))
 
 	for i, limit := range limits {
 		resources[i] = string(limit.Resource)
@@ -420,7 +423,42 @@ func (t *tenantLimitRepository) updateLimits(ctx context.Context, dbtx sqlcv1.DB
 		}
 	}
 
+	return resources, limitValues, alarmValues, windows, customValueMeters
+}
+
+func (t *tenantLimitRepository) updateLimits(ctx context.Context, dbtx sqlcv1.DBTX, tenantId uuid.UUID, limits []Limit) error {
+	if len(limits) == 0 {
+		return nil
+	}
+
+	if dbtx == nil {
+		dbtx = t.pool
+	}
+
+	resources, limitValues, alarmValues, windows, customValueMeters := prepareTenantResourceLimitParams(limits)
+
 	return t.queries.UpsertTenantResourceLimits(ctx, dbtx, sqlcv1.UpsertTenantResourceLimitsParams{
+		Tenantid:          tenantId,
+		Resources:         resources,
+		Limitvalues:       limitValues,
+		Alarmvalues:       alarmValues,
+		Windows:           windows,
+		Customvaluemeters: customValueMeters,
+	})
+}
+
+// insertDefaultLimitsIfMissing inserts DefaultLimits() with ON CONFLICT DO NOTHING so
+// first-use of a missing resource cannot overwrite existing paid/custom limit rows.
+// Caller must pass a non-nil dbtx (canCreate always normalizes nil → pool first).
+func (t *tenantLimitRepository) insertDefaultLimitsIfMissing(ctx context.Context, dbtx sqlcv1.DBTX, tenantId uuid.UUID) error {
+	limits := t.DefaultLimits()
+	if len(limits) == 0 {
+		return nil
+	}
+
+	resources, limitValues, alarmValues, windows, customValueMeters := prepareTenantResourceLimitParams(limits)
+
+	return t.queries.InsertTenantResourceLimitsIfNotExists(ctx, dbtx, sqlcv1.InsertTenantResourceLimitsIfNotExistsParams{
 		Tenantid:          tenantId,
 		Resources:         resources,
 		Limitvalues:       limitValues,

--- a/pkg/repository/tenant_limit_test.go
+++ b/pkg/repository/tenant_limit_test.go
@@ -1,0 +1,192 @@
+//go:build !e2e && !load && !rampup && !integration
+
+package repository
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hatchet-dev/hatchet/pkg/config/limits"
+	"github.com/hatchet-dev/hatchet/pkg/repository/cache"
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
+)
+
+// upsertAffectedFields are the columns UpsertTenantResourceLimits updates on conflict.
+type upsertAffectedFields struct {
+	LimitValue int32
+	AlarmValue pgtype.Int4
+	UpdatedAt  time.Time
+}
+
+func createTenantLimitRepositoryForTest(t *testing.T, pool *pgxpool.Pool, config limits.LimitConfigFile) *tenantLimitRepository {
+	t.Helper()
+
+	logger := zerolog.Nop()
+	c := cache.New(time.Minute)
+	t.Cleanup(c.Stop)
+
+	return &tenantLimitRepository{
+		sharedRepository: &sharedRepository{
+			pool:    pool,
+			ddlPool: pool,
+			l:       &logger,
+			queries: sqlcv1.New(),
+		},
+		config:        config,
+		enforceLimits: true,
+		c:             c,
+		unflushed:     make(meterSet),
+	}
+}
+
+func defaultLimitTestConfig() limits.LimitConfigFile {
+	return limits.LimitConfigFile{
+		DefaultTaskRunLimit:              100,
+		DefaultTaskRunAlarmLimit:         80,
+		DefaultTaskRunWindow:             24 * time.Hour,
+		DefaultEventLimit:                50,
+		DefaultEventAlarmLimit:           40,
+		DefaultEventWindow:               24 * time.Hour,
+		DefaultWorkerLimit:               3,
+		DefaultWorkerAlarmLimit:          2,
+		DefaultWorkerSlotLimit:           100,
+		DefaultWorkerSlotAlarmLimit:      80,
+		DefaultIncomingWebhookLimit:      5,
+		DefaultIncomingWebhookAlarmLimit: 4,
+	}
+}
+
+func createLimitTestTenant(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+
+	tenantID := uuid.New()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO "Tenant" ("id", "name", "slug", "createdAt", "updatedAt")
+		VALUES ($1, $2, $3, NOW(), NOW())
+	`, tenantID, "limit-test-"+tenantID.String(), "limit-test-"+tenantID.String())
+	require.NoError(t, err)
+
+	return tenantID
+}
+
+func loadUpsertAffectedFields(ctx context.Context, pool *pgxpool.Pool, tenantID uuid.UUID, resource sqlcv1.LimitResource) (upsertAffectedFields, error) {
+	var fields upsertAffectedFields
+	var updatedAt pgtype.Timestamp
+
+	err := pool.QueryRow(ctx, `
+		SELECT "limitValue", "alarmValue", "updatedAt"
+		FROM "TenantResourceLimit"
+		WHERE "tenantId" = $1 AND "resource" = $2::"LimitResource"
+	`, tenantID, string(resource)).Scan(&fields.LimitValue, &fields.AlarmValue, &updatedAt)
+	if err != nil {
+		return upsertAffectedFields{}, err
+	}
+
+	if !updatedAt.Valid {
+		return upsertAffectedFields{}, errors.New("updatedAt is NULL")
+	}
+	fields.UpdatedAt = updatedAt.Time.UTC()
+
+	return fields, nil
+}
+
+func requireUpsertAffectedFields(t *testing.T, pool *pgxpool.Pool, tenantID uuid.UUID, resource sqlcv1.LimitResource) upsertAffectedFields {
+	t.Helper()
+
+	fields, err := loadUpsertAffectedFields(context.Background(), pool, tenantID, resource)
+	require.NoError(t, err)
+	return fields
+}
+
+func TestCanCreate_MissingIncomingWebhook_PreservesPaidLimits(t *testing.T) {
+	pool, cleanup := setupPostgresWithMigration(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	tenantID := createLimitTestTenant(t, pool)
+
+	const paidTaskRunLimit int32 = 10000
+	const paidTaskRunAlarm int32 = 8000
+	const paidEventLimit int32 = 5000
+	const paidEventAlarm int32 = 4000
+
+	// Fixed past updatedAt so an upsert DO UPDATE would visibly move the timestamp.
+	paidUpdatedAt := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Millisecond)
+
+	_, err := pool.Exec(ctx, `
+		INSERT INTO "TenantResourceLimit" (
+			"id", "createdAt", "updatedAt", "tenantId", "resource", "value",
+			"limitValue", "alarmValue", "window", "customValueMeter", "lastRefill"
+		) VALUES
+			(gen_random_uuid(), $4, $4, $1, 'TASK_RUN', 0, $2, $5, '24h0m0s', false, $4),
+			(gen_random_uuid(), $4, $4, $1, 'EVENT', 0, $3, $6, '24h0m0s', false, $4)
+	`, tenantID, paidTaskRunLimit, paidEventLimit, paidUpdatedAt, paidTaskRunAlarm, paidEventAlarm)
+	require.NoError(t, err)
+
+	cfg := defaultLimitTestConfig()
+	// Defaults are far below the paid rows; upsert would clobber limit/alarm and bump updatedAt.
+	require.Less(t, cfg.DefaultTaskRunLimit, paidTaskRunLimit)
+	require.Less(t, cfg.DefaultTaskRunAlarmLimit, paidTaskRunAlarm)
+	require.Less(t, cfg.DefaultEventLimit, paidEventLimit)
+	require.Less(t, cfg.DefaultEventAlarmLimit, paidEventAlarm)
+
+	beforeTaskRun := requireUpsertAffectedFields(t, pool, tenantID, sqlcv1.LimitResourceTASKRUN)
+	beforeEvent := requireUpsertAffectedFields(t, pool, tenantID, sqlcv1.LimitResourceEVENT)
+
+	repo := createTenantLimitRepositoryForTest(t, pool, cfg)
+
+	ok, _, err := repo.canCreate(ctx, nil, sqlcv1.LimitResourceINCOMINGWEBHOOK, tenantID, 1)
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	afterTaskRun := requireUpsertAffectedFields(t, pool, tenantID, sqlcv1.LimitResourceTASKRUN)
+	afterEvent := requireUpsertAffectedFields(t, pool, tenantID, sqlcv1.LimitResourceEVENT)
+
+	assert.Equal(t, beforeTaskRun, afterTaskRun, "insert-only self-heal must not change upsert-affected TASK_RUN fields")
+	assert.Equal(t, beforeEvent, afterEvent, "insert-only self-heal must not change upsert-affected EVENT fields")
+	assert.Equal(t, paidTaskRunLimit, afterTaskRun.LimitValue)
+	assert.Equal(t, paidTaskRunAlarm, afterTaskRun.AlarmValue.Int32)
+	assert.True(t, afterTaskRun.AlarmValue.Valid)
+	assert.Equal(t, paidEventLimit, afterEvent.LimitValue)
+	assert.Equal(t, paidEventAlarm, afterEvent.AlarmValue.Int32)
+	assert.True(t, afterEvent.AlarmValue.Valid)
+
+	webhook, err := loadUpsertAffectedFields(ctx, pool, tenantID, sqlcv1.LimitResourceINCOMINGWEBHOOK)
+	require.NoError(t, err)
+	assert.Equal(t, cfg.DefaultIncomingWebhookLimit, webhook.LimitValue)
+}
+
+func TestCanCreate_MissingIncomingWebhook_ReReadsAndEnforcesDefault(t *testing.T) {
+	pool, cleanup := setupPostgresWithMigration(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	tenantID := createLimitTestTenant(t, pool)
+	cfg := defaultLimitTestConfig()
+	repo := createTenantLimitRepositoryForTest(t, pool, cfg)
+
+	_, err := loadUpsertAffectedFields(ctx, pool, tenantID, sqlcv1.LimitResourceINCOMINGWEBHOOK)
+	require.ErrorIs(t, err, pgx.ErrNoRows, "webhook limit must be absent before self-heal")
+
+	// Old bug returned true immediately after inserting defaults. With value=0 and
+	// limit=5, requesting 6 must deny: value+n-1 = 5 >= 5.
+	ok, percent, err := repo.canCreate(ctx, nil, sqlcv1.LimitResourceINCOMINGWEBHOOK, tenantID, 6)
+	require.NoError(t, err)
+	assert.False(t, ok, "inserted default must be re-read and enforced, not auto-allowed")
+	assert.Equal(t, 100, percent)
+
+	webhook := requireUpsertAffectedFields(t, pool, tenantID, sqlcv1.LimitResourceINCOMINGWEBHOOK)
+	assert.Equal(t, cfg.DefaultIncomingWebhookLimit, webhook.LimitValue)
+	assert.True(t, webhook.AlarmValue.Valid)
+	assert.Equal(t, cfg.DefaultIncomingWebhookAlarmLimit, webhook.AlarmValue.Int32)
+}


### PR DESCRIPTION
# Description

When one tenant resource-limit row is missing, recovery reuses overwrite-capable upsert semantics and can alter unrelated existing or custom limits.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

- Add a dedicated insert-only conflict path for missing defaults.
- Add focused Postgres regression tests and generated sqlc output.

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

- `go test -count=1 -timeout 10m -v -run 'TestCanCreate_MissingIncomingWebhook_' ./pkg/repository/`

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Cursor (GPT-5.6 Sol) assisted with implementation, tests, and PR preparation; the changes were reviewed and verified with the commands above.

</details>