### PR TITLE
fix(loadtest): stop rampup teardown from racing channel close

### DIFF
--- a/cmd/hatchet-loadtest/rampup/do.go
+++ b/cmd/hatchet-loadtest/rampup/do.go
@@ -146,7 +146,9 @@ func do(duration time.Duration, startEventsPerSecond, amount int, increase, dela
 	}()
 
 	registered := make(chan error, 1)
+	runDone := make(chan struct{})
 	go func() {
+		defer close(runDone)
 		run(ctx, delay, concurrency, maxAcceptableDuration, hook, executed, executionTimes, registered)
 	}()
 
@@ -158,11 +160,14 @@ func do(duration time.Duration, startEventsPerSecond, amount int, increase, dela
 
 	time.Sleep(after)
 
+	// emit() has already waited for its push workers, so these are safe to close.
 	close(scheduled)
-	close(executed)
 	close(scheduledTimes)
-	close(executionTimes)
-	close(hook)
+
+	// Stop the worker before closing channels it still writes to. run()
+	// serializes those sends with the close so late callbacks cannot race.
+	cancel()
+	<-runDone
 
 	finalScheduledResult := <-scheduledResult
 	finalExecutionResult := <-executionResult

--- a/cmd/hatchet-loadtest/rampup/run.go
+++ b/cmd/hatchet-loadtest/rampup/run.go
@@ -44,6 +44,34 @@ func run(ctx context.Context, delay time.Duration, concurrency int, maxAcceptabl
 	var uniques int64
 	var executed []int64
 
+	var sendMu sync.Mutex
+	resultsClosed := false
+	closeResults := func() {
+		sendMu.Lock()
+		defer sendMu.Unlock()
+		if resultsClosed {
+			return
+		}
+		resultsClosed = true
+		close(executedCh)
+		close(executionTimes)
+		close(hook)
+	}
+	defer closeResults()
+
+	sendResults := func(id int64, took time.Duration) {
+		sendMu.Lock()
+		defer sendMu.Unlock()
+		if resultsClosed {
+			return
+		}
+		if took > maxAcceptableDuration {
+			hook <- took
+		}
+		executionTimes <- took
+		executedCh <- id
+	}
+
 	var concurrencyOpts *worker.WorkflowConcurrency
 	if concurrency > 0 {
 		concurrencyOpts = worker.Concurrency(getConcurrencyKey).MaxRuns(int32(concurrency)) // nolint: gosec
@@ -67,12 +95,7 @@ func run(ctx context.Context, delay time.Duration, concurrency int, maxAcceptabl
 
 					l.Debug().Msgf("executing %d took %s", input.ID, took)
 
-					if took > maxAcceptableDuration {
-						hook <- took
-					}
-
-					executionTimes <- took
-					executedCh <- input.ID
+					sendResults(input.ID, took)
 
 					mx.Lock()
 


### PR DESCRIPTION
## Summary
- The rampup job can print success and then fail under `-race` because `do()` closed `executed` / `executionTimes` while worker callbacks were still sending on them
- Stop the worker first, then close those channels under the same lock as the sends so late callbacks cannot race the closer

Seen on https://github.com/hatchet-dev/hatchet/actions/runs/31803392917/job/94776420615 (`TestRampUp/normal_test`).

## Test plan
- [ ] Confirm `go test -c ./cmd/hatchet-loadtest/rampup` still builds
- [ ] Re-run the `rampup` CI job (or wait for it on this PR) and confirm it no longer fails with `WARNING: DATA RACE` on `close(executed)`