### PR TITLE
chore(go-sdk): log pending workflow result waits

### DIFF
--- a/pkg/client/workflow.go
+++ b/pkg/client/workflow.go
@@ -3,8 +3,10 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -93,6 +95,17 @@ func (r *WorkflowResult) Results() (interface{}, error) {
 // (StreamSyncMaxAttempts) for send and subscribe failures. The background
 // listen loop reconnects unboundedly while the listener remains open.
 func (r *Workflow) Result() (*WorkflowResult, error) {
+	return r.result(nil)
+}
+
+// ResultWithContext waits for the workflow run to complete and logs if the
+// caller's context ends after the result subscription was sent successfully.
+// Context cancellation is diagnostic only and does not change Result behavior.
+func (r *Workflow) ResultWithContext(ctx context.Context) (*WorkflowResult, error) {
+	return r.result(ctx)
+}
+
+func (r *Workflow) result(ctx context.Context) (*WorkflowResult, error) {
 	resChan := make(chan *WorkflowResult, 1)
 	failChan := make(chan error, 1)
 	sessionId := uuid.NewString()
@@ -115,15 +128,30 @@ func (r *Workflow) Result() (*WorkflowResult, error) {
 	}
 	defer r.listener.RemoveWorkflowRun(r.workflowRunId, sessionId)
 
-	select {
-	case res := <-resChan:
-		for _, stepRunResult := range res.workflowRun.Results {
-			if stepRunResult.Error != nil {
-				return nil, fmt.Errorf("%s", *stepRunResult.Error)
+	waitStarted := time.Now()
+	var contextDone <-chan struct{}
+	if ctx != nil {
+		contextDone = ctx.Done()
+	}
+
+	for {
+		select {
+		case res := <-resChan:
+			for _, stepRunResult := range res.workflowRun.Results {
+				if stepRunResult.Error != nil {
+					return nil, fmt.Errorf("%s", *stepRunResult.Error)
+				}
 			}
+			return res, nil
+		case err := <-failChan:
+			return nil, fmt.Errorf("workflow run listener terminated while waiting for %s: %w", r.workflowRunId, err)
+		case <-contextDone:
+			r.listener.l.Warn().
+				Err(ctx.Err()).
+				Str("workflow_run_id", r.workflowRunId).
+				Dur("wait_duration", time.Since(waitStarted)).
+				Msg("workflow result still pending after subscription send succeeded")
+			contextDone = nil
 		}
-		return res, nil
-	case err := <-failChan:
-		return nil, fmt.Errorf("workflow run listener terminated while waiting for %s: %w", r.workflowRunId, err)
 	}
 }

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -838,11 +838,21 @@ type WorkflowRunRef struct {
 
 // V0Workflow returns the underlying v0Client.Workflow.
 func (wr *WorkflowRunRef) Result() (*WorkflowResult, error) {
+	return wr.resultWithContext(nil)
+}
+
+func (wr *WorkflowRunRef) resultWithContext(ctx context.Context) (*WorkflowResult, error) {
 	if wr.resultFn != nil {
 		return wr.resultFn()
 	}
 
-	result, err := wr.v0Workflow.Result()
+	var result *v0Client.WorkflowResult
+	var err error
+	if ctx == nil {
+		result, err = wr.v0Workflow.Result()
+	} else {
+		result, err = wr.v0Workflow.ResultWithContext(ctx)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/sdks/go/workflow.go
+++ b/sdks/go/workflow.go
@@ -846,8 +846,10 @@ func (w *Workflow) OnFailure(fn any) {
 func (w *Workflow) Run(ctx context.Context, input any, opts ...RunOptFunc) (*WorkflowResult, error) {
 	tracer := otel.Tracer("github.com/hatchet-dev/hatchet/sdks/go")
 	otelCtx := ctx
+	var resultWaitContext context.Context
 	if hCtx, ok := ctx.(Context); ok {
 		otelCtx = hCtx.GetContext()
+		resultWaitContext = otelCtx
 	}
 	otelCtx, span := tracer.Start(otelCtx, hatchetotel.SpanRunWorkflow,
 		trace.WithSpanKind(trace.SpanKindProducer),
@@ -863,7 +865,7 @@ func (w *Workflow) Run(ctx context.Context, input any, opts ...RunOptFunc) (*Wor
 		return nil, err
 	}
 
-	workflowResult, err := workflowRunRef.resultWithContext(ctx)
+	workflowResult, err := workflowRunRef.resultWithContext(resultWaitContext)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		span.RecordError(err)

--- a/sdks/go/workflow.go
+++ b/sdks/go/workflow.go
@@ -863,7 +863,7 @@ func (w *Workflow) Run(ctx context.Context, input any, opts ...RunOptFunc) (*Wor
 		return nil, err
 	}
 
-	workflowResult, err := workflowRunRef.Result()
+	workflowResult, err := workflowRunRef.resultWithContext(ctx)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		span.RecordError(err)


### PR DESCRIPTION
# Description

Log when a child workflow result remains pending after its parent task context is cancelled.

## Type of change

- [x] Chore (changes which are not directly related to any business logic)


## What's Changed

- [x] Warn once when a parent task context ends after its child result subscription succeeds.

**Why do I want to add this?**

`Workflow.Run` does two things:

1. Starts the child workflow.
2. Subscribes to a notification saying when the child finishes.

The SDK can successfully send that subscription request, then wait indefinitely if the notification never arrives. When the parent task eventually times out, we currently get no client-side clue showing where it was stuck. The logline helps distinguish a silent result-delivery problem from a failure to start or subscribe.

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

`go test -race ./pkg/client ./sdks/go -count=1`

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Cursor-assisted implementation and review.

</details>