### PR TITLE
fix(engine): don't call idempotency query if there are no keys

### DIFF
--- a/pkg/repository/ids.go
+++ b/pkg/repository/ids.go
@@ -264,6 +264,7 @@ func (s *sharedRepository) generateExternalIdsForChildWorkflows(ctx context.Cont
 		datas,
 		makeEventTypeArr(sqlcv1.V1TaskEventTypeSIGNALCREATED, len(taskIds)),
 		newEventKeys,
+		nil,
 	)
 
 	if err != nil {

--- a/pkg/repository/match.go
+++ b/pkg/repository/match.go
@@ -919,6 +919,7 @@ func (m *sharedRepository) processEventMatches(ctx context.Context, tx sqlcv1.DB
 			datas,
 			makeEventTypeArr(sqlcv1.V1TaskEventTypeSIGNALCOMPLETED, len(taskIds)),
 			eventKeys,
+			nil,
 		)
 
 		if err != nil {

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -2613,6 +2613,7 @@ func (r *sharedRepository) insertTasks(
 		eventDatas,
 		eventTypes,
 		make([]string, len(eventTaskIdRetryCounts)),
+		nil,
 	)
 
 	if err != nil {
@@ -2976,6 +2977,7 @@ func (r *sharedRepository) replayTasks(
 		eventDatas,
 		eventTypes,
 		make([]string, len(eventTaskIdRetryCounts)),
+		nil,
 	)
 
 	if err != nil {
@@ -3142,11 +3144,15 @@ func (r *sharedRepository) createTaskEventsAfterRelease(
 	datas := make([][]byte, len(releasedTasks))
 	externalIds := make([]uuid.UUID, len(releasedTasks))
 	isCurrentRetry := make([]bool, len(releasedTasks))
+	taskIdToIdempotencyKey := make(map[int64]string, len(releasedTasks))
 
 	for i, releasedTask := range releasedTasks {
 		datas[i] = outputs[i]
 		externalIds[i] = releasedTask.ExternalID
 		isCurrentRetry[i] = releasedTask.IsCurrentRetry
+		if releasedTask.IdempotencyKey.Valid {
+			taskIdToIdempotencyKey[releasedTask.ID] = releasedTask.IdempotencyKey.String
+		}
 	}
 
 	// filter out any rows which are not the current retry
@@ -3173,6 +3179,7 @@ func (r *sharedRepository) createTaskEventsAfterRelease(
 		filteredDatas,
 		makeEventTypeArr(eventType, len(filteredExternalIds)),
 		make([]string, len(filteredExternalIds)),
+		taskIdToIdempotencyKey,
 	)
 }
 
@@ -3214,6 +3221,7 @@ func (r *sharedRepository) createTaskEvents(
 	eventDatas [][]byte,
 	eventTypes []sqlcv1.V1TaskEventType,
 	eventKeys []string,
+	taskIdToIdempotencyKey map[int64]string,
 ) ([]InternalTaskEvent, error) {
 	if len(tasks) != len(eventDatas) {
 		return nil, fmt.Errorf("mismatched task and event data lengths")
@@ -3230,7 +3238,7 @@ func (r *sharedRepository) createTaskEvents(
 	internalTaskEvents := make([]InternalTaskEvent, len(tasks))
 
 	externalIdToData := make(map[uuid.UUID][]byte, len(tasks))
-	releaseIdempotencyKeysOpts := make([]ReleaseIdempotencyKeysOpt, len(tasks))
+	releaseIdempotencyKeysOpts := make([]ReleaseIdempotencyKeysOpt, 0, len(tasks))
 
 	for i, task := range tasks {
 		taskIds[i] = task.Id
@@ -3263,13 +3271,17 @@ func (r *sharedRepository) createTaskEvents(
 			Data:           eventDatas[i],
 		}
 
-		releaseIdempotencyKeysOpts[i] = ReleaseIdempotencyKeysOpt{
-			TaskIdInsertedAtRetryCount: &TaskIdInsertedAtRetryCount{
-				Id:         task.Id,
-				InsertedAt: task.InsertedAt,
-				RetryCount: task.RetryCount,
-			},
-			EventType: eventTypes[i],
+		if idempotencyKey, ok := taskIdToIdempotencyKey[task.Id]; ok && idempotencyKey != "" {
+			releaseIdempotencyKeysOpts = append(
+				releaseIdempotencyKeysOpts, ReleaseIdempotencyKeysOpt{
+					TaskIdInsertedAtRetryCount: &TaskIdInsertedAtRetryCount{
+						Id:         task.Id,
+						InsertedAt: task.InsertedAt,
+						RetryCount: task.RetryCount,
+					},
+					EventType: eventTypes[i],
+				},
+			)
 		}
 	}
 
@@ -3288,8 +3300,10 @@ func (r *sharedRepository) createTaskEvents(
 		return nil, err
 	}
 
-	if err := r.releaseIdempotencyKeysForStatusPolicies(ctx, dbtx, releaseIdempotencyKeysOpts); err != nil {
-		return nil, fmt.Errorf("failed to release idempotency keys: %w", err)
+	if len(releaseIdempotencyKeysOpts) > 0 {
+		if err := r.releaseIdempotencyKeysForStatusPolicies(ctx, dbtx, releaseIdempotencyKeysOpts); err != nil {
+			return nil, fmt.Errorf("failed to release idempotency keys: %w", err)
+		}
 	}
 
 	storePayloadOpts := make([]StorePayloadOpts, len(taskEvents))

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -2555,6 +2555,7 @@ func (r *sharedRepository) insertTasks(
 	eventTaskExternalIds := make([]uuid.UUID, 0)
 	eventDatas := make([][]byte, 0)
 	eventTypes := make([]sqlcv1.V1TaskEventType, 0)
+	taskIdToIdempotencyKey := make(map[int64]string)
 
 	for stepId, params := range stepIdsToParams {
 		createdTasks, err := r.queries.CreateTasks(ctx, tx, params)
@@ -2563,9 +2564,7 @@ func (r *sharedRepository) insertTasks(
 			return nil, fmt.Errorf("failed to create tasks for step id %s: %w", stepId, err)
 		}
 
-		createdTasksWithPayloads := make([]*V1TaskWithPayload, len(createdTasks))
-
-		for i, task := range createdTasks {
+		for _, task := range createdTasks {
 			input := externalIdToInput[task.ExternalID]
 			withPayload := V1TaskWithPayload{
 				V1Task:  task,
@@ -2574,31 +2573,32 @@ func (r *sharedRepository) insertTasks(
 			}
 
 			res = append(res, &withPayload)
-			createdTasksWithPayloads[i] = &withPayload
-		}
 
-		for _, createdTask := range createdTasksWithPayloads {
 			idRetryCount := TaskIdInsertedAtRetryCount{
-				Id:         createdTask.ID,
-				InsertedAt: createdTask.InsertedAt,
-				RetryCount: createdTask.RetryCount,
+				Id:         withPayload.ID,
+				InsertedAt: withPayload.InsertedAt,
+				RetryCount: withPayload.RetryCount,
 			}
 
-			switch createdTask.InitialState {
+			if task.IdempotencyKey.Valid {
+				taskIdToIdempotencyKey[withPayload.ID] = task.IdempotencyKey.String
+			}
+
+			switch withPayload.InitialState {
 			case sqlcv1.V1TaskInitialStateFAILED:
 				eventTaskIdRetryCounts = append(eventTaskIdRetryCounts, idRetryCount)
-				eventTaskExternalIds = append(eventTaskExternalIds, createdTask.ExternalID)
-				eventDatas = append(eventDatas, NewFailedTaskOutputEventFromTask(createdTask).Bytes())
+				eventTaskExternalIds = append(eventTaskExternalIds, withPayload.ExternalID)
+				eventDatas = append(eventDatas, NewFailedTaskOutputEventFromTask(&withPayload).Bytes())
 				eventTypes = append(eventTypes, sqlcv1.V1TaskEventTypeFAILED)
 			case sqlcv1.V1TaskInitialStateCANCELLED:
 				eventTaskIdRetryCounts = append(eventTaskIdRetryCounts, idRetryCount)
-				eventTaskExternalIds = append(eventTaskExternalIds, createdTask.ExternalID)
-				eventDatas = append(eventDatas, NewCancelledTaskOutputEventFromTask(createdTask).Bytes())
+				eventTaskExternalIds = append(eventTaskExternalIds, withPayload.ExternalID)
+				eventDatas = append(eventDatas, NewCancelledTaskOutputEventFromTask(&withPayload).Bytes())
 				eventTypes = append(eventTypes, sqlcv1.V1TaskEventTypeCANCELLED)
 			case sqlcv1.V1TaskInitialStateSKIPPED:
 				eventTaskIdRetryCounts = append(eventTaskIdRetryCounts, idRetryCount)
-				eventTaskExternalIds = append(eventTaskExternalIds, createdTask.ExternalID)
-				eventDatas = append(eventDatas, NewSkippedTaskOutputEventFromTask(createdTask).Bytes())
+				eventTaskExternalIds = append(eventTaskExternalIds, withPayload.ExternalID)
+				eventDatas = append(eventDatas, NewSkippedTaskOutputEventFromTask(&withPayload).Bytes())
 				eventTypes = append(eventTypes, sqlcv1.V1TaskEventTypeCOMPLETED)
 			}
 		}
@@ -2613,7 +2613,7 @@ func (r *sharedRepository) insertTasks(
 		eventDatas,
 		eventTypes,
 		make([]string, len(eventTaskIdRetryCounts)),
-		nil,
+		taskIdToIdempotencyKey,
 	)
 
 	if err != nil {
@@ -2909,6 +2909,7 @@ func (r *sharedRepository) replayTasks(
 	eventTaskExternalIds := make([]uuid.UUID, 0)
 	eventDatas := make([][]byte, 0)
 	eventTypes := make([]sqlcv1.V1TaskEventType, 0)
+	taskIdToIdempotencyKey := make(map[int64]string)
 
 	for stepId, params := range stepIdsToParams {
 		replayRes, err := r.queries.ReplayTasks(ctx, tx, params)
@@ -2929,40 +2930,40 @@ func (r *sharedRepository) replayTasks(
 			return nil, fmt.Errorf("failed to store payloads for step id %s: %w", stepId, err)
 		}
 
-		replayResWithPayloads := make([]*V1TaskWithPayload, len(replayRes))
-		for i, task := range replayRes {
+		for _, task := range replayRes {
 			input := externalIdToInput[task.ExternalID]
 			withPayload := V1TaskWithPayload{
 				V1Task:  task,
 				Runtime: nil,
 				Payload: input,
 			}
-			replayResWithPayloads[i] = &withPayload
 			res = append(res, &withPayload)
-		}
 
-		for _, replayedTask := range replayResWithPayloads {
-			idRetryCount := TaskIdInsertedAtRetryCount{
-				Id:         replayedTask.ID,
-				InsertedAt: replayedTask.InsertedAt,
-				RetryCount: replayedTask.RetryCount,
+			if task.IdempotencyKey.Valid {
+				taskIdToIdempotencyKey[withPayload.ID] = task.IdempotencyKey.String
 			}
 
-			switch replayedTask.InitialState {
+			idRetryCount := TaskIdInsertedAtRetryCount{
+				Id:         withPayload.ID,
+				InsertedAt: withPayload.InsertedAt,
+				RetryCount: withPayload.RetryCount,
+			}
+
+			switch withPayload.InitialState {
 			case sqlcv1.V1TaskInitialStateFAILED:
 				eventTaskIdRetryCounts = append(eventTaskIdRetryCounts, idRetryCount)
-				eventTaskExternalIds = append(eventTaskExternalIds, replayedTask.ExternalID)
-				eventDatas = append(eventDatas, NewFailedTaskOutputEventFromTask(replayedTask).Bytes())
+				eventTaskExternalIds = append(eventTaskExternalIds, withPayload.ExternalID)
+				eventDatas = append(eventDatas, NewFailedTaskOutputEventFromTask(&withPayload).Bytes())
 				eventTypes = append(eventTypes, sqlcv1.V1TaskEventTypeFAILED)
 			case sqlcv1.V1TaskInitialStateCANCELLED:
 				eventTaskIdRetryCounts = append(eventTaskIdRetryCounts, idRetryCount)
-				eventTaskExternalIds = append(eventTaskExternalIds, replayedTask.ExternalID)
-				eventDatas = append(eventDatas, NewCancelledTaskOutputEventFromTask(replayedTask).Bytes())
+				eventTaskExternalIds = append(eventTaskExternalIds, withPayload.ExternalID)
+				eventDatas = append(eventDatas, NewCancelledTaskOutputEventFromTask(&withPayload).Bytes())
 				eventTypes = append(eventTypes, sqlcv1.V1TaskEventTypeCANCELLED)
 			case sqlcv1.V1TaskInitialStateSKIPPED:
 				eventTaskIdRetryCounts = append(eventTaskIdRetryCounts, idRetryCount)
-				eventTaskExternalIds = append(eventTaskExternalIds, replayedTask.ExternalID)
-				eventDatas = append(eventDatas, NewSkippedTaskOutputEventFromTask(replayedTask).Bytes())
+				eventTaskExternalIds = append(eventTaskExternalIds, withPayload.ExternalID)
+				eventDatas = append(eventDatas, NewSkippedTaskOutputEventFromTask(&withPayload).Bytes())
 				eventTypes = append(eventTypes, sqlcv1.V1TaskEventTypeCOMPLETED)
 			}
 		}
@@ -2977,7 +2978,7 @@ func (r *sharedRepository) replayTasks(
 		eventDatas,
 		eventTypes,
 		make([]string, len(eventTaskIdRetryCounts)),
-		nil,
+		taskIdToIdempotencyKey,
 	)
 
 	if err != nil {


### PR DESCRIPTION
# Description

Avoids calling an expensive idempotency query if no keys are provided to improve performance

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI

</details>
