### PR TITLE
WIP: feat: partition high-volume OLAP tables for native retention

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260729000000_v1_0_136.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260729000000_v1_0_136.sql
@@ -1,0 +1,502 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+
+-- Converts the four remaining high-volume, unpartitioned OLAP tables to
+-- range-partitioned tables so they can participate in partition-based
+-- retention (and so downstream consumers don't need TimescaleDB for
+-- retention on these tables):
+--
+--   - v1_statuses_olap      partitioned by inserted_at
+--   - v1_task_events_olap   partitioned by task_inserted_at
+--   - v1_lookup_table_olap  partitioned by inserted_at (PK widened to (external_id, inserted_at))
+--   - v1_dag_to_task_olap   partitioned by dag_inserted_at
+--
+-- For each table, the existing table becomes the first ("legacy") partition of a
+-- new partitioned parent, covering (MINVALUE, tomorrow). The legacy partition is
+-- deliberately named {table}_{YYYYMMDD} for the migration day so that:
+--
+--   1. create_v1_range_partition skips creating a conflicting partition for
+--      the migration day (it checks for the table name before creating), and
+--   2. get_v1_partitions_before_date picks the legacy partition up for retention
+--      once the migration day falls outside the retention window.
+--
+-- To attach without holding an ACCESS EXCLUSIVE lock during a full-table
+-- validation scan, we first add a CHECK constraint matching the partition bound
+-- as NOT VALID (brief lock), VALIDATE it (SHARE UPDATE EXCLUSIVE, writes
+-- continue), and only then do the rename + attach dance, which is catalog-only.
+--
+-- This migration runs outside a transaction (required for CREATE INDEX
+-- CONCURRENTLY), so every statement is written to be idempotent in case of a
+-- partial failure and re-run. Migration-day state (the partition boundary) is
+-- persisted in a scratch table that is dropped at the end.
+--
+-- NOTE: if this migration is run close to midnight UTC on a very large database,
+-- there is a small window between adding the CHECK constraint and the swap where
+-- inserts with a partition-key timestamp past midnight would be rejected by the
+-- constraint. Prefer running this migration away from the UTC day boundary.
+
+-- +goose StatementBegin
+DO $mig$
+DECLARE
+    part_boundary date := (now() AT TIME ZONE 'UTC')::date + 1;
+    t record;
+BEGIN
+    CREATE TABLE IF NOT EXISTS v1_olap_partition_migration_state (
+        table_name text PRIMARY KEY,
+        boundary date NOT NULL
+    );
+
+    FOR t IN
+        SELECT * FROM (VALUES
+            ('v1_statuses_olap', 'inserted_at'),
+            ('v1_task_events_olap', 'task_inserted_at'),
+            ('v1_lookup_table_olap', 'inserted_at'),
+            ('v1_dag_to_task_olap', 'dag_inserted_at')
+        ) AS v(table_name, part_col)
+    LOOP
+        -- skip tables that are already partitioned (fresh re-run after partial failure)
+        IF EXISTS (
+            SELECT 1 FROM pg_class
+            WHERE relname = t.table_name AND relkind = 'p' AND relnamespace = 'public'::regnamespace
+        ) THEN
+            CONTINUE;
+        END IF;
+
+        INSERT INTO v1_olap_partition_migration_state (table_name, boundary)
+        VALUES (t.table_name, part_boundary)
+        ON CONFLICT (table_name) DO NOTHING;
+
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conrelid = t.table_name::regclass
+              AND conname = t.table_name || '_partition_check'
+        ) THEN
+            EXECUTE format(
+                'ALTER TABLE %I ADD CONSTRAINT %I CHECK (%I < %L::timestamptz) NOT VALID',
+                t.table_name,
+                t.table_name || '_partition_check',
+                t.part_col,
+                (SELECT s.boundary FROM v1_olap_partition_migration_state s WHERE s.table_name = t.table_name)
+            );
+        END IF;
+    END LOOP;
+END
+$mig$;
+-- +goose StatementEnd
+
+-- Validate the CHECK constraints. This scans each table but only takes a
+-- SHARE UPDATE EXCLUSIVE lock, so reads and writes continue.
+-- +goose StatementBegin
+DO $mig$
+DECLARE
+    c record;
+BEGIN
+    FOR c IN
+        SELECT conrelid::regclass::text AS tbl, conname
+        FROM pg_constraint
+        WHERE conname IN (
+            'v1_statuses_olap_partition_check',
+            'v1_task_events_olap_partition_check',
+            'v1_lookup_table_olap_partition_check',
+            'v1_dag_to_task_olap_partition_check'
+        )
+        AND NOT convalidated
+    LOOP
+        EXECUTE format('ALTER TABLE %s VALIDATE CONSTRAINT %I', c.tbl, c.conname);
+    END LOOP;
+END
+$mig$;
+-- +goose StatementEnd
+
+-- v1_lookup_table_olap needs a unique index on (external_id, inserted_at) so it
+-- can back the new parent's primary key when attached. Drop a leftover invalid
+-- index from a previously interrupted run, if any, then build it concurrently.
+-- +goose StatementBegin
+DO $mig$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_index i
+        JOIN pg_class c ON c.oid = i.indexrelid
+        WHERE c.relname = 'v1_lookup_table_olap_external_id_inserted_at_key'
+          AND NOT i.indisvalid
+    ) THEN
+        EXECUTE 'DROP INDEX v1_lookup_table_olap_external_id_inserted_at_key';
+    END IF;
+END
+$mig$;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS v1_lookup_table_olap_external_id_inserted_at_key
+    ON v1_lookup_table_olap (external_id, inserted_at);
+-- +goose StatementEnd
+
+-- Swap v1_statuses_olap. Catalog-only: rename old table + indexes out of the way,
+-- create the partitioned parent, attach the old table as the legacy partition
+-- (no scan thanks to the validated CHECK constraint), create tomorrow's partition.
+-- +goose StatementBegin
+DO $mig$
+DECLARE
+    part_boundary date;
+    legacy_name text;
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_class
+        WHERE relname = 'v1_statuses_olap' AND relkind = 'p' AND relnamespace = 'public'::regnamespace
+    ) THEN
+        RETURN;
+    END IF;
+
+    SET LOCAL lock_timeout = '30s';
+
+    SELECT s.boundary INTO STRICT part_boundary
+    FROM v1_olap_partition_migration_state s
+    WHERE s.table_name = 'v1_statuses_olap';
+
+    legacy_name := 'v1_statuses_olap_' || to_char(part_boundary - 1, 'YYYYMMDD');
+
+    EXECUTE format('ALTER TABLE v1_statuses_olap RENAME TO %I', legacy_name);
+    EXECUTE format('ALTER INDEX v1_statuses_olap_pkey RENAME TO %I', legacy_name || '_pkey');
+    EXECUTE format('ALTER INDEX idx_v1_statuses_olap_query_optim RENAME TO %I', 'idx_' || legacy_name || '_query_optim');
+
+    CREATE TABLE v1_statuses_olap (
+        external_id UUID NOT NULL,
+        inserted_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        tenant_id UUID NOT NULL,
+        workflow_id UUID NOT NULL,
+        kind v1_run_kind NOT NULL,
+        readable_status v1_readable_status_olap NOT NULL DEFAULT 'QUEUED',
+
+        PRIMARY KEY (external_id, inserted_at)
+    ) PARTITION BY RANGE(inserted_at);
+
+    CREATE INDEX idx_v1_statuses_olap_query_optim ON v1_statuses_olap (tenant_id, workflow_id);
+
+    EXECUTE format(
+        'ALTER TABLE v1_statuses_olap ATTACH PARTITION %I FOR VALUES FROM (MINVALUE) TO (%L)',
+        legacy_name, to_char(part_boundary, 'YYYYMMDD')
+    );
+    EXECUTE format('ALTER TABLE %I DROP CONSTRAINT v1_statuses_olap_partition_check', legacy_name);
+
+    PERFORM create_v1_range_partition('v1_statuses_olap', part_boundary);
+END
+$mig$;
+-- +goose StatementEnd
+
+-- Swap v1_task_events_olap. Same dance, plus identity/sequence handling: the
+-- legacy table keeps its identity (pointing at the renamed sequence), and the
+-- new parent's identity sequence is advanced past the legacy sequence so ids
+-- keep increasing.
+-- +goose StatementBegin
+DO $mig$
+DECLARE
+    part_boundary date;
+    legacy_name text;
+    legacy_last_value bigint;
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_class
+        WHERE relname = 'v1_task_events_olap' AND relkind = 'p' AND relnamespace = 'public'::regnamespace
+    ) THEN
+        RETURN;
+    END IF;
+
+    SET LOCAL lock_timeout = '30s';
+
+    SELECT s.boundary INTO STRICT part_boundary
+    FROM v1_olap_partition_migration_state s
+    WHERE s.table_name = 'v1_task_events_olap';
+
+    legacy_name := 'v1_task_events_olap_' || to_char(part_boundary - 1, 'YYYYMMDD');
+
+    EXECUTE format('ALTER TABLE v1_task_events_olap RENAME TO %I', legacy_name);
+    EXECUTE format('ALTER INDEX v1_task_events_olap_pkey RENAME TO %I', legacy_name || '_pkey');
+    EXECUTE format('ALTER INDEX v1_task_events_olap_task_id_idx RENAME TO %I', legacy_name || '_task_id_idx');
+    EXECUTE format('ALTER SEQUENCE v1_task_events_olap_id_seq RENAME TO %I', legacy_name || '_id_seq');
+
+    CREATE TABLE v1_task_events_olap (
+        tenant_id UUID NOT NULL,
+        id BIGINT GENERATED ALWAYS AS IDENTITY,
+        inserted_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        task_id BIGINT NOT NULL,
+        task_inserted_at TIMESTAMPTZ NOT NULL,
+        event_type v1_event_type_olap NOT NULL,
+        workflow_id UUID NOT NULL,
+        event_timestamp TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        readable_status v1_readable_status_olap NOT NULL,
+        retry_count INT NOT NULL DEFAULT 0,
+        error_message TEXT,
+        output JSONB,
+        worker_id UUID,
+        additional__event_data TEXT,
+        additional__event_message TEXT,
+        external_id UUID NOT NULL DEFAULT gen_random_uuid(),
+        durable_invocation_count INT NOT NULL DEFAULT 0,
+
+        PRIMARY KEY (task_id, task_inserted_at, id)
+    ) PARTITION BY RANGE(task_inserted_at);
+
+    CREATE INDEX v1_task_events_olap_task_id_idx ON v1_task_events_olap (task_id);
+
+    EXECUTE format('SELECT last_value FROM %I', legacy_name || '_id_seq') INTO legacy_last_value;
+    PERFORM setval(pg_get_serial_sequence('v1_task_events_olap', 'id'), legacy_last_value);
+
+    EXECUTE format(
+        'ALTER TABLE v1_task_events_olap ATTACH PARTITION %I FOR VALUES FROM (MINVALUE) TO (%L)',
+        legacy_name, to_char(part_boundary, 'YYYYMMDD')
+    );
+    EXECUTE format('ALTER TABLE %I DROP CONSTRAINT v1_task_events_olap_partition_check', legacy_name);
+
+    PERFORM create_v1_range_partition('v1_task_events_olap', part_boundary);
+END
+$mig$;
+-- +goose StatementEnd
+
+-- Swap v1_dag_to_task_olap.
+-- +goose StatementBegin
+DO $mig$
+DECLARE
+    part_boundary date;
+    legacy_name text;
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_class
+        WHERE relname = 'v1_dag_to_task_olap' AND relkind = 'p' AND relnamespace = 'public'::regnamespace
+    ) THEN
+        RETURN;
+    END IF;
+
+    SET LOCAL lock_timeout = '30s';
+
+    SELECT s.boundary INTO STRICT part_boundary
+    FROM v1_olap_partition_migration_state s
+    WHERE s.table_name = 'v1_dag_to_task_olap';
+
+    legacy_name := 'v1_dag_to_task_olap_' || to_char(part_boundary - 1, 'YYYYMMDD');
+
+    EXECUTE format('ALTER TABLE v1_dag_to_task_olap RENAME TO %I', legacy_name);
+    EXECUTE format('ALTER INDEX v1_dag_to_task_olap_pkey RENAME TO %I', legacy_name || '_pkey');
+
+    CREATE TABLE v1_dag_to_task_olap (
+        dag_id BIGINT NOT NULL,
+        dag_inserted_at TIMESTAMPTZ NOT NULL,
+        task_id BIGINT NOT NULL,
+        task_inserted_at TIMESTAMPTZ NOT NULL,
+        PRIMARY KEY (dag_id, dag_inserted_at, task_id, task_inserted_at)
+    ) PARTITION BY RANGE(dag_inserted_at);
+
+    EXECUTE format(
+        'ALTER TABLE v1_dag_to_task_olap ATTACH PARTITION %I FOR VALUES FROM (MINVALUE) TO (%L)',
+        legacy_name, to_char(part_boundary, 'YYYYMMDD')
+    );
+    EXECUTE format('ALTER TABLE %I DROP CONSTRAINT v1_dag_to_task_olap_partition_check', legacy_name);
+
+    PERFORM create_v1_range_partition('v1_dag_to_task_olap', part_boundary);
+END
+$mig$;
+-- +goose StatementEnd
+
+-- Swap v1_lookup_table_olap. The primary key is widened from (external_id) to
+-- (external_id, inserted_at) — required because the partition key must be part
+-- of any unique constraint. The concurrently-built unique index on the legacy
+-- table backs the new parent PK on attach, and the old single-column PK is
+-- dropped so replays (same external_id, new inserted_at) aren't rejected while
+-- today's rows still route to the legacy partition.
+--
+-- The two trigger functions whose ON CONFLICT target referenced the old PK are
+-- replaced in the same transaction.
+-- +goose StatementBegin
+DO $mig$
+DECLARE
+    part_boundary date;
+    legacy_name text;
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_class
+        WHERE relname = 'v1_lookup_table_olap' AND relkind = 'p' AND relnamespace = 'public'::regnamespace
+    ) THEN
+        RETURN;
+    END IF;
+
+    SET LOCAL lock_timeout = '30s';
+
+    SELECT s.boundary INTO STRICT part_boundary
+    FROM v1_olap_partition_migration_state s
+    WHERE s.table_name = 'v1_lookup_table_olap';
+
+    legacy_name := 'v1_lookup_table_olap_' || to_char(part_boundary - 1, 'YYYYMMDD');
+
+    EXECUTE format('ALTER TABLE v1_lookup_table_olap RENAME TO %I', legacy_name);
+
+    -- Drop the legacy single-column PK before attaching: a partition cannot have
+    -- its own PK in addition to the parent's. Uniqueness on the legacy partition
+    -- is enforced by the concurrently-built (external_id, inserted_at) index,
+    -- which backs the parent PK on attach.
+    EXECUTE format('ALTER TABLE %I DROP CONSTRAINT v1_lookup_table_olap_pkey', legacy_name);
+
+    CREATE TABLE v1_lookup_table_olap (
+        tenant_id UUID NOT NULL,
+        external_id UUID NOT NULL,
+        task_id BIGINT,
+        dag_id BIGINT,
+        inserted_at TIMESTAMPTZ NOT NULL,
+
+        PRIMARY KEY (external_id, inserted_at)
+    ) PARTITION BY RANGE(inserted_at);
+
+    EXECUTE format(
+        'ALTER TABLE v1_lookup_table_olap ATTACH PARTITION %I FOR VALUES FROM (MINVALUE) TO (%L)',
+        legacy_name, to_char(part_boundary, 'YYYYMMDD')
+    );
+
+    EXECUTE format('ALTER TABLE %I DROP CONSTRAINT v1_lookup_table_olap_partition_check', legacy_name);
+
+    PERFORM create_v1_range_partition('v1_lookup_table_olap', part_boundary);
+
+    CREATE OR REPLACE FUNCTION v1_tasks_olap_insert_function()
+    RETURNS TRIGGER AS
+    $fn$
+    BEGIN
+        INSERT INTO v1_runs_olap (
+            tenant_id,
+            id,
+            inserted_at,
+            external_id,
+            readable_status,
+            kind,
+            workflow_id,
+            workflow_version_id,
+            additional_metadata,
+            parent_task_external_id,
+            idempotency_key
+        )
+        SELECT
+            tenant_id,
+            id,
+            inserted_at,
+            external_id,
+            readable_status,
+            'TASK',
+            workflow_id,
+            workflow_version_id,
+            additional_metadata,
+            parent_task_external_id,
+            idempotency_key
+        FROM new_rows
+        WHERE dag_id IS NULL
+        ON CONFLICT (inserted_at, id) DO NOTHING;
+
+        INSERT INTO v1_lookup_table_olap (
+            tenant_id,
+            external_id,
+            task_id,
+            inserted_at
+        )
+        SELECT
+            tenant_id,
+            external_id,
+            id,
+            inserted_at
+        FROM new_rows
+        ON CONFLICT (external_id, inserted_at) DO NOTHING;
+
+        -- If the task has a dag_id and dag_inserted_at, insert into the lookup table
+        INSERT INTO v1_dag_to_task_olap (
+            dag_id,
+            dag_inserted_at,
+            task_id,
+            task_inserted_at
+        )
+        SELECT
+            dag_id,
+            dag_inserted_at,
+            id,
+            inserted_at
+        FROM new_rows
+        WHERE dag_id IS NOT NULL
+        ON CONFLICT (dag_id, dag_inserted_at, task_id, task_inserted_at) DO NOTHING;
+
+        RETURN NULL;
+    END;
+    $fn$
+    LANGUAGE plpgsql;
+
+    CREATE OR REPLACE FUNCTION v1_dags_olap_insert_function()
+    RETURNS TRIGGER AS
+    $fn$
+    BEGIN
+        INSERT INTO v1_runs_olap (
+            tenant_id,
+            id,
+            inserted_at,
+            external_id,
+            readable_status,
+            kind,
+            workflow_id,
+            workflow_version_id,
+            additional_metadata,
+            parent_task_external_id,
+            idempotency_key
+        )
+        SELECT
+            tenant_id,
+            id,
+            inserted_at,
+            external_id,
+            readable_status,
+            'DAG',
+            workflow_id,
+            workflow_version_id,
+            additional_metadata,
+            parent_task_external_id,
+            idempotency_key
+        FROM new_rows
+        ON CONFLICT (inserted_at, id) DO NOTHING;
+
+        INSERT INTO v1_lookup_table_olap (
+            tenant_id,
+            external_id,
+            dag_id,
+            inserted_at
+        )
+        SELECT
+            tenant_id,
+            external_id,
+            id,
+            inserted_at
+        FROM new_rows
+        ON CONFLICT (external_id, inserted_at) DO NOTHING;
+
+        RETURN NULL;
+    END;
+    $fn$
+    LANGUAGE plpgsql;
+END
+$mig$;
+-- +goose StatementEnd
+
+-- Drop the scratch state table once all four tables are partitioned.
+-- +goose StatementBegin
+DO $mig$
+BEGIN
+    IF (
+        SELECT count(*) FROM pg_class
+        WHERE relname IN ('v1_statuses_olap', 'v1_task_events_olap', 'v1_lookup_table_olap', 'v1_dag_to_task_olap')
+          AND relkind = 'p'
+          AND relnamespace = 'public'::regnamespace
+    ) = 4 THEN
+        DROP TABLE IF EXISTS v1_olap_partition_migration_state;
+    END IF;
+END
+$mig$;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DO $mig$
+BEGIN
+    RAISE EXCEPTION 'v1_0_136 (partitioning of v1_statuses_olap, v1_task_events_olap, v1_lookup_table_olap, v1_dag_to_task_olap) is not reversible';
+END
+$mig$;
+-- +goose StatementEnd

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -362,6 +362,11 @@ type OLAPRepositoryImpl struct {
 
 	shouldPartitionEventsTables bool
 	shouldPartitionOtelTables   bool
+	// shouldPartitionHighVolumeTables gates partition maintenance for the high-volume
+	// OLAP tables (v1_statuses_olap, v1_task_events_olap, v1_lookup_table_olap,
+	// v1_dag_to_task_olap). Downstream consumers that manage these tables externally
+	// (e.g. as TimescaleDB hypertables) set this to false.
+	shouldPartitionHighVolumeTables bool
 
 	statusUpdateBatchSizeLimits StatusUpdateBatchSizeLimits
 }
@@ -376,15 +381,16 @@ func NewOLAPRepositoryFromPool(
 	statusUpdateBatchSizeLimits StatusUpdateBatchSizeLimits,
 	cacheDuration time.Duration,
 	shouldPartitionOtelTables bool,
+	shouldPartitionHighVolumeTables bool,
 ) (OLAPRepository, func() error) {
 	v := validator.NewDefaultValidator()
 
 	shared, cleanupShared := newSharedRepository(pool, pool, v, l, payloadStoreOpts, tenantLimitConfig, enforceLimits, cacheDuration)
 
-	return newOLAPRepository(shared, olapRetentionPeriod, shouldPartitionEventsTables, shouldPartitionOtelTables, statusUpdateBatchSizeLimits), cleanupShared
+	return newOLAPRepository(shared, olapRetentionPeriod, shouldPartitionEventsTables, shouldPartitionOtelTables, shouldPartitionHighVolumeTables, statusUpdateBatchSizeLimits), cleanupShared
 }
 
-func newOLAPRepository(shared *sharedRepository, olapRetentionPeriod time.Duration, shouldPartitionEventsTables bool, shouldPartitionOtelTables bool, statusUpdateBatchSizeLimits StatusUpdateBatchSizeLimits) OLAPRepository {
+func newOLAPRepository(shared *sharedRepository, olapRetentionPeriod time.Duration, shouldPartitionEventsTables bool, shouldPartitionOtelTables bool, shouldPartitionHighVolumeTables bool, statusUpdateBatchSizeLimits StatusUpdateBatchSizeLimits) OLAPRepository {
 	eventCache, err := lru.New[string, bool](100000)
 
 	if err != nil {
@@ -392,13 +398,14 @@ func newOLAPRepository(shared *sharedRepository, olapRetentionPeriod time.Durati
 	}
 
 	return &OLAPRepositoryImpl{
-		sharedRepository:            shared,
-		readPool:                    shared.pool,
-		eventCache:                  eventCache,
-		olapRetentionPeriod:         olapRetentionPeriod,
-		shouldPartitionEventsTables: shouldPartitionEventsTables,
-		shouldPartitionOtelTables:   shouldPartitionOtelTables,
-		statusUpdateBatchSizeLimits: statusUpdateBatchSizeLimits,
+		sharedRepository:                shared,
+		readPool:                        shared.pool,
+		eventCache:                      eventCache,
+		olapRetentionPeriod:             olapRetentionPeriod,
+		shouldPartitionEventsTables:     shouldPartitionEventsTables,
+		shouldPartitionOtelTables:       shouldPartitionOtelTables,
+		shouldPartitionHighVolumeTables: shouldPartitionHighVolumeTables,
+		statusUpdateBatchSizeLimits:     statusUpdateBatchSizeLimits,
 	}
 }
 
@@ -484,6 +491,14 @@ func (r *OLAPRepositoryImpl) UpdateTablePartitions(ctx context.Context) error {
 		}
 	}
 
+	if r.shouldPartitionHighVolumeTables {
+		if err = runPartitionDDLWithLockTimeout(ctx, r.ddlPool, r.l, func(tx pgx.Tx) error {
+			return r.queries.CreateOLAPHighVolumePartitions(ctx, tx, pgtype.Date{Time: today, Valid: true})
+		}); err != nil {
+			return err
+		}
+	}
+
 	if err = runPartitionDDLWithLockTimeout(ctx, r.ddlPool, r.l, func(tx pgx.Tx) error {
 		return r.queries.CreateOLAPPartitions(ctx, tx, sqlcv1.CreateOLAPPartitionsParams{
 			Date:       pgtype.Date{Time: tomorrow, Valid: true},
@@ -509,9 +524,18 @@ func (r *OLAPRepositoryImpl) UpdateTablePartitions(ctx context.Context) error {
 		}
 	}
 
+	if r.shouldPartitionHighVolumeTables {
+		if err = runPartitionDDLWithLockTimeout(ctx, r.ddlPool, r.l, func(tx pgx.Tx) error {
+			return r.queries.CreateOLAPHighVolumePartitions(ctx, tx, pgtype.Date{Time: tomorrow, Valid: true})
+		}); err != nil {
+			return err
+		}
+	}
+
 	params := sqlcv1.ListOLAPPartitionsBeforeDateParams{
-		Shouldpartitioneventstables: r.shouldPartitionEventsTables,
-		Shouldpartitionoteltables:   r.shouldPartitionOtelTables,
+		Shouldpartitioneventstables:     r.shouldPartitionEventsTables,
+		Shouldpartitionoteltables:       r.shouldPartitionOtelTables,
+		Shouldpartitionhighvolumetables: r.shouldPartitionHighVolumeTables,
 		Date: pgtype.Date{
 			Time:  removeBefore,
 			Valid: true,

--- a/pkg/repository/olap_status_update_test.go
+++ b/pkg/repository/olap_status_update_test.go
@@ -77,6 +77,7 @@ func createOLAPRepositoryWithPayloadStore(t *testing.T, pool *pgxpool.Pool) *OLA
 		24*time.Hour,
 		false,
 		false,
+		false,
 		StatusUpdateBatchSizeLimits{Task: 1000, DAG: 1000},
 	).(*OLAPRepositoryImpl)
 	require.True(t, ok)

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -122,7 +122,7 @@ func NewRepository(
 		tasks:             newTaskRepository(shared, taskRetentionPeriod, maxInternalRetryCount, taskLimits.TimeoutLimit, taskLimits.ReassignLimit, taskLimits.RetryQueueLimit, taskLimits.DurableSleepLimit),
 		scheduler:         newSchedulerRepository(shared),
 		matches:           newMatchRepository(shared),
-		olap:              newOLAPRepository(shared, olapRetentionPeriod, true, true, statusUpdateBatchSizeLimits),
+		olap:              newOLAPRepository(shared, olapRetentionPeriod, true, true, true, statusUpdateBatchSizeLimits),
 		logs:              newLogLineRepository(shared),
 		workers:           newWorkerRepository(shared),
 		workflows:         newWorkflowRepository(shared),

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -8,6 +8,14 @@ SELECT
     create_v1_range_partition('v1_payloads_olap'::text, @date::date)
 ;
 
+-- name: CreateOLAPHighVolumePartitions :exec
+SELECT
+    create_v1_range_partition('v1_statuses_olap'::text, @date::date),
+    create_v1_range_partition('v1_task_events_olap'::text, @date::date),
+    create_v1_range_partition('v1_lookup_table_olap'::text, @date::date),
+    create_v1_range_partition('v1_dag_to_task_olap'::text, @date::date)
+;
+
 -- name: CreateOLAPEventPartitions :exec
 SELECT
     create_v1_range_partition('v1_events_olap'::text, @date::date),
@@ -64,6 +72,14 @@ WITH task_partitions AS (
     SELECT 'v1_otel_trace_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_otel_trace_olap', @date::date) AS p
 ), otel_trace_lookup_partitions AS (
     SELECT 'v1_otel_trace_lookup_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_otel_trace_lookup_olap', @date::date) AS p
+), statuses_partitions AS (
+    SELECT 'v1_statuses_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_statuses_olap', @date::date) AS p
+), task_events_partitions AS (
+    SELECT 'v1_task_events_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_task_events_olap', @date::date) AS p
+), lookup_table_partitions AS (
+    SELECT 'v1_lookup_table_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_lookup_table_olap', @date::date) AS p
+), dag_to_task_partitions AS (
+    SELECT 'v1_dag_to_task_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_dag_to_task_olap', @date::date) AS p
 ), candidates AS (
     SELECT
         *
@@ -140,6 +156,34 @@ WITH task_partitions AS (
     FROM
         otel_trace_lookup_partitions
 
+    UNION ALL
+
+    SELECT
+        *
+    FROM
+        statuses_partitions
+
+    UNION ALL
+
+    SELECT
+        *
+    FROM
+        task_events_partitions
+
+    UNION ALL
+
+    SELECT
+        *
+    FROM
+        lookup_table_partitions
+
+    UNION ALL
+
+    SELECT
+        *
+    FROM
+        dag_to_task_partitions
+
 )
 
 SELECT *
@@ -152,6 +196,10 @@ WHERE
     AND CASE
         WHEN @shouldPartitionOtelTables::BOOLEAN THEN TRUE
         ELSE parent_table NOT IN ('v1_otel_trace_olap', 'v1_otel_trace_lookup_olap')
+    END
+    AND CASE
+        WHEN @shouldPartitionHighVolumeTables::BOOLEAN THEN TRUE
+        ELSE parent_table NOT IN ('v1_statuses_olap', 'v1_task_events_olap', 'v1_lookup_table_olap', 'v1_dag_to_task_olap')
     END
 ;
 

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -373,6 +373,19 @@ func (q *Queries) CreateOLAPEventPartitions(ctx context.Context, db DBTX, date p
 	return err
 }
 
+const createOLAPHighVolumePartitions = `-- name: CreateOLAPHighVolumePartitions :exec
+SELECT
+    create_v1_range_partition('v1_statuses_olap'::text, $1::date),
+    create_v1_range_partition('v1_task_events_olap'::text, $1::date),
+    create_v1_range_partition('v1_lookup_table_olap'::text, $1::date),
+    create_v1_range_partition('v1_dag_to_task_olap'::text, $1::date)
+`
+
+func (q *Queries) CreateOLAPHighVolumePartitions(ctx context.Context, db DBTX, date pgtype.Date) error {
+	_, err := db.Exec(ctx, createOLAPHighVolumePartitions, date)
+	return err
+}
+
 const createOLAPOffloadedPayloadIndexBlock = `-- name: CreateOLAPOffloadedPayloadIndexBlock :exec
 INSERT INTO v1_payloads_olap_offloaded_block_index (
     payload_inserted_at_date,
@@ -1425,27 +1438,35 @@ func (q *Queries) ListEvents(ctx context.Context, db DBTX, arg ListEventsParams)
 
 const listOLAPPartitionsBeforeDate = `-- name: ListOLAPPartitionsBeforeDate :many
 WITH task_partitions AS (
-    SELECT 'v1_tasks_olap' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_tasks_olap'::text, $3::date) AS p
+    SELECT 'v1_tasks_olap' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_tasks_olap'::text, $4::date) AS p
 ), dag_partitions AS (
-    SELECT 'v1_dags_olap' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_dags_olap', $3::date) AS p
+    SELECT 'v1_dags_olap' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_dags_olap', $4::date) AS p
 ), runs_partitions AS (
-    SELECT 'v1_runs_olap' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_runs_olap', $3::date) AS p
+    SELECT 'v1_runs_olap' AS parent_table, p::text as partition_name FROM get_v1_partitions_before_date('v1_runs_olap', $4::date) AS p
 ), events_partitions AS (
-    SELECT 'v1_events_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_events_olap', $3::date) AS p
+    SELECT 'v1_events_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_events_olap', $4::date) AS p
 ), event_trigger_partitions AS (
-    SELECT 'v1_event_to_run_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_event_to_run_olap', $3::date) AS p
+    SELECT 'v1_event_to_run_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_event_to_run_olap', $4::date) AS p
 ), events_lookup_table_partitions AS (
-    SELECT 'v1_event_lookup_table_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_weekly_partitions_before_date('v1_event_lookup_table_olap', $3::date) AS p
+    SELECT 'v1_event_lookup_table_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_weekly_partitions_before_date('v1_event_lookup_table_olap', $4::date) AS p
 ), incoming_webhook_validation_failure_partitions AS (
-    SELECT 'v1_incoming_webhook_validation_failures_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_incoming_webhook_validation_failures_olap', $3::date) AS p
+    SELECT 'v1_incoming_webhook_validation_failures_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_incoming_webhook_validation_failures_olap', $4::date) AS p
 ), cel_evaluation_failures_partitions AS (
-    SELECT 'v1_cel_evaluation_failures_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_cel_evaluation_failures_olap', $3::date) AS p
+    SELECT 'v1_cel_evaluation_failures_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_cel_evaluation_failures_olap', $4::date) AS p
 ), payloads_partitions AS (
-    SELECT 'v1_payloads_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_payloads_olap', $3::date) AS p
+    SELECT 'v1_payloads_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_payloads_olap', $4::date) AS p
 ), otel_trace_partitions AS (
-    SELECT 'v1_otel_trace_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_otel_trace_olap', $3::date) AS p
+    SELECT 'v1_otel_trace_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_otel_trace_olap', $4::date) AS p
 ), otel_trace_lookup_partitions AS (
-    SELECT 'v1_otel_trace_lookup_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_otel_trace_lookup_olap', $3::date) AS p
+    SELECT 'v1_otel_trace_lookup_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_otel_trace_lookup_olap', $4::date) AS p
+), statuses_partitions AS (
+    SELECT 'v1_statuses_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_statuses_olap', $4::date) AS p
+), task_events_partitions AS (
+    SELECT 'v1_task_events_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_task_events_olap', $4::date) AS p
+), lookup_table_partitions AS (
+    SELECT 'v1_lookup_table_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_lookup_table_olap', $4::date) AS p
+), dag_to_task_partitions AS (
+    SELECT 'v1_dag_to_task_olap' AS parent_table, p::TEXT AS partition_name FROM get_v1_partitions_before_date('v1_dag_to_task_olap', $4::date) AS p
 ), candidates AS (
     SELECT
         parent_table, partition_name
@@ -1522,6 +1543,34 @@ WITH task_partitions AS (
     FROM
         otel_trace_lookup_partitions
 
+    UNION ALL
+
+    SELECT
+        parent_table, partition_name
+    FROM
+        statuses_partitions
+
+    UNION ALL
+
+    SELECT
+        parent_table, partition_name
+    FROM
+        task_events_partitions
+
+    UNION ALL
+
+    SELECT
+        parent_table, partition_name
+    FROM
+        lookup_table_partitions
+
+    UNION ALL
+
+    SELECT
+        parent_table, partition_name
+    FROM
+        dag_to_task_partitions
+
 )
 
 SELECT parent_table, partition_name
@@ -1535,12 +1584,17 @@ WHERE
         WHEN $2::BOOLEAN THEN TRUE
         ELSE parent_table NOT IN ('v1_otel_trace_olap', 'v1_otel_trace_lookup_olap')
     END
+    AND CASE
+        WHEN $3::BOOLEAN THEN TRUE
+        ELSE parent_table NOT IN ('v1_statuses_olap', 'v1_task_events_olap', 'v1_lookup_table_olap', 'v1_dag_to_task_olap')
+    END
 `
 
 type ListOLAPPartitionsBeforeDateParams struct {
-	Shouldpartitioneventstables bool        `json:"shouldpartitioneventstables"`
-	Shouldpartitionoteltables   bool        `json:"shouldpartitionoteltables"`
-	Date                        pgtype.Date `json:"date"`
+	Shouldpartitioneventstables     bool        `json:"shouldpartitioneventstables"`
+	Shouldpartitionoteltables       bool        `json:"shouldpartitionoteltables"`
+	Shouldpartitionhighvolumetables bool        `json:"shouldpartitionhighvolumetables"`
+	Date                            pgtype.Date `json:"date"`
 }
 
 type ListOLAPPartitionsBeforeDateRow struct {
@@ -1549,7 +1603,12 @@ type ListOLAPPartitionsBeforeDateRow struct {
 }
 
 func (q *Queries) ListOLAPPartitionsBeforeDate(ctx context.Context, db DBTX, arg ListOLAPPartitionsBeforeDateParams) ([]*ListOLAPPartitionsBeforeDateRow, error) {
-	rows, err := db.Query(ctx, listOLAPPartitionsBeforeDate, arg.Shouldpartitioneventstables, arg.Shouldpartitionoteltables, arg.Date)
+	rows, err := db.Query(ctx, listOLAPPartitionsBeforeDate,
+		arg.Shouldpartitioneventstables,
+		arg.Shouldpartitionoteltables,
+		arg.Shouldpartitionhighvolumetables,
+		arg.Date,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/schema/v1-olap.sql
+++ b/sql/schema/v1-olap.sql
@@ -289,8 +289,8 @@ CREATE TABLE v1_lookup_table_olap (
     dag_id BIGINT,
     inserted_at TIMESTAMPTZ NOT NULL,
 
-    PRIMARY KEY (external_id)
-);
+    PRIMARY KEY (external_id, inserted_at)
+) PARTITION BY RANGE(inserted_at);
 
 CREATE TABLE v1_dag_to_task_olap (
     dag_id BIGINT NOT NULL,
@@ -298,7 +298,7 @@ CREATE TABLE v1_dag_to_task_olap (
     task_id BIGINT NOT NULL,
     task_inserted_at TIMESTAMPTZ NOT NULL,
     PRIMARY KEY (dag_id, dag_inserted_at, task_id, task_inserted_at)
-);
+) PARTITION BY RANGE(dag_inserted_at);
 
 -- STATUS DEFINITION --
 CREATE TYPE v1_status_kind AS ENUM ('TASK', 'DAG');
@@ -312,7 +312,9 @@ CREATE TABLE v1_statuses_olap (
     readable_status v1_readable_status_olap NOT NULL DEFAULT 'QUEUED',
 
     PRIMARY KEY (external_id, inserted_at)
-);
+) PARTITION BY RANGE(inserted_at);
+
+CREATE INDEX idx_v1_statuses_olap_query_optim ON v1_statuses_olap (tenant_id, workflow_id);
 
 
 -- EVENT DEFINITIONS --
@@ -406,7 +408,7 @@ CREATE TABLE v1_task_events_olap (
     durable_invocation_count INT NOT NULL DEFAULT 0,
 
     PRIMARY KEY (task_id, task_inserted_at, id)
-);
+) PARTITION BY RANGE(task_inserted_at);
 
 CREATE INDEX v1_task_events_olap_task_id_idx ON v1_task_events_olap (task_id);
 
@@ -653,7 +655,7 @@ BEGIN
         id,
         inserted_at
     FROM new_rows
-    ON CONFLICT (external_id) DO NOTHING;
+    ON CONFLICT (external_id, inserted_at) DO NOTHING;
 
     -- If the task has a dag_id and dag_inserted_at, insert into the lookup table
     INSERT INTO v1_dag_to_task_olap (
@@ -775,7 +777,7 @@ BEGIN
         id,
         inserted_at
     FROM new_rows
-    ON CONFLICT (external_id) DO NOTHING;
+    ON CONFLICT (external_id, inserted_at) DO NOTHING;
 
     RETURN NULL;
 END;


### PR DESCRIPTION
## Summary

- Converts the four unpartitioned high-volume OLAP tables — `v1_statuses_olap`, `v1_task_events_olap`, `v1_lookup_table_olap`, and `v1_dag_to_task_olap` — to range-partitioned tables (daily, matching the other OLAP tables), so they participate in partition-based creation/retention via `UpdateTablePartitions` instead of growing unboundedly.
- Widens the `v1_lookup_table_olap` primary key to `(external_id, inserted_at)` (required for range partitioning) and updates the `ON CONFLICT` targets in the tasks/DAGs insert trigger functions to match.
- Adds a `CreateOLAPHighVolumePartitions` query and a `shouldPartitionHighVolumeTables` flag on the OLAP repository (true in OSS) gating partition creation/retention for these tables, so downstream consumers that manage them externally (e.g. as TimescaleDB hypertables) can opt out.

## Migration (`v1_0_136`, goose NO TRANSACTION)

For each table, the existing table is renamed to `<table>_legacy` and attached as the first partition of a new partitioned parent covering `(-infinity, tomorrow)`:

- A `NOT VALID` check constraint is added and then validated separately (`SHARE UPDATE EXCLUSIVE`, no long blocking scan), so the subsequent `ATTACH PARTITION` is catalog-only and skips the full-table scan.
- The rename + attach swap holds `ACCESS EXCLUSIVE` only briefly.
- The legacy lookup-table PK is dropped before attach and the composite PK is enforced by the parent.
- The `v1_task_events_olap` identity sequence on the new parent is advanced past the legacy max id.
- Every step is idempotent so a partially applied migration can be safely re-run.
- Down migration is a no-op (irreversible), consistent with other destructive migrations.

## Behavior change

These four tables previously retained data indefinitely; after this change they follow the configured OLAP retention period like the rest of the OLAP tables.

## Test plan

- [x] Fresh database: full migration set applies cleanly; schema matches `sql/schema/v1-olap.sql`
- [x] Populated database: migration attaches legacy data as a partition with rows intact; sequence continues past legacy max id; re-running the migration steps is idempotent
- [x] Trigger chain verified post-migration (task/DAG inserts, lookup upserts on the widened PK, status replay)
- [x] `UpdateTablePartitions` creates tomorrow's partitions and drops expired ones for all six partitioned OLAP tables
- [x] `go build` / `go vet` / `golangci-lint` pass