### PR TITLE
fix: keep side panel open updates from stale history index

### DIFF
--- a/frontend/app/src/hooks/use-side-panel.tsx
+++ b/frontend/app/src/hooks/use-side-panel.tsx
@@ -20,6 +20,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 
@@ -115,6 +116,8 @@ function useSidePanelData(): SidePanelData {
   const [isOpen, setIsOpen] = useState(false);
   const [history, setHistory] = useState<UseSidePanelProps[]>([]);
   const [currentIndex, setCurrentIndex] = useState(-1);
+  const currentIndexRef = useRef(currentIndex);
+  currentIndexRef.current = currentIndex;
   const location = useLocation();
 
   const props =
@@ -172,18 +175,15 @@ function useSidePanelData(): SidePanelData {
     }
   }, [props]);
 
-  const open = useCallback(
-    (newProps: UseSidePanelProps) => {
-      setHistory((prev) => {
-        const newHistory = prev.slice(0, currentIndex + 1);
-        newHistory.push(newProps);
-        return newHistory;
-      });
-      setCurrentIndex((prev) => prev + 1);
-      setIsOpen(true);
-    },
-    [currentIndex],
-  );
+  const open = useCallback((newProps: UseSidePanelProps) => {
+    setHistory((prev) => {
+      const newHistory = prev.slice(0, currentIndexRef.current + 1);
+      newHistory.push(newProps);
+      return newHistory;
+    });
+    setCurrentIndex((prev) => prev + 1);
+    setIsOpen(true);
+  }, []);
 
   const close = useCallback(() => {
     setIsOpen(false);

--- a/frontend/app/src/pages/main/v1/scheduled-runs/index.tsx
+++ b/frontend/app/src/pages/main/v1/scheduled-runs/index.tsx
@@ -177,8 +177,7 @@ function ScheduledRunsTable({
           });
         },
       }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [tenantId, selectedAdditionalMetaJobId],
+    [tenantId, selectedAdditionalMetaJobId, open, triggerNow],
   );
 
   const effectiveWorkflowId = workflowId || selectedWorkflowIds[0];


### PR DESCRIPTION
## Summary
- Side panel `open()` was closing over a stale history index, so clicking another row while the panel was already open could leave the panel open with no content
- Read the current index via a ref, and include `open` / `triggerNow` in the scheduled runs column memo deps

## Test plan
- [ ] Open a scheduled run from the list — detail panel shows the correct run
- [ ] With the panel still open, click a different scheduled run — panel updates to that run
- [ ] Use back/forward in the panel header — history still works
- [ ] Repeat for events / filters side panels if convenient