### PR TITLE
fix(frontend): normalize Windows path separators in generate.py

### DIFF
--- a/frontend/snippets/generate.py
+++ b/frontend/snippets/generate.py
@@ -123,7 +123,7 @@ def parse_snippets(ctx: SDKParsingContext, filename: str) -> list[Snippet]:
     with open(filename) as f:
         content = f.read()
 
-    code_path = f"examples/{ctx.name.lower()}{filename.replace(base_path, '')}"
+    code_path = f"examples/{ctx.name.lower()}{filename.replace(os.sep, '/').replace('\\', '/').replace(base_path.replace(os.sep, '/'), '')}"
 
     github_url = f"https://github.com/{OUTPUT_GITHUB_ORG}/{OUTPUT_GITHUB_REPO}/tree/main/{code_path}"
 
@@ -159,7 +159,7 @@ def process_example(ctx: SDKParsingContext, filename: str) -> ProcessedExample:
         return ProcessedExample(
             context=ctx,
             filepath=filename,
-            output_path=f"examples/{ctx.name.lower()}{filename.replace(ROOT + ctx.value.example_path, '')}",
+            output_path=f"examples/{ctx.name.lower()}{filename.replace(os.sep, '/').replace('\\', '/').replace((ROOT + ctx.value.example_path).replace(os.sep, '/'), '')}",
             snippets=parse_snippets(ctx, filename),
             raw_content=content,
         )
@@ -337,7 +337,8 @@ def write_doc_index_to_app() -> None:
             )
 
             keys = (
-                filename.replace(pages_dir, "")
+                filename.replace(os.sep, "/").replace("\\", "/")
+                .replace(pages_dir.replace(os.sep, "/"), "")
                 .replace("_meta.js", "")
                 .rstrip("/")
                 .split("/")


### PR DESCRIPTION
## Summary
`generate.py` builds the docs/snippet trees consumed by the Hatchet dashboard. It strips `pages_dir` and splits glob results on `/`, but on Windows `glob`/`os.path.join` return backslash paths, so the prefix is never stripped. `docsPages` then nests under garbage keys like `{"..":{"..":{"frontend\docs\pages\":{...}}}}`, and the dashboard reads `docsPages.v1.quickstart` -> `undefined` -> TypeError, making every sidebar link throw "Something went wrong".

Normalizing path separators to `/` before computing the keys fixes Windows while staying a no-op on Linux/macOS.

## Test plan
- [ ] Windows: `python frontend/snippets/generate.py` -> `docsPages` top-level contains `v1`, `cookbooks`, `self-hosting`, ...
- [ ] Linux/macOS: generated `docs/index.ts` is unchanged (no-op)