### PR TITLE
refactor(dashboard): remove uses of `v1_statuses_olap` 

### DIFF
--- a/pkg/repository/sqlcv1/models.go
+++ b/pkg/repository/sqlcv1/models.go
@@ -1798,48 +1798,6 @@ func (ns NullV1RunKind) Value() (driver.Value, error) {
 	return string(ns.V1RunKind), nil
 }
 
-type V1StatusKind string
-
-const (
-	V1StatusKindTASK V1StatusKind = "TASK"
-	V1StatusKindDAG  V1StatusKind = "DAG"
-)
-
-func (e *V1StatusKind) Scan(src interface{}) error {
-	switch s := src.(type) {
-	case []byte:
-		*e = V1StatusKind(s)
-	case string:
-		*e = V1StatusKind(s)
-	default:
-		return fmt.Errorf("unsupported scan type for V1StatusKind: %T", src)
-	}
-	return nil
-}
-
-type NullV1StatusKind struct {
-	V1StatusKind V1StatusKind `json:"v1_status_kind"`
-	Valid        bool         `json:"valid"` // Valid is true if V1StatusKind is not NULL
-}
-
-// Scan implements the Scanner interface.
-func (ns *NullV1StatusKind) Scan(value interface{}) error {
-	if value == nil {
-		ns.V1StatusKind, ns.Valid = "", false
-		return nil
-	}
-	ns.Valid = true
-	return ns.V1StatusKind.Scan(value)
-}
-
-// Value implements the driver Valuer interface.
-func (ns NullV1StatusKind) Value() (driver.Value, error) {
-	if !ns.Valid {
-		return nil, nil
-	}
-	return string(ns.V1StatusKind), nil
-}
-
 type V1StepMatchConditionKind string
 
 const (
@@ -3629,15 +3587,6 @@ type V1RunsOlap struct {
 	AdditionalMetadata   []byte               `json:"additional_metadata"`
 	ParentTaskExternalID *uuid.UUID           `json:"parent_task_external_id"`
 	IdempotencyKey       pgtype.Text          `json:"idempotency_key"`
-}
-
-type V1StatusesOlap struct {
-	ExternalID     uuid.UUID            `json:"external_id"`
-	InsertedAt     pgtype.Timestamptz   `json:"inserted_at"`
-	TenantID       uuid.UUID            `json:"tenant_id"`
-	WorkflowID     uuid.UUID            `json:"workflow_id"`
-	Kind           V1RunKind            `json:"kind"`
-	ReadableStatus V1ReadableStatusOlap `json:"readable_status"`
 }
 
 type V1StepBatchConfig struct {

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -1460,7 +1460,7 @@ SELECT
     ) :: TIMESTAMPTZ AS minute_bucket,
     COUNT(*) FILTER (WHERE readable_status = 'COMPLETED') AS completed_count,
     COUNT(*) FILTER (WHERE readable_status = 'FAILED') AS failed_count
-FROM v1_statuses_olap
+FROM v1_tasks_olap -- todo: probably need indexing?
 WHERE
     tenant_id = @tenantId::UUID
     AND inserted_at BETWEEN @createdAfter::TIMESTAMPTZ AND @createdBefore::TIMESTAMPTZ
@@ -1515,7 +1515,7 @@ SELECT
     COUNT(*) FILTER (WHERE readable_status = 'CANCELLED') AS total_cancelled,
     COUNT(*) FILTER (WHERE readable_status = 'FAILED') AS total_failed,
     COUNT(*) FILTER (WHERE readable_status = 'EVICTED') AS total_evicted
-FROM v1_statuses_olap
+FROM v1_tasks_olap
 WHERE
     tenant_id = @tenantId::UUID
     AND inserted_at >= @createdAfter::TIMESTAMPTZ
@@ -1526,6 +1526,7 @@ WHERE
         sqlc.narg('workflowIds')::UUID[] IS NULL OR workflow_id = ANY(sqlc.narg('workflowIds')::UUID[])
     )
     AND external_id IN (
+        -- todo: indexing - go through the lookup table
         SELECT external_id
         FROM task_external_ids
     )

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -1460,7 +1460,7 @@ SELECT
     ) :: TIMESTAMPTZ AS minute_bucket,
     COUNT(*) FILTER (WHERE readable_status = 'COMPLETED') AS completed_count,
     COUNT(*) FILTER (WHERE readable_status = 'FAILED') AS failed_count
-FROM v1_tasks_olap -- todo: probably need indexing?
+FROM v1_runs_olap
 WHERE
     tenant_id = @tenantId::UUID
     AND inserted_at BETWEEN @createdAfter::TIMESTAMPTZ AND @createdBefore::TIMESTAMPTZ
@@ -1469,44 +1469,6 @@ ORDER BY minute_bucket;
 
 
 -- name: GetTenantStatusMetrics :one
-WITH task_external_ids AS (
-    SELECT external_id
-    FROM v1_runs_olap
-    WHERE (
-        sqlc.narg('parentTaskExternalId')::UUID IS NULL OR parent_task_external_id = sqlc.narg('parentTaskExternalId')::UUID
-    ) AND (
-        sqlc.narg('triggeringEventExternalId')::UUID IS NULL
-        OR (id, inserted_at) IN (
-            SELECT etr.run_id, etr.run_inserted_at
-            FROM v1_event_lookup_table_olap lt
-            JOIN v1_events_olap e ON (lt.tenant_id, lt.event_id, lt.event_seen_at) = (e.tenant_id, e.id, e.seen_at)
-            JOIN v1_event_to_run_olap etr ON (e.id, e.seen_at) = (etr.event_id, etr.event_seen_at)
-            WHERE
-                lt.tenant_id = @tenantId::uuid
-                AND lt.external_id = sqlc.narg('triggeringEventExternalId')::UUID
-        )
-    )
-    AND (
-        sqlc.narg('additionalMetaKeys')::text[] IS NULL
-        OR sqlc.narg('additionalMetaValues')::text[] IS NULL
-        OR EXISTS (
-            SELECT 1 FROM jsonb_each_text(additional_metadata) kv
-            JOIN LATERAL (
-                SELECT unnest(sqlc.narg('additionalMetaKeys')::text[]) AS k,
-                    unnest(sqlc.narg('additionalMetaValues')::text[]) AS v
-            ) AS u ON kv.key = u.k AND kv.value = u.v
-        )
-    )
-    AND tenant_id = @tenantId::UUID
-    AND inserted_at >= @createdAfter::TIMESTAMPTZ
-    AND (
-        sqlc.narg('createdBefore')::TIMESTAMPTZ IS NULL OR inserted_at <= sqlc.narg('createdBefore')::TIMESTAMPTZ
-    )
-    AND (
-        sqlc.narg('workflowIds')::UUID[] IS NULL OR workflow_id = ANY(sqlc.narg('workflowIds')::UUID[])
-    )
-)
-
 SELECT
     tenant_id,
     COUNT(*) FILTER (WHERE readable_status = 'QUEUED') AS total_queued,
@@ -1515,21 +1477,40 @@ SELECT
     COUNT(*) FILTER (WHERE readable_status = 'CANCELLED') AS total_cancelled,
     COUNT(*) FILTER (WHERE readable_status = 'FAILED') AS total_failed,
     COUNT(*) FILTER (WHERE readable_status = 'EVICTED') AS total_evicted
-FROM v1_tasks_olap
-WHERE
-    tenant_id = @tenantId::UUID
-    AND inserted_at >= @createdAfter::TIMESTAMPTZ
-    AND (
-        sqlc.narg('createdBefore')::TIMESTAMPTZ IS NULL OR inserted_at <= sqlc.narg('createdBefore')::TIMESTAMPTZ
+FROM v1_runs_olap
+WHERE (
+    sqlc.narg('parentTaskExternalId')::UUID IS NULL OR parent_task_external_id = sqlc.narg('parentTaskExternalId')::UUID
+) AND (
+    sqlc.narg('triggeringEventExternalId')::UUID IS NULL
+    OR (id, inserted_at) IN (
+        SELECT etr.run_id, etr.run_inserted_at
+        FROM v1_event_lookup_table_olap lt
+        JOIN v1_events_olap e ON (lt.tenant_id, lt.event_id, lt.event_seen_at) = (e.tenant_id, e.id, e.seen_at)
+        JOIN v1_event_to_run_olap etr ON (e.id, e.seen_at) = (etr.event_id, etr.event_seen_at)
+        WHERE
+            lt.tenant_id = @tenantId::uuid
+            AND lt.external_id = sqlc.narg('triggeringEventExternalId')::UUID
     )
-    AND (
-        sqlc.narg('workflowIds')::UUID[] IS NULL OR workflow_id = ANY(sqlc.narg('workflowIds')::UUID[])
+)
+AND (
+    sqlc.narg('additionalMetaKeys')::text[] IS NULL
+    OR sqlc.narg('additionalMetaValues')::text[] IS NULL
+    OR EXISTS (
+        SELECT 1 FROM jsonb_each_text(additional_metadata) kv
+        JOIN LATERAL (
+            SELECT unnest(sqlc.narg('additionalMetaKeys')::text[]) AS k,
+                unnest(sqlc.narg('additionalMetaValues')::text[]) AS v
+        ) AS u ON kv.key = u.k AND kv.value = u.v
     )
-    AND external_id IN (
-        -- todo: indexing - go through the lookup table
-        SELECT external_id
-        FROM task_external_ids
-    )
+)
+AND tenant_id = @tenantId::UUID
+AND inserted_at >= @createdAfter::TIMESTAMPTZ
+AND (
+    sqlc.narg('createdBefore')::TIMESTAMPTZ IS NULL OR inserted_at <= sqlc.narg('createdBefore')::TIMESTAMPTZ
+)
+AND (
+    sqlc.narg('workflowIds')::UUID[] IS NULL OR workflow_id = ANY(sqlc.narg('workflowIds')::UUID[])
+)
 GROUP BY tenant_id
 ;
 

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -1041,7 +1041,7 @@ SELECT
     ) :: TIMESTAMPTZ AS minute_bucket,
     COUNT(*) FILTER (WHERE readable_status = 'COMPLETED') AS completed_count,
     COUNT(*) FILTER (WHERE readable_status = 'FAILED') AS failed_count
-FROM v1_tasks_olap -- todo: probably need indexing?
+FROM v1_runs_olap
 WHERE
     tenant_id = $2::UUID
     AND inserted_at BETWEEN $3::TIMESTAMPTZ AND $4::TIMESTAMPTZ
@@ -1149,44 +1149,6 @@ func (q *Queries) GetTaskStartedTimestamps(ctx context.Context, db DBTX, arg Get
 }
 
 const getTenantStatusMetrics = `-- name: GetTenantStatusMetrics :one
-WITH task_external_ids AS (
-    SELECT external_id
-    FROM v1_runs_olap
-    WHERE (
-        $5::UUID IS NULL OR parent_task_external_id = $5::UUID
-    ) AND (
-        $6::UUID IS NULL
-        OR (id, inserted_at) IN (
-            SELECT etr.run_id, etr.run_inserted_at
-            FROM v1_event_lookup_table_olap lt
-            JOIN v1_events_olap e ON (lt.tenant_id, lt.event_id, lt.event_seen_at) = (e.tenant_id, e.id, e.seen_at)
-            JOIN v1_event_to_run_olap etr ON (e.id, e.seen_at) = (etr.event_id, etr.event_seen_at)
-            WHERE
-                lt.tenant_id = $1::uuid
-                AND lt.external_id = $6::UUID
-        )
-    )
-    AND (
-        $7::text[] IS NULL
-        OR $8::text[] IS NULL
-        OR EXISTS (
-            SELECT 1 FROM jsonb_each_text(additional_metadata) kv
-            JOIN LATERAL (
-                SELECT unnest($7::text[]) AS k,
-                    unnest($8::text[]) AS v
-            ) AS u ON kv.key = u.k AND kv.value = u.v
-        )
-    )
-    AND tenant_id = $1::UUID
-    AND inserted_at >= $2::TIMESTAMPTZ
-    AND (
-        $3::TIMESTAMPTZ IS NULL OR inserted_at <= $3::TIMESTAMPTZ
-    )
-    AND (
-        $4::UUID[] IS NULL OR workflow_id = ANY($4::UUID[])
-    )
-)
-
 SELECT
     tenant_id,
     COUNT(*) FILTER (WHERE readable_status = 'QUEUED') AS total_queued,
@@ -1195,33 +1157,52 @@ SELECT
     COUNT(*) FILTER (WHERE readable_status = 'CANCELLED') AS total_cancelled,
     COUNT(*) FILTER (WHERE readable_status = 'FAILED') AS total_failed,
     COUNT(*) FILTER (WHERE readable_status = 'EVICTED') AS total_evicted
-FROM v1_tasks_olap
-WHERE
-    tenant_id = $1::UUID
-    AND inserted_at >= $2::TIMESTAMPTZ
-    AND (
-        $3::TIMESTAMPTZ IS NULL OR inserted_at <= $3::TIMESTAMPTZ
+FROM v1_runs_olap
+WHERE (
+    $1::UUID IS NULL OR parent_task_external_id = $1::UUID
+) AND (
+    $2::UUID IS NULL
+    OR (id, inserted_at) IN (
+        SELECT etr.run_id, etr.run_inserted_at
+        FROM v1_event_lookup_table_olap lt
+        JOIN v1_events_olap e ON (lt.tenant_id, lt.event_id, lt.event_seen_at) = (e.tenant_id, e.id, e.seen_at)
+        JOIN v1_event_to_run_olap etr ON (e.id, e.seen_at) = (etr.event_id, etr.event_seen_at)
+        WHERE
+            lt.tenant_id = $3::uuid
+            AND lt.external_id = $2::UUID
     )
-    AND (
-        $4::UUID[] IS NULL OR workflow_id = ANY($4::UUID[])
+)
+AND (
+    $4::text[] IS NULL
+    OR $5::text[] IS NULL
+    OR EXISTS (
+        SELECT 1 FROM jsonb_each_text(additional_metadata) kv
+        JOIN LATERAL (
+            SELECT unnest($4::text[]) AS k,
+                unnest($5::text[]) AS v
+        ) AS u ON kv.key = u.k AND kv.value = u.v
     )
-    AND external_id IN (
-        -- todo: indexing - go through the lookup table
-        SELECT external_id
-        FROM task_external_ids
-    )
+)
+AND tenant_id = $3::UUID
+AND inserted_at >= $6::TIMESTAMPTZ
+AND (
+    $7::TIMESTAMPTZ IS NULL OR inserted_at <= $7::TIMESTAMPTZ
+)
+AND (
+    $8::UUID[] IS NULL OR workflow_id = ANY($8::UUID[])
+)
 GROUP BY tenant_id
 `
 
 type GetTenantStatusMetricsParams struct {
+	ParentTaskExternalId      *uuid.UUID         `json:"parentTaskExternalId"`
+	TriggeringEventExternalId *uuid.UUID         `json:"triggeringEventExternalId"`
 	Tenantid                  uuid.UUID          `json:"tenantid"`
+	AdditionalMetaKeys        []string           `json:"additionalMetaKeys"`
+	AdditionalMetaValues      []string           `json:"additionalMetaValues"`
 	Createdafter              pgtype.Timestamptz `json:"createdafter"`
 	CreatedBefore             pgtype.Timestamptz `json:"createdBefore"`
 	WorkflowIds               []uuid.UUID        `json:"workflowIds"`
-	ParentTaskExternalId      *uuid.UUID         `json:"parentTaskExternalId"`
-	TriggeringEventExternalId *uuid.UUID         `json:"triggeringEventExternalId"`
-	AdditionalMetaKeys        []string           `json:"additionalMetaKeys"`
-	AdditionalMetaValues      []string           `json:"additionalMetaValues"`
 }
 
 type GetTenantStatusMetricsRow struct {
@@ -1236,14 +1217,14 @@ type GetTenantStatusMetricsRow struct {
 
 func (q *Queries) GetTenantStatusMetrics(ctx context.Context, db DBTX, arg GetTenantStatusMetricsParams) (*GetTenantStatusMetricsRow, error) {
 	row := db.QueryRow(ctx, getTenantStatusMetrics,
+		arg.ParentTaskExternalId,
+		arg.TriggeringEventExternalId,
 		arg.Tenantid,
+		arg.AdditionalMetaKeys,
+		arg.AdditionalMetaValues,
 		arg.Createdafter,
 		arg.CreatedBefore,
 		arg.WorkflowIds,
-		arg.ParentTaskExternalId,
-		arg.TriggeringEventExternalId,
-		arg.AdditionalMetaKeys,
-		arg.AdditionalMetaValues,
 	)
 	var i GetTenantStatusMetricsRow
 	err := row.Scan(

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -1041,7 +1041,7 @@ SELECT
     ) :: TIMESTAMPTZ AS minute_bucket,
     COUNT(*) FILTER (WHERE readable_status = 'COMPLETED') AS completed_count,
     COUNT(*) FILTER (WHERE readable_status = 'FAILED') AS failed_count
-FROM v1_statuses_olap
+FROM v1_tasks_olap -- todo: probably need indexing?
 WHERE
     tenant_id = $2::UUID
     AND inserted_at BETWEEN $3::TIMESTAMPTZ AND $4::TIMESTAMPTZ
@@ -1195,7 +1195,7 @@ SELECT
     COUNT(*) FILTER (WHERE readable_status = 'CANCELLED') AS total_cancelled,
     COUNT(*) FILTER (WHERE readable_status = 'FAILED') AS total_failed,
     COUNT(*) FILTER (WHERE readable_status = 'EVICTED') AS total_evicted
-FROM v1_statuses_olap
+FROM v1_tasks_olap
 WHERE
     tenant_id = $1::UUID
     AND inserted_at >= $2::TIMESTAMPTZ
@@ -1206,6 +1206,7 @@ WHERE
         $4::UUID[] IS NULL OR workflow_id = ANY($4::UUID[])
     )
     AND external_id IN (
+        -- todo: indexing - go through the lookup table
         SELECT external_id
         FROM task_external_ids
     )

--- a/sql/schema/v1-olap.sql
+++ b/sql/schema/v1-olap.sql
@@ -301,18 +301,19 @@ CREATE TABLE v1_dag_to_task_olap (
 );
 
 -- STATUS DEFINITION --
-CREATE TYPE v1_status_kind AS ENUM ('TASK', 'DAG');
+-- these are basically unused
+-- CREATE TYPE v1_status_kind AS ENUM ('TASK', 'DAG');
 
-CREATE TABLE v1_statuses_olap (
-    external_id UUID NOT NULL,
-    inserted_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    tenant_id UUID NOT NULL,
-    workflow_id UUID NOT NULL,
-    kind v1_run_kind NOT NULL,
-    readable_status v1_readable_status_olap NOT NULL DEFAULT 'QUEUED',
+-- CREATE TABLE v1_statuses_olap (
+--     external_id UUID NOT NULL,
+--     inserted_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+--     tenant_id UUID NOT NULL,
+--     workflow_id UUID NOT NULL,
+--     kind v1_run_kind NOT NULL,
+--     readable_status v1_readable_status_olap NOT NULL DEFAULT 'QUEUED',
 
-    PRIMARY KEY (external_id, inserted_at)
-);
+--     PRIMARY KEY (external_id, inserted_at)
+-- );
 
 
 -- EVENT DEFINITIONS --
@@ -836,81 +837,83 @@ REFERENCING NEW TABLE AS new_rows
 FOR EACH STATEMENT
 EXECUTE FUNCTION v1_dags_olap_status_update_function();
 
-CREATE OR REPLACE FUNCTION v1_runs_olap_insert_function()
-RETURNS TRIGGER AS
-$$
-BEGIN
-    INSERT INTO v1_statuses_olap (
-        external_id,
-        inserted_at,
-        tenant_id,
-        workflow_id,
-        kind,
-        readable_status
-    )
-    SELECT
-        external_id,
-        inserted_at,
-        tenant_id,
-        workflow_id,
-        kind,
-        readable_status
-    FROM new_rows
-    ON CONFLICT (external_id, inserted_at) DO NOTHING;
+-- basically unused if we use `v1_runs_olap` instead of `v1_statuses_olap`
+-- CREATE OR REPLACE FUNCTION v1_runs_olap_insert_function()
+-- RETURNS TRIGGER AS
+-- $$
+-- BEGIN
+--     INSERT INTO v1_statuses_olap (
+--         external_id,
+--         inserted_at,
+--         tenant_id,
+--         workflow_id,
+--         kind,
+--         readable_status
+--     )
+--     SELECT
+--         external_id,
+--         inserted_at,
+--         tenant_id,
+--         workflow_id,
+--         kind,
+--         readable_status
+--     FROM new_rows
+--     ON CONFLICT (external_id, inserted_at) DO NOTHING;
 
-    RETURN NULL;
-END;
-$$
-LANGUAGE plpgsql;
+--     RETURN NULL;
+-- END;
+-- $$
+-- LANGUAGE plpgsql;
 
-CREATE TRIGGER v1_runs_olap_status_insert_trigger
-AFTER INSERT ON v1_runs_olap
-REFERENCING NEW TABLE AS new_rows
-FOR EACH STATEMENT
-EXECUTE FUNCTION v1_runs_olap_insert_function();
+-- CREATE TRIGGER v1_runs_olap_status_insert_trigger
+-- AFTER INSERT ON v1_runs_olap
+-- REFERENCING NEW TABLE AS new_rows
+-- FOR EACH STATEMENT
+-- EXECUTE FUNCTION v1_runs_olap_insert_function();
 
+-- basically unused
 -- We use INSERT INTO rather than UPDATE for ensuring this query is fast on TimescaleDB,
 -- which does not have effective runtime partition pruning on UPDATE and would involve scanning
 -- every partition in v1_statuses_olap.
-CREATE OR REPLACE FUNCTION v1_runs_olap_status_update_function()
-RETURNS TRIGGER AS
-$$
-BEGIN
-    INSERT INTO v1_statuses_olap (
-        external_id,
-        inserted_at,
-        tenant_id,
-        workflow_id,
-        kind,
-        readable_status
-    )
-    -- DISTINCT ON: nothing constraint-enforces (external_id, inserted_at)
-    -- uniqueness across new_rows, and ON CONFLICT DO UPDATE errors if a single
-    -- statement affects the same row twice. On duplicates, keep the
-    -- highest-priority status.
-    SELECT DISTINCT ON (external_id, inserted_at)
-        external_id,
-        inserted_at,
-        tenant_id,
-        workflow_id,
-        kind,
-        readable_status
-    FROM new_rows
-    ORDER BY external_id, inserted_at, v1_status_to_priority(readable_status) DESC
-    ON CONFLICT (external_id, inserted_at) DO UPDATE
-    SET readable_status = EXCLUDED.readable_status
-    WHERE v1_statuses_olap.readable_status IS DISTINCT FROM EXCLUDED.readable_status;
+-- CREATE OR REPLACE FUNCTION v1_runs_olap_status_update_function()
+-- RETURNS TRIGGER AS
+-- $$
+-- BEGIN
+--     INSERT INTO v1_statuses_olap (
+--         external_id,
+--         inserted_at,
+--         tenant_id,
+--         workflow_id,
+--         kind,
+--         readable_status
+--     )
+--     -- DISTINCT ON: nothing constraint-enforces (external_id, inserted_at)
+--     -- uniqueness across new_rows, and ON CONFLICT DO UPDATE errors if a single
+--     -- statement affects the same row twice. On duplicates, keep the
+--     -- highest-priority status.
+--     SELECT DISTINCT ON (external_id, inserted_at)
+--         external_id,
+--         inserted_at,
+--         tenant_id,
+--         workflow_id,
+--         kind,
+--         readable_status
+--     FROM new_rows
+--     ORDER BY external_id, inserted_at, v1_status_to_priority(readable_status) DESC
+--     ON CONFLICT (external_id, inserted_at) DO UPDATE
+--     SET readable_status = EXCLUDED.readable_status
+--     WHERE v1_statuses_olap.readable_status IS DISTINCT FROM EXCLUDED.readable_status;
 
-    RETURN NULL;
-END;
-$$
-LANGUAGE plpgsql;
+--     RETURN NULL;
+-- END;
+-- $$
+-- LANGUAGE plpgsql;
 
-CREATE TRIGGER v1_runs_olap_status_update_trigger
-AFTER UPDATE ON v1_runs_olap
-REFERENCING NEW TABLE AS new_rows
-FOR EACH STATEMENT
-EXECUTE FUNCTION v1_runs_olap_status_update_function();
+-- CREATE TRIGGER v1_runs_olap_status_update_trigger
+-- AFTER UPDATE ON v1_runs_olap
+-- REFERENCING NEW TABLE AS new_rows
+-- FOR EACH STATEMENT
+-- EXECUTE FUNCTION v1_runs_olap_status_update_function();
 
 CREATE OR REPLACE FUNCTION v1_events_lookup_table_olap_insert_function()
 RETURNS TRIGGER AS


### PR DESCRIPTION
# Description

Part 1 of a few bits of cleanup that'll help us consolidate the cloud repo and this one. I can't see why we need this table, although maybe I'm missing it. We only rely on it for hypertables in cloud and for the status metrics in the OSS, and we could also just use the runs table for those AFAICT, and get rid of all of the churn on this table.

Let me know if I'm missing something obvious here 🤷  I'm thinking we can ship this and then just drop that table after, or at least shut off the triggers into it...

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI use here

</details>
