### PR TITLE
fix: add missing Go SDK durable wait and webhook args

### DIFF
--- a/examples/go/durable/event/main.go
+++ b/examples/go/durable/event/main.go
@@ -49,6 +49,26 @@ func main() {
 		return DurableOutput{}, nil
 	}
 
+	_ = func(ctx hatchet.DurableContext) (DurableOutput, error) {
+		// > Wait for event with lookback
+		now, err := ctx.Now()
+		if err != nil {
+			return DurableOutput{}, err
+		}
+
+		// Matches a "user:update" event scoped to this user, including events
+		// pushed up to a minute before this wait was registered.
+		_, err = ctx.WaitForEvent("user:update", "",
+			hatchet.WithEventScope("user_id:1234"),
+			hatchet.WithConsiderEventsSince(now.Add(-time.Minute)),
+		)
+		if err != nil {
+			return DurableOutput{}, err
+		}
+
+		return DurableOutput{}, nil
+	}
+
 	worker, err := client.NewWorker("durable-event-worker",
 		hatchet.WithWorkflows(task),
 		hatchet.WithDurableSlots(10),

--- a/examples/go/webhooks/main.go
+++ b/examples/go/webhooks/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
+	"github.com/hatchet-dev/hatchet/pkg/client/rest"
 	"github.com/hatchet-dev/hatchet/pkg/cmdutils"
 	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
+	"github.com/hatchet-dev/hatchet/sdks/go/features"
 )
 
 func main() {
@@ -146,6 +149,22 @@ func main() {
 		},
 		hatchet.WithWorkflowEvents("slack:interaction:block_actions"),
 	)
+
+	// > Create webhook returning the event as the response payload
+	returnEvent := true
+	_, err = client.Webhooks().Create(context.Background(), features.CreateWebhookOpts{
+		Name:                         "incoming-payments",
+		SourceName:                   rest.GENERIC,
+		EventKeyExpression:           `"stripe:" + input.type`,
+		ReturnEventAsResponsePayload: &returnEvent,
+		Auth: features.APIKeyAuth{
+			HeaderName: "X-Api-Key",
+			APIKey:     "your-api-key",
+		},
+	})
+	if err != nil {
+		log.Printf("failed to create webhook: %v", err)
+	}
 
 	worker, err := client.NewWorker("webhook-worker",
 		hatchet.WithWorkflows(

--- a/frontend/docs/content/docs/v1/durable-event-waits.mdx
+++ b/frontend/docs/content/docs/v1/durable-event-waits.mdx
@@ -91,10 +91,7 @@ As a simple example, if you're establishing an event wait with a CEL expression 
 </Tabs.Tab>
 <Tabs.Tab title="Go">
 
-<Callout type="info">
-  Lookback window support for the Go SDK is coming soon. Join our
-  [Discord](https://hatchet.run/discord) to stay up to date.
-</Callout>
+<Snippet src={snippets.go.durable.event.main.wait_for_event_with_lookback} />
 
 </Tabs.Tab>
   <Tabs.Tab title="Ruby">

--- a/pkg/worker/condition/condition.go
+++ b/pkg/worker/condition/condition.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	contracts "github.com/hatchet-dev/hatchet/internal/services/shared/proto/v1"
 )
@@ -84,15 +85,36 @@ func (s *sleepCondition) ToPB(action contracts.Action) *ConditionMulti {
 type userEventCondition struct {
 	baseCondition
 
-	eventKey string
+	eventKey            string
+	eventScope          *string
+	considerEventsSince *time.Time
+}
+
+// UserEventConditionOpt configures optional behavior on a UserEventCondition.
+type UserEventConditionOpt func(*userEventCondition)
+
+// WithEventScope restricts the condition to events pushed with a matching scope.
+func WithEventScope(scope string) UserEventConditionOpt {
+	return func(u *userEventCondition) {
+		u.eventScope = &scope
+	}
+}
+
+// WithConsiderEventsSince makes the condition also match events that were pushed
+// after the given time but before the wait was registered (event lookback).
+// Requires WithEventScope to be set as well.
+func WithConsiderEventsSince(since time.Time) UserEventConditionOpt {
+	return func(u *userEventCondition) {
+		u.considerEventsSince = &since
+	}
 }
 
 // UserEventCondition creates a new condition that waits for a user event to occur.
 // The eventKey is the key of the user event that the condition is waiting for.
 // The expression is an optional CEL expression that can be used to filter the user event,
 // such as `event.data.key == "value"`.
-func UserEventCondition(eventKey string, expression string) *userEventCondition {
-	return &userEventCondition{
+func UserEventCondition(eventKey string, expression string, opts ...UserEventConditionOpt) *userEventCondition {
+	c := &userEventCondition{
 		baseCondition: baseCondition{
 			readableDataKey: eventKey,
 			orGroupID:       uuid.New(),
@@ -100,12 +122,23 @@ func UserEventCondition(eventKey string, expression string) *userEventCondition 
 		},
 		eventKey: eventKey,
 	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
 }
 
 func (u *userEventCondition) ToPB(action contracts.Action) *ConditionMulti {
 	userEvent := &contracts.UserEventMatchCondition{
 		Base:         u.baseCondition.baseCondition(action),
 		UserEventKey: u.eventKey,
+		EventScope:   u.eventScope,
+	}
+
+	if u.considerEventsSince != nil {
+		userEvent.ConsiderEventsSince = timestamppb.New(*u.considerEventsSince)
 	}
 
 	return &ConditionMulti{

--- a/pkg/worker/condition/condition_test.go
+++ b/pkg/worker/condition/condition_test.go
@@ -37,3 +37,28 @@ func TestSleepConditionToPB_SleepForFormat(t *testing.T) {
 		})
 	}
 }
+
+func TestUserEventConditionToPB_ScopeAndLookback(t *testing.T) {
+	since := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+
+	c := condition.UserEventCondition("user:create", "input.user_id == 1234",
+		condition.WithEventScope("user_id:1234"),
+		condition.WithConsiderEventsSince(since),
+	)
+	pb := c.ToPB(contracts.Action_CREATE)
+
+	assert.Len(t, pb.UserEventConditions, 1)
+	cond := pb.UserEventConditions[0]
+	assert.Equal(t, "user:create", cond.UserEventKey)
+	assert.Equal(t, "input.user_id == 1234", cond.Base.Expression)
+	assert.Equal(t, "user_id:1234", cond.GetEventScope())
+	assert.Equal(t, since, cond.GetConsiderEventsSince().AsTime())
+}
+
+func TestUserEventConditionToPB_NoOpts(t *testing.T) {
+	pb := condition.UserEventCondition("user:create", "").ToPB(contracts.Action_CREATE)
+
+	assert.Len(t, pb.UserEventConditions, 1)
+	assert.Nil(t, pb.UserEventConditions[0].EventScope)
+	assert.Nil(t, pb.UserEventConditions[0].ConsiderEventsSince)
+}

--- a/pkg/worker/context.go
+++ b/pkg/worker/context.go
@@ -1033,7 +1033,9 @@ type DurableHatchetContext interface {
 	SleepFor(duration time.Duration) (*SingleWaitResult, error)
 
 	// WaitForEvent pauses execution until the specified user event is received.
-	WaitForEvent(eventKey, expression string) (*SingleWaitResult, error)
+	// Options such as condition.WithEventScope and condition.WithConsiderEventsSince
+	// can be used to scope the wait and match events pushed before the wait started.
+	WaitForEvent(eventKey, expression string, opts ...condition.UserEventConditionOpt) (*SingleWaitResult, error)
 
 	// WaitFor pauses execution until the specified conditions are met.
 	// Conditions are "global" meaning they will wait in real time regardless of transient failures
@@ -1085,10 +1087,10 @@ func (d *durableHatchetContext) SleepFor(duration time.Duration) (*SingleWaitRes
 }
 
 // WaitForEvent implements the DurableHatchetContext.WaitForEvent method.
-func (d *durableHatchetContext) WaitForEvent(eventKey, expression string) (*SingleWaitResult, error) {
+func (d *durableHatchetContext) WaitForEvent(eventKey, expression string, opts ...condition.UserEventConditionOpt) (*SingleWaitResult, error) {
 	namespace := d.c.Namespace()
 	eventKey = clientconfig.ApplyNamespace(eventKey, &namespace)
-	wr, err := d.waitFor(condition.UserEventCondition(eventKey, expression), "wait_for_event", eventKey)
+	wr, err := d.waitFor(condition.UserEventCondition(eventKey, expression, opts...), "wait_for_event", eventKey)
 
 	if err != nil {
 		return nil, err

--- a/sdks/go/e2e/durable_test.go
+++ b/sdks/go/e2e/durable_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	v0client "github.com/hatchet-dev/hatchet/pkg/client"
 	"github.com/hatchet-dev/hatchet/pkg/client/rest"
 	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
 )
@@ -564,4 +565,68 @@ func TestDurableErrorOnErrorInChild(t *testing.T) {
 		}
 		return *parentStatus == rest.V1TaskStatusCOMPLETED, nil
 	})
+}
+
+func TestEventLookbackBeforeWait(t *testing.T) {
+	ctx := newTestContext(t)
+	scope := uuid.NewString()
+
+	err := sharedClient.Events().Push(ctx, lookbackEventKey, LookbackEvent{Order: "first"}, v0client.WithFilterScope(&scope))
+	require.NoError(t, err)
+
+	time.Sleep(1 * time.Second)
+
+	ref, err := testEventLookback.RunNoWait(ctx, EventLookbackInput{Scope: scope})
+	require.NoError(t, err)
+
+	result := workflowResultWithin(t, ref, 60*time.Second)
+	output := resultMap(t, result, "durable-event-lookback")
+
+	assert.Equal(t, "first", output["order"])
+	assert.Less(t, output["elapsed"].(float64), 3.0,
+		"event lookback should find the event pushed before the wait started, so the wait should be near-instantaneous")
+}
+
+func TestOrGroupEventLookbackBeforeWait(t *testing.T) {
+	ctx := newTestContext(t)
+	scope := uuid.NewString()
+
+	err := sharedClient.Events().Push(ctx, lookbackEventKey, LookbackEvent{Order: "first"}, v0client.WithFilterScope(&scope))
+	require.NoError(t, err)
+
+	time.Sleep(1 * time.Second)
+
+	ref, err := testOrEventLookback.RunNoWait(ctx, EventLookbackInput{Scope: scope})
+	require.NoError(t, err)
+
+	result := workflowResultWithin(t, ref, 60*time.Second)
+	output := resultMap(t, result, "durable-or-event-lookback")
+
+	assert.Less(t, output["elapsed"].(float64), float64(sleepTime),
+		"the user event branch of the or-group should match via lookback before the sleep branch fires")
+}
+
+func TestTwoEventWaitsSecondPushedFirst(t *testing.T) {
+	ctx := newTestContext(t)
+	scope := uuid.NewString()
+
+	err := sharedClient.Events().Push(ctx, lookbackKey2, LookbackEvent{Order: "second"}, v0client.WithFilterScope(&scope))
+	require.NoError(t, err)
+
+	time.Sleep(1 * time.Second)
+
+	ref, err := testTwoEventsLookback.RunNoWait(ctx, EventLookbackInput{Scope: scope})
+	require.NoError(t, err)
+
+	time.Sleep(3 * time.Second)
+
+	err = sharedClient.Events().Push(ctx, lookbackKey1, LookbackEvent{Order: "first"}, v0client.WithFilterScope(&scope))
+	require.NoError(t, err)
+
+	result := workflowResultWithin(t, ref, 60*time.Second)
+	output := resultMap(t, result, "durable-two-events-lookback")
+
+	assert.Equal(t, "first", output["order1"])
+	assert.Equal(t, "second", output["order2"],
+		"the second wait should find the event pushed before the task started via lookback")
 }

--- a/sdks/go/e2e/worker.go
+++ b/sdks/go/e2e/worker.go
@@ -18,12 +18,24 @@ const (
 	evictionTTLSeconds   = 5
 	longSleepSeconds     = 15
 	evictionEventKey     = "durable-eviction:event"
+	lookbackEventKey     = "durable-lookback:event"
+	lookbackKey1         = "durable-lookback:key1"
+	lookbackKey2         = "durable-lookback:key2"
+	lookbackWindow       = time.Minute
 )
 
 // --- Durable test workflows ---
 
 type AwaitedEvent struct {
 	ID string `json:"id"`
+}
+
+type EventLookbackInput struct {
+	Scope string `json:"scope"`
+}
+
+type LookbackEvent struct {
+	Order string `json:"order"`
 }
 
 type DurableBulkSpawnInput struct {
@@ -65,6 +77,9 @@ var (
 	testWaitForOrGroup1           *hatchet.Task
 	testWaitForOrGroup2           *hatchet.Task
 	testWaitForSleepTwice         *hatchet.StandaloneTask
+	testEventLookback             *hatchet.StandaloneTask
+	testOrEventLookback           *hatchet.StandaloneTask
+	testTwoEventsLookback         *hatchet.StandaloneTask
 	testSpawnChildTask            *hatchet.StandaloneTask
 	testDurableWithSpawn          *hatchet.StandaloneTask
 	testDurableWithBulkSpawn      *hatchet.StandaloneTask
@@ -202,6 +217,96 @@ func registerAllWorkflows(client *hatchet.Client) {
 		}
 		return map[string]float64{"runtime": time.Since(start).Seconds()}, nil
 	})
+
+	testEventLookback = client.NewStandaloneDurableTask("durable-event-lookback",
+		func(ctx hatchet.DurableContext, input EventLookbackInput) (map[string]any, error) {
+			start := time.Now()
+			now, err := ctx.Now()
+			if err != nil {
+				return nil, err
+			}
+
+			event, err := ctx.WaitForEvent(lookbackEventKey, "",
+				hatchet.WithEventScope(input.Scope),
+				hatchet.WithConsiderEventsSince(now.Add(-lookbackWindow)),
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			var evt LookbackEvent
+			if err := event.Unmarshal(&evt); err != nil {
+				return nil, err
+			}
+
+			return map[string]any{
+				"elapsed": time.Since(start).Seconds(),
+				"order":   evt.Order,
+			}, nil
+		})
+
+	testOrEventLookback = client.NewStandaloneDurableTask("durable-or-event-lookback",
+		func(ctx hatchet.DurableContext, input EventLookbackInput) (map[string]any, error) {
+			start := time.Now()
+			now, err := ctx.Now()
+			if err != nil {
+				return nil, err
+			}
+
+			_, err = ctx.WaitFor(
+				hatchet.OrCondition(
+					hatchet.SleepCondition(time.Duration(sleepTime)*time.Second),
+					hatchet.UserEventCondition(lookbackEventKey, "",
+						hatchet.WithEventScope(input.Scope),
+						hatchet.WithConsiderEventsSince(now.Add(-lookbackWindow)),
+					),
+				),
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			return map[string]any{"elapsed": time.Since(start).Seconds()}, nil
+		})
+
+	testTwoEventsLookback = client.NewStandaloneDurableTask("durable-two-events-lookback",
+		func(ctx hatchet.DurableContext, input EventLookbackInput) (map[string]any, error) {
+			start := time.Now()
+			now, err := ctx.Now()
+			if err != nil {
+				return nil, err
+			}
+
+			event1, err := ctx.WaitForEvent(lookbackKey1, "",
+				hatchet.WithEventScope(input.Scope),
+				hatchet.WithConsiderEventsSince(now.Add(-lookbackWindow)),
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			event2, err := ctx.WaitForEvent(lookbackKey2, "",
+				hatchet.WithEventScope(input.Scope),
+				hatchet.WithConsiderEventsSince(now.Add(-lookbackWindow)),
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			var evt1, evt2 LookbackEvent
+			if err := event1.Unmarshal(&evt1); err != nil {
+				return nil, err
+			}
+			if err := event2.Unmarshal(&evt2); err != nil {
+				return nil, err
+			}
+
+			return map[string]any{
+				"elapsed": time.Since(start).Seconds(),
+				"order1":  evt1.Order,
+				"order2":  evt2.Order,
+			}, nil
+		})
 
 	testSpawnChildTask = client.NewStandaloneTask("spawn-child-task", func(ctx hatchet.Context, input DurableBulkSpawnInput) (map[string]string, error) {
 		return map[string]string{"message": fmt.Sprintf("hello from child %d", input.N)}, nil
@@ -634,6 +739,9 @@ func startTestWorker(client *hatchet.Client) (*hatchet.Worker, func() error, err
 			testDagChildWorkflow,
 			testDAGPayloadWorkflow,
 			testWaitForSleepTwice,
+			testEventLookback,
+			testOrEventLookback,
+			testTwoEventsLookback,
 			testSpawnChildTask,
 			testDurableWithSpawn,
 			testDurableWithBulkSpawn,

--- a/sdks/go/examples/durable/event/main.go
+++ b/sdks/go/examples/durable/event/main.go
@@ -51,6 +51,27 @@ func main() {
 		return DurableOutput{}, nil
 	}
 
+	_ = func(ctx hatchet.DurableContext) (DurableOutput, error) {
+		// > Wait for event with lookback
+		now, err := ctx.Now()
+		if err != nil {
+			return DurableOutput{}, err
+		}
+
+		// Matches a "user:update" event scoped to this user, including events
+		// pushed up to a minute before this wait was registered.
+		_, err = ctx.WaitForEvent("user:update", "",
+			hatchet.WithEventScope("user_id:1234"),
+			hatchet.WithConsiderEventsSince(now.Add(-time.Minute)),
+		)
+		if err != nil {
+			return DurableOutput{}, err
+		}
+		// !!
+
+		return DurableOutput{}, nil
+	}
+
 	worker, err := client.NewWorker("durable-event-worker",
 		hatchet.WithWorkflows(task),
 		hatchet.WithDurableSlots(10),

--- a/sdks/go/examples/webhooks/main.go
+++ b/sdks/go/examples/webhooks/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
+	"github.com/hatchet-dev/hatchet/pkg/client/rest"
 	"github.com/hatchet-dev/hatchet/pkg/cmdutils"
 	hatchet "github.com/hatchet-dev/hatchet/sdks/go"
+	"github.com/hatchet-dev/hatchet/sdks/go/features"
 )
 
 func main() {
@@ -150,6 +153,23 @@ func main() {
 		},
 		hatchet.WithWorkflowEvents("slack:interaction:block_actions"),
 	)
+	// !!
+
+	// > Create webhook returning the event as the response payload
+	returnEvent := true
+	_, err = client.Webhooks().Create(context.Background(), features.CreateWebhookOpts{
+		Name:                         "incoming-payments",
+		SourceName:                   rest.GENERIC,
+		EventKeyExpression:           `"stripe:" + input.type`,
+		ReturnEventAsResponsePayload: &returnEvent,
+		Auth: features.APIKeyAuth{
+			HeaderName: "X-Api-Key",
+			APIKey:     "your-api-key",
+		},
+	})
+	if err != nil {
+		log.Printf("failed to create webhook: %v", err)
+	}
 	// !!
 
 	worker, err := client.NewWorker("webhook-worker",

--- a/sdks/go/features/webhooks.go
+++ b/sdks/go/features/webhooks.go
@@ -21,12 +21,13 @@ type BasicAuth struct {
 func (a BasicAuth) toCreateRequest(opts CreateWebhookOpts) (rest.V1CreateWebhookRequest, error) {
 	var req rest.V1CreateWebhookRequest
 	err := req.FromV1CreateWebhookRequestBasicAuth(rest.V1CreateWebhookRequestBasicAuth{
-		Name:               opts.Name,
-		SourceName:         opts.SourceName,
-		EventKeyExpression: opts.EventKeyExpression,
-		ScopeExpression:    opts.ScopeExpression,
-		StaticPayload:      opts.StaticPayload,
-		AuthType:           rest.V1CreateWebhookRequestBasicAuthAuthType("BASIC"),
+		Name:                         opts.Name,
+		SourceName:                   opts.SourceName,
+		EventKeyExpression:           opts.EventKeyExpression,
+		ScopeExpression:              opts.ScopeExpression,
+		StaticPayload:                opts.StaticPayload,
+		ReturnEventAsResponsePayload: opts.ReturnEventAsResponsePayload,
+		AuthType:                     rest.V1CreateWebhookRequestBasicAuthAuthType("BASIC"),
 		Auth: rest.V1WebhookBasicAuth{
 			Username: a.Username,
 			Password: a.Password,
@@ -43,12 +44,13 @@ type APIKeyAuth struct {
 func (a APIKeyAuth) toCreateRequest(opts CreateWebhookOpts) (rest.V1CreateWebhookRequest, error) {
 	var req rest.V1CreateWebhookRequest
 	err := req.FromV1CreateWebhookRequestAPIKey(rest.V1CreateWebhookRequestAPIKey{
-		Name:               opts.Name,
-		SourceName:         opts.SourceName,
-		EventKeyExpression: opts.EventKeyExpression,
-		ScopeExpression:    opts.ScopeExpression,
-		StaticPayload:      opts.StaticPayload,
-		AuthType:           rest.V1CreateWebhookRequestAPIKeyAuthType("API_KEY"),
+		Name:                         opts.Name,
+		SourceName:                   opts.SourceName,
+		EventKeyExpression:           opts.EventKeyExpression,
+		ScopeExpression:              opts.ScopeExpression,
+		StaticPayload:                opts.StaticPayload,
+		ReturnEventAsResponsePayload: opts.ReturnEventAsResponsePayload,
+		AuthType:                     rest.V1CreateWebhookRequestAPIKeyAuthType("API_KEY"),
 		Auth: rest.V1WebhookAPIKeyAuth{
 			HeaderName: a.HeaderName,
 			ApiKey:     a.APIKey,
@@ -67,12 +69,13 @@ type HMACAuth struct {
 func (a HMACAuth) toCreateRequest(opts CreateWebhookOpts) (rest.V1CreateWebhookRequest, error) {
 	var req rest.V1CreateWebhookRequest
 	err := req.FromV1CreateWebhookRequestHMAC(rest.V1CreateWebhookRequestHMAC{
-		Name:               opts.Name,
-		SourceName:         opts.SourceName,
-		EventKeyExpression: opts.EventKeyExpression,
-		ScopeExpression:    opts.ScopeExpression,
-		StaticPayload:      opts.StaticPayload,
-		AuthType:           rest.V1CreateWebhookRequestHMACAuthType("HMAC"),
+		Name:                         opts.Name,
+		SourceName:                   opts.SourceName,
+		EventKeyExpression:           opts.EventKeyExpression,
+		ScopeExpression:              opts.ScopeExpression,
+		StaticPayload:                opts.StaticPayload,
+		ReturnEventAsResponsePayload: opts.ReturnEventAsResponsePayload,
+		AuthType:                     rest.V1CreateWebhookRequestHMACAuthType("HMAC"),
 		Auth: rest.V1WebhookHMACAuth{
 			SigningSecret:       a.SigningSecret,
 			SignatureHeaderName: a.SignatureHeaderName,
@@ -93,12 +96,13 @@ type SvixAuth struct {
 func (a SvixAuth) toCreateRequest(opts CreateWebhookOpts) (rest.V1CreateWebhookRequest, error) {
 	var req rest.V1CreateWebhookRequest
 	err := req.FromV1CreateWebhookRequestHMAC(rest.V1CreateWebhookRequestHMAC{
-		Name:               opts.Name,
-		SourceName:         rest.SVIX,
-		EventKeyExpression: opts.EventKeyExpression,
-		ScopeExpression:    opts.ScopeExpression,
-		StaticPayload:      opts.StaticPayload,
-		AuthType:           rest.V1CreateWebhookRequestHMACAuthType("HMAC"),
+		Name:                         opts.Name,
+		SourceName:                   rest.SVIX,
+		EventKeyExpression:           opts.EventKeyExpression,
+		ScopeExpression:              opts.ScopeExpression,
+		StaticPayload:                opts.StaticPayload,
+		ReturnEventAsResponsePayload: opts.ReturnEventAsResponsePayload,
+		AuthType:                     rest.V1CreateWebhookRequestHMACAuthType("HMAC"),
 		Auth: rest.V1WebhookHMACAuth{
 			SigningSecret:       a.SigningSecret,
 			SignatureHeaderName: "svix-signature",
@@ -110,18 +114,20 @@ func (a SvixAuth) toCreateRequest(opts CreateWebhookOpts) (rest.V1CreateWebhookR
 }
 
 type CreateWebhookOpts struct {
-	Name               string
-	SourceName         rest.V1WebhookSourceName
-	EventKeyExpression string
-	ScopeExpression    *string
-	StaticPayload      *map[string]interface{}
-	Auth               WebhookAuth
+	Name                         string
+	SourceName                   rest.V1WebhookSourceName
+	EventKeyExpression           string
+	ScopeExpression              *string
+	StaticPayload                *map[string]interface{}
+	ReturnEventAsResponsePayload *bool
+	Auth                         WebhookAuth
 }
 
 type UpdateWebhookOpts struct {
-	EventKeyExpression *string
-	ScopeExpression    *string
-	StaticPayload      *map[string]interface{}
+	EventKeyExpression           *string
+	ScopeExpression              *string
+	StaticPayload                *map[string]interface{}
+	ReturnEventAsResponsePayload *bool
 }
 
 // WebhooksClient provides methods for managing webhook configurations
@@ -213,9 +219,10 @@ func (c *WebhooksClient) Update(ctx context.Context, webhookName string, opts Up
 		c.tenantId,
 		webhookName,
 		rest.V1UpdateWebhookRequest{
-			EventKeyExpression: opts.EventKeyExpression,
-			ScopeExpression:    opts.ScopeExpression,
-			StaticPayload:      opts.StaticPayload,
+			EventKeyExpression:           opts.EventKeyExpression,
+			ScopeExpression:              opts.ScopeExpression,
+			StaticPayload:                opts.StaticPayload,
+			ReturnEventAsResponsePayload: opts.ReturnEventAsResponsePayload,
 		},
 	)
 	if err != nil {

--- a/sdks/go/hatchet.go
+++ b/sdks/go/hatchet.go
@@ -73,8 +73,20 @@ func SleepCondition(duration time.Duration) condition.Condition {
 }
 
 // UserEventCondition creates a condition that waits for a user event.
-func UserEventCondition(eventKey, expression string) condition.Condition {
-	return condition.UserEventCondition(eventKey, expression)
+func UserEventCondition(eventKey, expression string, opts ...condition.UserEventConditionOpt) condition.Condition {
+	return condition.UserEventCondition(eventKey, expression, opts...)
+}
+
+// WithEventScope restricts a user event condition to events pushed with a matching scope.
+func WithEventScope(scope string) condition.UserEventConditionOpt {
+	return condition.WithEventScope(scope)
+}
+
+// WithConsiderEventsSince makes a user event condition also match events pushed
+// after the given time but before the wait was registered (event lookback).
+// Requires WithEventScope to be set as well.
+func WithConsiderEventsSince(since time.Time) condition.UserEventConditionOpt {
+	return condition.WithConsiderEventsSince(since)
 }
 
 // ParentCondition creates a condition based on a parent task's output.


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds missing args from durable wait conditions in the Go SDK. Also adds missing `ReturnEventAsResponsePayload` to the webhook paths in the Go SDK.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Documentation change (pure documentation change)
- [x] New feature (non-breaking change which adds functionality)
- [x] Test changes (add, refactor, improve or change a test)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
