### PR TITLE
docs: show released tag for self hosting GHCR images instead of `latest`

### DIFF
--- a/frontend/docs/app/api/latest-version/route.ts
+++ b/frontend/docs/app/api/latest-version/route.ts
@@ -1,0 +1,25 @@
+export async function GET() {
+  try {
+    const res = await fetch(
+      "https://api.github.com/repos/hatchet-dev/hatchet/releases/latest",
+      { next: { revalidate: 3600 } },
+    );
+    if (!res.ok) {
+      throw new Error(`GitHub API returned ${res.status}`);
+    }
+    const { tag_name } = await res.json();
+    if (!/^v\d+\.\d+\.\d+$/.test(tag_name)) {
+      throw new Error(`unexpected tag_name: ${tag_name}`);
+    }
+    return Response.json(
+      { tag_name },
+      {
+        headers: {
+          "Cache-Control": "public, max-age=3600, stale-while-revalidate=3600",
+        },
+      },
+    );
+  } catch {
+    return Response.json({ tag_name: null }, { status: 502 });
+  }
+}

--- a/frontend/docs/components/LatestImageTags.tsx
+++ b/frontend/docs/components/LatestImageTags.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect } from "react";
+
+const IMAGE_TAG_REGEX =
+  /(ghcr\.io\/hatchet-dev\/hatchet\/hatchet-[a-z-]+:)latest\b/g;
+
+let latestTag: Promise<string | undefined> | undefined;
+
+function fetchLatestTag() {
+  latestTag ??= fetch("/api/latest-version")
+    .then((res) => (res.ok ? res.json() : undefined))
+    .then((release) =>
+      /^v\d+\.\d+\.\d+$/.test(release?.tag_name)
+        ? (release.tag_name as string)
+        : undefined,
+    )
+    .catch(() => undefined)
+    .then((tag) => {
+      if (!tag) latestTag = undefined;
+      return tag;
+    });
+  return latestTag;
+}
+
+/**
+ * Rewrites `ghcr.io/hatchet-dev/hatchet/*:latest` image references on the page
+ * to the latest public release tag. Falls back to `:latest` if the GitHub API
+ * is unreachable.
+ */
+function swapTags(root: Node, tag: string) {
+  const swap = (node: Node) => {
+    if (!node.nodeValue?.includes("ghcr.io/hatchet-dev/hatchet/")) return;
+    const swapped = node.nodeValue.replace(IMAGE_TAG_REGEX, `$1${tag}`);
+    if (swapped !== node.nodeValue) {
+      node.nodeValue = swapped;
+    }
+  };
+  if (root.nodeType === Node.TEXT_NODE) {
+    swap(root);
+    return;
+  }
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    swap(node);
+  }
+}
+
+export default function LatestImageTags() {
+  useEffect(() => {
+    let cancelled = false;
+    let observer: MutationObserver | undefined;
+    fetchLatestTag().then((tag) => {
+      if (!tag || cancelled) return;
+      swapTags(document.body, tag);
+      // Re-renders (hydration recovery, tab switches) can restore or remount
+      // text with the original `:latest`, so keep watching for it.
+      observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+          if (mutation.type === "characterData") {
+            swapTags(mutation.target, tag);
+          } else {
+            mutation.addedNodes.forEach((node) => swapTags(node, tag));
+          }
+        }
+      });
+      observer.observe(document.body, {
+        subtree: true,
+        childList: true,
+        characterData: true,
+      });
+    });
+    return () => {
+      cancelled = true;
+      observer?.disconnect();
+    };
+  }, []);
+
+  return null;
+}

--- a/frontend/docs/content/docs/self-hosting/configuration-options.mdx
+++ b/frontend/docs/content/docs/self-hosting/configuration-options.mdx
@@ -3,6 +3,9 @@ title: "Engine Configuration Options"
 ---
 
 import { Callout } from "@/components/nextra-compat";
+import LatestImageTags from "@/components/LatestImageTags";
+
+<LatestImageTags />
 
 # Configuration Options
 

--- a/frontend/docs/content/docs/self-hosting/docker-compose.mdx
+++ b/frontend/docs/content/docs/self-hosting/docker-compose.mdx
@@ -4,6 +4,9 @@ title: "Docker Compose"
 
 import { Tabs, Steps, Callout, FileTree } from "@/components/nextra-compat";
 import UniversalTabs from "@/components/UniversalTabs";
+import LatestImageTags from "@/components/LatestImageTags";
+
+<LatestImageTags />
 
 # Docker Compose Deployment
 

--- a/frontend/docs/content/docs/self-hosting/hatchet-lite.mdx
+++ b/frontend/docs/content/docs/self-hosting/hatchet-lite.mdx
@@ -5,6 +5,9 @@ title: "Hatchet Lite"
 import { Steps, Callout } from "@/components/nextra-compat";
 import { Tabs } from "@/components/nextra-compat";
 import UniversalTabs from "@/components/UniversalTabs";
+import LatestImageTags from "@/components/LatestImageTags";
+
+<LatestImageTags />
 
 # Hatchet Lite Deployment
 

--- a/frontend/docs/content/docs/self-hosting/kubernetes-helm-configuration.mdx
+++ b/frontend/docs/content/docs/self-hosting/kubernetes-helm-configuration.mdx
@@ -2,6 +2,10 @@
 title: "Configuring the Helm Chart"
 ---
 
+import LatestImageTags from "@/components/LatestImageTags";
+
+<LatestImageTags />
+
 # Configuring the Helm Chart
 
 ## Shared Config


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Shows released GHCR tags in the self hosting docs instead of `:latest`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Documentation change (pure documentation change)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
