### PR TITLE
fix(engine): park and evict idle MQ buffer flushers

### DIFF
--- a/internal/msgqueue/mq_buffer_core.go
+++ b/internal/msgqueue/mq_buffer_core.go
@@ -4,8 +4,17 @@ import (
 	"context"
 	"os"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"time"
 )
+
+// BUFFER_IDLE_TIMEOUT is how long a per-(tenantId, msgId) buffer can go
+// without an enqueue before it is evicted from its buffer map and its
+// goroutines are stopped.
+//
+// nolint: staticcheck
+var BUFFER_IDLE_TIMEOUT = 5 * time.Minute
 
 // nolint: staticcheck
 func init() {
@@ -13,6 +22,11 @@ func init() {
 		if d, err := time.ParseDuration(v); err == nil && d > 0 {
 			PUB_FLUSH_INTERVAL = d
 			SUB_FLUSH_INTERVAL = d
+		}
+	}
+	if v := os.Getenv("SERVER_DEFAULT_BUFFER_IDLE_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			BUFFER_IDLE_TIMEOUT = d
 		}
 	}
 	if v := os.Getenv("SERVER_DEFAULT_BUFFER_SIZE"); v != "" {
@@ -45,10 +59,18 @@ type bufferCore struct {
 	disableImmediateFlush bool
 	// drainOnShutdown controls whether flush is called synchronously on ctx cancellation.
 	drainOnShutdown bool
+
+	// evictMu guards closed: producers hold it shared for the duration of an
+	// enqueue, the evictor holds it exclusively to close the buffer.
+	evictMu    sync.RWMutex
+	closed     bool
+	lastActive atomic.Int64 // unix nanos of the last enqueue
+	// stop cancels the buffer's flusher and semaphore-releaser goroutines.
+	stop context.CancelFunc
 }
 
-func newBufferCore(flushInterval time.Duration, bufferSize, maxConcurrency int, disableImmediateFlush, drainOnShutdown bool) bufferCore {
-	return bufferCore{
+func newBufferCore(flushInterval time.Duration, bufferSize, maxConcurrency int, disableImmediateFlush, drainOnShutdown bool) *bufferCore {
+	c := &bufferCore{
 		notifier:              make(chan struct{}),
 		semaphore:             make(chan struct{}, maxConcurrency),
 		semaphoreRelease:      make(chan time.Duration, maxConcurrency),
@@ -58,6 +80,45 @@ func newBufferCore(flushInterval time.Duration, bufferSize, maxConcurrency int, 
 		disableImmediateFlush: disableImmediateFlush,
 		drainOnShutdown:       drainOnShutdown,
 	}
+	c.lastActive.Store(time.Now().UnixNano())
+	return c
+}
+
+// tryAcquire registers an enqueue against the buffer, returning false if the
+// buffer has been evicted, in which case the caller must load or create a
+// fresh buffer. On success the caller must call release once it has finished
+// enqueueing.
+func (c *bufferCore) tryAcquire() bool {
+	c.evictMu.RLock()
+
+	if c.closed {
+		c.evictMu.RUnlock()
+		return false
+	}
+
+	c.lastActive.Store(time.Now().UnixNano())
+
+	return true
+}
+
+func (c *bufferCore) release() {
+	c.evictMu.RUnlock()
+}
+
+// tryEvict marks the buffer closed if it has not seen an enqueue for at least
+// idleTimeout. Once closed no enqueue can acquire the buffer again, so it is
+// safe to remove it from the buffer map and stop its goroutines.
+func (c *bufferCore) tryEvict(idleTimeout time.Duration) bool {
+	c.evictMu.Lock()
+	defer c.evictMu.Unlock()
+
+	if c.closed || time.Since(time.Unix(0, c.lastActive.Load())) < idleTimeout {
+		return false
+	}
+
+	c.closed = true
+
+	return true
 }
 
 // startFlusher starts the ticker- and notifier-driven flush loop. flush is called

--- a/internal/msgqueue/mq_buffer_core.go
+++ b/internal/msgqueue/mq_buffer_core.go
@@ -63,12 +63,39 @@ func newBufferCore(flushInterval time.Duration, bufferSize, maxConcurrency int, 
 // startFlusher starts the ticker- and notifier-driven flush loop. flush is called
 // as go flush() for ticker and notifier events; on shutdown it is called
 // synchronously when drainOnShutdown is set.
-func (c *bufferCore) startFlusher(ctx context.Context, flush func()) {
+//
+// Buffers are created per (tenantId, msgId) and never removed, so the flusher
+// parks with the ticker stopped once the buffer is empty. Otherwise every
+// buffer ever created keeps waking up each flushInterval forever, which
+// accumulates CPU on long-running processes as tenants come and go. Producers
+// always send on notifier after enqueueing, so a parked flusher is guaranteed
+// to be woken by the next message.
+func (c *bufferCore) startFlusher(ctx context.Context, bufLen func() int, flush func()) {
 	go func() {
 		ticker := time.NewTicker(c.flushInterval)
 		defer ticker.Stop()
 
+		idle := false
+
 		for {
+			if idle {
+				select {
+				case <-ctx.Done():
+					if c.drainOnShutdown {
+						flush()
+					}
+					return
+				case <-c.notifier:
+					idle = false
+					ticker.Reset(c.flushInterval)
+					if !c.disableImmediateFlush {
+						go flush()
+					}
+				}
+
+				continue
+			}
+
 			select {
 			case <-ctx.Done():
 				if c.drainOnShutdown {
@@ -76,6 +103,12 @@ func (c *bufferCore) startFlusher(ctx context.Context, flush func()) {
 				}
 				return
 			case <-ticker.C:
+				if bufLen() == 0 {
+					ticker.Stop()
+					idle = true
+					continue
+				}
+
 				go flush()
 			case <-c.notifier:
 				if !c.disableImmediateFlush {

--- a/internal/msgqueue/mq_buffer_core_test.go
+++ b/internal/msgqueue/mq_buffer_core_test.go
@@ -1,0 +1,100 @@
+package msgqueue
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func waitForFlushCount(t *testing.T, flushCount *atomic.Int64, min int64) {
+	t.Helper()
+
+	deadline := time.After(time.Second)
+
+	for flushCount.Load() < min {
+		select {
+		case <-deadline:
+			t.Fatalf("expected at least %d flushes, got %d", min, flushCount.Load())
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+// TestFlusherParksWhenIdle verifies the flush loop stops ticking while the buffer
+// is empty and resumes when a producer signals the notifier. Buffers are never
+// removed from the per-(tenantId, msgId) maps, so a flusher that keeps ticking
+// while idle accumulates CPU forever on long-running processes.
+func TestFlusherParksWhenIdle(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := newBufferCore(5*time.Millisecond, 10, 3, false, false)
+
+	var bufLen atomic.Int64
+	var flushCount atomic.Int64
+
+	c.startFlusher(ctx, func() int { return int(bufLen.Load()) }, func() {
+		flushCount.Add(1)
+	})
+
+	// The first tick observes an empty buffer and parks; no flushes should fire.
+	time.Sleep(50 * time.Millisecond)
+
+	if got := flushCount.Load(); got != 0 {
+		t.Fatalf("expected no flushes while idle, got %d", got)
+	}
+
+	bufLen.Store(1)
+	c.notifier <- struct{}{}
+
+	waitForFlushCount(t, &flushCount, 1)
+
+	// Drain the buffer and confirm the flusher parks again.
+	bufLen.Store(0)
+	time.Sleep(50 * time.Millisecond)
+
+	parked := flushCount.Load()
+	time.Sleep(50 * time.Millisecond)
+
+	if got := flushCount.Load(); got != parked {
+		t.Fatalf("expected flusher to park after buffer drained, flushes went %d -> %d", parked, got)
+	}
+
+	// A parked flusher must wake again for subsequent messages.
+	bufLen.Store(1)
+	c.notifier <- struct{}{}
+
+	waitForFlushCount(t, &flushCount, parked+1)
+}
+
+// TestParkedFlusherRestartsTickerWithImmediateFlushDisabled verifies that when
+// immediate flushes are disabled, waking from the parked state restarts the
+// ticker so the buffered message is still flushed on the next interval.
+func TestParkedFlusherRestartsTickerWithImmediateFlushDisabled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := newBufferCore(5*time.Millisecond, 10, 3, true, false)
+
+	var bufLen atomic.Int64
+	var flushCount atomic.Int64
+
+	c.startFlusher(ctx, func() int { return int(bufLen.Load()) }, func() {
+		flushCount.Add(1)
+	})
+
+	// Let the flusher park on an empty buffer.
+	time.Sleep(50 * time.Millisecond)
+
+	if got := flushCount.Load(); got != 0 {
+		t.Fatalf("expected no flushes while idle, got %d", got)
+	}
+
+	// With immediate flush disabled the notifier only rearms the ticker, so the
+	// flush must come from a tick.
+	bufLen.Store(1)
+	c.notifier <- struct{}{}
+
+	waitForFlushCount(t, &flushCount, 1)
+}

--- a/internal/msgqueue/mq_buffer_core_test.go
+++ b/internal/msgqueue/mq_buffer_core_test.go
@@ -5,6 +5,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func waitForFlushCount(t *testing.T, flushCount *atomic.Int64, min int64) {
@@ -66,6 +68,64 @@ func TestFlusherParksWhenIdle(t *testing.T) {
 	c.notifier <- struct{}{}
 
 	waitForFlushCount(t, &flushCount, parked+1)
+}
+
+// TestSubBufferEvictsIdleBuffers verifies that buffers which have not seen a
+// message for BUFFER_IDLE_TIMEOUT are removed from the buffers map and that a
+// later message for the same key is processed through a freshly created buffer.
+func TestSubBufferEvictsIdleBuffers(t *testing.T) {
+	oldTimeout := BUFFER_IDLE_TIMEOUT
+	BUFFER_IDLE_TIMEOUT = 20 * time.Millisecond
+	defer func() { BUFFER_IDLE_TIMEOUT = oldTimeout }()
+
+	var handler MsgHandler
+	sub := func(preAck MsgHandler, postAck MsgHandler) (func() error, error) {
+		handler = preAck
+		return func() error { return nil }, nil
+	}
+
+	var processed atomic.Int64
+	dst := func(tenantId uuid.UUID, msgId string, payloads [][]byte) error {
+		processed.Add(1)
+		return nil
+	}
+
+	buf := NewSubBufferFromSubscribe(sub, dst)
+
+	cleanup, err := buf.Start()
+	if err != nil {
+		t.Fatalf("could not start sub buffer: %v", err)
+	}
+	defer cleanup() // nolint: errcheck
+
+	send := func() {
+		msg := &Message{TenantID: testTenantID, ID: "test-msg", Payloads: [][]byte{[]byte("p")}}
+		if err := handler(msg); err != nil {
+			t.Fatalf("could not handle message: %v", err)
+		}
+	}
+
+	send()
+
+	if got := buf.buffers.Len(); got != 1 {
+		t.Fatalf("expected 1 buffer after first message, got %d", got)
+	}
+
+	deadline := time.After(time.Second)
+	for buf.buffers.Len() != 0 {
+		select {
+		case <-deadline:
+			t.Fatal("idle buffer was not evicted")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+
+	// a message after eviction must create a fresh buffer and still be processed
+	send()
+
+	if got := processed.Load(); got != 2 {
+		t.Fatalf("expected 2 processed flushes, got %d", got)
+	}
 }
 
 // TestParkedFlusherRestartsTickerWithImmediateFlushDisabled verifies that when

--- a/internal/msgqueue/mq_pub_buffer.go
+++ b/internal/msgqueue/mq_pub_buffer.go
@@ -107,7 +107,7 @@ func newMsgIDPubBuffer(ctx context.Context, tenantID uuid.UUID, msgID string, pu
 		msgIdPubBufferCh: make(chan *msgWithErrCh, PUB_BUFFER_SIZE),
 		pub:              pub,
 	}
-	b.startFlusher(ctx, b.flush)
+	b.startFlusher(ctx, func() int { return len(b.msgIdPubBufferCh) }, b.flush)
 	b.startSemaphoreReleaser(ctx, func() int { return len(b.msgIdPubBufferCh) }, b.flush)
 	return b
 }

--- a/internal/msgqueue/mq_pub_buffer.go
+++ b/internal/msgqueue/mq_pub_buffer.go
@@ -33,7 +33,33 @@ type MQPubBuffer struct {
 
 func NewMQPubBuffer(mq MessageQueue) *MQPubBuffer {
 	ctx, cancel := context.WithCancel(context.Background())
-	return &MQPubBuffer{mq: mq, ctx: ctx, cancel: cancel}
+	m := &MQPubBuffer{mq: mq, ctx: ctx, cancel: cancel}
+	go m.runEvictor(ctx)
+	return m
+}
+
+// runEvictor periodically removes buffers that have not seen a message for
+// BUFFER_IDLE_TIMEOUT. Without eviction the buffers map grows with every
+// (queue, tenantId, msgId) key seen over the lifetime of the process.
+func (m *MQPubBuffer) runEvictor(ctx context.Context) {
+	ticker := time.NewTicker(BUFFER_IDLE_TIMEOUT / 2)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.buffers.Range(func(k string, b *msgIdPubBuffer) bool {
+				if len(b.msgIdPubBufferCh) == 0 && b.tryEvict(BUFFER_IDLE_TIMEOUT) {
+					m.buffers.Delete(k)
+					b.stop()
+				}
+
+				return true
+			})
+		}
+	}
 }
 
 func (m *MQPubBuffer) Stop() {
@@ -52,14 +78,33 @@ func (m *MQPubBuffer) Pub(ctx context.Context, queue Queue, msg *Message, wait b
 
 	k := getPubKey(queue, msg.TenantID, msg.ID)
 
-	msgBuf, ok := m.buffers.Load(k)
+	var msgBuf *msgIdPubBuffer
 
-	if !ok {
-		msgBuf, _ = m.buffers.LoadOrStore(k, newMsgIDPubBuffer(m.ctx, msg.TenantID, msg.ID, func(msg *Message) error {
-			msgCtx, cancel := context.WithTimeout(context.Background(), PUB_TIMEOUT)
-			defer cancel()
-			return m.mq.SendMessage(msgCtx, queue, msg)
-		}))
+	for {
+		var ok bool
+		msgBuf, ok = m.buffers.Load(k)
+
+		if !ok {
+			newBuf := newMsgIDPubBuffer(m.ctx, msg.TenantID, msg.ID, func(msg *Message) error {
+				msgCtx, cancel := context.WithTimeout(context.Background(), PUB_TIMEOUT)
+				defer cancel()
+				return m.mq.SendMessage(msgCtx, queue, msg)
+			})
+
+			var loaded bool
+			msgBuf, loaded = m.buffers.LoadOrStore(k, newBuf)
+
+			if loaded {
+				// lost the store race; stop the discarded buffer's goroutines
+				newBuf.stop()
+			}
+		}
+
+		// the buffer may have been evicted between the load and the acquire, in
+		// which case it is no longer in the map and we create a fresh one
+		if msgBuf.tryAcquire() {
+			break
+		}
 	}
 
 	msgWithErr := &msgWithErrCh{msg: msg}
@@ -78,6 +123,7 @@ func (m *MQPubBuffer) Pub(ctx context.Context, queue Queue, msg *Message, wait b
 	// this places some backpressure on the consumer if buffers are full
 	msgBuf.msgIdPubBufferCh <- msgWithErr
 	msgBuf.notifier <- struct{}{}
+	msgBuf.release()
 
 	if wait {
 		return <-msgWithErr.errCh
@@ -91,7 +137,7 @@ func getPubKey(q Queue, tenantId uuid.UUID, msgId string) string {
 }
 
 type msgIdPubBuffer struct {
-	bufferCore
+	*bufferCore
 
 	tenantId         uuid.UUID
 	msgId            string
@@ -100,6 +146,8 @@ type msgIdPubBuffer struct {
 }
 
 func newMsgIDPubBuffer(ctx context.Context, tenantID uuid.UUID, msgID string, pub PubFunc) *msgIdPubBuffer {
+	ctx, stop := context.WithCancel(ctx)
+
 	b := &msgIdPubBuffer{
 		bufferCore:       newBufferCore(PUB_FLUSH_INTERVAL, PUB_BUFFER_SIZE, PUB_MAX_CONCURRENCY, false, true),
 		tenantId:         tenantID,
@@ -107,6 +155,7 @@ func newMsgIDPubBuffer(ctx context.Context, tenantID uuid.UUID, msgID string, pu
 		msgIdPubBufferCh: make(chan *msgWithErrCh, PUB_BUFFER_SIZE),
 		pub:              pub,
 	}
+	b.stop = stop
 	b.startFlusher(ctx, func() int { return len(b.msgIdPubBufferCh) }, b.flush)
 	b.startSemaphoreReleaser(ctx, func() int { return len(b.msgIdPubBufferCh) }, b.flush)
 	return b

--- a/internal/msgqueue/mq_sub_buffer.go
+++ b/internal/msgqueue/mq_sub_buffer.go
@@ -229,7 +229,7 @@ func newMsgIDBuffer(ctx context.Context, tenantID uuid.UUID, msgID string, dst D
 		msgIdBufferCh: make(chan *msgWithResultCh, bufferSize),
 		dst:           dst,
 	}
-	b.startFlusher(ctx, b.flush)
+	b.startFlusher(ctx, func() int { return len(b.msgIdBufferCh) }, b.flush)
 	b.startSemaphoreReleaser(ctx, func() int { return len(b.msgIdBufferCh) }, b.flush)
 	return b
 }

--- a/internal/msgqueue/mq_sub_buffer.go
+++ b/internal/msgqueue/mq_sub_buffer.go
@@ -149,6 +149,8 @@ func (m *MQSubBuffer) Start() (func() error, error) {
 		return nil, fmt.Errorf("could not subscribe in mq buffer: %w", err)
 	}
 
+	go m.runEvictor(ctx)
+
 	cleanup := func() error {
 		defer cancel()
 		if err := cleanupQueue(); err != nil {
@@ -177,10 +179,29 @@ func (m *MQSubBuffer) handleMsg(ctx context.Context, msg *Message) error {
 
 	k := getKey(msg.TenantID, msg.ID)
 
-	msgBuf, ok := m.buffers.Load(k)
+	var msgBuf *msgIdBuffer
 
-	if !ok {
-		msgBuf, _ = m.buffers.LoadOrStore(k, newMsgIDBuffer(ctx, msg.TenantID, msg.ID, m.dst, m.flushInterval, m.bufferSize, m.maxConcurrency, m.disableImmediateFlush))
+	for {
+		var ok bool
+		msgBuf, ok = m.buffers.Load(k)
+
+		if !ok {
+			newBuf := newMsgIDBuffer(ctx, msg.TenantID, msg.ID, m.dst, m.flushInterval, m.bufferSize, m.maxConcurrency, m.disableImmediateFlush)
+
+			var loaded bool
+			msgBuf, loaded = m.buffers.LoadOrStore(k, newBuf)
+
+			if loaded {
+				// lost the store race; stop the discarded buffer's goroutines
+				newBuf.stop()
+			}
+		}
+
+		// the buffer may have been evicted between the load and the acquire, in
+		// which case it is no longer in the map and we create a fresh one
+		if msgBuf.tryAcquire() {
+			break
+		}
 	}
 
 	// Signal early flush if the send would block due to capacity.
@@ -196,6 +217,7 @@ func (m *MQSubBuffer) handleMsg(ctx context.Context, msg *Message) error {
 		msgBuf.msgIdBufferCh <- msgWithResult
 	}
 	msgBuf.notifier <- struct{}{}
+	msgBuf.release()
 
 	// wait for the message to be processed
 	err, ok := <-msgWithResult.result
@@ -212,8 +234,32 @@ func getKey(tenantId uuid.UUID, msgId string) string {
 	return tenantId.String() + msgId
 }
 
+// runEvictor periodically removes buffers that have not seen a message for
+// BUFFER_IDLE_TIMEOUT. Without eviction the buffers map grows with every
+// (tenantId, msgId) pair seen over the lifetime of the process.
+func (m *MQSubBuffer) runEvictor(ctx context.Context) {
+	ticker := time.NewTicker(BUFFER_IDLE_TIMEOUT / 2)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.buffers.Range(func(k string, b *msgIdBuffer) bool {
+				if len(b.msgIdBufferCh) == 0 && b.tryEvict(BUFFER_IDLE_TIMEOUT) {
+					m.buffers.Delete(k)
+					b.stop()
+				}
+
+				return true
+			})
+		}
+	}
+}
+
 type msgIdBuffer struct {
-	bufferCore
+	*bufferCore
 
 	tenantId      uuid.UUID
 	msgId         string
@@ -222,6 +268,8 @@ type msgIdBuffer struct {
 }
 
 func newMsgIDBuffer(ctx context.Context, tenantID uuid.UUID, msgID string, dst DstFunc, flushInterval time.Duration, bufferSize, maxConcurrency int, disableImmediateFlush bool) *msgIdBuffer {
+	ctx, stop := context.WithCancel(ctx)
+
 	b := &msgIdBuffer{
 		bufferCore:    newBufferCore(flushInterval, bufferSize, maxConcurrency, disableImmediateFlush, false),
 		tenantId:      tenantID,
@@ -229,6 +277,7 @@ func newMsgIDBuffer(ctx context.Context, tenantID uuid.UUID, msgID string, dst D
 		msgIdBufferCh: make(chan *msgWithResultCh, bufferSize),
 		dst:           dst,
 	}
+	b.stop = stop
 	b.startFlusher(ctx, func() int { return len(b.msgIdBufferCh) }, b.flush)
 	b.startSemaphoreReleaser(ctx, func() int { return len(b.msgIdBufferCh) }, b.flush)
 	return b

--- a/internal/msgqueue/rabbitmq/rabbitmq_test.go
+++ b/internal/msgqueue/rabbitmq/rabbitmq_test.go
@@ -213,6 +213,7 @@ func TestBufferedPubMessageQueueIntegration(t *testing.T) {
 	}
 
 	pub := msgqueue.NewMQPubBuffer(tq)
+	defer pub.Stop()
 
 	task, err := msgqueue.NewTenantMessage(testTenantUUID, id, false, true, &testMessagePayload{
 		Key: "value",

--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -403,6 +403,7 @@ func (d *DispatcherImpl) Start() (func() error, error) {
 		wg.Wait()
 
 		d.pubBuffer.Stop()
+		d.serviceV1.pubBuffer.Stop()
 		d.refreshTimeoutBuf.stop()
 
 		// drain the existing connections


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Per-(tenantId, msgId) pub/sub buffers kept a flush ticker running forever after first use, so long-lived engine processes accumulated idle timer/select CPU and goroutines. Idle flushers now park when empty, and buffers unused for `BUFFER_IDLE_TIMEOUT` (default 5m) are evicted.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

- [x] Park MQ buffer flushers when the buffer is empty (stop the flush ticker until the next enqueue)
- [x] Periodically evict idle pub/sub buffers and cancel their goroutines
- [x] Retry load/create when a producer races an eviction; stop discarded buffers from lost `LoadOrStore` races
- [x] Add unit tests for park-when-idle, wake-with-immediate-flush-disabled, and idle eviction

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

- `go test -race ./internal/msgqueue/`
- Confirmed via pprof that idle `startFlusher` / `startSemaphoreReleaser` goroutines grow with process uptime on the unfixed build

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Used to implement the park/evict changes, add regression tests, and draft this description.

</details>