### PR TITLE
fix: load test dag results not printing

### DIFF
--- a/cmd/hatchet-loadtest/do.go
+++ b/cmd/hatchet-loadtest/do.go
@@ -106,16 +106,24 @@ func workflowNamesForKey(key eventkeys.EventKey, namespace string, fanout int) [
 		return []string{applyNamespace(eventkeys.WorkflowBatchName, namespace)}
 	case eventkeys.EventKeyDurable:
 		return []string{applyNamespace(eventkeys.WorkflowDurableName, namespace)}
+	case eventkeys.EventKeyDag:
+		return []string{applyNamespace(eventkeys.WorkflowDagName, namespace)}
 	default:
 		return nil
 	}
 }
 
+const dagWorkflowSteps = 2
+
 func executionsPerPush(key eventkeys.EventKey, fanout, dagSteps int) int64 {
-	if key == eventkeys.EventKeyDefault {
+	switch key {
+	case eventkeys.EventKeyDefault:
 		return int64(fanout) * int64(dagSteps)
+	case eventkeys.EventKeyDag:
+		return dagWorkflowSteps
+	default:
+		return 1
 	}
-	return 1
 }
 
 // phaseAccumulator computes a simple running mean per phase from a stream of


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Fixed some cases I missed that made it so the results didn't print out right.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
