### PR TITLE
refactor(engine): pub messages to mq to trigger child runs from durable tasks

### DIFF
--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -168,7 +168,7 @@ jobs:
         run: |
           echo "Using HATCHET_CLIENT_NAMESPACE: $HATCHET_CLIENT_NAMESPACE"
           export HATCHET_CLIENT_SERVER_URL=http://localhost:8080
-          poetry run pytest -s -vvv --maxfail=5 --capture=no --retries 3 --retry-delay 2 -n 8
+          poetry run pytest -s -vvv --maxfail=5 --capture=no --retries 3 --retry-delay 2 -n 8 --timeout 60
 
       - name: Test with wheel
         run: |

--- a/internal/msgqueue/message_ids.go
+++ b/internal/msgqueue/message_ids.go
@@ -27,6 +27,7 @@ const (
 	MsgIDUserEvent                    = "user-event"
 	MsgIDWorkflowRunFinished          = "workflow-run-finished"
 	MsgIDWorkflowRunFinishedCandidate = "workflow-run-finished-candidate"
+	MsgIDDurableRunTrigger            = "durable-run-trigger"
 	MsgIDCronCreate                   = "cron-create"
 	MsgIDCronUpdate                   = "cron-update"
 	MsgIDCronDelete                   = "cron-delete"

--- a/internal/services/controllers/task/controller.go
+++ b/internal/services/controllers/task/controller.go
@@ -1117,9 +1117,11 @@ func (tc *TasksControllerImpl) handleProcessTaskTrigger(ctx context.Context, ten
 	return err
 }
 
-// handleProcessDurableRunTrigger triggers child tasks / dags from durable run triggers (pretty similar to handleProcessTaskTrigger)
+// handleProcessDurableRunTrigger triggers child tasks / dags from durable run triggers (pretty similar to handleProcessTaskTrigger).
 func (tc *TasksControllerImpl) handleProcessDurableRunTrigger(ctx context.Context, tenantId uuid.UUID, payloads [][]byte) error {
 	msgs := msgqueue.JSONConvert[tasktypes.DurableRunTriggerMessage](payloads)
+
+	tasks := make([]v1.TriggerPendingRunEntriesOpt, 0, len(msgs))
 
 	for _, msg := range msgs {
 		task := &sqlcv1.FlattenExternalIdsRow{
@@ -1138,22 +1140,27 @@ func (tc *TasksControllerImpl) handleProcessDurableRunTrigger(ctx context.Contex
 			}
 		}
 
-		createdTasks, createdDags, celFailures, err := tc.repov1.DurableEvents().TriggerPendingRunEntries(ctx, tenantId, task, pending)
+		tasks = append(tasks, v1.TriggerPendingRunEntriesOpt{
+			Task:        task,
+			PendingRuns: pending,
+		})
+	}
 
-		if err != nil {
-			return fmt.Errorf("failed to trigger pending durable run entries: %w", err)
+	createdTasks, createdDags, celFailures, err := tc.repov1.DurableEvents().TriggerPendingRunEntries(ctx, tenantId, tasks)
+
+	if err != nil {
+		return fmt.Errorf("failed to trigger pending durable run entries: %w", err)
+	}
+
+	if len(createdTasks) > 0 || len(createdDags) > 0 {
+		if sigErr := tc.signaler.SignalCreated(ctx, tenantId, createdTasks, createdDags); sigErr != nil {
+			tc.l.Error().Ctx(ctx).Err(sigErr).Msg("failed to signal created tasks/DAGs for durable run trigger")
 		}
+	}
 
-		if len(createdTasks) > 0 || len(createdDags) > 0 {
-			if sigErr := tc.signaler.SignalCreated(ctx, tenantId, createdTasks, createdDags); sigErr != nil {
-				tc.l.Error().Ctx(ctx).Err(sigErr).Msg("failed to signal created tasks/DAGs for durable run trigger")
-			}
-		}
-
-		if len(celFailures) > 0 {
-			if sigErr := tc.signaler.SignalCELEvaluationFailures(ctx, tenantId, celFailures); sigErr != nil {
-				tc.l.Error().Ctx(ctx).Err(sigErr).Msg("failed to signal CEL evaluation failures for durable run trigger")
-			}
+	if len(celFailures) > 0 {
+		if sigErr := tc.signaler.SignalCELEvaluationFailures(ctx, tenantId, celFailures); sigErr != nil {
+			tc.l.Error().Ctx(ctx).Err(sigErr).Msg("failed to signal CEL evaluation failures for durable run trigger")
 		}
 	}
 

--- a/internal/services/controllers/task/controller.go
+++ b/internal/services/controllers/task/controller.go
@@ -474,6 +474,8 @@ func (tc *TasksControllerImpl) handleBufferedMsgs(tenantId uuid.UUID, msgId stri
 		return tc.handleProcessInternalEvents(ctx, tenantId, payloads)
 	case msgqueue.MsgIDTaskTrigger:
 		return tc.handleProcessTaskTrigger(ctx, tenantId, payloads)
+	case msgqueue.MsgIDDurableRunTrigger:
+		return tc.handleProcessDurableRunTrigger(ctx, tenantId, payloads)
 	case msgqueue.MsgIDDurableRestoreTask:
 		return tc.handleDurableRestoreTask(ctx, tenantId, payloads)
 	}
@@ -1113,6 +1115,49 @@ func (tc *TasksControllerImpl) handleProcessInternalEvents(ctx context.Context, 
 func (tc *TasksControllerImpl) handleProcessTaskTrigger(ctx context.Context, tenantId uuid.UUID, payloads [][]byte) error {
 	_, err := tc.tw.TriggerFromWorkflowNames(ctx, tenantId, msgqueue.JSONConvert[v1.WorkflowNameTriggerOpts](payloads))
 	return err
+}
+
+// handleProcessDurableRunTrigger triggers child tasks / dags from durable run triggers (pretty similar to handleProcessTaskTrigger)
+func (tc *TasksControllerImpl) handleProcessDurableRunTrigger(ctx context.Context, tenantId uuid.UUID, payloads [][]byte) error {
+	msgs := msgqueue.JSONConvert[tasktypes.DurableRunTriggerMessage](payloads)
+
+	for _, msg := range msgs {
+		task := &sqlcv1.FlattenExternalIdsRow{
+			ID:         msg.DurableTaskId,
+			InsertedAt: msg.DurableTaskInsertedAt,
+			ExternalID: msg.DurableTaskExternalId,
+		}
+
+		pending := make([]v1.PendingDurableRunTrigger, len(msg.Entries))
+
+		for i, e := range msg.Entries {
+			pending[i] = v1.PendingDurableRunTrigger{
+				NodeId:      e.NodeId,
+				BranchId:    e.BranchId,
+				TriggerOpts: e.TriggerOpts,
+			}
+		}
+
+		createdTasks, createdDags, celFailures, err := tc.repov1.DurableEvents().TriggerPendingRunEntries(ctx, tenantId, task, pending)
+
+		if err != nil {
+			return fmt.Errorf("failed to trigger pending durable run entries: %w", err)
+		}
+
+		if len(createdTasks) > 0 || len(createdDags) > 0 {
+			if sigErr := tc.signaler.SignalCreated(ctx, tenantId, createdTasks, createdDags); sigErr != nil {
+				tc.l.Error().Ctx(ctx).Err(sigErr).Msg("failed to signal created tasks/DAGs for durable run trigger")
+			}
+		}
+
+		if len(celFailures) > 0 {
+			if sigErr := tc.signaler.SignalCELEvaluationFailures(ctx, tenantId, celFailures); sigErr != nil {
+				tc.l.Error().Ctx(ctx).Err(sigErr).Msg("failed to signal CEL evaluation failures for durable run trigger")
+			}
+		}
+	}
+
+	return nil
 }
 
 // processUserEventMatches looks for user event matches

--- a/internal/services/dispatcher/server_v1.go
+++ b/internal/services/dispatcher/server_v1.go
@@ -918,12 +918,32 @@ func (d *DispatcherServiceImpl) handleTriggerRuns(
 		})
 	}
 
-	dags := ingestionResult.TriggerRunsResult.CreatedDAGs
-	tasks := ingestionResult.TriggerRunsResult.CreatedTasks
+	if pending := ingestionResult.TriggerRunsResult.PendingTriggers; len(pending) > 0 {
+		entries := make([]tasktypes.PendingDurableRunTriggerPayload, len(pending))
 
-	if len(dags) > 0 || len(tasks) > 0 {
-		if sigErr := d.triggerWriter.SignalCreated(ctx, invocation.tenantId, tasks, dags); sigErr != nil {
-			d.l.Error().Err(sigErr).Msg("failed to signal created tasks/DAGs for durable run trigger")
+		for i, p := range pending {
+			entries[i] = tasktypes.PendingDurableRunTriggerPayload{
+				NodeId:      p.NodeId,
+				BranchId:    p.BranchId,
+				TriggerOpts: p.TriggerOpts,
+			}
+		}
+
+		msg, msgErr := tasktypes.DurableRunTriggerTaskMessage(invocation.tenantId, tasktypes.DurableRunTriggerMessage{
+			DurableTaskId:         task.ID,
+			DurableTaskInsertedAt: task.InsertedAt,
+			DurableTaskExternalId: task.ExternalID,
+			Entries:               entries,
+		})
+		if msgErr != nil {
+			return status.Errorf(codes.Internal, "failed to build durable run trigger message: %v", msgErr)
+		}
+
+		// publish before acking: if this is lost, the child task never gets created and the
+		// durable task would hang forever with no other recovery path, so treat it as fatal
+		// to the RPC rather than best-effort
+		if sendErr := d.mq.SendMessage(ctx, msgqueue.TASK_PROCESSING_QUEUE, msg); sendErr != nil {
+			return status.Errorf(codes.Internal, "failed to enqueue durable run trigger: %v", sendErr)
 		}
 	}
 

--- a/internal/services/shared/tasktypes/v1/task.go
+++ b/internal/services/shared/tasktypes/v1/task.go
@@ -19,6 +19,29 @@ func TriggerTaskMessage(tenantId uuid.UUID, payloads ...*v1.WorkflowNameTriggerO
 	)
 }
 
+type PendingDurableRunTriggerPayload struct {
+	NodeId      int64                       `json:"node_id"`
+	BranchId    int64                       `json:"branch_id"`
+	TriggerOpts *v1.WorkflowNameTriggerOpts `json:"trigger_opts"`
+}
+
+type DurableRunTriggerMessage struct {
+	DurableTaskId         int64                             `json:"durable_task_id"`
+	DurableTaskInsertedAt pgtype.Timestamptz                `json:"durable_task_inserted_at"`
+	DurableTaskExternalId uuid.UUID                         `json:"durable_task_external_id"`
+	Entries               []PendingDurableRunTriggerPayload `json:"entries"`
+}
+
+func DurableRunTriggerTaskMessage(tenantId uuid.UUID, msg DurableRunTriggerMessage) (*msgqueue.Message, error) {
+	return msgqueue.NewTenantMessage(
+		tenantId,
+		msgqueue.MsgIDDurableRunTrigger,
+		false,
+		true,
+		msg,
+	)
+}
+
 type CompletedTaskPayload struct {
 	// (required) the task id
 	TaskId int64 `validate:"required"`

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -89,11 +89,9 @@ type IngestTriggerRunsEntry struct {
 }
 
 type IngestTriggerRunsResult struct {
-	Entries               []*IngestTriggerRunsEntry
-	CreatedTasks          []*V1TaskWithPayload
-	CreatedDAGs           []*DAGWithData
-	InvocationCount       int32
-	CELEvaluationFailures []CELEvaluationFailure
+	Entries         []*IngestTriggerRunsEntry
+	PendingTriggers []PendingDurableRunTrigger
+	InvocationCount int32
 }
 
 type IngestWaitForResult struct {
@@ -143,6 +141,7 @@ type NodeIdBranchIdTuple struct {
 type DurableEventsRepository interface {
 	IngestDurableTaskEvent(ctx context.Context, opts IngestDurableTaskEventOpts) (*IngestDurableTaskEventResult, error)
 	HandleBranch(ctx context.Context, tenantId uuid.UUID, nodeId, branchId int64, task *sqlcv1.FlattenExternalIdsRow) (*HandleBranchResult, error)
+	TriggerPendingRunEntries(ctx context.Context, tenantId uuid.UUID, task *sqlcv1.FlattenExternalIdsRow, pending []PendingDurableRunTrigger) ([]*V1TaskWithPayload, []*DAGWithData, []CELEvaluationFailure, error)
 
 	GetSatisfiedDurableEvents(ctx context.Context, tenantId uuid.UUID, events []TaskExternalIdNodeIdBranchId) ([]*SatisfiedEventWithPayload, error)
 	GetDurableTaskInvocationCounts(ctx context.Context, tenantId uuid.UUID, tasks []IdInsertedAt) (map[IdInsertedAt]*int32, error)
@@ -1064,9 +1063,10 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 	return results, pendingStorePayloadOpts, nil
 }
 
-type pendingRunTrigger struct {
-	entry       *EventLogEntryWithPayloads
-	triggerOpts *WorkflowNameTriggerOpts
+type PendingDurableRunTrigger struct {
+	NodeId      int64
+	BranchId    int64
+	TriggerOpts *WorkflowNameTriggerOpts
 }
 
 func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, opts IngestDurableTaskEventOpts) (*IngestDurableTaskEventResult, error) {
@@ -1141,7 +1141,7 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 			Entries:         entries,
 		}
 
-		var pending []pendingRunTrigger
+		var pending []PendingDurableRunTrigger
 
 		for _, le := range logEntries {
 			if le.Entry.TriggeredAt.Valid {
@@ -1167,20 +1167,14 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 			triggerOptsCopy := *triggerOpts
 			triggerOptsCopy.ExternalId = *le.Entry.ChildTaskExternalID
 
-			pending = append(pending, pendingRunTrigger{entry: le, triggerOpts: &triggerOptsCopy})
+			pending = append(pending, PendingDurableRunTrigger{
+				NodeId:      le.Entry.NodeID,
+				BranchId:    le.Entry.BranchID,
+				TriggerOpts: &triggerOptsCopy,
+			})
 		}
 
-		if len(pending) > 0 {
-			createdTasks, createdDags, celFailures, triggerErr := r.triggerPendingRunEntries(ctx, tenantId, task, pending)
-
-			if triggerErr != nil {
-				return nil, fmt.Errorf("failed to trigger pending durable runs: %w", triggerErr)
-			}
-
-			triggerRunsResult.CreatedTasks = createdTasks
-			triggerRunsResult.CreatedDAGs = createdDags
-			triggerRunsResult.CELEvaluationFailures = celFailures
-		}
+		triggerRunsResult.PendingTriggers = pending
 	case sqlcv1.V1DurableEventLogKindWAITFOR:
 		if len(logEntries) != 1 {
 			// note: we implicitly assume that there will only be one log entry for wait for conditions
@@ -1462,7 +1456,7 @@ func (r *durableEventsRepository) appendDurableEventLog(ctx context.Context, opt
 	return logEntries, nodeIdBranchIdToTriggerOpts, nil
 }
 
-func (r *durableEventsRepository) triggerPendingRunEntries(ctx context.Context, tenantId uuid.UUID, task *sqlcv1.FlattenExternalIdsRow, pending []pendingRunTrigger) ([]*V1TaskWithPayload, []*DAGWithData, []CELEvaluationFailure, error) {
+func (r *durableEventsRepository) TriggerPendingRunEntries(ctx context.Context, tenantId uuid.UUID, task *sqlcv1.FlattenExternalIdsRow, pending []PendingDurableRunTrigger) ([]*V1TaskWithPayload, []*DAGWithData, []CELEvaluationFailure, error) {
 	ctx, span := telemetry.NewSpan(ctx, "trigger-pending-durable-run-entries")
 	defer span.End()
 
@@ -1479,7 +1473,7 @@ func (r *durableEventsRepository) triggerPendingRunEntries(ctx context.Context, 
 	nodesToClaim := make([]NodeIdBranchIdTuple, len(pending))
 
 	for i, p := range pending {
-		nodesToClaim[i] = NodeIdBranchIdTuple{NodeId: p.entry.Entry.NodeID, BranchId: p.entry.Entry.BranchID}
+		nodesToClaim[i] = NodeIdBranchIdTuple{NodeId: p.NodeId, BranchId: p.BranchId}
 	}
 
 	claimedSet, err := r.claimDurableEventLogEntriesForTrigger(ctx, tx, task.ID, task.InsertedAt, nodesToClaim)
@@ -1496,14 +1490,14 @@ func (r *durableEventsRepository) triggerPendingRunEntries(ctx context.Context, 
 	externalIdToNodeBranch := make(map[uuid.UUID]NodeIdBranchIdTuple, len(claimedSet))
 
 	for _, p := range pending {
-		nodeIdBranchIdTuple := NodeIdBranchIdTuple{NodeId: p.entry.Entry.NodeID, BranchId: p.entry.Entry.BranchID}
+		nodeIdBranchIdTuple := NodeIdBranchIdTuple{NodeId: p.NodeId, BranchId: p.BranchId}
 
 		if _, ok := claimedSet[nodeIdBranchIdTuple]; !ok {
 			continue
 		}
 
-		triggerOpts = append(triggerOpts, p.triggerOpts)
-		externalIdToNodeBranch[p.triggerOpts.ExternalId] = nodeIdBranchIdTuple
+		triggerOpts = append(triggerOpts, p.TriggerOpts)
+		externalIdToNodeBranch[p.TriggerOpts.ExternalId] = nodeIdBranchIdTuple
 	}
 
 	createdTasks, createdDags, _, celFailures, triggerStorePayloadOpts, err := r.triggerFromWorkflowNames(ctx, optTx, tenantId, triggerOpts)

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -1513,7 +1513,7 @@ func (r *durableEventsRepository) TriggerPendingRunEntries(ctx context.Context, 
 				DurableTaskExternalId: t.Task.ExternalID,
 			}
 
-			if _, ok := claimedSet[k]; !ok {
+			if _, ok := claimedSet[k.claim()]; !ok {
 				continue
 			}
 
@@ -1722,19 +1722,31 @@ type DurableTaskEventLogEntryKey struct {
 	BranchID              int64
 }
 
-func (r *durableEventsRepository) claimDurableEventLogEntriesForTrigger(ctx context.Context, tx sqlcv1.DBTX, nodesToClaim []DurableTaskEventLogEntryKey) (map[DurableTaskEventLogEntryKey]struct{}, error) {
+type durableEventLogEntryClaim struct {
+	DurableTaskID int64
+	NodeID        int64
+	BranchID      int64
+}
+
+func (k DurableTaskEventLogEntryKey) claim() durableEventLogEntryClaim {
+	return durableEventLogEntryClaim{
+		DurableTaskID: k.DurableTaskID,
+		NodeID:        k.NodeID,
+		BranchID:      k.BranchID,
+	}
+}
+
+func (r *durableEventsRepository) claimDurableEventLogEntriesForTrigger(ctx context.Context, tx sqlcv1.DBTX, nodesToClaim []DurableTaskEventLogEntryKey) (map[durableEventLogEntryClaim]struct{}, error) {
 	nodeIds := make([]int64, len(nodesToClaim))
 	branchIds := make([]int64, len(nodesToClaim))
 	durableTaskIds := make([]int64, len(nodesToClaim))
 	durableTaskInsertedAts := make([]pgtype.Timestamptz, len(nodesToClaim))
-	taskIdToExternalId := make(map[int64]uuid.UUID)
 
 	for i, k := range nodesToClaim {
 		nodeIds[i] = k.NodeID
 		branchIds[i] = k.BranchID
 		durableTaskIds[i] = k.DurableTaskID
 		durableTaskInsertedAts[i] = k.DurableTaskInsertedAt
-		taskIdToExternalId[k.DurableTaskID] = k.DurableTaskExternalId
 	}
 
 	claimed, err := r.queries.ClaimDurableEventLogEntriesForTrigger(ctx, tx, sqlcv1.ClaimDurableEventLogEntriesForTriggerParams{
@@ -1748,21 +1760,13 @@ func (r *durableEventsRepository) claimDurableEventLogEntriesForTrigger(ctx cont
 		return nil, err
 	}
 
-	claimedSet := make(map[DurableTaskEventLogEntryKey]struct{}, len(claimed))
+	claimedSet := make(map[durableEventLogEntryClaim]struct{}, len(claimed))
 
 	for _, c := range claimed {
-		externalId, ok := taskIdToExternalId[c.DurableTaskID]
-
-		if !ok {
-			return nil, fmt.Errorf("claimed durable event log entry for task id %d but could not find external id", c.DurableTaskID)
-		}
-
-		claimedSet[DurableTaskEventLogEntryKey{
-			NodeID:                c.NodeID,
-			BranchID:              c.BranchID,
-			DurableTaskID:         c.DurableTaskID,
-			DurableTaskInsertedAt: c.DurableTaskInsertedAt,
-			DurableTaskExternalId: externalId,
+		claimedSet[durableEventLogEntryClaim{
+			DurableTaskID: c.DurableTaskID,
+			NodeID:        c.NodeID,
+			BranchID:      c.BranchID,
 		}] = struct{}{}
 	}
 

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -138,10 +138,15 @@ type NodeIdBranchIdTuple struct {
 	BranchId int64
 }
 
+type TriggerPendingRunEntriesOpt struct {
+	Task        *sqlcv1.FlattenExternalIdsRow
+	PendingRuns []PendingDurableRunTrigger
+}
+
 type DurableEventsRepository interface {
 	IngestDurableTaskEvent(ctx context.Context, opts IngestDurableTaskEventOpts) (*IngestDurableTaskEventResult, error)
 	HandleBranch(ctx context.Context, tenantId uuid.UUID, nodeId, branchId int64, task *sqlcv1.FlattenExternalIdsRow) (*HandleBranchResult, error)
-	TriggerPendingRunEntries(ctx context.Context, tenantId uuid.UUID, task *sqlcv1.FlattenExternalIdsRow, pending []PendingDurableRunTrigger) ([]*V1TaskWithPayload, []*DAGWithData, []CELEvaluationFailure, error)
+	TriggerPendingRunEntries(ctx context.Context, tenantId uuid.UUID, tasks []TriggerPendingRunEntriesOpt) ([]*V1TaskWithPayload, []*DAGWithData, []CELEvaluationFailure, error)
 
 	GetSatisfiedDurableEvents(ctx context.Context, tenantId uuid.UUID, events []TaskExternalIdNodeIdBranchId) ([]*SatisfiedEventWithPayload, error)
 	GetDurableTaskInvocationCounts(ctx context.Context, tenantId uuid.UUID, tasks []IdInsertedAt) (map[IdInsertedAt]*int32, error)
@@ -1456,27 +1461,36 @@ func (r *durableEventsRepository) appendDurableEventLog(ctx context.Context, opt
 	return logEntries, nodeIdBranchIdToTriggerOpts, nil
 }
 
-func (r *durableEventsRepository) TriggerPendingRunEntries(ctx context.Context, tenantId uuid.UUID, task *sqlcv1.FlattenExternalIdsRow, pending []PendingDurableRunTrigger) ([]*V1TaskWithPayload, []*DAGWithData, []CELEvaluationFailure, error) {
+func (r *durableEventsRepository) TriggerPendingRunEntries(ctx context.Context, tenantId uuid.UUID, tasks []TriggerPendingRunEntriesOpt) ([]*V1TaskWithPayload, []*DAGWithData, []CELEvaluationFailure, error) {
 	ctx, span := telemetry.NewSpan(ctx, "trigger-pending-durable-run-entries")
 	defer span.End()
-
-	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "pending_count", Value: len(pending)})
 
 	optTx, err := r.PrepareOptimisticTx(ctx)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to prepare tx: %w", err)
 	}
+
 	defer optTx.Rollback()
 
 	tx := optTx.tx
 
-	nodesToClaim := make([]NodeIdBranchIdTuple, len(pending))
+	nodesToClaim := make([]DurableTaskEventLogEntryKey, 0)
 
-	for i, p := range pending {
-		nodesToClaim[i] = NodeIdBranchIdTuple{NodeId: p.NodeId, BranchId: p.BranchId}
+	for _, t := range tasks {
+		for _, p := range t.PendingRuns {
+			nodesToClaim = append(nodesToClaim, DurableTaskEventLogEntryKey{
+				NodeID:                p.NodeId,
+				BranchID:              p.BranchId,
+				DurableTaskID:         t.Task.ID,
+				DurableTaskInsertedAt: t.Task.InsertedAt,
+				DurableTaskExternalId: t.Task.ExternalID,
+			})
+		}
 	}
 
-	claimedSet, err := r.claimDurableEventLogEntriesForTrigger(ctx, tx, task.ID, task.InsertedAt, nodesToClaim)
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "nodes_to_claim", Value: len(nodesToClaim)})
+
+	claimedSet, err := r.claimDurableEventLogEntriesForTrigger(ctx, tx, nodesToClaim)
 
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to claim durable run entries for trigger: %w", err)
@@ -1487,17 +1501,25 @@ func (r *durableEventsRepository) TriggerPendingRunEntries(ctx context.Context, 
 	}
 
 	triggerOpts := make([]*WorkflowNameTriggerOpts, 0, len(claimedSet))
-	externalIdToNodeBranch := make(map[uuid.UUID]NodeIdBranchIdTuple, len(claimedSet))
+	externalIdToEventLogEntryPK := make(map[uuid.UUID]DurableTaskEventLogEntryKey, len(claimedSet))
 
-	for _, p := range pending {
-		nodeIdBranchIdTuple := NodeIdBranchIdTuple{NodeId: p.NodeId, BranchId: p.BranchId}
+	for _, t := range tasks {
+		for _, p := range t.PendingRuns {
+			k := DurableTaskEventLogEntryKey{
+				NodeID:                p.NodeId,
+				BranchID:              p.BranchId,
+				DurableTaskID:         t.Task.ID,
+				DurableTaskInsertedAt: t.Task.InsertedAt,
+				DurableTaskExternalId: t.Task.ExternalID,
+			}
 
-		if _, ok := claimedSet[nodeIdBranchIdTuple]; !ok {
-			continue
+			if _, ok := claimedSet[k]; !ok {
+				continue
+			}
+
+			triggerOpts = append(triggerOpts, p.TriggerOpts)
+			externalIdToEventLogEntryPK[p.TriggerOpts.ExternalId] = k
 		}
-
-		triggerOpts = append(triggerOpts, p.TriggerOpts)
-		externalIdToNodeBranch[p.TriggerOpts.ExternalId] = nodeIdBranchIdTuple
 	}
 
 	createdTasks, createdDags, _, celFailures, triggerStorePayloadOpts, err := r.triggerFromWorkflowNames(ctx, optTx, tenantId, triggerOpts)
@@ -1557,22 +1579,22 @@ func (r *durableEventsRepository) TriggerPendingRunEntries(ctx context.Context, 
 			},
 		}
 
-		nodeIdBranchId := externalIdToNodeBranch[ct.ExternalID]
+		eventLogEntryKey := externalIdToEventLogEntryPK[ct.ExternalID]
 
-		nodeId := nodeIdBranchId.NodeId
-		branchId := nodeIdBranchId.BranchId
+		nodeId := eventLogEntryKey.NodeID
+		branchId := eventLogEntryKey.BranchID
+		taskExternalId := eventLogEntryKey.DurableTaskExternalId
+		taskId := eventLogEntryKey.DurableTaskID
 
-		runEventLogEntrySignalKey := fmt.Sprintf("durable_run:%s:%d:%d", task.ExternalID.String(), branchId, nodeId)
-
-		taskId := task.ID
+		runEventLogEntrySignalKey := fmt.Sprintf("durable_run:%s:%d:%d", taskExternalId.String(), branchId, nodeId)
 
 		createMatchOpts = append(createMatchOpts, CreateMatchOpts{
 			Kind:                         sqlcv1.V1MatchKindSIGNAL,
 			Conditions:                   conditions,
 			SignalTaskId:                 &taskId,
-			SignalTaskInsertedAt:         task.InsertedAt,
+			SignalTaskInsertedAt:         eventLogEntryKey.DurableTaskInsertedAt,
 			SignalExternalId:             &ct.ExternalID,
-			SignalTaskExternalId:         &task.ExternalID,
+			SignalTaskExternalId:         &taskExternalId,
 			SignalKey:                    &runEventLogEntrySignalKey,
 			DurableEventLogEntryNodeId:   &nodeId,
 			DurableEventLogEntryBranchId: &branchId,
@@ -1622,23 +1644,24 @@ func (r *durableEventsRepository) TriggerPendingRunEntries(ctx context.Context, 
 			)
 		}
 
-		nodeIdBranchId := externalIdToNodeBranch[dag.ExternalID]
+		eventLogEntryKey := externalIdToEventLogEntryPK[dag.ExternalID]
 
-		nodeId := nodeIdBranchId.NodeId
-		branchId := nodeIdBranchId.BranchId
+		nodeId := eventLogEntryKey.NodeID
+		branchId := eventLogEntryKey.BranchID
+		taskExternalId := eventLogEntryKey.DurableTaskExternalId
 
-		runEventLogEntrySignalKey := fmt.Sprintf("durable_run:%s:%d:%d", task.ExternalID.String(), branchId, nodeId)
+		runEventLogEntrySignalKey := fmt.Sprintf("durable_run:%s:%d:%d", taskExternalId.String(), branchId, nodeId)
 
-		taskId := task.ID
+		taskId := eventLogEntryKey.DurableTaskID
 		dagExternalId := dag.ExternalID
 
 		createMatchOpts = append(createMatchOpts, CreateMatchOpts{
 			Kind:                         sqlcv1.V1MatchKindSIGNAL,
 			Conditions:                   conditions,
 			SignalTaskId:                 &taskId,
-			SignalTaskInsertedAt:         task.InsertedAt,
+			SignalTaskInsertedAt:         eventLogEntryKey.DurableTaskInsertedAt,
 			SignalExternalId:             &dagExternalId,
-			SignalTaskExternalId:         &task.ExternalID,
+			SignalTaskExternalId:         &taskExternalId,
 			SignalKey:                    &runEventLogEntrySignalKey,
 			DurableEventLogEntryNodeId:   &nodeId,
 			DurableEventLogEntryBranchId: &branchId,
@@ -1669,7 +1692,13 @@ func (r *durableEventsRepository) triggerPendingWaitFor(ctx context.Context, ten
 	}
 	defer rollback()
 
-	claimedSet, err := r.claimDurableEventLogEntriesForTrigger(ctx, tx, task.ID, task.InsertedAt, []NodeIdBranchIdTuple{{NodeId: nodeId, BranchId: branchId}})
+	claimedSet, err := r.claimDurableEventLogEntriesForTrigger(ctx, tx, []DurableTaskEventLogEntryKey{{
+		NodeID:                nodeId,
+		BranchID:              branchId,
+		DurableTaskID:         task.ID,
+		DurableTaskInsertedAt: task.InsertedAt,
+		DurableTaskExternalId: task.ExternalID,
+	}})
 	if err != nil {
 		return fmt.Errorf("failed to claim durable wait for entry for trigger: %w", err)
 	}
@@ -1685,30 +1714,56 @@ func (r *durableEventsRepository) triggerPendingWaitFor(ctx context.Context, ten
 	return commit(ctx)
 }
 
-func (r *durableEventsRepository) claimDurableEventLogEntriesForTrigger(ctx context.Context, tx sqlcv1.DBTX, durableTaskId int64, durableTaskInsertedAt pgtype.Timestamptz, nodesToClaim []NodeIdBranchIdTuple) (map[NodeIdBranchIdTuple]struct{}, error) {
+type DurableTaskEventLogEntryKey struct {
+	DurableTaskID         int64
+	DurableTaskInsertedAt pgtype.Timestamptz
+	DurableTaskExternalId uuid.UUID
+	NodeID                int64
+	BranchID              int64
+}
+
+func (r *durableEventsRepository) claimDurableEventLogEntriesForTrigger(ctx context.Context, tx sqlcv1.DBTX, nodesToClaim []DurableTaskEventLogEntryKey) (map[DurableTaskEventLogEntryKey]struct{}, error) {
 	nodeIds := make([]int64, len(nodesToClaim))
 	branchIds := make([]int64, len(nodesToClaim))
+	durableTaskIds := make([]int64, len(nodesToClaim))
+	durableTaskInsertedAts := make([]pgtype.Timestamptz, len(nodesToClaim))
+	taskIdToExternalId := make(map[int64]uuid.UUID)
 
 	for i, k := range nodesToClaim {
-		nodeIds[i] = k.NodeId
-		branchIds[i] = k.BranchId
+		nodeIds[i] = k.NodeID
+		branchIds[i] = k.BranchID
+		durableTaskIds[i] = k.DurableTaskID
+		durableTaskInsertedAts[i] = k.DurableTaskInsertedAt
+		taskIdToExternalId[k.DurableTaskID] = k.DurableTaskExternalId
 	}
 
 	claimed, err := r.queries.ClaimDurableEventLogEntriesForTrigger(ctx, tx, sqlcv1.ClaimDurableEventLogEntriesForTriggerParams{
-		Durabletaskid:         durableTaskId,
-		Durabletaskinsertedat: durableTaskInsertedAt,
-		Nodeids:               nodeIds,
-		Branchids:             branchIds,
+		Durabletaskids:         durableTaskIds,
+		Durabletaskinsertedats: durableTaskInsertedAts,
+		Nodeids:                nodeIds,
+		Branchids:              branchIds,
 	})
 
 	if err != nil {
 		return nil, err
 	}
 
-	claimedSet := make(map[NodeIdBranchIdTuple]struct{}, len(claimed))
+	claimedSet := make(map[DurableTaskEventLogEntryKey]struct{}, len(claimed))
 
 	for _, c := range claimed {
-		claimedSet[NodeIdBranchIdTuple{NodeId: c.NodeID, BranchId: c.BranchID}] = struct{}{}
+		externalId, ok := taskIdToExternalId[c.DurableTaskID]
+
+		if !ok {
+			return nil, fmt.Errorf("claimed durable event log entry for task id %d but could not find external id", c.DurableTaskID)
+		}
+
+		claimedSet[DurableTaskEventLogEntryKey{
+			NodeID:                c.NodeID,
+			BranchID:              c.BranchID,
+			DurableTaskID:         c.DurableTaskID,
+			DurableTaskInsertedAt: c.DurableTaskInsertedAt,
+			DurableTaskExternalId: externalId,
+		}] = struct{}{}
 	}
 
 	return claimedSet, nil

--- a/pkg/repository/sqlcv1/durable_event_log.sql
+++ b/pkg/repository/sqlcv1/durable_event_log.sql
@@ -301,18 +301,20 @@ WHERE (lf.durable_task_id, lf.durable_task_inserted_at, lf.tenant_id) IN (
 WITH inputs AS (
     SELECT
         UNNEST(@nodeIds::BIGINT[]) AS node_id,
-        UNNEST(@branchIds::BIGINT[]) AS branch_id
+        UNNEST(@branchIds::BIGINT[]) AS branch_id,
+        UNNEST(@durableTaskIds::BIGINT[]) AS durable_task_id,
+        UNNEST(@durableTaskInsertedAts::TIMESTAMPTZ[]) AS durable_task_inserted_at
 )
 
 UPDATE v1_durable_event_log_entry e
 SET triggered_at = NOW()
 FROM inputs i
-WHERE e.durable_task_id = @durableTaskId::BIGINT
-  AND e.durable_task_inserted_at = @durableTaskInsertedAt::TIMESTAMPTZ
+WHERE e.durable_task_id = i.durable_task_id
+  AND e.durable_task_inserted_at = i.durable_task_inserted_at
   AND e.node_id = i.node_id
   AND e.branch_id = i.branch_id
   AND e.triggered_at IS NULL
-RETURNING e.node_id, e.branch_id
+RETURNING e.*
 ;
 
 -- name: ListDurableEventLogBranchPoints :many

--- a/pkg/repository/sqlcv1/durable_event_log.sql
+++ b/pkg/repository/sqlcv1/durable_event_log.sql
@@ -304,16 +304,32 @@ WITH inputs AS (
         UNNEST(@branchIds::BIGINT[]) AS branch_id,
         UNNEST(@durableTaskIds::BIGINT[]) AS durable_task_id,
         UNNEST(@durableTaskInsertedAts::TIMESTAMPTZ[]) AS durable_task_inserted_at
+), to_claim AS (
+    SELECT
+        e.durable_task_id,
+        e.durable_task_inserted_at,
+        e.branch_id,
+        e.node_id
+    FROM
+        v1_durable_event_log_entry e
+    JOIN
+        inputs i ON e.durable_task_id = i.durable_task_id
+            AND e.durable_task_inserted_at = i.durable_task_inserted_at
+            AND e.node_id = i.node_id
+            AND e.branch_id = i.branch_id
+    WHERE
+        e.triggered_at IS NULL
+    ORDER BY e.durable_task_id, e.durable_task_inserted_at, e.branch_id, e.node_id
+    FOR UPDATE
 )
 
 UPDATE v1_durable_event_log_entry e
 SET triggered_at = NOW()
-FROM inputs i
-WHERE e.durable_task_id = i.durable_task_id
-  AND e.durable_task_inserted_at = i.durable_task_inserted_at
-  AND e.node_id = i.node_id
-  AND e.branch_id = i.branch_id
-  AND e.triggered_at IS NULL
+FROM to_claim c
+WHERE e.durable_task_id = c.durable_task_id
+  AND e.durable_task_inserted_at = c.durable_task_inserted_at
+  AND e.branch_id = c.branch_id
+  AND e.node_id = c.node_id
 RETURNING e.*
 ;
 

--- a/pkg/repository/sqlcv1/durable_event_log.sql.go
+++ b/pkg/repository/sqlcv1/durable_event_log.sql.go
@@ -260,48 +260,66 @@ func (q *Queries) BulkGetDurableEventLogEntries(ctx context.Context, db DBTX, ar
 const claimDurableEventLogEntriesForTrigger = `-- name: ClaimDurableEventLogEntriesForTrigger :many
 WITH inputs AS (
     SELECT
-        UNNEST($3::BIGINT[]) AS node_id,
-        UNNEST($4::BIGINT[]) AS branch_id
+        UNNEST($1::BIGINT[]) AS node_id,
+        UNNEST($2::BIGINT[]) AS branch_id,
+        UNNEST($3::BIGINT[]) AS durable_task_id,
+        UNNEST($4::TIMESTAMPTZ[]) AS durable_task_inserted_at
 )
 
 UPDATE v1_durable_event_log_entry e
 SET triggered_at = NOW()
 FROM inputs i
-WHERE e.durable_task_id = $1::BIGINT
-  AND e.durable_task_inserted_at = $2::TIMESTAMPTZ
+WHERE e.durable_task_id = i.durable_task_id
+  AND e.durable_task_inserted_at = i.durable_task_inserted_at
   AND e.node_id = i.node_id
   AND e.branch_id = i.branch_id
   AND e.triggered_at IS NULL
-RETURNING e.node_id, e.branch_id
+RETURNING e.tenant_id, e.external_id, e.result_payload_external_id, e.child_task_external_id, e.child_task_is_failure, e.child_task_error_message, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.satisfied_order, e.user_message, e.wait_data, e.triggered_at
 `
 
 type ClaimDurableEventLogEntriesForTriggerParams struct {
-	Durabletaskid         int64              `json:"durabletaskid"`
-	Durabletaskinsertedat pgtype.Timestamptz `json:"durabletaskinsertedat"`
-	Nodeids               []int64            `json:"nodeids"`
-	Branchids             []int64            `json:"branchids"`
+	Nodeids                []int64              `json:"nodeids"`
+	Branchids              []int64              `json:"branchids"`
+	Durabletaskids         []int64              `json:"durabletaskids"`
+	Durabletaskinsertedats []pgtype.Timestamptz `json:"durabletaskinsertedats"`
 }
 
-type ClaimDurableEventLogEntriesForTriggerRow struct {
-	NodeID   int64 `json:"node_id"`
-	BranchID int64 `json:"branch_id"`
-}
-
-func (q *Queries) ClaimDurableEventLogEntriesForTrigger(ctx context.Context, db DBTX, arg ClaimDurableEventLogEntriesForTriggerParams) ([]*ClaimDurableEventLogEntriesForTriggerRow, error) {
+func (q *Queries) ClaimDurableEventLogEntriesForTrigger(ctx context.Context, db DBTX, arg ClaimDurableEventLogEntriesForTriggerParams) ([]*V1DurableEventLogEntry, error) {
 	rows, err := db.Query(ctx, claimDurableEventLogEntriesForTrigger,
-		arg.Durabletaskid,
-		arg.Durabletaskinsertedat,
 		arg.Nodeids,
 		arg.Branchids,
+		arg.Durabletaskids,
+		arg.Durabletaskinsertedats,
 	)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*ClaimDurableEventLogEntriesForTriggerRow
+	var items []*V1DurableEventLogEntry
 	for rows.Next() {
-		var i ClaimDurableEventLogEntriesForTriggerRow
-		if err := rows.Scan(&i.NodeID, &i.BranchID); err != nil {
+		var i V1DurableEventLogEntry
+		if err := rows.Scan(
+			&i.TenantID,
+			&i.ExternalID,
+			&i.ResultPayloadExternalID,
+			&i.ChildTaskExternalID,
+			&i.ChildTaskIsFailure,
+			&i.ChildTaskErrorMessage,
+			&i.InsertedAt,
+			&i.ID,
+			&i.DurableTaskID,
+			&i.DurableTaskInsertedAt,
+			&i.Kind,
+			&i.NodeID,
+			&i.BranchID,
+			&i.IdempotencyKey,
+			&i.IsSatisfied,
+			&i.SatisfiedAt,
+			&i.SatisfiedOrder,
+			&i.UserMessage,
+			&i.WaitData,
+			&i.TriggeredAt,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)

--- a/pkg/repository/sqlcv1/durable_event_log.sql.go
+++ b/pkg/repository/sqlcv1/durable_event_log.sql.go
@@ -264,16 +264,32 @@ WITH inputs AS (
         UNNEST($2::BIGINT[]) AS branch_id,
         UNNEST($3::BIGINT[]) AS durable_task_id,
         UNNEST($4::TIMESTAMPTZ[]) AS durable_task_inserted_at
+), to_claim AS (
+    SELECT
+        e.durable_task_id,
+        e.durable_task_inserted_at,
+        e.branch_id,
+        e.node_id
+    FROM
+        v1_durable_event_log_entry e
+    JOIN
+        inputs i ON e.durable_task_id = i.durable_task_id
+            AND e.durable_task_inserted_at = i.durable_task_inserted_at
+            AND e.node_id = i.node_id
+            AND e.branch_id = i.branch_id
+    WHERE
+        e.triggered_at IS NULL
+    ORDER BY e.durable_task_id, e.durable_task_inserted_at, e.branch_id, e.node_id
+    FOR UPDATE
 )
 
 UPDATE v1_durable_event_log_entry e
 SET triggered_at = NOW()
-FROM inputs i
-WHERE e.durable_task_id = i.durable_task_id
-  AND e.durable_task_inserted_at = i.durable_task_inserted_at
-  AND e.node_id = i.node_id
-  AND e.branch_id = i.branch_id
-  AND e.triggered_at IS NULL
+FROM to_claim c
+WHERE e.durable_task_id = c.durable_task_id
+  AND e.durable_task_inserted_at = c.durable_task_inserted_at
+  AND e.branch_id = c.branch_id
+  AND e.node_id = c.node_id
 RETURNING e.tenant_id, e.external_id, e.result_payload_external_id, e.child_task_external_id, e.child_task_is_failure, e.child_task_error_message, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.satisfied_order, e.user_message, e.wait_data, e.triggered_at
 `
 

--- a/sdks/python/poetry.lock
+++ b/sdks/python/poetry.lock
@@ -687,14 +687,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
-optional = true
+optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main"]
-markers = "(sys_platform != \"emscripten\" and (extra == \"openai\" or extra == \"claude\") or extra == \"docs\" or extra == \"lint\") and platform_system == \"Windows\" or extra == \"test\" and sys_platform == \"win32\" or platform_system == \"Windows\" and (extra == \"docs\" or extra == \"openai\")"
+groups = ["main", "test"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+markers = {main = "(sys_platform != \"emscripten\" and (extra == \"openai\" or extra == \"claude\") or extra == \"docs\" or extra == \"lint\") and platform_system == \"Windows\" or extra == \"test\" and sys_platform == \"win32\" or platform_system == \"Windows\" and (extra == \"docs\" or extra == \"openai\")", test = "sys_platform == \"win32\""}
 
 [[package]]
 name = "cryptography"
@@ -795,14 +795,14 @@ test = ["pytest"]
 name = "exceptiongroup"
 version = "1.3.1"
 description = "Backport of PEP 654 (exception groups)"
-optional = true
+optional = false
 python-versions = ">=3.7"
-groups = ["main"]
-markers = "(extra == \"test\" or extra == \"openai\" or extra == \"claude\" or extra == \"docs\") and python_version == \"3.10\""
+groups = ["main", "test"]
 files = [
     {file = "exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"},
     {file = "exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219"},
 ]
+markers = {main = "(extra == \"test\" or extra == \"openai\" or extra == \"claude\" or extra == \"docs\") and python_version == \"3.10\"", test = "python_version == \"3.10\""}
 
 [package.dependencies]
 typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
@@ -1313,14 +1313,14 @@ type = ["mypy (<1.19) ; platform_python_implementation == \"PyPy\"", "pytest-myp
 name = "iniconfig"
 version = "2.3.0"
 description = "brain-dead simple config-ini parsing"
-optional = true
+optional = false
 python-versions = ">=3.10"
-groups = ["main"]
-markers = "extra == \"test\""
+groups = ["main", "test"]
 files = [
     {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
     {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
 ]
+markers = {main = "extra == \"test\""}
 
 [[package]]
 name = "jinja2"
@@ -2407,14 +2407,14 @@ typing-extensions = ">=4.5.0"
 name = "packaging"
 version = "26.0"
 description = "Core utilities for Python packages"
-optional = true
+optional = false
 python-versions = ">=3.8"
-groups = ["main"]
-markers = "extra == \"otel\" or extra == \"lint\" or extra == \"test\" or extra == \"docs\""
+groups = ["main", "test"]
 files = [
     {file = "packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"},
     {file = "packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4"},
 ]
+markers = {main = "extra == \"otel\" or extra == \"lint\" or extra == \"test\" or extra == \"docs\""}
 
 [[package]]
 name = "pathspec"
@@ -2452,14 +2452,14 @@ files = [
 name = "pluggy"
 version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
-optional = true
+optional = false
 python-versions = ">=3.9"
-groups = ["main"]
-markers = "extra == \"test\""
+groups = ["main", "test"]
 files = [
     {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
     {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
 ]
+markers = {main = "extra == \"test\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
@@ -2932,14 +2932,14 @@ flake8 = ["flake8 (>=4)"]
 name = "pygments"
 version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
-optional = true
+optional = false
 python-versions = ">=3.9"
-groups = ["main"]
-markers = "extra == \"test\""
+groups = ["main", "test"]
 files = [
     {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
     {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
 ]
+markers = {main = "extra == \"test\""}
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
@@ -2988,14 +2988,14 @@ extra = ["pygments (>=2.19.1)"]
 name = "pytest"
 version = "9.1.1"
 description = "pytest: simple powerful testing with Python"
-optional = true
+optional = false
 python-versions = ">=3.10"
-groups = ["main"]
-markers = "extra == \"test\""
+groups = ["main", "test"]
 files = [
     {file = "pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"},
     {file = "pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"},
 ]
+markers = {main = "extra == \"test\""}
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
@@ -3067,6 +3067,21 @@ pytest = ">=7.0.0"
 
 [package.extras]
 dev = ["black", "flake8", "isort", "mypy"]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+description = "pytest plugin to abort hanging tests"
+optional = false
+python-versions = ">=3.7"
+groups = ["test"]
+files = [
+    {file = "pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2"},
+    {file = "pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
 
 [[package]]
 name = "pytest-xdist"
@@ -3657,10 +3672,9 @@ test = ["pytest", "tornado (>=4.5)", "typeguard"]
 name = "tomli"
 version = "2.4.1"
 description = "A lil' TOML parser"
-optional = true
+optional = false
 python-versions = ">=3.8"
-groups = ["main"]
-markers = "(extra == \"lint\" or extra == \"test\" or extra == \"docs\") and python_version == \"3.10\""
+groups = ["main", "test"]
 files = [
     {file = "tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30"},
     {file = "tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a"},
@@ -3710,6 +3724,7 @@ files = [
     {file = "tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe"},
     {file = "tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f"},
 ]
+markers = {main = "(extra == \"lint\" or extra == \"test\" or extra == \"docs\") and python_version == \"3.10\"", test = "python_version == \"3.10\""}
 
 [[package]]
 name = "tqdm"
@@ -3856,11 +3871,12 @@ version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
+markers = {test = "python_version == \"3.10\""}
 
 [[package]]
 name = "typing-inspection"
@@ -4240,4 +4256,4 @@ test = ["boto3", "botocore", "psycopg", "pytest", "pytest-asyncio", "pytest-env"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "a4c8fe6cdb2f368a24dcce5f3f3a3f6c89b948099a3bd09b7aef420de9c868e8"
+content-hash = "7dcbe1bd3dfccb4a22ad8446af5f3b5c56fe270002d67116c33e925a8c53454a"

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -183,3 +183,8 @@ style = "sphinx"
 exclude = "v0|clients/rest/*|contracts/*|.venv|site/*|examples/dependency_injection/dependency_annotations312.py"
 arg-type-hints-in-docstring = false
 check-return-types = false
+
+[dependency-groups]
+test = [
+    "pytest-timeout (>=2.4.0,<3.0.0)"
+]


### PR DESCRIPTION
# Description

The next thing in my stack of ideas - instead of triggering inline, pubbing messages over the mq so we can buffer the triggers, which I think should help a lot

## Type of change

- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude Code to help with the copy pasting

</details>
