### PR TITLE
fix(sdks/ts): recover from inactive listener stream on heartbeat rejection

### DIFF
--- a/sdks/typescript/src/clients/dispatcher/action-listener.test.ts
+++ b/sdks/typescript/src/clients/dispatcher/action-listener.test.ts
@@ -1,10 +1,19 @@
 import { ActionType, AssignedAction } from '@hatchet/protoc/dispatcher';
 import sleep from '@util/sleep';
-// import { ServerError, Status } from 'nice-grpc-common';
+import { AbortError } from '@hatchet/util/abort-error';
 import { DEFAULT_LOGGER } from '@clients/hatchet-client/hatchet-logger';
 import { DispatcherClient } from './dispatcher-client';
 import { ActionListener } from './action-listener';
 import { mockChannel, mockFactory } from '../../legacy/legacy-client.test';
+import {
+  LISTENER_RECONNECT_REASON,
+  LISTENER_SHUTDOWN_REASON,
+} from './listener-abort';
+
+jest.mock('@util/sleep', () => ({
+  __esModule: true,
+  default: jest.fn(() => Promise.resolve()),
+}));
 
 let dispatcher: DispatcherClient;
 
@@ -253,5 +262,66 @@ describe('ActionListener', () => {
     //   expect(unsubscribeSpy).toHaveBeenCalled();
     //   expect(res.workerId).toEqual('WORKER_ID');
     // });
+  });
+
+  describe('inactive stream reconnect', () => {
+    it('reconnects on listener reconnect abort without exiting the generator', async () => {
+      const listener = new ActionListener(dispatcher, 'WORKER_ID', 1, 5);
+      const getListenClientSpy = jest.spyOn(listener, 'getListenClient');
+
+      getListenClientSpy
+        .mockResolvedValueOnce(
+          (async function* first() {
+            yield mockAssignedActions[0] as AssignedAction;
+            throw new AbortError(LISTENER_RECONNECT_REASON);
+          })()
+        )
+        .mockResolvedValueOnce(
+          (async function* second() {
+            yield mockAssignedActions[0] as AssignedAction;
+            throw new AbortError(LISTENER_SHUTDOWN_REASON);
+          })()
+        );
+
+      const actions = listener.actions();
+      const first = await actions.next();
+      expect(first.done).toBe(false);
+
+      const second = await actions.next();
+      expect(second.done).toBe(false);
+
+      expect(getListenClientSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('exits the generator on shutdown abort', async () => {
+      const listener = new ActionListener(dispatcher, 'WORKER_ID', 1, 5);
+      const getListenClientSpy = jest.spyOn(listener, 'getListenClient');
+
+      getListenClientSpy.mockResolvedValueOnce(
+        (async function* shutdown() {
+          yield mockAssignedActions[0] as AssignedAction;
+          throw new AbortError(LISTENER_SHUTDOWN_REASON);
+        })()
+      );
+
+      const actions = listener.actions();
+      const results = [];
+      for await (const action of actions) {
+        results.push(action);
+      }
+
+      expect(results).toHaveLength(1);
+      expect(getListenClientSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('marks worker unhealthy when stream goes inactive', () => {
+      const listener = new ActionListener(dispatcher, 'WORKER_ID');
+      const statusChanges: string[] = [];
+      listener.setWorkerStatusCallback((status) => statusChanges.push(status));
+
+      (listener as any).handleStreamInactive();
+
+      expect(statusChanges).toEqual(['UNHEALTHY']);
+    });
   });
 });

--- a/sdks/typescript/src/clients/dispatcher/action-listener.ts
+++ b/sdks/typescript/src/clients/dispatcher/action-listener.ts
@@ -11,9 +11,18 @@ import { Logger } from '@hatchet/util/logger';
 import { DispatcherClient } from './dispatcher-client';
 import { Heartbeat } from './heartbeat/heartbeat-controller';
 import { classifyListenerFailure } from './listener-severity';
+import {
+  isListenerReconnectAbort,
+  isListenerShutdownAbort,
+  LISTENER_RECONNECT_REASON,
+  LISTENER_SHUTDOWN_REASON,
+} from './listener-abort';
+import { WorkerStatus, workerStatus } from '@hatchet/v1/client/worker/health-server';
 
 const DEFAULT_ACTION_LISTENER_RETRY_INTERVAL = 5000; // milliseconds
 const DEFAULT_ACTION_LISTENER_RETRY_COUNT = 20;
+const DEFAULT_STREAM_INACTIVE_RECONNECT_COUNT = 10;
+const STREAM_INACTIVE_RECONNECT_BACKOFF_MS = 3000;
 
 enum ListenStrategy {
   LISTEN_STRATEGY_V1 = 1,
@@ -56,6 +65,10 @@ export class ActionListener {
   listenStrategy = ListenStrategy.LISTEN_STRATEGY_V2;
   heartbeat: Heartbeat;
   abortController?: AbortController;
+  streamInactiveReconnects = 0;
+  maxStreamInactiveReconnects = DEFAULT_STREAM_INACTIVE_RECONNECT_COUNT;
+  reconnecting = false;
+  onWorkerStatusChange?: (status: WorkerStatus) => void;
 
   constructor(
     client: DispatcherClient,
@@ -72,6 +85,30 @@ export class ActionListener {
     this.heartbeat = new Heartbeat(client, workerId);
   }
 
+  setWorkerStatusCallback(callback: (status: WorkerStatus) => void): void {
+    this.onWorkerStatusChange = callback;
+  }
+
+  private handleStreamInactive(): void {
+    if (this.done || this.reconnecting) {
+      return;
+    }
+
+    this.reconnecting = true;
+    this.streamInactiveReconnects += 1;
+    this.onWorkerStatusChange?.(workerStatus.UNHEALTHY);
+
+    this.logger.warn(
+      `Listener stream inactive, reconnecting (${this.streamInactiveReconnects}/${this.maxStreamInactiveReconnects})`
+    );
+
+    this.heartbeat.stop();
+
+    if (this.abortController) {
+      this.abortController.abort(LISTENER_RECONNECT_REASON);
+    }
+  }
+
   actions = () =>
     (async function* gen(client: ActionListener) {
       while (true) {
@@ -86,8 +123,26 @@ export class ActionListener {
             yield createAction(assignedAction);
           }
         } catch (e: unknown) {
-          // If the stream was aborted (e.g., during worker shutdown), exit gracefully
           if (isAbortError(e)) {
+            if (isListenerReconnectAbort(e)) {
+              client.reconnecting = false;
+
+              if (client.streamInactiveReconnects > client.maxStreamInactiveReconnects) {
+                throw new HatchetError(
+                  `Could not re-establish listener after ${client.maxStreamInactiveReconnects} inactive-stream reconnect attempts`
+                );
+              }
+
+              client.logger.warn('Listener reconnecting after inactive stream');
+              await sleep(STREAM_INACTIVE_RECONNECT_BACKOFF_MS);
+              continue;
+            }
+
+            if (isListenerShutdownAbort(e)) {
+              client.logger.info('Listener aborted, exiting generator');
+              break;
+            }
+
             client.logger.info('Listener aborted, exiting generator');
             break;
           }
@@ -185,7 +240,9 @@ export class ActionListener {
         }
       );
 
-      await this.heartbeat.start();
+      await this.heartbeat.start(() => this.handleStreamInactive());
+      this.streamInactiveReconnects = 0;
+      this.onWorkerStatusChange?.(workerStatus.HEALTHY);
       this.logger.green('Connection established using LISTEN_STRATEGY_V2');
       return res;
     } catch (e: unknown) {
@@ -213,7 +270,7 @@ export class ActionListener {
 
     // Abort the gRPC stream to immediately cancel the generator
     if (this.abortController) {
-      this.abortController.abort('Worker stopping');
+      this.abortController.abort(LISTENER_SHUTDOWN_REASON);
     }
 
     try {

--- a/sdks/typescript/src/clients/dispatcher/heartbeat/heartbeat-controller.ts
+++ b/sdks/typescript/src/clients/dispatcher/heartbeat/heartbeat-controller.ts
@@ -7,15 +7,31 @@ import { ClientConfig } from '../../hatchet-client';
 import { DispatcherClient } from '../dispatcher-client';
 import { z } from 'zod/v4';
 
-const HeartbeatMessageSchema = z.object({
+const HeartbeatLogMessageSchema = z.object({
   type: z.enum(['info', 'warn', 'error', 'debug']),
   message: z.string(),
 });
+
+const HeartbeatStreamInactiveMessageSchema = z.object({
+  type: z.literal('stream_inactive'),
+  message: z.string(),
+  consecutiveFailures: z.number(),
+});
+
+const HeartbeatMessageSchema = z.union([
+  HeartbeatLogMessageSchema,
+  HeartbeatStreamInactiveMessageSchema,
+]);
 
 export type HeartbeatMessage = z.infer<typeof HeartbeatMessageSchema>;
 
 export const isHeartbeatMessage = (message: unknown): message is HeartbeatMessage =>
   HeartbeatMessageSchema.safeParse(message).success;
+
+export const isStreamInactiveMessage = (
+  message: HeartbeatMessage
+): message is z.infer<typeof HeartbeatStreamInactiveMessageSchema> =>
+  message.type === 'stream_inactive';
 
 export const STOP_HEARTBEAT = 'stop';
 export class Heartbeat {
@@ -25,6 +41,7 @@ export class Heartbeat {
   logger: Logger;
 
   heartbeatWorker: Worker | undefined;
+  onStreamInactive?: () => void;
 
   constructor(client: DispatcherClient, workerId: string) {
     this.config = client.config;
@@ -33,7 +50,9 @@ export class Heartbeat {
     this.logger = client.config.logger(`HeartbeatController`, this.config.log_level);
   }
 
-  async start() {
+  async start(onStreamInactive?: () => void) {
+    this.onStreamInactive = onStreamInactive;
+
     if (!this.heartbeatWorker) {
       const {
         middleware: _m,
@@ -49,6 +68,12 @@ export class Heartbeat {
 
       this.heartbeatWorker.on('message', (message: unknown) => {
         if (!isHeartbeatMessage(message)) {
+          return;
+        }
+
+        if (isStreamInactiveMessage(message)) {
+          this.logger.error(message.message);
+          this.onStreamInactive?.();
           return;
         }
 

--- a/sdks/typescript/src/clients/dispatcher/heartbeat/heartbeat-worker.ts
+++ b/sdks/typescript/src/clients/dispatcher/heartbeat/heartbeat-worker.ts
@@ -5,11 +5,11 @@ import { DispatcherClient as PbDispatcherClient } from '@hatchet/protoc/dispatch
 import { ConfigLoader } from '@hatchet/util/config-loader';
 import { Status, createClientFactory } from 'nice-grpc';
 import { getErrorMessage } from '@util/errors/hatchet-error';
-import { getGrpcErrorCode } from '@util/grpc-error';
+import { getGrpcErrorCode, isWorkerStreamInactiveError } from '@util/grpc-error';
 import { addTokenMiddleware, channelFactory } from '@hatchet/util/grpc-helpers';
 import { DispatcherClient } from '../dispatcher-client';
 import { HeartbeatMessage, STOP_HEARTBEAT } from './heartbeat-controller';
-import { classifyHeartbeatFailure } from './heartbeat-severity';
+import { classifyHeartbeatFailure, MAX_MISSED_HEARTBEATS } from './heartbeat-severity';
 
 const HEARTBEAT_INTERVAL = 4000;
 // Fail fast on a stalled connection: without a deadline, a heartbeat RPC on a dead
@@ -28,6 +28,7 @@ class HeartbeatWorker {
   workerId: string;
   timeLastHeartbeat = new Date().getTime();
   missedHeartbeats = 0;
+  consecutiveStreamInactiveFailures = 0;
 
   constructor(config: ClientConfig, workerId: string) {
     this.workerId = workerId;
@@ -91,6 +92,7 @@ class HeartbeatWorker {
         });
         this.timeLastHeartbeat = now;
         this.missedHeartbeats = 0;
+        this.consecutiveStreamInactiveFailures = 0;
       } catch (e: unknown) {
         if (getGrpcErrorCode(e) === Status.UNIMPLEMENTED) {
           // break out of interval
@@ -105,6 +107,23 @@ class HeartbeatWorker {
         }
 
         this.missedHeartbeats += 1;
+
+        if (isWorkerStreamInactiveError(e)) {
+          this.consecutiveStreamInactiveFailures += 1;
+
+          if (this.consecutiveStreamInactiveFailures >= MAX_MISSED_HEARTBEATS) {
+            const message = `Worker listener stream inactive for ${this.consecutiveStreamInactiveFailures} consecutive heartbeats, requesting reconnect`;
+            this.logger.error(message);
+            postMessage({
+              type: 'stream_inactive',
+              message,
+              consecutiveFailures: this.consecutiveStreamInactiveFailures,
+            });
+            this.consecutiveStreamInactiveFailures = 0;
+          }
+        } else {
+          this.consecutiveStreamInactiveFailures = 0;
+        }
 
         const message = `Failed to send heartbeat: ${getErrorMessage(e)}`;
         this.logger.debug(message);

--- a/sdks/typescript/src/clients/dispatcher/listener-abort.ts
+++ b/sdks/typescript/src/clients/dispatcher/listener-abort.ts
@@ -1,0 +1,13 @@
+import { isAbortError } from 'abort-controller-x';
+import { getErrorMessage } from '@util/errors/hatchet-error';
+
+export const LISTENER_SHUTDOWN_REASON = 'Worker stopping';
+export const LISTENER_RECONNECT_REASON = 'Listener reconnect';
+
+export function isListenerReconnectAbort(e: unknown): boolean {
+  return isAbortError(e) && getErrorMessage(e).includes(LISTENER_RECONNECT_REASON);
+}
+
+export function isListenerShutdownAbort(e: unknown): boolean {
+  return isAbortError(e) && getErrorMessage(e).includes(LISTENER_SHUTDOWN_REASON);
+}

--- a/sdks/typescript/src/util/grpc-error.test.ts
+++ b/sdks/typescript/src/util/grpc-error.test.ts
@@ -1,0 +1,25 @@
+import { Status, ServerError } from 'nice-grpc';
+import {
+  isWorkerStreamInactiveError,
+  WORKER_STREAM_INACTIVE_MESSAGE,
+} from './grpc-error';
+
+describe('isWorkerStreamInactiveError', () => {
+  it('returns true for FailedPrecondition with inactive stream message', () => {
+    const err = new ServerError(
+      Status.FAILED_PRECONDITION,
+      `Heartbeat rejected: ${WORKER_STREAM_INACTIVE_MESSAGE}: worker-1`
+    );
+    expect(isWorkerStreamInactiveError(err)).toBe(true);
+  });
+
+  it('returns false for other FailedPrecondition errors', () => {
+    const err = new ServerError(Status.FAILED_PRECONDITION, 'some other precondition');
+    expect(isWorkerStreamInactiveError(err)).toBe(false);
+  });
+
+  it('returns false for UNAVAILABLE errors', () => {
+    const err = new ServerError(Status.UNAVAILABLE, WORKER_STREAM_INACTIVE_MESSAGE);
+    expect(isWorkerStreamInactiveError(err)).toBe(false);
+  });
+});

--- a/sdks/typescript/src/util/grpc-error.ts
+++ b/sdks/typescript/src/util/grpc-error.ts
@@ -42,3 +42,19 @@ export function getGrpcErrorDetails(e: unknown): string | undefined {
   }
   return undefined;
 }
+
+/** Engine message when the ListenV2 stream is dead but unary heartbeats still reach the server. */
+export const WORKER_STREAM_INACTIVE_MESSAGE = 'worker stream is not active';
+
+/**
+ * Returns true when the engine rejected a heartbeat because the worker's listener
+ * stream is no longer active (FailedPrecondition). This is distinct from other
+ * FAILED_PRECONDITION errors and signals the SDK must re-establish ListenV2.
+ */
+export function isWorkerStreamInactiveError(e: unknown): boolean {
+  if (getGrpcErrorCode(e) !== Status.FAILED_PRECONDITION) {
+    return false;
+  }
+  const details = getGrpcErrorDetails(e);
+  return details !== undefined && details.includes(WORKER_STREAM_INACTIVE_MESSAGE);
+}

--- a/sdks/typescript/src/util/listener-abort.test.ts
+++ b/sdks/typescript/src/util/listener-abort.test.ts
@@ -1,0 +1,19 @@
+import { AbortError } from '@hatchet/util/abort-error';
+import {
+  isListenerReconnectAbort,
+  isListenerShutdownAbort,
+  LISTENER_RECONNECT_REASON,
+  LISTENER_SHUTDOWN_REASON,
+} from '../clients/dispatcher/listener-abort';
+
+describe('listener abort helpers', () => {
+  it('detects reconnect abort reason', () => {
+    expect(isListenerReconnectAbort(new AbortError(LISTENER_RECONNECT_REASON))).toBe(true);
+    expect(isListenerReconnectAbort(new AbortError(LISTENER_SHUTDOWN_REASON))).toBe(false);
+  });
+
+  it('detects shutdown abort reason', () => {
+    expect(isListenerShutdownAbort(new AbortError(LISTENER_SHUTDOWN_REASON))).toBe(true);
+    expect(isListenerShutdownAbort(new AbortError(LISTENER_RECONNECT_REASON))).toBe(false);
+  });
+});

--- a/sdks/typescript/src/v1/client/worker/health-server.test.ts
+++ b/sdks/typescript/src/v1/client/worker/health-server.test.ts
@@ -1,0 +1,61 @@
+import http from 'node:http';
+import { HealthServer, workerStatus, type WorkerStatus } from './health-server';
+
+function noopLogger() {
+  return { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+}
+
+describe('HealthServer /health', () => {
+  let server: HealthServer;
+  let currentStatus: WorkerStatus = workerStatus.HEALTHY;
+  let port = 0;
+
+  beforeEach(async () => {
+    currentStatus = workerStatus.HEALTHY;
+    server = new HealthServer(
+      0,
+      () => currentStatus,
+      'test-worker',
+      () => 10,
+      () => ['action-a'],
+      () => ({}),
+      noopLogger() as any
+    );
+    await server.start();
+    const address = (server as any).server.address();
+    port = typeof address === 'object' && address ? address.port : 0;
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  async function getHealthStatus(): Promise<{ statusCode: number; body: any }> {
+    return new Promise((resolve, reject) => {
+      http
+        .get(`http://127.0.0.1:${port}/health`, (res) => {
+          let data = '';
+          res.on('data', (chunk) => {
+            data += chunk;
+          });
+          res.on('end', () => {
+            resolve({ statusCode: res.statusCode ?? 0, body: JSON.parse(data) });
+          });
+        })
+        .on('error', reject);
+    });
+  }
+
+  it('returns HTTP 200 when worker is HEALTHY', async () => {
+    const { statusCode, body } = await getHealthStatus();
+    expect(statusCode).toBe(200);
+    expect(body.status).toBe(workerStatus.HEALTHY);
+  });
+
+  it('returns HTTP 503 when worker is UNHEALTHY', async () => {
+    currentStatus = workerStatus.UNHEALTHY;
+    const { statusCode, body } = await getHealthStatus();
+    expect(statusCode).toBe(503);
+    expect(body.status).toBe(workerStatus.UNHEALTHY);
+  });
+});

--- a/sdks/typescript/src/v1/client/worker/health-server.ts
+++ b/sdks/typescript/src/v1/client/worker/health-server.ts
@@ -61,8 +61,9 @@ export class HealthServer {
   }
 
   private async handleHealth(res: ServerResponse): Promise<void> {
+    const status = this.getStatus();
     const response: HealthCheckResponse = {
-      status: this.getStatus(),
+      status,
       name: this.workerName,
       slots: this.getSlots(),
       actions: this.getActions(),
@@ -70,7 +71,8 @@ export class HealthServer {
       nodeVersion: process.version,
     };
 
-    res.writeHead(200, { 'Content-Type': 'application/json' });
+    const httpStatus = status === workerStatus.HEALTHY ? 200 : 503;
+    res.writeHead(httpStatus, { 'Content-Type': 'application/json' });
     await res.end(JSON.stringify(response));
   }
 

--- a/sdks/typescript/src/v1/client/worker/worker-internal.ts
+++ b/sdks/typescript/src/v1/client/worker/worker-internal.ts
@@ -1111,6 +1111,7 @@ export class InternalWorker {
 
     try {
       this.listener = await this.createListener();
+      this.listener.setWorkerStatusCallback((status) => this.setStatus(status));
 
       this.workerId = this.listener.workerId;
       this.setStatus(workerStatus.HEALTHY);


### PR DESCRIPTION
## Summary

Fixes #4824 — when the engine loses a worker's ListenV2 stream but unary heartbeats still reach the server, the TypeScript SDK now self-heals instead of entering a permanent zombie state.

- **Detect**: heartbeat worker tracks consecutive `FailedPrecondition` rejections whose message is `worker stream is not active`; after 3 consecutive failures, posts a `stream_inactive` IPC message
- **Reconnect**: `ActionListener` aborts the current ListenV2 with a reconnect-specific reason (distinct from shutdown), stops the heartbeat thread, and the existing `actions()` loop re-establishes via `getListenClient()` / `listenV2`. Capped at 10 reconnects with 3s backoff
- **Surface**: worker status flips to `UNHEALTHY` during reconnect; `/health` returns **503** when unhealthy (also fixes #4823 for K8s `httpGet` probes)

No engine changes.

## Test plan

- [x] `isWorkerStreamInactiveError` unit tests
- [x] shutdown vs reconnect abort distinction tests
- [x] action-listener reconnect does not exit generator; shutdown abort does
- [x] health-server returns 200 when HEALTHY, 503 when UNHEALTHY
- [ ] Manual validation against the nice-grpc repro harness from #4824 (happy to run if maintainers want)


Made with [Cursor](https://cursor.com)