### PR TITLE
fix(engine): serialization for operator dag status updates

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260825203952_v1_0_148.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260825203952_v1_0_148.sql
@@ -1,23 +1,11 @@
 -- +goose Up
 -- +goose StatementBegin
 ALTER TABLE v1_dags_olap
-    ADD COLUMN is_operator_run BOOLEAN NOT NULL DEFAULT FALSE,
     ADD COLUMN latest_retry_count INT NOT NULL DEFAULT 0;
-
--- Matt note: going to run this manually for instances we've turned on, don't think it's practical to run during the migration
--- but we do need it to prevent dags from hanging
--- UPDATE v1_dags_olap d
--- SET is_operator_run = TRUE
--- FROM v1_dag_to_task_olap dt
--- WHERE
---     (d.id, d.inserted_at) = (dt.dag_id, dt.dag_inserted_at)
---     AND (dt.dag_id, dt.dag_inserted_at) = (dt.task_id, dt.task_inserted_at)
---     AND d.inserted_at > << timestamp here >>;
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
 ALTER TABLE v1_dags_olap
-    DROP COLUMN is_operator_run,
     DROP COLUMN latest_retry_count;
 -- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20260825203952_v1_0_148.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260825203952_v1_0_148.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE v1_dags_olap
+    ADD COLUMN is_operator_run BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN latest_retry_count INT NOT NULL DEFAULT 0;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE v1_dags_olap
+    DROP COLUMN is_operator_run,
+    DROP COLUMN latest_retry_count;
+-- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20260825203952_v1_0_148.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260825203952_v1_0_148.sql
@@ -1,5 +1,7 @@
 -- +goose Up
 -- +goose StatementBegin
+
+-- todo: make sure that adding this here is safe (and doesn't bork updates on either side of the migration)
 ALTER TABLE v1_dags_olap
     ADD COLUMN latest_retry_count INT NOT NULL DEFAULT 0;
 -- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20260825203952_v1_0_148.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260825203952_v1_0_148.sql
@@ -11,7 +11,8 @@ ALTER TABLE v1_dags_olap
 -- FROM v1_dag_to_task_olap dt
 -- WHERE
 --     (d.id, d.inserted_at) = (dt.dag_id, dt.dag_inserted_at)
---     AND (dt.dag_id, dt.dag_inserted_at) = (dt.task_id, dt.task_inserted_at);
+--     AND (dt.dag_id, dt.dag_inserted_at) = (dt.task_id, dt.task_inserted_at)
+--     AND d.inserted_at > << timestamp here >>;
 -- +goose StatementEnd
 
 -- +goose Down

--- a/cmd/hatchet-migrate/migrate/migrations/20260825203952_v1_0_148.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260825203952_v1_0_148.sql
@@ -1,7 +1,5 @@
 -- +goose Up
 -- +goose StatementBegin
-
--- todo: make sure that adding this here is safe (and doesn't bork updates on either side of the migration)
 ALTER TABLE v1_dags_olap
     ADD COLUMN latest_retry_count INT NOT NULL DEFAULT 0;
 -- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20260825203952_v1_0_148.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260825203952_v1_0_148.sql
@@ -3,6 +3,15 @@
 ALTER TABLE v1_dags_olap
     ADD COLUMN is_operator_run BOOLEAN NOT NULL DEFAULT FALSE,
     ADD COLUMN latest_retry_count INT NOT NULL DEFAULT 0;
+
+-- Matt note: going to run this manually for instances we've turned on, don't think it's practical to run during the migration
+-- but we do need it to prevent dags from hanging
+-- UPDATE v1_dags_olap d
+-- SET is_operator_run = TRUE
+-- FROM v1_dag_to_task_olap dt
+-- WHERE
+--     (d.id, d.inserted_at) = (dt.dag_id, dt.dag_inserted_at)
+--     AND (dt.dag_id, dt.dag_inserted_at) = (dt.task_id, dt.task_inserted_at);
 -- +goose StatementEnd
 
 -- +goose Down

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -898,30 +898,63 @@ func (tc *OLAPControllerImpl) emitEventSpans(ctx context.Context, tenantId uuid.
 	tc.writeEngineSpans(ctx, tenantId, spans, "event")
 }
 
-func orchestratorDAGStatusFromEventType(eventType sqlcv1.V1EventTypeOlap) (status sqlcv1.V1ReadableStatusOlap, ok bool) {
+func olapEventTypeToReadableStatus(eventType sqlcv1.V1EventTypeOlap) sqlcv1.V1ReadableStatusOlap {
 	switch eventType {
-	case sqlcv1.V1EventTypeOlapFAILED,
-		sqlcv1.V1EventTypeOlapTIMEDOUT,
-		sqlcv1.V1EventTypeOlapSCHEDULINGTIMEDOUT,
-		sqlcv1.V1EventTypeOlapRATELIMITERROR,
-		sqlcv1.V1EventTypeOlapCOULDNOTSENDTOWORKER:
-		return sqlcv1.V1ReadableStatusOlapFAILED, true
+	case sqlcv1.V1EventTypeOlapRETRYING:
+		return sqlcv1.V1ReadableStatusOlapQUEUED
+	case sqlcv1.V1EventTypeOlapREASSIGNED:
+		return sqlcv1.V1ReadableStatusOlapQUEUED
+	case sqlcv1.V1EventTypeOlapRETRIEDBYUSER:
+		return sqlcv1.V1ReadableStatusOlapQUEUED
+	case sqlcv1.V1EventTypeOlapCREATED:
+		return sqlcv1.V1ReadableStatusOlapQUEUED
+	case sqlcv1.V1EventTypeOlapQUEUED:
+		return sqlcv1.V1ReadableStatusOlapQUEUED
+	case sqlcv1.V1EventTypeOlapREQUEUEDNOWORKER:
+		return sqlcv1.V1ReadableStatusOlapQUEUED
+	case sqlcv1.V1EventTypeOlapREQUEUEDRATELIMIT:
+		return sqlcv1.V1ReadableStatusOlapQUEUED
+	case sqlcv1.V1EventTypeOlapASSIGNED:
+		return sqlcv1.V1ReadableStatusOlapRUNNING
+	case sqlcv1.V1EventTypeOlapACKNOWLEDGED:
+		return sqlcv1.V1ReadableStatusOlapRUNNING
+	case sqlcv1.V1EventTypeOlapSENTTOWORKER:
+		return sqlcv1.V1ReadableStatusOlapRUNNING
+	case sqlcv1.V1EventTypeOlapSLOTRELEASED:
+		return sqlcv1.V1ReadableStatusOlapRUNNING
+	case sqlcv1.V1EventTypeOlapSTARTED:
+		return sqlcv1.V1ReadableStatusOlapRUNNING
+	case sqlcv1.V1EventTypeOlapTIMEOUTREFRESHED:
+		return sqlcv1.V1ReadableStatusOlapRUNNING
+	case sqlcv1.V1EventTypeOlapSCHEDULINGTIMEDOUT:
+		return sqlcv1.V1ReadableStatusOlapFAILED
+	case sqlcv1.V1EventTypeOlapFINISHED:
+		return sqlcv1.V1ReadableStatusOlapCOMPLETED
+	case sqlcv1.V1EventTypeOlapFAILED:
+		return sqlcv1.V1ReadableStatusOlapFAILED
 	case sqlcv1.V1EventTypeOlapCANCELLED:
-		return sqlcv1.V1ReadableStatusOlapCANCELLED, true
-	case sqlcv1.V1EventTypeOlapFINISHED, sqlcv1.V1EventTypeOlapSKIPPED:
-		return sqlcv1.V1ReadableStatusOlapCOMPLETED, true
+		return sqlcv1.V1ReadableStatusOlapCANCELLED
+	case sqlcv1.V1EventTypeOlapTIMEDOUT:
+		return sqlcv1.V1ReadableStatusOlapFAILED
+	case sqlcv1.V1EventTypeOlapRATELIMITERROR:
+		return sqlcv1.V1ReadableStatusOlapFAILED
+	case sqlcv1.V1EventTypeOlapSKIPPED:
+		return sqlcv1.V1ReadableStatusOlapCOMPLETED
+	case sqlcv1.V1EventTypeOlapCOULDNOTSENDTOWORKER:
+		return sqlcv1.V1ReadableStatusOlapFAILED
 	case sqlcv1.V1EventTypeOlapDURABLEEVICTED:
-		return sqlcv1.V1ReadableStatusOlapEVICTED, true
-	case sqlcv1.V1EventTypeOlapRETRYING, sqlcv1.V1EventTypeOlapRETRIEDBYUSER:
-		return sqlcv1.V1ReadableStatusOlapQUEUED, true
-	case sqlcv1.V1EventTypeOlapASSIGNED,
-		sqlcv1.V1EventTypeOlapACKNOWLEDGED,
-		sqlcv1.V1EventTypeOlapSENTTOWORKER,
-		sqlcv1.V1EventTypeOlapSTARTED,
-		sqlcv1.V1EventTypeOlapDURABLERESTORING:
-		return sqlcv1.V1ReadableStatusOlapRUNNING, true
+		return sqlcv1.V1ReadableStatusOlapEVICTED
+	case sqlcv1.V1EventTypeOlapDURABLERESTORING:
+		return sqlcv1.V1ReadableStatusOlapRUNNING
+	case sqlcv1.V1EventTypeOlapBATCHBUFFERED:
+		return sqlcv1.V1ReadableStatusOlapQUEUED
+	case sqlcv1.V1EventTypeOlapWAITINGFORBATCH:
+		return sqlcv1.V1ReadableStatusOlapQUEUED
+	case sqlcv1.V1EventTypeOlapBATCHFLUSHED:
+		// Running until the individual tasks are completed
+		return sqlcv1.V1ReadableStatusOlapRUNNING
 	default:
-		return "", false
+		return sqlcv1.V1ReadableStatusOlapQUEUED
 	}
 }
 
@@ -985,16 +1018,18 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 			continue
 		}
 
+		readableStatus := olapEventTypeToReadableStatus(msg.EventType)
+
 		if taskMeta.IsDagOrchestrator {
-			if status, ok := orchestratorDAGStatusFromEventType(msg.EventType); ok {
-				orchestratorUpdates = append(orchestratorUpdates, v1.OrchestratorDAGStatusUpdateOpt{
-					DagId:          msg.TaskId,
-					DagInsertedAt:  taskMeta.InsertedAt,
-					ReadableStatus: status,
-					RetryCount:     msg.RetryCount,
-				})
-			}
+			orchestratorUpdates = append(orchestratorUpdates, v1.OrchestratorDAGStatusUpdateOpt{
+				DagId:          msg.TaskId,
+				DagInsertedAt:  taskMeta.InsertedAt,
+				ReadableStatus: readableStatus,
+				RetryCount:     msg.RetryCount,
+			})
 		}
+
+		readableStatuses = append(readableStatuses, readableStatus)
 
 		taskIds = append(taskIds, msg.TaskId)
 		taskInsertedAts = append(taskInsertedAts, taskMeta.InsertedAt)
@@ -1041,64 +1076,6 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 			workerIds = append(workerIds, uuid.Nil)
 		}
 
-		switch msg.EventType {
-		case sqlcv1.V1EventTypeOlapRETRYING:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapQUEUED)
-		case sqlcv1.V1EventTypeOlapREASSIGNED:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapQUEUED)
-		case sqlcv1.V1EventTypeOlapRETRIEDBYUSER:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapQUEUED)
-		case sqlcv1.V1EventTypeOlapCREATED:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapQUEUED)
-		case sqlcv1.V1EventTypeOlapQUEUED:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapQUEUED)
-		case sqlcv1.V1EventTypeOlapREQUEUEDNOWORKER:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapQUEUED)
-		case sqlcv1.V1EventTypeOlapREQUEUEDRATELIMIT:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapQUEUED)
-		case sqlcv1.V1EventTypeOlapASSIGNED:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapRUNNING)
-		case sqlcv1.V1EventTypeOlapACKNOWLEDGED:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapRUNNING)
-		case sqlcv1.V1EventTypeOlapSENTTOWORKER:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapRUNNING)
-		case sqlcv1.V1EventTypeOlapSLOTRELEASED:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapRUNNING)
-		case sqlcv1.V1EventTypeOlapSTARTED:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapRUNNING)
-		case sqlcv1.V1EventTypeOlapTIMEOUTREFRESHED:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapRUNNING)
-		case sqlcv1.V1EventTypeOlapSCHEDULINGTIMEDOUT:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapFAILED)
-		case sqlcv1.V1EventTypeOlapFINISHED:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapCOMPLETED)
-		case sqlcv1.V1EventTypeOlapFAILED:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapFAILED)
-		case sqlcv1.V1EventTypeOlapCANCELLED:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapCANCELLED)
-		case sqlcv1.V1EventTypeOlapTIMEDOUT:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapFAILED)
-		case sqlcv1.V1EventTypeOlapRATELIMITERROR:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapFAILED)
-		case sqlcv1.V1EventTypeOlapSKIPPED:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapCOMPLETED)
-		case sqlcv1.V1EventTypeOlapCOULDNOTSENDTOWORKER:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapFAILED)
-		case sqlcv1.V1EventTypeOlapDURABLEEVICTED:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapEVICTED)
-		case sqlcv1.V1EventTypeOlapDURABLERESTORING:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapRUNNING)
-		case sqlcv1.V1EventTypeOlapBATCHBUFFERED:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapQUEUED)
-		case sqlcv1.V1EventTypeOlapWAITINGFORBATCH:
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapQUEUED)
-		case sqlcv1.V1EventTypeOlapBATCHFLUSHED:
-			// Running until the individual tasks are completed
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapRUNNING)
-		default:
-			// Treat unknown or informational events as queued to keep array lengths aligned.
-			readableStatuses = append(readableStatuses, sqlcv1.V1ReadableStatusOlapQUEUED)
-		}
 	}
 
 	opts := make([]sqlcv1.CreateTaskEventsOLAPParams, 0)

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -898,29 +898,30 @@ func (tc *OLAPControllerImpl) emitEventSpans(ctx context.Context, tenantId uuid.
 	tc.writeEngineSpans(ctx, tenantId, spans, "event")
 }
 
-// orchestratorDAGStatusFromEventType maps an orchestrator task's lifecycle event to the status
-// override for its run's DAG row. Completion events deliberately don't map to COMPLETED: DAG
-// completion must come from child task counting, which protects against the orchestrator
-// finishing while a child event is still in flight.
-func orchestratorDAGStatusFromEventType(eventType sqlcv1.V1EventTypeOlap) (status sqlcv1.V1ReadableStatusOlap, isReset bool, ok bool) {
+func orchestratorDAGStatusFromEventType(eventType sqlcv1.V1EventTypeOlap) (status sqlcv1.V1ReadableStatusOlap, ok bool) {
 	switch eventType {
 	case sqlcv1.V1EventTypeOlapFAILED,
 		sqlcv1.V1EventTypeOlapTIMEDOUT,
 		sqlcv1.V1EventTypeOlapSCHEDULINGTIMEDOUT,
 		sqlcv1.V1EventTypeOlapRATELIMITERROR,
 		sqlcv1.V1EventTypeOlapCOULDNOTSENDTOWORKER:
-		return sqlcv1.V1ReadableStatusOlapFAILED, false, true
+		return sqlcv1.V1ReadableStatusOlapFAILED, true
 	case sqlcv1.V1EventTypeOlapCANCELLED:
-		return sqlcv1.V1ReadableStatusOlapCANCELLED, false, true
+		return sqlcv1.V1ReadableStatusOlapCANCELLED, true
+	case sqlcv1.V1EventTypeOlapFINISHED, sqlcv1.V1EventTypeOlapSKIPPED:
+		return sqlcv1.V1ReadableStatusOlapCOMPLETED, true
+	case sqlcv1.V1EventTypeOlapDURABLEEVICTED:
+		return sqlcv1.V1ReadableStatusOlapEVICTED, true
 	case sqlcv1.V1EventTypeOlapRETRYING, sqlcv1.V1EventTypeOlapRETRIEDBYUSER:
-		return sqlcv1.V1ReadableStatusOlapRUNNING, true, true
+		return sqlcv1.V1ReadableStatusOlapQUEUED, true
 	case sqlcv1.V1EventTypeOlapASSIGNED,
 		sqlcv1.V1EventTypeOlapACKNOWLEDGED,
 		sqlcv1.V1EventTypeOlapSENTTOWORKER,
-		sqlcv1.V1EventTypeOlapSTARTED:
-		return sqlcv1.V1ReadableStatusOlapRUNNING, false, true
+		sqlcv1.V1EventTypeOlapSTARTED,
+		sqlcv1.V1EventTypeOlapDURABLERESTORING:
+		return sqlcv1.V1ReadableStatusOlapRUNNING, true
 	default:
-		return "", false, false
+		return "", false
 	}
 }
 
@@ -965,15 +966,11 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 	eventExternalIds := make([]uuid.UUID, 0)
 	msgIxToSpanEvent := make(map[int]engineSpanEvent)
 
-	// orchestrator tasks have no v1_tasks_olap row; their lifecycle events are applied to
-	// their run's DAG row instead. keyed by (dag id, dag inserted_at), last event wins,
-	// except that a plain RUNNING transition never replaces a terminal override.
-	type dagKey struct {
-		id         int64
-		insertedAt int64
-	}
-
-	orchestratorUpdates := make(map[dagKey]v1.OrchestratorDAGStatusUpdate)
+	// orchestrator tasks have no v1_tasks_olap row; their lifecycle events are applied to their
+	// run's DAG row instead. accumulated in arrival order -- the repository dedupes to the newest
+	// event per DAG, and the query decides from there whether it actually applies.
+	orchestratorUpdates := make([]v1.OrchestratorDAGStatusUpdateOpt, 0)
+	operatorRunIds := make(map[uuid.UUID]struct{})
 
 	for ix, msg := range msgs {
 		taskMeta := taskIdsToMetas[msg.TaskId]
@@ -989,20 +986,13 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		}
 
 		if taskMeta.IsDagOrchestrator {
-			if status, isReset, ok := orchestratorDAGStatusFromEventType(msg.EventType); ok {
-				key := dagKey{id: msg.TaskId, insertedAt: taskMeta.InsertedAt.Time.UnixNano()}
-
-				existing, hasExisting := orchestratorUpdates[key]
-				existingIsTerminal := hasExisting && (existing.ReadableStatus == sqlcv1.V1ReadableStatusOlapFAILED || existing.ReadableStatus == sqlcv1.V1ReadableStatusOlapCANCELLED)
-
-				if !hasExisting || !existingIsTerminal || isReset {
-					orchestratorUpdates[key] = v1.OrchestratorDAGStatusUpdate{
-						DagId:          msg.TaskId,
-						DagInsertedAt:  taskMeta.InsertedAt,
-						ReadableStatus: status,
-						IsReset:        isReset,
-					}
-				}
+			if status, ok := orchestratorDAGStatusFromEventType(msg.EventType); ok {
+				orchestratorUpdates = append(orchestratorUpdates, v1.OrchestratorDAGStatusUpdateOpt{
+					DagId:          msg.TaskId,
+					DagInsertedAt:  taskMeta.InsertedAt,
+					ReadableStatus: status,
+					RetryCount:     msg.RetryCount,
+				})
 			}
 		}
 
@@ -1020,6 +1010,10 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 
 		eventExternalIdToWorkflowRunId[externalId] = taskMeta.WorkflowRunID
 		externalIdToMsg[externalId] = msg
+
+		if taskMeta.WasTriggeredByDagOrchestrator {
+			operatorRunIds[taskMeta.WorkflowRunID] = struct{}{}
+		}
 
 		msgIxToSpanEvent[ix] = engineSpanEvent{
 			taskID:             msg.TaskId,
@@ -1164,7 +1158,7 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 
 		attempts++
 
-		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTaskEvents(ctx, tenantId, opts, eventExternalIdToWorkflowRunId)
+		result, workflowRunIdsOfLocksNotAcquired, err := tc.repo.OLAP().CreateTaskEvents(ctx, tenantId, opts, eventExternalIdToWorkflowRunId, orchestratorUpdates, operatorRunIds)
 
 		if err != nil {
 			return fmt.Errorf("failed to create task events: %w", err)
@@ -1224,24 +1218,6 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 
 		if len(remainingOpts) > 0 && attempts < maxLockAttempts {
 			tc.sleepWithBackoff(attempts)
-		}
-	}
-
-	if len(orchestratorUpdates) > 0 {
-		updates := make([]v1.OrchestratorDAGStatusUpdate, 0, len(orchestratorUpdates))
-
-		for _, update := range orchestratorUpdates {
-			updates = append(updates, update)
-		}
-
-		result, err := tc.repo.OLAP().ApplyOrchestratorEventsToDAGs(ctx, tenantId, updates)
-
-		if err != nil {
-			return fmt.Errorf("failed to apply orchestrator events to DAGs: %w", err)
-		}
-
-		if err := tc.notifyStatusUpdates(ctx, result); err != nil {
-			return fmt.Errorf("failed to notify DAG status updates from orchestrator events: %w", err)
 		}
 	}
 

--- a/internal/services/controllers/olap/controller.go
+++ b/internal/services/controllers/olap/controller.go
@@ -1075,7 +1075,6 @@ func (tc *OLAPControllerImpl) handleCreateMonitoringEvent(ctx context.Context, t
 		} else {
 			workerIds = append(workerIds, uuid.Nil)
 		}
-
 	}
 
 	opts := make([]sqlcv1.CreateTaskEventsOLAPParams, 0)

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -1997,8 +1997,7 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 		}
 	}
 
-	// In the same transaction as the events themselves, so an orchestrator's outcome can't be
-	// consumed and then dropped if the batch fails afterwards.
+	// same transaction as the events, so an outcome can't be consumed and then dropped on failure
 	orchestratorDAGRows, err := r.applyOrchestratorEventsToDAGs(ctx, tx, tenantId, orchestratorUpdates)
 
 	if err != nil {
@@ -2504,9 +2503,8 @@ type OrchestratorDAGStatusUpdateOpt struct {
 	RetryCount     int32
 }
 
-// dedupeOrchestratorUpdates picks one update per DAG the same way prepareStatusUpdateBatch does for tasks:
-// highest retry count wins, then highest status priority. Deduping on arrival order instead would let
-// a stale RUNNING in the same batch discard a terminal outcome the query would otherwise have applied.
+// Picks one update per DAG like prepareStatusUpdateBatch does for tasks: highest retry count wins, then
+// highest status priority. Going by arrival order would let a stale RUNNING discard a terminal outcome.
 func dedupeOrchestratorUpdates(updates []OrchestratorDAGStatusUpdateOpt) []OrchestratorDAGStatusUpdateOpt {
 	winners := make(map[IdInsertedAt]OrchestratorDAGStatusUpdateOpt, len(updates))
 	order := make([]IdInsertedAt, 0, len(updates))

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -2447,7 +2447,6 @@ func (r *OLAPRepositoryImpl) writeDAGBatch(ctx context.Context, tenantId uuid.UU
 		params.Parenttaskexternalids = append(params.Parenttaskexternalids, dag.ParentTaskExternalID)
 		params.Totaltasks = append(params.Totaltasks, int32(dag.TotalTasks)) // nolint: gosec
 		params.IdempotencyKeys = append(params.IdempotencyKeys, dag.IdempotencyKey)
-		params.Isoperatorruns = append(params.Isoperatorruns, dag.IsOperatorRun)
 
 		putPayloadOpts = append(putPayloadOpts, StoreOLAPPayloadOpts{
 			ExternalId: dag.ExternalID,

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -261,9 +261,8 @@ type OLAPRepository interface {
 	ListWorkflowRunDisplayNames(ctx context.Context, tenantId uuid.UUID, externalIds []uuid.UUID) ([]*sqlcv1.ListWorkflowRunDisplayNamesRow, error)
 	ReadTaskRunMetrics(ctx context.Context, tenantId uuid.UUID, opts ReadTaskRunMetricsOpts) ([]TaskRunMetric, error)
 	CreateTasks(ctx context.Context, tenantId uuid.UUID, tasks []*V1TaskWithPayload) (*StatusUpdateResult, map[uuid.UUID]struct{}, error)
-	CreateTaskEvents(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, eventExternalIdToWorkflowRunId map[uuid.UUID]uuid.UUID) (*StatusUpdateResult, map[uuid.UUID]struct{}, error)
+	CreateTaskEvents(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, eventExternalIdToWorkflowRunId map[uuid.UUID]uuid.UUID, orchestratorUpdates []OrchestratorDAGStatusUpdateOpt, operatorRunIds map[uuid.UUID]struct{}) (*StatusUpdateResult, map[uuid.UUID]struct{}, error)
 	CreateDAGs(ctx context.Context, tenantId uuid.UUID, dags []*DAGWithData) (map[uuid.UUID]struct{}, error)
-	ApplyOrchestratorEventsToDAGs(ctx context.Context, tenantId uuid.UUID, updates []OrchestratorDAGStatusUpdate) (*StatusUpdateResult, error)
 	GetTaskPointMetrics(ctx context.Context, tenantId uuid.UUID, startTimestamp *time.Time, endTimestamp *time.Time, bucketInterval time.Duration) ([]*sqlcv1.GetTaskPointMetricsRow, error)
 	UpdateTaskStatuses(ctx context.Context, tenantIds []uuid.UUID) (bool, []UpdateTaskStatusRow, error)
 	UpdateDAGStatuses(ctx context.Context, tenantIds []uuid.UUID) (bool, []UpdateDAGStatusRow, error)
@@ -1874,7 +1873,7 @@ func (r *OLAPRepositoryImpl) tryAcquireAdvisoryLocksForWorkflowRuns(ctx context.
 	return locksNotAcquired, nil
 }
 
-func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, eventExternalIdToWorkflowRunId map[uuid.UUID]uuid.UUID) (*StatusUpdateResult, map[uuid.UUID]struct{}, error) {
+func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, eventExternalIdToWorkflowRunId map[uuid.UUID]uuid.UUID, orchestratorUpdates []OrchestratorDAGStatusUpdateOpt, operatorRunIds map[uuid.UUID]struct{}) (*StatusUpdateResult, map[uuid.UUID]struct{}, error) {
 	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 	if err != nil {
 		return nil, nil, err
@@ -1884,6 +1883,10 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 	workflowRunIds := make([]uuid.UUID, 0, len(events))
 
 	for _, workflowRunId := range eventExternalIdToWorkflowRunId {
+		if _, isOperatorRun := operatorRunIds[workflowRunId]; isOperatorRun {
+			continue
+		}
+
 		workflowRunIds = append(workflowRunIds, workflowRunId)
 	}
 
@@ -1930,7 +1933,7 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 		})
 	}
 
-	if len(eventsForStatusUpdate) == 0 {
+	if len(eventsForStatusUpdate) == 0 && len(orchestratorUpdates) == 0 {
 		return nil, workflowRunIdsOfLocksNotAcquired, nil
 	}
 
@@ -1941,12 +1944,17 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 		}
 	}
 
-	statusUpdates := r.prepareStatusUpdateBatch(ctx, tenantId, eventsForStatusUpdate)
 	result := &StatusUpdateResult{}
 
-	taskRows, err := r.queries.UpdateTaskStatusesFromMQ(ctx, tx, statusUpdates)
-	if err != nil {
-		return nil, nil, err
+	var taskRows []*sqlcv1.UpdateTaskStatusesFromMQRow
+
+	if len(eventsForStatusUpdate) > 0 {
+		statusUpdates := r.prepareStatusUpdateBatch(ctx, tenantId, eventsForStatusUpdate)
+
+		taskRows, err = r.queries.UpdateTaskStatusesFromMQ(ctx, tx, statusUpdates)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	for _, row := range taskRows {
@@ -1988,6 +1996,16 @@ func (r *OLAPRepositoryImpl) writeTaskEventBatch(ctx context.Context, tenantId u
 			})
 		}
 	}
+
+	// In the same transaction as the events themselves, so an orchestrator's outcome can't be
+	// consumed and then dropped if the batch fails afterwards.
+	orchestratorDAGRows, err := r.applyOrchestratorEventsToDAGs(ctx, tx, tenantId, orchestratorUpdates)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result.DAGRows = append(result.DAGRows, orchestratorDAGRows...)
 
 	if len(payloadsToWrite) > 0 {
 		err = r.PutPayloads(ctx, tx, tenantId, payloadsToWrite...)
@@ -2238,9 +2256,15 @@ func (r *OLAPRepositoryImpl) UpdateDAGStatuses(ctx context.Context, tenantIds []
 }
 
 func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId uuid.UUID, tasks []*V1TaskWithPayload) (*StatusUpdateResult, map[uuid.UUID]struct{}, error) {
-	workflowRunIds := make([]uuid.UUID, len(tasks))
-	for i, task := range tasks {
-		workflowRunIds[i] = task.WorkflowRunID
+	workflowRunIds := make([]uuid.UUID, 0, len(tasks))
+	for _, task := range tasks {
+		if task.IsOperatorRun {
+			// we don't need to acquire any locks for workflow runs (and their tasks)
+			// that are part of an operator-orchestrated DAG
+			continue
+		}
+
+		workflowRunIds = append(workflowRunIds, task.WorkflowRunID)
 	}
 
 	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
@@ -2377,9 +2401,15 @@ func (r *OLAPRepositoryImpl) writeTaskBatch(ctx context.Context, tenantId uuid.U
 }
 
 func (r *OLAPRepositoryImpl) writeDAGBatch(ctx context.Context, tenantId uuid.UUID, dags []*DAGWithData) (map[uuid.UUID]struct{}, error) {
-	dagIds := make([]uuid.UUID, len(dags))
-	for i, dag := range dags {
-		dagIds[i] = dag.ExternalID
+	dagIds := make([]uuid.UUID, 0, len(dags))
+	for _, dag := range dags {
+		// we don't need to acquire any locks for workflow runs (and their DAGs)
+		// that are part of an operator-orchestrated DAG
+		if dag.IsOperatorRun {
+			continue
+		}
+
+		dagIds = append(dagIds, dag.ExternalID)
 	}
 
 	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
@@ -2418,6 +2448,7 @@ func (r *OLAPRepositoryImpl) writeDAGBatch(ctx context.Context, tenantId uuid.UU
 		params.Parenttaskexternalids = append(params.Parenttaskexternalids, dag.ParentTaskExternalID)
 		params.Totaltasks = append(params.Totaltasks, int32(dag.TotalTasks)) // nolint: gosec
 		params.IdempotencyKeys = append(params.IdempotencyKeys, dag.IdempotencyKey)
+		params.Isoperatorruns = append(params.Isoperatorruns, dag.IsOperatorRun)
 
 		putPayloadOpts = append(putPayloadOpts, StoreOLAPPayloadOpts{
 			ExternalId: dag.ExternalID,
@@ -2454,8 +2485,8 @@ func (r *OLAPRepositoryImpl) writeDAGBatch(ctx context.Context, tenantId uuid.UU
 	return workflowRunIdsOfLocksNotAcquired, nil
 }
 
-func (r *OLAPRepositoryImpl) CreateTaskEvents(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, eventExternalIdToWorkflowRunId map[uuid.UUID]uuid.UUID) (*StatusUpdateResult, map[uuid.UUID]struct{}, error) {
-	return r.writeTaskEventBatch(ctx, tenantId, events, eventExternalIdToWorkflowRunId)
+func (r *OLAPRepositoryImpl) CreateTaskEvents(ctx context.Context, tenantId uuid.UUID, events []sqlcv1.CreateTaskEventsOLAPParams, eventExternalIdToWorkflowRunId map[uuid.UUID]uuid.UUID, orchestratorUpdates []OrchestratorDAGStatusUpdateOpt, operatorRunIds map[uuid.UUID]struct{}) (*StatusUpdateResult, map[uuid.UUID]struct{}, error) {
+	return r.writeTaskEventBatch(ctx, tenantId, events, eventExternalIdToWorkflowRunId, orchestratorUpdates, operatorRunIds)
 }
 
 func (r *OLAPRepositoryImpl) CreateTasks(ctx context.Context, tenantId uuid.UUID, tasks []*V1TaskWithPayload) (*StatusUpdateResult, map[uuid.UUID]struct{}, error) {
@@ -2466,30 +2497,62 @@ func (r *OLAPRepositoryImpl) CreateDAGs(ctx context.Context, tenantId uuid.UUID,
 	return r.writeDAGBatch(ctx, tenantId, dags)
 }
 
-type OrchestratorDAGStatusUpdate struct {
+type OrchestratorDAGStatusUpdateOpt struct {
 	DagInsertedAt  pgtype.Timestamptz
 	ReadableStatus sqlcv1.V1ReadableStatusOlap
 	DagId          int64
-	IsReset        bool
+	RetryCount     int32
 }
 
-func (r *OLAPRepositoryImpl) ApplyOrchestratorEventsToDAGs(ctx context.Context, tenantId uuid.UUID, updates []OrchestratorDAGStatusUpdate) (*StatusUpdateResult, error) {
+// dedupeOrchestratorUpdates picks one update per DAG the same way prepareStatusUpdateBatch does for tasks:
+// highest retry count wins, then highest status priority. Deduping on arrival order instead would let
+// a stale RUNNING in the same batch discard a terminal outcome the query would otherwise have applied.
+func dedupeOrchestratorUpdates(updates []OrchestratorDAGStatusUpdateOpt) []OrchestratorDAGStatusUpdateOpt {
+	winners := make(map[IdInsertedAt]OrchestratorDAGStatusUpdateOpt, len(updates))
+	order := make([]IdInsertedAt, 0, len(updates))
+
+	for _, update := range updates {
+		key := IdInsertedAt{ID: update.DagId, InsertedAtUnixMicros: update.DagInsertedAt.Time.UnixMicro()}
+
+		existing, seen := winners[key]
+
+		if !seen {
+			order = append(order, key)
+		}
+
+		if !seen ||
+			update.RetryCount > existing.RetryCount ||
+			(update.RetryCount == existing.RetryCount && compareStatuses(update.ReadableStatus, existing.ReadableStatus)) {
+			winners[key] = update
+		}
+	}
+
+	deduped := make([]OrchestratorDAGStatusUpdateOpt, 0, len(order))
+
+	for _, key := range order {
+		deduped = append(deduped, winners[key])
+	}
+
+	return deduped
+}
+
+func (r *OLAPRepositoryImpl) applyOrchestratorEventsToDAGs(ctx context.Context, tx sqlcv1.DBTX, tenantId uuid.UUID, updates []OrchestratorDAGStatusUpdateOpt) ([]UpdateDAGStatusRow, error) {
 	if len(updates) == 0 {
-		return &StatusUpdateResult{}, nil
+		return nil, nil
 	}
 
 	params := sqlcv1.UpdateDAGStatusesFromOrchestratorEventsParams{
 		Tenantid: tenantId,
 	}
 
-	for _, update := range updates {
+	for _, update := range dedupeOrchestratorUpdates(updates) {
 		params.Dagids = append(params.Dagids, update.DagId)
 		params.Daginsertedats = append(params.Daginsertedats, update.DagInsertedAt)
 		params.Statuses = append(params.Statuses, update.ReadableStatus)
-		params.Isresets = append(params.Isresets, update.IsReset)
+		params.Retrycounts = append(params.Retrycounts, update.RetryCount)
 	}
 
-	rows, err := r.queries.UpdateDAGStatusesFromOrchestratorEvents(ctx, r.pool, params)
+	rows, err := r.queries.UpdateDAGStatusesFromOrchestratorEvents(ctx, tx, params)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to update DAG statuses from orchestrator events: %w", err)
@@ -2508,7 +2571,7 @@ func (r *OLAPRepositoryImpl) ApplyOrchestratorEventsToDAGs(ctx context.Context, 
 		})
 	}
 
-	return &StatusUpdateResult{DAGRows: dagRows}, nil
+	return dagRows, nil
 }
 
 func (r *OLAPRepositoryImpl) GetTaskPointMetrics(ctx context.Context, tenantId uuid.UUID, startTimestamp *time.Time, endTimestamp *time.Time, bucketInterval time.Duration) ([]*sqlcv1.GetTaskPointMetricsRow, error) {

--- a/pkg/repository/olap_operator_dag_test.go
+++ b/pkg/repository/olap_operator_dag_test.go
@@ -24,14 +24,20 @@ type operatorDagFixture struct {
 	workflowId    uuid.UUID
 }
 
-func seedOperatorDag(t *testing.T, ctx context.Context, repo *OLAPRepositoryImpl, dagId int64, totalTasks int) operatorDagFixture {
+func seedOperatorDag(t *testing.T, ctx context.Context, repo *OLAPRepositoryImpl, dagId int64) operatorDagFixture {
+	t.Helper()
+
+	return seedOperatorDagWithExternalId(t, ctx, repo, dagId, uuid.New())
+}
+
+func seedOperatorDagWithExternalId(t *testing.T, ctx context.Context, repo *OLAPRepositoryImpl, dagId int64, dagExternalId uuid.UUID) operatorDagFixture {
 	t.Helper()
 
 	f := operatorDagFixture{
 		tenantId:      uuid.New(),
 		dagId:         dagId,
 		dagInsertedAt: pgtype.Timestamptz{Time: time.Now().UTC().Truncate(time.Microsecond), Valid: true},
-		dagExternalId: uuid.New(),
+		dagExternalId: dagExternalId,
 		workflowId:    uuid.New(),
 	}
 
@@ -47,7 +53,6 @@ func seedOperatorDag(t *testing.T, ctx context.Context, repo *OLAPRepositoryImpl
 		},
 		Input:              []byte(`{}`),
 		AdditionalMetadata: []byte(`{}`),
-		TotalTasks:         totalTasks,
 		IsOperatorRun:      true,
 	}
 
@@ -92,7 +97,8 @@ func (f operatorDagFixture) createChild(t *testing.T, ctx context.Context, repo 
 			DagID:              pgtype.Int8{Int64: f.dagId, Valid: true},
 			DagInsertedAt:      f.dagInsertedAt,
 		},
-		Payload: []byte(`{}`),
+		Payload:       []byte(`{}`),
+		IsOperatorRun: true,
 	}
 
 	_, locksNotAcquired, err := repo.CreateTasks(ctx, child.tenantId, []*V1TaskWithPayload{task})
@@ -110,9 +116,32 @@ func (f operatorDagFixture) applyChildEvents(t *testing.T, ctx context.Context, 
 		eventExternalIdToWorkflowRunId[e.ExternalID] = f.dagExternalId
 	}
 
-	_, locksNotAcquired, err := repo.CreateTaskEvents(ctx, f.tenantId, events, eventExternalIdToWorkflowRunId)
+	_, locksNotAcquired, err := repo.CreateTaskEvents(ctx, f.tenantId, events, eventExternalIdToWorkflowRunId, nil, f.operatorRunIds())
 	require.NoError(t, err)
 	require.Empty(t, locksNotAcquired)
+}
+
+func (f operatorDagFixture) operatorRunIds() map[uuid.UUID]struct{} {
+	return map[uuid.UUID]struct{}{f.dagExternalId: {}}
+}
+
+func (f operatorDagFixture) orchestratorUpdate(status sqlcv1.V1ReadableStatusOlap, retryCount int32) OrchestratorDAGStatusUpdateOpt {
+	return OrchestratorDAGStatusUpdateOpt{
+		DagId:          f.dagId,
+		DagInsertedAt:  f.dagInsertedAt,
+		ReadableStatus: status,
+		RetryCount:     retryCount,
+	}
+}
+
+func (f operatorDagFixture) applyOrchestratorEvents(t *testing.T, ctx context.Context, repo *OLAPRepositoryImpl, updates ...OrchestratorDAGStatusUpdateOpt) *StatusUpdateResult {
+	t.Helper()
+
+	result, locksNotAcquired, err := repo.CreateTaskEvents(ctx, f.tenantId, nil, nil, updates, f.operatorRunIds())
+	require.NoError(t, err)
+	require.Empty(t, locksNotAcquired)
+
+	return result
 }
 
 func (f operatorDagFixture) assertDagStatus(t *testing.T, ctx context.Context, pool *pgxpool.Pool, wantStatus string) {
@@ -141,7 +170,7 @@ func (f operatorDagFixture) assertDagStatus(t *testing.T, ctx context.Context, p
 	assert.Equal(t, wantStatus, runStatus, "v1_runs_olap.readable_status")
 }
 
-func TestOperatorDAG_ChildrenConvergeStatus(t *testing.T) {
+func TestOperatorDAG_StatusComesFromOrchestratorNotChildren(t *testing.T) {
 	basePool, cleanup := setupPostgresWithMigration(t)
 	defer cleanup()
 
@@ -153,9 +182,8 @@ func TestOperatorDAG_ChildrenConvergeStatus(t *testing.T) {
 
 	require.NoError(t, repo.UpdateTablePartitions(ctx))
 
-	f := seedOperatorDag(t, ctx, repo, 100, 2)
+	f := seedOperatorDag(t, ctx, repo, 100)
 
-	// the DAG row exists, plus a self-mapping junction row for the orchestrator's events
 	var selfMappings int
 	err := pool.QueryRow(ctx, `
 		SELECT COUNT(*)
@@ -170,7 +198,6 @@ func TestOperatorDAG_ChildrenConvergeStatus(t *testing.T) {
 	childA := f.createChild(t, ctx, repo, 101)
 	childB := f.createChild(t, ctx, repo, 102)
 
-	// children must not appear as standalone runs
 	var childRuns int
 	err = pool.QueryRow(ctx, `
 		SELECT COUNT(*)
@@ -180,19 +207,19 @@ func TestOperatorDAG_ChildrenConvergeStatus(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, childRuns, "children should not be v1_runs_olap rows")
 
+	f.applyOrchestratorEvents(t, ctx, repo, f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapRUNNING, 0))
+	f.assertDagStatus(t, ctx, pool, "RUNNING")
+
+	// every child completing must NOT complete the DAG: only the orchestrator can do that
 	f.applyChildEvents(t, ctx, repo, []sqlcv1.CreateTaskEventsOLAPParams{
 		childA.event(sqlcv1.V1EventTypeOlapSTARTED, sqlcv1.V1ReadableStatusOlapRUNNING, 0),
 		childA.event(sqlcv1.V1EventTypeOlapFINISHED, sqlcv1.V1ReadableStatusOlapCOMPLETED, 0),
-	})
-
-	// one of two children finished: the DAG is still running
-	f.assertDagStatus(t, ctx, pool, "RUNNING")
-
-	f.applyChildEvents(t, ctx, repo, []sqlcv1.CreateTaskEventsOLAPParams{
 		childB.event(sqlcv1.V1EventTypeOlapSTARTED, sqlcv1.V1ReadableStatusOlapRUNNING, 0),
 		childB.event(sqlcv1.V1EventTypeOlapFINISHED, sqlcv1.V1ReadableStatusOlapCOMPLETED, 0),
 	})
+	f.assertDagStatus(t, ctx, pool, "RUNNING")
 
+	f.applyOrchestratorEvents(t, ctx, repo, f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapCOMPLETED, 0))
 	f.assertDagStatus(t, ctx, pool, "COMPLETED")
 }
 
@@ -208,14 +235,9 @@ func TestOperatorDAG_OrchestratorFailureOverride(t *testing.T) {
 
 	require.NoError(t, repo.UpdateTablePartitions(ctx))
 
-	// total_tasks = 3, but only one child will ever be created: the operator died mid-run
-	f := seedOperatorDag(t, ctx, repo, 200, 3)
+	f := seedOperatorDag(t, ctx, repo, 200)
 
-	// a non-reset RUNNING event (orchestrator started) moves the DAG out of QUEUED
-	result, err := repo.ApplyOrchestratorEventsToDAGs(ctx, f.tenantId, []OrchestratorDAGStatusUpdate{
-		{DagId: f.dagId, DagInsertedAt: f.dagInsertedAt, ReadableStatus: sqlcv1.V1ReadableStatusOlapRUNNING},
-	})
-	require.NoError(t, err)
+	result := f.applyOrchestratorEvents(t, ctx, repo, f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapRUNNING, 0))
 	require.Len(t, result.DAGRows, 1)
 	f.assertDagStatus(t, ctx, pool, "RUNNING")
 
@@ -224,34 +246,185 @@ func TestOperatorDAG_OrchestratorFailureOverride(t *testing.T) {
 		child.event(sqlcv1.V1EventTypeOlapSTARTED, sqlcv1.V1ReadableStatusOlapRUNNING, 0),
 	})
 
-	// orchestrator failed terminally (e.g. timed out) while the run is incomplete
-	result, err = repo.ApplyOrchestratorEventsToDAGs(ctx, f.tenantId, []OrchestratorDAGStatusUpdate{
-		{DagId: f.dagId, DagInsertedAt: f.dagInsertedAt, ReadableStatus: sqlcv1.V1ReadableStatusOlapFAILED},
-	})
-	require.NoError(t, err)
+	result = f.applyOrchestratorEvents(t, ctx, repo, f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapFAILED, 0))
 	require.Len(t, result.DAGRows, 1)
 	f.assertDagStatus(t, ctx, pool, "FAILED")
 
-	// a late child event recomputes the DAG status from counts; with only 1 of 3
-	// tasks created, the recompute must not downgrade the terminal status
+	// a late child event must not disturb the terminal status
 	f.applyChildEvents(t, ctx, repo, []sqlcv1.CreateTaskEventsOLAPParams{
 		child.event(sqlcv1.V1EventTypeOlapFINISHED, sqlcv1.V1ReadableStatusOlapCOMPLETED, 0),
 	})
 	f.assertDagStatus(t, ctx, pool, "FAILED")
 
-	// a non-reset RUNNING event must not revive a failed DAG
-	result, err = repo.ApplyOrchestratorEventsToDAGs(ctx, f.tenantId, []OrchestratorDAGStatusUpdate{
-		{DagId: f.dagId, DagInsertedAt: f.dagInsertedAt, ReadableStatus: sqlcv1.V1ReadableStatusOlapRUNNING},
-	})
-	require.NoError(t, err)
+	// a stale RUNNING from the same attempt must not revive a failed DAG
+	result = f.applyOrchestratorEvents(t, ctx, repo, f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapRUNNING, 0))
 	require.Empty(t, result.DAGRows)
 	f.assertDagStatus(t, ctx, pool, "FAILED")
 
-	// a retry (user replay) resets the DAG back to RUNNING
-	result, err = repo.ApplyOrchestratorEventsToDAGs(ctx, f.tenantId, []OrchestratorDAGStatusUpdate{
-		{DagId: f.dagId, DagInsertedAt: f.dagInsertedAt, ReadableStatus: sqlcv1.V1ReadableStatusOlapRUNNING, IsReset: true},
-	})
+	// a retry is a strictly newer attempt, so it resets the DAG
+	result = f.applyOrchestratorEvents(t, ctx, repo, f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapQUEUED, 1))
+	require.Len(t, result.DAGRows, 1)
+	f.assertDagStatus(t, ctx, pool, "QUEUED")
+
+	f.applyOrchestratorEvents(t, ctx, repo, f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapRUNNING, 1))
+	f.assertDagStatus(t, ctx, pool, "RUNNING")
+
+	// a straggler from the previous attempt can no longer clobber the new one
+	result = f.applyOrchestratorEvents(t, ctx, repo, f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapFAILED, 0))
+	require.Empty(t, result.DAGRows)
+	f.assertDagStatus(t, ctx, pool, "RUNNING")
+}
+
+// Keying admission on the attempt number is what makes delivery order irrelevant, which is what
+// lets these updates run without an advisory lock on the workflow run.
+func TestOperatorDAG_OrchestratorEventsAreOrderIndependent(t *testing.T) {
+	basePool, cleanup := setupPostgresWithMigration(t)
+	defer cleanup()
+
+	pool := createEnumAwarePool(t, basePool)
+	repo := createOLAPRepositoryWithPayloadStore(t, pool)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	require.NoError(t, repo.UpdateTablePartitions(ctx))
+
+	testCases := []struct {
+		name  string
+		dagId int64
+		apply func(f operatorDagFixture) []OrchestratorDAGStatusUpdateOpt
+	}{
+		{
+			name:  "reversed",
+			dagId: 310,
+			apply: func(f operatorDagFixture) []OrchestratorDAGStatusUpdateOpt {
+				return []OrchestratorDAGStatusUpdateOpt{
+					f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapRUNNING, 1),
+					f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapQUEUED, 1),
+					f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapFAILED, 0),
+					f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapRUNNING, 0),
+				}
+			},
+		},
+		{
+			name:  "interleaved with duplicates",
+			dagId: 320,
+			apply: func(f operatorDagFixture) []OrchestratorDAGStatusUpdateOpt {
+				return []OrchestratorDAGStatusUpdateOpt{
+					f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapFAILED, 0),
+					f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapRUNNING, 1),
+					f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapRUNNING, 0),
+					f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapFAILED, 0),
+					f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapQUEUED, 1),
+					f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapRUNNING, 1),
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := seedOperatorDag(t, ctx, repo, tc.dagId)
+
+			// one batch per update, so each is its own transaction like real delivery
+			for _, update := range tc.apply(f) {
+				f.applyOrchestratorEvents(t, ctx, repo, update)
+			}
+
+			f.assertDagStatus(t, ctx, pool, "RUNNING")
+		})
+	}
+}
+
+// Only one update per DAG reaches the query, so a batch must collapse to the highest update, not the last.
+func TestOperatorDAG_HighestUpdateInBatchWins(t *testing.T) {
+	basePool, cleanup := setupPostgresWithMigration(t)
+	defer cleanup()
+
+	pool := createEnumAwarePool(t, basePool)
+	repo := createOLAPRepositoryWithPayloadStore(t, pool)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	require.NoError(t, repo.UpdateTablePartitions(ctx))
+
+	testCases := []struct {
+		name    string
+		want    string
+		dagId   int64
+		updates func(f operatorDagFixture) []OrchestratorDAGStatusUpdateOpt
+	}{
+		{
+			name:  "terminal outcome is not discarded by a later same-attempt RUNNING",
+			dagId: 330,
+			want:  "FAILED",
+			updates: func(f operatorDagFixture) []OrchestratorDAGStatusUpdateOpt {
+				return []OrchestratorDAGStatusUpdateOpt{
+					f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapFAILED, 0),
+					f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapRUNNING, 0),
+				}
+			},
+		},
+		{
+			name:  "newer attempt beats an earlier attempt's terminal outcome",
+			dagId: 340,
+			want:  "RUNNING",
+			updates: func(f operatorDagFixture) []OrchestratorDAGStatusUpdateOpt {
+				return []OrchestratorDAGStatusUpdateOpt{
+					f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapRUNNING, 1),
+					f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapFAILED, 0),
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := seedOperatorDag(t, ctx, repo, tc.dagId)
+
+			f.applyOrchestratorEvents(t, ctx, repo, tc.updates(f)...)
+			f.assertDagStatus(t, ctx, pool, tc.want)
+		})
+	}
+}
+
+func TestOperatorDAG_UpdatesIgnoreWorkflowRunAdvisoryLock(t *testing.T) {
+	basePool, cleanup := setupPostgresWithMigration(t)
+	defer cleanup()
+
+	pool := createEnumAwarePool(t, basePool)
+	repo := createOLAPRepositoryWithPayloadStore(t, pool)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	require.NoError(t, repo.UpdateTablePartitions(ctx))
+
+	// held for the whole test, so nothing below may depend on taking it
+	dagExternalId := uuid.New()
+
+	blocker, err := pool.Begin(ctx)
 	require.NoError(t, err)
+	defer blocker.Rollback(ctx) // nolint: errcheck
+
+	_, err = blocker.Exec(ctx, "SELECT pg_advisory_xact_lock($1)", workflowRunAdvisoryInt(dagExternalId))
+	require.NoError(t, err)
+
+	f := seedOperatorDagWithExternalId(t, ctx, repo, 500, dagExternalId)
+	f.assertDagStatus(t, ctx, pool, "QUEUED")
+
+	child := f.createChild(t, ctx, repo, 501)
+
+	f.applyChildEvents(t, ctx, repo, []sqlcv1.CreateTaskEventsOLAPParams{
+		child.event(sqlcv1.V1EventTypeOlapSTARTED, sqlcv1.V1ReadableStatusOlapRUNNING, 0),
+	})
+
+	result := f.applyOrchestratorEvents(t, ctx, repo, f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapRUNNING, 0))
 	require.Len(t, result.DAGRows, 1)
 	f.assertDagStatus(t, ctx, pool, "RUNNING")
+
+	result = f.applyOrchestratorEvents(t, ctx, repo, f.orchestratorUpdate(sqlcv1.V1ReadableStatusOlapFAILED, 0))
+	require.Len(t, result.DAGRows, 1)
+	f.assertDagStatus(t, ctx, pool, "FAILED")
 }

--- a/pkg/repository/olap_status_update_test.go
+++ b/pkg/repository/olap_status_update_test.go
@@ -283,7 +283,7 @@ func TestOLAPStatusUpdate_ReplayOfCompletedTask(t *testing.T) {
 
 			eventExternalIdToWorkflowRunId := map[uuid.UUID]uuid.UUID{f.externalId: f.externalId}
 
-			_, locksNotAcquired, err := repo.CreateTaskEvents(ctx, f.tenantId, events, eventExternalIdToWorkflowRunId)
+			_, locksNotAcquired, err := repo.CreateTaskEvents(ctx, f.tenantId, events, eventExternalIdToWorkflowRunId, nil, nil)
 			require.NoError(t, err)
 			require.Empty(t, locksNotAcquired)
 		}
@@ -321,7 +321,7 @@ func TestOLAPStatusUpdate_ReplayOfCompletedTask(t *testing.T) {
 		batches := replayEventBatches(f)
 
 		eventExternalIdToWorkflowRunId := map[uuid.UUID]uuid.UUID{f.externalId: f.externalId}
-		_, locksNotAcquired, err := repo.CreateTaskEvents(ctx, f.tenantId, batches[0], eventExternalIdToWorkflowRunId)
+		_, locksNotAcquired, err := repo.CreateTaskEvents(ctx, f.tenantId, batches[0], eventExternalIdToWorkflowRunId, nil, nil)
 		require.NoError(t, err)
 		require.Empty(t, locksNotAcquired)
 		assertOLAPTaskStatus(t, ctx, pool, f, "COMPLETED", 1)

--- a/pkg/repository/sqlcv1/models.go
+++ b/pkg/repository/sqlcv1/models.go
@@ -3332,7 +3332,6 @@ type V1DagsOlap struct {
 	ParentTaskExternalID *uuid.UUID           `json:"parent_task_external_id"`
 	TotalTasks           int32                `json:"total_tasks"`
 	IdempotencyKey       pgtype.Text          `json:"idempotency_key"`
-	IsOperatorRun        bool                 `json:"is_operator_run"`
 	LatestRetryCount     int32                `json:"latest_retry_count"`
 }
 

--- a/pkg/repository/sqlcv1/models.go
+++ b/pkg/repository/sqlcv1/models.go
@@ -3332,6 +3332,8 @@ type V1DagsOlap struct {
 	ParentTaskExternalID *uuid.UUID           `json:"parent_task_external_id"`
 	TotalTasks           int32                `json:"total_tasks"`
 	IdempotencyKey       pgtype.Text          `json:"idempotency_key"`
+	IsOperatorRun        bool                 `json:"is_operator_run"`
+	LatestRetryCount     int32                `json:"latest_retry_count"`
 }
 
 type V1DurableEventLogBranchPoint struct {

--- a/pkg/repository/sqlcv1/olap-overwrite.go
+++ b/pkg/repository/sqlcv1/olap-overwrite.go
@@ -1218,14 +1218,6 @@ WITH inputs AS (
     FROM inputs i
     JOIN v1_dag_to_task_olap dt ON (i.id, i.inserted_at) = (dt.dag_id, dt.dag_inserted_at)
     JOIN v1_tasks_olap t ON (dt.task_id, dt.task_inserted_at) = (t.id, t.inserted_at)
-    -- operator DAGs never derive their status from children; see UpdateDAGStatusesFromMQ
-    WHERE NOT EXISTS (
-        SELECT 1
-        FROM v1_dag_to_task_olap self
-        WHERE
-            (self.dag_id, self.dag_inserted_at) = (i.id, i.inserted_at)
-            AND (self.task_id, self.task_inserted_at) = (i.id, i.inserted_at)
-    )
     GROUP BY i.id, i.inserted_at, i.total_tasks
 ), dag_statuses AS (
     SELECT

--- a/pkg/repository/sqlcv1/olap-overwrite.go
+++ b/pkg/repository/sqlcv1/olap-overwrite.go
@@ -1202,8 +1202,7 @@ WITH inputs AS (
         UNNEST($8::JSONB[]) AS additional_metadata,
         UNNEST($9::UUID[]) AS parent_task_external_id,
         UNNEST($10::INTEGER[]) AS total_tasks,
-		UNNEST($11::TEXT[]) AS idempotency_key,
-        UNNEST($12::BOOLEAN[]) AS is_operator_run
+		UNNEST($11::TEXT[]) AS idempotency_key
 ), dag_task_counts AS (
     SELECT
         i.id,
@@ -1219,7 +1218,14 @@ WITH inputs AS (
     FROM inputs i
     JOIN v1_dag_to_task_olap dt ON (i.id, i.inserted_at) = (dt.dag_id, dt.dag_inserted_at)
     JOIN v1_tasks_olap t ON (dt.task_id, dt.task_inserted_at) = (t.id, t.inserted_at)
-    WHERE NOT i.is_operator_run
+    -- operator DAGs never derive their status from children; see UpdateDAGStatusesFromMQ
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM v1_dag_to_task_olap self
+        WHERE
+            (self.dag_id, self.dag_inserted_at) = (i.id, i.inserted_at)
+            AND (self.task_id, self.task_inserted_at) = (i.id, i.inserted_at)
+    )
     GROUP BY i.id, i.inserted_at, i.total_tasks
 ), dag_statuses AS (
     SELECT
@@ -1250,8 +1256,7 @@ INSERT INTO v1_dags_olap (
     parent_task_external_id,
     total_tasks,
     readable_status,
-	idempotency_key,
-    is_operator_run
+	idempotency_key
 )
 SELECT
     i.tenant_id,
@@ -1266,8 +1271,7 @@ SELECT
     i.parent_task_external_id,
     i.total_tasks,
     COALESCE(ds.computed_status, 'QUEUED'::v1_readable_status_olap),
-	i.idempotency_key,
-    i.is_operator_run
+	i.idempotency_key
 FROM inputs i
 LEFT JOIN dag_statuses ds ON (i.id, i.inserted_at) = (ds.id, ds.inserted_at)
 ON CONFLICT (inserted_at, id) DO UPDATE SET
@@ -1290,7 +1294,6 @@ type CreateDAGsOLAPOverwriteParams struct {
 	Parenttaskexternalids []*uuid.UUID         `json:"parenttaskexternalids"`
 	Totaltasks            []int32              `json:"totaltasks"`
 	IdempotencyKeys       []pgtype.Text        `json:"idempotencyKeys"`
-	Isoperatorruns        []bool               `json:"isoperatorruns"`
 }
 
 func (q *Queries) CreateDAGsOLAP(ctx context.Context, db DBTX, arg CreateDAGsOLAPOverwriteParams) error {
@@ -1306,7 +1309,6 @@ func (q *Queries) CreateDAGsOLAP(ctx context.Context, db DBTX, arg CreateDAGsOLA
 		arg.Parenttaskexternalids,
 		arg.Totaltasks,
 		arg.IdempotencyKeys,
-		arg.Isoperatorruns,
 	)
 	return err
 }

--- a/pkg/repository/sqlcv1/olap-overwrite.go
+++ b/pkg/repository/sqlcv1/olap-overwrite.go
@@ -1202,7 +1202,8 @@ WITH inputs AS (
         UNNEST($8::JSONB[]) AS additional_metadata,
         UNNEST($9::UUID[]) AS parent_task_external_id,
         UNNEST($10::INTEGER[]) AS total_tasks,
-		UNNEST($11::TEXT[]) AS idempotency_key
+		UNNEST($11::TEXT[]) AS idempotency_key,
+        UNNEST($12::BOOLEAN[]) AS is_operator_run
 ), dag_task_counts AS (
     SELECT
         i.id,
@@ -1218,6 +1219,7 @@ WITH inputs AS (
     FROM inputs i
     JOIN v1_dag_to_task_olap dt ON (i.id, i.inserted_at) = (dt.dag_id, dt.dag_inserted_at)
     JOIN v1_tasks_olap t ON (dt.task_id, dt.task_inserted_at) = (t.id, t.inserted_at)
+    WHERE NOT i.is_operator_run
     GROUP BY i.id, i.inserted_at, i.total_tasks
 ), dag_statuses AS (
     SELECT
@@ -1248,7 +1250,8 @@ INSERT INTO v1_dags_olap (
     parent_task_external_id,
     total_tasks,
     readable_status,
-	idempotency_key
+	idempotency_key,
+    is_operator_run
 )
 SELECT
     i.tenant_id,
@@ -1263,7 +1266,8 @@ SELECT
     i.parent_task_external_id,
     i.total_tasks,
     COALESCE(ds.computed_status, 'QUEUED'::v1_readable_status_olap),
-	i.idempotency_key
+	i.idempotency_key,
+    i.is_operator_run
 FROM inputs i
 LEFT JOIN dag_statuses ds ON (i.id, i.inserted_at) = (ds.id, ds.inserted_at)
 ON CONFLICT (inserted_at, id) DO UPDATE SET
@@ -1286,6 +1290,7 @@ type CreateDAGsOLAPOverwriteParams struct {
 	Parenttaskexternalids []*uuid.UUID         `json:"parenttaskexternalids"`
 	Totaltasks            []int32              `json:"totaltasks"`
 	IdempotencyKeys       []pgtype.Text        `json:"idempotencyKeys"`
+	Isoperatorruns        []bool               `json:"isoperatorruns"`
 }
 
 func (q *Queries) CreateDAGsOLAP(ctx context.Context, db DBTX, arg CreateDAGsOLAPOverwriteParams) error {
@@ -1301,6 +1306,7 @@ func (q *Queries) CreateDAGsOLAP(ctx context.Context, db DBTX, arg CreateDAGsOLA
 		arg.Parenttaskexternalids,
 		arg.Totaltasks,
 		arg.IdempotencyKeys,
+		arg.Isoperatorruns,
 	)
 	return err
 }

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -1025,14 +1025,23 @@ WITH inputs AS (
         UNNEST(@dagInsertedAts::TIMESTAMPTZ[]) AS dag_inserted_at
 ), locked_dags AS (
     SELECT *
-    FROM v1_dags_olap
-    WHERE (inserted_at, id, tenant_id) IN (
-        SELECT dag_inserted_at, dag_id, tenant_id
-        FROM inputs
+    FROM v1_dags_olap d
+    WHERE
+        (d.inserted_at, d.id, d.tenant_id) IN (
+            SELECT dag_inserted_at, dag_id, tenant_id
+            FROM inputs
+        )
+    -- this is a trick to figure out if the dag is an operator (dag-as-durable-task)
+    -- operator dags are updated by the separate UpdateDAGStatusesFromOrchestratorEvents. the
+    -- orchestrator's self-mapping row is what marks them, and older binaries already write it, so
+    -- this classifies correctly even for dags created by a pod that predates this change
+    AND NOT EXISTS (
+        SELECT 1
+        FROM v1_dag_to_task_olap dt
+        WHERE
+            (dt.dag_id, dt.dag_inserted_at) = (d.id, d.inserted_at)
+            AND (dt.task_id, dt.task_inserted_at) = (d.id, d.inserted_at)
     )
-    -- don't need to update operator dags because they'll be updated by the
-    -- separate UpdateDAGStatusesFromOrchestratorEvents
-    AND NOT is_operator_run
     ORDER BY inserted_at, id
     FOR UPDATE
 ), dag_task_counts AS (
@@ -1163,7 +1172,14 @@ WITH tenants AS (
             FROM
                 distinct_dags dd
         )
-        AND NOT d.is_operator_run
+        -- see UpdateDAGStatusesFromMQ
+        AND NOT EXISTS (
+            SELECT 1
+            FROM v1_dag_to_task_olap dt
+            WHERE
+                (dt.dag_id, dt.dag_inserted_at) = (d.id, d.inserted_at)
+                AND (dt.task_id, dt.task_inserted_at) = (d.id, d.inserted_at)
+        )
     ORDER BY
         d.inserted_at, d.id
     FOR UPDATE

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -1030,6 +1030,9 @@ WITH inputs AS (
         SELECT dag_inserted_at, dag_id, tenant_id
         FROM inputs
     )
+    -- don't need to update operator dags because they'll be updated by the
+    -- separate UpdateDAGStatusesFromOrchestratorEvents
+    AND NOT is_operator_run
     ORDER BY inserted_at, id
     FOR UPDATE
 ), dag_task_counts AS (
@@ -1062,9 +1065,6 @@ WITH inputs AS (
         CASE
             -- If we only have queued events, we should keep the status as is
             WHEN dtc.queued_count = dtc.task_count THEN dtc.readable_status
-            -- Operator-managed DAGs can fail terminally before all of their tasks are created,
-            -- so a non-converged task count must not downgrade a terminal status
-            WHEN dtc.task_count != dtc.total_tasks AND dtc.readable_status IN ('FAILED', 'CANCELLED') THEN dtc.readable_status
             -- If the task count is not equal to the total tasks, we should set the status to running
             WHEN dtc.task_count != dtc.total_tasks THEN 'RUNNING'
             -- If we have any running or queued tasks, we should set the status to running
@@ -1163,6 +1163,7 @@ WITH tenants AS (
             FROM
                 distinct_dags dd
         )
+        AND NOT d.is_operator_run
     ORDER BY
         d.inserted_at, d.id
     FOR UPDATE
@@ -1217,9 +1218,6 @@ WITH tenants AS (
         CASE
             -- If we only have queued events, we should keep the status as is
             WHEN dtc.queued_count = dtc.task_count THEN dtc.readable_status
-            -- Operator-managed DAGs can fail terminally before all of their tasks are created,
-            -- so a non-converged task count must not downgrade a terminal status
-            WHEN dtc.task_count != dtc.total_tasks AND dtc.readable_status IN ('FAILED', 'CANCELLED') THEN dtc.readable_status
             -- If the task count is not equal to the total tasks, we should set the status to running
             WHEN dtc.task_count != dtc.total_tasks THEN 'RUNNING'
             -- If we have any running or queued tasks, we should set the status to running
@@ -2430,41 +2428,53 @@ WHERE
 RETURNING t.tenant_id, t.id, t.inserted_at, t.external_id, t.readable_status, t.latest_worker_id, t.workflow_id, t.dag_id, t.dag_inserted_at;
 
 -- name: UpdateDAGStatusesFromOrchestratorEvents :many
--- Applies orchestrator task lifecycle events to their operator-managed DAGs. The orchestrator
--- has no v1_tasks_olap row, so its terminal failures must be forced onto the DAG directly:
--- children may never be created, in which case count-based derivation cannot converge. Retry
--- events reset a terminal DAG back to RUNNING; non-reset RUNNING events only move a DAG out of
--- QUEUED. Completion is never applied here — it must come from child task counting.
+-- important: need to dedupe the dags before calling this query to make
+-- sure each dag only gets one candidate update per call
 WITH inputs AS (
     SELECT
         UNNEST(@dagIds::BIGINT[]) AS dag_id,
         UNNEST(@dagInsertedAts::TIMESTAMPTZ[]) AS dag_inserted_at,
         UNNEST(@statuses::v1_readable_status_olap[]) AS new_readable_status,
-        UNNEST(@isResets::BOOLEAN[]) AS is_reset
+        UNNEST(@retryCounts::INTEGER[]) AS retry_count
 ), locked_dags AS (
     SELECT
         d.id,
         d.inserted_at,
         d.tenant_id,
         i.new_readable_status,
-        i.is_reset
+        i.retry_count AS new_retry_count
     FROM v1_dags_olap d
     JOIN inputs i ON (d.id, d.inserted_at) = (i.dag_id, i.dag_inserted_at)
-    WHERE d.tenant_id = @tenantId::UUID
+    WHERE
+        d.tenant_id = @tenantId::UUID
+        AND (
+            -- a newer attempt always applies, so a replay revives a terminal DAG and a straggler
+            -- from the previous attempt can no longer clobber it
+            (
+                i.retry_count > d.latest_retry_count
+            ) OR
+            -- within an attempt, only move forward through QUEUED -> RUNNING -> terminal
+            (
+                i.retry_count = d.latest_retry_count
+                AND v1_status_to_priority(i.new_readable_status) > v1_status_to_priority(d.readable_status)
+            ) OR
+            -- EVICTED is reversible (a durable restore moves it back to RUNNING) but outranks
+            -- RUNNING by priority, so it needs an explicit escape hatch
+            (
+                i.retry_count = d.latest_retry_count
+                AND d.readable_status = 'EVICTED'
+                AND i.new_readable_status != 'EVICTED'
+            )
+        )
     ORDER BY d.inserted_at, d.id
-    FOR UPDATE
+    FOR UPDATE OF d
 ), updated_dags AS (
     UPDATE v1_dags_olap d
-    SET readable_status = ld.new_readable_status
+    SET
+        readable_status = ld.new_readable_status,
+        latest_retry_count = ld.new_retry_count
     FROM locked_dags ld
-    WHERE
-        (d.inserted_at, d.id, d.tenant_id) = (ld.inserted_at, ld.id, ld.tenant_id)
-        AND d.readable_status != ld.new_readable_status
-        AND (
-            (ld.new_readable_status IN ('FAILED', 'CANCELLED') AND d.readable_status NOT IN ('COMPLETED', 'FAILED', 'CANCELLED'))
-            OR (ld.new_readable_status = 'RUNNING' AND ld.is_reset AND d.readable_status IN ('QUEUED', 'FAILED', 'CANCELLED'))
-            OR (ld.new_readable_status = 'RUNNING' AND NOT ld.is_reset AND d.readable_status = 'QUEUED')
-        )
+    WHERE (d.inserted_at, d.id, d.tenant_id) = (ld.inserted_at, ld.id, ld.tenant_id)
     RETURNING d.tenant_id, d.id, d.inserted_at, d.external_id, d.readable_status, d.workflow_id
 )
 SELECT

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -3050,7 +3050,7 @@ WITH lookup_task AS (
         external_id = $1::uuid
 )
 SELECT
-    d.id, d.inserted_at, d.tenant_id, d.external_id, d.display_name, d.workflow_id, d.workflow_version_id, d.readable_status, d.input, d.additional_metadata, d.parent_task_external_id, d.total_tasks, d.idempotency_key, d.is_operator_run, d.latest_retry_count
+    d.id, d.inserted_at, d.tenant_id, d.external_id, d.display_name, d.workflow_id, d.workflow_version_id, d.readable_status, d.input, d.additional_metadata, d.parent_task_external_id, d.total_tasks, d.idempotency_key, d.latest_retry_count
 FROM
     v1_dags_olap d
 JOIN
@@ -3074,7 +3074,6 @@ func (q *Queries) ReadDAGByExternalID(ctx context.Context, db DBTX, externalid u
 		&i.ParentTaskExternalID,
 		&i.TotalTasks,
 		&i.IdempotencyKey,
-		&i.IsOperatorRun,
 		&i.LatestRetryCount,
 	)
 	return &i, err
@@ -3571,7 +3570,14 @@ WITH tenants AS (
             FROM
                 distinct_dags dd
         )
-        AND NOT d.is_operator_run
+        -- see UpdateDAGStatusesFromMQ
+        AND NOT EXISTS (
+            SELECT 1
+            FROM v1_dag_to_task_olap dt
+            WHERE
+                (dt.dag_id, dt.dag_inserted_at) = (d.id, d.inserted_at)
+                AND (dt.task_id, dt.task_inserted_at) = (d.id, d.inserted_at)
+        )
     ORDER BY
         d.inserted_at, d.id
     FOR UPDATE
@@ -3832,15 +3838,24 @@ WITH inputs AS (
         UNNEST($2::BIGINT[]) AS dag_id,
         UNNEST($3::TIMESTAMPTZ[]) AS dag_inserted_at
 ), locked_dags AS (
-    SELECT id, inserted_at, tenant_id, external_id, display_name, workflow_id, workflow_version_id, readable_status, input, additional_metadata, parent_task_external_id, total_tasks, idempotency_key, is_operator_run, latest_retry_count
-    FROM v1_dags_olap
-    WHERE (inserted_at, id, tenant_id) IN (
-        SELECT dag_inserted_at, dag_id, tenant_id
-        FROM inputs
+    SELECT id, inserted_at, tenant_id, external_id, display_name, workflow_id, workflow_version_id, readable_status, input, additional_metadata, parent_task_external_id, total_tasks, idempotency_key, latest_retry_count
+    FROM v1_dags_olap d
+    WHERE
+        (d.inserted_at, d.id, d.tenant_id) IN (
+            SELECT dag_inserted_at, dag_id, tenant_id
+            FROM inputs
+        )
+    -- this is a trick to figure out if the dag is an operator (dag-as-durable-task)
+    -- operator dags are updated by the separate UpdateDAGStatusesFromOrchestratorEvents. the
+    -- orchestrator's self-mapping row is what marks them, and older binaries already write it, so
+    -- this classifies correctly even for dags created by a pod that predates this change
+    AND NOT EXISTS (
+        SELECT 1
+        FROM v1_dag_to_task_olap dt
+        WHERE
+            (dt.dag_id, dt.dag_inserted_at) = (d.id, d.inserted_at)
+            AND (dt.task_id, dt.task_inserted_at) = (d.id, d.inserted_at)
     )
-    -- don't need to update operator dags because they'll be updated by the
-    -- separate UpdateDAGStatusesFromOrchestratorEvents
-    AND NOT is_operator_run
     ORDER BY inserted_at, id
     FOR UPDATE
 ), dag_task_counts AS (

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -3050,7 +3050,7 @@ WITH lookup_task AS (
         external_id = $1::uuid
 )
 SELECT
-    d.id, d.inserted_at, d.tenant_id, d.external_id, d.display_name, d.workflow_id, d.workflow_version_id, d.readable_status, d.input, d.additional_metadata, d.parent_task_external_id, d.total_tasks, d.idempotency_key
+    d.id, d.inserted_at, d.tenant_id, d.external_id, d.display_name, d.workflow_id, d.workflow_version_id, d.readable_status, d.input, d.additional_metadata, d.parent_task_external_id, d.total_tasks, d.idempotency_key, d.is_operator_run, d.latest_retry_count
 FROM
     v1_dags_olap d
 JOIN
@@ -3074,6 +3074,8 @@ func (q *Queries) ReadDAGByExternalID(ctx context.Context, db DBTX, externalid u
 		&i.ParentTaskExternalID,
 		&i.TotalTasks,
 		&i.IdempotencyKey,
+		&i.IsOperatorRun,
+		&i.LatestRetryCount,
 	)
 	return &i, err
 }
@@ -3569,6 +3571,7 @@ WITH tenants AS (
             FROM
                 distinct_dags dd
         )
+        AND NOT d.is_operator_run
     ORDER BY
         d.inserted_at, d.id
     FOR UPDATE
@@ -3623,9 +3626,6 @@ WITH tenants AS (
         CASE
             -- If we only have queued events, we should keep the status as is
             WHEN dtc.queued_count = dtc.task_count THEN dtc.readable_status
-            -- Operator-managed DAGs can fail terminally before all of their tasks are created,
-            -- so a non-converged task count must not downgrade a terminal status
-            WHEN dtc.task_count != dtc.total_tasks AND dtc.readable_status IN ('FAILED', 'CANCELLED') THEN dtc.readable_status
             -- If the task count is not equal to the total tasks, we should set the status to running
             WHEN dtc.task_count != dtc.total_tasks THEN 'RUNNING'
             -- If we have any running or queued tasks, we should set the status to running
@@ -3832,12 +3832,15 @@ WITH inputs AS (
         UNNEST($2::BIGINT[]) AS dag_id,
         UNNEST($3::TIMESTAMPTZ[]) AS dag_inserted_at
 ), locked_dags AS (
-    SELECT id, inserted_at, tenant_id, external_id, display_name, workflow_id, workflow_version_id, readable_status, input, additional_metadata, parent_task_external_id, total_tasks, idempotency_key
+    SELECT id, inserted_at, tenant_id, external_id, display_name, workflow_id, workflow_version_id, readable_status, input, additional_metadata, parent_task_external_id, total_tasks, idempotency_key, is_operator_run, latest_retry_count
     FROM v1_dags_olap
     WHERE (inserted_at, id, tenant_id) IN (
         SELECT dag_inserted_at, dag_id, tenant_id
         FROM inputs
     )
+    -- don't need to update operator dags because they'll be updated by the
+    -- separate UpdateDAGStatusesFromOrchestratorEvents
+    AND NOT is_operator_run
     ORDER BY inserted_at, id
     FOR UPDATE
 ), dag_task_counts AS (
@@ -3870,9 +3873,6 @@ WITH inputs AS (
         CASE
             -- If we only have queued events, we should keep the status as is
             WHEN dtc.queued_count = dtc.task_count THEN dtc.readable_status
-            -- Operator-managed DAGs can fail terminally before all of their tasks are created,
-            -- so a non-converged task count must not downgrade a terminal status
-            WHEN dtc.task_count != dtc.total_tasks AND dtc.readable_status IN ('FAILED', 'CANCELLED') THEN dtc.readable_status
             -- If the task count is not equal to the total tasks, we should set the status to running
             WHEN dtc.task_count != dtc.total_tasks THEN 'RUNNING'
             -- If we have any running or queued tasks, we should set the status to running
@@ -3957,31 +3957,46 @@ WITH inputs AS (
         UNNEST($1::BIGINT[]) AS dag_id,
         UNNEST($2::TIMESTAMPTZ[]) AS dag_inserted_at,
         UNNEST($3::v1_readable_status_olap[]) AS new_readable_status,
-        UNNEST($4::BOOLEAN[]) AS is_reset
+        UNNEST($4::INTEGER[]) AS retry_count
 ), locked_dags AS (
     SELECT
         d.id,
         d.inserted_at,
         d.tenant_id,
         i.new_readable_status,
-        i.is_reset
+        i.retry_count AS new_retry_count
     FROM v1_dags_olap d
     JOIN inputs i ON (d.id, d.inserted_at) = (i.dag_id, i.dag_inserted_at)
-    WHERE d.tenant_id = $5::UUID
+    WHERE
+        d.tenant_id = $5::UUID
+        AND (
+            -- a newer attempt always applies, so a replay revives a terminal DAG and a straggler
+            -- from the previous attempt can no longer clobber it
+            (
+                i.retry_count > d.latest_retry_count
+            ) OR
+            -- within an attempt, only move forward through QUEUED -> RUNNING -> terminal
+            (
+                i.retry_count = d.latest_retry_count
+                AND v1_status_to_priority(i.new_readable_status) > v1_status_to_priority(d.readable_status)
+            ) OR
+            -- EVICTED is reversible (a durable restore moves it back to RUNNING) but outranks
+            -- RUNNING by priority, so it needs an explicit escape hatch
+            (
+                i.retry_count = d.latest_retry_count
+                AND d.readable_status = 'EVICTED'
+                AND i.new_readable_status != 'EVICTED'
+            )
+        )
     ORDER BY d.inserted_at, d.id
-    FOR UPDATE
+    FOR UPDATE OF d
 ), updated_dags AS (
     UPDATE v1_dags_olap d
-    SET readable_status = ld.new_readable_status
+    SET
+        readable_status = ld.new_readable_status,
+        latest_retry_count = ld.new_retry_count
     FROM locked_dags ld
-    WHERE
-        (d.inserted_at, d.id, d.tenant_id) = (ld.inserted_at, ld.id, ld.tenant_id)
-        AND d.readable_status != ld.new_readable_status
-        AND (
-            (ld.new_readable_status IN ('FAILED', 'CANCELLED') AND d.readable_status NOT IN ('COMPLETED', 'FAILED', 'CANCELLED'))
-            OR (ld.new_readable_status = 'RUNNING' AND ld.is_reset AND d.readable_status IN ('QUEUED', 'FAILED', 'CANCELLED'))
-            OR (ld.new_readable_status = 'RUNNING' AND NOT ld.is_reset AND d.readable_status = 'QUEUED')
-        )
+    WHERE (d.inserted_at, d.id, d.tenant_id) = (ld.inserted_at, ld.id, ld.tenant_id)
     RETURNING d.tenant_id, d.id, d.inserted_at, d.external_id, d.readable_status, d.workflow_id
 )
 SELECT
@@ -3998,7 +4013,7 @@ type UpdateDAGStatusesFromOrchestratorEventsParams struct {
 	Dagids         []int64                `json:"dagids"`
 	Daginsertedats []pgtype.Timestamptz   `json:"daginsertedats"`
 	Statuses       []V1ReadableStatusOlap `json:"statuses"`
-	Isresets       []bool                 `json:"isresets"`
+	Retrycounts    []int32                `json:"retrycounts"`
 	Tenantid       uuid.UUID              `json:"tenantid"`
 }
 
@@ -4011,17 +4026,14 @@ type UpdateDAGStatusesFromOrchestratorEventsRow struct {
 	WorkflowID     uuid.UUID            `json:"workflow_id"`
 }
 
-// Applies orchestrator task lifecycle events to their operator-managed DAGs. The orchestrator
-// has no v1_tasks_olap row, so its terminal failures must be forced onto the DAG directly:
-// children may never be created, in which case count-based derivation cannot converge. Retry
-// events reset a terminal DAG back to RUNNING; non-reset RUNNING events only move a DAG out of
-// QUEUED. Completion is never applied here — it must come from child task counting.
+// important: need to dedupe the dags before calling this query to make
+// sure each dag only gets one candidate update per call
 func (q *Queries) UpdateDAGStatusesFromOrchestratorEvents(ctx context.Context, db DBTX, arg UpdateDAGStatusesFromOrchestratorEventsParams) ([]*UpdateDAGStatusesFromOrchestratorEventsRow, error) {
 	rows, err := db.Query(ctx, updateDAGStatusesFromOrchestratorEvents,
 		arg.Dagids,
 		arg.Daginsertedats,
 		arg.Statuses,
-		arg.Isresets,
+		arg.Retrycounts,
 		arg.Tenantid,
 	)
 	if err != nil {

--- a/pkg/repository/sqlcv1/tasks.sql
+++ b/pkg/repository/sqlcv1/tasks.sql
@@ -275,7 +275,15 @@ SELECT
     display_name,
     workflow_version_id,
     step_id,
-    is_dag_orchestrator
+    is_dag_orchestrator,
+    EXISTS (
+        SELECT 1
+        FROM "Job" j
+        JOIN "Step" s ON s."jobId" = j."id"
+        WHERE
+            j."workflowVersionId" = v1_task.workflow_version_id
+            AND s."isDagOrchestrator"
+    ) AS was_triggered_by_dag_orchestrator
 FROM
     v1_task
 WHERE

--- a/pkg/repository/sqlcv1/tasks.sql.go
+++ b/pkg/repository/sqlcv1/tasks.sql.go
@@ -1663,7 +1663,15 @@ SELECT
     display_name,
     workflow_version_id,
     step_id,
-    is_dag_orchestrator
+    is_dag_orchestrator,
+    EXISTS (
+        SELECT 1
+        FROM "Job" j
+        JOIN "Step" s ON s."jobId" = j."id"
+        WHERE
+            j."workflowVersionId" = v1_task.workflow_version_id
+            AND s."isDagOrchestrator"
+    ) AS was_triggered_by_dag_orchestrator
 FROM
     v1_task
 WHERE
@@ -1677,19 +1685,20 @@ type ListTaskMetasParams struct {
 }
 
 type ListTaskMetasRow struct {
-	ID                 int64              `json:"id"`
-	InsertedAt         pgtype.Timestamptz `json:"inserted_at"`
-	ExternalID         uuid.UUID          `json:"external_id"`
-	RetryCount         int32              `json:"retry_count"`
-	WorkflowID         uuid.UUID          `json:"workflow_id"`
-	WorkflowRunID      uuid.UUID          `json:"workflow_run_id"`
-	AdditionalMetadata []byte             `json:"additional_metadata"`
-	StepReadableID     string             `json:"step_readable_id"`
-	ActionID           string             `json:"action_id"`
-	DisplayName        string             `json:"display_name"`
-	WorkflowVersionID  uuid.UUID          `json:"workflow_version_id"`
-	StepID             uuid.UUID          `json:"step_id"`
-	IsDagOrchestrator  bool               `json:"is_dag_orchestrator"`
+	ID                            int64              `json:"id"`
+	InsertedAt                    pgtype.Timestamptz `json:"inserted_at"`
+	ExternalID                    uuid.UUID          `json:"external_id"`
+	RetryCount                    int32              `json:"retry_count"`
+	WorkflowID                    uuid.UUID          `json:"workflow_id"`
+	WorkflowRunID                 uuid.UUID          `json:"workflow_run_id"`
+	AdditionalMetadata            []byte             `json:"additional_metadata"`
+	StepReadableID                string             `json:"step_readable_id"`
+	ActionID                      string             `json:"action_id"`
+	DisplayName                   string             `json:"display_name"`
+	WorkflowVersionID             uuid.UUID          `json:"workflow_version_id"`
+	StepID                        uuid.UUID          `json:"step_id"`
+	IsDagOrchestrator             bool               `json:"is_dag_orchestrator"`
+	WasTriggeredByDagOrchestrator bool               `json:"was_triggered_by_dag_orchestrator"`
 }
 
 func (q *Queries) ListTaskMetas(ctx context.Context, db DBTX, arg ListTaskMetasParams) ([]*ListTaskMetasRow, error) {
@@ -1715,6 +1724,7 @@ func (q *Queries) ListTaskMetas(ctx context.Context, db DBTX, arg ListTaskMetasP
 			&i.WorkflowVersionID,
 			&i.StepID,
 			&i.IsDagOrchestrator,
+			&i.WasTriggeredByDagOrchestrator,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -418,7 +418,6 @@ func (s *sharedRepository) appendOperatorDAGs(
 	tasks []*V1TaskWithPayload,
 	dags []*DAGWithData,
 	operatorDagTuples map[uuid.UUID]triggerTuple,
-	operatorDagTotalTasks map[uuid.UUID]int,
 ) []*DAGWithData {
 	if len(operatorDagTuples) == 0 {
 		return dags
@@ -447,7 +446,6 @@ func (s *sharedRepository) appendOperatorDAGs(
 			Input:                tuple.input,
 			AdditionalMetadata:   tuple.additionalMetadata,
 			ParentTaskExternalID: tuple.parentExternalId,
-			TotalTasks:           operatorDagTotalTasks[task.ExternalID],
 			IsOperatorRun:        true,
 		})
 	}
@@ -462,13 +460,13 @@ func (s *sharedRepository) triggerFromWorkflowNames(ctx context.Context, tx *Opt
 		return nil, nil, nil, nil, nil, fmt.Errorf("failed to prepare trigger from workflow names: %w", err)
 	}
 
-	tasks, dags, idempotencyKeyCollisions, celEvaluationFailures, storePayloadOpts, operatorDagTuples, operatorDagTotalTasks, err := s.triggerWorkflowsCore(ctx, tx, tenantId, triggerOpts, nil, false)
+	tasks, dags, idempotencyKeyCollisions, celEvaluationFailures, storePayloadOpts, operatorDagTuples, err := s.triggerWorkflowsCore(ctx, tx, tenantId, triggerOpts, nil, false)
 
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
 
-	dags = s.appendOperatorDAGs(tenantId, tasks, dags, operatorDagTuples, operatorDagTotalTasks)
+	dags = s.appendOperatorDAGs(tenantId, tasks, dags, operatorDagTuples)
 
 	return tasks, dags, idempotencyKeyCollisions, celEvaluationFailures, storePayloadOpts, nil
 }
@@ -794,9 +792,9 @@ func (r *sharedRepository) triggerWorkflowsCore(
 	triggerCandidateTuples []triggerTuple,
 	coreEvents *createCoreUserEventOpts,
 	ownsTx bool,
-) ([]*V1TaskWithPayload, []*DAGWithData, []IdempotencyCollision, []CELEvaluationFailure, []StorePayloadOpts, map[uuid.UUID]triggerTuple, map[uuid.UUID]int, error) {
+) ([]*V1TaskWithPayload, []*DAGWithData, []IdempotencyCollision, []CELEvaluationFailure, []StorePayloadOpts, map[uuid.UUID]triggerTuple, error) {
 	if optTx == nil {
-		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("triggerWorkflowsCore requires a non-nil transaction")
+		return nil, nil, nil, nil, nil, nil, fmt.Errorf("triggerWorkflowsCore requires a non-nil transaction")
 	}
 
 	preflightTx := optTx.tx
@@ -851,7 +849,7 @@ func (r *sharedRepository) triggerWorkflowsCore(
 		})
 
 		if err != nil {
-			return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to claim idempotency keys: %w", err)
+			return nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to claim idempotency keys: %w", err)
 		}
 
 		idempotencyKeyToLockHolder := make(map[string]uuid.UUID, len(claims))
@@ -906,7 +904,7 @@ func (r *sharedRepository) triggerWorkflowsCore(
 	workflowVersionToSteps, err := r.listStepsByWorkflowVersionIds(ctx, preflightTx, tenantId, workflowVersionIds)
 
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to get workflow versions for engine: %w", err)
+		return nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to get workflow versions for engine: %w", err)
 	}
 
 	// group steps by workflow version ids
@@ -941,7 +939,7 @@ func (r *sharedRepository) triggerWorkflowsCore(
 	preTask, postTask := r.m.Meter(ctx, preflightTx, sqlcv1.LimitResourceTASKRUN, tenantId, int32(countTasks)) // nolint: gosec
 
 	if err := preTask(); err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, err
 	}
 
 	stepsToAdditionalMatches := make(map[uuid.UUID][]*sqlcv1.V1StepMatchCondition)
@@ -953,7 +951,7 @@ func (r *sharedRepository) triggerWorkflowsCore(
 		})
 
 		if err != nil {
-			return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to list step match conditions: %w", err)
+			return nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to list step match conditions: %w", err)
 		}
 
 		for _, match := range additionalMatches {
@@ -1033,13 +1031,12 @@ func (r *sharedRepository) triggerWorkflowsCore(
 	tuplesToSkip, err := r.registerChildWorkflows(ctx, tx, tenantId, tuples, stepsToExternalIds, workflowVersionToSteps)
 
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to register child workflows: %w", err)
+		return nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to register child workflows: %w", err)
 	}
 
 	// for operator-managed DAG runs, we synthesize an OLAP-only DAG from the orchestrator
 	// task after it's created, keyed by the run's external id
 	operatorDagTuples := make(map[uuid.UUID]triggerTuple)
-	operatorDagTotalTasks := make(map[uuid.UUID]int)
 
 	// OLAP-only DAG stamps for operator children, keyed by the child's external id
 	type olapDagStamp struct {
@@ -1076,7 +1073,7 @@ func (r *sharedRepository) triggerWorkflowsCore(
 
 			if len(regularSteps) == 0 {
 				// Matching no step would silently hang the caller's durable log entry forever.
-				return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("no step with action id %q found in workflow version %s", *tuple.targetActionId, tuple.workflowVersionId)
+				return nil, nil, nil, nil, nil, nil, fmt.Errorf("no step with action id %q found in workflow version %s", *tuple.targetActionId, tuple.workflowVersionId)
 			}
 		}
 		isDag := len(regularSteps) > 1
@@ -1095,7 +1092,6 @@ func (r *sharedRepository) triggerWorkflowsCore(
 			orchestratorInput.DesiredWorkerLabels = tuple.desiredWorkerLabels
 
 			operatorDagTuples[tuple.externalId] = tuple
-			operatorDagTotalTasks[tuple.externalId] = len(regularSteps)
 
 			nonDagTaskOpts = append(nonDagTaskOpts, CreateTaskOpts{
 				ExternalId:                tuple.externalId,
@@ -1241,7 +1237,7 @@ func (r *sharedRepository) triggerWorkflowsCore(
 							)
 
 							if err != nil {
-								return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to create sleep condition: %w", err)
+								return nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to create sleep condition: %w", err)
 							}
 
 							groupConditions = append(groupConditions, *c)
@@ -1524,7 +1520,7 @@ func (r *sharedRepository) triggerWorkflowsCore(
 	dags, err := r.createDAGs(ctx, tx, tenantId, dagOpts)
 
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to create DAGs: %w", err)
+		return nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to create DAGs: %w", err)
 	}
 
 	// populate taskOpts with inserted DAG data
@@ -1549,7 +1545,7 @@ func (r *sharedRepository) triggerWorkflowsCore(
 	tasks, err := r.createTasks(ctx, tx, tenantId, createTaskOpts)
 
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to create tasks: %w", err)
+		return nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to create tasks: %w", err)
 	}
 
 	// stamp the OLAP DAG identity onto operator children so they're written to OLAP as DAG
@@ -1558,6 +1554,11 @@ func (r *sharedRepository) triggerWorkflowsCore(
 		if stamp, ok := olapDagStamps[task.ExternalID]; ok {
 			task.DagID = pgtype.Int8{Int64: stamp.dagId, Valid: true}
 			task.DagInsertedAt = sqlchelpers.TimestamptzFromTime(stamp.dagInsertedAt)
+			task.IsOperatorRun = true
+		}
+
+		if _, ok := operatorDagTuples[task.ExternalID]; ok {
+			task.IsOperatorRun = true
 		}
 	}
 
@@ -1572,7 +1573,7 @@ func (r *sharedRepository) triggerWorkflowsCore(
 			Workflowids: workflowIds,
 			Tenantid:    tenantId,
 		}); err != nil {
-			return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to move queue items for paused workflows: %w", err)
+			return nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to move queue items for paused workflows: %w", err)
 		}
 	}
 
@@ -1590,7 +1591,7 @@ func (r *sharedRepository) triggerWorkflowsCore(
 	err = r.createEventMatches(ctx, tx, tenantId, createMatchOpts)
 
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to create event matches: %w", err)
+		return nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to create event matches: %w", err)
 	}
 
 	storePayloadOpts := make([]StorePayloadOpts, 0, len(tasks)+len(dags))
@@ -1621,7 +1622,7 @@ func (r *sharedRepository) triggerWorkflowsCore(
 		createdEvents, err := r.queries.BulkCreateEvents(ctx, tx, coreEvents.params)
 
 		if err != nil {
-			return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to create core events: %w", err)
+			return nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to create core events: %w", err)
 		}
 
 		for _, e := range createdEvents {
@@ -1644,7 +1645,7 @@ func (r *sharedRepository) triggerWorkflowsCore(
 
 	optTx.AddPostCommit(postTask)
 
-	return tasks, dags, idempotencyKeyCollisions, celEvaluationFailures, storePayloadOpts, operatorDagTuples, operatorDagTotalTasks, nil
+	return tasks, dags, idempotencyKeyCollisions, celEvaluationFailures, storePayloadOpts, operatorDagTuples, nil
 }
 
 func (r *sharedRepository) triggerWorkflows(
@@ -1669,7 +1670,7 @@ func (r *sharedRepository) triggerWorkflows(
 		ownsTx = true
 	}
 
-	tasks, dags, idempotencyKeyCollisions, celEvaluationFailures, storePayloadOpts, operatorDagTuples, operatorDagTotalTasks, err := r.triggerWorkflowsCore(ctx, tx, tenantId, triggerCandidateTuples, coreEvents, ownsTx)
+	tasks, dags, idempotencyKeyCollisions, celEvaluationFailures, storePayloadOpts, operatorDagTuples, err := r.triggerWorkflowsCore(ctx, tx, tenantId, triggerCandidateTuples, coreEvents, ownsTx)
 
 	if err != nil {
 		return nil, nil, nil, nil, err
@@ -1681,7 +1682,7 @@ func (r *sharedRepository) triggerWorkflows(
 		}
 	}
 
-	dags = r.appendOperatorDAGs(tenantId, tasks, dags, operatorDagTuples, operatorDagTotalTasks)
+	dags = r.appendOperatorDAGs(tenantId, tasks, dags, operatorDagTuples)
 
 	// commit if we started the transaction
 	if ownsTx {
@@ -1717,6 +1718,9 @@ type V1TaskWithPayload struct {
 	*sqlcv1.V1Task
 	Runtime *sqlcv1.V1TaskRuntime `json:"runtime,omitempty"`
 	Payload []byte                `json:"payload"`
+
+	// IsOperatorRun is true for an operator-managed run's orchestrator task and for its children.
+	IsOperatorRun bool `json:"is_operator_run,omitempty"`
 }
 
 type V1TaskEventWithPayload struct {

--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -1556,10 +1556,6 @@ func (r *sharedRepository) triggerWorkflowsCore(
 			task.DagInsertedAt = sqlchelpers.TimestamptzFromTime(stamp.dagInsertedAt)
 			task.IsOperatorRun = true
 		}
-
-		if _, ok := operatorDagTuples[task.ExternalID]; ok {
-			task.IsOperatorRun = true
-		}
 	}
 
 	if len(pausedWorkflowIds) > 0 {
@@ -1719,7 +1715,8 @@ type V1TaskWithPayload struct {
 	Runtime *sqlcv1.V1TaskRuntime `json:"runtime,omitempty"`
 	Payload []byte                `json:"payload"`
 
-	// IsOperatorRun is true for an operator-managed run's orchestrator task and for its children.
+	// IsOperatorRun is true for an operator-managed run's children. The orchestrator itself is
+	// never written to OLAP as a task, so it is never flagged here.
 	IsOperatorRun bool `json:"is_operator_run,omitempty"`
 }
 

--- a/sql/schema/v1-olap.sql
+++ b/sql/schema/v1-olap.sql
@@ -248,6 +248,8 @@ CREATE TABLE v1_dags_olap (
     parent_task_external_id UUID,
     total_tasks INT NOT NULL DEFAULT 1,
     idempotency_key TEXT,
+    is_operator_run BOOLEAN NOT NULL DEFAULT FALSE,
+    latest_retry_count INT NOT NULL DEFAULT 0,
     PRIMARY KEY (inserted_at, id)
 ) PARTITION BY RANGE(inserted_at);
 

--- a/sql/schema/v1-olap.sql
+++ b/sql/schema/v1-olap.sql
@@ -248,7 +248,6 @@ CREATE TABLE v1_dags_olap (
     parent_task_external_id UUID,
     total_tasks INT NOT NULL DEFAULT 1,
     idempotency_key TEXT,
-    is_operator_run BOOLEAN NOT NULL DEFAULT FALSE,
     latest_retry_count INT NOT NULL DEFAULT 0,
     PRIMARY KEY (inserted_at, id)
 ) PARTITION BY RANGE(inserted_at);


### PR DESCRIPTION
# Description

On the old path, we'd need advisory locks for serializing status updates for DAGs, since we'd infer their status from the statuses of the corresponding tasks. But on the durable operator path we don't need to do that, since the dag itself is a task with its own status, so there's a lot less locking that needs to happen.

This is basically a correctness fix + a performance improvement to handle status updates better on the new path

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement (non-breaking change which improves performance)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Opus for code review and suggesting further ideas to refactor

</details>
