### PR TITLE
fix: stop resource limit alert spam when meter window is empty

### DIFF
--- a/pkg/repository/sqlcv1/tenant_limits.sql
+++ b/pkg/repository/sqlcv1/tenant_limits.sql
@@ -66,6 +66,10 @@ FROM input_values iv
 ON CONFLICT ("tenantId", "resource") DO UPDATE SET
     "limitValue" = EXCLUDED."limitValue",
     "alarmValue" = EXCLUDED."alarmValue",
+    -- Keep an existing window when the input omits one (NULL after NULLIF), so
+    -- partial entitlement syncs cannot clear the meter window and break alert dedupe.
+    "window" = COALESCE(EXCLUDED."window", "TenantResourceLimit"."window"),
+    "customValueMeter" = EXCLUDED."customValueMeter",
     "updatedAt" = CURRENT_TIMESTAMP;
 
 -- name: InsertTenantResourceLimitsIfNotExists :exec

--- a/pkg/repository/sqlcv1/tenant_limits.sql.go
+++ b/pkg/repository/sqlcv1/tenant_limits.sql.go
@@ -391,6 +391,10 @@ FROM input_values iv
 ON CONFLICT ("tenantId", "resource") DO UPDATE SET
     "limitValue" = EXCLUDED."limitValue",
     "alarmValue" = EXCLUDED."alarmValue",
+    -- Keep an existing window when the input omits one (NULL after NULLIF), so
+    -- partial entitlement syncs cannot clear the meter window and break alert dedupe.
+    "window" = COALESCE(EXCLUDED."window", "TenantResourceLimit"."window"),
+    "customValueMeter" = EXCLUDED."customValueMeter",
     "updatedAt" = CURRENT_TIMESTAMP
 `
 

--- a/pkg/repository/sqlcv1/ticker.sql
+++ b/pkg/repository/sqlcv1/ticker.sql
@@ -359,7 +359,9 @@ new_alerts AS (
             FROM "TenantResourceLimitAlert" AS trla
             WHERE trla."resourceLimitId" = arl."resourceLimitId"
             AND trla."alertType" = arl."alertType"::"TenantResourceLimitAlertType"
-            AND trla."createdAt" >= NOW() - arl."window"::INTERVAL
+            -- Gauge resources (WORKER / WORKER_SLOT) have a null window; default to
+            -- 24h so Exhausted/Alarm alerts cannot re-fire on every ticker poll.
+            AND trla."createdAt" >= NOW() - COALESCE(NULLIF(arl."window", '')::INTERVAL, INTERVAL '24 hours')
         ) AS "existingAlert"
     FROM
         alerting_resource_limits AS arl

--- a/pkg/repository/sqlcv1/ticker.sql.go
+++ b/pkg/repository/sqlcv1/ticker.sql.go
@@ -684,7 +684,9 @@ new_alerts AS (
             FROM "TenantResourceLimitAlert" AS trla
             WHERE trla."resourceLimitId" = arl."resourceLimitId"
             AND trla."alertType" = arl."alertType"::"TenantResourceLimitAlertType"
-            AND trla."createdAt" >= NOW() - arl."window"::INTERVAL
+            -- Gauge resources (WORKER / WORKER_SLOT) have a null window; default to
+            -- 24h so Exhausted/Alarm alerts cannot re-fire on every ticker poll.
+            AND trla."createdAt" >= NOW() - COALESCE(NULLIF(arl."window", '')::INTERVAL, INTERVAL '24 hours')
         ) AS "existingAlert"
     FROM
         alerting_resource_limits AS arl

--- a/pkg/repository/tenant_limit_test.go
+++ b/pkg/repository/tenant_limit_test.go
@@ -21,7 +21,9 @@ import (
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 )
 
-// upsertAffectedFields are the columns UpsertTenantResourceLimits updates on conflict.
+// upsertAffectedFields are the columns UpsertTenantResourceLimits updates on conflict
+// (limit/alarm/updatedAt). Window/customValueMeter are also updated on upsert, but
+// insert-only self-heal tests only need these fields to detect a DO UPDATE clobber.
 type upsertAffectedFields struct {
 	LimitValue int32
 	AlarmValue pgtype.Int4


### PR DESCRIPTION
## Summary
- Resource-limit alert dedupe treated a null/empty meter `window` as “no prior alert,” so Exhausted emails re-fired on every ticker poll (~every 5–15m after a FREE downgrade left usage over limit).
- Persist `window` / `customValueMeter` on `UpsertTenantResourceLimits` conflict (keep existing window when the input omits one).
- Fall back to a 24h dedupe interval when `window` is null/empty so gauge resources cannot spam either.

## Test plan
- [ ] Confirm a tenant with empty `TASK_RUN`/`EVENT` windows no longer inserts duplicate `TenantResourceLimitAlert` rows on successive ticker polls while still Exhausted
- [ ] Confirm entitlement upsert with an explicit window updates the stored window, and an upsert that omits window leaves the existing value
- [ ] Confirm WORKER/WORKER_SLOT Exhausted alerts (null window) dedupe for at least 24h