### PR TITLE
feat: support private CA TLS for the NATS pub/sub

### DIFF
--- a/frontend/docs/content/docs/self-hosting/configuration-options.mdx
+++ b/frontend/docs/content/docs/self-hosting/configuration-options.mdx
@@ -318,6 +318,7 @@ Variables marked with ⚠️ are conditionally required when specific features a
 | `SERVER_MSGQUEUE_PUBSUB_NATS_URL`                   | Pub/sub NATS seed URL(s), comma-separated for a cluster                                                    |                  |
 | `SERVER_MSGQUEUE_PUBSUB_NATS_USERNAME`              | Pub/sub NATS username (sent as a connect option, so reconnects also authenticate)                          |                  |
 | `SERVER_MSGQUEUE_PUBSUB_NATS_PASSWORD`              | Pub/sub NATS password (see username)                                                                       |                  |
+| `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE`      | Pub/sub NATS PEM CA bundle for verifying the server; setting it enables TLS even with a `nats://` URL      |                  |
 | `SERVER_MSGQUEUE_PUBSUB_NATS_SUBJECT_PREFIX`        | Pub/sub NATS subject prefix, joined to topic names with `.`                                                | `hatchet.pubsub` |
 | `SERVER_SINGLE_QUEUE_LIMIT`                         | Single queue limit                                                                                         | `100`            |
 
@@ -335,6 +336,12 @@ an oversized publish.
 Prefer bare hosts in `SERVER_MSGQUEUE_PUBSUB_NATS_URL` and set the username and
 password separately. Credentials embedded in the URL are not reapplied when the
 client reconnects to a cluster peer it learned about through gossip.
+
+To connect over TLS to a server whose certificate is signed by a private CA,
+point `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE` at a PEM CA bundle.
+Setting it enables TLS even when the URL uses the `nats://` scheme, and the CA
+also applies when the client reconnects to rediscovered cluster peers. A
+`tls://` URL without a CA file verifies the server against the system roots.
 
 Unlike the other backends, which isolate installations at the connection level
 (a RabbitMQ vhost, a Postgres database), NATS isolates by subject. Set

--- a/frontend/docs/content/docs/self-hosting/configuration-options.mdx
+++ b/frontend/docs/content/docs/self-hosting/configuration-options.mdx
@@ -318,7 +318,8 @@ Variables marked with ⚠️ are conditionally required when specific features a
 | `SERVER_MSGQUEUE_PUBSUB_NATS_URL`                   | Pub/sub NATS seed URL(s), comma-separated for a cluster                                                    |                  |
 | `SERVER_MSGQUEUE_PUBSUB_NATS_USERNAME`              | Pub/sub NATS username (sent as a connect option, so reconnects also authenticate)                          |                  |
 | `SERVER_MSGQUEUE_PUBSUB_NATS_PASSWORD`              | Pub/sub NATS password (see username)                                                                       |                  |
-| `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE`      | Pub/sub NATS PEM CA bundle for verifying the server; setting it enables TLS even with a `nats://` URL      |                  |
+| `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED`           | Pub/sub NATS: when `true`, require verified TLS regardless of the URL scheme                               | `false`          |
+| `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE`      | Pub/sub NATS PEM CA bundle for a private CA; requires `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED=true`       |                  |
 | `SERVER_MSGQUEUE_PUBSUB_NATS_SUBJECT_PREFIX`        | Pub/sub NATS subject prefix, joined to topic names with `.`                                                | `hatchet.pubsub` |
 | `SERVER_SINGLE_QUEUE_LIMIT`                         | Single queue limit                                                                                         | `100`            |
 
@@ -337,11 +338,15 @@ Prefer bare hosts in `SERVER_MSGQUEUE_PUBSUB_NATS_URL` and set the username and
 password separately. Credentials embedded in the URL are not reapplied when the
 client reconnects to a cluster peer it learned about through gossip.
 
-To connect over TLS to a server whose certificate is signed by a private CA,
-point `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE` at a PEM CA bundle.
-Setting it enables TLS even when the URL uses the `nats://` scheme, and the CA
-also applies when the client reconnects to rediscovered cluster peers. A
-`tls://` URL without a CA file verifies the server against the system roots.
+Set `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED=true` to require verified TLS
+regardless of the URL scheme; without a CA file the server certificate is
+verified against the system roots. If the server's certificate is signed by a
+private CA, also point `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE` at a PEM
+CA bundle, which also applies when the client reconnects to rediscovered
+cluster peers. The CA file only takes effect with TLS enabled, so Hatchet
+refuses to start if it is set while `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED`
+is false. A `tls://` URL enables TLS with the system roots via the scheme
+alone.
 
 Unlike the other backends, which isolate installations at the connection level
 (a RabbitMQ vhost, a Postgres database), NATS isolates by subject. Set

--- a/frontend/docs/content/docs/self-hosting/configuration-options.mdx
+++ b/frontend/docs/content/docs/self-hosting/configuration-options.mdx
@@ -347,8 +347,7 @@ system roots. If the server's certificate is signed by a private CA, also
 point `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE` at a PEM CA bundle, which
 also applies when the client reconnects to rediscovered cluster peers. The CA
 file only takes effect with TLS enabled, so Hatchet refuses to start if it is
-set while `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED` is false. A `tls://` URL
-does standard INFO-first TLS with the system roots via the scheme alone.
+set while `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED` is false.
 
 Unlike the other backends, which isolate installations at the connection level
 (a RabbitMQ vhost, a Postgres database), NATS isolates by subject. Set

--- a/frontend/docs/content/docs/self-hosting/configuration-options.mdx
+++ b/frontend/docs/content/docs/self-hosting/configuration-options.mdx
@@ -318,9 +318,8 @@ Variables marked with ⚠️ are conditionally required when specific features a
 | `SERVER_MSGQUEUE_PUBSUB_NATS_URL`                   | Pub/sub NATS seed URL(s), comma-separated for a cluster                                                    |                  |
 | `SERVER_MSGQUEUE_PUBSUB_NATS_USERNAME`              | Pub/sub NATS username (sent as a connect option, so reconnects also authenticate)                          |                  |
 | `SERVER_MSGQUEUE_PUBSUB_NATS_PASSWORD`              | Pub/sub NATS password (see username)                                                                       |                  |
-| `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED`           | Pub/sub NATS: when `true`, require verified TLS regardless of the URL scheme                               | `false`          |
+| `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED`           | Pub/sub NATS: verified TLS with a TLS-first handshake (server must set `handshake_first`)                  | `false`          |
 | `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE`      | Pub/sub NATS PEM CA bundle for a private CA; requires `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED=true`       |                  |
-| `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_HANDSHAKE_FIRST`   | Pub/sub NATS: TLS handshake before the server's `INFO` (server must set `handshake_first`); requires TLS   | `false`          |
 | `SERVER_MSGQUEUE_PUBSUB_NATS_SUBJECT_PREFIX`        | Pub/sub NATS subject prefix, joined to topic names with `.`                                                | `hatchet.pubsub` |
 | `SERVER_SINGLE_QUEUE_LIMIT`                         | Single queue limit                                                                                         | `100`            |
 
@@ -340,17 +339,16 @@ password separately. Credentials embedded in the URL are not reapplied when the
 client reconnects to a cluster peer it learned about through gossip.
 
 Set `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED=true` to require verified TLS
-regardless of the URL scheme; without a CA file the server certificate is
-verified against the system roots. If the server's certificate is signed by a
-private CA, also point `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE` at a PEM
-CA bundle, which also applies when the client reconnects to rediscovered
-cluster peers. The CA file only takes effect with TLS enabled, so Hatchet
-refuses to start if it is set while `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED`
-is false. A `tls://` URL enables TLS with the system roots via the scheme
-alone. If the server sets `handshake_first` in its tls block (the TLS
-handshake happens before the server's `INFO` message), also set
-`SERVER_MSGQUEUE_PUBSUB_NATS_TLS_HANDSHAKE_FIRST=true`; both sides must agree
-on the mode or the connect fails.
+with a TLS-first handshake: the handshake happens before the server's `INFO`
+message, so the server must set `handshake_first` in its tls block, and a
+client with this flag fails to connect to an INFO-first TLS or plaintext
+server. Without a CA file the server certificate is verified against the
+system roots. If the server's certificate is signed by a private CA, also
+point `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE` at a PEM CA bundle, which
+also applies when the client reconnects to rediscovered cluster peers. The CA
+file only takes effect with TLS enabled, so Hatchet refuses to start if it is
+set while `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED` is false. A `tls://` URL
+does standard INFO-first TLS with the system roots via the scheme alone.
 
 Unlike the other backends, which isolate installations at the connection level
 (a RabbitMQ vhost, a Postgres database), NATS isolates by subject. Set

--- a/frontend/docs/content/docs/self-hosting/configuration-options.mdx
+++ b/frontend/docs/content/docs/self-hosting/configuration-options.mdx
@@ -320,6 +320,7 @@ Variables marked with ⚠️ are conditionally required when specific features a
 | `SERVER_MSGQUEUE_PUBSUB_NATS_PASSWORD`              | Pub/sub NATS password (see username)                                                                       |                  |
 | `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED`           | Pub/sub NATS: when `true`, require verified TLS regardless of the URL scheme                               | `false`          |
 | `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE`      | Pub/sub NATS PEM CA bundle for a private CA; requires `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED=true`       |                  |
+| `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_HANDSHAKE_FIRST`   | Pub/sub NATS: TLS handshake before the server's `INFO` (server must set `handshake_first`); requires TLS   | `false`          |
 | `SERVER_MSGQUEUE_PUBSUB_NATS_SUBJECT_PREFIX`        | Pub/sub NATS subject prefix, joined to topic names with `.`                                                | `hatchet.pubsub` |
 | `SERVER_SINGLE_QUEUE_LIMIT`                         | Single queue limit                                                                                         | `100`            |
 
@@ -346,7 +347,10 @@ CA bundle, which also applies when the client reconnects to rediscovered
 cluster peers. The CA file only takes effect with TLS enabled, so Hatchet
 refuses to start if it is set while `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED`
 is false. A `tls://` URL enables TLS with the system roots via the scheme
-alone.
+alone. If the server sets `handshake_first` in its tls block (the TLS
+handshake happens before the server's `INFO` message), also set
+`SERVER_MSGQUEUE_PUBSUB_NATS_TLS_HANDSHAKE_FIRST=true`; both sides must agree
+on the mode or the connect fails.
 
 Unlike the other backends, which isolate installations at the connection level
 (a RabbitMQ vhost, a Postgres database), NATS isolates by subject. Set

--- a/internal/msgqueue/nats/pubsub.go
+++ b/internal/msgqueue/nats/pubsub.go
@@ -2,6 +2,7 @@ package nats
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"slices"
@@ -32,6 +33,7 @@ type PubSubOpts struct {
 	url           string
 	username      string
 	password      string
+	tlsEnabled    bool
 	tlsRootCAFile string
 	subjectPrefix string
 }
@@ -67,10 +69,19 @@ func WithPubSubPassword(password string) PubSubOpt {
 	}
 }
 
-// WithPubSubTLSRootCAFile sets a PEM CA bundle used to verify the NATS
-// server. Non-empty enables TLS even with a nats:// URL (nats.RootCAs
-// implies Secure and carries to rediscovered cluster peers); empty leaves
-// TLS to the URL scheme.
+// WithPubSubTLSEnabled requires verified TLS regardless of the URL scheme.
+// Without a CA file the server certificate is verified against the system
+// roots. False leaves TLS to the URL scheme (tls:// uses system roots).
+func WithPubSubTLSEnabled(enabled bool) PubSubOpt {
+	return func(opts *PubSubOpts) {
+		opts.tlsEnabled = enabled
+	}
+}
+
+// WithPubSubTLSRootCAFile sets a PEM CA bundle used to verify a NATS server
+// whose certificate is signed by a private CA (nats.RootCAs, which carries to
+// rediscovered cluster peers). Requires WithPubSubTLSEnabled(true); NewPubSub
+// fails fast otherwise.
 func WithPubSubTLSRootCAFile(path string) PubSubOpt {
 	return func(opts *PubSubOpts) {
 		opts.tlsRootCAFile = path
@@ -103,6 +114,10 @@ func NewPubSub(fs ...PubSubOpt) (func() error, *PubSub, error) {
 
 	if opts.url == "" {
 		return nil, nil, fmt.Errorf("nats pubsub requires a URL to be set")
+	}
+
+	if opts.tlsRootCAFile != "" && !opts.tlsEnabled {
+		return nil, nil, fmt.Errorf("nats pubsub tlsRootCAFile is set but tlsEnabled is false; a private CA bundle only takes effect with tlsEnabled: true (SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED)")
 	}
 
 	l := opts.l
@@ -149,12 +164,20 @@ func NewPubSub(fs ...PubSubOpt) (func() error, *PubSub, error) {
 		}),
 	}
 
-	if opts.tlsRootCAFile != "" {
-		// RootCAs implies Secure, so TLS is enabled even with a nats:// URL,
-		// and the CA pool applies to rediscovered cluster peers too. An
-		// unreadable or non-PEM file fails Connect with a descriptive error
-		// before any dial, so no stat/parse check is needed here.
-		connectOpts = append(connectOpts, natsgo.RootCAs(opts.tlsRootCAFile))
+	if opts.tlsEnabled {
+		// Always pass a non-nil TLS config: per nats.go's doc comment, bare
+		// Secure() without one skips server verification. With no CA file
+		// the server is verified against the system roots.
+		connectOpts = append(connectOpts, natsgo.Secure(&tls.Config{MinVersion: tls.VersionTLS12}))
+
+		if opts.tlsRootCAFile != "" {
+			// RootCAs keeps the TLS config set by Secure above and attaches
+			// the CA pool via a callback, which also applies to rediscovered
+			// cluster peers. An unreadable or non-PEM file fails Connect with
+			// a descriptive error before any dial, so no stat/parse check is
+			// needed here.
+			connectOpts = append(connectOpts, natsgo.RootCAs(opts.tlsRootCAFile))
+		}
 	}
 
 	nc, err := natsgo.Connect(opts.url, connectOpts...)

--- a/internal/msgqueue/nats/pubsub.go
+++ b/internal/msgqueue/nats/pubsub.go
@@ -29,14 +29,13 @@ type PubSub struct {
 type PubSubOpt func(*PubSubOpts)
 
 type PubSubOpts struct {
-	l                 *zerolog.Logger
-	url               string
-	username          string
-	password          string
-	tlsEnabled        bool
-	tlsRootCAFile     string
-	tlsHandshakeFirst bool
-	subjectPrefix     string
+	l             *zerolog.Logger
+	url           string
+	username      string
+	password      string
+	tlsEnabled    bool
+	tlsRootCAFile string
+	subjectPrefix string
 }
 
 func defaultPubSubOpts() *PubSubOpts {
@@ -70,9 +69,12 @@ func WithPubSubPassword(password string) PubSubOpt {
 	}
 }
 
-// WithPubSubTLSEnabled requires verified TLS regardless of the URL scheme.
-// Without a CA file the server certificate is verified against the system
-// roots. False leaves TLS to the URL scheme (tls:// uses system roots).
+// WithPubSubTLSEnabled requires verified TLS with a TLS-first handshake: the
+// handshake happens before the server's INFO message, so the server must set
+// handshake_first in its tls block. A client with this flag fails to connect
+// to an INFO-first TLS or plaintext server. Without a CA file the server
+// certificate is verified against the system roots. False leaves TLS to the
+// URL scheme (tls:// does standard INFO-first TLS with system roots).
 func WithPubSubTLSEnabled(enabled bool) PubSubOpt {
 	return func(opts *PubSubOpts) {
 		opts.tlsEnabled = enabled
@@ -86,18 +88,6 @@ func WithPubSubTLSEnabled(enabled bool) PubSubOpt {
 func WithPubSubTLSRootCAFile(path string) PubSubOpt {
 	return func(opts *PubSubOpts) {
 		opts.tlsRootCAFile = path
-	}
-}
-
-// WithPubSubTLSHandshakeFirst performs the TLS handshake before the server's
-// INFO message, for servers with handshake_first in their tls block. Against
-// a server that sends INFO first, the client's TLS handshake reads the
-// plaintext INFO as a malformed handshake reply and fails the connect within
-// the connect timeout. Requires WithPubSubTLSEnabled(true); NewPubSub fails
-// fast otherwise.
-func WithPubSubTLSHandshakeFirst(handshakeFirst bool) PubSubOpt {
-	return func(opts *PubSubOpts) {
-		opts.tlsHandshakeFirst = handshakeFirst
 	}
 }
 
@@ -131,10 +121,6 @@ func NewPubSub(fs ...PubSubOpt) (func() error, *PubSub, error) {
 
 	if opts.tlsRootCAFile != "" && !opts.tlsEnabled {
 		return nil, nil, fmt.Errorf("nats pubsub tlsRootCAFile is set but tlsEnabled is false; a private CA bundle only takes effect with tlsEnabled: true (SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED)")
-	}
-
-	if opts.tlsHandshakeFirst && !opts.tlsEnabled {
-		return nil, nil, fmt.Errorf("nats pubsub tlsHandshakeFirst is set but tlsEnabled is false; a TLS-first handshake only takes effect with tlsEnabled: true (SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED)")
 	}
 
 	l := opts.l
@@ -187,6 +173,13 @@ func NewPubSub(fs ...PubSubOpt) (func() error, *PubSub, error) {
 		// the server is verified against the system roots.
 		connectOpts = append(connectOpts, natsgo.Secure(&tls.Config{MinVersion: tls.VersionTLS12}))
 
+		// tlsEnabled always means a TLS-first handshake (before the server's
+		// INFO message); the server must set handshake_first in its tls
+		// block. Against an INFO-first server the client's TLS handshake
+		// reads the plaintext INFO as a malformed handshake reply and fails
+		// the connect within the connect timeout.
+		connectOpts = append(connectOpts, natsgo.TLSHandshakeFirst())
+
 		if opts.tlsRootCAFile != "" {
 			// RootCAs keeps the TLS config set by Secure above and attaches
 			// the CA pool via a callback, which also applies to rediscovered
@@ -194,10 +187,6 @@ func NewPubSub(fs ...PubSubOpt) (func() error, *PubSub, error) {
 			// a descriptive error before any dial, so no stat/parse check is
 			// needed here.
 			connectOpts = append(connectOpts, natsgo.RootCAs(opts.tlsRootCAFile))
-		}
-
-		if opts.tlsHandshakeFirst {
-			connectOpts = append(connectOpts, natsgo.TLSHandshakeFirst())
 		}
 	}
 

--- a/internal/msgqueue/nats/pubsub.go
+++ b/internal/msgqueue/nats/pubsub.go
@@ -29,13 +29,14 @@ type PubSub struct {
 type PubSubOpt func(*PubSubOpts)
 
 type PubSubOpts struct {
-	l             *zerolog.Logger
-	url           string
-	username      string
-	password      string
-	tlsEnabled    bool
-	tlsRootCAFile string
-	subjectPrefix string
+	l                 *zerolog.Logger
+	url               string
+	username          string
+	password          string
+	tlsEnabled        bool
+	tlsRootCAFile     string
+	tlsHandshakeFirst bool
+	subjectPrefix     string
 }
 
 func defaultPubSubOpts() *PubSubOpts {
@@ -88,6 +89,18 @@ func WithPubSubTLSRootCAFile(path string) PubSubOpt {
 	}
 }
 
+// WithPubSubTLSHandshakeFirst performs the TLS handshake before the server's
+// INFO message, for servers with handshake_first in their tls block. Against
+// a server that sends INFO first, the client's TLS handshake reads the
+// plaintext INFO as a malformed handshake reply and fails the connect within
+// the connect timeout. Requires WithPubSubTLSEnabled(true); NewPubSub fails
+// fast otherwise.
+func WithPubSubTLSHandshakeFirst(handshakeFirst bool) PubSubOpt {
+	return func(opts *PubSubOpts) {
+		opts.tlsHandshakeFirst = handshakeFirst
+	}
+}
+
 // WithPubSubSubjectPrefix sets the NATS subject prefix (default
 // "hatchet.pubsub"). Empty falls back to the default. No trimming or
 // validation: a bad prefix fails loudly via nats ErrBadSubject at startup.
@@ -118,6 +131,10 @@ func NewPubSub(fs ...PubSubOpt) (func() error, *PubSub, error) {
 
 	if opts.tlsRootCAFile != "" && !opts.tlsEnabled {
 		return nil, nil, fmt.Errorf("nats pubsub tlsRootCAFile is set but tlsEnabled is false; a private CA bundle only takes effect with tlsEnabled: true (SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED)")
+	}
+
+	if opts.tlsHandshakeFirst && !opts.tlsEnabled {
+		return nil, nil, fmt.Errorf("nats pubsub tlsHandshakeFirst is set but tlsEnabled is false; a TLS-first handshake only takes effect with tlsEnabled: true (SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED)")
 	}
 
 	l := opts.l
@@ -177,6 +194,10 @@ func NewPubSub(fs ...PubSubOpt) (func() error, *PubSub, error) {
 			// a descriptive error before any dial, so no stat/parse check is
 			// needed here.
 			connectOpts = append(connectOpts, natsgo.RootCAs(opts.tlsRootCAFile))
+		}
+
+		if opts.tlsHandshakeFirst {
+			connectOpts = append(connectOpts, natsgo.TLSHandshakeFirst())
 		}
 	}
 

--- a/internal/msgqueue/nats/pubsub.go
+++ b/internal/msgqueue/nats/pubsub.go
@@ -32,6 +32,7 @@ type PubSubOpts struct {
 	url           string
 	username      string
 	password      string
+	tlsRootCAFile string
 	subjectPrefix string
 }
 
@@ -63,6 +64,16 @@ func WithPubSubUsername(username string) PubSubOpt {
 func WithPubSubPassword(password string) PubSubOpt {
 	return func(opts *PubSubOpts) {
 		opts.password = password
+	}
+}
+
+// WithPubSubTLSRootCAFile sets a PEM CA bundle used to verify the NATS
+// server. Non-empty enables TLS even with a nats:// URL (nats.RootCAs
+// implies Secure and carries to rediscovered cluster peers); empty leaves
+// TLS to the URL scheme.
+func WithPubSubTLSRootCAFile(path string) PubSubOpt {
+	return func(opts *PubSubOpts) {
+		opts.tlsRootCAFile = path
 	}
 }
 
@@ -136,6 +147,14 @@ func NewPubSub(fs ...PubSubOpt) (func() error, *PubSub, error) {
 			}
 			l.Error().Err(err).Str("subject", subject).Msg("nats pubsub async error")
 		}),
+	}
+
+	if opts.tlsRootCAFile != "" {
+		// RootCAs implies Secure, so TLS is enabled even with a nats:// URL,
+		// and the CA pool applies to rediscovered cluster peers too. An
+		// unreadable or non-PEM file fails Connect with a descriptive error
+		// before any dial, so no stat/parse check is needed here.
+		connectOpts = append(connectOpts, natsgo.RootCAs(opts.tlsRootCAFile))
 	}
 
 	nc, err := natsgo.Connect(opts.url, connectOpts...)

--- a/internal/msgqueue/nats/pubsub.go
+++ b/internal/msgqueue/nats/pubsub.go
@@ -69,21 +69,17 @@ func WithPubSubPassword(password string) PubSubOpt {
 	}
 }
 
-// WithPubSubTLSEnabled requires verified TLS with a TLS-first handshake: the
-// handshake happens before the server's INFO message, so the server must set
-// handshake_first in its tls block. A client with this flag fails to connect
-// to an INFO-first TLS or plaintext server. Without a CA file the server
-// certificate is verified against the system roots.
+// WithPubSubTLSEnabled requires TLS with a TLS-first handshake (the server
+// must enable handshake_first). Verification uses the system roots unless a
+// root CA file is set.
 func WithPubSubTLSEnabled(enabled bool) PubSubOpt {
 	return func(opts *PubSubOpts) {
 		opts.tlsEnabled = enabled
 	}
 }
 
-// WithPubSubTLSRootCAFile sets a PEM CA bundle used to verify a NATS server
-// whose certificate is signed by a private CA (nats.RootCAs, which carries to
-// rediscovered cluster peers). Requires WithPubSubTLSEnabled(true); NewPubSub
-// fails fast otherwise.
+// WithPubSubTLSRootCAFile sets a PEM CA bundle for server verification.
+// Requires WithPubSubTLSEnabled(true).
 func WithPubSubTLSRootCAFile(path string) PubSubOpt {
 	return func(opts *PubSubOpts) {
 		opts.tlsRootCAFile = path
@@ -167,24 +163,15 @@ func NewPubSub(fs ...PubSubOpt) (func() error, *PubSub, error) {
 	}
 
 	if opts.tlsEnabled {
-		// Always pass a non-nil TLS config: per nats.go's doc comment, bare
-		// Secure() without one skips server verification. With no CA file
-		// the server is verified against the system roots.
-		connectOpts = append(connectOpts, natsgo.Secure(&tls.Config{MinVersion: tls.VersionTLS12}))
-
-		// tlsEnabled always means a TLS-first handshake (before the server's
-		// INFO message); the server must set handshake_first in its tls
-		// block. Against an INFO-first server the client's TLS handshake
-		// reads the plaintext INFO as a malformed handshake reply and fails
-		// the connect within the connect timeout.
-		connectOpts = append(connectOpts, natsgo.TLSHandshakeFirst())
+		// Non-nil config: bare Secure() skips server verification per its
+		// doc comment.
+		connectOpts = append(connectOpts,
+			natsgo.Secure(&tls.Config{MinVersion: tls.VersionTLS12}),
+			natsgo.TLSHandshakeFirst(),
+		)
 
 		if opts.tlsRootCAFile != "" {
-			// RootCAs keeps the TLS config set by Secure above and attaches
-			// the CA pool via a callback, which also applies to rediscovered
-			// cluster peers. An unreadable or non-PEM file fails Connect with
-			// a descriptive error before any dial, so no stat/parse check is
-			// needed here.
+			// RootCAs fails Connect on a missing or non-PEM file before any dial.
 			connectOpts = append(connectOpts, natsgo.RootCAs(opts.tlsRootCAFile))
 		}
 	}

--- a/internal/msgqueue/nats/pubsub.go
+++ b/internal/msgqueue/nats/pubsub.go
@@ -73,8 +73,7 @@ func WithPubSubPassword(password string) PubSubOpt {
 // handshake happens before the server's INFO message, so the server must set
 // handshake_first in its tls block. A client with this flag fails to connect
 // to an INFO-first TLS or plaintext server. Without a CA file the server
-// certificate is verified against the system roots. False leaves TLS to the
-// URL scheme (tls:// does standard INFO-first TLS with system roots).
+// certificate is verified against the system roots.
 func WithPubSubTLSEnabled(enabled bool) PubSubOpt {
 	return func(opts *PubSubOpts) {
 		opts.tlsEnabled = enabled

--- a/internal/msgqueue/nats/pubsub.go
+++ b/internal/msgqueue/nats/pubsub.go
@@ -166,7 +166,7 @@ func NewPubSub(fs ...PubSubOpt) (func() error, *PubSub, error) {
 		// Non-nil config: bare Secure() skips server verification per its
 		// doc comment.
 		connectOpts = append(connectOpts,
-			natsgo.Secure(&tls.Config{MinVersion: tls.VersionTLS12}),
+			natsgo.Secure(&tls.Config{MinVersion: tls.VersionTLS13}),
 			natsgo.TLSHandshakeFirst(),
 		)
 

--- a/internal/msgqueue/nats/pubsub_tls_test.go
+++ b/internal/msgqueue/nats/pubsub_tls_test.go
@@ -26,6 +26,19 @@ func TestNewPubSubTLSRootCAFileRequiresTLSEnabled(t *testing.T) {
 	assert.Nil(t, ps)
 }
 
+func TestNewPubSubTLSHandshakeFirstRequiresTLSEnabled(t *testing.T) {
+	cleanup, ps, err := NewPubSub(
+		WithPubSubURL("nats://127.0.0.1:4222"),
+		WithPubSubTLSHandshakeFirst(true),
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tlsHandshakeFirst")
+	assert.Contains(t, err.Error(), "tlsEnabled")
+	assert.Nil(t, cleanup)
+	assert.Nil(t, ps)
+}
+
 func TestNewPubSubTLSRootCAFileMissing(t *testing.T) {
 	cleanup, ps, err := NewPubSub(
 		WithPubSubURL("nats://127.0.0.1:4222"),

--- a/internal/msgqueue/nats/pubsub_tls_test.go
+++ b/internal/msgqueue/nats/pubsub_tls_test.go
@@ -9,13 +9,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// These tests need no NATS server: nats.go's RootCAs option loads and parses
-// the CA bundle while options are applied, so a bad file fails Connect with a
-// descriptive error before any dial.
+// These tests need no NATS server: the tlsRootCAFile/tlsEnabled consistency
+// check runs before options are built, and nats.go's RootCAs option loads and
+// parses the CA bundle while options are applied, so misconfiguration fails
+// Connect with a descriptive error before any dial.
+
+func TestNewPubSubTLSRootCAFileRequiresTLSEnabled(t *testing.T) {
+	cleanup, ps, err := NewPubSub(
+		WithPubSubURL("nats://127.0.0.1:4222"),
+		WithPubSubTLSRootCAFile("/etc/hatchet/nats-ca.pem"),
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tlsEnabled")
+	assert.Nil(t, cleanup)
+	assert.Nil(t, ps)
+}
 
 func TestNewPubSubTLSRootCAFileMissing(t *testing.T) {
 	cleanup, ps, err := NewPubSub(
 		WithPubSubURL("nats://127.0.0.1:4222"),
+		WithPubSubTLSEnabled(true),
 		WithPubSubTLSRootCAFile("/nonexistent/ca.pem"),
 	)
 
@@ -31,6 +45,7 @@ func TestNewPubSubTLSRootCAFileNotPEM(t *testing.T) {
 
 	cleanup, ps, err := NewPubSub(
 		WithPubSubURL("nats://127.0.0.1:4222"),
+		WithPubSubTLSEnabled(true),
 		WithPubSubTLSRootCAFile(caPath),
 	)
 

--- a/internal/msgqueue/nats/pubsub_tls_test.go
+++ b/internal/msgqueue/nats/pubsub_tls_test.go
@@ -26,19 +26,6 @@ func TestNewPubSubTLSRootCAFileRequiresTLSEnabled(t *testing.T) {
 	assert.Nil(t, ps)
 }
 
-func TestNewPubSubTLSHandshakeFirstRequiresTLSEnabled(t *testing.T) {
-	cleanup, ps, err := NewPubSub(
-		WithPubSubURL("nats://127.0.0.1:4222"),
-		WithPubSubTLSHandshakeFirst(true),
-	)
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "tlsHandshakeFirst")
-	assert.Contains(t, err.Error(), "tlsEnabled")
-	assert.Nil(t, cleanup)
-	assert.Nil(t, ps)
-}
-
 func TestNewPubSubTLSRootCAFileMissing(t *testing.T) {
 	cleanup, ps, err := NewPubSub(
 		WithPubSubURL("nats://127.0.0.1:4222"),

--- a/internal/msgqueue/nats/pubsub_tls_test.go
+++ b/internal/msgqueue/nats/pubsub_tls_test.go
@@ -1,0 +1,41 @@
+package nats
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests need no NATS server: nats.go's RootCAs option loads and parses
+// the CA bundle while options are applied, so a bad file fails Connect with a
+// descriptive error before any dial.
+
+func TestNewPubSubTLSRootCAFileMissing(t *testing.T) {
+	cleanup, ps, err := NewPubSub(
+		WithPubSubURL("nats://127.0.0.1:4222"),
+		WithPubSubTLSRootCAFile("/nonexistent/ca.pem"),
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rootCA file")
+	assert.Nil(t, cleanup)
+	assert.Nil(t, ps)
+}
+
+func TestNewPubSubTLSRootCAFileNotPEM(t *testing.T) {
+	caPath := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(caPath, []byte("not a pem certificate"), 0o600))
+
+	cleanup, ps, err := NewPubSub(
+		WithPubSubURL("nats://127.0.0.1:4222"),
+		WithPubSubTLSRootCAFile(caPath),
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse root certificate")
+	assert.Nil(t, cleanup)
+	assert.Nil(t, ps)
+}

--- a/internal/msgqueue/nats/pubsub_tls_test.go
+++ b/internal/msgqueue/nats/pubsub_tls_test.go
@@ -9,11 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// These tests need no NATS server: the tlsRootCAFile/tlsEnabled consistency
-// check runs before options are built, and nats.go's RootCAs option loads and
-// parses the CA bundle while options are applied, so misconfiguration fails
-// Connect with a descriptive error before any dial.
-
 func TestNewPubSubTLSRootCAFileRequiresTLSEnabled(t *testing.T) {
 	cleanup, ps, err := NewPubSub(
 		WithPubSubURL("nats://127.0.0.1:4222"),

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -1049,6 +1049,7 @@ func createPubSubV1(dc *database.Layer, cf *server.ServerConfigFile, l *zerolog.
 			natsmq.WithPubSubURL(natsURL),
 			natsmq.WithPubSubUsername(cf.MessageQueue.PubSub.NATS.Username),
 			natsmq.WithPubSubPassword(cf.MessageQueue.PubSub.NATS.Password),
+			natsmq.WithPubSubTLSEnabled(cf.MessageQueue.PubSub.NATS.TLSEnabled),
 			natsmq.WithPubSubTLSRootCAFile(cf.MessageQueue.PubSub.NATS.TLSRootCAFile),
 			natsmq.WithPubSubSubjectPrefix(cf.MessageQueue.PubSub.NATS.SubjectPrefix),
 			natsmq.WithPubSubLogger(l),

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -1049,6 +1049,7 @@ func createPubSubV1(dc *database.Layer, cf *server.ServerConfigFile, l *zerolog.
 			natsmq.WithPubSubURL(natsURL),
 			natsmq.WithPubSubUsername(cf.MessageQueue.PubSub.NATS.Username),
 			natsmq.WithPubSubPassword(cf.MessageQueue.PubSub.NATS.Password),
+			natsmq.WithPubSubTLSRootCAFile(cf.MessageQueue.PubSub.NATS.TLSRootCAFile),
 			natsmq.WithPubSubSubjectPrefix(cf.MessageQueue.PubSub.NATS.SubjectPrefix),
 			natsmq.WithPubSubLogger(l),
 		)

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -1051,6 +1051,7 @@ func createPubSubV1(dc *database.Layer, cf *server.ServerConfigFile, l *zerolog.
 			natsmq.WithPubSubPassword(cf.MessageQueue.PubSub.NATS.Password),
 			natsmq.WithPubSubTLSEnabled(cf.MessageQueue.PubSub.NATS.TLSEnabled),
 			natsmq.WithPubSubTLSRootCAFile(cf.MessageQueue.PubSub.NATS.TLSRootCAFile),
+			natsmq.WithPubSubTLSHandshakeFirst(cf.MessageQueue.PubSub.NATS.TLSHandshakeFirst),
 			natsmq.WithPubSubSubjectPrefix(cf.MessageQueue.PubSub.NATS.SubjectPrefix),
 			natsmq.WithPubSubLogger(l),
 		)

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -1051,7 +1051,6 @@ func createPubSubV1(dc *database.Layer, cf *server.ServerConfigFile, l *zerolog.
 			natsmq.WithPubSubPassword(cf.MessageQueue.PubSub.NATS.Password),
 			natsmq.WithPubSubTLSEnabled(cf.MessageQueue.PubSub.NATS.TLSEnabled),
 			natsmq.WithPubSubTLSRootCAFile(cf.MessageQueue.PubSub.NATS.TLSRootCAFile),
-			natsmq.WithPubSubTLSHandshakeFirst(cf.MessageQueue.PubSub.NATS.TLSHandshakeFirst),
 			natsmq.WithPubSubSubjectPrefix(cf.MessageQueue.PubSub.NATS.SubjectPrefix),
 			natsmq.WithPubSubLogger(l),
 		)

--- a/pkg/config/loader/loader_pubsub_test.go
+++ b/pkg/config/loader/loader_pubsub_test.go
@@ -21,6 +21,7 @@ func TestPubSubSettingsInheritance(t *testing.T) {
 		wantNatsURL           string
 		wantNatsUsername      string
 		wantNatsPassword      string
+		wantNatsTLSEnabled    bool
 		wantNatsTLSRootCAFile string
 		wantNatsSubjectPrefix string
 		wantMaxPub            int32
@@ -118,17 +119,19 @@ func TestPubSubSettingsInheritance(t *testing.T) {
 			wantMaxSub:       20,
 		},
 		{
-			name: "nats pubsub with tls root ca file",
+			name: "nats pubsub with tls enabled and root ca file",
 			env: map[string]string{
 				"SERVER_MSGQUEUE_KIND":                         "rabbitmq",
 				"SERVER_MSGQUEUE_RABBITMQ_URL":                 "amqp://user:password@rabbit:5672/",
 				"SERVER_MSGQUEUE_PUBSUB_KIND":                  "nats",
 				"SERVER_MSGQUEUE_PUBSUB_NATS_URL":              "nats://nats:4222",
+				"SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED":      "true",
 				"SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE": "/etc/hatchet/nats-ca.pem",
 			},
 			wantKind:              "nats",
 			wantURL:               "amqp://user:password@rabbit:5672/",
 			wantNatsURL:           "nats://nats:4222",
+			wantNatsTLSEnabled:    true,
 			wantNatsTLSRootCAFile: "/etc/hatchet/nats-ca.pem",
 			wantMaxPub:            10,
 			wantMaxSub:            20,
@@ -169,6 +172,7 @@ func TestPubSubSettingsInheritance(t *testing.T) {
 			assert.Equal(t, tc.wantNatsURL, cf.MessageQueue.PubSub.NATS.URL)
 			assert.Equal(t, tc.wantNatsUsername, cf.MessageQueue.PubSub.NATS.Username)
 			assert.Equal(t, tc.wantNatsPassword, cf.MessageQueue.PubSub.NATS.Password)
+			assert.Equal(t, tc.wantNatsTLSEnabled, cf.MessageQueue.PubSub.NATS.TLSEnabled)
 			assert.Equal(t, tc.wantNatsTLSRootCAFile, cf.MessageQueue.PubSub.NATS.TLSRootCAFile)
 			assert.Equal(t, tc.wantNatsSubjectPrefix, cf.MessageQueue.PubSub.NATS.SubjectPrefix)
 		})

--- a/pkg/config/loader/loader_pubsub_test.go
+++ b/pkg/config/loader/loader_pubsub_test.go
@@ -21,6 +21,7 @@ func TestPubSubSettingsInheritance(t *testing.T) {
 		wantNatsURL           string
 		wantNatsUsername      string
 		wantNatsPassword      string
+		wantNatsTLSRootCAFile string
 		wantNatsSubjectPrefix string
 		wantMaxPub            int32
 		wantMaxSub            int32
@@ -117,6 +118,22 @@ func TestPubSubSettingsInheritance(t *testing.T) {
 			wantMaxSub:       20,
 		},
 		{
+			name: "nats pubsub with tls root ca file",
+			env: map[string]string{
+				"SERVER_MSGQUEUE_KIND":                         "rabbitmq",
+				"SERVER_MSGQUEUE_RABBITMQ_URL":                 "amqp://user:password@rabbit:5672/",
+				"SERVER_MSGQUEUE_PUBSUB_KIND":                  "nats",
+				"SERVER_MSGQUEUE_PUBSUB_NATS_URL":              "nats://nats:4222",
+				"SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE": "/etc/hatchet/nats-ca.pem",
+			},
+			wantKind:              "nats",
+			wantURL:               "amqp://user:password@rabbit:5672/",
+			wantNatsURL:           "nats://nats:4222",
+			wantNatsTLSRootCAFile: "/etc/hatchet/nats-ca.pem",
+			wantMaxPub:            10,
+			wantMaxSub:            20,
+		},
+		{
 			name: "nats pubsub with subject prefix",
 			env: map[string]string{
 				"SERVER_MSGQUEUE_KIND":                       "rabbitmq",
@@ -152,6 +169,7 @@ func TestPubSubSettingsInheritance(t *testing.T) {
 			assert.Equal(t, tc.wantNatsURL, cf.MessageQueue.PubSub.NATS.URL)
 			assert.Equal(t, tc.wantNatsUsername, cf.MessageQueue.PubSub.NATS.Username)
 			assert.Equal(t, tc.wantNatsPassword, cf.MessageQueue.PubSub.NATS.Password)
+			assert.Equal(t, tc.wantNatsTLSRootCAFile, cf.MessageQueue.PubSub.NATS.TLSRootCAFile)
 			assert.Equal(t, tc.wantNatsSubjectPrefix, cf.MessageQueue.PubSub.NATS.SubjectPrefix)
 		})
 	}

--- a/pkg/config/loader/loader_pubsub_test.go
+++ b/pkg/config/loader/loader_pubsub_test.go
@@ -14,18 +14,19 @@ import (
 // fully configured pub/sub path with zero new variables.
 func TestPubSubSettingsInheritance(t *testing.T) {
 	cases := []struct {
-		name                  string
-		env                   map[string]string
-		wantKind              string
-		wantURL               string
-		wantNatsURL           string
-		wantNatsUsername      string
-		wantNatsPassword      string
-		wantNatsTLSEnabled    bool
-		wantNatsTLSRootCAFile string
-		wantNatsSubjectPrefix string
-		wantMaxPub            int32
-		wantMaxSub            int32
+		name                      string
+		env                       map[string]string
+		wantKind                  string
+		wantURL                   string
+		wantNatsURL               string
+		wantNatsUsername          string
+		wantNatsPassword          string
+		wantNatsTLSEnabled        bool
+		wantNatsTLSRootCAFile     string
+		wantNatsTLSHandshakeFirst bool
+		wantNatsSubjectPrefix     string
+		wantMaxPub                int32
+		wantMaxSub                int32
 	}{
 		{
 			name: "modern rabbit env only",
@@ -119,22 +120,24 @@ func TestPubSubSettingsInheritance(t *testing.T) {
 			wantMaxSub:       20,
 		},
 		{
-			name: "nats pubsub with tls enabled and root ca file",
+			name: "nats pubsub with tls enabled, root ca file, and handshake first",
 			env: map[string]string{
-				"SERVER_MSGQUEUE_KIND":                         "rabbitmq",
-				"SERVER_MSGQUEUE_RABBITMQ_URL":                 "amqp://user:password@rabbit:5672/",
-				"SERVER_MSGQUEUE_PUBSUB_KIND":                  "nats",
-				"SERVER_MSGQUEUE_PUBSUB_NATS_URL":              "nats://nats:4222",
-				"SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED":      "true",
-				"SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE": "/etc/hatchet/nats-ca.pem",
+				"SERVER_MSGQUEUE_KIND":                            "rabbitmq",
+				"SERVER_MSGQUEUE_RABBITMQ_URL":                    "amqp://user:password@rabbit:5672/",
+				"SERVER_MSGQUEUE_PUBSUB_KIND":                     "nats",
+				"SERVER_MSGQUEUE_PUBSUB_NATS_URL":                 "nats://nats:4222",
+				"SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED":         "true",
+				"SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE":    "/etc/hatchet/nats-ca.pem",
+				"SERVER_MSGQUEUE_PUBSUB_NATS_TLS_HANDSHAKE_FIRST": "true",
 			},
-			wantKind:              "nats",
-			wantURL:               "amqp://user:password@rabbit:5672/",
-			wantNatsURL:           "nats://nats:4222",
-			wantNatsTLSEnabled:    true,
-			wantNatsTLSRootCAFile: "/etc/hatchet/nats-ca.pem",
-			wantMaxPub:            10,
-			wantMaxSub:            20,
+			wantKind:                  "nats",
+			wantURL:                   "amqp://user:password@rabbit:5672/",
+			wantNatsURL:               "nats://nats:4222",
+			wantNatsTLSEnabled:        true,
+			wantNatsTLSRootCAFile:     "/etc/hatchet/nats-ca.pem",
+			wantNatsTLSHandshakeFirst: true,
+			wantMaxPub:                10,
+			wantMaxSub:                20,
 		},
 		{
 			name: "nats pubsub with subject prefix",
@@ -174,6 +177,7 @@ func TestPubSubSettingsInheritance(t *testing.T) {
 			assert.Equal(t, tc.wantNatsPassword, cf.MessageQueue.PubSub.NATS.Password)
 			assert.Equal(t, tc.wantNatsTLSEnabled, cf.MessageQueue.PubSub.NATS.TLSEnabled)
 			assert.Equal(t, tc.wantNatsTLSRootCAFile, cf.MessageQueue.PubSub.NATS.TLSRootCAFile)
+			assert.Equal(t, tc.wantNatsTLSHandshakeFirst, cf.MessageQueue.PubSub.NATS.TLSHandshakeFirst)
 			assert.Equal(t, tc.wantNatsSubjectPrefix, cf.MessageQueue.PubSub.NATS.SubjectPrefix)
 		})
 	}

--- a/pkg/config/loader/loader_pubsub_test.go
+++ b/pkg/config/loader/loader_pubsub_test.go
@@ -14,18 +14,18 @@ import (
 // fully configured pub/sub path with zero new variables.
 func TestPubSubSettingsInheritance(t *testing.T) {
 	cases := []struct {
-		name                      string
-		env                       map[string]string
-		wantKind                  string
-		wantURL                   string
-		wantNatsURL               string
-		wantNatsUsername          string
-		wantNatsPassword          string
+		name                  string
+		env                   map[string]string
+		wantKind              string
+		wantURL               string
+		wantNatsURL           string
+		wantNatsUsername      string
+		wantNatsPassword      string
 		wantNatsTLSEnabled    bool
 		wantNatsTLSRootCAFile string
-		wantNatsSubjectPrefix     string
-		wantMaxPub                int32
-		wantMaxSub                int32
+		wantNatsSubjectPrefix string
+		wantMaxPub            int32
+		wantMaxSub            int32
 	}{
 		{
 			name: "modern rabbit env only",

--- a/pkg/config/loader/loader_pubsub_test.go
+++ b/pkg/config/loader/loader_pubsub_test.go
@@ -21,9 +21,8 @@ func TestPubSubSettingsInheritance(t *testing.T) {
 		wantNatsURL               string
 		wantNatsUsername          string
 		wantNatsPassword          string
-		wantNatsTLSEnabled        bool
-		wantNatsTLSRootCAFile     string
-		wantNatsTLSHandshakeFirst bool
+		wantNatsTLSEnabled    bool
+		wantNatsTLSRootCAFile string
 		wantNatsSubjectPrefix     string
 		wantMaxPub                int32
 		wantMaxSub                int32
@@ -120,24 +119,22 @@ func TestPubSubSettingsInheritance(t *testing.T) {
 			wantMaxSub:       20,
 		},
 		{
-			name: "nats pubsub with tls enabled, root ca file, and handshake first",
+			name: "nats pubsub with tls enabled and root ca file",
 			env: map[string]string{
-				"SERVER_MSGQUEUE_KIND":                            "rabbitmq",
-				"SERVER_MSGQUEUE_RABBITMQ_URL":                    "amqp://user:password@rabbit:5672/",
-				"SERVER_MSGQUEUE_PUBSUB_KIND":                     "nats",
-				"SERVER_MSGQUEUE_PUBSUB_NATS_URL":                 "nats://nats:4222",
-				"SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED":         "true",
-				"SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE":    "/etc/hatchet/nats-ca.pem",
-				"SERVER_MSGQUEUE_PUBSUB_NATS_TLS_HANDSHAKE_FIRST": "true",
+				"SERVER_MSGQUEUE_KIND":                         "rabbitmq",
+				"SERVER_MSGQUEUE_RABBITMQ_URL":                 "amqp://user:password@rabbit:5672/",
+				"SERVER_MSGQUEUE_PUBSUB_KIND":                  "nats",
+				"SERVER_MSGQUEUE_PUBSUB_NATS_URL":              "nats://nats:4222",
+				"SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED":      "true",
+				"SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE": "/etc/hatchet/nats-ca.pem",
 			},
-			wantKind:                  "nats",
-			wantURL:                   "amqp://user:password@rabbit:5672/",
-			wantNatsURL:               "nats://nats:4222",
-			wantNatsTLSEnabled:        true,
-			wantNatsTLSRootCAFile:     "/etc/hatchet/nats-ca.pem",
-			wantNatsTLSHandshakeFirst: true,
-			wantMaxPub:                10,
-			wantMaxSub:                20,
+			wantKind:              "nats",
+			wantURL:               "amqp://user:password@rabbit:5672/",
+			wantNatsURL:           "nats://nats:4222",
+			wantNatsTLSEnabled:    true,
+			wantNatsTLSRootCAFile: "/etc/hatchet/nats-ca.pem",
+			wantMaxPub:            10,
+			wantMaxSub:            20,
 		},
 		{
 			name: "nats pubsub with subject prefix",
@@ -177,7 +174,6 @@ func TestPubSubSettingsInheritance(t *testing.T) {
 			assert.Equal(t, tc.wantNatsPassword, cf.MessageQueue.PubSub.NATS.Password)
 			assert.Equal(t, tc.wantNatsTLSEnabled, cf.MessageQueue.PubSub.NATS.TLSEnabled)
 			assert.Equal(t, tc.wantNatsTLSRootCAFile, cf.MessageQueue.PubSub.NATS.TLSRootCAFile)
-			assert.Equal(t, tc.wantNatsTLSHandshakeFirst, cf.MessageQueue.PubSub.NATS.TLSHandshakeFirst)
 			assert.Equal(t, tc.wantNatsSubjectPrefix, cf.MessageQueue.PubSub.NATS.SubjectPrefix)
 		})
 	}

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -594,6 +594,14 @@ type PubSubNATSConfigFile struct {
 	// cluster peers). Requires TLSEnabled: true; startup fails otherwise.
 	TLSRootCAFile string `mapstructure:"tlsRootCAFile" json:"tlsRootCAFile,omitempty"`
 
+	// TLSHandshakeFirst performs the TLS handshake before the server's INFO
+	// message; the server must enable handshake_first in its tls block.
+	// Against a server that sends INFO first, the client's TLS handshake
+	// reads the plaintext INFO as a malformed handshake reply and fails the
+	// connect within the connect timeout. Requires TLSEnabled: true; startup
+	// fails otherwise.
+	TLSHandshakeFirst bool `mapstructure:"tlsHandshakeFirst" json:"tlsHandshakeFirst,omitempty"`
+
 	// SubjectPrefix is prepended (with a trailing ".") to topic names.
 	// Empty defaults to "hatchet.pubsub".
 	SubjectPrefix string `mapstructure:"subjectPrefix" json:"subjectPrefix,omitempty"`
@@ -962,6 +970,7 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("msgQueue.pubSub.nats.subjectPrefix", "SERVER_MSGQUEUE_PUBSUB_NATS_SUBJECT_PREFIX")
 	_ = v.BindEnv("msgQueue.pubSub.nats.tlsEnabled", "SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED")
 	_ = v.BindEnv("msgQueue.pubSub.nats.tlsRootCAFile", "SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE")
+	_ = v.BindEnv("msgQueue.pubSub.nats.tlsHandshakeFirst", "SERVER_MSGQUEUE_PUBSUB_NATS_TLS_HANDSHAKE_FIRST")
 	_ = v.BindEnv("runtime.singleQueueLimit", "SERVER_SINGLE_QUEUE_LIMIT")
 	_ = v.BindEnv("runtime.optimisticSchedulingEnabled", "SERVER_OPTIMISTIC_SCHEDULING_ENABLED")
 	_ = v.BindEnv("runtime.optimisticSchedulingSlots", "SERVER_OPTIMISTIC_SCHEDULING_SLOTS")

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -584,23 +584,19 @@ type PubSubNATSConfigFile struct {
 	Username string `mapstructure:"username" json:"username,omitempty"`
 	Password string `mapstructure:"password" json:"password,omitempty"`
 
-	// TLSEnabled requires verified TLS regardless of the URL scheme. Without
-	// TLSRootCAFile the server certificate is verified against the system
-	// roots. False leaves TLS to the URL scheme alone.
+	// TLSEnabled requires verified TLS with a TLS-first handshake: the
+	// handshake happens before the server's INFO message, so the server must
+	// set handshake_first in its tls block. A client with this flag fails to
+	// connect to an INFO-first TLS or plaintext server. Without TLSRootCAFile
+	// the server certificate is verified against the system roots. False
+	// leaves TLS to the URL scheme alone (tls:// does standard INFO-first
+	// TLS with system roots).
 	TLSEnabled bool `mapstructure:"tlsEnabled" json:"tlsEnabled,omitempty"`
 
 	// TLSRootCAFile is a PEM CA bundle used to verify a NATS server whose
 	// certificate is signed by a private CA (it also applies to rediscovered
 	// cluster peers). Requires TLSEnabled: true; startup fails otherwise.
 	TLSRootCAFile string `mapstructure:"tlsRootCAFile" json:"tlsRootCAFile,omitempty"`
-
-	// TLSHandshakeFirst performs the TLS handshake before the server's INFO
-	// message; the server must enable handshake_first in its tls block.
-	// Against a server that sends INFO first, the client's TLS handshake
-	// reads the plaintext INFO as a malformed handshake reply and fails the
-	// connect within the connect timeout. Requires TLSEnabled: true; startup
-	// fails otherwise.
-	TLSHandshakeFirst bool `mapstructure:"tlsHandshakeFirst" json:"tlsHandshakeFirst,omitempty"`
 
 	// SubjectPrefix is prepended (with a trailing ".") to topic names.
 	// Empty defaults to "hatchet.pubsub".
@@ -970,7 +966,6 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("msgQueue.pubSub.nats.subjectPrefix", "SERVER_MSGQUEUE_PUBSUB_NATS_SUBJECT_PREFIX")
 	_ = v.BindEnv("msgQueue.pubSub.nats.tlsEnabled", "SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED")
 	_ = v.BindEnv("msgQueue.pubSub.nats.tlsRootCAFile", "SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE")
-	_ = v.BindEnv("msgQueue.pubSub.nats.tlsHandshakeFirst", "SERVER_MSGQUEUE_PUBSUB_NATS_TLS_HANDSHAKE_FIRST")
 	_ = v.BindEnv("runtime.singleQueueLimit", "SERVER_SINGLE_QUEUE_LIMIT")
 	_ = v.BindEnv("runtime.optimisticSchedulingEnabled", "SERVER_OPTIMISTIC_SCHEDULING_ENABLED")
 	_ = v.BindEnv("runtime.optimisticSchedulingSlots", "SERVER_OPTIMISTIC_SCHEDULING_SLOTS")

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -576,12 +576,19 @@ type PubSubNATSConfigFile struct {
 	// URL is comma-separated seed URL(s). Prefer bare hosts (e.g.
 	// nats://nats:4222); put auth in Username/Password so rediscovered
 	// cluster peers authenticate too. URL-embedded user:pass still works for
-	// single-server/dev. Use tls:// for TLS. No durable-MQ inheritance —
-	// NATS is pub/sub only.
+	// single-server/dev. Use tls:// for TLS with system roots; set
+	// TLSRootCAFile for a private CA. No durable-MQ inheritance — NATS is
+	// pub/sub only.
 	URL string `mapstructure:"url" json:"url,omitempty"`
 
 	Username string `mapstructure:"username" json:"username,omitempty"`
 	Password string `mapstructure:"password" json:"password,omitempty"`
+
+	// TLSRootCAFile is a PEM CA bundle used to verify the NATS server.
+	// Setting it enables TLS even with a nats:// URL (nats.go RootCAs
+	// implies Secure and carries to rediscovered cluster peers). Empty means
+	// TLS is decided by the URL scheme alone.
+	TLSRootCAFile string `mapstructure:"tlsRootCAFile" json:"tlsRootCAFile,omitempty"`
 
 	// SubjectPrefix is prepended (with a trailing ".") to topic names.
 	// Empty defaults to "hatchet.pubsub".
@@ -949,6 +956,7 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("msgQueue.pubSub.nats.username", "SERVER_MSGQUEUE_PUBSUB_NATS_USERNAME")
 	_ = v.BindEnv("msgQueue.pubSub.nats.password", "SERVER_MSGQUEUE_PUBSUB_NATS_PASSWORD")
 	_ = v.BindEnv("msgQueue.pubSub.nats.subjectPrefix", "SERVER_MSGQUEUE_PUBSUB_NATS_SUBJECT_PREFIX")
+	_ = v.BindEnv("msgQueue.pubSub.nats.tlsRootCAFile", "SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE")
 	_ = v.BindEnv("runtime.singleQueueLimit", "SERVER_SINGLE_QUEUE_LIMIT")
 	_ = v.BindEnv("runtime.optimisticSchedulingEnabled", "SERVER_OPTIMISTIC_SCHEDULING_ENABLED")
 	_ = v.BindEnv("runtime.optimisticSchedulingSlots", "SERVER_OPTIMISTIC_SCHEDULING_SLOTS")

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -582,16 +582,13 @@ type PubSubNATSConfigFile struct {
 	Username string `mapstructure:"username" json:"username,omitempty"`
 	Password string `mapstructure:"password" json:"password,omitempty"`
 
-	// TLSEnabled requires verified TLS with a TLS-first handshake: the
-	// handshake happens before the server's INFO message, so the server must
-	// set handshake_first in its tls block. A client with this flag fails to
-	// connect to an INFO-first TLS or plaintext server. Without TLSRootCAFile
-	// the server certificate is verified against the system roots.
+	// TLSEnabled requires TLS with a TLS-first handshake (the server must
+	// enable handshake_first). Without TLSRootCAFile, verification uses the
+	// system roots.
 	TLSEnabled bool `mapstructure:"tlsEnabled" json:"tlsEnabled,omitempty"`
 
-	// TLSRootCAFile is a PEM CA bundle used to verify a NATS server whose
-	// certificate is signed by a private CA (it also applies to rediscovered
-	// cluster peers). Requires TLSEnabled: true; startup fails otherwise.
+	// TLSRootCAFile is a PEM CA bundle for server verification. Requires
+	// TLSEnabled.
 	TLSRootCAFile string `mapstructure:"tlsRootCAFile" json:"tlsRootCAFile,omitempty"`
 
 	// SubjectPrefix is prepended (with a trailing ".") to topic names.

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -576,18 +576,22 @@ type PubSubNATSConfigFile struct {
 	// URL is comma-separated seed URL(s). Prefer bare hosts (e.g.
 	// nats://nats:4222); put auth in Username/Password so rediscovered
 	// cluster peers authenticate too. URL-embedded user:pass still works for
-	// single-server/dev. Use tls:// for TLS with system roots; set
-	// TLSRootCAFile for a private CA. No durable-MQ inheritance — NATS is
-	// pub/sub only.
+	// single-server/dev. A tls:// scheme enables TLS with system roots; see
+	// TLSEnabled/TLSRootCAFile for scheme-independent TLS and private CAs.
+	// No durable-MQ inheritance — NATS is pub/sub only.
 	URL string `mapstructure:"url" json:"url,omitempty"`
 
 	Username string `mapstructure:"username" json:"username,omitempty"`
 	Password string `mapstructure:"password" json:"password,omitempty"`
 
-	// TLSRootCAFile is a PEM CA bundle used to verify the NATS server.
-	// Setting it enables TLS even with a nats:// URL (nats.go RootCAs
-	// implies Secure and carries to rediscovered cluster peers). Empty means
-	// TLS is decided by the URL scheme alone.
+	// TLSEnabled requires verified TLS regardless of the URL scheme. Without
+	// TLSRootCAFile the server certificate is verified against the system
+	// roots. False leaves TLS to the URL scheme alone.
+	TLSEnabled bool `mapstructure:"tlsEnabled" json:"tlsEnabled,omitempty"`
+
+	// TLSRootCAFile is a PEM CA bundle used to verify a NATS server whose
+	// certificate is signed by a private CA (it also applies to rediscovered
+	// cluster peers). Requires TLSEnabled: true; startup fails otherwise.
 	TLSRootCAFile string `mapstructure:"tlsRootCAFile" json:"tlsRootCAFile,omitempty"`
 
 	// SubjectPrefix is prepended (with a trailing ".") to topic names.
@@ -956,6 +960,7 @@ func BindAllEnv(v *viper.Viper) {
 	_ = v.BindEnv("msgQueue.pubSub.nats.username", "SERVER_MSGQUEUE_PUBSUB_NATS_USERNAME")
 	_ = v.BindEnv("msgQueue.pubSub.nats.password", "SERVER_MSGQUEUE_PUBSUB_NATS_PASSWORD")
 	_ = v.BindEnv("msgQueue.pubSub.nats.subjectPrefix", "SERVER_MSGQUEUE_PUBSUB_NATS_SUBJECT_PREFIX")
+	_ = v.BindEnv("msgQueue.pubSub.nats.tlsEnabled", "SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED")
 	_ = v.BindEnv("msgQueue.pubSub.nats.tlsRootCAFile", "SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE")
 	_ = v.BindEnv("runtime.singleQueueLimit", "SERVER_SINGLE_QUEUE_LIMIT")
 	_ = v.BindEnv("runtime.optimisticSchedulingEnabled", "SERVER_OPTIMISTIC_SCHEDULING_ENABLED")

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -576,9 +576,7 @@ type PubSubNATSConfigFile struct {
 	// URL is comma-separated seed URL(s). Prefer bare hosts (e.g.
 	// nats://nats:4222); put auth in Username/Password so rediscovered
 	// cluster peers authenticate too. URL-embedded user:pass still works for
-	// single-server/dev. A tls:// scheme enables TLS with system roots; see
-	// TLSEnabled/TLSRootCAFile for scheme-independent TLS and private CAs.
-	// No durable-MQ inheritance — NATS is pub/sub only.
+	// single-server/dev. No durable-MQ inheritance — NATS is pub/sub only.
 	URL string `mapstructure:"url" json:"url,omitempty"`
 
 	Username string `mapstructure:"username" json:"username,omitempty"`
@@ -588,9 +586,7 @@ type PubSubNATSConfigFile struct {
 	// handshake happens before the server's INFO message, so the server must
 	// set handshake_first in its tls block. A client with this flag fails to
 	// connect to an INFO-first TLS or plaintext server. Without TLSRootCAFile
-	// the server certificate is verified against the system roots. False
-	// leaves TLS to the URL scheme alone (tls:// does standard INFO-first
-	// TLS with system roots).
+	// the server certificate is verified against the system roots.
 	TLSEnabled bool `mapstructure:"tlsEnabled" json:"tlsEnabled,omitempty"`
 
 	// TLSRootCAFile is a PEM CA bundle used to verify a NATS server whose


### PR DESCRIPTION
# Description

Adds optional TLS settings to the NATS pub/sub backend:

- `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED` (`tlsEnabled`): when `true`, the client requires verified TLS 1.3+ with a TLS-first handshake — the TLS handshake happens before the server's `INFO` protocol message (nats.go's `TLSHandshakeFirst` option), so even `INFO` is encrypted, as with HTTPS. The server must set `handshake_first` in its `tls` block; a client with this flag fails to connect to an INFO-first TLS or plaintext server. The client always passes an explicit TLS config to nats.go's `Secure` option (a bare `Secure()` without a config skips server verification, so a config with `MinVersion: TLS 1.3` is always supplied). Without a CA file, the server certificate is verified against the system roots.
- `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE` (`tlsRootCAFile`): a PEM CA bundle for servers whose certificates are signed by a private CA, passed to nats.go's `RootCAs` option so the CA pool also applies when the client reconnects to cluster peers discovered through gossip. Requires `tlsEnabled: true` — Hatchet fails at startup with a clear error if the CA file is set while TLS is disabled, and an unreadable or non-PEM CA file also fails `Connect` with a descriptive error before any dial.
- When both are unset, these settings configure nothing and behavior is unchanged.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

Changes have been:

- [x] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

- `go build ./...` passes.
- New unit tests (no NATS server required):
  - `pkg/config/loader`: `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ENABLED` and `SERVER_MSGQUEUE_PUBSUB_NATS_TLS_ROOT_CA_FILE` populate the config fields.
  - `internal/msgqueue/nats`: `NewPubSub` fails fast with a descriptive error when the CA file is set without `tlsEnabled`, when the CA file is missing, and when the CA file is not valid PEM.
- `go test ./internal/msgqueue/nats/... ./pkg/config/loader/...` passes; `golangci-lint run` on the changed packages reports 0 issues.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Code, tests, and docs drafted with Cursor (Claude) from a human-written design, then verified locally with the build, unit tests, and golangci-lint.

</details>
