### PR TITLE
refactor: move the extension contract into pkg/scheduling

### DIFF
--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -858,8 +858,6 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 			return nil, nil, fmt.Errorf("could not create scheduling pool (v1alpha): %w", err)
 		}
 
-		pool.Extensions.Add(v1alpha.NewPrometheusExtension(promGate))
-
 		schedulingPoolV1 = pool
 		cleanupSchedulingPoolV1 = cleanupPool
 	} else {
@@ -885,11 +883,13 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 			return nil, nil, fmt.Errorf("could not create scheduling pool (v1): %w", err)
 		}
 
-		pool.Extensions.Add(v1.NewPrometheusExtension(promGate))
-
 		schedulingPoolV1 = pool
 		cleanupSchedulingPoolV1 = cleanupPool
 	}
+
+	// the prometheus extension is written against the shared extension contract
+	// in pkg/scheduling, so one registration serves either implementation
+	schedulingPoolV1.AddExtension(v1.NewPrometheusExtension(promGate))
 
 	cleanup = func() error {
 		log.Printf("cleaning up server config")

--- a/pkg/scheduling/extension.go
+++ b/pkg/scheduling/extension.go
@@ -1,0 +1,134 @@
+package scheduling
+
+import (
+	"context"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/google/uuid"
+
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
+	"github.com/hatchet-dev/hatchet/pkg/telemetry"
+)
+
+type PostAssignInput struct {
+	HasUnassignedStepRuns bool
+}
+
+type SnapshotInput struct {
+	Workers map[uuid.UUID]*WorkerCp
+
+	// WorkerSlotUtilization is the per-worker slot utilization summed across slot types.
+	WorkerSlotUtilization map[uuid.UUID]*SlotUtilization
+
+	// WorkerSlotUtilizationByType breaks WorkerSlotUtilization down by slot type.
+	WorkerSlotUtilizationByType map[uuid.UUID]map[string]*SlotUtilization
+}
+
+type SlotUtilization struct {
+	UtilizedSlots    int
+	NonUtilizedSlots int
+}
+
+type WorkerCp struct {
+	WorkerId uuid.UUID
+	MaxRuns  int
+	Labels   []*sqlcv1.ListManyWorkerLabelsRow
+	Name     string
+}
+
+type SlotCp struct {
+	WorkerId uuid.UUID
+	Used     bool
+}
+
+type SchedulerExtension interface {
+	SetTenants(tenants []*sqlcv1.Tenant)
+	ReportSnapshot(ctx context.Context, tenantId uuid.UUID, input *SnapshotInput)
+	PostAssign(tenantId uuid.UUID, input *PostAssignInput)
+	CleanupTenant(tenantId uuid.UUID) error
+	Cleanup() error
+}
+
+type Extensions struct {
+	mu   sync.RWMutex
+	exts []SchedulerExtension
+}
+
+func (e *Extensions) Add(ext SchedulerExtension) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.exts == nil {
+		e.exts = make([]SchedulerExtension, 0)
+	}
+
+	e.exts = append(e.exts, ext)
+}
+
+func (e *Extensions) ReportSnapshot(ctx context.Context, tenantId uuid.UUID, input *SnapshotInput) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	// Extensions run in their own goroutines. `ctx` is the scheduler-lifetime
+	// context (not a per-iteration one), so it's safe to hand to a fire-and-
+	// forget goroutine; each gets its own child span under the snapshot trace.
+	for _, ext := range e.exts {
+		f := ext.ReportSnapshot
+		go func() {
+			spanCtx, span := telemetry.NewSpan(ctx, "report-snapshot")
+			defer span.End()
+
+			f(spanCtx, tenantId, input)
+		}()
+	}
+}
+
+func (e *Extensions) PostAssign(tenantId uuid.UUID, input *PostAssignInput) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	for _, ext := range e.exts {
+		f := ext.PostAssign
+		go f(tenantId, input)
+	}
+}
+
+func (e *Extensions) CleanupTenant(tenantId uuid.UUID) error {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	eg := errgroup.Group{}
+
+	for _, ext := range e.exts {
+		f := ext.CleanupTenant
+		eg.Go(func() error { return f(tenantId) })
+	}
+
+	return eg.Wait()
+}
+
+func (e *Extensions) Cleanup() error {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	eg := errgroup.Group{}
+
+	for _, ext := range e.exts {
+		f := ext.Cleanup
+		eg.Go(f)
+	}
+
+	return eg.Wait()
+}
+
+func (e *Extensions) SetTenants(tenants []*sqlcv1.Tenant) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	for _, ext := range e.exts {
+		f := ext.SetTenants
+		go f(tenants)
+	}
+}

--- a/pkg/scheduling/scheduling.go
+++ b/pkg/scheduling/scheduling.go
@@ -48,6 +48,11 @@ type Pool interface {
 	GetResultsCh() chan *QueueResults
 	GetConcurrencyResultsCh() chan *ConcurrencyResults
 
+	// AddExtension registers a scheduler extension (metrics, autoscaling, ...)
+	// against the pool. Extensions are written once against the shared contract
+	// in this package and work with either implementation.
+	AddExtension(ext SchedulerExtension)
+
 	SetTenants(tenants []*sqlcv1.Tenant)
 	Replenish(ctx context.Context, tenantId uuid.UUID)
 

--- a/pkg/scheduling/v1/extension.go
+++ b/pkg/scheduling/v1/extension.go
@@ -1,134 +1,14 @@
 package v1
 
-import (
-	"context"
-	"sync"
+import "github.com/hatchet-dev/hatchet/pkg/scheduling"
 
-	"golang.org/x/sync/errgroup"
-
-	"github.com/google/uuid"
-
-	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
-	"github.com/hatchet-dev/hatchet/pkg/telemetry"
-)
-
-type PostAssignInput struct {
-	HasUnassignedStepRuns bool
-}
-
-type SnapshotInput struct {
-	Workers map[uuid.UUID]*WorkerCp
-
-	// WorkerSlotUtilization is the per-worker slot utilization summed across slot types.
-	WorkerSlotUtilization map[uuid.UUID]*SlotUtilization
-
-	// WorkerSlotUtilizationByType breaks WorkerSlotUtilization down by slot type.
-	WorkerSlotUtilizationByType map[uuid.UUID]map[string]*SlotUtilization
-}
-
-type SlotUtilization struct {
-	UtilizedSlots    int
-	NonUtilizedSlots int
-}
-
-type WorkerCp struct {
-	WorkerId uuid.UUID
-	MaxRuns  int
-	Labels   []*sqlcv1.ListManyWorkerLabelsRow
-	Name     string
-}
-
-type SlotCp struct {
-	WorkerId uuid.UUID
-	Used     bool
-}
-
-type SchedulerExtension interface {
-	SetTenants(tenants []*sqlcv1.Tenant)
-	ReportSnapshot(ctx context.Context, tenantId uuid.UUID, input *SnapshotInput)
-	PostAssign(tenantId uuid.UUID, input *PostAssignInput)
-	CleanupTenant(tenantId uuid.UUID) error
-	Cleanup() error
-}
-
-type Extensions struct {
-	mu   sync.RWMutex
-	exts []SchedulerExtension
-}
-
-func (e *Extensions) Add(ext SchedulerExtension) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
-	if e.exts == nil {
-		e.exts = make([]SchedulerExtension, 0)
-	}
-
-	e.exts = append(e.exts, ext)
-}
-
-func (e *Extensions) ReportSnapshot(ctx context.Context, tenantId uuid.UUID, input *SnapshotInput) {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
-
-	// Extensions run in their own goroutines. `ctx` is the scheduler-lifetime
-	// context (not a per-iteration one), so it's safe to hand to a fire-and-
-	// forget goroutine; each gets its own child span under the snapshot trace.
-	for _, ext := range e.exts {
-		f := ext.ReportSnapshot
-		go func() {
-			spanCtx, span := telemetry.NewSpan(ctx, "report-snapshot")
-			defer span.End()
-
-			f(spanCtx, tenantId, input)
-		}()
-	}
-}
-
-func (e *Extensions) PostAssign(tenantId uuid.UUID, input *PostAssignInput) {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
-
-	for _, ext := range e.exts {
-		f := ext.PostAssign
-		go f(tenantId, input)
-	}
-}
-
-func (e *Extensions) CleanupTenant(tenantId uuid.UUID) error {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
-
-	eg := errgroup.Group{}
-
-	for _, ext := range e.exts {
-		f := ext.CleanupTenant
-		eg.Go(func() error { return f(tenantId) })
-	}
-
-	return eg.Wait()
-}
-
-func (e *Extensions) Cleanup() error {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
-
-	eg := errgroup.Group{}
-
-	for _, ext := range e.exts {
-		f := ext.Cleanup
-		eg.Go(f)
-	}
-
-	return eg.Wait()
-}
-
-func (e *Extensions) SetTenants(tenants []*sqlcv1.Tenant) {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
-
-	for _, ext := range e.exts {
-		f := ext.SetTenants
-		go f(tenants)
-	}
-}
+// The extension contract crosses the engine boundary — cloud and OSS register
+// extensions into whichever pool implementation a shard runs — so it is
+// defined once in pkg/scheduling and aliased here.
+type PostAssignInput = scheduling.PostAssignInput
+type SnapshotInput = scheduling.SnapshotInput
+type SlotUtilization = scheduling.SlotUtilization
+type WorkerCp = scheduling.WorkerCp
+type SlotCp = scheduling.SlotCp
+type SchedulerExtension = scheduling.SchedulerExtension
+type Extensions = scheduling.Extensions

--- a/pkg/scheduling/v1/pool.go
+++ b/pkg/scheduling/v1/pool.go
@@ -114,6 +114,10 @@ func NewSchedulingPool(
 	}, nil
 }
 
+func (p *SchedulingPool) AddExtension(ext scheduling.SchedulerExtension) {
+	p.Extensions.Add(ext)
+}
+
 func (p *SchedulingPool) GetResultsCh() chan *QueueResults {
 	return p.resultsCh
 }

--- a/pkg/scheduling/v1alpha/extension.go
+++ b/pkg/scheduling/v1alpha/extension.go
@@ -1,134 +1,14 @@
 package v1alpha
 
-import (
-	"context"
-	"sync"
+import "github.com/hatchet-dev/hatchet/pkg/scheduling"
 
-	"golang.org/x/sync/errgroup"
-
-	"github.com/google/uuid"
-
-	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
-	"github.com/hatchet-dev/hatchet/pkg/telemetry"
-)
-
-type PostAssignInput struct {
-	HasUnassignedStepRuns bool
-}
-
-type SnapshotInput struct {
-	Workers map[uuid.UUID]*WorkerCp
-
-	// WorkerSlotUtilization is the per-worker slot utilization summed across slot types.
-	WorkerSlotUtilization map[uuid.UUID]*SlotUtilization
-
-	// WorkerSlotUtilizationByType breaks WorkerSlotUtilization down by slot type.
-	WorkerSlotUtilizationByType map[uuid.UUID]map[string]*SlotUtilization
-}
-
-type SlotUtilization struct {
-	UtilizedSlots    int
-	NonUtilizedSlots int
-}
-
-type WorkerCp struct {
-	WorkerId uuid.UUID
-	MaxRuns  int
-	Labels   []*sqlcv1.ListManyWorkerLabelsRow
-	Name     string
-}
-
-type SlotCp struct {
-	WorkerId uuid.UUID
-	Used     bool
-}
-
-type SchedulerExtension interface {
-	SetTenants(tenants []*sqlcv1.Tenant)
-	ReportSnapshot(ctx context.Context, tenantId uuid.UUID, input *SnapshotInput)
-	PostAssign(tenantId uuid.UUID, input *PostAssignInput)
-	CleanupTenant(tenantId uuid.UUID) error
-	Cleanup() error
-}
-
-type Extensions struct {
-	mu   sync.RWMutex
-	exts []SchedulerExtension
-}
-
-func (e *Extensions) Add(ext SchedulerExtension) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
-	if e.exts == nil {
-		e.exts = make([]SchedulerExtension, 0)
-	}
-
-	e.exts = append(e.exts, ext)
-}
-
-func (e *Extensions) ReportSnapshot(ctx context.Context, tenantId uuid.UUID, input *SnapshotInput) {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
-
-	// Extensions run in their own goroutines. `ctx` is the scheduler-lifetime
-	// context (not a per-iteration one), so it's safe to hand to a fire-and-
-	// forget goroutine; each gets its own child span under the snapshot trace.
-	for _, ext := range e.exts {
-		f := ext.ReportSnapshot
-		go func() {
-			spanCtx, span := telemetry.NewSpan(ctx, "report-snapshot")
-			defer span.End()
-
-			f(spanCtx, tenantId, input)
-		}()
-	}
-}
-
-func (e *Extensions) PostAssign(tenantId uuid.UUID, input *PostAssignInput) {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
-
-	for _, ext := range e.exts {
-		f := ext.PostAssign
-		go f(tenantId, input)
-	}
-}
-
-func (e *Extensions) CleanupTenant(tenantId uuid.UUID) error {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
-
-	eg := errgroup.Group{}
-
-	for _, ext := range e.exts {
-		f := ext.CleanupTenant
-		eg.Go(func() error { return f(tenantId) })
-	}
-
-	return eg.Wait()
-}
-
-func (e *Extensions) Cleanup() error {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
-
-	eg := errgroup.Group{}
-
-	for _, ext := range e.exts {
-		f := ext.Cleanup
-		eg.Go(f)
-	}
-
-	return eg.Wait()
-}
-
-func (e *Extensions) SetTenants(tenants []*sqlcv1.Tenant) {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
-
-	for _, ext := range e.exts {
-		f := ext.SetTenants
-		go f(tenants)
-	}
-}
+// The extension contract crosses the engine boundary — cloud and OSS register
+// extensions into whichever pool implementation a shard runs — so it is
+// defined once in pkg/scheduling and aliased here.
+type PostAssignInput = scheduling.PostAssignInput
+type SnapshotInput = scheduling.SnapshotInput
+type SlotUtilization = scheduling.SlotUtilization
+type WorkerCp = scheduling.WorkerCp
+type SlotCp = scheduling.SlotCp
+type SchedulerExtension = scheduling.SchedulerExtension
+type Extensions = scheduling.Extensions

--- a/pkg/scheduling/v1alpha/pool.go
+++ b/pkg/scheduling/v1alpha/pool.go
@@ -114,6 +114,10 @@ func NewSchedulingPool(
 	}, nil
 }
 
+func (p *SchedulingPool) AddExtension(ext scheduling.SchedulerExtension) {
+	p.Extensions.Add(ext)
+}
+
 func (p *SchedulingPool) GetResultsCh() chan *QueueResults {
 	return p.resultsCh
 }


### PR DESCRIPTION
# Description

I broke some things downstream, moving the extension registration into the top level Pool interface. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Refactor (non-breaking changes to code which doesn't change any behaviour)

## What's Changed

See above. 

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Tested (unit, integration, or manually with steps specified)
- [X] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [X] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude w/ Fable

</details>
