### PR TITLE
refactor(engine): make `IdInsertedAt` struct use `int64` instead of `pgtype.Timestamptz`

### DIFF
--- a/internal/services/controllers/task/durable_callbacks.go
+++ b/internal/services/controllers/task/durable_callbacks.go
@@ -58,7 +58,7 @@ func (tc *TasksControllerImpl) handleDurableRestoreTask(ctx context.Context, ten
 
 	invCountOpts := make([]v1.IdInsertedAt, 0, len(flatTasks))
 	for _, t := range flatTasks {
-		invCountOpts = append(invCountOpts, v1.IdInsertedAt{ID: t.ID, InsertedAt: t.InsertedAt})
+		invCountOpts = append(invCountOpts, v1.IdInsertedAt{ID: t.ID, InsertedAtUnixMillis: t.InsertedAt.Time.UnixMilli()})
 	}
 
 	invocationCounts, err := tc.repov1.DurableEvents().GetDurableTaskInvocationCounts(ctx, tenantId, invCountOpts)
@@ -76,7 +76,7 @@ func (tc *TasksControllerImpl) handleDurableRestoreTask(ctx context.Context, ten
 		}
 
 		var durableInvCount int32
-		if count, ok := invocationCounts[v1.IdInsertedAt{ID: t.ID, InsertedAt: t.InsertedAt}]; ok && count != nil {
+		if count, ok := invocationCounts[v1.IdInsertedAt{ID: t.ID, InsertedAtUnixMillis: t.InsertedAt.Time.UnixMilli()}]; ok && count != nil {
 			durableInvCount = *count
 		}
 

--- a/internal/services/controllers/task/durable_callbacks.go
+++ b/internal/services/controllers/task/durable_callbacks.go
@@ -58,7 +58,7 @@ func (tc *TasksControllerImpl) handleDurableRestoreTask(ctx context.Context, ten
 
 	invCountOpts := make([]v1.IdInsertedAt, 0, len(flatTasks))
 	for _, t := range flatTasks {
-		invCountOpts = append(invCountOpts, v1.IdInsertedAt{ID: t.ID, InsertedAtUnixMillis: t.InsertedAt.Time.UnixMilli()})
+		invCountOpts = append(invCountOpts, v1.IdInsertedAt{ID: t.ID, InsertedAtUnixMicros: t.InsertedAt.Time.UnixMicro()})
 	}
 
 	invocationCounts, err := tc.repov1.DurableEvents().GetDurableTaskInvocationCounts(ctx, tenantId, invCountOpts)
@@ -76,7 +76,7 @@ func (tc *TasksControllerImpl) handleDurableRestoreTask(ctx context.Context, ten
 		}
 
 		var durableInvCount int32
-		if count, ok := invocationCounts[v1.IdInsertedAt{ID: t.ID, InsertedAtUnixMillis: t.InsertedAt.Time.UnixMilli()}]; ok && count != nil {
+		if count, ok := invocationCounts[v1.IdInsertedAt{ID: t.ID, InsertedAtUnixMicros: t.InsertedAt.Time.UnixMicro()}]; ok && count != nil {
 			durableInvCount = *count
 		}
 

--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -722,7 +722,7 @@ func (d *DispatcherImpl) HandleLocalAssignments(ctx context.Context, tenantId, w
 		if assigned.Task.IsDurable.Valid && assigned.Task.IsDurable.Bool {
 			getDurableInvocationCountOpts = append(getDurableInvocationCountOpts, v1.IdInsertedAt{
 				ID:                   assigned.Task.ID,
-				InsertedAtUnixMillis: assigned.Task.InsertedAt.Time.UnixMilli(),
+				InsertedAtUnixMicros: assigned.Task.InsertedAt.Time.UnixMicro(),
 			})
 		}
 	}
@@ -737,7 +737,7 @@ func (d *DispatcherImpl) HandleLocalAssignments(ctx context.Context, tenantId, w
 				if assigned.Task.IsDurable.Valid && assigned.Task.IsDurable.Bool {
 					count := invocationCounts[v1.IdInsertedAt{
 						ID:                   assigned.Task.ID,
-						InsertedAtUnixMillis: assigned.Task.InsertedAt.Time.UnixMilli(),
+						InsertedAtUnixMicros: assigned.Task.InsertedAt.Time.UnixMicro(),
 					}]
 					taskIdToData[assigned.Task.ID].InvocationCount = count
 				}
@@ -785,7 +785,7 @@ func (d *DispatcherImpl) populateTaskData(
 		if task.IsDurable.Valid && task.IsDurable.Bool {
 			getInvocationCountOpts = append(getInvocationCountOpts, v1.IdInsertedAt{
 				ID:                   task.ID,
-				InsertedAtUnixMillis: task.InsertedAt.Time.UnixMilli(),
+				InsertedAtUnixMicros: task.InsertedAt.Time.UnixMicro(),
 			})
 		}
 	}
@@ -966,7 +966,7 @@ func (d *DispatcherImpl) populateTaskData(
 
 		invocationCount := invocationCounts[v1.IdInsertedAt{
 			ID:                   task.ID,
-			InsertedAtUnixMillis: task.InsertedAt.Time.UnixMilli(),
+			InsertedAtUnixMicros: task.InsertedAt.Time.UnixMicro(),
 		}]
 
 		taskIdToData[task.ID] = &V1TaskWithPayloadAndInvocationCount{
@@ -1324,7 +1324,7 @@ func (d *DispatcherImpl) handleTaskCancelled(ctx context.Context, msg *msgqueue.
 		if task.IsDurable.Valid && task.IsDurable.Bool {
 			durableTaskIds = append(durableTaskIds, v1.IdInsertedAt{
 				ID:                   task.ID,
-				InsertedAtUnixMillis: task.InsertedAt.Time.UnixMilli(),
+				InsertedAtUnixMicros: task.InsertedAt.Time.UnixMicro(),
 			})
 		}
 	}

--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -721,8 +721,8 @@ func (d *DispatcherImpl) HandleLocalAssignments(ctx context.Context, tenantId, w
 
 		if assigned.Task.IsDurable.Valid && assigned.Task.IsDurable.Bool {
 			getDurableInvocationCountOpts = append(getDurableInvocationCountOpts, v1.IdInsertedAt{
-				ID:         assigned.Task.ID,
-				InsertedAt: assigned.Task.InsertedAt,
+				ID:                   assigned.Task.ID,
+				InsertedAtUnixMillis: assigned.Task.InsertedAt.Time.UnixMilli(),
 			})
 		}
 	}
@@ -736,8 +736,8 @@ func (d *DispatcherImpl) HandleLocalAssignments(ctx context.Context, tenantId, w
 			for _, assigned := range tasks {
 				if assigned.Task.IsDurable.Valid && assigned.Task.IsDurable.Bool {
 					count := invocationCounts[v1.IdInsertedAt{
-						ID:         assigned.Task.ID,
-						InsertedAt: assigned.Task.InsertedAt,
+						ID:                   assigned.Task.ID,
+						InsertedAtUnixMillis: assigned.Task.InsertedAt.Time.UnixMilli(),
 					}]
 					taskIdToData[assigned.Task.ID].InvocationCount = count
 				}
@@ -784,8 +784,8 @@ func (d *DispatcherImpl) populateTaskData(
 	for _, task := range bulkDatas {
 		if task.IsDurable.Valid && task.IsDurable.Bool {
 			getInvocationCountOpts = append(getInvocationCountOpts, v1.IdInsertedAt{
-				ID:         task.ID,
-				InsertedAt: task.InsertedAt,
+				ID:                   task.ID,
+				InsertedAtUnixMillis: task.InsertedAt.Time.UnixMilli(),
 			})
 		}
 	}
@@ -965,8 +965,8 @@ func (d *DispatcherImpl) populateTaskData(
 		}
 
 		invocationCount := invocationCounts[v1.IdInsertedAt{
-			ID:         task.ID,
-			InsertedAt: task.InsertedAt,
+			ID:                   task.ID,
+			InsertedAtUnixMillis: task.InsertedAt.Time.UnixMilli(),
 		}]
 
 		taskIdToData[task.ID] = &V1TaskWithPayloadAndInvocationCount{
@@ -1323,8 +1323,8 @@ func (d *DispatcherImpl) handleTaskCancelled(ctx context.Context, msg *msgqueue.
 
 		if task.IsDurable.Valid && task.IsDurable.Bool {
 			durableTaskIds = append(durableTaskIds, v1.IdInsertedAt{
-				ID:         task.ID,
-				InsertedAt: task.InsertedAt,
+				ID:                   task.ID,
+				InsertedAtUnixMillis: task.InsertedAt.Time.UnixMilli(),
 			})
 		}
 	}

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -1327,10 +1327,10 @@ func (s *DispatcherImpl) sendStepActionEventV1(ctx context.Context, request *con
 
 	if task.IsDurable.Bool {
 		invocationCounts, err := s.repov1.DurableEvents().GetDurableTaskInvocationCounts(ctx, tenant.ID, []v1.IdInsertedAt{
-			{ID: task.ID, InsertedAt: task.InsertedAt},
+			{ID: task.ID, InsertedAtUnixMillis: task.InsertedAt.Time.UnixMilli()},
 		})
 		if err == nil {
-			if count, ok := invocationCounts[v1.IdInsertedAt{ID: task.ID, InsertedAt: task.InsertedAt}]; ok && count != nil {
+			if count, ok := invocationCounts[v1.IdInsertedAt{ID: task.ID, InsertedAtUnixMillis: task.InsertedAt.Time.UnixMilli()}]; ok && count != nil {
 				durableInvCount = *count
 			}
 		}
@@ -1628,7 +1628,7 @@ func (s *DispatcherImpl) handleBatchTaskStarted(
 	idInsertedAts := make([]v1.IdInsertedAt, 0, len(tasks))
 
 	for _, task := range tasks {
-		idInsertedAts = append(idInsertedAts, v1.IdInsertedAt{ID: task.ID, InsertedAt: task.InsertedAt})
+		idInsertedAts = append(idInsertedAts, v1.IdInsertedAt{ID: task.ID, InsertedAtUnixMillis: task.InsertedAt.Time.UnixMilli()})
 	}
 
 	durableInvocationCounts, err := s.repov1.DurableEvents().GetDurableTaskInvocationCounts(inputCtx, tenantId, idInsertedAts)
@@ -1660,7 +1660,7 @@ func (s *DispatcherImpl) handleBatchTaskStarted(
 
 		var durableInvocationCount int32
 
-		if count, ok := durableInvocationCounts[v1.IdInsertedAt{ID: task.ID, InsertedAt: task.InsertedAt}]; ok && count != nil {
+		if count, ok := durableInvocationCounts[v1.IdInsertedAt{ID: task.ID, InsertedAtUnixMillis: task.InsertedAt.Time.UnixMilli()}]; ok && count != nil {
 			durableInvocationCount = *count
 		}
 
@@ -1718,7 +1718,7 @@ func (s *DispatcherImpl) handleBatchTaskCompleted(
 	idInsertedAts := make([]v1.IdInsertedAt, 0, len(tasks))
 
 	for _, task := range tasks {
-		idInsertedAts = append(idInsertedAts, v1.IdInsertedAt{ID: task.ID, InsertedAt: task.InsertedAt})
+		idInsertedAts = append(idInsertedAts, v1.IdInsertedAt{ID: task.ID, InsertedAtUnixMillis: task.InsertedAt.Time.UnixMilli()})
 	}
 
 	durableInvocationCounts, err := s.repov1.DurableEvents().GetDurableTaskInvocationCounts(inputCtx, tenantId, idInsertedAts)
@@ -1779,7 +1779,7 @@ func (s *DispatcherImpl) handleBatchTaskCompleted(
 
 		var durableInvocationCount int32
 
-		if count, ok := durableInvocationCounts[v1.IdInsertedAt{ID: task.ID, InsertedAt: task.InsertedAt}]; ok && count != nil {
+		if count, ok := durableInvocationCounts[v1.IdInsertedAt{ID: task.ID, InsertedAtUnixMillis: task.InsertedAt.Time.UnixMilli()}]; ok && count != nil {
 			durableInvocationCount = *count
 		}
 

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -1327,10 +1327,10 @@ func (s *DispatcherImpl) sendStepActionEventV1(ctx context.Context, request *con
 
 	if task.IsDurable.Bool {
 		invocationCounts, err := s.repov1.DurableEvents().GetDurableTaskInvocationCounts(ctx, tenant.ID, []v1.IdInsertedAt{
-			{ID: task.ID, InsertedAtUnixMillis: task.InsertedAt.Time.UnixMilli()},
+			{ID: task.ID, InsertedAtUnixMicros: task.InsertedAt.Time.UnixMicro()},
 		})
 		if err == nil {
-			if count, ok := invocationCounts[v1.IdInsertedAt{ID: task.ID, InsertedAtUnixMillis: task.InsertedAt.Time.UnixMilli()}]; ok && count != nil {
+			if count, ok := invocationCounts[v1.IdInsertedAt{ID: task.ID, InsertedAtUnixMicros: task.InsertedAt.Time.UnixMicro()}]; ok && count != nil {
 				durableInvCount = *count
 			}
 		}
@@ -1628,7 +1628,7 @@ func (s *DispatcherImpl) handleBatchTaskStarted(
 	idInsertedAts := make([]v1.IdInsertedAt, 0, len(tasks))
 
 	for _, task := range tasks {
-		idInsertedAts = append(idInsertedAts, v1.IdInsertedAt{ID: task.ID, InsertedAtUnixMillis: task.InsertedAt.Time.UnixMilli()})
+		idInsertedAts = append(idInsertedAts, v1.IdInsertedAt{ID: task.ID, InsertedAtUnixMicros: task.InsertedAt.Time.UnixMicro()})
 	}
 
 	durableInvocationCounts, err := s.repov1.DurableEvents().GetDurableTaskInvocationCounts(inputCtx, tenantId, idInsertedAts)
@@ -1660,7 +1660,7 @@ func (s *DispatcherImpl) handleBatchTaskStarted(
 
 		var durableInvocationCount int32
 
-		if count, ok := durableInvocationCounts[v1.IdInsertedAt{ID: task.ID, InsertedAtUnixMillis: task.InsertedAt.Time.UnixMilli()}]; ok && count != nil {
+		if count, ok := durableInvocationCounts[v1.IdInsertedAt{ID: task.ID, InsertedAtUnixMicros: task.InsertedAt.Time.UnixMicro()}]; ok && count != nil {
 			durableInvocationCount = *count
 		}
 
@@ -1718,7 +1718,7 @@ func (s *DispatcherImpl) handleBatchTaskCompleted(
 	idInsertedAts := make([]v1.IdInsertedAt, 0, len(tasks))
 
 	for _, task := range tasks {
-		idInsertedAts = append(idInsertedAts, v1.IdInsertedAt{ID: task.ID, InsertedAtUnixMillis: task.InsertedAt.Time.UnixMilli()})
+		idInsertedAts = append(idInsertedAts, v1.IdInsertedAt{ID: task.ID, InsertedAtUnixMicros: task.InsertedAt.Time.UnixMicro()})
 	}
 
 	durableInvocationCounts, err := s.repov1.DurableEvents().GetDurableTaskInvocationCounts(inputCtx, tenantId, idInsertedAts)
@@ -1779,7 +1779,7 @@ func (s *DispatcherImpl) handleBatchTaskCompleted(
 
 		var durableInvocationCount int32
 
-		if count, ok := durableInvocationCounts[v1.IdInsertedAt{ID: task.ID, InsertedAtUnixMillis: task.InsertedAt.Time.UnixMilli()}]; ok && count != nil {
+		if count, ok := durableInvocationCounts[v1.IdInsertedAt{ID: task.ID, InsertedAtUnixMicros: task.InsertedAt.Time.UnixMicro()}]; ok && count != nil {
 			durableInvocationCount = *count
 		}
 

--- a/internal/services/dispatcher/server_v1.go
+++ b/internal/services/dispatcher/server_v1.go
@@ -1404,7 +1404,7 @@ func (d *DispatcherServiceImpl) handleWorkerStatus(
 			taskIdToExternalId := make(map[v1.IdInsertedAt]uuid.UUID, len(tasks))
 
 			for _, t := range tasks {
-				key := v1.IdInsertedAt{ID: t.ID, InsertedAtUnixMillis: t.InsertedAt.Time.UnixMilli()}
+				key := v1.IdInsertedAt{ID: t.ID, InsertedAtUnixMicros: t.InsertedAt.Time.UnixMicro()}
 				idInsertedAts = append(idInsertedAts, key)
 				taskIdToExternalId[key] = t.ExternalID
 			}

--- a/internal/services/dispatcher/server_v1.go
+++ b/internal/services/dispatcher/server_v1.go
@@ -1404,7 +1404,7 @@ func (d *DispatcherServiceImpl) handleWorkerStatus(
 			taskIdToExternalId := make(map[v1.IdInsertedAt]uuid.UUID, len(tasks))
 
 			for _, t := range tasks {
-				key := v1.IdInsertedAt{ID: t.ID, InsertedAt: t.InsertedAt}
+				key := v1.IdInsertedAt{ID: t.ID, InsertedAtUnixMillis: t.InsertedAt.Time.UnixMilli()}
 				idInsertedAts = append(idInsertedAts, key)
 				taskIdToExternalId[key] = t.ExternalID
 			}

--- a/internal/services/scheduler/v1/scheduler.go
+++ b/internal/services/scheduler/v1/scheduler.go
@@ -491,7 +491,7 @@ func (s *Scheduler) scheduleStepRuns(ctx context.Context, tenantId uuid.UUID, re
 			if a.IsDurable {
 				invCountOpts = append(invCountOpts, repov1.IdInsertedAt{
 					ID:                   a.QueueItem.TaskID,
-					InsertedAtUnixMillis: a.QueueItem.TaskInsertedAt.Time.UnixMilli(),
+					InsertedAtUnixMicros: a.QueueItem.TaskInsertedAt.Time.UnixMicro(),
 				})
 			}
 		}
@@ -543,7 +543,7 @@ func (s *Scheduler) scheduleStepRuns(ctx context.Context, tenantId uuid.UUID, re
 			var durableInvCount int32
 			if count, ok := invocationCounts[repov1.IdInsertedAt{
 				ID:                   taskId,
-				InsertedAtUnixMillis: bulkAssigned.QueueItem.TaskInsertedAt.Time.UnixMilli(),
+				InsertedAtUnixMicros: bulkAssigned.QueueItem.TaskInsertedAt.Time.UnixMicro(),
 			}]; ok && count != nil {
 				durableInvCount = *count
 			}

--- a/internal/services/scheduler/v1/scheduler.go
+++ b/internal/services/scheduler/v1/scheduler.go
@@ -490,8 +490,8 @@ func (s *Scheduler) scheduleStepRuns(ctx context.Context, tenantId uuid.UUID, re
 		for _, a := range res.Assigned {
 			if a.IsDurable {
 				invCountOpts = append(invCountOpts, repov1.IdInsertedAt{
-					ID:         a.QueueItem.TaskID,
-					InsertedAt: a.QueueItem.TaskInsertedAt,
+					ID:                   a.QueueItem.TaskID,
+					InsertedAtUnixMillis: a.QueueItem.TaskInsertedAt.Time.UnixMilli(),
 				})
 			}
 		}
@@ -541,7 +541,10 @@ func (s *Scheduler) scheduleStepRuns(ctx context.Context, tenantId uuid.UUID, re
 			taskId := bulkAssigned.QueueItem.TaskID
 
 			var durableInvCount int32
-			if count, ok := invocationCounts[repov1.IdInsertedAt{ID: taskId, InsertedAt: bulkAssigned.QueueItem.TaskInsertedAt}]; ok && count != nil {
+			if count, ok := invocationCounts[repov1.IdInsertedAt{
+				ID:                   taskId,
+				InsertedAtUnixMillis: bulkAssigned.QueueItem.TaskInsertedAt.Time.UnixMilli(),
+			}]; ok && count != nil {
 				durableInvCount = *count
 			}
 

--- a/internal/services/shared/durable/dispatch.go
+++ b/internal/services/shared/durable/dispatch.go
@@ -21,8 +21,8 @@ func DispatchCallbacks(ctx context.Context, l *zerolog.Logger, mq msgqueue.Messa
 
 	for _, cb := range callbacks {
 		idInsertedAtTuples = append(idInsertedAtTuples, v1.IdInsertedAt{
-			ID:         cb.DurableTaskId,
-			InsertedAt: cb.DurableTaskInsertedAt,
+			ID:                   cb.DurableTaskId,
+			InsertedAtUnixMillis: cb.DurableTaskInsertedAt.Time.UnixMilli(),
 		})
 	}
 
@@ -36,8 +36,8 @@ func DispatchCallbacks(ctx context.Context, l *zerolog.Logger, mq msgqueue.Messa
 
 	for _, cb := range callbacks {
 		key := v1.IdInsertedAt{
-			ID:         cb.DurableTaskId,
-			InsertedAt: cb.DurableTaskInsertedAt,
+			ID:                   cb.DurableTaskId,
+			InsertedAtUnixMillis: cb.DurableTaskInsertedAt.Time.UnixMilli(),
 		}
 
 		dispatcherLookup, ok := idInsertedAtToDispatcherId[key]

--- a/internal/services/shared/durable/dispatch.go
+++ b/internal/services/shared/durable/dispatch.go
@@ -22,7 +22,7 @@ func DispatchCallbacks(ctx context.Context, l *zerolog.Logger, mq msgqueue.Messa
 	for _, cb := range callbacks {
 		idInsertedAtTuples = append(idInsertedAtTuples, v1.IdInsertedAt{
 			ID:                   cb.DurableTaskId,
-			InsertedAtUnixMillis: cb.DurableTaskInsertedAt.Time.UnixMilli(),
+			InsertedAtUnixMicros: cb.DurableTaskInsertedAt.Time.UnixMicro(),
 		})
 	}
 
@@ -37,7 +37,7 @@ func DispatchCallbacks(ctx context.Context, l *zerolog.Logger, mq msgqueue.Messa
 	for _, cb := range callbacks {
 		key := v1.IdInsertedAt{
 			ID:                   cb.DurableTaskId,
-			InsertedAtUnixMillis: cb.DurableTaskInsertedAt.Time.UnixMilli(),
+			InsertedAtUnixMicros: cb.DurableTaskInsertedAt.Time.UnixMicro(),
 		}
 
 		dispatcherLookup, ok := idInsertedAtToDispatcherId[key]

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -2388,7 +2388,7 @@ func (r *durableEventsRepository) GetDurableTaskInvocationCounts(ctx context.Con
 
 	for i, t := range tasks {
 		taskIds[i] = t.ID
-		taskInsertedAts[i] = t.InsertedAt
+		taskInsertedAts[i] = sqlchelpers.TimestamptzFromUnixMillis(t.InsertedAtUnixMillis)
 		tenantIds[i] = tenantId
 	}
 
@@ -2406,8 +2406,8 @@ func (r *durableEventsRepository) GetDurableTaskInvocationCounts(ctx context.Con
 
 	for _, logFile := range logFiles {
 		key := IdInsertedAt{
-			ID:         logFile.DurableTaskID,
-			InsertedAt: logFile.DurableTaskInsertedAt,
+			ID:                   logFile.DurableTaskID,
+			InsertedAtUnixMillis: logFile.DurableTaskInsertedAt.Time.UnixMilli(),
 		}
 
 		result[key] = &logFile.LatestInvocationCount

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -2388,7 +2388,7 @@ func (r *durableEventsRepository) GetDurableTaskInvocationCounts(ctx context.Con
 
 	for i, t := range tasks {
 		taskIds[i] = t.ID
-		taskInsertedAts[i] = sqlchelpers.TimestamptzFromUnixMillis(t.InsertedAtUnixMillis)
+		taskInsertedAts[i] = sqlchelpers.TimestamptzFromUnixMicros(t.InsertedAtUnixMicros)
 		tenantIds[i] = tenantId
 	}
 
@@ -2407,7 +2407,7 @@ func (r *durableEventsRepository) GetDurableTaskInvocationCounts(ctx context.Con
 	for _, logFile := range logFiles {
 		key := IdInsertedAt{
 			ID:                   logFile.DurableTaskID,
-			InsertedAtUnixMillis: logFile.DurableTaskInsertedAt.Time.UnixMilli(),
+			InsertedAtUnixMicros: logFile.DurableTaskInsertedAt.Time.UnixMicro(),
 		}
 
 		result[key] = &logFile.LatestInvocationCount

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -924,8 +924,8 @@ func (r *OLAPRepositoryImpl) ListTasks(ctx context.Context, tenantId uuid.UUID, 
 
 	for _, row := range rows {
 		idsInsertedAts = append(idsInsertedAts, IdInsertedAt{
-			ID:         row.ID,
-			InsertedAt: row.InsertedAt,
+			ID:                   row.ID,
+			InsertedAtUnixMillis: row.InsertedAt.Time.UnixMilli(),
 		})
 	}
 
@@ -1023,8 +1023,8 @@ func (r *OLAPRepositoryImpl) ListTasksByDAGId(ctx context.Context, tenantId uuid
 	for _, row := range tasks {
 		taskIdToDagExternalId[row.TaskID] = row.DagExternalID
 		idsInsertedAts = append(idsInsertedAts, IdInsertedAt{
-			ID:         row.TaskID,
-			InsertedAt: row.TaskInsertedAt,
+			ID:                   row.TaskID,
+			InsertedAtUnixMillis: row.TaskInsertedAt.Time.UnixMilli(),
 		})
 	}
 
@@ -1111,8 +1111,8 @@ func (r *OLAPRepositoryImpl) ListTasksByIdAndInsertedAt(ctx context.Context, ten
 
 	for _, metadata := range taskMetadata {
 		idsInsertedAts = append(idsInsertedAts, IdInsertedAt{
-			ID:         metadata.TaskID,
-			InsertedAt: pgtype.Timestamptz{Time: metadata.TaskInsertedAt, Valid: true},
+			ID:                   metadata.TaskID,
+			InsertedAtUnixMillis: metadata.TaskInsertedAt.UnixMilli(),
 		})
 	}
 
@@ -1291,8 +1291,8 @@ func (r *OLAPRepositoryImpl) ListWorkflowRuns(ctx context.Context, tenantId uuid
 			runInsertedAtsWithDAGs = append(runInsertedAtsWithDAGs, row.InsertedAt)
 		} else {
 			taskIdsInsertedAts = append(taskIdsInsertedAts, IdInsertedAt{
-				ID:         row.ID,
-				InsertedAt: row.InsertedAt,
+				ID:                   row.ID,
+				InsertedAtUnixMillis: row.InsertedAt.Time.UnixMilli(),
 			})
 		}
 	}
@@ -1723,14 +1723,14 @@ func (r *OLAPRepositoryImpl) prepareStatusUpdateBatch(ctx context.Context, tenan
 
 	for _, event := range events {
 		statusAndRetryCount, seen := taskIdInsertedAtToMeta[IdInsertedAt{
-			ID:         event.TaskID,
-			InsertedAt: event.TaskInsertedAt,
+			ID:                   event.TaskID,
+			InsertedAtUnixMillis: event.TaskInsertedAt.Time.UnixMilli(),
 		}]
 
 		if !seen || event.RetryCount > statusAndRetryCount.RetryCount || (event.RetryCount == statusAndRetryCount.RetryCount && compareStatuses(event.ReadableStatus, statusAndRetryCount.Status)) {
 			taskIdInsertedAtToMeta[IdInsertedAt{
-				ID:         event.TaskID,
-				InsertedAt: event.TaskInsertedAt,
+				ID:                   event.TaskID,
+				InsertedAtUnixMillis: event.TaskInsertedAt.Time.UnixMilli(),
 			}] = statusRetryCountWorkerIdTuple{
 				Status:     event.ReadableStatus,
 				RetryCount: event.RetryCount,
@@ -1749,7 +1749,7 @@ func (r *OLAPRepositoryImpl) prepareStatusUpdateBatch(ctx context.Context, tenan
 	for idInsertedAt, meta := range taskIdInsertedAtToMeta {
 		tenantIds = append(tenantIds, tenantId)
 		taskIds = append(taskIds, idInsertedAt.ID)
-		taskInsertedAts = append(taskInsertedAts, idInsertedAt.InsertedAt)
+		taskInsertedAts = append(taskInsertedAts, sqlchelpers.TimestamptzFromUnixMillis(idInsertedAt.InsertedAtUnixMillis))
 		statuses = append(statuses, meta.Status)
 		retryCounts = append(retryCounts, meta.RetryCount)
 
@@ -1781,7 +1781,7 @@ func (r *OLAPRepositoryImpl) prepareDAGStatusUpdateBatch(taskRows []*sqlcv1.Upda
 			continue
 		}
 
-		key := IdInsertedAt{ID: row.DagID.Int64, InsertedAt: row.DagInsertedAt}
+		key := IdInsertedAt{ID: row.DagID.Int64, InsertedAtUnixMillis: row.DagInsertedAt.Time.UnixMilli()}
 
 		if _, ok := seen[key]; !ok {
 			seen[key] = struct{}{}
@@ -1809,7 +1809,7 @@ func (r *OLAPRepositoryImpl) prepareDAGStatusUpdateBatchFromReconcile(taskRows [
 			continue
 		}
 
-		key := IdInsertedAt{ID: row.DagID.Int64, InsertedAt: row.DagInsertedAt}
+		key := IdInsertedAt{ID: row.DagID.Int64, InsertedAtUnixMillis: row.DagInsertedAt.Time.UnixMilli()}
 
 		if _, ok := seen[key]; !ok {
 			seen[key] = struct{}{}
@@ -2613,8 +2613,8 @@ func (r *OLAPRepositoryImpl) GetTaskTimings(ctx context.Context, tenantId uuid.U
 	for _, row := range runsList {
 		idsToDepth[row.ExternalID] = row.Depth
 		idsInsertedAts = append(idsInsertedAts, IdInsertedAt{
-			ID:         row.ID,
-			InsertedAt: row.InsertedAt,
+			ID:                   row.ID,
+			InsertedAtUnixMillis: row.InsertedAt.Time.UnixMilli(),
 		})
 	}
 
@@ -3383,8 +3383,8 @@ func (r *OLAPRepositoryImpl) AnalyzeOLAPTables(ctx context.Context) error {
 }
 
 type IdInsertedAt struct {
-	ID         int64              `json:"id"`
-	InsertedAt pgtype.Timestamptz `json:"inserted_at"`
+	ID                   int64
+	InsertedAtUnixMillis int64
 }
 
 func (r *OLAPRepositoryImpl) populateTaskRunData(ctx context.Context, tx pgx.Tx, tenantId uuid.UUID, opts []IdInsertedAt, includePayloads bool) ([]*sqlcv1.PopulateTaskRunDataRow, error) {
@@ -3395,8 +3395,8 @@ func (r *OLAPRepositoryImpl) populateTaskRunData(ctx context.Context, tx pgx.Tx,
 
 	for _, opt := range opts {
 		uniqueTaskIdInsertedAts[IdInsertedAt{
-			ID:         opt.ID,
-			InsertedAt: opt.InsertedAt,
+			ID:                   opt.ID,
+			InsertedAtUnixMillis: opt.InsertedAtUnixMillis,
 		}] = struct{}{}
 	}
 
@@ -3415,7 +3415,7 @@ func (r *OLAPRepositoryImpl) populateTaskRunData(ctx context.Context, tx pgx.Tx,
 
 	for idInsertedAt := range uniqueTaskIdInsertedAts {
 		taskIds = append(taskIds, idInsertedAt.ID)
-		taskInsertedAts = append(taskInsertedAts, idInsertedAt.InsertedAt)
+		taskInsertedAts = append(taskInsertedAts, sqlchelpers.TimestamptzFromUnixMillis(idInsertedAt.InsertedAtUnixMillis))
 	}
 
 	taskData, err := r.queries.PopulateTaskRunData(ctx, tx, sqlcv1.PopulateTaskRunDataParams{

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -3384,7 +3384,7 @@ func (r *OLAPRepositoryImpl) AnalyzeOLAPTables(ctx context.Context) error {
 
 type IdInsertedAt struct {
 	ID                   int64
-	InsertedAtUnixMicros int64
+	InsertedAtUnixMicros int64 // using microseconds because it matches the max precision allowed by `TIMESTAMPTZ` in PG
 }
 
 func (r *OLAPRepositoryImpl) populateTaskRunData(ctx context.Context, tx pgx.Tx, tenantId uuid.UUID, opts []IdInsertedAt, includePayloads bool) ([]*sqlcv1.PopulateTaskRunDataRow, error) {

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -925,7 +925,7 @@ func (r *OLAPRepositoryImpl) ListTasks(ctx context.Context, tenantId uuid.UUID, 
 	for _, row := range rows {
 		idsInsertedAts = append(idsInsertedAts, IdInsertedAt{
 			ID:                   row.ID,
-			InsertedAtUnixMillis: row.InsertedAt.Time.UnixMilli(),
+			InsertedAtUnixMicros: row.InsertedAt.Time.UnixMicro(),
 		})
 	}
 
@@ -1024,7 +1024,7 @@ func (r *OLAPRepositoryImpl) ListTasksByDAGId(ctx context.Context, tenantId uuid
 		taskIdToDagExternalId[row.TaskID] = row.DagExternalID
 		idsInsertedAts = append(idsInsertedAts, IdInsertedAt{
 			ID:                   row.TaskID,
-			InsertedAtUnixMillis: row.TaskInsertedAt.Time.UnixMilli(),
+			InsertedAtUnixMicros: row.TaskInsertedAt.Time.UnixMicro(),
 		})
 	}
 
@@ -1112,7 +1112,7 @@ func (r *OLAPRepositoryImpl) ListTasksByIdAndInsertedAt(ctx context.Context, ten
 	for _, metadata := range taskMetadata {
 		idsInsertedAts = append(idsInsertedAts, IdInsertedAt{
 			ID:                   metadata.TaskID,
-			InsertedAtUnixMillis: metadata.TaskInsertedAt.UnixMilli(),
+			InsertedAtUnixMicros: metadata.TaskInsertedAt.UnixMicro(),
 		})
 	}
 
@@ -1292,7 +1292,7 @@ func (r *OLAPRepositoryImpl) ListWorkflowRuns(ctx context.Context, tenantId uuid
 		} else {
 			taskIdsInsertedAts = append(taskIdsInsertedAts, IdInsertedAt{
 				ID:                   row.ID,
-				InsertedAtUnixMillis: row.InsertedAt.Time.UnixMilli(),
+				InsertedAtUnixMicros: row.InsertedAt.Time.UnixMicro(),
 			})
 		}
 	}
@@ -1724,13 +1724,13 @@ func (r *OLAPRepositoryImpl) prepareStatusUpdateBatch(ctx context.Context, tenan
 	for _, event := range events {
 		statusAndRetryCount, seen := taskIdInsertedAtToMeta[IdInsertedAt{
 			ID:                   event.TaskID,
-			InsertedAtUnixMillis: event.TaskInsertedAt.Time.UnixMilli(),
+			InsertedAtUnixMicros: event.TaskInsertedAt.Time.UnixMicro(),
 		}]
 
 		if !seen || event.RetryCount > statusAndRetryCount.RetryCount || (event.RetryCount == statusAndRetryCount.RetryCount && compareStatuses(event.ReadableStatus, statusAndRetryCount.Status)) {
 			taskIdInsertedAtToMeta[IdInsertedAt{
 				ID:                   event.TaskID,
-				InsertedAtUnixMillis: event.TaskInsertedAt.Time.UnixMilli(),
+				InsertedAtUnixMicros: event.TaskInsertedAt.Time.UnixMicro(),
 			}] = statusRetryCountWorkerIdTuple{
 				Status:     event.ReadableStatus,
 				RetryCount: event.RetryCount,
@@ -1749,7 +1749,7 @@ func (r *OLAPRepositoryImpl) prepareStatusUpdateBatch(ctx context.Context, tenan
 	for idInsertedAt, meta := range taskIdInsertedAtToMeta {
 		tenantIds = append(tenantIds, tenantId)
 		taskIds = append(taskIds, idInsertedAt.ID)
-		taskInsertedAts = append(taskInsertedAts, sqlchelpers.TimestamptzFromUnixMillis(idInsertedAt.InsertedAtUnixMillis))
+		taskInsertedAts = append(taskInsertedAts, sqlchelpers.TimestamptzFromUnixMicros(idInsertedAt.InsertedAtUnixMicros))
 		statuses = append(statuses, meta.Status)
 		retryCounts = append(retryCounts, meta.RetryCount)
 
@@ -1781,7 +1781,7 @@ func (r *OLAPRepositoryImpl) prepareDAGStatusUpdateBatch(taskRows []*sqlcv1.Upda
 			continue
 		}
 
-		key := IdInsertedAt{ID: row.DagID.Int64, InsertedAtUnixMillis: row.DagInsertedAt.Time.UnixMilli()}
+		key := IdInsertedAt{ID: row.DagID.Int64, InsertedAtUnixMicros: row.DagInsertedAt.Time.UnixMicro()}
 
 		if _, ok := seen[key]; !ok {
 			seen[key] = struct{}{}
@@ -1809,7 +1809,7 @@ func (r *OLAPRepositoryImpl) prepareDAGStatusUpdateBatchFromReconcile(taskRows [
 			continue
 		}
 
-		key := IdInsertedAt{ID: row.DagID.Int64, InsertedAtUnixMillis: row.DagInsertedAt.Time.UnixMilli()}
+		key := IdInsertedAt{ID: row.DagID.Int64, InsertedAtUnixMicros: row.DagInsertedAt.Time.UnixMicro()}
 
 		if _, ok := seen[key]; !ok {
 			seen[key] = struct{}{}
@@ -2614,7 +2614,7 @@ func (r *OLAPRepositoryImpl) GetTaskTimings(ctx context.Context, tenantId uuid.U
 		idsToDepth[row.ExternalID] = row.Depth
 		idsInsertedAts = append(idsInsertedAts, IdInsertedAt{
 			ID:                   row.ID,
-			InsertedAtUnixMillis: row.InsertedAt.Time.UnixMilli(),
+			InsertedAtUnixMicros: row.InsertedAt.Time.UnixMicro(),
 		})
 	}
 
@@ -3384,7 +3384,7 @@ func (r *OLAPRepositoryImpl) AnalyzeOLAPTables(ctx context.Context) error {
 
 type IdInsertedAt struct {
 	ID                   int64
-	InsertedAtUnixMillis int64
+	InsertedAtUnixMicros int64
 }
 
 func (r *OLAPRepositoryImpl) populateTaskRunData(ctx context.Context, tx pgx.Tx, tenantId uuid.UUID, opts []IdInsertedAt, includePayloads bool) ([]*sqlcv1.PopulateTaskRunDataRow, error) {
@@ -3396,7 +3396,7 @@ func (r *OLAPRepositoryImpl) populateTaskRunData(ctx context.Context, tx pgx.Tx,
 	for _, opt := range opts {
 		uniqueTaskIdInsertedAts[IdInsertedAt{
 			ID:                   opt.ID,
-			InsertedAtUnixMillis: opt.InsertedAtUnixMillis,
+			InsertedAtUnixMicros: opt.InsertedAtUnixMicros,
 		}] = struct{}{}
 	}
 
@@ -3415,7 +3415,7 @@ func (r *OLAPRepositoryImpl) populateTaskRunData(ctx context.Context, tx pgx.Tx,
 
 	for idInsertedAt := range uniqueTaskIdInsertedAts {
 		taskIds = append(taskIds, idInsertedAt.ID)
-		taskInsertedAts = append(taskInsertedAts, sqlchelpers.TimestamptzFromUnixMillis(idInsertedAt.InsertedAtUnixMillis))
+		taskInsertedAts = append(taskInsertedAts, sqlchelpers.TimestamptzFromUnixMicros(idInsertedAt.InsertedAtUnixMicros))
 	}
 
 	taskData, err := r.queries.PopulateTaskRunData(ctx, tx, sqlcv1.PopulateTaskRunDataParams{

--- a/pkg/repository/sqlchelpers/timestamp.go
+++ b/pkg/repository/sqlchelpers/timestamp.go
@@ -6,6 +6,16 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+func TimestamptzFromUnixMillis(millis int64) pgtype.Timestamptz {
+	if millis == 0 {
+		return pgtype.Timestamptz{}
+	}
+
+	t := time.UnixMilli(millis)
+
+	return TimestamptzFromTime(t)
+}
+
 func TimestampFromTime(t time.Time) pgtype.Timestamp {
 	if t.IsZero() {
 		return pgtype.Timestamp{}

--- a/pkg/repository/sqlchelpers/timestamp.go
+++ b/pkg/repository/sqlchelpers/timestamp.go
@@ -6,12 +6,12 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-func TimestamptzFromUnixMillis(millis int64) pgtype.Timestamptz {
-	if millis == 0 {
+func TimestamptzFromUnixMicros(micros int64) pgtype.Timestamptz {
+	if micros == 0 {
 		return pgtype.Timestamptz{}
 	}
 
-	t := time.UnixMilli(millis)
+	t := time.UnixMicro(micros)
 
 	return TimestamptzFromTime(t)
 }

--- a/pkg/repository/worker.go
+++ b/pkg/repository/worker.go
@@ -967,7 +967,7 @@ func (w *workerRepository) GetDurableDispatcherIdsForTasks(ctx context.Context, 
 
 	for i, tuple := range idInsertedAtTuples {
 		taskIds[i] = tuple.ID
-		taskInsertedAts[i] = tuple.InsertedAt
+		taskInsertedAts[i] = sqlchelpers.TimestamptzFromUnixMillis(tuple.InsertedAtUnixMillis)
 	}
 
 	rows, err := w.queries.ListDurableTaskDispatcherIdsForTasks(ctx, w.pool, sqlcv1.ListDurableTaskDispatcherIdsForTasksParams{
@@ -984,8 +984,8 @@ func (w *workerRepository) GetDurableDispatcherIdsForTasks(ctx context.Context, 
 
 	for _, row := range rows {
 		taskIdToDispatcherInfo[IdInsertedAt{
-			ID:         row.TaskID,
-			InsertedAt: row.TaskInsertedAt,
+			ID:                   row.TaskID,
+			InsertedAtUnixMillis: row.TaskInsertedAt.Time.UnixMilli(),
 		}] = DurableTaskDispatcherLookup{
 			DispatcherId: row.DurableTaskDispatcherId,
 			IsEvicted:    row.EvictedAt.Valid,

--- a/pkg/repository/worker.go
+++ b/pkg/repository/worker.go
@@ -967,7 +967,7 @@ func (w *workerRepository) GetDurableDispatcherIdsForTasks(ctx context.Context, 
 
 	for i, tuple := range idInsertedAtTuples {
 		taskIds[i] = tuple.ID
-		taskInsertedAts[i] = sqlchelpers.TimestamptzFromUnixMillis(tuple.InsertedAtUnixMillis)
+		taskInsertedAts[i] = sqlchelpers.TimestamptzFromUnixMicros(tuple.InsertedAtUnixMicros)
 	}
 
 	rows, err := w.queries.ListDurableTaskDispatcherIdsForTasks(ctx, w.pool, sqlcv1.ListDurableTaskDispatcherIdsForTasksParams{
@@ -985,7 +985,7 @@ func (w *workerRepository) GetDurableDispatcherIdsForTasks(ctx context.Context, 
 	for _, row := range rows {
 		taskIdToDispatcherInfo[IdInsertedAt{
 			ID:                   row.TaskID,
-			InsertedAtUnixMillis: row.TaskInsertedAt.Time.UnixMilli(),
+			InsertedAtUnixMicros: row.TaskInsertedAt.Time.UnixMicro(),
 		}] = DurableTaskDispatcherLookup{
 			DispatcherId: row.DurableTaskDispatcherId,
 			IsEvicted:    row.EvictedAt.Valid,


### PR DESCRIPTION
# Description

We had a weird bug in the durable logic last week caused by using `pgtype.Timestamptz` in a map key, so I'm getting rid of this in a bunch of places just to make extra sure

## Type of change

- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI

</details>
