### PR TITLE
docs: list all scheduled quickstart languages in the CLI reference

### DIFF
--- a/frontend/docs/pages/reference/cli/quickstarts.mdx
+++ b/frontend/docs/pages/reference/cli/quickstarts.mdx
@@ -16,7 +16,7 @@ Templates are organized by use case. The default use case is `simple`, a worker 
 hatchet quickstart --use-case scheduled --language go
 ```
 
-The `scheduled` use case is a Go project whose workflow runs on a cron schedule. With the worker running, its `manual-run` trigger runs the workflow once on demand:
+The `scheduled` use case generates a workflow that runs on a cron schedule, in Python, TypeScript, or Go. While the worker running, its `manual-run` trigger will run the workflow once on demand:
 
 ```sh
 hatchet trigger manual-run


### PR DESCRIPTION
Closes #4107

# Description

The CLI reference still described the `scheduled` use case as a Go project. Scheduled has since been updated to include support for Python and TypeScript. This PR updates to docs to reflect that and completes the last Phase 5 item on #4107.

## Type of change

- [x] Documentation change (pure documentation change)

## What's Changed

- `frontend/docs/pages/reference/cli/quickstarts.mdx` updates the scheduled use case supported language list. 

## Checklist

Changes have been:

- [x] Linted and formatted

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: N/A

</details>
