### PR TITLE
fix: Batch get dag parent outputs to avoid N+1 query

### DIFF
--- a/internal/services/dispatcher/dag_parent_outputs_test.go
+++ b/internal/services/dispatcher/dag_parent_outputs_test.go
@@ -1,0 +1,150 @@
+package dispatcher
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/hatchet-dev/hatchet/pkg/repository"
+)
+
+func newDagChildInput(t *testing.T, taskId int64, parentExternalIds ...uuid.UUID) *dagChildTaskInput {
+	t.Helper()
+
+	return &dagChildTaskInput{
+		payloadKey: v1.RetrievePayloadOpts{Id: taskId},
+		currInput: &v1.V1StepRunData{
+			DagParentTaskRunIds: parentExternalIds,
+		},
+	}
+}
+
+func parentOutputEvent(t *testing.T, externalId uuid.UUID, stepReadableId string, output any) *v1.TaskOutputEvent {
+	t.Helper()
+
+	b, err := json.Marshal(output)
+	require.NoError(t, err)
+
+	return &v1.TaskOutputEvent{
+		TaskExternalId: externalId,
+		StepReadableID: stepReadableId,
+		Output:         b,
+	}
+}
+
+// unmarshalParents round-trips inputs[key] the same way a worker would when it receives the
+// dispatched task, confirming resolveDagParentOutputs' effect actually survives serialization.
+func unmarshalParents(t *testing.T, inputs map[v1.RetrievePayloadOpts][]byte, key v1.RetrievePayloadOpts) map[string]map[string]interface{} {
+	t.Helper()
+
+	raw, ok := inputs[key]
+	require.True(t, ok, "expected inputs to contain an entry for %+v", key)
+
+	var data v1.V1StepRunData
+	require.NoError(t, json.Unmarshal(raw, &data))
+
+	return data.Parents
+}
+
+func TestResolveDagParentOutputs_PopulatesParentsFromBatch(t *testing.T) {
+	parentA := uuid.New()
+	parentB := uuid.New()
+
+	// taskX depends on both parentA and parentB; taskY depends only on parentB. This mirrors
+	// what populateTaskData builds: a single dagParentOutputs batch shared across every
+	// dag-child task in the dispatch batch, each pulling out only its own parents.
+	taskX := newDagChildInput(t, 1, parentA, parentB)
+	taskY := newDagChildInput(t, 2, parentB)
+
+	dagParentOutputs := map[uuid.UUID]*v1.TaskOutputEvent{
+		parentA: parentOutputEvent(t, parentA, "step_a", map[string]int{"random_number": 1}),
+		parentB: parentOutputEvent(t, parentB, "step_b", map[string]int{"random_number": 2}),
+	}
+
+	inputs := make(map[v1.RetrievePayloadOpts][]byte)
+
+	resolveDagParentOutputs(context.Background(), zerologNop(), []*dagChildTaskInput{taskX, taskY}, dagParentOutputs, inputs)
+
+	xParents := unmarshalParents(t, inputs, taskX.payloadKey)
+	assert.Equal(t, map[string]interface{}{"random_number": float64(1)}, xParents["step_a"])
+	assert.Equal(t, map[string]interface{}{"random_number": float64(2)}, xParents["step_b"])
+	assert.Len(t, xParents, 2)
+
+	yParents := unmarshalParents(t, inputs, taskY.payloadKey)
+	assert.Equal(t, map[string]interface{}{"random_number": float64(2)}, yParents["step_b"])
+	assert.Len(t, yParents, 1, "taskY never listed parentA, so it must not see step_a's output")
+}
+
+// TestResolveDagParentOutputs_DoesNotLeakAcrossDifferentDagRuns is the regression test for the
+// bug the batching redesign fixes: two unrelated DAG runs can both have a step named "start",
+// so the shared dagParentOutputs batch must be keyed by parent external ID, never by step
+// readable ID, or one run's output would silently clobber the other's.
+func TestResolveDagParentOutputs_DoesNotLeakAcrossDifferentDagRuns(t *testing.T) {
+	runOneParent := uuid.New()
+	runTwoParent := uuid.New()
+
+	runOneChild := newDagChildInput(t, 1, runOneParent)
+	runTwoChild := newDagChildInput(t, 2, runTwoParent)
+
+	dagParentOutputs := map[uuid.UUID]*v1.TaskOutputEvent{
+		runOneParent: parentOutputEvent(t, runOneParent, "start", map[string]int{"random_number": 1}),
+		runTwoParent: parentOutputEvent(t, runTwoParent, "start", map[string]int{"random_number": 99}),
+	}
+
+	inputs := make(map[v1.RetrievePayloadOpts][]byte)
+
+	resolveDagParentOutputs(context.Background(), zerologNop(), []*dagChildTaskInput{runOneChild, runTwoChild}, dagParentOutputs, inputs)
+
+	runOneParents := unmarshalParents(t, inputs, runOneChild.payloadKey)
+	runTwoParents := unmarshalParents(t, inputs, runTwoChild.payloadKey)
+
+	assert.Equal(t, map[string]interface{}{"random_number": float64(1)}, runOneParents["start"])
+	assert.Equal(t, map[string]interface{}{"random_number": float64(99)}, runTwoParents["start"])
+}
+
+// TestResolveDagParentOutputs_IsolatesMissingOrUnparsableParents checks that a gap in
+// dagParentOutputs (e.g. a parent the batched/fallback lookup couldn't find) or a malformed
+// payload for one parent only drops that one entry rather than the whole task's Parents map,
+// and never affects a sibling task in the same batch.
+func TestResolveDagParentOutputs_IsolatesMissingOrUnparsableParents(t *testing.T) {
+	goodParent := uuid.New()
+	missingParent := uuid.New()
+	malformedParent := uuid.New()
+
+	affected := newDagChildInput(t, 1, goodParent, missingParent, malformedParent)
+	sibling := newDagChildInput(t, 2, goodParent)
+
+	dagParentOutputs := map[uuid.UUID]*v1.TaskOutputEvent{
+		goodParent: parentOutputEvent(t, goodParent, "good", map[string]int{"random_number": 7}),
+		malformedParent: {
+			TaskExternalId: malformedParent,
+			StepReadableID: "malformed",
+			Output:         []byte("{not valid json"),
+		},
+		// missingParent intentionally absent, simulating a lookup that never resolved it.
+	}
+
+	inputs := make(map[v1.RetrievePayloadOpts][]byte)
+
+	resolveDagParentOutputs(context.Background(), zerologNop(), []*dagChildTaskInput{affected, sibling}, dagParentOutputs, inputs)
+
+	affectedParents := unmarshalParents(t, inputs, affected.payloadKey)
+	assert.Equal(t, map[string]interface{}{"random_number": float64(7)}, affectedParents["good"])
+	assert.NotContains(t, affectedParents, "missing")
+	assert.NotContains(t, affectedParents, "malformed")
+	assert.Len(t, affectedParents, 1)
+
+	siblingParents := unmarshalParents(t, inputs, sibling.payloadKey)
+	assert.Equal(t, map[string]interface{}{"random_number": float64(7)}, siblingParents["good"])
+	assert.Len(t, siblingParents, 1, "the malformed/missing parents on a different task must not affect this sibling")
+}
+
+func zerologNop() *zerolog.Logger {
+	l := zerolog.Nop()
+	return &l
+}

--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -851,11 +851,6 @@ func (d *DispatcherImpl) populateTaskData(
 	// dagChildInputs holds the tasks whose parents need to be resolved via GetDagParentOutputs
 	// (durable DAG-operator children); we resolve all of them with a single batched lookup below
 	// instead of one DB round trip per task.
-	type dagChildTaskInput struct {
-		payloadKey v1.RetrievePayloadOpts
-		currInput  *v1.V1StepRunData
-	}
-
 	dagChildInputs := make([]*dagChildTaskInput, 0)
 	dagParentExternalIdSet := make(map[uuid.UUID]struct{})
 
@@ -922,32 +917,27 @@ func (d *DispatcherImpl) populateTaskData(
 		dagParentOutputs, err := d.repov1.Tasks().GetDagParentOutputs(ctx, tenantId, dagParentExternalIds)
 
 		if err != nil {
-			d.l.Warn().Ctx(ctx).Err(err).Msgf("failed to look up dag parent outputs for %d tasks", len(dagChildInputs))
-		} else {
+			// if we failed to get all of them at once in a batch, do it 1 by 1. Unfortunately results in an N+1 query pattern,
+			// but not much we can do.
+			d.l.Warn().Ctx(ctx).Err(err).Msgf("failed to batch look up dag parent outputs for %d tasks, falling back to per-task lookups", len(dagChildInputs))
+
+			dagParentOutputs = make(map[uuid.UUID]*v1.TaskOutputEvent)
+
 			for _, entry := range dagChildInputs {
-				parents := make(map[string]map[string]interface{})
+				perTaskOutputs, perTaskErr := d.repov1.Tasks().GetDagParentOutputs(ctx, tenantId, entry.currInput.DagParentTaskRunIds)
 
-				for _, parentExternalId := range entry.currInput.DagParentTaskRunIds {
-					parentOutput, ok := dagParentOutputs[parentExternalId]
-
-					if !ok {
-						continue
-					}
-
-					outputMap := make(map[string]interface{})
-
-					if err := json.Unmarshal(parentOutput.Output, &outputMap); err != nil {
-						d.l.Warn().Ctx(ctx).Err(err).Msgf("failed to unmarshal dag parent output for %s", parentOutput.StepReadableID)
-						continue
-					}
-
-					parents[parentOutput.StepReadableID] = outputMap
+				if perTaskErr != nil {
+					d.l.Warn().Ctx(ctx).Err(perTaskErr).Msg("failed to look up dag parent outputs")
+					continue
 				}
 
-				entry.currInput.Parents = parents
-				inputs[entry.payloadKey] = entry.currInput.Bytes()
+				for parentExternalId, output := range perTaskOutputs {
+					dagParentOutputs[parentExternalId] = output
+				}
 			}
 		}
+
+		resolveDagParentOutputs(ctx, d.l, dagChildInputs, dagParentOutputs, inputs)
 	}
 
 	runtimes, err := d.repov1.Tasks().ListTaskRuntimes(ctx, tenantId, bulkDatas)
@@ -990,6 +980,46 @@ func (d *DispatcherImpl) populateTaskData(
 	}
 
 	return taskIdToData, nil
+}
+
+// dagChildTaskInput is a durable DAG-operator child task awaiting parent output resolution:
+// its own payload key (to write the resolved input back into `inputs`) plus its unmarshaled
+// input (which carries the list of parent external IDs it needs outputs for).
+type dagChildTaskInput struct {
+	payloadKey v1.RetrievePayloadOpts
+	currInput  *v1.V1StepRunData
+}
+
+func resolveDagParentOutputs(
+	ctx context.Context,
+	l *zerolog.Logger,
+	dagChildInputs []*dagChildTaskInput,
+	dagParentOutputs map[uuid.UUID]*v1.TaskOutputEvent,
+	inputs map[v1.RetrievePayloadOpts][]byte,
+) {
+	for _, entry := range dagChildInputs {
+		parents := make(map[string]map[string]interface{})
+
+		for _, parentExternalId := range entry.currInput.DagParentTaskRunIds {
+			parentOutput, ok := dagParentOutputs[parentExternalId]
+
+			if !ok {
+				continue
+			}
+
+			outputMap := make(map[string]interface{})
+
+			if err := json.Unmarshal(parentOutput.Output, &outputMap); err != nil {
+				l.Warn().Ctx(ctx).Err(err).Msgf("failed to unmarshal dag parent output for %s", parentOutput.StepReadableID)
+				continue
+			}
+
+			parents[parentOutput.StepReadableID] = outputMap
+		}
+
+		entry.currInput.Parents = parents
+		inputs[entry.payloadKey] = entry.currInput.Bytes()
+	}
 }
 
 func (d *DispatcherImpl) sendTasksToWorker(

--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -848,6 +848,17 @@ func (d *DispatcherImpl) populateTaskData(
 		inputs = make(map[v1.RetrievePayloadOpts][]byte)
 	}
 
+	// dagChildInputs holds the tasks whose parents need to be resolved via GetDagParentOutputs
+	// (durable DAG-operator children); we resolve all of them with a single batched lookup below
+	// instead of one DB round trip per task.
+	type dagChildTaskInput struct {
+		payloadKey v1.RetrievePayloadOpts
+		currInput  *v1.V1StepRunData
+	}
+
+	dagChildInputs := make([]*dagChildTaskInput, 0)
+	dagParentExternalIdSet := make(map[uuid.UUID]struct{})
+
 	for _, task := range bulkDatas {
 		payloadKey := v1.RetrievePayloadOpts{
 			Id:         task.ID,
@@ -875,26 +886,10 @@ func (d *DispatcherImpl) populateTaskData(
 		}
 
 		if len(currInput.DagParentTaskRunIds) > 0 {
-			dagParentOutputs, err := d.repov1.Tasks().GetDagParentOutputs(ctx, tenantId, currInput.DagParentTaskRunIds)
+			dagChildInputs = append(dagChildInputs, &dagChildTaskInput{payloadKey: payloadKey, currInput: currInput})
 
-			if err != nil {
-				d.l.Warn().Ctx(ctx).Err(err).Msg("failed to look up dag parent outputs")
-			} else {
-				parents := make(map[string]map[string]interface{})
-
-				for stepReadableId, rawOutput := range dagParentOutputs {
-					outputMap := make(map[string]interface{})
-
-					if err := json.Unmarshal(rawOutput, &outputMap); err != nil {
-						d.l.Warn().Ctx(ctx).Err(err).Msgf("failed to unmarshal dag parent output for %s", stepReadableId)
-						continue
-					}
-
-					parents[stepReadableId] = outputMap
-				}
-
-				currInput.Parents = parents
-				inputs[payloadKey] = currInput.Bytes()
+			for _, parentExternalId := range currInput.DagParentTaskRunIds {
+				dagParentExternalIdSet[parentExternalId] = struct{}{}
 			}
 		} else if parentData, ok := parentDataMap[task.ID]; ok {
 			readableIdToData := make(map[string]map[string]interface{})
@@ -914,6 +909,44 @@ func (d *DispatcherImpl) populateTaskData(
 
 			currInput.Parents = readableIdToData
 			inputs[payloadKey] = currInput.Bytes()
+		}
+	}
+
+	if len(dagChildInputs) > 0 {
+		dagParentExternalIds := make([]uuid.UUID, 0, len(dagParentExternalIdSet))
+
+		for parentExternalId := range dagParentExternalIdSet {
+			dagParentExternalIds = append(dagParentExternalIds, parentExternalId)
+		}
+
+		dagParentOutputs, err := d.repov1.Tasks().GetDagParentOutputs(ctx, tenantId, dagParentExternalIds)
+
+		if err != nil {
+			d.l.Warn().Ctx(ctx).Err(err).Msgf("failed to look up dag parent outputs for %d tasks", len(dagChildInputs))
+		} else {
+			for _, entry := range dagChildInputs {
+				parents := make(map[string]map[string]interface{})
+
+				for _, parentExternalId := range entry.currInput.DagParentTaskRunIds {
+					parentOutput, ok := dagParentOutputs[parentExternalId]
+
+					if !ok {
+						continue
+					}
+
+					outputMap := make(map[string]interface{})
+
+					if err := json.Unmarshal(parentOutput.Output, &outputMap); err != nil {
+						d.l.Warn().Ctx(ctx).Err(err).Msgf("failed to unmarshal dag parent output for %s", parentOutput.StepReadableID)
+						continue
+					}
+
+					parents[parentOutput.StepReadableID] = outputMap
+				}
+
+				entry.currInput.Parents = parents
+				inputs[entry.payloadKey] = entry.currInput.Bytes()
+			}
 		}
 	}
 

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -282,9 +282,10 @@ type TaskRepository interface {
 	// with the v1 engine, and shouldn't be called from new v1 endpoints.
 	ListTaskParentOutputs(ctx context.Context, tenantId uuid.UUID, tasks []*sqlcv1.V1Task) (map[int64][]*TaskOutputEvent, error)
 
-	// GetDagParentOutputs looks up completed output data for tasks identified by their workflow run external IDs.
-	// Used for durable DAG orchestration where parent outputs are resolved at dispatch time.
-	GetDagParentOutputs(ctx context.Context, tenantId uuid.UUID, parentExternalIds []uuid.UUID) (map[string]json.RawMessage, error)
+	// GetDagParentOutputs looks up completed output data for tasks identified by their workflow run external IDs,
+	// keyed by each parent's own external ID. Used for durable DAG orchestration where parent outputs are
+	// resolved at dispatch time.
+	GetDagParentOutputs(ctx context.Context, tenantId uuid.UUID, parentExternalIds []uuid.UUID) (map[uuid.UUID]*TaskOutputEvent, error)
 
 	DefaultTaskActivityGauge(ctx context.Context, tenantId string) (int, error)
 
@@ -4279,7 +4280,7 @@ func (r *TaskRepositoryImpl) ListTaskParentOutputs(ctx context.Context, tenantId
 	return resMap, nil
 }
 
-func (r *TaskRepositoryImpl) GetDagParentOutputs(ctx context.Context, tenantId uuid.UUID, parentExternalIds []uuid.UUID) (map[string]json.RawMessage, error) {
+func (r *TaskRepositoryImpl) GetDagParentOutputs(ctx context.Context, tenantId uuid.UUID, parentExternalIds []uuid.UUID) (map[uuid.UUID]*TaskOutputEvent, error) {
 	return r.sharedRepository.lookupParentOutputsByWorkflowRunIds(ctx, tenantId, parentExternalIds)
 }
 

--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -2942,25 +2942,22 @@ func (r *sharedRepository) NewTriggerTaskData(
 	return t, nil
 }
 
-func (r *sharedRepository) lookupParentOutputsByWorkflowRunIds(ctx context.Context, tenantId uuid.UUID, parentTaskExternalIds []uuid.UUID) (map[string]json.RawMessage, error) {
+func (r *sharedRepository) lookupParentOutputsByWorkflowRunIds(ctx context.Context, tenantId uuid.UUID, parentTaskExternalIds []uuid.UUID) (map[uuid.UUID]*TaskOutputEvent, error) {
 	rows, err := r.queries.ListTaskOutputEventIdsByTaskRunExternalIds(ctx, r.pool, parentTaskExternalIds)
 	if err != nil {
 		return nil, err
 	}
 
 	retrieveOpts := make([]RetrievePayloadOpts, 0, len(rows))
-	retrieveOptToRow := make(map[RetrievePayloadOpts]*sqlcv1.ListTaskOutputEventIdsByTaskRunExternalIdsRow, len(rows))
 
 	for _, row := range rows {
-		opt := RetrievePayloadOpts{
+		retrieveOpts = append(retrieveOpts, RetrievePayloadOpts{
 			Id:         row.TaskEventID,
 			InsertedAt: row.TaskEventInsertedAt,
 			Type:       sqlcv1.V1PayloadTypeTASKEVENTDATA,
 			TenantId:   tenantId,
 			ExternalId: row.OutputEventExternalID,
-		}
-		retrieveOpts = append(retrieveOpts, opt)
-		retrieveOptToRow[opt] = row
+		})
 	}
 
 	payloads, err := r.payloadStore.Retrieve(ctx, r.pool, retrieveOpts...)
@@ -2968,7 +2965,7 @@ func (r *sharedRepository) lookupParentOutputsByWorkflowRunIds(ctx context.Conte
 		return nil, fmt.Errorf("failed to retrieve parent output payloads: %w", err)
 	}
 
-	result := make(map[string]json.RawMessage, len(rows))
+	result := make(map[uuid.UUID]*TaskOutputEvent, len(rows))
 
 	for _, payload := range payloads {
 		e, err := newTaskEventFromBytes(payload)
@@ -2978,7 +2975,7 @@ func (r *sharedRepository) lookupParentOutputsByWorkflowRunIds(ctx context.Conte
 		}
 
 		if e.IsCompleted() {
-			result[e.StepReadableID] = json.RawMessage(e.Output)
+			result[e.TaskExternalId] = e
 		}
 	}
 


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

See title. This query was taking a long time, fixes N+1 query by fetching all the parent outputs at once for all the child step ids into a map, and then keying off it.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] Performance improvement (non-breaking change which improves performance)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
