### PR TITLE
refactor(engine): split txs for durable event ingest

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260813070123_v1_0_140.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260813070123_v1_0_140.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE v1_durable_event_log_entry ADD COLUMN triggered_at TIMESTAMPTZ;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE v1_durable_event_log_entry DROP COLUMN triggered_at;
+-- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20260813070132_v1_0_141.go
+++ b/cmd/hatchet-migrate/migrate/migrations/20260813070132_v1_0_141.go
@@ -1,0 +1,99 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationNoTxContext(upV10141, downV10141)
+}
+
+const v1DurableEventLogEntryTable = "v1_durable_event_log_entry"
+
+func upV10141(ctx context.Context, db *sql.DB) error {
+	const batchSize = 5000
+
+	partitions, err := listLeafPartitions(ctx, db, v1DurableEventLogEntryTable, 1)
+	if err != nil {
+		return err
+	}
+
+	for _, partition := range partitions {
+		var lastDurableTaskId, lastBranchId, lastNodeId int64
+		var lastDurableTaskInsertedAt pgtype.Timestamptz
+
+		for {
+			// #nosec G201 -- identifier is quoted and derived from pg_partition_tree, not user input
+			stmt := fmt.Sprintf(
+				`
+				WITH batch AS (
+					SELECT durable_task_id, durable_task_inserted_at, branch_id, node_id
+					FROM %s
+					WHERE (durable_task_id, durable_task_inserted_at, branch_id, node_id) > ($1, $2, $3, $4)
+					ORDER BY durable_task_id, durable_task_inserted_at, branch_id, node_id
+					LIMIT $5
+				), updates AS (
+					UPDATE %s e
+					SET triggered_at = e.inserted_at
+					FROM batch
+					WHERE (e.durable_task_id, e.durable_task_inserted_at, e.branch_id, e.node_id) = (batch.durable_task_id, batch.durable_task_inserted_at, batch.branch_id, batch.node_id)
+					RETURNING e.durable_task_id, e.durable_task_inserted_at, e.branch_id, e.node_id
+				)
+
+				SELECT durable_task_id, durable_task_inserted_at, branch_id, node_id
+				FROM updates
+				ORDER BY durable_task_id DESC, durable_task_inserted_at DESC, branch_id DESC, node_id DESC
+				`,
+				quoteIdent(partition),
+				quoteIdent(partition),
+			)
+
+			rows, err := db.QueryContext(ctx, stmt, lastDurableTaskId, lastDurableTaskInsertedAt, lastBranchId, lastNodeId, batchSize)
+			if err != nil {
+				return fmt.Errorf("failed to backfill triggered_at on %s: %w", partition, err)
+			}
+
+			count := 0
+			for rows.Next() {
+				var durableTaskId, branchId, nodeId int64
+				var durableTaskInsertedAt pgtype.Timestamptz
+
+				if err := rows.Scan(&durableTaskId, &durableTaskInsertedAt, &branchId, &nodeId); err != nil {
+					rows.Close()
+					return fmt.Errorf("failed to scan backfilled row on %s: %w", partition, err)
+				}
+
+				if count == 0 {
+					lastDurableTaskId = durableTaskId
+					lastDurableTaskInsertedAt = durableTaskInsertedAt
+					lastBranchId = branchId
+					lastNodeId = nodeId
+				}
+
+				count++
+			}
+
+			if err := rows.Err(); err != nil {
+				rows.Close()
+				return fmt.Errorf("failed to iterate backfilled rows on %s: %w", partition, err)
+			}
+
+			rows.Close()
+
+			if count == 0 {
+				break
+			}
+		}
+	}
+
+	return nil
+}
+
+func downV10141(_ context.Context, _ *sql.DB) error {
+	return nil
+}

--- a/cmd/hatchet-migrate/migrate/migrations/20260813070132_v1_0_141.go
+++ b/cmd/hatchet-migrate/migrate/migrations/20260813070132_v1_0_141.go
@@ -41,12 +41,14 @@ func upV10141(ctx context.Context, db *sql.DB) error {
 					UPDATE %s e
 					SET triggered_at = e.inserted_at
 					FROM batch
-					WHERE (e.durable_task_id, e.durable_task_inserted_at, e.branch_id, e.node_id) = (batch.durable_task_id, batch.durable_task_inserted_at, batch.branch_id, batch.node_id)
+					WHERE
+						(e.durable_task_id, e.durable_task_inserted_at, e.branch_id, e.node_id) = (batch.durable_task_id, batch.durable_task_inserted_at, batch.branch_id, batch.node_id)
+						AND e.triggered_at IS NULL
 					RETURNING e.durable_task_id, e.durable_task_inserted_at, e.branch_id, e.node_id
 				)
 
 				SELECT durable_task_id, durable_task_inserted_at, branch_id, node_id
-				FROM updates
+				FROM batch
 				ORDER BY durable_task_id DESC, durable_task_inserted_at DESC, branch_id DESC, node_id DESC
 				`,
 				quoteIdent(partition),

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -1475,15 +1475,34 @@ func (r *durableEventsRepository) triggerPendingRunEntries(ctx context.Context, 
 
 	tx := optTx.tx
 
-	triggerOpts := make([]*WorkflowNameTriggerOpts, len(pending))
-	externalIdToNodeBranch := make(map[uuid.UUID]NodeIdBranchIdTuple, len(pending))
-	entryKeys := make([]NodeIdBranchIdTuple, len(pending))
+	nodesToClaim := make([]NodeIdBranchIdTuple, len(pending))
 
 	for i, p := range pending {
-		triggerOpts[i] = p.triggerOpts
-		key := NodeIdBranchIdTuple{NodeId: p.entry.Entry.NodeID, BranchId: p.entry.Entry.BranchID}
-		externalIdToNodeBranch[p.triggerOpts.ExternalId] = key
-		entryKeys[i] = key
+		nodesToClaim[i] = NodeIdBranchIdTuple{NodeId: p.entry.Entry.NodeID, BranchId: p.entry.Entry.BranchID}
+	}
+
+	claimedSet, err := r.claimDurableEventLogEntriesForTrigger(ctx, tx, task.ID, task.InsertedAt, nodesToClaim)
+
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to claim durable run entries for trigger: %w", err)
+	}
+
+	if len(claimedSet) == 0 {
+		return nil, nil, nil, nil
+	}
+
+	triggerOpts := make([]*WorkflowNameTriggerOpts, 0, len(claimedSet))
+	externalIdToNodeBranch := make(map[uuid.UUID]NodeIdBranchIdTuple, len(claimedSet))
+
+	for _, p := range pending {
+		nodeIdBranchIdTuple := NodeIdBranchIdTuple{NodeId: p.entry.Entry.NodeID, BranchId: p.entry.Entry.BranchID}
+
+		if _, ok := claimedSet[nodeIdBranchIdTuple]; !ok {
+			continue
+		}
+
+		triggerOpts = append(triggerOpts, p.triggerOpts)
+		externalIdToNodeBranch[p.triggerOpts.ExternalId] = nodeIdBranchIdTuple
 	}
 
 	createdTasks, createdDags, _, celFailures, triggerStorePayloadOpts, err := r.triggerFromWorkflowNames(ctx, optTx, tenantId, triggerOpts)
@@ -1637,10 +1656,6 @@ func (r *durableEventsRepository) triggerPendingRunEntries(ctx context.Context, 
 		}
 	}
 
-	if err := r.markDurableEventLogEntriesTriggered(ctx, tx, task.ID, task.InsertedAt, entryKeys); err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to mark durable run entries as triggered: %w", err)
-	}
-
 	if err := optTx.Commit(ctx); err != nil {
 		return nil, nil, nil, err
 	}
@@ -1659,32 +1674,49 @@ func (r *durableEventsRepository) triggerPendingWaitFor(ctx context.Context, ten
 	}
 	defer rollback()
 
-	if err := r.handleWaitFor(ctx, tx, tenantId, branchId, nodeId, waitForConditions, task); err != nil {
-		return err
+	claimedSet, err := r.claimDurableEventLogEntriesForTrigger(ctx, tx, task.ID, task.InsertedAt, []NodeIdBranchIdTuple{{NodeId: nodeId, BranchId: branchId}})
+	if err != nil {
+		return fmt.Errorf("failed to claim durable wait for entry for trigger: %w", err)
 	}
 
-	if err := r.markDurableEventLogEntriesTriggered(ctx, tx, task.ID, task.InsertedAt, []NodeIdBranchIdTuple{{NodeId: nodeId, BranchId: branchId}}); err != nil {
-		return fmt.Errorf("failed to mark durable wait for entry as triggered: %w", err)
+	if len(claimedSet) == 0 {
+		return nil
+	}
+
+	if err := r.handleWaitFor(ctx, tx, tenantId, branchId, nodeId, waitForConditions, task); err != nil {
+		return err
 	}
 
 	return commit(ctx)
 }
 
-func (r *durableEventsRepository) markDurableEventLogEntriesTriggered(ctx context.Context, tx sqlcv1.DBTX, durableTaskId int64, durableTaskInsertedAt pgtype.Timestamptz, keys []NodeIdBranchIdTuple) error {
-	nodeIds := make([]int64, len(keys))
-	branchIds := make([]int64, len(keys))
+func (r *durableEventsRepository) claimDurableEventLogEntriesForTrigger(ctx context.Context, tx sqlcv1.DBTX, durableTaskId int64, durableTaskInsertedAt pgtype.Timestamptz, nodesToClaim []NodeIdBranchIdTuple) (map[NodeIdBranchIdTuple]struct{}, error) {
+	nodeIds := make([]int64, len(nodesToClaim))
+	branchIds := make([]int64, len(nodesToClaim))
 
-	for i, k := range keys {
+	for i, k := range nodesToClaim {
 		nodeIds[i] = k.NodeId
 		branchIds[i] = k.BranchId
 	}
 
-	return r.queries.MarkDurableEventLogEntriesTriggered(ctx, tx, sqlcv1.MarkDurableEventLogEntriesTriggeredParams{
+	claimed, err := r.queries.ClaimDurableEventLogEntriesForTrigger(ctx, tx, sqlcv1.ClaimDurableEventLogEntriesForTriggerParams{
 		Durabletaskid:         durableTaskId,
 		Durabletaskinsertedat: durableTaskInsertedAt,
 		Nodeids:               nodeIds,
 		Branchids:             branchIds,
 	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	claimedSet := make(map[NodeIdBranchIdTuple]struct{}, len(claimed))
+
+	for _, c := range claimed {
+		claimedSet[NodeIdBranchIdTuple{NodeId: c.NodeID, BranchId: c.BranchID}] = struct{}{}
+	}
+
+	return claimedSet, nil
 }
 
 func (r *durableEventsRepository) handleEventLookback(ctx context.Context, tenantId uuid.UUID, initialWaitForResult *IngestWaitForResult, waitForConditions []CreateExternalSignalConditionOpt) (*IngestWaitForResult, error) {

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -460,10 +460,11 @@ type GetOrCreateLogEntryOpts struct {
 }
 
 type EventLogEntryWithPayloads struct {
-	Entry          *sqlcv1.BulkGetDurableEventLogEntriesRow
-	InputPayload   []byte
-	ResultPayload  []byte
-	AlreadyExisted bool
+	Entry           *sqlcv1.BulkGetDurableEventLogEntriesRow
+	InputPayload    []byte
+	ResultPayload   []byte
+	AlreadyExisted  bool
+	IsSkipReference bool
 }
 
 func (r *durableEventsRepository) GetSatisfiedDurableEvents(ctx context.Context, tenantId uuid.UUID, events []TaskExternalIdNodeIdBranchId) ([]*SatisfiedEventWithPayload, error) {
@@ -934,6 +935,7 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 				SatisfiedOrder:          row.SatisfiedOrder,
 				UserMessage:             row.UserMessage,
 				WaitData:                row.WaitData,
+				TriggeredAt:             row.TriggeredAt,
 				InvocationCount:         row.InvocationCount,
 			}
 		}
@@ -1045,9 +1047,10 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 	for _, o := range skipOpts {
 		e := childTaskExternalIdToSkipEntry[o.ChildTaskExternalId]
 		results = append(results, &EventLogEntryWithPayloads{
-			Entry:          e,
-			AlreadyExisted: true,
-			ResultPayload:  resultPayload(e),
+			Entry:           e,
+			AlreadyExisted:  true,
+			ResultPayload:   resultPayload(e),
+			IsSkipReference: true,
 		})
 	}
 
@@ -1059,6 +1062,11 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 	})
 
 	return results, pendingStorePayloadOpts, nil
+}
+
+type pendingRunTrigger struct {
+	entry       *EventLogEntryWithPayloads
+	triggerOpts *WorkflowNameTriggerOpts
 }
 
 func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, opts IngestDurableTaskEventOpts) (*IngestDurableTaskEventResult, error) {
@@ -1086,26 +1094,175 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 	tenantId := opts.TenantId
 	task := opts.Task
 
-	optTx, err := r.PrepareOptimisticTx(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to prepare tx: %w", err)
-	}
-	defer optTx.Rollback()
+	logEntries, externalIdToTriggerOpts, err := r.appendDurableEventLog(ctx, opts)
 
-	tx := optTx.tx
+	if err != nil {
+		return nil, err
+	}
+
+	var memoResult *IngestMemoResult
+	var waitForResult *IngestWaitForResult
+	var triggerRunsResult *IngestTriggerRunsResult
+
+	switch opts.Kind {
+	case sqlcv1.V1DurableEventLogKindRUN:
+		entries := make([]*IngestTriggerRunsEntry, len(logEntries))
+
+		for i, entry := range logEntries {
+			// important: this is a hack for falling back for child_task_external_id
+			// for task runs created before this column was added, since those external ids
+			// were written to the external_id column on the event log entry
+			workflowRunExternalId := entry.Entry.ExternalID
+			if entry.Entry.ChildTaskExternalID != nil {
+				workflowRunExternalId = *entry.Entry.ChildTaskExternalID
+			}
+
+			var childTaskErrorMessage *string
+
+			if entry.Entry.ChildTaskErrorMessage.Valid {
+				childTaskErrorMessage = &entry.Entry.ChildTaskErrorMessage.String
+			}
+
+			entries[i] = &IngestTriggerRunsEntry{
+				NodeId:                entry.Entry.NodeID,
+				BranchId:              entry.Entry.BranchID,
+				IsSatisfied:           entry.Entry.IsSatisfied,
+				AlreadyExisted:        entry.AlreadyExisted,
+				ResultPayload:         entry.ResultPayload,
+				WorkflowRunExternalId: workflowRunExternalId,
+				SatisfiedOrder:        satisfiedOrderPtr(entry.Entry.SatisfiedOrder),
+				ChildTaskIsFailure:    entry.Entry.ChildTaskIsFailure,
+				ChildTaskErrorMessage: childTaskErrorMessage,
+			}
+		}
+
+		triggerRunsResult = &IngestTriggerRunsResult{
+			InvocationCount: opts.InvocationCount,
+			Entries:         entries,
+		}
+
+		var pending []pendingRunTrigger
+
+		for _, le := range logEntries {
+			if le.Entry.TriggeredAt.Valid {
+				continue
+			}
+
+			if le.IsSkipReference {
+				continue
+			}
+
+			if le.Entry.ChildTaskExternalID == nil {
+				return nil, fmt.Errorf("untriggered RUN log entry at nodeId %d branchId %d is missing child_task_external_id", le.Entry.NodeID, le.Entry.BranchID)
+			}
+
+			triggerOpts, ok := externalIdToTriggerOpts[*le.Entry.ChildTaskExternalID]
+			if !ok {
+				continue
+			}
+
+			// always trigger using the id already committed on the entry -- the caller's
+			// replayed request isn't guaranteed to regenerate the same external id
+			triggerOptsCopy := *triggerOpts
+			triggerOptsCopy.ExternalId = *le.Entry.ChildTaskExternalID
+
+			pending = append(pending, pendingRunTrigger{entry: le, triggerOpts: &triggerOptsCopy})
+		}
+
+		if len(pending) > 0 {
+			createdTasks, createdDags, celFailures, triggerErr := r.triggerPendingRunEntries(ctx, tenantId, task, pending)
+
+			if triggerErr != nil {
+				return nil, fmt.Errorf("failed to trigger pending durable runs: %w", triggerErr)
+			}
+
+			triggerRunsResult.CreatedTasks = createdTasks
+			triggerRunsResult.CreatedDAGs = createdDags
+			triggerRunsResult.CELEvaluationFailures = celFailures
+		}
+	case sqlcv1.V1DurableEventLogKindWAITFOR:
+		if len(logEntries) != 1 {
+			// note: we implicitly assume that there will only be one log entry for wait for conditions
+			// if we get more than one, it's an indication something is wrong
+			return nil, fmt.Errorf("expected to get exactly one log entry for wait for condition, but got %d", len(logEntries))
+		}
+		le := logEntries[0]
+
+		if !le.Entry.TriggeredAt.Valid {
+			if err := r.triggerPendingWaitFor(ctx, tenantId, task, le.Entry.BranchID, le.Entry.NodeID, opts.WaitFor.WaitForConditions); err != nil {
+				return nil, fmt.Errorf("failed to handle wait for conditions: %w", err)
+			}
+		}
+
+		waitForResult = &IngestWaitForResult{
+			InvocationCount: opts.InvocationCount,
+			IsSatisfied:     le.Entry.IsSatisfied,
+			NodeId:          le.Entry.NodeID,
+			BranchId:        le.Entry.BranchID,
+			AlreadyExisted:  le.AlreadyExisted,
+			ResultPayload:   le.ResultPayload,
+			SatisfiedOrder:  satisfiedOrderPtr(le.Entry.SatisfiedOrder),
+		}
+	case sqlcv1.V1DurableEventLogKindMEMO:
+		if len(logEntries) != 1 {
+			// note: we implicitly assume that there will only be one log entry for memo
+			// if we get more than one, it's an indication something is wrong
+			return nil, fmt.Errorf("expected to get exactly one log entry for memo, but got %d", len(logEntries))
+		}
+
+		le := logEntries[0]
+
+		memoResult = &IngestMemoResult{
+			InvocationCount: opts.InvocationCount,
+			IsSatisfied:     le.Entry.IsSatisfied,
+			NodeId:          le.Entry.NodeID,
+			BranchId:        le.Entry.BranchID,
+			ResultPayload:   le.ResultPayload,
+			AlreadyExisted:  le.AlreadyExisted,
+		}
+	}
+
+	if opts.Kind == sqlcv1.V1DurableEventLogKindWAITFOR {
+		waitForResult, err = r.handleEventLookback(ctx, tenantId, waitForResult, opts.WaitFor.WaitForConditions)
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &IngestDurableTaskEventResult{
+		Kind:              opts.Kind,
+		MemoResult:        memoResult,
+		WaitForResult:     waitForResult,
+		TriggerRunsResult: triggerRunsResult,
+	}, nil
+}
+
+func (r *durableEventsRepository) appendDurableEventLog(ctx context.Context, opts IngestDurableTaskEventOpts) ([]*EventLogEntryWithPayloads, map[uuid.UUID]*WorkflowNameTriggerOpts, error) {
+	tenantId := opts.TenantId
+	task := opts.Task
+
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to prepare tx: %w", err)
+	}
+
+	defer rollback()
 
 	logFile, err := r.getAndLockLogFile(ctx, tx, tenantId, task.ID, task.InsertedAt)
+
 	if err != nil {
-		return nil, fmt.Errorf("failed to lock log file: %w", err)
+		return nil, nil, fmt.Errorf("failed to lock log file: %w", err)
 	}
 
 	nextBranchIdToBranchPoint, err := r.listEventLogBranchPoints(ctx, tx, tenantId, task.ID, task.InsertedAt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list log branch points: %w", err)
+		return nil, nil, fmt.Errorf("failed to list log branch points: %w", err)
 	}
 
 	if logFile.LatestInvocationCount != opts.InvocationCount {
-		return nil, &StaleInvocationError{
+		return nil, nil, &StaleInvocationError{
 			TaskExternalId:          opts.Task.ExternalID,
 			ExpectedInvocationCount: logFile.LatestInvocationCount,
 			ActualInvocationCount:   opts.InvocationCount,
@@ -1116,14 +1273,12 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 
 	var getOrCreateOpts GetOrCreateLogEntryOpts
 
-	nodeIdBranchIdToTriggerOpts := make(map[NodeIdBranchIdTuple]*WorkflowNameTriggerOpts)
-	runExternalIdToNodeIdBranchId := make(map[uuid.UUID]NodeIdBranchIdTuple)
 	externalIdToTriggerOpts := make(map[uuid.UUID]*WorkflowNameTriggerOpts)
 
 	switch opts.Kind {
 	case sqlcv1.V1DurableEventLogKindRUN:
 		if populateErr := r.populateExternalIdsForWorkflow(ctx, tx, tenantId, opts.TriggerRuns.TriggerOpts); populateErr != nil {
-			return nil, fmt.Errorf("failed to populate external ids for workflow: %w", populateErr)
+			return nil, nil, fmt.Errorf("failed to populate external ids for workflow: %w", populateErr)
 		}
 
 		innerOpts := make([]GetOrCreateLogEntryOpt, len(opts.TriggerRuns.TriggerOpts))
@@ -1140,7 +1295,7 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 				if triggerOpts.ChildKey == nil {
 					key, keyErr := r.createIdempotencyKey(sqlcv1.V1DurableEventLogKindRUN, triggerOpts, nil)
 					if keyErr != nil {
-						return nil, fmt.Errorf("failed to create idempotency key: %w", keyErr)
+						return nil, nil, fmt.Errorf("failed to create idempotency key: %w", keyErr)
 					}
 					idempotencyKey = key
 				}
@@ -1160,12 +1315,12 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 
 			inputPayload, marshalErr := json.Marshal(triggerOpts)
 			if marshalErr != nil {
-				return nil, fmt.Errorf("failed to marshal trigger opts: %w", marshalErr)
+				return nil, nil, fmt.Errorf("failed to marshal trigger opts: %w", marshalErr)
 			}
 
 			idempotencyKey, keyErr := r.createIdempotencyKey(sqlcv1.V1DurableEventLogKindRUN, triggerOpts, nil)
 			if keyErr != nil {
-				return nil, fmt.Errorf("failed to create idempotency key: %w", keyErr)
+				return nil, nil, fmt.Errorf("failed to create idempotency key: %w", keyErr)
 			}
 
 			innerOpts[i] = GetOrCreateLogEntryOpt{
@@ -1178,10 +1333,6 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 				InputPayload:        inputPayload,
 				WaitData:            marshalWaitData(waitDataFromTriggerOpt(triggerOpts)),
 			}
-
-			nodeBranchKey := NodeIdBranchIdTuple{NodeId: nodeId, BranchId: branchId}
-			nodeIdBranchIdToTriggerOpts[nodeBranchKey] = opts.TriggerRuns.TriggerOpts[i]
-			runExternalIdToNodeIdBranchId[triggerOpts.ExternalId] = nodeBranchKey
 		}
 
 		getOrCreateOpts = GetOrCreateLogEntryOpts{
@@ -1196,12 +1347,12 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 
 		inputPayload, marshalErr := json.Marshal(opts.WaitFor.WaitForConditions)
 		if marshalErr != nil {
-			return nil, fmt.Errorf("failed to marshal wait for conditions: %w", marshalErr)
+			return nil, nil, fmt.Errorf("failed to marshal wait for conditions: %w", marshalErr)
 		}
 
 		idempotencyKey, keyErr := r.createIdempotencyKey(sqlcv1.V1DurableEventLogKindWAITFOR, nil, opts.WaitFor.WaitForConditions)
 		if keyErr != nil {
-			return nil, fmt.Errorf("failed to create idempotency key: %w", keyErr)
+			return nil, nil, fmt.Errorf("failed to create idempotency key: %w", keyErr)
 		}
 
 		getOrCreateOpts = GetOrCreateLogEntryOpts{
@@ -1246,7 +1397,7 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 			}},
 		}
 	default:
-		return nil, fmt.Errorf("unsupported durable event log entry kind: %s", opts.Kind)
+		return nil, nil, fmt.Errorf("unsupported durable event log entry kind: %s", opts.Kind)
 	}
 
 	logEntries, entryStorePayloadOpts, err := r.getOrCreateEventLogEntries(ctx, tx, getOrCreateOpts)
@@ -1275,265 +1426,12 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 			nde.Detail = nonDeterminismDetail(opts, nde.ExpectedKind, existingPayload)
 		}
 
-		return nil, fmt.Errorf("failed to get or create event log entries: %w", err)
-	}
-
-	var memoResult *IngestMemoResult
-	var waitForResult *IngestWaitForResult
-	var triggerRunsResult *IngestTriggerRunsResult
-
-	switch opts.Kind {
-	case sqlcv1.V1DurableEventLogKindRUN:
-		entries := make([]*IngestTriggerRunsEntry, len(getOrCreateOpts.Entries))
-
-		for i, entry := range logEntries {
-			// important: this is a hack for falling back for child_task_external_id
-			// for task runs created before this column was added, since those external ids
-			// were written to the external_id column on the event log entry
-			workflowRunExternalId := entry.Entry.ExternalID
-			if entry.Entry.ChildTaskExternalID != nil {
-				workflowRunExternalId = *entry.Entry.ChildTaskExternalID
-			}
-
-			var childTaskErrorMessage *string
-
-			if entry.Entry.ChildTaskErrorMessage.Valid {
-				childTaskErrorMessage = &entry.Entry.ChildTaskErrorMessage.String
-			}
-
-			entries[i] = &IngestTriggerRunsEntry{
-				NodeId:                entry.Entry.NodeID,
-				BranchId:              entry.Entry.BranchID,
-				IsSatisfied:           entry.Entry.IsSatisfied,
-				AlreadyExisted:        entry.AlreadyExisted,
-				ResultPayload:         entry.ResultPayload,
-				WorkflowRunExternalId: workflowRunExternalId,
-				SatisfiedOrder:        satisfiedOrderPtr(entry.Entry.SatisfiedOrder),
-				ChildTaskIsFailure:    entry.Entry.ChildTaskIsFailure,
-				ChildTaskErrorMessage: childTaskErrorMessage,
-			}
-		}
-
-		triggerRunsResult = &IngestTriggerRunsResult{
-			InvocationCount: opts.InvocationCount,
-			Entries:         entries,
-		}
-
-		var newTriggerOpts []*WorkflowNameTriggerOpts
-
-		for _, le := range logEntries {
-			if le.AlreadyExisted {
-				continue
-			}
-
-			if le.Entry.ChildTaskExternalID == nil {
-				return nil, fmt.Errorf("new RUN log entry at nodeId %d branchId %d is missing child_task_external_id", le.Entry.NodeID, le.Entry.BranchID)
-			}
-
-			triggerOpts := externalIdToTriggerOpts[*le.Entry.ChildTaskExternalID]
-			if triggerOpts != nil {
-				newTriggerOpts = append(newTriggerOpts, triggerOpts)
-			}
-		}
-
-		if len(newTriggerOpts) > 0 {
-			createdTasks, createdDags, _, celFailures, triggerStorePayloadOpts, triggerErr := r.triggerFromWorkflowNames(ctx, optTx, tenantId, newTriggerOpts)
-
-			if triggerErr != nil {
-				return nil, fmt.Errorf("failed to trigger workflows: %w", triggerErr)
-			}
-
-			entryStorePayloadOpts = append(entryStorePayloadOpts, triggerStorePayloadOpts...)
-
-			triggerRunsResult.CreatedTasks = createdTasks
-			triggerRunsResult.CreatedDAGs = createdDags
-			triggerRunsResult.CELEvaluationFailures = celFailures
-
-			createMatchOpts := make([]CreateMatchOpts, 0, len(createdTasks)+len(createdDags))
-
-			dagExternalIds := make(map[uuid.UUID]struct{}, len(createdDags))
-
-			for _, dag := range createdDags {
-				dagExternalIds[dag.ExternalID] = struct{}{}
-			}
-
-			for _, ct := range createdTasks {
-				if _, isDagTask := dagExternalIds[ct.WorkflowRunID]; isDagTask {
-					continue
-				}
-
-				childHint := ct.ExternalID.String()
-				orGroupId := uuid.New()
-
-				conditions := []GroupMatchCondition{
-					{
-						GroupId:           orGroupId,
-						EventType:         sqlcv1.V1EventTypeINTERNAL,
-						EventKey:          string(sqlcv1.V1TaskEventTypeCOMPLETED),
-						ReadableDataKey:   "output",
-						EventResourceHint: &childHint,
-						Expression:        "true",
-						Action:            sqlcv1.V1MatchConditionActionCREATE,
-					},
-					{
-						GroupId:           orGroupId,
-						EventType:         sqlcv1.V1EventTypeINTERNAL,
-						EventKey:          string(sqlcv1.V1TaskEventTypeFAILED),
-						ReadableDataKey:   "output",
-						EventResourceHint: &childHint,
-						Expression:        "true",
-						Action:            sqlcv1.V1MatchConditionActionCREATE,
-					},
-					{
-						GroupId:           orGroupId,
-						EventType:         sqlcv1.V1EventTypeINTERNAL,
-						EventKey:          string(sqlcv1.V1TaskEventTypeCANCELLED),
-						ReadableDataKey:   "output",
-						EventResourceHint: &childHint,
-						Expression:        "true",
-						Action:            sqlcv1.V1MatchConditionActionCREATE,
-					},
-				}
-
-				nodeIdBranchId := runExternalIdToNodeIdBranchId[ct.ExternalID]
-
-				nodeId := nodeIdBranchId.NodeId
-				branchId := nodeIdBranchId.BranchId
-
-				runEventLogEntrySignalKey := fmt.Sprintf("durable_run:%s:%d:%d", task.ExternalID.String(), branchId, nodeId)
-
-				taskId := task.ID
-
-				createMatchOpts = append(createMatchOpts, CreateMatchOpts{
-					Kind:                         sqlcv1.V1MatchKindSIGNAL,
-					Conditions:                   conditions,
-					SignalTaskId:                 &taskId,
-					SignalTaskInsertedAt:         task.InsertedAt,
-					SignalExternalId:             &ct.ExternalID,
-					SignalTaskExternalId:         &task.ExternalID,
-					SignalKey:                    &runEventLogEntrySignalKey,
-					DurableEventLogEntryNodeId:   &nodeId,
-					DurableEventLogEntryBranchId: &branchId,
-				})
-			}
-
-			for _, dag := range createdDags {
-				conditions := make([]GroupMatchCondition, 0, len(dag.TaskExternalIDs)*3)
-
-				for i, taskExtId := range dag.TaskExternalIDs {
-					childHint := taskExtId.String()
-					orGroupId := uuid.New()
-
-					readableDataKey := "output"
-					if i < len(dag.TaskStepReadableIDs) {
-						readableDataKey = dag.TaskStepReadableIDs[i]
-					}
-
-					conditions = append(conditions,
-						GroupMatchCondition{
-							GroupId:           orGroupId,
-							EventType:         sqlcv1.V1EventTypeINTERNAL,
-							EventKey:          string(sqlcv1.V1TaskEventTypeCOMPLETED),
-							ReadableDataKey:   readableDataKey,
-							EventResourceHint: &childHint,
-							Expression:        "true",
-							Action:            sqlcv1.V1MatchConditionActionCREATE,
-						},
-						GroupMatchCondition{
-							GroupId:           orGroupId,
-							EventType:         sqlcv1.V1EventTypeINTERNAL,
-							EventKey:          string(sqlcv1.V1TaskEventTypeFAILED),
-							ReadableDataKey:   readableDataKey,
-							EventResourceHint: &childHint,
-							Expression:        "true",
-							Action:            sqlcv1.V1MatchConditionActionCREATE,
-						},
-						GroupMatchCondition{
-							GroupId:           orGroupId,
-							EventType:         sqlcv1.V1EventTypeINTERNAL,
-							EventKey:          string(sqlcv1.V1TaskEventTypeCANCELLED),
-							ReadableDataKey:   readableDataKey,
-							EventResourceHint: &childHint,
-							Expression:        "true",
-							Action:            sqlcv1.V1MatchConditionActionCREATE,
-						},
-					)
-				}
-
-				nodeIdBranchId := runExternalIdToNodeIdBranchId[dag.ExternalID]
-
-				nodeId := nodeIdBranchId.NodeId
-				branchId := nodeIdBranchId.BranchId
-
-				runEventLogEntrySignalKey := fmt.Sprintf("durable_run:%s:%d:%d", task.ExternalID.String(), branchId, nodeId)
-
-				taskId := task.ID
-				dagExternalId := dag.ExternalID
-
-				createMatchOpts = append(createMatchOpts, CreateMatchOpts{
-					Kind:                         sqlcv1.V1MatchKindSIGNAL,
-					Conditions:                   conditions,
-					SignalTaskId:                 &taskId,
-					SignalTaskInsertedAt:         task.InsertedAt,
-					SignalExternalId:             &dagExternalId,
-					SignalTaskExternalId:         &task.ExternalID,
-					SignalKey:                    &runEventLogEntrySignalKey,
-					DurableEventLogEntryNodeId:   &nodeId,
-					DurableEventLogEntryBranchId: &branchId,
-				})
-			}
-
-			if len(createMatchOpts) > 0 {
-				if matchErr := r.createEventMatches(ctx, tx, tenantId, createMatchOpts); matchErr != nil {
-					return nil, fmt.Errorf("failed to register run completion matches: %w", matchErr)
-				}
-			}
-		}
-	case sqlcv1.V1DurableEventLogKindWAITFOR:
-		if len(logEntries) != 1 {
-			// note: we implicitly assume that there will only be one log entry for wait for conditions
-			// if we get more than one, it's an indication something is wrong
-			return nil, fmt.Errorf("expected to get exactly one log entry for wait for condition, but got %d", len(logEntries))
-		}
-		le := logEntries[0]
-
-		if !le.AlreadyExisted {
-			if err = r.handleWaitFor(ctx, tx, tenantId, le.Entry.BranchID, le.Entry.NodeID, opts.WaitFor.WaitForConditions, task); err != nil {
-				return nil, fmt.Errorf("failed to handle wait for conditions: %w", err)
-			}
-		}
-
-		waitForResult = &IngestWaitForResult{
-			InvocationCount: opts.InvocationCount,
-			IsSatisfied:     le.Entry.IsSatisfied,
-			NodeId:          le.Entry.NodeID,
-			BranchId:        le.Entry.BranchID,
-			AlreadyExisted:  le.AlreadyExisted,
-			ResultPayload:   le.ResultPayload,
-			SatisfiedOrder:  satisfiedOrderPtr(le.Entry.SatisfiedOrder),
-		}
-	case sqlcv1.V1DurableEventLogKindMEMO:
-		if len(logEntries) != 1 {
-			// note: we implicitly assume that there will only be one log entry for memo
-			// if we get more than one, it's an indication something is wrong
-			return nil, fmt.Errorf("expected to get exactly one log entry for memo, but got %d", len(logEntries))
-		}
-
-		le := logEntries[0]
-
-		memoResult = &IngestMemoResult{
-			InvocationCount: opts.InvocationCount,
-			IsSatisfied:     le.Entry.IsSatisfied,
-			NodeId:          le.Entry.NodeID,
-			BranchId:        le.Entry.BranchID,
-			ResultPayload:   le.ResultPayload,
-			AlreadyExisted:  le.AlreadyExisted,
-		}
+		return nil, nil, fmt.Errorf("failed to get or create event log entries: %w", err)
 	}
 
 	if len(entryStorePayloadOpts) > 0 {
 		if storeErr := r.payloadStore.Store(ctx, tx, entryStorePayloadOpts...); storeErr != nil {
-			return nil, fmt.Errorf("failed to store payloads for new entries: %w", storeErr)
+			return nil, nil, fmt.Errorf("failed to store payloads for new entries: %w", storeErr)
 		}
 	}
 
@@ -1552,28 +1450,241 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 		})
 
 		if err != nil {
-			return nil, fmt.Errorf("failed to update latest node id: %w", err)
+			return nil, nil, fmt.Errorf("failed to update latest node id: %w", err)
 		}
+	}
+
+	if err := commit(ctx); err != nil {
+		return nil, nil, err
+	}
+
+	return logEntries, externalIdToTriggerOpts, nil
+}
+
+func (r *durableEventsRepository) triggerPendingRunEntries(ctx context.Context, tenantId uuid.UUID, task *sqlcv1.FlattenExternalIdsRow, pending []pendingRunTrigger) ([]*V1TaskWithPayload, []*DAGWithData, []CELEvaluationFailure, error) {
+	ctx, span := telemetry.NewSpan(ctx, "trigger-pending-durable-run-entries")
+	defer span.End()
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "pending_count", Value: len(pending)})
+
+	optTx, err := r.PrepareOptimisticTx(ctx)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to prepare tx: %w", err)
+	}
+	defer optTx.Rollback()
+
+	tx := optTx.tx
+
+	triggerOpts := make([]*WorkflowNameTriggerOpts, len(pending))
+	externalIdToNodeBranch := make(map[uuid.UUID]NodeIdBranchIdTuple, len(pending))
+	entryKeys := make([]NodeIdBranchIdTuple, len(pending))
+
+	for i, p := range pending {
+		triggerOpts[i] = p.triggerOpts
+		key := NodeIdBranchIdTuple{NodeId: p.entry.Entry.NodeID, BranchId: p.entry.Entry.BranchID}
+		externalIdToNodeBranch[p.triggerOpts.ExternalId] = key
+		entryKeys[i] = key
+	}
+
+	createdTasks, createdDags, _, celFailures, triggerStorePayloadOpts, err := r.triggerFromWorkflowNames(ctx, optTx, tenantId, triggerOpts)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to trigger workflows: %w", err)
+	}
+
+	if len(triggerStorePayloadOpts) > 0 {
+		if err := r.payloadStore.Store(ctx, tx, triggerStorePayloadOpts...); err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to store payloads for triggered runs: %w", err)
+		}
+	}
+
+	createMatchOpts := make([]CreateMatchOpts, 0, len(createdTasks)+len(createdDags))
+
+	dagExternalIds := make(map[uuid.UUID]struct{}, len(createdDags))
+
+	for _, dag := range createdDags {
+		dagExternalIds[dag.ExternalID] = struct{}{}
+	}
+
+	for _, ct := range createdTasks {
+		if _, isDagTask := dagExternalIds[ct.WorkflowRunID]; isDagTask {
+			continue
+		}
+
+		childHint := ct.ExternalID.String()
+		orGroupId := uuid.New()
+
+		conditions := []GroupMatchCondition{
+			{
+				GroupId:           orGroupId,
+				EventType:         sqlcv1.V1EventTypeINTERNAL,
+				EventKey:          string(sqlcv1.V1TaskEventTypeCOMPLETED),
+				ReadableDataKey:   "output",
+				EventResourceHint: &childHint,
+				Expression:        "true",
+				Action:            sqlcv1.V1MatchConditionActionCREATE,
+			},
+			{
+				GroupId:           orGroupId,
+				EventType:         sqlcv1.V1EventTypeINTERNAL,
+				EventKey:          string(sqlcv1.V1TaskEventTypeFAILED),
+				ReadableDataKey:   "output",
+				EventResourceHint: &childHint,
+				Expression:        "true",
+				Action:            sqlcv1.V1MatchConditionActionCREATE,
+			},
+			{
+				GroupId:           orGroupId,
+				EventType:         sqlcv1.V1EventTypeINTERNAL,
+				EventKey:          string(sqlcv1.V1TaskEventTypeCANCELLED),
+				ReadableDataKey:   "output",
+				EventResourceHint: &childHint,
+				Expression:        "true",
+				Action:            sqlcv1.V1MatchConditionActionCREATE,
+			},
+		}
+
+		nodeIdBranchId := externalIdToNodeBranch[ct.ExternalID]
+
+		nodeId := nodeIdBranchId.NodeId
+		branchId := nodeIdBranchId.BranchId
+
+		runEventLogEntrySignalKey := fmt.Sprintf("durable_run:%s:%d:%d", task.ExternalID.String(), branchId, nodeId)
+
+		taskId := task.ID
+
+		createMatchOpts = append(createMatchOpts, CreateMatchOpts{
+			Kind:                         sqlcv1.V1MatchKindSIGNAL,
+			Conditions:                   conditions,
+			SignalTaskId:                 &taskId,
+			SignalTaskInsertedAt:         task.InsertedAt,
+			SignalExternalId:             &ct.ExternalID,
+			SignalTaskExternalId:         &task.ExternalID,
+			SignalKey:                    &runEventLogEntrySignalKey,
+			DurableEventLogEntryNodeId:   &nodeId,
+			DurableEventLogEntryBranchId: &branchId,
+		})
+	}
+
+	for _, dag := range createdDags {
+		conditions := make([]GroupMatchCondition, 0, len(dag.TaskExternalIDs)*3)
+
+		for i, taskExtId := range dag.TaskExternalIDs {
+			childHint := taskExtId.String()
+			orGroupId := uuid.New()
+
+			readableDataKey := "output"
+			if i < len(dag.TaskStepReadableIDs) {
+				readableDataKey = dag.TaskStepReadableIDs[i]
+			}
+
+			conditions = append(conditions,
+				GroupMatchCondition{
+					GroupId:           orGroupId,
+					EventType:         sqlcv1.V1EventTypeINTERNAL,
+					EventKey:          string(sqlcv1.V1TaskEventTypeCOMPLETED),
+					ReadableDataKey:   readableDataKey,
+					EventResourceHint: &childHint,
+					Expression:        "true",
+					Action:            sqlcv1.V1MatchConditionActionCREATE,
+				},
+				GroupMatchCondition{
+					GroupId:           orGroupId,
+					EventType:         sqlcv1.V1EventTypeINTERNAL,
+					EventKey:          string(sqlcv1.V1TaskEventTypeFAILED),
+					ReadableDataKey:   readableDataKey,
+					EventResourceHint: &childHint,
+					Expression:        "true",
+					Action:            sqlcv1.V1MatchConditionActionCREATE,
+				},
+				GroupMatchCondition{
+					GroupId:           orGroupId,
+					EventType:         sqlcv1.V1EventTypeINTERNAL,
+					EventKey:          string(sqlcv1.V1TaskEventTypeCANCELLED),
+					ReadableDataKey:   readableDataKey,
+					EventResourceHint: &childHint,
+					Expression:        "true",
+					Action:            sqlcv1.V1MatchConditionActionCREATE,
+				},
+			)
+		}
+
+		nodeIdBranchId := externalIdToNodeBranch[dag.ExternalID]
+
+		nodeId := nodeIdBranchId.NodeId
+		branchId := nodeIdBranchId.BranchId
+
+		runEventLogEntrySignalKey := fmt.Sprintf("durable_run:%s:%d:%d", task.ExternalID.String(), branchId, nodeId)
+
+		taskId := task.ID
+		dagExternalId := dag.ExternalID
+
+		createMatchOpts = append(createMatchOpts, CreateMatchOpts{
+			Kind:                         sqlcv1.V1MatchKindSIGNAL,
+			Conditions:                   conditions,
+			SignalTaskId:                 &taskId,
+			SignalTaskInsertedAt:         task.InsertedAt,
+			SignalExternalId:             &dagExternalId,
+			SignalTaskExternalId:         &task.ExternalID,
+			SignalKey:                    &runEventLogEntrySignalKey,
+			DurableEventLogEntryNodeId:   &nodeId,
+			DurableEventLogEntryBranchId: &branchId,
+		})
+	}
+
+	if len(createMatchOpts) > 0 {
+		if err := r.createEventMatches(ctx, tx, tenantId, createMatchOpts); err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to register run completion matches: %w", err)
+		}
+	}
+
+	if err := r.markDurableEventLogEntriesTriggered(ctx, tx, task.ID, task.InsertedAt, entryKeys); err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to mark durable run entries as triggered: %w", err)
 	}
 
 	if err := optTx.Commit(ctx); err != nil {
-		return nil, err
+		return nil, nil, nil, err
 	}
 
-	if opts.Kind == sqlcv1.V1DurableEventLogKindWAITFOR {
-		waitForResult, err = r.handleEventLookback(ctx, tenantId, waitForResult, opts.WaitFor.WaitForConditions)
+	return createdTasks, createdDags, celFailures, nil
+}
 
-		if err != nil {
-			return nil, err
-		}
+func (r *durableEventsRepository) triggerPendingWaitFor(ctx context.Context, tenantId uuid.UUID, task *sqlcv1.FlattenExternalIdsRow, branchId, nodeId int64, waitForConditions []CreateExternalSignalConditionOpt) error {
+	ctx, span := telemetry.NewSpan(ctx, "trigger-pending-durable-wait-for")
+	defer span.End()
+
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
+
+	if err != nil {
+		return fmt.Errorf("failed to prepare tx: %w", err)
+	}
+	defer rollback()
+
+	if err := r.handleWaitFor(ctx, tx, tenantId, branchId, nodeId, waitForConditions, task); err != nil {
+		return err
 	}
 
-	return &IngestDurableTaskEventResult{
-		Kind:              opts.Kind,
-		MemoResult:        memoResult,
-		WaitForResult:     waitForResult,
-		TriggerRunsResult: triggerRunsResult,
-	}, nil
+	if err := r.markDurableEventLogEntriesTriggered(ctx, tx, task.ID, task.InsertedAt, []NodeIdBranchIdTuple{{NodeId: nodeId, BranchId: branchId}}); err != nil {
+		return fmt.Errorf("failed to mark durable wait for entry as triggered: %w", err)
+	}
+
+	return commit(ctx)
+}
+
+func (r *durableEventsRepository) markDurableEventLogEntriesTriggered(ctx context.Context, tx sqlcv1.DBTX, durableTaskId int64, durableTaskInsertedAt pgtype.Timestamptz, keys []NodeIdBranchIdTuple) error {
+	nodeIds := make([]int64, len(keys))
+	branchIds := make([]int64, len(keys))
+
+	for i, k := range keys {
+		nodeIds[i] = k.NodeId
+		branchIds[i] = k.BranchId
+	}
+
+	return r.queries.MarkDurableEventLogEntriesTriggered(ctx, tx, sqlcv1.MarkDurableEventLogEntriesTriggeredParams{
+		Durabletaskid:         durableTaskId,
+		Durabletaskinsertedat: durableTaskInsertedAt,
+		Nodeids:               nodeIds,
+		Branchids:             branchIds,
+	})
 }
 
 func (r *durableEventsRepository) handleEventLookback(ctx context.Context, tenantId uuid.UUID, initialWaitForResult *IngestWaitForResult, waitForConditions []CreateExternalSignalConditionOpt) (*IngestWaitForResult, error) {

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -1094,7 +1094,7 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 	tenantId := opts.TenantId
 	task := opts.Task
 
-	logEntries, externalIdToTriggerOpts, err := r.appendDurableEventLog(ctx, opts)
+	logEntries, nodeIdBranchIdToTriggerOpts, err := r.appendDurableEventLog(ctx, opts)
 
 	if err != nil {
 		return nil, err
@@ -1156,13 +1156,14 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 				return nil, fmt.Errorf("untriggered RUN log entry at nodeId %d branchId %d is missing child_task_external_id", le.Entry.NodeID, le.Entry.BranchID)
 			}
 
-			triggerOpts, ok := externalIdToTriggerOpts[*le.Entry.ChildTaskExternalID]
+			key := NodeIdBranchIdTuple{NodeId: le.Entry.NodeID, BranchId: le.Entry.BranchID}
+			triggerOpts, ok := nodeIdBranchIdToTriggerOpts[key]
 			if !ok {
-				continue
+				return nil, fmt.Errorf("untriggered RUN log entry at nodeId %d branchId %d has no matching trigger in the request", le.Entry.NodeID, le.Entry.BranchID)
 			}
 
-			// always trigger using the id already committed on the entry -- the caller's
-			// replayed request isn't guaranteed to regenerate the same external id
+			// trigger using the child external id already committed on the entry so re-triggering
+			// reuses the same child instead of spawning a new one
 			triggerOptsCopy := *triggerOpts
 			triggerOptsCopy.ExternalId = *le.Entry.ChildTaskExternalID
 
@@ -1238,7 +1239,7 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 	}, nil
 }
 
-func (r *durableEventsRepository) appendDurableEventLog(ctx context.Context, opts IngestDurableTaskEventOpts) ([]*EventLogEntryWithPayloads, map[uuid.UUID]*WorkflowNameTriggerOpts, error) {
+func (r *durableEventsRepository) appendDurableEventLog(ctx context.Context, opts IngestDurableTaskEventOpts) ([]*EventLogEntryWithPayloads, map[NodeIdBranchIdTuple]*WorkflowNameTriggerOpts, error) {
 	tenantId := opts.TenantId
 	task := opts.Task
 
@@ -1273,7 +1274,7 @@ func (r *durableEventsRepository) appendDurableEventLog(ctx context.Context, opt
 
 	var getOrCreateOpts GetOrCreateLogEntryOpts
 
-	externalIdToTriggerOpts := make(map[uuid.UUID]*WorkflowNameTriggerOpts)
+	nodeIdBranchIdToTriggerOpts := make(map[NodeIdBranchIdTuple]*WorkflowNameTriggerOpts)
 
 	switch opts.Kind {
 	case sqlcv1.V1DurableEventLogKindRUN:
@@ -1285,8 +1286,6 @@ func (r *durableEventsRepository) appendDurableEventLog(ctx context.Context, opt
 
 		nonSkipOffset := int64(0)
 		for i, triggerOpts := range opts.TriggerRuns.TriggerOpts {
-			externalIdToTriggerOpts[triggerOpts.ExternalId] = triggerOpts
-
 			if triggerOpts.ShouldSkip {
 				// only index-based dedupe is validated against the existing entry's
 				// idempotency key: an explicit child_key intentionally reuses the
@@ -1312,6 +1311,8 @@ func (r *durableEventsRepository) appendDurableEventLog(ctx context.Context, opt
 			nodeId := baseNodeId + nonSkipOffset
 			nonSkipOffset++
 			branchId := resolveBranchForNode(nodeId, logFile.LatestBranchID, nextBranchIdToBranchPoint)
+
+			nodeIdBranchIdToTriggerOpts[NodeIdBranchIdTuple{NodeId: nodeId, BranchId: branchId}] = triggerOpts
 
 			inputPayload, marshalErr := json.Marshal(triggerOpts)
 			if marshalErr != nil {
@@ -1458,7 +1459,7 @@ func (r *durableEventsRepository) appendDurableEventLog(ctx context.Context, opt
 		return nil, nil, err
 	}
 
-	return logEntries, externalIdToTriggerOpts, nil
+	return logEntries, nodeIdBranchIdToTriggerOpts, nil
 }
 
 func (r *durableEventsRepository) triggerPendingRunEntries(ctx context.Context, tenantId uuid.UUID, task *sqlcv1.FlattenExternalIdsRow, pending []pendingRunTrigger) ([]*V1TaskWithPayload, []*DAGWithData, []CELEvaluationFailure, error) {

--- a/pkg/repository/sqlcv1/durable_event_log.sql
+++ b/pkg/repository/sqlcv1/durable_event_log.sql
@@ -293,6 +293,22 @@ WHERE (lf.durable_task_id, lf.durable_task_inserted_at, lf.tenant_id) IN (
 )
 ;
 
+-- name: MarkDurableEventLogEntriesTriggered :exec
+WITH inputs AS (
+    SELECT
+        UNNEST(@nodeIds::BIGINT[]) AS node_id,
+        UNNEST(@branchIds::BIGINT[]) AS branch_id
+)
+UPDATE v1_durable_event_log_entry e
+SET triggered_at = NOW()
+FROM inputs i
+WHERE e.durable_task_id = @durableTaskId::BIGINT
+  AND e.durable_task_inserted_at = @durableTaskInsertedAt::TIMESTAMPTZ
+  AND e.node_id = i.node_id
+  AND e.branch_id = i.branch_id
+  AND e.triggered_at IS NULL
+;
+
 -- name: ListDurableEventLogBranchPoints :many
 SELECT *
 FROM v1_durable_event_log_branch_point

--- a/pkg/repository/sqlcv1/durable_event_log.sql
+++ b/pkg/repository/sqlcv1/durable_event_log.sql
@@ -293,12 +293,13 @@ WHERE (lf.durable_task_id, lf.durable_task_inserted_at, lf.tenant_id) IN (
 )
 ;
 
--- name: MarkDurableEventLogEntriesTriggered :exec
+-- name: ClaimDurableEventLogEntriesForTrigger :many
 WITH inputs AS (
     SELECT
         UNNEST(@nodeIds::BIGINT[]) AS node_id,
         UNNEST(@branchIds::BIGINT[]) AS branch_id
 )
+
 UPDATE v1_durable_event_log_entry e
 SET triggered_at = NOW()
 FROM inputs i
@@ -307,6 +308,7 @@ WHERE e.durable_task_id = @durableTaskId::BIGINT
   AND e.node_id = i.node_id
   AND e.branch_id = i.branch_id
   AND e.triggered_at IS NULL
+RETURNING e.node_id, e.branch_id
 ;
 
 -- name: ListDurableEventLogBranchPoints :many

--- a/pkg/repository/sqlcv1/durable_event_log.sql.go
+++ b/pkg/repository/sqlcv1/durable_event_log.sql.go
@@ -59,10 +59,10 @@ WITH inputs AS (
         CASE WHEN i.wait_data = '' THEN NULL ELSE i.wait_data::JSONB END
     FROM inputs i
     ON CONFLICT (durable_task_id, durable_task_inserted_at, branch_id, node_id) DO NOTHING
-    RETURNING tenant_id, external_id, result_payload_external_id, child_task_external_id, child_task_is_failure, child_task_error_message, inserted_at, id, durable_task_id, durable_task_inserted_at, kind, node_id, branch_id, idempotency_key, is_satisfied, satisfied_at, satisfied_order, user_message, wait_data
+    RETURNING tenant_id, external_id, result_payload_external_id, child_task_external_id, child_task_is_failure, child_task_error_message, inserted_at, id, durable_task_id, durable_task_inserted_at, kind, node_id, branch_id, idempotency_key, is_satisfied, satisfied_at, satisfied_order, user_message, wait_data, triggered_at
 )
 
-SELECT i.tenant_id, i.external_id, i.result_payload_external_id, i.child_task_external_id, i.child_task_is_failure, i.child_task_error_message, i.inserted_at, i.id, i.durable_task_id, i.durable_task_inserted_at, i.kind, i.node_id, i.branch_id, i.idempotency_key, i.is_satisfied, i.satisfied_at, i.satisfied_order, i.user_message, i.wait_data, lf.latest_invocation_count AS invocation_count
+SELECT i.tenant_id, i.external_id, i.result_payload_external_id, i.child_task_external_id, i.child_task_is_failure, i.child_task_error_message, i.inserted_at, i.id, i.durable_task_id, i.durable_task_inserted_at, i.kind, i.node_id, i.branch_id, i.idempotency_key, i.is_satisfied, i.satisfied_at, i.satisfied_order, i.user_message, i.wait_data, i.triggered_at, lf.latest_invocation_count AS invocation_count
 FROM inserts i
 JOIN v1_durable_event_log_file lf ON (lf.durable_task_id, lf.durable_task_inserted_at) = (i.durable_task_id, i.durable_task_inserted_at)
 `
@@ -102,6 +102,7 @@ type BulkCreateDurableEventLogEntriesRow struct {
 	SatisfiedOrder          pgtype.Int8           `json:"satisfied_order"`
 	UserMessage             pgtype.Text           `json:"user_message"`
 	WaitData                []byte                `json:"wait_data"`
+	TriggeredAt             pgtype.Timestamptz    `json:"triggered_at"`
 	InvocationCount         int32                 `json:"invocation_count"`
 }
 
@@ -147,6 +148,7 @@ func (q *Queries) BulkCreateDurableEventLogEntries(ctx context.Context, db DBTX,
 			&i.SatisfiedOrder,
 			&i.UserMessage,
 			&i.WaitData,
+			&i.TriggeredAt,
 			&i.InvocationCount,
 		); err != nil {
 			return nil, err
@@ -165,7 +167,7 @@ WITH inputs AS (
         UNNEST($3::BIGINT[]) AS branch_id,
         UNNEST($4::BIGINT[]) AS node_id
 )
-SELECT e.tenant_id, e.external_id, e.result_payload_external_id, e.child_task_external_id, e.child_task_is_failure, e.child_task_error_message, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.satisfied_order, e.user_message, e.wait_data, lf.latest_invocation_count AS invocation_count
+SELECT e.tenant_id, e.external_id, e.result_payload_external_id, e.child_task_external_id, e.child_task_is_failure, e.child_task_error_message, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.satisfied_order, e.user_message, e.wait_data, e.triggered_at, lf.latest_invocation_count AS invocation_count
 FROM v1_durable_event_log_entry e
 JOIN inputs i ON e.branch_id = i.branch_id AND e.node_id = i.node_id
 JOIN v1_durable_event_log_file lf ON (lf.durable_task_id, lf.durable_task_inserted_at) = (e.durable_task_id, e.durable_task_inserted_at)
@@ -200,6 +202,7 @@ type BulkGetDurableEventLogEntriesRow struct {
 	SatisfiedOrder          pgtype.Int8           `json:"satisfied_order"`
 	UserMessage             pgtype.Text           `json:"user_message"`
 	WaitData                []byte                `json:"wait_data"`
+	TriggeredAt             pgtype.Timestamptz    `json:"triggered_at"`
 	InvocationCount         int32                 `json:"invocation_count"`
 }
 
@@ -237,6 +240,7 @@ func (q *Queries) BulkGetDurableEventLogEntries(ctx context.Context, db DBTX, ar
 			&i.SatisfiedOrder,
 			&i.UserMessage,
 			&i.WaitData,
+			&i.TriggeredAt,
 			&i.InvocationCount,
 		); err != nil {
 			return nil, err
@@ -323,7 +327,7 @@ func (q *Queries) GetAndLockLogFile(ctx context.Context, db DBTX, arg GetAndLock
 }
 
 const getDurableEventLogEntriesByChildTaskExternalIds = `-- name: GetDurableEventLogEntriesByChildTaskExternalIds :many
-SELECT e.tenant_id, e.external_id, e.result_payload_external_id, e.child_task_external_id, e.child_task_is_failure, e.child_task_error_message, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.satisfied_order, e.user_message, e.wait_data, lf.latest_invocation_count AS invocation_count
+SELECT e.tenant_id, e.external_id, e.result_payload_external_id, e.child_task_external_id, e.child_task_is_failure, e.child_task_error_message, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.satisfied_order, e.user_message, e.wait_data, e.triggered_at, lf.latest_invocation_count AS invocation_count
 FROM v1_durable_event_log_entry e
 JOIN v1_durable_event_log_file lf ON (lf.durable_task_id, lf.durable_task_inserted_at) = (e.durable_task_id, e.durable_task_inserted_at)
 WHERE
@@ -359,6 +363,7 @@ type GetDurableEventLogEntriesByChildTaskExternalIdsRow struct {
 	SatisfiedOrder          pgtype.Int8           `json:"satisfied_order"`
 	UserMessage             pgtype.Text           `json:"user_message"`
 	WaitData                []byte                `json:"wait_data"`
+	TriggeredAt             pgtype.Timestamptz    `json:"triggered_at"`
 	InvocationCount         int32                 `json:"invocation_count"`
 }
 
@@ -391,6 +396,7 @@ func (q *Queries) GetDurableEventLogEntriesByChildTaskExternalIds(ctx context.Co
 			&i.SatisfiedOrder,
 			&i.UserMessage,
 			&i.WaitData,
+			&i.TriggeredAt,
 			&i.InvocationCount,
 		); err != nil {
 			return nil, err
@@ -404,7 +410,7 @@ func (q *Queries) GetDurableEventLogEntriesByChildTaskExternalIds(ctx context.Co
 }
 
 const getDurableEventLogEntry = `-- name: GetDurableEventLogEntry :one
-SELECT tenant_id, external_id, result_payload_external_id, child_task_external_id, child_task_is_failure, child_task_error_message, inserted_at, id, durable_task_id, durable_task_inserted_at, kind, node_id, branch_id, idempotency_key, is_satisfied, satisfied_at, satisfied_order, user_message, wait_data
+SELECT tenant_id, external_id, result_payload_external_id, child_task_external_id, child_task_is_failure, child_task_error_message, inserted_at, id, durable_task_id, durable_task_inserted_at, kind, node_id, branch_id, idempotency_key, is_satisfied, satisfied_at, satisfied_order, user_message, wait_data, triggered_at
 FROM v1_durable_event_log_entry
 WHERE durable_task_id = $1::BIGINT
   AND durable_task_inserted_at = $2::TIMESTAMPTZ
@@ -447,6 +453,7 @@ func (q *Queries) GetDurableEventLogEntry(ctx context.Context, db DBTX, arg GetD
 		&i.SatisfiedOrder,
 		&i.UserMessage,
 		&i.WaitData,
+		&i.TriggeredAt,
 	)
 	return &i, err
 }
@@ -616,7 +623,7 @@ func (q *Queries) ListDurableEventLogBranchPoints(ctx context.Context, db DBTX, 
 }
 
 const listDurableEventLogEntriesBeforeNode = `-- name: ListDurableEventLogEntriesBeforeNode :many
-SELECT tenant_id, external_id, result_payload_external_id, child_task_external_id, child_task_is_failure, child_task_error_message, inserted_at, id, durable_task_id, durable_task_inserted_at, kind, node_id, branch_id, idempotency_key, is_satisfied, satisfied_at, satisfied_order, user_message, wait_data
+SELECT tenant_id, external_id, result_payload_external_id, child_task_external_id, child_task_is_failure, child_task_error_message, inserted_at, id, durable_task_id, durable_task_inserted_at, kind, node_id, branch_id, idempotency_key, is_satisfied, satisfied_at, satisfied_order, user_message, wait_data, triggered_at
 FROM v1_durable_event_log_entry
 WHERE durable_task_id = $1::BIGINT
   AND durable_task_inserted_at = $2::TIMESTAMPTZ
@@ -666,6 +673,7 @@ func (q *Queries) ListDurableEventLogEntriesBeforeNode(ctx context.Context, db D
 			&i.SatisfiedOrder,
 			&i.UserMessage,
 			&i.WaitData,
+			&i.TriggeredAt,
 		); err != nil {
 			return nil, err
 		}
@@ -678,7 +686,7 @@ func (q *Queries) ListDurableEventLogEntriesBeforeNode(ctx context.Context, db D
 }
 
 const listDurableEventLogForTask = `-- name: ListDurableEventLogForTask :many
-SELECT e.tenant_id, e.external_id, e.result_payload_external_id, e.child_task_external_id, e.child_task_is_failure, e.child_task_error_message, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.satisfied_order, e.user_message, e.wait_data, t.external_id AS durable_task_external_id, t.display_name AS durable_task_display_name
+SELECT e.tenant_id, e.external_id, e.result_payload_external_id, e.child_task_external_id, e.child_task_is_failure, e.child_task_error_message, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.satisfied_order, e.user_message, e.wait_data, e.triggered_at, t.external_id AS durable_task_external_id, t.display_name AS durable_task_display_name
 FROM v1_durable_event_log_entry e
 JOIN v1_task t ON (t.id, t.inserted_at) = (e.durable_task_id, e.durable_task_inserted_at)
 WHERE e.durable_task_id = $1::BIGINT
@@ -717,6 +725,7 @@ type ListDurableEventLogForTaskRow struct {
 	SatisfiedOrder          pgtype.Int8           `json:"satisfied_order"`
 	UserMessage             pgtype.Text           `json:"user_message"`
 	WaitData                []byte                `json:"wait_data"`
+	TriggeredAt             pgtype.Timestamptz    `json:"triggered_at"`
 	DurableTaskExternalID   uuid.UUID             `json:"durable_task_external_id"`
 	DurableTaskDisplayName  string                `json:"durable_task_display_name"`
 }
@@ -756,6 +765,7 @@ func (q *Queries) ListDurableEventLogForTask(ctx context.Context, db DBTX, arg L
 			&i.SatisfiedOrder,
 			&i.UserMessage,
 			&i.WaitData,
+			&i.TriggeredAt,
 			&i.DurableTaskExternalID,
 			&i.DurableTaskDisplayName,
 		); err != nil {
@@ -783,7 +793,7 @@ WITH inputs AS (
 )
 
 SELECT
-    e.tenant_id, e.external_id, e.result_payload_external_id, e.child_task_external_id, e.child_task_is_failure, e.child_task_error_message, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.satisfied_order, e.user_message, e.wait_data,
+    e.tenant_id, e.external_id, e.result_payload_external_id, e.child_task_external_id, e.child_task_is_failure, e.child_task_error_message, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.satisfied_order, e.user_message, e.wait_data, e.triggered_at,
     twn.external_id AS task_external_id,
     lf.latest_invocation_count AS invocation_count
 FROM v1_durable_event_log_entry e
@@ -821,6 +831,7 @@ type ListSatisfiedEntriesRow struct {
 	SatisfiedOrder          pgtype.Int8           `json:"satisfied_order"`
 	UserMessage             pgtype.Text           `json:"user_message"`
 	WaitData                []byte                `json:"wait_data"`
+	TriggeredAt             pgtype.Timestamptz    `json:"triggered_at"`
 	TaskExternalID          uuid.UUID             `json:"task_external_id"`
 	InvocationCount         int32                 `json:"invocation_count"`
 }
@@ -854,6 +865,7 @@ func (q *Queries) ListSatisfiedEntries(ctx context.Context, db DBTX, arg ListSat
 			&i.SatisfiedOrder,
 			&i.UserMessage,
 			&i.WaitData,
+			&i.TriggeredAt,
 			&i.TaskExternalID,
 			&i.InvocationCount,
 		); err != nil {
@@ -867,6 +879,39 @@ func (q *Queries) ListSatisfiedEntries(ctx context.Context, db DBTX, arg ListSat
 	return items, nil
 }
 
+const markDurableEventLogEntriesTriggered = `-- name: MarkDurableEventLogEntriesTriggered :exec
+WITH inputs AS (
+    SELECT
+        UNNEST($3::BIGINT[]) AS node_id,
+        UNNEST($4::BIGINT[]) AS branch_id
+)
+UPDATE v1_durable_event_log_entry e
+SET triggered_at = NOW()
+FROM inputs i
+WHERE e.durable_task_id = $1::BIGINT
+  AND e.durable_task_inserted_at = $2::TIMESTAMPTZ
+  AND e.node_id = i.node_id
+  AND e.branch_id = i.branch_id
+  AND e.triggered_at IS NULL
+`
+
+type MarkDurableEventLogEntriesTriggeredParams struct {
+	Durabletaskid         int64              `json:"durabletaskid"`
+	Durabletaskinsertedat pgtype.Timestamptz `json:"durabletaskinsertedat"`
+	Nodeids               []int64            `json:"nodeids"`
+	Branchids             []int64            `json:"branchids"`
+}
+
+func (q *Queries) MarkDurableEventLogEntriesTriggered(ctx context.Context, db DBTX, arg MarkDurableEventLogEntriesTriggeredParams) error {
+	_, err := db.Exec(ctx, markDurableEventLogEntriesTriggered,
+		arg.Durabletaskid,
+		arg.Durabletaskinsertedat,
+		arg.Nodeids,
+		arg.Branchids,
+	)
+	return err
+}
+
 const markDurableEventLogEntrySatisfied = `-- name: MarkDurableEventLogEntrySatisfied :one
 UPDATE v1_durable_event_log_entry
 SET
@@ -876,7 +921,7 @@ WHERE durable_task_id = $1::BIGINT
   AND durable_task_inserted_at = $2::TIMESTAMPTZ
   AND branch_id = $3::BIGINT
   AND node_id = $4::BIGINT
-RETURNING tenant_id, external_id, result_payload_external_id, child_task_external_id, child_task_is_failure, child_task_error_message, inserted_at, id, durable_task_id, durable_task_inserted_at, kind, node_id, branch_id, idempotency_key, is_satisfied, satisfied_at, satisfied_order, user_message, wait_data
+RETURNING tenant_id, external_id, result_payload_external_id, child_task_external_id, child_task_is_failure, child_task_error_message, inserted_at, id, durable_task_id, durable_task_inserted_at, kind, node_id, branch_id, idempotency_key, is_satisfied, satisfied_at, satisfied_order, user_message, wait_data, triggered_at
 `
 
 type MarkDurableEventLogEntrySatisfiedParams struct {
@@ -914,6 +959,7 @@ func (q *Queries) MarkDurableEventLogEntrySatisfied(ctx context.Context, db DBTX
 		&i.SatisfiedOrder,
 		&i.UserMessage,
 		&i.WaitData,
+		&i.TriggeredAt,
 	)
 	return &i, err
 }
@@ -968,7 +1014,7 @@ WITH inputs AS (
       AND e.durable_task_inserted_at = inputs.durable_task_inserted_at
       AND e.node_id = inputs.node_id
       AND e.branch_id = inputs.branch_id
-    RETURNING e.tenant_id, e.external_id, e.result_payload_external_id, e.child_task_external_id, e.child_task_is_failure, e.child_task_error_message, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.satisfied_order, e.user_message, e.wait_data
+    RETURNING e.tenant_id, e.external_id, e.result_payload_external_id, e.child_task_external_id, e.child_task_is_failure, e.child_task_error_message, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.satisfied_order, e.user_message, e.wait_data, e.triggered_at
 ), max_satisfied_orders_to_apply AS (
     SELECT durable_task_id, durable_task_inserted_at, MAX(satisfied_order) AS satisfied_order
     FROM satisfied_orders_to_apply
@@ -980,7 +1026,7 @@ WITH inputs AS (
     WHERE (lf.durable_task_id, lf.durable_task_inserted_at) = (so.durable_task_id, so.durable_task_inserted_at)
 )
 
-SELECT updated.tenant_id, updated.external_id, updated.result_payload_external_id, updated.child_task_external_id, updated.child_task_is_failure, updated.child_task_error_message, updated.inserted_at, updated.id, updated.durable_task_id, updated.durable_task_inserted_at, updated.kind, updated.node_id, updated.branch_id, updated.idempotency_key, updated.is_satisfied, updated.satisfied_at, updated.satisfied_order, updated.user_message, updated.wait_data, lf.latest_invocation_count AS invocation_count
+SELECT updated.tenant_id, updated.external_id, updated.result_payload_external_id, updated.child_task_external_id, updated.child_task_is_failure, updated.child_task_error_message, updated.inserted_at, updated.id, updated.durable_task_id, updated.durable_task_inserted_at, updated.kind, updated.node_id, updated.branch_id, updated.idempotency_key, updated.is_satisfied, updated.satisfied_at, updated.satisfied_order, updated.user_message, updated.wait_data, updated.triggered_at, lf.latest_invocation_count AS invocation_count
 FROM updated
 JOIN v1_durable_event_log_file lf ON (lf.durable_task_id, lf.durable_task_inserted_at) = (updated.durable_task_id, updated.durable_task_inserted_at)
 `
@@ -1014,6 +1060,7 @@ type UpdateDurableEventLogEntriesSatisfiedRow struct {
 	SatisfiedOrder          pgtype.Int8           `json:"satisfied_order"`
 	UserMessage             pgtype.Text           `json:"user_message"`
 	WaitData                []byte                `json:"wait_data"`
+	TriggeredAt             pgtype.Timestamptz    `json:"triggered_at"`
 	InvocationCount         int32                 `json:"invocation_count"`
 }
 
@@ -1053,6 +1100,7 @@ func (q *Queries) UpdateDurableEventLogEntriesSatisfied(ctx context.Context, db 
 			&i.SatisfiedOrder,
 			&i.UserMessage,
 			&i.WaitData,
+			&i.TriggeredAt,
 			&i.InvocationCount,
 		); err != nil {
 			return nil, err

--- a/pkg/repository/sqlcv1/durable_event_log.sql.go
+++ b/pkg/repository/sqlcv1/durable_event_log.sql.go
@@ -253,6 +253,61 @@ func (q *Queries) BulkGetDurableEventLogEntries(ctx context.Context, db DBTX, ar
 	return items, nil
 }
 
+const claimDurableEventLogEntriesForTrigger = `-- name: ClaimDurableEventLogEntriesForTrigger :many
+WITH inputs AS (
+    SELECT
+        UNNEST($3::BIGINT[]) AS node_id,
+        UNNEST($4::BIGINT[]) AS branch_id
+)
+
+UPDATE v1_durable_event_log_entry e
+SET triggered_at = NOW()
+FROM inputs i
+WHERE e.durable_task_id = $1::BIGINT
+  AND e.durable_task_inserted_at = $2::TIMESTAMPTZ
+  AND e.node_id = i.node_id
+  AND e.branch_id = i.branch_id
+  AND e.triggered_at IS NULL
+RETURNING e.node_id, e.branch_id
+`
+
+type ClaimDurableEventLogEntriesForTriggerParams struct {
+	Durabletaskid         int64              `json:"durabletaskid"`
+	Durabletaskinsertedat pgtype.Timestamptz `json:"durabletaskinsertedat"`
+	Nodeids               []int64            `json:"nodeids"`
+	Branchids             []int64            `json:"branchids"`
+}
+
+type ClaimDurableEventLogEntriesForTriggerRow struct {
+	NodeID   int64 `json:"node_id"`
+	BranchID int64 `json:"branch_id"`
+}
+
+func (q *Queries) ClaimDurableEventLogEntriesForTrigger(ctx context.Context, db DBTX, arg ClaimDurableEventLogEntriesForTriggerParams) ([]*ClaimDurableEventLogEntriesForTriggerRow, error) {
+	rows, err := db.Query(ctx, claimDurableEventLogEntriesForTrigger,
+		arg.Durabletaskid,
+		arg.Durabletaskinsertedat,
+		arg.Nodeids,
+		arg.Branchids,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*ClaimDurableEventLogEntriesForTriggerRow
+	for rows.Next() {
+		var i ClaimDurableEventLogEntriesForTriggerRow
+		if err := rows.Scan(&i.NodeID, &i.BranchID); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const createDurableEventLogBranchPoint = `-- name: CreateDurableEventLogBranchPoint :exec
 INSERT INTO v1_durable_event_log_branch_point (
     tenant_id,
@@ -877,39 +932,6 @@ func (q *Queries) ListSatisfiedEntries(ctx context.Context, db DBTX, arg ListSat
 		return nil, err
 	}
 	return items, nil
-}
-
-const markDurableEventLogEntriesTriggered = `-- name: MarkDurableEventLogEntriesTriggered :exec
-WITH inputs AS (
-    SELECT
-        UNNEST($3::BIGINT[]) AS node_id,
-        UNNEST($4::BIGINT[]) AS branch_id
-)
-UPDATE v1_durable_event_log_entry e
-SET triggered_at = NOW()
-FROM inputs i
-WHERE e.durable_task_id = $1::BIGINT
-  AND e.durable_task_inserted_at = $2::TIMESTAMPTZ
-  AND e.node_id = i.node_id
-  AND e.branch_id = i.branch_id
-  AND e.triggered_at IS NULL
-`
-
-type MarkDurableEventLogEntriesTriggeredParams struct {
-	Durabletaskid         int64              `json:"durabletaskid"`
-	Durabletaskinsertedat pgtype.Timestamptz `json:"durabletaskinsertedat"`
-	Nodeids               []int64            `json:"nodeids"`
-	Branchids             []int64            `json:"branchids"`
-}
-
-func (q *Queries) MarkDurableEventLogEntriesTriggered(ctx context.Context, db DBTX, arg MarkDurableEventLogEntriesTriggeredParams) error {
-	_, err := db.Exec(ctx, markDurableEventLogEntriesTriggered,
-		arg.Durabletaskid,
-		arg.Durabletaskinsertedat,
-		arg.Nodeids,
-		arg.Branchids,
-	)
-	return err
 }
 
 const markDurableEventLogEntrySatisfied = `-- name: MarkDurableEventLogEntrySatisfied :one

--- a/pkg/repository/sqlcv1/models.go
+++ b/pkg/repository/sqlcv1/models.go
@@ -3276,6 +3276,7 @@ type V1DurableEventLogEntry struct {
 	SatisfiedOrder          pgtype.Int8           `json:"satisfied_order"`
 	UserMessage             pgtype.Text           `json:"user_message"`
 	WaitData                []byte                `json:"wait_data"`
+	TriggeredAt             pgtype.Timestamptz    `json:"triggered_at"`
 }
 
 type V1DurableEventLogFile struct {

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -2537,6 +2537,8 @@ CREATE TABLE v1_durable_event_log_entry (
     user_message TEXT,
     wait_data JSONB,
 
+    triggered_at TIMESTAMPTZ,
+
     CONSTRAINT v1_durable_event_log_entry_pkey PRIMARY KEY (durable_task_id, durable_task_inserted_at, branch_id, node_id)
 ) PARTITION BY RANGE(durable_task_inserted_at);
 


### PR DESCRIPTION
# Description

Splitting durable event ingestion into two separate transactions, one which writes into the event log under the lock, and the second that actually does the triggering of runs/waits. The hope is this will make us hold connections for much less time and hold that lock for less time too, and maybe also help us do more buffering of the trigger writes now that they're decoupled from the log file stuff

The key implementation detail here is I added a `triggered_at` column to the event log which starts as null and then is stamped when the run/wait is actually processed in the second tx, which basically functions like an outbox where we write the row and then we can retry the trigger as many times as we need in a tx-safe way until it succeeds and stamps the row with the timestamp

One note is we'd need to fix forward if this breaks, but it'd be easy enough (can just revert the code changes, leave the schema as-is, and regenerate)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude Code to help with the copy / paste into helper functions

</details>
