### PR TITLE
fix: count allocated crons via DISTINCT ON latest workflow version

### DIFF
--- a/pkg/repository/sqlcv1/allocated_resources.sql
+++ b/pkg/repository/sqlcv1/allocated_resources.sql
@@ -7,30 +7,39 @@
 -- webhook_count: row count on v1_incoming_webhook.
 -- NULL tenantIds drops the tenant filter (hourly shard-wide collect).
 -- The result is still one row per tenant, not a summed shard total.
-WITH cron_counts AS (
-    SELECT
-        w."tenantId" AS tenant_id,
-        count(*)::bigint AS cron_count
-    FROM "WorkflowTriggerCronRef" c
-    JOIN "WorkflowTriggers" t ON t."id" = c."parentId"
-    JOIN "WorkflowVersion" v ON v."id" = t."workflowVersionId"
+-- latest_versions uses DISTINCT ON (workflowId) ORDER BY order DESC so
+-- Postgres can use idx_workflow_version_workflow_id_order.
+WITH latest_versions AS (
+    SELECT DISTINCT ON (v."workflowId")
+        v.id,
+        v."workflowId"
+    FROM "WorkflowVersion" v
     JOIN "Workflow" w ON w."id" = v."workflowId"
     WHERE
-        c."deletedAt" IS NULL
-        AND c."enabled" = true
-        AND t."deletedAt" IS NULL
-        AND v."deletedAt" IS NULL
+        v."deletedAt" IS NULL
         AND w."deletedAt" IS NULL
         AND (
             sqlc.narg('tenantIds')::uuid[] IS NULL
             OR w."tenantId" = ANY(sqlc.narg('tenantIds')::uuid[])
         )
-        AND NOT EXISTS (
-            SELECT 1
-            FROM "WorkflowVersion" newer
-            WHERE newer."workflowId" = v."workflowId"
-              AND newer."deletedAt" IS NULL
-              AND newer."order" > v."order"
+    ORDER BY v."workflowId", v."order" DESC
+),
+cron_counts AS (
+    SELECT
+        w."tenantId" AS tenant_id,
+        count(*)::bigint AS cron_count
+    FROM "WorkflowTriggerCronRef" c
+    JOIN "WorkflowTriggers" t ON t."id" = c."parentId"
+    JOIN latest_versions lv ON lv.id = t."workflowVersionId"
+    JOIN "Workflow" w ON w."id" = lv."workflowId"
+    WHERE
+        c."deletedAt" IS NULL
+        AND c."enabled" = true
+        AND t."deletedAt" IS NULL
+        AND w."deletedAt" IS NULL
+        AND (
+            sqlc.narg('tenantIds')::uuid[] IS NULL
+            OR w."tenantId" = ANY(sqlc.narg('tenantIds')::uuid[])
         )
     GROUP BY w."tenantId"
 ),

--- a/pkg/repository/sqlcv1/allocated_resources.sql.go
+++ b/pkg/repository/sqlcv1/allocated_resources.sql.go
@@ -12,30 +12,37 @@ import (
 )
 
 const countAllocatedResourcesByTenant = `-- name: CountAllocatedResourcesByTenant :many
-WITH cron_counts AS (
-    SELECT
-        w."tenantId" AS tenant_id,
-        count(*)::bigint AS cron_count
-    FROM "WorkflowTriggerCronRef" c
-    JOIN "WorkflowTriggers" t ON t."id" = c."parentId"
-    JOIN "WorkflowVersion" v ON v."id" = t."workflowVersionId"
+WITH latest_versions AS (
+    SELECT DISTINCT ON (v."workflowId")
+        v.id,
+        v."workflowId"
+    FROM "WorkflowVersion" v
     JOIN "Workflow" w ON w."id" = v."workflowId"
     WHERE
-        c."deletedAt" IS NULL
-        AND c."enabled" = true
-        AND t."deletedAt" IS NULL
-        AND v."deletedAt" IS NULL
+        v."deletedAt" IS NULL
         AND w."deletedAt" IS NULL
         AND (
             $1::uuid[] IS NULL
             OR w."tenantId" = ANY($1::uuid[])
         )
-        AND NOT EXISTS (
-            SELECT 1
-            FROM "WorkflowVersion" newer
-            WHERE newer."workflowId" = v."workflowId"
-              AND newer."deletedAt" IS NULL
-              AND newer."order" > v."order"
+    ORDER BY v."workflowId", v."order" DESC
+),
+cron_counts AS (
+    SELECT
+        w."tenantId" AS tenant_id,
+        count(*)::bigint AS cron_count
+    FROM "WorkflowTriggerCronRef" c
+    JOIN "WorkflowTriggers" t ON t."id" = c."parentId"
+    JOIN latest_versions lv ON lv.id = t."workflowVersionId"
+    JOIN "Workflow" w ON w."id" = lv."workflowId"
+    WHERE
+        c."deletedAt" IS NULL
+        AND c."enabled" = true
+        AND t."deletedAt" IS NULL
+        AND w."deletedAt" IS NULL
+        AND (
+            $1::uuid[] IS NULL
+            OR w."tenantId" = ANY($1::uuid[])
         )
     GROUP BY w."tenantId"
 ),
@@ -97,6 +104,8 @@ type CountAllocatedResourcesByTenantRow struct {
 // webhook_count: row count on v1_incoming_webhook.
 // NULL tenantIds drops the tenant filter (hourly shard-wide collect).
 // The result is still one row per tenant, not a summed shard total.
+// latest_versions uses DISTINCT ON (workflowId) ORDER BY order DESC so
+// Postgres can use idx_workflow_version_workflow_id_order.
 func (q *Queries) CountAllocatedResourcesByTenant(ctx context.Context, db DBTX, tenantids []uuid.UUID) ([]*CountAllocatedResourcesByTenantRow, error) {
 	rows, err := db.Query(ctx, countAllocatedResourcesByTenant, tenantids)
 	if err != nil {


### PR DESCRIPTION
# Description

`CountAllocatedResourcesByTenant` timed out on shards with long `WorkflowVersion` histories because the latest-version anti-join is quadratic. Switch cron counting to `DISTINCT ON` so Postgres can use `idx_workflow_version_workflow_id_order`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What's Changed

- [x] Resolve latest workflow versions with `DISTINCT ON (workflowId) ORDER BY order DESC`
- [x] Join cron counts to that CTE instead of a `NOT EXISTS` anti-join on `WorkflowVersion`
- [x] Regenerate sqlc

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

## Testing

`EXPLAIN ANALYZE` on a production shard with a large version history: previous plan ~63s, rewrite ~150ms. Existing `TestCountAllocatedResourcesByTenant` still covers the count semantics.

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Rewrote the allocated-resources SQL, regenerated sqlc, and drafted the PR description.

</details>