### PR TITLE
fix(engine): validate jsonb for error messages too

### DIFF
--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -1272,8 +1272,8 @@ func (s *DispatcherImpl) sendStepActionEventV1(ctx context.Context, request *con
 	}
 
 	if request.EventType == contracts.StepActionEventType_STEP_EVENT_TYPE_FAILED {
-		if validationErr := v1.ValidateJSONB([]byte(request.EventPayload), "errorMessage"); validationErr != nil {
-			request.EventPayload = validationErr.Error()
+		if isValidUnicode := v1.IsUnicodeValid([]byte(request.EventPayload)); !isValidUnicode {
+			request.EventPayload = fmt.Sprintf("invalid unicode in error message: %q", request.EventPayload)
 		}
 	}
 

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -1271,6 +1271,12 @@ func (s *DispatcherImpl) sendStepActionEventV1(ctx context.Context, request *con
 		}
 	}
 
+	if request.EventType == contracts.StepActionEventType_STEP_EVENT_TYPE_FAILED {
+		if validationErr := v1.ValidateJSONB([]byte(request.EventPayload), "errorMessage"); validationErr != nil {
+			request.EventPayload = validationErr.Error()
+		}
+	}
+
 	var durableInvCount int32
 	invocationCounts, err := s.repov1.DurableEvents().GetDurableTaskInvocationCounts(ctx, tenant.ID, []v1.IdInsertedAt{
 		{ID: task.ID, InsertedAt: task.InsertedAt},

--- a/pkg/repository/jsonb.go
+++ b/pkg/repository/jsonb.go
@@ -12,7 +12,7 @@ func ValidateJSONB(jsonb []byte, fieldName string) error {
 		return nil
 	}
 
-	if !isUnicodeValid(jsonb) {
+	if !IsUnicodeValid(jsonb) {
 		return fmt.Errorf("encoded jsonb contains invalid null character \\u0000 in field `%s`", fieldName)
 	}
 
@@ -23,7 +23,7 @@ func ValidateJSONB(jsonb []byte, fieldName string) error {
 	return nil
 }
 
-func isUnicodeValid(jsonb []byte) bool {
+func IsUnicodeValid(jsonb []byte) bool {
 	dec := json.NewDecoder(bytes.NewReader(jsonb))
 	for {
 		token, err := dec.Token()

--- a/pkg/repository/jsonb_test.go
+++ b/pkg/repository/jsonb_test.go
@@ -38,7 +38,7 @@ func TestValidateJSONB_RejectsEncodedNull(t *testing.T) {
 		[]byte(`[{"a":"A","b":"B","c":"C\u0000"}]`),
 	}
 	for _, c := range cases {
-		if isValid := isUnicodeValid(c); isValid {
+		if isValid := IsUnicodeValid(c); isValid {
 			t.Fatalf("expected invalid unicode for json %q, got valid", string(c))
 		}
 	}


### PR DESCRIPTION
# Description

Validates error messages in addition to completed messages on task outputs to avoid the dreaded pg jsonb error about unicode characters

Fixes #4611

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI

</details>
