### PR TITLE
fix(engine): attempt II - reject invalid unicode in error message

### DIFF
--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -1273,7 +1273,7 @@ func (s *DispatcherImpl) sendStepActionEventV1(ctx context.Context, request *con
 
 	if request.EventType == contracts.StepActionEventType_STEP_EVENT_TYPE_FAILED {
 		if isValidUnicode := v1.IsUnicodeValid([]byte(request.EventPayload)); !isValidUnicode {
-			request.EventPayload = fmt.Sprintf("invalid unicode in error message: %q", request.EventPayload)
+			request.EventPayload = "error message contains invalid null character \\u0000. you likely need to either escape the character or strip it out of the error. this generally is the result of an LLM producing this unicode sequence in its output."
 		}
 	}
 


### PR DESCRIPTION
# Description

Attempt 2 at fixing this - realized that I didn't actually drop the error itself so we'd still end up writing to the db 🤦 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI

</details>
