### PR TITLE
test(python): add repro for durable non-determinism errors after eviction when children use thread/process offloading

### DIFF
--- a/sdks/python/examples/bug_tests/durable_child_thread_nondeterminism/driver.py
+++ b/sdks/python/examples/bug_tests/durable_child_thread_nondeterminism/driver.py
@@ -1,0 +1,139 @@
+"""Driver for the durable thread/process-pool nondeterminism repro.
+
+Per iteration:
+1. trigger document_pipeline
+2. while it runs, restore it whenever the engine evicts it (each restore
+   replays the durable function from the top against the recorded event log)
+3. after completion, replay the whole run once more via the runs API
+4. record any failure containing "non-determinism"
+
+Usage:
+    poetry run python -m examples.bug_tests.durable_child_thread_nondeterminism.driver [iterations] [mode]
+
+Modes:
+    threads   (default) children use asyncio.to_thread + ProcessPoolExecutor
+    nothreads same shape, no thread/process offloading at all
+    evict     threads + a long-tail child so the TTL eviction fires mid-run;
+              the driver restores the run instead of manually replaying
+"""
+
+import asyncio
+import sys
+from typing import Any
+
+from examples.bug_tests.durable_child_thread_nondeterminism.worker import (
+    PipelineInput,
+    document_pipeline,
+)
+from hatchet_sdk import Hatchet
+from hatchet_sdk.clients.rest.api.task_api import TaskApi
+
+POLL_INTERVAL_SECONDS = 0.25
+PHASE_TIMEOUT_SECONDS = 180
+
+hatchet = Hatchet()
+
+
+def _restore(task_external_id: str) -> None:
+    with hatchet.runs.client() as client:
+        TaskApi(client).v1_task_restore(task=task_external_id)
+
+
+async def _await_result_with_restores(
+    workflow_run_id: str, result_task: "asyncio.Task[Any]", label: str
+) -> tuple[str, str, int]:
+    """Wait for the run to finish, restoring on every eviction.
+
+    Returns (outcome, error_text, restore_count).
+    """
+    restores = 0
+    elapsed = 0.0
+
+    while not result_task.done():
+        if elapsed > PHASE_TIMEOUT_SECONDS:
+            result_task.cancel()
+            return "timeout", "", restores
+
+        details = await hatchet.runs.aio_get_details(workflow_run_id)
+        for task_run in details.task_runs.values():
+            if task_run.is_evicted:
+                restores += 1
+                print(
+                    f"    [{label}] restoring evicted task "
+                    f"{task_run.external_id} (restore #{restores})"
+                )
+                await asyncio.to_thread(_restore, task_run.external_id)
+
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)
+        elapsed += POLL_INTERVAL_SECONDS
+
+    try:
+        result = result_task.result()
+        n_docs = result.get("n_docs") if isinstance(result, dict) else None
+        return "completed", f"n_docs={n_docs}", restores
+    except Exception as e:  # noqa: BLE001 - we want the raw engine error text
+        return "failed", str(e), restores
+
+
+async def run_iteration(mode: str) -> list[tuple[str, str, str, int]]:
+    outcomes: list[tuple[str, str, str, int]] = []
+
+    pipeline_input = PipelineInput(
+        n_docs=8,
+        use_threads=mode in ("threads", "evict"),
+        long_tail_seconds=12.0 if mode.startswith("evict") else 0.0,
+    )
+
+    ref = await document_pipeline.aio_run(pipeline_input, wait_for_result=False)
+    print(f"  run {ref.workflow_run_id}")
+
+    result_task = asyncio.ensure_future(ref.aio_result())
+    outcome, detail, restores = await _await_result_with_restores(
+        ref.workflow_run_id, result_task, "initial"
+    )
+    print(f"  initial: {outcome} ({restores} restores) {detail[:200]}")
+    outcomes.append(("initial", outcome, detail, restores))
+
+    # in evict mode the eviction+restore cycle already exercised replay
+    if outcome == "completed" and mode != "evict":
+        await hatchet.runs.aio_replay(ref.workflow_run_id)
+        await asyncio.sleep(1)
+        result_task = asyncio.ensure_future(ref.aio_result())
+        outcome, detail, restores = await _await_result_with_restores(
+            ref.workflow_run_id, result_task, "replay"
+        )
+        print(f"  replay:  {outcome} ({restores} restores) {detail[:200]}")
+        outcomes.append(("replay", outcome, detail, restores))
+
+    return outcomes
+
+
+async def main() -> None:
+    iterations = int(sys.argv[1]) if len(sys.argv) > 1 else 10
+    mode = sys.argv[2] if len(sys.argv) > 2 else "threads"
+    print(f"mode: {mode}")
+
+    nondeterminism_hits: list[tuple[int, str, str]] = []
+    other_failures: list[tuple[int, str, str]] = []
+
+    for i in range(iterations):
+        print(f"iteration {i + 1}/{iterations}")
+        for phase, outcome, detail, _restores in await run_iteration(mode):
+            if outcome in ("failed", "timeout"):
+                if "non-determinism" in detail.lower():
+                    nondeterminism_hits.append((i, phase, detail))
+                else:
+                    other_failures.append((i, phase, f"{outcome}: {detail}"))
+
+    print()
+    print(f"=== SUMMARY ({iterations} iterations) ===")
+    print(f"nondeterminism errors: {len(nondeterminism_hits)}")
+    for i, phase, detail in nondeterminism_hits:
+        print(f"  iter {i} [{phase}]: {detail[:500]}")
+    print(f"other failures/timeouts: {len(other_failures)}")
+    for i, phase, detail in other_failures:
+        print(f"  iter {i} [{phase}]: {detail[:300]}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/sdks/python/examples/bug_tests/durable_child_thread_nondeterminism/worker.py
+++ b/sdks/python/examples/bug_tests/durable_child_thread_nondeterminism/worker.py
@@ -1,0 +1,144 @@
+"""Repro for reported nondeterminism errors on the virtualized (evictable)
+durable engine when non-durable child tasks use asyncio.to_thread and
+ProcessPoolExecutor.
+
+Shape of the reported workload (document pipeline):
+- durable parent runs several per-document flows concurrently via asyncio.gather
+- each flow spawns a non-durable child, does thread-offloaded work, then spawns
+  a second child (so later spawn ordering depends on thread/child timing)
+- children offload to asyncio.to_thread and a ProcessPoolExecutor
+- the parent has an eviction policy, so it can be evicted mid-run and replayed
+"""
+
+import asyncio
+import hashlib
+from concurrent.futures import ProcessPoolExecutor
+from datetime import timedelta
+from typing import Any
+
+from pydantic import BaseModel
+
+from hatchet_sdk import Context, DurableContext, Hatchet
+from hatchet_sdk.runnables.eviction import EvictionPolicy
+
+hatchet = Hatchet()
+
+EVICTION_TTL_SECONDS = 5
+
+_process_pool: ProcessPoolExecutor | None = None
+
+
+def _get_process_pool() -> ProcessPoolExecutor:
+    # NOTE: lazy so importing this module (e.g. from the driver) does not fork pools
+    global _process_pool
+    if _process_pool is None:
+        _process_pool = ProcessPoolExecutor(max_workers=2)
+    return _process_pool
+
+
+def _cpu_work(seed: int, rounds: int = 20_000) -> str:
+    h = hashlib.sha256(str(seed).encode())
+    for _ in range(rounds):
+        h = hashlib.sha256(h.digest())
+    return h.hexdigest()
+
+
+class DocStageInput(BaseModel):
+    doc_id: int
+    stage: str
+    sleep_seconds: float
+    use_threads: bool = True
+
+
+class PipelineInput(BaseModel):
+    n_docs: int = 8
+    use_threads: bool = True
+    # sleep for doc 0's extract child; set above the eviction TTL to force a
+    # TTL eviction while the parent is mid-gather
+    long_tail_seconds: float = 0.0
+
+
+@hatchet.task(input_validator=DocStageInput)
+async def doc_stage_child(input: DocStageInput, ctx: Context) -> dict[str, Any]:
+    thread_digest = ""
+    process_digest = ""
+
+    if input.use_threads:
+        thread_digest = await asyncio.to_thread(_cpu_work, input.doc_id)
+
+        loop = asyncio.get_running_loop()
+        process_digest = await loop.run_in_executor(
+            _get_process_pool(), _cpu_work, input.doc_id + 1000
+        )
+
+    await asyncio.sleep(input.sleep_seconds)
+
+    return {
+        "doc_id": input.doc_id,
+        "stage": input.stage,
+        "thread_digest": thread_digest[:8],
+        "process_digest": process_digest[:8],
+    }
+
+
+@hatchet.durable_task(
+    input_validator=PipelineInput,
+    execution_timeout=timedelta(minutes=5),
+    eviction_policy=EvictionPolicy(
+        ttl=timedelta(seconds=EVICTION_TTL_SECONDS),
+        allow_capacity_eviction=True,
+    ),
+)
+async def document_pipeline(
+    input: PipelineInput, ctx: DurableContext
+) -> dict[str, Any]:
+    async def per_doc(doc_id: int) -> dict[str, Any]:
+        extract_sleep = 1.0 + (doc_id % 4)
+        if doc_id == 0 and input.long_tail_seconds:
+            extract_sleep = input.long_tail_seconds
+
+        extract = await doc_stage_child.aio_run(
+            input=DocStageInput(
+                doc_id=doc_id,
+                stage="extract",
+                # variable child runtimes so completion order differs between
+                # the first invocation and post-eviction replays
+                sleep_seconds=extract_sleep,
+                use_threads=input.use_threads,
+            )
+        )
+
+        # thread-offloaded work between the two durable spawns, mirroring the
+        # reported asyncio.to_thread usage inside the pipeline
+        if input.use_threads:
+            await asyncio.to_thread(_cpu_work, doc_id)
+
+        # NOTE: all child inputs are deterministic functions of doc_id, so the
+        # idempotency hash for a given logical spawn is identical across
+        # replays; only scheduling/ordering can differ
+        classify = await doc_stage_child.aio_run(
+            input=DocStageInput(
+                doc_id=doc_id,
+                stage="classify",
+                sleep_seconds=((doc_id * 7) % 5) / 4,
+                use_threads=input.use_threads,
+            )
+        )
+
+        return {"extract": extract, "classify": classify}
+
+    results = await asyncio.gather(*(per_doc(i) for i in range(input.n_docs)))
+
+    return {"n_docs": len(results), "results": results}
+
+
+def main() -> None:
+    worker = hatchet.worker(
+        "durable-thread-nondeterminism-worker",
+        workflows=[document_pipeline, doc_stage_child],
+    )
+    worker.start()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Description

Adds a reproduction for reported non-determinism errors on the evictable ("virtualized") durable engine: a durable parent running concurrent child spawns via `asyncio.gather` fails on replay after eviction+restore with `non-determinism error in task … at node N:1` when the non-durable children (and the code between spawns) use `asyncio.to_thread` / `ProcessPoolExecutor` — even though all child inputs are fully deterministic. Reproduces at roughly a 25% rate per eviction/restore cycle on current `main` with SDK 1.38.1 (which already includes the #4733 callback-ordering fix); the same shape without thread/process offloading passes.

## Type of change

- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

- Add `examples/bug_tests/durable_child_thread_nondeterminism/worker.py`: durable parent gathering 8 two-stage child pipelines; children offload to `asyncio.to_thread` and a `ProcessPoolExecutor`, with a thread hop between the two durable spawns; eviction policy with a 5s TTL
- Add `driver.py`: triggers runs, restores on every eviction (and optionally replays completed runs), and tallies non-determinism failures across `threads` / `nothreads` / `evict` / `evict-nothreads` modes

## Checklist

Changes have been:

- [x] Tested (manually: `poetry run python -m examples.bug_tests.durable_child_thread_nondeterminism.driver 10 evict` against a local engine; 2/10 and 2/6 iterations fail with non-determinism errors, 0/6 without thread offloading)
- [x] Linted and formatted

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: repro worker/driver and PR description written with LLM assistance (Cursor); failure rates verified by running the driver locally

</details>