### PR TITLE
fix: `head-prepend` frontend base path config

### DIFF
--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -33,12 +33,12 @@ export default defineConfig({
               {
                 tag: 'base',
                 attrs: { href: '{{ .BasePath }}' },
-                injectTo: 'head',
+                injectTo: 'head-prepend',
               },
               {
                 tag: 'script',
                 children: 'window.__CONFIG__ = { BASE_PATH: "{{ .BasePath }}" };',
-                injectTo: 'head',
+                injectTo: 'head-prepend',
               },
             ],
           };

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -33,12 +33,10 @@ export default defineConfig({
               {
                 tag: 'base',
                 attrs: { href: '{{ .BasePath }}' },
-                injectTo: 'head-prepend',
               },
               {
                 tag: 'script',
                 children: 'window.__CONFIG__ = { BASE_PATH: "{{ .BasePath }}" };',
-                injectTo: 'head-prepend',
               },
             ],
           };


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Blank pages resulted since the base path was being appended to the generated `index.html` whereas they should be prepended before the generated React JS bundle file.

`head-prepend` is the default as per Vite's [documentation](https://vite.dev/guide/api-plugin#transformindexhtml) so removing those lines works in our case.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
