### PR TITLE
[Proposal]: Roll-your-own continuous aggregates

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260730164108_v1_0_136.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260730164108_v1_0_136.sql
@@ -1,6 +1,6 @@
 -- +goose Up
 -- +goose StatementBegin
-CREATE TABLE v1_cagg_task_statuses_minute_do_not_use_directly (
+CREATE TABLE v1_cagg_task_statuses_minute (
     bucket TIMESTAMPTZ NOT NULL,
     tenant_id UUID NOT NULL,
     workflow_id UUID NOT NULL,
@@ -12,40 +12,9 @@ CREATE TABLE v1_cagg_task_statuses_minute_do_not_use_directly (
     evicted_count BIGINT NOT NULL DEFAULT 0,
     PRIMARY KEY (bucket, tenant_id, workflow_id)
 );
-
-CREATE VIEW v1_cagg_task_statuses_minute AS
-WITH max_time AS (
-    SELECT MAX(bucket) AS max_time_bucket
-    FROM v1_cagg_task_statuses_minute_do_not_use_directly
-), unioned AS (
-    SELECT *
-    FROM v1_cagg_task_statuses_minute_do_not_use_directly
-
-    UNION
-
-    SELECT
-        date_bin('1 minute', inserted_at, TIMESTAMPTZ '1970-01-01 00:00:00+00') AS bucket,
-        tenant_id,
-        workflow_id,
-        COUNT(*) FILTER (WHERE readable_status = 'QUEUED') AS queued_count,
-        COUNT(*) FILTER (WHERE readable_status = 'RUNNING') AS running_count,
-        COUNT(*) FILTER (WHERE readable_status = 'COMPLETED') AS completed_count,
-        COUNT(*) FILTER (WHERE readable_status = 'CANCELLED') AS cancelled_count,
-        COUNT(*) FILTER (WHERE readable_status = 'FAILED') AS failed_count,
-        COUNT(*) FILTER (WHERE readable_status = 'EVICTED') AS evicted_count
-    FROM v1_statuses_olap
-    WHERE inserted_at > (SELECT max_time_bucket FROM max_time)
-    GROUP BY bucket, tenant_id, workflow_id
-)
-
-SELECT *
-FROM unioned
-ORDER BY bucket, tenant_id, workflow_id
-;
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
-DROP VIEW v1_cagg_task_statuses_minute;
-DROP TABLE v1_cagg_task_statuses_minute_do_not_use_directly;
+DROP TABLE v1_cagg_task_statuses_minute;
 -- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20260730164108_v1_0_136.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260730164108_v1_0_136.sql
@@ -1,7 +1,7 @@
 -- +goose Up
 -- +goose StatementBegin
 CREATE TABLE v1_cagg_task_statuses_minute_do_not_use_directly (
-    time_bucket TIMESTAMPTZ NOT NULL,
+    bucket TIMESTAMPTZ NOT NULL,
     tenant_id UUID NOT NULL,
     workflow_id UUID NOT NULL,
     queued_count BIGINT NOT NULL DEFAULT 0,
@@ -10,12 +10,12 @@ CREATE TABLE v1_cagg_task_statuses_minute_do_not_use_directly (
     cancelled_count BIGINT NOT NULL DEFAULT 0,
     failed_count BIGINT NOT NULL DEFAULT 0,
     evicted_count BIGINT NOT NULL DEFAULT 0,
-    PRIMARY KEY (time_bucket, tenant_id, workflow_id)
+    PRIMARY KEY (bucket, tenant_id, workflow_id)
 );
 
 CREATE VIEW v1_cagg_task_statuses_minute AS
 WITH max_time AS (
-    SELECT MAX(time_bucket) AS max_time_bucket
+    SELECT MAX(bucket) AS max_time_bucket
     FROM v1_cagg_task_statuses_minute_do_not_use_directly
 ), unioned AS (
     SELECT *
@@ -24,7 +24,7 @@ WITH max_time AS (
     UNION
 
     SELECT
-        date_bin('1 minute', inserted_at, TIMESTAMP '2001-01-01') AS time_bucket,
+        date_bin('1 minute', inserted_at, TIMESTAMPTZ '1970-01-01 00:00:00+00') AS bucket,
         tenant_id,
         workflow_id,
         COUNT(*) FILTER (WHERE readable_status = 'QUEUED') AS queued_count,
@@ -35,12 +35,12 @@ WITH max_time AS (
         COUNT(*) FILTER (WHERE readable_status = 'EVICTED') AS evicted_count
     FROM v1_statuses_olap
     WHERE inserted_at > (SELECT max_time_bucket FROM max_time)
-    GROUP BY time_bucket, tenant_id, workflow_id
+    GROUP BY bucket, tenant_id, workflow_id
 )
 
 SELECT *
 FROM unioned
-ORDER BY time_bucket, tenant_id, workflow_id
+ORDER BY bucket, tenant_id, workflow_id
 ;
 -- +goose StatementEnd
 

--- a/cmd/hatchet-migrate/migrate/migrations/20260730164108_v1_0_136.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260730164108_v1_0_136.sql
@@ -1,0 +1,51 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE v1_cagg_task_statuses_minute_do_not_use_directly (
+    time_bucket TIMESTAMPTZ NOT NULL,
+    tenant_id UUID NOT NULL,
+    workflow_id UUID NOT NULL,
+    queued_count BIGINT NOT NULL DEFAULT 0,
+    running_count BIGINT NOT NULL DEFAULT 0,
+    completed_count BIGINT NOT NULL DEFAULT 0,
+    cancelled_count BIGINT NOT NULL DEFAULT 0,
+    failed_count BIGINT NOT NULL DEFAULT 0,
+    evicted_count BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (time_bucket, tenant_id, workflow_id)
+);
+
+CREATE VIEW v1_cagg_task_statuses_minute AS
+WITH max_time AS (
+    SELECT MAX(time_bucket) AS max_time_bucket
+    FROM v1_cagg_task_statuses_minute_do_not_use_directly
+), unioned AS (
+    SELECT *
+    FROM v1_cagg_task_statuses_minute_do_not_use_directly
+
+    UNION
+
+    SELECT
+        date_bin('1 minute', inserted_at, TIMESTAMP '2001-01-01') AS time_bucket,
+        tenant_id,
+        workflow_id,
+        COUNT(*) FILTER (WHERE readable_status = 'QUEUED') AS queued_count,
+        COUNT(*) FILTER (WHERE readable_status = 'RUNNING') AS running_count,
+        COUNT(*) FILTER (WHERE readable_status = 'COMPLETED') AS completed_count,
+        COUNT(*) FILTER (WHERE readable_status = 'CANCELLED') AS cancelled_count,
+        COUNT(*) FILTER (WHERE readable_status = 'FAILED') AS failed_count,
+        COUNT(*) FILTER (WHERE readable_status = 'EVICTED') AS evicted_count
+    FROM v1_statuses_olap
+    WHERE inserted_at > (SELECT max_time_bucket FROM max_time)
+    GROUP BY time_bucket, tenant_id, workflow_id
+)
+
+SELECT *
+FROM unioned
+ORDER BY time_bucket, tenant_id, workflow_id
+;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP VIEW v1_cagg_task_statuses_minute;
+DROP TABLE v1_cagg_task_statuses_minute_do_not_use_directly;
+-- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20260730165050_v1_0_137.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260730165050_v1_0_137.sql
@@ -1,0 +1,63 @@
+-- +goose Up
+-- +goose StatementBegin
+DO $$
+DECLARE
+  chunk_start TIMESTAMPTZ;
+  chunk_end TIMESTAMPTZ;
+  max_time TIMESTAMPTZ;
+BEGIN
+  SELECT MIN(inserted_at), MAX(inserted_at)
+  INTO chunk_start, max_time
+  FROM v1_statuses_olap;
+
+  IF chunk_start IS NULL THEN
+    RETURN;
+  END IF;
+
+  chunk_start := date_trunc('hour', chunk_start);
+
+  WHILE chunk_start <= max_time LOOP
+    chunk_end := chunk_start + INTERVAL '1 hour';
+
+    INSERT INTO v1_cagg_task_statuses_minute_do_not_use_directly (
+        time_bucket,
+        tenant_id,
+        workflow_id,
+        queued_count,
+        running_count,
+        completed_count,
+        cancelled_count,
+        failed_count,
+        evicted_count
+    )
+    SELECT
+        date_bin('1 minute', inserted_at, TIMESTAMP '2001-01-01') AS time_bucket,
+        tenant_id,
+        workflow_id,
+        COUNT(*) FILTER (WHERE readable_status = 'QUEUED') AS queued_count,
+        COUNT(*) FILTER (WHERE readable_status = 'RUNNING') AS running_count,
+        COUNT(*) FILTER (WHERE readable_status = 'COMPLETED') AS completed_count,
+        COUNT(*) FILTER (WHERE readable_status = 'CANCELLED') AS cancelled_count,
+        COUNT(*) FILTER (WHERE readable_status = 'FAILED') AS failed_count,
+        COUNT(*) FILTER (WHERE readable_status = 'EVICTED') AS evicted_count
+    FROM v1_statuses_olap
+    WHERE inserted_at >= chunk_start
+      AND inserted_at < chunk_end
+    GROUP BY time_bucket, tenant_id, workflow_id
+    ON CONFLICT (time_bucket, tenant_id, workflow_id) DO UPDATE SET
+        queued_count = EXCLUDED.queued_count,
+        running_count = EXCLUDED.running_count,
+        completed_count = EXCLUDED.completed_count,
+        cancelled_count = EXCLUDED.cancelled_count,
+        failed_count = EXCLUDED.failed_count,
+        evicted_count = EXCLUDED.evicted_count;
+
+    chunk_start := chunk_end;
+  END LOOP;
+END $$;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+TRUNCATE TABLE v1_cagg_task_statuses_minute_do_not_use_directly;
+-- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20260730165050_v1_0_137.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260730165050_v1_0_137.sql
@@ -19,7 +19,7 @@ BEGIN
   WHILE chunk_start <= max_time LOOP
     chunk_end := chunk_start + INTERVAL '1 hour';
 
-    INSERT INTO v1_cagg_task_statuses_minute_do_not_use_directly (
+    INSERT INTO v1_cagg_task_statuses_minute (
         bucket,
         tenant_id,
         workflow_id,
@@ -59,5 +59,5 @@ END $$;
 
 -- +goose Down
 -- +goose StatementBegin
-TRUNCATE TABLE v1_cagg_task_statuses_minute_do_not_use_directly;
+TRUNCATE TABLE v1_cagg_task_statuses_minute;
 -- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20260730165050_v1_0_137.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260730165050_v1_0_137.sql
@@ -20,7 +20,7 @@ BEGIN
     chunk_end := chunk_start + INTERVAL '1 hour';
 
     INSERT INTO v1_cagg_task_statuses_minute_do_not_use_directly (
-        time_bucket,
+        bucket,
         tenant_id,
         workflow_id,
         queued_count,
@@ -31,7 +31,7 @@ BEGIN
         evicted_count
     )
     SELECT
-        date_bin('1 minute', inserted_at, TIMESTAMP '2001-01-01') AS time_bucket,
+        date_bin('1 minute', inserted_at, TIMESTAMPTZ '1970-01-01 00:00:00+00') AS bucket,
         tenant_id,
         workflow_id,
         COUNT(*) FILTER (WHERE readable_status = 'QUEUED') AS queued_count,
@@ -43,8 +43,8 @@ BEGIN
     FROM v1_statuses_olap
     WHERE inserted_at >= chunk_start
       AND inserted_at < chunk_end
-    GROUP BY time_bucket, tenant_id, workflow_id
-    ON CONFLICT (time_bucket, tenant_id, workflow_id) DO UPDATE SET
+    GROUP BY bucket, tenant_id, workflow_id
+    ON CONFLICT (bucket, tenant_id, workflow_id) DO UPDATE SET
         queued_count = EXCLUDED.queued_count,
         running_count = EXCLUDED.running_count,
         completed_count = EXCLUDED.completed_count,

--- a/pkg/repository/sqlcv1/models.go
+++ b/pkg/repository/sqlcv1/models.go
@@ -3165,19 +3165,7 @@ type V1BatchedQueueItem struct {
 }
 
 type V1CaggTaskStatusesMinute struct {
-	TimeBucket     pgtype.Timestamptz `json:"time_bucket"`
-	TenantID       uuid.UUID          `json:"tenant_id"`
-	WorkflowID     uuid.UUID          `json:"workflow_id"`
-	QueuedCount    int64              `json:"queued_count"`
-	RunningCount   int64              `json:"running_count"`
-	CompletedCount int64              `json:"completed_count"`
-	CancelledCount int64              `json:"cancelled_count"`
-	FailedCount    int64              `json:"failed_count"`
-	EvictedCount   int64              `json:"evicted_count"`
-}
-
-type V1CaggTaskStatusesMinuteDoNotUseDirectly struct {
-	TimeBucket     pgtype.Timestamptz `json:"time_bucket"`
+	Bucket         pgtype.Timestamptz `json:"bucket"`
 	TenantID       uuid.UUID          `json:"tenant_id"`
 	WorkflowID     uuid.UUID          `json:"workflow_id"`
 	QueuedCount    int64              `json:"queued_count"`

--- a/pkg/repository/sqlcv1/models.go
+++ b/pkg/repository/sqlcv1/models.go
@@ -3164,6 +3164,30 @@ type V1BatchedQueueItem struct {
 	PayloadSize       int32              `json:"payload_size"`
 }
 
+type V1CaggTaskStatusesMinute struct {
+	TimeBucket     pgtype.Timestamptz `json:"time_bucket"`
+	TenantID       uuid.UUID          `json:"tenant_id"`
+	WorkflowID     uuid.UUID          `json:"workflow_id"`
+	QueuedCount    int64              `json:"queued_count"`
+	RunningCount   int64              `json:"running_count"`
+	CompletedCount int64              `json:"completed_count"`
+	CancelledCount int64              `json:"cancelled_count"`
+	FailedCount    int64              `json:"failed_count"`
+	EvictedCount   int64              `json:"evicted_count"`
+}
+
+type V1CaggTaskStatusesMinuteDoNotUseDirectly struct {
+	TimeBucket     pgtype.Timestamptz `json:"time_bucket"`
+	TenantID       uuid.UUID          `json:"tenant_id"`
+	WorkflowID     uuid.UUID          `json:"workflow_id"`
+	QueuedCount    int64              `json:"queued_count"`
+	RunningCount   int64              `json:"running_count"`
+	CompletedCount int64              `json:"completed_count"`
+	CancelledCount int64              `json:"cancelled_count"`
+	FailedCount    int64              `json:"failed_count"`
+	EvictedCount   int64              `json:"evicted_count"`
+}
+
 type V1CelEvaluationFailuresOlap struct {
 	ID         int64                        `json:"id"`
 	TenantID   uuid.UUID                    `json:"tenant_id"`

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -1457,15 +1457,27 @@ SELECT
         COALESCE(sqlc.narg('interval')::INTERVAL, '1 minute'),
         inserted_at,
         TIMESTAMPTZ '1970-01-01 00:00:00+00'
-    ) :: TIMESTAMPTZ AS minute_bucket,
-    COUNT(*) FILTER (WHERE readable_status = 'COMPLETED') AS completed_count,
-    COUNT(*) FILTER (WHERE readable_status = 'FAILED') AS failed_count
-FROM v1_statuses_olap
+    ) :: TIMESTAMPTZ AS bucket_2,
+    SUM(completed_count)::int as completed_count,
+    SUM(failed_count)::int as failed_count
+FROM
+    v1_cagg_task_statuses_minute
 WHERE
-    tenant_id = @tenantId::UUID
-    AND inserted_at BETWEEN @createdAfter::TIMESTAMPTZ AND @createdBefore::TIMESTAMPTZ
-GROUP BY minute_bucket
-ORDER BY minute_bucket;
+    tenant_id = @tenantId::uuid AND
+    -- timestamptz makes this fast, apparently:
+    -- https://www.timescale.com/forum/t/very-slow-query-planning-time-in-postgresql/255/8
+    bucket >= DATE_BIN(
+        '1 minute',
+        @createdAfter::timestamptz,
+        TIMESTAMPTZ '1970-01-01 00:00:00+00'
+    ) AND
+    bucket <= DATE_BIN(
+        '1 minute',
+        @createdBefore::timestamptz,
+        TIMESTAMPTZ '1970-01-01 00:00:00+00'
+    )
+GROUP BY bucket_2
+ORDER BY bucket_2;
 
 
 -- name: GetTenantStatusMetrics :one

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -1452,32 +1452,67 @@ LEFT JOIN max_retry_count mrc ON r.run_id = mrc.run_id
 ORDER BY r.inserted_at DESC, r.run_id DESC;
 
 -- name: GetTaskPointMetrics :many
-SELECT
-    DATE_BIN(
-        COALESCE(sqlc.narg('interval')::INTERVAL, '1 minute'),
-        bucket,
-        TIMESTAMPTZ '1970-01-01 00:00:00+00'
-    ) :: TIMESTAMPTZ AS minute_bucket,
-    SUM(completed_count)::int as completed_count,
-    SUM(failed_count)::int as failed_count
-FROM
-    v1_cagg_task_statuses_minute
-WHERE
-    tenant_id = @tenantId::uuid AND
-    -- timestamptz makes this fast, apparently:
-    -- https://www.timescale.com/forum/t/very-slow-query-planning-time-in-postgresql/255/8
-    bucket >= DATE_BIN(
-        '1 minute',
-        @createdAfter::timestamptz,
-        TIMESTAMPTZ '1970-01-01 00:00:00+00'
-    ) AND
-    bucket <= DATE_BIN(
-        '1 minute',
-        @createdBefore::timestamptz,
-        TIMESTAMPTZ '1970-01-01 00:00:00+00'
-    )
-GROUP BY minute_bucket
-ORDER BY minute_bucket;
+WITH candidates AS (
+    SELECT *
+    FROM v1_cagg_task_statuses_minute
+    WHERE
+        tenant_id = @tenantId::UUID
+        AND bucket >= DATE_BIN(
+            COALESCE(sqlc.narg('interval')::INTERVAL, '1 minute'),
+            @createdAfter::timestamptz,
+            TIMESTAMPTZ '1970-01-01 00:00:00+00'
+        )
+        AND bucket <= DATE_BIN(
+            COALESCE(sqlc.narg('interval')::INTERVAL, '1 minute'),
+            @createdBefore::timestamptz,
+            TIMESTAMPTZ '1970-01-01 00:00:00+00'
+        )
+), max_time AS (
+    SELECT MAX(bucket) AS max_time_bucket
+    FROM candidates
+), unioned AS (
+    SELECT
+        DATE_BIN(
+            COALESCE(sqlc.narg('interval')::INTERVAL, '1 minute'),
+            bucket,
+            TIMESTAMPTZ '1970-01-01 00:00:00+00'
+        ) :: TIMESTAMPTZ AS minute_bucket,
+        SUM(completed_count)::int as completed_count,
+        SUM(failed_count)::int as failed_count
+    FROM candidates
+    GROUP BY minute_bucket
+
+    UNION
+
+    SELECT
+        DATE_BIN(
+            COALESCE(sqlc.narg('interval')::INTERVAL, '1 minute'),
+            inserted_at,
+            TIMESTAMPTZ '1970-01-01 00:00:00+00'
+        ) AS minute_bucket,
+        COUNT(*) FILTER (WHERE readable_status = 'COMPLETED') AS completed_count,
+        COUNT(*) FILTER (WHERE readable_status = 'FAILED') AS failed_count
+    FROM v1_statuses_olap
+    WHERE
+        inserted_at > (SELECT max_time_bucket FROM max_time)
+        AND tenant_id = @tenantId::UUID
+        AND inserted_at >= DATE_BIN(
+            COALESCE(sqlc.narg('interval')::INTERVAL, '1 minute'),
+            @createdAfter::timestamptz,
+            TIMESTAMPTZ '1970-01-01 00:00:00+00'
+        )
+        AND inserted_at <= DATE_BIN(
+            COALESCE(sqlc.narg('interval')::INTERVAL, '1 minute'),
+            @createdBefore::timestamptz,
+            TIMESTAMPTZ '1970-01-01 00:00:00+00'
+        )
+    GROUP BY minute_bucket
+)
+
+SELECT *
+FROM unioned
+ORDER BY minute_bucket
+;
 
 
 -- name: GetTenantStatusMetrics :one

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -1455,7 +1455,7 @@ ORDER BY r.inserted_at DESC, r.run_id DESC;
 SELECT
     DATE_BIN(
         COALESCE(sqlc.narg('interval')::INTERVAL, '1 minute'),
-        inserted_at,
+        bucket,
         TIMESTAMPTZ '1970-01-01 00:00:00+00'
     ) :: TIMESTAMPTZ AS minute_bucket,
     SUM(completed_count)::int as completed_count,

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -1457,7 +1457,7 @@ SELECT
         COALESCE(sqlc.narg('interval')::INTERVAL, '1 minute'),
         inserted_at,
         TIMESTAMPTZ '1970-01-01 00:00:00+00'
-    ) :: TIMESTAMPTZ AS bucket_2,
+    ) :: TIMESTAMPTZ AS minute_bucket,
     SUM(completed_count)::int as completed_count,
     SUM(failed_count)::int as failed_count
 FROM
@@ -1476,8 +1476,8 @@ WHERE
         @createdBefore::timestamptz,
         TIMESTAMPTZ '1970-01-01 00:00:00+00'
     )
-GROUP BY bucket_2
-ORDER BY bucket_2;
+GROUP BY minute_bucket
+ORDER BY minute_bucket;
 
 
 -- name: GetTenantStatusMetrics :one

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -1038,7 +1038,7 @@ SELECT
         COALESCE($1::INTERVAL, '1 minute'),
         inserted_at,
         TIMESTAMPTZ '1970-01-01 00:00:00+00'
-    ) :: TIMESTAMPTZ AS bucket_2,
+    ) :: TIMESTAMPTZ AS minute_bucket,
     SUM(completed_count)::int as completed_count,
     SUM(failed_count)::int as failed_count
 FROM
@@ -1057,8 +1057,8 @@ WHERE
         $4::timestamptz,
         TIMESTAMPTZ '1970-01-01 00:00:00+00'
     )
-GROUP BY bucket_2
-ORDER BY bucket_2
+GROUP BY minute_bucket
+ORDER BY minute_bucket
 `
 
 type GetTaskPointMetricsParams struct {
@@ -1069,7 +1069,7 @@ type GetTaskPointMetricsParams struct {
 }
 
 type GetTaskPointMetricsRow struct {
-	Bucket2        pgtype.Timestamptz `json:"bucket_2"`
+	MinuteBucket   pgtype.Timestamptz `json:"minute_bucket"`
 	CompletedCount int32              `json:"completed_count"`
 	FailedCount    int32              `json:"failed_count"`
 }
@@ -1088,7 +1088,7 @@ func (q *Queries) GetTaskPointMetrics(ctx context.Context, db DBTX, arg GetTaskP
 	var items []*GetTaskPointMetricsRow
 	for rows.Next() {
 		var i GetTaskPointMetricsRow
-		if err := rows.Scan(&i.Bucket2, &i.CompletedCount, &i.FailedCount); err != nil {
+		if err := rows.Scan(&i.MinuteBucket, &i.CompletedCount, &i.FailedCount); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -1033,37 +1033,71 @@ func (q *Queries) GetTaskDurationsByTaskIds(ctx context.Context, db DBTX, arg Ge
 }
 
 const getTaskPointMetrics = `-- name: GetTaskPointMetrics :many
-SELECT
-    DATE_BIN(
-        COALESCE($1::INTERVAL, '1 minute'),
-        bucket,
-        TIMESTAMPTZ '1970-01-01 00:00:00+00'
-    ) :: TIMESTAMPTZ AS minute_bucket,
-    SUM(completed_count)::int as completed_count,
-    SUM(failed_count)::int as failed_count
-FROM
-    v1_cagg_task_statuses_minute
-WHERE
-    tenant_id = $2::uuid AND
-    -- timestamptz makes this fast, apparently:
-    -- https://www.timescale.com/forum/t/very-slow-query-planning-time-in-postgresql/255/8
-    bucket >= DATE_BIN(
-        '1 minute',
-        $3::timestamptz,
-        TIMESTAMPTZ '1970-01-01 00:00:00+00'
-    ) AND
-    bucket <= DATE_BIN(
-        '1 minute',
-        $4::timestamptz,
-        TIMESTAMPTZ '1970-01-01 00:00:00+00'
-    )
-GROUP BY minute_bucket
+WITH candidates AS (
+    SELECT bucket, tenant_id, workflow_id, queued_count, running_count, completed_count, cancelled_count, failed_count, evicted_count
+    FROM v1_cagg_task_statuses_minute
+    WHERE
+        tenant_id = $1::UUID
+        AND bucket >= DATE_BIN(
+            COALESCE($2::INTERVAL, '1 minute'),
+            $3::timestamptz,
+            TIMESTAMPTZ '1970-01-01 00:00:00+00'
+        )
+        AND bucket <= DATE_BIN(
+            COALESCE($2::INTERVAL, '1 minute'),
+            $4::timestamptz,
+            TIMESTAMPTZ '1970-01-01 00:00:00+00'
+        )
+), max_time AS (
+    SELECT MAX(bucket) AS max_time_bucket
+    FROM candidates
+), unioned AS (
+    SELECT
+        DATE_BIN(
+            COALESCE($2::INTERVAL, '1 minute'),
+            bucket,
+            TIMESTAMPTZ '1970-01-01 00:00:00+00'
+        ) :: TIMESTAMPTZ AS minute_bucket,
+        SUM(completed_count)::int as completed_count,
+        SUM(failed_count)::int as failed_count
+    FROM candidates
+    GROUP BY minute_bucket
+
+    UNION
+
+    SELECT
+        DATE_BIN(
+            COALESCE($2::INTERVAL, '1 minute'),
+            inserted_at,
+            TIMESTAMPTZ '1970-01-01 00:00:00+00'
+        ) AS minute_bucket,
+        COUNT(*) FILTER (WHERE readable_status = 'COMPLETED') AS completed_count,
+        COUNT(*) FILTER (WHERE readable_status = 'FAILED') AS failed_count
+    FROM v1_statuses_olap
+    WHERE
+        inserted_at > (SELECT max_time_bucket FROM max_time)
+        AND tenant_id = $1::UUID
+        AND inserted_at >= DATE_BIN(
+            COALESCE($2::INTERVAL, '1 minute'),
+            $3::timestamptz,
+            TIMESTAMPTZ '1970-01-01 00:00:00+00'
+        )
+        AND inserted_at <= DATE_BIN(
+            COALESCE($2::INTERVAL, '1 minute'),
+            $4::timestamptz,
+            TIMESTAMPTZ '1970-01-01 00:00:00+00'
+        )
+    GROUP BY minute_bucket
+)
+
+SELECT minute_bucket, completed_count, failed_count
+FROM unioned
 ORDER BY minute_bucket
 `
 
 type GetTaskPointMetricsParams struct {
-	Interval      pgtype.Interval    `json:"interval"`
 	Tenantid      uuid.UUID          `json:"tenantid"`
+	Interval      pgtype.Interval    `json:"interval"`
 	Createdafter  pgtype.Timestamptz `json:"createdafter"`
 	Createdbefore pgtype.Timestamptz `json:"createdbefore"`
 }
@@ -1076,8 +1110,8 @@ type GetTaskPointMetricsRow struct {
 
 func (q *Queries) GetTaskPointMetrics(ctx context.Context, db DBTX, arg GetTaskPointMetricsParams) ([]*GetTaskPointMetricsRow, error) {
 	rows, err := db.Query(ctx, getTaskPointMetrics,
-		arg.Interval,
 		arg.Tenantid,
+		arg.Interval,
 		arg.Createdafter,
 		arg.Createdbefore,
 	)

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -1036,7 +1036,7 @@ const getTaskPointMetrics = `-- name: GetTaskPointMetrics :many
 SELECT
     DATE_BIN(
         COALESCE($1::INTERVAL, '1 minute'),
-        inserted_at,
+        bucket,
         TIMESTAMPTZ '1970-01-01 00:00:00+00'
     ) :: TIMESTAMPTZ AS minute_bucket,
     SUM(completed_count)::int as completed_count,

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -1038,15 +1038,27 @@ SELECT
         COALESCE($1::INTERVAL, '1 minute'),
         inserted_at,
         TIMESTAMPTZ '1970-01-01 00:00:00+00'
-    ) :: TIMESTAMPTZ AS minute_bucket,
-    COUNT(*) FILTER (WHERE readable_status = 'COMPLETED') AS completed_count,
-    COUNT(*) FILTER (WHERE readable_status = 'FAILED') AS failed_count
-FROM v1_statuses_olap
+    ) :: TIMESTAMPTZ AS bucket_2,
+    SUM(completed_count)::int as completed_count,
+    SUM(failed_count)::int as failed_count
+FROM
+    v1_cagg_task_statuses_minute
 WHERE
-    tenant_id = $2::UUID
-    AND inserted_at BETWEEN $3::TIMESTAMPTZ AND $4::TIMESTAMPTZ
-GROUP BY minute_bucket
-ORDER BY minute_bucket
+    tenant_id = $2::uuid AND
+    -- timestamptz makes this fast, apparently:
+    -- https://www.timescale.com/forum/t/very-slow-query-planning-time-in-postgresql/255/8
+    bucket >= DATE_BIN(
+        '1 minute',
+        $3::timestamptz,
+        TIMESTAMPTZ '1970-01-01 00:00:00+00'
+    ) AND
+    bucket <= DATE_BIN(
+        '1 minute',
+        $4::timestamptz,
+        TIMESTAMPTZ '1970-01-01 00:00:00+00'
+    )
+GROUP BY bucket_2
+ORDER BY bucket_2
 `
 
 type GetTaskPointMetricsParams struct {
@@ -1057,9 +1069,9 @@ type GetTaskPointMetricsParams struct {
 }
 
 type GetTaskPointMetricsRow struct {
-	MinuteBucket   pgtype.Timestamptz `json:"minute_bucket"`
-	CompletedCount int64              `json:"completed_count"`
-	FailedCount    int64              `json:"failed_count"`
+	Bucket2        pgtype.Timestamptz `json:"bucket_2"`
+	CompletedCount int32              `json:"completed_count"`
+	FailedCount    int32              `json:"failed_count"`
 }
 
 func (q *Queries) GetTaskPointMetrics(ctx context.Context, db DBTX, arg GetTaskPointMetricsParams) ([]*GetTaskPointMetricsRow, error) {
@@ -1076,7 +1088,7 @@ func (q *Queries) GetTaskPointMetrics(ctx context.Context, db DBTX, arg GetTaskP
 	var items []*GetTaskPointMetricsRow
 	for rows.Next() {
 		var i GetTaskPointMetricsRow
-		if err := rows.Scan(&i.MinuteBucket, &i.CompletedCount, &i.FailedCount); err != nil {
+		if err := rows.Scan(&i.Bucket2, &i.CompletedCount, &i.FailedCount); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)

--- a/sql/schema/v1-olap.sql
+++ b/sql/schema/v1-olap.sql
@@ -1410,8 +1410,8 @@ CREATE TABLE v1_otel_trace_lookup_olap (
     PRIMARY KEY (tenant_id, external_id, retry_count, start_time)
 ) PARTITION BY RANGE (start_time);
 
-CREATE TABLE v1_cagg_task_statuses_minute_do_not_use_directly (
-    time_bucket TIMESTAMPTZ NOT NULL,
+CREATE TABLE v1_cagg_task_statuses_minute (
+    bucket TIMESTAMPTZ NOT NULL,
     tenant_id UUID NOT NULL,
     workflow_id UUID NOT NULL,
     queued_count BIGINT NOT NULL DEFAULT 0,
@@ -1420,35 +1420,5 @@ CREATE TABLE v1_cagg_task_statuses_minute_do_not_use_directly (
     cancelled_count BIGINT NOT NULL DEFAULT 0,
     failed_count BIGINT NOT NULL DEFAULT 0,
     evicted_count BIGINT NOT NULL DEFAULT 0,
-    PRIMARY KEY (time_bucket, tenant_id, workflow_id)
+    PRIMARY KEY (bucket, tenant_id, workflow_id)
 );
-
-CREATE VIEW v1_cagg_task_statuses_minute AS
-WITH max_time AS (
-    SELECT MAX(time_bucket) AS max_time_bucket
-    FROM v1_cagg_task_statuses_minute_do_not_use_directly
-), unioned AS (
-    SELECT *
-    FROM v1_cagg_task_statuses_minute_do_not_use_directly
-
-    UNION
-
-    SELECT
-        date_bin('1 minute', inserted_at, TIMESTAMP '2001-01-01') AS time_bucket,
-        tenant_id,
-        workflow_id,
-        COUNT(*) FILTER (WHERE readable_status = 'QUEUED') AS queued_count,
-        COUNT(*) FILTER (WHERE readable_status = 'RUNNING') AS running_count,
-        COUNT(*) FILTER (WHERE readable_status = 'COMPLETED') AS completed_count,
-        COUNT(*) FILTER (WHERE readable_status = 'CANCELLED') AS cancelled_count,
-        COUNT(*) FILTER (WHERE readable_status = 'FAILED') AS failed_count,
-        COUNT(*) FILTER (WHERE readable_status = 'EVICTED') AS evicted_count
-    FROM v1_statuses_olap
-    WHERE inserted_at > (SELECT max_time_bucket FROM max_time)
-    GROUP BY time_bucket, tenant_id, workflow_id
-)
-
-SELECT *
-FROM unioned
-ORDER BY time_bucket, tenant_id, workflow_id
-;

--- a/sql/schema/v1-olap.sql
+++ b/sql/schema/v1-olap.sql
@@ -1409,3 +1409,46 @@ CREATE TABLE v1_otel_trace_lookup_olap (
     start_time      TIMESTAMPTZ NOT NULL,
     PRIMARY KEY (tenant_id, external_id, retry_count, start_time)
 ) PARTITION BY RANGE (start_time);
+
+CREATE TABLE v1_cagg_task_statuses_minute_do_not_use_directly (
+    time_bucket TIMESTAMPTZ NOT NULL,
+    tenant_id UUID NOT NULL,
+    workflow_id UUID NOT NULL,
+    queued_count BIGINT NOT NULL DEFAULT 0,
+    running_count BIGINT NOT NULL DEFAULT 0,
+    completed_count BIGINT NOT NULL DEFAULT 0,
+    cancelled_count BIGINT NOT NULL DEFAULT 0,
+    failed_count BIGINT NOT NULL DEFAULT 0,
+    evicted_count BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (time_bucket, tenant_id, workflow_id)
+);
+
+CREATE VIEW v1_cagg_task_statuses_minute AS
+WITH max_time AS (
+    SELECT MAX(time_bucket) AS max_time_bucket
+    FROM v1_cagg_task_statuses_minute_do_not_use_directly
+), unioned AS (
+    SELECT *
+    FROM v1_cagg_task_statuses_minute_do_not_use_directly
+
+    UNION
+
+    SELECT
+        date_bin('1 minute', inserted_at, TIMESTAMP '2001-01-01') AS time_bucket,
+        tenant_id,
+        workflow_id,
+        COUNT(*) FILTER (WHERE readable_status = 'QUEUED') AS queued_count,
+        COUNT(*) FILTER (WHERE readable_status = 'RUNNING') AS running_count,
+        COUNT(*) FILTER (WHERE readable_status = 'COMPLETED') AS completed_count,
+        COUNT(*) FILTER (WHERE readable_status = 'CANCELLED') AS cancelled_count,
+        COUNT(*) FILTER (WHERE readable_status = 'FAILED') AS failed_count,
+        COUNT(*) FILTER (WHERE readable_status = 'EVICTED') AS evicted_count
+    FROM v1_statuses_olap
+    WHERE inserted_at > (SELECT max_time_bucket FROM max_time)
+    GROUP BY time_bucket, tenant_id, workflow_id
+)
+
+SELECT *
+FROM unioned
+ORDER BY time_bucket, tenant_id, workflow_id
+;


### PR DESCRIPTION
# Description

Just a small PoC / proposal for now of what it'd look like to roll our own continuous aggregates. Basic idea is to have a "base" table we insert into, and a view on top of it that unions the base table with the more recent data that hasn't been aggregated yet to get an up to date snapshot of the aggregate quickly.

Didn't write it yet, but we'll need some job that basically runs this to "refresh" the aggregate:

```sql
INSERT INTO v1_cagg_task_statuses_minute
SELECT date_bin(...) as bucket, do, the, aggregations
FROM v1_statuses_olap
WHERE inserted_at > ...
```

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
