### PR TITLE
fix: async-commit OLAP PutPayloads to cut WALWrite stalls

### DIFF
--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -3132,6 +3132,15 @@ func (r *OLAPRepositoryImpl) PutPayloads(ctx context.Context, tx sqlcv1.DBTX, te
 		defer rollback()
 	}
 
+	// OLAP payloads are best-effort secondary data. Skip waiting for WAL fsync on
+	// commit so fat INLINE inserts do not stall behind WALWrite/WalSync. SET LOCAL
+	// applies to the whole transaction (including status updates when PutPayloads
+	// shares a flush txn). Crash before walwriter flush can lose this commit after
+	// the MQ ack — acceptable for this path, not for primary task state.
+	if _, err := tx.Exec(ctx, "SET LOCAL synchronous_commit = off"); err != nil {
+		return fmt.Errorf("error setting synchronous_commit off in `PutPayload`: %w", err)
+	}
+
 	insertedAts := make([]pgtype.Timestamptz, 0, len(putPayloadOpts))
 	tenantIds := make([]uuid.UUID, 0, len(putPayloadOpts))
 	externalIds := make([]uuid.UUID, 0, len(putPayloadOpts))


### PR DESCRIPTION
## Summary
- Set `SET LOCAL synchronous_commit = off` in `PutPayloads` so OLAP flush commits do not wait for per-commit WAL fsync.
- Targets production WALWrite / WalSync convoys on shared Timescale when draining fat INLINE payload inserts (e.g. olap_queue_v2`).
- Applies to any txn that calls `PutPayloads` (including shared flush txns with status updates). OLAP is secondary: a crash before walwriter flush can lose a commit after the MQ ack.

## Test plan
- [ ] Controllers build and start with this change
- [ ] Confirm `SET LOCAL` works for the DB role (`synchronous_commit` context is `user`)
- [ ] After deploy to a hot shard): `WALWrite` waiters in `pg_stat_activity` drop; `wal_sync` growth rate in `pg_stat_wal` slows vs `wal_write`
- [ ] `olap_queue_v2` ack rate improves without multi-second `query commit` tails
- [ ] Spot-check that primary (non-OLAP) task DB paths are unchanged