### PR TITLE
docs: content negotiaiton for AI agents

### DIFF
--- a/frontend/docs/app/robots.ts
+++ b/frontend/docs/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: "https://docs.hatchet.run/sitemap.xml",
+  };
+}

--- a/frontend/docs/app/sitemap.ts
+++ b/frontend/docs/app/sitemap.ts
@@ -1,0 +1,8 @@
+import type { MetadataRoute } from "next";
+import { source } from "@/lib/source";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return source
+    .getPages()
+    .map((page) => ({ url: `https://docs.hatchet.run${page.url}` }));
+}

--- a/frontend/docs/proxy.ts
+++ b/frontend/docs/proxy.ts
@@ -1,6 +1,18 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
+function markdownPath(pathname: string): string | null {
+  if (
+    pathname.startsWith('/api/') ||
+    pathname.startsWith('/llms') ||
+    pathname === '/' ||
+    /\.[a-z0-9]+$/i.test(pathname)
+  ) {
+    return null
+  }
+  return `/llms${pathname}.md`
+}
+
 export default function proxy(request: NextRequest) {
   // Get the host header (the domain being requested)
   const host = request.headers.get('host')
@@ -30,12 +42,30 @@ export default function proxy(request: NextRequest) {
     return response
   }
 
+  const { pathname } = request.nextUrl
+
+  // Serve markdown to agents: /v1/tasks.md mirrors /llms/v1/tasks.md
+  if (/\.md$/.test(pathname) && !pathname.startsWith('/llms')) {
+    return NextResponse.rewrite(new URL(`/llms${pathname}`, request.url))
+  }
+
+  const mdPath = markdownPath(pathname)
+
+  // Content negotiation: Accept: text/markdown gets the markdown mirror
+  if (mdPath && request.headers.get('accept')?.includes('text/markdown')) {
+    return NextResponse.rewrite(new URL(mdPath, request.url))
+  }
+
   const response = NextResponse.next()
 
   response.headers.set('Access-Control-Allow-Origin', "*")
   response.headers.set('Access-Control-Allow-Credentials', 'true')
   response.headers.set('Cross-Origin-Resource-Policy', 'cross-origin')
   response.headers.set('Cross-Origin-Embedder-Policy', 'credentialless')
+
+  if (mdPath) {
+    response.headers.set('Link', `<${mdPath}>; rel="alternate"; type="text/markdown"`)
+  }
 
   return response
 }


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds content negotiation and better discovery for AI agents. We already generate per-page markdown (`public/llms/<path>.md`, `llms.txt`, `llms-full.txt`) at build time, but agents had no standard way to reach it:
- `Accept: text/markdown` requests returned full HTML — no content negotiation
- No `.md` URL mirror (the convention nextjs.org and Mintlify use, and the fallback for agents like Codex that don't send the Accept header)
- `robots.txt` and `sitemap.xml` both 404'd, so crawlers had no discovery path
- The only pointer was a `<link rel="alternate">` tag, which agent fetchers largely ignore


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Documentation change (pure documentation change)

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
