### PR TITLE
fix(sdk/typescript): return 503 from /health when worker is unhealthy

### DIFF
--- a/sdks/typescript/src/v1/client/worker/health-server.test.ts
+++ b/sdks/typescript/src/v1/client/worker/health-server.test.ts
@@ -1,0 +1,84 @@
+import http from 'node:http';
+import { AddressInfo } from 'node:net';
+import { HealthServer, workerStatus, WorkerStatus } from './health-server';
+import { Logger } from '@hatchet/util/logger';
+
+function getJson(port: number, path: string): Promise<{ statusCode: number; body: any }> {
+  return new Promise((resolve, reject) => {
+    http
+      .get({ host: '127.0.0.1', port, path }, (res) => {
+        let data = '';
+        res.on('data', (chunk) => {
+          data += chunk;
+        });
+        res.on('end', () => {
+          resolve({ statusCode: res.statusCode || 0, body: data ? JSON.parse(data) : undefined });
+        });
+      })
+      .on('error', reject);
+  });
+}
+
+describe('HealthServer', () => {
+  let server: HealthServer;
+  let status: WorkerStatus;
+  const logger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    green: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  } as unknown as Logger;
+
+  const startServer = async () => {
+    server = new HealthServer(
+      0,
+      () => status,
+      'test-worker',
+      () => 5,
+      () => ['action-1'],
+      () => ({}),
+      logger
+    );
+    await server.start();
+    const address = (server as unknown as { server: http.Server }).server.address() as AddressInfo;
+    return address.port;
+  };
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it('returns 200 when the worker status is HEALTHY', async () => {
+    status = workerStatus.HEALTHY;
+    const port = await startServer();
+
+    const { statusCode, body } = await getJson(port, '/health');
+
+    expect(statusCode).toBe(200);
+    expect(body.status).toBe(workerStatus.HEALTHY);
+  });
+
+  it.each([workerStatus.STARTING, workerStatus.INITIALIZED])(
+    'returns 200 when the worker status is %s',
+    async (candidateStatus) => {
+      status = candidateStatus;
+      const port = await startServer();
+
+      const { statusCode, body } = await getJson(port, '/health');
+
+      expect(statusCode).toBe(200);
+      expect(body.status).toBe(candidateStatus);
+    }
+  );
+
+  it('returns 503 when the worker status is UNHEALTHY', async () => {
+    status = workerStatus.UNHEALTHY;
+    const port = await startServer();
+
+    const { statusCode, body } = await getJson(port, '/health');
+
+    expect(statusCode).toBe(503);
+    expect(body.status).toBe(workerStatus.UNHEALTHY);
+  });
+});

--- a/sdks/typescript/src/v1/client/worker/health-server.ts
+++ b/sdks/typescript/src/v1/client/worker/health-server.ts
@@ -70,7 +70,8 @@ export class HealthServer {
       nodeVersion: process.version,
     };
 
-    res.writeHead(200, { 'Content-Type': 'application/json' });
+    const httpStatus = response.status === workerStatus.UNHEALTHY ? 503 : 200;
+    res.writeHead(httpStatus, { 'Content-Type': 'application/json' });
     await res.end(JSON.stringify(response));
   }
 


### PR DESCRIPTION
## Summary

- The TypeScript SDK health server always returns HTTP 200 regardless of worker status
- Kubernetes `httpGet` liveness probes evaluate the HTTP status code and cannot inspect the JSON body, so an unhealthy worker is never restarted
- Return 503 when worker status is `UNHEALTHY`, matching the Python SDK behavior

## Changes

- `health-server.ts`: conditionally set HTTP status to 503 for `UNHEALTHY`, 200 otherwise
- Added test suite covering HEALTHY, STARTING, INITIALIZED (200) and UNHEALTHY (503)

## Test plan

- [x] New tests verify 200 for healthy/starting/initialized states
- [x] New test verifies 503 for unhealthy state
- [x] Existing functionality preserved (JSON body format unchanged)

Closes #4823