### PR TITLE
fix(mcp): Include `get_docs` in tools list

### DIFF
--- a/frontend/docs/app/api/mcp/route.ts
+++ b/frontend/docs/app/api/mcp/route.ts
@@ -281,9 +281,9 @@ function handleToolsList(id: string | number | null): JsonRpcResponse {
     result: {
       tools: [
         {
-          name: "get_full_docs",
+          name: "get_docs",
           description:
-            "Retrieve the full Hatchet documentation as a single text file.",
+            "Retrieve the index Hatchet documentation page as a text file.",
           inputSchema: { type: "object", properties: {}, required: [] },
         },
         {
@@ -321,6 +321,10 @@ function handleToolsCall(
 
   if (toolName === "search_docs") {
     return handleSearchDocs(id, args);
+  }
+
+  if (toolName === "get_docs") {
+    return handleGetDocs();
   }
 
   if (toolName === "get_full_docs") {
@@ -438,6 +442,31 @@ function handleSearchDocs(
     id,
     result: {
       content: [{ type: "text", text }],
+    },
+  };
+}
+
+function handleGetDocs(): JsonRpcResponse {
+  const docsPath = path.join(process.cwd(), "public", "llms.txt");
+  let content = "";
+  try {
+    content = fs.readFileSync(docsPath, "utf-8");
+  } catch {
+    return {
+      jsonrpc: "2.0",
+      id: null,
+      error: {
+        code: -32603,
+        message: "Failed to read documentation index file",
+      },
+    };
+  }
+
+  return {
+    jsonrpc: "2.0",
+    id: null,
+    result: {
+      content: [{ type: "text", text: content }],
     },
   };
 }

--- a/frontend/docs/app/api/mcp/route.ts
+++ b/frontend/docs/app/api/mcp/route.ts
@@ -281,6 +281,12 @@ function handleToolsList(id: string | number | null): JsonRpcResponse {
     result: {
       tools: [
         {
+          name: "get_full_docs",
+          description:
+            "Retrieve the full Hatchet documentation as a single text file.",
+          inputSchema: { type: "object", properties: {}, required: [] },
+        },
+        {
           name: "search_docs",
           description:
             "Search Hatchet documentation by keyword. Returns matching page titles and URIs.",


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This helps to improve documentation discovery for Agents/LLMs my including the (previously omitted) `get_docs` tool in the return value of `tools/list`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [x] Added `get__docs` to the list returned by `tools/list`

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
    - Manually verified that the new tools/list endpoint returns both `search_docs` and `get_full_docs` 
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
