### PR TITLE
fix(dashboard): hide managed workers tab again

### DIFF
--- a/frontend/app/src/pages/main/v1/index.tsx
+++ b/frontend/app/src/pages/main/v1/index.tsx
@@ -13,7 +13,7 @@ import {
   useContextFromParent,
 } from '@/lib/outlet';
 import { OutletWithContext, useOutletContext } from '@/lib/router-helpers';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { ReactNode, useEffect, useMemo } from 'react';
 
 export function MainShell({ children }: { children?: ReactNode }) {
@@ -39,14 +39,23 @@ export function MainShell({ children }: { children?: ReactNode }) {
     );
   }, [queryClient, tenantId]);
 
+  const listManagedWorkersQuery = useQuery({
+    ...queries.cloud.listManagedWorkers(tenantId ?? ''),
+    enabled: isControlPlaneEnabled && !!tenantId,
+  });
+
+  const hasManagedWorkers =
+    (listManagedWorkersQuery.data?.rows?.length || 0) > 0;
+
   const navSections = useMemo(
     () =>
       sideNavItems({
         canBill,
         isControlPlaneEnabled,
         orgId,
+        hasManagedWorkers,
       }),
-    [canBill, isControlPlaneEnabled, orgId],
+    [canBill, isControlPlaneEnabled, orgId, hasManagedWorkers],
   );
 
   const childCtx = useContextFromParent({

--- a/frontend/app/src/pages/main/v1/side-nav-items.tsx
+++ b/frontend/app/src/pages/main/v1/side-nav-items.tsx
@@ -20,6 +20,7 @@ export function sideNavItems(opts: {
   canBill?: boolean;
   isControlPlaneEnabled?: boolean;
   orgId?: string;
+  hasManagedWorkers?: boolean;
 }): SideNavSection[] {
   return [
     {
@@ -208,7 +209,7 @@ export function sideNavItems(opts: {
             />
           ),
         },
-        ...(opts.isControlPlaneEnabled
+        ...(opts.isControlPlaneEnabled && opts.hasManagedWorkers
           ? [
               {
                 key: 'managed-compute',


### PR DESCRIPTION
# Description

Hides the managed workers tab for anyone who doesn't have an existing managed worker since managed compute is deprecated

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI

</details>
