### PR TITLE
fix(engine): duped rows causing on conflict error on assign

### DIFF
--- a/pkg/repository/scheduler_queue.go
+++ b/pkg/repository/scheduler_queue.go
@@ -43,6 +43,11 @@ type RateLimitResult struct {
 	RetryCount     int32
 }
 
+type taskIdRetryCount struct {
+	taskId     int64
+	retryCount int32
+}
+
 type AssignedItem struct {
 	WorkerId uuid.UUID
 
@@ -291,12 +296,15 @@ func (d *sharedRepository) markQueueItemsProcessed(ctx context.Context, tenantId
 
 	idsToUnqueue := make([]int64, 0, len(r.Assigned)+len(r.Buffered))
 	queueItemIdsToAssignedItem := make(map[int64]*AssignedItem, len(r.Assigned))
-	taskIdToAssignedItem := make(map[int64]*AssignedItem, len(r.Assigned))
+	taskRetryToAssignedItem := make(map[taskIdRetryCount]*AssignedItem, len(r.Assigned))
 
 	for _, assignedItem := range r.Assigned {
 		idsToUnqueue = append(idsToUnqueue, assignedItem.QueueItem.ID)
 		queueItemIdsToAssignedItem[assignedItem.QueueItem.ID] = assignedItem
-		taskIdToAssignedItem[assignedItem.QueueItem.TaskID] = assignedItem
+		taskRetryToAssignedItem[taskIdRetryCount{
+			taskId:     assignedItem.QueueItem.TaskID,
+			retryCount: assignedItem.QueueItem.RetryCount,
+		}] = assignedItem
 	}
 
 	tasksToRelease := make([]TaskIdInsertedAtRetryCount, 0, len(r.SchedulingTimedOut))
@@ -446,6 +454,7 @@ func (d *sharedRepository) markQueueItemsProcessed(ctx context.Context, tenantId
 
 	taskIds := make([]int64, 0, len(r.Assigned))
 	taskInsertedAts := make([]pgtype.Timestamptz, 0, len(r.Assigned))
+	taskRetryCounts := make([]int32, 0, len(r.Assigned))
 	workerIds := make([]uuid.UUID, 0, len(r.Assigned))
 
 	var minTaskInsertedAt pgtype.Timestamptz
@@ -456,6 +465,7 @@ func (d *sharedRepository) markQueueItemsProcessed(ctx context.Context, tenantId
 		if _, ok := queuedItemsMap[id]; ok {
 			taskIds = append(taskIds, assignedItem.QueueItem.TaskID)
 			taskInsertedAts = append(taskInsertedAts, assignedItem.QueueItem.TaskInsertedAt)
+			taskRetryCounts = append(taskRetryCounts, assignedItem.QueueItem.RetryCount)
 			workerIds = append(workerIds, assignedItem.WorkerId)
 
 			if assignedItem.QueueItem.TaskInsertedAt.Valid && (!minTaskInsertedAt.Valid || assignedItem.QueueItem.TaskInsertedAt.Time.Before(minTaskInsertedAt.Time)) {
@@ -487,6 +497,7 @@ func (d *sharedRepository) markQueueItemsProcessed(ctx context.Context, tenantId
 	updatedTasks, err := d.queries.UpdateTasksToAssigned(ctx, tx, sqlcv1.UpdateTasksToAssignedParams{
 		Taskids:           taskIds,
 		Taskinsertedats:   taskInsertedAts,
+		Taskretrycounts:   taskRetryCounts,
 		Mintaskinsertedat: minTaskInsertedAt,
 		Workerids:         workerIds,
 		Tenantid:          tenantId,
@@ -522,17 +533,19 @@ func (d *sharedRepository) markQueueItemsProcessed(ctx context.Context, tenantId
 	failed = make([]*AssignedItem, 0, len(r.Assigned))
 
 	for _, row := range updatedTasks {
-		if assignedItem, ok := taskIdToAssignedItem[row.TaskID]; ok {
+		key := taskIdRetryCount{taskId: row.TaskID, retryCount: row.RetryCount}
+
+		if assignedItem, ok := taskRetryToAssignedItem[key]; ok {
 			if row.IsDurable.Valid {
 				assignedItem.IsDurable = row.IsDurable.Bool
 			}
 
 			succeeded = append(succeeded, assignedItem)
-			delete(taskIdToAssignedItem, row.TaskID)
+			delete(taskRetryToAssignedItem, key)
 		}
 	}
 
-	for _, assignedItem := range taskIdToAssignedItem {
+	for _, assignedItem := range taskRetryToAssignedItem {
 		failed = append(failed, assignedItem)
 	}
 
@@ -1196,6 +1209,7 @@ func (b *batchQueueRepository) commitAssignmentsTx(ctx context.Context, tx pgx.T
 	ids := make([]int64, 0, len(assignments))
 	taskIds := make([]int64, 0, len(assignments))
 	taskInsertedAts := make([]pgtype.Timestamptz, 0, len(assignments))
+	taskRetryCounts := make([]int32, 0, len(assignments))
 	workerIds := make([]uuid.UUID, 0, len(assignments))
 
 	var minTaskInsertedAt pgtype.Timestamptz
@@ -1208,6 +1222,7 @@ func (b *batchQueueRepository) commitAssignmentsTx(ctx context.Context, tx pgx.T
 		ids = append(ids, assignment.BatchQueueItemID)
 		taskIds = append(taskIds, assignment.TaskID)
 		taskInsertedAts = append(taskInsertedAts, assignment.TaskInsertedAt)
+		taskRetryCounts = append(taskRetryCounts, assignment.RetryCount)
 		workerIds = append(workerIds, assignment.WorkerID)
 
 		if assignment.TaskInsertedAt.Valid && (!minTaskInsertedAt.Valid || assignment.TaskInsertedAt.Time.Before(minTaskInsertedAt.Time)) {
@@ -1226,6 +1241,7 @@ func (b *batchQueueRepository) commitAssignmentsTx(ctx context.Context, tx pgx.T
 	updated, err := b.queries.UpdateTasksToAssigned(ctx, tx, sqlcv1.UpdateTasksToAssignedParams{
 		Taskids:           taskIds,
 		Taskinsertedats:   taskInsertedAts,
+		Taskretrycounts:   taskRetryCounts,
 		Workerids:         workerIds,
 		Mintaskinsertedat: minTaskInsertedAt,
 		Tenantid:          b.tenantId,
@@ -1234,10 +1250,10 @@ func (b *batchQueueRepository) commitAssignmentsTx(ctx context.Context, tx pgx.T
 		return nil, fmt.Errorf("could not update tasks to assigned: %w", err)
 	}
 
-	updatedTaskIDs := make(map[int64]struct{}, len(updated))
+	updatedTaskIDs := make(map[taskIdRetryCount]struct{}, len(updated))
 	for _, row := range updated {
 		if row != nil {
-			updatedTaskIDs[row.TaskID] = struct{}{}
+			updatedTaskIDs[taskIdRetryCount{taskId: row.TaskID, retryCount: row.RetryCount}] = struct{}{}
 		}
 	}
 
@@ -1246,7 +1262,7 @@ func (b *batchQueueRepository) commitAssignmentsTx(ctx context.Context, tx pgx.T
 		if a == nil {
 			continue
 		}
-		if _, ok := updatedTaskIDs[a.TaskID]; ok {
+		if _, ok := updatedTaskIDs[taskIdRetryCount{taskId: a.TaskID, retryCount: a.RetryCount}]; ok {
 			succeeded = append(succeeded, a)
 		}
 	}

--- a/pkg/repository/sqlcv1/queue.sql
+++ b/pkg/repository/sqlcv1/queue.sql
@@ -249,12 +249,14 @@ WITH input AS (
     SELECT
         id,
         inserted_at,
+        retry_count,
         worker_id
     FROM
         (
             SELECT
                 UNNEST(@taskIds::bigint[]) AS id,
                 UNNEST(@taskInsertedAts::timestamptz[]) AS inserted_at,
+                UNNEST(@taskRetryCounts::integer[]) AS retry_count,
                 UNNEST(@workerIds::uuid[]) AS worker_id
         ) AS subquery
     ORDER BY id
@@ -272,7 +274,7 @@ WITH input AS (
     FROM
         v1_task t
     JOIN
-        input i ON (t.id, t.inserted_at) = (i.id, i.inserted_at)
+        input i ON (t.id, t.inserted_at, t.retry_count) = (i.id, i.inserted_at, i.retry_count)
     WHERE
         t.inserted_at >= @minTaskInsertedAt::timestamptz
     ORDER BY t.id
@@ -345,6 +347,7 @@ WHERE v1_task_runtime.evicted_at IS NOT NULL
 SELECT
     asr.task_id,
     asr.task_inserted_at,
+    asr.retry_count,
     asr.worker_id,
     ut.is_durable
 FROM

--- a/pkg/repository/sqlcv1/queue.sql.go
+++ b/pkg/repository/sqlcv1/queue.sql.go
@@ -1985,13 +1985,15 @@ WITH input AS (
     SELECT
         id,
         inserted_at,
+        retry_count,
         worker_id
     FROM
         (
             SELECT
                 UNNEST($1::bigint[]) AS id,
                 UNNEST($2::timestamptz[]) AS inserted_at,
-                UNNEST($3::uuid[]) AS worker_id
+                UNNEST($3::integer[]) AS retry_count,
+                UNNEST($4::uuid[]) AS worker_id
         ) AS subquery
     ORDER BY id
 ), updated_tasks AS (
@@ -2008,9 +2010,9 @@ WITH input AS (
     FROM
         v1_task t
     JOIN
-        input i ON (t.id, t.inserted_at) = (i.id, i.inserted_at)
+        input i ON (t.id, t.inserted_at, t.retry_count) = (i.id, i.inserted_at, i.retry_count)
     WHERE
-        t.inserted_at >= $4::timestamptz
+        t.inserted_at >= $5::timestamptz
     ORDER BY t.id
 ), assigned_tasks AS (
     INSERT INTO v1_task_runtime (
@@ -2027,7 +2029,7 @@ WITH input AS (
         t.inserted_at,
         t.retry_count,
         t.worker_id,
-        $5::uuid,
+        $6::uuid,
         t.batch_key,
         t.timeout_at
     FROM
@@ -2081,6 +2083,7 @@ WHERE v1_task_runtime.evicted_at IS NOT NULL
 SELECT
     asr.task_id,
     asr.task_inserted_at,
+    asr.retry_count,
     asr.worker_id,
     ut.is_durable
 FROM
@@ -2092,6 +2095,7 @@ JOIN
 type UpdateTasksToAssignedParams struct {
 	Taskids           []int64              `json:"taskids"`
 	Taskinsertedats   []pgtype.Timestamptz `json:"taskinsertedats"`
+	Taskretrycounts   []int32              `json:"taskretrycounts"`
 	Workerids         []uuid.UUID          `json:"workerids"`
 	Mintaskinsertedat pgtype.Timestamptz   `json:"mintaskinsertedat"`
 	Tenantid          uuid.UUID            `json:"tenantid"`
@@ -2100,6 +2104,7 @@ type UpdateTasksToAssignedParams struct {
 type UpdateTasksToAssignedRow struct {
 	TaskID         int64              `json:"task_id"`
 	TaskInsertedAt pgtype.Timestamptz `json:"task_inserted_at"`
+	RetryCount     int32              `json:"retry_count"`
 	WorkerID       *uuid.UUID         `json:"worker_id"`
 	IsDurable      pgtype.Bool        `json:"is_durable"`
 }
@@ -2108,6 +2113,7 @@ func (q *Queries) UpdateTasksToAssigned(ctx context.Context, db DBTX, arg Update
 	rows, err := db.Query(ctx, updateTasksToAssigned,
 		arg.Taskids,
 		arg.Taskinsertedats,
+		arg.Taskretrycounts,
 		arg.Workerids,
 		arg.Mintaskinsertedat,
 		arg.Tenantid,
@@ -2122,6 +2128,7 @@ func (q *Queries) UpdateTasksToAssigned(ctx context.Context, db DBTX, arg Update
 		if err := rows.Scan(
 			&i.TaskID,
 			&i.TaskInsertedAt,
+			&i.RetryCount,
 			&i.WorkerID,
 			&i.IsDurable,
 		); err != nil {

--- a/pkg/repository/sqlcv1/tasks-overwrite.go
+++ b/pkg/repository/sqlcv1/tasks-overwrite.go
@@ -450,7 +450,24 @@ WITH input AS (
         unnest($8::uuid[]) AS triggering_event_external_id,
         unnest($9::text[]) AS triggering_event_key,
 		unnest($10::text[]) AS batch_key
+), deleted_stale_queue_items AS (
+    DELETE FROM v1_queue_item qi
+    USING input i
+    WHERE (qi.task_id, qi.task_inserted_at) = (i.task_id, i.task_inserted_at)
+), deleted_stale_batched_queue_items AS (
+    DELETE FROM v1_batched_queue_item bqi
+    USING input i
+    WHERE (bqi.task_id, bqi.task_inserted_at) = (i.task_id, i.task_inserted_at)
+), deleted_stale_rate_limited_queue_items AS (
+    DELETE FROM v1_rate_limited_queue_items rlqi
+    USING input i
+    WHERE (rlqi.task_id, rlqi.task_inserted_at) = (i.task_id, i.task_inserted_at)
+), deleted_stale_paused_workflow_queue_items AS (
+    DELETE FROM v1_paused_workflow_queue_item pwqi
+    USING input i
+    WHERE (pwqi.task_id, pwqi.task_inserted_at) = (i.task_id, i.task_inserted_at)
 )
+
 UPDATE
     v1_task
 SET

--- a/pkg/repository/sqlcv1/tasks-overwrite.go
+++ b/pkg/repository/sqlcv1/tasks-overwrite.go
@@ -450,22 +450,6 @@ WITH input AS (
         unnest($8::uuid[]) AS triggering_event_external_id,
         unnest($9::text[]) AS triggering_event_key,
 		unnest($10::text[]) AS batch_key
-), deleted_stale_queue_items AS (
-    DELETE FROM v1_queue_item qi
-    USING input i
-    WHERE (qi.task_id, qi.task_inserted_at) = (i.task_id, i.task_inserted_at)
-), deleted_stale_batched_queue_items AS (
-    DELETE FROM v1_batched_queue_item bqi
-    USING input i
-    WHERE (bqi.task_id, bqi.task_inserted_at) = (i.task_id, i.task_inserted_at)
-), deleted_stale_rate_limited_queue_items AS (
-    DELETE FROM v1_rate_limited_queue_items rlqi
-    USING input i
-    WHERE (rlqi.task_id, rlqi.task_inserted_at) = (i.task_id, i.task_inserted_at)
-), deleted_stale_paused_workflow_queue_items AS (
-    DELETE FROM v1_paused_workflow_queue_item pwqi
-    USING input i
-    WHERE (pwqi.task_id, pwqi.task_inserted_at) = (i.task_id, i.task_inserted_at)
 )
 
 UPDATE

--- a/pkg/repository/sqlcv1/tasks.sql
+++ b/pkg/repository/sqlcv1/tasks.sql
@@ -928,7 +928,7 @@ FROM
 
 -- name: PreflightCheckTasksForReplay :many
 -- Checks whether tasks can be replayed by ensuring that they don't have any active runtimes,
--- concurrency slots, or retry queue items. Returns the tasks which cannot be replayed.
+-- concurrency slots, retry queue items, or pending queue items. Returns the tasks which cannot be replayed.
 WITH input AS (
     SELECT
         UNNEST(@taskIds::bigint[]) AS task_id,
@@ -952,6 +952,14 @@ LEFT JOIN
     v1_concurrency_slot cs ON cs.task_id = t.id AND cs.task_inserted_at = t.inserted_at AND cs.task_retry_count = t.retry_count
 LEFT JOIN
     v1_retry_queue_item rqi ON rqi.task_id = t.id AND rqi.task_inserted_at = t.inserted_at AND rqi.task_retry_count = t.retry_count
+LEFT JOIN
+    v1_queue_item qi ON qi.task_id = t.id AND qi.task_inserted_at = t.inserted_at AND qi.retry_count = t.retry_count
+LEFT JOIN
+    v1_batched_queue_item bqi ON bqi.task_id = t.id AND bqi.task_inserted_at = t.inserted_at AND bqi.retry_count = t.retry_count
+LEFT JOIN
+    v1_rate_limited_queue_items rlqi ON rlqi.task_id = t.id AND rlqi.task_inserted_at = t.inserted_at AND rlqi.retry_count = t.retry_count
+LEFT JOIN
+    v1_paused_workflow_queue_item pwqi ON pwqi.task_id = t.id AND pwqi.task_inserted_at = t.inserted_at AND pwqi.retry_count = t.retry_count
 WHERE
     t.tenant_id = @tenantId::uuid
     AND NOT EXISTS (
@@ -963,7 +971,15 @@ WHERE
             AND (e.task_id, e.task_inserted_at, e.retry_count) = (t.id, t.inserted_at, t.retry_count)
             AND e.event_type = ANY('{COMPLETED, FAILED, CANCELLED}'::v1_task_event_type[])
     )
-    AND (tr.task_id IS NOT NULL OR cs.task_id IS NOT NULL OR rqi.task_id IS NOT NULL)
+    AND (
+        tr.task_id IS NOT NULL
+        OR cs.task_id IS NOT NULL
+        OR rqi.task_id IS NOT NULL
+        OR qi.task_id IS NOT NULL
+        OR bqi.task_id IS NOT NULL
+        OR rlqi.task_id IS NOT NULL
+        OR pwqi.task_id IS NOT NULL
+    )
 ;
 
 -- name: ListAllTasksInDags :many

--- a/pkg/repository/sqlcv1/tasks.sql.go
+++ b/pkg/repository/sqlcv1/tasks.sql.go
@@ -2911,6 +2911,14 @@ LEFT JOIN
     v1_concurrency_slot cs ON cs.task_id = t.id AND cs.task_inserted_at = t.inserted_at AND cs.task_retry_count = t.retry_count
 LEFT JOIN
     v1_retry_queue_item rqi ON rqi.task_id = t.id AND rqi.task_inserted_at = t.inserted_at AND rqi.task_retry_count = t.retry_count
+LEFT JOIN
+    v1_queue_item qi ON qi.task_id = t.id AND qi.task_inserted_at = t.inserted_at AND qi.retry_count = t.retry_count
+LEFT JOIN
+    v1_batched_queue_item bqi ON bqi.task_id = t.id AND bqi.task_inserted_at = t.inserted_at AND bqi.retry_count = t.retry_count
+LEFT JOIN
+    v1_rate_limited_queue_items rlqi ON rlqi.task_id = t.id AND rlqi.task_inserted_at = t.inserted_at AND rlqi.retry_count = t.retry_count
+LEFT JOIN
+    v1_paused_workflow_queue_item pwqi ON pwqi.task_id = t.id AND pwqi.task_inserted_at = t.inserted_at AND pwqi.retry_count = t.retry_count
 WHERE
     t.tenant_id = $1::uuid
     AND NOT EXISTS (
@@ -2922,7 +2930,15 @@ WHERE
             AND (e.task_id, e.task_inserted_at, e.retry_count) = (t.id, t.inserted_at, t.retry_count)
             AND e.event_type = ANY('{COMPLETED, FAILED, CANCELLED}'::v1_task_event_type[])
     )
-    AND (tr.task_id IS NOT NULL OR cs.task_id IS NOT NULL OR rqi.task_id IS NOT NULL)
+    AND (
+        tr.task_id IS NOT NULL
+        OR cs.task_id IS NOT NULL
+        OR rqi.task_id IS NOT NULL
+        OR qi.task_id IS NOT NULL
+        OR bqi.task_id IS NOT NULL
+        OR rlqi.task_id IS NOT NULL
+        OR pwqi.task_id IS NOT NULL
+    )
 `
 
 type PreflightCheckTasksForReplayParams struct {
@@ -2938,7 +2954,7 @@ type PreflightCheckTasksForReplayRow struct {
 }
 
 // Checks whether tasks can be replayed by ensuring that they don't have any active runtimes,
-// concurrency slots, or retry queue items. Returns the tasks which cannot be replayed.
+// concurrency slots, retry queue items, or pending queue items. Returns the tasks which cannot be replayed.
 func (q *Queries) PreflightCheckTasksForReplay(ctx context.Context, db DBTX, arg PreflightCheckTasksForReplayParams) ([]*PreflightCheckTasksForReplayRow, error) {
 	rows, err := db.Query(ctx, preflightCheckTasksForReplay,
 		arg.Tenantid,

--- a/pkg/repository/task_replay_test.go
+++ b/pkg/repository/task_replay_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 )
 
-// replaying a task already has a queue item shouldn't create a duplicate queue item for the same task,
-// which has been happening before. instead, we should just use a last-write-wins strategy and delete the prior queue
-// item(s) for the task
-func TestReplayQueuedTaskDoesNotDuplicateQueueItems(t *testing.T) {
+// replaying a task that already has a queue item used to create a duplicate queue item for the same
+// task at a different retry count. the preflight check must reject replays of tasks that are still
+// waiting in the queue so this can't happen.
+func TestReplayQueuedTaskIsRejected(t *testing.T) {
 	pool, cleanup := setupPostgresWithMigration(t)
 	defer cleanup()
 
@@ -83,12 +83,14 @@ func TestReplayQueuedTaskDoesNotDuplicateQueueItems(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.Len(t, replayed.ReplayedTasks, 1)
+	require.Empty(t, replayed.ReplayedTasks,
+		"replaying a task that is still waiting in the queue must be rejected by the preflight check")
 
 	var taskRetryCount int32
 	require.NoError(t, pool.QueryRow(ctx, `
 		SELECT retry_count FROM v1_task WHERE id = $1`, task.ID).Scan(&taskRetryCount))
+	require.Equal(t, int32(0), taskRetryCount)
 
-	require.Equal(t, []int32{taskRetryCount}, listQueueItemRetryCounts(),
-		"replaying a queued task must leave exactly one queue item, at the task's current retry count")
+	require.Equal(t, []int32{0}, listQueueItemRetryCounts(),
+		"a rejected replay must leave the existing queue item untouched")
 }

--- a/pkg/repository/task_replay_test.go
+++ b/pkg/repository/task_replay_test.go
@@ -1,0 +1,94 @@
+//go:build !e2e && !load && !rampup && !integration
+
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
+)
+
+// replaying a task already has a queue item shouldn't create a duplicate queue item for the same task,
+// which has been happening before. instead, we should just use a last-write-wins strategy and delete the prior queue
+// item(s) for the task
+func TestReplayQueuedTaskDoesNotDuplicateQueueItems(t *testing.T) {
+	pool, cleanup := setupPostgresWithMigration(t)
+	defer cleanup()
+
+	repo := newBatchTestRepository(pool)
+	workflows := &workflowRepository{sharedRepository: repo.sharedRepository}
+
+	ctx := context.Background()
+
+	wf, err := workflows.PutWorkflowVersion(ctx, internalTenantId, minimalWorkflowOpts("replay-queued-task", "v1", nil))
+	require.NoError(t, err)
+
+	steps, err := repo.queries.ListStepsByWorkflowVersionIds(ctx, pool, sqlcv1.ListStepsByWorkflowVersionIdsParams{
+		Ids:      []uuid.UUID{wf.WorkflowVersion.ID},
+		Tenantid: internalTenantId,
+	})
+	require.NoError(t, err)
+	require.Len(t, steps, 1)
+
+	stepID := steps[0].ID
+
+	stepIdsToConfig, err := repo.sharedRepository.listStepsByIds(ctx, pool, internalTenantId, []uuid.UUID{stepID})
+	require.NoError(t, err)
+	require.Contains(t, stepIdsToConfig, stepID)
+
+	insertedTasks, err := repo.sharedRepository.insertTasks(ctx, repo.pool, internalTenantId, []CreateTaskOpts{
+		{
+			ExternalId:    uuid.New(),
+			WorkflowRunId: uuid.New(),
+			StepId:        stepID,
+			Input:         &TaskInput{Input: map[string]interface{}{"key": "value"}},
+			StepIndex:     0,
+			InitialState:  sqlcv1.V1TaskInitialStateQUEUED,
+		},
+	}, stepIdsToConfig)
+	require.NoError(t, err)
+	require.Len(t, insertedTasks, 1)
+
+	task := insertedTasks[0]
+
+	listQueueItemRetryCounts := func() []int32 {
+		rows, err := pool.Query(ctx, `
+			SELECT retry_count FROM v1_queue_item WHERE task_id = $1 ORDER BY retry_count`,
+			task.ID,
+		)
+		require.NoError(t, err)
+		defer rows.Close()
+
+		var retryCounts []int32
+		for rows.Next() {
+			var retryCount int32
+			require.NoError(t, rows.Scan(&retryCount))
+			retryCounts = append(retryCounts, retryCount)
+		}
+		require.NoError(t, rows.Err())
+		return retryCounts
+	}
+
+	require.Equal(t, []int32{0}, listQueueItemRetryCounts())
+
+	replayed, err := repo.ReplayTasks(ctx, internalTenantId, []TaskIdInsertedAtRetryCount{
+		{
+			Id:         task.ID,
+			InsertedAt: task.InsertedAt,
+			RetryCount: task.RetryCount,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, replayed.ReplayedTasks, 1)
+
+	var taskRetryCount int32
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT retry_count FROM v1_task WHERE id = $1`, task.ID).Scan(&taskRetryCount))
+
+	require.Equal(t, []int32{taskRetryCount}, listQueueItemRetryCounts(),
+		"replaying a queued task must leave exactly one queue item, at the task's current retry count")
+}

--- a/pkg/repository/task_test.go
+++ b/pkg/repository/task_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog"
@@ -18,6 +19,7 @@ import (
 	"github.com/hatchet-dev/hatchet/pkg/repository/cache"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlchelpers"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
+	"github.com/hatchet-dev/hatchet/pkg/validator"
 )
 
 func newBatchTestRepository(pool *pgxpool.Pool) *TaskRepositoryImpl {
@@ -34,13 +36,16 @@ func newBatchTestRepository(pool *pgxpool.Pool) *TaskRepositoryImpl {
 
 	shared := &sharedRepository{
 		pool:                pool,
+		ddlPool:             pool,
 		l:                   &logger,
+		v:                   validator.NewDefaultValidator(),
 		queries:             queries,
 		queueCache:          queueCache,
 		stepExpressionCache: stepExpressionCache,
 		celParser:           cel.NewCELParser(),
 		taskLookupCache:     taskLookupCache,
 		payloadStore:        payloadStore,
+		stepIdConfigCache:   expirable.NewLRU(10000, func(key uuid.UUID, value *sqlcv1.ListStepsByIdsRow) {}, 5*time.Minute),
 	}
 
 	return &TaskRepositoryImpl{


### PR DESCRIPTION
# Description

We've been seeing a bunch of this:

```
ERR error marking queue items processed error="ERROR: ON CONFLICT DO UPDATE command cannot affect row a second time (SQLSTATE 21000)"
```

Which I think is coming from the same task but with two different retry counts being inserted at the same time, and failing. Instead, we should only try to insert a runtime for the current retry, and drop the old one on the floor. Just doing a join + threading the retry counts here through to achieve that

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI

</details>
