### PR TITLE
fix(dashboard): correctly show duration and cancellation reason for orchestrator tasks

### DIFF
--- a/api/v1/server/oas/transformers/v1/tasks.go
+++ b/api/v1/server/oas/transformers/v1/tasks.go
@@ -394,7 +394,14 @@ func ToWorkflowRunDetails(
 	opts ...PayloadOption,
 ) (gen.V1WorkflowRunDetails, error) {
 	o := applyPayloadOptions(opts)
-	duration := int(workflowRun.FinishedAt.Time.Sub(workflowRun.StartedAt.Time).Milliseconds())
+
+	var duration *int
+
+	if workflowRun.StartedAt.Valid && workflowRun.FinishedAt.Valid {
+		durInt := int(workflowRun.FinishedAt.Time.Sub(workflowRun.StartedAt.Time).Milliseconds())
+		duration = &durInt
+	}
+
 	input := jsonToMap(workflowRun.Input)
 	output := emptyJSON()
 	additionalMetadata := jsonToMap(workflowRun.AdditionalMetadata)
@@ -417,7 +424,7 @@ func ToWorkflowRunDetails(
 		AdditionalMetadata:   additionalMetadataPtr,
 		CreatedAt:            &workflowRun.CreatedAt.Time,
 		DisplayName:          workflowRun.DisplayName,
-		Duration:             &duration,
+		Duration:             duration,
 		ErrorMessage:         &workflowRun.ErrorMessage,
 		FinishedAt:           &workflowRun.FinishedAt.Time,
 		ParentTaskExternalId: workflowRun.ParentTaskExternalId,

--- a/api/v1/server/oas/transformers/v1/tasks.go
+++ b/api/v1/server/oas/transformers/v1/tasks.go
@@ -402,6 +402,12 @@ func ToWorkflowRunDetails(
 		duration = &durInt
 	}
 
+	var startedAt *time.Time
+
+	if workflowRun.StartedAt.Valid {
+		startedAt = &workflowRun.StartedAt.Time
+	}
+
 	input := jsonToMap(workflowRun.Input)
 	output := emptyJSON()
 	additionalMetadata := jsonToMap(workflowRun.AdditionalMetadata)
@@ -433,7 +439,7 @@ func ToWorkflowRunDetails(
 			CreatedAt: workflowRun.InsertedAt.Time,
 			UpdatedAt: workflowRun.InsertedAt.Time,
 		},
-		StartedAt:          &workflowRun.StartedAt.Time,
+		StartedAt:          startedAt,
 		Status:             wrStatus,
 		TenantId:           workflowRun.TenantID,
 		WorkflowId:         workflowRun.WorkflowID,

--- a/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/header.tsx
+++ b/frontend/app/src/pages/main/v1/workflow-runs-v1/$run/v2components/header.tsx
@@ -100,7 +100,7 @@ const V1RunSummary = () => {
         <RelativeDate date={workflowRun.startedAt} />
       </div>,
     );
-  } else {
+  } else if (workflowRun.status === V1TaskStatus.RUNNING) {
     timings.push(
       <div key="running" className="text-sm text-muted-foreground">
         Running

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -590,7 +590,7 @@ WITH input AS (
 ), error_message AS (
     SELECT
         DISTINCT ON (e.task_id) e.task_id::bigint,
-        COALESCE(e.error_message, e.additional__event_message) AS error_message
+        e.error_message
     FROM
         relevant_events e
     JOIN
@@ -600,9 +600,9 @@ WITH input AS (
             AND e.task_inserted_at = mrc.task_inserted_at
             AND e.retry_count = mrc.max_retry_count
     WHERE
-        e.readable_status = ANY(ARRAY['FAILED', 'CANCELLED']::v1_readable_status_olap[])
+        e.readable_status = 'FAILED'
     ORDER BY
-        e.task_id, e.retry_count DESC, e.event_timestamp DESC
+        e.task_id, e.retry_count DESC
 ), task_output AS (
     SELECT
         DISTINCT ON (task_id)
@@ -1431,13 +1431,13 @@ WITH input AS (
 ), error_message AS (
     SELECT
         DISTINCT ON (e.run_id) e.run_id::bigint,
-        COALESCE(e.error_message, e.additional__event_message) AS error_message
+        e.error_message
     FROM
         relevant_events e
     WHERE
-        e.readable_status IN ('FAILED', 'CANCELLED')
+        e.readable_status = 'FAILED'
     ORDER BY
-        e.run_id, e.retry_count DESC, e.event_timestamp DESC
+        e.run_id, e.retry_count DESC
 ), task_output AS (
     SELECT
         run_id,

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -318,6 +318,16 @@ WITH tasks AS (
     WHERE
         lt.external_id = @workflowRunId::uuid
         AND lt.tenant_id = @tenantId::uuid
+        AND (
+            dt.task_id != dt.dag_id
+            OR NOT EXISTS (
+                SELECT 1
+                FROM v1_dag_to_task_olap other
+                WHERE other.dag_id = dt.dag_id
+                    AND other.dag_inserted_at = dt.dag_inserted_at
+                    AND other.task_id != other.dag_id
+            )
+        )
 ), aggregated_events AS (
     SELECT
         e.tenant_id,

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -312,60 +312,58 @@ LIMIT @eventLimit::bigint OFFSET @eventOffset::bigint;
 
 -- name: ListTaskEventsForWorkflowRun :many
 WITH tasks AS (
-    SELECT dt.task_id, dt.task_inserted_at
+    SELECT dt.task_id, dt.task_inserted_at, dt.dag_id, dt.dag_inserted_at
     FROM v1_lookup_table_olap lt
     JOIN v1_dag_to_task_olap dt ON lt.dag_id = dt.dag_id AND lt.inserted_at = dt.dag_inserted_at
     WHERE
         lt.external_id = @workflowRunId::uuid
         AND lt.tenant_id = @tenantId::uuid
 ), aggregated_events AS (
-  SELECT
-    tenant_id,
-    task_id,
-    task_inserted_at,
-    retry_count,
-    event_type,
-    durable_invocation_count,
-    MIN(event_timestamp)::timestamptz AS time_first_seen,
-    MAX(event_timestamp)::timestamptz AS time_last_seen,
-    COUNT(*) AS count,
-    MIN(id) AS first_id
-  FROM v1_task_events_olap
-  WHERE
-    tenant_id = @tenantId::uuid
-    AND (task_id, task_inserted_at) IN (SELECT task_id, task_inserted_at FROM tasks)
-  GROUP BY tenant_id, task_id, task_inserted_at, retry_count, event_type, durable_invocation_count
+    SELECT
+        e.tenant_id,
+        e.task_id,
+        e.task_inserted_at,
+        t.dag_id,
+        t.dag_inserted_at,
+        e.retry_count,
+        e.event_type,
+        e.durable_invocation_count,
+        MIN(e.event_timestamp)::timestamptz AS time_first_seen,
+        MAX(e.event_timestamp)::timestamptz AS time_last_seen,
+        COUNT(*) AS count,
+        MIN(e.id) AS first_id
+    FROM v1_task_events_olap e
+    JOIN tasks t ON t.task_id = e.task_id AND t.task_inserted_at = e.task_inserted_at
+    WHERE
+        e.tenant_id = @tenantId::uuid
+    GROUP BY e.tenant_id, e.task_id, e.task_inserted_at, t.dag_id, t.dag_inserted_at, e.retry_count, e.event_type, e.durable_invocation_count
 )
 SELECT
-  a.tenant_id,
-  a.task_id,
-  a.task_inserted_at,
-  a.retry_count,
-  a.event_type,
-  a.durable_invocation_count,
-  a.time_first_seen,
-  a.time_last_seen,
-  a.count,
-  t.id,
-  t.event_timestamp,
-  t.readable_status,
-  t.error_message,
-  t.output,
-  t.external_id AS event_external_id,
-  t.worker_id,
-  t.additional__event_data,
-  t.additional__event_message,
-  tsk.display_name,
-  tsk.external_id AS task_external_id
+    a.tenant_id,
+    a.task_id,
+    a.task_inserted_at,
+    a.retry_count,
+    a.event_type,
+    a.durable_invocation_count,
+    a.time_first_seen,
+    a.time_last_seen,
+    a.count,
+    e.id,
+    e.event_timestamp,
+    e.readable_status,
+    e.error_message,
+    e.output,
+    e.external_id AS event_external_id,
+    e.worker_id,
+    e.additional__event_data,
+    e.additional__event_message,
+    COALESCE(t.display_name, d.display_name) AS display_name,
+    COALESCE(t.external_id, d.external_id) AS task_external_id
 FROM aggregated_events a
-JOIN v1_task_events_olap t
-  ON t.tenant_id = a.tenant_id
-  AND t.task_id = a.task_id
-  AND t.task_inserted_at = a.task_inserted_at
-  AND t.id = a.first_id
-JOIN v1_tasks_olap tsk
-    ON (tsk.tenant_id, tsk.id, tsk.inserted_at) = (t.tenant_id, t.task_id, t.task_inserted_at)
-ORDER BY a.time_first_seen DESC, t.event_timestamp DESC;
+JOIN v1_task_events_olap e ON (e.task_id, e.task_inserted_at, e.tenant_id, e.id) = (a.task_id, a.task_inserted_at, a.tenant_id, a.first_id)
+LEFT JOIN v1_tasks_olap t ON (t.inserted_at, t.id, t.tenant_id) = (e.task_inserted_at, e.task_id, e.tenant_id)
+LEFT JOIN v1_dags_olap d ON (d.inserted_at, d.id, d.tenant_id) = (a.dag_inserted_at, a.dag_id, a.tenant_id)
+ORDER BY a.time_first_seen DESC, e.event_timestamp DESC;
 
 -- name: PopulateSingleTaskRunData :one
 WITH selected_retry_count AS (
@@ -436,11 +434,11 @@ WITH selected_retry_count AS (
     LIMIT 1
 ), error_message AS (
     SELECT
-        error_message
+        COALESCE(error_message, additional__event_message) AS error_message
     FROM
         relevant_events
     WHERE
-        readable_status = 'FAILED'
+        readable_status IN ('FAILED', 'CANCELLED')
     ORDER BY
         event_timestamp DESC
     LIMIT 1
@@ -592,7 +590,7 @@ WITH input AS (
 ), error_message AS (
     SELECT
         DISTINCT ON (e.task_id) e.task_id::bigint,
-        e.error_message
+        COALESCE(e.error_message, e.additional__event_message) AS error_message
     FROM
         relevant_events e
     JOIN
@@ -602,9 +600,9 @@ WITH input AS (
             AND e.task_inserted_at = mrc.task_inserted_at
             AND e.retry_count = mrc.max_retry_count
     WHERE
-        e.readable_status = 'FAILED'
+        e.readable_status = ANY(ARRAY['FAILED', 'CANCELLED']::v1_readable_status_olap[])
     ORDER BY
-        e.task_id, e.retry_count DESC
+        e.task_id, e.retry_count DESC, e.event_timestamp DESC
 ), task_output AS (
     SELECT
         DISTINCT ON (task_id)
@@ -1433,13 +1431,13 @@ WITH input AS (
 ), error_message AS (
     SELECT
         DISTINCT ON (e.run_id) e.run_id::bigint,
-        e.error_message
+        COALESCE(e.error_message, e.additional__event_message) AS error_message
     FROM
         relevant_events e
     WHERE
-        e.readable_status = 'FAILED'
+        e.readable_status IN ('FAILED', 'CANCELLED')
     ORDER BY
-        e.run_id, e.retry_count DESC
+        e.run_id, e.retry_count DESC, e.event_timestamp DESC
 ), task_output AS (
     SELECT
         run_id,
@@ -1636,13 +1634,13 @@ WITH runs AS (
     JOIN max_retry_counts mrc ON (e.task_id, e.retry_count) = (mrc.task_id, mrc.max_retry_count)
 ), error_message AS (
     SELECT
-        e.error_message
+        COALESCE(e.error_message, e.additional__event_message) AS error_message
     FROM
         relevant_events e
     WHERE
-        e.readable_status = 'FAILED'
+        e.readable_status IN ('FAILED', 'CANCELLED')
     ORDER BY
-        e.retry_count DESC
+        e.retry_count DESC, e.event_timestamp DESC
     LIMIT 1
 ), output_event_external_id AS (
     SELECT

--- a/pkg/repository/sqlcv1/olap.sql
+++ b/pkg/repository/sqlcv1/olap.sql
@@ -434,11 +434,11 @@ WITH selected_retry_count AS (
     LIMIT 1
 ), error_message AS (
     SELECT
-        COALESCE(error_message, additional__event_message) AS error_message
+        error_message
     FROM
         relevant_events
     WHERE
-        readable_status IN ('FAILED', 'CANCELLED')
+        readable_status = 'FAILED'
     ORDER BY
         event_timestamp DESC
     LIMIT 1
@@ -1634,13 +1634,13 @@ WITH runs AS (
     JOIN max_retry_counts mrc ON (e.task_id, e.retry_count) = (mrc.task_id, mrc.max_retry_count)
 ), error_message AS (
     SELECT
-        COALESCE(e.error_message, e.additional__event_message) AS error_message
+        e.error_message
     FROM
         relevant_events e
     WHERE
-        e.readable_status IN ('FAILED', 'CANCELLED')
+        e.readable_status = 'FAILED'
     ORDER BY
-        e.retry_count DESC, e.event_timestamp DESC
+        e.retry_count DESC
     LIMIT 1
 ), output_event_external_id AS (
     SELECT

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -1831,60 +1831,58 @@ func (q *Queries) ListTaskEvents(ctx context.Context, db DBTX, arg ListTaskEvent
 
 const listTaskEventsForWorkflowRun = `-- name: ListTaskEventsForWorkflowRun :many
 WITH tasks AS (
-    SELECT dt.task_id, dt.task_inserted_at
+    SELECT dt.task_id, dt.task_inserted_at, dt.dag_id, dt.dag_inserted_at
     FROM v1_lookup_table_olap lt
     JOIN v1_dag_to_task_olap dt ON lt.dag_id = dt.dag_id AND lt.inserted_at = dt.dag_inserted_at
     WHERE
         lt.external_id = $1::uuid
         AND lt.tenant_id = $2::uuid
 ), aggregated_events AS (
-  SELECT
-    tenant_id,
-    task_id,
-    task_inserted_at,
-    retry_count,
-    event_type,
-    durable_invocation_count,
-    MIN(event_timestamp)::timestamptz AS time_first_seen,
-    MAX(event_timestamp)::timestamptz AS time_last_seen,
-    COUNT(*) AS count,
-    MIN(id) AS first_id
-  FROM v1_task_events_olap
-  WHERE
-    tenant_id = $2::uuid
-    AND (task_id, task_inserted_at) IN (SELECT task_id, task_inserted_at FROM tasks)
-  GROUP BY tenant_id, task_id, task_inserted_at, retry_count, event_type, durable_invocation_count
+    SELECT
+        e.tenant_id,
+        e.task_id,
+        e.task_inserted_at,
+        t.dag_id,
+        t.dag_inserted_at,
+        e.retry_count,
+        e.event_type,
+        e.durable_invocation_count,
+        MIN(e.event_timestamp)::timestamptz AS time_first_seen,
+        MAX(e.event_timestamp)::timestamptz AS time_last_seen,
+        COUNT(*) AS count,
+        MIN(e.id) AS first_id
+    FROM v1_task_events_olap e
+    JOIN tasks t ON t.task_id = e.task_id AND t.task_inserted_at = e.task_inserted_at
+    WHERE
+        e.tenant_id = $2::uuid
+    GROUP BY e.tenant_id, e.task_id, e.task_inserted_at, t.dag_id, t.dag_inserted_at, e.retry_count, e.event_type, e.durable_invocation_count
 )
 SELECT
-  a.tenant_id,
-  a.task_id,
-  a.task_inserted_at,
-  a.retry_count,
-  a.event_type,
-  a.durable_invocation_count,
-  a.time_first_seen,
-  a.time_last_seen,
-  a.count,
-  t.id,
-  t.event_timestamp,
-  t.readable_status,
-  t.error_message,
-  t.output,
-  t.external_id AS event_external_id,
-  t.worker_id,
-  t.additional__event_data,
-  t.additional__event_message,
-  tsk.display_name,
-  tsk.external_id AS task_external_id
+    a.tenant_id,
+    a.task_id,
+    a.task_inserted_at,
+    a.retry_count,
+    a.event_type,
+    a.durable_invocation_count,
+    a.time_first_seen,
+    a.time_last_seen,
+    a.count,
+    e.id,
+    e.event_timestamp,
+    e.readable_status,
+    e.error_message,
+    e.output,
+    e.external_id AS event_external_id,
+    e.worker_id,
+    e.additional__event_data,
+    e.additional__event_message,
+    COALESCE(t.display_name, d.display_name) AS display_name,
+    COALESCE(t.external_id, d.external_id) AS task_external_id
 FROM aggregated_events a
-JOIN v1_task_events_olap t
-  ON t.tenant_id = a.tenant_id
-  AND t.task_id = a.task_id
-  AND t.task_inserted_at = a.task_inserted_at
-  AND t.id = a.first_id
-JOIN v1_tasks_olap tsk
-    ON (tsk.tenant_id, tsk.id, tsk.inserted_at) = (t.tenant_id, t.task_id, t.task_inserted_at)
-ORDER BY a.time_first_seen DESC, t.event_timestamp DESC
+JOIN v1_task_events_olap e ON (e.task_id, e.task_inserted_at, e.tenant_id, e.id) = (a.task_id, a.task_inserted_at, a.tenant_id, a.first_id)
+LEFT JOIN v1_tasks_olap t ON (t.inserted_at, t.id, t.tenant_id) = (e.task_inserted_at, e.task_id, e.tenant_id)
+LEFT JOIN v1_dags_olap d ON (d.inserted_at, d.id, d.tenant_id) = (a.dag_inserted_at, a.dag_id, a.tenant_id)
+ORDER BY a.time_first_seen DESC, e.event_timestamp DESC
 `
 
 type ListTaskEventsForWorkflowRunParams struct {
@@ -2292,13 +2290,13 @@ WITH input AS (
 ), error_message AS (
     SELECT
         DISTINCT ON (e.run_id) e.run_id::bigint,
-        e.error_message
+        COALESCE(e.error_message, e.additional__event_message) AS error_message
     FROM
         relevant_events e
     WHERE
-        e.readable_status = 'FAILED'
+        e.readable_status IN ('FAILED', 'CANCELLED')
     ORDER BY
-        e.run_id, e.retry_count DESC
+        e.run_id, e.retry_count DESC, e.event_timestamp DESC
 ), task_output AS (
     SELECT
         run_id,
@@ -2545,11 +2543,11 @@ WITH selected_retry_count AS (
     LIMIT 1
 ), error_message AS (
     SELECT
-        error_message
+        COALESCE(error_message, additional__event_message) AS error_message
     FROM
         relevant_events
     WHERE
-        readable_status = 'FAILED'
+        readable_status IN ('FAILED', 'CANCELLED')
     ORDER BY
         event_timestamp DESC
     LIMIT 1
@@ -2799,7 +2797,7 @@ WITH input AS (
 ), error_message AS (
     SELECT
         DISTINCT ON (e.task_id) e.task_id::bigint,
-        e.error_message
+        COALESCE(e.error_message, e.additional__event_message) AS error_message
     FROM
         relevant_events e
     JOIN
@@ -2809,9 +2807,9 @@ WITH input AS (
             AND e.task_inserted_at = mrc.task_inserted_at
             AND e.retry_count = mrc.max_retry_count
     WHERE
-        e.readable_status = 'FAILED'
+        e.readable_status = ANY(ARRAY['FAILED', 'CANCELLED']::v1_readable_status_olap[])
     ORDER BY
-        e.task_id, e.retry_count DESC
+        e.task_id, e.retry_count DESC, e.event_timestamp DESC
 ), task_output AS (
     SELECT
         DISTINCT ON (task_id)
@@ -3296,13 +3294,13 @@ WITH runs AS (
     JOIN max_retry_counts mrc ON (e.task_id, e.retry_count) = (mrc.task_id, mrc.max_retry_count)
 ), error_message AS (
     SELECT
-        e.error_message
+        COALESCE(e.error_message, e.additional__event_message) AS error_message
     FROM
         relevant_events e
     WHERE
-        e.readable_status = 'FAILED'
+        e.readable_status IN ('FAILED', 'CANCELLED')
     ORDER BY
-        e.retry_count DESC
+        e.retry_count DESC, e.event_timestamp DESC
     LIMIT 1
 ), output_event_external_id AS (
     SELECT

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -1837,6 +1837,16 @@ WITH tasks AS (
     WHERE
         lt.external_id = $1::uuid
         AND lt.tenant_id = $2::uuid
+        AND (
+            dt.task_id != dt.dag_id
+            OR NOT EXISTS (
+                SELECT 1
+                FROM v1_dag_to_task_olap other
+                WHERE other.dag_id = dt.dag_id
+                    AND other.dag_inserted_at = dt.dag_inserted_at
+                    AND other.task_id != other.dag_id
+            )
+        )
 ), aggregated_events AS (
     SELECT
         e.tenant_id,

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -2543,11 +2543,11 @@ WITH selected_retry_count AS (
     LIMIT 1
 ), error_message AS (
     SELECT
-        COALESCE(error_message, additional__event_message) AS error_message
+        error_message
     FROM
         relevant_events
     WHERE
-        readable_status IN ('FAILED', 'CANCELLED')
+        readable_status = 'FAILED'
     ORDER BY
         event_timestamp DESC
     LIMIT 1
@@ -3294,13 +3294,13 @@ WITH runs AS (
     JOIN max_retry_counts mrc ON (e.task_id, e.retry_count) = (mrc.task_id, mrc.max_retry_count)
 ), error_message AS (
     SELECT
-        COALESCE(e.error_message, e.additional__event_message) AS error_message
+        e.error_message
     FROM
         relevant_events e
     WHERE
-        e.readable_status IN ('FAILED', 'CANCELLED')
+        e.readable_status = 'FAILED'
     ORDER BY
-        e.retry_count DESC, e.event_timestamp DESC
+        e.retry_count DESC
     LIMIT 1
 ), output_event_external_id AS (
     SELECT

--- a/pkg/repository/sqlcv1/olap.sql.go
+++ b/pkg/repository/sqlcv1/olap.sql.go
@@ -2290,13 +2290,13 @@ WITH input AS (
 ), error_message AS (
     SELECT
         DISTINCT ON (e.run_id) e.run_id::bigint,
-        COALESCE(e.error_message, e.additional__event_message) AS error_message
+        e.error_message
     FROM
         relevant_events e
     WHERE
-        e.readable_status IN ('FAILED', 'CANCELLED')
+        e.readable_status = 'FAILED'
     ORDER BY
-        e.run_id, e.retry_count DESC, e.event_timestamp DESC
+        e.run_id, e.retry_count DESC
 ), task_output AS (
     SELECT
         run_id,
@@ -2797,7 +2797,7 @@ WITH input AS (
 ), error_message AS (
     SELECT
         DISTINCT ON (e.task_id) e.task_id::bigint,
-        COALESCE(e.error_message, e.additional__event_message) AS error_message
+        e.error_message
     FROM
         relevant_events e
     JOIN
@@ -2807,9 +2807,9 @@ WITH input AS (
             AND e.task_inserted_at = mrc.task_inserted_at
             AND e.retry_count = mrc.max_retry_count
     WHERE
-        e.readable_status = ANY(ARRAY['FAILED', 'CANCELLED']::v1_readable_status_olap[])
+        e.readable_status = 'FAILED'
     ORDER BY
-        e.task_id, e.retry_count DESC, e.event_timestamp DESC
+        e.task_id, e.retry_count DESC
 ), task_output AS (
     SELECT
         DISTINCT ON (task_id)


### PR DESCRIPTION
# Description

Durations were showing as massive numbers (zero value issue) and the cancellation reason wasn't showing up, so this fixes that

Better to review without whitespace: https://github.com/hatchet-dev/hatchet/pull/4811/changes?w=1

<img width="1728" height="968" alt="Screenshot 2026-08-26 at 5 07 34 PM" src="https://github.com/user-attachments/assets/0aef0044-f5f1-46b8-ba0f-fcb1c9f953dd" />

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI

</details>
