### PR TITLE
fix(typescript-sdk): resolve config yaml path against cwd

### DIFF
--- a/sdks/typescript/src/util/config-loader/config-loader.test.ts
+++ b/sdks/typescript/src/util/config-loader/config-loader.test.ts
@@ -1,6 +1,13 @@
+import * as fs from 'fs';
+import * as path from 'path';
 import { ChannelCredentials } from 'nice-grpc';
 import { ConfigLoader } from './config-loader';
 import { HatchetClient } from '@hatchet/v1';
+
+// Fixtures live alongside this test file. Tests are allowed to know their own
+// location via __dirname; the library code under test must not rely on that
+// (see config-loader.ts) since it may be installed inside node_modules.
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
 
 describe('ConfigLoader', () => {
   beforeEach(() => {
@@ -72,7 +79,7 @@ describe('ConfigLoader', () => {
       ConfigLoader.loadClientConfig(
         {},
         {
-          path: './fixtures/not-found.yaml',
+          path: path.join(FIXTURES_DIR, 'not-found.yaml'),
         }
       )
     ).toThrow();
@@ -84,7 +91,7 @@ describe('ConfigLoader', () => {
       ConfigLoader.loadClientConfig(
         {},
         {
-          path: './fixtures/.hatchet-invalid.yaml',
+          path: path.join(FIXTURES_DIR, '.hatchet-invalid.yaml'),
         }
       )
     ).toThrow();
@@ -94,7 +101,7 @@ describe('ConfigLoader', () => {
     const config = ConfigLoader.loadClientConfig(
       {},
       {
-        path: './fixtures/.hatchet.yaml',
+        path: path.join(FIXTURES_DIR, '.hatchet.yaml'),
       }
     );
     expect(config).toEqual({
@@ -140,29 +147,43 @@ describe('ConfigLoader', () => {
     expect(client.config.cancellation_warning_threshold).toEqual(300);
   });
 
-  xit('should attempt to load the root .hatchet.yaml config', () => {
-    //  i'm not sure the best way to test this, maybe spy on readFileSync called with
+  describe('default path resolution (process.cwd())', () => {
+    const cwdConfigPath = path.join(process.cwd(), '.hatchet.yaml');
+
+    afterEach(() => {
+      if (fs.existsSync(cwdConfigPath)) {
+        fs.unlinkSync(cwdConfigPath);
+      }
+    });
+
+    it('should load a .hatchet.yaml that actually exists at the caller cwd', () => {
+      fs.writeFileSync(cwdConfigPath, "namespace: from-cwd-yaml\n");
+
+      const config = ConfigLoader.loadYamlConfig();
+
+      expect(config).toEqual({ namespace: 'from-cwd-yaml' });
+    });
+
+    it('should return undefined when no .hatchet.yaml exists at the caller cwd', () => {
+      expect(fs.existsSync(cwdConfigPath)).toBe(false);
+      expect(ConfigLoader.loadYamlConfig()).toBeUndefined();
+    });
+  });
+
+  it('should resolve an explicit relative config path against process.cwd(), not this module\'s own directory', () => {
+    // Regression test for a bug where an explicit relative `path` was resolved via
+    // path.join(__dirname, path) -- i.e. relative to config-loader.ts's own location
+    // (which, when the SDK is installed as a dependency, is inside node_modules) --
+    // instead of the caller's working directory.
+    const relativeDir = path.relative(process.cwd(), FIXTURES_DIR);
+
     const config = ConfigLoader.loadClientConfig(
       {},
       {
-        path: './fixtures/.hatchet.yaml',
+        path: path.join(relativeDir, '.hatchet.yaml'),
       }
     );
-    expect(config).toEqual({
-      token:
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJncnBjX2Jyb2FkY2FzdF9hZGRyZXNzIjoiMTI3LjAuMC4xOjgwODAiLCJzZXJ2ZXJfdXJsIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwIiwic3ViIjoiNzA3ZDA4NTUtODBhYi00ZTFmLWExNTYtZjFjNDU0NmNiZjUyIn0K.abcdef',
-      host_port: 'HOST_PORT_YAML',
-      tls_config: {
-        tls_strategy: 'tls',
-        cert_file: 'TLS_CERT_FILE_YAML',
-        key_file: 'TLS_KEY_FILE_YAML',
-        ca_file: 'TLS_ROOT_CA_FILE_YAML',
-        server_name: 'TLS_SERVER_NAME_YAML',
-      },
-      healthcheck: {
-        enabled: true,
-        port: 8002,
-      },
-    });
+
+    expect(config?.host_port).toEqual('HOST_PORT_YAML');
   });
 });

--- a/sdks/typescript/src/util/config-loader/config-loader.ts
+++ b/sdks/typescript/src/util/config-loader/config-loader.ts
@@ -215,11 +215,15 @@ export class ConfigLoader {
   }
 
   static loadYamlConfig(path?: string): ClientConfig | undefined {
+    // Resolve relative to the caller's current working directory, not this
+    // module's own install directory (which, when the SDK is consumed as a
+    // dependency, would be somewhere inside node_modules). `default_yaml_config_path`
+    // is already an absolute path rooted at process.cwd(), and p.resolve leaves an
+    // already-absolute `path` untouched, so this correctly handles both cases.
+    const resolvedPath = path ? p.resolve(process.cwd(), path) : this.default_yaml_config_path;
+
     try {
-      const configFile = readFileSync(
-        p.join(__dirname, path ?? this.default_yaml_config_path),
-        'utf8'
-      );
+      const configFile = readFileSync(resolvedPath, 'utf8');
 
       const config = parse(configFile);
 


### PR DESCRIPTION
Fixes #4591

# Description

`ConfigLoader.loadYamlConfig` (`sdks/typescript/src/util/config-loader/config-loader.ts`) resolved the yaml config path with `path.join(__dirname, path ?? this.default_yaml_config_path)`. Since `default_yaml_config_path` is already an absolute path (`path.join(process.cwd(), '.hatchet.yaml')`), and `path.join` (unlike `path.resolve`) does not treat an absolute second segment as a root reset, this always produced a nonexistent path such as `<sdk-install-dir>/dist/util/config-loader/home/<user>/project/.hatchet.yaml`.

The practical effect:
- A real `.hatchet.yaml` in the project root was **silently never loaded** — `readFileSync` throws `ENOENT`, and since `path` is `undefined` in the default case, the `catch` block swallows the error and returns `undefined` with no warning.
- An explicit `config_path` passed to `HatchetClient` was also broken, since it was resolved relative to the SDK's own install directory (`__dirname`, i.e. inside `node_modules` when installed as a dependency) instead of the caller's project directory.

Fixed by resolving with `path.resolve(process.cwd(), path)` when an explicit path is given, and using the already-absolute default path as-is otherwise. `path.resolve` correctly no-ops when `path` is already absolute, so both cases are handled by the one line.

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [x] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed
- [x] `config-loader.ts`: resolve `loadYamlConfig`'s target path with `path.resolve(process.cwd(), path)` instead of `path.join(__dirname, ...)`
- [x] `config-loader.test.ts`: fixed the two existing yaml-override tests, which were only passing by coincidence — their relative fixture paths (`./fixtures/.hatchet.yaml`) happened to align with `__dirname` of the module itself rather than being resolved against a real caller cwd. They now build absolute fixture paths via `path.join(__dirname, 'fixtures', ...)` in the test file (legitimate, since test code — unlike library code — is allowed to know its own location)
- [x] Replaced the previously skipped test (`xit('should attempt to load the root .hatchet.yaml config'...)`, which had a "not sure the best way to test this" comment) with real coverage: writes/removes a temp `.hatchet.yaml` at `process.cwd()` and asserts `loadYamlConfig()` picks it up, plus a case asserting `undefined` is returned when no file exists
- [x] Added a regression test asserting an explicit relative `config_path` resolves against `process.cwd()`, not the module's own directory

## Checklist
Changes have been:
- [x] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)


## Testing
Added/updated unit tests in `config-loader.test.ts`:
- `should load a .hatchet.yaml that actually exists at the caller cwd` — writes a temp `.hatchet.yaml` to `process.cwd()`, calls `ConfigLoader.loadYamlConfig()` with no override, asserts the file is read
- `should return undefined when no .hatchet.yaml exists at the caller cwd`
- `should resolve an explicit relative config path against process.cwd(), not this module's own directory` — regression test for the `config_path` override case
- Existing yaml-override tests (`should favor yaml config over env vars`, `should throw an error if the file is not found`) updated to use absolute fixture paths so they actually validate real path resolution instead of coincidentally passing

Run with `npx jest config-loader` from `sdks/typescript`.

Root cause and repro originally identified in the linked issue, including a standalone repro script showing `ConfigLoader.loadYamlConfig()` returning `undefined` for a `.hatchet.yaml` that exists at the documented default location.

---
<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>
- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._
- **Details**: Claude (Anthropic) was used to diagnose the root cause from the issue report,
</details>