### PR TITLE
refactor(engine): buffer durable event ingestion

### DIFF
--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -391,6 +391,12 @@ func (c *ConfigLoader) InitDataLayer() (res *database.Layer, err error) {
 		DAG:  int32(scf.OLAPStatusUpdates.DagBatchSizeLimit),  // #nosec G115 -- admin-configured server setting, not attacker-controlled
 	}
 
+	durableEventBufferOpts := repov1.DurableEventBufferOpts{
+		FlushInterval:        scf.Runtime.DurableEventBufferFlushInterval,
+		MaxBatchSize:         scf.Runtime.DurableEventBufferMaxSize,
+		MaxConcurrentFlushes: scf.Runtime.DurableEventBufferMaxConcurrentFlushes,
+	}
+
 	v1, cleanupV1 := repov1.NewRepository(
 		pool,
 		ddlPool,
@@ -404,6 +410,7 @@ func (c *ConfigLoader) InitDataLayer() (res *database.Layer, err error) {
 		statusUpdateOpts,
 		scf.Runtime.Limits,
 		scf.Runtime.EnforceLimits,
+		durableEventBufferOpts,
 	)
 
 	if readReplicaPool != nil {

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -342,7 +342,7 @@ type ConfigFileRuntime struct {
 
 	// DurableEventBufferMaxSize caps how many durable task events a single flush
 	// batches together, so a burst of traffic still flushes promptly.
-	DurableEventBufferMaxSize int `mapstructure:"durableEventBufferMaxSize" json:"durableEventBufferMaxSize,omitempty" default:"20"`
+	DurableEventBufferMaxSize int `mapstructure:"durableEventBufferMaxSize" json:"durableEventBufferMaxSize,omitempty" default:"100"`
 
 	// DurableEventBufferMaxConcurrentFlushes bounds how many durable event ingestion
 	// transactions run concurrently.

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -336,6 +336,18 @@ type ConfigFileRuntime struct {
 	// WorkflowRunBufferSize is the buffer size for workflow run event batching in the dispatcher
 	WorkflowRunBufferSize int `mapstructure:"workflowRunBufferSize" json:"workflowRunBufferSize,omitempty" default:"1000"`
 
+	// DurableEventBufferFlushInterval is how long a durable task event waits in the
+	// ingestion buffer to accumulate a batch before the batch is flushed to the database.
+	DurableEventBufferFlushInterval time.Duration `mapstructure:"durableEventBufferFlushInterval" json:"durableEventBufferFlushInterval,omitempty" default:"10ms"`
+
+	// DurableEventBufferMaxSize caps how many durable task events a single flush
+	// batches together, so a burst of traffic still flushes promptly.
+	DurableEventBufferMaxSize int `mapstructure:"durableEventBufferMaxSize" json:"durableEventBufferMaxSize,omitempty" default:"20"`
+
+	// DurableEventBufferMaxConcurrentFlushes bounds how many durable event ingestion
+	// transactions run concurrently.
+	DurableEventBufferMaxConcurrentFlushes int `mapstructure:"durableEventBufferMaxConcurrentFlushes" json:"durableEventBufferMaxConcurrentFlushes,omitempty" default:"16"`
+
 	// StreamEventBufferTimeout is the timeout duration for the stream event buffer in the dispatcher.
 	// This controls how long the buffer waits for out-of-order events before flushing them.
 	StreamEventBufferTimeout time.Duration `mapstructure:"streamEventBufferTimeout" json:"streamEventBufferTimeout,omitempty" default:"5s"`
@@ -1061,6 +1073,9 @@ func BindAllEnv(v *viper.Viper) {
 
 	// dispatcher options
 	_ = v.BindEnv("runtime.workflowRunBufferSize", "SERVER_WORKFLOW_RUN_BUFFER_SIZE")
+	_ = v.BindEnv("runtime.durableEventBufferFlushInterval", "SERVER_DURABLE_EVENT_BUFFER_FLUSH_INTERVAL")
+	_ = v.BindEnv("runtime.durableEventBufferMaxSize", "SERVER_DURABLE_EVENT_BUFFER_MAX_SIZE")
+	_ = v.BindEnv("runtime.durableEventBufferMaxConcurrentFlushes", "SERVER_DURABLE_EVENT_BUFFER_MAX_CONCURRENT_FLUSHES")
 	_ = v.BindEnv("runtime.streamEventBufferTimeout", "SERVER_STREAM_EVENT_BUFFER_TIMEOUT")
 
 	// payload store options

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -169,6 +169,9 @@ type durableEventsRepository struct {
 	ingestBuffer *durableEventIngestBuffer
 }
 
+// DurableEventBufferOpts configures how IngestDurableTaskEvent requests are buffered into
+// batched database transactions: each request waits up to FlushInterval to accumulate a batch
+// of at most MaxBatchSize requests, and at most MaxConcurrentFlushes batches run at once.
 type DurableEventBufferOpts struct {
 	FlushInterval        time.Duration
 	MaxBatchSize         int
@@ -185,7 +188,7 @@ func newDurableEventsRepository(shared *sharedRepository, opts DurableEventBuffe
 	return r
 }
 
-type TaskId int64
+type durableTaskId int64
 
 type appendDurableEventLogResult struct {
 	logEntries                  []*EventLogEntryWithPayloads
@@ -199,7 +202,7 @@ type durableEventIngestResponse struct {
 }
 
 type durableEventIngestRequest struct {
-	taskId     TaskId
+	taskId     durableTaskId
 	opts       IngestDurableTaskEventOpts
 	responseCh chan durableEventIngestResponse
 }
@@ -211,11 +214,11 @@ type durableEventIngestBuffer struct {
 	flushInterval  time.Duration
 	maxBatchSize   int
 	flushSemaphore chan struct{}
-	ingest         func(ctx context.Context, batch map[TaskId]IngestDurableTaskEventOpts) (map[TaskId]*appendDurableEventLogResult, map[TaskId]error, error)
+	ingest         func(ctx context.Context, batch map[durableTaskId]IngestDurableTaskEventOpts) (map[durableTaskId]*appendDurableEventLogResult, map[durableTaskId]error, error)
 }
 
 func newDurableEventIngestBuffer(
-	ingest func(ctx context.Context, batch map[TaskId]IngestDurableTaskEventOpts) (map[TaskId]*appendDurableEventLogResult, map[TaskId]error, error),
+	ingest func(ctx context.Context, batch map[durableTaskId]IngestDurableTaskEventOpts) (map[durableTaskId]*appendDurableEventLogResult, map[durableTaskId]error, error),
 	flushInterval time.Duration,
 	maxBatchSize int,
 	maxConcurrentFlushes int,
@@ -228,7 +231,7 @@ func newDurableEventIngestBuffer(
 	}
 }
 
-func (b *durableEventIngestBuffer) submit(ctx context.Context, taskId TaskId, opts IngestDurableTaskEventOpts) (*appendDurableEventLogResult, error) {
+func (b *durableEventIngestBuffer) submit(ctx context.Context, taskId durableTaskId, opts IngestDurableTaskEventOpts) (*appendDurableEventLogResult, error) {
 	request := &durableEventIngestRequest{
 		taskId:     taskId,
 		opts:       opts,
@@ -277,11 +280,15 @@ func (b *durableEventIngestBuffer) flushAfterInterval() {
 }
 
 func (b *durableEventIngestBuffer) flush(requests []*durableEventIngestRequest) {
-	batch := make(map[TaskId]IngestDurableTaskEventOpts, len(requests))
-	requestByTaskId := make(map[TaskId]*durableEventIngestRequest, len(requests))
+	batch := make(map[durableTaskId]IngestDurableTaskEventOpts, len(requests))
+	requestByTaskId := make(map[durableTaskId]*durableEventIngestRequest, len(requests))
 
-	// two requests for the same task must not share a batch: each ingest needs to observe the
-	// log file state left behind by the previous one, so later duplicates go to a follow-up flush
+	// concurrent requests for the same task (parallel durable operations in user code, or a stale
+	// invocation racing a replay) used to be serialized by the log file row lock, with each
+	// transaction reading the latest_node_id the previous one committed. A batch takes that lock
+	// once and reads the log file once, so same-task duplicates would plan colliding node ids from
+	// the same snapshot — instead they wait for a follow-up flush, which starts after this batch's
+	// ingest completes and therefore sees its committed state
 	var deferredRequests []*durableEventIngestRequest
 
 	for _, request := range requests {
@@ -917,13 +924,13 @@ func resolveBranchForNode(nodeId, currentBranchId int64, nextBranchIdToBranchPoi
 }
 
 type taskNodeBranchKey struct {
-	taskId   TaskId
+	taskId   durableTaskId
 	nodeId   int64
 	branchId int64
 }
 
 type taskLogEntryState struct {
-	taskId             TaskId
+	taskId             durableTaskId
 	opts               GetOrCreateLogEntryOpts
 	skipOpts           []GetOrCreateLogEntryOpt
 	nonSkipOpts        []GetOrCreateLogEntryOpt
@@ -933,15 +940,11 @@ type taskLogEntryState struct {
 	skipEntryByChildId map[uuid.UUID]*sqlcv1.BulkGetDurableEventLogEntriesRow
 }
 
-// getOrCreateEventLogEntriesForTasks processes one GetOrCreateLogEntryOpts per task inside the
-// shared transaction. A task whose entries fail validation before anything is written for it gets
-// a per-task error and is excluded from the rest of the batch; errors after that point (failed
-// queries, skip-entry validation) abort the whole transaction and are returned as the batch error.
 func (r *durableEventsRepository) getOrCreateEventLogEntriesForTasks(
 	ctx context.Context,
 	tx sqlcv1.DBTX,
 	batch []GetOrCreateLogEntryOpts,
-) (map[TaskId][]*EventLogEntryWithPayloads, []StorePayloadOpts, map[TaskId]error, error) {
+) (map[durableTaskId][]*EventLogEntryWithPayloads, []StorePayloadOpts, map[durableTaskId]error, error) {
 	ctx, span := telemetry.NewSpan(ctx, "get-or-create-durable-event-log-entries")
 	defer span.End()
 
@@ -955,11 +958,11 @@ func (r *durableEventsRepository) getOrCreateEventLogEntriesForTasks(
 		telemetry.AttributeKV{Key: "entry_count", Value: entryCount},
 	)
 
-	taskErrors := make(map[TaskId]error)
-	resultsByTaskId := make(map[TaskId][]*EventLogEntryWithPayloads, len(batch))
+	taskErrors := make(map[durableTaskId]error)
+	resultsByTaskId := make(map[durableTaskId][]*EventLogEntryWithPayloads, len(batch))
 
 	states := make([]*taskLogEntryState, 0, len(batch))
-	stateByTaskId := make(map[TaskId]*taskLogEntryState, len(batch))
+	stateByTaskId := make(map[durableTaskId]*taskLogEntryState, len(batch))
 
 	for _, opts := range batch {
 		if len(opts.Entries) == 0 {
@@ -967,7 +970,7 @@ func (r *durableEventsRepository) getOrCreateEventLogEntriesForTasks(
 		}
 
 		state := &taskLogEntryState{
-			taskId:             TaskId(opts.DurableTaskId),
+			taskId:             durableTaskId(opts.DurableTaskId),
 			opts:               opts,
 			existedEntries:     make(map[NodeIdBranchIdTuple]*sqlcv1.BulkGetDurableEventLogEntriesRow),
 			newEntryByKey:      make(map[NodeIdBranchIdTuple]GetOrCreateLogEntryOpt),
@@ -1007,7 +1010,7 @@ func (r *durableEventsRepository) getOrCreateEventLogEntriesForTasks(
 		}
 
 		for _, e := range existing {
-			existingByKey[taskNodeBranchKey{TaskId(e.DurableTaskID), e.NodeID, e.BranchID}] = e
+			existingByKey[taskNodeBranchKey{durableTaskId(e.DurableTaskID), e.NodeID, e.BranchID}] = e
 		}
 	}
 
@@ -1096,7 +1099,7 @@ func (r *durableEventsRepository) getOrCreateEventLogEntriesForTasks(
 		}
 
 		for _, createdRow := range createdRows {
-			state, ok := stateByTaskId[TaskId(createdRow.DurableTaskID)]
+			state, ok := stateByTaskId[durableTaskId(createdRow.DurableTaskID)]
 			if !ok {
 				continue
 			}
@@ -1425,7 +1428,7 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 	tenantId := opts.TenantId
 	task := opts.Task
 
-	appendResult, err := r.ingestBuffer.submit(ctx, TaskId(task.ID), opts)
+	appendResult, err := r.ingestBuffer.submit(ctx, durableTaskId(task.ID), opts)
 
 	if err != nil {
 		r.enrichNonDeterminismErrorDetail(ctx, opts, err)
@@ -1654,13 +1657,13 @@ func (r *durableEventsRepository) resolveChildExternalIds(ctx context.Context, t
 	return nil
 }
 
-func (r *durableEventsRepository) appendDurableEventLogBatch(ctx context.Context, batch map[TaskId]IngestDurableTaskEventOpts) (map[TaskId]*appendDurableEventLogResult, map[TaskId]error, error) {
+func (r *durableEventsRepository) appendDurableEventLogBatch(ctx context.Context, batch map[durableTaskId]IngestDurableTaskEventOpts) (map[durableTaskId]*appendDurableEventLogResult, map[durableTaskId]error, error) {
 	ctx, span := telemetry.NewSpan(ctx, "append-durable-event-log-batch")
 	defer span.End()
 
 	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "batch_size", Value: len(batch)})
 
-	taskIds := make([]TaskId, 0, len(batch))
+	taskIds := make([]durableTaskId, 0, len(batch))
 	for taskId := range batch {
 		taskIds = append(taskIds, taskId)
 	}
@@ -1698,12 +1701,12 @@ func (r *durableEventsRepository) appendDurableEventLogBatch(ctx context.Context
 		return nil, nil, fmt.Errorf("failed to lock log files: %w", err)
 	}
 
-	logFileByTaskId := make(map[TaskId]*sqlcv1.V1DurableEventLogFile, len(batch))
-	branchPointsByTaskId := make(map[TaskId]map[int64]*sqlcv1.V1DurableEventLogBranchPoint, len(batch))
+	logFileByTaskId := make(map[durableTaskId]*sqlcv1.V1DurableEventLogFile, len(batch))
+	branchPointsByTaskId := make(map[durableTaskId]map[int64]*sqlcv1.V1DurableEventLogBranchPoint, len(batch))
 
 	for _, row := range lockRows {
 		logFile := row.V1DurableEventLogFile
-		taskId := TaskId(logFile.DurableTaskID)
+		taskId := durableTaskId(logFile.DurableTaskID)
 
 		if _, ok := logFileByTaskId[taskId]; !ok {
 			logFileCopy := logFile
@@ -1728,8 +1731,8 @@ func (r *durableEventsRepository) appendDurableEventLogBatch(ctx context.Context
 		}
 	}
 
-	taskErrors := make(map[TaskId]error)
-	planByTaskId := make(map[TaskId]*durableEventLogAppendPlan, len(batch))
+	taskErrors := make(map[durableTaskId]error)
+	planByTaskId := make(map[durableTaskId]*durableEventLogAppendPlan, len(batch))
 	orderedGetOrCreateOpts := make([]GetOrCreateLogEntryOpts, 0, len(batch))
 
 	for _, taskId := range taskIds {
@@ -1844,12 +1847,12 @@ func (r *durableEventsRepository) appendDurableEventLogBatch(ctx context.Context
 			nodeId := le.Entry.NodeID
 			branchId := le.Entry.BranchID
 			runEventLogEntrySignalKey := fmt.Sprintf("durable_run:%s:%d:%d", task.ExternalID.String(), branchId, nodeId)
-			durableTaskId := task.ID
+			signalTaskId := task.ID
 
 			replayMatchOptsByTenantId[plan.opts.TenantId] = append(replayMatchOptsByTenantId[plan.opts.TenantId], CreateMatchOpts{
 				Kind:                         sqlcv1.V1MatchKindSIGNAL,
 				Conditions:                   conditions,
-				SignalTaskId:                 &durableTaskId,
+				SignalTaskId:                 &signalTaskId,
 				SignalTaskInsertedAt:         task.InsertedAt,
 				SignalExternalId:             &childExternalId,
 				SignalTaskExternalId:         &task.ExternalID,
@@ -1899,7 +1902,7 @@ func (r *durableEventsRepository) appendDurableEventLogBatch(ctx context.Context
 		return nil, nil, err
 	}
 
-	results := make(map[TaskId]*appendDurableEventLogResult, len(planByTaskId))
+	results := make(map[durableTaskId]*appendDurableEventLogResult, len(planByTaskId))
 
 	for taskId, plan := range planByTaskId {
 		results[taskId] = &appendDurableEventLogResult{

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -175,33 +175,12 @@ type DurableEventBufferOpts struct {
 	MaxConcurrentFlushes int
 }
 
-const (
-	defaultDurableEventIngestFlushInterval        = 10 * time.Millisecond
-	defaultDurableEventIngestMaxBatchSize         = 20
-	defaultDurableEventIngestMaxConcurrentFlushes = 16
-)
-
 func newDurableEventsRepository(shared *sharedRepository, opts DurableEventBufferOpts) *durableEventsRepository {
 	r := &durableEventsRepository{
 		sharedRepository: shared,
 	}
 
-	flushInterval := opts.FlushInterval
-	if flushInterval <= 0 {
-		flushInterval = defaultDurableEventIngestFlushInterval
-	}
-
-	maxBatchSize := opts.MaxBatchSize
-	if maxBatchSize <= 0 {
-		maxBatchSize = defaultDurableEventIngestMaxBatchSize
-	}
-
-	maxConcurrentFlushes := opts.MaxConcurrentFlushes
-	if maxConcurrentFlushes <= 0 {
-		maxConcurrentFlushes = defaultDurableEventIngestMaxConcurrentFlushes
-	}
-
-	r.ingestBuffer = newDurableEventIngestBuffer(r.appendDurableEventLogBatch, flushInterval, maxBatchSize, maxConcurrentFlushes)
+	r.ingestBuffer = newDurableEventIngestBuffer(r.appendDurableEventLogBatch, opts.FlushInterval, opts.MaxBatchSize, opts.MaxConcurrentFlushes)
 
 	return r
 }

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -164,11 +165,191 @@ type DurableEventsRepository interface {
 
 type durableEventsRepository struct {
 	*sharedRepository
+
+	ingestBuffer *durableEventIngestBuffer
 }
 
-func newDurableEventsRepository(shared *sharedRepository) DurableEventsRepository {
-	return &durableEventsRepository{
+type DurableEventBufferOpts struct {
+	FlushInterval        time.Duration
+	MaxBatchSize         int
+	MaxConcurrentFlushes int
+}
+
+const (
+	defaultDurableEventIngestFlushInterval        = 10 * time.Millisecond
+	defaultDurableEventIngestMaxBatchSize         = 20
+	defaultDurableEventIngestMaxConcurrentFlushes = 16
+)
+
+func newDurableEventsRepository(shared *sharedRepository, opts DurableEventBufferOpts) *durableEventsRepository {
+	r := &durableEventsRepository{
 		sharedRepository: shared,
+	}
+
+	flushInterval := opts.FlushInterval
+	if flushInterval <= 0 {
+		flushInterval = defaultDurableEventIngestFlushInterval
+	}
+
+	maxBatchSize := opts.MaxBatchSize
+	if maxBatchSize <= 0 {
+		maxBatchSize = defaultDurableEventIngestMaxBatchSize
+	}
+
+	maxConcurrentFlushes := opts.MaxConcurrentFlushes
+	if maxConcurrentFlushes <= 0 {
+		maxConcurrentFlushes = defaultDurableEventIngestMaxConcurrentFlushes
+	}
+
+	r.ingestBuffer = newDurableEventIngestBuffer(r.appendDurableEventLogBatch, flushInterval, maxBatchSize, maxConcurrentFlushes)
+
+	return r
+}
+
+type TaskId int64
+
+type appendDurableEventLogResult struct {
+	logEntries                  []*EventLogEntryWithPayloads
+	nodeIdBranchIdToTriggerOpts map[NodeIdBranchIdTuple]*WorkflowNameTriggerOpts
+	childrenToReplay            map[uuid.UUID]bool
+}
+
+type durableEventIngestResponse struct {
+	result *appendDurableEventLogResult
+	err    error
+}
+
+type durableEventIngestRequest struct {
+	taskId     TaskId
+	opts       IngestDurableTaskEventOpts
+	responseCh chan durableEventIngestResponse
+}
+
+type durableEventIngestBuffer struct {
+	mu             sync.Mutex
+	pending        []*durableEventIngestRequest
+	flushScheduled bool
+	flushInterval  time.Duration
+	maxBatchSize   int
+	flushSemaphore chan struct{}
+	ingest         func(ctx context.Context, batch map[TaskId]IngestDurableTaskEventOpts) (map[TaskId]*appendDurableEventLogResult, map[TaskId]error, error)
+}
+
+func newDurableEventIngestBuffer(
+	ingest func(ctx context.Context, batch map[TaskId]IngestDurableTaskEventOpts) (map[TaskId]*appendDurableEventLogResult, map[TaskId]error, error),
+	flushInterval time.Duration,
+	maxBatchSize int,
+	maxConcurrentFlushes int,
+) *durableEventIngestBuffer {
+	return &durableEventIngestBuffer{
+		flushInterval:  flushInterval,
+		maxBatchSize:   maxBatchSize,
+		flushSemaphore: make(chan struct{}, maxConcurrentFlushes),
+		ingest:         ingest,
+	}
+}
+
+func (b *durableEventIngestBuffer) submit(ctx context.Context, taskId TaskId, opts IngestDurableTaskEventOpts) (*appendDurableEventLogResult, error) {
+	request := &durableEventIngestRequest{
+		taskId:     taskId,
+		opts:       opts,
+		responseCh: make(chan durableEventIngestResponse, 1),
+	}
+
+	b.mu.Lock()
+	b.pending = append(b.pending, request)
+
+	var requestsToFlush []*durableEventIngestRequest
+
+	if len(b.pending) >= b.maxBatchSize {
+		requestsToFlush = b.pending
+		b.pending = nil
+		b.flushScheduled = false
+	} else if !b.flushScheduled {
+		b.flushScheduled = true
+		go b.flushAfterInterval()
+	}
+	b.mu.Unlock()
+
+	if requestsToFlush != nil {
+		go b.flush(requestsToFlush) // #nosec G118 -- one flush serves many request contexts, so it intentionally runs detached from any single one
+	}
+
+	select {
+	case response := <-request.responseCh:
+		return response.result, response.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (b *durableEventIngestBuffer) flushAfterInterval() {
+	time.Sleep(b.flushInterval)
+
+	b.mu.Lock()
+	requestsToFlush := b.pending
+	b.pending = nil
+	b.flushScheduled = false
+	b.mu.Unlock()
+
+	if len(requestsToFlush) > 0 {
+		b.flush(requestsToFlush)
+	}
+}
+
+func (b *durableEventIngestBuffer) flush(requests []*durableEventIngestRequest) {
+	batch := make(map[TaskId]IngestDurableTaskEventOpts, len(requests))
+	requestByTaskId := make(map[TaskId]*durableEventIngestRequest, len(requests))
+
+	// two requests for the same task must not share a batch: each ingest needs to observe the
+	// log file state left behind by the previous one, so later duplicates go to a follow-up flush
+	var deferredRequests []*durableEventIngestRequest
+
+	for _, request := range requests {
+		if _, exists := batch[request.taskId]; exists {
+			deferredRequests = append(deferredRequests, request)
+			continue
+		}
+
+		batch[request.taskId] = request.opts
+		requestByTaskId[request.taskId] = request
+	}
+
+	b.flushSemaphore <- struct{}{}
+	results, taskErrors, err := b.ingest(context.Background(), batch)
+	<-b.flushSemaphore
+
+	// a batch-wide error can't be attributed to a single task, so retry each request as its own
+	// single-request batch: a poison request then only fails its own caller instead of every
+	// sibling that happened to share the flush window
+	if err != nil && len(batch) > 1 {
+		for _, request := range requestByTaskId {
+			go b.flush([]*durableEventIngestRequest{request})
+		}
+
+		if len(deferredRequests) > 0 {
+			go b.flush(deferredRequests)
+		}
+
+		return
+	}
+
+	for taskId, request := range requestByTaskId {
+		if err != nil {
+			request.responseCh <- durableEventIngestResponse{err: err}
+			continue
+		}
+
+		if taskErr, ok := taskErrors[taskId]; ok {
+			request.responseCh <- durableEventIngestResponse{err: taskErr}
+			continue
+		}
+
+		request.responseCh <- durableEventIngestResponse{result: results[taskId]}
+	}
+
+	if len(deferredRequests) > 0 {
+		go b.flush(deferredRequests)
 	}
 }
 
@@ -683,10 +864,11 @@ func (r *durableEventsRepository) getAndLockLogFile(ctx context.Context, tx sqlc
 		telemetry.AttributeKV{Key: "durable_task_id", Value: durableTaskId},
 	)
 
-	rows, err := r.queries.GetAndLockLogFileWithBranchPoints(ctx, tx, sqlcv1.GetAndLockLogFileWithBranchPointsParams{
-		Durabletaskid:         durableTaskId,
-		Durabletaskinsertedat: durableTaskInsertedAt,
-		Tenantid:              tenantId,
+	rows, err := r.queries.GetAndLockLogFilesWithBranchPoints(ctx, tx, sqlcv1.GetAndLockLogFilesWithBranchPointsParams{
+		Durabletaskids:           []int64{durableTaskId},
+		Durabletaskinsertedats:   []pgtype.Timestamptz{durableTaskInsertedAt},
+		Tenantids:                []uuid.UUID{tenantId},
+		Mindurabletaskinsertedat: durableTaskInsertedAt,
 	})
 
 	if err != nil {
@@ -755,70 +937,118 @@ func resolveBranchForNode(nodeId, currentBranchId int64, nextBranchIdToBranchPoi
 	return tree[i-1].BranchId
 }
 
-func (r *durableEventsRepository) getOrCreateEventLogEntries(
+type taskNodeBranchKey struct {
+	taskId   TaskId
+	nodeId   int64
+	branchId int64
+}
+
+type taskLogEntryState struct {
+	taskId             TaskId
+	opts               GetOrCreateLogEntryOpts
+	skipOpts           []GetOrCreateLogEntryOpt
+	nonSkipOpts        []GetOrCreateLogEntryOpt
+	existedEntries     map[NodeIdBranchIdTuple]*sqlcv1.BulkGetDurableEventLogEntriesRow
+	newEntryByKey      map[NodeIdBranchIdTuple]GetOrCreateLogEntryOpt
+	createdEntryByKey  map[NodeIdBranchIdTuple]*sqlcv1.BulkCreateDurableEventLogEntriesRow
+	skipEntryByChildId map[uuid.UUID]*sqlcv1.BulkGetDurableEventLogEntriesRow
+}
+
+// getOrCreateEventLogEntriesForTasks processes one GetOrCreateLogEntryOpts per task inside the
+// shared transaction. A task whose entries fail validation before anything is written for it gets
+// a per-task error and is excluded from the rest of the batch; errors after that point (failed
+// queries, skip-entry validation) abort the whole transaction and are returned as the batch error.
+func (r *durableEventsRepository) getOrCreateEventLogEntriesForTasks(
 	ctx context.Context,
 	tx sqlcv1.DBTX,
-	opts GetOrCreateLogEntryOpts,
-) ([]*EventLogEntryWithPayloads, []StorePayloadOpts, error) {
+	batch []GetOrCreateLogEntryOpts,
+) (map[TaskId][]*EventLogEntryWithPayloads, []StorePayloadOpts, map[TaskId]error, error) {
 	ctx, span := telemetry.NewSpan(ctx, "get-or-create-durable-event-log-entries")
 	defer span.End()
 
-	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "entry_count", Value: len(opts.Entries)})
-
-	if len(opts.Entries) == 0 {
-		return nil, nil, nil
+	entryCount := 0
+	for _, opts := range batch {
+		entryCount += len(opts.Entries)
 	}
 
-	var pendingStorePayloadOpts []StorePayloadOpts
+	telemetry.WithAttributes(span,
+		telemetry.AttributeKV{Key: "task_count", Value: len(batch)},
+		telemetry.AttributeKV{Key: "entry_count", Value: entryCount},
+	)
 
-	var skipOpts, nonSkipOpts []GetOrCreateLogEntryOpt
-	for _, o := range opts.Entries {
-		if o.ShouldSkip {
-			skipOpts = append(skipOpts, o)
-		} else {
-			nonSkipOpts = append(nonSkipOpts, o)
+	taskErrors := make(map[TaskId]error)
+	resultsByTaskId := make(map[TaskId][]*EventLogEntryWithPayloads, len(batch))
+
+	states := make([]*taskLogEntryState, 0, len(batch))
+	stateByTaskId := make(map[TaskId]*taskLogEntryState, len(batch))
+
+	for _, opts := range batch {
+		if len(opts.Entries) == 0 {
+			continue
+		}
+
+		state := &taskLogEntryState{
+			taskId:             TaskId(opts.DurableTaskId),
+			opts:               opts,
+			existedEntries:     make(map[NodeIdBranchIdTuple]*sqlcv1.BulkGetDurableEventLogEntriesRow),
+			newEntryByKey:      make(map[NodeIdBranchIdTuple]GetOrCreateLogEntryOpt),
+			createdEntryByKey:  make(map[NodeIdBranchIdTuple]*sqlcv1.BulkCreateDurableEventLogEntriesRow),
+			skipEntryByChildId: make(map[uuid.UUID]*sqlcv1.BulkGetDurableEventLogEntriesRow),
+		}
+
+		for _, o := range opts.Entries {
+			if o.ShouldSkip {
+				state.skipOpts = append(state.skipOpts, o)
+			} else {
+				state.nonSkipOpts = append(state.nonSkipOpts, o)
+			}
+		}
+
+		states = append(states, state)
+		stateByTaskId[state.taskId] = state
+	}
+
+	getParams := sqlcv1.BulkGetDurableEventLogEntriesParams{}
+
+	for _, state := range states {
+		for _, o := range state.nonSkipOpts {
+			getParams.Durabletaskids = append(getParams.Durabletaskids, state.opts.DurableTaskId)
+			getParams.Durabletaskinsertedats = append(getParams.Durabletaskinsertedats, state.opts.DurableTaskInsertedAt)
+			getParams.Branchids = append(getParams.Branchids, o.BranchId)
+			getParams.Nodeids = append(getParams.Nodeids, o.NodeId)
 		}
 	}
 
-	existedEntries := make(map[NodeIdBranchIdTuple]*sqlcv1.BulkGetDurableEventLogEntriesRow)
-	nodeIdBranchIdToNewEntry := make(map[NodeIdBranchIdTuple]GetOrCreateLogEntryOpt)
-	nodeIdBranchIdToCreatedEntry := make(map[NodeIdBranchIdTuple]*sqlcv1.BulkCreateDurableEventLogEntriesRow)
+	existingByKey := make(map[taskNodeBranchKey]*sqlcv1.BulkGetDurableEventLogEntriesRow)
 
-	if len(nonSkipOpts) > 0 {
-		branchIds := make([]int64, len(nonSkipOpts))
-		nodeIds := make([]int64, len(nonSkipOpts))
-		for i, o := range nonSkipOpts {
-			branchIds[i] = o.BranchId
-			nodeIds[i] = o.NodeId
-		}
-
-		existing, err := r.queries.BulkGetDurableEventLogEntries(ctx, tx, sqlcv1.BulkGetDurableEventLogEntriesParams{
-			Durabletaskid:         opts.DurableTaskId,
-			Durabletaskinsertedat: opts.DurableTaskInsertedAt,
-			Branchids:             branchIds,
-			Nodeids:               nodeIds,
-		})
+	if len(getParams.Nodeids) > 0 {
+		existing, err := r.queries.BulkGetDurableEventLogEntries(ctx, tx, getParams)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to bulk-get existing entries: %w", err)
+			return nil, nil, nil, fmt.Errorf("failed to bulk-get existing entries: %w", err)
 		}
 
-		existingByKey := make(map[NodeIdBranchIdTuple]*sqlcv1.BulkGetDurableEventLogEntriesRow, len(existing))
 		for _, e := range existing {
-			existingByKey[NodeIdBranchIdTuple{e.NodeID, e.BranchID}] = e
+			existingByKey[taskNodeBranchKey{TaskId(e.DurableTaskID), e.NodeID, e.BranchID}] = e
 		}
+	}
 
-		for _, o := range nonSkipOpts {
+	survivingStates := make([]*taskLogEntryState, 0, len(states))
+
+	for _, state := range states {
+		var nonDeterminismErr error
+
+		for _, o := range state.nonSkipOpts {
 			key := NodeIdBranchIdTuple{o.NodeId, o.BranchId}
-			e, found := existingByKey[key]
+			e, found := existingByKey[taskNodeBranchKey{state.taskId, o.NodeId, o.BranchId}]
 			if !found {
-				nodeIdBranchIdToNewEntry[key] = o
+				state.newEntryByKey[key] = o
 				continue
 			}
 			if !bytes.Equal(o.IdempotencyKey, e.IdempotencyKey) {
-				return nil, nil, &NonDeterminismError{
+				nonDeterminismErr = &NonDeterminismError{
 					BranchId:                o.BranchId,
 					NodeId:                  o.NodeId,
-					TaskExternalId:          opts.DurableTaskExternalId,
+					TaskExternalId:          state.opts.DurableTaskExternalId,
 					ExpectedIdempotencyKey:  e.IdempotencyKey,
 					ActualIdempotencyKey:    o.IdempotencyKey,
 					ExpectedKind:            e.Kind,
@@ -827,33 +1057,41 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 					ExistingEntryInsertedAt: e.InsertedAt,
 					ExistingEntryTenantId:   e.TenantID,
 				}
+				break
 			}
-			existedEntries[key] = e
+			state.existedEntries[key] = e
 		}
+
+		if nonDeterminismErr != nil {
+			taskErrors[state.taskId] = nonDeterminismErr
+			continue
+		}
+
+		survivingStates = append(survivingStates, state)
 	}
 
-	if len(nodeIdBranchIdToNewEntry) > 0 {
-		createParams := sqlcv1.BulkCreateDurableEventLogEntriesParams{
-			Tenantids:              make([]uuid.UUID, 0),
-			Externalids:            make([]uuid.UUID, 0),
-			Childtaskexternalids:   make([]uuid.UUID, 0),
-			Durabletaskids:         make([]int64, 0),
-			Durabletaskinsertedats: make([]pgtype.Timestamptz, 0),
-			Kinds:                  make([]string, 0),
-			Nodeids:                make([]int64, 0),
-			Branchids:              make([]int64, 0),
-			Idempotencykeys:        make([][]byte, 0),
-			Issatisfieds:           make([]bool, 0),
-			Usermessages:           make([]string, 0),
-			Waitdatas:              make([]string, 0),
-		}
+	createParams := sqlcv1.BulkCreateDurableEventLogEntriesParams{
+		Tenantids:              make([]uuid.UUID, 0),
+		Externalids:            make([]uuid.UUID, 0),
+		Childtaskexternalids:   make([]uuid.UUID, 0),
+		Durabletaskids:         make([]int64, 0),
+		Durabletaskinsertedats: make([]pgtype.Timestamptz, 0),
+		Kinds:                  make([]string, 0),
+		Nodeids:                make([]int64, 0),
+		Branchids:              make([]int64, 0),
+		Idempotencykeys:        make([][]byte, 0),
+		Issatisfieds:           make([]bool, 0),
+		Usermessages:           make([]string, 0),
+		Waitdatas:              make([]string, 0),
+	}
 
-		for _, entry := range nodeIdBranchIdToNewEntry {
-			createParams.Tenantids = append(createParams.Tenantids, opts.TenantId)
+	for _, state := range survivingStates {
+		for _, entry := range state.newEntryByKey {
+			createParams.Tenantids = append(createParams.Tenantids, state.opts.TenantId)
 			createParams.Externalids = append(createParams.Externalids, uuid.New())
 			createParams.Childtaskexternalids = append(createParams.Childtaskexternalids, entry.ChildTaskExternalId)
-			createParams.Durabletaskids = append(createParams.Durabletaskids, opts.DurableTaskId)
-			createParams.Durabletaskinsertedats = append(createParams.Durabletaskinsertedats, opts.DurableTaskInsertedAt)
+			createParams.Durabletaskids = append(createParams.Durabletaskids, state.opts.DurableTaskId)
+			createParams.Durabletaskinsertedats = append(createParams.Durabletaskinsertedats, state.opts.DurableTaskInsertedAt)
 			createParams.Kinds = append(createParams.Kinds, string(entry.Kind))
 			createParams.Nodeids = append(createParams.Nodeids, entry.NodeId)
 			createParams.Branchids = append(createParams.Branchids, entry.BranchId)
@@ -868,55 +1106,62 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 
 			createParams.Waitdatas = append(createParams.Waitdatas, entry.WaitData)
 		}
+	}
 
+	var pendingStorePayloadOpts []StorePayloadOpts
+
+	if len(createParams.Nodeids) > 0 {
 		createdRows, createErr := r.queries.BulkCreateDurableEventLogEntries(ctx, tx, createParams)
 		if createErr != nil {
-			return nil, nil, fmt.Errorf("failed to bulk-create event log entries: %w", createErr)
+			return nil, nil, nil, fmt.Errorf("failed to bulk-create event log entries: %w", createErr)
 		}
 
 		for _, createdRow := range createdRows {
-			nodeIdBranchIdToCreatedEntry[NodeIdBranchIdTuple{createdRow.NodeID, createdRow.BranchID}] = createdRow
-		}
+			state, ok := stateByTaskId[TaskId(createdRow.DurableTaskID)]
+			if !ok {
+				continue
+			}
 
-		storePayloadOpts := make([]StorePayloadOpts, 0, len(nodeIdBranchIdToNewEntry)*2)
-		for _, createdRow := range createdRows {
-			opt, ok := nodeIdBranchIdToNewEntry[NodeIdBranchIdTuple{createdRow.NodeID, createdRow.BranchID}]
+			key := NodeIdBranchIdTuple{createdRow.NodeID, createdRow.BranchID}
+			state.createdEntryByKey[key] = createdRow
+
+			opt, ok := state.newEntryByKey[key]
 			if !ok {
 				continue
 			}
 			if len(opt.InputPayload) > 0 {
-				storePayloadOpts = append(storePayloadOpts, StorePayloadOpts{
+				pendingStorePayloadOpts = append(pendingStorePayloadOpts, StorePayloadOpts{
 					Id:         createdRow.ID,
 					InsertedAt: createdRow.InsertedAt,
 					ExternalId: createdRow.ExternalID,
 					Type:       sqlcv1.V1PayloadTypeDURABLEEVENTLOGENTRYDATA,
 					Payload:    opt.InputPayload,
-					TenantId:   opts.TenantId,
+					TenantId:   state.opts.TenantId,
 				})
 			}
 			if len(opt.ResultPayload) > 0 {
-				storePayloadOpts = append(storePayloadOpts, StorePayloadOpts{
+				pendingStorePayloadOpts = append(pendingStorePayloadOpts, StorePayloadOpts{
 					Id:         createdRow.ID,
 					InsertedAt: createdRow.InsertedAt,
 					ExternalId: createdRow.ResultPayloadExternalID,
 					Type:       sqlcv1.V1PayloadTypeDURABLEEVENTLOGENTRYRESULTDATA,
 					Payload:    opt.ResultPayload,
-					TenantId:   opts.TenantId,
+					TenantId:   state.opts.TenantId,
 				})
 			}
 		}
-
-		pendingStorePayloadOpts = storePayloadOpts
 	}
 
-	childTaskExternalIdToSkipEntry := make(map[uuid.UUID]*sqlcv1.BulkGetDurableEventLogEntriesRow)
+	for _, state := range survivingStates {
+		if len(state.skipOpts) == 0 {
+			continue
+		}
 
-	if len(skipOpts) > 0 {
-		childTaskExternalIds := make([]uuid.UUID, 0, len(skipOpts))
-		seenChildTaskExternalIds := make(map[uuid.UUID]struct{}, len(skipOpts))
-		for _, o := range skipOpts {
+		childTaskExternalIds := make([]uuid.UUID, 0, len(state.skipOpts))
+		seenChildTaskExternalIds := make(map[uuid.UUID]struct{}, len(state.skipOpts))
+		for _, o := range state.skipOpts {
 			if o.ChildTaskExternalId == uuid.Nil {
-				return nil, nil, fmt.Errorf("skipped child entries must include a non-nil child task external id")
+				return nil, nil, nil, fmt.Errorf("skipped child entries must include a non-nil child task external id")
 			}
 
 			if _, ok := seenChildTaskExternalIds[o.ChildTaskExternalId]; ok {
@@ -928,12 +1173,12 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 		}
 
 		skipRows, err := r.queries.GetDurableEventLogEntriesByChildTaskExternalIds(ctx, tx, sqlcv1.GetDurableEventLogEntriesByChildTaskExternalIdsParams{
-			Durabletaskid:         opts.DurableTaskId,
-			Durabletaskinsertedat: opts.DurableTaskInsertedAt,
+			Durabletaskid:         state.opts.DurableTaskId,
+			Durabletaskinsertedat: state.opts.DurableTaskInsertedAt,
 			Childtaskexternalids:  childTaskExternalIds,
 		})
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to get log entries by child task external ids: %w", err)
+			return nil, nil, nil, fmt.Errorf("failed to get log entries by child task external ids: %w", err)
 		}
 
 		for _, row := range skipRows {
@@ -941,26 +1186,26 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 				continue
 			}
 			// node ids restart every re-invocation, so a child's newest entry is on the highest branch
-			if existing, ok := childTaskExternalIdToSkipEntry[*row.ChildTaskExternalID]; ok && existing.BranchID >= row.BranchID {
+			if existing, ok := state.skipEntryByChildId[*row.ChildTaskExternalID]; ok && existing.BranchID >= row.BranchID {
 				continue
 			}
 
-			r := sqlcv1.BulkGetDurableEventLogEntriesRow(*row)
-			childTaskExternalIdToSkipEntry[*row.ChildTaskExternalID] = &r
+			converted := sqlcv1.BulkGetDurableEventLogEntriesRow(*row)
+			state.skipEntryByChildId[*row.ChildTaskExternalID] = &converted
 		}
 
-		for _, o := range skipOpts {
-			e, ok := childTaskExternalIdToSkipEntry[o.ChildTaskExternalId]
+		for _, o := range state.skipOpts {
+			e, ok := state.skipEntryByChildId[o.ChildTaskExternalId]
 
 			if !ok {
-				return nil, nil, fmt.Errorf("expected to find log entry for skipped child task external id %s", o.ChildTaskExternalId)
+				return nil, nil, nil, fmt.Errorf("expected to find log entry for skipped child task external id %s", o.ChildTaskExternalId)
 			}
 
 			if len(o.IdempotencyKey) > 0 && !bytes.Equal(o.IdempotencyKey, e.IdempotencyKey) {
-				return nil, nil, &NonDeterminismError{
+				return nil, nil, nil, &NonDeterminismError{
 					BranchId:                e.BranchID,
 					NodeId:                  e.NodeID,
-					TaskExternalId:          opts.DurableTaskExternalId,
+					TaskExternalId:          state.opts.DurableTaskExternalId,
 					ExpectedIdempotencyKey:  e.IdempotencyKey,
 					ActualIdempotencyKey:    o.IdempotencyKey,
 					ExpectedKind:            e.Kind,
@@ -975,24 +1220,27 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 	}
 
 	var retrieveOpts []RetrievePayloadOpts
-	for _, entry := range existedEntries {
-		retrieveOpts = append(retrieveOpts, RetrievePayloadOpts{
-			Id:         entry.ID,
-			InsertedAt: entry.InsertedAt,
-			Type:       sqlcv1.V1PayloadTypeDURABLEEVENTLOGENTRYRESULTDATA,
-			TenantId:   opts.TenantId,
-			ExternalId: entry.ResultPayloadExternalID,
-		})
-	}
 
-	for _, entry := range childTaskExternalIdToSkipEntry {
-		retrieveOpts = append(retrieveOpts, RetrievePayloadOpts{
-			Id:         entry.ID,
-			InsertedAt: entry.InsertedAt,
-			Type:       sqlcv1.V1PayloadTypeDURABLEEVENTLOGENTRYRESULTDATA,
-			TenantId:   opts.TenantId,
-			ExternalId: entry.ResultPayloadExternalID,
-		})
+	for _, state := range survivingStates {
+		for _, entry := range state.existedEntries {
+			retrieveOpts = append(retrieveOpts, RetrievePayloadOpts{
+				Id:         entry.ID,
+				InsertedAt: entry.InsertedAt,
+				Type:       sqlcv1.V1PayloadTypeDURABLEEVENTLOGENTRYRESULTDATA,
+				TenantId:   state.opts.TenantId,
+				ExternalId: entry.ResultPayloadExternalID,
+			})
+		}
+
+		for _, entry := range state.skipEntryByChildId {
+			retrieveOpts = append(retrieveOpts, RetrievePayloadOpts{
+				Id:         entry.ID,
+				InsertedAt: entry.InsertedAt,
+				Type:       sqlcv1.V1PayloadTypeDURABLEEVENTLOGENTRYRESULTDATA,
+				TenantId:   state.opts.TenantId,
+				ExternalId: entry.ResultPayloadExternalID,
+			})
+		}
 	}
 
 	var existingPayloads map[RetrievePayloadOpts][]byte
@@ -1004,7 +1252,7 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 		}
 	}
 
-	resultPayload := func(e *sqlcv1.BulkGetDurableEventLogEntriesRow) []byte {
+	resultPayload := func(tenantId uuid.UUID, e *sqlcv1.BulkGetDurableEventLogEntriesRow) []byte {
 		if existingPayloads == nil {
 			return nil
 		}
@@ -1013,64 +1261,68 @@ func (r *durableEventsRepository) getOrCreateEventLogEntries(
 			Id:         e.ID,
 			InsertedAt: e.InsertedAt,
 			Type:       sqlcv1.V1PayloadTypeDURABLEEVENTLOGENTRYRESULTDATA,
-			TenantId:   opts.TenantId,
+			TenantId:   tenantId,
 			ExternalId: e.ResultPayloadExternalID,
 		}]
 	}
 
-	var results []*EventLogEntryWithPayloads
+	for _, state := range survivingStates {
+		var results []*EventLogEntryWithPayloads
 
-	for _, o := range nonSkipOpts {
-		key := NodeIdBranchIdTuple{o.NodeId, o.BranchId}
-		if e, ok := existedEntries[key]; ok {
+		for _, o := range state.nonSkipOpts {
+			key := NodeIdBranchIdTuple{o.NodeId, o.BranchId}
+			if e, ok := state.existedEntries[key]; ok {
+				results = append(results, &EventLogEntryWithPayloads{
+					Entry:          e,
+					InputPayload:   o.InputPayload,
+					ResultPayload:  resultPayload(state.opts.TenantId, e),
+					AlreadyExisted: true,
+				})
+			} else {
+				created := state.createdEntryByKey[key]
+				results = append(results, &EventLogEntryWithPayloads{
+					Entry: &sqlcv1.BulkGetDurableEventLogEntriesRow{
+						TenantID:              created.TenantID,
+						ExternalID:            created.ExternalID,
+						ChildTaskExternalID:   created.ChildTaskExternalID,
+						ID:                    created.ID,
+						DurableTaskID:         created.DurableTaskID,
+						DurableTaskInsertedAt: created.DurableTaskInsertedAt,
+						Kind:                  created.Kind,
+						NodeID:                created.NodeID,
+						BranchID:              created.BranchID,
+						IdempotencyKey:        created.IdempotencyKey,
+						IsSatisfied:           created.IsSatisfied,
+						InvocationCount:       created.InvocationCount,
+					},
+					InputPayload:   o.InputPayload,
+					ResultPayload:  o.ResultPayload,
+					AlreadyExisted: false,
+				})
+			}
+		}
+
+		for _, o := range state.skipOpts {
+			e := state.skipEntryByChildId[o.ChildTaskExternalId]
 			results = append(results, &EventLogEntryWithPayloads{
-				Entry:          e,
-				InputPayload:   o.InputPayload,
-				ResultPayload:  resultPayload(e),
-				AlreadyExisted: true,
-			})
-		} else {
-			created := nodeIdBranchIdToCreatedEntry[key]
-			results = append(results, &EventLogEntryWithPayloads{
-				Entry: &sqlcv1.BulkGetDurableEventLogEntriesRow{
-					TenantID:              created.TenantID,
-					ExternalID:            created.ExternalID,
-					ChildTaskExternalID:   created.ChildTaskExternalID,
-					ID:                    created.ID,
-					DurableTaskID:         created.DurableTaskID,
-					DurableTaskInsertedAt: created.DurableTaskInsertedAt,
-					Kind:                  created.Kind,
-					NodeID:                created.NodeID,
-					BranchID:              created.BranchID,
-					IdempotencyKey:        created.IdempotencyKey,
-					IsSatisfied:           created.IsSatisfied,
-					InvocationCount:       created.InvocationCount,
-				},
-				InputPayload:   o.InputPayload,
-				ResultPayload:  o.ResultPayload,
-				AlreadyExisted: false,
+				Entry:           e,
+				AlreadyExisted:  true,
+				ResultPayload:   resultPayload(state.opts.TenantId, e),
+				IsSkipReference: true,
 			})
 		}
-	}
 
-	for _, o := range skipOpts {
-		e := childTaskExternalIdToSkipEntry[o.ChildTaskExternalId]
-		results = append(results, &EventLogEntryWithPayloads{
-			Entry:           e,
-			AlreadyExisted:  true,
-			ResultPayload:   resultPayload(e),
-			IsSkipReference: true,
+		slices.SortFunc(results, func(i, j *EventLogEntryWithPayloads) int {
+			if i.Entry.NodeID != j.Entry.NodeID {
+				return int(i.Entry.NodeID - j.Entry.NodeID)
+			}
+			return int(i.Entry.BranchID - j.Entry.BranchID)
 		})
+
+		resultsByTaskId[state.taskId] = results
 	}
 
-	slices.SortFunc(results, func(i, j *EventLogEntryWithPayloads) int {
-		if i.Entry.NodeID != j.Entry.NodeID {
-			return int(i.Entry.NodeID - j.Entry.NodeID)
-		}
-		return int(i.Entry.BranchID - j.Entry.BranchID)
-	})
-
-	return results, pendingStorePayloadOpts, nil
+	return resultsByTaskId, pendingStorePayloadOpts, taskErrors, nil
 }
 
 func (r *durableEventsRepository) resolveOrphanedChildDedupes(
@@ -1194,11 +1446,16 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 	tenantId := opts.TenantId
 	task := opts.Task
 
-	logEntries, nodeIdBranchIdToTriggerOpts, childrenToReplay, err := r.appendDurableEventLog(ctx, opts)
+	appendResult, err := r.ingestBuffer.submit(ctx, TaskId(task.ID), opts)
 
 	if err != nil {
+		r.enrichNonDeterminismErrorDetail(ctx, opts, err)
 		return nil, err
 	}
+
+	logEntries := appendResult.logEntries
+	nodeIdBranchIdToTriggerOpts := appendResult.nodeIdBranchIdToTriggerOpts
+	childrenToReplay := appendResult.childrenToReplay
 
 	var memoResult *IngestMemoResult
 	var waitForResult *IngestWaitForResult
@@ -1418,31 +1675,283 @@ func (r *durableEventsRepository) resolveChildExternalIds(ctx context.Context, t
 	return nil
 }
 
-func (r *durableEventsRepository) appendDurableEventLog(ctx context.Context, opts IngestDurableTaskEventOpts) ([]*EventLogEntryWithPayloads, map[NodeIdBranchIdTuple]*WorkflowNameTriggerOpts, map[uuid.UUID]bool, error) {
-	tenantId := opts.TenantId
-	task := opts.Task
+func (r *durableEventsRepository) appendDurableEventLogBatch(ctx context.Context, batch map[TaskId]IngestDurableTaskEventOpts) (map[TaskId]*appendDurableEventLogResult, map[TaskId]error, error) {
+	ctx, span := telemetry.NewSpan(ctx, "append-durable-event-log-batch")
+	defer span.End()
+
+	telemetry.WithAttributes(span, telemetry.AttributeKV{Key: "batch_size", Value: len(batch)})
+
+	taskIds := make([]TaskId, 0, len(batch))
+	for taskId := range batch {
+		taskIds = append(taskIds, taskId)
+	}
+	slices.Sort(taskIds)
 
 	tx, commit, rollback, err := sqlchelpers.PrepareTx(ctx, r.pool, r.l)
 
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to prepare tx: %w", err)
+		return nil, nil, fmt.Errorf("failed to prepare tx: %w", err)
 	}
 
 	defer rollback()
 
-	logFile, nextBranchIdToBranchPoint, err := r.getAndLockLogFile(ctx, tx, tenantId, task.ID, task.InsertedAt)
-
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to lock log file: %w", err)
+	lockParams := sqlcv1.GetAndLockLogFilesWithBranchPointsParams{
+		Durabletaskids:           make([]int64, 0, len(batch)),
+		Durabletaskinsertedats:   make([]pgtype.Timestamptz, 0, len(batch)),
+		Tenantids:                make([]uuid.UUID, 0, len(batch)),
+		Mindurabletaskinsertedat: sqlchelpers.TimestamptzFromTime(time.Now().UTC()),
 	}
 
-	if logFile.LatestInvocationCount != opts.InvocationCount {
-		return nil, nil, nil, &StaleInvocationError{
-			TaskExternalId:          opts.Task.ExternalID,
-			ExpectedInvocationCount: logFile.LatestInvocationCount,
-			ActualInvocationCount:   opts.InvocationCount,
+	for _, taskId := range taskIds {
+		opts := batch[taskId]
+		lockParams.Durabletaskids = append(lockParams.Durabletaskids, opts.Task.ID)
+		lockParams.Durabletaskinsertedats = append(lockParams.Durabletaskinsertedats, opts.Task.InsertedAt)
+		lockParams.Tenantids = append(lockParams.Tenantids, opts.TenantId)
+
+		if opts.Task.InsertedAt.Time.Before(lockParams.Mindurabletaskinsertedat.Time) {
+			lockParams.Mindurabletaskinsertedat = sqlchelpers.TimestamptzFromTime(opts.Task.InsertedAt.Time)
 		}
 	}
+
+	lockRows, err := r.queries.GetAndLockLogFilesWithBranchPoints(ctx, tx, lockParams)
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to lock log files: %w", err)
+	}
+
+	logFileByTaskId := make(map[TaskId]*sqlcv1.V1DurableEventLogFile, len(batch))
+	branchPointsByTaskId := make(map[TaskId]map[int64]*sqlcv1.V1DurableEventLogBranchPoint, len(batch))
+
+	for _, row := range lockRows {
+		logFile := row.V1DurableEventLogFile
+		taskId := TaskId(logFile.DurableTaskID)
+
+		if _, ok := logFileByTaskId[taskId]; !ok {
+			logFileCopy := logFile
+			logFileByTaskId[taskId] = &logFileCopy
+			branchPointsByTaskId[taskId] = make(map[int64]*sqlcv1.V1DurableEventLogBranchPoint)
+		}
+
+		if !row.NextBranchID.Valid {
+			continue
+		}
+
+		branchPointsByTaskId[taskId][row.NextBranchID.Int64] = &sqlcv1.V1DurableEventLogBranchPoint{
+			TenantID:               logFile.TenantID,
+			ID:                     row.ID.Int64,
+			InsertedAt:             row.InsertedAt,
+			DurableTaskID:          logFile.DurableTaskID,
+			DurableTaskInsertedAt:  logFile.DurableTaskInsertedAt,
+			FirstNodeIDInNewBranch: row.FirstNodeIDInNewBranch.Int64,
+			ParentBranchID:         row.ParentBranchID.Int64,
+			NextBranchID:           row.NextBranchID.Int64,
+			ReplayChildExternalIds: row.ReplayChildExternalIds,
+		}
+	}
+
+	taskErrors := make(map[TaskId]error)
+	planByTaskId := make(map[TaskId]*durableEventLogAppendPlan, len(batch))
+	orderedGetOrCreateOpts := make([]GetOrCreateLogEntryOpts, 0, len(batch))
+
+	for _, taskId := range taskIds {
+		opts := batch[taskId]
+
+		logFile, ok := logFileByTaskId[taskId]
+
+		if !ok {
+			taskErrors[taskId] = fmt.Errorf("failed to lock log file: %w", pgx.ErrNoRows)
+			continue
+		}
+
+		if logFile.LatestInvocationCount != opts.InvocationCount {
+			taskErrors[taskId] = &StaleInvocationError{
+				TaskExternalId:          opts.Task.ExternalID,
+				ExpectedInvocationCount: logFile.LatestInvocationCount,
+				ActualInvocationCount:   opts.InvocationCount,
+			}
+			continue
+		}
+
+		plan, taskErr, fatalErr := r.planDurableEventLogAppend(ctx, tx, opts, logFile, branchPointsByTaskId[taskId])
+
+		if fatalErr != nil {
+			return nil, nil, fatalErr
+		}
+
+		if taskErr != nil {
+			taskErrors[taskId] = taskErr
+			continue
+		}
+
+		planByTaskId[taskId] = plan
+		orderedGetOrCreateOpts = append(orderedGetOrCreateOpts, plan.getOrCreateOpts)
+	}
+
+	logEntriesByTaskId, entryStorePayloadOpts, entryTaskErrors, err := r.getOrCreateEventLogEntriesForTasks(ctx, tx, orderedGetOrCreateOpts)
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get or create event log entries: %w", err)
+	}
+
+	for taskId, entryErr := range entryTaskErrors {
+		taskErrors[taskId] = fmt.Errorf("failed to get or create event log entries: %w", entryErr)
+		delete(planByTaskId, taskId)
+	}
+
+	if len(entryStorePayloadOpts) > 0 {
+		if storeErr := r.payloadStore.Store(ctx, tx, entryStorePayloadOpts...); storeErr != nil {
+			return nil, nil, fmt.Errorf("failed to store payloads for new entries: %w", storeErr)
+		}
+	}
+
+	// Re-executed children keep their task rows, so no new run will be triggered for them — but
+	// the previous completion match was consumed when the old entry was satisfied, so a fresh
+	// match tied to the new entry must be registered before the caller replays the task.
+	replayMatchOptsByTenantId := make(map[uuid.UUID][]CreateMatchOpts)
+
+	for _, taskId := range taskIds {
+		plan, ok := planByTaskId[taskId]
+
+		if !ok || len(plan.childrenToReplay) == 0 {
+			continue
+		}
+
+		task := plan.opts.Task
+
+		for _, le := range logEntriesByTaskId[taskId] {
+			if le.AlreadyExisted || le.Entry.IsSatisfied || le.Entry.ChildTaskExternalID == nil {
+				continue
+			}
+
+			childExternalId := *le.Entry.ChildTaskExternalID
+
+			if !plan.childrenToReplay[childExternalId] {
+				continue
+			}
+
+			childHint := childExternalId.String()
+			orGroupId := uuid.New()
+
+			conditions := []GroupMatchCondition{
+				{
+					GroupId:           orGroupId,
+					EventType:         sqlcv1.V1EventTypeINTERNAL,
+					EventKey:          string(sqlcv1.V1TaskEventTypeCOMPLETED),
+					ReadableDataKey:   "output",
+					EventResourceHint: &childHint,
+					Expression:        "true",
+					Action:            sqlcv1.V1MatchConditionActionCREATE,
+				},
+				{
+					GroupId:           orGroupId,
+					EventType:         sqlcv1.V1EventTypeINTERNAL,
+					EventKey:          string(sqlcv1.V1TaskEventTypeFAILED),
+					ReadableDataKey:   "output",
+					EventResourceHint: &childHint,
+					Expression:        "true",
+					Action:            sqlcv1.V1MatchConditionActionCREATE,
+				},
+				{
+					GroupId:           orGroupId,
+					EventType:         sqlcv1.V1EventTypeINTERNAL,
+					EventKey:          string(sqlcv1.V1TaskEventTypeCANCELLED),
+					ReadableDataKey:   "output",
+					EventResourceHint: &childHint,
+					Expression:        "true",
+					Action:            sqlcv1.V1MatchConditionActionCREATE,
+				},
+			}
+
+			nodeId := le.Entry.NodeID
+			branchId := le.Entry.BranchID
+			runEventLogEntrySignalKey := fmt.Sprintf("durable_run:%s:%d:%d", task.ExternalID.String(), branchId, nodeId)
+			durableTaskId := task.ID
+
+			replayMatchOptsByTenantId[plan.opts.TenantId] = append(replayMatchOptsByTenantId[plan.opts.TenantId], CreateMatchOpts{
+				Kind:                         sqlcv1.V1MatchKindSIGNAL,
+				Conditions:                   conditions,
+				SignalTaskId:                 &durableTaskId,
+				SignalTaskInsertedAt:         task.InsertedAt,
+				SignalExternalId:             &childExternalId,
+				SignalTaskExternalId:         &task.ExternalID,
+				SignalKey:                    &runEventLogEntrySignalKey,
+				DurableEventLogEntryNodeId:   &nodeId,
+				DurableEventLogEntryBranchId: &branchId,
+			})
+		}
+	}
+
+	for tenantId, replayMatchOpts := range replayMatchOptsByTenantId {
+		if matchErr := r.createEventMatches(ctx, tx, tenantId, replayMatchOpts); matchErr != nil {
+			return nil, nil, fmt.Errorf("failed to register replayed run completion matches: %w", matchErr)
+		}
+	}
+
+	nodeIdUpdateParams := sqlcv1.UpdateLogFileLatestNodeIdsParams{}
+
+	for _, taskId := range taskIds {
+		plan, ok := planByTaskId[taskId]
+
+		if !ok {
+			continue
+		}
+
+		maxNodeId := int64(0)
+		for _, le := range logEntriesByTaskId[taskId] {
+			if le.Entry.NodeID > maxNodeId {
+				maxNodeId = le.Entry.NodeID
+			}
+		}
+
+		if maxNodeId > 0 {
+			nodeIdUpdateParams.Durabletaskids = append(nodeIdUpdateParams.Durabletaskids, plan.opts.Task.ID)
+			nodeIdUpdateParams.Durabletaskinsertedats = append(nodeIdUpdateParams.Durabletaskinsertedats, plan.opts.Task.InsertedAt)
+			nodeIdUpdateParams.Nodeids = append(nodeIdUpdateParams.Nodeids, maxNodeId)
+		}
+	}
+
+	if len(nodeIdUpdateParams.Durabletaskids) > 0 {
+		if updateErr := r.queries.UpdateLogFileLatestNodeIds(ctx, tx, nodeIdUpdateParams); updateErr != nil {
+			return nil, nil, fmt.Errorf("failed to update latest node ids: %w", updateErr)
+		}
+	}
+
+	if err := commit(ctx); err != nil {
+		return nil, nil, err
+	}
+
+	results := make(map[TaskId]*appendDurableEventLogResult, len(planByTaskId))
+
+	for taskId, plan := range planByTaskId {
+		results[taskId] = &appendDurableEventLogResult{
+			logEntries:                  logEntriesByTaskId[taskId],
+			nodeIdBranchIdToTriggerOpts: plan.nodeIdBranchIdToTriggerOpts,
+			childrenToReplay:            plan.childrenToReplay,
+		}
+	}
+
+	return results, taskErrors, nil
+}
+
+type durableEventLogAppendPlan struct {
+	opts                        IngestDurableTaskEventOpts
+	getOrCreateOpts             GetOrCreateLogEntryOpts
+	nodeIdBranchIdToTriggerOpts map[NodeIdBranchIdTuple]*WorkflowNameTriggerOpts
+	childrenToReplay            map[uuid.UUID]bool
+}
+
+// planDurableEventLogAppend builds the log entries to get-or-create for one task in the batch. A
+// non-nil taskErr fails only this task's request; a non-nil fatalErr means a query inside the
+// shared transaction failed, which aborts the transaction and therefore the whole batch.
+func (r *durableEventsRepository) planDurableEventLogAppend(
+	ctx context.Context,
+	tx sqlcv1.DBTX,
+	opts IngestDurableTaskEventOpts,
+	logFile *sqlcv1.V1DurableEventLogFile,
+	nextBranchIdToBranchPoint map[int64]*sqlcv1.V1DurableEventLogBranchPoint,
+) (plan *durableEventLogAppendPlan, taskErr error, fatalErr error) {
+	tenantId := opts.TenantId
+	task := opts.Task
 
 	baseNodeId := logFile.LatestNodeID + 1
 
@@ -1454,13 +1963,15 @@ func (r *durableEventsRepository) appendDurableEventLog(ctx context.Context, opt
 	switch opts.Kind {
 	case sqlcv1.V1DurableEventLogKindRUN:
 		if resolveErr := r.resolveChildExternalIds(ctx, tx, tenantId, task, opts.TriggerRuns.TriggerOpts); resolveErr != nil {
-			return nil, nil, nil, fmt.Errorf("failed to resolve child external ids: %w", resolveErr)
+			return nil, nil, fmt.Errorf("failed to resolve child external ids: %w", resolveErr)
 		}
 
-		childrenToReplay, err = r.resolveOrphanedChildDedupes(ctx, tx, logFile, nextBranchIdToBranchPoint, opts.TriggerRuns.TriggerOpts)
-		if err != nil {
-			return nil, nil, nil, err
+		resolvedChildrenToReplay, dedupeErr := r.resolveOrphanedChildDedupes(ctx, tx, logFile, nextBranchIdToBranchPoint, opts.TriggerRuns.TriggerOpts)
+		if dedupeErr != nil {
+			return nil, nil, dedupeErr
 		}
+
+		childrenToReplay = resolvedChildrenToReplay
 
 		innerOpts := make([]GetOrCreateLogEntryOpt, len(opts.TriggerRuns.TriggerOpts))
 
@@ -1474,7 +1985,7 @@ func (r *durableEventsRepository) appendDurableEventLog(ctx context.Context, opt
 				if triggerOpts.ChildKey == nil {
 					key, keyErr := r.createIdempotencyKey(sqlcv1.V1DurableEventLogKindRUN, triggerOpts, nil)
 					if keyErr != nil {
-						return nil, nil, nil, fmt.Errorf("failed to create idempotency key: %w", keyErr)
+						return nil, fmt.Errorf("failed to create idempotency key: %w", keyErr), nil
 					}
 					idempotencyKey = key
 				}
@@ -1496,12 +2007,12 @@ func (r *durableEventsRepository) appendDurableEventLog(ctx context.Context, opt
 
 			inputPayload, marshalErr := json.Marshal(triggerOpts)
 			if marshalErr != nil {
-				return nil, nil, nil, fmt.Errorf("failed to marshal trigger opts: %w", marshalErr)
+				return nil, fmt.Errorf("failed to marshal trigger opts: %w", marshalErr), nil
 			}
 
 			idempotencyKey, keyErr := r.createIdempotencyKey(sqlcv1.V1DurableEventLogKindRUN, triggerOpts, nil)
 			if keyErr != nil {
-				return nil, nil, nil, fmt.Errorf("failed to create idempotency key: %w", keyErr)
+				return nil, fmt.Errorf("failed to create idempotency key: %w", keyErr), nil
 			}
 
 			// A child that is being cancelled or skipped never runs, so no completion event
@@ -1536,12 +2047,12 @@ func (r *durableEventsRepository) appendDurableEventLog(ctx context.Context, opt
 
 		inputPayload, marshalErr := json.Marshal(opts.WaitFor.WaitForConditions)
 		if marshalErr != nil {
-			return nil, nil, nil, fmt.Errorf("failed to marshal wait for conditions: %w", marshalErr)
+			return nil, fmt.Errorf("failed to marshal wait for conditions: %w", marshalErr), nil
 		}
 
 		idempotencyKey, keyErr := r.createIdempotencyKey(sqlcv1.V1DurableEventLogKindWAITFOR, nil, opts.WaitFor.WaitForConditions)
 		if keyErr != nil {
-			return nil, nil, nil, fmt.Errorf("failed to create idempotency key: %w", keyErr)
+			return nil, fmt.Errorf("failed to create idempotency key: %w", keyErr), nil
 		}
 
 		getOrCreateOpts = GetOrCreateLogEntryOpts{
@@ -1586,143 +2097,38 @@ func (r *durableEventsRepository) appendDurableEventLog(ctx context.Context, opt
 			}},
 		}
 	default:
-		return nil, nil, nil, fmt.Errorf("unsupported durable event log entry kind: %s", opts.Kind)
+		return nil, fmt.Errorf("unsupported durable event log entry kind: %s", opts.Kind), nil
 	}
 
-	logEntries, entryStorePayloadOpts, err := r.getOrCreateEventLogEntries(ctx, tx, getOrCreateOpts)
-	if err != nil {
-		var nde *NonDeterminismError
-		if errors.As(err, &nde) {
-			var existingPayload []byte
-			payloads, retrieveErr := r.payloadStore.Retrieve(ctx, tx, RetrievePayloadOpts{
-				Id:         nde.ExistingEntryId,
-				InsertedAt: nde.ExistingEntryInsertedAt,
-				Type:       sqlcv1.V1PayloadTypeDURABLEEVENTLOGENTRYDATA,
-				TenantId:   nde.ExistingEntryTenantId,
-				ExternalId: nde.ExistingEntryExternalId,
-			})
+	return &durableEventLogAppendPlan{
+		opts:                        opts,
+		getOrCreateOpts:             getOrCreateOpts,
+		nodeIdBranchIdToTriggerOpts: nodeIdBranchIdToTriggerOpts,
+		childrenToReplay:            childrenToReplay,
+	}, nil, nil
+}
 
-			if retrieveErr == nil {
-				existingPayload = payloads[RetrievePayloadOpts{
-					Id:         nde.ExistingEntryId,
-					InsertedAt: nde.ExistingEntryInsertedAt,
-					Type:       sqlcv1.V1PayloadTypeDURABLEEVENTLOGENTRYDATA,
-					TenantId:   nde.ExistingEntryTenantId,
-					ExternalId: nde.ExistingEntryExternalId,
-				}]
-			}
-
-			nde.Detail = nonDeterminismDetail(opts, nde.ExpectedKind, existingPayload)
-		}
-
-		return nil, nil, nil, fmt.Errorf("failed to get or create event log entries: %w", err)
+func (r *durableEventsRepository) enrichNonDeterminismErrorDetail(ctx context.Context, opts IngestDurableTaskEventOpts, err error) {
+	var nde *NonDeterminismError
+	if !errors.As(err, &nde) || nde.Detail != nil {
+		return
 	}
 
-	if len(entryStorePayloadOpts) > 0 {
-		if storeErr := r.payloadStore.Store(ctx, tx, entryStorePayloadOpts...); storeErr != nil {
-			return nil, nil, nil, fmt.Errorf("failed to store payloads for new entries: %w", storeErr)
-		}
+	retrieveOpts := RetrievePayloadOpts{
+		Id:         nde.ExistingEntryId,
+		InsertedAt: nde.ExistingEntryInsertedAt,
+		Type:       sqlcv1.V1PayloadTypeDURABLEEVENTLOGENTRYDATA,
+		TenantId:   nde.ExistingEntryTenantId,
+		ExternalId: nde.ExistingEntryExternalId,
 	}
 
-	// Re-executed children keep their task rows, so no new run will be triggered for them — but
-	// the previous completion match was consumed when the old entry was satisfied, so a fresh
-	// match tied to the new entry must be registered before the caller replays the task.
-	if len(childrenToReplay) > 0 {
-		replayMatchOpts := make([]CreateMatchOpts, 0)
-
-		for _, le := range logEntries {
-			if le.AlreadyExisted || le.Entry.IsSatisfied || le.Entry.ChildTaskExternalID == nil {
-				continue
-			}
-
-			childExternalId := *le.Entry.ChildTaskExternalID
-
-			if !childrenToReplay[childExternalId] {
-				continue
-			}
-
-			childHint := childExternalId.String()
-			orGroupId := uuid.New()
-
-			conditions := []GroupMatchCondition{
-				{
-					GroupId:           orGroupId,
-					EventType:         sqlcv1.V1EventTypeINTERNAL,
-					EventKey:          string(sqlcv1.V1TaskEventTypeCOMPLETED),
-					ReadableDataKey:   "output",
-					EventResourceHint: &childHint,
-					Expression:        "true",
-					Action:            sqlcv1.V1MatchConditionActionCREATE,
-				},
-				{
-					GroupId:           orGroupId,
-					EventType:         sqlcv1.V1EventTypeINTERNAL,
-					EventKey:          string(sqlcv1.V1TaskEventTypeFAILED),
-					ReadableDataKey:   "output",
-					EventResourceHint: &childHint,
-					Expression:        "true",
-					Action:            sqlcv1.V1MatchConditionActionCREATE,
-				},
-				{
-					GroupId:           orGroupId,
-					EventType:         sqlcv1.V1EventTypeINTERNAL,
-					EventKey:          string(sqlcv1.V1TaskEventTypeCANCELLED),
-					ReadableDataKey:   "output",
-					EventResourceHint: &childHint,
-					Expression:        "true",
-					Action:            sqlcv1.V1MatchConditionActionCREATE,
-				},
-			}
-
-			nodeId := le.Entry.NodeID
-			branchId := le.Entry.BranchID
-			runEventLogEntrySignalKey := fmt.Sprintf("durable_run:%s:%d:%d", task.ExternalID.String(), branchId, nodeId)
-			taskId := task.ID
-
-			replayMatchOpts = append(replayMatchOpts, CreateMatchOpts{
-				Kind:                         sqlcv1.V1MatchKindSIGNAL,
-				Conditions:                   conditions,
-				SignalTaskId:                 &taskId,
-				SignalTaskInsertedAt:         task.InsertedAt,
-				SignalExternalId:             &childExternalId,
-				SignalTaskExternalId:         &task.ExternalID,
-				SignalKey:                    &runEventLogEntrySignalKey,
-				DurableEventLogEntryNodeId:   &nodeId,
-				DurableEventLogEntryBranchId: &branchId,
-			})
-		}
-
-		if len(replayMatchOpts) > 0 {
-			if matchErr := r.createEventMatches(ctx, tx, tenantId, replayMatchOpts); matchErr != nil {
-				return nil, nil, nil, fmt.Errorf("failed to register replayed run completion matches: %w", matchErr)
-			}
-		}
+	var existingPayload []byte
+	payloads, retrieveErr := r.payloadStore.Retrieve(ctx, r.pool, retrieveOpts)
+	if retrieveErr == nil {
+		existingPayload = payloads[retrieveOpts]
 	}
 
-	maxNodeId := int64(0)
-	for _, le := range logEntries {
-		if le.Entry.NodeID > maxNodeId {
-			maxNodeId = le.Entry.NodeID
-		}
-	}
-
-	if maxNodeId > 0 {
-		_, err = r.queries.UpdateLogFile(ctx, tx, sqlcv1.UpdateLogFileParams{
-			NodeId:                sqlchelpers.ToBigInt(&maxNodeId),
-			Durabletaskid:         task.ID,
-			Durabletaskinsertedat: task.InsertedAt,
-		})
-
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to update latest node id: %w", err)
-		}
-	}
-
-	if err := commit(ctx); err != nil {
-		return nil, nil, nil, err
-	}
-
-	return logEntries, nodeIdBranchIdToTriggerOpts, childrenToReplay, nil
+	nde.Detail = nonDeterminismDetail(opts, nde.ExpectedKind, existingPayload)
 }
 
 func (r *durableEventsRepository) TriggerPendingRunEntries(ctx context.Context, tenantId uuid.UUID, tasks []TriggerPendingRunEntriesOpt) ([]*V1TaskWithPayload, []*DAGWithData, []CELEvaluationFailure, error) {

--- a/pkg/repository/match_scope_test.go
+++ b/pkg/repository/match_scope_test.go
@@ -42,7 +42,11 @@ func newUserEventScopeTestRepositories(t *testing.T, pool *pgxpool.Pool) userEve
 	t.Cleanup(func() { _ = cleanup() })
 
 	return userEventScopeTestRepositories{
-		durable: newDurableEventsRepository(shared, DurableEventBufferOpts{}),
+		durable: newDurableEventsRepository(shared, DurableEventBufferOpts{
+			FlushInterval:        10 * time.Millisecond,
+			MaxBatchSize:         20,
+			MaxConcurrentFlushes: 16,
+		}),
 		matches: &MatchRepositoryImpl{sharedRepository: shared},
 		shared:  shared,
 	}

--- a/pkg/repository/match_scope_test.go
+++ b/pkg/repository/match_scope_test.go
@@ -42,7 +42,7 @@ func newUserEventScopeTestRepositories(t *testing.T, pool *pgxpool.Pool) userEve
 	t.Cleanup(func() { _ = cleanup() })
 
 	return userEventScopeTestRepositories{
-		durable: &durableEventsRepository{sharedRepository: shared},
+		durable: newDurableEventsRepository(shared, DurableEventBufferOpts{}),
 		matches: &MatchRepositoryImpl{sharedRepository: shared},
 		shared:  shared,
 	}

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -106,6 +106,7 @@ func NewRepository(
 	statusUpdateBatchSizeLimits StatusUpdateBatchSizeLimits,
 	tenantLimitConfig limits.LimitConfigFile,
 	enforceLimits bool,
+	durableEventBufferOpts DurableEventBufferOpts,
 ) (Repository, func() error) {
 	v := validator.NewDefaultValidator()
 
@@ -116,7 +117,7 @@ func NewRepository(
 	impl := &repositoryImpl{
 		apiToken:          newAPITokenRepository(shared, cacheDuration),
 		dispatcher:        newDispatcherRepository(shared),
-		durableEvents:     newDurableEventsRepository(shared),
+		durableEvents:     newDurableEventsRepository(shared, durableEventBufferOpts),
 		health:            newHealthRepository(shared),
 		messageQueue:      mq,
 		rateLimit:         newRateLimitRepository(shared),

--- a/pkg/repository/sqlcv1/durable_event_log.sql
+++ b/pkg/repository/sqlcv1/durable_event_log.sql
@@ -8,7 +8,7 @@ WITH inputs AS (
     SELECT lf.*
     FROM v1_durable_event_log_file lf
     JOIN inputs i ON (lf.durable_task_id, lf.durable_task_inserted_at, lf.tenant_id) = (i.durable_task_id, i.durable_task_inserted_at, i.tenant_id)
-    WHERE lf.inserted_at >= @minDurableTaskInsertedAt::TIMESTAMPTZ
+    WHERE lf.durable_task_inserted_at >= @minDurableTaskInsertedAt::TIMESTAMPTZ
     ORDER BY lf.durable_task_id, lf.durable_task_inserted_at
     FOR UPDATE
 )

--- a/pkg/repository/sqlcv1/durable_event_log.sql
+++ b/pkg/repository/sqlcv1/durable_event_log.sql
@@ -1,33 +1,26 @@
--- name: GetAndLockLogFile :one
-SELECT *
-FROM v1_durable_event_log_file
-WHERE
-    durable_task_id = @durableTaskId::BIGINT
-    AND durable_task_inserted_at = @durableTaskInsertedAt::TIMESTAMPTZ
-    AND tenant_id = @tenantId::UUID
-FOR UPDATE
-;
-
--- name: GetAndLockLogFileWithBranchPoints :many
-WITH locked_file AS (
-    SELECT *
-    FROM v1_durable_event_log_file
-    WHERE
-        durable_task_id = @durableTaskId::BIGINT
-        AND durable_task_inserted_at = @durableTaskInsertedAt::TIMESTAMPTZ
-        AND tenant_id = @tenantId::UUID
+-- name: GetAndLockLogFilesWithBranchPoints :many
+WITH inputs AS (
+    SELECT
+        UNNEST(@durableTaskIds::BIGINT[]) AS durable_task_id,
+        UNNEST(@durableTaskInsertedAts::TIMESTAMPTZ[]) AS durable_task_inserted_at,
+        UNNEST(@tenantIds::UUID[]) AS tenant_id
+), locked_files AS (
+    SELECT lf.*
+    FROM v1_durable_event_log_file lf
+    JOIN inputs i ON (lf.durable_task_id, lf.durable_task_inserted_at, lf.tenant_id) = (i.durable_task_id, i.durable_task_inserted_at, i.tenant_id)
+    WHERE lf.inserted_at >= @minDurableTaskInsertedAt::TIMESTAMPTZ
+    ORDER BY lf.durable_task_id, lf.durable_task_inserted_at
     FOR UPDATE
 )
 
 SELECT
     sqlc.embed(to_embed),
     bp.*
-FROM locked_file lf
--- note: intentionally using the params for the join so we can prune partitions
+FROM locked_files lf
 JOIN v1_durable_event_log_file to_embed
-    ON (to_embed.durable_task_id, to_embed.durable_task_inserted_at, to_embed.tenant_id) = (@durableTaskId::BIGINT, @durableTaskInsertedAt::TIMESTAMPTZ, @tenantId::UUID)
+    ON (to_embed.durable_task_id, to_embed.durable_task_inserted_at, to_embed.tenant_id) = (lf.durable_task_id, lf.durable_task_inserted_at, lf.tenant_id)
 LEFT JOIN v1_durable_event_log_branch_point bp
-    ON (bp.durable_task_id, bp.durable_task_inserted_at, bp.tenant_id) = (@durableTaskId::BIGINT, @durableTaskInsertedAt::TIMESTAMPTZ, @tenantId::UUID)
+    ON (bp.durable_task_id, bp.durable_task_inserted_at, bp.tenant_id) = (lf.durable_task_id, lf.durable_task_inserted_at, lf.tenant_id)
 ;
 
 -- name: IncrementLogFileInvocationCounts :many
@@ -56,6 +49,8 @@ SELECT
     0,
     1
 FROM inputs
+-- note: consistent lock ordering with batched ingestion, which locks multiple log files per transaction
+ORDER BY durable_task_id, durable_task_inserted_at
 ON CONFLICT (durable_task_id, durable_task_inserted_at) DO UPDATE
 SET
     latest_invocation_count = v1_durable_event_log_file.latest_invocation_count + 1,
@@ -75,6 +70,23 @@ SET
 WHERE durable_task_id = @durableTaskId::BIGINT
   AND durable_task_inserted_at = @durableTaskInsertedAt::TIMESTAMPTZ
 RETURNING *;
+
+-- name: UpdateLogFileLatestNodeIds :exec
+WITH inputs AS (
+    SELECT
+        UNNEST(@durableTaskIds::BIGINT[]) AS durable_task_id,
+        UNNEST(@durableTaskInsertedAts::TIMESTAMPTZ[]) AS durable_task_inserted_at,
+        UNNEST(@nodeIds::BIGINT[]) AS node_id
+)
+
+UPDATE v1_durable_event_log_file lf
+SET
+    -- important: need `GREATEST` here to avoid moving the `latest_node_id` backwards in the case of child spawning with
+    -- a child_key set, which, if the child was cached, would not create a new log entry and thus not move the latest node forward
+    latest_node_id = GREATEST(lf.latest_node_id, i.node_id)
+FROM inputs i
+WHERE (lf.durable_task_id, lf.durable_task_inserted_at) = (i.durable_task_id, i.durable_task_inserted_at)
+;
 
 -- name: CreateDurableEventLogBranchPoint :exec
 INSERT INTO v1_durable_event_log_branch_point (
@@ -225,15 +237,16 @@ RETURNING *
 -- name: BulkGetDurableEventLogEntries :many
 WITH inputs AS (
     SELECT
+        UNNEST(@durableTaskIds::BIGINT[]) AS durable_task_id,
+        UNNEST(@durableTaskInsertedAts::TIMESTAMPTZ[]) AS durable_task_inserted_at,
         UNNEST(@branchIds::BIGINT[]) AS branch_id,
         UNNEST(@nodeIds::BIGINT[]) AS node_id
 )
 SELECT e.*, lf.latest_invocation_count AS invocation_count
 FROM v1_durable_event_log_entry e
-JOIN inputs i ON e.branch_id = i.branch_id AND e.node_id = i.node_id
-JOIN v1_durable_event_log_file lf ON (lf.durable_task_id, lf.durable_task_inserted_at) = (e.durable_task_id, e.durable_task_inserted_at)
-WHERE e.durable_task_id = @durableTaskId::BIGINT
-  AND e.durable_task_inserted_at = @durableTaskInsertedAt::TIMESTAMPTZ;
+JOIN inputs i
+    ON (e.durable_task_id, e.durable_task_inserted_at, e.branch_id, e.node_id) = (i.durable_task_id, i.durable_task_inserted_at, i.branch_id, i.node_id)
+JOIN v1_durable_event_log_file lf ON (lf.durable_task_id, lf.durable_task_inserted_at) = (e.durable_task_id, e.durable_task_inserted_at);
 
 -- name: GetDurableEventLogEntriesByChildTaskExternalIds :many
 SELECT e.*, lf.latest_invocation_count AS invocation_count

--- a/pkg/repository/sqlcv1/durable_event_log.sql.go
+++ b/pkg/repository/sqlcv1/durable_event_log.sql.go
@@ -168,22 +168,23 @@ func (q *Queries) BulkCreateDurableEventLogEntries(ctx context.Context, db DBTX,
 const bulkGetDurableEventLogEntries = `-- name: BulkGetDurableEventLogEntries :many
 WITH inputs AS (
     SELECT
+        UNNEST($1::BIGINT[]) AS durable_task_id,
+        UNNEST($2::TIMESTAMPTZ[]) AS durable_task_inserted_at,
         UNNEST($3::BIGINT[]) AS branch_id,
         UNNEST($4::BIGINT[]) AS node_id
 )
 SELECT e.tenant_id, e.external_id, e.result_payload_external_id, e.child_task_external_id, e.child_task_is_failure, e.child_task_error_message, e.inserted_at, e.id, e.durable_task_id, e.durable_task_inserted_at, e.kind, e.node_id, e.branch_id, e.idempotency_key, e.is_satisfied, e.satisfied_at, e.satisfied_order, e.user_message, e.wait_data, e.triggered_at, lf.latest_invocation_count AS invocation_count
 FROM v1_durable_event_log_entry e
-JOIN inputs i ON e.branch_id = i.branch_id AND e.node_id = i.node_id
+JOIN inputs i
+    ON (e.durable_task_id, e.durable_task_inserted_at, e.branch_id, e.node_id) = (i.durable_task_id, i.durable_task_inserted_at, i.branch_id, i.node_id)
 JOIN v1_durable_event_log_file lf ON (lf.durable_task_id, lf.durable_task_inserted_at) = (e.durable_task_id, e.durable_task_inserted_at)
-WHERE e.durable_task_id = $1::BIGINT
-  AND e.durable_task_inserted_at = $2::TIMESTAMPTZ
 `
 
 type BulkGetDurableEventLogEntriesParams struct {
-	Durabletaskid         int64              `json:"durabletaskid"`
-	Durabletaskinsertedat pgtype.Timestamptz `json:"durabletaskinsertedat"`
-	Branchids             []int64            `json:"branchids"`
-	Nodeids               []int64            `json:"nodeids"`
+	Durabletaskids         []int64              `json:"durabletaskids"`
+	Durabletaskinsertedats []pgtype.Timestamptz `json:"durabletaskinsertedats"`
+	Branchids              []int64              `json:"branchids"`
+	Nodeids                []int64              `json:"nodeids"`
 }
 
 type BulkGetDurableEventLogEntriesRow struct {
@@ -212,8 +213,8 @@ type BulkGetDurableEventLogEntriesRow struct {
 
 func (q *Queries) BulkGetDurableEventLogEntries(ctx context.Context, db DBTX, arg BulkGetDurableEventLogEntriesParams) ([]*BulkGetDurableEventLogEntriesRow, error) {
 	rows, err := db.Query(ctx, bulkGetDurableEventLogEntries,
-		arg.Durabletaskid,
-		arg.Durabletaskinsertedat,
+		arg.Durabletaskids,
+		arg.Durabletaskinsertedats,
 		arg.Branchids,
 		arg.Nodeids,
 	)
@@ -391,66 +392,39 @@ func (q *Queries) CreateDurableEventLogBranchPoint(ctx context.Context, db DBTX,
 	return err
 }
 
-const getAndLockLogFile = `-- name: GetAndLockLogFile :one
-SELECT tenant_id, durable_task_id, durable_task_inserted_at, latest_invocation_count, latest_inserted_at, latest_node_id, latest_branch_id, latest_satisfied_order
-FROM v1_durable_event_log_file
-WHERE
-    durable_task_id = $1::BIGINT
-    AND durable_task_inserted_at = $2::TIMESTAMPTZ
-    AND tenant_id = $3::UUID
-FOR UPDATE
-`
-
-type GetAndLockLogFileParams struct {
-	Durabletaskid         int64              `json:"durabletaskid"`
-	Durabletaskinsertedat pgtype.Timestamptz `json:"durabletaskinsertedat"`
-	Tenantid              uuid.UUID          `json:"tenantid"`
-}
-
-func (q *Queries) GetAndLockLogFile(ctx context.Context, db DBTX, arg GetAndLockLogFileParams) (*V1DurableEventLogFile, error) {
-	row := db.QueryRow(ctx, getAndLockLogFile, arg.Durabletaskid, arg.Durabletaskinsertedat, arg.Tenantid)
-	var i V1DurableEventLogFile
-	err := row.Scan(
-		&i.TenantID,
-		&i.DurableTaskID,
-		&i.DurableTaskInsertedAt,
-		&i.LatestInvocationCount,
-		&i.LatestInsertedAt,
-		&i.LatestNodeID,
-		&i.LatestBranchID,
-		&i.LatestSatisfiedOrder,
-	)
-	return &i, err
-}
-
-const getAndLockLogFileWithBranchPoints = `-- name: GetAndLockLogFileWithBranchPoints :many
-WITH locked_file AS (
-    SELECT tenant_id, durable_task_id, durable_task_inserted_at, latest_invocation_count, latest_inserted_at, latest_node_id, latest_branch_id, latest_satisfied_order
-    FROM v1_durable_event_log_file
-    WHERE
-        durable_task_id = $1::BIGINT
-        AND durable_task_inserted_at = $2::TIMESTAMPTZ
-        AND tenant_id = $3::UUID
+const getAndLockLogFilesWithBranchPoints = `-- name: GetAndLockLogFilesWithBranchPoints :many
+WITH inputs AS (
+    SELECT
+        UNNEST($1::BIGINT[]) AS durable_task_id,
+        UNNEST($2::TIMESTAMPTZ[]) AS durable_task_inserted_at,
+        UNNEST($3::UUID[]) AS tenant_id
+), locked_files AS (
+    SELECT lf.tenant_id, lf.durable_task_id, lf.durable_task_inserted_at, lf.latest_invocation_count, lf.latest_inserted_at, lf.latest_node_id, lf.latest_branch_id, lf.latest_satisfied_order
+    FROM v1_durable_event_log_file lf
+    JOIN inputs i ON (lf.durable_task_id, lf.durable_task_inserted_at, lf.tenant_id) = (i.durable_task_id, i.durable_task_inserted_at, i.tenant_id)
+    WHERE lf.inserted_at >= $4::TIMESTAMPTZ
+    ORDER BY lf.durable_task_id, lf.durable_task_inserted_at
     FOR UPDATE
 )
 
 SELECT
     to_embed.tenant_id, to_embed.durable_task_id, to_embed.durable_task_inserted_at, to_embed.latest_invocation_count, to_embed.latest_inserted_at, to_embed.latest_node_id, to_embed.latest_branch_id, to_embed.latest_satisfied_order,
     bp.tenant_id, bp.id, bp.inserted_at, bp.durable_task_id, bp.durable_task_inserted_at, bp.first_node_id_in_new_branch, bp.parent_branch_id, bp.next_branch_id, bp.replay_child_external_ids
-FROM locked_file lf
+FROM locked_files lf
 JOIN v1_durable_event_log_file to_embed
-    ON (to_embed.durable_task_id, to_embed.durable_task_inserted_at, to_embed.tenant_id) = ($1::BIGINT, $2::TIMESTAMPTZ, $3::UUID)
+    ON (to_embed.durable_task_id, to_embed.durable_task_inserted_at, to_embed.tenant_id) = (lf.durable_task_id, lf.durable_task_inserted_at, lf.tenant_id)
 LEFT JOIN v1_durable_event_log_branch_point bp
-    ON (bp.durable_task_id, bp.durable_task_inserted_at, bp.tenant_id) = ($1::BIGINT, $2::TIMESTAMPTZ, $3::UUID)
+    ON (bp.durable_task_id, bp.durable_task_inserted_at, bp.tenant_id) = (lf.durable_task_id, lf.durable_task_inserted_at, lf.tenant_id)
 `
 
-type GetAndLockLogFileWithBranchPointsParams struct {
-	Durabletaskid         int64              `json:"durabletaskid"`
-	Durabletaskinsertedat pgtype.Timestamptz `json:"durabletaskinsertedat"`
-	Tenantid              uuid.UUID          `json:"tenantid"`
+type GetAndLockLogFilesWithBranchPointsParams struct {
+	Durabletaskids           []int64              `json:"durabletaskids"`
+	Durabletaskinsertedats   []pgtype.Timestamptz `json:"durabletaskinsertedats"`
+	Tenantids                []uuid.UUID          `json:"tenantids"`
+	Mindurabletaskinsertedat pgtype.Timestamptz   `json:"mindurabletaskinsertedat"`
 }
 
-type GetAndLockLogFileWithBranchPointsRow struct {
+type GetAndLockLogFilesWithBranchPointsRow struct {
 	V1DurableEventLogFile  V1DurableEventLogFile `json:"v1_durable_event_log_file"`
 	TenantID               *uuid.UUID            `json:"tenant_id"`
 	ID                     pgtype.Int8           `json:"id"`
@@ -463,16 +437,20 @@ type GetAndLockLogFileWithBranchPointsRow struct {
 	ReplayChildExternalIds []uuid.UUID           `json:"replay_child_external_ids"`
 }
 
-// note: intentionally using the params for the join so we can prune partitions
-func (q *Queries) GetAndLockLogFileWithBranchPoints(ctx context.Context, db DBTX, arg GetAndLockLogFileWithBranchPointsParams) ([]*GetAndLockLogFileWithBranchPointsRow, error) {
-	rows, err := db.Query(ctx, getAndLockLogFileWithBranchPoints, arg.Durabletaskid, arg.Durabletaskinsertedat, arg.Tenantid)
+func (q *Queries) GetAndLockLogFilesWithBranchPoints(ctx context.Context, db DBTX, arg GetAndLockLogFilesWithBranchPointsParams) ([]*GetAndLockLogFilesWithBranchPointsRow, error) {
+	rows, err := db.Query(ctx, getAndLockLogFilesWithBranchPoints,
+		arg.Durabletaskids,
+		arg.Durabletaskinsertedats,
+		arg.Tenantids,
+		arg.Mindurabletaskinsertedat,
+	)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []*GetAndLockLogFileWithBranchPointsRow
+	var items []*GetAndLockLogFilesWithBranchPointsRow
 	for rows.Next() {
-		var i GetAndLockLogFileWithBranchPointsRow
+		var i GetAndLockLogFilesWithBranchPointsRow
 		if err := rows.Scan(
 			&i.V1DurableEventLogFile.TenantID,
 			&i.V1DurableEventLogFile.DurableTaskID,
@@ -711,6 +689,7 @@ SELECT
     0,
     1
 FROM inputs
+ORDER BY durable_task_id, durable_task_inserted_at
 ON CONFLICT (durable_task_id, durable_task_inserted_at) DO UPDATE
 SET
     latest_invocation_count = v1_durable_event_log_file.latest_invocation_count + 1,
@@ -724,6 +703,7 @@ type IncrementLogFileInvocationCountsParams struct {
 	Tenantids              []uuid.UUID          `json:"tenantids"`
 }
 
+// note: consistent lock ordering with batched ingestion, which locks multiple log files per transaction
 func (q *Queries) IncrementLogFileInvocationCounts(ctx context.Context, db DBTX, arg IncrementLogFileInvocationCountsParams) ([]*V1DurableEventLogFile, error) {
 	rows, err := db.Query(ctx, incrementLogFileInvocationCounts, arg.Durabletaskids, arg.Durabletaskinsertedats, arg.Tenantids)
 	if err != nil {
@@ -1255,6 +1235,34 @@ func (q *Queries) UpdateLogFile(ctx context.Context, db DBTX, arg UpdateLogFileP
 		&i.LatestSatisfiedOrder,
 	)
 	return &i, err
+}
+
+const updateLogFileLatestNodeIds = `-- name: UpdateLogFileLatestNodeIds :exec
+WITH inputs AS (
+    SELECT
+        UNNEST($1::BIGINT[]) AS durable_task_id,
+        UNNEST($2::TIMESTAMPTZ[]) AS durable_task_inserted_at,
+        UNNEST($3::BIGINT[]) AS node_id
+)
+
+UPDATE v1_durable_event_log_file lf
+SET
+    -- important: need ` + "`" + `GREATEST` + "`" + ` here to avoid moving the ` + "`" + `latest_node_id` + "`" + ` backwards in the case of child spawning with
+    -- a child_key set, which, if the child was cached, would not create a new log entry and thus not move the latest node forward
+    latest_node_id = GREATEST(lf.latest_node_id, i.node_id)
+FROM inputs i
+WHERE (lf.durable_task_id, lf.durable_task_inserted_at) = (i.durable_task_id, i.durable_task_inserted_at)
+`
+
+type UpdateLogFileLatestNodeIdsParams struct {
+	Durabletaskids         []int64              `json:"durabletaskids"`
+	Durabletaskinsertedats []pgtype.Timestamptz `json:"durabletaskinsertedats"`
+	Nodeids                []int64              `json:"nodeids"`
+}
+
+func (q *Queries) UpdateLogFileLatestNodeIds(ctx context.Context, db DBTX, arg UpdateLogFileLatestNodeIdsParams) error {
+	_, err := db.Exec(ctx, updateLogFileLatestNodeIds, arg.Durabletaskids, arg.Durabletaskinsertedats, arg.Nodeids)
+	return err
 }
 
 const upsertDurableChildSignalCreatedEvents = `-- name: UpsertDurableChildSignalCreatedEvents :many

--- a/pkg/repository/sqlcv1/durable_event_log.sql.go
+++ b/pkg/repository/sqlcv1/durable_event_log.sql.go
@@ -402,7 +402,7 @@ WITH inputs AS (
     SELECT lf.tenant_id, lf.durable_task_id, lf.durable_task_inserted_at, lf.latest_invocation_count, lf.latest_inserted_at, lf.latest_node_id, lf.latest_branch_id, lf.latest_satisfied_order
     FROM v1_durable_event_log_file lf
     JOIN inputs i ON (lf.durable_task_id, lf.durable_task_inserted_at, lf.tenant_id) = (i.durable_task_id, i.durable_task_inserted_at, i.tenant_id)
-    WHERE lf.inserted_at >= $4::TIMESTAMPTZ
+    WHERE lf.durable_task_inserted_at >= $4::TIMESTAMPTZ
     ORDER BY lf.durable_task_id, lf.durable_task_inserted_at
     FOR UPDATE
 )

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -1923,11 +1923,13 @@ func (r *TaskRepositoryImpl) EvictTask(ctx context.Context, tenantId uuid.UUID, 
 
 	defer rollback()
 
-	_, err = r.queries.GetAndLockLogFile(ctx, tx, sqlcv1.GetAndLockLogFileParams{
-		Durabletaskid:         task.Id,
-		Durabletaskinsertedat: task.InsertedAt,
-		Tenantid:              tenantId,
+	_, err = r.queries.GetAndLockLogFilesWithBranchPoints(ctx, tx, sqlcv1.GetAndLockLogFilesWithBranchPointsParams{
+		Durabletaskids:           []int64{task.Id},
+		Durabletaskinsertedats:   []pgtype.Timestamptz{task.InsertedAt},
+		Tenantids:                []uuid.UUID{tenantId},
+		Mindurabletaskinsertedat: task.InsertedAt,
 	})
+
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

Sets up a buffer for `IngestDurableTaskEvent` so that we can try to batch db operations a little bit instead of having many writes for every call of that function. I think this is the last big lever that's relatively straightforward that we have for improving the performance of this path

## Type of change

- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [x] Performance improvement (non-breaking change which improves performance)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Fable to help wire up the buffer after I wrote the new queries and env vars

</details>
