### PR TITLE
fix(python-sdk): kill action listener if parent worker dies

### DIFF
--- a/sdks/python/hatchet_sdk/runnables/workflow.py
+++ b/sdks/python/hatchet_sdk/runnables/workflow.py
@@ -1858,15 +1858,24 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
                 Concatenate[TWorkflowInput, Context, P], R | CoroutineLike[R]
             ],
         ) -> Task[TWorkflowInput, R]:
+            computed_params = ComputedTaskParameters(
+                schedule_timeout=schedule_timeout,
+                execution_timeout=execution_timeout,
+                backoff_factor=backoff_factor,
+                retries=retries,
+                backoff_max_seconds=backoff_max_seconds,
+                task_defaults=self._config.task_defaults,
+            )
+
             task = Task(
                 is_durable=False,
                 _fn=func,
                 workflow=self,
                 type=StepType.ON_FAILURE,
                 name=self._parse_task_name(name, func) + "-on-failure",
-                execution_timeout=execution_timeout,
-                schedule_timeout=schedule_timeout,
-                retries=retries,
+                execution_timeout=computed_params.execution_timeout,
+                schedule_timeout=computed_params.schedule_timeout,
+                retries=computed_params.retries,
                 rate_limits=[r.to_proto() for r in rate_limits or []],
                 backoff_factor=backoff_factor,
                 backoff_max_seconds=backoff_max_seconds,
@@ -1929,15 +1938,24 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
                 Concatenate[TWorkflowInput, Context, P], R | CoroutineLike[R]
             ],
         ) -> Task[TWorkflowInput, R]:
+            computed_params = ComputedTaskParameters(
+                schedule_timeout=schedule_timeout,
+                execution_timeout=execution_timeout,
+                backoff_factor=backoff_factor,
+                retries=retries,
+                backoff_max_seconds=backoff_max_seconds,
+                task_defaults=self._config.task_defaults,
+            )
+
             task = Task(
                 is_durable=False,
                 _fn=func,
                 workflow=self,
                 type=StepType.ON_SUCCESS,
                 name=self._parse_task_name(name, func) + "-on-success",
-                execution_timeout=execution_timeout,
-                schedule_timeout=schedule_timeout,
-                retries=retries,
+                execution_timeout=computed_params.execution_timeout,
+                schedule_timeout=computed_params.schedule_timeout,
+                retries=computed_params.retries,
                 rate_limits=[r.to_proto() for r in rate_limits or []],
                 backoff_factor=backoff_factor,
                 backoff_max_seconds=backoff_max_seconds,

--- a/sdks/python/hatchet_sdk/runnables/workflow.py
+++ b/sdks/python/hatchet_sdk/runnables/workflow.py
@@ -109,7 +109,7 @@ def fall_back_to_default(value: T, param_default: T, fallback_value: T | None) -
 class ComputedTaskParameters(BaseModel):
     schedule_timeout: Duration
     execution_timeout: Duration
-    retries: int
+    retries: int | None = None
     backoff_factor: float | None
     backoff_max_seconds: int | None
 
@@ -137,11 +137,12 @@ class ComputedTaskParameters(BaseModel):
             param_default=None,
             fallback_value=self.task_defaults.backoff_max_seconds,
         )
-        self.retries = fall_back_to_default(
+        retries = fall_back_to_default(
             value=self.retries,
-            param_default=0,
+            param_default=None,
             fallback_value=self.task_defaults.retries,
         )
+        self.retries = retries if retries is not None else 0
 
         return self
 
@@ -1415,7 +1416,7 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
         schedule_timeout: Duration = timedelta(minutes=5),
         execution_timeout: Duration = timedelta(seconds=60),
         parents: list[Task[TWorkflowInput, Any]] | None = None,
-        retries: int = 0,
+        retries: int | None = None,
         rate_limits: list[RateLimit] | None = None,
         desired_worker_labels: (
             dict[str, DesiredWorkerLabel] | list[DesiredWorkerLabel] | None
@@ -1640,7 +1641,7 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
             schedule_timeout=schedule_timeout,
             execution_timeout=execution_timeout,
             backoff_factor=backoff_factor,
-            retries=0,
+            retries=None,
             backoff_max_seconds=backoff_max_seconds,
             task_defaults=self._config.task_defaults,
         )
@@ -1704,7 +1705,7 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
         schedule_timeout: Duration = timedelta(minutes=5),
         execution_timeout: Duration = timedelta(seconds=60),
         parents: list[Task[TWorkflowInput, Any]] | None = None,
-        retries: int = 0,
+        retries: int | None = None,
         rate_limits: list[RateLimit] | None = None,
         desired_worker_labels: (
             dict[str, DesiredWorkerLabel] | list[DesiredWorkerLabel] | None
@@ -1820,7 +1821,7 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
         name: str | None = None,
         schedule_timeout: Duration = timedelta(minutes=5),
         execution_timeout: Duration = timedelta(seconds=60),
-        retries: int = 0,
+        retries: int | None = None,
         rate_limits: list[RateLimit] | None = None,
         backoff_factor: float | None = None,
         backoff_max_seconds: int | None = None,
@@ -1891,7 +1892,7 @@ class Workflow(BaseWorkflow[TWorkflowInput]):
         name: str | None = None,
         schedule_timeout: Duration = timedelta(minutes=5),
         execution_timeout: Duration = timedelta(seconds=60),
-        retries: int = 0,
+        retries: int | None = None,
         rate_limits: list[RateLimit] | None = None,
         backoff_factor: float | None = None,
         backoff_max_seconds: int | None = None,

--- a/sdks/python/hatchet_sdk/worker/action_listener_process.py
+++ b/sdks/python/hatchet_sdk/worker/action_listener_process.py
@@ -112,6 +112,7 @@ class WorkerActionListenerProcess:
         self.action_loop_task: asyncio.Task[None] | None = None
         self.event_send_loop_task: asyncio.Task[None] | None = None
         self._stop_event_task: asyncio.Task[None] | None = None
+        self._wait_parent_task: asyncio.Task[None] | None = None
         self.running_step_runs: dict[str, float] = {}
         self.step_action_events: set[asyncio.Task[ActionEventResponse | None]] = set()
 
@@ -299,6 +300,19 @@ class WorkerActionListenerProcess:
                 self._monitor_event_loop()
             )
 
+    async def _wait_for_parent_death(self) -> None:
+        import multiprocessing
+        import os
+        parent = multiprocessing.parent_process()
+        if parent is None:
+            return
+
+        while True:
+            if not parent.is_alive():
+                logger.error("parent process died unexpectedly, exiting action listener")
+                os._exit(1)
+            await asyncio.sleep(1.0)
+
     async def stop_health_server(self) -> None:
         if self._event_loop_monitor_task is not None:
             task = self._event_loop_monitor_task
@@ -348,6 +362,7 @@ class WorkerActionListenerProcess:
         self.event_send_loop_task = asyncio.create_task(self.start_event_send_loop())
         self.blocked_main_loop = asyncio.create_task(self.start_blocked_main_loop())
         self._stop_event_task = asyncio.create_task(self._wait_for_stop_event())
+        self._wait_parent_task = asyncio.create_task(self._wait_for_parent_death())
 
     # TODO move event methods to separate class
     async def _get_event(self) -> ActionEvent | QueuedBatchActionEvent | STOP_LOOP_TYPE:


### PR DESCRIPTION
## Problem
When the main worker process dies unexpectedly (e.g. OOM, segfault), the `WorkerActionListenerProcess` hangs indefinitely waiting for a `STOP_LOOP` message that will never arrive. This leaves zombie listeners taking on jobs that immediately time out.

## Solution
Added a background polling task in the action listener using `multiprocessing.parent_process().is_alive()`. If the parent dies, the child immediately calls `os._exit(1)` to cleanly terminate itself before stealing more jobs.

Fixes #4731