### PR TITLE
fix(engine): add ordering + for update lock

### DIFF
--- a/pkg/repository/sqlcv1/tasks-overwrite.go
+++ b/pkg/repository/sqlcv1/tasks-overwrite.go
@@ -700,7 +700,7 @@ WITH input AS (
 DELETE FROM
     v1_batched_queue_item
 WHERE
-    (task_id, task_inserted_at, retry_count) IN (SELECT task_id, task_inserted_at, retry_count FROM input)
+    (task_id, task_inserted_at, retry_count) IN (SELECT task_id, task_inserted_at, retry_count FROM batched_queue_items_to_delete)
 `
 
 const releaseRateLimitedQueueItems = `-- name: ReleaseRateLimitedQueueItems :batchexec

--- a/pkg/repository/sqlcv1/tasks-overwrite.go
+++ b/pkg/repository/sqlcv1/tasks-overwrite.go
@@ -681,16 +681,22 @@ WHERE
 
 const releaseBatchedQueueItems = `-- name: ReleaseBatchedQueueItems :batchexec
 WITH input AS (
-    SELECT
-        task_id, task_inserted_at, retry_count
-    FROM
-        (
-            SELECT
-                unnest($1::bigint[]) AS task_id,
-                unnest($2::timestamptz[]) AS task_inserted_at,
-                unnest($3::integer[]) AS retry_count
-        ) AS subquery
+	SELECT
+		unnest($1::bigint[]) AS task_id,
+		unnest($2::timestamptz[]) AS task_inserted_at,
+		unnest($3::integer[]) AS retry_count
+), batched_queue_items_to_delete AS (
+	SELECT
+		task_id, task_inserted_at, retry_count
+	FROM
+		v1_batched_queue_item
+	WHERE
+		(task_id, task_inserted_at, retry_count) IN (SELECT task_id, task_inserted_at, retry_count FROM input)
+	ORDER BY
+		task_id, task_inserted_at, retry_count
+	FOR UPDATE
 )
+
 DELETE FROM
     v1_batched_queue_item
 WHERE


### PR DESCRIPTION
# Description

Adds ordering + a FOR UPDATE lock in releaseBatchQueueItems

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI

</details>
