### PR TITLE
fix(lite): exec the engine so SIGTERM reaches it

### DIFF
--- a/hack/lite/start.sh
+++ b/hack/lite/start.sh
@@ -22,5 +22,8 @@ if ./hatchet-admin authdisabled; then
   echo "====================================================================="
 fi
 
-# Run the Go binary
-./hatchet-lite --config ./config
+# Run the Go binary. exec replaces the shell so the engine becomes PID 1 and
+# receives SIGTERM from `docker stop` directly. Without it bash stays PID 1,
+# Linux skips the default signal disposition for PID 1, and the engine is
+# SIGKILLed at the end of the grace period without draining.
+exec ./hatchet-lite --config ./config


### PR DESCRIPTION
# Description

`hack/lite/start.sh:26` launched the engine without `exec`, so bash stayed PID 1 with `hatchet-lite` as its child. Linux does not apply default signal dispositions to PID 1, so bash absorbed the SIGTERM from `docker stop` and never forwarded it. Docker then waited out the full grace period and SIGKILLed the container, so the engine's graceful shutdown never ran and the container exited 137.

`exec` replaces the shell with the engine, so it becomes PID 1 and receives SIGTERM directly.

Fixes #4609

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] `exec` the `hatchet-lite` binary in `hack/lite/start.sh` so it becomes PID 1
- [x] Comment explaining why `exec` is load bearing, so it does not get dropped in a future edit

## Checklist

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable)

## Testing

Being straight with you: I have not built the lite image locally to watch the exit code change, so I have left the tested box unchecked. The reasoning is standard PID 1 signal behaviour and the repro in #4609 is precise. If you want it confirmed before merge:

```
docker run -d --name lite ghcr.io/hatchet-dev/hatchet/hatchet-lite-dev:latest
time docker stop lite && docker inspect -f '{{.State.ExitCode}}' lite
```

Before: stop takes the full grace period and exit code is 137. After: stop returns as soon as the engine drains and exit code is 0.

The migrate and quickstart steps above the change are unaffected, since `exec` is on the last line.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Claude Code (Opus) read the issue, checked `hack/lite/start.sh`, made the one-line change and drafted this description. I reviewed the diff and the reasoning before opening, and I chose to leave the tested checkbox unchecked rather than claim a run I did not do. Opened against an `accepted` issue per the policy.

</details>
