### PR TITLE
feat(analytics): emit tenant:connect when a CLI attaches to a tenant

### DIFF
--- a/api/v1/server/handlers/tenants/get.go
+++ b/api/v1/server/handlers/tenants/get.go
@@ -1,19 +1,59 @@
 package tenants
 
 import (
+	"context"
+
 	"github.com/labstack/echo/v4"
 
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/gen"
 	"github.com/hatchet-dev/hatchet/api/v1/server/oas/transformers"
+	"github.com/hatchet-dev/hatchet/pkg/analytics"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 )
 
 func (t *TenantService) TenantGet(ctx echo.Context, request gen.TenantGetRequestObject) (gen.TenantGetResponseObject, error) {
 	maybeTenant := ctx.Get("tenant").(*sqlcv1.Tenant)
 
+	t.trackClientConnect(ctx, maybeTenant)
+
 	tenant := transformers.ToTenant(maybeTenant, t.config.Runtime.ServerURL)
 
 	return gen.TenantGet200JSONResponse(
 		*tenant,
 	), nil
+}
+
+// trackClientConnect emits a tenant:connect event when a client identifies itself
+// as the CLI, which happens when a profile is created or updated against this
+// tenant. This is what links a CLI install to a tenant in analytics.
+//
+// The UI polls this endpoint, so requests without the header are ignored: the
+// event is meant to mark a client attaching itself, not every tenant read.
+func (t *TenantService) trackClientConnect(ctx echo.Context, tenant *sqlcv1.Tenant) {
+	source := analytics.Source(ctx.Request().Header.Get(analytics.SourceMetadataKey))
+
+	if source != analytics.SourceCLI {
+		return
+	}
+
+	// The REST auth middleware hardcodes SourceAPI for token auth, so the real
+	// source is set on the analytics context here rather than plumbed through authn.
+	analyticsCtx := context.WithValue(ctx.Request().Context(), analytics.SourceKey, source)
+
+	props := analytics.Properties{}
+
+	if version := ctx.Request().Header.Get(analytics.CLIVersionMetadataKey); version != "" {
+		props["cli_version"] = version
+	}
+
+	if command := ctx.Request().Header.Get(analytics.CLICommandMetadataKey); command != "" {
+		props["command"] = command
+	}
+
+	t.config.Analytics.Enqueue(
+		analyticsCtx,
+		analytics.Tenant, analytics.Connect,
+		tenant.ID.String(),
+		props,
+	)
 }

--- a/cmd/hatchet-cli/cli/profile.go
+++ b/cmd/hatchet-cli/cli/profile.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"slices"
 	"sort"
 	"strings"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/config/cli"
 	"github.com/hatchet-dev/hatchet/cmd/hatchet-cli/cli/internal/styles"
+	"github.com/hatchet-dev/hatchet/pkg/analytics"
 	"github.com/hatchet-dev/hatchet/pkg/client"
 	"github.com/hatchet-dev/hatchet/pkg/config/loader/loaderutils"
 
@@ -439,6 +441,27 @@ func addProfileFromToken(cmd *cobra.Command) (string, error) {
 	return name, nil
 }
 
+// cliSourceEditor tags an outgoing REST request as coming from the CLI, so the
+// server can record that this CLI was attached to the tenant. Every caller of
+// getProfileFromToken is a point where a token gets bound to this machine, which
+// is the moment worth recording.
+//
+// This honors the same opt-out as the anonymous version-check ping, so
+// telemetry.enabled=false stays a single switch from a user's point of view.
+func cliSourceEditor(cmd *cobra.Command) func(context.Context, *http.Request) error {
+	return func(_ context.Context, req *http.Request) error {
+		if !cli.TelemetryEnabled() {
+			return nil
+		}
+
+		req.Header.Set(analytics.SourceMetadataKey, string(analytics.SourceCLI))
+		req.Header.Set(analytics.CLIVersionMetadataKey, Version)
+		req.Header.Set(analytics.CLICommandMetadataKey, cmd.CommandPath())
+
+		return nil
+	}
+}
+
 func getProfileFromToken(cmd *cobra.Command, token, nameOverride, tlsOverride string) (*cliconfig.Profile, error) {
 	name := nameOverride
 	parsedTokenConf, err := loaderutils.GetConfFromJWT(token)
@@ -455,7 +478,7 @@ func getProfileFromToken(cmd *cobra.Command, token, nameOverride, tlsOverride st
 		cli.Logger.Fatalf("could not create client with provided token: %v", err)
 	}
 
-	tenant, err := client.API().TenantGetWithResponse(cmd.Context(), uuid.MustParse(client.TenantId()))
+	tenant, err := client.API().TenantGetWithResponse(cmd.Context(), uuid.MustParse(client.TenantId()), cliSourceEditor(cmd))
 
 	if err != nil {
 		cli.Logger.Fatalf("could not connect to Hatchet server with provided token: %v", err)

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -52,6 +52,7 @@ const (
 	Branch    Action = "branch"
 	Memo      Action = "memo"
 	WaitFor   Action = "wait-for"
+	Connect   Action = "connect"
 )
 
 type Properties map[string]interface{}
@@ -75,6 +76,13 @@ const (
 	SourceKey         = contextKey("source")
 
 	SourceMetadataKey = "x-hatchet-source"
+
+	// CLIVersionMetadataKey and CLICommandMetadataKey carry CLI build and
+	// subcommand details alongside SourceMetadataKey. They are advisory: a client
+	// can set them to anything, so treat the values as reporting detail rather
+	// than as anything to branch on.
+	CLIVersionMetadataKey = "x-hatchet-cli-version"
+	CLICommandMetadataKey = "x-hatchet-cli-command"
 )
 
 type Analytics interface {


### PR DESCRIPTION
# Description

Adds a new `tenant:connect` event when the CLI connects to a cloud tenant. 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## What's Changed

See above. 

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Tested (unit, integration, or manually with steps specified)
- [X] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [X] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude Opus 5

</details>
