### PR TITLE
chore: Require that PR author is assigned to issue

### DIFF
--- a/.github/workflows/close-unaccepted-prs.yml
+++ b/.github/workflows/close-unaccepted-prs.yml
@@ -39,7 +39,7 @@ jobs:
                   || ['admin', 'write'].includes(data.permission);
               } catch (err) {
                 core.info(`could not resolve permission for ${login}: ${err.message}`);
-                return false;
+                return null;
               }
             }
 
@@ -48,22 +48,25 @@ jobs:
               "Thanks for taking the time to open this pull request! :heart:",
               "",
               "To keep our review queue focused, we only accept pull requests that are linked to an " +
-                "issue the Hatchet team has already triaged and marked as `" + ACCEPTED_LABEL + "`.",
+                "issue the Hatchet team has already triaged, labelled `" + ACCEPTED_LABEL + "`, and " +
+                "assigned to you.",
               "",
-              "We couldn't find a linked accepted issue for this PR, so we're closing it for now. " +
-                "This isn't a reflection of the quality of your work — it just helps us make sure " +
-                "effort is spent on changes we're ready to merge.",
+              "We couldn't find a linked issue that's both accepted and assigned to you, so we're " +
+                "closing this PR for now. This isn't a reflection of the quality of your work — it " +
+                "just helps us make sure effort goes into changes we're ready to merge, and that two " +
+                "people don't unknowingly build the same thing.",
               "",
               "**What to do next:**",
-              "1. Open (or find) an issue describing the change and wait for a maintainer to add the " +
-                "`" + ACCEPTED_LABEL + "` label.",
-              "2. Once the issue is accepted, link it from this PR using a closing keyword " +
-                "(e.g. `Closes #123`) in the description and reopen the PR.",
-              "",
+              "1. Open (or find) an issue describing the change, and comment there to say you'd like " +
+                "to take it on.",
+              "2. Wait for a maintainer to add the `" + ACCEPTED_LABEL + "` label and assign the " +
+                "issue to you.",
+              "3. Link the issue from this PR using a closing keyword (e.g. `Closes #123`) in the " +
+                "description, then reopen the PR.",
               "Thanks again for contributing to Hatchet! :axe:",
             ].join('\n');
 
-            async function linkedAcceptedIssue(number) {
+            async function linkedAcceptedIssue(number, author) {
               const query = `
                 query($owner:String!, $repo:String!, $number:Int!) {
                   repository(owner:$owner, name:$repo) {
@@ -72,6 +75,7 @@ jobs:
                         nodes {
                           number
                           labels(first:50) { nodes { name } }
+                          assignees(first:20) { nodes { login } }
                         }
                       }
                     }
@@ -85,6 +89,7 @@ jobs:
               const nodes = res.repository.pullRequest.closingIssuesReferences.nodes || [];
               return nodes.some(issue =>
                 (issue.labels.nodes || []).some(l => l.name.toLowerCase() === ACCEPTED_LABEL)
+                && (issue.assignees.nodes || []).some(a => a.login.toLowerCase() === author.toLowerCase())
               );
             }
 
@@ -113,7 +118,13 @@ jobs:
                 core.info(`#${number}: bot author, skipping`);
                 return;
               }
-              if (await isMaintainer(pr.user && pr.user.login)) {
+              const author = pr.user && pr.user.login;
+              const maintainer = await isMaintainer(author);
+              if (maintainer === null) {
+                core.info(`#${number}: permission lookup failed, leaving open`);
+                return;
+              }
+              if (maintainer) {
                 core.info(`#${number}: author is a maintainer, skipping`);
                 return;
               }
@@ -121,7 +132,7 @@ jobs:
                 core.info(`#${number}: has ${ACCEPTED_LABEL} label, skipping`);
                 return;
               }
-              if (await linkedAcceptedIssue(number)) {
+              if (await linkedAcceptedIssue(number, author)) {
                 core.info(`#${number}: linked to an accepted issue, skipping`);
                 return;
               }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ The following requirements apply to all contributions.
 
 - First-time contributors may have at most one open pull request at a time.
 - Issues labeled [![good first issue](https://img.shields.io/github/labels/hatchet-dev/hatchet/good%20first%20issue)](https://github.com/hatchet-dev/hatchet/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22) are reserved for first-time contributors.
-- Pull requests must reference a corresponding issue labeled [![accepted](https://img.shields.io/github/labels/hatchet-dev/hatchet/accepted)](https://github.com/hatchet-dev/hatchet/issues?q=is%3Aissue%20state%3Aopen%20label%3Aaccepted).
+- Pull requests must reference a corresponding issue labeled [![accepted](https://img.shields.io/github/labels/hatchet-dev/hatchet/accepted)](https://github.com/hatchet-dev/hatchet/issues?q=is%3Aissue%20state%3Aopen%20label%3Aaccepted) **and assigned to you**. Pull requests that do not meet this requirement will be automatically closed.
 - Your GitHub account's [Activity Overview](https://docs.github.com/en/account-and-profile/how-tos/contribution-settings/showing-an-overview-of-your-activity-on-your-profile) must be public.
 - AI usage must be disclosed and comply with [AI_POLICY.md](./AI_POLICY.md) (see [AI Usage](#ai-usage)).
 
@@ -63,9 +63,13 @@ We recommend installing these tools individually using your preferred package ma
 
 ## Pull Requests
 
-Before opening a PR, check if there's a related and accepted issue in our [backlog](https://github.com/hatchet-dev/hatchet/issues).
+To keep our review queue focused, **we only accept pull requests that are linked to an issue the Hatchet team has already triaged, labeled `accepted`, and assigned to you.**
 
-For non-trivial changes (anything beyond typos or patch version bumps), please create an issue first so we can discuss the proposal and ensure it aligns with the project.
+If you want to contribute a change, please follow these steps before opening a PR:
+
+1. **Find or open an issue:** Check our [backlog](https://github.com/hatchet-dev/hatchet/issues) for a related issue, or open a new one describing your proposed change, and comment on the issue stating that you'd like to take it on.
+2. **Wait for assignment:** Wait for a maintainer to add the `accepted` label and assign the issue to you.
+3. **Link the issue:** When you open your pull request, you must link the issue from the PR description using a closing keyword (e.g., `Closes #123`).
 
 Next, ensure all changes are:
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Ensures the autoclose job correctly falls back when GH actions API fails to find permissions -- leaving the PR open instead of autoclosing. Also, updates the CONTRIBUTING.md to reflect new contributor requirements.

## Type of change

<!-- Please delete options that are not relevant. -->


- [x] Documentation change (pure documentation change)
- [x] CI (any automation pipeline changes)

## What's Changed

- Failing to retrieve author details keeps the PR open instead of auto-closing.
- Enforces that an issue must be assigned to the PR author.
- Updates CONTRIBUTING.md with new guidelines.

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude Code Opus 5 was used to enact this change on the GH actions workflow.

</details>
