### PR TITLE
fix(python): isolate worker internal executor

### DIFF
--- a/sdks/python/hatchet_sdk/context/context.py
+++ b/sdks/python/hatchet_sdk/context/context.py
@@ -62,6 +62,7 @@ from hatchet_sdk.utils.timedelta_to_expression import (
     expr_to_timedelta,
     timedelta_to_expr,
 )
+from hatchet_sdk.utils.executor import hatchet_to_thread
 from hatchet_sdk.utils.typing import (
     DataclassInstance,
     JSONSerializableMapping,
@@ -179,7 +180,7 @@ class Context:
         ]
 
     async def aio_upsert_worker_labels(self, labels: dict[str, str | int]) -> None:
-        await asyncio.to_thread(self.upsert_worker_labels, labels)
+        await hatchet_to_thread(self.upsert_worker_labels, labels)
 
     @property
     def data(self) -> ActionPayload:
@@ -520,7 +521,7 @@ class Context:
         :return: None
         """
 
-        await asyncio.to_thread(self.log, line, raise_on_error)
+        await hatchet_to_thread(self.log, line, raise_on_error)
 
     def release_slot(self) -> None:
         """
@@ -536,7 +537,7 @@ class Context:
 
         :return: None
         """
-        return await asyncio.to_thread(
+        return await hatchet_to_thread(
             self._dispatcher_client.release_slot, self.task_run_id
         )
 
@@ -604,7 +605,7 @@ class Context:
         :return: None
         """
 
-        await asyncio.to_thread(self.refresh_timeout, increment_by)
+        await hatchet_to_thread(self.refresh_timeout, increment_by)
 
     @property
     def retry_count(self) -> int:
@@ -1186,7 +1187,7 @@ class DurableContext(Context):
         return result
 
     async def _now(self) -> MemoNowResult:
-        ts = await asyncio.to_thread(datetime.now, timezone.utc)
+        ts = await hatchet_to_thread(datetime.now, timezone.utc)
         return MemoNowResult(ts=ts)
 
     async def aio_now(self) -> datetime:

--- a/sdks/python/hatchet_sdk/context/worker_context.py
+++ b/sdks/python/hatchet_sdk/context/worker_context.py
@@ -1,4 +1,3 @@
-import asyncio
 from warnings import warn
 
 from hatchet_sdk.clients.dispatcher.dispatcher import DispatcherClient
@@ -46,7 +45,8 @@ class WorkerContext:
         self._labels.update(labels)
 
     async def async_upsert_labels(self, labels: dict[str, str | int]) -> None:
-        await asyncio.to_thread(self.upsert_labels, labels)
+        from hatchet_sdk.utils.executor import hatchet_to_thread
+        await hatchet_to_thread(self.upsert_labels, labels)
 
     def id(self) -> str | None:
         warn(

--- a/sdks/python/hatchet_sdk/hatchet.py
+++ b/sdks/python/hatchet_sdk/hatchet.py
@@ -136,7 +136,9 @@ class Hatchet:
         sidecar without blocking the event loop, and return once it has fully
         exited. No-op when no embedded engine is running in this process.
         """
-        await asyncio.to_thread(self.stop_embedded)
+        from hatchet_sdk.utils.executor import hatchet_to_thread
+
+        await hatchet_to_thread(self.stop_embedded)
 
     @property
     def cel(self) -> CELClient:

--- a/sdks/python/hatchet_sdk/runnables/task.py
+++ b/sdks/python/hatchet_sdk/runnables/task.py
@@ -66,6 +66,7 @@ from hatchet_sdk.serde import HATCHET_PYDANTIC_SENTINEL
 from hatchet_sdk.types.concurrency import ConcurrencyExpression
 from hatchet_sdk.types.labels import DesiredWorkerLabel
 from hatchet_sdk.types.priority import Priority
+from hatchet_sdk.utils.executor import hatchet_to_thread
 from hatchet_sdk.utils.timedelta_to_expression import Duration, timedelta_to_expr
 from hatchet_sdk.utils.typing import (
     AwaitableLike,
@@ -312,7 +313,7 @@ class Task(Generic[TWorkflowInput, R]):
             return entered_value, to_exit
 
         if is_sync_context_manager(value):
-            entered_value = await asyncio.to_thread(value.__enter__)
+            entered_value = await hatchet_to_thread(value.__enter__)
 
             if cms_to_exit is not None:
                 to_exit = value
@@ -402,7 +403,7 @@ class Task(Generic[TWorkflowInput, R]):
 
                     return DependencyToInject(
                         name=name,
-                        value=await asyncio.to_thread(item._fn, input, ctx, **deps),
+                        value=await hatchet_to_thread(item._fn, input, ctx, **deps),
                     )
 
         return None
@@ -450,7 +451,7 @@ class Task(Generic[TWorkflowInput, R]):
                 if is_async_context_manager(cm):
                     await cm.__aexit__(None, None, None)
                 elif is_sync_context_manager(cm):
-                    await asyncio.to_thread(cm.__exit__, None, None, None)
+                    await hatchet_to_thread(cm.__exit__, None, None, None)
 
     def call(
         self, ctx: Context | DurableContext, dependencies: dict[str, Any] | None = None

--- a/sdks/python/hatchet_sdk/utils/executor.py
+++ b/sdks/python/hatchet_sdk/utils/executor.py
@@ -1,0 +1,74 @@
+"""Dedicated internal executor for Hatchet SDK control-plane blocking work.
+
+This module provides a private, lifecycle-managed ``ThreadPoolExecutor`` used
+by the SDK's own ``asyncio.to_thread`` calls (e.g. logging, label updates,
+timeout refreshes, dependency resolution).
+
+The goal is to isolate Hatchet-internal blocking work from user code that
+may call ``asyncio.to_thread`` or ``loop.run_in_executor(None, ...)``.
+User code shares the event-loop **default** executor; this module gives the
+SDK its own pool so user saturation of the default executor cannot starve
+SDK control-plane operations (issue #4803).
+
+Lifecycle
+---------
+* The executor is created lazily on first use.
+* ``shutdown_executor()`` must be called during worker shutdown to avoid
+  thread leaks.  It is safe to call multiple times.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import functools
+import os
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, TypeVar
+
+_T = TypeVar("_T")
+
+_executor: ThreadPoolExecutor[Any] | None = None
+
+# Match CPython's default: min(32, os.cpu_count() + 4)
+_DEFAULT_WORKERS = min(32, (os.cpu_count() or 1) + 4)
+
+
+def _get_executor() -> ThreadPoolExecutor[Any]:
+    """Return (and lazily create) the dedicated Hatchet internal executor."""
+    global _executor
+    if _executor is None:
+        _executor = ThreadPoolExecutor(max_workers=_DEFAULT_WORKERS)
+    return _executor
+
+
+async def hatchet_to_thread(fn: Any, /, *args: Any, **kwargs: Any) -> Any:
+    """Run *fn* on the dedicated Hatchet internal executor.
+
+    Drop-in replacement for ``asyncio.to_thread`` that avoids the default
+    executor pool.  Accepts both positional and keyword arguments.
+
+    Preserves ``contextvars`` context identically to ``asyncio.to_thread``:
+    a snapshot of the current context is captured at call time and replayed
+    in the worker thread.
+    """
+    loop = asyncio.get_running_loop()
+    ctx = contextvars.copy_context()
+
+    if kwargs:
+        fn = functools.partial(fn, *args, **kwargs)
+        args = ()
+
+    return await loop.run_in_executor(_get_executor(), ctx.run, fn, *args)
+
+
+def shutdown_executor(*, wait: bool = True, cancel_futures: bool = False) -> None:
+    """Shut down the internal executor.
+
+    Intended to be called once during worker shutdown.
+    Safe to call multiple times (no-op if already shut down).
+    """
+    global _executor
+    if _executor is not None:
+        _executor.shutdown(wait=wait, cancel_futures=cancel_futures)
+        _executor = None

--- a/sdks/python/hatchet_sdk/worker/action_listener_process.py
+++ b/sdks/python/hatchet_sdk/worker/action_listener_process.py
@@ -351,8 +351,9 @@ class WorkerActionListenerProcess:
 
     # TODO move event methods to separate class
     async def _get_event(self) -> ActionEvent | QueuedBatchActionEvent | STOP_LOOP_TYPE:
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, self.event_queue.get)
+        from hatchet_sdk.utils.executor import hatchet_to_thread
+
+        return await hatchet_to_thread(self.event_queue.get)
 
     async def start_event_send_loop(self) -> None:
         while True:
@@ -529,8 +530,9 @@ class WorkerActionListenerProcess:
         This is the primary shutdown trigger — the parent calls
         _stop_listener_event.set() instead of sending SIGTERM.
         """
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, self._stop_event.wait)
+        from hatchet_sdk.utils.executor import hatchet_to_thread
+
+        await hatchet_to_thread(self._stop_event.wait)
         await self._stop_action_loop()
 
     async def _stop_action_loop(self) -> None:

--- a/sdks/python/hatchet_sdk/worker/runner/run_loop_manager.py
+++ b/sdks/python/hatchet_sdk/worker/runner/run_loop_manager.py
@@ -126,7 +126,9 @@ class WorkerActionRunLoopManager:
         logger.debug("action runner loop stopped")
 
     async def _get_action(self) -> Action | STOP_LOOP_TYPE:
-        return await self.loop.run_in_executor(None, self.action_queue.get)
+        from hatchet_sdk.utils.executor import hatchet_to_thread
+
+        return await hatchet_to_thread(self.action_queue.get)
 
     async def exit_gracefully(self) -> None:
         if self.killing:

--- a/sdks/python/hatchet_sdk/worker/worker.py
+++ b/sdks/python/hatchet_sdk/worker/worker.py
@@ -31,6 +31,7 @@ from hatchet_sdk.runnables.contextvars import task_count
 from hatchet_sdk.runnables.task import Task
 from hatchet_sdk.runnables.workflow import BaseWorkflow
 from hatchet_sdk.types.labels import WorkerLabel, _warn_if_dict_worker_labels
+from hatchet_sdk.utils.executor import hatchet_to_thread, shutdown_executor
 from hatchet_sdk.utils.typing import STOP_LOOP, STOP_LOOP_TYPE
 from hatchet_sdk.worker.action_listener_process import (
     ActionEvent,
@@ -733,6 +734,10 @@ class Worker:
         if self._action_runner is not None:
             self._action_runner.cleanup()
 
+        # Shut down the dedicated Hatchet internal executor so threads are
+        # reclaimed on worker exit (issue #4803).
+        shutdown_executor()
+
         # Also clean up the durable action runner (legacy mode)
         if self._legacy_durable_action_runner is not None:
             self._legacy_durable_action_runner.cleanup()
@@ -749,7 +754,7 @@ class Worker:
         stops routing new work here while in-flight tasks finish.
         """
         try:
-            worker_id = await asyncio.to_thread(self._worker_id_queue.get, timeout=10)
+            worker_id = await hatchet_to_thread(self._worker_id_queue.get, timeout=10)
         except Exception:
             logger.warning("could not read worker_id; skipping pause")
             return
@@ -805,9 +810,8 @@ class Worker:
             self._durable_event_queue.put(STOP_LOOP)
 
         if self._durable_action_listener_process is not None:
-            await asyncio.get_event_loop().run_in_executor(
-                None,
-                lambda: self._durable_action_listener_process.join(),  # type: ignore[union-attr]
+            await hatchet_to_thread(
+                self._durable_action_listener_process.join,  # type: ignore[union-attr]
             )
 
         try:

--- a/sdks/python/tests/unit/test_executor_isolation.py
+++ b/sdks/python/tests/unit/test_executor_isolation.py
@@ -1,0 +1,196 @@
+"""Regression tests for issue #4803: internal executor isolation.
+
+These tests verify that Hatchet SDK internal blocking operations
+can proceed even when the event-loop's **default** executor pool
+is fully saturated by user code, and that contextvars are preserved.
+
+The tests do NOT require a live Hatchet backend, Go engine, Docker,
+network, or API token.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+
+_TINY_POOL_SIZE = 2
+
+
+def _block_for_executor(released: threading.Event) -> None:
+    """Block until *released* is set (or 30 s timeout)."""
+    released.wait(timeout=30)
+
+
+class TestDefaultExecutorStarvation:
+    """Prove that asyncio.to_thread is blocked when the default executor
+    is saturated (the bug reported in #4803).
+    """
+
+    async def test_asyncio_to_thread_blocked_by_saturated_default_executor(
+        self,
+    ) -> None:
+        loop = asyncio.get_running_loop()
+        released = threading.Event()
+
+        tiny_executor = ThreadPoolExecutor(max_workers=_TINY_POOL_SIZE)
+        loop.set_default_executor(tiny_executor)
+
+        try:
+            loop.run_in_executor(tiny_executor, _block_for_executor, released)
+            loop.run_in_executor(tiny_executor, _block_for_executor, released)
+            await asyncio.sleep(0.05)
+
+            done = threading.Event()
+
+            async def _to_thread_call() -> None:
+                await asyncio.to_thread(done.wait, timeout=0.5)
+
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(_to_thread_call(), timeout=2.0)
+
+            assert not done.is_set()
+
+        finally:
+            released.set()
+            tiny_executor.shutdown(wait=False, cancel_futures=True)
+
+
+class TestHatchetInternalExecutorIsolation:
+    """Verify that hatchet_to_thread completes even when the default
+    executor is saturated — this is the fix for #4803.
+    """
+
+    async def test_hatchet_to_thread_completes_with_saturated_default_executor(
+        self,
+    ) -> None:
+        from hatchet_sdk.utils.executor import hatchet_to_thread
+
+        loop = asyncio.get_running_loop()
+        released = threading.Event()
+
+        tiny_executor = ThreadPoolExecutor(max_workers=_TINY_POOL_SIZE)
+        loop.set_default_executor(tiny_executor)
+
+        try:
+            loop.run_in_executor(tiny_executor, _block_for_executor, released)
+            loop.run_in_executor(tiny_executor, _block_for_executor, released)
+            await asyncio.sleep(0.05)
+
+            result = await hatchet_to_thread(lambda: 42)
+            assert result == 42
+
+        finally:
+            released.set()
+            tiny_executor.shutdown(wait=False, cancel_futures=True)
+
+    async def test_internal_work_not_blocked_by_user_thread_calls(
+        self,
+    ) -> None:
+        from hatchet_sdk.utils.executor import hatchet_to_thread
+
+        loop = asyncio.get_running_loop()
+        released = threading.Event()
+
+        tiny_executor = ThreadPoolExecutor(max_workers=_TINY_POOL_SIZE)
+        loop.set_default_executor(tiny_executor)
+
+        try:
+            loop.run_in_executor(tiny_executor, _block_for_executor, released)
+            loop.run_in_executor(tiny_executor, _block_for_executor, released)
+            await asyncio.sleep(0.05)
+
+            results: list[int] = []
+
+            async def _internal_work(value: int) -> None:
+                res = await hatchet_to_thread(lambda v=value: v * 10)
+                results.append(res)
+
+            await asyncio.gather(*[_internal_work(i) for i in range(5)])
+
+            assert sorted(results) == [0, 10, 20, 30, 40]
+
+        finally:
+            released.set()
+            tiny_executor.shutdown(wait=False, cancel_futures=True)
+
+    async def test_hatchet_to_thread_with_kwargs(self) -> None:
+        from hatchet_sdk.utils.executor import hatchet_to_thread
+
+        def _add(a: int, b: int) -> int:
+            return a + b
+
+        result = await hatchet_to_thread(_add, 3, b=7)
+        assert result == 10
+
+    async def test_hatchet_to_thread_exception_propagation(self) -> None:
+        from hatchet_sdk.utils.executor import hatchet_to_thread
+
+        def _fail() -> None:
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            await hatchet_to_thread(_fail)
+
+    async def test_contextvars_propagation(self) -> None:
+        """contextvars must propagate through hatchet_to_thread identically
+        to asyncio.to_thread — this is critical for Hatchet SDK internals
+        that rely on contextvars (ctx_step_run_id, ctx_worker_id, etc.).
+        """
+        from hatchet_sdk.utils.executor import hatchet_to_thread
+
+        test_var = contextvars.ContextVar("test_var", default="unset")
+        test_var.set("hello_from_caller")
+
+        def _read_in_thread() -> str:
+            return test_var.get()
+
+        # hatchet_to_thread must see the value set in the calling context
+        result = await hatchet_to_thread(_read_in_thread)
+        assert result == "hello_from_caller"
+
+        # Verify isolation: the value should NOT leak into a new context
+        test_var.set("second_value")
+
+        async def _read_in_new_ctx() -> str:
+            # Run in a fresh context (simulating a new task)
+            ctx = contextvars.copy_context()
+            loop = asyncio.get_running_loop()
+            from hatchet_sdk.utils.executor import _get_executor
+
+            def _inner() -> str:
+                return test_var.get()
+
+            return await loop.run_in_executor(_get_executor(), ctx.run, _inner)
+
+        # New context should have the copied value
+        result2 = await _read_in_new_ctx()
+        assert result2 == "second_value"
+
+
+class TestShutdownExecutor:
+    """Verify executor lifecycle."""
+
+    def test_shutdown_executor_is_idempotent(self) -> None:
+        from hatchet_sdk.utils.executor import shutdown_executor
+
+        shutdown_executor()
+        shutdown_executor()
+
+    def test_executor_lazy_creation(self) -> None:
+        import hatchet_sdk.utils.executor as mod
+
+        mod._executor = None
+
+        assert mod._executor is None
+
+        executor = mod._get_executor()
+        assert executor is not None
+        assert mod._executor is executor
+
+        mod.shutdown_executor()


### PR DESCRIPTION
## Summary

Prevents Hatchet Python worker control-plane operations from being starved when user code saturates asyncio's default thread executor.

### Changes

- isolates Hatchet internal blocking operations in a dedicated executor
- prevents user `asyncio.to_thread()` workloads from starving worker internals
- preserves `contextvars` propagation
- adds deterministic regression coverage

### Testing

- 8 executor-isolation regression tests passing
- 29 relevant existing tests passing
- 37 relevant tests passing total

Fixes #4803