### PR TITLE
fix(ts): account for slotCost and separate slot pools in worker health/metrics

### DIFF
--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Hatchet's TypeScript SDK will be documented in this chang
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- The worker's own `/health` `slots` field and `hatchet_worker_slots` gauge now charge each running task the `slotCost` it was registered with, instead of counting every running task as one slot.
+- Free capacity is now tracked per slot pool instead of summing the `default` and `durable` pools into one number. `/health` gained a `slotsByPool` field and `/metrics` gained a `hatchet_worker_available_slots{slot_type="..."}` gauge with the breakdown; the scalar `slots` value is now the minimum across the configured pools.
+
 ## [1.28.1] - 2026-07-30
 
 ### Fixed

--- a/sdks/typescript/src/v1/client/worker/health-server.test.ts
+++ b/sdks/typescript/src/v1/client/worker/health-server.test.ts
@@ -1,0 +1,86 @@
+import { ServerResponse } from 'node:http';
+import { HealthServer, workerStatus } from '@hatchet/v1/client/worker/health-server';
+
+const logger: any = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+  error: jest.fn(),
+};
+
+function fakeResponse() {
+  const chunks: string[] = [];
+  const res = {
+    writeHead: jest.fn(),
+    end: jest.fn((body?: string) => {
+      if (body) chunks.push(body);
+    }),
+  };
+  return { res: res as unknown as ServerResponse, body: () => chunks.join('') };
+}
+
+function buildServer(slots: number, slotsByPool: Record<string, number>) {
+  return new HealthServer(
+    8999,
+    () => workerStatus.HEALTHY,
+    'test-worker',
+    () => slots,
+    () => slotsByPool,
+    () => ['wf:task'],
+    () => ({}),
+    logger
+  );
+}
+
+describe('HealthServer slot reporting', () => {
+  it('includes the per-pool breakdown alongside the scalar slot count in /health', async () => {
+    const server = buildServer(0, { default: 0, durable: 3 });
+    const { res, body } = fakeResponse();
+
+    await (server as any).handleHealth(res);
+
+    expect(JSON.parse(body())).toMatchObject({
+      status: workerStatus.HEALTHY,
+      name: 'test-worker',
+      slots: 0,
+      slotsByPool: { default: 0, durable: 3 },
+    });
+  });
+
+  it('exposes a slot_type-labeled gauge on /metrics', async () => {
+    const server = buildServer(2, { default: 2, durable: 7 });
+    const { res, body } = fakeResponse();
+
+    await (server as any).handleMetrics(res);
+
+    const metrics = body();
+    expect(metrics).toContain('hatchet_worker_slots 2');
+    expect(metrics).toContain('hatchet_worker_available_slots{slot_type="default"} 2');
+    expect(metrics).toContain('hatchet_worker_available_slots{slot_type="durable"} 7');
+  });
+
+  it('drops pools that are no longer reported between scrapes', async () => {
+    let slotsByPool: Record<string, number> = { default: 2, durable: 7 };
+    const server = new HealthServer(
+      8999,
+      () => workerStatus.HEALTHY,
+      'test-worker',
+      () => 2,
+      () => slotsByPool,
+      () => [],
+      () => ({}),
+      logger
+    );
+
+    const first = fakeResponse();
+    await (server as any).handleMetrics(first.res);
+    expect(first.body()).toContain('hatchet_worker_available_slots{slot_type="durable"} 7');
+
+    slotsByPool = { default: 2 };
+
+    const second = fakeResponse();
+    await (server as any).handleMetrics(second.res);
+    expect(second.body()).toContain('hatchet_worker_available_slots{slot_type="default"} 2');
+    expect(second.body()).not.toContain('slot_type="durable"');
+  });
+});

--- a/sdks/typescript/src/v1/client/worker/health-server.ts
+++ b/sdks/typescript/src/v1/client/worker/health-server.ts
@@ -8,6 +8,8 @@ interface PromRegistry {
 }
 interface PromGauge {
   set(value: number): void;
+  set(labels: Record<string, string>, value: number): void;
+  reset(): void;
 }
 
 export const workerStatus = {
@@ -21,7 +23,13 @@ export type WorkerStatus = (typeof workerStatus)[keyof typeof workerStatus];
 interface HealthCheckResponse {
   status: string;
   name: string;
+  /**
+   * Free capacity, taken as the minimum across the worker's slot pools. Pools are
+   * independent, so this is the conservative number; `slotsByPool` has the breakdown.
+   */
   slots: number;
+  /** Free capacity per slot pool, e.g. `{ "default": 5, "durable": 3 }`. */
+  slotsByPool: Record<string, number>;
   actions: string[];
   labels: Record<string, string | number>;
   nodeVersion: string;
@@ -32,6 +40,7 @@ export class HealthServer {
   private register: PromRegistry | null = null;
   private workerStatusGauge: PromGauge | null = null;
   private workerSlotsGauge: PromGauge | null = null;
+  private workerSlotsByPoolGauge: PromGauge | null = null;
   private workerActionsGauge: PromGauge | null = null;
   private metricsInitialized: boolean = false;
 
@@ -40,6 +49,7 @@ export class HealthServer {
     private getStatus: () => WorkerStatus,
     private workerName: string,
     private getSlots: () => number,
+    private getSlotsByPool: () => Record<string, number>,
     private getActions: () => string[],
     private getLabels: () => Record<string, string | number>,
     private logger: Logger
@@ -65,6 +75,7 @@ export class HealthServer {
       status: this.getStatus(),
       name: this.workerName,
       slots: this.getSlots(),
+      slotsByPool: this.getSlotsByPool(),
       actions: this.getActions(),
       labels: this.getLabels(),
       nodeVersion: process.version,
@@ -94,10 +105,25 @@ export class HealthServer {
 
       this.workerSlotsGauge = new Gauge({
         name: 'hatchet_worker_slots',
-        help: 'Total slots available on the worker',
+        help: 'Free slots on the worker, taken as the minimum across its slot pools',
         registers: [this.register as never],
         collect: () => {
           this.workerSlotsGauge!.set(this.getSlots());
+        },
+      }) as PromGauge;
+
+      this.workerSlotsByPoolGauge = new Gauge({
+        name: 'hatchet_worker_available_slots',
+        help: 'Free slots on the worker, broken down by slot pool',
+        labelNames: ['slot_type'],
+        registers: [this.register as never],
+        collect: () => {
+          // Pools can disappear between scrapes (nothing registered against them anymore),
+          // so clear stale series rather than leaving them at their last value.
+          this.workerSlotsByPoolGauge!.reset();
+          for (const [slotType, slots] of Object.entries(this.getSlotsByPool())) {
+            this.workerSlotsByPoolGauge!.set({ slot_type: slotType }, slots);
+          }
         },
       }) as PromGauge;
 

--- a/sdks/typescript/src/v1/client/worker/worker-available-slots.test.ts
+++ b/sdks/typescript/src/v1/client/worker/worker-available-slots.test.ts
@@ -1,0 +1,178 @@
+import { InternalWorker } from '@hatchet/v1/client/worker/worker-internal';
+import { WorkflowDeclaration } from '../../declaration';
+import { SlotType } from '../../slot-types';
+
+const getAvailableSlots = (fakeThis: any): number =>
+  (InternalWorker.prototype as any).getAvailableSlots.call({
+    ...fakeThis,
+    // getAvailableSlots delegates to the per-pool breakdown.
+    getAvailableSlotsByPool: (InternalWorker.prototype as any).getAvailableSlotsByPool,
+  });
+
+const getAvailableSlotsByPool = (fakeThis: any): Record<string, number> =>
+  (InternalWorker.prototype as any).getAvailableSlotsByPool.call(fakeThis);
+
+const slotRequestsForAction = (fakeThis: any, actionId: string): Record<string, number> =>
+  (InternalWorker.prototype as any).slotRequestsForAction.call(fakeThis, actionId);
+
+describe('InternalWorker available slot reporting', () => {
+  it('charges a running task its actual slot cost', () => {
+    const fakeThis: any = {
+      slotConfig: { default: 10 },
+      running_slot_requests: { 'expensive-task-run/0': { default: 5 } },
+    };
+
+    expect(getAvailableSlots(fakeThis)).toBe(5);
+    expect(getAvailableSlotsByPool(fakeThis)).toEqual({ default: 5 });
+  });
+
+  it('does not conflate the default and durable pools', () => {
+    const fakeThis: any = {
+      slotConfig: { default: 5, durable: 3 },
+      running_slot_requests: {
+        'run-1/0': { default: 1 },
+        'run-2/0': { default: 1 },
+        'run-3/0': { default: 1 },
+        'run-4/0': { default: 1 },
+        'run-5/0': { default: 1 },
+      },
+    };
+
+    // The default pool is full, so no queued non-durable task can be picked up, even
+    // though the durable pool still has room.
+    expect(getAvailableSlots(fakeThis)).toBe(0);
+    expect(getAvailableSlotsByPool(fakeThis)).toEqual({ default: 0, durable: 3 });
+  });
+
+  it('reports the durable pool independently', () => {
+    const fakeThis: any = {
+      slotConfig: { default: 5, durable: 3 },
+      running_slot_requests: {
+        'run-1/0': { durable: 1 },
+        'run-2/0': { durable: 1 },
+      },
+    };
+
+    expect(getAvailableSlotsByPool(fakeThis)).toEqual({ default: 5, durable: 1 });
+    expect(getAvailableSlots(fakeThis)).toBe(1);
+  });
+
+  it('reports full capacity when nothing is running', () => {
+    const fakeThis: any = {
+      slotConfig: { default: 100, durable: 1000 },
+      running_slot_requests: {},
+    };
+
+    expect(getAvailableSlots(fakeThis)).toBe(100);
+    expect(getAvailableSlotsByPool(fakeThis)).toEqual({ default: 100, durable: 1000 });
+  });
+
+  it('never reports negative capacity when running costs exceed the pool', () => {
+    const fakeThis: any = {
+      slotConfig: { default: 2 },
+      running_slot_requests: {
+        'run-1/0': { default: 5 },
+      },
+    };
+
+    expect(getAvailableSlots(fakeThis)).toBe(0);
+    expect(getAvailableSlotsByPool(fakeThis)).toEqual({ default: 0 });
+  });
+
+  it('ignores costs charged against a pool the worker has not configured', () => {
+    const fakeThis: any = {
+      slotConfig: { default: 5 },
+      running_slot_requests: {
+        'run-1/0': { durable: 1 },
+      },
+    };
+
+    expect(getAvailableSlotsByPool(fakeThis)).toEqual({ default: 5 });
+  });
+
+  it('reports zero when no slot pools are configured', () => {
+    const fakeThis: any = { slotConfig: {}, running_slot_requests: {} };
+
+    expect(getAvailableSlots(fakeThis)).toBe(0);
+    expect(getAvailableSlotsByPool(fakeThis)).toEqual({});
+  });
+});
+
+describe('InternalWorker.slotRequestsForAction', () => {
+  it('uses the slot requests recorded when the action was registered', () => {
+    const fakeThis: any = {
+      action_slot_requests: { 'wf:heavy': { default: 5 } },
+      durable_action_set: new Set<string>(),
+    };
+
+    expect(slotRequestsForAction(fakeThis, 'wf:heavy')).toEqual({ default: 5 });
+  });
+
+  it('falls back to one default slot for an unregistered action', () => {
+    const fakeThis: any = {
+      action_slot_requests: {},
+      durable_action_set: new Set<string>(),
+    };
+
+    expect(slotRequestsForAction(fakeThis, 'wf:unknown')).toEqual({ [SlotType.Default]: 1 });
+  });
+
+  it('falls back to one durable slot for an unregistered durable action', () => {
+    const fakeThis: any = {
+      action_slot_requests: {},
+      durable_action_set: new Set(['wf:durable']),
+    };
+
+    expect(slotRequestsForAction(fakeThis, 'wf:durable')).toEqual({ [SlotType.Durable]: 1 });
+  });
+});
+
+describe('InternalWorker action registration records slot requests', () => {
+  it('records slotCost for tasks and the durable pool for durable tasks', () => {
+    const workflow = new WorkflowDeclaration({ name: 'slots-wf' });
+    workflow.task({ name: 'cheap', fn: async () => undefined });
+    workflow.task({ name: 'heavy', slotCost: 5, fn: async () => undefined });
+    workflow.durableTask({ name: 'durable-task', fn: async () => undefined });
+
+    const fakeThis: any = {
+      action_registry: {},
+      action_slot_requests: {},
+      durable_action_set: new Set<string>(),
+      eviction_policies: new Map(),
+      client: { config: { namespace: '' } },
+    };
+
+    (InternalWorker.prototype as any).registerActions.call(fakeThis, {
+      ...workflow.definition,
+      name: 'slots-wf',
+    });
+    InternalWorker.prototype.registerDurableActions.call(fakeThis, {
+      ...workflow.definition,
+      name: 'slots-wf',
+    } as any);
+
+    expect(fakeThis.action_slot_requests['slots-wf:cheap']).toEqual({ default: 1 });
+    expect(fakeThis.action_slot_requests['slots-wf:heavy']).toEqual({ default: 5 });
+    expect(fakeThis.action_slot_requests['slots-wf:durable-task']).toEqual({ durable: 1 });
+  });
+});
+
+describe('InternalWorker.cleanupRun releases held slots', () => {
+  it('drops the run from the slot bookkeeping', () => {
+    const fakeThis: any = {
+      slotConfig: { default: 10 },
+      futures: { 'run-1/0': {} },
+      contexts: {},
+      running_slot_requests: { 'run-1/0': { default: 5 } },
+      evictionManager: undefined,
+      client: { durableListener: { cleanupTaskState: jest.fn() } },
+    };
+
+    expect(getAvailableSlots(fakeThis)).toBe(5);
+
+    (InternalWorker.prototype as any).cleanupRun.call(fakeThis, 'run-1/0');
+
+    expect(fakeThis.running_slot_requests['run-1/0']).toBeUndefined();
+    expect(getAvailableSlots(fakeThis)).toBe(10);
+  });
+});

--- a/sdks/typescript/src/v1/client/worker/worker-internal.ts
+++ b/sdks/typescript/src/v1/client/worker/worker-internal.ts
@@ -37,7 +37,7 @@ import { Duration, durationToString, durationToMs } from '../duration';
 import { Context, DurableContext } from './context';
 import { parentRunContextManager } from '../../parent-run-context-vars';
 import { HealthServer, workerStatus, type WorkerStatus } from './health-server';
-import { SlotConfig } from '../../slot-types';
+import { SlotConfig, SlotType } from '../../slot-types';
 import { DurableEvictionManager } from './eviction/eviction-manager';
 import { EvictionPolicy, DEFAULT_DURABLE_TASK_EVICTION_POLICY } from './eviction/eviction-policy';
 import { DurableRunRecord } from './eviction/eviction-cache';
@@ -71,6 +71,10 @@ export class InternalWorker {
   listener: ActionListener | undefined;
   futures: Record<ActionKey, HatchetPromise<any>> = {};
   contexts: Record<ActionKey, Context<any, any>> = {};
+  /** Slot requests per registered action id, captured at registration time. */
+  action_slot_requests: Record<string, SlotRequests> = {};
+  /** Slot requests held by each currently running task, keyed the same way as `futures`. */
+  running_slot_requests: Record<ActionKey, SlotRequests> = {};
   slots?: number;
   durableSlots?: number;
   slotConfig: SlotConfig;
@@ -135,17 +139,64 @@ export class InternalWorker {
       () => this.status,
       this.name,
       () => this.getAvailableSlots(),
+      () => this.getAvailableSlotsByPool(),
       () => this.getRegisteredActions(),
       () => this.getFilteredLabels(),
       this.logger
     );
   }
 
+  /**
+   * Free capacity per slot pool. Pools are independent (a durable slot can't run a
+   * non-durable task), so they're reported separately, and each running task is
+   * charged the slot cost it was registered with rather than a flat one slot.
+   */
+  private getAvailableSlotsByPool(): Record<string, number> {
+    const consumed: Record<string, number> = {};
+
+    for (const requests of Object.values(this.running_slot_requests)) {
+      for (const [pool, cost] of Object.entries(requests)) {
+        consumed[pool] = (consumed[pool] || 0) + cost;
+      }
+    }
+
+    const available: Record<string, number> = {};
+    for (const [pool, total] of Object.entries(this.slotConfig)) {
+      available[pool] = Math.max(0, (total ?? 0) - (consumed[pool] || 0));
+    }
+
+    return available;
+  }
+
+  /**
+   * A single number for the `/health` `slots` field and the `hatchet_worker_slots` gauge.
+   * Since the pools aren't fungible, this is the most conservative reading: the smallest
+   * amount of free capacity across the configured pools. Use `slotsByPool` in the health
+   * response (or the `slot_type`-labeled gauges) for the full picture.
+   */
   private getAvailableSlots(): number {
-    // sum all the slots in the slot config
-    const totalSlots = Object.values(this.slotConfig).reduce((acc, curr) => acc + curr, 0);
-    const currentRuns = Object.keys(this.futures).length;
-    return Math.max(0, totalSlots - currentRuns);
+    const available = Object.values(this.getAvailableSlotsByPool());
+
+    if (available.length === 0) {
+      return 0;
+    }
+
+    return Math.min(...available);
+  }
+
+  /**
+   * Slot requests a task holds while it runs. Falls back to a single slot on the pool the
+   * action belongs to when the action wasn't registered through this worker.
+   */
+  private slotRequestsForAction(actionId: string): SlotRequests {
+    const registered = this.action_slot_requests[actionId];
+    if (registered) {
+      return registered;
+    }
+
+    return this.durable_action_set.has(actionId)
+      ? { [SlotType.Durable]: 1 }
+      : { [SlotType.Default]: 1 };
   }
 
   private getRegisteredActions(): string[] {
@@ -178,6 +229,7 @@ export class InternalWorker {
         acc[actionId] = (ctx: Context<any, any>) =>
           task.fn!(ctx.input, ctx as DurableContext<any, any>);
         this.durable_action_set.add(actionId);
+        this.action_slot_requests[actionId] = mapSlotRequestsPb(task, true);
         this.eviction_policies.set(
           actionId,
           task.evictionPolicy !== undefined
@@ -206,6 +258,8 @@ export class InternalWorker {
           acc[actionId] = (ctx: Context<any, any>) => task.fn!(ctx.input, ctx);
         }
 
+        this.action_slot_requests[actionId] = mapSlotRequestsPb(task, false);
+
         return acc;
       }, {});
 
@@ -220,6 +274,15 @@ export class InternalWorker {
           [onFailureTaskName(workflow)]: (ctx: Context<any, any>) => onFailureFn(ctx.input, ctx),
         }
       : {};
+
+    if (onFailureFn) {
+      const onFailureOpts =
+        typeof workflow.onFailure === 'object' ? (workflow.onFailure as { slotCost?: number }) : {};
+      this.action_slot_requests[onFailureTaskName(workflow)] = mapSlotRequestsPb(
+        onFailureOpts,
+        false
+      );
+    }
 
     this.action_registry = {
       ...this.action_registry,
@@ -512,6 +575,7 @@ export class InternalWorker {
     this.evictionManager?.unregisterRun(key);
     delete this.futures[key];
     delete this.contexts[key];
+    delete this.running_slot_requests[key];
   }
 
   /**
@@ -715,6 +779,7 @@ export class InternalWorker {
         })()
       );
       this.futures[actionKey] = future;
+      this.running_slot_requests[actionKey] = this.slotRequestsForAction(actionId);
 
       // Send the action event to the dispatcher
       const event = this.getStepActionEvent(
@@ -1237,11 +1302,14 @@ function isLeafTask(task: LeafableTask, allTasks: LeafableTask[]): boolean {
   return !allTasks.some((t) => t.parents?.some((p) => p.name === task.name));
 }
 
+/** Slots a task requests, keyed by pool name (see {@link SlotType}). */
+export type SlotRequests = Record<string, number>;
+
 /** Durable tasks stay on the durable pool; slotCost applies only to the default pool. */
 export function mapSlotRequestsPb(
-  task: { slotRequests?: Record<string, number>; slotCost?: number },
+  task: { slotRequests?: SlotRequests; slotCost?: number },
   isDurable: boolean
-): Record<string, number> {
+): SlotRequests {
   if (task.slotRequests) {
     return task.slotRequests;
   }


### PR DESCRIPTION
# Description

Fixes #4615

`InternalWorker.getAvailableSlots()` computed the `slots` value that this worker reports on its own `/health` endpoint and `hatchet_worker_slots` gauge as `(sum of every slot pool) - (number of running futures)`. That's wrong in two independent ways:

1. **`slotCost` was ignored.** Nothing recorded a task's slot cost while it ran, so a worker running one `slotCost: 5` task out of a 10-slot pool reported 9 slots free instead of 5.
2. **The `default` and `durable` pools were summed together.** They aren't fungible (a durable slot can't run a non-durable task), so with the default pool full and the durable pool empty, the worker reported free capacity that no queued non-durable task could actually use.

The fix captures each action's slot requests at registration time (reusing the existing `mapSlotRequestsPb`), records them against the run key when a task starts, and releases them in `cleanupRun`. Availability is then computed per pool.

Since the pools are separate, one number can't tell the whole story, so `/health` gained a `slotsByPool` breakdown and `/metrics` gained a `hatchet_worker_available_slots{slot_type="..."}` gauge. The existing scalar `slots` / `hatchet_worker_slots` is now the minimum across the configured pools, which is the conservative "how many more tasks can this worker definitely take" reading.

Blast radius is only this worker process's self-reported values. `slotConfig` is still sent to the engine once at registration and nothing re-reads local availability, so task assignment is untouched. The documented autoscaling signal (`hatchet_tenant_available_worker_slots`) is computed engine-side and is also unaffected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Track slot requests per registered action id (`action_slot_requests`) and per running task (`running_slot_requests`)
- [x] `getAvailableSlotsByPool()` charges each running task its registered `slotCost` against the pool it actually occupies
- [x] `getAvailableSlots()` returns the minimum free capacity across configured pools instead of a cross-pool sum
- [x] `/health` response gained `slotsByPool`
- [x] `/metrics` gained `hatchet_worker_available_slots{slot_type="..."}`, with stale label series reset between scrapes
- [x] Tests for slot-cost accounting, pool isolation, registration bookkeeping, slot release on cleanup, and the health/metrics output

## Checklist

Changes have been:

- [x] Tested (unit)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

`pnpm run test:unit` in `sdks/typescript`. The 15 new tests pass and `tsc --noEmit` is clean.

Note: `src/v1/client/admin.test.ts` and `src/clients/event/event-client.test.ts` fail with 6 failures on this branch, but they fail identically on a clean `main` checkout (assertions on `HatchetError` message formatting). Unrelated to this change.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Claude Code was used to trace the `slotCost`/`slotConfig` lifecycle through registration and the running-task path, write the implementation and tests, and confirm the pre-existing unrelated test failures against a clean checkout. Reviewed and verified manually before submission.

</details>
