### PR TITLE
fix: acquire step batch configs on the caller's transaction

### DIFF
--- a/pkg/repository/scheduler.go
+++ b/pkg/repository/scheduler.go
@@ -42,7 +42,7 @@ type QueueRepository interface {
 	RequeueRateLimitedItems(ctx context.Context, tenantId uuid.UUID, queueName string) ([]*sqlcv1.RequeueRateLimitedQueueItemsRow, error)
 	GetDesiredLabels(ctx context.Context, tx *OptimisticTx, stepIds []uuid.UUID) (map[uuid.UUID][]*sqlcv1.GetDesiredLabelsRow, error)
 	GetStepSlotRequests(ctx context.Context, tx *OptimisticTx, stepIds []uuid.UUID) (map[uuid.UUID]map[string]int32, error)
-	GetStepBatchConfigs(ctx context.Context, stepIds []uuid.UUID) (map[string]bool, error)
+	GetStepBatchConfigs(ctx context.Context, tx *OptimisticTx, stepIds []uuid.UUID) (map[string]bool, error)
 	Cleanup()
 }
 

--- a/pkg/repository/scheduler_queue.go
+++ b/pkg/repository/scheduler_queue.go
@@ -894,24 +894,49 @@ func (d *queueRepository) GetStepSlotRequests(ctx context.Context, tx *Optimisti
 	return stepIdToRequests, nil
 }
 
-func (d *queueRepository) GetStepBatchConfigs(ctx context.Context, stepIds []uuid.UUID) (map[string]bool, error) {
+func (d *queueRepository) GetStepBatchConfigs(ctx context.Context, tx *OptimisticTx, stepIds []uuid.UUID) (map[string]bool, error) {
 	ctx, span := telemetry.NewSpan(ctx, "get-step-batch-configs")
 	defer span.End()
 
 	uniqueStepIds := listutils.Uniq(stepIds)
 	res := make(map[string]bool, len(uniqueStepIds))
 
-	for _, stepID := range uniqueStepIds {
-		res[stepID.String()] = false
+	stepIdsToLookup := make([]uuid.UUID, 0, len(uniqueStepIds))
+
+	for _, stepId := range uniqueStepIds {
+		if value, found := d.stepIdHasBatchConfigCache.Get(stepId); found {
+			res[stepId.String()] = value
+		} else {
+			res[stepId.String()] = false
+			stepIdsToLookup = append(stepIdsToLookup, stepId)
+		}
 	}
 
-	steps, err := d.queries.ListStepsWithBatchConfig(ctx, d.pool, uniqueStepIds)
+	if len(stepIdsToLookup) == 0 {
+		return res, nil
+	}
+
+	var queryTx sqlcv1.DBTX
+
+	if tx != nil {
+		queryTx = tx.tx
+	} else {
+		queryTx = d.pool
+	}
+
+	steps, err := d.queries.ListStepsWithBatchConfig(ctx, queryTx, stepIdsToLookup)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, step := range steps {
 		res[step.String()] = true
+	}
+
+	// cache the outcome for every looked-up step — steps without a batch config
+	// cache false, so the common case also skips the DB lookup
+	for _, stepId := range stepIdsToLookup {
+		d.stepIdHasBatchConfigCache.Add(stepId, res[stepId.String()])
 	}
 
 	return res, nil

--- a/pkg/repository/shared.go
+++ b/pkg/repository/shared.go
@@ -40,6 +40,7 @@ type sharedRepository struct {
 	stepsInWorkflowVersionCache *expirable.LRU[uuid.UUID, []*sqlcv1.ListStepsByWorkflowVersionIdsRow]
 	stepIdLabelsCache           *expirable.LRU[uuid.UUID, []*sqlcv1.GetDesiredLabelsRow]
 	stepIdSlotRequestsCache     *expirable.LRU[uuid.UUID, map[string]int32]
+	stepIdHasBatchConfigCache   *expirable.LRU[uuid.UUID, bool]
 
 	celParser       *cel.CELParser
 	env             *celgo.Env
@@ -69,6 +70,7 @@ func newSharedRepository(
 	stepsInWorkflowVersionCache := expirable.NewLRU(10000, func(key uuid.UUID, value []*sqlcv1.ListStepsByWorkflowVersionIdsRow) {}, 5*time.Minute)
 	stepIdLabelsCache := expirable.NewLRU(10000, func(key uuid.UUID, value []*sqlcv1.GetDesiredLabelsRow) {}, 5*time.Minute)
 	stepIdSlotRequestsCache := expirable.NewLRU(10000, func(key uuid.UUID, value map[string]int32) {}, 5*time.Minute)
+	stepIdHasBatchConfigCache := expirable.NewLRU(10000, func(key uuid.UUID, value bool) {}, 5*time.Minute)
 
 	celParser := cel.NewCELParser()
 
@@ -106,6 +108,7 @@ func newSharedRepository(
 		stepsInWorkflowVersionCache: stepsInWorkflowVersionCache,
 		stepIdLabelsCache:           stepIdLabelsCache,
 		stepIdSlotRequestsCache:     stepIdSlotRequestsCache,
+		stepIdHasBatchConfigCache:   stepIdHasBatchConfigCache,
 		celParser:                   celParser,
 		env:                         env,
 		celProgramCache:             celProgramCache,

--- a/pkg/scheduling/v1/batch_scheduler_test.go
+++ b/pkg/scheduling/v1/batch_scheduler_test.go
@@ -228,7 +228,7 @@ func (f *fakeQueueRepository) GetTaskRateLimits(context.Context, *v1repo.Optimis
 	return nil, nil
 }
 
-func (f *fakeQueueRepository) GetStepBatchConfigs(context.Context, []uuid.UUID) (map[string]bool, error) {
+func (f *fakeQueueRepository) GetStepBatchConfigs(context.Context, *v1repo.OptimisticTx, []uuid.UUID) (map[string]bool, error) {
 	return map[string]bool{}, nil
 }
 

--- a/pkg/scheduling/v1/queuer.go
+++ b/pkg/scheduling/v1/queuer.go
@@ -310,7 +310,7 @@ func (q *Queuer) loopQueue(ctx context.Context) {
 		desiredLabelsTime := time.Since(checkpoint)
 		checkpoint = time.Now()
 
-		batchConfigs, err := q.repo.GetStepBatchConfigs(ctx, stepIds)
+		batchConfigs, err := q.repo.GetStepBatchConfigs(ctx, nil, stepIds)
 
 		if err != nil {
 			span.RecordError(err)
@@ -847,7 +847,7 @@ func (q *Queuer) runOptimisticQueue(
 		}
 
 	}
-	batchConfigs, err := q.repo.GetStepBatchConfigs(ctx, stepIds)
+	batchConfigs, err := q.repo.GetStepBatchConfigs(ctx, tx, stepIds)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION

<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Mitigates a deadlock risk I noticed while staring at some traces, where `GetStepBatchConfigs` required a new connection from the pool within an existing tx, which immediately raises alarm bells. Also adds a cache to mirror behavior elsewhere. 

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [X] LRU cache for batch config
- [X] Deadlock mitigation

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Tested (unit, integration, or manually with steps specified)
- [X] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [X] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude w/ Fable for implementation

</details>
