### PR TITLE
fix: buffer and coalesce RefreshTimeout updates

### DIFF
--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/hatchet-dev/hatchet/internal/datautils"
@@ -66,6 +67,7 @@ type DispatcherImpl struct {
 	workflowRunBufferSize               int
 	payloadSizeThreshold                int
 	dispatcherId                        uuid.UUID
+	refreshTimeoutGroup                 singleflight.Group
 }
 
 // CancelStreamSessions hangs up all registered long-lived subscriber streams. It is

--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -68,6 +68,7 @@ type DispatcherImpl struct {
 	payloadSizeThreshold                int
 	dispatcherId                        uuid.UUID
 	refreshTimeoutGroup                 singleflight.Group
+	refreshTimeoutBuf                   *refreshTimeoutBuffer
 }
 
 // CancelStreamSessions hangs up all registered long-lived subscriber streams. It is
@@ -332,6 +333,7 @@ func New(fs ...DispatcherOpt) (*DispatcherImpl, error) {
 		analytics:                           opts.analytics,
 		streamEventBufferTimeout:            opts.streamEventBufferTimeout,
 		version:                             opts.version,
+		refreshTimeoutBuf:                   newRefreshTimeoutBuffer(),
 		serviceV1:                           newDispatcherService(opts.repov1, opts.mqv1, opts.pubsub, v, opts.l, opts.dispatcherId, opts.analytics, opts.promGate),
 	}, nil
 }
@@ -401,6 +403,7 @@ func (d *DispatcherImpl) Start() (func() error, error) {
 		wg.Wait()
 
 		d.pubBuffer.Stop()
+		d.refreshTimeoutBuf.stop()
 
 		// drain the existing connections
 		d.l.Debug().Ctx(ctx).Msg("draining existing connections")

--- a/internal/services/dispatcher/refresh_timeout_buffer.go
+++ b/internal/services/dispatcher/refresh_timeout_buffer.go
@@ -1,0 +1,162 @@
+package dispatcher
+
+import (
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// refreshTimeoutFlushInterval caps how often a given task's buffered timeout
+// refreshes are flushed to Postgres on this engine process.
+const refreshTimeoutFlushInterval = time.Second
+
+type refreshTimeoutBuffer struct {
+	mu      sync.Mutex
+	entries map[string]*refreshTimeoutBufEntry
+}
+
+type refreshTimeoutBufEntry struct {
+	tenantId       uuid.UUID
+	taskExternalId uuid.UUID
+	pending        time.Duration
+	lastTimeoutAt  time.Time
+	lastFlushAt    time.Time
+	timer          *time.Timer
+}
+
+func newRefreshTimeoutBuffer() *refreshTimeoutBuffer {
+	return &refreshTimeoutBuffer{
+		entries: make(map[string]*refreshTimeoutBufEntry),
+	}
+}
+
+func (b *refreshTimeoutBuffer) add(key string, tenantId, taskExternalId uuid.UUID, increment time.Duration) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	e := b.entries[key]
+	if e == nil {
+		e = &refreshTimeoutBufEntry{
+			tenantId:       tenantId,
+			taskExternalId: taskExternalId,
+		}
+		b.entries[key] = e
+	}
+
+	e.pending += increment
+}
+
+func (b *refreshTimeoutBuffer) take(key string) (tenantId, taskExternalId uuid.UUID, sum time.Duration, ok bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	e := b.entries[key]
+	if e == nil || e.pending <= 0 {
+		return uuid.Nil, uuid.Nil, 0, false
+	}
+
+	sum = e.pending
+	e.pending = 0
+	return e.tenantId, e.taskExternalId, sum, true
+}
+
+func (b *refreshTimeoutBuffer) hasPending(key string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	e := b.entries[key]
+	return e != nil && e.pending > 0
+}
+
+func (b *refreshTimeoutBuffer) shouldFlush(key string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	e := b.entries[key]
+	if e == nil {
+		return true
+	}
+
+	b.maybeExpireLocked(key, e)
+
+	e = b.entries[key]
+	if e == nil {
+		return true
+	}
+
+	return e.lastFlushAt.IsZero() || time.Since(e.lastFlushAt) >= refreshTimeoutFlushInterval
+}
+
+func (b *refreshTimeoutBuffer) markFlushed(key string, timeoutAt time.Time) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	e := b.entries[key]
+	if e == nil {
+		e = &refreshTimeoutBufEntry{}
+		b.entries[key] = e
+	}
+
+	e.lastFlushAt = time.Now()
+	e.lastTimeoutAt = timeoutAt
+}
+
+// maybeExpireLocked drops idle entries once they are past the debounce window
+// so the map does not grow without bound.
+func (b *refreshTimeoutBuffer) maybeExpireLocked(key string, e *refreshTimeoutBufEntry) {
+	if e.pending > 0 || e.timer != nil || e.lastFlushAt.IsZero() {
+		return
+	}
+
+	if time.Since(e.lastFlushAt) >= 2*refreshTimeoutFlushInterval {
+		delete(b.entries, key)
+	}
+}
+
+func (b *refreshTimeoutBuffer) lastTimeout(key string) (time.Time, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	e := b.entries[key]
+	if e == nil || e.lastTimeoutAt.IsZero() {
+		return time.Time{}, false
+	}
+
+	return e.lastTimeoutAt.Add(e.pending), true
+}
+
+// scheduleTrailingFlush arms a single timer to flush remaining pending increments
+// after the debounce window. flushKey must re-enter the normal flush path.
+func (b *refreshTimeoutBuffer) scheduleTrailingFlush(key string, flushKey func(string)) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	e := b.entries[key]
+	if e == nil || e.pending <= 0 || e.timer != nil {
+		return
+	}
+
+	e.timer = time.AfterFunc(refreshTimeoutFlushInterval, func() {
+		b.mu.Lock()
+		if entry := b.entries[key]; entry != nil {
+			entry.timer = nil
+		}
+		b.mu.Unlock()
+
+		flushKey(key)
+	})
+}
+
+func (b *refreshTimeoutBuffer) stop() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for key, e := range b.entries {
+		if e.timer != nil {
+			e.timer.Stop()
+			e.timer = nil
+		}
+		delete(b.entries, key)
+	}
+}

--- a/internal/services/dispatcher/refresh_timeout_buffer.go
+++ b/internal/services/dispatcher/refresh_timeout_buffer.go
@@ -9,7 +9,7 @@ import (
 
 // refreshTimeoutFlushInterval caps how often a given task's buffered timeout
 // refreshes are flushed to Postgres on this engine process.
-const refreshTimeoutFlushInterval = time.Second
+const refreshTimeoutFlushInterval = 500 * time.Millisecond
 
 type refreshTimeoutBuffer struct {
 	mu      sync.Mutex

--- a/internal/services/dispatcher/refresh_timeout_buffer.go
+++ b/internal/services/dispatcher/refresh_timeout_buffer.go
@@ -11,57 +11,61 @@ import (
 // refreshes are flushed to Postgres on this engine process.
 const refreshTimeoutFlushInterval = 500 * time.Millisecond
 
+type refreshTimeoutKey struct {
+	tenantId       uuid.UUID
+	taskExternalId uuid.UUID
+}
+
+func (k refreshTimeoutKey) String() string {
+	return k.tenantId.String() + ":" + k.taskExternalId.String()
+}
+
 type refreshTimeoutBuffer struct {
 	mu      sync.Mutex
-	entries map[string]*refreshTimeoutBufEntry
+	entries map[refreshTimeoutKey]*refreshTimeoutBufEntry
 }
 
 type refreshTimeoutBufEntry struct {
-	tenantId       uuid.UUID
-	taskExternalId uuid.UUID
-	pending        time.Duration
-	lastTimeoutAt  time.Time
-	lastFlushAt    time.Time
-	timer          *time.Timer
+	pending       time.Duration
+	lastTimeoutAt time.Time
+	lastFlushAt   time.Time
+	timer         *time.Timer
 }
 
 func newRefreshTimeoutBuffer() *refreshTimeoutBuffer {
 	return &refreshTimeoutBuffer{
-		entries: make(map[string]*refreshTimeoutBufEntry),
+		entries: make(map[refreshTimeoutKey]*refreshTimeoutBufEntry),
 	}
 }
 
-func (b *refreshTimeoutBuffer) add(key string, tenantId, taskExternalId uuid.UUID, increment time.Duration) {
+func (b *refreshTimeoutBuffer) add(key refreshTimeoutKey, increment time.Duration) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	e := b.entries[key]
 	if e == nil {
-		e = &refreshTimeoutBufEntry{
-			tenantId:       tenantId,
-			taskExternalId: taskExternalId,
-		}
+		e = &refreshTimeoutBufEntry{}
 		b.entries[key] = e
 	}
 
 	e.pending += increment
 }
 
-func (b *refreshTimeoutBuffer) take(key string) (tenantId, taskExternalId uuid.UUID, sum time.Duration, ok bool) {
+func (b *refreshTimeoutBuffer) take(key refreshTimeoutKey) (sum time.Duration, ok bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	e := b.entries[key]
 	if e == nil || e.pending <= 0 {
-		return uuid.Nil, uuid.Nil, 0, false
+		return 0, false
 	}
 
 	sum = e.pending
 	e.pending = 0
-	return e.tenantId, e.taskExternalId, sum, true
+	return sum, true
 }
 
-func (b *refreshTimeoutBuffer) hasPending(key string) bool {
+func (b *refreshTimeoutBuffer) hasPending(key refreshTimeoutKey) bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -69,7 +73,7 @@ func (b *refreshTimeoutBuffer) hasPending(key string) bool {
 	return e != nil && e.pending > 0
 }
 
-func (b *refreshTimeoutBuffer) shouldFlush(key string) bool {
+func (b *refreshTimeoutBuffer) shouldFlush(key refreshTimeoutKey) bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -88,7 +92,7 @@ func (b *refreshTimeoutBuffer) shouldFlush(key string) bool {
 	return e.lastFlushAt.IsZero() || time.Since(e.lastFlushAt) >= refreshTimeoutFlushInterval
 }
 
-func (b *refreshTimeoutBuffer) markFlushed(key string, timeoutAt time.Time) {
+func (b *refreshTimeoutBuffer) markFlushed(key refreshTimeoutKey, timeoutAt time.Time) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -104,7 +108,7 @@ func (b *refreshTimeoutBuffer) markFlushed(key string, timeoutAt time.Time) {
 
 // maybeExpireLocked drops idle entries once they are past the debounce window
 // so the map does not grow without bound.
-func (b *refreshTimeoutBuffer) maybeExpireLocked(key string, e *refreshTimeoutBufEntry) {
+func (b *refreshTimeoutBuffer) maybeExpireLocked(key refreshTimeoutKey, e *refreshTimeoutBufEntry) {
 	if e.pending > 0 || e.timer != nil || e.lastFlushAt.IsZero() {
 		return
 	}
@@ -114,7 +118,7 @@ func (b *refreshTimeoutBuffer) maybeExpireLocked(key string, e *refreshTimeoutBu
 	}
 }
 
-func (b *refreshTimeoutBuffer) lastTimeout(key string) (time.Time, bool) {
+func (b *refreshTimeoutBuffer) lastTimeout(key refreshTimeoutKey) (time.Time, bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -128,7 +132,7 @@ func (b *refreshTimeoutBuffer) lastTimeout(key string) (time.Time, bool) {
 
 // scheduleTrailingFlush arms a single timer to flush remaining pending increments
 // after the debounce window. flushKey must re-enter the normal flush path.
-func (b *refreshTimeoutBuffer) scheduleTrailingFlush(key string, flushKey func(string)) {
+func (b *refreshTimeoutBuffer) scheduleTrailingFlush(key refreshTimeoutKey, flushKey func(refreshTimeoutKey)) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 

--- a/internal/services/dispatcher/refresh_timeout_buffer_test.go
+++ b/internal/services/dispatcher/refresh_timeout_buffer_test.go
@@ -1,0 +1,52 @@
+package dispatcher
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRefreshTimeoutBufferSumsPending(t *testing.T) {
+	b := newRefreshTimeoutBuffer()
+	key := "k"
+	tenantId := uuid.New()
+	taskId := uuid.New()
+
+	b.add(key, tenantId, taskId, time.Second)
+	b.add(key, tenantId, taskId, 2*time.Second)
+
+	gotTenant, gotTask, sum, ok := b.take(key)
+	require.True(t, ok)
+	assert.Equal(t, tenantId, gotTenant)
+	assert.Equal(t, taskId, gotTask)
+	assert.Equal(t, 3*time.Second, sum)
+
+	_, _, _, ok = b.take(key)
+	assert.False(t, ok)
+}
+
+func TestRefreshTimeoutBufferDebounceAndTrailingEstimate(t *testing.T) {
+	b := newRefreshTimeoutBuffer()
+	key := "k"
+	tenantId := uuid.New()
+	taskId := uuid.New()
+
+	assert.True(t, b.shouldFlush(key))
+
+	b.add(key, tenantId, taskId, time.Second)
+	_, _, sum, ok := b.take(key)
+	require.True(t, ok)
+	assert.Equal(t, time.Second, sum)
+
+	flushedAt := time.Now().Add(5 * time.Second)
+	b.markFlushed(key, flushedAt)
+	assert.False(t, b.shouldFlush(key))
+
+	b.add(key, tenantId, taskId, 2*time.Second)
+	estimate, ok := b.lastTimeout(key)
+	require.True(t, ok)
+	assert.Equal(t, flushedAt.Add(2*time.Second), estimate)
+}

--- a/internal/services/dispatcher/refresh_timeout_buffer_test.go
+++ b/internal/services/dispatcher/refresh_timeout_buffer_test.go
@@ -11,33 +11,33 @@ import (
 
 func TestRefreshTimeoutBufferSumsPending(t *testing.T) {
 	b := newRefreshTimeoutBuffer()
-	key := "k"
-	tenantId := uuid.New()
-	taskId := uuid.New()
+	key := refreshTimeoutKey{
+		tenantId:       uuid.New(),
+		taskExternalId: uuid.New(),
+	}
 
-	b.add(key, tenantId, taskId, time.Second)
-	b.add(key, tenantId, taskId, 2*time.Second)
+	b.add(key, time.Second)
+	b.add(key, 2*time.Second)
 
-	gotTenant, gotTask, sum, ok := b.take(key)
+	sum, ok := b.take(key)
 	require.True(t, ok)
-	assert.Equal(t, tenantId, gotTenant)
-	assert.Equal(t, taskId, gotTask)
 	assert.Equal(t, 3*time.Second, sum)
 
-	_, _, _, ok = b.take(key)
+	_, ok = b.take(key)
 	assert.False(t, ok)
 }
 
 func TestRefreshTimeoutBufferDebounceAndTrailingEstimate(t *testing.T) {
 	b := newRefreshTimeoutBuffer()
-	key := "k"
-	tenantId := uuid.New()
-	taskId := uuid.New()
+	key := refreshTimeoutKey{
+		tenantId:       uuid.New(),
+		taskExternalId: uuid.New(),
+	}
 
 	assert.True(t, b.shouldFlush(key))
 
-	b.add(key, tenantId, taskId, time.Second)
-	_, _, sum, ok := b.take(key)
+	b.add(key, time.Second)
+	sum, ok := b.take(key)
 	require.True(t, ok)
 	assert.Equal(t, time.Second, sum)
 
@@ -45,7 +45,7 @@ func TestRefreshTimeoutBufferDebounceAndTrailingEstimate(t *testing.T) {
 	b.markFlushed(key, flushedAt)
 	assert.False(t, b.shouldFlush(key))
 
-	b.add(key, tenantId, taskId, 2*time.Second)
+	b.add(key, 2*time.Second)
 	estimate, ok := b.lastTimeout(key)
 	require.True(t, ok)
 	assert.Equal(t, flushedAt.Add(2*time.Second), estimate)

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -1848,17 +1848,70 @@ func (d *DispatcherImpl) refreshTimeoutV1(ctx context.Context, tenant *sqlcv1.Te
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid request: %s", apiErrors.String())
 	}
 
+	increment, err := time.ParseDuration(request.IncrementTimeoutBy)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid increment timeout by %s: %v", request.IncrementTimeoutBy, err)
+	}
+
 	cacheKey := fmt.Sprintf("refresh-timeout:%s:%s", tenantId, taskExternalId)
+	d.refreshTimeoutBuf.add(cacheKey, tenantId, taskExternalId, increment)
 
 	timeoutAt, err, _ := d.refreshTimeoutGroup.Do(cacheKey, func() (interface{}, error) {
-		if cached, ok := d.cache.Get(cacheKey); ok {
-			return cached.(time.Time), nil
+		return d.flushRefreshTimeout(ctx, cacheKey)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &contracts.RefreshTimeoutResponse{
+		TimeoutAt: timestamppb.New(timeoutAt.(time.Time)),
+	}, nil
+}
+
+func (d *DispatcherImpl) flushRefreshTimeout(ctx context.Context, cacheKey string) (time.Time, error) {
+	if !d.refreshTimeoutBuf.shouldFlush(cacheKey) {
+		if timeoutAt, ok := d.refreshTimeoutBuf.lastTimeout(cacheKey); ok {
+			d.refreshTimeoutBuf.scheduleTrailingFlush(cacheKey, func(key string) {
+				flushCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+
+				_, err, _ := d.refreshTimeoutGroup.Do(key, func() (interface{}, error) {
+					return d.flushRefreshTimeout(flushCtx, key)
+				})
+				if err != nil {
+					d.l.Error().Err(err).Str("key", key).Msg("failed to flush buffered refresh timeout")
+				}
+			})
+			return timeoutAt, nil
+		}
+	}
+
+	var timeoutAt time.Time
+
+	for {
+		tenantId, taskExternalId, sum, ok := d.refreshTimeoutBuf.take(cacheKey)
+		if !ok {
+			if !timeoutAt.IsZero() {
+				return timeoutAt, nil
+			}
+			if cached, ok := d.refreshTimeoutBuf.lastTimeout(cacheKey); ok {
+				return cached, nil
+			}
+			return time.Time{}, fmt.Errorf("no buffered refresh timeout for %s", cacheKey)
 		}
 
-		taskRuntime, err := d.repov1.Tasks().RefreshTimeoutBy(ctx, tenantId, opts)
+		taskRuntime, err := d.repov1.Tasks().RefreshTimeoutBy(ctx, tenantId, v1.RefreshTimeoutBy{
+			TaskExternalId:     taskExternalId,
+			IncrementTimeoutBy: sum.String(),
+		})
 		if err != nil {
-			return nil, err
+			// Put the failed sum back so a retry can flush it.
+			d.refreshTimeoutBuf.add(cacheKey, tenantId, taskExternalId, sum)
+			return time.Time{}, err
 		}
+
+		timeoutAt = taskRuntime.TimeoutAt.Time
+		d.refreshTimeoutBuf.markFlushed(cacheKey, timeoutAt)
 
 		msg, err := tasktypes.MonitoringEventMessageFromInternal(
 			tenantId,
@@ -1868,28 +1921,21 @@ func (d *DispatcherImpl) refreshTimeoutV1(ctx context.Context, tenant *sqlcv1.Te
 				WorkerId:       taskRuntime.WorkerID,
 				EventTimestamp: time.Now(),
 				EventType:      sqlcv1.V1EventTypeOlapTIMEOUTREFRESHED,
-				EventMessage:   fmt.Sprintf("Timeout refreshed by %s", request.IncrementTimeoutBy),
+				EventMessage:   fmt.Sprintf("Timeout refreshed by %s", sum.String()),
 			},
 		)
 		if err != nil {
-			return nil, err
+			return time.Time{}, err
 		}
 
 		if err := d.pubBuffer.Pub(ctx, msgqueue.OLAP_QUEUE, msg, false); err != nil {
-			return nil, err
+			return time.Time{}, err
 		}
 
-		d.cache.Set(cacheKey, taskRuntime.TimeoutAt.Time)
-
-		return taskRuntime.TimeoutAt.Time, nil
-	})
-	if err != nil {
-		return nil, err
+		if !d.refreshTimeoutBuf.hasPending(cacheKey) {
+			return timeoutAt, nil
+		}
 	}
-
-	return &contracts.RefreshTimeoutResponse{
-		TimeoutAt: timestamppb.New(timeoutAt.(time.Time)),
-	}, nil
 }
 
 func (d *DispatcherImpl) releaseSlot(ctx context.Context, tenant *sqlcv1.Tenant, request *contracts.ReleaseSlotRequest) (*contracts.ReleaseSlotResponse, error) {

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -1853,11 +1853,14 @@ func (d *DispatcherImpl) refreshTimeoutV1(ctx context.Context, tenant *sqlcv1.Te
 		return nil, status.Errorf(codes.InvalidArgument, "invalid increment timeout by %s: %v", request.IncrementTimeoutBy, err)
 	}
 
-	cacheKey := fmt.Sprintf("refresh-timeout:%s:%s", tenantId, taskExternalId)
-	d.refreshTimeoutBuf.add(cacheKey, tenantId, taskExternalId, increment)
+	key := refreshTimeoutKey{
+		tenantId:       tenantId,
+		taskExternalId: taskExternalId,
+	}
+	d.refreshTimeoutBuf.add(key, increment)
 
-	timeoutAt, err, _ := d.refreshTimeoutGroup.Do(cacheKey, func() (interface{}, error) {
-		return d.flushRefreshTimeout(ctx, cacheKey)
+	timeoutAt, err, _ := d.refreshTimeoutGroup.Do(key.String(), func() (interface{}, error) {
+		return d.flushRefreshTimeout(ctx, key)
 	})
 	if err != nil {
 		return nil, err
@@ -1868,18 +1871,18 @@ func (d *DispatcherImpl) refreshTimeoutV1(ctx context.Context, tenant *sqlcv1.Te
 	}, nil
 }
 
-func (d *DispatcherImpl) flushRefreshTimeout(ctx context.Context, cacheKey string) (time.Time, error) {
-	if !d.refreshTimeoutBuf.shouldFlush(cacheKey) {
-		if timeoutAt, ok := d.refreshTimeoutBuf.lastTimeout(cacheKey); ok {
-			d.refreshTimeoutBuf.scheduleTrailingFlush(cacheKey, func(key string) {
+func (d *DispatcherImpl) flushRefreshTimeout(ctx context.Context, key refreshTimeoutKey) (time.Time, error) {
+	if !d.refreshTimeoutBuf.shouldFlush(key) {
+		if timeoutAt, ok := d.refreshTimeoutBuf.lastTimeout(key); ok {
+			d.refreshTimeoutBuf.scheduleTrailingFlush(key, func(k refreshTimeoutKey) {
 				flushCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
 
-				_, err, _ := d.refreshTimeoutGroup.Do(key, func() (interface{}, error) {
-					return d.flushRefreshTimeout(flushCtx, key)
+				_, err, _ := d.refreshTimeoutGroup.Do(k.String(), func() (interface{}, error) {
+					return d.flushRefreshTimeout(flushCtx, k)
 				})
 				if err != nil {
-					d.l.Error().Err(err).Str("key", key).Msg("failed to flush buffered refresh timeout")
+					d.l.Error().Err(err).Str("key", k.String()).Msg("failed to flush buffered refresh timeout")
 				}
 			})
 			return timeoutAt, nil
@@ -1889,32 +1892,32 @@ func (d *DispatcherImpl) flushRefreshTimeout(ctx context.Context, cacheKey strin
 	var timeoutAt time.Time
 
 	for {
-		tenantId, taskExternalId, sum, ok := d.refreshTimeoutBuf.take(cacheKey)
+		sum, ok := d.refreshTimeoutBuf.take(key)
 		if !ok {
 			if !timeoutAt.IsZero() {
 				return timeoutAt, nil
 			}
-			if cached, ok := d.refreshTimeoutBuf.lastTimeout(cacheKey); ok {
+			if cached, ok := d.refreshTimeoutBuf.lastTimeout(key); ok {
 				return cached, nil
 			}
-			return time.Time{}, fmt.Errorf("no buffered refresh timeout for %s", cacheKey)
+			return time.Time{}, fmt.Errorf("no buffered refresh timeout for %s", key)
 		}
 
-		taskRuntime, err := d.repov1.Tasks().RefreshTimeoutBy(ctx, tenantId, v1.RefreshTimeoutBy{
-			TaskExternalId:     taskExternalId,
+		taskRuntime, err := d.repov1.Tasks().RefreshTimeoutBy(ctx, key.tenantId, v1.RefreshTimeoutBy{
+			TaskExternalId:     key.taskExternalId,
 			IncrementTimeoutBy: sum.String(),
 		})
 		if err != nil {
 			// Put the failed sum back so a retry can flush it.
-			d.refreshTimeoutBuf.add(cacheKey, tenantId, taskExternalId, sum)
+			d.refreshTimeoutBuf.add(key, sum)
 			return time.Time{}, err
 		}
 
 		timeoutAt = taskRuntime.TimeoutAt.Time
-		d.refreshTimeoutBuf.markFlushed(cacheKey, timeoutAt)
+		d.refreshTimeoutBuf.markFlushed(key, timeoutAt)
 
 		msg, err := tasktypes.MonitoringEventMessageFromInternal(
-			tenantId,
+			key.tenantId,
 			tasktypes.CreateMonitoringEventPayload{
 				TaskId:         taskRuntime.TaskID,
 				RetryCount:     taskRuntime.RetryCount,
@@ -1932,7 +1935,7 @@ func (d *DispatcherImpl) flushRefreshTimeout(ctx context.Context, cacheKey strin
 			return time.Time{}, err
 		}
 
-		if !d.refreshTimeoutBuf.hasPending(cacheKey) {
+		if !d.refreshTimeoutBuf.hasPending(key) {
 			return timeoutAt, nil
 		}
 	}

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -1848,39 +1848,47 @@ func (d *DispatcherImpl) refreshTimeoutV1(ctx context.Context, tenant *sqlcv1.Te
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid request: %s", apiErrors.String())
 	}
 
-	taskRuntime, err := d.repov1.Tasks().RefreshTimeoutBy(ctx, tenantId, opts)
+	cacheKey := fmt.Sprintf("refresh-timeout:%s:%s", tenantId, taskExternalId)
 
-	if err != nil {
-		return nil, err
-	}
+	timeoutAt, err, _ := d.refreshTimeoutGroup.Do(cacheKey, func() (interface{}, error) {
+		if cached, ok := d.cache.Get(cacheKey); ok {
+			return cached.(time.Time), nil
+		}
 
-	workerId := taskRuntime.WorkerID
+		taskRuntime, err := d.repov1.Tasks().RefreshTimeoutBy(ctx, tenantId, opts)
+		if err != nil {
+			return nil, err
+		}
 
-	// send to the OLAP repository
-	msg, err := tasktypes.MonitoringEventMessageFromInternal(
-		tenantId,
-		tasktypes.CreateMonitoringEventPayload{
-			TaskId:         taskRuntime.TaskID,
-			RetryCount:     taskRuntime.RetryCount,
-			WorkerId:       workerId,
-			EventTimestamp: time.Now(),
-			EventType:      sqlcv1.V1EventTypeOlapTIMEOUTREFRESHED,
-			EventMessage:   fmt.Sprintf("Timeout refreshed by %s", request.IncrementTimeoutBy),
-		},
-	)
+		msg, err := tasktypes.MonitoringEventMessageFromInternal(
+			tenantId,
+			tasktypes.CreateMonitoringEventPayload{
+				TaskId:         taskRuntime.TaskID,
+				RetryCount:     taskRuntime.RetryCount,
+				WorkerId:       taskRuntime.WorkerID,
+				EventTimestamp: time.Now(),
+				EventType:      sqlcv1.V1EventTypeOlapTIMEOUTREFRESHED,
+				EventMessage:   fmt.Sprintf("Timeout refreshed by %s", request.IncrementTimeoutBy),
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
 
-	if err != nil {
-		return nil, err
-	}
+		if err := d.pubBuffer.Pub(ctx, msgqueue.OLAP_QUEUE, msg, false); err != nil {
+			return nil, err
+		}
 
-	err = d.pubBuffer.Pub(ctx, msgqueue.OLAP_QUEUE, msg, false)
+		d.cache.Set(cacheKey, taskRuntime.TimeoutAt.Time)
 
+		return taskRuntime.TimeoutAt.Time, nil
+	})
 	if err != nil {
 		return nil, err
 	}
 
 	return &contracts.RefreshTimeoutResponse{
-		TimeoutAt: timestamppb.New(taskRuntime.TimeoutAt.Time),
+		TimeoutAt: timestamppb.New(timeoutAt.(time.Time)),
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- Hot-looping `refreshTimeout` callers can stampede `RefreshTimeoutBy` against a single `v1_task_runtime` row, creating large `Lock:transactionid` / `Lock:tuple` load on shared Postgres.
- Buffer `IncrementTimeoutBy` per task in-memory on each engine, sum pending increments, and flush at most once every 500ms with a single UPDATE.
- Concurrent callers coalesce via `singleflight`; a trailing flush applies increments that arrive during the debounce window so extensions are preserved rather than dropped.
- Per-engine buffering is enough — a few writes/sec across engines is still much better than hundreds of contended row updates.

## Test plan
- [x] `go test ./internal/services/dispatcher/ -run TestRefreshTimeoutBuffer`
- [x] `go build ./internal/services/dispatcher/`
- [ ] Spam `RefreshTimeout` for one task and confirm ~2 DB updates/sec/engine with `timeout_at` extended by the summed increments
- [ ] Confirm a normal single refresh still succeeds and updates `timeout_at`
- [ ] After deploy, check Performance Insights / `pg_stat_activity` for `RefreshTimeoutBy` lock waits under previously noisy tenants