### PR TITLE
feat(engine): enable durable tasks running on the dag operator to be evicted

### DIFF
--- a/internal/services/dispatcher/server_v1.go
+++ b/internal/services/dispatcher/server_v1.go
@@ -497,6 +497,9 @@ func (s *durableTaskInvocation) deliverOrdered(taskExternalId uuid.UUID, invocat
 		}
 	default:
 		if buffered, exists := rel.bufferedCompletions[order]; exists {
+			if buffered == nil || resp == nil {
+				return nil
+			}
 			existingRef := buffered.GetEntryCompleted().GetRef()
 			incomingRef := resp.GetEntryCompleted().GetRef()
 			if existingRef.GetNodeId() != incomingRef.GetNodeId() || existingRef.GetBranchId() != incomingRef.GetBranchId() {
@@ -516,6 +519,9 @@ func (s *durableTaskInvocation) deliverOrdered(taskExternalId uuid.UUID, invocat
 	}
 
 	for _, r := range toSend {
+		if r == nil {
+			continue
+		}
 		if err := s.send(r); err != nil {
 			return err
 		}
@@ -566,10 +572,10 @@ func (d *DispatcherServiceImpl) DurableTask(server contracts.V1Dispatcher_Durabl
 
 	defer func() {
 		for taskId := range registeredTasks {
-			d.durableInvocations.Delete(durableInvocationsKey{
+			d.durableInvocations.CompareAndDelete(durableInvocationsKey{
 				tenantId: tenantId,
 				taskId:   taskId,
-			})
+			}, invocation)
 		}
 	}()
 
@@ -729,7 +735,7 @@ func (d *DispatcherServiceImpl) RegisterDurableTask(ctx context.Context, externa
 			cancel()
 
 			for taskId := range registeredTasks {
-				d.durableInvocations.Delete(durableInvocationsKey{tenantId: invocation.tenantId, taskId: taskId})
+				d.durableInvocations.CompareAndDelete(durableInvocationsKey{tenantId: invocation.tenantId, taskId: taskId}, invocation)
 			}
 
 			invocation.sendMu.Lock()
@@ -1499,7 +1505,7 @@ func (d *DispatcherServiceImpl) handleWorkerStatus(
 		d.evictIdleOperatorTasks(ctx, invocation, uniqueExternalIds, staleExternalIds, callbacks)
 	}
 
-	d.evictStalledOrderedReleases(invocation)
+	d.evictStalledOrderedReleases(ctx, invocation)
 	invocation.pruneIdleReleases(durableReleaseIdleTTL)
 
 	return nil
@@ -1557,13 +1563,18 @@ func (d *DispatcherServiceImpl) evictIdleOperatorTasks(
 const durableOrderedReleaseGapTimeout = 60 * time.Second
 const durableReleaseIdleTTL = 24 * time.Hour
 
-func (d *DispatcherServiceImpl) evictStalledOrderedReleases(invocation *durableTaskInvocation) {
+func (d *DispatcherServiceImpl) evictStalledOrderedReleases(ctx context.Context, invocation *durableTaskInvocation) {
 	for _, key := range invocation.staleReleaseHolds(durableOrderedReleaseGapTimeout) {
 		d.l.Error().Msgf(
 			"durable task %s (invocation %d): ordered release stalled waiting for a missing satisfied_order for over %s; evicting to restart. "+
 				"if this repeats, the task was likely forked with BranchDurableTask across an out-of-order satisfaction, which is not supported",
 			key.taskExternalId, key.invocationCount, durableOrderedReleaseGapTimeout,
 		)
+
+		if _, err := d.evictDurableTask(ctx, invocation.tenantId, key.taskExternalId, key.invocationCount, "ordered durable completion release stalled on a missing entry"); err != nil {
+			d.l.Error().Err(err).Msgf("failed to evict durable task %s for stalled ordered release", key.taskExternalId)
+			continue
+		}
 
 		if err := invocation.send(&contracts.DurableTaskResponse{
 			Message: &contracts.DurableTaskResponse_ServerEvict{
@@ -1759,6 +1770,28 @@ func (d *DispatcherServiceImpl) TriggerDAGStep(ctx context.Context, tenantId uui
 
 	if len(ingestionResult.TriggerRunsResult.Entries) == 0 {
 		return nil, fmt.Errorf("no entries returned from durable event ingestion")
+	}
+
+	if inv, ok := d.durableInvocations.Load(durableInvocationsKey{tenantId: tenantId, taskId: task.ExternalID}); ok {
+		invocationCount := ingestionResult.TriggerRunsResult.InvocationCount
+		satisfiedEntries := make([]*v1.IngestTriggerRunsEntry, 0, len(ingestionResult.TriggerRunsResult.Entries))
+		for _, e := range ingestionResult.TriggerRunsResult.Entries {
+			if e.IsSatisfied {
+				satisfiedEntries = append(satisfiedEntries, e)
+			}
+		}
+
+		go func() {
+			for _, e := range satisfiedEntries {
+				if e.SatisfiedOrder == nil {
+					return
+				}
+
+				if err := inv.deliverOrdered(task.ExternalID, invocationCount, e.SatisfiedOrder, nil); err != nil {
+					d.l.Error().Err(err).Msgf("failed to advance ordered release for task %s past satisfied_order %d", task.ExternalID, *e.SatisfiedOrder)
+				}
+			}
+		}()
 	}
 
 	entry := ingestionResult.TriggerRunsResult.Entries[0]

--- a/internal/services/dispatcher/server_v1.go
+++ b/internal/services/dispatcher/server_v1.go
@@ -1348,6 +1348,25 @@ func (d *DispatcherServiceImpl) evictDurableTask(
 		return nil, fmt.Errorf("task not found: %w", err)
 	}
 
+	// An eviction request from an older invocation (e.g. a stalled ordered release held by a
+	// previous session) must not evict the newer invocation that replaced it: the notice would
+	// be dropped by the worker's invocation-count check, leaving the run evicted in the
+	// database while its worker keeps executing it.
+	idInsertedAt := v1.IdInsertedAt{ID: task.ID, InsertedAtUnixMicros: task.InsertedAt.Time.UnixMicro()}
+
+	currentCounts, err := d.repo.DurableEvents().GetDurableTaskInvocationCounts(ctx, tenantId, []v1.IdInsertedAt{idInsertedAt})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current invocation count: %w", err)
+	}
+
+	if current, ok := currentCounts[idInsertedAt]; ok && current != nil && invocationCount < *current {
+		d.l.Warn().Msgf(
+			"skipping eviction of durable task %s: requested for invocation %d but current invocation is %d",
+			taskExternalId, invocationCount, *current,
+		)
+		return &v1.EvictTaskResult{}, nil
+	}
+
 	evictRes, err := d.repo.Tasks().EvictTask(ctx, tenantId, v1.TaskIdInsertedAtRetryCount{
 		Id:         task.ID,
 		InsertedAt: task.InsertedAt,
@@ -1571,8 +1590,14 @@ func (d *DispatcherServiceImpl) evictStalledOrderedReleases(ctx context.Context,
 			key.taskExternalId, key.invocationCount, durableOrderedReleaseGapTimeout,
 		)
 
-		if _, err := d.evictDurableTask(ctx, invocation.tenantId, key.taskExternalId, key.invocationCount, "ordered durable completion release stalled on a missing entry"); err != nil {
+		evictRes, err := d.evictDurableTask(ctx, invocation.tenantId, key.taskExternalId, key.invocationCount, "ordered durable completion release stalled on a missing entry")
+		if err != nil {
 			d.l.Error().Err(err).Msgf("failed to evict durable task %s for stalled ordered release", key.taskExternalId)
+			continue
+		}
+
+		if !evictRes.WasEvicted {
+			invocation.clearRelease(key)
 			continue
 		}
 

--- a/internal/services/dispatcher/server_v1.go
+++ b/internal/services/dispatcher/server_v1.go
@@ -339,6 +339,8 @@ type durableTaskInvocation struct {
 	tenantId uuid.UUID
 	closed   bool // channel transport only; guarded by sendMu
 
+	isRunningOnOperator bool
+
 	releasesMu sync.Mutex
 	releases   map[orderedReleaseKey]*orderedRelease
 }
@@ -393,8 +395,17 @@ func (d *DispatcherServiceImpl) processDurableTaskMessage(
 	}
 
 	if err := d.handleDurableTaskRequest(ctx, invocation, req); err != nil {
-		d.l.Error().Err(err).Msg("error handling durable task request")
+		d.logDurableTaskRequestError(err)
 	}
+}
+
+func (d *DispatcherServiceImpl) logDurableTaskRequestError(err error) {
+	if errors.Is(err, context.Canceled) || errors.Is(err, errDurableTaskSessionClosed) {
+		d.l.Debug().Err(err).Msg("durable task request abandoned because its session closed")
+		return
+	}
+
+	d.l.Error().Err(err).Msg("error handling durable task request")
 }
 
 func (s *durableTaskInvocation) getRelease(key orderedReleaseKey) *orderedRelease {
@@ -644,7 +655,7 @@ func (d *DispatcherServiceImpl) DurableTask(server contracts.V1Dispatcher_Durabl
 				defer reqWg.Done()
 
 				if err := d.handleDurableTaskRequest(ctx, invocation, req); err != nil {
-					d.l.Error().Err(err).Msg("error handling durable task request")
+					d.logDurableTaskRequestError(err)
 				}
 			}(r.req)
 		}
@@ -676,8 +687,9 @@ func (d *DispatcherServiceImpl) RegisterDurableTask(ctx context.Context, externa
 	respCh := make(chan *contracts.DurableTaskResponse)
 
 	invocation := &durableTaskInvocation{
-		tenantId: tenant.ID,
-		l:        d.l,
+		tenantId:            tenant.ID,
+		l:                   d.l,
+		isRunningOnOperator: true,
 		sendFn: func(resp *contracts.DurableTaskResponse) error {
 			select {
 			case respCh <- resp:
@@ -1287,63 +1299,13 @@ func (d *DispatcherServiceImpl) handleEvictInvocation(
 		telemetry.AttributeKV{Key: "invocation_count", Value: req.InvocationCount},
 	)
 
-	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
-	defer cancel()
-
 	taskExternalId, err := uuid.Parse(req.DurableTaskExternalId)
 	if err != nil {
 		return d.sendEvictionError(invocation, req, fmt.Sprintf("invalid durable_task_external_id: %v", err))
 	}
 
-	d.analytics.Count(ctx, analytics.DurableTask, analytics.Evict)
-
-	task, err := d.repo.Tasks().GetTaskByExternalId(ctx, invocation.tenantId, taskExternalId, false)
-	if err != nil {
-		return d.sendEvictionError(invocation, req, fmt.Sprintf("task not found: %v", err))
-	}
-
-	evictRes, err := d.repo.Tasks().EvictTask(ctx, invocation.tenantId, v1.TaskIdInsertedAtRetryCount{
-		Id:         task.ID,
-		InsertedAt: task.InsertedAt,
-		RetryCount: task.RetryCount,
-	})
-	if err != nil {
-		return d.sendEvictionError(invocation, req, fmt.Sprintf("failed to evict task: %v", err))
-	}
-
-	if !evictRes.HasUnsatisfiedEntries {
-		// see comment on the `EvictTaskResult` - if the evicted task has no unsatisfied entries, we have to immediately restore it,
-		// otherwise it can hang forever since nothing will ever wake it up. note that this does cause some churn, but I think that's okay
-		// in exchange for not hitting the indefinitely hang case
-		restoreMsg, msgErr := tasktypes.DurableRestoreTaskMessage(invocation.tenantId, task.ExternalID, "all durable events satisfied at eviction time")
-		if msgErr != nil {
-			return d.sendEvictionError(invocation, req, fmt.Sprintf("failed to build restore message: %v", msgErr))
-		}
-
-		if sendErr := d.mq.SendMessage(ctx, msgqueue.TASK_PROCESSING_QUEUE, restoreMsg); sendErr != nil {
-			return d.sendEvictionError(invocation, req, fmt.Sprintf("failed to publish restore message: %v", sendErr))
-		}
-	}
-
-	if evictRes.WasEvicted {
-		msg, err := tasktypes.MonitoringEventMessageFromInternal(
-			invocation.tenantId,
-			tasktypes.CreateMonitoringEventPayload{
-				TaskId:                 task.ID,
-				RetryCount:             task.RetryCount,
-				DurableInvocationCount: req.InvocationCount,
-				EventTimestamp:         time.Now(),
-				EventType:              sqlcv1.V1EventTypeOlapDURABLEEVICTED,
-				EventMessage:           durableEvictionMessage(req),
-			},
-		)
-		if err != nil {
-			d.l.Warn().Err(err).Msg("failed to build DURABLE_EVICTED monitoring message")
-		} else if err := d.pubBuffer.Pub(ctx, msgqueue.OLAP_QUEUE, msg, false); err != nil {
-			d.l.Warn().Err(err).Msg("failed to publish DURABLE_EVICTED to OLAP")
-		}
-	} else {
-		d.l.Debug().Str("task_external_id", req.DurableTaskExternalId).Msg("eviction skipped, task likely already timed out")
+	if _, err := d.evictDurableTask(ctx, invocation.tenantId, taskExternalId, req.InvocationCount, durableEvictionMessage(req)); err != nil {
+		return d.sendEvictionError(invocation, req, err.Error())
 	}
 
 	return invocation.send(&contracts.DurableTaskResponse{
@@ -1361,6 +1323,70 @@ func durableEvictionMessage(req *contracts.DurableTaskEvictInvocationRequest) st
 		return reason
 	}
 	return "Task paused and evicted from worker"
+}
+
+func (d *DispatcherServiceImpl) evictDurableTask(
+	ctx context.Context,
+	tenantId uuid.UUID,
+	taskExternalId uuid.UUID,
+	invocationCount int32,
+	reason string,
+) (*v1.EvictTaskResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	d.analytics.Count(ctx, analytics.DurableTask, analytics.Evict)
+
+	task, err := d.repo.Tasks().GetTaskByExternalId(ctx, tenantId, taskExternalId, false)
+	if err != nil {
+		return nil, fmt.Errorf("task not found: %w", err)
+	}
+
+	evictRes, err := d.repo.Tasks().EvictTask(ctx, tenantId, v1.TaskIdInsertedAtRetryCount{
+		Id:         task.ID,
+		InsertedAt: task.InsertedAt,
+		RetryCount: task.RetryCount,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to evict task: %w", err)
+	}
+
+	if !evictRes.HasUnsatisfiedEntries {
+		// see comment on the `EvictTaskResult` - if the evicted task has no unsatisfied entries, we have to immediately restore it,
+		// otherwise it can hang forever since nothing will ever wake it up. note that this does cause some churn, but I think that's okay
+		// in exchange for not hitting the indefinitely hang case
+		restoreMsg, msgErr := tasktypes.DurableRestoreTaskMessage(tenantId, task.ExternalID, "all durable events satisfied at eviction time")
+		if msgErr != nil {
+			return nil, fmt.Errorf("failed to build restore message: %w", msgErr)
+		}
+
+		if sendErr := d.mq.SendMessage(ctx, msgqueue.TASK_PROCESSING_QUEUE, restoreMsg); sendErr != nil {
+			return nil, fmt.Errorf("failed to publish restore message: %w", sendErr)
+		}
+	}
+
+	if evictRes.WasEvicted {
+		msg, err := tasktypes.MonitoringEventMessageFromInternal(
+			tenantId,
+			tasktypes.CreateMonitoringEventPayload{
+				TaskId:                 task.ID,
+				RetryCount:             task.RetryCount,
+				DurableInvocationCount: invocationCount,
+				EventTimestamp:         time.Now(),
+				EventType:              sqlcv1.V1EventTypeOlapDURABLEEVICTED,
+				EventMessage:           reason,
+			},
+		)
+		if err != nil {
+			d.l.Warn().Err(err).Msg("failed to build DURABLE_EVICTED monitoring message")
+		} else if err := d.pubBuffer.Pub(ctx, msgqueue.OLAP_QUEUE, msg, false); err != nil {
+			d.l.Warn().Err(err).Msg("failed to publish DURABLE_EVICTED to OLAP")
+		}
+	} else {
+		d.l.Debug().Str("task_external_id", taskExternalId.String()).Msg("eviction skipped, task likely already timed out")
+	}
+
+	return evictRes, nil
 }
 
 func (d *DispatcherServiceImpl) handleWorkerStatus(
@@ -1403,6 +1429,8 @@ func (d *DispatcherServiceImpl) handleWorkerStatus(
 		return nil
 	}
 
+	staleExternalIds := make(map[uuid.UUID]struct{})
+
 	if len(uniqueExternalIds) > 0 {
 		externalIds := make([]uuid.UUID, 0, len(uniqueExternalIds))
 		for extId := range uniqueExternalIds {
@@ -1437,6 +1465,8 @@ func (d *DispatcherServiceImpl) handleWorkerStatus(
 					continue
 				}
 				if workerInvocationCount < *currentCount {
+					staleExternalIds[extId] = struct{}{}
+
 					err = invocation.send(&contracts.DurableTaskResponse{
 						Message: &contracts.DurableTaskResponse_ServerEvict{
 							ServerEvict: &contracts.DurableTaskServerEvictNotice{
@@ -1465,10 +1495,61 @@ func (d *DispatcherServiceImpl) handleWorkerStatus(
 		}
 	}
 
+	if invocation.isRunningOnOperator {
+		d.evictIdleOperatorTasks(ctx, invocation, uniqueExternalIds, staleExternalIds, callbacks)
+	}
+
 	d.evictStalledOrderedReleases(invocation)
 	invocation.pruneIdleReleases(durableReleaseIdleTTL)
 
 	return nil
+}
+
+func (d *DispatcherServiceImpl) evictIdleOperatorTasks(
+	ctx context.Context,
+	invocation *durableTaskInvocation,
+	waitingInvocationCounts map[uuid.UUID]int32,
+	staleExternalIds map[uuid.UUID]struct{},
+	satisfiedCallbacks []*v1.SatisfiedEventWithPayload,
+) {
+	tasksWithSatisfiedEntries := make(map[uuid.UUID]struct{}, len(satisfiedCallbacks))
+	for _, cb := range satisfiedCallbacks {
+		tasksWithSatisfiedEntries[cb.TaskExternalId] = struct{}{}
+	}
+
+	for taskExternalId, invocationCount := range waitingInvocationCounts {
+		if _, isStale := staleExternalIds[taskExternalId]; isStale {
+			continue
+		}
+		if _, hasSatisfied := tasksWithSatisfiedEntries[taskExternalId]; hasSatisfied {
+			continue
+		}
+
+		const reason = "operator run is blocked waiting on durable events"
+
+		evictRes, err := d.evictDurableTask(ctx, invocation.tenantId, taskExternalId, invocationCount, reason)
+		if err != nil {
+			d.l.Error().Err(err).Str("task_external_id", taskExternalId.String()).Msg("failed to auto-evict operator durable task")
+			continue
+		}
+
+		if !evictRes.WasEvicted {
+			continue
+		}
+
+		err = invocation.send(&contracts.DurableTaskResponse{
+			Message: &contracts.DurableTaskResponse_ServerEvict{
+				ServerEvict: &contracts.DurableTaskServerEvictNotice{
+					DurableTaskExternalId: taskExternalId.String(),
+					InvocationCount:       invocationCount,
+					Reason:                reason,
+				},
+			},
+		})
+		if err != nil {
+			d.l.Error().Err(err).Str("task_external_id", taskExternalId.String()).Msg("failed to send eviction notice to operator session")
+		}
+	}
 }
 
 // durableOrderedReleaseGapTimeout bounds how long a held EntryCompleted may wait for a

--- a/internal/syncx/map.go
+++ b/internal/syncx/map.go
@@ -29,6 +29,12 @@ func (m *Map[K, V]) Delete(key K) {
 	m.m.Delete(key)
 }
 
+// CompareAndDelete deletes the entry for key only if its current value equals old.
+// The stored value must be comparable (e.g. a pointer), or this panics.
+func (m *Map[K, V]) CompareAndDelete(key K, old V) bool {
+	return m.m.CompareAndDelete(key, old)
+}
+
 // LoadOrStore loads or stores the value for a key.
 func (m *Map[K, V]) LoadOrStore(key K, value V) (actual V, loaded bool) {
 	a, loaded := m.m.LoadOrStore(key, value)

--- a/pkg/operator/dagoperator/dag.go
+++ b/pkg/operator/dagoperator/dag.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
@@ -43,6 +44,20 @@ func (e *dagChildFailedError) Error() string {
 
 func isDagChildFailedErr(err error) bool {
 	var e *dagChildFailedError
+	return errors.As(err, &e)
+}
+
+type dagEngineError struct {
+	errorType    string
+	errorMessage string
+}
+
+func (e *dagEngineError) Error() string {
+	return fmt.Sprintf("durable task error from engine (%s): %s", e.errorType, e.errorMessage)
+}
+
+func isDagEngineErr(err error) bool {
+	var e *dagEngineError
 	return errors.As(err, &e)
 }
 
@@ -217,14 +232,6 @@ func dagDurableTask(
 			break
 		}
 
-		if err := d.reportBlockedOnDurableEvents(ctx); err != nil {
-			return err
-		}
-
-		if len(d.queuedResponses) > 0 {
-			continue
-		}
-
 		resp, err := d.awaitResponse(ctx, responseCh)
 
 		if err != nil {
@@ -253,6 +260,8 @@ func dagDurableTask(
 	return nil
 }
 
+var blockedStatusReportInterval = 10 * time.Second
+
 // blocks until the child task returns - this is basically here to just reveal bottlenecks, especially on child spawning, in the traces
 func (d *dag) awaitResponse(ctx context.Context, responseCh <-chan *v1contracts.DurableTaskResponse) (*v1contracts.DurableTaskResponse, error) {
 	_, span := telemetry.NewSpan(ctx, "dag.awaitResponse")
@@ -275,20 +284,37 @@ func (d *dag) awaitResponse(ctx context.Context, responseCh <-chan *v1contracts.
 		attribute.Int("dag.pending_task_count", len(d.pendingTasks)),
 	)
 
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case resp, ok := <-responseCh:
-		if !ok {
-			return nil, fmt.Errorf("durable task session closed")
-		}
+	timer := time.NewTimer(blockedStatusReportInterval)
+	defer timer.Stop()
 
-		return resp, nil
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case resp, ok := <-responseCh:
+			if !ok {
+				return nil, fmt.Errorf("durable task session closed")
+			}
+
+			return resp, nil
+		case <-timer.C:
+			if err := d.reportBlockedOnDurableEvents(ctx); err != nil {
+				return nil, err
+			}
+
+			if len(d.queuedResponses) > 0 {
+				resp := d.queuedResponses[0]
+				d.queuedResponses = d.queuedResponses[1:]
+				return resp, nil
+			}
+
+			timer.Reset(blockedStatusReportInterval)
+		}
 	}
 }
 
-// tells the dispatcher which unsatisfied durable event log entries that are about to block so
-// we can evict the durable task to free its slot
+// tells the dispatcher which unsatisfied durable event log entries we've been blocked on so
+// it can evict the durable task to free its slot
 func (d *dag) reportBlockedOnDurableEvents(ctx context.Context) error {
 	if len(d.pendingWaitAcks) > 0 || len(d.pendingEntryCompletions) > 0 {
 		return nil
@@ -371,13 +397,8 @@ func (d *dag) emitReadyTasks(ctx context.Context) (bool, error) {
 
 	progressed := false
 
-	stillPending := d.pendingTasks[:0]
-
+	readyAtPassStart := make(map[*task]bool, len(d.pendingTasks))
 	for _, t := range d.pendingTasks {
-		if t.isTriggered || t.isSkipped {
-			continue
-		}
-
 		ready := true
 		for _, p := range t.parents {
 			if !p.isCompleted {
@@ -385,8 +406,17 @@ func (d *dag) emitReadyTasks(ctx context.Context) (bool, error) {
 				break
 			}
 		}
+		readyAtPassStart[t] = ready
+	}
 
-		if !ready {
+	stillPending := d.pendingTasks[:0]
+
+	for _, t := range d.pendingTasks {
+		if t.isTriggered || t.isSkipped {
+			continue
+		}
+
+		if !readyAtPassStart[t] {
 			stillPending = append(stillPending, t)
 			continue
 		}
@@ -572,6 +602,15 @@ func (d *dag) taskConsumer(ctx context.Context, resp *v1contracts.DurableTaskRes
 		}
 
 		d.err = &dagEvictedError{reason: m.ServerEvict.GetReason()}
+
+	case *v1contracts.DurableTaskResponse_Error:
+		if ref := m.Error.GetRef(); ref != nil && ref.GetDurableTaskExternalId() != d.externalId.String() {
+			return
+		}
+
+		// Dropping this would leave the run waiting forever for an ack or completion that
+		// will never arrive (e.g. a nondeterminism error means the wait was never committed).
+		d.err = &dagEngineError{errorType: m.Error.GetErrorType().String(), errorMessage: m.Error.GetErrorMessage()}
 	}
 }
 

--- a/pkg/operator/dagoperator/dag.go
+++ b/pkg/operator/dagoperator/dag.go
@@ -597,7 +597,8 @@ func (d *dag) taskConsumer(ctx context.Context, resp *v1contracts.DurableTaskRes
 		}
 
 	case *v1contracts.DurableTaskResponse_ServerEvict:
-		if m.ServerEvict.GetDurableTaskExternalId() != d.externalId.String() {
+		if m.ServerEvict.GetDurableTaskExternalId() != d.externalId.String() ||
+			m.ServerEvict.GetInvocationCount() != d.invocationCount {
 			return
 		}
 

--- a/pkg/operator/dagoperator/dag.go
+++ b/pkg/operator/dagoperator/dag.go
@@ -46,6 +46,19 @@ func isDagChildFailedErr(err error) bool {
 	return errors.As(err, &e)
 }
 
+type dagEvictedError struct {
+	reason string
+}
+
+func (e *dagEvictedError) Error() string {
+	return fmt.Sprintf("invocation evicted by the engine: %s", e.reason)
+}
+
+func isDagEvictedErr(err error) bool {
+	var e *dagEvictedError
+	return errors.As(err, &e)
+}
+
 type dag struct {
 	requestCh    chan<- *v1contracts.DurableTaskRequest
 	responseCh   <-chan *v1contracts.DurableTaskResponse
@@ -60,6 +73,7 @@ type dag struct {
 
 	pendingTasks    []*task
 	externalId      uuid.UUID
+	workerId        uuid.UUID
 	invocationCount int32
 	input           string
 	err             error
@@ -148,6 +162,7 @@ func dagDurableTask(
 	tasks []*task,
 	onFailureTask *task,
 	externalId uuid.UUID,
+	workerId uuid.UUID,
 	invocationCount int32,
 	input string,
 	requestCh chan<- *v1contracts.DurableTaskRequest,
@@ -173,6 +188,7 @@ func dagDurableTask(
 		responseCh:       responseCh,
 		evalBoolExpr:     evalBoolExpr,
 		externalId:       externalId,
+		workerId:         workerId,
 		invocationCount:  invocationCount,
 		input:            input,
 		triggerStep:      triggerStep,
@@ -199,6 +215,14 @@ func dagDurableTask(
 
 		if d.isDone() {
 			break
+		}
+
+		if err := d.reportBlockedOnDurableEvents(ctx); err != nil {
+			return err
+		}
+
+		if len(d.queuedResponses) > 0 {
+			continue
 		}
 
 		resp, err := d.awaitResponse(ctx, responseCh)
@@ -261,6 +285,62 @@ func (d *dag) awaitResponse(ctx context.Context, responseCh <-chan *v1contracts.
 
 		return resp, nil
 	}
+}
+
+// tells the dispatcher which unsatisfied durable event log entries that are about to block so
+// we can evict the durable task to free its slot
+func (d *dag) reportBlockedOnDurableEvents(ctx context.Context) error {
+	if len(d.pendingWaitAcks) > 0 || len(d.pendingEntryCompletions) > 0 {
+		return nil
+	}
+
+	entries := d.outstandingWaitingEntries()
+
+	if len(entries) == 0 {
+		return nil
+	}
+
+	return d.send(ctx, &v1contracts.DurableTaskRequest{
+		Message: &v1contracts.DurableTaskRequest_WorkerStatus{
+			WorkerStatus: &v1contracts.DurableTaskWorkerStatusRequest{
+				WorkerId:       d.workerId.String(),
+				WaitingEntries: entries,
+			},
+		},
+	})
+}
+
+func (d *dag) outstandingWaitingEntries() []*v1contracts.DurableTaskAwaitedCompletedEntry {
+	var entries []*v1contracts.DurableTaskAwaitedCompletedEntry
+
+	appendEntry := func(nodeId, branchId int64) {
+		entries = append(entries, &v1contracts.DurableTaskAwaitedCompletedEntry{
+			DurableTaskExternalId: d.externalId.String(),
+			InvocationCount:       d.invocationCount,
+			NodeId:                nodeId,
+			BranchId:              branchId,
+		})
+	}
+
+	for _, t := range d.tasks {
+		if t.isTriggered && !t.isCompleted {
+			appendEntry(t.nodeId, t.branchId)
+		}
+
+		if t.isWaiting && !t.isWaitSatisfied {
+			appendEntry(t.waitNodeId, t.waitBranchId)
+		}
+
+		if t.skipWatchRegistered && !t.skipWatchFired {
+			appendEntry(t.skipWatchNodeId, t.skipWatchBranchId)
+		}
+
+		if t.cancelWatchRegistered && !t.cancelWatchFired {
+			appendEntry(t.cancelWatchNodeId, t.cancelWatchBranchId)
+		}
+	}
+
+	return entries
 }
 
 func (d *dag) taskEmitter(ctx context.Context) error {
@@ -485,6 +565,13 @@ func (d *dag) taskConsumer(ctx context.Context, resp *v1contracts.DurableTaskRes
 			// Raced ahead of its own WaitForAck; retry once that ack lands.
 			d.pendingEntryCompletions = append(d.pendingEntryCompletions, entry)
 		}
+
+	case *v1contracts.DurableTaskResponse_ServerEvict:
+		if m.ServerEvict.GetDurableTaskExternalId() != d.externalId.String() {
+			return
+		}
+
+		d.err = &dagEvictedError{reason: m.ServerEvict.GetReason()}
 	}
 }
 

--- a/pkg/operator/dagoperator/dag_test.go
+++ b/pkg/operator/dagoperator/dag_test.go
@@ -1301,6 +1301,36 @@ func TestDag_ServerEvictForDifferentTaskIgnored(t *testing.T) {
 	require.True(t, a.isCompleted)
 }
 
+func TestDag_ServerEvictForOlderInvocationIgnored(t *testing.T) {
+	a := newTestTask("a", "action-a", 0)
+
+	trigger, triggered := asyncTrigger(map[string]bool{"action-a": true})
+
+	h := startDAG(t, []*task{a}, trigger)
+	defer h.cleanup()
+
+	first := recvTriggered(t, triggered)
+
+	select {
+	case h.responseCh <- &v1contracts.DurableTaskResponse{
+		Message: &v1contracts.DurableTaskResponse_ServerEvict{
+			ServerEvict: &v1contracts.DurableTaskServerEvictNotice{
+				DurableTaskExternalId: h.externalId.String(),
+				InvocationCount:       0,
+				Reason:                "delayed notice for a previous invocation",
+			},
+		},
+	}:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out sending ServerEvict response")
+	}
+
+	sendEntryCompleted(t, h.responseCh, first.ref, mapToJson(map[string]interface{}{"ok": true}))
+
+	require.NoError(t, h.waitErr(t))
+	require.True(t, a.isCompleted)
+}
+
 func TestDag_NoBlockedStatusReportBeforeInterval(t *testing.T) {
 	a := newTestTask("a", "action-a", 0)
 	b := newTestTask("b", "action-b", 1, a)

--- a/pkg/operator/dagoperator/dag_test.go
+++ b/pkg/operator/dagoperator/dag_test.go
@@ -1190,6 +1190,16 @@ func TestDag_EntryCompletedRacesAheadOfWaitForAck(t *testing.T) {
 	require.False(t, b.isCancelled)
 }
 
+func shortenBlockedStatusReportInterval(t *testing.T, interval time.Duration) {
+	t.Helper()
+
+	previous := blockedStatusReportInterval
+	blockedStatusReportInterval = interval
+	t.Cleanup(func() {
+		blockedStatusReportInterval = previous
+	})
+}
+
 func (h *dagHarness) waitWorkerStatus(t *testing.T) *v1contracts.DurableTaskWorkerStatusRequest {
 	t.Helper()
 
@@ -1221,6 +1231,8 @@ func sendServerEvict(t *testing.T, responseCh chan *v1contracts.DurableTaskRespo
 }
 
 func TestDag_ReportsBlockedStatusWhileAwaitingChild(t *testing.T) {
+	shortenBlockedStatusReportInterval(t, 20*time.Millisecond)
+
 	a := newTestTask("a", "action-a", 0)
 	b := newTestTask("b", "action-b", 1, a)
 
@@ -1247,6 +1259,8 @@ func TestDag_ReportsBlockedStatusWhileAwaitingChild(t *testing.T) {
 }
 
 func TestDag_ServerEvictEndsRunWithEvictedError(t *testing.T) {
+	shortenBlockedStatusReportInterval(t, 20*time.Millisecond)
+
 	a := newTestTask("a", "action-a", 0)
 	b := newTestTask("b", "action-b", 1, a)
 
@@ -1285,4 +1299,29 @@ func TestDag_ServerEvictForDifferentTaskIgnored(t *testing.T) {
 
 	require.NoError(t, h.waitErr(t))
 	require.True(t, a.isCompleted)
+}
+
+func TestDag_NoBlockedStatusReportBeforeInterval(t *testing.T) {
+	a := newTestTask("a", "action-a", 0)
+	b := newTestTask("b", "action-b", 1, a)
+
+	trigger, triggered := asyncTrigger(map[string]bool{"action-a": true, "action-b": true})
+
+	h := startDAG(t, []*task{a, b}, trigger)
+	defer h.cleanup()
+
+	first := recvTriggered(t, triggered)
+	sendEntryCompleted(t, h.responseCh, first.ref, mapToJson(map[string]interface{}{"ok": true}))
+
+	second := recvTriggered(t, triggered)
+	sendEntryCompleted(t, h.responseCh, second.ref, mapToJson(map[string]interface{}{"ok": true}))
+
+	require.NoError(t, h.waitErr(t))
+	require.True(t, a.isCompleted && b.isCompleted)
+
+	select {
+	case status := <-h.fd.workerStatuses:
+		t.Fatalf("dag reported blocked status before the interval elapsed: %v", status)
+	default:
+	}
 }

--- a/pkg/operator/dagoperator/dag_test.go
+++ b/pkg/operator/dagoperator/dag_test.go
@@ -63,11 +63,15 @@ func stubTriggerStep(t *testing.T, async map[string]bool) triggerStepFn {
 }
 
 type fakeDispatcher struct {
-	acks chan *v1contracts.DurableEventLogEntryRef
+	acks           chan *v1contracts.DurableEventLogEntryRef
+	workerStatuses chan *v1contracts.DurableTaskWorkerStatusRequest
 }
 
 func newFakeDispatcher(requestCh chan *v1contracts.DurableTaskRequest, responseCh chan *v1contracts.DurableTaskResponse, stop <-chan struct{}) *fakeDispatcher {
-	fd := &fakeDispatcher{acks: make(chan *v1contracts.DurableEventLogEntryRef, 16)}
+	fd := &fakeDispatcher{
+		acks:           make(chan *v1contracts.DurableEventLogEntryRef, 16),
+		workerStatuses: make(chan *v1contracts.DurableTaskWorkerStatusRequest, 16),
+	}
 
 	go func() {
 		var nextId int64 = 1000
@@ -79,6 +83,14 @@ func newFakeDispatcher(requestCh chan *v1contracts.DurableTaskRequest, responseC
 			case req, ok := <-requestCh:
 				if !ok {
 					return
+				}
+
+				if workerStatus := req.GetWorkerStatus(); workerStatus != nil {
+					select {
+					case fd.workerStatuses <- workerStatus:
+					default:
+					}
+					continue
 				}
 
 				waitFor := req.GetWaitFor()
@@ -137,6 +149,7 @@ type dagHarness struct {
 	errCh      chan error
 	responseCh chan *v1contracts.DurableTaskResponse
 	fd         *fakeDispatcher
+	externalId uuid.UUID
 	cleanup    func()
 }
 
@@ -162,14 +175,17 @@ func startDAGFull(t *testing.T, tasks []*task, onFailureTask *task, triggerStep 
 	errCh := make(chan error, 1)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 
+	externalId := uuid.New()
+
 	go func() {
-		errCh <- dagDurableTask(ctx, tasks, onFailureTask, uuid.New(), 1, "{}", requestCh, responseCh, evaluator.EvalBoolExpr, triggerStep)
+		errCh <- dagDurableTask(ctx, tasks, onFailureTask, externalId, uuid.New(), 1, "{}", requestCh, responseCh, evaluator.EvalBoolExpr, triggerStep)
 	}()
 
 	return &dagHarness{
 		errCh:      errCh,
 		responseCh: responseCh,
 		fd:         fd,
+		externalId: externalId,
 		cleanup: func() {
 			close(stop)
 			cancel()
@@ -496,7 +512,7 @@ func TestDag_SleepWaitCondition(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		errCh <- dagDurableTask(ctx, []*task{a, b}, nil, uuid.New(), 1, "{}", requestCh, responseCh, evaluator.EvalBoolExpr, stubTriggerStep(t, nil))
+		errCh <- dagDurableTask(ctx, []*task{a, b}, nil, uuid.New(), uuid.New(), 1, "{}", requestCh, responseCh, evaluator.EvalBoolExpr, stubTriggerStep(t, nil))
 	}()
 
 	var ref *v1contracts.DurableEventLogEntryRef
@@ -1121,7 +1137,7 @@ func TestDag_EntryCompletedRacesAheadOfWaitForAck(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		errCh <- dagDurableTask(ctx, []*task{a, b}, nil, uuid.New(), 1, "{}", requestCh, responseCh, evaluator.EvalBoolExpr, stubTriggerStep(t, nil))
+		errCh <- dagDurableTask(ctx, []*task{a, b}, nil, uuid.New(), uuid.New(), 1, "{}", requestCh, responseCh, evaluator.EvalBoolExpr, stubTriggerStep(t, nil))
 	}()
 
 	// Drive the dispatcher side ourselves (instead of using newFakeDispatcher) so we can choose
@@ -1172,4 +1188,101 @@ func TestDag_EntryCompletedRacesAheadOfWaitForAck(t *testing.T) {
 	require.True(t, b.isSkipped)
 	require.True(t, b.isCompleted)
 	require.False(t, b.isCancelled)
+}
+
+func (h *dagHarness) waitWorkerStatus(t *testing.T) *v1contracts.DurableTaskWorkerStatusRequest {
+	t.Helper()
+
+	select {
+	case status := <-h.fd.workerStatuses:
+		return status
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for a worker status report")
+		return nil
+	}
+}
+
+func sendServerEvict(t *testing.T, responseCh chan *v1contracts.DurableTaskResponse, externalId string, reason string) {
+	t.Helper()
+
+	select {
+	case responseCh <- &v1contracts.DurableTaskResponse{
+		Message: &v1contracts.DurableTaskResponse_ServerEvict{
+			ServerEvict: &v1contracts.DurableTaskServerEvictNotice{
+				DurableTaskExternalId: externalId,
+				InvocationCount:       1,
+				Reason:                reason,
+			},
+		},
+	}:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out sending ServerEvict response")
+	}
+}
+
+func TestDag_ReportsBlockedStatusWhileAwaitingChild(t *testing.T) {
+	a := newTestTask("a", "action-a", 0)
+	b := newTestTask("b", "action-b", 1, a)
+
+	trigger, triggered := asyncTrigger(map[string]bool{"action-a": true})
+
+	h := startDAG(t, []*task{a, b}, trigger)
+	defer h.cleanup()
+
+	first := recvTriggered(t, triggered)
+	require.Equal(t, "action-a", first.actionId)
+
+	status := h.waitWorkerStatus(t)
+	require.Len(t, status.WaitingEntries, 1)
+	entry := status.WaitingEntries[0]
+	require.Equal(t, h.externalId.String(), entry.DurableTaskExternalId)
+	require.Equal(t, int32(1), entry.InvocationCount)
+	require.Equal(t, first.ref.NodeId, entry.NodeId)
+	require.Equal(t, first.ref.BranchId, entry.BranchId)
+
+	sendEntryCompleted(t, h.responseCh, first.ref, mapToJson(map[string]interface{}{"ok": true}))
+
+	require.NoError(t, h.waitErr(t))
+	require.True(t, a.isCompleted && b.isCompleted)
+}
+
+func TestDag_ServerEvictEndsRunWithEvictedError(t *testing.T) {
+	a := newTestTask("a", "action-a", 0)
+	b := newTestTask("b", "action-b", 1, a)
+
+	trigger, triggered := asyncTrigger(map[string]bool{"action-a": true})
+
+	h := startDAG(t, []*task{a, b}, trigger)
+	defer h.cleanup()
+
+	first := recvTriggered(t, triggered)
+	require.Equal(t, "action-a", first.actionId)
+
+	h.waitWorkerStatus(t)
+
+	sendServerEvict(t, h.responseCh, h.externalId.String(), "operator run is blocked waiting on durable events")
+
+	err := h.waitErr(t)
+	require.Error(t, err)
+	require.True(t, isDagEvictedErr(err))
+	require.False(t, a.isCompleted)
+	require.False(t, b.isTriggered)
+}
+
+func TestDag_ServerEvictForDifferentTaskIgnored(t *testing.T) {
+	a := newTestTask("a", "action-a", 0)
+
+	trigger, triggered := asyncTrigger(map[string]bool{"action-a": true})
+
+	h := startDAG(t, []*task{a}, trigger)
+	defer h.cleanup()
+
+	first := recvTriggered(t, triggered)
+
+	sendServerEvict(t, h.responseCh, uuid.NewString(), "not for this run")
+
+	sendEntryCompleted(t, h.responseCh, first.ref, mapToJson(map[string]interface{}{"ok": true}))
+
+	require.NoError(t, h.waitErr(t))
+	require.True(t, a.isCompleted)
 }

--- a/pkg/operator/dagoperator/operator.go
+++ b/pkg/operator/dagoperator/operator.go
@@ -432,9 +432,14 @@ func (d *DAGOperator) run(action *contracts.AssignedAction) error {
 		if errors.Is(dagErr, context.Canceled) {
 			return d.handleRunCancellation(span, action, tasks, dagErr)
 		}
-		// A child task failing is a terminal DAG outcome that replay reproduces deterministically,
-		// so it must not be retried; anything else (operational errors) remains retriable.
-		return d.fail(span, action, fmt.Errorf("dag failed: %w", dagErr), isDagChildFailedErr(dagErr))
+		// A child task failing, an engine-reported durable task error (e.g. nondeterminism), or a
+		// nondeterministic ingestion are all terminal DAG outcomes that replay reproduces
+		// deterministically, so they must not be retried; anything else (operational errors)
+		// remains retriable.
+		var nonDeterminismErr *repository.NonDeterminismError
+		shouldNotRetry := isDagChildFailedErr(dagErr) || isDagEngineErr(dagErr) || errors.As(dagErr, &nonDeterminismErr)
+
+		return d.fail(span, action, fmt.Errorf("dag failed: %w", dagErr), shouldNotRetry)
 	}
 
 	output := make(map[string]json.RawMessage, len(tasks))

--- a/pkg/operator/dagoperator/operator.go
+++ b/pkg/operator/dagoperator/operator.go
@@ -402,6 +402,7 @@ func (d *DAGOperator) run(action *contracts.AssignedAction) error {
 		tasks,
 		onFailureTask,
 		externalId,
+		d.WorkerId(),
 		action.GetDurableTaskInvocationCount(),
 		action.ActionPayload,
 		requestCh,
@@ -416,6 +417,15 @@ func (d *DAGOperator) run(action *contracts.AssignedAction) error {
 	}
 
 	if dagErr != nil {
+		if isDagEvictedErr(dagErr) {
+			span.SetAttributes(attribute.Bool("dagoperator.evicted", true))
+
+			d.Logger().Debug().
+				Str("task_run_external_id", action.TaskRunExternalId).
+				Msg("dag run evicted while waiting on durable events; slots released until restore")
+
+			return nil
+		}
 		if isDagCancelledErr(dagErr) {
 			return d.cancelDAG(span, action, dagErr.Error())
 		}

--- a/pkg/repository/sqlcv1/workflows.sql
+++ b/pkg/repository/sqlcv1/workflows.sql
@@ -41,7 +41,8 @@ SELECT
 FROM
     steps s
 LEFT JOIN
-    step_orders so ON so."stepId" = s."id";
+    step_orders so ON so."stepId" = s."id"
+ORDER BY s."createdAt", s."id";
 
 -- name: ListStepsByIds :many
 SELECT
@@ -657,7 +658,8 @@ FROM
     v1_step_match_condition
 WHERE
     step_id = ANY(@stepIds::uuid[])
-    AND tenant_id = @tenantId::uuid;
+    AND tenant_id = @tenantId::uuid
+ORDER BY step_id, id;
 
 -- name: LockWorkflowVersion :one
 SELECT

--- a/pkg/repository/sqlcv1/workflows.sql.go
+++ b/pkg/repository/sqlcv1/workflows.sql.go
@@ -1675,6 +1675,7 @@ FROM
 WHERE
     step_id = ANY($1::uuid[])
     AND tenant_id = $2::uuid
+ORDER BY step_id, id
 `
 
 type ListStepMatchConditionsParams struct {
@@ -1869,6 +1870,7 @@ FROM
     steps s
 LEFT JOIN
     step_orders so ON so."stepId" = s."id"
+ORDER BY s."createdAt", s."id"
 `
 
 type ListStepsByWorkflowVersionIdsParams struct {


### PR DESCRIPTION
# Description

Enables eviction on the dag operator so we can free slots up while dags are just waiting for children to complete

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

Changes have been:

- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [ ] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: [e.g. generating tests, writing docs]

</details>
