### PR TITLE
fix(sdks/ts): resolve config path against cwd instead of module dir

### DIFF
--- a/sdks/typescript/src/legacy/legacy-client.test.ts
+++ b/sdks/typescript/src/legacy/legacy-client.test.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import { ChannelCredentials, createChannel, createClientFactory } from 'nice-grpc';
 import { LegacyHatchetClient } from './legacy-client';
 
@@ -106,7 +107,7 @@ describe('Client', () => {
         },
       },
       {
-        config_path: './fixtures/.hatchet.yaml',
+        config_path: path.join(__dirname, '../util/config-loader/fixtures/.hatchet.yaml'),
         credentials: ChannelCredentials.createInsecure(),
       }
     );

--- a/sdks/typescript/src/util/config-loader/config-loader.test.ts
+++ b/sdks/typescript/src/util/config-loader/config-loader.test.ts
@@ -1,3 +1,5 @@
+import * as fs from 'fs';
+import * as path from 'path';
 import { ChannelCredentials } from 'nice-grpc';
 import { ConfigLoader } from './config-loader';
 import { HatchetClient } from '@hatchet/v1';
@@ -72,7 +74,7 @@ describe('ConfigLoader', () => {
       ConfigLoader.loadClientConfig(
         {},
         {
-          path: './fixtures/not-found.yaml',
+          path: path.join(__dirname, 'fixtures/not-found.yaml'),
         }
       )
     ).toThrow();
@@ -84,7 +86,7 @@ describe('ConfigLoader', () => {
       ConfigLoader.loadClientConfig(
         {},
         {
-          path: './fixtures/.hatchet-invalid.yaml',
+          path: path.join(__dirname, 'fixtures/.hatchet-invalid.yaml'),
         }
       )
     ).toThrow();
@@ -94,7 +96,7 @@ describe('ConfigLoader', () => {
     const config = ConfigLoader.loadClientConfig(
       {},
       {
-        path: './fixtures/.hatchet.yaml',
+        path: path.join(__dirname, 'fixtures/.hatchet.yaml'),
       }
     );
     expect(config).toEqual({
@@ -140,29 +142,18 @@ describe('ConfigLoader', () => {
     expect(client.config.cancellation_warning_threshold).toEqual(300);
   });
 
-  xit('should attempt to load the root .hatchet.yaml config', () => {
-    //  i'm not sure the best way to test this, maybe spy on readFileSync called with
-    const config = ConfigLoader.loadClientConfig(
-      {},
-      {
-        path: './fixtures/.hatchet.yaml',
-      }
-    );
-    expect(config).toEqual({
-      token:
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJncnBjX2Jyb2FkY2FzdF9hZGRyZXNzIjoiMTI3LjAuMC4xOjgwODAiLCJzZXJ2ZXJfdXJsIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwIiwic3ViIjoiNzA3ZDA4NTUtODBhYi00ZTFmLWExNTYtZjFjNDU0NmNiZjUyIn0K.abcdef',
-      host_port: 'HOST_PORT_YAML',
-      tls_config: {
-        tls_strategy: 'tls',
-        cert_file: 'TLS_CERT_FILE_YAML',
-        key_file: 'TLS_KEY_FILE_YAML',
-        ca_file: 'TLS_ROOT_CA_FILE_YAML',
-        server_name: 'TLS_SERVER_NAME_YAML',
-      },
-      healthcheck: {
-        enabled: true,
-        port: 8002,
-      },
-    });
+  it('should attempt to load the root .hatchet.yaml config', () => {
+    // Regression test for https://github.com/hatchet-dev/hatchet/issues/4591:
+    // loadYamlConfig() with no explicit path must resolve against process.cwd(),
+    // not the config-loader module's own directory.
+    const cwdConfigPath = path.join(process.cwd(), '.hatchet.yaml');
+    fs.writeFileSync(cwdConfigPath, 'namespace: from-cwd-yaml\n');
+
+    try {
+      const config = ConfigLoader.loadYamlConfig();
+      expect(config).toEqual({ namespace: 'from-cwd-yaml' });
+    } finally {
+      fs.unlinkSync(cwdConfigPath);
+    }
   });
 });

--- a/sdks/typescript/src/util/config-loader/config-loader.ts
+++ b/sdks/typescript/src/util/config-loader/config-loader.ts
@@ -216,10 +216,7 @@ export class ConfigLoader {
 
   static loadYamlConfig(path?: string): ClientConfig | undefined {
     try {
-      const configFile = readFileSync(
-        p.join(__dirname, path ?? this.default_yaml_config_path),
-        'utf8'
-      );
+      const configFile = readFileSync(p.join(path ?? this.default_yaml_config_path), 'utf8');
 
       const config = parse(configFile);
 


### PR DESCRIPTION
Fixes #4591

## Problem

`ConfigLoader.loadYamlConfig` joined the config path with `__dirname`:

```ts
p.join(__dirname, path ?? this.default_yaml_config_path)
```

`default_yaml_config_path` is already absolute (built from `process.cwd()`), and an explicit `config_path` is meant to be resolved relative to the caller's project, not the SDK's own install directory. `path.join` doesn't reset to root for an absolute second argument — it concatenates both — so the resulting path never existed. The `ENOENT` was silently swallowed whenever no explicit override was given, so a `.hatchet.yaml` in a project's root was never actually loaded.

## Fix

Drop the `__dirname` join. `readFileSync` resolves relative paths against `process.cwd()` on its own, so this correctly handles both the default (already-absolute) path and an explicit relative `config_path`, with no behavior to preserve for backward compatibility since the old resolution never worked for any caller.

## Test changes

- `config-loader.test.ts`: fixture references switched from `./fixtures/...` (previously resolved by luck against the module's own directory) to `path.join(__dirname, 'fixtures/...')` computed in the test file, since paths are now resolved against the caller's cwd rather than `__dirname`. Replaced the stale skipped test (`xit('should attempt to load the root .hatchet.yaml config', ...)`, which never actually exercised the default-cwd-loading path — see its own "not sure how to test this" comment) with a real regression test that writes a `.hatchet.yaml` to `process.cwd()` and confirms it's loaded.
- `legacy-client.test.ts`: same `./fixtures/.hatchet.yaml` fallout — this file's mocks are imported by `action-listener.test.ts`, `dispatcher-client.test.ts`, `admin-client.test.ts`, and `event-client.test.ts`, so the same fix here resolved the same failure across all four.

## Test evidence

- `npx jest src/util/config-loader` — 10 passed, 1 pre-existing skipped (unrelated stale invalid-yaml fixture, untouched).
- Full suite `npx jest --testMatch='**/*.test.ts'` — 228 passed, 2 failed (`admin.test.ts`, `event-client.test.ts`), 1 skipped. Confirmed via `git stash` that these same 2 failures exist identically on `main` before this change — unrelated pre-existing issues, not touched by this PR.
- `npx tsc --noEmit` — clean.
- `npx eslint`/`prettier --list-different` on the 3 changed files — clean. (Repo-wide `eslint:check` has 9 pre-existing errors in unrelated files, confirmed present on `main` without this change.)

---

<details open id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Claude Code was used to implement the agreed fix (from issue #4591 discussion with @gregfurman), update the fallout in dependent test files, trace the shared-import root cause behind the other 4 failing suites, and run/verify the full test/lint/type-check gates. Reviewed and verified manually before submission.

</details>
