### PR TITLE
fix: Small FE fixes for viewer role/tenant moving

### DIFF
--- a/frontend/app/src/pages/main/v1/managed-workers/components/billing-required.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/components/billing-required.tsx
@@ -1,4 +1,6 @@
 import { Button } from '@/components/v1/ui/button';
+import useCanWrite from '@/hooks/use-can-write';
+import { useOrganizations } from '@/hooks/use-organizations';
 import { useCurrentTenantId } from '@/hooks/use-tenant';
 import { Tenant } from '@/lib/api';
 import { BillingContext } from '@/lib/atoms';
@@ -23,6 +25,10 @@ export function BillingRequired({
   portalLoading,
 }: BillingRequiredProps) {
   const { tenantId } = useCurrentTenantId();
+  const canWrite = useCanWrite();
+  const { getOrganizationForTenant } = useOrganizations();
+  const isOrganizationOwner =
+    getOrganizationForTenant(tenantId)?.isOwner ?? false;
 
   return (
     <div className="h-full w-full flex-grow">
@@ -88,39 +94,55 @@ export function BillingRequired({
             </div>
 
             <div className="flex w-full flex-col gap-4">
-              <Button
-                onClick={manageClicked}
-                disabled={portalLoading}
-                className="min-w-40 px-8 py-6 text-base"
-                size="lg"
-              >
-                {portalLoading ? 'Loading...' : 'Set Up Billing →'}
-              </Button>
+              {canWrite ? (
+                <>
+                  {isOrganizationOwner ? (
+                    <Button
+                      onClick={manageClicked}
+                      disabled={portalLoading}
+                      className="min-w-40 px-8 py-6 text-base"
+                      size="lg"
+                    >
+                      {portalLoading ? 'Loading...' : 'Set Up Billing →'}
+                    </Button>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      Only the organization owner can set up billing. Ask your
+                      organization owner, or deploy a free demo template below.
+                    </p>
+                  )}
 
-              <div className="relative">
-                <div className="absolute inset-0 flex items-center">
-                  <span className="w-full border-t" />
-                </div>
-                <div className="relative flex justify-center text-xs uppercase">
-                  <span className="bg-card px-2 text-muted-foreground">
-                    Not ready yet?
-                  </span>
-                </div>
-              </div>
+                  <div className="relative">
+                    <div className="absolute inset-0 flex items-center">
+                      <span className="w-full border-t" />
+                    </div>
+                    <div className="relative flex justify-center text-xs uppercase">
+                      <span className="bg-card px-2 text-muted-foreground">
+                        Not ready yet?
+                      </span>
+                    </div>
+                  </div>
 
-              <Link
-                to={appRoutes.tenantManagedWorkersTemplateRoute.to}
-                params={{ tenant: tenantId }}
-                className="w-full"
-              >
-                <Button
-                  variant="outline"
-                  className="w-full min-w-40 px-8 py-6 text-base"
-                  size="lg"
-                >
-                  Deploy a Demo Template for Free
-                </Button>
-              </Link>
+                  <Link
+                    to={appRoutes.tenantManagedWorkersTemplateRoute.to}
+                    params={{ tenant: tenantId }}
+                    className="w-full"
+                  >
+                    <Button
+                      variant="outline"
+                      className="w-full min-w-40 px-8 py-6 text-base"
+                      size="lg"
+                    >
+                      Deploy a Demo Template for Free
+                    </Button>
+                  </Link>
+                </>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  You must be an owner, admin, or member of this tenant to set
+                  up Managed Compute. Contact a tenant admin if you need access.
+                </p>
+              )}
 
               <div className="relative mt-4">
                 <div className="absolute inset-0 flex items-center">

--- a/frontend/app/src/pages/main/v1/managed-workers/components/require-write-access.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/components/require-write-access.tsx
@@ -1,0 +1,32 @@
+import { Button } from '@/components/v1/ui/button';
+import useCanWrite from '@/hooks/use-can-write';
+import { ErrorPageLayout } from '@/pages/error/components/layout';
+import { Lock, Undo2 } from 'lucide-react';
+import { PropsWithChildren } from 'react';
+
+export function RequireManagedComputeWriteAccess({
+  children,
+}: PropsWithChildren) {
+  const canWrite = useCanWrite();
+
+  if (canWrite) {
+    return <>{children}</>;
+  }
+
+  return (
+    <ErrorPageLayout
+      icon={<Lock className="h-5 w-5" />}
+      title="You don't have access to set up Managed Compute"
+      description="You must be an owner, admin, or member of this tenant to set up Managed Compute. Contact a tenant admin if you need access."
+      actions={
+        <Button
+          leftIcon={<Undo2 className="h-4 w-4" />}
+          variant="outline"
+          onClick={() => window.history.back()}
+        >
+          Go back
+        </Button>
+      }
+    />
+  );
+}

--- a/frontend/app/src/pages/main/v1/managed-workers/create/index.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/create/index.tsx
@@ -1,5 +1,6 @@
 import { BillingRequired } from '../components/billing-required';
 import { ManagedWorkersGate } from '../components/managed-workers-gate';
+import { RequireManagedComputeWriteAccess } from '../components/require-write-access';
 import CreateWorkerForm from './components/create-worker-form';
 import { Separator } from '@/components/v1/ui/separator';
 import { useCurrentTenantId, useTenantDetails } from '@/hooks/use-tenant';
@@ -100,7 +101,9 @@ function CreateWorkerImpl() {
 export default function CreateWorker() {
   return (
     <ManagedWorkersGate>
-      <CreateWorkerImpl />
+      <RequireManagedComputeWriteAccess>
+        <CreateWorkerImpl />
+      </RequireManagedComputeWriteAccess>
     </ManagedWorkersGate>
   );
 }

--- a/frontend/app/src/pages/main/v1/managed-workers/demo-template/index.tsx
+++ b/frontend/app/src/pages/main/v1/managed-workers/demo-template/index.tsx
@@ -1,4 +1,5 @@
 import { ManagedWorkersGate } from '../components/managed-workers-gate';
+import { RequireManagedComputeWriteAccess } from '../components/require-write-access';
 import { Button } from '@/components/v1/ui/button';
 import { Card } from '@/components/v1/ui/card';
 import { CodeHighlighter } from '@/components/v1/ui/code-highlighter';
@@ -940,7 +941,9 @@ func main() {
 export default function DemoTemplate() {
   return (
     <ManagedWorkersGate>
-      <DemoTemplateImpl />
+      <RequireManagedComputeWriteAccess>
+        <DemoTemplateImpl />
+      </RequireManagedComputeWriteAccess>
     </ManagedWorkersGate>
   );
 }

--- a/frontend/app/src/pages/organizations/$organization/components/transfer-tenant-modal.tsx
+++ b/frontend/app/src/pages/organizations/$organization/components/transfer-tenant-modal.tsx
@@ -166,10 +166,13 @@ export function TransferTenantModal({
               ) : previewQuery.data && previewQuery.data.rows.length > 0 ? (
                 <>
                   <p className="mb-2">
-                    {previewQuery.data.rows.length} users
-                    {previewQuery.data.rows.length !== 1 ? 's' : ''} currently
-                    have access to <strong>{tenantName}</strong> and will be
-                    added to <strong>{selectedOrgName}</strong> as members:
+                    {previewQuery.data.rows.length} user
+                    {previewQuery.data.rows.length !== 1
+                      ? 's'
+                      : ''} currently{' '}
+                    {previewQuery.data.rows.length !== 1 ? 'have' : 'has'}{' '}
+                    access to <strong>{tenantName}</strong> and will be added to{' '}
+                    <strong>{selectedOrgName}</strong> as members:
                   </p>
                   <ul className="list-inside list-disc space-y-0.5">
                     {previewQuery.data.rows.map((member) => (

--- a/frontend/app/src/pages/organizations/$organization/components/transfer-tenant-modal.tsx
+++ b/frontend/app/src/pages/organizations/$organization/components/transfer-tenant-modal.tsx
@@ -172,7 +172,8 @@ export function TransferTenantModal({
                       : ''} currently{' '}
                     {previewQuery.data.rows.length !== 1 ? 'have' : 'has'}{' '}
                     access to <strong>{tenantName}</strong> and will be added to{' '}
-                    <strong>{selectedOrgName}</strong> as members:
+                    <strong>{selectedOrgName}</strong> as member
+                    {previewQuery.data.rows.length !== 1 ? 's' : ''}::
                   </p>
                   <ul className="list-inside list-disc space-y-0.5">
                     {previewQuery.data.rows.map((member) => (

--- a/frontend/app/src/pages/organizations/$organization/components/transfer-tenant-modal.tsx
+++ b/frontend/app/src/pages/organizations/$organization/components/transfer-tenant-modal.tsx
@@ -172,8 +172,7 @@ export function TransferTenantModal({
                       : ''} currently{' '}
                     {previewQuery.data.rows.length !== 1 ? 'have' : 'has'}{' '}
                     access to <strong>{tenantName}</strong> and will be added to{' '}
-                    <strong>{selectedOrgName}</strong> as member
-                    {previewQuery.data.rows.length !== 1 ? 's' : ''}::
+                    <strong>{selectedOrgName}</strong>
                   </p>
                   <ul className="list-inside list-disc space-y-0.5">
                     {previewQuery.data.rows.map((member) => (


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

VIEWER role was able to see but not interact with the managed compute panel. Tenant move had wrong pluralization in dialog.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [ ] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
