### PR TITLE
docs: link CEL feature clients on reference overview pages

### DIFF
--- a/frontend/docs/content/docs/reference/go/index.mdx
+++ b/frontend/docs/content/docs/reference/go/index.mdx
@@ -19,7 +19,7 @@ Feature clients are accessed via methods on the [client](/reference/go/client), 
 
 | Client                                                    | Description                                                                   | Guide                                        |
 | --------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------- |
-| [CEL](/reference/go/feature-clients/cel)                  | Evaluate and debug CEL expressions used in event filters and concurrency keys |                                              |
+| [CEL](/reference/go/feature-clients/cel)                  | Evaluate and debug CEL expressions used in event filters and concurrency keys | [CEL Expressions](/v1/cel-expressions)       |
 | [Crons](/reference/go/feature-clients/crons)              | Create and manage cron triggers that run workflows on a schedule              | [Cron Runs](/v1/cron-runs)                   |
 | [Filters](/reference/go/feature-clients/filters)          | Manage event filters that scope which events trigger runs                     | [Events](/v1/events)                         |
 | [Logs](/reference/go/feature-clients/logs)                | Read logs written by task runs                                                | [Logging](/v1/logging)                       |

--- a/frontend/docs/content/docs/reference/python/index.mdx
+++ b/frontend/docs/content/docs/reference/python/index.mdx
@@ -18,7 +18,7 @@ Feature clients are available as properties on the [client](/reference/python/cl
 
 | Client                                                        | Description                                                                   | Guide                                                    |
 | ------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------- |
-| [CEL](/reference/python/feature-clients/cel)                  | Evaluate and debug CEL expressions used in event filters and concurrency keys |                                                          |
+| [CEL](/reference/python/feature-clients/cel)                  | Evaluate and debug CEL expressions used in event filters and concurrency keys | [CEL Expressions](/v1/cel-expressions)                   |
 | [Crons](/reference/python/feature-clients/cron)               | Create and manage cron triggers that run workflows on a schedule              | [Cron Runs](/v1/cron-runs)                               |
 | [Filters](/reference/python/feature-clients/filters)          | Manage event filters that scope which events trigger runs                     | [Events](/v1/events)                                     |
 | [Logs](/reference/python/feature-clients/logs)                | Read logs written by task runs                                                | [Logging](/v1/logging)                                   |

--- a/frontend/docs/content/docs/reference/ruby/index.mdx
+++ b/frontend/docs/content/docs/reference/ruby/index.mdx
@@ -18,7 +18,7 @@ Feature clients are available as methods on the [client](/reference/ruby/client)
 
 | Client                                                      | Description                                                                   | Guide                                        |
 | ----------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------- |
-| [CEL](/reference/ruby/feature-clients/cel)                  | Evaluate and debug CEL expressions used in event filters and concurrency keys |                                              |
+| [CEL](/reference/ruby/feature-clients/cel)                  | Evaluate and debug CEL expressions used in event filters and concurrency keys | [CEL Expressions](/v1/cel-expressions)       |
 | [Crons](/reference/ruby/feature-clients/cron)               | Create and manage cron triggers that run workflows on a schedule              | [Cron Runs](/v1/cron-runs)                   |
 | [Events](/reference/ruby/feature-clients/events)            | Push events and inspect event history                                         | [Events](/v1/events)                         |
 | [Filters](/reference/ruby/feature-clients/filters)          | Manage event filters that scope which events trigger runs                     | [Events](/v1/events)                         |

--- a/frontend/docs/content/docs/reference/typescript/index.mdx
+++ b/frontend/docs/content/docs/reference/typescript/index.mdx
@@ -19,7 +19,7 @@ Feature clients are available as properties on the [client](/reference/typescrip
 
 | Client                                                            | Description                                                                   | Guide                                        |
 | ----------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------- |
-| [CEL](/reference/typescript/feature-clients/cel)                  | Evaluate and debug CEL expressions used in event filters and concurrency keys |                                              |
+| [CEL](/reference/typescript/feature-clients/cel)                  | Evaluate and debug CEL expressions used in event filters and concurrency keys | [CEL Expressions](/v1/cel-expressions)       |
 | [Crons](/reference/typescript/feature-clients/crons)              | Create and manage cron triggers that run workflows on a schedule              | [Cron Runs](/v1/cron-runs)                   |
 | [Filters](/reference/typescript/feature-clients/filters)          | Manage event filters that scope which events trigger runs                     | [Events](/v1/events)                         |
 | [Logs](/reference/typescript/feature-clients/logs)                | Read logs written by task runs                                                | [Logging](/v1/logging)                       |

--- a/frontend/docs/reference-map.json
+++ b/frontend/docs/reference-map.json
@@ -39,8 +39,8 @@
     "cel": {
       "title": "CEL",
       "description": "Evaluate and debug CEL expressions used in event filters and concurrency keys",
-      "guide": null,
-      "guideTitle": null,
+      "guide": "/v1/cel-expressions",
+      "guideTitle": "CEL Expressions",
       "slugs": {
         "python": "cel",
         "typescript": "cel",


### PR DESCRIPTION
# Description

Regenerates the overview pages to include links to the CEL doc. 

## Type of change

- [X] Documentation change (pure documentation change)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Documented (where applicable)
- [X] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [X] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude w/ Fable

</details>
