### PR TITLE
feat: Batch tasks documentation

### DIFF
--- a/examples/python/batch_assign/worker.py
+++ b/examples/python/batch_assign/worker.py
@@ -72,6 +72,7 @@ class ChildOutput(BaseModel):
     message_len: int
 
 
+# > Declaring a batch task
 @hatchet.batch_task(
     batch_max_size=3,
     batch_max_interval=timedelta(milliseconds=200),
@@ -86,6 +87,9 @@ async def batch_simple(
     }
 
 
+
+
+# > Declaring a keyed batch task
 @hatchet.batch_task(
     batch_max_size=2,
     batch_max_interval=timedelta(milliseconds=200),
@@ -105,6 +109,8 @@ async def batch_keyed(
         )
         for id, inp in tasks.items()
     }
+
+
 
 
 @hatchet.batch_task(
@@ -186,6 +192,7 @@ async def batch_ordered(
     return {id: OrderedOutput(index=inp.index) for id, inp in tasks.items()}
 
 
+# > Declaring a broadcast batch task
 @hatchet.batch_task(
     batch_max_size=10,
     batch_max_interval=timedelta(seconds=2),
@@ -196,6 +203,8 @@ async def batch_broadcast(
     tasks: dict[BatchMemberId, SimpleInput], context: Context
 ) -> BroadcastOutput:
     return BroadcastOutput(sum=sum(len(i.message) for _, i in tasks.items()))
+
+
 
 
 @hatchet.batch_task(

--- a/examples/typescript/batch_assign/workflow.ts
+++ b/examples/typescript/batch_assign/workflow.ts
@@ -30,6 +30,7 @@ type BroadcastOutput = { sum: number };
 type ChildOutput = { message_len: number };
 type ChildBatchOutput = { out: Record<string, SimpleInput> };
 
+// > Declaring a batch task
 export const batchSimple = hatchet.batchTask({
   name: 'batch-simple',
   batch: { maxSize: 3, maxInterval: 200 },
@@ -42,6 +43,7 @@ export const batchSimple = hatchet.batchTask({
   },
 });
 
+// > Declaring a keyed batch task
 export const batchKeyed = hatchet.batchTask({
   name: 'batch-keyed',
   batch: { maxSize: 2, maxInterval: 200, groupKey: 'input.group' },
@@ -136,6 +138,7 @@ export const batchOrdered = hatchet.batchTask({
   },
 });
 
+// > Declaring a broadcast batch task
 export const batchBroadcast = hatchet.batchTask({
   name: 'batch-broadcast',
   batch: { maxSize: 10, maxInterval: 2_000, broadcastOutput: true },

--- a/frontend/docs/pages/v1/_meta.js
+++ b/frontend/docs/pages/v1/_meta.js
@@ -40,6 +40,7 @@ export default {
   "rate-limits": "Rate Limits",
   priority: "Priority",
   idempotency: "Idempotency",
+  "batch-tasks": "Batched Tasks",
   "--durable-workflows-section": {
     title: "Durable Execution",
     type: "separator",

--- a/frontend/docs/pages/v1/_meta.js
+++ b/frontend/docs/pages/v1/_meta.js
@@ -40,7 +40,7 @@ export default {
   "rate-limits": "Rate Limits",
   priority: "Priority",
   idempotency: "Idempotency",
-  "batch-tasks": "Batched Tasks",
+  "batch-tasks": "Batch Tasks",
   "--durable-workflows-section": {
     title: "Durable Execution",
     type: "separator",

--- a/frontend/docs/pages/v1/batch-tasks.mdx
+++ b/frontend/docs/pages/v1/batch-tasks.mdx
@@ -14,8 +14,9 @@ to a batch task is a map that associates the ID of the originating task with
 it's input. The output *must* be the same shape, using the same keys, to send
 outputs back to the original call site (unless output broadcasting is used, see
 [Broadcasting outputs](#broadcasting-outputs)). For the caller of a batch task,
-the batched execution is hidden. It is called, and receives outputs, in the same
-manner as a normal task.
+the batched execution is hidden. It is called, and receives output, the same way as a normal task.
+Though each batch will be executed in one handler function, the call site only receives output corresponding to its input, not
+the output for the entire batch.
 
 ## Batch flushing behavior
 
@@ -25,7 +26,7 @@ Batches will accumulate tasks continuously, preventing them from executing until
 - The maximum interval has elapsed since the last batch flush.
 - The size of the payloads for the buffered tasks has exceeded the 4Mb gRPC message limit.
 
-In the following example, the batch task will be executed once 10 tasks have accumulated, or every 200ms, whichever comes first.
+In the following example, the batch task will be executed once 3 tasks have accumulated, or every 200ms, whichever comes first.
 
 <UniversalTabs items={["Python", "Typescript", "Go", "Ruby"]}>
   <Tabs.Tab>
@@ -47,7 +48,8 @@ In the following example, the batch task will be executed once 10 tasks have acc
 ## Batch keys
 
 To allow for accumulation of multiple batches simultaneously using the same workflow, batch keys can be used.
-In the following example, the batches will flush independently based on the `group` value.
+For example, if you had multiple tenants, and wanted to ensure that each batch execution did not mix inputs from multiple
+tenants, batch keys can be used to partition the inputs. In the following example, the batches will flush independently based on the `group` value.
 
 <UniversalTabs items={["Python", "Typescript", "Go", "Ruby"]}>
   <Tabs.Tab>

--- a/frontend/docs/pages/v1/batch-tasks.mdx
+++ b/frontend/docs/pages/v1/batch-tasks.mdx
@@ -14,9 +14,10 @@ to a batch task is a map that associates the ID of the originating task with
 it's input. The output *must* be the same shape, using the same keys, to send
 outputs back to the original call site (unless output broadcasting is used, see
 [Broadcasting outputs](#broadcasting-outputs)). For the caller of a batch task,
-the batched execution is hidden. It is called, and receives output, the same way as a normal task.
-Though each batch will be executed in one handler function, the call site only receives output corresponding to its input, not
-the output for the entire batch.
+the batched execution is hidden. It is called, and receives output, the same way
+as a normal task. Though each batch will be executed in one handler function,
+the call site only receives output corresponding to its input, not the output
+for the entire batch.
 
 ## Batch flushing behavior
 

--- a/frontend/docs/pages/v1/batch-tasks.mdx
+++ b/frontend/docs/pages/v1/batch-tasks.mdx
@@ -13,7 +13,7 @@ to automatically accumulate tasks and execute them in a single batch. The input
 to a batch task is a map that associates the ID of the originating task with
 it's input. The output *must* be the same shape, using the same keys, to send
 outputs back to the original call site (unless output broadcasting is used, see
-[Broadcasting outputs](#broadcasting-outputs). For the caller of a batch task,
+[Broadcasting outputs](#broadcasting-outputs)). For the caller of a batch task,
 the batched execution is hidden. It is called, and receives outputs, in the same
 manner as a normal task.
 

--- a/frontend/docs/pages/v1/batch-tasks.mdx
+++ b/frontend/docs/pages/v1/batch-tasks.mdx
@@ -1,0 +1,107 @@
+import { Callout, Card, Cards, Steps, Tabs } from "nextra/components";
+import { snippets } from "@/lib/generated/snippets";
+import { Snippet } from "@/components/code";
+import UniversalTabs from "../../components/UniversalTabs";
+
+# Batch Tasks
+
+<Callout type="warning">
+  Batch tasks are in beta and may change in future releases.
+</Callout>
+For tasks that do not need to be executed immediately, you can use batch tasks
+to automatically accumulate tasks and execute them in a single batch. The input
+to a batch task is a map that associates the ID of the originating task with
+it's input. The output *must* be the same shape, using the same keys, to send
+outputs back to the original call site (unless output broadcasting is used, see
+[Broadcasting outputs](#broadcasting-outputs). For the caller of a batch task,
+the batched execution is hidden. It is called, and receives outputs, in the same
+manner as a normal task.
+
+## Batch flushing behavior
+
+Batches will accumulate tasks continuously, preventing them from executing until one of the following conditions is true:
+
+- The max size for the batch is reached.
+- The maximum interval has elapsed since the last batch flush.
+- The size of the payloads for the buffered tasks has exceeded the 4Mb gRPC message limit.
+
+In the following example, the batch task will be executed once 10 tasks have accumulated, or every 200ms, whichever comes first.
+
+<UniversalTabs items={["Python", "Typescript", "Go", "Ruby"]}>
+  <Tabs.Tab>
+    <Snippet src={snippets.python.batch_assign.worker.declaring_a_batch_task} />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <Snippet
+      src={snippets.typescript.batch_assign.workflow.declaring_a_batch_task}
+    />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <Snippet src={snippets.go.batch_assign.main.declaring_a_batch_task} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Ruby">
+    <Snippet src={snippets.ruby.batch_assign.worker.declaring_a_batch_task} />
+  </Tabs.Tab>
+</UniversalTabs>
+
+## Batch keys
+
+To allow for accumulation of multiple batches simultaneously using the same workflow, batch keys can be used.
+In the following example, the batches will flush independently based on the `group` value.
+
+<UniversalTabs items={["Python", "Typescript", "Go", "Ruby"]}>
+  <Tabs.Tab>
+    <Snippet
+      src={snippets.python.batch_assign.worker.declaring_a_keyed_batch_task}
+    />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <Snippet
+      src={
+        snippets.typescript.batch_assign.workflow.declaring_a_keyed_batch_task
+      }
+    />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <Snippet src={snippets.go.batch_assign.main.declaring_a_keyed_batch_task} />
+  </Tabs.Tab>
+  <Tabs.Tab title="Ruby">
+    <Snippet
+      src={snippets.ruby.batch_assign.worker.declaring_a_keyed_batch_task}
+    />
+  </Tabs.Tab>
+</UniversalTabs>
+
+## Broadcasting outputs
+
+In the default case, batch outputs are mapped 1-1 back to the callers. So if you called a batch task with input `a` and `b` at separate
+call sites, you would receive back outputs `a'` and `b'` respectively, despite the fact they would both be executed at the same time, in the same handler.
+However, if you wish to return the same input back to all callsites, you can use output broadcasting.
+In the following example, every task will receive the same output regardless of call site. Note, however, that this will only return
+the same output to every task buffered into the same batch. See the batch flushing rules above for more details.
+
+<UniversalTabs items={["Python", "Typescript", "Go", "Ruby"]}>
+  <Tabs.Tab>
+    <Snippet
+      src={snippets.python.batch_assign.worker.declaring_a_broadcast_batch_task}
+    />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <Snippet
+      src={
+        snippets.typescript.batch_assign.workflow
+          .declaring_a_broadcast_batch_task
+      }
+    />
+  </Tabs.Tab>
+  <Tabs.Tab>
+    <Snippet
+      src={snippets.go.batch_assign.main.declaring_a_broadcast_batch_task}
+    />
+  </Tabs.Tab>
+  <Tabs.Tab title="Ruby">
+    <Snippet
+      src={snippets.ruby.batch_assign.worker.declaring_a_broadcast_batch_task}
+    />
+  </Tabs.Tab>
+</UniversalTabs>

--- a/sdks/go/examples/batch_assign/main.go
+++ b/sdks/go/examples/batch_assign/main.go
@@ -55,6 +55,7 @@ func main() {
 			MaxInterval: durationPtr(200 * time.Millisecond),
 		},
 	)
+	// !!
 
 	// > Declaring a keyed batch task
 	batchKeyed := client.NewStandaloneBatchTask("batch-keyed",
@@ -81,6 +82,7 @@ func main() {
 			GroupKey:    stringPtr("input.group"),
 		},
 	)
+	// !!
 
 	// > Declaring a broadcast batch task
 	batchBroadcast := client.NewStandaloneBatchTask("batch-broadcast",
@@ -97,6 +99,7 @@ func main() {
 			BroadcastOutput: true,
 		},
 	)
+	// !!
 
 	worker, err := client.NewWorker("batch-assign-worker",
 		hatchet.WithWorkflows(batchSimple, batchKeyed, batchBroadcast),

--- a/sdks/python/examples/batch_assign/worker.py
+++ b/sdks/python/examples/batch_assign/worker.py
@@ -72,6 +72,7 @@ class ChildOutput(BaseModel):
     message_len: int
 
 
+# > Declaring a batch task
 @hatchet.batch_task(
     batch_max_size=3,
     batch_max_interval=timedelta(milliseconds=200),
@@ -86,6 +87,10 @@ async def batch_simple(
     }
 
 
+# !!
+
+
+# > Declaring a keyed batch task
 @hatchet.batch_task(
     batch_max_size=2,
     batch_max_interval=timedelta(milliseconds=200),
@@ -105,6 +110,9 @@ async def batch_keyed(
         )
         for id, inp in tasks.items()
     }
+
+
+# !!
 
 
 @hatchet.batch_task(
@@ -186,6 +194,7 @@ async def batch_ordered(
     return {id: OrderedOutput(index=inp.index) for id, inp in tasks.items()}
 
 
+# > Declaring a broadcast batch task
 @hatchet.batch_task(
     batch_max_size=10,
     batch_max_interval=timedelta(seconds=2),
@@ -196,6 +205,9 @@ async def batch_broadcast(
     tasks: dict[BatchMemberId, SimpleInput], context: Context
 ) -> BroadcastOutput:
     return BroadcastOutput(sum=sum(len(i.message) for _, i in tasks.items()))
+
+
+# !!
 
 
 @hatchet.batch_task(

--- a/sdks/typescript/src/v1/examples/batch_assign/workflow.ts
+++ b/sdks/typescript/src/v1/examples/batch_assign/workflow.ts
@@ -30,6 +30,7 @@ type BroadcastOutput = { sum: number };
 type ChildOutput = { message_len: number };
 type ChildBatchOutput = { out: Record<string, SimpleInput> };
 
+// > Declaring a batch task
 export const batchSimple = hatchet.batchTask({
   name: 'batch-simple',
   batch: { maxSize: 3, maxInterval: 200 },
@@ -41,7 +42,9 @@ export const batchSimple = hatchet.batchTask({
     return out;
   },
 });
+// !!
 
+// > Declaring a keyed batch task
 export const batchKeyed = hatchet.batchTask({
   name: 'batch-keyed',
   batch: { maxSize: 2, maxInterval: 200, groupKey: 'input.group' },
@@ -60,6 +63,7 @@ export const batchKeyed = hatchet.batchTask({
     return out;
   },
 });
+// !!
 
 export const batchKeyedFailable = hatchet.batchTask({
   name: 'batch-keyed-failable',
@@ -136,6 +140,7 @@ export const batchOrdered = hatchet.batchTask({
   },
 });
 
+// > Declaring a broadcast batch task
 export const batchBroadcast = hatchet.batchTask({
   name: 'batch-broadcast',
   batch: { maxSize: 10, maxInterval: 2_000, broadcastOutput: true },
@@ -144,6 +149,7 @@ export const batchBroadcast = hatchet.batchTask({
     return { sum };
   },
 });
+// !!
 
 export const batchCancel = hatchet.batchTask({
   name: 'batch-cancel',


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
