### PR TITLE
chore(dispatcher): warn on task assigned bulk send failures

### DIFF
--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -570,7 +570,7 @@ func (d *DispatcherImpl) handleTaskBulkAssignedTask(ctx context.Context, msg *ms
 		}
 
 		if outerErr != nil {
-			d.l.Error().Ctx(ctx).Err(outerErr).Msg("failed to handle task assigned bulk message")
+			d.l.Warn().Ctx(ctx).Err(outerErr).Msg("failed to handle task assigned bulk message")
 		}
 	}()
 


### PR DESCRIPTION
## Summary
- Downgrade `failed to handle task assigned bulk message` from error to warning in the dispatcher.
- These failures (especially worker send flow control) are already requeued via the retry path, so error-level logging is noisy.

## Test plan
- [ ] Confirm dispatcher still requeues tasks when send fails / flow control is active
- [ ] Confirm the log appears as `WRN` rather than `ERR` under flow control