### PR TITLE
fix(engine): honor maxRuns by counting filled concurrency slots

### DIFF
--- a/pkg/repository/sqlcv1/concurrency.sql
+++ b/pkg/repository/sqlcv1/concurrency.sql
@@ -227,8 +227,17 @@ WITH eligible_slots_per_group AS (
             wcs_all.key = distinct_keys.key
             AND wcs_all.tenant_id = @tenantId::uuid
             AND wcs_all.strategy_id = @strategyId::bigint
+            AND wcs_all.is_filled = FALSE
         ORDER BY wcs_all.sort_id ASC
-        LIMIT @maxRuns::int
+        LIMIT (
+            SELECT @maxRuns::int - COUNT(*)::int
+            FROM v1_concurrency_slot wcs_all
+            WHERE
+                wcs_all.key = distinct_keys.key
+                AND wcs_all.tenant_id = @tenantId::uuid
+                AND wcs_all.strategy_id = @strategyId::bigint
+                AND wcs_all.is_filled = TRUE
+        )
     ) cs ON true
 ), schedule_timeout_slots AS (
     SELECT

--- a/pkg/repository/sqlcv1/concurrency.sql.go
+++ b/pkg/repository/sqlcv1/concurrency.sql.go
@@ -944,8 +944,17 @@ WITH eligible_slots_per_group AS (
             wcs_all.key = distinct_keys.key
             AND wcs_all.tenant_id = $1::uuid
             AND wcs_all.strategy_id = $2::bigint
+            AND wcs_all.is_filled = FALSE
         ORDER BY wcs_all.sort_id ASC
-        LIMIT $3::int
+        LIMIT (
+            SELECT $3::int - COUNT(*)::int
+            FROM v1_concurrency_slot wcs_all
+            WHERE
+                wcs_all.key = distinct_keys.key
+                AND wcs_all.tenant_id = $1::uuid
+                AND wcs_all.strategy_id = $2::bigint
+                AND wcs_all.is_filled = TRUE
+        )
     ) cs ON true
 ), schedule_timeout_slots AS (
     SELECT


### PR DESCRIPTION
Closes #4778

## Summary

This fixes a bug where a concurrency limit (`max_runs`) was not always respected on the SQL group round robin path. You could set a max of 2 for a key and still end up with 3 or 4 runs marked as filled.

The same bug shows up on the **parent** path (`RunParentGroupRoundRobin`). That matters on current defaults: when a strategy has a parent (workflow-level concurrency above a task-level one), the engine still uses the SQL parent query even with in-memory scheduling on. So we fixed both.

<details open id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Cursor was used to explore the codebase, reproduce the bug, draft the SQL change, and help write this PR. I reviewed and directed the investigation and the final change.

</details>

## What I investigated

I started by understanding what a concurrency **key** is.

A key is a label on a run. You choose the rule (a short expression over the run input). When a run starts, Hatchet turns that into a string. Runs with the same key share one limit. Runs with different keys each get their own limit.

So if the expression is based on a user id, Alice’s runs share one cap and Bob’s share another. Hatchet does not invent that meaning. It only sees the string.

Hatchet’s platform “User” (login / dashboard account) is a different thing. Concurrency does not use that.

## Reproducing the error

I reproduced the ticket’s SQL case locally.

Setup: `max_runs = 2`, one key, and the same admission shape as `RunGroupRoundRobin`.

What happened:

1. First pass: only one row was visible. It got admitted. 1 filled. Fine.
2. Second pass: more rows with lower sort numbers became visible. The already-filled row sat outside the “first 2 by sort order” window, so the check did not count it. It admitted more work.

Results before the fix:

- Ticket shape → **3 filled** with a max of **2**
- Larger displace (higher sort ids fill first) → **4 filled** with a max of **2**

That matched the bug report: the check was looking at a short window of rows, not counting how many were already running. The overshoot is not always +1.

## Looking at the SQL and the LIMIT pattern

The old query ordered by `sort_id` and used `LIMIT` set to `max_runs`. Then it admitted unfilled rows inside that window.

I also looked at nearby concurrency queries. The same kind of pattern shows up elsewhere: order the line, then `LIMIT`.

That made me careful. The `LIMIT` is probably there on purpose. It is a way to look at the front of the line and decide who should go next. I did not want to rip that idea out everywhere.

What was wrong here is using that same window as the seat counter. “Who is at the front of the line?” and “How many seats are taken?” got merged into one step. The first question still needs ordering. The second needs a real count.

I first changed only `RunGroupRoundRobin`. Then I checked the issue again: on current defaults, a strategy **with a parent** still goes through SQL. That path uses `RunParentGroupRoundRobin`, which has the same window logic. I reproduced the same over-admission there (3 and 4 against max 2), so I applied the same fix to the parent query. I still left cancel queries alone until those are verified separately.

## The fix

Same idea in both places:

1. `RunGroupRoundRobin` (task slots)
2. `RunParentGroupRoundRobin` (workflow / parent slots)

For each:

1. Only consider rows that are not filled yet (waiters).
2. Set `LIMIT` to `max_runs - (number of filled rows for that key)`.

So:

- Cap = count how many are already filled
- Line order = still used to pick which waiters get the free seats

Parent keeps `ORDER BY priority DESC, sort_id ASC`. Same alias names. No extra comments. Generated Go query strings updated by hand to match (sqlc currently fails on `LIMIT (SELECT ...)`).

## Tests

### Child / `RunGroupRoundRobin` SQL shape

1. Local SQL reproduction of the ticket interleaving case  
   - Before: 3 filled with max 2  
   - After: 2 filled with max 2
2. Larger displace case  
   - Before: 4 filled with max 2  
   - After: 2 filled with max 2

### Parent / `RunParentGroupRoundRobin` SQL shape

Same cases on the parent query shape:

- Buggy: filled **3** and **4** with max 2  
- Fixed: filled **2** and **2**

### Integration

`go test -tags integration ./pkg/scheduling/v1/ -run TestConcurrency_`:

- `TestConcurrency_GroupRoundRobin` — PASS  
- `TestConcurrency_CancelNewest` — PASS  
- `TestConcurrency_CancelInProgress` — PASS  
- In-memory cancel variants — PASS  
- `TestConcurrency_ChainedStrategiesDoNotContaminate` — PASS  
- `TestConcurrency_MultipleStrategiesContention` — PASS  
- `TestConcurrency_ColdStrategyScheduledPromptly` — PASS  

## Note for maintainers

Issue #4778 needs the `accepted` label and assignment before this PR can stay open per CONTRIBUTING. I commented on the issue asking to take it on.

## Test plan

- [x] Reproduce over-admission with the old window logic (3 and 4 filled / max 2) on child and parent shapes
- [x] Confirm fixed logic keeps filled count at max 2 on those cases for child and parent
- [x] Run `TestConcurrency_*` integration suite
- [ ] Reviewer: confirm cancel queries can stay as-is for now
- [ ] Reviewer: note `sqlc generate` currently fails on `LIMIT (SELECT ...)`, so `concurrency.sql.go` was updated by hand to match