### PR TITLE
ci: remove optimistic scheduling from the sdk test matrices

### DIFF
--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -82,7 +82,6 @@ jobs:
     strategy:
       matrix:
         python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.14"]') || fromJSON('["3.10", "3.11", "3.12", "3.13", "3.14"]') }}
-        optimistic-scheduling: ["true", "false"]
         concurrency-in-memory-index: ["true", "false"]
         dag-operator: ["true", "false"]
         exclude:
@@ -127,7 +126,6 @@ jobs:
           export SERVER_AUTH_COOKIE_DOMAIN=localhost
           export SERVER_AUTH_COOKIE_INSECURE=true
           export SERVER_MSGQUEUE_RABBITMQ_URL="amqp://user:password@localhost:5672/"
-          export SERVER_OPTIMISTIC_SCHEDULING_ENABLED=${{ matrix.optimistic-scheduling }}
           export SERVER_CONCURRENCY_IN_MEMORY_INDEX_ENABLED=${{ matrix.concurrency-in-memory-index }}
           export SERVER_OBSERVABILITY_ENABLED=true
           export SERVER_SECURITY_CHECK_ENABLED=false
@@ -197,14 +195,14 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.HATCHET_CLIENT_NAMESPACE }}-opt-${{ matrix.optimistic-scheduling }}-cimi-${{ matrix.concurrency-in-memory-index }}-dag-${{ matrix.dag-operator }}-engine-logs
+          name: ${{ env.HATCHET_CLIENT_NAMESPACE }}-cimi-${{ matrix.concurrency-in-memory-index }}-dag-${{ matrix.dag-operator }}-engine-logs
           path: engine.log
 
       - name: Upload API logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.HATCHET_CLIENT_NAMESPACE }}-opt-${{ matrix.optimistic-scheduling }}-cimi-${{ matrix.concurrency-in-memory-index }}-dag-${{ matrix.dag-operator }}-api-logs
+          name: ${{ env.HATCHET_CLIENT_NAMESPACE }}-cimi-${{ matrix.concurrency-in-memory-index }}-dag-${{ matrix.dag-operator }}-api-logs
           path: api.log
 
   publish:

--- a/.github/workflows/sdk-ruby.yml
+++ b/.github/workflows/sdk-ruby.yml
@@ -75,7 +75,6 @@ jobs:
     strategy:
       matrix:
         ruby-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.2"]') || fromJSON('["3.2", "3.3"]') }}
-        optimistic-scheduling: ["true", "false"]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -114,7 +113,6 @@ jobs:
           export SERVER_AUTH_COOKIE_DOMAIN=localhost
           export SERVER_AUTH_COOKIE_INSECURE=true
           export SERVER_MSGQUEUE_RABBITMQ_URL="amqp://user:password@localhost:5672/"
-          export SERVER_OPTIMISTIC_SCHEDULING_ENABLED=${{ matrix.optimistic-scheduling }}
           export SERVER_SECURITY_CHECK_ENABLED=false
 
           go run ./cmd/hatchet-admin quickstart
@@ -238,21 +236,21 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.HATCHET_CLIENT_NAMESPACE }}-opt-${{ matrix.optimistic-scheduling }}-worker-logs
+          name: ${{ env.HATCHET_CLIENT_NAMESPACE }}-worker-logs
           path: ./sdks/ruby/examples/worker.log
 
       - name: Upload engine logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.HATCHET_CLIENT_NAMESPACE }}-opt-${{ matrix.optimistic-scheduling }}-engine-logs
+          name: ${{ env.HATCHET_CLIENT_NAMESPACE }}-engine-logs
           path: engine.log
 
       - name: Upload API logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.HATCHET_CLIENT_NAMESPACE }}-opt-${{ matrix.optimistic-scheduling }}-api-logs
+          name: ${{ env.HATCHET_CLIENT_NAMESPACE }}-api-logs
           path: api.log
 
   publish:


### PR DESCRIPTION
# Description

Removes optimistic scheduling from the test matrices, which is default-on, so we just use the default now instead

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] Performance improvement (non-breaking change which improves performance)
- [x] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI

</details>
