### PR TITLE
refactor(engine): bulk operation for `UpsertDurableChildSignalCreatedEvents`

### DIFF
--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -2034,8 +2034,6 @@ func (r *durableEventsRepository) planDurableEventLogAppend(
 
 	switch opts.Kind {
 	case sqlcv1.V1DurableEventLogKindRUN:
-		// child external ids were already resolved for the whole batch in
-		// resolveChildExternalIdsForBatch before the plan loop
 		resolvedChildrenToReplay, dedupeErr := r.resolveOrphanedChildDedupes(ctx, tx, logFile, nextBranchIdToBranchPoint, opts.TriggerRuns.TriggerOpts)
 		if dedupeErr != nil {
 			return nil, nil, dedupeErr

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -1626,73 +1626,84 @@ func (r *durableEventsRepository) IngestDurableTaskEvent(ctx context.Context, op
 	}, nil
 }
 
-func (r *durableEventsRepository) resolveChildExternalIds(ctx context.Context, tx sqlcv1.DBTX, tenantId uuid.UUID, task *sqlcv1.FlattenExternalIdsRow, opts []*WorkflowNameTriggerOpts) error {
+type resolveChildExternalIdsTask struct {
+	tenantId    uuid.UUID
+	task        *sqlcv1.FlattenExternalIdsRow
+	triggerOpts []*WorkflowNameTriggerOpts
+}
+
+type taskIdSpawnKey struct {
+	taskId   int64
+	spawnKey string
+}
+
+func (r *durableEventsRepository) resolveChildExternalIdsForBatch(ctx context.Context, tx sqlcv1.DBTX, tasks []resolveChildExternalIdsTask) error {
 	ctx, span := telemetry.NewSpan(ctx, "resolve-child-external-ids")
 	defer span.End()
 
-	candidateIdByKey := make(map[string]uuid.UUID, len(opts))
-	eventKeys := make([]string, 0, len(opts))
-	childExternalIds := make([]uuid.UUID, 0, len(opts))
+	candidateIdByKey := make(map[taskIdSpawnKey]uuid.UUID)
+	optsByKey := make(map[taskIdSpawnKey][]*WorkflowNameTriggerOpts)
+	params := sqlcv1.BulkUpsertDurableChildSignalCreatedEventsParams{}
 
-	for _, opt := range opts {
-		spawnKey := opt.childSpawnKey()
+	for _, t := range tasks {
+		for _, opt := range t.triggerOpts {
+			spawnKey := opt.childSpawnKey()
 
-		if spawnKey == "" {
-			opt.ExternalId = uuid.New()
-			continue
+			if spawnKey == "" {
+				opt.ExternalId = uuid.New()
+				continue
+			}
+
+			key := taskIdSpawnKey{taskId: t.task.ID, spawnKey: spawnKey}
+
+			if _, seen := candidateIdByKey[key]; !seen {
+				childExternalId := uuid.New()
+				candidateIdByKey[key] = childExternalId
+
+				params.Tenantids = append(params.Tenantids, t.tenantId)
+				params.Durabletaskids = append(params.Durabletaskids, t.task.ID)
+				params.Durabletaskinsertedats = append(params.Durabletaskinsertedats, t.task.InsertedAt)
+				params.Eventkeys = append(params.Eventkeys, spawnKey)
+				params.Childexternalids = append(params.Childexternalids, childExternalId)
+			}
+
+			optsByKey[key] = append(optsByKey[key], opt)
 		}
-
-		if _, seen := candidateIdByKey[spawnKey]; seen {
-			continue
-		}
-
-		childExternalId := uuid.New()
-		candidateIdByKey[spawnKey] = childExternalId
-
-		eventKeys = append(eventKeys, spawnKey)
-		childExternalIds = append(childExternalIds, childExternalId)
 	}
 
-	if len(eventKeys) == 0 {
+	telemetry.WithAttributes(span,
+		telemetry.AttributeKV{Key: "n_tasks", Value: len(tasks)},
+		telemetry.AttributeKV{Key: "n_keys", Value: len(params.Eventkeys)},
+	)
+
+	if len(params.Eventkeys) == 0 {
 		return nil
 	}
 
-	rows, err := r.queries.UpsertDurableChildSignalCreatedEvents(ctx, tx, sqlcv1.UpsertDurableChildSignalCreatedEventsParams{
-		Tenantid:              tenantId,
-		Durabletaskid:         task.ID,
-		Durabletaskinsertedat: task.InsertedAt,
-		Eventkeys:             eventKeys,
-		Childexternalids:      childExternalIds,
-	})
+	rows, err := r.queries.BulkUpsertDurableChildSignalCreatedEvents(ctx, tx, params)
 
 	if err != nil {
 		return fmt.Errorf("failed to upsert child signal created events: %w", err)
 	}
 
-	resolvedIdByKey := make(map[string]uuid.UUID, len(rows))
+	resolvedIdByKey := make(map[taskIdSpawnKey]uuid.UUID, len(rows))
 
 	for _, row := range rows {
-		resolvedIdByKey[row.EventKey.String] = *row.ChildExternalID
+		resolvedIdByKey[taskIdSpawnKey{taskId: row.TaskID, spawnKey: row.EventKey.String}] = *row.ChildExternalID
 	}
 
-	claimed := make(map[string]bool, len(rows))
-
-	for _, opt := range opts {
-		spawnKey := opt.childSpawnKey()
-
-		if spawnKey == "" {
-			continue
-		}
-
-		resolvedId, ok := resolvedIdByKey[spawnKey]
+	for key, opts := range optsByKey {
+		resolvedId, ok := resolvedIdByKey[key]
 
 		if !ok {
-			return fmt.Errorf("no child external id resolved for spawn key %s", spawnKey)
+			return fmt.Errorf("no child external id resolved for task %d spawn key %s", key.taskId, key.spawnKey)
 		}
 
-		opt.ExternalId = resolvedId
-		opt.ShouldSkip = resolvedId != candidateIdByKey[spawnKey] || claimed[spawnKey]
-		claimed[spawnKey] = true
+		for i, opt := range opts {
+			opt.ExternalId = resolvedId
+			// only the first opt for a spawn key may trigger a new child; the rest reuse it
+			opt.ShouldSkip = i > 0 || resolvedId != candidateIdByKey[key]
+		}
 	}
 
 	return nil
@@ -1780,6 +1791,7 @@ func (r *durableEventsRepository) appendDurableEventLogBatch(ctx context.Context
 	taskErrors := make(map[durableTaskId]error)
 	planByTaskId := make(map[durableTaskId]*durableEventLogAppendPlan, len(batch))
 	orderedGetOrCreateOpts := make([]GetOrCreateLogEntryOpts, 0, len(batch))
+	eligibleTaskIds := make([]durableTaskId, 0, len(batch))
 
 	for _, taskId := range taskIds {
 		opts := batch[taskId]
@@ -1799,6 +1811,33 @@ func (r *durableEventsRepository) appendDurableEventLogBatch(ctx context.Context
 			}
 			continue
 		}
+
+		eligibleTaskIds = append(eligibleTaskIds, taskId)
+	}
+
+	resolveTasks := make([]resolveChildExternalIdsTask, 0, len(eligibleTaskIds))
+
+	for _, taskId := range eligibleTaskIds {
+		opts := batch[taskId]
+
+		if opts.Kind == sqlcv1.V1DurableEventLogKindRUN {
+			resolveTasks = append(resolveTasks, resolveChildExternalIdsTask{
+				tenantId:    opts.TenantId,
+				task:        opts.Task,
+				triggerOpts: opts.TriggerRuns.TriggerOpts,
+			})
+		}
+	}
+
+	if len(resolveTasks) > 0 {
+		if resolveErr := r.resolveChildExternalIdsForBatch(ctx, tx, resolveTasks); resolveErr != nil {
+			return nil, nil, fmt.Errorf("failed to resolve child external ids: %w", resolveErr)
+		}
+	}
+
+	for _, taskId := range eligibleTaskIds {
+		opts := batch[taskId]
+		logFile := logFileByTaskId[taskId]
 
 		plan, taskErr, fatalErr := r.planDurableEventLogAppend(ctx, tx, opts, logFile, branchPointsByTaskId[taskId])
 
@@ -1995,10 +2034,8 @@ func (r *durableEventsRepository) planDurableEventLogAppend(
 
 	switch opts.Kind {
 	case sqlcv1.V1DurableEventLogKindRUN:
-		if resolveErr := r.resolveChildExternalIds(ctx, tx, tenantId, task, opts.TriggerRuns.TriggerOpts); resolveErr != nil {
-			return nil, nil, fmt.Errorf("failed to resolve child external ids: %w", resolveErr)
-		}
-
+		// child external ids were already resolved for the whole batch in
+		// resolveChildExternalIdsForBatch before the plan loop
 		resolvedChildrenToReplay, dedupeErr := r.resolveOrphanedChildDedupes(ctx, tx, logFile, nextBranchIdToBranchPoint, opts.TriggerRuns.TriggerOpts)
 		if dedupeErr != nil {
 			return nil, nil, dedupeErr

--- a/pkg/repository/sqlcv1/durable_event_log.sql
+++ b/pkg/repository/sqlcv1/durable_event_log.sql
@@ -382,9 +382,12 @@ OFFSET @eventLogOffset::BIGINT
 LIMIT @eventLogLimit::BIGINT
 ;
 
--- name: UpsertDurableChildSignalCreatedEvents :many
+-- name: BulkUpsertDurableChildSignalCreatedEvents :many
 WITH input AS (
     SELECT
+        UNNEST(@tenantIds::UUID[]) AS tenant_id,
+        UNNEST(@durableTaskIds::BIGINT[]) AS task_id,
+        UNNEST(@durableTaskInsertedAts::TIMESTAMPTZ[]) AS task_inserted_at,
         UNNEST(@eventKeys::TEXT[]) AS event_key,
         UNNEST(@childExternalIds::UUID[]) AS child_external_id
 )
@@ -399,9 +402,9 @@ INSERT INTO v1_task_event (
     child_external_id
 )
 SELECT
-    @tenantId::UUID,
-    @durableTaskId::BIGINT,
-    @durableTaskInsertedAt::TIMESTAMPTZ,
+    i.tenant_id,
+    i.task_id,
+    i.task_inserted_at,
     -1,
     'SIGNAL_CREATED',
     i.event_key,
@@ -410,6 +413,7 @@ FROM input i
 ON CONFLICT (tenant_id, task_id, task_inserted_at, event_type, event_key) WHERE event_key IS NOT NULL
 DO UPDATE SET child_external_id = COALESCE(v1_task_event.child_external_id, EXCLUDED.child_external_id)
 RETURNING
+    v1_task_event.task_id,
     v1_task_event.event_key,
     v1_task_event.child_external_id
 ;

--- a/pkg/repository/sqlcv1/durable_event_log.sql.go
+++ b/pkg/repository/sqlcv1/durable_event_log.sql.go
@@ -258,6 +258,82 @@ func (q *Queries) BulkGetDurableEventLogEntries(ctx context.Context, db DBTX, ar
 	return items, nil
 }
 
+const bulkUpsertDurableChildSignalCreatedEvents = `-- name: BulkUpsertDurableChildSignalCreatedEvents :many
+WITH input AS (
+    SELECT
+        UNNEST($1::UUID[]) AS tenant_id,
+        UNNEST($2::BIGINT[]) AS task_id,
+        UNNEST($3::TIMESTAMPTZ[]) AS task_inserted_at,
+        UNNEST($4::TEXT[]) AS event_key,
+        UNNEST($5::UUID[]) AS child_external_id
+)
+
+INSERT INTO v1_task_event (
+    tenant_id,
+    task_id,
+    task_inserted_at,
+    retry_count,
+    event_type,
+    event_key,
+    child_external_id
+)
+SELECT
+    i.tenant_id,
+    i.task_id,
+    i.task_inserted_at,
+    -1,
+    'SIGNAL_CREATED',
+    i.event_key,
+    i.child_external_id
+FROM input i
+ON CONFLICT (tenant_id, task_id, task_inserted_at, event_type, event_key) WHERE event_key IS NOT NULL
+DO UPDATE SET child_external_id = COALESCE(v1_task_event.child_external_id, EXCLUDED.child_external_id)
+RETURNING
+    v1_task_event.task_id,
+    v1_task_event.event_key,
+    v1_task_event.child_external_id
+`
+
+type BulkUpsertDurableChildSignalCreatedEventsParams struct {
+	Tenantids              []uuid.UUID          `json:"tenantids"`
+	Durabletaskids         []int64              `json:"durabletaskids"`
+	Durabletaskinsertedats []pgtype.Timestamptz `json:"durabletaskinsertedats"`
+	Eventkeys              []string             `json:"eventkeys"`
+	Childexternalids       []uuid.UUID          `json:"childexternalids"`
+}
+
+type BulkUpsertDurableChildSignalCreatedEventsRow struct {
+	TaskID          int64       `json:"task_id"`
+	EventKey        pgtype.Text `json:"event_key"`
+	ChildExternalID *uuid.UUID  `json:"child_external_id"`
+}
+
+func (q *Queries) BulkUpsertDurableChildSignalCreatedEvents(ctx context.Context, db DBTX, arg BulkUpsertDurableChildSignalCreatedEventsParams) ([]*BulkUpsertDurableChildSignalCreatedEventsRow, error) {
+	rows, err := db.Query(ctx, bulkUpsertDurableChildSignalCreatedEvents,
+		arg.Tenantids,
+		arg.Durabletaskids,
+		arg.Durabletaskinsertedats,
+		arg.Eventkeys,
+		arg.Childexternalids,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*BulkUpsertDurableChildSignalCreatedEventsRow
+	for rows.Next() {
+		var i BulkUpsertDurableChildSignalCreatedEventsRow
+		if err := rows.Scan(&i.TaskID, &i.EventKey, &i.ChildExternalID); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const claimDurableEventLogEntriesForTrigger = `-- name: ClaimDurableEventLogEntriesForTrigger :many
 WITH inputs AS (
     SELECT
@@ -1263,75 +1339,4 @@ type UpdateLogFileLatestNodeIdsParams struct {
 func (q *Queries) UpdateLogFileLatestNodeIds(ctx context.Context, db DBTX, arg UpdateLogFileLatestNodeIdsParams) error {
 	_, err := db.Exec(ctx, updateLogFileLatestNodeIds, arg.Durabletaskids, arg.Durabletaskinsertedats, arg.Nodeids)
 	return err
-}
-
-const upsertDurableChildSignalCreatedEvents = `-- name: UpsertDurableChildSignalCreatedEvents :many
-WITH input AS (
-    SELECT
-        UNNEST($4::TEXT[]) AS event_key,
-        UNNEST($5::UUID[]) AS child_external_id
-)
-
-INSERT INTO v1_task_event (
-    tenant_id,
-    task_id,
-    task_inserted_at,
-    retry_count,
-    event_type,
-    event_key,
-    child_external_id
-)
-SELECT
-    $1::UUID,
-    $2::BIGINT,
-    $3::TIMESTAMPTZ,
-    -1,
-    'SIGNAL_CREATED',
-    i.event_key,
-    i.child_external_id
-FROM input i
-ON CONFLICT (tenant_id, task_id, task_inserted_at, event_type, event_key) WHERE event_key IS NOT NULL
-DO UPDATE SET child_external_id = COALESCE(v1_task_event.child_external_id, EXCLUDED.child_external_id)
-RETURNING
-    v1_task_event.event_key,
-    v1_task_event.child_external_id
-`
-
-type UpsertDurableChildSignalCreatedEventsParams struct {
-	Tenantid              uuid.UUID          `json:"tenantid"`
-	Durabletaskid         int64              `json:"durabletaskid"`
-	Durabletaskinsertedat pgtype.Timestamptz `json:"durabletaskinsertedat"`
-	Eventkeys             []string           `json:"eventkeys"`
-	Childexternalids      []uuid.UUID        `json:"childexternalids"`
-}
-
-type UpsertDurableChildSignalCreatedEventsRow struct {
-	EventKey        pgtype.Text `json:"event_key"`
-	ChildExternalID *uuid.UUID  `json:"child_external_id"`
-}
-
-func (q *Queries) UpsertDurableChildSignalCreatedEvents(ctx context.Context, db DBTX, arg UpsertDurableChildSignalCreatedEventsParams) ([]*UpsertDurableChildSignalCreatedEventsRow, error) {
-	rows, err := db.Query(ctx, upsertDurableChildSignalCreatedEvents,
-		arg.Tenantid,
-		arg.Durabletaskid,
-		arg.Durabletaskinsertedat,
-		arg.Eventkeys,
-		arg.Childexternalids,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*UpsertDurableChildSignalCreatedEventsRow
-	for rows.Next() {
-		var i UpsertDurableChildSignalCreatedEventsRow
-		if err := rows.Scan(&i.EventKey, &i.ChildExternalID); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
 }


### PR DESCRIPTION
# Description

Gets rid of one more N+1 query

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [x] Performance improvement (non-breaking change which improves performance)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude Code for review

</details>
