### PR TITLE
fix: Add exclusive locks for every table touched during batch migration

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260722000000_batching_consolidated_v1_0_133.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260722000000_batching_consolidated_v1_0_133.sql
@@ -1,5 +1,15 @@
 -- +goose Up
 -- +goose StatementBegin
+-- Acquire exclusive locks on every pre-existing table this migration alters, up front and in a
+-- fixed order, before making any changes. This avoids a lock-order deadlock with concurrent app
+-- transactions (e.g. task reassignment) that touch v1_task_runtime and v1_task together: without
+-- this, the ALTER TABLE statements below take these locks one at a time, interleaved with DDL,
+-- which lets a concurrent transaction hold one of these tables while waiting on another.
+-- lock_timeout bounds the wait so a stuck/long-running transaction fails the migration fast
+-- (retryable) instead of risking a long block or a deadlock-detector abort.
+SET LOCAL lock_timeout = '5s';
+LOCK TABLE v1_queue_item, v1_rate_limited_queue_items, v1_task, v1_task_runtime IN ACCESS EXCLUSIVE MODE;
+
 -- v0 schema alignment
 ALTER TYPE "LeaseKind" ADD VALUE IF NOT EXISTS 'BATCH';
 
@@ -750,6 +760,11 @@ EXECUTE FUNCTION after_v1_task_runtime_delete_cleanup_batch_runtime_fn();
 
 -- +goose Down
 -- +goose StatementBegin
+-- Same lock-order-deadlock guard as the Up migration: take exclusive locks on every table
+-- touched below, up front and in a fixed order, before making any changes.
+SET LOCAL lock_timeout = '5s';
+LOCK TABLE v1_queue_item, v1_rate_limited_queue_items, v1_task, v1_task_runtime IN ACCESS EXCLUSIVE MODE;
+
 DROP TRIGGER after_v1_task_runtime_delete_cleanup_batch_runtime ON v1_task_runtime;
 DROP FUNCTION after_v1_task_runtime_delete_cleanup_batch_runtime_fn();
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
