### PR TITLE
fix: taskfile latest tag computation

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -80,13 +80,13 @@ tasks:
     vars:
       CHANGELOGS:
         map:
-          platform: 'CHANGELOG.md'
-          python: 'sdks/python/CHANGELOG.md'
-          typescript: 'sdks/typescript/CHANGELOG.md'
-          ruby: 'sdks/ruby/src/CHANGELOG.md'
+          platform: "CHANGELOG.md"
+          python: "sdks/python/CHANGELOG.md"
+          typescript: "sdks/typescript/CHANGELOG.md"
+          ruby: "sdks/ruby/src/CHANGELOG.md"
     cmd:
-        for: { var: CHANGELOGS }
-        cmd: bash ./hack/docs/sync-changelog.sh {{.ITEM}} frontend/docs/content/docs/reference/changelog/{{.KEY}}.mdx
+      for: { var: CHANGELOGS }
+      cmd: bash ./hack/docs/sync-changelog.sh {{.ITEM}} frontend/docs/content/docs/reference/changelog/{{.KEY}}.mdx
   pre:
     aliases: [fmt]
     cmds:
@@ -336,11 +336,11 @@ tasks:
     vars:
       CURRENT:
         sh: git tag --points-at HEAD --sort=-v:refname | head -n1
-      TAG: '{{.TAG | default .CURRENT}}'
+      TAG: "{{.TAG | default .CURRENT}}"
     preconditions:
       - sh: '[ -n "{{.TAG}}" ]'
         msg: "No TAG value found"
-      - sh: '! gh release view {{.TAG}} >/dev/null 2>&1'
+      - sh: "! gh release view {{.TAG}} >/dev/null 2>&1"
         msg: "{{.TAG}} already has a GitHub Release."
       - sh: '[ "$(git cat-file -t {{.TAG}})" != "tag" ]'
         msg: "{{.TAG}} is already an annotated tag."
@@ -357,7 +357,13 @@ tasks:
     cmds:
       - |
         set -e
-        current=$(git describe --tags --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*')
+        branch=$(git rev-parse --abbrev-ref HEAD)
+        if [ "${branch}" != "main" ]; then
+          echo "Error: must be on 'main' to bump the version (currently on '${branch}')" >&2
+          exit 1
+        fi
+        git fetch origin main
+        git pull origin main
         current=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1)
         IFS='.' read -r major minor patch <<< "${current#v}"
         patch=$((patch + 1))
@@ -371,6 +377,13 @@ tasks:
     cmds:
       - |
         set -e
+        branch=$(git rev-parse --abbrev-ref HEAD)
+        if [ "${branch}" != "main" ]; then
+          echo "Error: must be on 'main' to bump the version (currently on '${branch}')" >&2
+          exit 1
+        fi
+        git fetch origin main
+        git pull origin main
         current=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1)
         IFS='.' read -r major minor patch <<< "${current#v}"
         minor=$((minor + 1))

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -358,6 +358,7 @@ tasks:
       - |
         set -e
         current=$(git describe --tags --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*')
+        current=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1)
         IFS='.' read -r major minor patch <<< "${current#v}"
         patch=$((patch + 1))
         next="v${major}.${minor}.${patch}"
@@ -370,7 +371,7 @@ tasks:
     cmds:
       - |
         set -e
-        current=$(git describe --tags --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*')
+        current=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1)
         IFS='.' read -r major minor patch <<< "${current#v}"
         minor=$((minor + 1))
         next="v${major}.${minor}.0"
@@ -383,7 +384,7 @@ tasks:
     cmds:
       - |
         set -e
-        current=$(git describe --tags --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*')
+        current=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1)
         base="${current%%-alpha.*}"
         if [[ "${current}" == *-alpha.* ]]; then
           alpha_num="${current##*-alpha.}"


### PR DESCRIPTION
# Description

Fixes a bug where this would figure out the wrong tag if two tags were tied to the same commit

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI

</details>
