### PR TITLE
feat(dashboard): add CTAs pointing to Cloud on timeouts

### DIFF
--- a/frontend/app/src/components/v1/nav/cloud-cta.tsx
+++ b/frontend/app/src/components/v1/nav/cloud-cta.tsx
@@ -1,0 +1,55 @@
+import { Button } from '@/components/v1/ui/button';
+import useControlPlane from '@/hooks/use-control-plane';
+import { getCloudCTAUrl } from '@/lib/external-links';
+import { cn } from '@/lib/utils';
+import { BiCloud } from 'react-icons/bi';
+
+export function SidebarCloudCTA({
+  collapsed,
+  className,
+}: {
+  collapsed: boolean;
+  className?: string;
+}) {
+  const { isSelfHosted, isControlPlaneLoading } = useControlPlane();
+
+  if (isControlPlaneLoading || !isSelfHosted) {
+    return null;
+  }
+
+  const href = getCloudCTAUrl('sidebar');
+
+  if (collapsed) {
+    return (
+      <Button
+        variant="icon"
+        size="icon"
+        aria-label="Try Cloud"
+        hoverText="Try Cloud"
+        hoverTextSide="right"
+        className={cn('w-10', className)}
+        asChild
+      >
+        <a href={href} target="_blank" rel="noopener noreferrer">
+          <BiCloud className="h-6 w-6 cursor-pointer text-foreground" />
+        </a>
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      className={cn(
+        'w-full justify-start pl-2 min-w-0 overflow-hidden',
+        className,
+      )}
+      asChild
+    >
+      <a href={href} target="_blank" rel="noopener noreferrer">
+        <BiCloud className="size-4 mr-2" />
+        <span className="truncate">Try Cloud</span>
+      </a>
+    </Button>
+  );
+}

--- a/frontend/app/src/components/v1/nav/help-dropdown.tsx
+++ b/frontend/app/src/components/v1/nav/help-dropdown.tsx
@@ -63,14 +63,12 @@ function HelpDropdownItems({ includeChat = true }: { includeChat?: boolean }) {
 }
 
 export function HelpDropdown({
-  variant = 'default',
   triggerVariant = 'icon',
   align = 'end',
   side,
   className,
 }: {
-  variant?: 'default' | 'sidebar';
-  triggerVariant?: 'icon' | 'button' | 'split';
+  triggerVariant?: 'icon' | 'split';
   align?: React.ComponentProps<typeof DropdownMenuContent>['align'];
   side?: React.ComponentProps<typeof DropdownMenuContent>['side'];
   className?: string;
@@ -127,16 +125,6 @@ export function HelpDropdown({
       );
     }
 
-    if (triggerVariant === 'button') {
-      return (
-        <SidebarButtonPrimaryAction
-          name="Help & Support"
-          icon={<BiHelpCircle className="size-4 mr-2" />}
-          className={cn(className)}
-        />
-      );
-    }
-
     return (
       <Button
         variant="icon"
@@ -160,7 +148,7 @@ export function HelpDropdown({
       )}
       <DropdownMenuContent
         className="w-56"
-        variant={variant === 'sidebar' ? 'sidebar' : 'default'}
+        variant={'sidebar'}
         align={align}
         side={side}
         forceMount

--- a/frontend/app/src/components/v1/nav/side-nav.tsx
+++ b/frontend/app/src/components/v1/nav/side-nav.tsx
@@ -7,6 +7,7 @@ import {
   RESIZE_DRAG_THRESHOLD_PX,
   useSidebar,
 } from '@/components/hooks/use-sidebar';
+import { SidebarCloudCTA } from '@/components/v1/nav/cloud-cta';
 import { HelpDropdown } from '@/components/v1/nav/help-dropdown';
 import {
   SidebarButtonPrimary,
@@ -466,8 +467,8 @@ export function SideNav({ className, navItems: navSections }: SideNavProps) {
             {/* Fixed footer */}
             <div className="w-full shrink-0 py-2">
               <div className="flex w-full flex-col items-center gap-1">
+                <SidebarCloudCTA collapsed className="w-10" />
                 <HelpDropdown
-                  variant="sidebar"
                   triggerVariant="icon"
                   align="start"
                   side="right"
@@ -551,8 +552,8 @@ export function SideNav({ className, navItems: navSections }: SideNavProps) {
               data-cy="v1-sidebar-footer"
               className="flex w-full shrink-0 flex-col gap-1 border-t border-slate-200 px-4 py-2 dark:border-slate-800"
             >
+              <SidebarCloudCTA collapsed={false} />
               <HelpDropdown
-                variant="sidebar"
                 triggerVariant="split"
                 align="start"
                 side="top"

--- a/frontend/app/src/lib/api/api.ts
+++ b/frontend/app/src/lib/api/api.ts
@@ -74,6 +74,9 @@ export const controlPlaneApi = new ControlPlaneApi({
   timeout: CONTROL_PLANE_REQUEST_TIMEOUT_MS,
 });
 
+export const SELF_HOSTED_LIST_TIMEOUT_MS =
+  api.instance.defaults.timeout || 30_000;
+
 api.instance.interceptors.request.use(exchangeTokenInterceptor);
 cloudApi.instance.interceptors.request.use(exchangeTokenInterceptor);
 

--- a/frontend/app/src/lib/api/queries.ts
+++ b/frontend/app/src/lib/api/queries.ts
@@ -1,5 +1,9 @@
 import { V1EventList, V1TaskSummaryList, WebhookWorkerCreateRequest } from '.';
-import api, { cloudApi, controlPlaneApi } from './api';
+import api, {
+  cloudApi,
+  controlPlaneApi,
+  SELF_HOSTED_LIST_TIMEOUT_MS,
+} from './api';
 import { TemplateOptions } from './generated/cloud/data-contracts';
 import { createQueryKeyStore } from '@lukemorales/query-key-factory';
 import { AxiosError } from 'axios';
@@ -270,7 +274,7 @@ export const queries = createQueryKeyStore({
     list: (tenant: string, query: V1EventListQuery, isSelfHosted: boolean) => ({
       queryKey: ['v1:events:list', tenant, query],
       queryFn: async (): Promise<V1EventList | 'timeout' | undefined> => {
-        const timeout = isSelfHosted ? 100 : undefined;
+        const timeout = isSelfHosted ? SELF_HOSTED_LIST_TIMEOUT_MS : undefined;
 
         try {
           return (await api.v1EventList(tenant, query, { timeout })).data;
@@ -292,7 +296,7 @@ export const queries = createQueryKeyStore({
     ) => ({
       queryKey: ['v1:workflow-run:list', tenant, query],
       queryFn: async (): Promise<V1TaskSummaryList | 'timeout' | undefined> => {
-        const timeout = isSelfHosted ? 100 : undefined;
+        const timeout = isSelfHosted ? SELF_HOSTED_LIST_TIMEOUT_MS : undefined;
 
         try {
           return (await api.v1WorkflowRunList(tenant, query, { timeout })).data;

--- a/frontend/app/src/lib/api/queries.ts
+++ b/frontend/app/src/lib/api/queries.ts
@@ -1,7 +1,8 @@
-import { WebhookWorkerCreateRequest } from '.';
+import { V1TaskSummaryList, WebhookWorkerCreateRequest } from '.';
 import api, { cloudApi, controlPlaneApi } from './api';
 import { TemplateOptions } from './generated/cloud/data-contracts';
 import { createQueryKeyStore } from '@lukemorales/query-key-factory';
+import { AxiosError } from 'axios';
 import invariant from 'tiny-invariant';
 
 type ListEventQuery = Parameters<typeof api.eventList>[1];
@@ -272,9 +273,25 @@ export const queries = createQueryKeyStore({
     }),
   },
   v1WorkflowRuns: {
-    list: (tenant: string, query: V2ListWorkflowRunsQuery) => ({
+    list: (
+      tenant: string,
+      query: V2ListWorkflowRunsQuery,
+      isSelfHosted: boolean,
+    ) => ({
       queryKey: ['v1:workflow-run:list', tenant, query],
-      queryFn: async () => (await api.v1WorkflowRunList(tenant, query)).data,
+      queryFn: async (): Promise<V1TaskSummaryList | 'timeout' | undefined> => {
+        const timeout = isSelfHosted ? 100 : undefined;
+
+        try {
+          return (await api.v1WorkflowRunList(tenant, query, { timeout })).data;
+        } catch (e) {
+          if (e instanceof AxiosError && e.code === 'ECONNABORTED') {
+            return 'timeout';
+          }
+
+          throw e;
+        }
+      },
     }),
     listTaskEvents: (workflowRunId: string) => ({
       queryKey: ['v1:workflow-run:list-tasks', workflowRunId],

--- a/frontend/app/src/lib/api/queries.ts
+++ b/frontend/app/src/lib/api/queries.ts
@@ -1,4 +1,4 @@
-import { V1TaskSummaryList, WebhookWorkerCreateRequest } from '.';
+import { V1EventList, V1TaskSummaryList, WebhookWorkerCreateRequest } from '.';
 import api, { cloudApi, controlPlaneApi } from './api';
 import { TemplateOptions } from './generated/cloud/data-contracts';
 import { createQueryKeyStore } from '@lukemorales/query-key-factory';
@@ -267,9 +267,21 @@ export const queries = createQueryKeyStore({
     }),
   },
   v1Events: {
-    list: (tenant: string, query: V1EventListQuery) => ({
+    list: (tenant: string, query: V1EventListQuery, isSelfHosted: boolean) => ({
       queryKey: ['v1:events:list', tenant, query],
-      queryFn: async () => (await api.v1EventList(tenant, query)).data,
+      queryFn: async (): Promise<V1EventList | 'timeout' | undefined> => {
+        const timeout = isSelfHosted ? 100 : undefined;
+
+        try {
+          return (await api.v1EventList(tenant, query, { timeout })).data;
+        } catch (e) {
+          if (e instanceof AxiosError && e.code === 'ECONNABORTED') {
+            return 'timeout';
+          }
+
+          throw e;
+        }
+      },
     }),
   },
   v1WorkflowRuns: {

--- a/frontend/app/src/lib/external-links.ts
+++ b/frontend/app/src/lib/external-links.ts
@@ -1,2 +1,10 @@
 export const OFFICE_HOURS_URL = 'https://cal.com/team/hatchet/talk-to-us';
 export const DISCORD_INVITE_URL = 'https://discord.com/invite/ZMeUafwH89';
+
+export function getCloudCTAUrl(utmCampaign: string) {
+  if (import.meta.env.DEV) {
+    return 'https://cloud.hatchet.run';
+  }
+
+  return `https://cloud.hatchet.run?utm_source=self_hosted_sidebar&utm_medium=app&utm_campaign=${encodeURIComponent(utmCampaign)}`;
+}

--- a/frontend/app/src/pages/main/v1/events/hooks/use-events.tsx
+++ b/frontend/app/src/pages/main/v1/events/hooks/use-events.tsx
@@ -237,8 +237,9 @@ export const useEvents = ({ key }: UseEventsProps) => {
   });
 
   const fetchTimedOut = data === 'timeout';
-  const events = (data !== 'timeout' && data?.rows) || [];
-  const numEvents = (data !== 'timeout' && data?.pagination?.num_pages) || 1;
+  const events = (data !== 'timeout' ? data?.rows : undefined) ?? [];
+  const numEvents =
+    (data !== 'timeout' ? data?.pagination?.num_pages : undefined) ?? 1;
 
   const { data: eventKeys, error: eventKeysError } = useQuery({
     queryKey: ['v1:events:listKeys', tenantId],

--- a/frontend/app/src/pages/main/v1/events/hooks/use-events.tsx
+++ b/frontend/app/src/pages/main/v1/events/hooks/use-events.tsx
@@ -11,6 +11,7 @@ import {
   TimeRangeConfig,
 } from '@/components/v1/molecules/data-table/data-table-toolbar';
 import { useRefetchInterval } from '@/contexts/refetch-interval-context';
+import useControlPlane from '@/hooks/use-control-plane';
 import { usePagination } from '@/hooks/use-pagination';
 import { useZodColumnFilters } from '@/hooks/use-zod-column-filters';
 import api, { queries, V1TaskStatus } from '@/lib/api';
@@ -212,25 +213,12 @@ export const useEvents = ({ key }: UseEventsProps) => {
       ],
     });
 
+  const { isSelfHosted } = useControlPlane();
+
   const { data, isLoading, refetch, error, isRefetching } = useQuery({
-    queryKey: [
-      'v1:events:list',
+    ...queries.v1Events.list(
       tenantId,
       {
-        keys: selectedKeys,
-        workflows: selectedWorkflowIds,
-        offset,
-        limit,
-        statuses: selectedStatuses,
-        additionalMetadata: selectedMetadata,
-        eventIds: selectedEventIds,
-        scopes: selectedScopes,
-        since,
-        until,
-      },
-    ],
-    queryFn: async () => {
-      const response = await api.v1EventList(tenantId, {
         offset,
         limit,
         keys: selectedKeys,
@@ -241,16 +229,16 @@ export const useEvents = ({ key }: UseEventsProps) => {
         additionalMetadata: selectedMetadata,
         workflowIds: selectedWorkflowIds,
         scopes: selectedScopes,
-      });
-
-      return response.data;
-    },
+      },
+      isSelfHosted,
+    ),
     refetchInterval: selectedEventIds?.length ? false : refetchInterval,
     placeholderData: (prev) => prev,
   });
 
-  const events = data?.rows ?? [];
-  const numEvents = data?.pagination?.num_pages ?? 1;
+  const fetchTimedOut = data === 'timeout';
+  const events = (data !== 'timeout' && data?.rows) || [];
+  const numEvents = (data !== 'timeout' && data?.pagination?.num_pages) || 1;
 
   const { data: eventKeys, error: eventKeysError } = useQuery({
     queryKey: ['v1:events:listKeys', tenantId],
@@ -290,6 +278,7 @@ export const useEvents = ({ key }: UseEventsProps) => {
   return {
     events,
     numEvents,
+    fetchTimedOut,
     isLoading: isLoading || workflowKeysIsLoading,
     refetch,
     error: error || eventKeysError || workflowKeysError,

--- a/frontend/app/src/pages/main/v1/events/index.tsx
+++ b/frontend/app/src/pages/main/v1/events/index.tsx
@@ -169,7 +169,7 @@ function EventsTable() {
         onResetFilters={resetFilters}
         emptyState={
           fetchTimedOut ? (
-            <RequestTimeoutCloudCTAEmptyState />
+            <RequestTimeoutCloudCTAEmptyState utmCampaign="events" />
           ) : hasActiveFilters ? (
             <EmptyState
               graphic={<RunsEmptyGraphic />}

--- a/frontend/app/src/pages/main/v1/events/index.tsx
+++ b/frontend/app/src/pages/main/v1/events/index.tsx
@@ -1,6 +1,7 @@
 import { useFilters } from '../filters/hooks/use-filters';
 import { RunsEmptyGraphic } from '../workflow-runs-v1/components/runs-empty-graphic';
 import { RunsTable } from '../workflow-runs-v1/components/runs-table';
+import { RequestTimeoutCloudCTAEmptyState } from '../workflow-runs-v1/components/runs-timeout-empty-state';
 import { RunsProvider } from '../workflow-runs-v1/hooks/runs-provider';
 import {
   columns,
@@ -60,6 +61,7 @@ function EventsTable() {
     isLoading,
     refetch,
     error,
+    fetchTimedOut,
     pagination,
     setPagination,
     setPageSize,
@@ -166,7 +168,9 @@ function EventsTable() {
         }}
         onResetFilters={resetFilters}
         emptyState={
-          hasActiveFilters ? (
+          fetchTimedOut ? (
+            <RequestTimeoutCloudCTAEmptyState />
+          ) : hasActiveFilters ? (
             <EmptyState
               graphic={<RunsEmptyGraphic />}
               title="No events matching your filters"

--- a/frontend/app/src/pages/main/v1/logs/hooks/use-tenant-logs.tsx
+++ b/frontend/app/src/pages/main/v1/logs/hooks/use-tenant-logs.tsx
@@ -2,6 +2,7 @@ import { parseLogQuery } from '@/components/v1/cloud/logging/log-search/parser';
 import { LOG_LEVEL_TO_API } from '@/components/v1/cloud/logging/log-search/types';
 import { LogLine } from '@/components/v1/cloud/logging/log-search/use-logs';
 import { useRefetchInterval } from '@/contexts/refetch-interval-context';
+import useControlPlane from '@/hooks/use-control-plane';
 import {
   V1LogLine,
   V1LogLineOrderByDirection,
@@ -13,6 +14,7 @@ import { useSearchParams } from '@/lib/router-helpers';
 import { appRoutes } from '@/router';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
+import { AxiosError } from 'axios';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { z } from 'zod';
 
@@ -55,7 +57,9 @@ function mapToLogLines(rows: V1LogLine[]): LogLine[] {
 export function useTenantLogs() {
   const { tenant: tenantId } = useParams({ from: appRoutes.tenantRoute.to });
   const { refetchInterval } = useRefetchInterval();
+  const { isSelfHosted } = useControlPlane();
   const [searchParams, setSearchParams] = useSearchParams();
+  const [fetchTimedOut, setFetchTimedOut] = useState(false);
   const workflowsQuery = useQuery({
     ...queries.workflows.list(tenantId, { limit: 1000 }),
     refetchInterval,
@@ -132,22 +136,38 @@ export function useTenantLogs() {
       workflowIds,
     ],
     queryFn: async ({ pageParam }: { pageParam: string | undefined }) => {
-      const response = await api.v1TenantLogLineList(tenantId, {
-        limit: LOGS_PER_PAGE,
-        since,
-        ...(pageParam
-          ? { until: pageParam }
-          : filters.until
-            ? { until: filters.until }
-            : {}),
-        ...(parsedQuery.level && {
-          levels: [LOG_LEVEL_TO_API[parsedQuery.level]],
-        }),
-        ...(parsedQuery.search && { search: parsedQuery.search }),
-        ...(workflowIds && { workflow_ids: workflowIds }),
-        order_by_direction: V1LogLineOrderByDirection.DESC,
-      });
-      return response.data;
+      const timeout = isSelfHosted ? 100 : undefined;
+
+      try {
+        const response = await api.v1TenantLogLineList(
+          tenantId,
+          {
+            limit: LOGS_PER_PAGE,
+            since,
+            ...(pageParam
+              ? { until: pageParam }
+              : filters.until
+                ? { until: filters.until }
+                : {}),
+            ...(parsedQuery.level && {
+              levels: [LOG_LEVEL_TO_API[parsedQuery.level]],
+            }),
+            ...(parsedQuery.search && { search: parsedQuery.search }),
+            ...(workflowIds && { workflow_ids: workflowIds }),
+            order_by_direction: V1LogLineOrderByDirection.DESC,
+          },
+          { timeout },
+        );
+        setFetchTimedOut(false);
+        return response.data;
+      } catch (e) {
+        if (e instanceof AxiosError && e.code === 'ECONNABORTED') {
+          setFetchTimedOut(true);
+          return { rows: [] };
+        }
+
+        throw e;
+      }
     },
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => {
@@ -267,6 +287,7 @@ export function useTenantLogs() {
 
   return {
     logs,
+    fetchTimedOut,
     isLoading: logsQuery.isLoading,
     isRefetching: logsQuery.isRefetching,
     isFetchingMore: logsQuery.isFetchingNextPage,

--- a/frontend/app/src/pages/main/v1/logs/hooks/use-tenant-logs.tsx
+++ b/frontend/app/src/pages/main/v1/logs/hooks/use-tenant-logs.tsx
@@ -166,6 +166,7 @@ export function useTenantLogs() {
           return { rows: [] };
         }
 
+        setFetchTimedOut(false);
         throw e;
       }
     },

--- a/frontend/app/src/pages/main/v1/logs/hooks/use-tenant-logs.tsx
+++ b/frontend/app/src/pages/main/v1/logs/hooks/use-tenant-logs.tsx
@@ -9,7 +9,7 @@ import {
   V1LogsPointMetric,
   queries,
 } from '@/lib/api';
-import api from '@/lib/api/api';
+import api, { SELF_HOSTED_LIST_TIMEOUT_MS } from '@/lib/api/api';
 import { useSearchParams } from '@/lib/router-helpers';
 import { appRoutes } from '@/router';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
@@ -136,7 +136,7 @@ export function useTenantLogs() {
       workflowIds,
     ],
     queryFn: async ({ pageParam }: { pageParam: string | undefined }) => {
-      const timeout = isSelfHosted ? 100 : undefined;
+      const timeout = isSelfHosted ? SELF_HOSTED_LIST_TIMEOUT_MS : undefined;
 
       try {
         const response = await api.v1TenantLogLineList(

--- a/frontend/app/src/pages/main/v1/logs/index.tsx
+++ b/frontend/app/src/pages/main/v1/logs/index.tsx
@@ -191,7 +191,7 @@ function TenantLogs() {
         showTaskName
         emptyComponent={
           fetchTimedOut ? (
-            <RequestTimeoutCloudCTAEmptyState />
+            <RequestTimeoutCloudCTAEmptyState utmCampaign="logs" />
           ) : hasActiveFilters ? (
             <EmptyState
               graphic={<RunsEmptyGraphic />}

--- a/frontend/app/src/pages/main/v1/logs/index.tsx
+++ b/frontend/app/src/pages/main/v1/logs/index.tsx
@@ -1,4 +1,5 @@
 import { RunsEmptyGraphic } from '../workflow-runs-v1/components/runs-empty-graphic';
+import { RequestTimeoutCloudCTAEmptyState } from '../workflow-runs-v1/components/runs-timeout-empty-state';
 import { LogsChart } from './components/logs-chart';
 import { useTenantLogs } from './hooks/use-tenant-logs';
 import type { TimeWindow } from './hooks/use-tenant-logs';
@@ -45,6 +46,7 @@ export default function TenantLogsPage() {
 function TenantLogs() {
   const {
     logs,
+    fetchTimedOut,
     isLoading,
     isRefetching,
     refetch,
@@ -188,7 +190,9 @@ function TenantLogs() {
         showAttempt={false}
         showTaskName
         emptyComponent={
-          hasActiveFilters ? (
+          fetchTimedOut ? (
+            <RequestTimeoutCloudCTAEmptyState />
+          ) : hasActiveFilters ? (
             <EmptyState
               graphic={<RunsEmptyGraphic />}
               title="No logs matching your filters"

--- a/frontend/app/src/pages/main/v1/overview/index.tsx
+++ b/frontend/app/src/pages/main/v1/overview/index.tsx
@@ -24,6 +24,7 @@ import { TokenSuccessDialog } from './components/token-success-dialog';
 import { type AvailableUseCaseKey } from './components/use-case-options';
 import { useAnalytics } from '@/hooks/use-analytics';
 import useAuthDisabled from '@/hooks/use-auth-disabled';
+import useControlPlane from '@/hooks/use-control-plane';
 import { useCurrentUser } from '@/hooks/use-current-user';
 import { useLocalStorageState } from '@/hooks/use-local-storage-state';
 import { useTenantDetails } from '@/hooks/use-tenant';
@@ -65,6 +66,7 @@ export default function Overview() {
     installMethodOptions.native.value,
   );
   const hasTrackedWorkerConnection = useRef(false);
+  const { isSelfHosted } = useControlPlane();
 
   // The raw stored value is normalized on every read, so malformed or
   // stale entries fall back to the defaults.
@@ -238,17 +240,21 @@ export default function Overview() {
       qualifiedRunQueryParams(
         selectionConfirmedAt ?? new Date(0).toISOString(),
       ),
+      isSelfHosted,
     ),
     enabled: !!tenantId && !!selectionConfirmedAt && !onboarding.hidden,
     refetchInterval: (query) =>
       selectedTab === workflowStepOptions.runTask.value &&
-      (query.state.data?.rows?.length ?? 0) === 0
+      (query.state.data !== 'timeout' &&
+        (query.state.data?.rows?.length ?? 0)) === 0
         ? 2000
         : false,
   });
 
   const hasQualifiedRun =
-    !!selectionConfirmedAt && (qualifiedRunQuery.data?.rows?.length ?? 0) > 0;
+    !!selectionConfirmedAt &&
+    qualifiedRunQuery.data !== 'timeout' &&
+    (qualifiedRunQuery.data?.rows?.length ?? 0) > 0;
 
   // The connection event fires once for each tenant, so a tenant switch
   // without a remount must re-arm it.

--- a/frontend/app/src/pages/main/v1/overview/index.tsx
+++ b/frontend/app/src/pages/main/v1/overview/index.tsx
@@ -243,12 +243,14 @@ export default function Overview() {
       isSelfHosted,
     ),
     enabled: !!tenantId && !!selectionConfirmedAt && !onboarding.hidden,
-    refetchInterval: (query) =>
-      selectedTab === workflowStepOptions.runTask.value &&
-      (query.state.data !== 'timeout' &&
-        (query.state.data?.rows?.length ?? 0)) === 0
+    refetchInterval: (query) => {
+      const hasRows =
+        query.state.data !== 'timeout' &&
+        (query.state.data?.rows?.length ?? 0) > 0;
+      return selectedTab === workflowStepOptions.runTask.value && !hasRows
         ? 2000
-        : false,
+        : false;
+    },
   });
 
   const hasQualifiedRun =

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
@@ -277,7 +277,7 @@ export function RunsTable({ leftLabel }: { leftLabel?: string }) {
         <DataTable
           emptyState={
             fetchTimedOut ? (
-              <RequestTimeoutCloudCTAEmptyState />
+              <RequestTimeoutCloudCTAEmptyState utmCampaign="runs" />
             ) : hasActiveFilters ? (
               <EmptyState
                 graphic={<RunsEmptyGraphic />}

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
@@ -206,8 +206,6 @@ export function RunsTable({ leftLabel }: { leftLabel?: string }) {
 
   const isRunningFirstLoad = isRunsLoading || isStatusCountsLoading;
 
-  console.log('fetchTimedOut', fetchTimedOut);
-
   const allStatusCount = Object.values(V1TaskStatus).length;
   const hasActiveFilters =
     (filters.apiFilters.statuses?.length ?? allStatusCount) < allStatusCount ||

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-table.tsx
@@ -3,6 +3,7 @@ import { TriggerWorkflowForm } from '../../workflows/$workflow/components/trigge
 import { useRunsContext } from '../hooks/runs-provider';
 import { AdditionalMetadataProp } from '../hooks/use-runs-table-filters';
 import { RunsEmptyGraphic } from './runs-empty-graphic';
+import { RequestTimeoutCloudCTAEmptyState } from './runs-timeout-empty-state';
 import { V1WorkflowRunsMetricsView } from './task-runs-metrics';
 import { columns, TaskRunColumn } from './v1/task-runs-columns';
 import {
@@ -119,6 +120,7 @@ export function RunsTable({ leftLabel }: { leftLabel?: string }) {
       setShowTriggerWorkflow,
       setShowQueueMetrics,
     },
+    fetchTimedOut,
   } = useRunsContext();
 
   const [selectedAdditionalMetaRunId, setSelectedAdditionalMetaRunId] =
@@ -204,6 +206,8 @@ export function RunsTable({ leftLabel }: { leftLabel?: string }) {
 
   const isRunningFirstLoad = isRunsLoading || isStatusCountsLoading;
 
+  console.log('fetchTimedOut', fetchTimedOut);
+
   const allStatusCount = Object.values(V1TaskStatus).length;
   const hasActiveFilters =
     (filters.apiFilters.statuses?.length ?? allStatusCount) < allStatusCount ||
@@ -274,7 +278,9 @@ export function RunsTable({ leftLabel }: { leftLabel?: string }) {
       <div className="min-h-0 flex-1">
         <DataTable
           emptyState={
-            hasActiveFilters ? (
+            fetchTimedOut ? (
+              <RequestTimeoutCloudCTAEmptyState />
+            ) : hasActiveFilters ? (
               <EmptyState
                 graphic={<RunsEmptyGraphic />}
                 title="No runs matching your filters"

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-timeout-empty-state.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-timeout-empty-state.tsx
@@ -1,7 +1,13 @@
 import { RunsEmptyGraphic } from './runs-empty-graphic';
 import { EmptyState } from '@/components/v1/molecules/empty-state/empty-state';
 
-export function RequestTimeoutCloudCTAEmptyState() {
+interface RequestTimeoutCloudCTAEmptyStateProps {
+  utmCampaign: string;
+}
+
+export function RequestTimeoutCloudCTAEmptyState({
+  utmCampaign,
+}: RequestTimeoutCloudCTAEmptyStateProps) {
   return (
     <EmptyState
       graphic={<RunsEmptyGraphic />}
@@ -10,7 +16,7 @@ export function RequestTimeoutCloudCTAEmptyState() {
       links={[
         {
           label: 'Try our managed cloud',
-          href: 'https://cloud.hatchet.run',
+          href: `https://cloud.hatchet.run?utm_source=timeout_cta&utm_medium=app&utm_campaign=${utmCampaign}`,
           external: true,
         },
       ]}

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-timeout-empty-state.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-timeout-empty-state.tsx
@@ -10,7 +10,7 @@ export function RequestTimeoutCloudCTAEmptyState({
 }: RequestTimeoutCloudCTAEmptyStateProps) {
   const href = import.meta.env.DEV
     ? 'https://cloud.hatchet.run'
-    : `https://cloud.hatchet.run?utm_source=timeout_cta&utm_medium=app&utm_campaign=${utmCampaign}`;
+    : `https://cloud.hatchet.run?utm_source=timeout_cta&utm_medium=app&utm_campaign=${encodeURIComponent(utmCampaign)}`;
 
   return (
     <EmptyState

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-timeout-empty-state.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-timeout-empty-state.tsx
@@ -8,6 +8,10 @@ interface RequestTimeoutCloudCTAEmptyStateProps {
 export function RequestTimeoutCloudCTAEmptyState({
   utmCampaign,
 }: RequestTimeoutCloudCTAEmptyStateProps) {
+  const href = import.meta.env.DEV
+    ? 'https://cloud.hatchet.run'
+    : `https://cloud.hatchet.run?utm_source=timeout_cta&utm_medium=app&utm_campaign=${utmCampaign}`;
+
   return (
     <EmptyState
       graphic={<RunsEmptyGraphic />}
@@ -16,7 +20,7 @@ export function RequestTimeoutCloudCTAEmptyState({
       links={[
         {
           label: 'Try our managed cloud',
-          href: `https://cloud.hatchet.run?utm_source=timeout_cta&utm_medium=app&utm_campaign=${utmCampaign}`,
+          href,
           external: true,
         },
       ]}

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-timeout-empty-state.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/components/runs-timeout-empty-state.tsx
@@ -1,0 +1,19 @@
+import { RunsEmptyGraphic } from './runs-empty-graphic';
+import { EmptyState } from '@/components/v1/molecules/empty-state/empty-state';
+
+export function RequestTimeoutCloudCTAEmptyState() {
+  return (
+    <EmptyState
+      graphic={<RunsEmptyGraphic />}
+      title="This request timed out"
+      description="Self-hosted instances can be slow to query at scale. Try our managed cloud for a faster, fully-managed experience."
+      links={[
+        {
+          label: 'Try our managed cloud',
+          href: 'https://cloud.hatchet.run',
+          external: true,
+        },
+      ]}
+    />
+  );
+}

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/runs-provider.tsx
@@ -95,6 +95,7 @@ type RunsContextType = {
   rowSelection: RowSelectionState;
   showTriggerWorkflow: boolean;
   showQueueMetrics: boolean;
+  fetchTimedOut: boolean;
 };
 
 const RunsContext = createContext<RunsContextType | null>(null);
@@ -203,6 +204,7 @@ export const RunsProvider = ({
     pagination,
     setPagination,
     setPageSize,
+    fetchTimedOut,
   } = useRuns({
     key: tableKey,
     rowSelection,
@@ -299,6 +301,7 @@ export const RunsProvider = ({
         setShowQueueMetrics,
         setShowTriggerWorkflow,
       },
+      fetchTimedOut,
     }),
     [
       filters,
@@ -340,6 +343,7 @@ export const RunsProvider = ({
       setColumnVisibility,
       rowSelection,
       showTriggerWorkflow,
+      fetchTimedOut,
     ],
   );
 

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-runs.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/hooks/use-runs.tsx
@@ -1,4 +1,5 @@
 import { useRefetchInterval } from '@/contexts/refetch-interval-context';
+import useControlPlane from '@/hooks/use-control-plane';
 import { usePagination } from '@/hooks/use-pagination';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
 import {
@@ -47,6 +48,7 @@ export const useRuns = ({
   onlyTasks,
   disablePagination = false,
 }: UseRunsProps) => {
+  const { isSelfHosted } = useControlPlane();
   const { tenantId } = useCurrentTenantId();
   const { refetchInterval } = useRefetchInterval();
   const { offset, pagination, setPageSize, setPagination } = usePagination({
@@ -81,28 +83,37 @@ export const useRuns = ({
   );
 
   const listTasksQuery = useQuery({
-    ...queries.v1WorkflowRuns.list(tenantId, {
-      offset: disablePagination ? 0 : offset,
-      limit: disablePagination ? 500 : pagination.pageSize,
-      statuses: statuses && statuses.length > 0 ? statuses : undefined,
-      workflow_ids: workflowIds && workflowIds.length > 0 ? workflowIds : [],
-      parent_task_external_id: parentTaskExternalId,
-      since,
-      until: finishedBefore,
-      additional_metadata: additionalMetadata,
-      idempotency_keys: idempotencyKeys,
-      additional_metadata_operator: additionalMetadataOperator,
-      worker_id: workerId,
-      only_tasks: onlyTasks,
-      triggering_event_external_id: triggeringEventExternalId,
-      include_payloads: false,
-      running_filter: runningFilter,
-    }),
+    ...queries.v1WorkflowRuns.list(
+      tenantId,
+      {
+        offset: disablePagination ? 0 : offset,
+        limit: disablePagination ? 500 : pagination.pageSize,
+        statuses: statuses && statuses.length > 0 ? statuses : undefined,
+        workflow_ids: workflowIds && workflowIds.length > 0 ? workflowIds : [],
+        parent_task_external_id: parentTaskExternalId,
+        since,
+        until: finishedBefore,
+        additional_metadata: additionalMetadata,
+        idempotency_keys: idempotencyKeys,
+        additional_metadata_operator: additionalMetadataOperator,
+        worker_id: workerId,
+        only_tasks: onlyTasks,
+        triggering_event_external_id: triggeringEventExternalId,
+        include_payloads: false,
+        running_filter: runningFilter,
+      },
+      isSelfHosted,
+    ),
     refetchInterval:
       Object.keys(rowSelection).length > 0 ? false : refetchInterval,
   });
 
-  const tasks = listTasksQuery.data;
+  const getRowId = useCallback((row: V1TaskSummary) => {
+    return row.metadata.id;
+  }, []);
+
+  const tasks =
+    listTasksQuery.data === 'timeout' ? undefined : listTasksQuery.data;
   const tableRows = useMemo(() => {
     return tasks?.rows || [];
   }, [tasks]);
@@ -131,9 +142,23 @@ export const useRuns = ({
       .filter((row) => row !== undefined) as V1TaskSummary[];
   }, [rowSelection, tableRows]);
 
-  const getRowId = useCallback((row: V1TaskSummary) => {
-    return row.metadata.id;
-  }, []);
+  if (listTasksQuery.data === 'timeout') {
+    return {
+      numPages: 0,
+      tableRows: [],
+      selectedRuns: [],
+      refetch: listTasksQuery.refetch,
+      isLoading: listTasksQuery.isLoading,
+      isError: listTasksQuery.isError,
+      isFetching: listTasksQuery.isFetching,
+      getRowId,
+      isRefetching: listTasksQuery.isRefetching,
+      pagination,
+      setPagination,
+      setPageSize,
+      fetchTimedOut: true,
+    };
+  }
 
   return {
     numPages: tasks?.pagination.num_pages || 0,
@@ -148,5 +173,6 @@ export const useRuns = ({
     pagination,
     setPagination,
     setPageSize,
+    fetchTimedOut: false,
   };
 };

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/index.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/index.tsx
@@ -2,7 +2,7 @@ import { RunsTable } from './components/runs-table';
 import { RunsProvider } from './hooks/runs-provider';
 import { EmptyState } from '@/components/v1/molecules/empty-state/empty-state';
 import { useOnboardingActions } from '@/components/v1/molecules/empty-state/workflows-guard';
-import { Loading } from '@/components/v1/ui/loading';
+import useControlPlane from '@/hooks/use-control-plane';
 import { queries } from '@/lib/api';
 import { docsPages } from '@/lib/generated/docs';
 import { appRoutes } from '@/router';
@@ -16,6 +16,7 @@ export default function RunsPage() {
     href: docsPages.v1.quickstart.href,
     description: 'Learn about running tasks',
   });
+  const { isSelfHosted } = useControlPlane();
 
   const since24h = useMemo(
     () => new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
@@ -26,20 +27,25 @@ export default function RunsPage() {
     queries.workflows.list(tenantId, { limit: 1, offset: 0 }),
   );
   const recentRunsQuery = useQuery(
-    queries.v1WorkflowRuns.list(tenantId, {
-      limit: 1,
-      offset: 0,
-      since: since24h,
-      only_tasks: false,
-    }),
+    queries.v1WorkflowRuns.list(
+      tenantId,
+      {
+        limit: 1,
+        offset: 0,
+        since: since24h,
+        only_tasks: false,
+      },
+      isSelfHosted,
+    ),
   );
 
-  if (workflowCountQuery.isLoading || recentRunsQuery.isLoading) {
-    return <Loading />;
-  }
+  // if (workflowCountQuery.isLoading || recentRunsQuery.isLoading) {
+  //   return <Loading />;
+  // }
 
   const hasWorkflows = (workflowCountQuery.data?.rows?.length ?? 0) > 0;
-  const hasRecentRuns = (recentRunsQuery.data?.rows?.length ?? 0) > 0;
+  // const hasRecentRuns = (recentRunsQuery.data?.rows?.length ?? 0) > 0;
+  const hasRecentRuns = true;
 
   // Fail open on probe errors: the table's own error handling is more useful
   // than trapping the user on the onboarding placeholder.

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/index.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/index.tsx
@@ -2,6 +2,7 @@ import { RunsTable } from './components/runs-table';
 import { RunsProvider } from './hooks/runs-provider';
 import { EmptyState } from '@/components/v1/molecules/empty-state/empty-state';
 import { useOnboardingActions } from '@/components/v1/molecules/empty-state/workflows-guard';
+import { Loading } from '@/components/v1/ui/loading';
 import useControlPlane from '@/hooks/use-control-plane';
 import { queries } from '@/lib/api';
 import { docsPages } from '@/lib/generated/docs';
@@ -39,13 +40,14 @@ export default function RunsPage() {
     ),
   );
 
-  // if (workflowCountQuery.isLoading || recentRunsQuery.isLoading) {
-  //   return <Loading />;
-  // }
+  if (workflowCountQuery.isLoading || recentRunsQuery.isLoading) {
+    return <Loading />;
+  }
 
   const hasWorkflows = (workflowCountQuery.data?.rows?.length ?? 0) > 0;
-  // const hasRecentRuns = (recentRunsQuery.data?.rows?.length ?? 0) > 0;
-  const hasRecentRuns = true;
+  const hasRecentRuns =
+    recentRunsQuery.data !== 'timeout' &&
+    (recentRunsQuery.data?.rows?.length ?? 0) > 0;
 
   // Fail open on probe errors: the table's own error handling is more useful
   // than trapping the user on the onboarding placeholder.

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/index.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/index.tsx
@@ -51,7 +51,10 @@ export default function RunsPage() {
 
   // Fail open on probe errors: the table's own error handling is more useful
   // than trapping the user on the onboarding placeholder.
-  const probesErrored = workflowCountQuery.isError || recentRunsQuery.isError;
+  const probesErrored =
+    workflowCountQuery.isError ||
+    recentRunsQuery.isError ||
+    recentRunsQuery.data === 'timeout';
 
   if (!probesErrored && !hasWorkflows && !hasRecentRuns) {
     return (


### PR DESCRIPTION
# Description

Adding CTAs that link to Cloud on timeouts in a few places in the OSS to test it out (the runs page, the events page, and the logs page). We'll send utms with the links so we can attribute page views them

<img width="1018" height="963" alt="Screenshot 2026-08-06 at 1 40 13 PM" src="https://github.com/user-attachments/assets/fea0ad83-be65-4d38-9f5f-a374af516ae5" />

<img width="531" height="270" alt="Screenshot 2026-08-07 at 10 41 09 AM" src="https://github.com/user-attachments/assets/9d9a150d-d348-4264-a06d-3600da07deb2" />

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI

</details>
