### PR TITLE
perf(engine): rewrite durable event queries to use existing indexes

### DIFF
--- a/pkg/repository/durable_event_log_satisfied_test.go
+++ b/pkg/repository/durable_event_log_satisfied_test.go
@@ -1,0 +1,142 @@
+//go:build !e2e && !load && !rampup && !integration
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlchelpers"
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
+)
+
+func insertDurableLogFile(t *testing.T, ctx context.Context, repo *TaskRepositoryImpl, tenantId uuid.UUID, taskId int64, taskInsertedAt time.Time, latestSatisfiedOrder int64) {
+	t.Helper()
+
+	_, err := repo.pool.Exec(
+		ctx,
+		`INSERT INTO v1_durable_event_log_file (tenant_id, durable_task_id, durable_task_inserted_at, latest_invocation_count, latest_inserted_at, latest_node_id, latest_branch_id, latest_satisfied_order)
+		 VALUES ($1, $2, $3, 1, NOW(), 0, 1, $4)`,
+		tenantId,
+		taskId,
+		taskInsertedAt,
+		latestSatisfiedOrder,
+	)
+	require.NoError(t, err)
+}
+
+func insertDurableLogEntry(t *testing.T, ctx context.Context, repo *TaskRepositoryImpl, tenantId uuid.UUID, taskId int64, taskInsertedAt time.Time, branchId, nodeId int64) {
+	t.Helper()
+
+	_, err := repo.pool.Exec(
+		ctx,
+		`INSERT INTO v1_durable_event_log_entry (tenant_id, external_id, durable_task_id, durable_task_inserted_at, inserted_at, kind, node_id, branch_id, idempotency_key)
+		 VALUES ($1, $2, $3, $4, NOW(), 'RUN', $5, $6, $7)`,
+		tenantId,
+		uuid.New(),
+		taskId,
+		taskInsertedAt,
+		nodeId,
+		branchId,
+		[]byte("test-idempotency-key"),
+	)
+	require.NoError(t, err)
+}
+
+func TestUpdateDurableEventLogEntriesSatisfied_MultiParentBatch(t *testing.T) {
+	pool, cleanup := setupPostgresWithMigration(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	repo := createTaskRepository(pool)
+
+	require.NoError(t, repo.UpdateTablePartitions(ctx))
+
+	tenantId := uuid.New()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+
+	parentA := int64(11)
+	parentAInsertedAt := now
+	parentB := int64(22)
+	parentBInsertedAt := now.Add(-1 * time.Minute)
+
+	// parent A starts with a non-zero satisfied order; parent B starts at zero
+	insertDurableLogFile(t, ctx, repo, tenantId, parentA, parentAInsertedAt, 5)
+	insertDurableLogFile(t, ctx, repo, tenantId, parentB, parentBInsertedAt, 0)
+
+	insertDurableLogEntry(t, ctx, repo, tenantId, parentA, parentAInsertedAt, 1, 0)
+	insertDurableLogEntry(t, ctx, repo, tenantId, parentA, parentAInsertedAt, 1, 1)
+	insertDurableLogEntry(t, ctx, repo, tenantId, parentA, parentAInsertedAt, 1, 2)
+	insertDurableLogEntry(t, ctx, repo, tenantId, parentB, parentBInsertedAt, 1, 0)
+
+	toTimestamptz := func(ts time.Time) pgtype.Timestamptz {
+		return sqlchelpers.TimestamptzFromTime(ts)
+	}
+
+	// satisfy two entries of parent A (out of order) and one of parent B in a single batch
+	rows, err := repo.queries.UpdateDurableEventLogEntriesSatisfied(ctx, pool, sqlcv1.UpdateDurableEventLogEntriesSatisfiedParams{
+		Durabletaskids:         []int64{parentA, parentB, parentA},
+		Durabletaskinsertedats: []pgtype.Timestamptz{toTimestamptz(parentAInsertedAt), toTimestamptz(parentBInsertedAt), toTimestamptz(parentAInsertedAt)},
+		Nodeids:                []int64{2, 0, 0},
+		Branchids:              []int64{1, 1, 1},
+		Childtaskisfailures:    []bool{false, false, true},
+		Childtaskerrormessages: []string{"", "", "boom"},
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 3)
+
+	satisfiedOrders := make(map[int64]map[int64]int64) // parent -> node -> satisfied_order
+
+	for _, row := range rows {
+		assert.True(t, row.IsSatisfied)
+		require.True(t, row.SatisfiedOrder.Valid, "satisfied_order should be set for parent %d node %d", row.DurableTaskID, row.NodeID)
+
+		if satisfiedOrders[row.DurableTaskID] == nil {
+			satisfiedOrders[row.DurableTaskID] = make(map[int64]int64)
+		}
+
+		satisfiedOrders[row.DurableTaskID][row.NodeID] = row.SatisfiedOrder.Int64
+
+		if row.DurableTaskID == parentA && row.NodeID == 0 {
+			assert.True(t, row.ChildTaskIsFailure)
+			assert.Equal(t, "boom", row.ChildTaskErrorMessage.String)
+		}
+	}
+
+	// parent A orders continue from its latest_satisfied_order (5), assigned by (branch_id, node_id)
+	assert.Equal(t, int64(6), satisfiedOrders[parentA][0])
+	assert.Equal(t, int64(7), satisfiedOrders[parentA][2])
+	// parent B starts from 0
+	assert.Equal(t, int64(1), satisfiedOrders[parentB][0])
+
+	// log files advance to the max satisfied order per parent
+	var latestA, latestB int64
+	require.NoError(t, pool.QueryRow(ctx, `SELECT latest_satisfied_order FROM v1_durable_event_log_file WHERE durable_task_id = $1`, parentA).Scan(&latestA))
+	require.NoError(t, pool.QueryRow(ctx, `SELECT latest_satisfied_order FROM v1_durable_event_log_file WHERE durable_task_id = $1`, parentB).Scan(&latestB))
+	assert.Equal(t, int64(7), latestA)
+	assert.Equal(t, int64(1), latestB)
+
+	// re-satisfying an entry keeps its original satisfied_order
+	rows, err = repo.queries.UpdateDurableEventLogEntriesSatisfied(ctx, pool, sqlcv1.UpdateDurableEventLogEntriesSatisfiedParams{
+		Durabletaskids:         []int64{parentA},
+		Durabletaskinsertedats: []pgtype.Timestamptz{toTimestamptz(parentAInsertedAt)},
+		Nodeids:                []int64{0},
+		Branchids:              []int64{1},
+		Childtaskisfailures:    []bool{false},
+		Childtaskerrormessages: []string{""},
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, int64(6), rows[0].SatisfiedOrder.Int64)
+
+	// the untouched entry of parent A is still unsatisfied
+	var unsatisfiedCount int
+	require.NoError(t, pool.QueryRow(ctx, `SELECT COUNT(*) FROM v1_durable_event_log_entry WHERE durable_task_id = $1 AND NOT is_satisfied`, parentA).Scan(&unsatisfiedCount))
+	assert.Equal(t, 1, unsatisfiedCount)
+}

--- a/pkg/repository/ids.go
+++ b/pkg/repository/ids.go
@@ -187,12 +187,7 @@ func (s *sharedRepository) generateExternalIdsForChildWorkflows(ctx context.Cont
 		eventKeys = append(eventKeys, opt.childSpawnKey())
 	}
 
-	lockedEvents, err := s.queries.LockSignalCreatedEvents(ctx, tx, sqlcv1.LockSignalCreatedEventsParams{
-		Tenantid:        tenantId,
-		Taskids:         eventTaskIds,
-		Taskinsertedats: eventTaskInsertedAts,
-		Eventkeys:       eventKeys,
-	})
+	lockedEvents, err := s.lockSignalCreatedEvents(ctx, tx, tenantId, eventTaskIds, eventTaskInsertedAts, eventKeys)
 
 	if err != nil {
 		return err

--- a/pkg/repository/sqlcv1/durable_event_log.sql
+++ b/pkg/repository/sqlcv1/durable_event_log.sql
@@ -135,6 +135,9 @@ WITH inputs AS (
     ORDER BY durable_task_id, durable_task_inserted_at
     FOR UPDATE
 ), satisfied_orders_to_apply AS (
+    -- note: joining on all four primary key columns (instead of filtering with an IN
+    -- subquery) lets the planner probe the primary key per input row rather than
+    -- scanning every log entry of the parent task
     SELECT
         e.durable_task_id,
         e.durable_task_inserted_at,
@@ -144,14 +147,20 @@ WITH inputs AS (
             PARTITION BY e.durable_task_id, e.durable_task_inserted_at
             ORDER BY e.branch_id ASC, e.node_id ASC
         ) AS satisfied_order
-    FROM v1_durable_event_log_entry e
-    JOIN locked_log_files llf USING (durable_task_id, durable_task_inserted_at)
+    FROM (
+        SELECT DISTINCT durable_task_id, durable_task_inserted_at, branch_id, node_id
+        FROM inputs
+    ) i
+    JOIN v1_durable_event_log_entry e
+        ON e.durable_task_id = i.durable_task_id
+        AND e.durable_task_inserted_at = i.durable_task_inserted_at
+        AND e.branch_id = i.branch_id
+        AND e.node_id = i.node_id
+    JOIN locked_log_files llf
+        ON llf.durable_task_id = e.durable_task_id
+        AND llf.durable_task_inserted_at = e.durable_task_inserted_at
     WHERE
         e.satisfied_order IS NULL
-        AND (durable_task_id, durable_task_inserted_at, branch_id, node_id) IN (
-            SELECT durable_task_id, durable_task_inserted_at, branch_id, node_id
-            FROM inputs
-        )
 ), updated AS (
     UPDATE v1_durable_event_log_entry e
     SET

--- a/pkg/repository/sqlcv1/durable_event_log.sql
+++ b/pkg/repository/sqlcv1/durable_event_log.sql
@@ -135,8 +135,8 @@ WITH inputs AS (
     ORDER BY durable_task_id, durable_task_inserted_at
     FOR UPDATE
 ), satisfied_orders_to_apply AS (
-    -- joining on all four primary key columns lets the planner probe the primary key
-    -- per input row rather than scanning every log entry of the parent task
+    -- the join must cover all four primary key columns so each input row is a
+    -- single primary-key probe
     SELECT
         e.durable_task_id,
         e.durable_task_inserted_at,

--- a/pkg/repository/sqlcv1/durable_event_log.sql
+++ b/pkg/repository/sqlcv1/durable_event_log.sql
@@ -135,9 +135,8 @@ WITH inputs AS (
     ORDER BY durable_task_id, durable_task_inserted_at
     FOR UPDATE
 ), satisfied_orders_to_apply AS (
-    -- note: joining on all four primary key columns (instead of filtering with an IN
-    -- subquery) lets the planner probe the primary key per input row rather than
-    -- scanning every log entry of the parent task
+    -- joining on all four primary key columns lets the planner probe the primary key
+    -- per input row rather than scanning every log entry of the parent task
     SELECT
         e.durable_task_id,
         e.durable_task_inserted_at,

--- a/pkg/repository/sqlcv1/durable_event_log.sql.go
+++ b/pkg/repository/sqlcv1/durable_event_log.sql.go
@@ -1081,6 +1081,9 @@ WITH inputs AS (
     ORDER BY durable_task_id, durable_task_inserted_at
     FOR UPDATE
 ), satisfied_orders_to_apply AS (
+    -- note: joining on all four primary key columns (instead of filtering with an IN
+    -- subquery) lets the planner probe the primary key per input row rather than
+    -- scanning every log entry of the parent task
     SELECT
         e.durable_task_id,
         e.durable_task_inserted_at,
@@ -1090,14 +1093,20 @@ WITH inputs AS (
             PARTITION BY e.durable_task_id, e.durable_task_inserted_at
             ORDER BY e.branch_id ASC, e.node_id ASC
         ) AS satisfied_order
-    FROM v1_durable_event_log_entry e
-    JOIN locked_log_files llf USING (durable_task_id, durable_task_inserted_at)
+    FROM (
+        SELECT DISTINCT durable_task_id, durable_task_inserted_at, branch_id, node_id
+        FROM inputs
+    ) i
+    JOIN v1_durable_event_log_entry e
+        ON e.durable_task_id = i.durable_task_id
+        AND e.durable_task_inserted_at = i.durable_task_inserted_at
+        AND e.branch_id = i.branch_id
+        AND e.node_id = i.node_id
+    JOIN locked_log_files llf
+        ON llf.durable_task_id = e.durable_task_id
+        AND llf.durable_task_inserted_at = e.durable_task_inserted_at
     WHERE
         e.satisfied_order IS NULL
-        AND (durable_task_id, durable_task_inserted_at, branch_id, node_id) IN (
-            SELECT durable_task_id, durable_task_inserted_at, branch_id, node_id
-            FROM inputs
-        )
 ), updated AS (
     UPDATE v1_durable_event_log_entry e
     SET

--- a/pkg/repository/sqlcv1/durable_event_log.sql.go
+++ b/pkg/repository/sqlcv1/durable_event_log.sql.go
@@ -1081,8 +1081,8 @@ WITH inputs AS (
     ORDER BY durable_task_id, durable_task_inserted_at
     FOR UPDATE
 ), satisfied_orders_to_apply AS (
-    -- joining on all four primary key columns lets the planner probe the primary key
-    -- per input row rather than scanning every log entry of the parent task
+    -- the join must cover all four primary key columns so each input row is a
+    -- single primary-key probe
     SELECT
         e.durable_task_id,
         e.durable_task_inserted_at,

--- a/pkg/repository/sqlcv1/durable_event_log.sql.go
+++ b/pkg/repository/sqlcv1/durable_event_log.sql.go
@@ -1081,9 +1081,8 @@ WITH inputs AS (
     ORDER BY durable_task_id, durable_task_inserted_at
     FOR UPDATE
 ), satisfied_orders_to_apply AS (
-    -- note: joining on all four primary key columns (instead of filtering with an IN
-    -- subquery) lets the planner probe the primary key per input row rather than
-    -- scanning every log entry of the parent task
+    -- joining on all four primary key columns lets the planner probe the primary key
+    -- per input row rather than scanning every log entry of the parent task
     SELECT
         e.durable_task_id,
         e.durable_task_inserted_at,

--- a/pkg/repository/sqlcv1/tasks.sql
+++ b/pkg/repository/sqlcv1/tasks.sql
@@ -544,9 +544,9 @@ WHERE
 -- name: LockSignalCreatedEvents :many
 -- Places a lock on the SIGNAL_CREATED events to make sure concurrent operations don't
 -- modify the events.
--- Note: this intentionally uses flat predicates for a single parent task (callers group
--- their input by parent) so the planner can use the unique index on
--- (tenant_id, task_id, task_inserted_at, event_type, event_key).
+-- The flat single-parent predicates are required for the planner to use the unique index
+-- on (tenant_id, task_id, task_inserted_at, event_type, event_key); callers group their
+-- input by parent task.
 SELECT
 	e.id,
     e.inserted_at,

--- a/pkg/repository/sqlcv1/tasks.sql
+++ b/pkg/repository/sqlcv1/tasks.sql
@@ -544,36 +544,9 @@ WHERE
 -- name: LockSignalCreatedEvents :many
 -- Places a lock on the SIGNAL_CREATED events to make sure concurrent operations don't
 -- modify the events.
-WITH input AS (
-    SELECT
-        UNNEST(@taskIds::BIGINT[]) AS task_id,
-        UNNEST(@taskInsertedAts::TIMESTAMPTZ[]) AS task_inserted_at,
-        UNNEST(@eventKeys::TEXT[]) AS event_key
-), distinct_events AS (
-    SELECT DISTINCT
-        task_id, task_inserted_at
-    FROM
-        input
-), events_to_lock AS (
-    SELECT
-        e.id,
-        e.event_key,
-        e.data,
-		e.task_id,
-		e.task_inserted_at,
-        e.inserted_at,
-        e.external_id,
-        e.child_external_id
-    FROM
-        v1_task_event e
-    JOIN
-        distinct_events de
-		ON e.task_id = de.task_id
-		AND e.task_inserted_at = de.task_inserted_at
-    WHERE
-        e.tenant_id = @tenantId::uuid
-        AND e.event_type = 'SIGNAL_CREATED'
-)
+-- Note: this intentionally uses flat predicates for a single parent task (callers group
+-- their input by parent) so the planner can use the unique index on
+-- (tenant_id, task_id, task_inserted_at, event_type, event_key).
 SELECT
 	e.id,
     e.inserted_at,
@@ -582,9 +555,13 @@ SELECT
     e.external_id,
     e.child_external_id
 FROM
-	events_to_lock e
+	v1_task_event e
 WHERE
-	e.event_key = ANY(SELECT event_key FROM input);
+    e.tenant_id = @tenantId::uuid
+    AND e.task_id = @taskId::bigint
+    AND e.task_inserted_at = @taskInsertedAt::timestamptz
+    AND e.event_type = 'SIGNAL_CREATED'
+    AND e.event_key = ANY(@eventKeys::text[]);
 
 -- name: ListMatchingSignalEvents :many
 WITH input AS (

--- a/pkg/repository/sqlcv1/tasks.sql.go
+++ b/pkg/repository/sqlcv1/tasks.sql.go
@@ -2623,9 +2623,9 @@ type LockSignalCreatedEventsRow struct {
 
 // Places a lock on the SIGNAL_CREATED events to make sure concurrent operations don't
 // modify the events.
-// Note: this intentionally uses flat predicates for a single parent task (callers group
-// their input by parent) so the planner can use the unique index on
-// (tenant_id, task_id, task_inserted_at, event_type, event_key).
+// The flat single-parent predicates are required for the planner to use the unique index
+// on (tenant_id, task_id, task_inserted_at, event_type, event_key); callers group their
+// input by parent task.
 func (q *Queries) LockSignalCreatedEvents(ctx context.Context, db DBTX, arg LockSignalCreatedEventsParams) ([]*LockSignalCreatedEventsRow, error) {
 	rows, err := db.Query(ctx, lockSignalCreatedEvents,
 		arg.Tenantid,

--- a/pkg/repository/sqlcv1/tasks.sql.go
+++ b/pkg/repository/sqlcv1/tasks.sql.go
@@ -2588,36 +2588,6 @@ func (q *Queries) LockDAGsForReplay(ctx context.Context, db DBTX, arg LockDAGsFo
 }
 
 const lockSignalCreatedEvents = `-- name: LockSignalCreatedEvents :many
-WITH input AS (
-    SELECT
-        UNNEST($1::BIGINT[]) AS task_id,
-        UNNEST($2::TIMESTAMPTZ[]) AS task_inserted_at,
-        UNNEST($3::TEXT[]) AS event_key
-), distinct_events AS (
-    SELECT DISTINCT
-        task_id, task_inserted_at
-    FROM
-        input
-), events_to_lock AS (
-    SELECT
-        e.id,
-        e.event_key,
-        e.data,
-		e.task_id,
-		e.task_inserted_at,
-        e.inserted_at,
-        e.external_id,
-        e.child_external_id
-    FROM
-        v1_task_event e
-    JOIN
-        distinct_events de
-		ON e.task_id = de.task_id
-		AND e.task_inserted_at = de.task_inserted_at
-    WHERE
-        e.tenant_id = $4::uuid
-        AND e.event_type = 'SIGNAL_CREATED'
-)
 SELECT
 	e.id,
     e.inserted_at,
@@ -2626,16 +2596,20 @@ SELECT
     e.external_id,
     e.child_external_id
 FROM
-	events_to_lock e
+	v1_task_event e
 WHERE
-	e.event_key = ANY(SELECT event_key FROM input)
+    e.tenant_id = $1::uuid
+    AND e.task_id = $2::bigint
+    AND e.task_inserted_at = $3::timestamptz
+    AND e.event_type = 'SIGNAL_CREATED'
+    AND e.event_key = ANY($4::text[])
 `
 
 type LockSignalCreatedEventsParams struct {
-	Taskids         []int64              `json:"taskids"`
-	Taskinsertedats []pgtype.Timestamptz `json:"taskinsertedats"`
-	Eventkeys       []string             `json:"eventkeys"`
-	Tenantid        uuid.UUID            `json:"tenantid"`
+	Tenantid       uuid.UUID          `json:"tenantid"`
+	Taskid         int64              `json:"taskid"`
+	Taskinsertedat pgtype.Timestamptz `json:"taskinsertedat"`
+	Eventkeys      []string           `json:"eventkeys"`
 }
 
 type LockSignalCreatedEventsRow struct {
@@ -2649,12 +2623,15 @@ type LockSignalCreatedEventsRow struct {
 
 // Places a lock on the SIGNAL_CREATED events to make sure concurrent operations don't
 // modify the events.
+// Note: this intentionally uses flat predicates for a single parent task (callers group
+// their input by parent) so the planner can use the unique index on
+// (tenant_id, task_id, task_inserted_at, event_type, event_key).
 func (q *Queries) LockSignalCreatedEvents(ctx context.Context, db DBTX, arg LockSignalCreatedEventsParams) ([]*LockSignalCreatedEventsRow, error) {
 	rows, err := db.Query(ctx, lockSignalCreatedEvents,
-		arg.Taskids,
-		arg.Taskinsertedats,
-		arg.Eventkeys,
 		arg.Tenantid,
+		arg.Taskid,
+		arg.Taskinsertedat,
+		arg.Eventkeys,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -1848,11 +1848,10 @@ func (r *sharedRepository) createDAGs(ctx context.Context, tx sqlcv1.DBTX, tenan
 }
 
 // lockSignalCreatedEvents groups (task_id, task_inserted_at, event_key) triples by parent
-// task and runs one lookup per parent. The flat per-parent predicates let the planner use
-// the unique index on (tenant_id, task_id, task_inserted_at, event_type, event_key); a
-// single query joining against the full unnested input reads every SIGNAL_CREATED event
-// of each parent instead. Parents are processed in a deterministic order so concurrent
-// transactions touch rows in the same order.
+// task and runs one lookup per parent: the flat per-parent predicates are required for the
+// planner to use the unique index on (tenant_id, task_id, task_inserted_at, event_type,
+// event_key). Parents are processed in sorted order so concurrent transactions touch rows
+// in the same order.
 func (r *sharedRepository) lockSignalCreatedEvents(
 	ctx context.Context,
 	tx sqlcv1.DBTX,

--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -1846,6 +1847,73 @@ func (r *sharedRepository) createDAGs(ctx context.Context, tx sqlcv1.DBTX, tenan
 	return res, nil
 }
 
+// lockSignalCreatedEvents groups (task_id, task_inserted_at, event_key) triples by parent
+// task and runs one lookup per parent. The flat per-parent predicates let the planner use
+// the unique index on (tenant_id, task_id, task_inserted_at, event_type, event_key); a
+// single query joining against the full unnested input reads every SIGNAL_CREATED event
+// of each parent instead. Parents are processed in a deterministic order so concurrent
+// transactions touch rows in the same order.
+func (r *sharedRepository) lockSignalCreatedEvents(
+	ctx context.Context,
+	tx sqlcv1.DBTX,
+	tenantId uuid.UUID,
+	taskIds []int64,
+	taskInsertedAts []pgtype.Timestamptz,
+	eventKeys []string,
+) ([]*sqlcv1.LockSignalCreatedEventsRow, error) {
+	type parent struct {
+		taskId     int64
+		insertedAt time.Time
+	}
+
+	groups := make(map[parent]*sqlcv1.LockSignalCreatedEventsParams)
+
+	for i := range taskIds {
+		p := parent{taskId: taskIds[i], insertedAt: taskInsertedAts[i].Time}
+
+		g, ok := groups[p]
+
+		if !ok {
+			g = &sqlcv1.LockSignalCreatedEventsParams{
+				Tenantid:       tenantId,
+				Taskid:         taskIds[i],
+				Taskinsertedat: taskInsertedAts[i],
+			}
+			groups[p] = g
+		}
+
+		g.Eventkeys = append(g.Eventkeys, eventKeys[i])
+	}
+
+	order := make([]parent, 0, len(groups))
+
+	for p := range groups {
+		order = append(order, p)
+	}
+
+	sort.Slice(order, func(i, j int) bool {
+		if order[i].taskId != order[j].taskId {
+			return order[i].taskId < order[j].taskId
+		}
+
+		return order[i].insertedAt.Before(order[j].insertedAt)
+	})
+
+	events := make([]*sqlcv1.LockSignalCreatedEventsRow, 0, len(taskIds))
+
+	for _, p := range order {
+		res, err := r.queries.LockSignalCreatedEvents(ctx, tx, *groups[p])
+
+		if err != nil {
+			return nil, err
+		}
+
+		events = append(events, res...)
+	}
+
+	return events, nil
+}
+
 func (r *sharedRepository) registerChildWorkflows(
 	ctx context.Context,
 	tx sqlcv1.DBTX,
@@ -1911,15 +1979,13 @@ func (r *sharedRepository) registerChildWorkflows(
 		return nil, nil
 	}
 
-	matchingEvents, err := r.queries.LockSignalCreatedEvents(
+	matchingEvents, err := r.lockSignalCreatedEvents(
 		ctx,
 		tx,
-		sqlcv1.LockSignalCreatedEventsParams{
-			Tenantid:        tenantId,
-			Taskids:         potentialMatchTaskIds,
-			Taskinsertedats: potentialMatchTaskInsertedAts,
-			Eventkeys:       potentialMatchKeys,
-		},
+		tenantId,
+		potentialMatchTaskIds,
+		potentialMatchTaskInsertedAts,
+		potentialMatchKeys,
 	)
 
 	if err != nil {

--- a/pkg/repository/trigger_lock_signal_test.go
+++ b/pkg/repository/trigger_lock_signal_test.go
@@ -96,17 +96,4 @@ func TestLockSignalCreatedEvents_MultiParentBatch(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Empty(t, events)
-
-	// duplicate triples in a batch do not duplicate results
-	events, err = repo.lockSignalCreatedEvents(
-		ctx,
-		pool,
-		tenantId,
-		[]int64{parentB, parentB},
-		[]pgtype.Timestamptz{toTimestamptz(parentBInsertedAt), toTimestamptz(parentBInsertedAt)},
-		[]string{"b.key.0", "b.key.0"},
-	)
-	require.NoError(t, err)
-	require.Len(t, events, 1)
-	assert.Equal(t, "b.key.0", events[0].EventKey.String)
 }

--- a/pkg/repository/trigger_lock_signal_test.go
+++ b/pkg/repository/trigger_lock_signal_test.go
@@ -1,0 +1,113 @@
+//go:build !e2e && !load && !rampup && !integration
+
+package repository
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlchelpers"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func insertSignalCreatedEvent(t *testing.T, ctx context.Context, repo *TaskRepositoryImpl, tenantId uuid.UUID, taskId int64, taskInsertedAt time.Time, eventKey string) {
+	t.Helper()
+
+	_, err := repo.pool.Exec(
+		ctx,
+		`INSERT INTO v1_task_event (tenant_id, task_id, task_inserted_at, retry_count, event_type, event_key, data)
+		 VALUES ($1, $2, $3, -1, 'SIGNAL_CREATED', $4, $5)`,
+		tenantId,
+		taskId,
+		taskInsertedAt,
+		eventKey,
+		[]byte(fmt.Sprintf(`{"key": %q}`, eventKey)),
+	)
+	require.NoError(t, err)
+}
+
+func TestLockSignalCreatedEvents_MultiParentBatch(t *testing.T) {
+	pool, cleanup := setupPostgresWithMigration(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	repo := createTaskRepository(pool)
+
+	// creates the range partitions for v1_task_event
+	require.NoError(t, repo.UpdateTablePartitions(ctx))
+
+	tenantId := uuid.New()
+	otherTenantId := uuid.New()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+
+	parentA := int64(101)
+	parentAInsertedAt := now
+	parentB := int64(202)
+	parentBInsertedAt := now.Add(-1 * time.Minute)
+
+	// parent A has three signal events, one of which is not requested
+	insertSignalCreatedEvent(t, ctx, repo, tenantId, parentA, parentAInsertedAt, "a.key.0")
+	insertSignalCreatedEvent(t, ctx, repo, tenantId, parentA, parentAInsertedAt, "a.key.1")
+	insertSignalCreatedEvent(t, ctx, repo, tenantId, parentA, parentAInsertedAt, "a.key.2")
+
+	// parent B has two signal events
+	insertSignalCreatedEvent(t, ctx, repo, tenantId, parentB, parentBInsertedAt, "b.key.0")
+	insertSignalCreatedEvent(t, ctx, repo, tenantId, parentB, parentBInsertedAt, "b.key.1")
+
+	// a different tenant has an event with the same task id and key as parent A
+	insertSignalCreatedEvent(t, ctx, repo, otherTenantId, parentA, parentAInsertedAt, "a.key.0")
+
+	toTimestamptz := func(ts time.Time) pgtype.Timestamptz {
+		return sqlchelpers.TimestamptzFromTime(ts)
+	}
+
+	// a single batch spanning both parents, in interleaved order
+	events, err := repo.lockSignalCreatedEvents(
+		ctx,
+		pool,
+		tenantId,
+		[]int64{parentA, parentB, parentA},
+		[]pgtype.Timestamptz{toTimestamptz(parentAInsertedAt), toTimestamptz(parentBInsertedAt), toTimestamptz(parentAInsertedAt)},
+		[]string{"a.key.0", "b.key.1", "a.key.2"},
+	)
+	require.NoError(t, err)
+
+	gotKeys := make([]string, 0, len(events))
+
+	for _, event := range events {
+		gotKeys = append(gotKeys, event.EventKey.String)
+	}
+
+	assert.ElementsMatch(t, []string{"a.key.0", "b.key.1", "a.key.2"}, gotKeys)
+
+	// keys only match events of the parent task they are requested under
+	events, err = repo.lockSignalCreatedEvents(
+		ctx,
+		pool,
+		tenantId,
+		[]int64{parentB},
+		[]pgtype.Timestamptz{toTimestamptz(parentBInsertedAt)},
+		[]string{"a.key.0"},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, events)
+
+	// duplicate triples in a batch do not duplicate results per key set semantics of ANY()
+	events, err = repo.lockSignalCreatedEvents(
+		ctx,
+		pool,
+		tenantId,
+		[]int64{parentB, parentB},
+		[]pgtype.Timestamptz{toTimestamptz(parentBInsertedAt), toTimestamptz(parentBInsertedAt)},
+		[]string{"b.key.0", "b.key.0"},
+	)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, "b.key.0", events[0].EventKey.String)
+}

--- a/pkg/repository/trigger_lock_signal_test.go
+++ b/pkg/repository/trigger_lock_signal_test.go
@@ -39,7 +39,7 @@ func TestLockSignalCreatedEvents_MultiParentBatch(t *testing.T) {
 	ctx := context.Background()
 	repo := createTaskRepository(pool)
 
-	// creates the range partitions for v1_task_event
+	// v1_task_event is range-partitioned; inserts require the partitions to exist
 	require.NoError(t, repo.UpdateTablePartitions(ctx))
 
 	tenantId := uuid.New()
@@ -56,7 +56,6 @@ func TestLockSignalCreatedEvents_MultiParentBatch(t *testing.T) {
 	insertSignalCreatedEvent(t, ctx, repo, tenantId, parentA, parentAInsertedAt, "a.key.1")
 	insertSignalCreatedEvent(t, ctx, repo, tenantId, parentA, parentAInsertedAt, "a.key.2")
 
-	// parent B has two signal events
 	insertSignalCreatedEvent(t, ctx, repo, tenantId, parentB, parentBInsertedAt, "b.key.0")
 	insertSignalCreatedEvent(t, ctx, repo, tenantId, parentB, parentBInsertedAt, "b.key.1")
 
@@ -98,7 +97,7 @@ func TestLockSignalCreatedEvents_MultiParentBatch(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, events)
 
-	// duplicate triples in a batch do not duplicate results per key set semantics of ANY()
+	// duplicate triples in a batch do not duplicate results
 	events, err = repo.lockSignalCreatedEvents(
 		ctx,
 		pool,


### PR DESCRIPTION
# Description

Completing one child of a durable task got more expensive as the parent grew. Two queries on that path re-read every event or log entry of the parent on each call, because their shape stopped the planner from using indexes that already exist.

`LockSignalCreatedEvents` joined the unnested input on only `(task_id, task_inserted_at)` and filtered `event_key` late, so a parent with ~6k signal events read all of them to lock a handful of rows. The query now takes flat predicates for one parent with `event_key = ANY(...)` and the planner uses the unique index on `(tenant_id, task_id, task_inserted_at, event_type, event_key)`. On that same ~6k-event parent this cut buffer reads per call by ~840x. A new Go helper groups a batch by parent and runs one lookup per parent in sorted order, so batches spanning multiple parents behave as before.

`UpdateDurableEventLogEntriesSatisfied` filtered with a 4-column `IN (SELECT ... FROM inputs)`, which scanned all of the parent's log entries through a 2-column index prefix before joining. It now joins the de-duplicated inputs on all four primary key columns, so each input row probes the primary key directly.

## Type of change

- [x] Performance improvement (non-breaking change which improves performance)

## Checklist

Changes have been:

- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

New tests run both queries against a real Postgres. They cover batches spanning multiple parents, keys requested under one parent not matching events of another, and satisfied-order assignment, including that re-satisfying an entry keeps its original order.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: A Cursor agent (Claude) wrote the query rewrites, the tests, and this description, and ran the buffer-read measurements. I reviewed the changes before submitting.

</details>
