### PR TITLE
fix: cache hashed frontend assets as immutable

### DIFF
--- a/cmd/hatchet-staticfileserver/staticfileserver/server.go
+++ b/cmd/hatchet-staticfileserver/staticfileserver/server.go
@@ -37,9 +37,13 @@ func NewStaticFileServer(staticFilePath, basePath string) *chi.Mux {
 			return
 		}
 
-		// Set static files involving html, js, or empty cache to "no-cache", which means they must be validated
-		// for changes before the browser uses the cache
-		if base := path.Base(r.URL.Path); strings.Contains(base, "html") || strings.Contains(base, "js") || base == "." || base == "/" {
+		// Vite emits content-hashed filenames under /assets, so those bytes never change for a
+		// given URL. Marking them immutable lets browsers and CDNs (e.g. Cloudflare) serve them
+		// from cache without revalidating against the origin on every request. Everything else
+		// involving html or js stays "no-cache" so new deploys are picked up via index.html.
+		if strings.HasPrefix(r.URL.Path, "/assets/") {
+			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+		} else if base := path.Base(r.URL.Path); strings.Contains(base, "html") || strings.Contains(base, "js") || base == "." || base == "/" {
 			w.Header().Set("Cache-Control", "no-cache")
 		}
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

Serve Vite content-hashed files under `/assets` with a long-lived immutable `Cache-Control` header so browsers and CDNs can reuse them without origin revalidation. HTML and other JS still use `no-cache` so new deploys are picked up through `index.html`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Cache hashed `/assets` files as `public, max-age=31536000, immutable`
- [x] Keep `no-cache` on HTML and non-hashed JS so deploys still take effect

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Drafted the cache-header change and PR description.

</details>