### PR TITLE
Fix links at https://docs.hatchet.run/self-hosting

### DIFF
--- a/frontend/docs/content/docs/self-hosting/index.mdx
+++ b/frontend/docs/content/docs/self-hosting/index.mdx
@@ -30,9 +30,9 @@ There are currently three supported ways to self-host the Hatchet Control Plane:
 
 Docker:
 
-1. [Hatchet Lite](./self-hosting/hatchet-lite.mdx) - Single docker image with bundled engine and API (development, testing, or low-throughput production)
-2. [Docker Compose](./self-hosting/docker-compose.mdx) - Multi-container setup with PostgreSQL and RabbitMQ (production)
+1. [Hatchet Lite](./self-hosting/hatchet-lite) - Single docker image with bundled engine and API (development, testing, or low-throughput production)
+2. [Docker Compose](./self-hosting/docker-compose) - Multi-container setup with PostgreSQL and RabbitMQ (production)
 
 Kubernetes:
 
-1. [Quickstart with Helm](./self-hosting/kubernetes-quickstart.mdx) - Production-ready Helm charts (production)
+1. [Quickstart with Helm](./self-hosting/kubernetes-quickstart) - Production-ready Helm charts (production)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Fixes links at https://docs.hatchet.run/self-hosting
Closes #4680 

I didn't make an issue for this since I think that adds more noise than me just doing this PR.
Let me know if you want issue for these things

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [X] Removed `.mdx` from links which broke them

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)


 ## Testing

I'll admit that I did the change from the Github UI because I am lazy so I did not do any testing

I checked another file for how to correctly make the link


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

No ai

</details>
