### PR TITLE
refactor(engine): simplify child id gen for the durable path

### DIFF
--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -1248,7 +1248,10 @@ func (s *DispatcherImpl) sendStepActionEventV1(ctx context.Context, request *con
 		return nil, status.Errorf(codes.InvalidArgument, "invalid task external run id %s: %v", request.TaskRunExternalId, err)
 	}
 
-	task, err := s.repov1.Tasks().GetTaskForActionEvent(ctx, tenant.ID, taskExternalId)
+	// if there's no retry count, we need to read it from the task, so we can't skip the cache
+	skipCache := request.RetryCount == nil
+
+	task, err := s.repov1.Tasks().GetTaskByExternalId(ctx, tenant.ID, taskExternalId, skipCache)
 
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid task external run id %s: %v", request.TaskRunExternalId, err)
@@ -1307,7 +1310,7 @@ func (s *DispatcherImpl) sendStepActionEventV1(ctx context.Context, request *con
 	return nil, status.Errorf(codes.InvalidArgument, "invalid task external run id %s", request.TaskRunExternalId)
 }
 
-func (s *DispatcherImpl) handleTaskStarted(inputCtx context.Context, task *sqlcv1.GetTaskForActionEventRow, retryCount, durableInvocationCount int32, request *contracts.StepActionEvent) (*contracts.ActionEventResponse, error) {
+func (s *DispatcherImpl) handleTaskStarted(inputCtx context.Context, task *sqlcv1.FlattenExternalIdsRow, retryCount, durableInvocationCount int32, request *contracts.StepActionEvent) (*contracts.ActionEventResponse, error) {
 	tenant := inputCtx.Value("tenant").(*sqlcv1.Tenant)
 	tenantId := tenant.ID
 
@@ -1335,7 +1338,7 @@ func (s *DispatcherImpl) handleTaskStarted(inputCtx context.Context, task *sqlcv
 	}, nil
 }
 
-func (s *DispatcherImpl) handleTaskCompleted(inputCtx context.Context, task *sqlcv1.GetTaskForActionEventRow, retryCount int32, durableInvocationCount int32, request *contracts.StepActionEvent) (*contracts.ActionEventResponse, error) {
+func (s *DispatcherImpl) handleTaskCompleted(inputCtx context.Context, task *sqlcv1.FlattenExternalIdsRow, retryCount int32, durableInvocationCount int32, request *contracts.StepActionEvent) (*contracts.ActionEventResponse, error) {
 	ctx := inputCtx
 	tenant := inputCtx.Value("tenant").(*sqlcv1.Tenant)
 	tenantId := tenant.ID
@@ -1392,7 +1395,7 @@ func (s *DispatcherImpl) handleTaskCompleted(inputCtx context.Context, task *sql
 	return resp, nil
 }
 
-func (s *DispatcherImpl) handleTaskFailed(inputCtx context.Context, task *sqlcv1.GetTaskForActionEventRow, retryCount int32, durableInvocationCount int32, request *contracts.StepActionEvent) (*contracts.ActionEventResponse, error) {
+func (s *DispatcherImpl) handleTaskFailed(inputCtx context.Context, task *sqlcv1.FlattenExternalIdsRow, retryCount int32, durableInvocationCount int32, request *contracts.StepActionEvent) (*contracts.ActionEventResponse, error) {
 	tenant := inputCtx.Value("tenant").(*sqlcv1.Tenant)
 	tenantId := tenant.ID
 

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -1242,14 +1242,14 @@ func (s *DispatcherImpl) taskEventsToWorkflowRunEvent(tenantId uuid.UUID, finali
 func (s *DispatcherImpl) sendStepActionEventV1(ctx context.Context, request *contracts.StepActionEvent) (*contracts.ActionEventResponse, error) {
 	tenant := ctx.Value("tenant").(*sqlcv1.Tenant)
 
+	// if there's no retry count, we need to read it from the task, so we can't skip the cache
+	skipCache := request.RetryCount == nil
+
 	taskExternalId, err := uuid.Parse(request.TaskRunExternalId)
 
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid task external run id %s: %v", request.TaskRunExternalId, err)
 	}
-
-	// if there's no retry count, we need to read it from the task, so we can't skip the cache
-	skipCache := request.RetryCount == nil
 
 	task, err := s.repov1.Tasks().GetTaskByExternalId(ctx, tenant.ID, taskExternalId, skipCache)
 

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -1242,15 +1242,13 @@ func (s *DispatcherImpl) taskEventsToWorkflowRunEvent(tenantId uuid.UUID, finali
 func (s *DispatcherImpl) sendStepActionEventV1(ctx context.Context, request *contracts.StepActionEvent) (*contracts.ActionEventResponse, error) {
 	tenant := ctx.Value("tenant").(*sqlcv1.Tenant)
 
-	// if there's no retry count, we need to read it from the task, so we can't skip the cache
-	skipCache := request.RetryCount == nil
 	taskExternalId, err := uuid.Parse(request.TaskRunExternalId)
 
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid task external run id %s: %v", request.TaskRunExternalId, err)
 	}
 
-	task, err := s.getSingleTask(ctx, tenant.ID, taskExternalId, skipCache)
+	task, err := s.repov1.Tasks().GetTaskForActionEvent(ctx, tenant.ID, taskExternalId)
 
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid task external run id %s: %v", request.TaskRunExternalId, err)
@@ -1278,12 +1276,15 @@ func (s *DispatcherImpl) sendStepActionEventV1(ctx context.Context, request *con
 	}
 
 	var durableInvCount int32
-	invocationCounts, err := s.repov1.DurableEvents().GetDurableTaskInvocationCounts(ctx, tenant.ID, []v1.IdInsertedAt{
-		{ID: task.ID, InsertedAt: task.InsertedAt},
-	})
-	if err == nil {
-		if count, ok := invocationCounts[v1.IdInsertedAt{ID: task.ID, InsertedAt: task.InsertedAt}]; ok && count != nil {
-			durableInvCount = *count
+
+	if task.IsDurable.Bool {
+		invocationCounts, err := s.repov1.DurableEvents().GetDurableTaskInvocationCounts(ctx, tenant.ID, []v1.IdInsertedAt{
+			{ID: task.ID, InsertedAt: task.InsertedAt},
+		})
+		if err == nil {
+			if count, ok := invocationCounts[v1.IdInsertedAt{ID: task.ID, InsertedAt: task.InsertedAt}]; ok && count != nil {
+				durableInvCount = *count
+			}
 		}
 	}
 
@@ -1306,7 +1307,7 @@ func (s *DispatcherImpl) sendStepActionEventV1(ctx context.Context, request *con
 	return nil, status.Errorf(codes.InvalidArgument, "invalid task external run id %s", request.TaskRunExternalId)
 }
 
-func (s *DispatcherImpl) handleTaskStarted(inputCtx context.Context, task *sqlcv1.FlattenExternalIdsRow, retryCount, durableInvocationCount int32, request *contracts.StepActionEvent) (*contracts.ActionEventResponse, error) {
+func (s *DispatcherImpl) handleTaskStarted(inputCtx context.Context, task *sqlcv1.GetTaskForActionEventRow, retryCount, durableInvocationCount int32, request *contracts.StepActionEvent) (*contracts.ActionEventResponse, error) {
 	tenant := inputCtx.Value("tenant").(*sqlcv1.Tenant)
 	tenantId := tenant.ID
 
@@ -1334,7 +1335,7 @@ func (s *DispatcherImpl) handleTaskStarted(inputCtx context.Context, task *sqlcv
 	}, nil
 }
 
-func (s *DispatcherImpl) handleTaskCompleted(inputCtx context.Context, task *sqlcv1.FlattenExternalIdsRow, retryCount int32, durableInvocationCount int32, request *contracts.StepActionEvent) (*contracts.ActionEventResponse, error) {
+func (s *DispatcherImpl) handleTaskCompleted(inputCtx context.Context, task *sqlcv1.GetTaskForActionEventRow, retryCount int32, durableInvocationCount int32, request *contracts.StepActionEvent) (*contracts.ActionEventResponse, error) {
 	ctx := inputCtx
 	tenant := inputCtx.Value("tenant").(*sqlcv1.Tenant)
 	tenantId := tenant.ID
@@ -1391,7 +1392,7 @@ func (s *DispatcherImpl) handleTaskCompleted(inputCtx context.Context, task *sql
 	return resp, nil
 }
 
-func (s *DispatcherImpl) handleTaskFailed(inputCtx context.Context, task *sqlcv1.FlattenExternalIdsRow, retryCount int32, durableInvocationCount int32, request *contracts.StepActionEvent) (*contracts.ActionEventResponse, error) {
+func (s *DispatcherImpl) handleTaskFailed(inputCtx context.Context, task *sqlcv1.GetTaskForActionEventRow, retryCount int32, durableInvocationCount int32, request *contracts.StepActionEvent) (*contracts.ActionEventResponse, error) {
 	tenant := inputCtx.Value("tenant").(*sqlcv1.Tenant)
 	tenantId := tenant.ID
 
@@ -1830,10 +1831,6 @@ func (s *DispatcherImpl) handleBatchTaskCancelled(
 	}
 
 	return resp, nil
-}
-
-func (d *DispatcherImpl) getSingleTask(ctx context.Context, tenantId, taskExternalId uuid.UUID, skipCache bool) (*sqlcv1.FlattenExternalIdsRow, error) {
-	return d.repov1.Tasks().GetTaskByExternalId(ctx, tenantId, taskExternalId, skipCache)
 }
 
 func (d *DispatcherImpl) refreshTimeoutV1(ctx context.Context, tenant *sqlcv1.Tenant, request *contracts.RefreshTimeoutRequest) (*contracts.RefreshTimeoutResponse, error) {

--- a/internal/services/ingestor/server_v1.go
+++ b/internal/services/ingestor/server_v1.go
@@ -27,7 +27,7 @@ func (i *IngestorImpl) putStreamEventV1(ctx context.Context, tenant *sqlcv1.Tena
 	}
 
 	// get single task
-	task, err := i.getSingleTask(ctx, tenantId, taskExternalId, false)
+	task, err := i.repov1.Tasks().GetTaskByExternalId(ctx, tenantId, taskExternalId, false)
 
 	if err != nil {
 		return nil, err
@@ -61,10 +61,6 @@ func (i *IngestorImpl) putStreamEventV1(ctx context.Context, tenant *sqlcv1.Tena
 	return &contracts.PutStreamEventResponse{}, nil
 }
 
-func (i *IngestorImpl) getSingleTask(ctx context.Context, tenantId, taskExternalId uuid.UUID, skipCache bool) (*sqlcv1.FlattenExternalIdsRow, error) {
-	return i.repov1.Tasks().GetTaskByExternalId(ctx, tenantId, taskExternalId, skipCache)
-}
-
 func (i *IngestorImpl) putLogV1(ctx context.Context, tenant *sqlcv1.Tenant, req *contracts.PutLogRequest) (*contracts.PutLogResponse, error) {
 	tenantId := tenant.ID
 	taskExternalId, err := uuid.Parse(req.TaskRunExternalId)
@@ -77,7 +73,7 @@ func (i *IngestorImpl) putLogV1(ctx context.Context, tenant *sqlcv1.Tenant, req 
 		return &contracts.PutLogResponse{}, nil
 	}
 
-	task, err := i.getSingleTask(ctx, tenantId, taskExternalId, false)
+	task, err := i.repov1.Tasks().GetTaskByExternalId(ctx, tenantId, taskExternalId, false)
 
 	if err != nil {
 		return nil, err

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -1238,6 +1238,81 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 	}, nil
 }
 
+func (r *durableEventsRepository) resolveChildExternalIds(ctx context.Context, tx sqlcv1.DBTX, tenantId uuid.UUID, task *sqlcv1.FlattenExternalIdsRow, opts []*WorkflowNameTriggerOpts) error {
+	ctx, span := telemetry.NewSpan(ctx, "resolve-child-external-ids")
+	defer span.End()
+
+	candidateIdByKey := make(map[string]uuid.UUID, len(opts))
+	eventKeys := make([]string, 0, len(opts))
+	childExternalIds := make([]uuid.UUID, 0, len(opts))
+
+	for _, opt := range opts {
+		// without a child index there's nothing to dedupe against, so the child is always new
+		spawnKey := opt.childSpawnKey()
+
+		if spawnKey == "" {
+			opt.ExternalId = uuid.New()
+			continue
+		}
+
+		if _, seen := candidateIdByKey[spawnKey]; seen {
+			continue
+		}
+
+		childExternalId := uuid.New()
+		candidateIdByKey[spawnKey] = childExternalId
+
+		eventKeys = append(eventKeys, spawnKey)
+		childExternalIds = append(childExternalIds, childExternalId)
+	}
+
+	if len(eventKeys) == 0 {
+		return nil
+	}
+
+	rows, err := r.queries.UpsertDurableChildSignalCreatedEvents(ctx, tx, sqlcv1.UpsertDurableChildSignalCreatedEventsParams{
+		Tenantid:              tenantId,
+		Durabletaskid:         task.ID,
+		Durabletaskinsertedat: task.InsertedAt,
+		Eventkeys:             eventKeys,
+		Childexternalids:      childExternalIds,
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to upsert child signal created events: %w", err)
+	}
+
+	resolvedIdByKey := make(map[string]uuid.UUID, len(rows))
+
+	for _, row := range rows {
+		resolvedIdByKey[row.EventKey.String] = *row.ChildExternalID
+	}
+
+	claimed := make(map[string]bool, len(rows))
+
+	for _, opt := range opts {
+		spawnKey := opt.childSpawnKey()
+
+		if spawnKey == "" {
+			continue
+		}
+
+		resolvedId, ok := resolvedIdByKey[spawnKey]
+
+		if !ok {
+			return fmt.Errorf("no child external id resolved for spawn key %s", spawnKey)
+		}
+
+		// this opt spawns the child only if its id won the upsert and no earlier opt in the batch
+		// already claimed it
+		opt.ExternalId = resolvedId
+		opt.ShouldSkip = resolvedId != candidateIdByKey[spawnKey] || claimed[spawnKey]
+		claimed[spawnKey] = true
+	}
+
+	return nil
+}
+
 func (r *durableEventsRepository) appendDurableEventLog(ctx context.Context, opts IngestDurableTaskEventOpts) ([]*EventLogEntryWithPayloads, map[NodeIdBranchIdTuple]*WorkflowNameTriggerOpts, error) {
 	tenantId := opts.TenantId
 	task := opts.Task
@@ -1277,8 +1352,8 @@ func (r *durableEventsRepository) appendDurableEventLog(ctx context.Context, opt
 
 	switch opts.Kind {
 	case sqlcv1.V1DurableEventLogKindRUN:
-		if populateErr := r.populateExternalIdsForWorkflow(ctx, tx, tenantId, opts.TriggerRuns.TriggerOpts); populateErr != nil {
-			return nil, nil, fmt.Errorf("failed to populate external ids for workflow: %w", populateErr)
+		if resolveErr := r.resolveChildExternalIds(ctx, tx, tenantId, task, opts.TriggerRuns.TriggerOpts); resolveErr != nil {
+			return nil, nil, fmt.Errorf("failed to resolve child external ids: %w", resolveErr)
 		}
 
 		innerOpts := make([]GetOrCreateLogEntryOpt, len(opts.TriggerRuns.TriggerOpts))

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -1247,7 +1247,6 @@ func (r *durableEventsRepository) resolveChildExternalIds(ctx context.Context, t
 	childExternalIds := make([]uuid.UUID, 0, len(opts))
 
 	for _, opt := range opts {
-		// without a child index there's nothing to dedupe against, so the child is always new
 		spawnKey := opt.childSpawnKey()
 
 		if spawnKey == "" {
@@ -1303,8 +1302,6 @@ func (r *durableEventsRepository) resolveChildExternalIds(ctx context.Context, t
 			return fmt.Errorf("no child external id resolved for spawn key %s", spawnKey)
 		}
 
-		// this opt spawns the child only if its id won the upsert and no earlier opt in the batch
-		// already claimed it
 		opt.ExternalId = resolvedId
 		opt.ShouldSkip = resolvedId != candidateIdByKey[spawnKey] || claimed[spawnKey]
 		claimed[spawnKey] = true

--- a/pkg/repository/payloadstore.go
+++ b/pkg/repository/payloadstore.go
@@ -186,6 +186,10 @@ func payloadUniqueKeyFromRow(payload *sqlcv1.V1Payload) PayloadUniqueKey {
 }
 
 func (p *payloadStoreRepositoryImpl) Store(ctx context.Context, tx sqlcv1.DBTX, payloads ...StorePayloadOpts) error {
+	if len(payloads) == 0 {
+		return nil
+	}
+
 	taskIds := make([]int64, 0, len(payloads))
 	taskInsertedAts := make([]pgtype.Timestamptz, 0, len(payloads))
 	payloadTypes := make([]string, 0, len(payloads))

--- a/pkg/repository/sqlcv1/durable_event_log.sql
+++ b/pkg/repository/sqlcv1/durable_event_log.sql
@@ -354,3 +354,35 @@ ORDER BY e.branch_id ASC, e.node_id ASC
 OFFSET @eventLogOffset::BIGINT
 LIMIT @eventLogLimit::BIGINT
 ;
+
+-- name: UpsertDurableChildSignalCreatedEvents :many
+WITH input AS (
+    SELECT
+        UNNEST(@eventKeys::TEXT[]) AS event_key,
+        UNNEST(@childExternalIds::UUID[]) AS child_external_id
+)
+
+INSERT INTO v1_task_event (
+    tenant_id,
+    task_id,
+    task_inserted_at,
+    retry_count,
+    event_type,
+    event_key,
+    child_external_id
+)
+SELECT
+    @tenantId::UUID,
+    @durableTaskId::BIGINT,
+    @durableTaskInsertedAt::TIMESTAMPTZ,
+    -1,
+    'SIGNAL_CREATED',
+    i.event_key,
+    i.child_external_id
+FROM input i
+ON CONFLICT (tenant_id, task_id, task_inserted_at, event_type, event_key) WHERE event_key IS NOT NULL
+DO UPDATE SET child_external_id = COALESCE(v1_task_event.child_external_id, EXCLUDED.child_external_id)
+RETURNING
+    v1_task_event.event_key,
+    v1_task_event.child_external_id
+;

--- a/pkg/repository/sqlcv1/durable_event_log.sql.go
+++ b/pkg/repository/sqlcv1/durable_event_log.sql.go
@@ -1218,3 +1218,74 @@ func (q *Queries) UpdateLogFile(ctx context.Context, db DBTX, arg UpdateLogFileP
 	)
 	return &i, err
 }
+
+const upsertDurableChildSignalCreatedEvents = `-- name: UpsertDurableChildSignalCreatedEvents :many
+WITH input AS (
+    SELECT
+        UNNEST($4::TEXT[]) AS event_key,
+        UNNEST($5::UUID[]) AS child_external_id
+)
+
+INSERT INTO v1_task_event (
+    tenant_id,
+    task_id,
+    task_inserted_at,
+    retry_count,
+    event_type,
+    event_key,
+    child_external_id
+)
+SELECT
+    $1::UUID,
+    $2::BIGINT,
+    $3::TIMESTAMPTZ,
+    -1,
+    'SIGNAL_CREATED',
+    i.event_key,
+    i.child_external_id
+FROM input i
+ON CONFLICT (tenant_id, task_id, task_inserted_at, event_type, event_key) WHERE event_key IS NOT NULL
+DO UPDATE SET child_external_id = COALESCE(v1_task_event.child_external_id, EXCLUDED.child_external_id)
+RETURNING
+    v1_task_event.event_key,
+    v1_task_event.child_external_id
+`
+
+type UpsertDurableChildSignalCreatedEventsParams struct {
+	Tenantid              uuid.UUID          `json:"tenantid"`
+	Durabletaskid         int64              `json:"durabletaskid"`
+	Durabletaskinsertedat pgtype.Timestamptz `json:"durabletaskinsertedat"`
+	Eventkeys             []string           `json:"eventkeys"`
+	Childexternalids      []uuid.UUID        `json:"childexternalids"`
+}
+
+type UpsertDurableChildSignalCreatedEventsRow struct {
+	EventKey        pgtype.Text `json:"event_key"`
+	ChildExternalID *uuid.UUID  `json:"child_external_id"`
+}
+
+func (q *Queries) UpsertDurableChildSignalCreatedEvents(ctx context.Context, db DBTX, arg UpsertDurableChildSignalCreatedEventsParams) ([]*UpsertDurableChildSignalCreatedEventsRow, error) {
+	rows, err := db.Query(ctx, upsertDurableChildSignalCreatedEvents,
+		arg.Tenantid,
+		arg.Durabletaskid,
+		arg.Durabletaskinsertedat,
+		arg.Eventkeys,
+		arg.Childexternalids,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*UpsertDurableChildSignalCreatedEventsRow
+	for rows.Next() {
+		var i UpsertDurableChildSignalCreatedEventsRow
+		if err := rows.Scan(&i.EventKey, &i.ChildExternalID); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/pkg/repository/sqlcv1/tasks.sql
+++ b/pkg/repository/sqlcv1/tasks.sql
@@ -216,28 +216,6 @@ WHERE
     AND l.tenant_id = @tenantId::uuid
 ;
 
--- name: GetTaskForActionEvent :one
--- Narrow lookup for the dispatcher's step action event path, which is the hottest path in
--- the engine and needs only identifiers plus retry_count / is_durable. The external id on
--- an action event is always a task external id, so this can hit v1_lookup_table's task
--- branch directly and skip the FlattenExternalIds union and its join through
--- v1_dag_to_task.
-SELECT
-    t.id,
-    t.inserted_at,
-    t.external_id,
-    t.workflow_run_id,
-    t.retry_count,
-    t.is_durable
-FROM
-    v1_lookup_table l
-JOIN
-    v1_task t ON t.id = l.task_id AND t.inserted_at = l.inserted_at
-WHERE
-    l.external_id = @externalId::uuid
-    AND l.tenant_id = @tenantId::uuid
-    AND l.task_id IS NOT NULL;
-
 -- name: LookupExternalIds :many
 SELECT
     *

--- a/pkg/repository/sqlcv1/tasks.sql
+++ b/pkg/repository/sqlcv1/tasks.sql
@@ -164,7 +164,8 @@ WITH lookup_rows AS (
         t.step_readable_id,
         l.external_id AS workflow_run_external_id,
         t.workflow_id,
-        t.step_id
+        t.step_id,
+        t.is_durable
     FROM
         lookup_rows l
     JOIN
@@ -190,7 +191,8 @@ SELECT
     t.step_readable_id,
     t.external_id AS workflow_run_external_id,
     t.workflow_id,
-    t.step_id
+    t.step_id,
+    t.is_durable
 FROM
     lookup_rows l
 JOIN
@@ -204,6 +206,28 @@ SELECT
     *
 FROM
     tasks_from_dags;
+
+-- name: GetTaskForActionEvent :one
+-- Narrow lookup for the dispatcher's step action event path, which is the hottest path in
+-- the engine and needs only identifiers plus retry_count / is_durable. The external id on
+-- an action event is always a task external id, so this can hit v1_lookup_table's task
+-- branch directly and skip the FlattenExternalIds union and its join through
+-- v1_dag_to_task.
+SELECT
+    t.id,
+    t.inserted_at,
+    t.external_id,
+    t.workflow_run_id,
+    t.retry_count,
+    t.is_durable
+FROM
+    v1_lookup_table l
+JOIN
+    v1_task t ON t.id = l.task_id AND t.inserted_at = l.inserted_at
+WHERE
+    l.external_id = @externalId::uuid
+    AND l.tenant_id = @tenantId::uuid
+    AND l.task_id IS NOT NULL;
 
 -- name: LookupExternalIds :many
 SELECT

--- a/pkg/repository/sqlcv1/tasks.sql
+++ b/pkg/repository/sqlcv1/tasks.sql
@@ -207,6 +207,15 @@ SELECT
 FROM
     tasks_from_dags;
 
+-- name: GetTaskByExternalId :one
+SELECT t.*
+FROM v1_lookup_table l
+JOIN v1_task t ON t.id = l.task_id AND t.inserted_at = l.inserted_at
+WHERE
+    l.external_id = @externalId::uuid
+    AND l.tenant_id = @tenantId::uuid
+;
+
 -- name: GetTaskForActionEvent :one
 -- Narrow lookup for the dispatcher's step action event path, which is the hottest path in
 -- the engine and needs only identifiers plus retry_count / is_durable. The external id on

--- a/pkg/repository/sqlcv1/tasks.sql.go
+++ b/pkg/repository/sqlcv1/tasks.sql.go
@@ -897,6 +897,71 @@ func (q *Queries) FlattenExternalIds(ctx context.Context, db DBTX, arg FlattenEx
 	return items, nil
 }
 
+const getTaskByExternalId = `-- name: GetTaskByExternalId :one
+SELECT t.id, t.inserted_at, t.tenant_id, t.queue, t.action_id, t.step_id, t.step_readable_id, t.workflow_id, t.workflow_version_id, t.workflow_run_id, t.schedule_timeout, t.step_timeout, t.priority, t.sticky, t.desired_worker_id, t.external_id, t.display_name, t.input, t.retry_count, t.internal_retry_count, t.app_retry_count, t.step_index, t.additional_metadata, t.dag_id, t.dag_inserted_at, t.parent_task_external_id, t.parent_task_id, t.parent_task_inserted_at, t.child_index, t.child_key, t.initial_state, t.initial_state_reason, t.concurrency_parent_strategy_ids, t.concurrency_strategy_ids, t.concurrency_keys, t.batch_key, t.retry_backoff_factor, t.retry_max_backoff, t.is_durable, t.desired_worker_label, t.triggering_event_external_id, t.triggering_event_key, t.idempotency_key
+FROM v1_lookup_table l
+JOIN v1_task t ON t.id = l.task_id AND t.inserted_at = l.inserted_at
+WHERE
+    l.external_id = $1::uuid
+    AND l.tenant_id = $2::uuid
+`
+
+type GetTaskByExternalIdParams struct {
+	Externalid uuid.UUID `json:"externalid"`
+	Tenantid   uuid.UUID `json:"tenantid"`
+}
+
+func (q *Queries) GetTaskByExternalId(ctx context.Context, db DBTX, arg GetTaskByExternalIdParams) (*V1Task, error) {
+	row := db.QueryRow(ctx, getTaskByExternalId, arg.Externalid, arg.Tenantid)
+	var i V1Task
+	err := row.Scan(
+		&i.ID,
+		&i.InsertedAt,
+		&i.TenantID,
+		&i.Queue,
+		&i.ActionID,
+		&i.StepID,
+		&i.StepReadableID,
+		&i.WorkflowID,
+		&i.WorkflowVersionID,
+		&i.WorkflowRunID,
+		&i.ScheduleTimeout,
+		&i.StepTimeout,
+		&i.Priority,
+		&i.Sticky,
+		&i.DesiredWorkerID,
+		&i.ExternalID,
+		&i.DisplayName,
+		&i.Input,
+		&i.RetryCount,
+		&i.InternalRetryCount,
+		&i.AppRetryCount,
+		&i.StepIndex,
+		&i.AdditionalMetadata,
+		&i.DagID,
+		&i.DagInsertedAt,
+		&i.ParentTaskExternalID,
+		&i.ParentTaskID,
+		&i.ParentTaskInsertedAt,
+		&i.ChildIndex,
+		&i.ChildKey,
+		&i.InitialState,
+		&i.InitialStateReason,
+		&i.ConcurrencyParentStrategyIds,
+		&i.ConcurrencyStrategyIds,
+		&i.ConcurrencyKeys,
+		&i.BatchKey,
+		&i.RetryBackoffFactor,
+		&i.RetryMaxBackoff,
+		&i.IsDurable,
+		&i.DesiredWorkerLabel,
+		&i.TriggeringEventExternalID,
+		&i.TriggeringEventKey,
+		&i.IdempotencyKey,
+	)
+	return &i, err
+}
+
 const getTaskForActionEvent = `-- name: GetTaskForActionEvent :one
 SELECT
     t.id,

--- a/pkg/repository/sqlcv1/tasks.sql.go
+++ b/pkg/repository/sqlcv1/tasks.sql.go
@@ -792,7 +792,8 @@ WITH lookup_rows AS (
         t.step_readable_id,
         l.external_id AS workflow_run_external_id,
         t.workflow_id,
-        t.step_id
+        t.step_id,
+        t.is_durable
     FROM
         lookup_rows l
     JOIN
@@ -817,7 +818,8 @@ SELECT
     t.step_readable_id,
     t.external_id AS workflow_run_external_id,
     t.workflow_id,
-    t.step_id
+    t.step_id,
+    t.is_durable
 FROM
     lookup_rows l
 JOIN
@@ -828,7 +830,7 @@ WHERE
 UNION ALL
 
 SELECT
-    id, inserted_at, retry_count, external_id, workflow_run_id, additional_metadata, dag_id, dag_inserted_at, parent_task_id, child_index, child_key, step_readable_id, workflow_run_external_id, workflow_id, step_id
+    id, inserted_at, retry_count, external_id, workflow_run_id, additional_metadata, dag_id, dag_inserted_at, parent_task_id, child_index, child_key, step_readable_id, workflow_run_external_id, workflow_id, step_id, is_durable
 FROM
     tasks_from_dags
 `
@@ -854,6 +856,7 @@ type FlattenExternalIdsRow struct {
 	WorkflowRunExternalID uuid.UUID          `json:"workflow_run_external_id"`
 	WorkflowID            uuid.UUID          `json:"workflow_id"`
 	StepID                uuid.UUID          `json:"step_id"`
+	IsDurable             pgtype.Bool        `json:"is_durable"`
 }
 
 // Union the tasks from the lookup table with the tasks from the DAGs
@@ -882,6 +885,7 @@ func (q *Queries) FlattenExternalIds(ctx context.Context, db DBTX, arg FlattenEx
 			&i.WorkflowRunExternalID,
 			&i.WorkflowID,
 			&i.StepID,
+			&i.IsDurable,
 		); err != nil {
 			return nil, err
 		}
@@ -891,6 +895,57 @@ func (q *Queries) FlattenExternalIds(ctx context.Context, db DBTX, arg FlattenEx
 		return nil, err
 	}
 	return items, nil
+}
+
+const getTaskForActionEvent = `-- name: GetTaskForActionEvent :one
+SELECT
+    t.id,
+    t.inserted_at,
+    t.external_id,
+    t.workflow_run_id,
+    t.retry_count,
+    t.is_durable
+FROM
+    v1_lookup_table l
+JOIN
+    v1_task t ON t.id = l.task_id AND t.inserted_at = l.inserted_at
+WHERE
+    l.external_id = $1::uuid
+    AND l.tenant_id = $2::uuid
+    AND l.task_id IS NOT NULL
+`
+
+type GetTaskForActionEventParams struct {
+	Externalid uuid.UUID `json:"externalid"`
+	Tenantid   uuid.UUID `json:"tenantid"`
+}
+
+type GetTaskForActionEventRow struct {
+	ID            int64              `json:"id"`
+	InsertedAt    pgtype.Timestamptz `json:"inserted_at"`
+	ExternalID    uuid.UUID          `json:"external_id"`
+	WorkflowRunID uuid.UUID          `json:"workflow_run_id"`
+	RetryCount    int32              `json:"retry_count"`
+	IsDurable     pgtype.Bool        `json:"is_durable"`
+}
+
+// Narrow lookup for the dispatcher's step action event path, which is the hottest path in
+// the engine and needs only identifiers plus retry_count / is_durable. The external id on
+// an action event is always a task external id, so this can hit v1_lookup_table's task
+// branch directly and skip the FlattenExternalIds union and its join through
+// v1_dag_to_task.
+func (q *Queries) GetTaskForActionEvent(ctx context.Context, db DBTX, arg GetTaskForActionEventParams) (*GetTaskForActionEventRow, error) {
+	row := db.QueryRow(ctx, getTaskForActionEvent, arg.Externalid, arg.Tenantid)
+	var i GetTaskForActionEventRow
+	err := row.Scan(
+		&i.ID,
+		&i.InsertedAt,
+		&i.ExternalID,
+		&i.WorkflowRunID,
+		&i.RetryCount,
+		&i.IsDurable,
+	)
+	return &i, err
 }
 
 const getTenantTaskStats = `-- name: GetTenantTaskStats :many

--- a/pkg/repository/sqlcv1/tasks.sql.go
+++ b/pkg/repository/sqlcv1/tasks.sql.go
@@ -962,57 +962,6 @@ func (q *Queries) GetTaskByExternalId(ctx context.Context, db DBTX, arg GetTaskB
 	return &i, err
 }
 
-const getTaskForActionEvent = `-- name: GetTaskForActionEvent :one
-SELECT
-    t.id,
-    t.inserted_at,
-    t.external_id,
-    t.workflow_run_id,
-    t.retry_count,
-    t.is_durable
-FROM
-    v1_lookup_table l
-JOIN
-    v1_task t ON t.id = l.task_id AND t.inserted_at = l.inserted_at
-WHERE
-    l.external_id = $1::uuid
-    AND l.tenant_id = $2::uuid
-    AND l.task_id IS NOT NULL
-`
-
-type GetTaskForActionEventParams struct {
-	Externalid uuid.UUID `json:"externalid"`
-	Tenantid   uuid.UUID `json:"tenantid"`
-}
-
-type GetTaskForActionEventRow struct {
-	ID            int64              `json:"id"`
-	InsertedAt    pgtype.Timestamptz `json:"inserted_at"`
-	ExternalID    uuid.UUID          `json:"external_id"`
-	WorkflowRunID uuid.UUID          `json:"workflow_run_id"`
-	RetryCount    int32              `json:"retry_count"`
-	IsDurable     pgtype.Bool        `json:"is_durable"`
-}
-
-// Narrow lookup for the dispatcher's step action event path, which is the hottest path in
-// the engine and needs only identifiers plus retry_count / is_durable. The external id on
-// an action event is always a task external id, so this can hit v1_lookup_table's task
-// branch directly and skip the FlattenExternalIds union and its join through
-// v1_dag_to_task.
-func (q *Queries) GetTaskForActionEvent(ctx context.Context, db DBTX, arg GetTaskForActionEventParams) (*GetTaskForActionEventRow, error) {
-	row := db.QueryRow(ctx, getTaskForActionEvent, arg.Externalid, arg.Tenantid)
-	var i GetTaskForActionEventRow
-	err := row.Scan(
-		&i.ID,
-		&i.InsertedAt,
-		&i.ExternalID,
-		&i.WorkflowRunID,
-		&i.RetryCount,
-		&i.IsDurable,
-	)
-	return &i, err
-}
-
 const getTenantTaskStats = `-- name: GetTenantTaskStats :many
 WITH queued_tasks AS (
     SELECT

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -255,6 +255,10 @@ type TaskRepository interface {
 	// GetTaskByExternalId is a heavily cached method to return task metadata by its external id
 	GetTaskByExternalId(ctx context.Context, tenantId, taskExternalId uuid.UUID, skipCache bool) (*sqlcv1.FlattenExternalIdsRow, error)
 
+	// GetTaskForActionEvent returns the subset of task metadata needed to handle a step action
+	// event. It exists so the dispatcher's hottest path can avoid the FlattenExternalIds union.
+	GetTaskForActionEvent(ctx context.Context, tenantId, taskExternalId uuid.UUID) (*sqlcv1.GetTaskForActionEventRow, error)
+
 	// FlattenExternalIds is a non-cached method to look up all tasks in a workflow run by their external ids.
 	// This is non-cacheable because tasks can be added to a workflow run as it executes.
 	FlattenExternalIds(ctx context.Context, tenantId uuid.UUID, externalIds []uuid.UUID) ([]*sqlcv1.FlattenExternalIdsRow, error)
@@ -569,6 +573,22 @@ func (r *sharedRepository) GetTaskByExternalId(ctx context.Context, tenantId, ta
 	r.taskLookupCache.Add(key, res)
 
 	return res, nil
+}
+
+func (r *sharedRepository) GetTaskForActionEvent(ctx context.Context, tenantId, taskExternalId uuid.UUID) (*sqlcv1.GetTaskForActionEventRow, error) {
+	ctx, span := telemetry.NewSpan(ctx, "TaskRepositoryImpl.GetTaskForActionEvent")
+	defer span.End()
+
+	task, err := r.queries.GetTaskForActionEvent(ctx, r.pool, sqlcv1.GetTaskForActionEventParams{
+		Externalid: taskExternalId,
+		Tenantid:   tenantId,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return task, nil
 }
 
 func (r *TaskRepositoryImpl) FlattenExternalIds(ctx context.Context, tenantId uuid.UUID, externalIds []uuid.UUID) ([]*sqlcv1.FlattenExternalIdsRow, error) {

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -525,7 +525,6 @@ func (r *TaskRepositoryImpl) UpdateTablePartitions(ctx context.Context) error {
 }
 
 func (r *sharedRepository) GetTaskByExternalId(ctx context.Context, tenantId, taskExternalId uuid.UUID, skipCache bool) (*sqlcv1.FlattenExternalIdsRow, error) {
-
 	ctx, span := telemetry.NewSpan(ctx, "TaskRepositoryImpl.GetTaskByExternalId")
 	defer span.End()
 
@@ -545,34 +544,42 @@ func (r *sharedRepository) GetTaskByExternalId(ctx context.Context, tenantId, ta
 	span.SetAttributes(attribute.Bool("cache_hit", false))
 
 	// lookup the task
-	dbTasks, err := r.queries.FlattenExternalIds(ctx, r.pool, sqlcv1.FlattenExternalIdsParams{
-		Tenantid:    tenantId,
-		Externalids: []uuid.UUID{taskExternalId},
+	res, err := r.queries.GetTaskByExternalId(ctx, r.pool, sqlcv1.GetTaskByExternalIdParams{
+		Tenantid:   tenantId,
+		Externalid: taskExternalId,
 	})
 
 	if err != nil {
 		return nil, err
 	}
 
-	if len(dbTasks) == 0 {
-		return nil, pgx.ErrNoRows
-	}
-
-	if len(dbTasks) > 1 {
-		return nil, fmt.Errorf("found more than one task for %s", taskExternalId)
-	}
-
-	// set the cache
-	res := dbTasks[0]
-
 	key := taskExternalIdTenantIdTuple{
 		externalId: taskExternalId,
 		tenantId:   tenantId,
 	}
 
-	r.taskLookupCache.Add(key, res)
+	row := sqlcv1.FlattenExternalIdsRow{
+		ID:                    res.ID,
+		InsertedAt:            res.InsertedAt,
+		RetryCount:            res.RetryCount,
+		ExternalID:            res.ExternalID,
+		WorkflowRunID:         res.WorkflowRunID,
+		AdditionalMetadata:    res.AdditionalMetadata,
+		DagID:                 res.DagID,
+		DagInsertedAt:         res.DagInsertedAt,
+		ParentTaskID:          res.ParentTaskID,
+		ChildIndex:            res.ChildIndex,
+		ChildKey:              res.ChildKey,
+		StepReadableID:        res.StepReadableID,
+		WorkflowRunExternalID: res.WorkflowRunID,
+		WorkflowID:            res.WorkflowID,
+		StepID:                res.StepID,
+		IsDurable:             res.IsDurable,
+	}
 
-	return res, nil
+	r.taskLookupCache.Add(key, &row)
+
+	return &row, nil
 }
 
 func (r *sharedRepository) GetTaskForActionEvent(ctx context.Context, tenantId, taskExternalId uuid.UUID) (*sqlcv1.GetTaskForActionEventRow, error) {

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -255,10 +255,6 @@ type TaskRepository interface {
 	// GetTaskByExternalId is a heavily cached method to return task metadata by its external id
 	GetTaskByExternalId(ctx context.Context, tenantId, taskExternalId uuid.UUID, skipCache bool) (*sqlcv1.FlattenExternalIdsRow, error)
 
-	// GetTaskForActionEvent returns the subset of task metadata needed to handle a step action
-	// event. It exists so the dispatcher's hottest path can avoid the FlattenExternalIds union.
-	GetTaskForActionEvent(ctx context.Context, tenantId, taskExternalId uuid.UUID) (*sqlcv1.GetTaskForActionEventRow, error)
-
 	// FlattenExternalIds is a non-cached method to look up all tasks in a workflow run by their external ids.
 	// This is non-cacheable because tasks can be added to a workflow run as it executes.
 	FlattenExternalIds(ctx context.Context, tenantId uuid.UUID, externalIds []uuid.UUID) ([]*sqlcv1.FlattenExternalIdsRow, error)
@@ -580,22 +576,6 @@ func (r *sharedRepository) GetTaskByExternalId(ctx context.Context, tenantId, ta
 	r.taskLookupCache.Add(key, &row)
 
 	return &row, nil
-}
-
-func (r *sharedRepository) GetTaskForActionEvent(ctx context.Context, tenantId, taskExternalId uuid.UUID) (*sqlcv1.GetTaskForActionEventRow, error) {
-	ctx, span := telemetry.NewSpan(ctx, "TaskRepositoryImpl.GetTaskForActionEvent")
-	defer span.End()
-
-	task, err := r.queries.GetTaskForActionEvent(ctx, r.pool, sqlcv1.GetTaskForActionEventParams{
-		Externalid: taskExternalId,
-		Tenantid:   tenantId,
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return task, nil
 }
 
 func (r *TaskRepositoryImpl) FlattenExternalIds(ctx context.Context, tenantId uuid.UUID, externalIds []uuid.UUID) ([]*sqlcv1.FlattenExternalIdsRow, error) {


### PR DESCRIPTION
# Description

Moves some unnecessary database i/o off of the durable path for child id generation. Previously, we were locking the task, looking up a row in the lookup table, etc., none of which we really needed to be doing. Should help shed some more load from the db / get rid of some more locking

## Type of change

- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude Opus for code review to make sure I didn't mess anything up

</details>
