### PR TITLE
feat(analytics): support an account group on captured events

### DIFF
--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -71,6 +71,7 @@ const (
 	APITokenIDKey     = contextKey("api_token_id")
 	TenantIDKey       = contextKey("tenant_id")
 	OrganizationIDKey = contextKey("organization_id")
+	AccountIDKey      = contextKey("account_id")
 	UserIDKey         = contextKey("user_id")
 	SourceKey         = contextKey("source")
 
@@ -103,6 +104,17 @@ func TenantIDFromContext(ctx context.Context) *uuid.UUID {
 
 func OrganizationIDFromContext(ctx context.Context) *uuid.UUID {
 	if id, ok := ctx.Value(OrganizationIDKey).(uuid.UUID); ok && id != uuid.Nil {
+		return &id
+	}
+	return nil
+}
+
+// AccountIDFromContext returns the account an event belongs to, if one was set.
+// An account groups the users, organizations and tenants of a single customer.
+// Unlike a tenant or token it is not an actor, so it never contributes a
+// distinct id — see DistinctID.
+func AccountIDFromContext(ctx context.Context) *uuid.UUID {
+	if id, ok := ctx.Value(AccountIDKey).(uuid.UUID); ok && id != uuid.Nil {
 		return &id
 	}
 	return nil

--- a/pkg/analytics/posthog/posthog.go
+++ b/pkg/analytics/posthog/posthog.go
@@ -107,16 +107,20 @@ func (p *PosthogAnalytics) Enqueue(ctx context.Context, resource analytics.Resou
 	}
 
 	orgID := analytics.OrganizationIDFromContext(ctx)
+	accountID := analytics.AccountIDFromContext(ctx)
 
 	var group posthog.Groups
 
-	if tenantID != nil || orgID != nil {
+	if tenantID != nil || orgID != nil || accountID != nil {
 		group = posthog.NewGroups()
 		if tenantID != nil {
 			group.Set("tenant", *tenantID)
 		}
 		if orgID != nil {
 			group.Set("organization", *orgID)
+		}
+		if accountID != nil {
+			group.Set("account", *accountID)
 		}
 	}
 

--- a/pkg/analytics/posthog/posthog_test.go
+++ b/pkg/analytics/posthog/posthog_test.go
@@ -1,6 +1,7 @@
 package posthog
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -88,5 +89,68 @@ func TestFlushCount_UnknownEventTimesOmitted(t *testing.T) {
 	}
 	if v, ok := capture.Properties["aggregate_last_event_at"]; ok {
 		t.Errorf("expected no aggregate_last_event_at, got %v", v)
+	}
+}
+
+func TestEnqueue_SetsAccountGroupFromContext(t *testing.T) {
+	fake := &fakeClient{}
+	p := newTestAnalytics(fake)
+
+	accountID := uuid.New()
+	orgID := uuid.New()
+
+	ctx := context.WithValue(context.Background(), analytics.AccountIDKey, accountID)
+	ctx = context.WithValue(ctx, analytics.OrganizationIDKey, orgID)
+
+	p.Enqueue(ctx, analytics.User, analytics.Create, "resource-1", nil)
+
+	capture := captureFrom(t, fake)
+
+	if capture.Groups == nil {
+		t.Fatal("expected groups to be set")
+	}
+
+	if got := capture.Groups["account"]; got != accountID {
+		t.Errorf("expected account group %v, got %v", accountID, got)
+	}
+
+	// The account must not displace the groups that were already supported.
+	if got := capture.Groups["organization"]; got != orgID {
+		t.Errorf("expected organization group %v, got %v", orgID, got)
+	}
+}
+
+// An account is a grouping, not an actor: it must never become the distinct id,
+// or account-scoped events would masquerade as a person.
+func TestEnqueue_AccountAloneDoesNotProduceDistinctID(t *testing.T) {
+	fake := &fakeClient{}
+	p := newTestAnalytics(fake)
+
+	accountID := uuid.New()
+	ctx := context.WithValue(context.Background(), analytics.AccountIDKey, accountID)
+
+	p.Enqueue(ctx, analytics.User, analytics.Create, "resource-1", nil)
+
+	capture := captureFrom(t, fake)
+
+	if capture.DistinctId != "" {
+		t.Errorf("expected an empty distinct id for an account-only context, got %q", capture.DistinctId)
+	}
+
+	if got := capture.Groups["account"]; got != accountID {
+		t.Errorf("expected account group %v, got %v", accountID, got)
+	}
+}
+
+func TestEnqueue_NoGroupsWhenContextIsEmpty(t *testing.T) {
+	fake := &fakeClient{}
+	p := newTestAnalytics(fake)
+
+	p.Enqueue(context.Background(), analytics.User, analytics.Create, "resource-1", nil)
+
+	capture := captureFrom(t, fake)
+
+	if capture.Groups != nil {
+		t.Errorf("expected no groups, got %v", capture.Groups)
 	}
 }


### PR DESCRIPTION
# Description

Adds group for `account` if set in the context.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## What's Changed

-  See above.

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Tested (unit, integration, or manually with steps specified)
- [X] Linted and formatted

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [X] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude w/ Opus 5

</details>
