### PR TITLE
feat: count ingested log and OTLP bytes after persist

### DIFF
--- a/cmd/hatchet-engine/engine/run.go
+++ b/cmd/hatchet-engine/engine/run.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hatchet-dev/hatchet/pkg/config/loader"
 	"github.com/hatchet-dev/hatchet/pkg/config/server"
 	"github.com/hatchet-dev/hatchet/pkg/config/shared"
+	"github.com/hatchet-dev/hatchet/pkg/o11yusage"
 	v1 "github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/cache"
 	"github.com/hatchet-dev/hatchet/pkg/telemetry"
@@ -127,8 +128,20 @@ func RunWithConfig(ctx context.Context, sc *server.ServerConfig, cleanup *cleanu
 	return runV0Config(ctx, sc, cleanup)
 }
 
+func startO11yUsage(sc *server.ServerConfig, cleanup *cleanup.Cleanup) *o11yusage.Aggregator {
+	if sc.O11yUsageFlush == nil {
+		return nil
+	}
+
+	agg := o11yusage.NewAggregator(sc.Logger, sc.Runtime.O11yUsageFlushInterval, sc.O11yUsageFlush)
+	agg.Start()
+	cleanup.Add(agg.Shutdown, "o11y-usage")
+	return agg
+}
+
 func runV0Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.Cleanup) error {
 	var l = sc.Logger
+	o11yUsage := startO11yUsage(sc, cleanup)
 
 	telemetryShutdown, err := telemetry.InitTracer(&telemetry.TracerOpts{
 		ServiceName:   sc.OpenTelemetry.ServiceName,
@@ -384,6 +397,7 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 			ingestor.WithGrpcTriggerSlots(sc.Runtime.GRPCTriggerWriteSlots),
 			ingestor.WithAnalytics(sc.Analytics),
 			ingestor.WithPrometheusGate(sc.PrometheusGate),
+			ingestor.WithO11yUsage(o11yUsage),
 		)
 
 		if err != nil {
@@ -444,6 +458,7 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 				otelcol.WithLogger(sc.Logger),
 				otelcol.WithMaxBatchSize(sc.Observability.MaxBatchSize),
 				otelcol.WithAnalytics(sc.Analytics),
+				otelcol.WithO11yUsage(o11yUsage),
 			)
 
 			if err != nil {
@@ -546,6 +561,7 @@ func runV0Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 
 func runV1Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.Cleanup) error {
 	var l = sc.Logger
+	o11yUsage := startO11yUsage(sc, cleanup)
 
 	telemetryShutdown, err := telemetry.InitTracer(&telemetry.TracerOpts{
 		ServiceName:   sc.OpenTelemetry.ServiceName,
@@ -833,6 +849,7 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 			ingestor.WithGrpcTriggerSlots(sc.Runtime.GRPCTriggerWriteSlots),
 			ingestor.WithAnalytics(sc.Analytics),
 			ingestor.WithPrometheusGate(sc.PrometheusGate),
+			ingestor.WithO11yUsage(o11yUsage),
 		)
 
 		if err != nil {
@@ -894,6 +911,7 @@ func runV1Config(ctx context.Context, sc *server.ServerConfig, cleanup *cleanup.
 				otelcol.WithLogger(sc.Logger),
 				otelcol.WithMaxBatchSize(sc.Observability.MaxBatchSize),
 				otelcol.WithAnalytics(sc.Analytics),
+				otelcol.WithO11yUsage(o11yUsage),
 			)
 
 			if err != nil {

--- a/internal/services/ingestor/ingestor.go
+++ b/internal/services/ingestor/ingestor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hatchet-dev/hatchet/pkg/analytics"
 	"github.com/hatchet-dev/hatchet/pkg/integrations/metrics/prometheus"
 	"github.com/hatchet-dev/hatchet/pkg/logger"
+	"github.com/hatchet-dev/hatchet/pkg/o11yusage"
 	v1 "github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 	"github.com/hatchet-dev/hatchet/pkg/validator"
@@ -50,6 +51,8 @@ type IngestorOpts struct {
 	grpcTriggerSlots    int
 
 	promGate *prometheus.Gate
+
+	o11yUsage *o11yusage.Aggregator
 }
 
 func WithMessageQueueV1(mq msgqueue.MessageQueue) IngestorOptFunc {
@@ -134,6 +137,12 @@ func WithPrometheusGate(gate *prometheus.Gate) IngestorOptFunc {
 	}
 }
 
+func WithO11yUsage(agg *o11yusage.Aggregator) IngestorOptFunc {
+	return func(opts *IngestorOpts) {
+		opts.o11yUsage = agg
+	}
+}
+
 type IngestorImpl struct {
 	contracts.UnimplementedEventsServiceServer
 
@@ -153,6 +162,7 @@ type IngestorImpl struct {
 	analytics analytics.Analytics
 	tw        *trigger.TriggerWriter
 	pubBuffer *msgqueue.MQPubBuffer
+	o11yUsage *o11yusage.Aggregator
 }
 
 func NewIngestor(fs ...IngestorOptFunc) (Ingestor, error) {
@@ -209,6 +219,7 @@ func NewIngestor(fs ...IngestorOptFunc) (Ingestor, error) {
 		localDispatcher:          opts.localDispatcher,
 		tw:                       tw,
 		pubBuffer:                pubBuffer,
+		o11yUsage:                opts.o11yUsage,
 	}, nil
 }
 

--- a/internal/services/ingestor/server_v1.go
+++ b/internal/services/ingestor/server_v1.go
@@ -17,6 +17,7 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 func (i *IngestorImpl) putStreamEventV1(ctx context.Context, tenant *sqlcv1.Tenant, req *contracts.PutStreamEventRequest) (*contracts.PutStreamEventResponse, error) {
@@ -146,6 +147,10 @@ func (i *IngestorImpl) putLogV1(ctx context.Context, tenant *sqlcv1.Tenant, req 
 
 	if err != nil {
 		return nil, err
+	}
+
+	if i.o11yUsage != nil {
+		i.o11yUsage.AddLogs(tenantId, int64(proto.Size(req)))
 	}
 
 	return &contracts.PutLogResponse{}, nil

--- a/internal/services/otelcol/otelcol.go
+++ b/internal/services/otelcol/otelcol.go
@@ -7,6 +7,7 @@ import (
 	collectortracev1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 
 	"github.com/hatchet-dev/hatchet/pkg/analytics"
+	"github.com/hatchet-dev/hatchet/pkg/o11yusage"
 	"github.com/hatchet-dev/hatchet/pkg/repository"
 )
 
@@ -21,6 +22,7 @@ type OTelCollectorOpts struct {
 	l            *zerolog.Logger
 	maxBatchSize int
 	a            analytics.Analytics
+	o11yUsage    *o11yusage.Aggregator
 }
 
 func WithRepository(r repository.Repository) OTelCollectorOpt {
@@ -44,6 +46,12 @@ func WithMaxBatchSize(n int) OTelCollectorOpt {
 func WithAnalytics(a analytics.Analytics) OTelCollectorOpt {
 	return func(opts *OTelCollectorOpts) {
 		opts.a = a
+	}
+}
+
+func WithO11yUsage(agg *o11yusage.Aggregator) OTelCollectorOpt {
+	return func(opts *OTelCollectorOpts) {
+		opts.o11yUsage = agg
 	}
 }
 
@@ -73,5 +81,6 @@ func NewOTelCollector(fs ...OTelCollectorOpt) (OTelCollector, error) {
 		l:            &newLogger,
 		maxBatchSize: opts.maxBatchSize,
 		a:            opts.a,
+		o11yUsage:    opts.o11yUsage,
 	}, nil
 }

--- a/internal/services/otelcol/server.go
+++ b/internal/services/otelcol/server.go
@@ -11,7 +11,10 @@ import (
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 
+	"google.golang.org/protobuf/proto"
+
 	"github.com/hatchet-dev/hatchet/pkg/analytics"
+	"github.com/hatchet-dev/hatchet/pkg/o11yusage"
 	"github.com/hatchet-dev/hatchet/pkg/repository"
 	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
 )
@@ -30,6 +33,7 @@ type otelCollectorImpl struct {
 	l            *zerolog.Logger
 	maxBatchSize int
 	a            analytics.Analytics
+	o11yUsage    *o11yusage.Aggregator
 }
 
 func (oc *otelCollectorImpl) Export(ctx context.Context, req *collectortracev1.ExportTraceServiceRequest) (*collectortracev1.ExportTraceServiceResponse, error) {
@@ -75,6 +79,10 @@ func (oc *otelCollectorImpl) Export(ctx context.Context, req *collectortracev1.E
 				ErrorMessage:  err.Error(),
 			},
 		}, nil
+	}
+
+	if oc.o11yUsage != nil {
+		oc.o11yUsage.AddOtel(tenantId, int64(proto.Size(req)))
 	}
 
 	err = olapRepo.CreateSpanLookupTableEntries(ctx, tenantId, &repository.CreateSpansOpts{

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hatchet-dev/hatchet/pkg/errors"
 	"github.com/hatchet-dev/hatchet/pkg/integrations/email"
 	"github.com/hatchet-dev/hatchet/pkg/integrations/metrics/prometheus"
+	"github.com/hatchet-dev/hatchet/pkg/o11yusage"
 	"github.com/hatchet-dev/hatchet/pkg/scheduling"
 	"github.com/hatchet-dev/hatchet/pkg/validator"
 )
@@ -329,6 +330,10 @@ type ConfigFileRuntime struct {
 
 	// LogIngestionEnabled controls whether the server enables log ingestion for tasks
 	LogIngestionEnabled bool `mapstructure:"logIngestionEnabled" json:"logIngestionEnabled,omitempty" default:"true"`
+
+	// O11yUsageFlushInterval is how often the engine flushes per-tenant ingested
+	// log/span bytes to the optional O11yUsageFlush callback.
+	O11yUsageFlushInterval time.Duration `mapstructure:"o11yUsageFlushInterval" json:"o11yUsageFlushInterval,omitempty" default:"30s"`
 
 	// TaskOperationLimits controls the limits for various task operations
 	TaskOperationLimits TaskOperationLimitsConfigFile `mapstructure:"taskOperationLimits" json:"taskOperationLimits,omitempty"`
@@ -728,6 +733,10 @@ type ServerConfig struct {
 
 	Analytics analytics.Analytics
 
+	// O11yUsageFlush, when set, receives periodic tenant → log/otel byte maps
+	// from the engine. Nil means the aggregator is not started (OSS / self-host).
+	O11yUsageFlush o11yusage.FlushFunc
+
 	Pylon *PylonConfig
 
 	FePosthog *FePosthogConfig
@@ -891,6 +900,7 @@ func BindAllEnv(v *viper.Viper) {
 
 	// log ingestion
 	_ = v.BindEnv("runtime.logIngestionEnabled", "SERVER_LOG_INGESTION_ENABLED")
+	_ = v.BindEnv("runtime.o11yUsageFlushInterval", "SERVER_O11Y_USAGE_FLUSH_INTERVAL")
 
 	// alerting options
 	_ = v.BindEnv("alerting.sentry.enabled", "SERVER_ALERTING_SENTRY_ENABLED")

--- a/pkg/o11yusage/aggregating.go
+++ b/pkg/o11yusage/aggregating.go
@@ -1,0 +1,177 @@
+package o11yusage
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+// Kind is a separately buffered ingest source. Both kinds flush together but
+// stay distinct through to Autumn event names.
+type Kind string
+
+const (
+	KindLogs Kind = "logs"
+	KindOtel Kind = "otel"
+)
+
+func (k Kind) valid() bool {
+	return k == KindLogs || k == KindOtel
+}
+
+// TenantBytes is one tenant's buffered ingest since the last flush.
+type TenantBytes struct {
+	Logs int64 `json:"logs,omitempty"`
+	Otel int64 `json:"otel,omitempty"`
+}
+
+// FlushFunc receives a snapshot of tenant → log/otel bytes since the last flush.
+// A non-nil error is logged and the snapshot is dropped (best-effort undercount).
+type FlushFunc func(tenants map[uuid.UUID]TenantBytes) error
+
+type counterKey struct {
+	TenantID uuid.UUID
+	Kind     Kind
+}
+
+// Aggregator batches per-tenant, per-kind byte counts and flushes them on an
+// interval, the same pattern as analytics.Aggregator. Add is the non-blocking
+// hot path. A nil FlushFunc disables the ticker.
+type Aggregator struct {
+	done     chan struct{}
+	flushFn  FlushFunc
+	l        *zerolog.Logger
+	counters sync.Map
+	wg       sync.WaitGroup
+	interval time.Duration
+	flushMu  sync.Mutex
+	stopOnce sync.Once
+}
+
+// NewAggregator returns an aggregator. If fn is nil, Start is a no-op.
+func NewAggregator(l *zerolog.Logger, interval time.Duration, fn FlushFunc) *Aggregator {
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+
+	return &Aggregator{
+		done:     make(chan struct{}),
+		flushFn:  fn,
+		l:        l,
+		interval: interval,
+	}
+}
+
+// AddLogs increments the tenant's log-ingest counter. Safe on a nil receiver.
+func (a *Aggregator) AddLogs(tenantID uuid.UUID, n int64) {
+	a.Add(tenantID, KindLogs, n)
+}
+
+// AddOtel increments the tenant's OTLP-ingest counter. Safe on a nil receiver.
+func (a *Aggregator) AddOtel(tenantID uuid.UUID, n int64) {
+	a.Add(tenantID, KindOtel, n)
+}
+
+// Add increments the tenant's counter for kind. Safe on a nil receiver.
+func (a *Aggregator) Add(tenantID uuid.UUID, kind Kind, n int64) {
+	if a == nil || a.flushFn == nil || n <= 0 || tenantID == uuid.Nil || !kind.valid() {
+		return
+	}
+
+	key := counterKey{TenantID: tenantID, Kind: kind}
+	if v, ok := a.counters.Load(key); ok {
+		v.(*atomic.Int64).Add(n)
+		return
+	}
+
+	c := &atomic.Int64{}
+	c.Add(n)
+	if existing, loaded := a.counters.LoadOrStore(key, c); loaded {
+		existing.(*atomic.Int64).Add(n)
+	}
+}
+
+// Start runs the flush ticker. Safe on a nil receiver or when no flush func is set.
+func (a *Aggregator) Start() {
+	if a == nil || a.flushFn == nil {
+		return
+	}
+
+	a.wg.Add(1)
+	go func() {
+		defer a.wg.Done()
+		ticker := time.NewTicker(a.interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				a.flush()
+			case <-a.done:
+				a.flush()
+				return
+			}
+		}
+	}()
+}
+
+// Shutdown stops the ticker and flushes remaining counters once.
+func (a *Aggregator) Shutdown() error {
+	if a == nil || a.flushFn == nil {
+		return nil
+	}
+
+	a.stopOnce.Do(func() {
+		close(a.done)
+	})
+	a.wg.Wait()
+	return nil
+}
+
+func (a *Aggregator) flush() {
+	if a.flushFn == nil {
+		return
+	}
+
+	if !a.flushMu.TryLock() {
+		if a.l != nil {
+			a.l.Error().Dur("interval", a.interval).Msg("o11y usage flush still running, skipping interval")
+		}
+		return
+	}
+	defer a.flushMu.Unlock()
+
+	tenants := a.snapshot()
+	if len(tenants) == 0 {
+		return
+	}
+
+	if err := a.flushFn(tenants); err != nil && a.l != nil {
+		a.l.Error().Err(err).Int("tenants", len(tenants)).Msg("o11y usage flush failed, dropping snapshot")
+	}
+}
+
+func (a *Aggregator) snapshot() map[uuid.UUID]TenantBytes {
+	out := make(map[uuid.UUID]TenantBytes)
+	a.counters.Range(func(key, val any) bool {
+		ck := key.(counterKey)
+		n := val.(*atomic.Int64).Swap(0)
+		if n <= 0 {
+			a.counters.Delete(key)
+			return true
+		}
+		cur := out[ck.TenantID]
+		switch ck.Kind {
+		case KindLogs:
+			cur.Logs += n
+		case KindOtel:
+			cur.Otel += n
+		}
+		out[ck.TenantID] = cur
+		return true
+	})
+	return out
+}

--- a/pkg/o11yusage/aggregating_test.go
+++ b/pkg/o11yusage/aggregating_test.go
@@ -1,0 +1,117 @@
+package o11yusage
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+func TestAddNilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var a *Aggregator
+	a.AddLogs(uuid.New(), 10)
+	a.AddOtel(uuid.New(), 10)
+	if err := a.Shutdown(); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+}
+
+func TestFlushKeepsKindsSeparate(t *testing.T) {
+	t.Parallel()
+
+	tenantA := uuid.New()
+	tenantB := uuid.New()
+
+	var got atomic.Value
+	done := make(chan struct{})
+
+	l := zerolog.Nop()
+	a := NewAggregator(&l, time.Hour, func(tenants map[uuid.UUID]TenantBytes) error {
+		got.Store(tenants)
+		close(done)
+		return nil
+	})
+
+	a.AddLogs(tenantA, 100)
+	a.AddLogs(tenantA, 50)
+	a.AddOtel(tenantA, 7)
+	a.AddOtel(tenantB, 3)
+	a.flush()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("flush did not run")
+	}
+
+	tenants, ok := got.Load().(map[uuid.UUID]TenantBytes)
+	if !ok {
+		t.Fatal("expected tenant map")
+	}
+	if tenants[tenantA] != (TenantBytes{Logs: 150, Otel: 7}) {
+		t.Fatalf("tenant A = %+v, want logs=150 otel=7", tenants[tenantA])
+	}
+	if tenants[tenantB] != (TenantBytes{Otel: 3}) {
+		t.Fatalf("tenant B = %+v, want otel=3", tenants[tenantB])
+	}
+
+	a.flush()
+	if v, ok := a.counters.Load(counterKey{TenantID: tenantA, Kind: KindLogs}); ok && v.(*atomic.Int64).Load() != 0 {
+		t.Fatalf("expected counters cleared after flush")
+	}
+}
+
+func TestShutdownFlushes(t *testing.T) {
+	t.Parallel()
+
+	tenantID := uuid.New()
+	var mu sync.Mutex
+	var flushed map[uuid.UUID]TenantBytes
+
+	l := zerolog.Nop()
+	a := NewAggregator(&l, time.Hour, func(tenants map[uuid.UUID]TenantBytes) error {
+		mu.Lock()
+		defer mu.Unlock()
+		flushed = tenants
+		return nil
+	})
+	a.Start()
+	a.AddLogs(tenantID, 42)
+
+	if err := a.Shutdown(); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if flushed[tenantID] != (TenantBytes{Logs: 42}) {
+		t.Fatalf("flushed = %v, want %s logs=42", flushed, tenantID)
+	}
+}
+
+func TestDropOnFlushError(t *testing.T) {
+	t.Parallel()
+
+	tenantID := uuid.New()
+	l := zerolog.Nop()
+	a := NewAggregator(&l, time.Hour, func(tenants map[uuid.UUID]TenantBytes) error {
+		return errFlush
+	})
+	a.AddOtel(tenantID, 9)
+	a.flush()
+
+	if v, ok := a.counters.Load(counterKey{TenantID: tenantID, Kind: KindOtel}); ok && v.(*atomic.Int64).Load() != 0 {
+		t.Fatalf("expected dropped snapshot after flush error, still have %d", v.(*atomic.Int64).Load())
+	}
+}
+
+var errFlush = errString("flush failed")
+
+type errString string
+
+func (e errString) Error() string { return string(e) }


### PR DESCRIPTION
# Description

Batch per-tenant ingested log and OTLP byte counts after persist, and flush them on an interval via an optional callback so embedders can meter ingest without blocking PutLog or Export. A nil callback is a complete no-op.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test changes (add, refactor, improve or change a test)

## What's Changed

- [x] Add `o11yusage.Aggregator` to batch per-tenant log vs OTLP ingest sizes
- [x] Count uncompressed proto size after successful `PutLog` and otelcol `Export`
- [x] Wire optional `ServerConfig.O11yUsageFlush` (default interval 30s, also flushes on shutdown)
- [x] Add unit tests for kind separation, shutdown flush, and drop-on-error

## Checklist

Changes have been:

- [x] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Wrote the aggregator, engine/ingestor/otelcol wiring, and unit tests.

</details>