### PR TITLE
fix(engine): bind workflow event subscribe before OLAP wait

### DIFF
--- a/examples/typescript/e2e-worker.ts
+++ b/examples/typescript/e2e-worker.ts
@@ -68,6 +68,7 @@ import {
   batchChildBatchSpawn,
 } from './batch_assign/workflow';
 import { streamingTask } from './streaming/workflow';
+import { dagStream, longStream } from './subscribe_to_stream/workflow';
 import { timeoutTask, refreshTimeoutTask } from './timeout/workflow';
 import { webhookWorkflow } from './webhooks/workflow';
 import {
@@ -136,6 +137,8 @@ const workflows = [
   helloWorld,
   helloWorldDurable,
   streamingTask,
+  dagStream,
+  longStream,
   timeoutTask,
   refreshTimeoutTask,
   webhookWorkflow,

--- a/internal/msgqueue/rabbitmq/pubsub.go
+++ b/internal/msgqueue/rabbitmq/pubsub.go
@@ -252,18 +252,11 @@ func (p *PubSub) Pub(ctx context.Context, topic msgqueue.Topic, msg *msgqueue.Me
 	exchange := ""
 	routingKey := topic.Name()
 
-	// scheduler wake-ups expire immediately: the well-known partition queue
-	// outlives its consumer, so anything longer piles up stale wake signals
-	// while a scheduler is down
+	// scheduler wake-ups expire immediately
 	expiration := "0"
 
 	if topic.Kind() == msgqueue.TopicKindTenantStream {
-		// tenant-stream subscriber queues are exclusive + auto-delete, so
-		// queued messages vanish with the subscriber. A TTL of 0 also drops
-		// messages whenever the consumer is momentarily busy (burst of stream
-		// chunks vs. per-delivery acks), which loses mid-stream chunks under
-		// load. A short real TTL survives those windows without unbounded
-		// buildup.
+		// we need a ttl of above 0 for tenant streams so they don't get dropped on network blips
 		expiration = tenantStreamMsgTTL
 		// tenant streams ride the per-tenant fanout exchange; declare it lazily
 		if _, ok := p.exchangeCache.Get(topic.Name()); !ok {

--- a/internal/msgqueue/rabbitmq/pubsub.go
+++ b/internal/msgqueue/rabbitmq/pubsub.go
@@ -18,6 +18,12 @@ import (
 	"github.com/hatchet-dev/hatchet/pkg/random"
 )
 
+// tenantStreamMsgTTL is the per-message TTL (in milliseconds, RabbitMQ string
+// form) for tenant-stream publishes. It must comfortably exceed the
+// dispatcher's stream reorder/hangup-drain window (5s) so chunks published
+// while a consumer is briefly busy still get delivered.
+const tenantStreamMsgTTL = "30000"
+
 // PubSub implements msgqueue.PubSub over RabbitMQ. Tenant topics map to the
 // legacy per-tenant fanout exchanges ("<uuid>_v1") and scheduler partition
 // topics map to the scheduler's exclusive queue on the default exchange, so
@@ -246,7 +252,19 @@ func (p *PubSub) Pub(ctx context.Context, topic msgqueue.Topic, msg *msgqueue.Me
 	exchange := ""
 	routingKey := topic.Name()
 
+	// scheduler wake-ups expire immediately: the well-known partition queue
+	// outlives its consumer, so anything longer piles up stale wake signals
+	// while a scheduler is down
+	expiration := "0"
+
 	if topic.Kind() == msgqueue.TopicKindTenantStream {
+		// tenant-stream subscriber queues are exclusive + auto-delete, so
+		// queued messages vanish with the subscriber. A TTL of 0 also drops
+		// messages whenever the consumer is momentarily busy (burst of stream
+		// chunks vs. per-delivery acks), which loses mid-stream chunks under
+		// load. A short real TTL survives those windows without unbounded
+		// buildup.
+		expiration = tenantStreamMsgTTL
 		// tenant streams ride the per-tenant fanout exchange; declare it lazily
 		if _, ok := p.exchangeCache.Get(topic.Name()); !ok {
 			if err := p.declareExchange(pub, topic.Name()); err != nil {
@@ -261,15 +279,14 @@ func (p *PubSub) Pub(ctx context.Context, topic msgqueue.Topic, msg *msgqueue.Me
 		routingKey = ""
 	}
 
-	// never persistent, expire immediately without an active consumer: this is
-	// an at-most-once notification path
+	// never persistent: this is an at-most-once notification path
 	//
 	// no timeout here on purpose: amqp091-go takes the context as `_` and
 	// clears socket deadlines after the handshake, so a publish is bounded
 	// only by TCP flow control on the pool's shared connection
 	err = pub.PublishWithContext(ctx, exchange, routingKey, false, false, amqp.Publishing{
 		Body:       body,
-		Expiration: "0",
+		Expiration: expiration,
 	})
 
 	if err != nil {

--- a/internal/services/controllers/olap/process_dag_status_updates.go
+++ b/internal/services/controllers/olap/process_dag_status_updates.go
@@ -53,6 +53,14 @@ func (o *OLAPControllerImpl) notifyDAGsUpdated(ctx context.Context, rows []v1.Up
 	tenantIdToPayloads := make(map[uuid.UUID][]tasktypes.NotifyFinalizedPayload)
 
 	for _, row := range rows {
+		// only terminal transitions are finalizations: UpdateDAGStatuses also
+		// returns QUEUED->RUNNING rows, and publishing those as
+		// workflow-run-finished makes stream subscribers hang up the moment a
+		// DAG run starts (the dispatcher treats the message as terminal)
+		if row.ReadableStatus != sqlcv1.V1ReadableStatusOlapCOMPLETED && row.ReadableStatus != sqlcv1.V1ReadableStatusOlapCANCELLED && row.ReadableStatus != sqlcv1.V1ReadableStatusOlapFAILED {
+			continue
+		}
+
 		tenantIdToPayloads[row.TenantId] = append(tenantIdToPayloads[row.TenantId], tasktypes.NotifyFinalizedPayload{
 			ExternalId: row.ExternalId,
 			Status:     row.ReadableStatus,

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -2222,8 +2222,7 @@ func (s *DispatcherImpl) subscribeToWorkflowEventsByWorkflowRunIdV1(workflowRunI
 			msgId,
 			payloads,
 			func(events []*contracts.WorkflowEvent) ([]*contracts.WorkflowEvent, error) {
-				workflowRunIds := make([]uuid.UUID, 0)
-				workflowRunIdsToEvents := make(map[string][]*contracts.WorkflowEvent)
+				res := make([]*contracts.WorkflowEvent, 0, len(events))
 
 				for _, e := range events {
 					wri, err := uuid.Parse(e.WorkflowRunId)
@@ -2236,26 +2235,7 @@ func (s *DispatcherImpl) subscribeToWorkflowEventsByWorkflowRunIdV1(workflowRunI
 						continue
 					}
 
-					workflowRunIds = append(workflowRunIds, wri)
-					workflowRunIdsToEvents[e.WorkflowRunId] = append(workflowRunIdsToEvents[e.WorkflowRunId], e)
-				}
-
-				workflowRuns, err := s.listWorkflowRuns(ctx, tenantId, workflowRunIds)
-
-				if err != nil {
-					return nil, err
-				}
-
-				workflowRunIdsToRow := make(map[uuid.UUID]*listWorkflowRunsResult)
-
-				for _, wr := range workflowRuns {
-					workflowRunIdsToRow[wr.WorkflowRunId] = wr
-				}
-
-				res := make([]*contracts.WorkflowEvent, 0)
-
-				for _, es := range workflowRunIdsToEvents {
-					res = append(res, es...)
+					res = append(res, e)
 				}
 
 				return res, nil
@@ -2299,8 +2279,8 @@ func (s *DispatcherImpl) subscribeToWorkflowEventsByWorkflowRunIdV1(workflowRunI
 		return nil
 	}
 
-	// Bind the tenant fanout before waiting on OLAP so stream chunks published
-	// during hydration are not dropped.
+	// Bind the tenant fanout before waiting on core so stream chunks published
+	// while the run is looked up are not dropped.
 	cleanupQueue, err := s.sharedBufferedReaderv1.Subscribe(tenantId, f)
 
 	if err != nil {
@@ -2327,22 +2307,13 @@ func (s *DispatcherImpl) subscribeToWorkflowEventsByWorkflowRunIdV1(workflowRunI
 			return nil
 		}
 
-		wr, err := s.repov1.OLAP().ReadWorkflowRun(ctx, workflowRunId)
+		tasks, err := s.repov1.Tasks().FlattenExternalIds(ctx, tenantId, []uuid.UUID{workflowRunId})
 
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				select {
-				case <-ctx.Done():
-					return nil
-				case <-time.After(time.Second):
-				}
-				continue
-			}
-
 			return err
 		}
 
-		if wr == nil || wr.WorkflowRun == nil {
+		if len(tasks) == 0 {
 			select {
 			case <-ctx.Done():
 				return nil
@@ -2351,16 +2322,30 @@ func (s *DispatcherImpl) subscribeToWorkflowEventsByWorkflowRunIdV1(workflowRunI
 			continue
 		}
 
-		if wr.WorkflowRun.TenantID != tenantId {
-			return status.Errorf(codes.NotFound, "workflow run %s not found", workflowRunId)
+		foundWorkflowRun = true
+
+		finalized, err := s.repov1.Tasks().ListFinalizedWorkflowRuns(ctx, tenantId, []uuid.UUID{workflowRunId})
+
+		if err != nil {
+			return err
 		}
 
-		span.SetAttributes(attribute.String("workflow_run.status", string(wr.WorkflowRun.ReadableStatus)))
+		var finalizedRun *v1.ListFinalizedWorkflowRunsResponse
 
-		if eventType, terminal := workflowRunEventTypeForOlapStatus(wr.WorkflowRun.ReadableStatus); terminal {
+		for _, wr := range finalized {
+			if wr.WorkflowRunId == workflowRunId {
+				finalizedRun = wr
+				break
+			}
+		}
+
+		if finalizedRun != nil {
+			eventType := workflowRunEventTypeFromOutputEvents(finalizedRun.OutputEvents)
+			span.SetAttributes(attribute.String("workflow_run.status", eventType.String()))
+
 			s.l.Warn().Ctx(ctx).
 				Str("workflow_run_id", workflowRunId.String()).
-				Str("status", string(wr.WorkflowRun.ReadableStatus)).
+				Str("status", eventType.String()).
 				Msg("workflow run already in terminal state, sending hangup")
 
 			streamBuffer.AddEvent(&contracts.WorkflowEvent{
@@ -2371,12 +2356,10 @@ func (s *DispatcherImpl) subscribeToWorkflowEventsByWorkflowRunIdV1(workflowRunI
 				Hangup:         true,
 				EventTimestamp: timestamppb.Now(),
 			})
-
-			foundWorkflowRun = true
-			break
+		} else {
+			span.SetAttributes(attribute.String("workflow_run.status", "RUNNING"))
 		}
 
-		foundWorkflowRun = true
 		break
 	}
 

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -900,7 +900,7 @@ func (b *StreamEventBuffer) flushBufferedStreamEventsLocked() {
 }
 
 func (b *StreamEventBuffer) hangupDrainLoop() {
-	ticker := time.NewTicker(50 * time.Millisecond)
+	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
 
 	for {

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -900,7 +900,7 @@ func (b *StreamEventBuffer) flushBufferedStreamEventsLocked() {
 }
 
 func (b *StreamEventBuffer) hangupDrainLoop() {
-	ticker := time.NewTicker(10 * time.Millisecond)
+	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
 
 	for {

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -715,8 +715,15 @@ type StreamEventBuffer struct {
 	cancel                    context.CancelFunc
 	timeoutDuration           time.Duration
 	gracePeriod               time.Duration
+	hangupQuietPeriod         time.Duration
+	hangupMaxWait             time.Duration
+	pendingHangup             *contracts.WorkflowEvent
+	hangupReceivedAt          time.Time
+	lastStreamTime            time.Time
 	mu                        sync.Mutex
 }
+
+const defaultHangupQuietPeriod = 500 * time.Millisecond
 
 func NewStreamEventBuffer(timeout time.Duration) *StreamEventBuffer {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -728,6 +735,8 @@ func NewStreamEventBuffer(timeout time.Duration) *StreamEventBuffer {
 		stepRunIdToCompletionTime: make(map[uuid.UUID]time.Time),
 		timeoutDuration:           timeout,
 		gracePeriod:               2 * time.Second, // Wait 2 seconds after completion for late events
+		hangupQuietPeriod:         defaultHangupQuietPeriod,
+		hangupMaxWait:             timeout,
 		eventsChan:                make(chan *contracts.WorkflowEvent, 100),
 		timedOutEventProducer:     make(chan timeoutEvent, 100),
 		ctx:                       ctx,
@@ -736,6 +745,7 @@ func NewStreamEventBuffer(timeout time.Duration) *StreamEventBuffer {
 
 	go buffer.processTimeoutEvents()
 	go buffer.periodicCleanup()
+	go buffer.hangupDrainLoop()
 
 	return buffer
 }
@@ -749,6 +759,24 @@ func isTerminalEvent(event *contracts.WorkflowEvent) bool {
 		(event.EventType == contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED ||
 			event.EventType == contracts.ResourceEventType_RESOURCE_EVENT_TYPE_FAILED ||
 			event.EventType == contracts.ResourceEventType_RESOURCE_EVENT_TYPE_CANCELLED)
+}
+
+func isWorkflowRunHangup(event *contracts.WorkflowEvent) bool {
+	if event == nil {
+		return false
+	}
+
+	if event.ResourceType != contracts.ResourceType_RESOURCE_TYPE_WORKFLOW_RUN {
+		return false
+	}
+
+	if event.Hangup {
+		return true
+	}
+
+	return event.EventType == contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED ||
+		event.EventType == contracts.ResourceEventType_RESOURCE_EVENT_TYPE_FAILED ||
+		event.EventType == contracts.ResourceEventType_RESOURCE_EVENT_TYPE_CANCELLED
 }
 
 func sortByEventIndex(a, b *contracts.WorkflowEvent) int {
@@ -804,6 +832,7 @@ func (b *StreamEventBuffer) processTimeoutEvents() {
 						for _, e := range bufferedEvents {
 							select {
 							case b.eventsChan <- e:
+								b.lastStreamTime = time.Now()
 							case <-b.ctx.Done():
 								b.mu.Unlock()
 								return
@@ -831,6 +860,90 @@ func (b *StreamEventBuffer) Events() <-chan *contracts.WorkflowEvent {
 // context cancellation.
 func (b *StreamEventBuffer) Close() {
 	b.cancel()
+}
+
+func (b *StreamEventBuffer) sendEventLocked(event *contracts.WorkflowEvent) bool {
+	select {
+	case b.eventsChan <- event:
+		return true
+	case <-b.ctx.Done():
+		return false
+	}
+}
+
+func (b *StreamEventBuffer) bufferedStreamCountLocked() int {
+	n := 0
+	for _, events := range b.stepRunIdToWorkflowEvents {
+		n += len(events)
+	}
+	return n
+}
+
+func (b *StreamEventBuffer) flushBufferedStreamEventsLocked() {
+	for stepRunId, events := range b.stepRunIdToWorkflowEvents {
+		if len(events) == 0 {
+			continue
+		}
+
+		slices.SortFunc(events, sortByEventIndex)
+
+		for _, e := range events {
+			if !b.sendEventLocked(e) {
+				return
+			}
+		}
+
+		delete(b.stepRunIdToWorkflowEvents, stepRunId)
+		delete(b.stepRunIdToLastSeenTime, stepRunId)
+		b.stepRunIdToExpectedIndex[stepRunId] = -1
+	}
+}
+
+func (b *StreamEventBuffer) hangupDrainLoop() {
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-b.ctx.Done():
+			return
+		case <-ticker.C:
+			b.maybeReleaseHangup()
+		}
+	}
+}
+
+func (b *StreamEventBuffer) maybeReleaseHangup() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.pendingHangup == nil {
+		return
+	}
+
+	now := time.Now()
+	sinceHangup := now.Sub(b.hangupReceivedAt)
+	bufferEmpty := b.bufferedStreamCountLocked() == 0
+
+	if !bufferEmpty {
+		if sinceHangup < b.hangupMaxWait {
+			return
+		}
+	} else {
+		anchor := b.hangupReceivedAt
+		if !b.lastStreamTime.IsZero() && b.lastStreamTime.After(b.hangupReceivedAt) {
+			anchor = b.lastStreamTime
+		}
+
+		if now.Sub(anchor) < b.hangupQuietPeriod && sinceHangup < b.hangupMaxWait {
+			return
+		}
+	}
+
+	b.flushBufferedStreamEventsLocked()
+	hangup := b.pendingHangup
+	b.pendingHangup = nil
+	b.sendEventLocked(hangup)
 }
 
 func (b *StreamEventBuffer) periodicCleanup() {
@@ -863,8 +976,17 @@ func (b *StreamEventBuffer) AddEvent(event *contracts.WorkflowEvent) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	stepRunId := uuid.MustParse(event.ResourceId)
 	now := time.Now()
+
+	if isWorkflowRunHangup(event) {
+		if b.pendingHangup == nil {
+			b.pendingHangup = event
+			b.hangupReceivedAt = now
+		}
+		return
+	}
+
+	stepRunId := uuid.MustParse(event.ResourceId)
 
 	if event.ResourceType != contracts.ResourceType_RESOURCE_TYPE_STEP_RUN ||
 		event.EventType != contracts.ResourceEventType_RESOURCE_EVENT_TYPE_STREAM {
@@ -898,6 +1020,7 @@ func (b *StreamEventBuffer) AddEvent(event *contracts.WorkflowEvent) {
 	}
 
 	b.stepRunIdToLastSeenTime[stepRunId] = now
+	b.lastStreamTime = now
 
 	if _, exists := b.stepRunIdToExpectedIndex[stepRunId]; !exists {
 		// IMPORTANT: Events are zero-indexed

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/rs/zerolog"
+	"go.opentelemetry.io/otel/attribute"
 	telemetry_codes "go.opentelemetry.io/otel/codes"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -2174,52 +2175,15 @@ func (s *DispatcherImpl) subscribeToWorkflowEventsByWorkflowRunIdV1(workflowRunI
 	deregister := s.streamSessions.Register(cancel)
 	defer deregister()
 
-	retries := 0
-	foundWorkflowRun := false
-
-	for retries < 10 {
-		wr, err := s.repov1.OLAP().ReadWorkflowRun(ctx, workflowRunId)
-
-		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				retries++
-				time.Sleep(1 * time.Second)
-				continue
-			}
-
-			return err
-		}
-
-		if wr == nil || wr.WorkflowRun == nil {
-			retries++
-			time.Sleep(1 * time.Second)
-			continue
-		}
-
-		if wr.WorkflowRun.TenantID != tenantId {
-			return status.Errorf(codes.NotFound, "workflow run %s not found", workflowRunId)
-		}
-
-		if wr.WorkflowRun.ReadableStatus == sqlcv1.V1ReadableStatusOlapCANCELLED ||
-			wr.WorkflowRun.ReadableStatus == sqlcv1.V1ReadableStatusOlapCOMPLETED ||
-			wr.WorkflowRun.ReadableStatus == sqlcv1.V1ReadableStatusOlapFAILED {
-			return nil
-		}
-
-		foundWorkflowRun = true
-		break
-	}
-
-	if !foundWorkflowRun {
-		return status.Errorf(codes.NotFound, "workflow run %s not found", workflowRunId)
-	}
+	ctx, span := telemetry.NewSpan(ctx, "subscribe-to-workflow-events-by-run-id")
+	defer span.End()
+	span.SetAttributes(attribute.String("workflow_run_id", workflowRunId.String()))
 
 	wg := sync.WaitGroup{}
 	var mu sync.Mutex     // Mutex to protect activeRunIds
 	var sendMu sync.Mutex // Mutex to protect sending messages
 
 	streamBuffer := NewStreamEventBuffer(s.streamEventBufferTimeout)
-	defer streamBuffer.Close()
 
 	// Handle events from the stream buffer
 	go func() {
@@ -2335,25 +2299,92 @@ func (s *DispatcherImpl) subscribeToWorkflowEventsByWorkflowRunIdV1(workflowRunI
 		return nil
 	}
 
-	// subscribe to the task queue for the tenant
+	// Bind the tenant fanout before waiting on OLAP so stream chunks published
+	// during hydration are not dropped.
 	cleanupQueue, err := s.sharedBufferedReaderv1.Subscribe(tenantId, f)
 
 	if err != nil {
+		streamBuffer.Close()
 		return fmt.Errorf("could not subscribe to shared tenant queue: %w", err)
 	}
 
-	<-ctx.Done()
+	defer func() {
+		// Close the buffer before unsubscribing so in-flight f callbacks cannot
+		// block on a full channel while waitFor waits on those same callbacks.
+		streamBuffer.Close()
 
-	// the consumer goroutine has exited with the context, so close the buffer now:
-	// otherwise in-flight f callbacks block sending to the buffer's full channel until
-	// this function returns, and waitFor below waits on those same callbacks
-	streamBuffer.Close()
+		if err := cleanupQueue(); err != nil {
+			s.l.Error().Ctx(ctx).Err(err).Msg("could not cleanup queue")
+		}
 
-	if err := cleanupQueue(); err != nil {
-		return fmt.Errorf("could not cleanup queue: %w", err)
+		waitFor(&wg, 60*time.Second, s.l)
+	}()
+
+	foundWorkflowRun := false
+
+	for retries := 0; retries < 10; retries++ {
+		if ctx.Err() != nil {
+			return nil
+		}
+
+		wr, err := s.repov1.OLAP().ReadWorkflowRun(ctx, workflowRunId)
+
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-time.After(time.Second):
+				}
+				continue
+			}
+
+			return err
+		}
+
+		if wr == nil || wr.WorkflowRun == nil {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(time.Second):
+			}
+			continue
+		}
+
+		if wr.WorkflowRun.TenantID != tenantId {
+			return status.Errorf(codes.NotFound, "workflow run %s not found", workflowRunId)
+		}
+
+		span.SetAttributes(attribute.String("workflow_run.status", string(wr.WorkflowRun.ReadableStatus)))
+
+		if eventType, terminal := workflowRunEventTypeForOlapStatus(wr.WorkflowRun.ReadableStatus); terminal {
+			s.l.Warn().Ctx(ctx).
+				Str("workflow_run_id", workflowRunId.String()).
+				Str("status", string(wr.WorkflowRun.ReadableStatus)).
+				Msg("workflow run already in terminal state, sending hangup")
+
+			streamBuffer.AddEvent(&contracts.WorkflowEvent{
+				WorkflowRunId:  workflowRunId.String(),
+				ResourceType:   contracts.ResourceType_RESOURCE_TYPE_WORKFLOW_RUN,
+				ResourceId:     workflowRunId.String(),
+				EventType:      eventType,
+				Hangup:         true,
+				EventTimestamp: timestamppb.Now(),
+			})
+
+			foundWorkflowRun = true
+			break
+		}
+
+		foundWorkflowRun = true
+		break
 	}
 
-	waitFor(&wg, 60*time.Second, s.l)
+	if !foundWorkflowRun {
+		return status.Errorf(codes.NotFound, "workflow run %s not found", workflowRunId)
+	}
+
+	<-ctx.Done()
 
 	return nil
 }

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -1005,28 +1005,14 @@ func (b *StreamEventBuffer) AddEvent(event *contracts.WorkflowEvent) {
 		event.EventType != contracts.ResourceEventType_RESOURCE_EVENT_TYPE_STREAM {
 
 		if isTerminalEvent(event) {
-			if events, exists := b.stepRunIdToWorkflowEvents[stepRunId]; exists && len(events) > 0 {
-				slices.SortFunc(events, sortByEventIndex)
-
-				for _, e := range events {
-					select {
-					case b.eventsChan <- e:
-					case <-b.ctx.Done():
-						return
-					}
-				}
-
-				delete(b.stepRunIdToWorkflowEvents, stepRunId)
-				delete(b.stepRunIdToLastSeenTime, stepRunId)
-			}
-
 			// The terminal event can leapfrog late stream chunks (they ride
-			// separate per-msgId flush buffers), so accept whatever index
-			// arrives next instead of resetting to 0: a straggler would
-			// otherwise buffer against an impossible expected index and be
-			// discarded by periodicCleanup, silently losing chunks.
-			b.stepRunIdToExpectedIndex[stepRunId] = -1
-
+			// separate per-msgId flush buffers), so don't flush buffered
+			// chunks past a hole here and don't reset the expected index:
+			// the straggler usually arrives moments later, fills the hole,
+			// and the buffer drains in order. The hangup drain (which holds
+			// the hangup until buffers are empty) and periodicCleanup (which
+			// flushes leftovers after the grace period) cover chunks that
+			// never arrive.
 			b.stepRunIdToCompletionTime[stepRunId] = now
 		}
 

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -2318,11 +2318,12 @@ func (s *DispatcherImpl) subscribeToWorkflowEventsByWorkflowRunIdV1(workflowRunI
 				if !ok {
 					return
 				}
-
+				ctx, span := telemetry.NewSpan(ctx, "send-streambuffer-events")
+				span.SetAttributes(attribute.String("workflow_run_id", workflowRunId.String()))
 				sendMu.Lock()
 				err := stream.Send(event)
 				sendMu.Unlock()
-
+				span.End()
 				if err != nil {
 					s.l.Error().Ctx(ctx).Err(err).Msgf("could not send workflow event to client")
 					cancel()
@@ -2340,7 +2341,9 @@ func (s *DispatcherImpl) subscribeToWorkflowEventsByWorkflowRunIdV1(workflowRunI
 	f := func(tenantId uuid.UUID, msgId string, payloads [][]byte) error {
 		wg.Add(1)
 		defer wg.Done()
-
+		ctx, span := telemetry.NewSpan(ctx, "get-workflow-events")
+		defer span.End()
+		span.SetAttributes(attribute.String("workflow_run_id", workflowRunId.String()))
 		events, err := msgsToWorkflowEvent(
 			msgId,
 			payloads,

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -960,6 +960,19 @@ func (b *StreamEventBuffer) periodicCleanup() {
 
 			for stepRunId, completionTime := range b.stepRunIdToCompletionTime {
 				if now.Sub(completionTime) > b.gracePeriod {
+					// flush leftovers instead of discarding them: buffered
+					// events here are real chunks the client never saw
+					if events, exists := b.stepRunIdToWorkflowEvents[stepRunId]; exists && len(events) > 0 {
+						slices.SortFunc(events, sortByEventIndex)
+
+						for _, e := range events {
+							if !b.sendEventLocked(e) {
+								b.mu.Unlock()
+								return
+							}
+						}
+					}
+
 					delete(b.stepRunIdToWorkflowEvents, stepRunId)
 					delete(b.stepRunIdToExpectedIndex, stepRunId)
 					delete(b.stepRunIdToLastSeenTime, stepRunId)
@@ -1004,9 +1017,15 @@ func (b *StreamEventBuffer) AddEvent(event *contracts.WorkflowEvent) {
 				}
 
 				delete(b.stepRunIdToWorkflowEvents, stepRunId)
-				delete(b.stepRunIdToExpectedIndex, stepRunId)
 				delete(b.stepRunIdToLastSeenTime, stepRunId)
 			}
+
+			// The terminal event can leapfrog late stream chunks (they ride
+			// separate per-msgId flush buffers), so accept whatever index
+			// arrives next instead of resetting to 0: a straggler would
+			// otherwise buffer against an impossible expected index and be
+			// discarded by periodicCleanup, silently losing chunks.
+			b.stepRunIdToExpectedIndex[stepRunId] = -1
 
 			b.stepRunIdToCompletionTime[stepRunId] = now
 		}

--- a/internal/services/dispatcher/stream_event_buffer_test.go
+++ b/internal/services/dispatcher/stream_event_buffer_test.go
@@ -14,6 +14,24 @@ import (
 const WORKFLOW_RUN_ID = "00000000-0000-0000-0000-000000000001"
 const RESOURCE = "11111111-1111-1111-1111-111111111111"
 
+func genWorkflowHangup() *contracts.WorkflowEvent {
+	return &contracts.WorkflowEvent{
+		WorkflowRunId:  WORKFLOW_RUN_ID,
+		ResourceType:   contracts.ResourceType_RESOURCE_TYPE_WORKFLOW_RUN,
+		ResourceId:     WORKFLOW_RUN_ID,
+		EventType:      contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED,
+		Hangup:         true,
+		EventTimestamp: timestamppb.Now(),
+	}
+}
+
+func newStreamEventBufferForTest(timeout, quiet, maxWait time.Duration) *StreamEventBuffer {
+	buffer := NewStreamEventBuffer(timeout)
+	buffer.hangupQuietPeriod = quiet
+	buffer.hangupMaxWait = maxWait
+	return buffer
+}
+
 func genEvent(payload string, hangup bool, eventIndex *int64) *contracts.WorkflowEvent {
 	return &contracts.WorkflowEvent{
 		WorkflowRunId:  WORKFLOW_RUN_ID,

--- a/internal/services/dispatcher/tenant_stream_events.go
+++ b/internal/services/dispatcher/tenant_stream_events.go
@@ -17,14 +17,16 @@ import (
 
 // eventConverter adapts a per-payload field mapping into a converter over raw
 // tenant-stream payloads: each payload is decoded as T and mapped to a
-// contracts.WorkflowEvent.
+// contracts.WorkflowEvent. A nil result skips the payload.
 func eventConverter[T any](toEvent func(payload *T) *contracts.WorkflowEvent) func(payloads [][]byte) []*contracts.WorkflowEvent {
 	return func(payloads [][]byte) []*contracts.WorkflowEvent {
 		converted := msgqueue.JSONConvert[T](payloads)
 		workflowEvents := []*contracts.WorkflowEvent{}
 
 		for _, payload := range converted {
-			workflowEvents = append(workflowEvents, toEvent(payload))
+			if event := toEvent(payload); event != nil {
+				workflowEvents = append(workflowEvents, event)
+			}
 		}
 
 		return workflowEvents
@@ -93,7 +95,10 @@ var workflowEventConverters = map[string]func(payloads [][]byte) []*contracts.Wo
 	msgqueue.MsgIDWorkflowRunFinished: eventConverter(func(payload *tasktypes.NotifyFinalizedPayload) *contracts.WorkflowEvent {
 		eventType, ok := workflowRunEventTypeForOlapStatus(payload.Status)
 		if !ok {
-			eventType = contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED
+			// non-terminal statuses (e.g. RUNNING from a DAG's QUEUED->RUNNING
+			// transition) must not become hangup-triggering COMPLETED events:
+			// that closes subscriber streams the moment a DAG run starts
+			return nil
 		}
 
 		return &contracts.WorkflowEvent{

--- a/internal/services/dispatcher/tenant_stream_events.go
+++ b/internal/services/dispatcher/tenant_stream_events.go
@@ -90,14 +90,8 @@ var workflowEventConverters = map[string]func(payloads [][]byte) []*contracts.Wo
 		}
 	}),
 	msgqueue.MsgIDWorkflowRunFinished: eventConverter(func(payload *tasktypes.NotifyFinalizedPayload) *contracts.WorkflowEvent {
-		eventType := contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED
-
-		switch payload.Status {
-		case sqlcv1.V1ReadableStatusOlapCANCELLED:
-			eventType = contracts.ResourceEventType_RESOURCE_EVENT_TYPE_CANCELLED
-		case sqlcv1.V1ReadableStatusOlapFAILED:
-			eventType = contracts.ResourceEventType_RESOURCE_EVENT_TYPE_FAILED
-		case sqlcv1.V1ReadableStatusOlapCOMPLETED:
+		eventType, ok := workflowRunEventTypeForOlapStatus(payload.Status)
+		if !ok {
 			eventType = contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED
 		}
 
@@ -109,6 +103,19 @@ var workflowEventConverters = map[string]func(payloads [][]byte) []*contracts.Wo
 			EventTimestamp: timestamppb.New(time.Now()),
 		}
 	}),
+}
+
+func workflowRunEventTypeForOlapStatus(status sqlcv1.V1ReadableStatusOlap) (contracts.ResourceEventType, bool) {
+	switch status {
+	case sqlcv1.V1ReadableStatusOlapCANCELLED:
+		return contracts.ResourceEventType_RESOURCE_EVENT_TYPE_CANCELLED, true
+	case sqlcv1.V1ReadableStatusOlapFAILED:
+		return contracts.ResourceEventType_RESOURCE_EVENT_TYPE_FAILED, true
+	case sqlcv1.V1ReadableStatusOlapCOMPLETED:
+		return contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED, true
+	default:
+		return 0, false
+	}
 }
 
 func msgsToWorkflowEvent(msgId string, payloads [][]byte, filter func(tasks []*contracts.WorkflowEvent) ([]*contracts.WorkflowEvent, error), hangupFunc func(tasks []*contracts.WorkflowEvent) ([]*contracts.WorkflowEvent, error)) ([]*contracts.WorkflowEvent, error) {

--- a/internal/services/dispatcher/tenant_stream_events.go
+++ b/internal/services/dispatcher/tenant_stream_events.go
@@ -1,6 +1,7 @@
 package dispatcher
 
 import (
+	"fmt"
 	"slices"
 	"time"
 
@@ -17,19 +18,24 @@ import (
 
 // eventConverter adapts a per-payload field mapping into a converter over raw
 // tenant-stream payloads: each payload is decoded as T and mapped to a
-// contracts.WorkflowEvent. A nil result skips the payload.
-func eventConverter[T any](toEvent func(payload *T) *contracts.WorkflowEvent) func(payloads [][]byte) []*contracts.WorkflowEvent {
-	return func(payloads [][]byte) []*contracts.WorkflowEvent {
+// contracts.WorkflowEvent. A nil result (with no error) skips the payload.
+func eventConverter[T any](toEvent func(payload *T) (*contracts.WorkflowEvent, error)) func(payloads [][]byte) ([]*contracts.WorkflowEvent, error) {
+	return func(payloads [][]byte) ([]*contracts.WorkflowEvent, error) {
 		converted := msgqueue.JSONConvert[T](payloads)
 		workflowEvents := []*contracts.WorkflowEvent{}
 
 		for _, payload := range converted {
-			if event := toEvent(payload); event != nil {
+			event, err := toEvent(payload)
+			if err != nil {
+				return nil, err
+			}
+
+			if event != nil {
 				workflowEvents = append(workflowEvents, event)
 			}
 		}
 
-		return workflowEvents
+		return workflowEvents, nil
 	}
 }
 
@@ -38,8 +44,8 @@ func eventConverter[T any](toEvent func(payload *T) *contracts.WorkflowEvent) fu
 // converter. Together with workflowRunMatchers, its keys are the source of
 // truth for the message IDs the streams consume: msgqueue's tenant-stream
 // publish allowlist is asserted against them in TestTenantStreamMsgIDsInSync.
-var workflowEventConverters = map[string]func(payloads [][]byte) []*contracts.WorkflowEvent{
-	msgqueue.MsgIDCreatedTask: eventConverter(func(payload *tasktypes.CreatedTaskPayload) *contracts.WorkflowEvent {
+var workflowEventConverters = map[string]func(payloads [][]byte) ([]*contracts.WorkflowEvent, error){
+	msgqueue.MsgIDCreatedTask: eventConverter(func(payload *tasktypes.CreatedTaskPayload) (*contracts.WorkflowEvent, error) {
 		return &contracts.WorkflowEvent{
 			WorkflowRunId:  payload.WorkflowRunID.String(),
 			ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
@@ -47,9 +53,9 @@ var workflowEventConverters = map[string]func(payloads [][]byte) []*contracts.Wo
 			EventType:      contracts.ResourceEventType_RESOURCE_EVENT_TYPE_STARTED,
 			EventTimestamp: timestamppb.New(payload.InsertedAt.Time),
 			RetryCount:     &payload.RetryCount,
-		}
+		}, nil
 	}),
-	msgqueue.MsgIDTaskCompleted: eventConverter(func(payload *tasktypes.CompletedTaskPayload) *contracts.WorkflowEvent {
+	msgqueue.MsgIDTaskCompleted: eventConverter(func(payload *tasktypes.CompletedTaskPayload) (*contracts.WorkflowEvent, error) {
 		return &contracts.WorkflowEvent{
 			WorkflowRunId:  payload.WorkflowRunId.String(),
 			ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
@@ -58,9 +64,9 @@ var workflowEventConverters = map[string]func(payloads [][]byte) []*contracts.Wo
 			EventTimestamp: timestamppb.New(time.Now()),
 			RetryCount:     &payload.RetryCount,
 			EventPayload:   string(payload.Output),
-		}
+		}, nil
 	}),
-	msgqueue.MsgIDTaskFailed: eventConverter(func(payload *tasktypes.FailedTaskPayload) *contracts.WorkflowEvent {
+	msgqueue.MsgIDTaskFailed: eventConverter(func(payload *tasktypes.FailedTaskPayload) (*contracts.WorkflowEvent, error) {
 		return &contracts.WorkflowEvent{
 			WorkflowRunId:  payload.WorkflowRunId.String(),
 			ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
@@ -69,9 +75,9 @@ var workflowEventConverters = map[string]func(payloads [][]byte) []*contracts.Wo
 			EventTimestamp: timestamppb.New(time.Now()),
 			RetryCount:     &payload.RetryCount,
 			EventPayload:   payload.ErrorMsg,
-		}
+		}, nil
 	}),
-	msgqueue.MsgIDTaskCancelled: eventConverter(func(payload *tasktypes.CancelledTaskPayload) *contracts.WorkflowEvent {
+	msgqueue.MsgIDTaskCancelled: eventConverter(func(payload *tasktypes.CancelledTaskPayload) (*contracts.WorkflowEvent, error) {
 		return &contracts.WorkflowEvent{
 			WorkflowRunId:  payload.WorkflowRunId.String(),
 			ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
@@ -79,9 +85,9 @@ var workflowEventConverters = map[string]func(payloads [][]byte) []*contracts.Wo
 			EventType:      contracts.ResourceEventType_RESOURCE_EVENT_TYPE_CANCELLED,
 			EventTimestamp: timestamppb.New(time.Now()),
 			RetryCount:     &payload.RetryCount,
-		}
+		}, nil
 	}),
-	msgqueue.MsgIDTaskStreamEvent: eventConverter(func(payload *tasktypes.StreamEventPayload) *contracts.WorkflowEvent {
+	msgqueue.MsgIDTaskStreamEvent: eventConverter(func(payload *tasktypes.StreamEventPayload) (*contracts.WorkflowEvent, error) {
 		return &contracts.WorkflowEvent{
 			WorkflowRunId:  payload.WorkflowRunId.String(),
 			ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
@@ -90,15 +96,18 @@ var workflowEventConverters = map[string]func(payloads [][]byte) []*contracts.Wo
 			EventTimestamp: timestamppb.New(payload.CreatedAt),
 			EventPayload:   string(payload.Payload),
 			EventIndex:     payload.EventIndex,
-		}
+		}, nil
 	}),
-	msgqueue.MsgIDWorkflowRunFinished: eventConverter(func(payload *tasktypes.NotifyFinalizedPayload) *contracts.WorkflowEvent {
+	msgqueue.MsgIDWorkflowRunFinished: eventConverter(func(payload *tasktypes.NotifyFinalizedPayload) (*contracts.WorkflowEvent, error) {
 		eventType, ok := workflowRunEventTypeForOlapStatus(payload.Status)
 		if !ok {
-			// non-terminal statuses (e.g. RUNNING from a DAG's QUEUED->RUNNING
-			// transition) must not become hangup-triggering COMPLETED events:
-			// that closes subscriber streams the moment a DAG run starts
-			return nil
+			// The OLAP controller only ever publishes terminal statuses
+			// (COMPLETED/CANCELLED/FAILED) as workflow-run-finished (see
+			// notifyDAGsUpdated and notifyTasksUpdated). Anything else reaching
+			// here is a bug upstream, not a case to paper over: silently
+			// dropping it (or worse, coercing it to COMPLETED) previously hid
+			// the DAG QUEUED->RUNNING hangup bug instead of surfacing it.
+			return nil, fmt.Errorf("unexpected non-terminal status %q for workflow-run-finished event on run %s", payload.Status, payload.ExternalId)
 		}
 
 		return &contracts.WorkflowEvent{
@@ -107,7 +116,7 @@ var workflowEventConverters = map[string]func(payloads [][]byte) []*contracts.Wo
 			ResourceId:     payload.ExternalId.String(),
 			EventType:      eventType,
 			EventTimestamp: timestamppb.New(time.Now()),
-		}
+		}, nil
 	}),
 }
 
@@ -156,7 +165,13 @@ func msgsToWorkflowEvent(msgId string, payloads [][]byte, filter func(tasks []*c
 	workflowEvents := []*contracts.WorkflowEvent{}
 
 	if convert, ok := workflowEventConverters[msgId]; ok {
-		workflowEvents = convert(payloads)
+		var err error
+
+		workflowEvents, err = convert(payloads)
+
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	matches, err := filter(workflowEvents)

--- a/internal/services/dispatcher/tenant_stream_events.go
+++ b/internal/services/dispatcher/tenant_stream_events.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hatchet-dev/hatchet/internal/msgqueue"
 	"github.com/hatchet-dev/hatchet/internal/services/dispatcher/contracts"
+	v1 "github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 
 	tasktypes "github.com/hatchet-dev/hatchet/internal/services/shared/tasktypes/v1"
@@ -116,6 +117,34 @@ func workflowRunEventTypeForOlapStatus(status sqlcv1.V1ReadableStatusOlap) (cont
 	default:
 		return 0, false
 	}
+}
+
+func workflowRunEventTypeFromOutputEvents(events []*v1.TaskOutputEvent) contracts.ResourceEventType {
+	hasFailed := false
+	hasCancelled := false
+
+	for _, e := range events {
+		if e == nil {
+			continue
+		}
+
+		switch {
+		case e.IsFailed():
+			hasFailed = true
+		case e.IsCancelled():
+			hasCancelled = true
+		}
+	}
+
+	if hasFailed {
+		return contracts.ResourceEventType_RESOURCE_EVENT_TYPE_FAILED
+	}
+
+	if hasCancelled {
+		return contracts.ResourceEventType_RESOURCE_EVENT_TYPE_CANCELLED
+	}
+
+	return contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED
 }
 
 func msgsToWorkflowEvent(msgId string, payloads [][]byte, filter func(tasks []*contracts.WorkflowEvent) ([]*contracts.WorkflowEvent, error), hangupFunc func(tasks []*contracts.WorkflowEvent) ([]*contracts.WorkflowEvent, error)) ([]*contracts.WorkflowEvent, error) {

--- a/internal/services/dispatcher/tenant_stream_events_test.go
+++ b/internal/services/dispatcher/tenant_stream_events_test.go
@@ -169,6 +169,62 @@ func TestStreamBuffer_WorkflowHangupWaitsForMissingIndex(t *testing.T) {
 	require.True(t, got[3].Hangup)
 }
 
+// TestStreamBuffer_ChunksAfterTerminalEventAreDelivered reproduces the
+// production loss pattern: the step-run terminal event leapfrogs late stream
+// chunks (separate per-msgId flush buffers), and the stragglers arriving after
+// it must still be delivered instead of buffering against a reset expected
+// index and being discarded by periodicCleanup.
+func TestStreamBuffer_ChunksAfterTerminalEventAreDelivered(t *testing.T) {
+	t.Parallel()
+
+	buffer := newStreamEventBufferForTest(5*time.Second, 100*time.Millisecond, 5*time.Second)
+	defer buffer.Close()
+
+	ix0, ix1, ix2, ix3 := int64(0), int64(1), int64(2), int64(3)
+
+	terminal := &contracts.WorkflowEvent{
+		WorkflowRunId:  WORKFLOW_RUN_ID,
+		ResourceId:     RESOURCE,
+		ResourceType:   contracts.ResourceType_RESOURCE_TYPE_STEP_RUN,
+		EventType:      contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED,
+		EventTimestamp: timestamppb.Now(),
+	}
+
+	// c00 flows through; c02/c03 buffer waiting on the missing c01; the
+	// terminal event then flushes the buffer while c01 is still in flight
+	buffer.AddEvent(genEvent("c00", false, &ix0))
+	buffer.AddEvent(genEvent("c02", false, &ix2))
+	buffer.AddEvent(genEvent("c03", false, &ix3))
+	buffer.AddEvent(terminal)
+
+	// the straggler arrives after the terminal event
+	buffer.AddEvent(genEvent("c01", false, &ix1))
+	buffer.AddEvent(genWorkflowHangup())
+
+	payloads := make([]string, 0, 4)
+	sawHangup := false
+
+	for i := 0; i < 6; i++ {
+		select {
+		case e := <-buffer.Events():
+			if e.Hangup {
+				sawHangup = true
+				continue
+			}
+			if e.EventType == contracts.ResourceEventType_RESOURCE_EVENT_TYPE_STREAM {
+				payloads = append(payloads, e.EventPayload)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out after %d events: %v", len(payloads), payloads)
+		}
+	}
+
+	// the terminal flush emits buffered chunks past the hole, so the straggler
+	// lands out of order — but it must not be lost
+	assert.ElementsMatch(t, []string{"c00", "c01", "c02", "c03"}, payloads)
+	require.True(t, sawHangup)
+}
+
 func TestStreamBuffer_WorkflowHangupAcceptsLateStreamChunks(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/dispatcher/tenant_stream_events_test.go
+++ b/internal/services/dispatcher/tenant_stream_events_test.go
@@ -46,13 +46,16 @@ func TestWorkflowRunEventTypeForOlapStatus(t *testing.T) {
 	}
 }
 
-// TestWorkflowRunFinishedConverterDropsNonTerminalStatuses reproduces the
-// premature-hangup bug for DAG runs: the OLAP controller's DAG status updater
-// used to publish QUEUED->RUNNING transitions as workflow-run-finished, and
-// the converter coerced the unknown RUNNING status into COMPLETED, hanging up
-// stream subscribers the moment the run started. Non-terminal statuses must
-// produce no event at all.
-func TestWorkflowRunFinishedConverterDropsNonTerminalStatuses(t *testing.T) {
+// TestWorkflowRunFinishedConverterErrorsOnNonTerminalStatus guards against the
+// premature-hangup bug for DAG runs re-entering in a different shape: the OLAP
+// controller's DAG status updater used to publish QUEUED->RUNNING transitions
+// as workflow-run-finished, and the converter used to coerce the unknown
+// RUNNING status into COMPLETED, hanging up stream subscribers the moment the
+// run started. notifyDAGsUpdated and notifyTasksUpdated now only ever publish
+// terminal statuses, so a non-terminal status reaching this converter is a bug
+// upstream and must fail loudly rather than being silently dropped or
+// defaulted to COMPLETED.
+func TestWorkflowRunFinishedConverterErrorsOnNonTerminalStatus(t *testing.T) {
 	t.Parallel()
 
 	convert := workflowEventConverters[msgqueue.MsgIDWorkflowRunFinished]
@@ -69,12 +72,17 @@ func TestWorkflowRunFinishedConverterDropsNonTerminalStatuses(t *testing.T) {
 		return body
 	}
 
-	events := convert([][]byte{
-		payload(sqlcv1.V1ReadableStatusOlapQUEUED),
-		payload(sqlcv1.V1ReadableStatusOlapRUNNING),
-		payload(sqlcv1.V1ReadableStatusOlapCOMPLETED),
-	})
+	events, err := convert([][]byte{payload(sqlcv1.V1ReadableStatusOlapRUNNING)})
+	require.Error(t, err)
+	assert.Nil(t, events)
+	assert.Contains(t, err.Error(), runId.String())
 
+	events, err = convert([][]byte{payload(sqlcv1.V1ReadableStatusOlapQUEUED)})
+	require.Error(t, err)
+	assert.Nil(t, events)
+
+	events, err = convert([][]byte{payload(sqlcv1.V1ReadableStatusOlapCOMPLETED)})
+	require.NoError(t, err)
 	require.Len(t, events, 1)
 	assert.Equal(t, contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED, events[0].EventType)
 	assert.Equal(t, runId.String(), events[0].WorkflowRunId)

--- a/internal/services/dispatcher/tenant_stream_events_test.go
+++ b/internal/services/dispatcher/tenant_stream_events_test.go
@@ -1,0 +1,69 @@
+//go:build !e2e && !load && !rampup && !integration
+
+package dispatcher
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hatchet-dev/hatchet/internal/services/dispatcher/contracts"
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestWorkflowRunEventTypeForOlapStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		status       sqlcv1.V1ReadableStatusOlap
+		wantType     contracts.ResourceEventType
+		wantTerminal bool
+	}{
+		{sqlcv1.V1ReadableStatusOlapCOMPLETED, contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED, true},
+		{sqlcv1.V1ReadableStatusOlapFAILED, contracts.ResourceEventType_RESOURCE_EVENT_TYPE_FAILED, true},
+		{sqlcv1.V1ReadableStatusOlapCANCELLED, contracts.ResourceEventType_RESOURCE_EVENT_TYPE_CANCELLED, true},
+		{sqlcv1.V1ReadableStatusOlapRUNNING, 0, false},
+		{sqlcv1.V1ReadableStatusOlapQUEUED, 0, false},
+		{sqlcv1.V1ReadableStatusOlapEVICTED, 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			t.Parallel()
+
+			gotType, gotTerminal := workflowRunEventTypeForOlapStatus(tt.status)
+			assert.Equal(t, tt.wantTerminal, gotTerminal)
+			assert.Equal(t, tt.wantType, gotType)
+		})
+	}
+}
+
+func TestStreamBuffer_WorkflowRunHangupIsReleased(t *testing.T) {
+	t.Parallel()
+
+	buffer := NewStreamEventBuffer(5 * time.Second)
+	defer buffer.Close()
+
+	hangup := &contracts.WorkflowEvent{
+		WorkflowRunId:  WORKFLOW_RUN_ID,
+		ResourceType:   contracts.ResourceType_RESOURCE_TYPE_WORKFLOW_RUN,
+		ResourceId:     WORKFLOW_RUN_ID,
+		EventType:      contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED,
+		Hangup:         true,
+		EventTimestamp: timestamppb.Now(),
+	}
+
+	buffer.AddEvent(hangup)
+
+	select {
+	case got := <-buffer.Events():
+		require.True(t, got.Hangup)
+		assert.Equal(t, contracts.ResourceType_RESOURCE_TYPE_WORKFLOW_RUN, got.ResourceType)
+		assert.Equal(t, contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED, got.EventType)
+		assert.Equal(t, WORKFLOW_RUN_ID, got.WorkflowRunId)
+	case <-time.After(time.Second):
+		t.Fatal("expected hangup event to be released immediately")
+	}
+}

--- a/internal/services/dispatcher/tenant_stream_events_test.go
+++ b/internal/services/dispatcher/tenant_stream_events_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hatchet-dev/hatchet/internal/services/dispatcher/contracts"
+	v1 "github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,6 +37,59 @@ func TestWorkflowRunEventTypeForOlapStatus(t *testing.T) {
 			gotType, gotTerminal := workflowRunEventTypeForOlapStatus(tt.status)
 			assert.Equal(t, tt.wantTerminal, gotTerminal)
 			assert.Equal(t, tt.wantType, gotType)
+		})
+	}
+}
+
+func TestWorkflowRunEventTypeFromOutputEvents(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		events   []*v1.TaskOutputEvent
+		wantType contracts.ResourceEventType
+	}{
+		{
+			name:     "empty defaults to completed",
+			events:   nil,
+			wantType: contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED,
+		},
+		{
+			name: "all completed",
+			events: []*v1.TaskOutputEvent{
+				{EventType: sqlcv1.V1TaskEventTypeCOMPLETED},
+			},
+			wantType: contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED,
+		},
+		{
+			name: "failed wins over completed",
+			events: []*v1.TaskOutputEvent{
+				{EventType: sqlcv1.V1TaskEventTypeCOMPLETED},
+				{EventType: sqlcv1.V1TaskEventTypeFAILED},
+			},
+			wantType: contracts.ResourceEventType_RESOURCE_EVENT_TYPE_FAILED,
+		},
+		{
+			name: "cancelled",
+			events: []*v1.TaskOutputEvent{
+				{EventType: sqlcv1.V1TaskEventTypeCANCELLED},
+			},
+			wantType: contracts.ResourceEventType_RESOURCE_EVENT_TYPE_CANCELLED,
+		},
+		{
+			name: "failed wins over cancelled",
+			events: []*v1.TaskOutputEvent{
+				{EventType: sqlcv1.V1TaskEventTypeCANCELLED},
+				{EventType: sqlcv1.V1TaskEventTypeFAILED},
+			},
+			wantType: contracts.ResourceEventType_RESOURCE_EVENT_TYPE_FAILED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.wantType, workflowRunEventTypeFromOutputEvents(tt.events))
 		})
 	}
 }

--- a/internal/services/dispatcher/tenant_stream_events_test.go
+++ b/internal/services/dispatcher/tenant_stream_events_test.go
@@ -3,10 +3,15 @@
 package dispatcher
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+
+	"github.com/hatchet-dev/hatchet/internal/msgqueue"
 	"github.com/hatchet-dev/hatchet/internal/services/dispatcher/contracts"
+	tasktypes "github.com/hatchet-dev/hatchet/internal/services/shared/tasktypes/v1"
 	v1 "github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 	"github.com/stretchr/testify/assert"
@@ -39,6 +44,40 @@ func TestWorkflowRunEventTypeForOlapStatus(t *testing.T) {
 			assert.Equal(t, tt.wantType, gotType)
 		})
 	}
+}
+
+// TestWorkflowRunFinishedConverterDropsNonTerminalStatuses reproduces the
+// premature-hangup bug for DAG runs: the OLAP controller's DAG status updater
+// used to publish QUEUED->RUNNING transitions as workflow-run-finished, and
+// the converter coerced the unknown RUNNING status into COMPLETED, hanging up
+// stream subscribers the moment the run started. Non-terminal statuses must
+// produce no event at all.
+func TestWorkflowRunFinishedConverterDropsNonTerminalStatuses(t *testing.T) {
+	t.Parallel()
+
+	convert := workflowEventConverters[msgqueue.MsgIDWorkflowRunFinished]
+	require.NotNil(t, convert)
+
+	runId := uuid.New()
+
+	payload := func(status sqlcv1.V1ReadableStatusOlap) []byte {
+		body, err := json.Marshal(tasktypes.NotifyFinalizedPayload{
+			ExternalId: runId,
+			Status:     status,
+		})
+		require.NoError(t, err)
+		return body
+	}
+
+	events := convert([][]byte{
+		payload(sqlcv1.V1ReadableStatusOlapQUEUED),
+		payload(sqlcv1.V1ReadableStatusOlapRUNNING),
+		payload(sqlcv1.V1ReadableStatusOlapCOMPLETED),
+	})
+
+	require.Len(t, events, 1)
+	assert.Equal(t, contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED, events[0].EventType)
+	assert.Equal(t, runId.String(), events[0].WorkflowRunId)
 }
 
 func TestWorkflowRunEventTypeFromOutputEvents(t *testing.T) {

--- a/internal/services/dispatcher/tenant_stream_events_test.go
+++ b/internal/services/dispatcher/tenant_stream_events_test.go
@@ -172,8 +172,9 @@ func TestStreamBuffer_WorkflowHangupWaitsForMissingIndex(t *testing.T) {
 // TestStreamBuffer_ChunksAfterTerminalEventAreDelivered reproduces the
 // production loss pattern: the step-run terminal event leapfrogs late stream
 // chunks (separate per-msgId flush buffers), and the stragglers arriving after
-// it must still be delivered instead of buffering against a reset expected
-// index and being discarded by periodicCleanup.
+// it must still be delivered — in order, since the buffer holds chunks past
+// the hole until the straggler fills it rather than flushing on the terminal
+// event.
 func TestStreamBuffer_ChunksAfterTerminalEventAreDelivered(t *testing.T) {
 	t.Parallel()
 
@@ -219,9 +220,8 @@ func TestStreamBuffer_ChunksAfterTerminalEventAreDelivered(t *testing.T) {
 		}
 	}
 
-	// the terminal flush emits buffered chunks past the hole, so the straggler
-	// lands out of order — but it must not be lost
-	assert.ElementsMatch(t, []string{"c00", "c01", "c02", "c03"}, payloads)
+	// the straggler fills the hole, so everything drains in order
+	assert.Equal(t, []string{"c00", "c01", "c02", "c03"}, payloads)
 	require.True(t, sawHangup)
 }
 

--- a/internal/services/dispatcher/tenant_stream_events_test.go
+++ b/internal/services/dispatcher/tenant_stream_events_test.go
@@ -112,12 +112,91 @@ func TestStreamBuffer_WorkflowRunHangupIsReleased(t *testing.T) {
 	buffer.AddEvent(hangup)
 
 	select {
+	case <-buffer.Events():
+		t.Fatal("workflow hangup must wait for the quiet period")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	select {
 	case got := <-buffer.Events():
 		require.True(t, got.Hangup)
 		assert.Equal(t, contracts.ResourceType_RESOURCE_TYPE_WORKFLOW_RUN, got.ResourceType)
 		assert.Equal(t, contracts.ResourceEventType_RESOURCE_EVENT_TYPE_COMPLETED, got.EventType)
 		assert.Equal(t, WORKFLOW_RUN_ID, got.WorkflowRunId)
-	case <-time.After(time.Second):
-		t.Fatal("expected hangup event to be released immediately")
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected hangup event after quiet period")
 	}
+}
+
+func TestStreamBuffer_WorkflowHangupWaitsForMissingIndex(t *testing.T) {
+	t.Parallel()
+
+	buffer := newStreamEventBufferForTest(5*time.Second, 50*time.Millisecond, 5*time.Second)
+	defer buffer.Close()
+
+	ix0, ix1, ix2 := int64(0), int64(1), int64(2)
+	event1 := genEvent("c01", false, &ix1)
+	event2 := genEvent("c02", false, &ix2)
+	event0 := genEvent("c00", false, &ix0)
+	hangup := genWorkflowHangup()
+
+	buffer.AddEvent(event1)
+	buffer.AddEvent(event2)
+	buffer.AddEvent(hangup)
+
+	select {
+	case <-buffer.Events():
+		t.Fatal("should not emit hangup or out-of-order chunks before index 0")
+	case <-time.After(80 * time.Millisecond):
+	}
+
+	buffer.AddEvent(event0)
+
+	got := make([]*contracts.WorkflowEvent, 0, 4)
+	for i := 0; i < 4; i++ {
+		select {
+		case e := <-buffer.Events():
+			got = append(got, e)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("expected event %d, got %d", i, len(got))
+		}
+	}
+
+	require.Len(t, got, 4)
+	assert.Equal(t, event0, got[0])
+	assert.Equal(t, event1, got[1])
+	assert.Equal(t, event2, got[2])
+	require.True(t, got[3].Hangup)
+}
+
+func TestStreamBuffer_WorkflowHangupAcceptsLateStreamChunks(t *testing.T) {
+	t.Parallel()
+
+	buffer := newStreamEventBufferForTest(5*time.Second, 150*time.Millisecond, 5*time.Second)
+	defer buffer.Close()
+
+	ix0, ix1 := int64(0), int64(1)
+	event0 := genEvent("c00", false, &ix0)
+	event1 := genEvent("c01", false, &ix1)
+	hangup := genWorkflowHangup()
+
+	buffer.AddEvent(event0)
+	buffer.AddEvent(hangup)
+	time.Sleep(40 * time.Millisecond)
+	buffer.AddEvent(event1)
+
+	got := make([]*contracts.WorkflowEvent, 0, 3)
+	for i := 0; i < 3; i++ {
+		select {
+		case e := <-buffer.Events():
+			got = append(got, e)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("expected event %d, got %d", i, len(got))
+		}
+	}
+
+	require.Len(t, got, 3)
+	assert.Equal(t, event0, got[0])
+	assert.Equal(t, event1, got[1])
+	require.True(t, got[2].Hangup)
 }

--- a/sdks/python/examples/bug_tests/subscribe_to_stream_dag/test_subscribe_to_stream_dag.py
+++ b/sdks/python/examples/bug_tests/subscribe_to_stream_dag/test_subscribe_to_stream_dag.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from subprocess import Popen
+from typing import Any
+
+import pytest
+
+from examples.bug_tests.subscribe_to_stream_dag.worker import (
+    INTER_CHUNK_S,
+    PRE_STREAM_SLEEP_S,
+    STREAM_CHUNKS,
+    dag_stream,
+    long_stream,
+)
+from hatchet_sdk import EmptyModel, Hatchet
+from hatchet_sdk.runnables.workflow import Workflow
+
+pytestmark = pytest.mark.parametrize(
+    "on_demand_worker",
+    [
+        [
+            "poetry",
+            "run",
+            "python",
+            "examples/bug_tests/subscribe_to_stream_dag/worker.py",
+        ],
+    ],
+    indirect=True,
+)
+
+
+async def collect_stream(hatchet: Hatchet, run_id: str) -> tuple[float, list[str]]:
+    chunks: list[str] = []
+    t0 = time.monotonic()
+    async for chunk in hatchet.runs.subscribe_to_stream(run_id):
+        chunks.append(chunk)
+    return time.monotonic() - t0, chunks
+
+
+async def subscribe_from_start(
+    hatchet: Hatchet, workflow: Workflow[EmptyModel]
+) -> tuple[float, list[str]]:
+    ref = await workflow.aio_run(wait_for_result=False)
+    elapsed, chunks = await collect_stream(hatchet, ref.workflow_run_id)
+    await ref.aio_result()
+    return elapsed, chunks
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_dag_subscribe_at_start_receives_every_chunk(
+    hatchet: Hatchet,
+    on_demand_worker: Popen[Any],
+) -> None:
+    elapsed, chunks = await subscribe_from_start(hatchet, dag_stream)
+
+    assert elapsed >= 1.2
+    assert chunks == STREAM_CHUNKS
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_single_task_subscribe_at_start_receives_every_chunk(
+    hatchet: Hatchet,
+    on_demand_worker: Popen[Any],
+) -> None:
+    elapsed, chunks = await subscribe_from_start(hatchet, long_stream)
+
+    assert elapsed >= 1.2
+    assert chunks == STREAM_CHUNKS
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_subscribe_while_running_receives_every_chunk(
+    hatchet: Hatchet,
+    on_demand_worker: Popen[Any],
+) -> None:
+    ref = await long_stream.aio_run(wait_for_result=False)
+    await asyncio.sleep(0.8)
+    elapsed, chunks = await collect_stream(hatchet, ref.workflow_run_id)
+    await ref.aio_result()
+
+    assert elapsed >= 1.2
+    assert chunks == STREAM_CHUNKS
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_late_join_mid_stream_stays_open(
+    hatchet: Hatchet,
+    on_demand_worker: Popen[Any],
+) -> None:
+    ref = await long_stream.aio_run(wait_for_result=False)
+    await asyncio.sleep(PRE_STREAM_SLEEP_S + INTER_CHUNK_S * 8)
+    elapsed, chunks = await collect_stream(hatchet, ref.workflow_run_id)
+    await ref.aio_result()
+
+    assert elapsed >= 0.8
+    assert len(chunks) > 0
+    assert "".join(STREAM_CHUNKS).endswith("".join(chunks))

--- a/sdks/python/examples/bug_tests/subscribe_to_stream_dag/worker.py
+++ b/sdks/python/examples/bug_tests/subscribe_to_stream_dag/worker.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import asyncio
+
+from hatchet_sdk import Context, EmptyModel, Hatchet
+
+hatchet = Hatchet()
+
+STREAM_CHUNKS = [f"c{i:02d}|" for i in range(20)]
+PRE_STREAM_SLEEP_S = 2.0
+INTER_CHUNK_S = 0.05
+
+long_stream = hatchet.workflow(name="subscribe-stream-long")
+
+
+@long_stream.task()
+async def long_streamer(_: EmptyModel, ctx: Context) -> None:
+    await asyncio.sleep(PRE_STREAM_SLEEP_S)
+    for chunk in STREAM_CHUNKS:
+        await ctx.aio_put_stream(chunk)
+        await asyncio.sleep(INTER_CHUNK_S)
+
+
+# An on_failure handler makes every run a DAG. DAG QUEUED->RUNNING used to be
+# published as workflow-run-finished, which hung up stream subscribers as soon
+# as the run started.
+dag_stream = hatchet.workflow(name="subscribe-stream-dag")
+
+
+@dag_stream.task()
+async def dag_streamer(_: EmptyModel, ctx: Context) -> None:
+    await asyncio.sleep(PRE_STREAM_SLEEP_S)
+    for chunk in STREAM_CHUNKS:
+        await ctx.aio_put_stream(chunk)
+
+
+@dag_stream.on_failure_task()
+async def on_failure(_: EmptyModel, _ctx: Context) -> None:
+    pass
+
+
+def main() -> None:
+    worker = hatchet.worker(
+        "subscribe-stream-dag-worker",
+        slots=8,
+        workflows=[long_stream, dag_stream],
+    )
+    worker.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/sdks/typescript/src/v1/examples/e2e-worker.ts
+++ b/sdks/typescript/src/v1/examples/e2e-worker.ts
@@ -68,6 +68,7 @@ import {
   batchChildBatchSpawn,
 } from './batch_assign/workflow';
 import { streamingTask } from './streaming/workflow';
+import { dagStream, longStream } from './subscribe_to_stream/workflow';
 import { timeoutTask, refreshTimeoutTask } from './timeout/workflow';
 import { webhookWorkflow } from './webhooks/workflow';
 import {
@@ -136,6 +137,8 @@ const workflows = [
   helloWorld,
   helloWorldDurable,
   streamingTask,
+  dagStream,
+  longStream,
   timeoutTask,
   refreshTimeoutTask,
   webhookWorkflow,

--- a/sdks/typescript/src/v1/examples/subscribe_to_stream/subscribe_to_stream.e2e.ts
+++ b/sdks/typescript/src/v1/examples/subscribe_to_stream/subscribe_to_stream.e2e.ts
@@ -19,62 +19,46 @@ async function collectStream(runId: string): Promise<{ elapsedSec: number; chunk
 }
 
 describe('subscribe-to-stream-e2e', () => {
-  it(
-    'DAG with onFailure: subscribe at start receives every chunk and does not hang up early',
-    async () => {
-      const ref = await dagStream.runNoWait({});
-      const runId = await ref.getWorkflowRunId();
-      const result = await collectStream(runId);
-      await ref.output;
+  it('DAG with onFailure: subscribe at start receives every chunk and does not hang up early', async () => {
+    const ref = await dagStream.runNoWait({});
+    const runId = await ref.getWorkflowRunId();
+    const result = await collectStream(runId);
+    await ref.output;
 
-      expect(result.elapsedSec).toBeGreaterThanOrEqual(1.2);
-      expect(result.chunks).toEqual(STREAM_CHUNKS);
-    },
-    60_000
-  );
+    expect(result.elapsedSec).toBeGreaterThanOrEqual(1.2);
+    expect(result.chunks).toEqual(STREAM_CHUNKS);
+  }, 60_000);
 
-  it(
-    'single task: subscribe at start receives every chunk',
-    async () => {
-      const ref = await longStream.runNoWait({});
-      const runId = await ref.getWorkflowRunId();
-      const result = await collectStream(runId);
-      await ref.output;
+  it('single task: subscribe at start receives every chunk', async () => {
+    const ref = await longStream.runNoWait({});
+    const runId = await ref.getWorkflowRunId();
+    const result = await collectStream(runId);
+    await ref.output;
 
-      expect(result.elapsedSec).toBeGreaterThanOrEqual(1.2);
-      expect(result.chunks).toEqual(STREAM_CHUNKS);
-    },
-    60_000
-  );
+    expect(result.elapsedSec).toBeGreaterThanOrEqual(1.2);
+    expect(result.chunks).toEqual(STREAM_CHUNKS);
+  }, 60_000);
 
-  it(
-    'subscribe after the task is RUNNING still receives every chunk',
-    async () => {
-      const ref = await longStream.runNoWait({});
-      const runId = await ref.getWorkflowRunId();
-      await sleep(800);
-      const result = await collectStream(runId);
-      await ref.output;
+  it('subscribe after the task is RUNNING still receives every chunk', async () => {
+    const ref = await longStream.runNoWait({});
+    const runId = await ref.getWorkflowRunId();
+    await sleep(800);
+    const result = await collectStream(runId);
+    await ref.output;
 
-      expect(result.elapsedSec).toBeGreaterThanOrEqual(1.2);
-      expect(result.chunks).toEqual(STREAM_CHUNKS);
-    },
-    60_000
-  );
+    expect(result.elapsedSec).toBeGreaterThanOrEqual(1.2);
+    expect(result.chunks).toEqual(STREAM_CHUNKS);
+  }, 60_000);
 
-  it(
-    'late join mid-stream stays open and receives the tail instead of hanging up empty',
-    async () => {
-      const ref = await longStream.runNoWait({});
-      const runId = await ref.getWorkflowRunId();
-      await sleep(PRE_STREAM_SLEEP_MS + INTER_CHUNK_MS * 8);
-      const result = await collectStream(runId);
-      await ref.output;
+  it('late join mid-stream stays open and receives the tail instead of hanging up empty', async () => {
+    const ref = await longStream.runNoWait({});
+    const runId = await ref.getWorkflowRunId();
+    await sleep(PRE_STREAM_SLEEP_MS + INTER_CHUNK_MS * 8);
+    const result = await collectStream(runId);
+    await ref.output;
 
-      expect(result.elapsedSec).toBeGreaterThanOrEqual(0.8);
-      expect(result.chunks.length).toBeGreaterThan(0);
-      expect(STREAM_CHUNKS.join('').endsWith(result.chunks.join(''))).toBe(true);
-    },
-    60_000
-  );
+    expect(result.elapsedSec).toBeGreaterThanOrEqual(0.8);
+    expect(result.chunks.length).toBeGreaterThan(0);
+    expect(STREAM_CHUNKS.join('').endsWith(result.chunks.join(''))).toBe(true);
+  }, 60_000);
 });

--- a/sdks/typescript/src/v1/examples/subscribe_to_stream/subscribe_to_stream.e2e.ts
+++ b/sdks/typescript/src/v1/examples/subscribe_to_stream/subscribe_to_stream.e2e.ts
@@ -1,0 +1,80 @@
+import sleep from '../../../util/sleep';
+import { makeE2EClient } from '../__e2e__/harness';
+import {
+  dagStream,
+  INTER_CHUNK_MS,
+  longStream,
+  PRE_STREAM_SLEEP_MS,
+  STREAM_CHUNKS,
+} from './workflow';
+
+async function collectStream(runId: string): Promise<{ elapsedSec: number; chunks: string[] }> {
+  const chunks: string[] = [];
+  const t0 = Date.now();
+  const hatchet = makeE2EClient();
+  for await (const chunk of hatchet.runs.subscribeToStream(runId)) {
+    chunks.push(chunk);
+  }
+  return { elapsedSec: (Date.now() - t0) / 1000, chunks };
+}
+
+describe('subscribe-to-stream-e2e', () => {
+  it(
+    'DAG with onFailure: subscribe at start receives every chunk and does not hang up early',
+    async () => {
+      const ref = await dagStream.runNoWait({});
+      const runId = await ref.getWorkflowRunId();
+      const result = await collectStream(runId);
+      await ref.output;
+
+      expect(result.elapsedSec).toBeGreaterThanOrEqual(1.2);
+      expect(result.chunks).toEqual(STREAM_CHUNKS);
+    },
+    60_000
+  );
+
+  it(
+    'single task: subscribe at start receives every chunk',
+    async () => {
+      const ref = await longStream.runNoWait({});
+      const runId = await ref.getWorkflowRunId();
+      const result = await collectStream(runId);
+      await ref.output;
+
+      expect(result.elapsedSec).toBeGreaterThanOrEqual(1.2);
+      expect(result.chunks).toEqual(STREAM_CHUNKS);
+    },
+    60_000
+  );
+
+  it(
+    'subscribe after the task is RUNNING still receives every chunk',
+    async () => {
+      const ref = await longStream.runNoWait({});
+      const runId = await ref.getWorkflowRunId();
+      await sleep(800);
+      const result = await collectStream(runId);
+      await ref.output;
+
+      expect(result.elapsedSec).toBeGreaterThanOrEqual(1.2);
+      expect(result.chunks).toEqual(STREAM_CHUNKS);
+    },
+    60_000
+  );
+
+  it(
+    'late join mid-stream stays open and receives the tail instead of hanging up empty',
+    async () => {
+      const ref = await longStream.runNoWait({});
+      const runId = await ref.getWorkflowRunId();
+      await sleep(PRE_STREAM_SLEEP_MS + INTER_CHUNK_MS * 8);
+      const result = await collectStream(runId);
+      await ref.output;
+
+      expect(result.elapsedSec).toBeGreaterThanOrEqual(0.8);
+      expect(result.chunks.length).toBeGreaterThan(0);
+      expect(STREAM_CHUNKS.join('').endsWith(result.chunks.join(''))).toBe(true);
+    },
+    60_000
+  );
+});

--- a/sdks/typescript/src/v1/examples/subscribe_to_stream/worker.ts
+++ b/sdks/typescript/src/v1/examples/subscribe_to_stream/worker.ts
@@ -1,0 +1,15 @@
+import { hatchet } from '../hatchet-client';
+import { dagStream, longStream } from './workflow';
+
+async function main() {
+  const worker = await hatchet.worker('subscribe-stream-worker', {
+    workflows: [longStream, dagStream],
+    slots: 8,
+  });
+
+  await worker.start();
+}
+
+if (require.main === module) {
+  main();
+}

--- a/sdks/typescript/src/v1/examples/subscribe_to_stream/workflow.ts
+++ b/sdks/typescript/src/v1/examples/subscribe_to_stream/workflow.ts
@@ -23,7 +23,11 @@ export const longStream = hatchet.task({
 // An onFailure handler makes the run a DAG. DAG QUEUED->RUNNING used to be
 // published as workflow-run-finished, which hung up stream subscribers as
 // soon as the run started.
-export const dagStream = hatchet.task({
+export const dagStream = hatchet.workflow({
+  name: 'subscribe-stream-dag',
+});
+
+dagStream.task({
   name: 'subscribe-stream-dag',
   fn: async (_, ctx) => {
     await sleep(PRE_STREAM_SLEEP_MS);
@@ -31,5 +35,9 @@ export const dagStream = hatchet.task({
       await ctx.putStream(chunk);
     }
   },
-  onFailure: async () => {},
+});
+
+dagStream.onFailure({
+  name: 'subscribe-stream-dag-on-failure',
+  fn: async () => {},
 });

--- a/sdks/typescript/src/v1/examples/subscribe_to_stream/workflow.ts
+++ b/sdks/typescript/src/v1/examples/subscribe_to_stream/workflow.ts
@@ -1,0 +1,35 @@
+import sleep from '../../../util/sleep';
+import { hatchet } from '../hatchet-client';
+
+export const STREAM_CHUNKS = Array.from(
+  { length: 20 },
+  (_, i) => `c${String(i).padStart(2, '0')}|`
+);
+
+export const PRE_STREAM_SLEEP_MS = 2000;
+export const INTER_CHUNK_MS = 50;
+
+export const longStream = hatchet.task({
+  name: 'subscribe-stream-long',
+  fn: async (_, ctx) => {
+    await sleep(PRE_STREAM_SLEEP_MS);
+    for (const chunk of STREAM_CHUNKS) {
+      await ctx.putStream(chunk);
+      await sleep(INTER_CHUNK_MS);
+    }
+  },
+});
+
+// An onFailure handler makes the run a DAG. DAG QUEUED->RUNNING used to be
+// published as workflow-run-finished, which hung up stream subscribers as
+// soon as the run started.
+export const dagStream = hatchet.task({
+  name: 'subscribe-stream-dag',
+  fn: async (_, ctx) => {
+    await sleep(PRE_STREAM_SLEEP_MS);
+    for (const chunk of STREAM_CHUNKS) {
+      await ctx.putStream(chunk);
+    }
+  },
+  onFailure: async () => {},
+});


### PR DESCRIPTION
# Description

Bind the tenant stream for `SubscribeToWorkflowEvents` before waiting on OLAP so chunks published during hydration are not dropped. When the run is already terminal, send a hangup event instead of returning an empty OK.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

- [x] Attach the tenant fanout subscribe before the OLAP poll on workflow-run event streams
- [x] Send a hangup `WorkflowEvent` (COMPLETED/FAILED/CANCELLED) instead of silently closing when OLAP already shows a terminal status
- [x] Log run id and status on that path, and add span attributes for run id and status
- [x] Add unit coverage for terminal status mapping and hangup release through the stream buffer

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: implemented the bind-first subscribe reorder, hangup-on-terminal path, and unit tests

</details>