### PR TITLE
refactor(engine): consolidate two more durable path queries

### DIFF
--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlchelpers"
@@ -673,7 +674,7 @@ func (r *sharedRepository) incrementDurableTaskInvocationCounts(ctx context.Cont
 	return result, nil
 }
 
-func (r *durableEventsRepository) getAndLockLogFile(ctx context.Context, tx sqlcv1.DBTX, tenantId uuid.UUID, durableTaskId int64, durableTaskInsertedAt pgtype.Timestamptz) (*sqlcv1.V1DurableEventLogFile, error) {
+func (r *durableEventsRepository) getAndLockLogFile(ctx context.Context, tx sqlcv1.DBTX, tenantId uuid.UUID, durableTaskId int64, durableTaskInsertedAt pgtype.Timestamptz) (*sqlcv1.V1DurableEventLogFile, map[int64]*sqlcv1.V1DurableEventLogBranchPoint, error) {
 	ctx, span := telemetry.NewSpan(ctx, "get-and-lock-durable-event-log-file")
 	defer span.End()
 
@@ -682,31 +683,44 @@ func (r *durableEventsRepository) getAndLockLogFile(ctx context.Context, tx sqlc
 		telemetry.AttributeKV{Key: "durable_task_id", Value: durableTaskId},
 	)
 
-	return r.queries.GetAndLockLogFile(ctx, tx, sqlcv1.GetAndLockLogFileParams{
-		Durabletaskid:         durableTaskId,
-		Durabletaskinsertedat: durableTaskInsertedAt,
-		Tenantid:              tenantId,
-	})
-}
-
-func (r *durableEventsRepository) listEventLogBranchPoints(ctx context.Context, tx sqlcv1.DBTX, tenantId uuid.UUID, durableTaskId int64, durableTaskInsertedAt pgtype.Timestamptz) (map[int64]*sqlcv1.V1DurableEventLogBranchPoint, error) {
-	branchPoints, err := r.queries.ListDurableEventLogBranchPoints(ctx, tx, sqlcv1.ListDurableEventLogBranchPointsParams{
+	rows, err := r.queries.GetAndLockLogFileWithBranchPoints(ctx, tx, sqlcv1.GetAndLockLogFileWithBranchPointsParams{
 		Durabletaskid:         durableTaskId,
 		Durabletaskinsertedat: durableTaskInsertedAt,
 		Tenantid:              tenantId,
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to list durable event log branch points: %w", err)
+		return nil, nil, err
 	}
 
-	nextBranchIdToBranchPoint := make(map[int64]*sqlcv1.V1DurableEventLogBranchPoint, len(branchPoints))
-
-	for _, bp := range branchPoints {
-		nextBranchIdToBranchPoint[bp.NextBranchID] = bp
+	if len(rows) == 0 {
+		return nil, nil, pgx.ErrNoRows
 	}
 
-	return nextBranchIdToBranchPoint, nil
+	logFile := rows[0].V1DurableEventLogFile
+
+	nextBranchIdToBranchPoint := make(map[int64]*sqlcv1.V1DurableEventLogBranchPoint, len(rows))
+
+	for _, row := range rows {
+		logFile := row.V1DurableEventLogFile
+
+		if !row.NextBranchID.Valid {
+			continue
+		}
+
+		nextBranchIdToBranchPoint[row.NextBranchID.Int64] = &sqlcv1.V1DurableEventLogBranchPoint{
+			TenantID:               logFile.TenantID,
+			ID:                     row.ID.Int64,
+			InsertedAt:             row.InsertedAt,
+			DurableTaskID:          logFile.DurableTaskID,
+			DurableTaskInsertedAt:  logFile.DurableTaskInsertedAt,
+			FirstNodeIDInNewBranch: row.FirstNodeIDInNewBranch.Int64,
+			ParentBranchID:         row.ParentBranchID.Int64,
+			NextBranchID:           row.NextBranchID.Int64,
+		}
+	}
+
+	return &logFile, nextBranchIdToBranchPoint, nil
 }
 
 type BranchIdFromNodeIdTuple struct {
@@ -1410,15 +1424,10 @@ func (r *durableEventsRepository) appendDurableEventLog(ctx context.Context, opt
 
 	defer rollback()
 
-	logFile, err := r.getAndLockLogFile(ctx, tx, tenantId, task.ID, task.InsertedAt)
+	logFile, nextBranchIdToBranchPoint, err := r.getAndLockLogFile(ctx, tx, tenantId, task.ID, task.InsertedAt)
 
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to lock log file: %w", err)
-	}
-
-	nextBranchIdToBranchPoint, err := r.listEventLogBranchPoints(ctx, tx, tenantId, task.ID, task.InsertedAt)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to list log branch points: %w", err)
 	}
 
 	if logFile.LatestInvocationCount != opts.InvocationCount {
@@ -2261,7 +2270,7 @@ func (r *durableEventsRepository) handleBranch(ctx context.Context, tenantId uui
 
 	tx := optTx.tx
 
-	logFile, err := r.getAndLockLogFile(ctx, tx, tenantId, task.ID, task.InsertedAt)
+	logFile, nextBranchIdToBranchPoint, err := r.getAndLockLogFile(ctx, tx, tenantId, task.ID, task.InsertedAt)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to lock log file: %w", err)
@@ -2269,11 +2278,6 @@ func (r *durableEventsRepository) handleBranch(ctx context.Context, tenantId uui
 
 	newBranchId := logFile.LatestBranchID + 1
 	zero := int64(0)
-
-	nextBranchIdToBranchPoint, err := r.listEventLogBranchPoints(ctx, tx, tenantId, task.ID, task.InsertedAt)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list log branch points: %w", err)
-	}
 
 	latestSatisfiedOrder, err := r.latestSatisfiedOrderBeforeBranchPoint(ctx, tx, tenantId, nodeId, branchId, task, nextBranchIdToBranchPoint)
 	if err != nil {

--- a/pkg/repository/sqlcv1/durable_event_log.sql
+++ b/pkg/repository/sqlcv1/durable_event_log.sql
@@ -8,6 +8,28 @@ WHERE
 FOR UPDATE
 ;
 
+-- name: GetAndLockLogFileWithBranchPoints :many
+WITH locked_file AS (
+    SELECT *
+    FROM v1_durable_event_log_file
+    WHERE
+        durable_task_id = @durableTaskId::BIGINT
+        AND durable_task_inserted_at = @durableTaskInsertedAt::TIMESTAMPTZ
+        AND tenant_id = @tenantId::UUID
+    FOR UPDATE
+)
+
+SELECT
+    sqlc.embed(to_embed),
+    sqlc.embed(bp)
+FROM locked_file lf
+-- note: intentionally using the params for the join so we can prune partitions
+JOIN v1_durable_event_log_file to_embed
+    ON (to_embed.durable_task_id, to_embed.durable_task_inserted_at, to_embed.tenant_id) = (@durableTaskId::BIGINT, @durableTaskInsertedAt::TIMESTAMPTZ, @tenantId::UUID)
+LEFT JOIN v1_durable_event_log_branch_point bp
+    ON (bp.durable_task_id, bp.durable_task_inserted_at, bp.tenant_id) = (@durableTaskId::BIGINT, @durableTaskInsertedAt::TIMESTAMPTZ, @tenantId::UUID)
+;
+
 -- name: IncrementLogFileInvocationCounts :many
 WITH inputs AS (
     SELECT
@@ -333,16 +355,6 @@ WHERE e.durable_task_id = c.durable_task_id
   AND e.branch_id = c.branch_id
   AND e.node_id = c.node_id
 RETURNING e.*
-;
-
--- name: ListDurableEventLogBranchPoints :many
-SELECT *
-FROM v1_durable_event_log_branch_point
-WHERE
-    durable_task_id = @durableTaskId::BIGINT
-    AND durable_task_inserted_at = @durableTaskInsertedAt::TIMESTAMPTZ
-    AND tenant_id = @tenantId::UUID
-ORDER BY id ASC
 ;
 
 -- name: ListDurableEventLogForTask :many

--- a/pkg/repository/sqlcv1/durable_event_log.sql
+++ b/pkg/repository/sqlcv1/durable_event_log.sql
@@ -21,7 +21,7 @@ WITH locked_file AS (
 
 SELECT
     sqlc.embed(to_embed),
-    sqlc.embed(bp)
+    bp.*
 FROM locked_file lf
 -- note: intentionally using the params for the join so we can prune partitions
 JOIN v1_durable_event_log_file to_embed

--- a/pkg/repository/sqlcv1/durable_event_log.sql.go
+++ b/pkg/repository/sqlcv1/durable_event_log.sql.go
@@ -451,8 +451,16 @@ type GetAndLockLogFileWithBranchPointsParams struct {
 }
 
 type GetAndLockLogFileWithBranchPointsRow struct {
-	V1DurableEventLogFile        V1DurableEventLogFile        `json:"v1_durable_event_log_file"`
-	V1DurableEventLogBranchPoint V1DurableEventLogBranchPoint `json:"v1_durable_event_log_branch_point"`
+	V1DurableEventLogFile  V1DurableEventLogFile `json:"v1_durable_event_log_file"`
+	TenantID               *uuid.UUID            `json:"tenant_id"`
+	ID                     pgtype.Int8           `json:"id"`
+	InsertedAt             pgtype.Timestamptz    `json:"inserted_at"`
+	DurableTaskID          pgtype.Int8           `json:"durable_task_id"`
+	DurableTaskInsertedAt  pgtype.Timestamptz    `json:"durable_task_inserted_at"`
+	FirstNodeIDInNewBranch pgtype.Int8           `json:"first_node_id_in_new_branch"`
+	ParentBranchID         pgtype.Int8           `json:"parent_branch_id"`
+	NextBranchID           pgtype.Int8           `json:"next_branch_id"`
+	ReplayChildExternalIds []uuid.UUID           `json:"replay_child_external_ids"`
 }
 
 // note: intentionally using the params for the join so we can prune partitions
@@ -474,15 +482,15 @@ func (q *Queries) GetAndLockLogFileWithBranchPoints(ctx context.Context, db DBTX
 			&i.V1DurableEventLogFile.LatestNodeID,
 			&i.V1DurableEventLogFile.LatestBranchID,
 			&i.V1DurableEventLogFile.LatestSatisfiedOrder,
-			&i.V1DurableEventLogBranchPoint.TenantID,
-			&i.V1DurableEventLogBranchPoint.ID,
-			&i.V1DurableEventLogBranchPoint.InsertedAt,
-			&i.V1DurableEventLogBranchPoint.DurableTaskID,
-			&i.V1DurableEventLogBranchPoint.DurableTaskInsertedAt,
-			&i.V1DurableEventLogBranchPoint.FirstNodeIDInNewBranch,
-			&i.V1DurableEventLogBranchPoint.ParentBranchID,
-			&i.V1DurableEventLogBranchPoint.NextBranchID,
-			&i.V1DurableEventLogBranchPoint.ReplayChildExternalIds,
+			&i.TenantID,
+			&i.ID,
+			&i.InsertedAt,
+			&i.DurableTaskID,
+			&i.DurableTaskInsertedAt,
+			&i.FirstNodeIDInNewBranch,
+			&i.ParentBranchID,
+			&i.NextBranchID,
+			&i.ReplayChildExternalIds,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/repository/sqlcv1/durable_event_log.sql.go
+++ b/pkg/repository/sqlcv1/durable_event_log.sql.go
@@ -423,6 +423,77 @@ func (q *Queries) GetAndLockLogFile(ctx context.Context, db DBTX, arg GetAndLock
 	return &i, err
 }
 
+const getAndLockLogFileWithBranchPoints = `-- name: GetAndLockLogFileWithBranchPoints :many
+WITH locked_file AS (
+    SELECT tenant_id, durable_task_id, durable_task_inserted_at, latest_invocation_count, latest_inserted_at, latest_node_id, latest_branch_id, latest_satisfied_order
+    FROM v1_durable_event_log_file
+    WHERE
+        durable_task_id = $1::BIGINT
+        AND durable_task_inserted_at = $2::TIMESTAMPTZ
+        AND tenant_id = $3::UUID
+    FOR UPDATE
+)
+
+SELECT
+    to_embed.tenant_id, to_embed.durable_task_id, to_embed.durable_task_inserted_at, to_embed.latest_invocation_count, to_embed.latest_inserted_at, to_embed.latest_node_id, to_embed.latest_branch_id, to_embed.latest_satisfied_order,
+    bp.tenant_id, bp.id, bp.inserted_at, bp.durable_task_id, bp.durable_task_inserted_at, bp.first_node_id_in_new_branch, bp.parent_branch_id, bp.next_branch_id, bp.replay_child_external_ids
+FROM locked_file lf
+JOIN v1_durable_event_log_file to_embed
+    ON (to_embed.durable_task_id, to_embed.durable_task_inserted_at, to_embed.tenant_id) = ($1::BIGINT, $2::TIMESTAMPTZ, $3::UUID)
+LEFT JOIN v1_durable_event_log_branch_point bp
+    ON (bp.durable_task_id, bp.durable_task_inserted_at, bp.tenant_id) = ($1::BIGINT, $2::TIMESTAMPTZ, $3::UUID)
+`
+
+type GetAndLockLogFileWithBranchPointsParams struct {
+	Durabletaskid         int64              `json:"durabletaskid"`
+	Durabletaskinsertedat pgtype.Timestamptz `json:"durabletaskinsertedat"`
+	Tenantid              uuid.UUID          `json:"tenantid"`
+}
+
+type GetAndLockLogFileWithBranchPointsRow struct {
+	V1DurableEventLogFile        V1DurableEventLogFile        `json:"v1_durable_event_log_file"`
+	V1DurableEventLogBranchPoint V1DurableEventLogBranchPoint `json:"v1_durable_event_log_branch_point"`
+}
+
+// note: intentionally using the params for the join so we can prune partitions
+func (q *Queries) GetAndLockLogFileWithBranchPoints(ctx context.Context, db DBTX, arg GetAndLockLogFileWithBranchPointsParams) ([]*GetAndLockLogFileWithBranchPointsRow, error) {
+	rows, err := db.Query(ctx, getAndLockLogFileWithBranchPoints, arg.Durabletaskid, arg.Durabletaskinsertedat, arg.Tenantid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*GetAndLockLogFileWithBranchPointsRow
+	for rows.Next() {
+		var i GetAndLockLogFileWithBranchPointsRow
+		if err := rows.Scan(
+			&i.V1DurableEventLogFile.TenantID,
+			&i.V1DurableEventLogFile.DurableTaskID,
+			&i.V1DurableEventLogFile.DurableTaskInsertedAt,
+			&i.V1DurableEventLogFile.LatestInvocationCount,
+			&i.V1DurableEventLogFile.LatestInsertedAt,
+			&i.V1DurableEventLogFile.LatestNodeID,
+			&i.V1DurableEventLogFile.LatestBranchID,
+			&i.V1DurableEventLogFile.LatestSatisfiedOrder,
+			&i.V1DurableEventLogBranchPoint.TenantID,
+			&i.V1DurableEventLogBranchPoint.ID,
+			&i.V1DurableEventLogBranchPoint.InsertedAt,
+			&i.V1DurableEventLogBranchPoint.DurableTaskID,
+			&i.V1DurableEventLogBranchPoint.DurableTaskInsertedAt,
+			&i.V1DurableEventLogBranchPoint.FirstNodeIDInNewBranch,
+			&i.V1DurableEventLogBranchPoint.ParentBranchID,
+			&i.V1DurableEventLogBranchPoint.NextBranchID,
+			&i.V1DurableEventLogBranchPoint.ReplayChildExternalIds,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getDurableEventLogEntriesByChildTaskExternalIds = `-- name: GetDurableEventLogEntriesByChildTaskExternalIds :many
 SELECT e.tenant_id, e.external_id, e.result_payload_external_id, e.child_task_external_id, e.child_task_is_failure, e.child_task_error_message, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.satisfied_order, e.user_message, e.wait_data, e.triggered_at, lf.latest_invocation_count AS invocation_count
 FROM v1_durable_event_log_entry e
@@ -663,52 +734,6 @@ func (q *Queries) IncrementLogFileInvocationCounts(ctx context.Context, db DBTX,
 			&i.LatestNodeID,
 			&i.LatestBranchID,
 			&i.LatestSatisfiedOrder,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listDurableEventLogBranchPoints = `-- name: ListDurableEventLogBranchPoints :many
-SELECT tenant_id, id, inserted_at, durable_task_id, durable_task_inserted_at, first_node_id_in_new_branch, parent_branch_id, next_branch_id, replay_child_external_ids
-FROM v1_durable_event_log_branch_point
-WHERE
-    durable_task_id = $1::BIGINT
-    AND durable_task_inserted_at = $2::TIMESTAMPTZ
-    AND tenant_id = $3::UUID
-ORDER BY id ASC
-`
-
-type ListDurableEventLogBranchPointsParams struct {
-	Durabletaskid         int64              `json:"durabletaskid"`
-	Durabletaskinsertedat pgtype.Timestamptz `json:"durabletaskinsertedat"`
-	Tenantid              uuid.UUID          `json:"tenantid"`
-}
-
-func (q *Queries) ListDurableEventLogBranchPoints(ctx context.Context, db DBTX, arg ListDurableEventLogBranchPointsParams) ([]*V1DurableEventLogBranchPoint, error) {
-	rows, err := db.Query(ctx, listDurableEventLogBranchPoints, arg.Durabletaskid, arg.Durabletaskinsertedat, arg.Tenantid)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*V1DurableEventLogBranchPoint
-	for rows.Next() {
-		var i V1DurableEventLogBranchPoint
-		if err := rows.Scan(
-			&i.TenantID,
-			&i.ID,
-			&i.InsertedAt,
-			&i.DurableTaskID,
-			&i.DurableTaskInsertedAt,
-			&i.FirstNodeIDInNewBranch,
-			&i.ParentBranchID,
-			&i.NextBranchID,
-			&i.ReplayChildExternalIds,
 		); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
# Description

Consolidates two more queries (the log file lock and the branch point list) into one. Probably won't help a ton, but just chipping away

## Type of change

- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)

## What's Changed

- [ ] Add a list of tasks or features here...

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->


<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI here

</details>
