### PR TITLE
feat(ci): Simplify for manual release only

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -1,10 +1,6 @@
 name: Release Hatchet CLI
 
 on:
-  push:
-    tags:
-      - "v*" # Trigger on version tags like v0.73.10
-      - "!v*-alpha*" # Do not trigger for alpha releases
   workflow_dispatch:
     inputs:
       tag:
@@ -16,14 +12,14 @@ permissions:
   contents: write
   packages: write
 
+env:
+  GITHUB_TAG: ${{ inputs.tag }}
+
 jobs:
   release-cli:
     name: Release CLI with GoReleaser
     runs-on: ubuntu-latest
     needs: [verify, generate-changelog]
-    env:
-      GITHUB_TAG: ${{ inputs.tag || github.ref_name }}
-    if: needs.verify.outputs.should_release == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -88,26 +84,26 @@ jobs:
     name: Verify Release Tag
     runs-on: ubuntu-latest
     env:
-      GITHUB_TAG: ${{ inputs.tag || github.ref_name }}
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
-      # We should only be triggering a release when using an annotated tag type.
-      should_release: ${{ steps.tag_name.outputs.tag_type == 'tag' }}
       prev_tag: ${{ steps.prev.outputs.prev_tag }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          fetch-depth: 0
-
-      - name: Fetch the tag object
-        run: git fetch --force origin tag "$GITHUB_TAG"
-
-      - name: Check if tag is annotated
-        id: tag_name
+      - name: Check the tag exists
         run: |
-          tag_type=$(git cat-file -t "$GITHUB_TAG")
-          echo "Tag [$GITHUB_TAG] is of type [$tag_type]."
-          echo "tag_type=$tag_type" >> $GITHUB_OUTPUT
+          if ! gh api "repos/{owner}/{repo}/git/ref/tags/$GITHUB_TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $GITHUB_TAG does not exist. Push the tag before running this workflow."
+            exit 1
+          fi
+          echo "Tag [$GITHUB_TAG] exists."
+
+      - name: Check no release exists for the tag
+        run: |
+          if gh release view "$GITHUB_TAG" >/dev/null 2>&1; then
+            echo "::error::A release for $GITHUB_TAG already exists (this includes drafts)."
+            exit 1
+          fi
+          echo "No existing release for [$GITHUB_TAG]."
 
       - name: Determine previous release tag
         id: prev
@@ -115,31 +111,25 @@ jobs:
           PREV_TAG=$(gh release view --json tagName --jq .tagName)
           echo "Previous release tag: $PREV_TAG"
           echo "prev_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   generate-changelog:
     name: Generate release_notes.md artifact
     runs-on: ubuntu-latest
     needs: [verify]
-    if: needs.verify.outputs.should_release == 'true'
-    env:
-      GITHUB_TAG: ${{ inputs.tag || github.ref_name }}
-      PREV_TAG: ${{ needs.verify.outputs.prev_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
-      - name: Fetch the tag object
-        run: git fetch --force origin tag "$GITHUB_TAG"
+      - name: Fetch all tags
+        run: git fetch --force --tags
 
       - name: Generate release section
         uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5
         with:
           config: cliff.toml
-          args: ${{ env.PREV_TAG }}..${{ env.GITHUB_TAG }}
+          args: ${{ needs.verify.outputs.prev_tag }}..${{ inputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OUTPUT: /tmp/CHANGES.md

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -89,6 +89,13 @@ jobs:
     outputs:
       prev_tag: ${{ steps.prev.outputs.prev_tag }}
     steps:
+      - name: Check the tag is a release version
+        run: |
+          if [[ ! "$GITHUB_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::$GITHUB_TAG is not a release tag. Expected vMAJOR.MINOR.PATCH with no pre-release suffix (e.g. v0.89.0)."
+            exit 1
+          fi
+
       - name: Check the tag exists
         run: |
           if ! gh api "repos/{owner}/{repo}/git/ref/tags/$GITHUB_TAG" >/dev/null 2>&1; then

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -332,7 +332,7 @@ tasks:
       - go test -count=1 -tags integration $(go list ./... | grep -v "quickstart") -v -failfast
 
   release:
-    desc: Create and push annotated tag, triggering the release pipeline.
+    desc: Push the release tag and dispatch the release pipeline.
     vars:
       CURRENT:
         sh: git tag --points-at HEAD --sort=-v:refname | head -n1
@@ -342,15 +342,12 @@ tasks:
         msg: "No TAG value found"
       - sh: '! gh release view {{.TAG}} >/dev/null 2>&1'
         msg: "{{.TAG}} already has a GitHub Release."
-      - sh: '[ "$(git cat-file -t {{.TAG}})" != "tag" ]'
-        msg: "{{.TAG}} is already an annotated tag."
       - sh: ./hack/ci/release-notes-cli.sh {{.TAG}}
         msg: "CHANGELOG.md must contain an entry for {{.TAG}}."
     prompt: Create new release for tag {{.TAG}}?
     cmds:
-      # cleanup=verbatim: markdown header hashes are otherwise stripped as comments.
-      - ./hack/ci/release-notes-cli.sh {{.TAG}} | git tag --cleanup=verbatim -a -f {{.TAG}} HEAD -F -
-      - git push --force origin {{.TAG}}
+      - gh workflow run release-cli.yaml -f tag={{.TAG}}
+      - gh run list --workflow=release-cli.yaml --limit 1
 
   patch:
     desc: Bump patch version (e.g. v0.83.16 → v0.83.17) and push the tag


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Simplifies the release pipeline to only run when manually triggered, as opposed to the mess that was the annotated tag approach.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] CI (any automation pipeline changes)

## What's Changed

- Releases can only be manually triggered.

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude web app using Opus 5 on Max effort

</details>
