### PR TITLE
fix: replace OLAP run advisory locks with snapshot-safe DAG rollup locking

### DIFF
--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -7,10 +7,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"hash/fnv"
 	"log"
 	"math/rand"
-	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -1826,54 +1824,12 @@ func (r *OLAPRepositoryImpl) prepareDAGStatusUpdateBatchFromReconcile(taskRows [
 	}
 }
 
-func workflowRunAdvisoryInt(id uuid.UUID) int64 {
-	hasher := fnv.New64a()
-	hasher.Write(id[:])
-	return int64(hasher.Sum64()) // nolint: gosec
-}
-
-func (r *OLAPRepositoryImpl) tryAcquireAdvisoryLocksForWorkflowRuns(ctx context.Context, tx pgx.Tx, workflowRunIds []uuid.UUID) (locksNotAcquired map[uuid.UUID]struct{}, err error) {
-	keyToWorkflowRunId := make(map[int64]uuid.UUID, len(workflowRunIds))
-	seen := make(map[uuid.UUID]struct{}, len(workflowRunIds))
-	keys := make([]int64, 0, len(workflowRunIds))
-
-	for _, id := range workflowRunIds {
-		if _, ok := seen[id]; ok {
-			continue
-		}
-
-		seen[id] = struct{}{}
-		key := workflowRunAdvisoryInt(id)
-		keys = append(keys, key)
-		keyToWorkflowRunId[key] = id
-	}
-
-	slices.Sort(keys)
-
-	locksNotAcquired = make(map[uuid.UUID]struct{})
-
-	lockResults, err := r.queries.TryAdvisoryLockMany(ctx, tx, keys)
-
-	if err != nil {
-		return nil, fmt.Errorf("error trying advisory lock for workflow run: %w", err)
-	}
-
-	for _, lock := range lockResults {
-		if !lock.Acquired {
-			workflowRunId, ok := keyToWorkflowRunId[lock.Key]
-
-			if !ok {
-				r.l.Error().Ctx(ctx).Msgf("could not find workflow run id for advisory lock key %d", lock.Key)
-				continue
-			}
-
-			locksNotAcquired[workflowRunId] = struct{}{}
-		}
-	}
-
-	return locksNotAcquired, nil
-}
-
+// Concurrent OLAP writers are safe without any run-level advisory lock:
+// task-status updates are monotonic (guarded by retry_count and
+// v1_status_to_priority, re-evaluated against the latest row version after a
+// row-lock wait), and the count-based DAG rollup takes its row locks in a
+// separate LockDAGsForStatusUpdate statement so the rollup's snapshot is
+// opened only after any concurrent rollup for the same DAG has committed.
 func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, eventExternalIdToWorkflowRunId map[uuid.UUID]uuid.UUID) (*StatusUpdateResult, map[uuid.UUID]struct{}, error) {
 	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 	if err != nil {
@@ -1881,30 +1837,13 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 	}
 	defer rollback()
 
-	workflowRunIds := make([]uuid.UUID, 0, len(events))
-
-	for _, workflowRunId := range eventExternalIdToWorkflowRunId {
-		workflowRunIds = append(workflowRunIds, workflowRunId)
-	}
-
-	workflowRunIdsOfLocksNotAcquired, err := r.tryAcquireAdvisoryLocksForWorkflowRuns(ctx, tx, workflowRunIds)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	eventsToWrite := make([]sqlcv1.CreateTaskEventsOLAPParams, 0)
 	eventsForStatusUpdate := make([]sqlcv1.CreateTaskEventsOLAPParams, 0, len(events))
 	payloadsToWrite := make([]StoreOLAPPayloadOpts, 0)
 
 	for _, event := range events {
-		workflowRunId, ok := eventExternalIdToWorkflowRunId[event.ExternalID]
-
-		if !ok {
+		if _, ok := eventExternalIdToWorkflowRunId[event.ExternalID]; !ok {
 			r.l.Error().Ctx(ctx).Msgf("could not find workflow run id for event with external id %s", event.ExternalID)
-			continue
-		}
-
-		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[workflowRunId]; notAcquired {
 			continue
 		}
 
@@ -1931,7 +1870,7 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 	}
 
 	if len(eventsForStatusUpdate) == 0 {
-		return nil, workflowRunIdsOfLocksNotAcquired, nil
+		return nil, map[uuid.UUID]struct{}{}, nil
 	}
 
 	if len(eventsToWrite) > 0 {
@@ -1970,6 +1909,11 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 	var dagRows []*sqlcv1.UpdateDAGStatusesFromMQRow
 
 	if len(dagStatusUpdates.Dagids) > 0 {
+		err = r.queries.LockDAGsForStatusUpdate(ctx, tx, sqlcv1.LockDAGsForStatusUpdateParams(dagStatusUpdates))
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to lock DAGs for status update: %w", err)
+		}
+
 		dagRows, err = r.queries.UpdateDAGStatusesFromMQ(ctx, tx, dagStatusUpdates)
 		if err != nil {
 			return nil, nil, err
@@ -2002,7 +1946,7 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 
 	r.saveEventsToCache(eventsToWrite)
 
-	return result, workflowRunIdsOfLocksNotAcquired, nil
+	return result, map[uuid.UUID]struct{}{}, nil
 }
 
 func (r *OLAPRepositoryImpl) UpdateTaskStatuses(ctx context.Context, tenantIds []uuid.UUID) (bool, []UpdateTaskStatusRow, error) {
@@ -2238,31 +2182,17 @@ func (r *OLAPRepositoryImpl) UpdateDAGStatuses(ctx context.Context, tenantIds []
 }
 
 func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId uuid.UUID, tasks []*V1TaskWithPayload) (*StatusUpdateResult, map[uuid.UUID]struct{}, error) {
-	workflowRunIds := make([]uuid.UUID, len(tasks))
-	for i, task := range tasks {
-		workflowRunIds[i] = task.WorkflowRunID
-	}
-
 	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 	if err != nil {
 		return nil, nil, err
 	}
 	defer rollback()
 
-	workflowRunIdsOfLocksNotAcquired, err := r.tryAcquireAdvisoryLocksForWorkflowRuns(ctx, tx, workflowRunIds)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	params := sqlcv1.CreateTasksOLAPParams{}
 	putPayloadOpts := make([]StoreOLAPPayloadOpts, 0)
 	minInsertedAt := pgtype.Timestamptz{}
 
 	for _, task := range tasks {
-		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[task.WorkflowRunID]; notAcquired {
-			continue
-		}
-
 		payload := task.Payload
 
 		// fall back to input if payload is empty
@@ -2307,7 +2237,7 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId uuid.U
 	}
 
 	if len(params.Ids) == 0 {
-		return nil, workflowRunIdsOfLocksNotAcquired, nil
+		return nil, map[uuid.UUID]struct{}{}, nil
 	}
 
 	err = r.queries.CreateTasksOLAP(ctx, tx, params)
@@ -2342,6 +2272,11 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId uuid.U
 
 		dagStatusUpdates := r.prepareDAGStatusUpdateBatchFromReconcile(reconciledTasks)
 		if len(dagStatusUpdates.Dagids) > 0 {
+			err = r.queries.LockDAGsForStatusUpdate(ctx, tx, sqlcv1.LockDAGsForStatusUpdateParams(dagStatusUpdates))
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to lock DAGs for status update after reconcile: %w", err)
+			}
+
 			dagRows, err = r.queries.UpdateDAGStatusesFromMQ(ctx, tx, dagStatusUpdates)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to update DAG statuses after reconcile: %w", err)
@@ -2373,35 +2308,21 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId uuid.U
 		})
 	}
 
-	return result, workflowRunIdsOfLocksNotAcquired, nil
+	return result, map[uuid.UUID]struct{}{}, nil
 }
 
 func (r *OLAPRepositoryImpl) writeDAGBatch(ctx context.Context, tenantId uuid.UUID, dags []*DAGWithData) (map[uuid.UUID]struct{}, error) {
-	dagIds := make([]uuid.UUID, len(dags))
-	for i, dag := range dags {
-		dagIds[i] = dag.ExternalID
-	}
-
 	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 	if err != nil {
 		return nil, err
 	}
 	defer rollback()
 
-	workflowRunIdsOfLocksNotAcquired, err := r.tryAcquireAdvisoryLocksForWorkflowRuns(ctx, tx, dagIds)
-	if err != nil {
-		return nil, err
-	}
-
 	params := sqlcv1.CreateDAGsOLAPOverwriteParams{}
 	putPayloadOpts := make([]StoreOLAPPayloadOpts, 0)
 	selfMappingParams := sqlcv1.CreateDagToTaskOLAPSelfMappingsParams{}
 
 	for _, dag := range dags {
-		if _, notAcquired := workflowRunIdsOfLocksNotAcquired[dag.ExternalID]; notAcquired {
-			continue
-		}
-
 		if dag.IsOperatorRun {
 			selfMappingParams.Dagids = append(selfMappingParams.Dagids, dag.ID)
 			selfMappingParams.Daginsertedats = append(selfMappingParams.Daginsertedats, dag.InsertedAt)
@@ -2427,7 +2348,7 @@ func (r *OLAPRepositoryImpl) writeDAGBatch(ctx context.Context, tenantId uuid.UU
 	}
 
 	if len(params.Ids) == 0 {
-		return workflowRunIdsOfLocksNotAcquired, nil
+		return map[uuid.UUID]struct{}{}, nil
 	}
 
 	err = r.queries.CreateDAGsOLAP(ctx, tx, params)
@@ -2451,7 +2372,7 @@ func (r *OLAPRepositoryImpl) writeDAGBatch(ctx context.Context, tenantId uuid.UU
 		return nil, err
 	}
 
-	return workflowRunIdsOfLocksNotAcquired, nil
+	return map[uuid.UUID]struct{}{}, nil
 }
 
 func (r *OLAPRepositoryImpl) CreateTaskEvents(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, eventExternalIdToWorkflowRunId map[uuid.UUID]uuid.UUID) (*StatusUpdateResult, map[uuid.UUID]struct{}, error) {

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -1880,6 +1880,20 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 		}
 	}
 
+	// Payloads are written before the task status update so the contended locks
+	// (task rows, then DAG rows) are acquired as late as possible in the
+	// transaction and held only across the status update, rollup, and commit.
+	// Concurrent flushes frequently carry events for the same tasks, so any work
+	// done after the task row locks are taken directly extends the lock convoy.
+	// All OLAP flush paths must take locks in the same order (payloads ->
+	// task rows -> DAG rows) to avoid lock-order deadlocks between them.
+	if len(payloadsToWrite) > 0 {
+		err = r.PutPayloads(ctx, tx, tenantId, payloadsToWrite...)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
 	statusUpdates := r.prepareStatusUpdateBatch(ctx, tenantId, eventsForStatusUpdate)
 	result := &StatusUpdateResult{}
 
@@ -1930,13 +1944,6 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 				ExternalId:     row.ExternalID,
 				WorkflowId:     row.WorkflowID,
 			})
-		}
-	}
-
-	if len(payloadsToWrite) > 0 {
-		err = r.PutPayloads(ctx, tx, tenantId, payloadsToWrite...)
-		if err != nil {
-			return nil, nil, err
 		}
 	}
 
@@ -2245,6 +2252,14 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId uuid.U
 		return nil, nil, err
 	}
 
+	// Written before the reconcile so the contended task/DAG row locks are held
+	// for as little of the transaction as possible; see writeTaskEventBatch for
+	// the required lock ordering across flush paths.
+	err = r.PutPayloads(ctx, tx, tenantId, putPayloadOpts...)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	reconciledTasks, err := r.queries.ReconcileTaskStatusesFromEvents(ctx, tx, sqlcv1.ReconcileTaskStatusesFromEventsParams{
 		Taskids:         params.Ids,
 		Taskinsertedats: params.Insertedats,
@@ -2282,11 +2297,6 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId uuid.U
 				return nil, nil, fmt.Errorf("failed to update DAG statuses after reconcile: %w", err)
 			}
 		}
-	}
-
-	err = r.PutPayloads(ctx, tx, tenantId, putPayloadOpts...)
-	if err != nil {
-		return nil, nil, err
 	}
 
 	if err := commit(ctx); err != nil {
@@ -2351,6 +2361,14 @@ func (r *OLAPRepositoryImpl) writeDAGBatch(ctx context.Context, tenantId uuid.UU
 		return map[uuid.UUID]struct{}{}, nil
 	}
 
+	// Written before CreateDAGsOLAP, which takes DAG row locks when a replay
+	// overwrites an existing DAG; see writeTaskEventBatch for the required lock
+	// ordering across flush paths.
+	err = r.PutPayloads(ctx, tx, tenantId, putPayloadOpts...)
+	if err != nil {
+		return nil, err
+	}
+
 	err = r.queries.CreateDAGsOLAP(ctx, tx, params)
 	if err != nil {
 		return nil, err
@@ -2361,11 +2379,6 @@ func (r *OLAPRepositoryImpl) writeDAGBatch(ctx context.Context, tenantId uuid.UU
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	err = r.PutPayloads(ctx, tx, tenantId, putPayloadOpts...)
-	if err != nil {
-		return nil, err
 	}
 
 	if err := commit(ctx); err != nil {

--- a/pkg/repository/olap_dag_rollup_race_test.go
+++ b/pkg/repository/olap_dag_rollup_race_test.go
@@ -1,0 +1,157 @@
+//go:build !e2e && !load && !rampup && !integration
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
+)
+
+// seedPlainDag mirrors seedOperatorDag but for a regular (non-operator) DAG,
+// whose readable status is derived purely from counting its child tasks.
+func seedPlainDag(t *testing.T, ctx context.Context, repo *OLAPRepositoryImpl, dagId int64, totalTasks int) operatorDagFixture {
+	t.Helper()
+
+	f := operatorDagFixture{
+		tenantId:      uuid.New(),
+		dagId:         dagId,
+		dagInsertedAt: pgtype.Timestamptz{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true},
+		dagExternalId: uuid.New(),
+		workflowId:    uuid.New(),
+	}
+
+	dag := &DAGWithData{
+		V1Dag: &sqlcv1.V1Dag{
+			ID:                f.dagId,
+			InsertedAt:        f.dagInsertedAt,
+			TenantID:          f.tenantId,
+			ExternalID:        f.dagExternalId,
+			DisplayName:       "dag-rollup-race-test",
+			WorkflowID:        f.workflowId,
+			WorkflowVersionID: uuid.New(),
+		},
+		Input:              []byte(`{}`),
+		AdditionalMetadata: []byte(`{}`),
+		TotalTasks:         totalTasks,
+	}
+
+	locksNotAcquired, err := repo.CreateDAGs(ctx, f.tenantId, []*DAGWithData{dag})
+	require.NoError(t, err)
+	require.Empty(t, locksNotAcquired)
+
+	return f
+}
+
+// TestOLAPDAGRollup_ConcurrentRollupsDoNotStrandDAG is a regression test for
+// the write-skew that the run-level advisory locks used to paper over.
+//
+// The DAG rollup recomputes a DAG's status from a join over its task rows.
+// Under READ COMMITTED, a single-statement rollup that blocks on the DAG row
+// lock resumes with the snapshot it started with: it re-reads the DAG row via
+// EvalPlanQual but still sees the *task* rows as of statement start. Two
+// transactions each completing one of a DAG's final two tasks could then both
+// count the other's task as RUNNING and both leave the DAG RUNNING — with no
+// later event ever arriving to fix it.
+//
+// The fix takes the DAG row locks in a separate LockDAGsForStatusUpdate
+// statement first, so the rollup statement's snapshot is opened only after
+// any concurrent rollup for the same DAG has committed.
+func TestOLAPDAGRollup_ConcurrentRollupsDoNotStrandDAG(t *testing.T) {
+	basePool, cleanup := setupPostgresWithMigration(t)
+	defer cleanup()
+
+	pool := createEnumAwarePool(t, basePool)
+	repo := createOLAPRepositoryWithPayloadStore(t, pool)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	require.NoError(t, repo.UpdateTablePartitions(ctx))
+
+	f := seedPlainDag(t, ctx, repo, 100, 2)
+	childA := f.createChild(t, ctx, repo, 101)
+	childB := f.createChild(t, ctx, repo, 102)
+
+	// Move both children to RUNNING through the normal ingestion path so the
+	// DAG itself is RUNNING before the race.
+	f.applyChildEvents(t, ctx, repo, []sqlcv1.CreateTaskEventsOLAPParams{
+		childA.event(sqlcv1.V1EventTypeOlapSTARTED, sqlcv1.V1ReadableStatusOlapRUNNING, 0),
+		childB.event(sqlcv1.V1EventTypeOlapSTARTED, sqlcv1.V1ReadableStatusOlapRUNNING, 0),
+	})
+	f.assertDagStatus(t, ctx, pool, "RUNNING")
+
+	completeTask := func(tx pgx.Tx, c replayStatusFixture) error {
+		_, err := repo.queries.UpdateTaskStatusesFromMQ(ctx, tx, sqlcv1.UpdateTaskStatusesFromMQParams{
+			Tenantids:       []uuid.UUID{c.tenantId},
+			Taskids:         []int64{c.taskId},
+			Taskinsertedats: []pgtype.Timestamptz{c.insertedAt},
+			Statuses:        []sqlcv1.V1ReadableStatusOlap{sqlcv1.V1ReadableStatusOlapCOMPLETED},
+			Workerids:       []uuid.UUID{uuid.Nil},
+			Retrycounts:     []int32{0},
+		})
+		return err
+	}
+
+	rollup := func(tx pgx.Tx) error {
+		if err := repo.queries.LockDAGsForStatusUpdate(ctx, tx, sqlcv1.LockDAGsForStatusUpdateParams{
+			Tenantids:      []uuid.UUID{f.tenantId},
+			Dagids:         []int64{f.dagId},
+			Daginsertedats: []pgtype.Timestamptz{f.dagInsertedAt},
+		}); err != nil {
+			return err
+		}
+
+		_, err := repo.queries.UpdateDAGStatusesFromMQ(ctx, tx, sqlcv1.UpdateDAGStatusesFromMQParams{
+			Tenantids:      []uuid.UUID{f.tenantId},
+			Dagids:         []int64{f.dagId},
+			Daginsertedats: []pgtype.Timestamptz{f.dagInsertedAt},
+		})
+		return err
+	}
+
+	tx1, err := pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx1.Rollback(ctx) }()
+
+	tx2, err := pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx2.Rollback(ctx) }()
+
+	// Each transaction completes one of the DAG's two remaining tasks.
+	require.NoError(t, completeTask(tx1, childA))
+	require.NoError(t, completeTask(tx2, childB))
+
+	// tx1's rollup runs while tx2's completion of child B is uncommitted, so
+	// it (correctly, at that instant) sees B as RUNNING, leaves the DAG
+	// RUNNING, and holds the DAG row lock until commit.
+	require.NoError(t, rollup(tx1))
+
+	// tx2's rollup must block on the DAG row lock until tx1 commits and then
+	// count child A's committed completion; with a single-statement rollup it
+	// would resume with its stale snapshot and strand the DAG in RUNNING.
+	tx2Done := make(chan error, 1)
+	go func() {
+		if err := rollup(tx2); err != nil {
+			tx2Done <- err
+			return
+		}
+		tx2Done <- tx2.Commit(ctx)
+	}()
+
+	// Let tx2 reach the DAG row lock wait before tx1 commits, so the blocked
+	// path is what's exercised rather than a sequential fast path.
+	time.Sleep(300 * time.Millisecond)
+
+	require.NoError(t, tx1.Commit(ctx))
+	require.NoError(t, <-tx2Done)
+
+	f.assertDagStatus(t, ctx, pool, "COMPLETED")
+}

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -1017,6 +1017,30 @@ WHERE (t.inserted_at, t.id, t.tenant_id) IN (
 )
 ;
 
+-- name: LockDAGsForStatusUpdate :exec
+-- Acquires the DAG row locks in their own statement *before* UpdateDAGStatusesFromMQ
+-- runs in the same transaction. The rollup in UpdateDAGStatusesFromMQ recomputes DAG
+-- status from a join over task rows; under READ COMMITTED, if the rollup statement
+-- itself blocked on the DAG row lock, it would resume with the snapshot it started
+-- with and count stale task statuses. Two concurrent rollups could then each miss the
+-- other's terminal task updates and leave the DAG stuck in a non-terminal status.
+-- Taking the locks in this earlier statement means the rollup statement's snapshot is
+-- opened only after any prior lock holder committed, so its task counts are current.
+WITH inputs AS (
+    SELECT
+        UNNEST(@tenantIds::UUID[]) AS tenant_id,
+        UNNEST(@dagIds::BIGINT[]) AS dag_id,
+        UNNEST(@dagInsertedAts::TIMESTAMPTZ[]) AS dag_inserted_at
+)
+SELECT id
+FROM v1_dags_olap
+WHERE (inserted_at, id, tenant_id) IN (
+    SELECT dag_inserted_at, dag_id, tenant_id
+    FROM inputs
+)
+ORDER BY inserted_at, id
+FOR UPDATE;
+
 -- name: UpdateDAGStatusesFromMQ :many
 WITH inputs AS (
     SELECT

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -2198,6 +2198,42 @@ func (q *Queries) ListYesterdayRunCountsByStatus(ctx context.Context, db DBTX) (
 	return items, nil
 }
 
+const lockDAGsForStatusUpdate = `-- name: LockDAGsForStatusUpdate :exec
+WITH inputs AS (
+    SELECT
+        UNNEST($1::UUID[]) AS tenant_id,
+        UNNEST($2::BIGINT[]) AS dag_id,
+        UNNEST($3::TIMESTAMPTZ[]) AS dag_inserted_at
+)
+SELECT id
+FROM v1_dags_olap
+WHERE (inserted_at, id, tenant_id) IN (
+    SELECT dag_inserted_at, dag_id, tenant_id
+    FROM inputs
+)
+ORDER BY inserted_at, id
+FOR UPDATE
+`
+
+type LockDAGsForStatusUpdateParams struct {
+	Tenantids      []uuid.UUID          `json:"tenantids"`
+	Dagids         []int64              `json:"dagids"`
+	Daginsertedats []pgtype.Timestamptz `json:"daginsertedats"`
+}
+
+// Acquires the DAG row locks in their own statement *before* UpdateDAGStatusesFromMQ
+// runs in the same transaction. The rollup in UpdateDAGStatusesFromMQ recomputes DAG
+// status from a join over task rows; under READ COMMITTED, if the rollup statement
+// itself blocked on the DAG row lock, it would resume with the snapshot it started
+// with and count stale task statuses. Two concurrent rollups could then each miss the
+// other's terminal task updates and leave the DAG stuck in a non-terminal status.
+// Taking the locks in this earlier statement means the rollup statement's snapshot is
+// opened only after any prior lock holder committed, so its task counts are current.
+func (q *Queries) LockDAGsForStatusUpdate(ctx context.Context, db DBTX, arg LockDAGsForStatusUpdateParams) error {
+	_, err := db.Exec(ctx, lockDAGsForStatusUpdate, arg.Tenantids, arg.Dagids, arg.Daginsertedats)
+	return err
+}
+
 const markOLAPCutoverJobAsCompleted = `-- name: MarkOLAPCutoverJobAsCompleted :exec
 UPDATE v1_payloads_olap_cutover_job_offset
 SET is_completed = TRUE


### PR DESCRIPTION
## Summary

- Removes the per-workflow-run advisory try-locks (`tryAcquireAdvisoryLocksForWorkflowRuns`) from the OLAP `created-task`, `created-dag`, and `create-monitoring-event` write paths. These serialized every OLAP write for a run across all three handlers; under high per-run event volume (large DAGs), handlers lose the try-lock, burn exponential-backoff sleeps (up to ~2s per batch across 10 attempts), and republish leftovers to the back of the queue — collapsing ingestion throughput and, past the requeue limit, dropping events.
- The task-status paths don't need the lock: `UpdateTaskStatusesFromMQ` and `ReconcileTaskStatusesFromEvents` are already monotonic (guarded by `retry_count` and `v1_status_to_priority`, re-evaluated against the latest row version after a row-lock wait), and `UpdateDAGStatusesFromOrchestratorEvents` is a per-row guarded write.
- The one thing the advisory lock actually protected is the count-based DAG rollup in `UpdateDAGStatusesFromMQ`: under `READ COMMITTED`, a single-statement rollup that blocks on the DAG row lock resumes with its original snapshot and counts stale task statuses. Two transactions completing a DAG's final two tasks could each see the other's task as still RUNNING and both leave the DAG stranded in RUNNING, with no later event to fix it. This PR fixes that directly with a new `LockDAGsForStatusUpdate` statement that acquires the DAG row locks *before* the rollup statement, so the rollup's snapshot is opened only after any concurrent rollup for the same DAG has committed.
- With the locks gone, the controller retry loops complete on the first attempt and the republish/drop paths go dead (left in place, now unreachable). Row locks are taken in sorted order with a consistent task-rows-then-DAG-rows statement order across all writers, so lock ordering remains deadlock-free.

## Test plan

- [x] New `TestOLAPDAGRollup_ConcurrentRollupsDoNotStrandDAG` deterministically reproduces the two-transaction write-skew interleaving (second rollup blocks on the DAG row lock while the first commits) and asserts the DAG converges to COMPLETED. Fails against the old single-statement rollup.
- [x] Existing `TestOLAPStatusUpdate_ReplayOfCompletedTask` (mq / tmp-table / reconcile paths) and `TestOperatorDAG_*` pass with the advisory locks removed.
- [x] `go build ./...`, `go vet`, golangci-lint clean.