### PR TITLE
feat: allow running migrations against an explicit database URL

### DIFF
--- a/cmd/hatchet-migrate/migrate/run.go
+++ b/cmd/hatchet-migrate/migrate/run.go
@@ -29,6 +29,7 @@ var embedMigrations embed.FS
 
 type runMigrationsOpt struct {
 	upToPenultimate bool
+	databaseURL     string
 }
 
 type RunMigrationsOpt func(*runMigrationsOpt)
@@ -36,6 +37,16 @@ type RunMigrationsOpt func(*runMigrationsOpt)
 func WithUpToPenultimate() RunMigrationsOpt {
 	return func(o *runMigrationsOpt) {
 		o.upToPenultimate = true
+	}
+}
+
+// WithDatabaseURL runs the migrations against the given database URL instead of
+// the DATABASE_URL environment variable. This is used by downstream consumers
+// (e.g. Hatchet Cloud) to apply the OSS schema to a separate database, such as a
+// dedicated OLAP database.
+func WithDatabaseURL(url string) RunMigrationsOpt {
+	return func(o *runMigrationsOpt) {
+		o.databaseURL = url
 	}
 }
 
@@ -52,7 +63,10 @@ func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) error {
 		phaseName      = "oss"
 	)
 
-	rawURL := os.Getenv(databaseEnvVar)
+	rawURL := options.databaseURL
+	if rawURL == "" {
+		rawURL = os.Getenv(databaseEnvVar)
+	}
 	if rawURL == "" {
 		return migratediag.MissingEnvError(databaseEnvVar, phaseName)
 	}


### PR DESCRIPTION
## Summary

- Adds a `WithDatabaseURL` option to `migrate.RunMigrations` that overrides the `DATABASE_URL` environment variable.
- This lets downstream consumers (e.g. Hatchet Cloud) apply the full OSS migration set to a separate database — specifically a dedicated native-Postgres OLAP database — using the exact same schema and migrations as OSS, without env mutation.
- Backwards compatible: when the option is not passed, behavior is unchanged (reads `DATABASE_URL`).

## Test plan

- [x] `go build` / `go vet` on `cmd/hatchet-migrate/...`
- [x] Verified downstream: ran `RunMigrations(ctx, WithDatabaseURL(url))` from hatchet-cloud against a fresh Postgres 16 database; all migrations (including pgoutbox) applied to the target database