### PR TITLE
fix: strip unsupported unicode escapes before writing payloads to jsonb

### DIFF
--- a/pkg/repository/jsonb.go
+++ b/pkg/repository/jsonb.go
@@ -23,6 +23,75 @@ func ValidateJSONB(jsonb []byte, fieldName string) error {
 	return nil
 }
 
+// nullEscape is the JSON escape sequence Postgres rejects with SQLSTATE 22P05
+// ("unsupported Unicode escape sequence") when casting to jsonb. JSON only
+// allows a lowercase `u` here and `0000` has no hex letters, so a plain byte
+// comparison covers every way it can be spelled.
+var nullEscape = []byte{'\\', 'u', '0', '0', '0', '0'}
+
+// SanitizeJSONB strips the characters Postgres refuses to store in a jsonb
+// column: `\u0000` escapes and raw NUL bytes. Both come in from data we don't
+// control (worker error messages, task outputs), and internal write paths like
+// the payload store can't reject them without wedging the queue consumer that
+// is trying to write them.
+//
+// The input is returned untouched when there is nothing to strip, so the common
+// case is one scan and no allocation.
+func SanitizeJSONB(jsonb []byte) []byte {
+	if !bytes.Contains(jsonb, nullEscape) && bytes.IndexByte(jsonb, 0) < 0 {
+		return jsonb
+	}
+
+	out := make([]byte, 0, len(jsonb))
+	inString := false
+
+	for i := 0; i < len(jsonb); {
+		c := jsonb[i]
+
+		switch {
+		case c == 0:
+			// a raw NUL byte is never valid inside a JSON document
+			i++
+		case !inString:
+			if c == '"' {
+				inString = true
+			}
+
+			out = append(out, c)
+			i++
+		case c == '\\':
+			// consume the escape sequence as a unit, otherwise an escaped
+			// backslash would make us misread the bytes after it as an escape
+			// of their own
+			if i+1 >= len(jsonb) {
+				out = append(out, c)
+				i++
+
+				continue
+			}
+
+			if i+len(nullEscape) <= len(jsonb) && bytes.Equal(jsonb[i:i+len(nullEscape)], nullEscape) {
+				i += len(nullEscape)
+
+				continue
+			}
+
+			out = append(out, c, jsonb[i+1])
+			i += 2
+		case c == '"':
+			inString = false
+
+			out = append(out, c)
+			i++
+		default:
+			out = append(out, c)
+			i++
+		}
+	}
+
+	return out
+}
+
 func isUnicodeValid(jsonb []byte) bool {
 	dec := json.NewDecoder(bytes.NewReader(jsonb))
 	for {

--- a/pkg/repository/jsonb_test.go
+++ b/pkg/repository/jsonb_test.go
@@ -43,3 +43,61 @@ func TestValidateJSONB_RejectsEncodedNull(t *testing.T) {
 		}
 	}
 }
+
+func TestSanitizeJSONB(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"clean object", `{"a":"b"}`, `{"a":"b"}`},
+		{"null escape in a value", `{"a":"b\u0000c"}`, `{"a":"bc"}`},
+		{"null escape in a key", `{"foo\u0000":"bar"}`, `{"foo":"bar"}`},
+		{"null escape in a nested value", `[{"a":"A","b":"B","c":"C\u0000"}]`, `[{"a":"A","b":"B","c":"C"}]`},
+		{"only a null escape", `{"a":"\u0000"}`, `{"a":""}`},
+		{"top level string", `"\u0000abc"`, `"abc"`},
+		{"escaped backslash is not the start of an escape", `{"a":"\\u0000"}`, `{"a":"\\u0000"}`},
+		{"escaped backslash followed by a null escape", `{"a":"\\\u0000"}`, `{"a":"\\"}`},
+		{"raw NUL byte", "{\"a\":\"b\x00c\"}", `{"a":"bc"}`},
+		{"empty", "", ""},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := string(SanitizeJSONB([]byte(c.in)))
+
+			if got != c.want {
+				t.Fatalf("SanitizeJSONB(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeJSONB_OutputPassesValidation(t *testing.T) {
+	cases := []string{
+		`{"a":"\u0000"}`,
+		`{"a":"\\\u0000"}`,
+		`{"foo\u0000":"bar"}`,
+		`{"f\u0000oo":"bar"}`,
+		`[{"f\u0000oo":"bar"}]`,
+		`[{"a":"A","b":"B","c":"C\u0000"}]`,
+		"{\"a\":\"b\x00c\"}",
+	}
+
+	for _, c := range cases {
+		sanitized := SanitizeJSONB([]byte(c))
+
+		if err := ValidateJSONB(sanitized, "field"); err != nil {
+			t.Fatalf("expected sanitized %q to validate, got %v", string(sanitized), err)
+		}
+	}
+}
+
+func TestSanitizeJSONB_DoesNotCopyCleanPayloads(t *testing.T) {
+	in := []byte(`{"a":"b"}`)
+	out := SanitizeJSONB(in)
+
+	if &in[0] != &out[0] {
+		t.Fatalf("expected a clean payload to be returned as-is, got a copy")
+	}
+}

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -3106,10 +3106,21 @@ func (r *OLAPRepositoryImpl) PutPayloads(ctx context.Context, tx sqlcv1.DBTX, te
 	externalKeys := make([]string, 0, len(putPayloadOpts))
 
 	for _, opt := range putPayloadOpts {
+		// same as the OLTP payload store: a single payload with a character
+		// Postgres can't store in jsonb would otherwise fail the whole batch
+		payload := SanitizeJSONB(opt.Payload)
+
+		if len(payload) != len(opt.Payload) {
+			r.l.Warn().Msgf(
+				"stripped unsupported unicode escapes from olap payload %s in tenant %s",
+				opt.ExternalId, tenantId,
+			)
+		}
+
 		externalIds = append(externalIds, opt.ExternalId)
 		insertedAts = append(insertedAts, opt.InsertedAt)
 		tenantIds = append(tenantIds, tenantId)
-		payloads = append(payloads, opt.Payload)
+		payloads = append(payloads, payload)
 		locations = append(locations, string(sqlcv1.V1PayloadLocationOlapINLINE))
 		externalKeys = append(externalKeys, "")
 	}

--- a/pkg/repository/payloadstore.go
+++ b/pkg/repository/payloadstore.go
@@ -217,12 +217,25 @@ func (p *payloadStoreRepositoryImpl) Store(ctx context.Context, tx sqlcv1.DBTX, 
 
 		seenPayloadUniqueKeys[uniqueKey] = struct{}{}
 
+		// payloads can carry data we don't control (worker error messages, task
+		// outputs), and Postgres rejects the whole insert if any of them contain
+		// a character it can't store in jsonb. Failing here means the message
+		// that triggered the write can never be acked, so strip instead.
+		inlineContent := SanitizeJSONB(payload.Payload)
+
+		if len(inlineContent) != len(payload.Payload) {
+			p.l.Warn().Msgf(
+				"stripped unsupported unicode escapes from %s payload for task %d in tenant %s",
+				payload.Type, payload.Id, tenantId,
+			)
+		}
+
 		taskIds = append(taskIds, payload.Id)
 		taskInsertedAts = append(taskInsertedAts, payload.InsertedAt)
 		payloadTypes = append(payloadTypes, string(payload.Type))
 		tenantIds = append(tenantIds, tenantId)
 		locations = append(locations, string(sqlcv1.V1PayloadLocationINLINE))
-		inlineContents = append(inlineContents, payload.Payload)
+		inlineContents = append(inlineContents, inlineContent)
 		externalIds = append(externalIds, payload.ExternalId)
 		externalLocationKeys = append(externalLocationKeys, "")
 	}


### PR DESCRIPTION
# Description

Failing a task can hard-fail in the `task-failed` pre-ack path when the error message contains a NUL character:

```
ERR error in pre-ack on msg task-failed: could not fail tasks: failed to fail tasks: failed to store task event payloads: failed to write payloads: ERROR: unsupported Unicode escape sequence (SQLSTATE 22P05)
```

Postgres can't represent `\u0000` in `jsonb`, so it rejects the insert. `FailTasks` marshals the worker's error message into the FAILED event data and hands it to the payload store, which writes it into `v1_payload.inline_content` (JSONB). Nothing on that path goes through `ValidateJSONB`, which only runs on API/gRPC ingest boundaries. So one task failing with a NUL in its error message (an LLM-generated message, some binary junk in a stack trace) fails the whole batch write, the message never gets acked, and the consumer keeps redelivering it.

The same output also goes to `OLAPRepository.PutPayloads` → `v1_payloads_olap.inline_content`, which is JSONB too, so that path can fail the same way.

Since these are internal write paths reacting to data that's already in the system, rejecting isn't useful, there's nothing the consumer can do with a rejection except get stuck again. Sanitizing keeps the failure path moving and loses only characters Postgres refused to store anyway.

Fixes #4611

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- Added `SanitizeJSONB` in `pkg/repository/jsonb.go`. Strips `\u0000` escapes and raw NUL bytes. The scan tracks string/escape state, so `\\u0000` (an escaped backslash followed by the literal text `u0000`) is left alone, matching what `ValidateJSONB` already considers valid.
- Applied it in `payloadStoreRepositoryImpl.Store` and `OLAPRepositoryImpl.PutPayloads`, with a warn log naming the tenant and payload when something is stripped.
- Unit tests for the sanitizer, including a check that sanitized output passes `ValidateJSONB` for every case the existing rejection test covers.

Clean payloads are returned as-is with no copy, so the cost on the normal path is one `bytes.Contains` plus one `IndexByte`.

## Checklist

Changes have been:

- [x] Tested (unit)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable)

## Testing

```
go test ./pkg/repository/ -run 'TestSanitizeJSONB|TestValidateJSONB' -v
```

All 16 pass. `go build ./pkg/... ./internal/...` and `go vet ./pkg/repository/` are clean.

Not covered by an integration test against a real Postgres, the existing tests in this package that need a DB spin up testcontainers and I didn't add one for this. Happy to if you'd prefer it.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Claude Code (Opus) used for tracing the write path, drafting the sanitizer and its tests, and drafting this description. Reviewed and edited by me.

</details>
