### PR TITLE
chore: version override

### DIFF
--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -450,6 +450,10 @@ func (c *ConfigLoader) CreateServerFromConfig(version string, overrides ...Serve
 		override(cf)
 	}
 
+	if cf.VersionOverride != "" {
+		version = cf.VersionOverride
+	}
+
 	return createControllerLayer(dc, cf, version)
 }
 

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -87,6 +87,8 @@ type ServerConfigFile struct {
 	CronOperations CronOperationsConfigFile `mapstructure:"cronOperations" json:"cronOperations,omitempty"`
 
 	OLAPStatusUpdates OLAPStatusUpdateConfigFile `mapstructure:"statusUpdates" json:"statusUpdates,omitempty"`
+
+	VersionOverride string `mapstructure:"versionOverride" json:"versionOverride,omitempty"`
 }
 
 type ConfigFileAdditionalLoggers struct {
@@ -1045,4 +1047,7 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("auth.controlPlaneExchangeToken.jwtPublicKeysetFile", "SERVER_AUTH_CONTROL_PLANE_EXCHANGE_TOKEN_JWT_PUBLIC_KEYSET_FILE")
 	_ = v.BindEnv("auth.controlPlaneExchangeToken.issuer", "SERVER_AUTH_CONTROL_PLANE_EXCHANGE_TOKEN_ISSUER")
 	_ = v.BindEnv("auth.controlPlaneExchangeToken.audience", "SERVER_AUTH_CONTROL_PLANE_EXCHANGE_TOKEN_AUDIENCE")
+
+	// misc options
+	_ = v.BindEnv("versionOverride", "SERVER_VERSION_OVERRIDE")
 }


### PR DESCRIPTION
# Description

Was getting sick of needing to manually set the version in the `WithVersion` helper so I'm setting this override so we can set versions in our .envs and forget it. Without setting the version, the durable stuff, etc. is all borked because of how we're flagigng

## Type of change

- [x] Chore (changes which are not directly related to any business logic)

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI

</details>
