### PR TITLE
fix(engine): round-robin workers with equal label affinity

### DIFF
--- a/pkg/scheduling/v1/action.go
+++ b/pkg/scheduling/v1/action.go
@@ -14,7 +14,8 @@ type action struct {
 	workerIds []uuid.UUID
 
 	// ringOffset rotates the starting worker between assignments so load spreads
-	// across the action's workers.
+	// across the action's workers. Sticky and label ranking keep higher scores
+	// first; the offset only rotates within the highest-rank tied group.
 	ringOffset int
 }
 

--- a/pkg/scheduling/v1/scheduler.go
+++ b/pkg/scheduling/v1/scheduler.go
@@ -1020,23 +1020,23 @@ func (s *Scheduler) assignSingleton(
 	candidates := a.workerIds
 	offset := a.ringOffset
 	a.ringOffset++
-	tiedLen := len(candidates)
+	topRankCount := len(candidates)
 
 	if qi.Sticky != sqlcv1.V1StickyStrategyNONE || len(labels) > 0 {
-		candidates, tiedLen = s.rankWorkerIds(qi, labels, a.workerIds)
+		candidates, topRankCount = s.rankWorkerIds(qi, labels, a.workerIds)
 	}
 
-	if len(candidates) == 0 || tiedLen == 0 {
+	if len(candidates) == 0 || topRankCount == 0 {
 		r.noSlots = true
 		return
 	}
 
-	offset %= tiedLen
+	offset %= topRankCount
 
 	var selected []*slot
 
-	for i := 0; i < tiedLen; i++ {
-		workerId := candidates[(offset+i)%tiedLen]
+	for i := 0; i < topRankCount; i++ {
+		workerId := candidates[(offset+i)%topRankCount]
 
 		if sel, ok := selectSlotsFromPools(s.poolsByWorker[workerId], requests, now); ok {
 			selected = sel
@@ -1045,7 +1045,7 @@ func (s *Scheduler) assignSingleton(
 	}
 
 	if selected == nil {
-		for i := tiedLen; i < len(candidates); i++ {
+		for i := topRankCount; i < len(candidates); i++ {
 			workerId := candidates[i]
 
 			if sel, ok := selectSlotsFromPools(s.poolsByWorker[workerId], requests, now); ok {
@@ -1204,17 +1204,17 @@ func (s *Scheduler) rankWorkerIds(
 		return []uuid.UUID{}, 0
 	}
 
-	tiedLen := len(ranked)
+	topRankCount := len(ranked)
 	for i := 1; i < len(ranked); i++ {
 		if ranked[i].rank != ranked[0].rank {
 			slices.SortStableFunc(ranked, func(left, right rankedWorker) int {
 				return right.rank - left.rank
 			})
 
-			tiedLen = 1
+			topRankCount = 1
 			topRank := ranked[0].rank
-			for tiedLen < len(ranked) && ranked[tiedLen].rank == topRank {
-				tiedLen++
+			for topRankCount < len(ranked) && ranked[topRankCount].rank == topRank {
+				topRankCount++
 			}
 			break
 		}
@@ -1224,7 +1224,7 @@ func (s *Scheduler) rankWorkerIds(
 	for index := range ranked {
 		result[index] = ranked[index].id
 	}
-	return result, tiedLen
+	return result, topRankCount
 }
 
 type assignedQueueItem struct {

--- a/pkg/scheduling/v1/scheduler.go
+++ b/pkg/scheduling/v1/scheduler.go
@@ -1035,6 +1035,9 @@ func (s *Scheduler) assignSingleton(
 
 	var selected []*slot
 
+	// NOTE: ringOffset increments each assign, so we start at that worker and
+	// wrap with % if it has no free slot, instead of always packing onto the
+	// first worker in the tied group.
 	for i := 0; i < topRankCount; i++ {
 		workerId := candidates[(offset+i)%topRankCount]
 
@@ -1045,6 +1048,7 @@ func (s *Scheduler) assignSingleton(
 	}
 
 	if selected == nil {
+		// Lower ranks are only considered after the top-rank group has no slots.
 		for i := topRankCount; i < len(candidates); i++ {
 			workerId := candidates[i]
 

--- a/pkg/scheduling/v1/scheduler.go
+++ b/pkg/scheduling/v1/scheduler.go
@@ -1020,27 +1020,38 @@ func (s *Scheduler) assignSingleton(
 	candidates := a.workerIds
 	offset := a.ringOffset
 	a.ringOffset++
+	tiedLen := len(candidates)
 
 	if qi.Sticky != sqlcv1.V1StickyStrategyNONE || len(labels) > 0 {
-		candidates = s.rankWorkerIds(qi, labels, a.workerIds)
-		offset = 0
+		candidates, tiedLen = s.rankWorkerIds(qi, labels, a.workerIds)
 	}
 
-	if len(candidates) == 0 {
+	if len(candidates) == 0 || tiedLen == 0 {
 		r.noSlots = true
 		return
 	}
 
-	offset %= len(candidates)
+	offset %= tiedLen
 
 	var selected []*slot
 
-	for i := 0; i < len(candidates); i++ {
-		workerId := candidates[(offset+i)%len(candidates)]
+	for i := 0; i < tiedLen; i++ {
+		workerId := candidates[(offset+i)%tiedLen]
 
 		if sel, ok := selectSlotsFromPools(s.poolsByWorker[workerId], requests, now); ok {
 			selected = sel
 			break
+		}
+	}
+
+	if selected == nil {
+		for i := tiedLen; i < len(candidates); i++ {
+			workerId := candidates[i]
+
+			if sel, ok := selectSlotsFromPools(s.poolsByWorker[workerId], requests, now); ok {
+				selected = sel
+				break
+			}
 		}
 	}
 
@@ -1146,11 +1157,13 @@ func selectSlotsFromPools(poolsByType map[string]*slotPool, requests map[string]
 }
 
 // rankWorkerIds runs on the run loop (it reads s.workers for label affinity).
+// The returned int is the length of the highest-rank prefix, so assignment can
+// round-robin ties without skipping a better match.
 func (s *Scheduler) rankWorkerIds(
 	qi *sqlcv1.V1QueueItem,
 	labels []*sqlcv1.GetDesiredLabelsRow,
 	workerIds []uuid.UUID,
-) []uuid.UUID {
+) ([]uuid.UUID, int) {
 	type rankedWorker struct {
 		id   uuid.UUID
 		rank int
@@ -1187,15 +1200,31 @@ func (s *Scheduler) rankWorkerIds(
 		ranked = append(ranked, rankedWorker{id: workerId, rank: rank})
 	}
 
-	slices.SortStableFunc(ranked, func(left, right rankedWorker) int {
-		return right.rank - left.rank
-	})
+	if len(ranked) == 0 {
+		return []uuid.UUID{}, 0
+	}
+
+	tiedLen := len(ranked)
+	for i := 1; i < len(ranked); i++ {
+		if ranked[i].rank != ranked[0].rank {
+			slices.SortStableFunc(ranked, func(left, right rankedWorker) int {
+				return right.rank - left.rank
+			})
+
+			tiedLen = 1
+			topRank := ranked[0].rank
+			for tiedLen < len(ranked) && ranked[tiedLen].rank == topRank {
+				tiedLen++
+			}
+			break
+		}
+	}
 
 	result := make([]uuid.UUID, len(ranked))
 	for index := range ranked {
 		result[index] = ranked[index].id
 	}
-	return result
+	return result, tiedLen
 }
 
 type assignedQueueItem struct {

--- a/pkg/scheduling/v1/scheduler_test.go
+++ b/pkg/scheduling/v1/scheduler_test.go
@@ -490,6 +490,48 @@ func TestScheduler_AssignSingleton_StickyHardForcesRanking(t *testing.T) {
 	require.Equal(t, desiredWorkerId, res.workerId)
 }
 
+func TestScheduler_AssignSingleton_EqualLabelsRoundRobin(t *testing.T) {
+	tenantId := uuid.New()
+	workerIds := []uuid.UUID{uuid.New(), uuid.New()}
+
+	regionLabel := &sqlcv1.ListManyWorkerLabelsRow{
+		Key:      "region",
+		StrValue: pgtype.Text{String: "us-east-1", Valid: true},
+	}
+	desired := []*sqlcv1.GetDesiredLabelsRow{{
+		Key:        "region",
+		StrValue:   pgtype.Text{String: "us-east-1", Valid: true},
+		Comparator: sqlcv1.WorkerLabelComparatorEQUAL,
+		Weight:     10,
+	}}
+
+	workers := make([]*repo.ListActiveWorkersResult, len(workerIds))
+	slots := make([]*slot, 0, len(workerIds)*2)
+
+	for i, id := range workerIds {
+		w := &repo.ListActiveWorkersResult{
+			ID:     id,
+			Name:   "w",
+			Labels: []*sqlcv1.ListManyWorkerLabelsRow{regionLabel},
+		}
+		workers[i] = w
+		ww := &worker{ListActiveWorkersResult: w}
+		// Extra capacity so packing onto the first worker is not forced by slots.
+		slots = append(slots, newSlot(ww, repo.SlotTypeDefault), newSlot(ww, repo.SlotTypeDefault))
+	}
+
+	s := newTestScheduler(t, tenantId, &mockAssignmentRepo{})
+	s.setWorkers(workers)
+	a := seedActionPools(t, s, "A", slots...)
+
+	first := assignOne(t, s, a, testQI(tenantId, "A", 1), desired, defaultRequest(), nil, nil)
+	require.True(t, first.succeeded)
+
+	second := assignOne(t, s, a, testQI(tenantId, "A", 2), desired, defaultRequest(), nil, nil)
+	require.True(t, second.succeeded)
+	require.NotEqual(t, first.workerId, second.workerId, "equal-affinity workers with free slots must not pack onto the same worker")
+}
+
 func TestScheduler_RankWorkerIds_StickyDoesNotRequirePoolsByWorker(t *testing.T) {
 	tenantId := uuid.New()
 	desiredWorkerId := uuid.New()
@@ -504,7 +546,7 @@ func TestScheduler_RankWorkerIds_StickyDoesNotRequirePoolsByWorker(t *testing.T)
 
 	var ranked []uuid.UUID
 	onLoop(t, s, func() {
-		ranked = s.rankWorkerIds(qi, nil, []uuid.UUID{desiredWorkerId})
+		ranked, _ = s.rankWorkerIds(qi, nil, []uuid.UUID{desiredWorkerId})
 	})
 	require.Equal(t, []uuid.UUID{desiredWorkerId}, ranked)
 }
@@ -536,7 +578,7 @@ func TestScheduler_RankWorkerIds_LabelsUseWorkersMap(t *testing.T) {
 	// No poolsByWorker entry — label ranking must still resolve the worker via s.workers.
 	var ranked []uuid.UUID
 	onLoop(t, s, func() {
-		ranked = s.rankWorkerIds(qi, labels, []uuid.UUID{workerId})
+		ranked, _ = s.rankWorkerIds(qi, labels, []uuid.UUID{workerId})
 	})
 	require.Equal(t, []uuid.UUID{workerId}, ranked)
 }

--- a/pkg/scheduling/v1/scheduler_test.go
+++ b/pkg/scheduling/v1/scheduler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	repo "github.com/hatchet-dev/hatchet/pkg/repository"
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlchelpers"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 )
 
@@ -272,7 +273,7 @@ func testQI(tenantId uuid.UUID, actionId string, taskId int64) *sqlcv1.V1QueueIt
 }
 
 func ts(tm time.Time) pgtype.Timestamp {
-	return pgtype.Timestamp{Time: tm, Valid: true}
+	return sqlchelpers.TimestampFromTime(tm)
 }
 
 func defaultRequest() map[string]int32 {
@@ -496,11 +497,11 @@ func TestScheduler_AssignSingleton_EqualLabelsRoundRobin(t *testing.T) {
 
 	regionLabel := &sqlcv1.ListManyWorkerLabelsRow{
 		Key:      "region",
-		StrValue: pgtype.Text{String: "us-east-1", Valid: true},
+		StrValue: sqlchelpers.TextFromStr("us-east-1"),
 	}
 	desired := []*sqlcv1.GetDesiredLabelsRow{{
 		Key:        "region",
-		StrValue:   pgtype.Text{String: "us-east-1", Valid: true},
+		StrValue:   sqlchelpers.TextFromStr("us-east-1"),
 		Comparator: sqlcv1.WorkerLabelComparatorEQUAL,
 		Weight:     10,
 	}}
@@ -562,7 +563,7 @@ func TestScheduler_RankWorkerIds_LabelsUseWorkersMap(t *testing.T) {
 		Labels: []*sqlcv1.ListManyWorkerLabelsRow{
 			{
 				Key:      "region",
-				StrValue: pgtype.Text{String: "us-east-1", Valid: true},
+				StrValue: sqlchelpers.TextFromStr("us-east-1"),
 			},
 		},
 	}})
@@ -570,7 +571,7 @@ func TestScheduler_RankWorkerIds_LabelsUseWorkersMap(t *testing.T) {
 	qi := testQI(tenantId, "A", 1)
 	labels := []*sqlcv1.GetDesiredLabelsRow{{
 		Key:        "region",
-		StrValue:   pgtype.Text{String: "us-east-1", Valid: true},
+		StrValue:   sqlchelpers.TextFromStr("us-east-1"),
 		Comparator: sqlcv1.WorkerLabelComparatorEQUAL,
 		Weight:     10,
 	}}
@@ -866,7 +867,7 @@ func TestScheduler_GetSnapshotInput_DerivesUsedSlotsFromCapacity(t *testing.T) {
 	s := newTestScheduler(t, tenantId, &mockAssignmentRepo{
 		listActionsForWorkersFn: func(ctx context.Context, tenantId uuid.UUID, workerIds []uuid.UUID) ([]*sqlcv1.ListActionsForWorkersRow, error) {
 			return []*sqlcv1.ListActionsForWorkersRow{
-				{WorkerId: workerId, ActionId: pgtype.Text{String: "A", Valid: true}},
+				{WorkerId: workerId, ActionId: sqlchelpers.TextFromStr("A")},
 			}, nil
 		},
 		listWorkerSlotConfigsFn: func(ctx context.Context, tenantId uuid.UUID, workerIds []uuid.UUID) ([]*sqlcv1.ListWorkerSlotConfigsRow, error) {
@@ -1195,7 +1196,7 @@ func TestScheduler_Replenish_MultipleSlotTypes_CallsRepoPerTypeAndPopulatesSlots
 	ar := &mockAssignmentRepo{
 		listActionsForWorkersFn: func(ctx context.Context, tenantId uuid.UUID, workerIds []uuid.UUID) ([]*sqlcv1.ListActionsForWorkersRow, error) {
 			return []*sqlcv1.ListActionsForWorkersRow{
-				{WorkerId: workerId, ActionId: pgtype.Text{String: "A", Valid: true}},
+				{WorkerId: workerId, ActionId: sqlchelpers.TextFromStr("A")},
 			}, nil
 		},
 		listWorkerSlotConfigsFn: func(ctx context.Context, tenantId uuid.UUID, workerIds []uuid.UUID) ([]*sqlcv1.ListWorkerSlotConfigsRow, error) {
@@ -1252,7 +1253,7 @@ func TestScheduler_Replenish_UnackedCountsPerSlotType(t *testing.T) {
 	ar := &mockAssignmentRepo{
 		listActionsForWorkersFn: func(ctx context.Context, tenantId uuid.UUID, workerIds []uuid.UUID) ([]*sqlcv1.ListActionsForWorkersRow, error) {
 			return []*sqlcv1.ListActionsForWorkersRow{
-				{WorkerId: workerId, ActionId: pgtype.Text{String: "A", Valid: true}},
+				{WorkerId: workerId, ActionId: sqlchelpers.TextFromStr("A")},
 			}, nil
 		},
 		listWorkerSlotConfigsFn: func(ctx context.Context, tenantId uuid.UUID, workerIds []uuid.UUID) ([]*sqlcv1.ListWorkerSlotConfigsRow, error) {
@@ -1329,7 +1330,7 @@ func TestScheduler_Replenish_SubtractsAcksDuringReplenish(t *testing.T) {
 	ar := &mockAssignmentRepo{
 		listActionsForWorkersFn: func(ctx context.Context, tenantId uuid.UUID, workerIds []uuid.UUID) ([]*sqlcv1.ListActionsForWorkersRow, error) {
 			return []*sqlcv1.ListActionsForWorkersRow{
-				{WorkerId: workerId, ActionId: pgtype.Text{String: "A", Valid: true}},
+				{WorkerId: workerId, ActionId: sqlchelpers.TextFromStr("A")},
 			}, nil
 		},
 		listAvailableSlotsForWorkersFn: func(ctx context.Context, tenantId uuid.UUID, params sqlcv1.ListAvailableSlotsForWorkersParams) ([]*sqlcv1.ListAvailableSlotsForWorkersRow, error) {
@@ -1402,7 +1403,7 @@ func TestScheduler_Replenish_PropagatesRepoErrors(t *testing.T) {
 		s := newTestScheduler(t, tenantId, &mockAssignmentRepo{
 			listActionsForWorkersFn: func(ctx context.Context, tenantId uuid.UUID, workerIds []uuid.UUID) ([]*sqlcv1.ListActionsForWorkersRow, error) {
 				return []*sqlcv1.ListActionsForWorkersRow{
-					{WorkerId: workerId, ActionId: pgtype.Text{String: "A", Valid: true}},
+					{WorkerId: workerId, ActionId: sqlchelpers.TextFromStr("A")},
 				}, nil
 			},
 			listWorkerSlotConfigsFn: func(ctx context.Context, tenantId uuid.UUID, workerIds []uuid.UUID) ([]*sqlcv1.ListWorkerSlotConfigsRow, error) {
@@ -1419,7 +1420,7 @@ func TestScheduler_Replenish_PropagatesRepoErrors(t *testing.T) {
 		s := newTestScheduler(t, tenantId, &mockAssignmentRepo{
 			listActionsForWorkersFn: func(ctx context.Context, tenantId uuid.UUID, workerIds []uuid.UUID) ([]*sqlcv1.ListActionsForWorkersRow, error) {
 				return []*sqlcv1.ListActionsForWorkersRow{
-					{WorkerId: workerId, ActionId: pgtype.Text{String: "A", Valid: true}},
+					{WorkerId: workerId, ActionId: sqlchelpers.TextFromStr("A")},
 				}, nil
 			},
 			listWorkerSlotConfigsFn: func(ctx context.Context, tenantId uuid.UUID, workerIds []uuid.UUID) ([]*sqlcv1.ListWorkerSlotConfigsRow, error) {
@@ -1449,7 +1450,7 @@ func TestScheduler_Replenish_CreatesActionAndSlots(t *testing.T) {
 			require.Equal(t, workerId, workerIds[0])
 
 			return []*sqlcv1.ListActionsForWorkersRow{
-				{WorkerId: workerId, ActionId: pgtype.Text{String: "A", Valid: true}},
+				{WorkerId: workerId, ActionId: sqlchelpers.TextFromStr("A")},
 			}, nil
 		},
 		listAvailableSlotsForWorkersFn: func(ctx context.Context, tenantId uuid.UUID, params sqlcv1.ListAvailableSlotsForWorkersParams) ([]*sqlcv1.ListAvailableSlotsForWorkersRow, error) {
@@ -1488,7 +1489,7 @@ func TestScheduler_Replenish_RemovesActionWhenWorkerPoolHasNoCapacity(t *testing
 	ar := &mockAssignmentRepo{
 		listActionsForWorkersFn: func(ctx context.Context, tenantId uuid.UUID, workerIds []uuid.UUID) ([]*sqlcv1.ListActionsForWorkersRow, error) {
 			return []*sqlcv1.ListActionsForWorkersRow{
-				{WorkerId: workerId, ActionId: pgtype.Text{String: "A", Valid: true}},
+				{WorkerId: workerId, ActionId: sqlchelpers.TextFromStr("A")},
 			}, nil
 		},
 		// simulate no rows returned => no new slots written
@@ -1532,12 +1533,12 @@ func TestScheduler_Replenish_RefreshesAllWorkerPoolsWhenTriggered(t *testing.T) 
 	ar := &mockAssignmentRepo{
 		listActionsForWorkersFn: func(ctx context.Context, tenantId uuid.UUID, workerIds []uuid.UUID) ([]*sqlcv1.ListActionsForWorkersRow, error) {
 			return []*sqlcv1.ListActionsForWorkersRow{
-				{WorkerId: w1Id, ActionId: pgtype.Text{String: "A", Valid: true}},
-				{WorkerId: w1Id, ActionId: pgtype.Text{String: "B", Valid: true}},
-				{WorkerId: w2Id, ActionId: pgtype.Text{String: "B", Valid: true}},
-				{WorkerId: w2Id, ActionId: pgtype.Text{String: "C", Valid: true}},
-				{WorkerId: w3Id, ActionId: pgtype.Text{String: "C", Valid: true}},
-				{WorkerId: w3Id, ActionId: pgtype.Text{String: "D", Valid: true}},
+				{WorkerId: w1Id, ActionId: sqlchelpers.TextFromStr("A")},
+				{WorkerId: w1Id, ActionId: sqlchelpers.TextFromStr("B")},
+				{WorkerId: w2Id, ActionId: sqlchelpers.TextFromStr("B")},
+				{WorkerId: w2Id, ActionId: sqlchelpers.TextFromStr("C")},
+				{WorkerId: w3Id, ActionId: sqlchelpers.TextFromStr("C")},
+				{WorkerId: w3Id, ActionId: sqlchelpers.TextFromStr("D")},
 			}, nil
 		},
 		// no new slots available, so replenish clears out all pools
@@ -1621,7 +1622,7 @@ func TestScheduler_Replenish_DenseSharedActions(t *testing.T) {
 				for _, aid := range actionIds {
 					rows = append(rows, &sqlcv1.ListActionsForWorkersRow{
 						WorkerId: wid,
-						ActionId: pgtype.Text{String: aid, Valid: true},
+						ActionId: sqlchelpers.TextFromStr(aid),
 					})
 				}
 			}
@@ -1680,7 +1681,7 @@ func BenchmarkScheduler_Replenish_DenseSharedActions(b *testing.B) {
 		for _, aid := range actionIds {
 			actionRows = append(actionRows, &sqlcv1.ListActionsForWorkersRow{
 				WorkerId: wid,
-				ActionId: pgtype.Text{String: aid, Valid: true},
+				ActionId: sqlchelpers.TextFromStr(aid),
 			})
 		}
 	}
@@ -1724,8 +1725,8 @@ func TestScheduler_Replenish_UpdatesAllActionIndexes(t *testing.T) {
 	ar := &mockAssignmentRepo{
 		listActionsForWorkersFn: func(ctx context.Context, tenantId uuid.UUID, workerIds []uuid.UUID) ([]*sqlcv1.ListActionsForWorkersRow, error) {
 			return []*sqlcv1.ListActionsForWorkersRow{
-				{WorkerId: workerId, ActionId: pgtype.Text{String: "A", Valid: true}},
-				{WorkerId: workerId, ActionId: pgtype.Text{String: "B", Valid: true}},
+				{WorkerId: workerId, ActionId: sqlchelpers.TextFromStr("A")},
+				{WorkerId: workerId, ActionId: sqlchelpers.TextFromStr("B")},
 			}, nil
 		},
 		listAvailableSlotsForWorkersFn: func(ctx context.Context, tenantId uuid.UUID, params sqlcv1.ListAvailableSlotsForWorkersParams) ([]*sqlcv1.ListAvailableSlotsForWorkersRow, error) {

--- a/pkg/scheduling/v1/slot_test.go
+++ b/pkg/scheduling/v1/slot_test.go
@@ -195,7 +195,7 @@ func TestRankWorkerIds(t *testing.T) {
 
 			var ranked []uuid.UUID
 			onLoop(t, s, func() {
-				ranked = s.rankWorkerIds(tt.qi, tt.labels, tt.candidates)
+				ranked, _ = s.rankWorkerIds(tt.qi, tt.labels, tt.candidates)
 			})
 
 			assert.Equal(t, tt.expected, ranked)


### PR DESCRIPTION
## Summary
- Label ranking was resetting the assignment ring to offset 0, so workers with the same `desired_worker_labels` score packed onto the first UUID until its slots filled.
- Keep higher affinity first, but round-robin within the highest-rank tied group (and skip the sort when every worker is tied).
- Regression test assigns two equal-affinity workers with spare slots and asserts they are not packed onto the same worker.

## Test plan
- [x] `go test ./pkg/scheduling/v1/`
- [x] `TestScheduler_AssignSingleton_EqualLabelsRoundRobin` fails against main packing behavior and passes on this branch
- [ ] Confirm sticky HARD/SOFT still prefer the desired worker
- [ ] Spot-check a labeled fleet: consecutive tasks should cycle workers instead of filling worker 1..N