### PR TITLE
fix(engine): shovel concurrency slots over to paused queue items table on pause

### DIFF
--- a/examples/python/bug_tests/workflow_pause/worker.py
+++ b/examples/python/bug_tests/workflow_pause/worker.py
@@ -1,0 +1,18 @@
+from hatchet_sdk import (
+    Context,
+    EmptyModel,
+    Hatchet,
+)
+import asyncio
+from datetime import timedelta
+
+hatchet = Hatchet()
+
+
+@hatchet.task(
+    concurrency=1,
+    execution_timeout=timedelta(seconds=3),
+    schedule_timeout=timedelta(seconds=15),
+)
+async def workflow_pause_concurrency_bug_task(_i: EmptyModel, _c: Context) -> None:
+    await asyncio.sleep(1)

--- a/examples/python/worker.py
+++ b/examples/python/worker.py
@@ -162,6 +162,7 @@ from examples.bug_tests.durable_dag_child.worker import (
     spawned_child,
     spawned_child_dag,
 )
+from examples.bug_tests.workflow_pause.worker import workflow_pause_concurrency_bug_task
 from hatchet_sdk import Hatchet
 
 hatchet = Hatchet()
@@ -301,6 +302,7 @@ def main() -> None:
             durable_spawner_dag,
             mixed_spawner_dag,
             evictable_durable,
+            workflow_pause_concurrency_bug_task,
         ],
         lifespan=lifespan,
     )

--- a/internal/services/controllers/task/controller.go
+++ b/internal/services/controllers/task/controller.go
@@ -1198,8 +1198,49 @@ func (tc *TasksControllerImpl) handlePauseWorkflow(ctx context.Context, tenantId
 		return fmt.Errorf("failed to move newly paused workflows: %w", err)
 	}
 
-	if err := tc.repov1.Workflows().RequeuePausedWorkflowQueueItems(ctx, tenantId, newlyUnpausedWorkflows); err != nil {
+	queueNames, concurrencyStrategyIds, err := tc.repov1.Workflows().RequeuePausedWorkflowQueueItems(ctx, tenantId, newlyUnpausedWorkflows)
+
+	if err != nil {
 		return fmt.Errorf("failed to requeued tasks for newly unpaused workflows: %w", err)
+	}
+
+	if len(queueNames) > 0 || len(concurrencyStrategyIds) > 0 {
+		if err := tc.notifySchedulerOfRequeuedItems(ctx, tenantId, queueNames, concurrencyStrategyIds); err != nil {
+			tc.l.Error().Ctx(ctx).Err(err).Msg("failed to notify scheduler after unpausing workflows")
+		}
+	}
+
+	return nil
+}
+
+func (tc *TasksControllerImpl) notifySchedulerOfRequeuedItems(ctx context.Context, tenantId uuid.UUID, queueNames []string, concurrencyStrategyIds []int64) error {
+	tenant, err := tc.repov1.Tenant().GetTenantByID(ctx, tenantId)
+
+	if err != nil {
+		return fmt.Errorf("could not get tenant for scheduler notification: %w", err)
+	}
+
+	if !tenant.SchedulerPartitionId.Valid {
+		return nil
+	}
+
+	msg, err := msgqueue.NewTenantMessage(
+		tenantId,
+		msgqueue.MsgIDCheckTenantQueue,
+		true,
+		false,
+		tasktypes.CheckTenantQueuesPayload{
+			QueueNames:  queueNames,
+			StrategyIds: concurrencyStrategyIds,
+		},
+	)
+
+	if err != nil {
+		return fmt.Errorf("failed to build check-tenant-queue message for queues %v: %w", queueNames, err)
+	}
+
+	if err := tc.pubsub.Pub(ctx, msgqueue.SchedulerPartitionTopic(tenant.SchedulerPartitionId.String), msg); err != nil {
+		return fmt.Errorf("failed to notify scheduler for queues %v: %w", queueNames, err)
 	}
 
 	return nil

--- a/internal/services/controllers/task/process_paused_workflow_ttl.go
+++ b/internal/services/controllers/task/process_paused_workflow_ttl.go
@@ -13,14 +13,26 @@ import (
 	"github.com/hatchet-dev/hatchet/pkg/telemetry"
 )
 
-func (tc *TasksControllerImpl) processPausedWorkflowQueueItemTTL(ctx context.Context, tenantId string) (bool, error) {
+func (tc *TasksControllerImpl) processPausedWorkflowQueueItemTTL(ctx context.Context, tenantIdStr string) (bool, error) {
 	ctx, span := telemetry.NewSpan(ctx, "process-paused-workflow-queue-item-ttl")
 	defer span.End()
 
-	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant.id", Value: tenantId})
-	tenantIdUUID := uuid.MustParse(tenantId)
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "tenant.id", Value: tenantIdStr})
+	tenantId, err := uuid.Parse(tenantIdStr)
 
-	res, shouldContinue, err := tc.repov1.Tasks().ExpirePausedWorkflowQueueItems(ctx, tenantIdUUID)
+	if err != nil {
+		return false, fmt.Errorf("could not parse tenant id %s: %w", tenantIdStr, err)
+	}
+
+	// this is a reconciliation step (running here just because this is a cron), which
+	// requeues any queue items that were stranded in the paused table when we unpaused,
+	// since there's a race condition on unpause between moving queue items out of this table
+	// and continuing to write into it before the pause flag propagates
+	if err := tc.requeueItemsForUnpausedWorkflows(ctx, tenantId); err != nil {
+		tc.l.Error().Ctx(ctx).Err(err).Msg("could not requeue paused queue items for unpaused workflows")
+	}
+
+	res, shouldContinue, err := tc.repov1.Tasks().ExpirePausedWorkflowQueueItems(ctx, tenantId)
 
 	if err != nil {
 		return false, fmt.Errorf("could not expire paused workflow queue items for tenant %s: %w", tenantId, err)
@@ -30,15 +42,15 @@ func (tc *TasksControllerImpl) processPausedWorkflowQueueItemTTL(ctx context.Con
 		return shouldContinue, nil
 	}
 
-	tc.notifyQueuesOnCompletion(ctx, tenantIdUUID, res.ReleasedTasks)
+	tc.notifyQueuesOnCompletion(ctx, tenantId, res.ReleasedTasks)
 
-	if err := tc.signaler.SendInternalEvents(ctx, tenantIdUUID, res.InternalEvents); err != nil {
+	if err := tc.signaler.SendInternalEvents(ctx, tenantId, res.InternalEvents); err != nil {
 		tc.l.Error().Ctx(ctx).Err(err).Msg("could not send internal events for cleaned up tasks")
 	}
 
 	for _, releasedTask := range res.ReleasedTasks {
 		olapMsg, err := tasktypes.MonitoringEventMessageFromInternal(
-			tenantIdUUID,
+			tenantId,
 			tasktypes.CreateMonitoringEventPayload{
 				TaskId:         releasedTask.ID,
 				RetryCount:     releasedTask.RetryCount,
@@ -59,4 +71,28 @@ func (tc *TasksControllerImpl) processPausedWorkflowQueueItemTTL(ctx context.Con
 	}
 
 	return shouldContinue, nil
+}
+
+func (tc *TasksControllerImpl) requeueItemsForUnpausedWorkflows(ctx context.Context, tenantId uuid.UUID) error {
+	workflowIds, err := tc.repov1.Workflows().ListUnpausedWorkflowsWithPausedQueueItems(ctx, tenantId)
+
+	if err != nil {
+		return fmt.Errorf("could not list unpaused workflows with paused queue items: %w", err)
+	}
+
+	if len(workflowIds) == 0 {
+		return nil
+	}
+
+	queueNames, concurrencyStrategyIds, err := tc.repov1.Workflows().RequeuePausedWorkflowQueueItems(ctx, tenantId, workflowIds)
+
+	if err != nil {
+		return fmt.Errorf("could not requeue paused queue items for unpaused workflows: %w", err)
+	}
+
+	if len(queueNames) > 0 || len(concurrencyStrategyIds) > 0 {
+		return tc.notifySchedulerOfRequeuedItems(ctx, tenantId, queueNames, concurrencyStrategyIds)
+	}
+
+	return nil
 }

--- a/pkg/repository/sqlcv1/queue.sql
+++ b/pkg/repository/sqlcv1/queue.sql
@@ -1232,7 +1232,7 @@ ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
 RETURNING tenant_id, task_id, task_inserted_at, retry_count;
 
 
--- name: RequeuePausedWorkflowQueueItems :exec
+-- name: RequeuePausedWorkflowQueueItems :many
 WITH ready_items AS (
     SELECT pqi.*
     FROM v1_paused_workflow_queue_item pqi
@@ -1292,10 +1292,10 @@ SELECT
     ri.batch_key
 FROM ready_items ri
 JOIN v1_task t ON (t.id, t.inserted_at, t.retry_count) = (ri.task_id, ri.task_inserted_at, ri.retry_count)
-RETURNING tenant_id, task_id, task_inserted_at, retry_count
+RETURNING queue
 ;
 
--- name: RequeuePausedWorkflowConcurrencySlots :exec
+-- name: RequeuePausedWorkflowConcurrencySlots :many
 WITH ready_items AS (
     SELECT pqi.*
     FROM v1_paused_workflow_queue_item pqi
@@ -1365,6 +1365,7 @@ SELECT
 FROM ready_items ri
 JOIN v1_task t ON (t.id, t.inserted_at, t.retry_count) = (ri.task_id, ri.task_inserted_at, ri.retry_count)
 ON CONFLICT (task_id, task_inserted_at, task_retry_count, strategy_id) DO NOTHING
+RETURNING strategy_id
 ;
 
 -- name: ListExpiredPausedWorkflowQueueItems :many

--- a/pkg/repository/sqlcv1/queue.sql
+++ b/pkg/repository/sqlcv1/queue.sql
@@ -1059,8 +1059,15 @@ WHERE q.tenant_id = i.tenant_id
 
 -- name: MovePausedWorkflowQueueItems :exec
 WITH moved_items AS (
-    DELETE FROM v1_queue_item
-    WHERE workflow_id = ANY(@workflowIds::UUID[]) AND tenant_id = @tenantId::UUID
+    DELETE FROM v1_queue_item qi
+    WHERE
+        qi.workflow_id = ANY(@workflowIds::UUID[])
+        AND qi.tenant_id = @tenantId::UUID
+        AND EXISTS (
+            SELECT 1
+            FROM "Workflow" w
+            WHERE w."id" = qi.workflow_id AND w."isPaused"
+        )
     RETURNING *
 ), released_slots AS (
     DELETE FROM v1_concurrency_slot cs
@@ -1116,12 +1123,17 @@ RETURNING tenant_id, task_id, task_inserted_at, retry_count;
 
 -- name: MovePausedWorkflowConcurrencySlots :exec
 WITH tasks_to_move AS (
-    SELECT DISTINCT task_id, task_inserted_at, task_retry_count
-    FROM v1_concurrency_slot
+    SELECT DISTINCT cs.task_id, cs.task_inserted_at, cs.task_retry_count
+    FROM v1_concurrency_slot cs
     WHERE
-        workflow_id = ANY(@workflowIds::UUID[])
-        AND tenant_id = @tenantId::UUID
-        AND is_filled = FALSE
+        cs.workflow_id = ANY(@workflowIds::UUID[])
+        AND cs.tenant_id = @tenantId::UUID
+        AND cs.is_filled = FALSE
+        AND EXISTS (
+            SELECT 1
+            FROM "Workflow" w
+            WHERE w."id" = cs.workflow_id AND w."isPaused"
+        )
 ), deleted_slots AS (
     DELETE FROM v1_concurrency_slot cs
     USING tasks_to_move p
@@ -1177,8 +1189,15 @@ RETURNING tenant_id, task_id, task_inserted_at, retry_count;
 
 -- name: MovePausedWorkflowRateLimitedQueueItems :exec
 WITH moved_items AS (
-    DELETE FROM v1_rate_limited_queue_items
-    WHERE workflow_id = ANY(@workflowIds::UUID[]) AND tenant_id = @tenantId::UUID
+    DELETE FROM v1_rate_limited_queue_items qi
+    WHERE
+        qi.workflow_id = ANY(@workflowIds::UUID[])
+        AND qi.tenant_id = @tenantId::UUID
+        AND EXISTS (
+            SELECT 1
+            FROM "Workflow" w
+            WHERE w."id" = qi.workflow_id AND w."isPaused"
+        )
     RETURNING *
 ), released_slots AS (
     DELETE FROM v1_concurrency_slot cs
@@ -1367,6 +1386,19 @@ JOIN v1_task t ON (t.id, t.inserted_at, t.retry_count) = (ri.task_id, ri.task_in
 ON CONFLICT (task_id, task_inserted_at, task_retry_count, strategy_id) DO NOTHING
 RETURNING strategy_id
 ;
+
+-- name: ListUnpausedWorkflowsWithPausedQueueItems :many
+SELECT w."id"
+FROM "Workflow" w
+WHERE
+    w."tenantId" = @tenantId::UUID
+    AND w."deletedAt" IS NULL
+    AND w."isPaused" = FALSE
+    AND EXISTS (
+        SELECT 1
+        FROM v1_paused_workflow_queue_item qi
+        WHERE qi.workflow_id = w."id" AND qi.tenant_id = @tenantId::UUID
+    );
 
 -- name: ListExpiredPausedWorkflowQueueItems :many
 SELECT

--- a/pkg/repository/sqlcv1/queue.sql
+++ b/pkg/repository/sqlcv1/queue.sql
@@ -1062,6 +1062,132 @@ WITH moved_items AS (
     DELETE FROM v1_queue_item
     WHERE workflow_id = ANY(@workflowIds::UUID[]) AND tenant_id = @tenantId::UUID
     RETURNING *
+), released_slots AS (
+    DELETE FROM v1_concurrency_slot cs
+    USING moved_items mi
+    WHERE
+        cs.task_id = mi.task_id
+        AND cs.task_inserted_at = mi.task_inserted_at
+        AND cs.task_retry_count = mi.retry_count
+    RETURNING cs.task_id
+)
+
+INSERT INTO v1_paused_workflow_queue_item (
+    tenant_id,
+    queue,
+    task_id,
+    task_inserted_at,
+    external_id,
+    action_id,
+    step_id,
+    workflow_id,
+    workflow_run_id,
+    schedule_timeout_at,
+    step_timeout,
+    priority,
+    sticky,
+    desired_worker_id,
+    retry_count,
+    desired_worker_label,
+    batch_key
+)
+SELECT
+    tenant_id,
+    queue,
+    task_id,
+    task_inserted_at,
+    external_id,
+    action_id,
+    step_id,
+    workflow_id,
+    workflow_run_id,
+    schedule_timeout_at,
+    step_timeout,
+    priority,
+    sticky,
+    desired_worker_id,
+    retry_count,
+    desired_worker_label,
+    batch_key
+FROM moved_items
+ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
+RETURNING tenant_id, task_id, task_inserted_at, retry_count;
+
+
+-- name: MovePausedWorkflowConcurrencySlots :exec
+WITH tasks_to_move AS (
+    SELECT DISTINCT task_id, task_inserted_at, task_retry_count
+    FROM v1_concurrency_slot
+    WHERE
+        workflow_id = ANY(@workflowIds::UUID[])
+        AND tenant_id = @tenantId::UUID
+        AND is_filled = FALSE
+), deleted_slots AS (
+    DELETE FROM v1_concurrency_slot cs
+    USING tasks_to_move p
+    WHERE
+        cs.task_id = p.task_id
+        AND cs.task_inserted_at = p.task_inserted_at
+        AND cs.task_retry_count = p.task_retry_count
+    RETURNING cs.task_id
+)
+
+INSERT INTO v1_paused_workflow_queue_item (
+    tenant_id,
+    queue,
+    task_id,
+    task_inserted_at,
+    external_id,
+    action_id,
+    step_id,
+    workflow_id,
+    workflow_run_id,
+    schedule_timeout_at,
+    step_timeout,
+    priority,
+    sticky,
+    desired_worker_id,
+    retry_count,
+    desired_worker_label,
+    batch_key
+)
+SELECT
+    t.tenant_id,
+    t.queue,
+    t.id,
+    t.inserted_at,
+    t.external_id,
+    t.action_id,
+    t.step_id,
+    t.workflow_id,
+    t.workflow_run_id,
+    (CURRENT_TIMESTAMP + convert_duration_to_interval(t.schedule_timeout))::TIMESTAMP(3),
+    t.step_timeout,
+    COALESCE(t.priority, 1),
+    t.sticky,
+    t.desired_worker_id,
+    t.retry_count,
+    t.desired_worker_label,
+    t.batch_key
+FROM tasks_to_move p
+JOIN v1_task t ON (t.id, t.inserted_at, t.retry_count) = (p.task_id, p.task_inserted_at, p.task_retry_count)
+ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
+RETURNING tenant_id, task_id, task_inserted_at, retry_count;
+
+
+-- name: MovePausedWorkflowRateLimitedQueueItems :exec
+WITH moved_items AS (
+    DELETE FROM v1_rate_limited_queue_items
+    WHERE workflow_id = ANY(@workflowIds::UUID[]) AND tenant_id = @tenantId::UUID
+    RETURNING *
+), released_slots AS (
+    DELETE FROM v1_concurrency_slot cs
+    USING moved_items mi
+    WHERE
+        cs.task_id = mi.task_id
+        AND cs.task_inserted_at = mi.task_inserted_at
+        AND cs.task_retry_count = mi.retry_count
+    RETURNING cs.task_id
 )
 
 INSERT INTO v1_paused_workflow_queue_item (
@@ -1108,11 +1234,15 @@ RETURNING tenant_id, task_id, task_inserted_at, retry_count;
 
 -- name: RequeuePausedWorkflowQueueItems :exec
 WITH ready_items AS (
-    SELECT *
-    FROM v1_paused_workflow_queue_item
-    WHERE workflow_id = ANY(@workflowIds::UUID[]) AND tenant_id = @tenantId::UUID
-    ORDER BY task_inserted_at, task_id, retry_count
-    FOR UPDATE SKIP LOCKED
+    SELECT pqi.*
+    FROM v1_paused_workflow_queue_item pqi
+    JOIN v1_task t ON (t.id, t.inserted_at, t.retry_count) = (pqi.task_id, pqi.task_inserted_at, pqi.retry_count)
+    WHERE
+        pqi.workflow_id = ANY(@workflowIds::UUID[])
+        AND pqi.tenant_id = @tenantId::UUID
+        AND t.concurrency_strategy_ids[1] IS NULL
+    ORDER BY pqi.task_inserted_at, pqi.task_id, pqi.retry_count
+    FOR UPDATE OF pqi SKIP LOCKED
 ), deleted_items AS (
     DELETE FROM v1_paused_workflow_queue_item
     WHERE (task_inserted_at, task_id, retry_count) IN (
@@ -1163,6 +1293,78 @@ SELECT
 FROM ready_items ri
 JOIN v1_task t ON (t.id, t.inserted_at, t.retry_count) = (ri.task_id, ri.task_inserted_at, ri.retry_count)
 RETURNING tenant_id, task_id, task_inserted_at, retry_count
+;
+
+-- name: RequeuePausedWorkflowConcurrencySlots :exec
+WITH ready_items AS (
+    SELECT pqi.*
+    FROM v1_paused_workflow_queue_item pqi
+    JOIN v1_task t ON (t.id, t.inserted_at, t.retry_count) = (pqi.task_id, pqi.task_inserted_at, pqi.retry_count)
+    WHERE
+        pqi.workflow_id = ANY(@workflowIds::UUID[])
+        AND pqi.tenant_id = @tenantId::UUID
+        AND t.concurrency_strategy_ids[1] IS NOT NULL
+    ORDER BY pqi.task_inserted_at, pqi.task_id, pqi.retry_count
+    FOR UPDATE OF pqi SKIP LOCKED
+), deleted_items AS (
+    DELETE FROM v1_paused_workflow_queue_item
+    WHERE (task_inserted_at, task_id, retry_count) IN (
+        SELECT task_inserted_at, task_id, retry_count
+        FROM ready_items
+    )
+    RETURNING *
+)
+
+INSERT INTO v1_concurrency_slot (
+    task_id,
+    task_inserted_at,
+    task_retry_count,
+    external_id,
+    tenant_id,
+    workflow_id,
+    workflow_version_id,
+    workflow_run_id,
+    parent_strategy_id,
+    next_parent_strategy_ids,
+    strategy_id,
+    next_strategy_ids,
+    priority,
+    key,
+    next_keys,
+    queue_to_notify,
+    schedule_timeout_at
+)
+
+SELECT
+    t.id,
+    t.inserted_at,
+    t.retry_count,
+    t.external_id,
+    t.tenant_id,
+    t.workflow_id,
+    t.workflow_version_id,
+    t.workflow_run_id,
+    t.concurrency_parent_strategy_ids[1],
+    CASE
+        WHEN array_length(t.concurrency_parent_strategy_ids, 1) > 1 THEN t.concurrency_parent_strategy_ids[2:array_length(t.concurrency_parent_strategy_ids, 1)]
+        ELSE '{}'::bigint[]
+    END,
+    t.concurrency_strategy_ids[1],
+    CASE
+        WHEN array_length(t.concurrency_strategy_ids, 1) > 1 THEN t.concurrency_strategy_ids[2:array_length(t.concurrency_strategy_ids, 1)]
+        ELSE '{}'::bigint[]
+    END,
+    ri.priority,
+    t.concurrency_keys[1],
+    CASE
+        WHEN array_length(t.concurrency_keys, 1) > 1 THEN t.concurrency_keys[2:array_length(t.concurrency_keys, 1)]
+        ELSE '{}'::text[]
+    END,
+    t.queue,
+    CURRENT_TIMESTAMP + convert_duration_to_interval(t.schedule_timeout)
+FROM ready_items ri
+JOIN v1_task t ON (t.id, t.inserted_at, t.retry_count) = (ri.task_id, ri.task_inserted_at, ri.retry_count)
+ON CONFLICT (task_id, task_inserted_at, task_retry_count, strategy_id) DO NOTHING
 ;
 
 -- name: ListExpiredPausedWorkflowQueueItems :many

--- a/pkg/repository/sqlcv1/queue.sql.go
+++ b/pkg/repository/sqlcv1/queue.sql.go
@@ -1493,11 +1493,90 @@ func (q *Queries) MoveBatchedQueueItems(ctx context.Context, db DBTX, ids []int6
 	return items, nil
 }
 
+const movePausedWorkflowConcurrencySlots = `-- name: MovePausedWorkflowConcurrencySlots :exec
+WITH tasks_to_move AS (
+    SELECT DISTINCT task_id, task_inserted_at, task_retry_count
+    FROM v1_concurrency_slot
+    WHERE
+        workflow_id = ANY($1::UUID[])
+        AND tenant_id = $2::UUID
+        AND is_filled = FALSE
+), deleted_slots AS (
+    DELETE FROM v1_concurrency_slot cs
+    USING tasks_to_move p
+    WHERE
+        cs.task_id = p.task_id
+        AND cs.task_inserted_at = p.task_inserted_at
+        AND cs.task_retry_count = p.task_retry_count
+    RETURNING cs.task_id
+)
+
+INSERT INTO v1_paused_workflow_queue_item (
+    tenant_id,
+    queue,
+    task_id,
+    task_inserted_at,
+    external_id,
+    action_id,
+    step_id,
+    workflow_id,
+    workflow_run_id,
+    schedule_timeout_at,
+    step_timeout,
+    priority,
+    sticky,
+    desired_worker_id,
+    retry_count,
+    desired_worker_label,
+    batch_key
+)
+SELECT
+    t.tenant_id,
+    t.queue,
+    t.id,
+    t.inserted_at,
+    t.external_id,
+    t.action_id,
+    t.step_id,
+    t.workflow_id,
+    t.workflow_run_id,
+    (CURRENT_TIMESTAMP + convert_duration_to_interval(t.schedule_timeout))::TIMESTAMP(3),
+    t.step_timeout,
+    COALESCE(t.priority, 1),
+    t.sticky,
+    t.desired_worker_id,
+    t.retry_count,
+    t.desired_worker_label,
+    t.batch_key
+FROM tasks_to_move p
+JOIN v1_task t ON (t.id, t.inserted_at, t.retry_count) = (p.task_id, p.task_inserted_at, p.task_retry_count)
+ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
+RETURNING tenant_id, task_id, task_inserted_at, retry_count
+`
+
+type MovePausedWorkflowConcurrencySlotsParams struct {
+	Workflowids []uuid.UUID `json:"workflowids"`
+	Tenantid    uuid.UUID   `json:"tenantid"`
+}
+
+func (q *Queries) MovePausedWorkflowConcurrencySlots(ctx context.Context, db DBTX, arg MovePausedWorkflowConcurrencySlotsParams) error {
+	_, err := db.Exec(ctx, movePausedWorkflowConcurrencySlots, arg.Workflowids, arg.Tenantid)
+	return err
+}
+
 const movePausedWorkflowQueueItems = `-- name: MovePausedWorkflowQueueItems :exec
 WITH moved_items AS (
     DELETE FROM v1_queue_item
     WHERE workflow_id = ANY($1::UUID[]) AND tenant_id = $2::UUID
     RETURNING id, tenant_id, queue, task_id, task_inserted_at, external_id, action_id, step_id, workflow_id, workflow_run_id, schedule_timeout_at, step_timeout, priority, sticky, desired_worker_id, retry_count, desired_worker_label, batch_key
+), released_slots AS (
+    DELETE FROM v1_concurrency_slot cs
+    USING moved_items mi
+    WHERE
+        cs.task_id = mi.task_id
+        AND cs.task_inserted_at = mi.task_inserted_at
+        AND cs.task_retry_count = mi.retry_count
+    RETURNING cs.task_id
 )
 
 INSERT INTO v1_paused_workflow_queue_item (
@@ -1549,6 +1628,73 @@ type MovePausedWorkflowQueueItemsParams struct {
 
 func (q *Queries) MovePausedWorkflowQueueItems(ctx context.Context, db DBTX, arg MovePausedWorkflowQueueItemsParams) error {
 	_, err := db.Exec(ctx, movePausedWorkflowQueueItems, arg.Workflowids, arg.Tenantid)
+	return err
+}
+
+const movePausedWorkflowRateLimitedQueueItems = `-- name: MovePausedWorkflowRateLimitedQueueItems :exec
+WITH moved_items AS (
+    DELETE FROM v1_rate_limited_queue_items
+    WHERE workflow_id = ANY($1::UUID[]) AND tenant_id = $2::UUID
+    RETURNING requeue_after, tenant_id, queue, task_id, task_inserted_at, external_id, action_id, step_id, workflow_id, workflow_run_id, schedule_timeout_at, step_timeout, priority, sticky, desired_worker_id, retry_count, desired_worker_label, batch_key
+), released_slots AS (
+    DELETE FROM v1_concurrency_slot cs
+    USING moved_items mi
+    WHERE
+        cs.task_id = mi.task_id
+        AND cs.task_inserted_at = mi.task_inserted_at
+        AND cs.task_retry_count = mi.retry_count
+    RETURNING cs.task_id
+)
+
+INSERT INTO v1_paused_workflow_queue_item (
+    tenant_id,
+    queue,
+    task_id,
+    task_inserted_at,
+    external_id,
+    action_id,
+    step_id,
+    workflow_id,
+    workflow_run_id,
+    schedule_timeout_at,
+    step_timeout,
+    priority,
+    sticky,
+    desired_worker_id,
+    retry_count,
+    desired_worker_label,
+    batch_key
+)
+SELECT
+    tenant_id,
+    queue,
+    task_id,
+    task_inserted_at,
+    external_id,
+    action_id,
+    step_id,
+    workflow_id,
+    workflow_run_id,
+    schedule_timeout_at,
+    step_timeout,
+    priority,
+    sticky,
+    desired_worker_id,
+    retry_count,
+    desired_worker_label,
+    batch_key
+FROM moved_items
+ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
+RETURNING tenant_id, task_id, task_inserted_at, retry_count
+`
+
+type MovePausedWorkflowRateLimitedQueueItemsParams struct {
+	Workflowids []uuid.UUID `json:"workflowids"`
+	Tenantid    uuid.UUID   `json:"tenantid"`
+}
+
+func (q *Queries) MovePausedWorkflowRateLimitedQueueItems(ctx context.Context, db DBTX, arg MovePausedWorkflowRateLimitedQueueItemsParams) error {
+	_, err := db.Exec(ctx, movePausedWorkflowRateLimitedQueueItems, arg.Workflowids, arg.Tenantid)
 	return err
 }
 
@@ -1779,13 +1925,99 @@ func (q *Queries) ReactivateInactiveQueuesWithItems(ctx context.Context, db DBTX
 	return db.Exec(ctx, reactivateInactiveQueuesWithItems)
 }
 
+const requeuePausedWorkflowConcurrencySlots = `-- name: RequeuePausedWorkflowConcurrencySlots :exec
+WITH ready_items AS (
+    SELECT pqi.tenant_id, pqi.queue, pqi.task_id, pqi.task_inserted_at, pqi.external_id, pqi.action_id, pqi.step_id, pqi.workflow_id, pqi.workflow_run_id, pqi.schedule_timeout_at, pqi.step_timeout, pqi.priority, pqi.sticky, pqi.desired_worker_id, pqi.retry_count, pqi.desired_worker_label, pqi.batch_key
+    FROM v1_paused_workflow_queue_item pqi
+    JOIN v1_task t ON (t.id, t.inserted_at, t.retry_count) = (pqi.task_id, pqi.task_inserted_at, pqi.retry_count)
+    WHERE
+        pqi.workflow_id = ANY($1::UUID[])
+        AND pqi.tenant_id = $2::UUID
+        AND t.concurrency_strategy_ids[1] IS NOT NULL
+    ORDER BY pqi.task_inserted_at, pqi.task_id, pqi.retry_count
+    FOR UPDATE OF pqi SKIP LOCKED
+), deleted_items AS (
+    DELETE FROM v1_paused_workflow_queue_item
+    WHERE (task_inserted_at, task_id, retry_count) IN (
+        SELECT task_inserted_at, task_id, retry_count
+        FROM ready_items
+    )
+    RETURNING tenant_id, queue, task_id, task_inserted_at, external_id, action_id, step_id, workflow_id, workflow_run_id, schedule_timeout_at, step_timeout, priority, sticky, desired_worker_id, retry_count, desired_worker_label, batch_key
+)
+
+INSERT INTO v1_concurrency_slot (
+    task_id,
+    task_inserted_at,
+    task_retry_count,
+    external_id,
+    tenant_id,
+    workflow_id,
+    workflow_version_id,
+    workflow_run_id,
+    parent_strategy_id,
+    next_parent_strategy_ids,
+    strategy_id,
+    next_strategy_ids,
+    priority,
+    key,
+    next_keys,
+    queue_to_notify,
+    schedule_timeout_at
+)
+
+SELECT
+    t.id,
+    t.inserted_at,
+    t.retry_count,
+    t.external_id,
+    t.tenant_id,
+    t.workflow_id,
+    t.workflow_version_id,
+    t.workflow_run_id,
+    t.concurrency_parent_strategy_ids[1],
+    CASE
+        WHEN array_length(t.concurrency_parent_strategy_ids, 1) > 1 THEN t.concurrency_parent_strategy_ids[2:array_length(t.concurrency_parent_strategy_ids, 1)]
+        ELSE '{}'::bigint[]
+    END,
+    t.concurrency_strategy_ids[1],
+    CASE
+        WHEN array_length(t.concurrency_strategy_ids, 1) > 1 THEN t.concurrency_strategy_ids[2:array_length(t.concurrency_strategy_ids, 1)]
+        ELSE '{}'::bigint[]
+    END,
+    ri.priority,
+    t.concurrency_keys[1],
+    CASE
+        WHEN array_length(t.concurrency_keys, 1) > 1 THEN t.concurrency_keys[2:array_length(t.concurrency_keys, 1)]
+        ELSE '{}'::text[]
+    END,
+    t.queue,
+    CURRENT_TIMESTAMP + convert_duration_to_interval(t.schedule_timeout)
+FROM ready_items ri
+JOIN v1_task t ON (t.id, t.inserted_at, t.retry_count) = (ri.task_id, ri.task_inserted_at, ri.retry_count)
+ON CONFLICT (task_id, task_inserted_at, task_retry_count, strategy_id) DO NOTHING
+`
+
+type RequeuePausedWorkflowConcurrencySlotsParams struct {
+	Workflowids []uuid.UUID `json:"workflowids"`
+	Tenantid    uuid.UUID   `json:"tenantid"`
+}
+
+func (q *Queries) RequeuePausedWorkflowConcurrencySlots(ctx context.Context, db DBTX, arg RequeuePausedWorkflowConcurrencySlotsParams) error {
+	_, err := db.Exec(ctx, requeuePausedWorkflowConcurrencySlots, arg.Workflowids, arg.Tenantid)
+	return err
+}
+
 const requeuePausedWorkflowQueueItems = `-- name: RequeuePausedWorkflowQueueItems :exec
 WITH ready_items AS (
-    SELECT tenant_id, queue, task_id, task_inserted_at, external_id, action_id, step_id, workflow_id, workflow_run_id, schedule_timeout_at, step_timeout, priority, sticky, desired_worker_id, retry_count, desired_worker_label, batch_key
-    FROM v1_paused_workflow_queue_item
-    WHERE workflow_id = ANY($1::UUID[]) AND tenant_id = $2::UUID
-    ORDER BY task_inserted_at, task_id, retry_count
-    FOR UPDATE SKIP LOCKED
+    SELECT pqi.tenant_id, pqi.queue, pqi.task_id, pqi.task_inserted_at, pqi.external_id, pqi.action_id, pqi.step_id, pqi.workflow_id, pqi.workflow_run_id, pqi.schedule_timeout_at, pqi.step_timeout, pqi.priority, pqi.sticky, pqi.desired_worker_id, pqi.retry_count, pqi.desired_worker_label, pqi.batch_key
+    FROM v1_paused_workflow_queue_item pqi
+    JOIN v1_task t ON (t.id, t.inserted_at, t.retry_count) = (pqi.task_id, pqi.task_inserted_at, pqi.retry_count)
+    WHERE
+        pqi.workflow_id = ANY($1::UUID[])
+        AND pqi.tenant_id = $2::UUID
+        AND t.concurrency_strategy_ids[1] IS NULL
+    ORDER BY pqi.task_inserted_at, pqi.task_id, pqi.retry_count
+    FOR UPDATE OF pqi SKIP LOCKED
 ), deleted_items AS (
     DELETE FROM v1_paused_workflow_queue_item
     WHERE (task_inserted_at, task_id, retry_count) IN (

--- a/pkg/repository/sqlcv1/queue.sql.go
+++ b/pkg/repository/sqlcv1/queue.sql.go
@@ -1925,7 +1925,7 @@ func (q *Queries) ReactivateInactiveQueuesWithItems(ctx context.Context, db DBTX
 	return db.Exec(ctx, reactivateInactiveQueuesWithItems)
 }
 
-const requeuePausedWorkflowConcurrencySlots = `-- name: RequeuePausedWorkflowConcurrencySlots :exec
+const requeuePausedWorkflowConcurrencySlots = `-- name: RequeuePausedWorkflowConcurrencySlots :many
 WITH ready_items AS (
     SELECT pqi.tenant_id, pqi.queue, pqi.task_id, pqi.task_inserted_at, pqi.external_id, pqi.action_id, pqi.step_id, pqi.workflow_id, pqi.workflow_run_id, pqi.schedule_timeout_at, pqi.step_timeout, pqi.priority, pqi.sticky, pqi.desired_worker_id, pqi.retry_count, pqi.desired_worker_label, pqi.batch_key
     FROM v1_paused_workflow_queue_item pqi
@@ -1995,6 +1995,7 @@ SELECT
 FROM ready_items ri
 JOIN v1_task t ON (t.id, t.inserted_at, t.retry_count) = (ri.task_id, ri.task_inserted_at, ri.retry_count)
 ON CONFLICT (task_id, task_inserted_at, task_retry_count, strategy_id) DO NOTHING
+RETURNING strategy_id
 `
 
 type RequeuePausedWorkflowConcurrencySlotsParams struct {
@@ -2002,12 +2003,27 @@ type RequeuePausedWorkflowConcurrencySlotsParams struct {
 	Tenantid    uuid.UUID   `json:"tenantid"`
 }
 
-func (q *Queries) RequeuePausedWorkflowConcurrencySlots(ctx context.Context, db DBTX, arg RequeuePausedWorkflowConcurrencySlotsParams) error {
-	_, err := db.Exec(ctx, requeuePausedWorkflowConcurrencySlots, arg.Workflowids, arg.Tenantid)
-	return err
+func (q *Queries) RequeuePausedWorkflowConcurrencySlots(ctx context.Context, db DBTX, arg RequeuePausedWorkflowConcurrencySlotsParams) ([]int64, error) {
+	rows, err := db.Query(ctx, requeuePausedWorkflowConcurrencySlots, arg.Workflowids, arg.Tenantid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []int64
+	for rows.Next() {
+		var strategy_id int64
+		if err := rows.Scan(&strategy_id); err != nil {
+			return nil, err
+		}
+		items = append(items, strategy_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
-const requeuePausedWorkflowQueueItems = `-- name: RequeuePausedWorkflowQueueItems :exec
+const requeuePausedWorkflowQueueItems = `-- name: RequeuePausedWorkflowQueueItems :many
 WITH ready_items AS (
     SELECT pqi.tenant_id, pqi.queue, pqi.task_id, pqi.task_inserted_at, pqi.external_id, pqi.action_id, pqi.step_id, pqi.workflow_id, pqi.workflow_run_id, pqi.schedule_timeout_at, pqi.step_timeout, pqi.priority, pqi.sticky, pqi.desired_worker_id, pqi.retry_count, pqi.desired_worker_label, pqi.batch_key
     FROM v1_paused_workflow_queue_item pqi
@@ -2067,7 +2083,7 @@ SELECT
     ri.batch_key
 FROM ready_items ri
 JOIN v1_task t ON (t.id, t.inserted_at, t.retry_count) = (ri.task_id, ri.task_inserted_at, ri.retry_count)
-RETURNING tenant_id, task_id, task_inserted_at, retry_count
+RETURNING queue
 `
 
 type RequeuePausedWorkflowQueueItemsParams struct {
@@ -2075,9 +2091,24 @@ type RequeuePausedWorkflowQueueItemsParams struct {
 	Tenantid    uuid.UUID   `json:"tenantid"`
 }
 
-func (q *Queries) RequeuePausedWorkflowQueueItems(ctx context.Context, db DBTX, arg RequeuePausedWorkflowQueueItemsParams) error {
-	_, err := db.Exec(ctx, requeuePausedWorkflowQueueItems, arg.Workflowids, arg.Tenantid)
-	return err
+func (q *Queries) RequeuePausedWorkflowQueueItems(ctx context.Context, db DBTX, arg RequeuePausedWorkflowQueueItemsParams) ([]string, error) {
+	rows, err := db.Query(ctx, requeuePausedWorkflowQueueItems, arg.Workflowids, arg.Tenantid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var queue string
+		if err := rows.Scan(&queue); err != nil {
+			return nil, err
+		}
+		items = append(items, queue)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const requeueRateLimitedQueueItems = `-- name: RequeueRateLimitedQueueItems :many

--- a/pkg/repository/sqlcv1/queue.sql.go
+++ b/pkg/repository/sqlcv1/queue.sql.go
@@ -1301,6 +1301,40 @@ func (q *Queries) ListStepsWithBatchConfig(ctx context.Context, db DBTX, stepids
 	return items, nil
 }
 
+const listUnpausedWorkflowsWithPausedQueueItems = `-- name: ListUnpausedWorkflowsWithPausedQueueItems :many
+SELECT w."id"
+FROM "Workflow" w
+WHERE
+    w."tenantId" = $1::UUID
+    AND w."deletedAt" IS NULL
+    AND w."isPaused" = FALSE
+    AND EXISTS (
+        SELECT 1
+        FROM v1_paused_workflow_queue_item qi
+        WHERE qi.workflow_id = w."id" AND qi.tenant_id = $1::UUID
+    )
+`
+
+func (q *Queries) ListUnpausedWorkflowsWithPausedQueueItems(ctx context.Context, db DBTX, tenantid uuid.UUID) ([]uuid.UUID, error) {
+	rows, err := db.Query(ctx, listUnpausedWorkflowsWithPausedQueueItems, tenantid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listWorkerActionSets = `-- name: ListWorkerActionSets :many
 WITH worker_actions AS MATERIALIZED (
     SELECT
@@ -1495,12 +1529,17 @@ func (q *Queries) MoveBatchedQueueItems(ctx context.Context, db DBTX, ids []int6
 
 const movePausedWorkflowConcurrencySlots = `-- name: MovePausedWorkflowConcurrencySlots :exec
 WITH tasks_to_move AS (
-    SELECT DISTINCT task_id, task_inserted_at, task_retry_count
-    FROM v1_concurrency_slot
+    SELECT DISTINCT cs.task_id, cs.task_inserted_at, cs.task_retry_count
+    FROM v1_concurrency_slot cs
     WHERE
-        workflow_id = ANY($1::UUID[])
-        AND tenant_id = $2::UUID
-        AND is_filled = FALSE
+        cs.workflow_id = ANY($1::UUID[])
+        AND cs.tenant_id = $2::UUID
+        AND cs.is_filled = FALSE
+        AND EXISTS (
+            SELECT 1
+            FROM "Workflow" w
+            WHERE w."id" = cs.workflow_id AND w."isPaused"
+        )
 ), deleted_slots AS (
     DELETE FROM v1_concurrency_slot cs
     USING tasks_to_move p
@@ -1566,8 +1605,15 @@ func (q *Queries) MovePausedWorkflowConcurrencySlots(ctx context.Context, db DBT
 
 const movePausedWorkflowQueueItems = `-- name: MovePausedWorkflowQueueItems :exec
 WITH moved_items AS (
-    DELETE FROM v1_queue_item
-    WHERE workflow_id = ANY($1::UUID[]) AND tenant_id = $2::UUID
+    DELETE FROM v1_queue_item qi
+    WHERE
+        qi.workflow_id = ANY($1::UUID[])
+        AND qi.tenant_id = $2::UUID
+        AND EXISTS (
+            SELECT 1
+            FROM "Workflow" w
+            WHERE w."id" = qi.workflow_id AND w."isPaused"
+        )
     RETURNING id, tenant_id, queue, task_id, task_inserted_at, external_id, action_id, step_id, workflow_id, workflow_run_id, schedule_timeout_at, step_timeout, priority, sticky, desired_worker_id, retry_count, desired_worker_label, batch_key
 ), released_slots AS (
     DELETE FROM v1_concurrency_slot cs
@@ -1633,8 +1679,15 @@ func (q *Queries) MovePausedWorkflowQueueItems(ctx context.Context, db DBTX, arg
 
 const movePausedWorkflowRateLimitedQueueItems = `-- name: MovePausedWorkflowRateLimitedQueueItems :exec
 WITH moved_items AS (
-    DELETE FROM v1_rate_limited_queue_items
-    WHERE workflow_id = ANY($1::UUID[]) AND tenant_id = $2::UUID
+    DELETE FROM v1_rate_limited_queue_items qi
+    WHERE
+        qi.workflow_id = ANY($1::UUID[])
+        AND qi.tenant_id = $2::UUID
+        AND EXISTS (
+            SELECT 1
+            FROM "Workflow" w
+            WHERE w."id" = qi.workflow_id AND w."isPaused"
+        )
     RETURNING requeue_after, tenant_id, queue, task_id, task_inserted_at, external_id, action_id, step_id, workflow_id, workflow_run_id, schedule_timeout_at, step_timeout, priority, sticky, desired_worker_id, retry_count, desired_worker_label, batch_key
 ), released_slots AS (
     DELETE FROM v1_concurrency_slot cs

--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -1575,6 +1575,13 @@ func (r *sharedRepository) triggerWorkflowsCore(
 		}); err != nil {
 			return nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to move queue items for paused workflows: %w", err)
 		}
+
+		if err := r.queries.MovePausedWorkflowConcurrencySlots(ctx, tx, sqlcv1.MovePausedWorkflowConcurrencySlotsParams{
+			Workflowids: workflowIds,
+			Tenantid:    tenantId,
+		}); err != nil {
+			return nil, nil, nil, nil, nil, nil, fmt.Errorf("failed to move concurrency slots for paused workflows: %w", err)
+		}
 	}
 
 	for _, dag := range dags {

--- a/pkg/repository/workflow.go
+++ b/pkg/repository/workflow.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hatchet-dev/hatchet/internal/cel"
 	"github.com/hatchet-dev/hatchet/internal/datautils"
 	"github.com/hatchet-dev/hatchet/internal/digest"
+	"github.com/hatchet-dev/hatchet/internal/listutils"
 	"github.com/hatchet-dev/hatchet/pkg/client/types"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlchelpers"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
@@ -269,7 +270,7 @@ type WorkflowRepository interface {
 
 	MovePausedWorkflowQueueItems(ctx context.Context, tenantId uuid.UUID, workflowIds []uuid.UUID) error
 
-	RequeuePausedWorkflowQueueItems(ctx context.Context, tenantId uuid.UUID, workflowIds []uuid.UUID) error
+	RequeuePausedWorkflowQueueItems(ctx context.Context, tenantId uuid.UUID, workflowIds []uuid.UUID) (queueNames []string, concurrencyStrategyIds []int64, err error)
 }
 
 type workflowRepository struct {
@@ -1518,37 +1519,45 @@ func (r *workflowRepository) MovePausedWorkflowQueueItems(ctx context.Context, t
 	return commit(ctx)
 }
 
-func (r *workflowRepository) RequeuePausedWorkflowQueueItems(ctx context.Context, tenantId uuid.UUID, workflowIds []uuid.UUID) error {
+func (r *workflowRepository) RequeuePausedWorkflowQueueItems(ctx context.Context, tenantId uuid.UUID, workflowIds []uuid.UUID) ([]string, []int64, error) {
 	ctx, span := telemetry.NewSpan(ctx, "requeue-paused-workflow-queue-items")
 	defer span.End()
 
 	if len(workflowIds) == 0 {
-		return nil
+		return nil, nil, nil
 	}
 
 	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	defer rollback()
 
-	if err := r.queries.RequeuePausedWorkflowQueueItems(ctx, tx, sqlcv1.RequeuePausedWorkflowQueueItemsParams{
+	queueNames, err := r.queries.RequeuePausedWorkflowQueueItems(ctx, tx, sqlcv1.RequeuePausedWorkflowQueueItemsParams{
 		Workflowids: workflowIds,
 		Tenantid:    tenantId,
-	}); err != nil {
-		return err
+	})
+
+	if err != nil {
+		return nil, nil, err
 	}
 
-	if err := r.queries.RequeuePausedWorkflowConcurrencySlots(ctx, tx, sqlcv1.RequeuePausedWorkflowConcurrencySlotsParams{
+	concurrencyStrategyIds, err := r.queries.RequeuePausedWorkflowConcurrencySlots(ctx, tx, sqlcv1.RequeuePausedWorkflowConcurrencySlotsParams{
 		Workflowids: workflowIds,
 		Tenantid:    tenantId,
-	}); err != nil {
-		return err
+	})
+
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return commit(ctx)
+	if err := commit(ctx); err != nil {
+		return nil, nil, err
+	}
+
+	return listutils.Uniq(queueNames), listutils.Uniq(concurrencyStrategyIds), nil
 }
 
 func checksumV1(opts *CreateWorkflowVersionOpts) (string, *CreateWorkflowVersionOpts, error) {

--- a/pkg/repository/workflow.go
+++ b/pkg/repository/workflow.go
@@ -1482,20 +1482,73 @@ func (r *workflowRepository) MovePausedWorkflowQueueItems(ctx context.Context, t
 	ctx, span := telemetry.NewSpan(ctx, "move-paused-workflow-queue-items")
 	defer span.End()
 
-	return r.queries.MovePausedWorkflowQueueItems(ctx, r.pool, sqlcv1.MovePausedWorkflowQueueItemsParams{
+	if len(workflowIds) == 0 {
+		return nil
+	}
+
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
+
+	if err != nil {
+		return err
+	}
+
+	defer rollback()
+
+	if err := r.queries.MovePausedWorkflowQueueItems(ctx, tx, sqlcv1.MovePausedWorkflowQueueItemsParams{
 		Workflowids: workflowIds,
 		Tenantid:    tenantId,
-	})
+	}); err != nil {
+		return err
+	}
+
+	if err := r.queries.MovePausedWorkflowConcurrencySlots(ctx, tx, sqlcv1.MovePausedWorkflowConcurrencySlotsParams{
+		Workflowids: workflowIds,
+		Tenantid:    tenantId,
+	}); err != nil {
+		return err
+	}
+
+	if err := r.queries.MovePausedWorkflowRateLimitedQueueItems(ctx, tx, sqlcv1.MovePausedWorkflowRateLimitedQueueItemsParams{
+		Workflowids: workflowIds,
+		Tenantid:    tenantId,
+	}); err != nil {
+		return err
+	}
+
+	return commit(ctx)
 }
 
 func (r *workflowRepository) RequeuePausedWorkflowQueueItems(ctx context.Context, tenantId uuid.UUID, workflowIds []uuid.UUID) error {
 	ctx, span := telemetry.NewSpan(ctx, "requeue-paused-workflow-queue-items")
 	defer span.End()
 
-	return r.queries.RequeuePausedWorkflowQueueItems(ctx, r.pool, sqlcv1.RequeuePausedWorkflowQueueItemsParams{
+	if len(workflowIds) == 0 {
+		return nil
+	}
+
+	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
+
+	if err != nil {
+		return err
+	}
+
+	defer rollback()
+
+	if err := r.queries.RequeuePausedWorkflowQueueItems(ctx, tx, sqlcv1.RequeuePausedWorkflowQueueItemsParams{
 		Workflowids: workflowIds,
 		Tenantid:    tenantId,
-	})
+	}); err != nil {
+		return err
+	}
+
+	if err := r.queries.RequeuePausedWorkflowConcurrencySlots(ctx, tx, sqlcv1.RequeuePausedWorkflowConcurrencySlotsParams{
+		Workflowids: workflowIds,
+		Tenantid:    tenantId,
+	}); err != nil {
+		return err
+	}
+
+	return commit(ctx)
 }
 
 func checksumV1(opts *CreateWorkflowVersionOpts) (string, *CreateWorkflowVersionOpts, error) {

--- a/pkg/repository/workflow.go
+++ b/pkg/repository/workflow.go
@@ -271,6 +271,8 @@ type WorkflowRepository interface {
 	MovePausedWorkflowQueueItems(ctx context.Context, tenantId uuid.UUID, workflowIds []uuid.UUID) error
 
 	RequeuePausedWorkflowQueueItems(ctx context.Context, tenantId uuid.UUID, workflowIds []uuid.UUID) (queueNames []string, concurrencyStrategyIds []int64, err error)
+
+	ListUnpausedWorkflowsWithPausedQueueItems(ctx context.Context, tenantId uuid.UUID) ([]uuid.UUID, error)
 }
 
 type workflowRepository struct {
@@ -1558,6 +1560,13 @@ func (r *workflowRepository) RequeuePausedWorkflowQueueItems(ctx context.Context
 	}
 
 	return listutils.Uniq(queueNames), listutils.Uniq(concurrencyStrategyIds), nil
+}
+
+func (r *workflowRepository) ListUnpausedWorkflowsWithPausedQueueItems(ctx context.Context, tenantId uuid.UUID) ([]uuid.UUID, error) {
+	ctx, span := telemetry.NewSpan(ctx, "list-unpaused-workflows-with-paused-queue-items")
+	defer span.End()
+
+	return r.queries.ListUnpausedWorkflowsWithPausedQueueItems(ctx, r.pool, tenantId)
 }
 
 func checksumV1(opts *CreateWorkflowVersionOpts) (string, *CreateWorkflowVersionOpts, error) {

--- a/sdks/python/examples/bug_tests/workflow_pause/test_workflow_pause_with_concurrency.py
+++ b/sdks/python/examples/bug_tests/workflow_pause/test_workflow_pause_with_concurrency.py
@@ -1,0 +1,31 @@
+import pytest
+
+from hatchet_sdk import Hatchet, RunStatus
+from datetime import timedelta, datetime, timezone
+
+from examples.bug_tests.workflow_pause.worker import workflow_pause_concurrency_bug_task
+import asyncio
+import time
+from uuid import uuid4
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_workflow_pause_under_concurrency(hatchet: Hatchet) -> None:
+    await workflow_pause_concurrency_bug_task.aio_pause(
+        queue_ttl=timedelta(seconds=60),
+    )
+
+    ref = await workflow_pause_concurrency_bug_task.aio_run(wait_for_result=False)
+
+    start = time.time()
+
+    while time.time() < start + 10:
+        details = await hatchet.runs.aio_get_details(ref.workflow_run_id)
+
+        assert (
+            details.status == RunStatus.QUEUED
+        ), f"Run {ref.workflow_run_id} is not queued."
+
+        await asyncio.sleep(1)
+
+    await hatchet.runs.aio_cancel(ref.workflow_run_id)

--- a/sdks/python/examples/bug_tests/workflow_pause/test_workflow_pause_with_concurrency.py
+++ b/sdks/python/examples/bug_tests/workflow_pause/test_workflow_pause_with_concurrency.py
@@ -1,12 +1,11 @@
 import pytest
 
 from hatchet_sdk import Hatchet, RunStatus
-from datetime import timedelta, datetime, timezone
+from datetime import timedelta
 
 from examples.bug_tests.workflow_pause.worker import workflow_pause_concurrency_bug_task
 import asyncio
 import time
-from uuid import uuid4
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -22,9 +21,9 @@ async def test_workflow_pause_under_concurrency(hatchet: Hatchet) -> None:
     while time.time() < start + 10:
         details = await hatchet.runs.aio_get_details(ref.workflow_run_id)
 
-        assert (
-            details.status == RunStatus.QUEUED
-        ), f"Run {ref.workflow_run_id} is not queued."
+        assert details.status == RunStatus.QUEUED, (
+            f"Run {ref.workflow_run_id} is not queued."
+        )
 
         await asyncio.sleep(1)
 

--- a/sdks/python/examples/bug_tests/workflow_pause/test_workflow_pause_with_concurrency.py
+++ b/sdks/python/examples/bug_tests/workflow_pause/test_workflow_pause_with_concurrency.py
@@ -21,9 +21,9 @@ async def test_workflow_pause_under_concurrency(hatchet: Hatchet) -> None:
     while time.time() < start + 10:
         details = await hatchet.runs.aio_get_details(ref.workflow_run_id)
 
-        assert details.status == RunStatus.QUEUED, (
-            f"Run {ref.workflow_run_id} is not queued."
-        )
+        assert (
+            details.status == RunStatus.QUEUED
+        ), f"Run {ref.workflow_run_id} is not queued."
 
         await asyncio.sleep(1)
 

--- a/sdks/python/examples/bug_tests/workflow_pause/worker.py
+++ b/sdks/python/examples/bug_tests/workflow_pause/worker.py
@@ -1,0 +1,29 @@
+from hatchet_sdk import (
+    Context,
+    EmptyModel,
+    Hatchet,
+    ConcurrencyExpression,
+    ConcurrencyLimitStrategy,
+)
+import asyncio
+from datetime import timedelta
+
+hatchet = Hatchet()
+
+
+@hatchet.task(
+    concurrency=[
+        ConcurrencyExpression(
+            expression="'*'",
+            max_runs=1,
+            limit_strategy=ConcurrencyLimitStrategy.GROUP_ROUND_ROBIN,
+        )
+    ],
+    execution_timeout=timedelta(seconds=3),
+    schedule_timeout=timedelta(seconds=15),
+)
+async def workflow_pause_concurrency_bug_task(
+    input: EmptyModel,
+    ctx: Context,
+) -> None:
+    await asyncio.sleep(1)

--- a/sdks/python/examples/bug_tests/workflow_pause/worker.py
+++ b/sdks/python/examples/bug_tests/workflow_pause/worker.py
@@ -12,13 +12,7 @@ hatchet = Hatchet()
 
 
 @hatchet.task(
-    concurrency=[
-        ConcurrencyExpression(
-            expression="'*'",
-            max_runs=1,
-            limit_strategy=ConcurrencyLimitStrategy.GROUP_ROUND_ROBIN,
-        )
-    ],
+    concurrency=1,
     execution_timeout=timedelta(seconds=3),
     schedule_timeout=timedelta(seconds=15),
 )

--- a/sdks/python/examples/bug_tests/workflow_pause/worker.py
+++ b/sdks/python/examples/bug_tests/workflow_pause/worker.py
@@ -2,8 +2,6 @@ from hatchet_sdk import (
     Context,
     EmptyModel,
     Hatchet,
-    ConcurrencyExpression,
-    ConcurrencyLimitStrategy,
 )
 import asyncio
 from datetime import timedelta

--- a/sdks/python/examples/bug_tests/workflow_pause/worker.py
+++ b/sdks/python/examples/bug_tests/workflow_pause/worker.py
@@ -22,8 +22,5 @@ hatchet = Hatchet()
     execution_timeout=timedelta(seconds=3),
     schedule_timeout=timedelta(seconds=15),
 )
-async def workflow_pause_concurrency_bug_task(
-    input: EmptyModel,
-    ctx: Context,
-) -> None:
+async def workflow_pause_concurrency_bug_task(_i: EmptyModel, _c: Context) -> None:
     await asyncio.sleep(1)

--- a/sdks/python/examples/worker.py
+++ b/sdks/python/examples/worker.py
@@ -162,6 +162,7 @@ from examples.bug_tests.durable_dag_child.worker import (
     spawned_child,
     spawned_child_dag,
 )
+from examples.bug_tests.workflow_pause.worker import workflow_pause_concurrency_bug_task
 from hatchet_sdk import Hatchet
 
 hatchet = Hatchet()
@@ -301,6 +302,7 @@ def main() -> None:
             durable_spawner_dag,
             mixed_spawner_dag,
             evictable_durable,
+            workflow_pause_concurrency_bug_task,
         ],
         lifespan=lifespan,
     )

--- a/sdks/python/examples/workflow_pause/test_workflow_pause.py
+++ b/sdks/python/examples/workflow_pause/test_workflow_pause.py
@@ -76,6 +76,58 @@ async def test_workflow_unpause(hatchet: Hatchet) -> None:
         await asyncio.sleep(1)
 
 
+async def trigger_workflows(test_run_id: str, runs: set[str]) -> None:
+    while True:
+        ref = await pausable_workflow.aio_run(
+            wait_for_result=False,
+            additional_metadata={"test_run_id": test_run_id},
+        )
+        runs.add(ref.workflow_run_id)
+        await asyncio.sleep(0.125)
+
+
+async def poll_until_completed(hatchet: Hatchet, run_id: str, timeout: int) -> bool:
+    start = time.time()
+
+    while time.time() - start < timeout:
+        details = await hatchet.runs.aio_get_details(run_id)
+
+        if details.status == RunStatus.COMPLETED:
+            return True
+
+    return False
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_unpause_no_stranded_runs(hatchet: Hatchet) -> None:
+    test_run_id = str(uuid4())
+    run_ids = set[str]()
+
+    t = asyncio.create_task(trigger_workflows(test_run_id, run_ids))
+
+    await asyncio.sleep(3)
+
+    await pausable_workflow.aio_pause(
+        queue_ttl=timedelta(minutes=10),
+    )
+
+    await asyncio.sleep(3)
+
+    await pausable_workflow.aio_unpause()
+
+    await asyncio.sleep(3)
+
+    t.cancel()
+
+    await asyncio.sleep(3)
+
+    completed_flags = await asyncio.gather(
+        *[poll_until_completed(hatchet, run_id, 10) for run_id in run_ids]
+    )
+
+    assert all(completed_flags)
+
+
 @pytest.mark.asyncio(loop_scope="session")
 async def test_workflow_pause_drop_crons_and_schedules(hatchet: Hatchet) -> None:
     test_run_id = str(uuid4())


### PR DESCRIPTION
# Description

Fixes a bug where when a workflow had a concurrency config set, workflow pause wouldn't work because we'd leave the concurrency slots and not shovel them over to the paused workflow queue items table. This will fix that by deleting concurrency slots in addition to deleting queue items on pause.

Also fixed one other thing, which was that we weren't pubbing a message to the scheduler on unpause so we'd fall back to polling for triggering the re-queued runs

Aaaaand one more, which is that there's a race condition on unpause where some workflow runs can still be written into the paused queue items table (I think from caching), so we need to also check for any stranded runs in that table while the workflow is unpaused to make sure nothing gets stuck

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI

</details>
