### PR TITLE
fix(engine): small durable event ingest db optimizations

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260812172010_v1_0_139.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260812172010_v1_0_139.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE v1_task_event ADD COLUMN child_external_id UUID;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE v1_task_event DROP COLUMN child_external_id;
+-- +goose StatementEnd

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -733,15 +733,17 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 	ctx context.Context,
 	tx sqlcv1.DBTX,
 	opts GetOrCreateLogEntryOpts,
-) ([]*EventLogEntryWithPayloads, error) {
+) ([]*EventLogEntryWithPayloads, []StorePayloadOpts, error) {
 	ctx, span := telemetry.NewSpan(ctx, "get-or-create-durable-event-log-entries")
 	defer span.End()
 
 	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "entry_count", Value: len(opts.Entries)})
 
 	if len(opts.Entries) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
+
+	var pendingStorePayloadOpts []StorePayloadOpts
 
 	var skipOpts, nonSkipOpts []GetOrCreateLogEntryOpt
 	for _, o := range opts.Entries {
@@ -771,7 +773,7 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 			Nodeids:               nodeIds,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("failed to bulk-get existing entries: %w", err)
+			return nil, nil, fmt.Errorf("failed to bulk-get existing entries: %w", err)
 		}
 
 		existingByKey := make(map[NodeIdBranchIdTuple]*sqlcv1.BulkGetDurableEventLogEntriesRow, len(existing))
@@ -787,7 +789,7 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 				continue
 			}
 			if !bytes.Equal(o.IdempotencyKey, e.IdempotencyKey) {
-				return nil, &NonDeterminismError{
+				return nil, nil, &NonDeterminismError{
 					BranchId:                o.BranchId,
 					NodeId:                  o.NodeId,
 					TaskExternalId:          opts.DurableTaskExternalId,
@@ -843,7 +845,7 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 
 		createdRows, createErr := r.queries.BulkCreateDurableEventLogEntries(ctx, tx, createParams)
 		if createErr != nil {
-			return nil, fmt.Errorf("failed to bulk-create event log entries: %w", createErr)
+			return nil, nil, fmt.Errorf("failed to bulk-create event log entries: %w", createErr)
 		}
 
 		for _, createdRow := range createdRows {
@@ -878,11 +880,7 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 			}
 		}
 
-		if len(storePayloadOpts) > 0 {
-			if storeErr := r.payloadStore.Store(ctx, tx, storePayloadOpts...); storeErr != nil {
-				return nil, fmt.Errorf("failed to store payloads for new entries: %w", storeErr)
-			}
-		}
+		pendingStorePayloadOpts = storePayloadOpts
 	}
 
 	childTaskExternalIdToSkipEntry := make(map[uuid.UUID]*sqlcv1.BulkGetDurableEventLogEntriesRow)
@@ -892,7 +890,7 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 		seenChildTaskExternalIds := make(map[uuid.UUID]struct{}, len(skipOpts))
 		for _, o := range skipOpts {
 			if o.ChildTaskExternalId == uuid.Nil {
-				return nil, fmt.Errorf("skipped child entries must include a non-nil child task external id")
+				return nil, nil, fmt.Errorf("skipped child entries must include a non-nil child task external id")
 			}
 
 			if _, ok := seenChildTaskExternalIds[o.ChildTaskExternalId]; ok {
@@ -909,7 +907,7 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 			Childtaskexternalids:  childTaskExternalIds,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("failed to get log entries by child task external ids: %w", err)
+			return nil, nil, fmt.Errorf("failed to get log entries by child task external ids: %w", err)
 		}
 
 		for _, row := range skipRows {
@@ -944,11 +942,11 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 			e, ok := childTaskExternalIdToSkipEntry[o.ChildTaskExternalId]
 
 			if !ok {
-				return nil, fmt.Errorf("expected to find log entry for skipped child task external id %s", o.ChildTaskExternalId)
+				return nil, nil, fmt.Errorf("expected to find log entry for skipped child task external id %s", o.ChildTaskExternalId)
 			}
 
 			if len(o.IdempotencyKey) > 0 && !bytes.Equal(o.IdempotencyKey, e.IdempotencyKey) {
-				return nil, &NonDeterminismError{
+				return nil, nil, &NonDeterminismError{
 					BranchId:                e.BranchID,
 					NodeId:                  e.NodeID,
 					TaskExternalId:          opts.DurableTaskExternalId,
@@ -1060,7 +1058,7 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 		return int(i.Entry.BranchID - j.Entry.BranchID)
 	})
 
-	return results, nil
+	return results, pendingStorePayloadOpts, nil
 }
 
 func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, opts IngestDurableTaskEventOpts) (*IngestDurableTaskEventResult, error) {
@@ -1251,7 +1249,7 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 		return nil, fmt.Errorf("unsupported durable event log entry kind: %s", opts.Kind)
 	}
 
-	logEntries, err := r.getOrCreateEventLogEntries(ctx, tx, getOrCreateOpts)
+	logEntries, entryStorePayloadOpts, err := r.getOrCreateEventLogEntries(ctx, tx, getOrCreateOpts)
 	if err != nil {
 		var nde *NonDeterminismError
 		if errors.As(err, &nde) {
@@ -1339,11 +1337,13 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 		}
 
 		if len(newTriggerOpts) > 0 {
-			createdTasks, createdDags, _, celFailures, triggerErr := r.triggerFromWorkflowNames(ctx, optTx, tenantId, newTriggerOpts)
+			createdTasks, createdDags, _, celFailures, triggerStorePayloadOpts, triggerErr := r.triggerFromWorkflowNames(ctx, optTx, tenantId, newTriggerOpts)
 
 			if triggerErr != nil {
 				return nil, fmt.Errorf("failed to trigger workflows: %w", triggerErr)
 			}
+
+			entryStorePayloadOpts = append(entryStorePayloadOpts, triggerStorePayloadOpts...)
 
 			triggerRunsResult.CreatedTasks = createdTasks
 			triggerRunsResult.CreatedDAGs = createdDags
@@ -1528,6 +1528,12 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 			BranchId:        le.Entry.BranchID,
 			ResultPayload:   le.ResultPayload,
 			AlreadyExisted:  le.AlreadyExisted,
+		}
+	}
+
+	if len(entryStorePayloadOpts) > 0 {
+		if storeErr := r.payloadStore.Store(ctx, tx, entryStorePayloadOpts...); storeErr != nil {
+			return nil, fmt.Errorf("failed to store payloads for new entries: %w", storeErr)
 		}
 	}
 

--- a/pkg/repository/ids.go
+++ b/pkg/repository/ids.go
@@ -242,7 +242,7 @@ func (s *sharedRepository) generateExternalIdsForChildWorkflows(ctx context.Cont
 	taskExternalIds := make([]uuid.UUID, 0, len(opts))
 	datas := make([][]byte, 0, len(opts))
 	newEventKeys := make([]string, 0, len(opts))
-	taskIdToChildExternalId := make(map[int64]*uuid.UUID)
+	childExternalIds := make([]*uuid.UUID, 0, len(opts))
 
 	// for all other opts, write the events to the database
 	for i := range opts {
@@ -271,7 +271,7 @@ func (s *sharedRepository) generateExternalIdsForChildWorkflows(ctx context.Cont
 		taskExternalIds = append(taskExternalIds, lookupRow.ExternalID)
 		datas = append(datas, data.Bytes())
 		newEventKeys = append(newEventKeys, getChildSignalEventKey(*opt.ParentExternalId, 0, *opt.ChildIndex, opt.ChildKey))
-		taskIdToChildExternalId[lookupRow.TaskID.Int64] = &generatedId
+		childExternalIds = append(childExternalIds, &generatedId)
 	}
 
 	// create the relevant events
@@ -285,7 +285,7 @@ func (s *sharedRepository) generateExternalIdsForChildWorkflows(ctx context.Cont
 		makeEventTypeArr(sqlcv1.V1TaskEventTypeSIGNALCREATED, len(taskIds)),
 		newEventKeys,
 		nil,
-		taskIdToChildExternalId,
+		childExternalIds,
 	)
 
 	if err != nil {

--- a/pkg/repository/ids.go
+++ b/pkg/repository/ids.go
@@ -177,46 +177,64 @@ func (s *sharedRepository) generateExternalIdsForChildWorkflows(ctx context.Cont
 		return err
 	}
 
-	retrievePayloadOpts := make([]RetrievePayloadOpts, len(lockedEvents))
+	// only need to hit the payload store for events created before the child_external_id column existed
+	retrievePayloadOpts := make([]RetrievePayloadOpts, 0, len(lockedEvents))
 
-	for i, lockedEvent := range lockedEvents {
-		retrievePayloadOpts[i] = RetrievePayloadOpts{
+	for _, lockedEvent := range lockedEvents {
+		if lockedEvent.ChildExternalID != nil {
+			continue
+		}
+
+		retrievePayloadOpts = append(retrievePayloadOpts, RetrievePayloadOpts{
 			Id:         lockedEvent.ID,
 			InsertedAt: lockedEvent.InsertedAt,
 			Type:       sqlcv1.V1PayloadTypeTASKEVENTDATA,
 			TenantId:   tenantId,
 			ExternalId: lockedEvent.ExternalID,
-		}
+		})
 	}
 
-	payloads, err := s.payloadStore.Retrieve(ctx, tx, retrievePayloadOpts...)
+	var payloads map[RetrievePayloadOpts][]byte
 
-	if err != nil {
-		return err
+	if len(retrievePayloadOpts) > 0 {
+		payloads, err = s.payloadStore.Retrieve(ctx, tx, retrievePayloadOpts...)
+
+		if err != nil {
+			return err
+		}
 	}
 
 	// for each locked event, write the correct external id to the opt
 	for _, lockedEvent := range lockedEvents {
 		opt := spawnKeyToOpt[lockedEvent.EventKey.String]
-		payload, ok := payloads[RetrievePayloadOpts{
-			Id:         lockedEvent.ID,
-			InsertedAt: lockedEvent.InsertedAt,
-			Type:       sqlcv1.V1PayloadTypeTASKEVENTDATA,
-			TenantId:   tenantId,
-			ExternalId: lockedEvent.ExternalID,
-		}]
 
-		if !ok {
-			payload = lockedEvent.Data
+		var childExternalId uuid.UUID
+
+		if lockedEvent.ChildExternalID != nil {
+			childExternalId = *lockedEvent.ChildExternalID
+		} else {
+			payload, ok := payloads[RetrievePayloadOpts{
+				Id:         lockedEvent.ID,
+				InsertedAt: lockedEvent.InsertedAt,
+				Type:       sqlcv1.V1PayloadTypeTASKEVENTDATA,
+				TenantId:   tenantId,
+				ExternalId: lockedEvent.ExternalID,
+			}]
+
+			if !ok {
+				payload = lockedEvent.Data
+			}
+
+			c, err := newChildWorkflowSignalCreatedDataFromBytes(payload)
+
+			if err != nil {
+				return err
+			}
+
+			childExternalId = c.ChildExternalId
 		}
 
-		c, err := newChildWorkflowSignalCreatedDataFromBytes(payload)
-
-		if err != nil {
-			return err
-		}
-
-		opt.ExternalId = c.ChildExternalId
+		opt.ExternalId = childExternalId
 		opt.ShouldSkip = true
 	}
 
@@ -224,6 +242,7 @@ func (s *sharedRepository) generateExternalIdsForChildWorkflows(ctx context.Cont
 	taskExternalIds := make([]uuid.UUID, 0, len(opts))
 	datas := make([][]byte, 0, len(opts))
 	newEventKeys := make([]string, 0, len(opts))
+	taskIdToChildExternalId := make(map[int64]*uuid.UUID)
 
 	// for all other opts, write the events to the database
 	for i := range opts {
@@ -252,6 +271,7 @@ func (s *sharedRepository) generateExternalIdsForChildWorkflows(ctx context.Cont
 		taskExternalIds = append(taskExternalIds, lookupRow.ExternalID)
 		datas = append(datas, data.Bytes())
 		newEventKeys = append(newEventKeys, getChildSignalEventKey(*opt.ParentExternalId, 0, *opt.ChildIndex, opt.ChildKey))
+		taskIdToChildExternalId[lookupRow.TaskID.Int64] = &generatedId
 	}
 
 	// create the relevant events
@@ -265,6 +285,7 @@ func (s *sharedRepository) generateExternalIdsForChildWorkflows(ctx context.Cont
 		makeEventTypeArr(sqlcv1.V1TaskEventTypeSIGNALCREATED, len(taskIds)),
 		newEventKeys,
 		nil,
+		taskIdToChildExternalId,
 	)
 
 	if err != nil {

--- a/pkg/repository/match.go
+++ b/pkg/repository/match.go
@@ -920,6 +920,7 @@ func (m *sharedRepository) processEventMatches(ctx context.Context, tx sqlcv1.DB
 			makeEventTypeArr(sqlcv1.V1TaskEventTypeSIGNALCOMPLETED, len(taskIds)),
 			eventKeys,
 			nil,
+			nil,
 		)
 
 		if err != nil {

--- a/pkg/repository/shared.go
+++ b/pkg/repository/shared.go
@@ -39,6 +39,7 @@ type sharedRepository struct {
 	tenantIdWorkflowNameCache   *expirable.LRU[string, *sqlcv1.ListWorkflowsByNamesRow]
 	workflowIdNameCache         *expirable.LRU[uuid.UUID, string]
 	stepsInWorkflowVersionCache *expirable.LRU[uuid.UUID, []*sqlcv1.ListStepsByWorkflowVersionIdsRow]
+	stepIdConfigCache           *expirable.LRU[uuid.UUID, *sqlcv1.ListStepsByIdsRow]
 	stepIdLabelsCache           *expirable.LRU[uuid.UUID, []*sqlcv1.GetDesiredLabelsRow]
 	stepIdSlotRequestsCache     *expirable.LRU[uuid.UUID, map[string]int32]
 	stepIdHasBatchConfigCache   *expirable.LRU[uuid.UUID, bool]
@@ -71,6 +72,7 @@ func newSharedRepository(
 	// a workflow id always maps to the same name, so a long TTL is safe
 	workflowIdNameCache := expirable.NewLRU(10000, func(key uuid.UUID, value string) {}, time.Hour)
 	stepsInWorkflowVersionCache := expirable.NewLRU(10000, func(key uuid.UUID, value []*sqlcv1.ListStepsByWorkflowVersionIdsRow) {}, 5*time.Minute)
+	stepIdConfigCache := expirable.NewLRU(10000, func(key uuid.UUID, value *sqlcv1.ListStepsByIdsRow) {}, 5*time.Minute)
 	stepIdLabelsCache := expirable.NewLRU(10000, func(key uuid.UUID, value []*sqlcv1.GetDesiredLabelsRow) {}, 5*time.Minute)
 	stepIdSlotRequestsCache := expirable.NewLRU(10000, func(key uuid.UUID, value map[string]int32) {}, 5*time.Minute)
 	stepIdHasBatchConfigCache := expirable.NewLRU(10000, func(key uuid.UUID, value bool) {}, 5*time.Minute)
@@ -110,6 +112,7 @@ func newSharedRepository(
 		tenantIdWorkflowNameCache:   tenantIdWorkflowNameCache,
 		workflowIdNameCache:         workflowIdNameCache,
 		stepsInWorkflowVersionCache: stepsInWorkflowVersionCache,
+		stepIdConfigCache:           stepIdConfigCache,
 		stepIdLabelsCache:           stepIdLabelsCache,
 		stepIdSlotRequestsCache:     stepIdSlotRequestsCache,
 		stepIdHasBatchConfigCache:   stepIdHasBatchConfigCache,

--- a/pkg/repository/sqlcv1/models.go
+++ b/pkg/repository/sqlcv1/models.go
@@ -3721,17 +3721,18 @@ type V1Task struct {
 }
 
 type V1TaskEvent struct {
-	ID             int64              `json:"id"`
-	InsertedAt     pgtype.Timestamptz `json:"inserted_at"`
-	TenantID       uuid.UUID          `json:"tenant_id"`
-	TaskID         int64              `json:"task_id"`
-	TaskInsertedAt pgtype.Timestamptz `json:"task_inserted_at"`
-	RetryCount     int32              `json:"retry_count"`
-	EventType      V1TaskEventType    `json:"event_type"`
-	EventKey       pgtype.Text        `json:"event_key"`
-	CreatedAt      pgtype.Timestamp   `json:"created_at"`
-	Data           []byte             `json:"data"`
-	ExternalID     uuid.UUID          `json:"external_id"`
+	ID              int64              `json:"id"`
+	InsertedAt      pgtype.Timestamptz `json:"inserted_at"`
+	TenantID        uuid.UUID          `json:"tenant_id"`
+	TaskID          int64              `json:"task_id"`
+	TaskInsertedAt  pgtype.Timestamptz `json:"task_inserted_at"`
+	RetryCount      int32              `json:"retry_count"`
+	EventType       V1TaskEventType    `json:"event_type"`
+	EventKey        pgtype.Text        `json:"event_key"`
+	CreatedAt       pgtype.Timestamp   `json:"created_at"`
+	Data            []byte             `json:"data"`
+	ExternalID      uuid.UUID          `json:"external_id"`
+	ChildExternalID *uuid.UUID         `json:"child_external_id"`
 }
 
 type V1TaskEventsOlap struct {

--- a/pkg/repository/sqlcv1/tasks-overwrite.go
+++ b/pkg/repository/sqlcv1/tasks-overwrite.go
@@ -326,7 +326,8 @@ WITH locked_tasks AS (
 		UNNEST(CAST($5::TEXT[] as v1_task_event_type[])) AS event_type,
 		UNNEST($6::TEXT[]) AS event_key,
 		UNNEST($7::JSONB[]) AS data,
-		UNNEST($8::UUID[]) as external_id
+		UNNEST($8::UUID[]) as external_id,
+		UNNEST($9::UUID[]) as child_external_id
 )
 INSERT INTO v1_task_event (
     tenant_id,
@@ -336,7 +337,8 @@ INSERT INTO v1_task_event (
     event_type,
     event_key,
     data,
-	external_id
+	external_id,
+	child_external_id
 )
 SELECT
     $1::uuid,
@@ -346,7 +348,8 @@ SELECT
     i.event_type,
     i.event_key,
     i.data,
-	i.external_id
+	i.external_id,
+	NULLIF(i.child_external_id, '00000000-0000-0000-0000-000000000000'::UUID) AS child_external_id
 FROM
     input i
 ON CONFLICT (tenant_id, task_id, task_inserted_at, event_type, event_key) WHERE event_key IS NOT NULL DO NOTHING
@@ -361,19 +364,21 @@ RETURNING
 	v1_task_event.event_key,
 	v1_task_event.created_at,
 	v1_task_event.data,
-	v1_task_event.external_id
+	v1_task_event.external_id,
+	v1_task_event.child_external_id
 ;
 `
 
 type CreateTaskEventsParams struct {
-	Tenantid        uuid.UUID            `json:"tenantid"`
-	Taskids         []int64              `json:"taskids"`
-	Taskinsertedats []pgtype.Timestamptz `json:"taskinsertedats"`
-	Retrycounts     []int32              `json:"retrycounts"`
-	Eventtypes      []string             `json:"eventtypes"`
-	Eventkeys       []pgtype.Text        `json:"eventkeys"`
-	Datas           [][]byte             `json:"datas"`
-	Externalids     []uuid.UUID          `json:"externalids"`
+	Tenantid         uuid.UUID            `json:"tenantid"`
+	Taskids          []int64              `json:"taskids"`
+	Taskinsertedats  []pgtype.Timestamptz `json:"taskinsertedats"`
+	Retrycounts      []int32              `json:"retrycounts"`
+	Eventtypes       []string             `json:"eventtypes"`
+	Eventkeys        []pgtype.Text        `json:"eventkeys"`
+	Datas            [][]byte             `json:"datas"`
+	Externalids      []uuid.UUID          `json:"externalids"`
+	Childexternalids []uuid.UUID          `json:"childexternalids"`
 }
 
 // We get a FOR UPDATE lock on tasks to prevent concurrent writes to the task events
@@ -388,6 +393,7 @@ func (q *Queries) CreateTaskEvents(ctx context.Context, db DBTX, arg CreateTaskE
 		arg.Eventkeys,
 		arg.Datas,
 		arg.Externalids,
+		arg.Childexternalids,
 	)
 
 	if err != nil {
@@ -411,6 +417,7 @@ func (q *Queries) CreateTaskEvents(ctx context.Context, db DBTX, arg CreateTaskE
 			&i.CreatedAt,
 			&i.Data,
 			&i.ExternalID,
+			&i.ChildExternalID,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/repository/sqlcv1/tasks.sql
+++ b/pkg/repository/sqlcv1/tasks.sql
@@ -538,7 +538,8 @@ WITH input AS (
 		e.task_id,
 		e.task_inserted_at,
         e.inserted_at,
-        e.external_id
+        e.external_id,
+        e.child_external_id
     FROM
         v1_task_event e
     JOIN
@@ -554,7 +555,8 @@ SELECT
     e.inserted_at,
 	e.event_key,
 	e.data,
-    e.external_id
+    e.external_id,
+    e.child_external_id
 FROM
 	events_to_lock e
 WHERE

--- a/pkg/repository/sqlcv1/tasks.sql.go
+++ b/pkg/repository/sqlcv1/tasks.sql.go
@@ -1227,7 +1227,7 @@ WITH input AS (
         ) AS subquery
 )
 SELECT
-    e.id, e.inserted_at, e.tenant_id, e.task_id, e.task_inserted_at, e.retry_count, e.event_type, e.event_key, e.created_at, e.data, e.external_id
+    e.id, e.inserted_at, e.tenant_id, e.task_id, e.task_inserted_at, e.retry_count, e.event_type, e.event_key, e.created_at, e.data, e.external_id, e.child_external_id
 FROM
     v1_task_event e
 JOIN
@@ -1272,6 +1272,7 @@ func (q *Queries) ListMatchingSignalEvents(ctx context.Context, db DBTX, arg Lis
 			&i.CreatedAt,
 			&i.Data,
 			&i.ExternalID,
+			&i.ChildExternalID,
 		); err != nil {
 			return nil, err
 		}
@@ -1297,7 +1298,7 @@ WITH input AS (
 )
 SELECT
     t.external_id as task_external_id,
-    e.id, e.inserted_at, e.tenant_id, e.task_id, e.task_inserted_at, e.retry_count, e.event_type, e.event_key, e.created_at, e.data, e.external_id
+    e.id, e.inserted_at, e.tenant_id, e.task_id, e.task_inserted_at, e.retry_count, e.event_type, e.event_key, e.created_at, e.data, e.external_id, e.child_external_id
 FROM
     v1_lookup_table l
 JOIN
@@ -1319,18 +1320,19 @@ type ListMatchingTaskEventsParams struct {
 }
 
 type ListMatchingTaskEventsRow struct {
-	TaskExternalID uuid.UUID          `json:"task_external_id"`
-	ID             int64              `json:"id"`
-	InsertedAt     pgtype.Timestamptz `json:"inserted_at"`
-	TenantID       uuid.UUID          `json:"tenant_id"`
-	TaskID         int64              `json:"task_id"`
-	TaskInsertedAt pgtype.Timestamptz `json:"task_inserted_at"`
-	RetryCount     int32              `json:"retry_count"`
-	EventType      V1TaskEventType    `json:"event_type"`
-	EventKey       pgtype.Text        `json:"event_key"`
-	CreatedAt      pgtype.Timestamp   `json:"created_at"`
-	Data           []byte             `json:"data"`
-	ExternalID     uuid.UUID          `json:"external_id"`
+	TaskExternalID  uuid.UUID          `json:"task_external_id"`
+	ID              int64              `json:"id"`
+	InsertedAt      pgtype.Timestamptz `json:"inserted_at"`
+	TenantID        uuid.UUID          `json:"tenant_id"`
+	TaskID          int64              `json:"task_id"`
+	TaskInsertedAt  pgtype.Timestamptz `json:"task_inserted_at"`
+	RetryCount      int32              `json:"retry_count"`
+	EventType       V1TaskEventType    `json:"event_type"`
+	EventKey        pgtype.Text        `json:"event_key"`
+	CreatedAt       pgtype.Timestamp   `json:"created_at"`
+	Data            []byte             `json:"data"`
+	ExternalID      uuid.UUID          `json:"external_id"`
+	ChildExternalID *uuid.UUID         `json:"child_external_id"`
 }
 
 // Lists the task events for the **latest** retry of a task, or task events which intentionally
@@ -1357,6 +1359,7 @@ func (q *Queries) ListMatchingTaskEvents(ctx context.Context, db DBTX, arg ListM
 			&i.CreatedAt,
 			&i.Data,
 			&i.ExternalID,
+			&i.ChildExternalID,
 		); err != nil {
 			return nil, err
 		}
@@ -2415,7 +2418,8 @@ WITH input AS (
 		e.task_id,
 		e.task_inserted_at,
         e.inserted_at,
-        e.external_id
+        e.external_id,
+        e.child_external_id
     FROM
         v1_task_event e
     JOIN
@@ -2431,7 +2435,8 @@ SELECT
     e.inserted_at,
 	e.event_key,
 	e.data,
-    e.external_id
+    e.external_id,
+    e.child_external_id
 FROM
 	events_to_lock e
 WHERE
@@ -2446,11 +2451,12 @@ type LockSignalCreatedEventsParams struct {
 }
 
 type LockSignalCreatedEventsRow struct {
-	ID         int64              `json:"id"`
-	InsertedAt pgtype.Timestamptz `json:"inserted_at"`
-	EventKey   pgtype.Text        `json:"event_key"`
-	Data       []byte             `json:"data"`
-	ExternalID uuid.UUID          `json:"external_id"`
+	ID              int64              `json:"id"`
+	InsertedAt      pgtype.Timestamptz `json:"inserted_at"`
+	EventKey        pgtype.Text        `json:"event_key"`
+	Data            []byte             `json:"data"`
+	ExternalID      uuid.UUID          `json:"external_id"`
+	ChildExternalID *uuid.UUID         `json:"child_external_id"`
 }
 
 // Places a lock on the SIGNAL_CREATED events to make sure concurrent operations don't
@@ -2475,6 +2481,7 @@ func (q *Queries) LockSignalCreatedEvents(ctx context.Context, db DBTX, arg Lock
 			&i.EventKey,
 			&i.Data,
 			&i.ExternalID,
+			&i.ChildExternalID,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -2640,6 +2640,7 @@ func (r *sharedRepository) insertTasks(
 		eventTypes,
 		make([]string, len(eventTaskIdRetryCounts)),
 		taskIdToIdempotencyKey,
+		nil,
 	)
 
 	if err != nil {
@@ -2996,6 +2997,7 @@ func (r *sharedRepository) replayTasks(
 		eventTypes,
 		make([]string, len(eventTaskIdRetryCounts)),
 		taskIdToIdempotencyKey,
+		nil,
 	)
 
 	if err != nil {
@@ -3198,6 +3200,7 @@ func (r *sharedRepository) createTaskEventsAfterRelease(
 		makeEventTypeArr(eventType, len(filteredExternalIds)),
 		make([]string, len(filteredExternalIds)),
 		taskIdToIdempotencyKey,
+		nil,
 	)
 }
 
@@ -3240,6 +3243,7 @@ func (r *sharedRepository) createTaskEvents(
 	eventTypes []sqlcv1.V1TaskEventType,
 	eventKeys []string,
 	taskIdToIdempotencyKey map[int64]string,
+	taskIdToChildExternalId map[int64]*uuid.UUID,
 ) ([]InternalTaskEvent, error) {
 	if len(tasks) != len(eventDatas) {
 		return nil, fmt.Errorf("mismatched task and event data lengths")
@@ -3252,6 +3256,7 @@ func (r *sharedRepository) createTaskEvents(
 	paramDatas := make([][]byte, len(tasks))
 	paramKeys := make([]pgtype.Text, len(tasks))
 	externalIds := make([]uuid.UUID, len(tasks))
+	childExternalIds := make([]uuid.UUID, len(tasks))
 
 	internalTaskEvents := make([]InternalTaskEvent, len(tasks))
 
@@ -3266,6 +3271,14 @@ func (r *sharedRepository) createTaskEvents(
 
 		externalId := uuid.New()
 		externalIds[i] = externalId
+
+		childExternalId, ok := taskIdToChildExternalId[task.Id]
+
+		if ok && childExternalId != nil {
+			childExternalIds[i] = *childExternalId
+		} else {
+			childExternalIds[i] = uuid.Nil
+		}
 
 		// important: if we don't set this to `eventDatas[i]` and instead allow it to be nil optionally
 		// we'll get errors downstream when we try to read the payload back and parse it in `registerChildWorkflows`
@@ -3304,14 +3317,15 @@ func (r *sharedRepository) createTaskEvents(
 	}
 
 	taskEvents, err := r.queries.CreateTaskEvents(ctx, dbtx, sqlcv1.CreateTaskEventsParams{
-		Tenantid:        tenantId,
-		Taskids:         taskIds,
-		Taskinsertedats: taskInsertedAts,
-		Retrycounts:     retryCounts,
-		Eventtypes:      eventTypesStrs,
-		Datas:           paramDatas,
-		Eventkeys:       paramKeys,
-		Externalids:     externalIds,
+		Tenantid:         tenantId,
+		Taskids:          taskIds,
+		Taskinsertedats:  taskInsertedAts,
+		Retrycounts:      retryCounts,
+		Eventtypes:       eventTypesStrs,
+		Datas:            paramDatas,
+		Eventkeys:        paramKeys,
+		Externalids:      externalIds,
+		Childexternalids: childExternalIds,
 	})
 
 	if err != nil {

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -3243,10 +3243,14 @@ func (r *sharedRepository) createTaskEvents(
 	eventTypes []sqlcv1.V1TaskEventType,
 	eventKeys []string,
 	taskIdToIdempotencyKey map[int64]string,
-	taskIdToChildExternalId map[int64]*uuid.UUID,
+	childExternalIdsByIndex []*uuid.UUID,
 ) ([]InternalTaskEvent, error) {
 	if len(tasks) != len(eventDatas) {
 		return nil, fmt.Errorf("mismatched task and event data lengths")
+	}
+
+	if childExternalIdsByIndex != nil && len(childExternalIdsByIndex) != len(tasks) {
+		return nil, fmt.Errorf("mismatched task and child external id lengths")
 	}
 
 	taskIds := make([]int64, len(tasks))
@@ -3272,10 +3276,8 @@ func (r *sharedRepository) createTaskEvents(
 		externalId := uuid.New()
 		externalIds[i] = externalId
 
-		childExternalId, ok := taskIdToChildExternalId[task.Id]
-
-		if ok && childExternalId != nil {
-			childExternalIds[i] = *childExternalId
+		if childExternalIdsByIndex != nil && childExternalIdsByIndex[i] != nil {
+			childExternalIds[i] = *childExternalIdsByIndex[i]
 		} else {
 			childExternalIds[i] = uuid.Nil
 		}

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -1978,6 +1978,41 @@ func getQueueCacheKey(tenantId uuid.UUID, queue string) string {
 	return fmt.Sprintf("%s:%s", tenantId, queue)
 }
 
+func (r *sharedRepository) listStepsByIds(ctx context.Context, tx sqlcv1.DBTX, tenantId uuid.UUID, stepIds []uuid.UUID) (map[uuid.UUID]*sqlcv1.ListStepsByIdsRow, error) {
+	res := make(map[uuid.UUID]*sqlcv1.ListStepsByIdsRow, len(stepIds))
+
+	stepIdsToLookup := make([]uuid.UUID, 0, len(stepIds))
+
+	for _, id := range stepIds {
+		if step, found := r.stepIdConfigCache.Get(id); found {
+			res[id] = step
+			continue
+		}
+
+		stepIdsToLookup = append(stepIdsToLookup, id)
+	}
+
+	if len(stepIdsToLookup) == 0 {
+		return res, nil
+	}
+
+	steps, err := r.queries.ListStepsByIds(ctx, tx, sqlcv1.ListStepsByIdsParams{
+		Ids:      stepIdsToLookup,
+		Tenantid: tenantId,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, step := range steps {
+		res[step.ID] = step
+		r.stepIdConfigCache.Add(step.ID, step)
+	}
+
+	return res, nil
+}
+
 func (r *sharedRepository) createTasks(
 	ctx context.Context,
 	tx sqlcv1.DBTX,
@@ -1997,19 +2032,10 @@ func (r *sharedRepository) createTasks(
 		}
 	}
 
-	steps, err := r.queries.ListStepsByIds(ctx, tx, sqlcv1.ListStepsByIdsParams{
-		Ids:      stepIds,
-		Tenantid: tenantId,
-	})
+	stepIdsToConfig, err := r.listStepsByIds(ctx, tx, tenantId, stepIds)
 
 	if err != nil {
 		return nil, err
-	}
-
-	stepIdsToConfig := make(map[uuid.UUID]*sqlcv1.ListStepsByIdsRow)
-
-	for _, step := range steps {
-		stepIdsToConfig[step.ID] = step
 	}
 
 	filteredTasks := make([]CreateTaskOpts, 0, len(tasks))
@@ -2672,19 +2698,10 @@ func (r *sharedRepository) replayTasks(
 		}
 	}
 
-	steps, err := r.queries.ListStepsByIds(ctx, tx, sqlcv1.ListStepsByIdsParams{
-		Ids:      stepIds,
-		Tenantid: tenantId,
-	})
+	stepIdsToConfig, err := r.listStepsByIds(ctx, tx, tenantId, stepIds)
 
 	if err != nil {
 		return nil, err
-	}
-
-	stepIdsToConfig := make(map[uuid.UUID]*sqlcv1.ListStepsByIdsRow)
-
-	for _, step := range steps {
-		stepIdsToConfig[step.ID] = step
 	}
 
 	filteredTasks := make([]ReplayTaskOpts, 0, len(tasks))

--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -2124,26 +2124,28 @@ func (r *sharedRepository) listStepsByWorkflowVersionIds(ctx context.Context, tx
 		workflowVersionsToLookup = append(workflowVersionsToLookup, id)
 	}
 
-	steps, err := r.queries.ListStepsByWorkflowVersionIds(ctx, tx, sqlcv1.ListStepsByWorkflowVersionIdsParams{
-		Tenantid: tenantId,
-		Ids:      workflowVersionsToLookup,
-	})
+	if len(workflowVersionsToLookup) > 0 {
+		steps, err := r.queries.ListStepsByWorkflowVersionIds(ctx, tx, sqlcv1.ListStepsByWorkflowVersionIdsParams{
+			Tenantid: tenantId,
+			Ids:      workflowVersionsToLookup,
+		})
 
-	if err != nil {
-		return nil, fmt.Errorf("failed to list steps by workflow version ids: %w", err)
-	}
+		if err != nil {
+			return nil, fmt.Errorf("failed to list steps by workflow version ids: %w", err)
+		}
 
-	for _, step := range steps {
-		k := step.WorkflowVersionId
-		res[k] = append(res[k], step)
-	}
+		for _, step := range steps {
+			k := step.WorkflowVersionId
+			res[k] = append(res[k], step)
+		}
 
-	// update the cache with all entries we looked up
-	for _, id := range workflowVersionsToLookup {
-		k := id
+		// update the cache with all entries we looked up
+		for _, id := range workflowVersionsToLookup {
+			k := id
 
-		if steps, ok := res[k]; ok {
-			r.stepsInWorkflowVersionCache.Add(k, steps)
+			if steps, ok := res[k]; ok {
+				r.stepsInWorkflowVersionCache.Add(k, steps)
+			}
 		}
 	}
 

--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -2085,23 +2085,25 @@ func (r *sharedRepository) listWorkflowsByNames(ctx context.Context, tx sqlcv1.D
 		workflowNamesToLookup = append(workflowNamesToLookup, name)
 	}
 
-	// look up the workflow versions for the workflow names
-	workflowVersions, err := r.queries.ListWorkflowsByNames(ctx, tx, sqlcv1.ListWorkflowsByNamesParams{
-		Tenantid:      tenantId,
-		Workflownames: workflowNamesToLookup,
-	})
+	if len(workflowNamesToLookup) > 0 {
+		// look up the workflow versions for the workflow names
+		workflowVersions, err := r.queries.ListWorkflowsByNames(ctx, tx, sqlcv1.ListWorkflowsByNamesParams{
+			Tenantid:      tenantId,
+			Workflownames: workflowNamesToLookup,
+		})
 
-	if err != nil {
-		return nil, fmt.Errorf("failed to list workflows by names: %w", err)
-	}
+		if err != nil {
+			return nil, fmt.Errorf("failed to list workflows by names: %w", err)
+		}
 
-	for _, workflowVersion := range workflowVersions {
-		// store in the cache
-		k := fmt.Sprintf("%s:%s", tenantId, workflowVersion.WorkflowName)
+		for _, workflowVersion := range workflowVersions {
+			// store in the cache
+			k := fmt.Sprintf("%s:%s", tenantId, workflowVersion.WorkflowName)
 
-		r.tenantIdWorkflowNameCache.Add(k, workflowVersion)
+			r.tenantIdWorkflowNameCache.Add(k, workflowVersion)
 
-		res = append(res, workflowVersion)
+			res = append(res, workflowVersion)
+		}
 	}
 
 	return res, nil

--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -1697,22 +1697,31 @@ func (r *sharedRepository) registerChildWorkflows(
 		return nil, err
 	}
 
-	retrievePayloadOpts := make([]RetrievePayloadOpts, len(matchingEvents))
+	// only need to hit the payload store for events created before the child_external_id column existed
+	retrievePayloadOpts := make([]RetrievePayloadOpts, 0, len(matchingEvents))
 
-	for i, event := range matchingEvents {
-		retrievePayloadOpts[i] = RetrievePayloadOpts{
+	for _, event := range matchingEvents {
+		if event.ChildExternalID != nil {
+			continue
+		}
+
+		retrievePayloadOpts = append(retrievePayloadOpts, RetrievePayloadOpts{
 			Id:         event.ID,
 			InsertedAt: event.InsertedAt,
 			Type:       sqlcv1.V1PayloadTypeTASKEVENTDATA,
 			TenantId:   tenantId,
 			ExternalId: event.ExternalID,
-		}
+		})
 	}
 
-	payloads, err := r.payloadStore.Retrieve(ctx, tx, retrievePayloadOpts...)
+	var payloads map[RetrievePayloadOpts][]byte
 
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve payloads for signal created events: %w", err)
+	if len(retrievePayloadOpts) > 0 {
+		payloads, err = r.payloadStore.Retrieve(ctx, tx, retrievePayloadOpts...)
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve payloads for signal created events: %w", err)
+		}
 	}
 
 	// parse the event match data, and determine whether the child external ID has already been written
@@ -1720,27 +1729,35 @@ func (r *sharedRepository) registerChildWorkflows(
 	rootExternalIdsToLookup := make([]uuid.UUID, 0, len(matchingEvents))
 
 	for _, event := range matchingEvents {
-		payload, ok := payloads[RetrievePayloadOpts{
-			Id:         event.ID,
-			InsertedAt: event.InsertedAt,
-			Type:       sqlcv1.V1PayloadTypeTASKEVENTDATA,
-			TenantId:   tenantId,
-			ExternalId: event.ExternalID,
-		}]
+		var childExternalId uuid.UUID
 
-		if !ok {
-			payload = event.Data
+		if event.ChildExternalID != nil {
+			childExternalId = *event.ChildExternalID
+		} else {
+			payload, ok := payloads[RetrievePayloadOpts{
+				Id:         event.ID,
+				InsertedAt: event.InsertedAt,
+				Type:       sqlcv1.V1PayloadTypeTASKEVENTDATA,
+				TenantId:   tenantId,
+				ExternalId: event.ExternalID,
+			}]
+
+			if !ok {
+				payload = event.Data
+			}
+
+			c, err := newChildWorkflowSignalCreatedDataFromBytes(payload)
+
+			if err != nil {
+				r.l.Error().Msgf("failed to unmarshal child workflow signal created data: %s", err)
+				continue
+			}
+
+			childExternalId = c.ChildExternalId
 		}
 
-		c, err := newChildWorkflowSignalCreatedDataFromBytes(payload)
-
-		if err != nil {
-			r.l.Error().Msgf("failed to unmarshal child workflow signal created data: %s", err)
-			continue
-		}
-
-		if c.ChildExternalId != uuid.Nil {
-			rootExternalIdsToLookup = append(rootExternalIdsToLookup, c.ChildExternalId)
+		if childExternalId != uuid.Nil {
+			rootExternalIdsToLookup = append(rootExternalIdsToLookup, childExternalId)
 		}
 	}
 

--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -377,14 +377,14 @@ func getEventExternalIdToRuns(opts []EventTriggerOpts, externalIdToEventIdAndFil
 	return eventExternalIdToRuns
 }
 
-func (s *sharedRepository) triggerFromWorkflowNames(ctx context.Context, tx *OptimisticTx, tenantId uuid.UUID, opts []*WorkflowNameTriggerOpts) ([]*V1TaskWithPayload, []*DAGWithData, []IdempotencyCollision, []CELEvaluationFailure, error) {
+func (s *sharedRepository) triggerFromWorkflowNames(ctx context.Context, tx *OptimisticTx, tenantId uuid.UUID, opts []*WorkflowNameTriggerOpts) ([]*V1TaskWithPayload, []*DAGWithData, []IdempotencyCollision, []CELEvaluationFailure, []StorePayloadOpts, error) {
 	triggerOpts, err := s.prepareTriggerFromWorkflowNames(ctx, tx.tx, tenantId, opts)
 
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("failed to prepare trigger from workflow names: %w", err)
+		return nil, nil, nil, nil, nil, fmt.Errorf("failed to prepare trigger from workflow names: %w", err)
 	}
 
-	return s.triggerWorkflows(ctx, tx, tenantId, triggerOpts, nil)
+	return s.triggerWorkflowsCore(ctx, tx, tenantId, triggerOpts, nil)
 }
 
 func (r *TriggerRepositoryImpl) TriggerFromWorkflowNames(ctx context.Context, tenantId uuid.UUID, opts []*WorkflowNameTriggerOpts) ([]*V1TaskWithPayload, []*DAGWithData, []IdempotencyCollision, []CELEvaluationFailure, error) {
@@ -396,10 +396,16 @@ func (r *TriggerRepositoryImpl) TriggerFromWorkflowNames(ctx context.Context, te
 
 	defer tx.Rollback()
 
-	tasks, dags, idempotencyKeyCollisions, celEvaluationFailures, err := r.triggerFromWorkflowNames(ctx, tx, tenantId, opts)
+	tasks, dags, idempotencyKeyCollisions, celEvaluationFailures, storePayloadOpts, err := r.triggerFromWorkflowNames(ctx, tx, tenantId, opts)
 
 	if err != nil {
 		return nil, nil, nil, nil, err
+	}
+
+	if len(storePayloadOpts) > 0 {
+		if err := r.payloadStore.Store(ctx, tx.tx, storePayloadOpts...); err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("failed to store payloads: %w", err)
+		}
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -679,18 +685,14 @@ func (r *sharedRepository) evalIdempotencyKey(tuple triggerTuple) (string, error
 	return key, nil
 }
 
-func (r *sharedRepository) triggerWorkflows(
+func (r *sharedRepository) triggerWorkflowsCore(
 	ctx context.Context,
-	existingTx *OptimisticTx,
+	optTx *OptimisticTx,
 	tenantId uuid.UUID,
 	triggerCandidateTuples []triggerTuple,
 	coreEvents *createCoreUserEventOpts,
-) ([]*V1TaskWithPayload, []*DAGWithData, []IdempotencyCollision, []CELEvaluationFailure, error) {
-	var preflightTx sqlcv1.DBTX = r.pool
-
-	if existingTx != nil {
-		preflightTx = existingTx.tx
-	}
+) ([]*V1TaskWithPayload, []*DAGWithData, []IdempotencyCollision, []CELEvaluationFailure, []StorePayloadOpts, error) {
+	preflightTx := optTx.tx
 
 	tuples := make([]triggerTuple, 0, len(triggerCandidateTuples))
 
@@ -738,7 +740,7 @@ func (r *sharedRepository) triggerWorkflows(
 		})
 
 		if err != nil {
-			return nil, nil, nil, nil, fmt.Errorf("failed to claim idempotency keys: %w", err)
+			return nil, nil, nil, nil, nil, fmt.Errorf("failed to claim idempotency keys: %w", err)
 		}
 
 		idempotencyKeyToLockHolder := make(map[string]uuid.UUID, len(claims))
@@ -788,7 +790,7 @@ func (r *sharedRepository) triggerWorkflows(
 	workflowVersionToSteps, err := r.listStepsByWorkflowVersionIds(ctx, preflightTx, tenantId, workflowVersionIds)
 
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("failed to get workflow versions for engine: %w", err)
+		return nil, nil, nil, nil, nil, fmt.Errorf("failed to get workflow versions for engine: %w", err)
 	}
 
 	// group steps by workflow version ids
@@ -823,7 +825,7 @@ func (r *sharedRepository) triggerWorkflows(
 	preTask, postTask := r.m.Meter(ctx, preflightTx, sqlcv1.LimitResourceTASKRUN, tenantId, int32(countTasks)) // nolint: gosec
 
 	if err := preTask(); err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, err
 	}
 
 	stepsToAdditionalMatches := make(map[uuid.UUID][]*sqlcv1.V1StepMatchCondition)
@@ -835,7 +837,7 @@ func (r *sharedRepository) triggerWorkflows(
 		})
 
 		if err != nil {
-			return nil, nil, nil, nil, fmt.Errorf("failed to list step match conditions: %w", err)
+			return nil, nil, nil, nil, nil, fmt.Errorf("failed to list step match conditions: %w", err)
 		}
 
 		for _, match := range additionalMatches {
@@ -908,28 +910,14 @@ func (r *sharedRepository) triggerWorkflows(
 		}
 	}
 
-	var commit func(context.Context) error
-	var rollback func()
-	var tx sqlcv1.DBTX
-
-	if existingTx == nil {
-		tx, commit, rollback, err = sqlchelpers.PrepareTx(ctx, r.pool, r.l)
-
-		if err != nil {
-			return nil, nil, nil, nil, err
-		}
-
-		defer rollback()
-	} else {
-		tx = existingTx.tx
-	}
+	tx := optTx.tx
 
 	// check if we should skip the creation of any workflows if they're child workflows which
 	// already have a signal registered
 	tuplesToSkip, err := r.registerChildWorkflows(ctx, tx, tenantId, tuples, stepsToExternalIds, workflowVersionToSteps)
 
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("failed to register child workflows: %w", err)
+		return nil, nil, nil, nil, nil, fmt.Errorf("failed to register child workflows: %w", err)
 	}
 
 	for i, tuple := range tuples {
@@ -1075,7 +1063,7 @@ func (r *sharedRepository) triggerWorkflows(
 							)
 
 							if err != nil {
-								return nil, nil, nil, nil, fmt.Errorf("failed to create sleep condition: %w", err)
+								return nil, nil, nil, nil, nil, fmt.Errorf("failed to create sleep condition: %w", err)
 							}
 
 							groupConditions = append(groupConditions, *c)
@@ -1344,7 +1332,7 @@ func (r *sharedRepository) triggerWorkflows(
 	dags, err := r.createDAGs(ctx, tx, tenantId, dagOpts)
 
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("failed to create DAGs: %w", err)
+		return nil, nil, nil, nil, nil, fmt.Errorf("failed to create DAGs: %w", err)
 	}
 
 	// populate taskOpts with inserted DAG data
@@ -1369,7 +1357,7 @@ func (r *sharedRepository) triggerWorkflows(
 	tasks, err := r.createTasks(ctx, tx, tenantId, createTaskOpts)
 
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("failed to create tasks: %w", err)
+		return nil, nil, nil, nil, nil, fmt.Errorf("failed to create tasks: %w", err)
 	}
 
 	for _, dag := range dags {
@@ -1386,10 +1374,10 @@ func (r *sharedRepository) triggerWorkflows(
 	err = r.createEventMatches(ctx, tx, tenantId, createMatchOpts)
 
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("failed to create event matches: %w", err)
+		return nil, nil, nil, nil, nil, fmt.Errorf("failed to create event matches: %w", err)
 	}
 
-	storePayloadOpts := make([]StorePayloadOpts, 0, len(tasks))
+	storePayloadOpts := make([]StorePayloadOpts, 0, len(tasks)+len(dags))
 
 	for _, task := range tasks {
 		storePayloadOpts = append(storePayloadOpts, StorePayloadOpts{
@@ -1417,7 +1405,7 @@ func (r *sharedRepository) triggerWorkflows(
 		createdEvents, err := r.queries.BulkCreateEvents(ctx, tx, coreEvents.params)
 
 		if err != nil {
-			return nil, nil, nil, nil, fmt.Errorf("failed to create core events: %w", err)
+			return nil, nil, nil, nil, nil, fmt.Errorf("failed to create core events: %w", err)
 		}
 
 		for _, e := range createdEvents {
@@ -1438,22 +1426,49 @@ func (r *sharedRepository) triggerWorkflows(
 		}
 	}
 
-	err = r.payloadStore.Store(ctx, tx, storePayloadOpts...)
+	optTx.AddPostCommit(postTask)
 
-	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("failed to store payloads: %w", err)
-	}
+	return tasks, dags, idempotencyKeyCollisions, celEvaluationFailures, storePayloadOpts, nil
+}
 
-	// commit if we started the transaction
-	if existingTx == nil {
-		if err := commit(ctx); err != nil {
+func (r *sharedRepository) triggerWorkflows(
+	ctx context.Context,
+	existingTx *OptimisticTx,
+	tenantId uuid.UUID,
+	triggerCandidateTuples []triggerTuple,
+	coreEvents *createCoreUserEventOpts,
+) ([]*V1TaskWithPayload, []*DAGWithData, []IdempotencyCollision, []CELEvaluationFailure, error) {
+	tx := existingTx
+	ownsTx := false
+
+	if tx == nil {
+		var err error
+		tx, err = r.PrepareOptimisticTx(ctx)
+
+		if err != nil {
 			return nil, nil, nil, nil, err
 		}
 
-		postTask()
+		defer tx.Rollback()
+		ownsTx = true
+	}
 
-	} else {
-		existingTx.AddPostCommit(postTask)
+	tasks, dags, idempotencyKeyCollisions, celEvaluationFailures, storePayloadOpts, err := r.triggerWorkflowsCore(ctx, tx, tenantId, triggerCandidateTuples, coreEvents)
+
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	if len(storePayloadOpts) > 0 {
+		if err := r.payloadStore.Store(ctx, tx.tx, storePayloadOpts...); err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("failed to store payloads: %w", err)
+		}
+	}
+
+	if ownsTx {
+		if err := tx.Commit(ctx); err != nil {
+			return nil, nil, nil, nil, err
+		}
 	}
 
 	return tasks, dags, idempotencyKeyCollisions, celEvaluationFailures, nil

--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -384,7 +384,7 @@ func (s *sharedRepository) triggerFromWorkflowNames(ctx context.Context, tx *Opt
 		return nil, nil, nil, nil, nil, fmt.Errorf("failed to prepare trigger from workflow names: %w", err)
 	}
 
-	return s.triggerWorkflowsCore(ctx, tx, tenantId, triggerOpts, nil)
+	return s.triggerWorkflowsCore(ctx, tx, tenantId, triggerOpts, nil, false)
 }
 
 func (r *TriggerRepositoryImpl) TriggerFromWorkflowNames(ctx context.Context, tenantId uuid.UUID, opts []*WorkflowNameTriggerOpts) ([]*V1TaskWithPayload, []*DAGWithData, []IdempotencyCollision, []CELEvaluationFailure, error) {
@@ -691,8 +691,17 @@ func (r *sharedRepository) triggerWorkflowsCore(
 	tenantId uuid.UUID,
 	triggerCandidateTuples []triggerTuple,
 	coreEvents *createCoreUserEventOpts,
+	ownsTx bool,
 ) ([]*V1TaskWithPayload, []*DAGWithData, []IdempotencyCollision, []CELEvaluationFailure, []StorePayloadOpts, error) {
+	if optTx == nil {
+		return nil, nil, nil, nil, nil, fmt.Errorf("triggerWorkflowsCore requires a non-nil transaction")
+	}
+
 	preflightTx := optTx.tx
+
+	if ownsTx {
+		preflightTx = r.pool
+	}
 
 	tuples := make([]triggerTuple, 0, len(triggerCandidateTuples))
 
@@ -1453,7 +1462,7 @@ func (r *sharedRepository) triggerWorkflows(
 		ownsTx = true
 	}
 
-	tasks, dags, idempotencyKeyCollisions, celEvaluationFailures, storePayloadOpts, err := r.triggerWorkflowsCore(ctx, tx, tenantId, triggerCandidateTuples, coreEvents)
+	tasks, dags, idempotencyKeyCollisions, celEvaluationFailures, storePayloadOpts, err := r.triggerWorkflowsCore(ctx, tx, tenantId, triggerCandidateTuples, coreEvents, ownsTx)
 
 	if err != nil {
 		return nil, nil, nil, nil, err

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -413,6 +413,7 @@ CREATE TABLE v1_task_event (
     created_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     data JSONB,
     external_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    child_external_id UUID,
     CONSTRAINT v1_task_event_pkey PRIMARY KEY (task_id, task_inserted_at, id)
 ) PARTITION BY RANGE(task_inserted_at);
 


### PR DESCRIPTION
## [Better to review without whitespace](https://github.com/hatchet-dev/hatchet/pull/4681/changes?w=1)

# Description

Adds a couple of optimizations to the durable event ingest path:

1. Adds a cache around `ListStepsByIds`
2. Removes empty call to `ListWorkflowsByNames` if all workflows were found in cache
3. Removes empty call to `ListStepsByWorkflowVersionIds` if all steps were found in cache
4. Removes an extra payload write by returning payloads to store out of a couple of the helper methods and calling `Store` at the end
5. Added a `child_external_id` col to `v1_task_event` so we can remove a payload read that we only need to do in order to get the child id

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI

</details>
