### PR TITLE
test(python): anchor test_waits on start completing

### DIFF
--- a/sdks/python/examples/conditions/test_conditions.py
+++ b/sdks/python/examples/conditions/test_conditions.py
@@ -1,22 +1,49 @@
 import asyncio
+import time
 
 import pytest
 
 from examples.conditions.worker import task_condition_workflow
-from examples.test_utils import wait_for_running_status
-from hatchet_sdk import Hatchet
+from hatchet_sdk import Hatchet, V1TaskStatus
+
+
+async def _wait_for_start_to_complete(
+    hatchet: Hatchet, workflow_run_id: str, timeout: float = 60.0
+) -> None:
+    interval = 0.5
+    deadline = time.monotonic() + timeout
+
+    while time.monotonic() < deadline:
+        details = await hatchet.runs.aio_get(workflow_run_id)
+
+        # a task's display name is "<step readable id>-<unix timestamp>"
+        if any(
+            t.status == V1TaskStatus.COMPLETED and t.display_name.startswith("start-")
+            for t in details.tasks
+        ):
+            return
+
+        await asyncio.sleep(interval)
+
+    raise TimeoutError(
+        f"start did not complete within {timeout}s for run {workflow_run_id}"
+    )
 
 
 @pytest.mark.asyncio(loop_scope="session")
 async def test_waits(hatchet: Hatchet) -> None:
     ref = task_condition_workflow.run(wait_for_result=False)
 
-    await wait_for_running_status(hatchet, ref.workflow_run_id)
-    await asyncio.sleep(15)
+    # skip_on_event's skip match and its 30s sleep are both registered when start
+    # completes, so the skip event only counts during the 30s after that.
+    await _wait_for_start_to_complete(hatchet, ref.workflow_run_id)
 
-    hatchet.event.push("skip_on_event:skip", {})
-    hatchet.event.push("wait_for_event:start", {})
-    await asyncio.sleep(5)
+    # Push twice: the read model can show start COMPLETED just before the engine
+    # registers the match, and an unmatched event is dropped silently.
+    for _ in range(2):
+        await hatchet.event.aio_push("skip_on_event:skip", {})
+        await hatchet.event.aio_push("wait_for_event:start", {})
+        await asyncio.sleep(2)
 
     result = await ref.aio_result()
 


### PR DESCRIPTION
# Description

`examples/conditions/test_conditions.py::test_waits` is the flakiest test in the repo — **10 fails / 32 runs (31%)** per the CI Health Dashboard (#4204). It fails as:

```
assert result["skip_on_event"] == {"skipped": True}
AssertionError: assert {'random_number': 17} == {'skipped': True}
```

**Why it fails.** `skip_on_event` has `parents=[start]`, `wait_for=[SleepCondition(30s)]`, `skip_if=[UserEventCondition("skip_on_event:skip")]`. Because it has wait_for/skip_if conditions, its parent-complete condition is registered with action `CREATE_MATCH` rather than `QUEUE` (`getParentInDAGGroupMatch`), so at trigger time neither the sleep nor the user-event match exists. Both are created only when `start` completes, in one transaction, with `sleep_until = CURRENT_TIMESTAMP + 30s`. So the skip event only counts during the 30s after `start` completes — pushed earlier it matches nothing and is dropped, pushed later the sleep has fired and the task ran.

The test measured its 15s pre-push delay from `wait_for_running_status`, which waits for the *run* to report RUNNING. But a run only reads RUNNING while some task holds a `v1_task_runtime` row, and every task here other than `start` is parked on a wait condition — so RUNNING is observable for a few milliseconds at a time (`start` at the very beginning, then `wait_for_sleep`/a branch near the 10s mark; in between the run reads QUEUED). That wait commonly returned ~10s in, the test then slept its full 15s, and the push landed ~25s into a 30s window: **~5s of margin**, which CI load eats. Because sustained load rather than chance drives it, all four retry attempts fail together with a different random number each time — exactly the observed signature.

**Regression history.** This was introduced by #3846 (May 2026), which inserted `wait_for_running_status` *in front of* a pre-existing `sleep(15)` that had been counted from run creation. The added wait can only delay the push, so it strictly reduced the late-side margin. Worth noting the test was already racy before, in the opposite direction: a fixed 15s from run creation risked arriving *before* `start` completed, which drops the event and fails identically. #3846 appears to have been fixing that early-side race and overcorrected. Hence the structural fix here rather than a retuned constant — any single fixed delay is exposed to one side or the other.

## Type of change

- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

- Anchor on the window's own opening edge: poll `runs.aio_get` until the `start` task reads `COMPLETED`, then push. Unlike the gRPC `aio_get_details`, that REST endpoint exposes live per-task status mid-run (prior art: `examples/on_failure/test_on_failure.py`). Margin goes from ~5s to ~28s and can't drift.
- Push twice, 2s apart: the read model can surface `start` as `COMPLETED` marginally before the engine commits the match registration, and a too-early push fails identically to a too-late one.
- Drop `wait_for_running_status` and both fixed sleeps from this test. All seven original assertions are unchanged.

Not touched on purpose: `examples/conditions/worker.py` (published docs snippets), `test_utils.py`, and the engine.

**Follow-up, not in this PR:** `wait_for_running_status` in `examples/test_utils.py` silently returns when its timeout expires instead of raising — its `for _ in range(max_iters)` loop just falls off the end. That turns "the run never started" into a confusing assertion failure much later. It also counts iterations rather than tracking a deadline, so a nominal 60s becomes longer under load. Three other tests still use it; left alone here to keep this PR's blast radius at zero.

## Checklist

Changes have been:

- [x] Tested (black, ruff, mypy, pydoclint all clean locally; the e2e itself runs in CI)
- [x] Linted and formatted
- [ ] Documented (n/a)
- [ ] Added to CHANGELOG (n/a — test-only)

## Testing

The e2e needs docker compose plus a live engine/API/worker, so it runs in CI here. A single local pass couldn't demonstrate a load-dependent flake is gone anyway; the argument for this change is the margin going from ~5s to ~28s and the anchor no longer being a proxy that sits ~10s downstream of the thing it's supposed to track.

Worth watching in review: `t.display_name.startswith("start-")` relies on a DAG task's display name being `<step_readable_id>-<unix>` (`pkg/repository/task.go`, `fmt.Sprintf("%s-%d", stepConfig.ReadableId.String, unix)`) — no namespace or workflow prefix.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Cursor agent diagnosed the flake against the engine source, then implemented and reviewed the test change from a plan I approved.

</details>