### PR TITLE
fix: replayed DAG runs no longer finalize with stale downstream task events

### DIFF
--- a/pkg/repository/sqlcv1/tasks.sql
+++ b/pkg/repository/sqlcv1/tasks.sql
@@ -966,6 +966,22 @@ WHERE
     AND (tr.task_id IS NOT NULL OR cs.task_id IS NOT NULL OR rqi.task_id IS NOT NULL)
 ;
 
+-- name: DeleteTerminalTaskEvents :exec
+WITH input AS (
+    SELECT
+        UNNEST(@taskIds::bigint[]) AS task_id,
+        UNNEST(@taskInsertedAts::timestamptz[]) AS task_inserted_at,
+        UNNEST(@taskRetryCounts::integer[]) AS task_retry_count
+)
+DELETE FROM
+    v1_task_event e
+USING
+    input i
+WHERE
+    e.tenant_id = @tenantId::uuid
+    AND (e.task_id, e.task_inserted_at, e.retry_count) = (i.task_id, i.task_inserted_at, i.task_retry_count)
+    AND e.event_type = ANY('{COMPLETED, FAILED, CANCELLED}'::v1_task_event_type[]);
+
 -- name: ListAllTasksInDags :many
 SELECT
     t.id,

--- a/pkg/repository/sqlcv1/tasks.sql.go
+++ b/pkg/repository/sqlcv1/tasks.sql.go
@@ -311,6 +311,40 @@ func (q *Queries) DeleteTaskBatchRun(ctx context.Context, db DBTX, arg DeleteTas
 	return err
 }
 
+const deleteTerminalTaskEvents = `-- name: DeleteTerminalTaskEvents :exec
+WITH input AS (
+    SELECT
+        UNNEST($2::bigint[]) AS task_id,
+        UNNEST($3::timestamptz[]) AS task_inserted_at,
+        UNNEST($4::integer[]) AS task_retry_count
+)
+DELETE FROM
+    v1_task_event e
+USING
+    input i
+WHERE
+    e.tenant_id = $1::uuid
+    AND (e.task_id, e.task_inserted_at, e.retry_count) = (i.task_id, i.task_inserted_at, i.task_retry_count)
+    AND e.event_type = ANY('{COMPLETED, FAILED, CANCELLED}'::v1_task_event_type[])
+`
+
+type DeleteTerminalTaskEventsParams struct {
+	Tenantid        uuid.UUID            `json:"tenantid"`
+	Taskids         []int64              `json:"taskids"`
+	Taskinsertedats []pgtype.Timestamptz `json:"taskinsertedats"`
+	Taskretrycounts []int32              `json:"taskretrycounts"`
+}
+
+func (q *Queries) DeleteTerminalTaskEvents(ctx context.Context, db DBTX, arg DeleteTerminalTaskEventsParams) error {
+	_, err := db.Exec(ctx, deleteTerminalTaskEvents,
+		arg.Tenantid,
+		arg.Taskids,
+		arg.Taskinsertedats,
+		arg.Taskretrycounts,
+	)
+	return err
+}
+
 const ensureTablePartitionsExist = `-- name: EnsureTablePartitionsExist :one
 WITH tomorrow_date AS (
     SELECT (NOW() + INTERVAL '1 day')::date AS date

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -3777,6 +3777,31 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 		dagIdsToAllTasks[task.DagID.Int64] = append(dagIdsToAllTasks[task.DagID.Int64], task)
 	}
 
+	deferredTaskIds := make([]int64, 0)
+	deferredTaskInsertedAts := make([]pgtype.Timestamptz, 0)
+	deferredTaskRetryCounts := make([]int32, 0)
+
+	for _, tasks := range dagIdsToChildTasks {
+		for _, task := range tasks {
+			deferredTaskIds = append(deferredTaskIds, task.ID)
+			deferredTaskInsertedAts = append(deferredTaskInsertedAts, task.InsertedAt)
+			deferredTaskRetryCounts = append(deferredTaskRetryCounts, task.RetryCount)
+		}
+	}
+
+	if len(deferredTaskIds) > 0 {
+		err = r.queries.DeleteTerminalTaskEvents(ctx, tx, sqlcv1.DeleteTerminalTaskEventsParams{
+			Tenantid:        tenantId,
+			Taskids:         deferredTaskIds,
+			Taskinsertedats: deferredTaskInsertedAts,
+			Taskretrycounts: deferredTaskRetryCounts,
+		})
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to delete terminal task events: %w", err)
+		}
+	}
+
 	upsertedTasks := make([]*V1TaskWithPayload, 0)
 
 	// NOTE: the tasks which are passed in represent a *subtree* of the DAG.


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR. https://github.com/hatchet-dev/hatchet/blob/main/CONTRIBUTING.md -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

On replay, downstream steps of the replayed subgraph or subtree are deferred until their parent completes, but keep their old `COMPLETED`/`FAILED`/`CANCELLED` events at the current `retry_count`. What happens due to this is that `ListFinalizedWorkflowRuns` reports the run as finished the moment any upstream step completes, so a parent awaiting the child sees it as `CANCELLED` while it's still running.

This PR deletes the deferred steps' terminal events inside the replay transaction itself.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI

</details>
