### PR TITLE
Improved billing and usage page

### DIFF
--- a/frontend/app/src/components/v1/cloud/billing/index.ts
+++ b/frontend/app/src/components/v1/cloud/billing/index.ts
@@ -1,3 +1,4 @@
 export * from './plan-selector';
 export * from './subscription';
 export * from './subscription-history';
+export * from './invoices';

--- a/frontend/app/src/components/v1/cloud/billing/invoice-formatters.test.ts
+++ b/frontend/app/src/components/v1/cloud/billing/invoice-formatters.test.ts
@@ -1,0 +1,64 @@
+import {
+  formatInvoiceAmount,
+  formatInvoiceDate,
+  formatPlanIds,
+  invoiceStatusBadge,
+} from './invoice-formatters';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+describe('formatInvoiceAmount', () => {
+  it('formats cents in the given currency', () => {
+    assert.equal(formatInvoiceAmount(51000, 'usd'), '$510.00');
+  });
+
+  it('falls back to USD for invalid currencies', () => {
+    assert.equal(formatInvoiceAmount(100, 'not-a-currency'), '$1.00');
+  });
+});
+
+describe('formatInvoiceDate', () => {
+  it('formats a valid timestamp', () => {
+    assert.notEqual(formatInvoiceDate('2026-07-30T16:31:00.000Z'), '—');
+  });
+
+  it('returns an em dash for missing or invalid values', () => {
+    assert.equal(formatInvoiceDate(), '—');
+    assert.equal(formatInvoiceDate('not-a-date'), '—');
+  });
+});
+
+describe('formatPlanIds', () => {
+  it('title-cases plan ids', () => {
+    assert.equal(formatPlanIds(['team_monthly']), 'Team Monthly');
+  });
+
+  it('joins multiple plan ids', () => {
+    assert.equal(
+      formatPlanIds(['team_monthly', 'task_runs']),
+      'Team Monthly, Task Runs',
+    );
+  });
+
+  it('uses a fallback when no plan ids are present', () => {
+    assert.equal(formatPlanIds([]), 'Invoice');
+    assert.equal(formatPlanIds(undefined), 'Invoice');
+  });
+});
+
+describe('invoiceStatusBadge', () => {
+  it('maps known statuses to badge variants', () => {
+    assert.deepEqual(invoiceStatusBadge('paid'), {
+      label: 'Paid',
+      variant: 'successful',
+    });
+    assert.deepEqual(invoiceStatusBadge('upcoming'), {
+      label: 'Upcoming',
+      variant: 'inProgress',
+    });
+    assert.deepEqual(invoiceStatusBadge('void'), {
+      label: 'Void',
+      variant: 'cancelled',
+    });
+  });
+});

--- a/frontend/app/src/components/v1/cloud/billing/invoice-formatters.ts
+++ b/frontend/app/src/components/v1/cloud/billing/invoice-formatters.ts
@@ -1,0 +1,96 @@
+import { BadgeProps } from '@/components/v1/ui/badge';
+
+export function formatInvoiceAmount(cents: number, currency = 'usd'): string {
+  try {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: currency.toUpperCase(),
+    }).format(cents / 100);
+  } catch {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+    }).format(cents / 100);
+  }
+}
+
+export function formatInvoiceDate(value?: string) {
+  if (!value) {
+    return '—';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+  return date.toLocaleString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+export function formatInvoicePeriod(start?: string, end?: string) {
+  const startLabel = formatInvoiceDate(start);
+  const endLabel = formatInvoiceDate(end);
+  if (startLabel === '—' && endLabel === '—') {
+    return null;
+  }
+  if (startLabel === '—') {
+    return endLabel;
+  }
+  if (endLabel === '—') {
+    return startLabel;
+  }
+  return `${startLabel} – ${endLabel}`;
+}
+
+export function formatPlanIds(planIds?: string[]) {
+  if (!planIds || planIds.length === 0) {
+    return 'Invoice';
+  }
+
+  return planIds
+    .map((planId) =>
+      planId
+        .split('_')
+        .filter(Boolean)
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' '),
+    )
+    .join(', ');
+}
+
+export function formatQuantity(quantity: number) {
+  return new Intl.NumberFormat('en-US').format(quantity);
+}
+
+export type InvoiceStatusTone = {
+  label: string;
+  variant: BadgeProps['variant'];
+};
+
+export function invoiceStatusBadge(status?: string): InvoiceStatusTone {
+  switch ((status ?? '').toLowerCase()) {
+    case 'paid':
+      return { label: 'Paid', variant: 'successful' };
+    case 'open':
+      return { label: 'Open', variant: 'inProgress' };
+    case 'draft':
+      return { label: 'Draft', variant: 'queued' };
+    case 'upcoming':
+      return { label: 'Upcoming', variant: 'inProgress' };
+    case 'void':
+      return { label: 'Void', variant: 'cancelled' };
+    case 'uncollectible':
+      return { label: 'Uncollectible', variant: 'failed' };
+    default:
+      return {
+        label: status
+          ? status.charAt(0).toUpperCase() + status.slice(1)
+          : 'Unknown',
+        variant: 'queued',
+      };
+  }
+}

--- a/frontend/app/src/components/v1/cloud/billing/invoices.tsx
+++ b/frontend/app/src/components/v1/cloud/billing/invoices.tsx
@@ -1,0 +1,263 @@
+import {
+  formatInvoiceAmount,
+  formatInvoiceDate,
+  formatPlanIds,
+  invoiceStatusBadge,
+} from './invoice-formatters';
+import { UpcomingInvoiceDialog } from './upcoming-invoice-dialog';
+import { Alert, AlertDescription, AlertTitle } from '@/components/v1/ui/alert';
+import { Badge } from '@/components/v1/ui/badge';
+import { Button } from '@/components/v1/ui/button';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/components/v1/ui/card';
+import { Skeleton } from '@/components/v1/ui/skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/v1/ui/table';
+import {
+  OrganizationInvoice,
+  OrganizationInvoicePreview,
+} from '@/lib/api/generated/control-plane/data-contracts';
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
+import { useMemo, useState } from 'react';
+
+interface InvoicesProps {
+  invoicePreviews?: OrganizationInvoicePreview[];
+  invoices?: OrganizationInvoice[];
+  isLoading?: boolean;
+  isError?: boolean;
+  onRetry?: () => void;
+}
+
+function InvoiceSectionLabel({ children }: { children: string }) {
+  return (
+    <span className="inline-flex items-center rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
+      {children}
+    </span>
+  );
+}
+
+function InvoiceTableSkeleton() {
+  return (
+    <Card
+      variant="light"
+      className="bg-transparent ring-1 ring-border/50 border-none"
+    >
+      <CardHeader className="p-4 border-b border-border/50">
+        <Skeleton className="h-4 w-24" />
+      </CardHeader>
+      <CardContent className="p-4 space-y-3">
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-3/4" />
+      </CardContent>
+    </Card>
+  );
+}
+
+function openHostedInvoice(url: string) {
+  window.open(url, '_blank', 'noopener,noreferrer');
+}
+
+function sortInvoices(invoices: OrganizationInvoice[]) {
+  return [...invoices].sort((a, b) => {
+    const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+    const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+    return bTime - aTime;
+  });
+}
+
+export function Invoices({
+  invoicePreviews,
+  invoices,
+  isLoading,
+  isError,
+  onRetry,
+}: InvoicesProps) {
+  const [selectedPreview, setSelectedPreview] =
+    useState<OrganizationInvoicePreview | null>(null);
+
+  const upcoming = invoicePreviews ?? [];
+  const previous = useMemo(() => sortInvoices(invoices ?? []), [invoices]);
+
+  if (isLoading) {
+    return <InvoiceTableSkeleton />;
+  }
+
+  if (isError) {
+    return (
+      <Alert variant="warn">
+        <AlertTitle>Invoices unavailable</AlertTitle>
+        <AlertDescription className="flex flex-col gap-3">
+          <span>
+            We couldn&apos;t load invoices for this organization. Your
+            subscription details are still available below.
+          </span>
+          {onRetry ? (
+            <div>
+              <Button size="sm" variant="outline" onClick={onRetry}>
+                Try again
+              </Button>
+            </div>
+          ) : null}
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (upcoming.length === 0 && previous.length === 0) {
+    return (
+      <Card
+        variant="light"
+        className="bg-transparent ring-1 ring-border/50 border-none"
+      >
+        <CardHeader className="p-4 border-b border-border/50">
+          <CardTitle className="font-mono font-normal tracking-wider uppercase text-xs text-muted-foreground">
+            Invoices
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-4">
+          <p className="text-sm text-muted-foreground">
+            No invoices yet. Upcoming and previous invoices will appear here.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {upcoming.length > 0 ? (
+        <div className="space-y-2">
+          <InvoiceSectionLabel>Upcoming</InvoiceSectionLabel>
+          <Card
+            variant="light"
+            className="bg-transparent ring-1 ring-border/50 border-none"
+          >
+            <CardContent className="p-0">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="px-4">Products</TableHead>
+                    <TableHead>Total</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Date</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {upcoming.map((preview, index) => {
+                    const status = invoiceStatusBadge('upcoming');
+                    return (
+                      <TableRow
+                        key={`${preview.planIds.join('-')}-${preview.invoiceAt}-${index}`}
+                        className="cursor-pointer"
+                        onClick={() => setSelectedPreview(preview)}
+                      >
+                        <TableCell className="px-4 font-medium text-foreground">
+                          {formatPlanIds(preview.planIds)}
+                        </TableCell>
+                        <TableCell className="text-foreground">
+                          {formatInvoiceAmount(
+                            preview.totalCents,
+                            preview.currency,
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant={status.variant}>{status.label}</Badge>
+                        </TableCell>
+                        <TableCell className="text-muted-foreground">
+                          {formatInvoiceDate(preview.invoiceAt)}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        </div>
+      ) : null}
+
+      {previous.length > 0 ? (
+        <div className="space-y-2">
+          <InvoiceSectionLabel>Previous</InvoiceSectionLabel>
+          <Card
+            variant="light"
+            className="bg-transparent ring-1 ring-border/50 border-none"
+          >
+            <CardContent className="p-0">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="px-4">Products</TableHead>
+                    <TableHead>Total</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Date</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {previous.map((invoice) => {
+                    const status = invoiceStatusBadge(invoice.status);
+                    const hostedInvoiceUrl = invoice.hostedInvoiceUrl;
+                    const canOpen = Boolean(hostedInvoiceUrl);
+                    return (
+                      <TableRow
+                        key={invoice.stripeId}
+                        className={canOpen ? 'cursor-pointer' : undefined}
+                        onClick={
+                          hostedInvoiceUrl
+                            ? () => openHostedInvoice(hostedInvoiceUrl)
+                            : undefined
+                        }
+                      >
+                        <TableCell className="px-4 font-medium text-foreground">
+                          <span className="inline-flex items-center gap-2">
+                            {formatPlanIds(invoice.planIds)}
+                            {canOpen ? (
+                              <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                            ) : null}
+                          </span>
+                        </TableCell>
+                        <TableCell className="text-foreground">
+                          {formatInvoiceAmount(
+                            invoice.totalCents,
+                            invoice.currency,
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant={status.variant}>{status.label}</Badge>
+                        </TableCell>
+                        <TableCell className="text-muted-foreground">
+                          {formatInvoiceDate(invoice.createdAt)}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        </div>
+      ) : null}
+
+      <UpcomingInvoiceDialog
+        preview={selectedPreview}
+        open={selectedPreview !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedPreview(null);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/app/src/components/v1/cloud/billing/upcoming-invoice-dialog.tsx
+++ b/frontend/app/src/components/v1/cloud/billing/upcoming-invoice-dialog.tsx
@@ -1,0 +1,117 @@
+import {
+  formatInvoiceAmount,
+  formatInvoiceDate,
+  formatInvoicePeriod,
+  formatQuantity,
+} from './invoice-formatters';
+import { Badge } from '@/components/v1/ui/badge';
+import { Button } from '@/components/v1/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/v1/ui/dialog';
+import { OrganizationInvoicePreview } from '@/lib/api/generated/control-plane/data-contracts';
+
+interface UpcomingInvoiceDialogProps {
+  preview: OrganizationInvoicePreview | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function UpcomingInvoiceDialog({
+  preview,
+  open,
+  onOpenChange,
+}: UpcomingInvoiceDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Upcoming invoice</DialogTitle>
+          <DialogDescription>
+            Estimated charges for the current billing cycle. Totals can change
+            as usage is reported.
+          </DialogDescription>
+        </DialogHeader>
+
+        {preview ? (
+          <div className="space-y-4">
+            <div className="flex items-baseline justify-between gap-4">
+              <p className="text-sm text-muted-foreground">
+                Invoice date {formatInvoiceDate(preview.invoiceAt)}
+              </p>
+              <p className="text-lg font-semibold text-foreground">
+                {formatInvoiceAmount(preview.totalCents, preview.currency)}
+              </p>
+            </div>
+
+            <div className="divide-y divide-border rounded-md border border-border/50">
+              {preview.lineItems.map((item, index) => {
+                const period = formatInvoicePeriod(
+                  item.periodStart,
+                  item.periodEnd,
+                );
+                return (
+                  <div
+                    key={`${item.planId}-${item.featureId ?? 'base'}-${index}`}
+                    className="p-4 space-y-2"
+                  >
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="min-w-0">
+                        <p className="font-medium text-foreground">
+                          {item.displayName}
+                        </p>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          {item.description}
+                        </p>
+                      </div>
+                      <p className="shrink-0 text-sm font-medium text-foreground">
+                        {formatInvoiceAmount(item.totalCents, preview.currency)}
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant="queued">
+                        Qty: {formatQuantity(item.quantity)}
+                      </Badge>
+                      {period ? (
+                        <span className="text-xs text-muted-foreground">
+                          {period}
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            {preview.subtotalCents !== preview.totalCents ? (
+              <div className="flex justify-between text-sm text-muted-foreground">
+                <span>Subtotal</span>
+                <span>
+                  {formatInvoiceAmount(preview.subtotalCents, preview.currency)}
+                </span>
+              </div>
+            ) : null}
+
+            <div className="flex justify-between text-sm font-medium text-foreground">
+              <span>Estimated total</span>
+              <span>
+                {formatInvoiceAmount(preview.totalCents, preview.currency)}
+              </span>
+            </div>
+          </div>
+        ) : null}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/app/src/lib/api/generated/control-plane/Api.ts
+++ b/frontend/app/src/lib/api/generated/control-plane/Api.ts
@@ -40,6 +40,7 @@ import {
   OrganizationEntitlements,
   OrganizationForUserList,
   OrganizationInviteList,
+  OrganizationInvoices,
   OrganizationMember,
   OrganizationPaymentMethodList,
   OrganizationTenant,
@@ -1718,6 +1719,26 @@ export class Api<
   ) =>
     this.request<OrganizationCreditBalance, APIErrors>({
       path: `/api/v1/control-plane/billing/organizations/${organization}/credit-balance`,
+      method: "GET",
+      secure: true,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get upcoming invoice previews and previous invoices for an organization
+   *
+   * @tags Billing
+   * @name OrganizationInvoicesGet
+   * @summary Get invoices for an organization
+   * @request GET:/api/v1/control-plane/billing/organizations/{organization}/invoices
+   * @secure
+   */
+  organizationInvoicesGet = (
+    organization: string,
+    params: RequestParams = {},
+  ) =>
+    this.request<OrganizationInvoices, APIErrors>({
+      path: `/api/v1/control-plane/billing/organizations/${organization}/invoices`,
       method: "GET",
       secure: true,
       format: "json",

--- a/frontend/app/src/lib/api/generated/control-plane/data-contracts.ts
+++ b/frontend/app/src/lib/api/generated/control-plane/data-contracts.ts
@@ -839,6 +839,97 @@ export interface Coupon {
   percent?: number;
 }
 
+export interface OrganizationInvoiceLineItemDiscount {
+  /** Discount amount in cents. */
+  amountOffCents: number;
+  /**
+   * Percentage discount, when the reward is a percent-off coupon.
+   * @format float
+   */
+  percentOff?: number;
+  /** Display name of the applied reward, when available. */
+  rewardName?: string;
+}
+
+export interface OrganizationInvoiceLineItem {
+  /** Plan or feature name to display for this line item. */
+  displayName: string;
+  /** Detailed description of the line item. */
+  description: string;
+  /** Amount before discounts and tax, in cents. */
+  subtotalCents: number;
+  /** Amount after discounts and tax, in cents. */
+  totalCents: number;
+  /** Autumn plan ID this line item belongs to. */
+  planId: string;
+  /** Autumn feature ID for usage line items, when present. */
+  featureId?: string;
+  /**
+   * Quantity billed for this line item.
+   * @format double
+   */
+  quantity: number;
+  /**
+   * Start of the usage or billing period for this line item.
+   * @format date-time
+   */
+  periodStart?: string;
+  /**
+   * End of the usage or billing period for this line item.
+   * @format date-time
+   */
+  periodEnd?: string;
+  /** Discounts applied to this line item. */
+  discounts?: OrganizationInvoiceLineItemDiscount[];
+}
+
+export interface OrganizationInvoicePreview {
+  /** Plan IDs contributing line items to this upcoming invoice. */
+  planIds: string[];
+  /**
+   * When this invoice will be created.
+   * @format date-time
+   */
+  invoiceAt: string;
+  /** ISO currency code for the invoice amounts. */
+  currency: string;
+  /** Total before discounts, in cents. */
+  subtotalCents: number;
+  /** Total after discounts, in cents. */
+  totalCents: number;
+  /** Usage accrued in the closing cycle plus recurring charges for the opening cycle. */
+  lineItems: OrganizationInvoiceLineItem[];
+}
+
+export interface OrganizationInvoice {
+  /** Plan IDs included on this invoice. */
+  planIds: string[];
+  /** Stripe invoice ID. */
+  stripeId: string;
+  /** Billing processor that owns this invoice. */
+  processorType?: string;
+  /** Invoice status (paid, open, draft, void, uncollectible). */
+  status: string;
+  /** Invoice total in cents. */
+  totalCents: number;
+  /** ISO currency code for the invoice amounts. */
+  currency: string;
+  /**
+   * When the invoice was created.
+   * @format date-time
+   */
+  createdAt: string;
+  /** URL to open the hosted invoice page. */
+  hostedInvoiceUrl?: string;
+}
+
+export interface OrganizationInvoices {
+  /** Upcoming invoices for the organization's subscriptions. */
+  invoicePreviews: OrganizationInvoicePreview[];
+  /** Previously issued invoices, most recent first. */
+  invoices: OrganizationInvoice[];
+}
+
 export interface OrganizationEntitlements {
   /** @example false */
   canSSO: boolean;

--- a/frontend/app/src/lib/api/queries.ts
+++ b/frontend/app/src/lib/api/queries.ts
@@ -64,6 +64,11 @@ export const queries = createQueryKeyStore({
         (await controlPlaneApi.organizationPaymentMethodsGet(organization))
           .data,
     }),
+    invoices: (organization: string) => ({
+      queryKey: ['organization-invoices:get', organization],
+      queryFn: async () =>
+        (await controlPlaneApi.organizationInvoicesGet(organization)).data,
+    }),
   },
   cloud: {
     createComputeDemoTemplate: (tenant: string, template: TemplateOptions) => ({

--- a/frontend/app/src/pages/organizations/$organization/billing.tsx
+++ b/frontend/app/src/pages/organizations/$organization/billing.tsx
@@ -1,5 +1,6 @@
 import { usePylon } from '@/components/support-chat';
 import {
+  Invoices,
   Subscription,
   SubscriptionHistory,
 } from '@/components/v1/cloud/billing';
@@ -180,6 +181,15 @@ function OrganizationBillingContent() {
     refetchInterval: isSyncing ? SYNC_POLL_INTERVAL_MS : false,
   });
 
+  const invoices = useQuery({
+    ...queries.controlPlane.invoices(organization),
+    enabled: isControlPlaneEnabled && canBill,
+    retry: (failureCount, error) => {
+      const status = getApiErrorStatus(error);
+      return status !== 401 && status !== 403 && failureCount < 3;
+    },
+  });
+
   const activePlanCode = resolveSubscriptionPlanCode(
     billingState.data?.currentSubscription,
     null,
@@ -305,6 +315,26 @@ function OrganizationBillingContent() {
         plans={billingState.data?.plans}
         coupons={billingState.data?.coupons}
       />
+
+      <div className="mt-12 space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">Invoices</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Upcoming charges and previously issued invoices for this
+            organization.
+          </p>
+        </div>
+
+        <Invoices
+          invoicePreviews={invoices.data?.invoicePreviews}
+          invoices={invoices.data?.invoices}
+          isLoading={invoices.isPending}
+          isError={invoices.isError}
+          onRetry={() => {
+            void invoices.refetch();
+          }}
+        />
+      </div>
 
       <div className="mt-12 space-y-4">
         <div>


### PR DESCRIPTION
## Summary
- Adds an Invoices section to the organization Billing & Usage page, above Plan history.
- Upcoming rows open an in-app usage dialog. Previous rows open Autumn's hosted invoice URL in a new tab.
- Invoice loading is isolated so a failure there does not break plan management.

Depends on the control-plane invoices API: https://github.com/hatchet-dev/hatchet-control-plane/pull/131

## Test plan
- [x] Invoice formatter unit tests
- [x] Local Billing & Usage page shows previous invoices for the seeded `sdks` org
- [ ] Upcoming invoice dialog on an org with a live paid Stripe subscription
- [ ] Previous row opens the hosted invoice in a new tab
- [ ] Invoice query error leaves subscription UI usable