### PR TITLE
refactor(engine): read core payloads with external id, add unique constraint

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260905022431_v1_0_152.go
+++ b/cmd/hatchet-migrate/migrate/migrations/20260905022431_v1_0_152.go
@@ -1,0 +1,88 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationNoTxContext(upV10152, downV10152)
+}
+
+func v10152IndexName(table string) string {
+	return fmt.Sprintf("%s_external_id_ins_at_uq", table)
+}
+
+func upV10152(ctx context.Context, db *sql.DB) error {
+	table := "v1_payload"
+
+	partitions, err := listLeafPartitions(ctx, db, table, 1)
+
+	if err != nil {
+		return err
+	}
+
+	for _, partition := range partitions {
+		indexName := v10152IndexName(partition)
+		valid, err := indexIsValid(ctx, db, indexName)
+
+		if err != nil {
+			return err
+		}
+
+		if valid {
+			continue
+		}
+
+		if _, err := db.ExecContext(ctx, fmt.Sprintf(`DROP INDEX CONCURRENTLY IF EXISTS %s;`, quoteIdent(indexName))); err != nil {
+			return fmt.Errorf("failed to drop stale index %s: %w", indexName, err)
+		}
+
+		// #nosec G201 -- identifiers are quoted and derived from internal migration logic, not user input
+		buildStmt := fmt.Sprintf(
+			`CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS %s ON %s (external_id ASC, inserted_at ASC);`,
+			quoteIdent(indexName),
+			quoteIdent(partition),
+		)
+
+		if _, err := db.ExecContext(ctx, buildStmt); err != nil {
+			return fmt.Errorf("failed to create index concurrently on %s: %w", partition, err)
+		}
+	}
+
+	// #nosec G201 -- identifiers are quoted and derived from internal migration logic, not user input
+	stmt := fmt.Sprintf("CREATE UNIQUE INDEX IF NOT EXISTS %s ON %s (external_id ASC, inserted_at ASC);", quoteIdent(v10152IndexName(table)), quoteIdent(table))
+
+	if _, err := db.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("failed to create index on %s: %w", table, err)
+	}
+
+	if _, err := db.ExecContext(ctx, "DROP INDEX IF EXISTS v1_payload_external_id_idx;"); err != nil {
+		return fmt.Errorf("failed to drop old index on %s: %w", table, err)
+	}
+
+	for _, partition := range partitions {
+		if _, err := db.ExecContext(ctx, fmt.Sprintf(`DROP INDEX CONCURRENTLY IF EXISTS %s;`, quoteIdent(v1PayloadPartitionIdxName(partition)))); err != nil {
+			return fmt.Errorf("failed to drop old index on %s: %w", partition, err)
+		}
+	}
+
+	return nil
+}
+
+func downV10152(ctx context.Context, db *sql.DB) error {
+	table := "v1_payload"
+
+	if _, err := db.ExecContext(ctx, fmt.Sprintf("DROP INDEX IF EXISTS %s;", quoteIdent(v10152IndexName(table)))); err != nil {
+		return fmt.Errorf("failed to drop index on %s: %w", table, err)
+	}
+
+	if _, err := db.ExecContext(ctx, "CREATE INDEX IF NOT EXISTS v1_payload_external_id_idx ON v1_payload (external_id ASC);"); err != nil {
+		return fmt.Errorf("failed to recreate old index on %s: %w", table, err)
+	}
+
+	return nil
+}

--- a/cmd/hatchet-migrate/migrate/migrations/20260905112431_v1_0_153.go
+++ b/cmd/hatchet-migrate/migrate/migrations/20260905112431_v1_0_153.go
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS v1_payload_new (
 	tenant_id UUID NOT NULL,
 	id BIGINT NOT NULL,
 	inserted_at TIMESTAMPTZ NOT NULL,
-	inserted_at_date DATE NOT NULL DEFAULT CURRENT_TIMESTAMP::DATE,
+	inserted_at_date DATE NOT NULL,
 	external_id UUID NOT NULL DEFAULT gen_random_uuid(),
 	type v1_payload_type NOT NULL,
 	location v1_payload_location NOT NULL,

--- a/cmd/hatchet-migrate/migrate/migrations/20260905112431_v1_0_153.go
+++ b/cmd/hatchet-migrate/migrate/migrations/20260905112431_v1_0_153.go
@@ -9,14 +9,14 @@ import (
 )
 
 func init() {
-	goose.AddMigrationNoTxContext(upV10152, downV10152)
+	goose.AddMigrationNoTxContext(upV10153, downV10153)
 }
 
-func v10152IndexName(table string) string {
+func v10153IndexName(table string) string {
 	return fmt.Sprintf("%s_external_id_ins_at_uq", table)
 }
 
-func upV10152(ctx context.Context, db *sql.DB) error {
+func upV10153(ctx context.Context, db *sql.DB) error {
 	table := "v1_payload"
 
 	partitions, err := listLeafPartitions(ctx, db, table, 1)
@@ -26,7 +26,7 @@ func upV10152(ctx context.Context, db *sql.DB) error {
 	}
 
 	for _, partition := range partitions {
-		indexName := v10152IndexName(partition)
+		indexName := v10153IndexName(partition)
 		valid, err := indexIsValid(ctx, db, indexName)
 
 		if err != nil {
@@ -54,7 +54,7 @@ func upV10152(ctx context.Context, db *sql.DB) error {
 	}
 
 	// #nosec G201 -- identifiers are quoted and derived from internal migration logic, not user input
-	stmt := fmt.Sprintf("CREATE UNIQUE INDEX IF NOT EXISTS %s ON %s (external_id ASC, inserted_at ASC);", quoteIdent(v10152IndexName(table)), quoteIdent(table))
+	stmt := fmt.Sprintf("CREATE UNIQUE INDEX IF NOT EXISTS %s ON %s (external_id ASC, inserted_at ASC);", quoteIdent(v10153IndexName(table)), quoteIdent(table))
 
 	if _, err := db.ExecContext(ctx, stmt); err != nil {
 		return fmt.Errorf("failed to create index on %s: %w", table, err)
@@ -73,10 +73,10 @@ func upV10152(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 
-func downV10152(ctx context.Context, db *sql.DB) error {
+func downV10153(ctx context.Context, db *sql.DB) error {
 	table := "v1_payload"
 
-	if _, err := db.ExecContext(ctx, fmt.Sprintf("DROP INDEX IF EXISTS %s;", quoteIdent(v10152IndexName(table)))); err != nil {
+	if _, err := db.ExecContext(ctx, fmt.Sprintf("DROP INDEX IF EXISTS %s;", quoteIdent(v10153IndexName(table)))); err != nil {
 		return fmt.Errorf("failed to drop index on %s: %w", table, err)
 	}
 

--- a/cmd/hatchet-migrate/migrate/migrations/20260905112431_v1_0_153.go
+++ b/cmd/hatchet-migrate/migrate/migrations/20260905112431_v1_0_153.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/pressly/goose/v3"
 )
@@ -12,76 +14,205 @@ func init() {
 	goose.AddMigrationNoTxContext(upV10153, downV10153)
 }
 
-func v10153IndexName(table string) string {
-	return fmt.Sprintf("%s_external_id_ins_at_uq", table)
+const v1PayloadNewCreateTableSQL = `
+CREATE TABLE IF NOT EXISTS v1_payload_new (
+	tenant_id UUID NOT NULL,
+	id BIGINT NOT NULL,
+	inserted_at TIMESTAMPTZ NOT NULL,
+	inserted_at_date DATE NOT NULL DEFAULT CURRENT_TIMESTAMP::DATE,
+	external_id UUID NOT NULL DEFAULT gen_random_uuid(),
+	type v1_payload_type NOT NULL,
+	location v1_payload_location NOT NULL,
+	external_location_key TEXT,
+	inline_content JSONB,
+	updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+	PRIMARY KEY (external_id, inserted_at_date),
+	-- explicitly named because ATTACH PARTITION matches check constraints by name, so the
+	-- offload swap breaks if the auto-generated name drifts between parent and temp tables
+	CONSTRAINT v1_payload_location_check CHECK (
+		location = 'INLINE'
+		OR
+		(location = 'EXTERNAL' AND inline_content IS NULL AND external_location_key IS NOT NULL)
+	)
+) PARTITION BY RANGE(inserted_at_date)`
+
+const v1PayloadMirrorFnSQL = `CREATE OR REPLACE FUNCTION v1_payload_mirror_fn()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+	IF TG_OP = 'INSERT' THEN
+		INSERT INTO v1_payload_new (
+			tenant_id,
+			id,
+			inserted_at,
+			inserted_at_date,
+			external_id,
+			type,
+			location,
+			external_location_key,
+			inline_content,
+			updated_at
+		) VALUES (
+			NEW.tenant_id,
+			NEW.id,
+			NEW.inserted_at,
+			NEW.inserted_at_date,
+			NEW.external_id,
+			NEW.type,
+			NEW.location,
+			NEW.external_location_key,
+			NEW.inline_content,
+			NEW.updated_at
+		)
+		ON CONFLICT (external_id, inserted_at_date)
+		DO UPDATE SET
+			tenant_id             = EXCLUDED.tenant_id,
+			id                    = EXCLUDED.id,
+			inserted_at           = EXCLUDED.inserted_at,
+			type                  = EXCLUDED.type,
+			location              = EXCLUDED.location,
+			external_location_key = EXCLUDED.external_location_key,
+			inline_content        = EXCLUDED.inline_content,
+			updated_at            = EXCLUDED.updated_at;
+		RETURN NEW;
+	ELSIF TG_OP = 'UPDATE' THEN
+		UPDATE v1_payload_new SET
+			tenant_id             = NEW.tenant_id,
+			id                    = NEW.id,
+			inserted_at           = NEW.inserted_at,
+			type                  = NEW.type,
+			location              = NEW.location,
+			external_location_key = NEW.external_location_key,
+			inline_content        = NEW.inline_content,
+			updated_at            = NEW.updated_at
+		WHERE external_id = NEW.external_id AND inserted_at_date = NEW.inserted_at_date;
+		RETURN NEW;
+	ELSIF TG_OP = 'DELETE' THEN
+		DELETE FROM v1_payload_new
+		WHERE external_id = OLD.external_id AND inserted_at_date = OLD.inserted_at_date;
+		RETURN OLD;
+	END IF;
+	RETURN NULL;
+END;
+$$`
+
+const v1PayloadMirrorTriggerSQL = `CREATE OR REPLACE TRIGGER v1_payload_mirror
+AFTER INSERT OR UPDATE OR DELETE ON v1_payload
+FOR EACH ROW EXECUTE FUNCTION v1_payload_mirror_fn()`
+
+var v1PayloadCols = []string{
+	"tenant_id",
+	"id",
+	"inserted_at",
+	"inserted_at_date",
+	"external_id",
+	"type",
+	"location",
+	"external_location_key",
+	"inline_content",
+	"updated_at",
+}
+
+func v1PayloadPartitionDates(ctx context.Context, db *sql.DB) ([]time.Time, error) {
+	partitions, err := listLeafPartitions(ctx, db, "v1_payload", 1)
+
+	if err != nil {
+		return nil, err
+	}
+
+	dates := make([]time.Time, 0, len(partitions))
+
+	for _, partition := range partitions {
+		suffix := partition[strings.LastIndex(partition, "_")+1:]
+		date, err := time.Parse("20060102", suffix)
+
+		if err != nil {
+			return nil, fmt.Errorf("could not parse partition date from %s: %w", partition, err)
+		}
+
+		dates = append(dates, date)
+	}
+
+	return dates, nil
 }
 
 func upV10153(ctx context.Context, db *sql.DB) error {
-	table := "v1_payload"
+	if _, err := db.ExecContext(ctx, v1PayloadNewCreateTableSQL); err != nil {
+		return fmt.Errorf("create v1_payload_new: %w", err)
+	}
 
-	partitions, err := listLeafPartitions(ctx, db, table, 1)
+	partitionDates, err := v1PayloadPartitionDates(ctx, db)
 
 	if err != nil {
 		return err
 	}
 
+	for _, date := range partitionDates {
+		if _, err := db.ExecContext(ctx, "SELECT create_v1_range_partition('v1_payload_new', $1::date)", date.Format("2006-01-02")); err != nil {
+			return fmt.Errorf("create v1_payload_new partition for %s: %w", date.Format("2006-01-02"), err)
+		}
+	}
+
+	if _, err := db.ExecContext(ctx, v1PayloadMirrorFnSQL); err != nil {
+		return fmt.Errorf("create mirror function: %w", err)
+	}
+
+	if _, err := db.ExecContext(ctx, v1PayloadMirrorTriggerSQL); err != nil {
+		return fmt.Errorf("create mirror trigger: %w", err)
+	}
+
+	partitions, err := listLeafPartitions(ctx, db, "v1_payload", 1)
+
+	if err != nil {
+		return fmt.Errorf("list v1_payload partitions: %w", err)
+	}
+
+	colList := strings.Join(v1PayloadCols, ", ")
+
 	for _, partition := range partitions {
-		indexName := v10153IndexName(partition)
-		valid, err := indexIsValid(ctx, db, indexName)
-
-		if err != nil {
-			return err
-		}
-
-		if valid {
-			continue
-		}
-
-		if _, err := db.ExecContext(ctx, fmt.Sprintf(`DROP INDEX CONCURRENTLY IF EXISTS %s;`, quoteIdent(indexName))); err != nil {
-			return fmt.Errorf("failed to drop stale index %s: %w", indexName, err)
-		}
-
-		// #nosec G201 -- identifiers are quoted and derived from internal migration logic, not user input
-		buildStmt := fmt.Sprintf(
-			`CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS %s ON %s (external_id ASC, inserted_at ASC);`,
-			quoteIdent(indexName),
-			quoteIdent(partition),
+		// #nosec G201 -- table/column identifiers are derived from internal migration logic, not user input
+		insertSQL := fmt.Sprintf(
+			"INSERT INTO v1_payload_new (%s) SELECT %s FROM %s ON CONFLICT DO NOTHING",
+			colList, colList, quoteIdent(partition),
 		)
 
-		if _, err := db.ExecContext(ctx, buildStmt); err != nil {
-			return fmt.Errorf("failed to create index concurrently on %s: %w", partition, err)
+		if _, err := db.ExecContext(ctx, insertSQL); err != nil {
+			return fmt.Errorf("backfill partition %s: %w", partition, err)
 		}
 	}
 
-	// #nosec G201 -- identifiers are quoted and derived from internal migration logic, not user input
-	stmt := fmt.Sprintf("CREATE UNIQUE INDEX IF NOT EXISTS %s ON %s (external_id ASC, inserted_at ASC);", quoteIdent(v10153IndexName(table)), quoteIdent(table))
+	var newCount, existingCount int64
 
-	if _, err := db.ExecContext(ctx, stmt); err != nil {
-		return fmt.Errorf("failed to create index on %s: %w", table, err)
+	if err := db.QueryRowContext(ctx, `
+		WITH counts AS (
+			SELECT
+				(SELECT COUNT(*) FROM v1_payload_new) AS new_count,
+				(SELECT COUNT(*) FROM v1_payload) AS existing_count
+		)
+		SELECT new_count, existing_count
+		FROM counts
+	`).Scan(&newCount, &existingCount); err != nil {
+		return fmt.Errorf("counting rows in v1_payload_new and v1_payload: %w", err)
 	}
 
-	if _, err := db.ExecContext(ctx, "DROP INDEX IF EXISTS v1_payload_external_id_idx;"); err != nil {
-		return fmt.Errorf("failed to drop old index on %s: %w", table, err)
-	}
-
-	for _, partition := range partitions {
-		if _, err := db.ExecContext(ctx, fmt.Sprintf(`DROP INDEX CONCURRENTLY IF EXISTS %s;`, quoteIdent(v1PayloadPartitionIdxName(partition)))); err != nil {
-			return fmt.Errorf("failed to drop old index on %s: %w", partition, err)
-		}
+	if newCount != existingCount {
+		return fmt.Errorf("row count mismatch after backfill: new=%d, existing=%d", newCount, existingCount)
 	}
 
 	return nil
 }
 
 func downV10153(ctx context.Context, db *sql.DB) error {
-	table := "v1_payload"
-
-	if _, err := db.ExecContext(ctx, fmt.Sprintf("DROP INDEX IF EXISTS %s;", quoteIdent(v10153IndexName(table)))); err != nil {
-		return fmt.Errorf("failed to drop index on %s: %w", table, err)
+	if _, err := db.ExecContext(ctx, `DROP TRIGGER IF EXISTS v1_payload_mirror ON v1_payload`); err != nil {
+		return fmt.Errorf("drop mirror trigger: %w", err)
 	}
 
-	if _, err := db.ExecContext(ctx, "CREATE INDEX IF NOT EXISTS v1_payload_external_id_idx ON v1_payload (external_id ASC);"); err != nil {
-		return fmt.Errorf("failed to recreate old index on %s: %w", table, err)
+	if _, err := db.ExecContext(ctx, `DROP FUNCTION IF EXISTS v1_payload_mirror_fn()`); err != nil {
+		return fmt.Errorf("drop mirror function: %w", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS v1_payload_new CASCADE`); err != nil {
+		return fmt.Errorf("drop v1_payload_new: %w", err)
 	}
 
 	return nil

--- a/cmd/hatchet-migrate/migrate/migrations/20260905112435_v1_0_154.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260905112435_v1_0_154.sql
@@ -16,6 +16,8 @@ BEGIN
     ALTER TABLE v1_payload_new RENAME TO v1_payload;
     ALTER INDEX v1_payload_new_pkey RENAME TO v1_payload_pkey;
 
+    ALTER TABLE v1_payload ALTER COLUMN inserted_at_date DROP DEFAULT;
+
     FOR partition_row IN
         SELECT inhrelid::regclass::text AS partition_name
         FROM pg_inherits
@@ -241,6 +243,7 @@ BEGIN
 
     ALTER TABLE v1_payload RENAME TO v1_payload_new;
     ALTER INDEX v1_payload_pkey RENAME TO v1_payload_new_pkey;
+    ALTER TABLE v1_payload_new ALTER COLUMN inserted_at_date SET DEFAULT CURRENT_TIMESTAMP::DATE;
 
     FOR partition_row IN
         SELECT inhrelid::regclass::text AS partition_name

--- a/cmd/hatchet-migrate/migrate/migrations/20260905112435_v1_0_154.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260905112435_v1_0_154.sql
@@ -1,0 +1,619 @@
+-- +goose Up
+-- +goose StatementBegin
+DO $$
+DECLARE
+    partition_row record;
+    renamed_name text;
+BEGIN
+    LOCK TABLE v1_payload IN ACCESS EXCLUSIVE MODE;
+    LOCK TABLE v1_payload_new IN ACCESS EXCLUSIVE MODE;
+
+    DROP TRIGGER IF EXISTS v1_payload_mirror ON v1_payload;
+    DROP FUNCTION IF EXISTS v1_payload_mirror_fn();
+
+    DROP TABLE v1_payload CASCADE;
+
+    ALTER TABLE v1_payload_new RENAME TO v1_payload;
+    ALTER INDEX v1_payload_new_pkey RENAME TO v1_payload_pkey;
+
+    FOR partition_row IN
+        SELECT inhrelid::regclass::text AS partition_name
+        FROM pg_inherits
+        WHERE inhparent = 'v1_payload'::regclass
+    LOOP
+        renamed_name := 'v1_payload_' || substring(partition_row.partition_name from '(\d{8})$');
+        EXECUTE format('ALTER TABLE %I RENAME TO %I', partition_row.partition_name, renamed_name);
+
+        IF to_regclass(partition_row.partition_name || '_pkey') IS NOT NULL THEN
+            EXECUTE format('ALTER INDEX %I RENAME TO %I', partition_row.partition_name || '_pkey', renamed_name || '_pkey');
+        END IF;
+    END LOOP;
+END;
+$$;
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION copy_v1_payload_partition_structure(
+    partition_date date
+) RETURNS text
+    LANGUAGE plpgsql AS
+$$
+DECLARE
+    partition_date_str varchar;
+    source_partition_name varchar;
+    target_table_name varchar;
+    trigger_function_name varchar;
+    trigger_name varchar;
+    partition_start date;
+    partition_end date;
+BEGIN
+    SELECT to_char(partition_date, 'YYYYMMDD') INTO partition_date_str;
+    SELECT format('v1_payload_%s', partition_date_str) INTO source_partition_name;
+    SELECT format('v1_payload_offload_tmp_%s', partition_date_str) INTO target_table_name;
+    SELECT format('sync_to_%s', target_table_name) INTO trigger_function_name;
+    SELECT format('trigger_sync_to_%s', target_table_name) INTO trigger_name;
+    partition_start := partition_date;
+    partition_end := partition_date + INTERVAL '1 day';
+
+    IF NOT EXISTS (SELECT 1 FROM pg_tables WHERE tablename = source_partition_name) THEN
+        RAISE EXCEPTION 'Source partition % does not exist', source_partition_name;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = target_table_name) THEN
+        RAISE NOTICE 'Target table % already exists, skipping creation', target_table_name;
+        RETURN target_table_name;
+    END IF;
+
+    EXECUTE format(
+        'CREATE TABLE %I (LIKE %I INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING INDEXES)',
+        target_table_name,
+        source_partition_name
+    );
+
+    EXECUTE format('
+        ALTER TABLE %I
+        ADD CONSTRAINT %I
+        CHECK (
+            inserted_at_date IS NOT NULL
+            AND inserted_at_date >= %L::DATE
+            AND inserted_at_date < %L::DATE
+        )
+        ',
+        target_table_name,
+        target_table_name || '_iat_chk_bounds',
+        partition_start,
+        partition_end
+    );
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I() RETURNS trigger
+            LANGUAGE plpgsql AS $func$
+        BEGIN
+            IF TG_OP = ''INSERT'' THEN
+                INSERT INTO %I (tenant_id, id, inserted_at, inserted_at_date, external_id, type, location, external_location_key, inline_content, updated_at)
+                VALUES (NEW.tenant_id, NEW.id, NEW.inserted_at, NEW.inserted_at_date, NEW.external_id, NEW.type, NEW.location, NEW.external_location_key, NEW.inline_content, NEW.updated_at)
+                ON CONFLICT (external_id, inserted_at_date) DO UPDATE
+                SET
+                    location = EXCLUDED.location,
+                    external_location_key = EXCLUDED.external_location_key,
+                    inline_content = EXCLUDED.inline_content,
+                    updated_at = EXCLUDED.updated_at;
+                RETURN NEW;
+            ELSIF TG_OP = ''UPDATE'' THEN
+                UPDATE %I
+                SET
+                    location = NEW.location,
+                    external_location_key = NEW.external_location_key,
+                    inline_content = NEW.inline_content,
+                    updated_at = NEW.updated_at
+                WHERE
+                    external_id = NEW.external_id
+                    AND inserted_at_date = NEW.inserted_at_date;
+                RETURN NEW;
+            ELSIF TG_OP = ''DELETE'' THEN
+                DELETE FROM %I
+                WHERE
+                    external_id = OLD.external_id
+                    AND inserted_at_date = OLD.inserted_at_date;
+                RETURN OLD;
+            END IF;
+            RETURN NULL;
+        END;
+        $func$;
+    ', trigger_function_name, target_table_name, target_table_name, target_table_name);
+
+    EXECUTE format('DROP TRIGGER IF EXISTS %I ON %I', trigger_name, source_partition_name);
+
+    EXECUTE format('
+        CREATE TRIGGER %I
+        AFTER INSERT OR UPDATE OR DELETE ON %I
+        FOR EACH ROW
+        EXECUTE FUNCTION %I();
+    ', trigger_name, source_partition_name, trigger_function_name);
+
+    RAISE NOTICE 'Created table % as a copy of partition % with sync trigger', target_table_name, source_partition_name;
+
+    RETURN target_table_name;
+END;
+$$;
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION swap_v1_payload_partition_with_temp(
+    partition_date date
+) RETURNS text
+    LANGUAGE plpgsql AS
+$$
+DECLARE
+    partition_date_str varchar;
+    source_partition_name varchar;
+    temp_table_name varchar;
+    old_pk_name varchar;
+    new_pk_name varchar;
+    partition_start date;
+    partition_end date;
+    trigger_function_name varchar;
+    trigger_name varchar;
+BEGIN
+    IF partition_date IS NULL THEN
+        RAISE EXCEPTION 'partition_date parameter cannot be NULL';
+    END IF;
+
+    SELECT to_char(partition_date, 'YYYYMMDD') INTO partition_date_str;
+    SELECT format('v1_payload_%s', partition_date_str) INTO source_partition_name;
+    SELECT format('v1_payload_offload_tmp_%s', partition_date_str) INTO temp_table_name;
+    SELECT format('v1_payload_offload_tmp_%s_pkey', partition_date_str) INTO old_pk_name;
+    SELECT format('v1_payload_%s_pkey', partition_date_str) INTO new_pk_name;
+    SELECT format('sync_to_%s', temp_table_name) INTO trigger_function_name;
+    SELECT format('trigger_sync_to_%s', temp_table_name) INTO trigger_name;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_tables WHERE tablename = temp_table_name) THEN
+        RAISE EXCEPTION 'Temp table % does not exist', temp_table_name;
+    END IF;
+
+    partition_start := partition_date;
+    partition_end := partition_date + INTERVAL '1 day';
+
+    EXECUTE format(
+        'ALTER TABLE %I SET (
+            autovacuum_vacuum_scale_factor = ''0.1'',
+            autovacuum_analyze_scale_factor = ''0.05'',
+            autovacuum_vacuum_threshold = ''25'',
+            autovacuum_analyze_threshold = ''25'',
+            autovacuum_vacuum_cost_delay = ''10'',
+            autovacuum_vacuum_cost_limit = ''1000''
+        )',
+        temp_table_name
+    );
+    RAISE NOTICE 'Set autovacuum settings on partition %', temp_table_name;
+
+    LOCK TABLE v1_payload IN ACCESS EXCLUSIVE MODE;
+
+    RAISE NOTICE 'Dropping trigger from partition %', source_partition_name;
+    EXECUTE format('DROP TRIGGER IF EXISTS %I ON %I', trigger_name, source_partition_name);
+
+    RAISE NOTICE 'Dropping trigger function %', trigger_function_name;
+    EXECUTE format('DROP FUNCTION IF EXISTS %I()', trigger_function_name);
+
+    IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = source_partition_name) THEN
+        RAISE NOTICE 'Dropping old partition %', source_partition_name;
+        EXECUTE format('ALTER TABLE v1_payload DETACH PARTITION %I', source_partition_name);
+        EXECUTE format('DROP TABLE %I CASCADE', source_partition_name);
+    END IF;
+
+    RAISE NOTICE 'Renaming primary key % to %', old_pk_name, new_pk_name;
+    EXECUTE format('ALTER INDEX %I RENAME TO %I', old_pk_name, new_pk_name);
+
+    RAISE NOTICE 'Renaming temp table % to %', temp_table_name, source_partition_name;
+    EXECUTE format('ALTER TABLE %I RENAME TO %I', temp_table_name, source_partition_name);
+
+    RAISE NOTICE 'Attaching new partition % to v1_payload', source_partition_name;
+    EXECUTE format(
+        'ALTER TABLE v1_payload ATTACH PARTITION %I FOR VALUES FROM (%L) TO (%L)',
+        source_partition_name,
+        partition_start,
+        partition_end
+    );
+
+    RAISE NOTICE 'Dropping hack check constraint';
+    EXECUTE format(
+        'ALTER TABLE %I DROP CONSTRAINT %I',
+        source_partition_name,
+        temp_table_name || '_iat_chk_bounds'
+    );
+
+    RAISE NOTICE 'Successfully swapped partition %', source_partition_name;
+    RETURN source_partition_name;
+END;
+$$;
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP FUNCTION IF EXISTS diff_payload_source_and_target_partitions(date);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DO $migration$
+DECLARE
+    partition_row record;
+    renamed_name text;
+    partition_date date;
+BEGIN
+    LOCK TABLE v1_payload IN ACCESS EXCLUSIVE MODE;
+
+    ALTER TABLE v1_payload RENAME TO v1_payload_new;
+    ALTER INDEX v1_payload_pkey RENAME TO v1_payload_new_pkey;
+
+    FOR partition_row IN
+        SELECT inhrelid::regclass::text AS partition_name
+        FROM pg_inherits
+        WHERE inhparent = 'v1_payload_new'::regclass
+    LOOP
+        renamed_name := 'v1_payload_new_' || substring(partition_row.partition_name from '(\d{8})$');
+        EXECUTE format('ALTER TABLE %I RENAME TO %I', partition_row.partition_name, renamed_name);
+
+        IF to_regclass(partition_row.partition_name || '_pkey') IS NOT NULL THEN
+            EXECUTE format('ALTER INDEX %I RENAME TO %I', partition_row.partition_name || '_pkey', renamed_name || '_pkey');
+        END IF;
+    END LOOP;
+
+    CREATE TABLE v1_payload (
+        tenant_id UUID NOT NULL,
+        id BIGINT NOT NULL,
+        inserted_at TIMESTAMPTZ NOT NULL,
+        inserted_at_date DATE NOT NULL DEFAULT CURRENT_TIMESTAMP::DATE,
+        external_id UUID NOT NULL DEFAULT gen_random_uuid(),
+        type v1_payload_type NOT NULL,
+        location v1_payload_location NOT NULL,
+        external_location_key TEXT,
+        inline_content JSONB,
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+        PRIMARY KEY (tenant_id, inserted_at, id, type),
+        CONSTRAINT v1_payload_check CHECK (
+            location = 'INLINE'
+            OR
+            (location = 'EXTERNAL' AND inline_content IS NULL AND external_location_key IS NOT NULL)
+        )
+    ) PARTITION BY RANGE(inserted_at);
+
+    FOR partition_row IN
+        SELECT inhrelid::regclass::text AS partition_name
+        FROM pg_inherits
+        WHERE inhparent = 'v1_payload_new'::regclass
+    LOOP
+        partition_date := to_date(substring(partition_row.partition_name from '(\d{8})$'), 'YYYYMMDD');
+        PERFORM create_v1_range_partition('v1_payload', partition_date);
+    END LOOP;
+
+    INSERT INTO v1_payload (tenant_id, id, inserted_at, inserted_at_date, external_id, type, location, external_location_key, inline_content, updated_at)
+    SELECT tenant_id, id, inserted_at, inserted_at_date, external_id, type, location, external_location_key, inline_content, updated_at
+    FROM v1_payload_new;
+
+    CREATE INDEX v1_payload_external_id_idx ON v1_payload (external_id ASC);
+END;
+$migration$;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION v1_payload_mirror_fn()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+	IF TG_OP = 'INSERT' THEN
+		INSERT INTO v1_payload_new (
+			tenant_id,
+			id,
+			inserted_at,
+			inserted_at_date,
+			external_id,
+			type,
+			location,
+			external_location_key,
+			inline_content,
+			updated_at
+		) VALUES (
+			NEW.tenant_id,
+			NEW.id,
+			NEW.inserted_at,
+			NEW.inserted_at_date,
+			NEW.external_id,
+			NEW.type,
+			NEW.location,
+			NEW.external_location_key,
+			NEW.inline_content,
+			NEW.updated_at
+		)
+		ON CONFLICT (external_id, inserted_at_date)
+		DO UPDATE SET
+			tenant_id             = EXCLUDED.tenant_id,
+			id                    = EXCLUDED.id,
+			inserted_at           = EXCLUDED.inserted_at,
+			type                  = EXCLUDED.type,
+			location              = EXCLUDED.location,
+			external_location_key = EXCLUDED.external_location_key,
+			inline_content        = EXCLUDED.inline_content,
+			updated_at            = EXCLUDED.updated_at;
+		RETURN NEW;
+	ELSIF TG_OP = 'UPDATE' THEN
+		UPDATE v1_payload_new SET
+			tenant_id             = NEW.tenant_id,
+			id                    = NEW.id,
+			inserted_at           = NEW.inserted_at,
+			type                  = NEW.type,
+			location              = NEW.location,
+			external_location_key = NEW.external_location_key,
+			inline_content        = NEW.inline_content,
+			updated_at            = NEW.updated_at
+		WHERE external_id = NEW.external_id AND inserted_at_date = NEW.inserted_at_date;
+		RETURN NEW;
+	ELSIF TG_OP = 'DELETE' THEN
+		DELETE FROM v1_payload_new
+		WHERE external_id = OLD.external_id AND inserted_at_date = OLD.inserted_at_date;
+		RETURN OLD;
+	END IF;
+	RETURN NULL;
+END;
+$$;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE TRIGGER v1_payload_mirror
+AFTER INSERT OR UPDATE OR DELETE ON v1_payload
+FOR EACH ROW EXECUTE FUNCTION v1_payload_mirror_fn();
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION copy_v1_payload_partition_structure(
+    partition_date date
+) RETURNS text
+    LANGUAGE plpgsql AS
+$$
+DECLARE
+    partition_date_str varchar;
+    source_partition_name varchar;
+    target_table_name varchar;
+    trigger_function_name varchar;
+    trigger_name varchar;
+    partition_start date;
+    partition_end date;
+BEGIN
+    SELECT to_char(partition_date, 'YYYYMMDD') INTO partition_date_str;
+    SELECT format('v1_payload_%s', partition_date_str) INTO source_partition_name;
+    SELECT format('v1_payload_offload_tmp_%s', partition_date_str) INTO target_table_name;
+    SELECT format('sync_to_%s', target_table_name) INTO trigger_function_name;
+    SELECT format('trigger_sync_to_%s', target_table_name) INTO trigger_name;
+    partition_start := partition_date;
+    partition_end := partition_date + INTERVAL '1 day';
+
+    IF NOT EXISTS (SELECT 1 FROM pg_tables WHERE tablename = source_partition_name) THEN
+        RAISE EXCEPTION 'Source partition % does not exist', source_partition_name;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = target_table_name) THEN
+        RAISE NOTICE 'Target table % already exists, skipping creation', target_table_name;
+        RETURN target_table_name;
+    END IF;
+
+    EXECUTE format(
+        'CREATE TABLE %I (LIKE %I INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING INDEXES)',
+        target_table_name,
+        source_partition_name
+    );
+
+    EXECUTE format('
+        ALTER TABLE %I
+        ADD CONSTRAINT %I
+        CHECK (
+            inserted_at IS NOT NULL
+            AND inserted_at >= %L::TIMESTAMPTZ
+            AND inserted_at < %L::TIMESTAMPTZ
+        )
+        ',
+        target_table_name,
+        target_table_name || '_iat_chk_bounds',
+        partition_start,
+        partition_end
+    );
+
+    EXECUTE format('
+        CREATE OR REPLACE FUNCTION %I() RETURNS trigger
+            LANGUAGE plpgsql AS $func$
+        BEGIN
+            IF TG_OP = ''INSERT'' THEN
+                INSERT INTO %I (tenant_id, id, inserted_at, external_id, type, location, external_location_key, inline_content, updated_at)
+                VALUES (NEW.tenant_id, NEW.id, NEW.inserted_at, NEW.external_id, NEW.type, NEW.location, NEW.external_location_key, NEW.inline_content, NEW.updated_at)
+                ON CONFLICT (tenant_id, id, inserted_at, type) DO UPDATE
+                SET
+                    location = EXCLUDED.location,
+                    external_location_key = EXCLUDED.external_location_key,
+                    inline_content = EXCLUDED.inline_content,
+                    updated_at = EXCLUDED.updated_at;
+                RETURN NEW;
+            ELSIF TG_OP = ''UPDATE'' THEN
+                UPDATE %I
+                SET
+                    location = NEW.location,
+                    external_location_key = NEW.external_location_key,
+                    inline_content = NEW.inline_content,
+                    updated_at = NEW.updated_at
+                WHERE
+                    tenant_id = NEW.tenant_id
+                    AND id = NEW.id
+                    AND inserted_at = NEW.inserted_at
+                    AND type = NEW.type;
+                RETURN NEW;
+            ELSIF TG_OP = ''DELETE'' THEN
+                DELETE FROM %I
+                WHERE
+                    tenant_id = OLD.tenant_id
+                    AND id = OLD.id
+                    AND inserted_at = OLD.inserted_at
+                    AND type = OLD.type;
+                RETURN OLD;
+            END IF;
+            RETURN NULL;
+        END;
+        $func$;
+    ', trigger_function_name, target_table_name, target_table_name, target_table_name);
+
+    EXECUTE format('DROP TRIGGER IF EXISTS %I ON %I', trigger_name, source_partition_name);
+
+    EXECUTE format('
+        CREATE TRIGGER %I
+        AFTER INSERT OR UPDATE OR DELETE ON %I
+        FOR EACH ROW
+        EXECUTE FUNCTION %I();
+    ', trigger_name, source_partition_name, trigger_function_name);
+
+    RAISE NOTICE 'Created table % as a copy of partition % with sync trigger', target_table_name, source_partition_name;
+
+    RETURN target_table_name;
+END;
+$$;
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION swap_v1_payload_partition_with_temp(
+    partition_date date
+) RETURNS text
+    LANGUAGE plpgsql AS
+$$
+DECLARE
+    partition_date_str varchar;
+    source_partition_name varchar;
+    temp_table_name varchar;
+    old_pk_name varchar;
+    new_pk_name varchar;
+    old_ext_id_idx_name varchar;
+    new_ext_id_idx_name varchar;
+    partition_start date;
+    partition_end date;
+    trigger_function_name varchar;
+    trigger_name varchar;
+BEGIN
+    IF partition_date IS NULL THEN
+        RAISE EXCEPTION 'partition_date parameter cannot be NULL';
+    END IF;
+
+    SELECT to_char(partition_date, 'YYYYMMDD') INTO partition_date_str;
+    SELECT format('v1_payload_%s', partition_date_str) INTO source_partition_name;
+    SELECT format('v1_payload_offload_tmp_%s', partition_date_str) INTO temp_table_name;
+    SELECT format('v1_payload_offload_tmp_%s_pkey', partition_date_str) INTO old_pk_name;
+    SELECT format('v1_payload_%s_pkey', partition_date_str) INTO new_pk_name;
+    SELECT format('v1_payload_offload_tmp_%s_external_id_idx', partition_date_str) INTO old_ext_id_idx_name;
+    SELECT format('v1_payload_%s_external_id_idx', partition_date_str) INTO new_ext_id_idx_name;
+    SELECT format('sync_to_%s', temp_table_name) INTO trigger_function_name;
+    SELECT format('trigger_sync_to_%s', temp_table_name) INTO trigger_name;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_tables WHERE tablename = temp_table_name) THEN
+        RAISE EXCEPTION 'Temp table % does not exist', temp_table_name;
+    END IF;
+
+    partition_start := partition_date;
+    partition_end := partition_date + INTERVAL '1 day';
+
+    EXECUTE format(
+        'ALTER TABLE %I SET (
+            autovacuum_vacuum_scale_factor = ''0.1'',
+            autovacuum_analyze_scale_factor = ''0.05'',
+            autovacuum_vacuum_threshold = ''25'',
+            autovacuum_analyze_threshold = ''25'',
+            autovacuum_vacuum_cost_delay = ''10'',
+            autovacuum_vacuum_cost_limit = ''1000''
+        )',
+        temp_table_name
+    );
+    RAISE NOTICE 'Set autovacuum settings on partition %', temp_table_name;
+
+    LOCK TABLE v1_payload IN ACCESS EXCLUSIVE MODE;
+
+    RAISE NOTICE 'Dropping trigger from partition %', source_partition_name;
+    EXECUTE format('DROP TRIGGER IF EXISTS %I ON %I', trigger_name, source_partition_name);
+
+    RAISE NOTICE 'Dropping trigger function %', trigger_function_name;
+    EXECUTE format('DROP FUNCTION IF EXISTS %I()', trigger_function_name);
+
+    IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = source_partition_name) THEN
+        RAISE NOTICE 'Dropping old partition %', source_partition_name;
+        EXECUTE format('ALTER TABLE v1_payload DETACH PARTITION %I', source_partition_name);
+        EXECUTE format('DROP TABLE %I CASCADE', source_partition_name);
+    END IF;
+
+    RAISE NOTICE 'Renaming primary key % to %', old_pk_name, new_pk_name;
+    EXECUTE format('ALTER INDEX %I RENAME TO %I', old_pk_name, new_pk_name);
+
+    RAISE NOTICE 'Renaming external_id index % to %', old_ext_id_idx_name, new_ext_id_idx_name;
+    EXECUTE format('ALTER INDEX %I RENAME TO %I', old_ext_id_idx_name, new_ext_id_idx_name);
+
+    RAISE NOTICE 'Renaming temp table % to %', temp_table_name, source_partition_name;
+    EXECUTE format('ALTER TABLE %I RENAME TO %I', temp_table_name, source_partition_name);
+
+    RAISE NOTICE 'Attaching new partition % to v1_payload', source_partition_name;
+    EXECUTE format(
+        'ALTER TABLE v1_payload ATTACH PARTITION %I FOR VALUES FROM (%L) TO (%L)',
+        source_partition_name,
+        partition_start,
+        partition_end
+    );
+
+    RAISE NOTICE 'Dropping hack check constraint';
+    EXECUTE format(
+        'ALTER TABLE %I DROP CONSTRAINT %I',
+        source_partition_name,
+        temp_table_name || '_iat_chk_bounds'
+    );
+
+    RAISE NOTICE 'Successfully swapped partition %', source_partition_name;
+    RETURN source_partition_name;
+END;
+$$;
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP FUNCTION IF EXISTS diff_payload_source_and_target_partitions(date);
+CREATE OR REPLACE FUNCTION diff_payload_source_and_target_partitions(
+    partition_date date
+) RETURNS TABLE (
+    tenant_id UUID,
+    id BIGINT,
+    inserted_at TIMESTAMPTZ,
+    external_id UUID,
+    type v1_payload_type,
+    location v1_payload_location,
+    external_location_key TEXT,
+    inline_content JSONB,
+    updated_at TIMESTAMPTZ
+)
+    LANGUAGE plpgsql AS
+$$
+DECLARE
+    partition_date_str varchar;
+    source_partition_name varchar;
+    temp_partition_name varchar;
+    query text;
+BEGIN
+    IF partition_date IS NULL THEN
+        RAISE EXCEPTION 'partition_date parameter cannot be NULL';
+    END IF;
+
+    SELECT to_char(partition_date, 'YYYYMMDD') INTO partition_date_str;
+    SELECT format('v1_payload_%s', partition_date_str) INTO source_partition_name;
+    SELECT format('v1_payload_offload_tmp_%s', partition_date_str) INTO temp_partition_name;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_tables WHERE tablename = source_partition_name) THEN
+        RAISE EXCEPTION 'Partition % does not exist', source_partition_name;
+    END IF;
+
+    query := format('
+        SELECT tenant_id, id, inserted_at, external_id, type, location, external_location_key, inline_content, updated_at
+        FROM %I source
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM %I AS target
+            WHERE
+                source.tenant_id = target.tenant_id
+                AND source.inserted_at = target.inserted_at
+                AND source.id = target.id
+                AND source.type = target.type
+        )
+    ', source_partition_name, temp_partition_name);
+
+    RETURN QUERY EXECUTE query;
+END;
+$$;
+-- +goose StatementEnd

--- a/cmd/hatchet-migrate/migrate/migrations/20260905112435_v1_0_154.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260905112435_v1_0_154.sql
@@ -16,8 +16,6 @@ BEGIN
     ALTER TABLE v1_payload_new RENAME TO v1_payload;
     ALTER INDEX v1_payload_new_pkey RENAME TO v1_payload_pkey;
 
-    ALTER TABLE v1_payload ALTER COLUMN inserted_at_date DROP DEFAULT;
-
     FOR partition_row IN
         SELECT inhrelid::regclass::text AS partition_name
         FROM pg_inherits
@@ -243,7 +241,6 @@ BEGIN
 
     ALTER TABLE v1_payload RENAME TO v1_payload_new;
     ALTER INDEX v1_payload_pkey RENAME TO v1_payload_new_pkey;
-    ALTER TABLE v1_payload_new ALTER COLUMN inserted_at_date SET DEFAULT CURRENT_TIMESTAMP::DATE;
 
     FOR partition_row IN
         SELECT inhrelid::regclass::text AS partition_name

--- a/internal/services/dispatcher/dag_parent_outputs_test.go
+++ b/internal/services/dispatcher/dag_parent_outputs_test.go
@@ -13,11 +13,11 @@ import (
 	v1 "github.com/hatchet-dev/hatchet/pkg/repository"
 )
 
-func newDagChildInput(t *testing.T, taskId int64, parentExternalIds ...uuid.UUID) *dagChildTaskInput {
+func newDagChildInput(t *testing.T, parentExternalIds ...uuid.UUID) *dagChildTaskInput {
 	t.Helper()
 
 	return &dagChildTaskInput{
-		payloadKey: v1.RetrievePayloadOpts{Id: taskId},
+		payloadKey: v1.RetrievePayloadOpts{ExternalId: uuid.New()},
 		currInput: &v1.V1StepRunData{
 			DagParentTaskRunIds: parentExternalIds,
 		},
@@ -58,8 +58,8 @@ func TestResolveDagParentOutputs_PopulatesParentsFromBatch(t *testing.T) {
 	// taskX depends on both parentA and parentB; taskY depends only on parentB. This mirrors
 	// what populateTaskData builds: a single dagParentOutputs batch shared across every
 	// dag-child task in the dispatch batch, each pulling out only its own parents.
-	taskX := newDagChildInput(t, 1, parentA, parentB)
-	taskY := newDagChildInput(t, 2, parentB)
+	taskX := newDagChildInput(t, parentA, parentB)
+	taskY := newDagChildInput(t, parentB)
 
 	dagParentOutputs := map[uuid.UUID]*v1.TaskOutputEvent{
 		parentA: parentOutputEvent(t, parentA, "step_a", map[string]int{"random_number": 1}),
@@ -88,8 +88,8 @@ func TestResolveDagParentOutputs_DoesNotLeakAcrossDifferentDagRuns(t *testing.T)
 	runOneParent := uuid.New()
 	runTwoParent := uuid.New()
 
-	runOneChild := newDagChildInput(t, 1, runOneParent)
-	runTwoChild := newDagChildInput(t, 2, runTwoParent)
+	runOneChild := newDagChildInput(t, runOneParent)
+	runTwoChild := newDagChildInput(t, runTwoParent)
 
 	dagParentOutputs := map[uuid.UUID]*v1.TaskOutputEvent{
 		runOneParent: parentOutputEvent(t, runOneParent, "start", map[string]int{"random_number": 1}),
@@ -116,8 +116,8 @@ func TestResolveDagParentOutputs_IsolatesMissingOrUnparsableParents(t *testing.T
 	missingParent := uuid.New()
 	malformedParent := uuid.New()
 
-	affected := newDagChildInput(t, 1, goodParent, missingParent, malformedParent)
-	sibling := newDagChildInput(t, 2, goodParent)
+	affected := newDagChildInput(t, goodParent, missingParent, malformedParent)
+	sibling := newDagChildInput(t, goodParent)
 
 	dagParentOutputs := map[uuid.UUID]*v1.TaskOutputEvent{
 		goodParent: parentOutputEvent(t, goodParent, "good", map[string]int{"random_number": 7}),

--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -839,9 +839,7 @@ func (d *DispatcherImpl) populateTaskData(
 
 	for i, task := range bulkDatas {
 		retrievePayloadOpts[i] = v1.RetrievePayloadOpts{
-			Id:         task.ID,
 			InsertedAt: task.InsertedAt,
-			Type:       sqlcv1.V1PayloadTypeTASKINPUT,
 			TenantId:   task.TenantID,
 			ExternalId: task.ExternalID,
 		}
@@ -875,9 +873,7 @@ func (d *DispatcherImpl) populateTaskData(
 
 	for _, task := range bulkDatas {
 		payloadKey := v1.RetrievePayloadOpts{
-			Id:         task.ID,
 			InsertedAt: task.InsertedAt,
-			Type:       sqlcv1.V1PayloadTypeTASKINPUT,
 			TenantId:   task.TenantID,
 			ExternalId: task.ExternalID,
 		}
@@ -970,9 +966,7 @@ func (d *DispatcherImpl) populateTaskData(
 
 	for _, task := range bulkDatas {
 		input, ok := inputs[v1.RetrievePayloadOpts{
-			Id:         task.ID,
 			InsertedAt: task.InsertedAt,
-			Type:       sqlcv1.V1PayloadTypeTASKINPUT,
 			TenantId:   task.TenantID,
 			ExternalId: task.ExternalID,
 		}]

--- a/pkg/repository/durable_events.go
+++ b/pkg/repository/durable_events.go
@@ -723,9 +723,7 @@ func (r *durableEventsRepository) GetSatisfiedDurableEvents(ctx context.Context,
 
 	for i, row := range rows {
 		retrievePayloadOpts[i] = RetrievePayloadOpts{
-			Id:         row.ID,
 			InsertedAt: row.InsertedAt,
-			Type:       sqlcv1.V1PayloadTypeDURABLEEVENTLOGENTRYRESULTDATA,
 			TenantId:   tenantId,
 			ExternalId: row.ResultPayloadExternalID,
 		}
@@ -741,9 +739,7 @@ func (r *durableEventsRepository) GetSatisfiedDurableEvents(ctx context.Context,
 
 	for _, row := range rows {
 		retrieveOpt := RetrievePayloadOpts{
-			Id:         row.ID,
 			InsertedAt: row.InsertedAt,
-			Type:       sqlcv1.V1PayloadTypeDURABLEEVENTLOGENTRYRESULTDATA,
 			TenantId:   tenantId,
 			ExternalId: row.ResultPayloadExternalID,
 		}
@@ -1248,9 +1244,7 @@ func (r *durableEventsRepository) getOrCreateEventLogEntriesForTasks(
 	for _, state := range survivingStates {
 		for _, entry := range state.existedEntries {
 			retrieveOpts = append(retrieveOpts, RetrievePayloadOpts{
-				Id:         entry.ID,
 				InsertedAt: entry.InsertedAt,
-				Type:       sqlcv1.V1PayloadTypeDURABLEEVENTLOGENTRYRESULTDATA,
 				TenantId:   state.opts.TenantId,
 				ExternalId: entry.ResultPayloadExternalID,
 			})
@@ -1258,9 +1252,7 @@ func (r *durableEventsRepository) getOrCreateEventLogEntriesForTasks(
 
 		for _, entry := range state.skipEntryByChildId {
 			retrieveOpts = append(retrieveOpts, RetrievePayloadOpts{
-				Id:         entry.ID,
 				InsertedAt: entry.InsertedAt,
-				Type:       sqlcv1.V1PayloadTypeDURABLEEVENTLOGENTRYRESULTDATA,
 				TenantId:   state.opts.TenantId,
 				ExternalId: entry.ResultPayloadExternalID,
 			})
@@ -1282,9 +1274,7 @@ func (r *durableEventsRepository) getOrCreateEventLogEntriesForTasks(
 		}
 
 		return existingPayloads[RetrievePayloadOpts{
-			Id:         e.ID,
 			InsertedAt: e.InsertedAt,
-			Type:       sqlcv1.V1PayloadTypeDURABLEEVENTLOGENTRYRESULTDATA,
 			TenantId:   tenantId,
 			ExternalId: e.ResultPayloadExternalID,
 		}]
@@ -2190,9 +2180,7 @@ func (r *durableEventsRepository) enrichNonDeterminismErrorDetail(ctx context.Co
 	}
 
 	retrieveOpts := RetrievePayloadOpts{
-		Id:         nde.ExistingEntryId,
 		InsertedAt: nde.ExistingEntryInsertedAt,
-		Type:       sqlcv1.V1PayloadTypeDURABLEEVENTLOGENTRYDATA,
 		TenantId:   nde.ExistingEntryTenantId,
 		ExternalId: nde.ExistingEntryExternalId,
 	}
@@ -2596,9 +2584,7 @@ func (r *durableEventsRepository) handleEventLookback(ctx context.Context, tenan
 
 	for _, row := range previousEventsFound {
 		retrievePayloadOpts = append(retrievePayloadOpts, RetrievePayloadOpts{
-			Id:         row.ID,
 			InsertedAt: row.SeenAt,
-			Type:       sqlcv1.V1PayloadTypeUSEREVENTINPUT,
 			TenantId:   tenantId,
 			ExternalId: row.ExternalID,
 		})
@@ -2614,9 +2600,7 @@ func (r *durableEventsRepository) handleEventLookback(ctx context.Context, tenan
 
 	for _, row := range previousEventsFound {
 		retrieveOpts := RetrievePayloadOpts{
-			Id:         row.ID,
 			InsertedAt: row.SeenAt,
-			Type:       sqlcv1.V1PayloadTypeUSEREVENTINPUT,
 			TenantId:   tenantId,
 			ExternalId: row.ExternalID,
 		}

--- a/pkg/repository/ids.go
+++ b/pkg/repository/ids.go
@@ -207,9 +207,7 @@ func (s *sharedRepository) generateExternalIdsForChildWorkflows(ctx context.Cont
 		}
 
 		retrievePayloadOpts = append(retrievePayloadOpts, RetrievePayloadOpts{
-			Id:         lockedEvent.ID,
 			InsertedAt: lockedEvent.InsertedAt,
-			Type:       sqlcv1.V1PayloadTypeTASKEVENTDATA,
 			TenantId:   tenantId,
 			ExternalId: lockedEvent.ExternalID,
 		})
@@ -235,9 +233,7 @@ func (s *sharedRepository) generateExternalIdsForChildWorkflows(ctx context.Cont
 			childExternalId = *lockedEvent.ChildExternalID
 		} else {
 			payload, ok := payloads[RetrievePayloadOpts{
-				Id:         lockedEvent.ID,
 				InsertedAt: lockedEvent.InsertedAt,
-				Type:       sqlcv1.V1PayloadTypeTASKEVENTDATA,
 				TenantId:   tenantId,
 				ExternalId: lockedEvent.ExternalID,
 			}]

--- a/pkg/repository/match.go
+++ b/pkg/repository/match.go
@@ -592,9 +592,7 @@ func (m *sharedRepository) processEventMatchesForTarget(ctx context.Context, tx 
 		retrievePayloadOpts := make([]RetrievePayloadOpts, len(dagInputDatas))
 		for i, dagData := range dagInputDatas {
 			retrievePayloadOpts[i] = RetrievePayloadOpts{
-				Id:         dagData.DagID,
 				InsertedAt: dagData.DagInsertedAt,
-				Type:       sqlcv1.V1PayloadTypeDAGINPUT,
 				TenantId:   tenantId,
 				ExternalId: dagData.ExternalID,
 			}
@@ -612,9 +610,7 @@ func (m *sharedRepository) processEventMatchesForTarget(ctx context.Context, tx 
 
 		for _, dagData := range dagInputDatas {
 			retrieveOpts := RetrievePayloadOpts{
-				Id:         dagData.DagID,
 				InsertedAt: dagData.DagInsertedAt,
-				Type:       sqlcv1.V1PayloadTypeDAGINPUT,
 				TenantId:   tenantId,
 				ExternalId: dagData.ExternalID,
 			}

--- a/pkg/repository/olap.go
+++ b/pkg/repository/olap.go
@@ -12,7 +12,6 @@ import (
 	"math/rand"
 	"slices"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -3602,43 +3601,6 @@ type OLAPCutoverBatchOutcome struct {
 	NextExternalId uuid.UUID
 }
 
-func (p *OLAPRepositoryImpl) ValidateNoDuplicateOLAPExternalIds(ctx context.Context, tx sqlcv1.DBTX, partitionDate PartitionDate) ([]*DuplicatedExternalIdRow, error) {
-	tableName := fmt.Sprintf("v1_payloads_olap_%s", partitionDate.String())
-	rows, err := tx.Query(
-		ctx,
-		fmt.Sprintf(
-			`
-			SELECT external_id, COUNT(*)
-			FROM %s
-			GROUP BY external_id
-			HAVING COUNT(*) > 1
-			LIMIT 100
-			`,
-			tableName,
-		),
-	)
-
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*DuplicatedExternalIdRow
-	for rows.Next() {
-		var i DuplicatedExternalIdRow
-		if err := rows.Scan(
-			&i.ExternalId,
-			&i.Count,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 func (p *OLAPRepositoryImpl) OptimizeOLAPPayloadWindowSize(ctx context.Context, tx sqlcv1.DBTX, partitionDate PartitionDate, candidateBatchNumRows int32, lastExternalId uuid.UUID) (*int32, error) {
 	if candidateBatchNumRows <= 0 {
 		// trivial case that we'll never hit, but to prevent infinite recursion
@@ -3925,74 +3887,6 @@ func (p *OLAPRepositoryImpl) processSinglePartition(ctx context.Context, process
 
 	if !jobMeta.ShouldRun {
 		return nil
-	}
-
-	// if the job is running for the first time, check that there aren't any duplicate external ids before proceeding
-	if jobMeta.LastExternalId == uuid.Nil {
-		connStatementTimeout := 15 * 60 * 1000 // 15 minutes
-
-		conn, release, err := sqlchelpers.AcquireConnectionWithStatementTimeout(ctx, p.pool, p.l, connStatementTimeout)
-
-		if err != nil {
-			return fmt.Errorf("failed to acquire connection with statement timeout: %w", err)
-		}
-
-		defer release()
-
-		stopLeaseExtension := make(chan struct{})
-		leaseExtensionDone := make(chan struct{})
-
-		go func() {
-			defer close(leaseExtensionDone)
-
-			ticker := time.NewTicker(30 * time.Second)
-			defer ticker.Stop()
-
-			for {
-				select {
-				case <-stopLeaseExtension:
-					return
-				case <-ticker.C:
-					leaseTx, leaseCommit, leaseRollback, txErr := sqlchelpers.PrepareTx(ctx, p.pool, p.l)
-
-					if txErr != nil {
-						p.l.Error().Err(txErr).Msg("failed to prepare transaction for lease extension during duplicate check")
-						continue
-					}
-
-					_, txErr = p.acquireOrExtendJobLease(ctx, leaseTx, processId, partitionDate, jobMeta.LastExternalId)
-
-					if txErr != nil {
-						leaseRollback()
-						p.l.Error().Err(txErr).Msg("failed to extend lease during duplicate check")
-						continue
-					}
-
-					if txErr = leaseCommit(ctx); txErr != nil {
-						leaseRollback()
-						p.l.Error().Err(txErr).Msg("failed to commit lease extension during duplicate check")
-					}
-				}
-			}
-		}()
-
-		duplicatedExternalIds, err := p.ValidateNoDuplicateOLAPExternalIds(ctx, conn, partitionDate)
-		close(stopLeaseExtension)
-		<-leaseExtensionDone
-
-		if err != nil {
-			return fmt.Errorf("failed to validate no duplicate external ids: %w", err)
-		}
-
-		if len(duplicatedExternalIds) > 0 {
-			var duplicatedIds []string
-
-			for _, row := range duplicatedExternalIds {
-				duplicatedIds = append(duplicatedIds, row.ExternalId.String())
-			}
-
-			return fmt.Errorf("found duplicate external ids in partition %s. Sampled ids: %s", partitionDate.String(), strings.Join(duplicatedIds, ", "))
-		}
 	}
 
 	lastExternalId := jobMeta.LastExternalId

--- a/pkg/repository/payloadstore.go
+++ b/pkg/repository/payloadstore.go
@@ -446,28 +446,12 @@ func (p *payloadStoreRepositoryImpl) ExternalStore() ExternalStore {
 	return p.externalStore
 }
 
-type BulkCutOverPayload struct {
-	TenantID            uuid.UUID
-	Id                  int64
-	InsertedAt          pgtype.Timestamptz
-	ExternalId          uuid.UUID
-	Type                sqlcv1.V1PayloadType
-	ExternalLocationKey ExternalPayloadLocationKey
-}
-
 type CutoverBatchOutcome struct {
 	ShouldContinue bool
 	NextExternalId uuid.UUID
 }
 
 type PartitionDate pgtype.Date
-
-type PayloadMetadata struct {
-	InsertedAt pgtype.Timestamptz
-	Type       sqlcv1.V1PayloadType
-	ID         int64
-	TenantID   uuid.UUID
-}
 
 func (d PartitionDate) String() string {
 	return d.Time.Format("20060102")

--- a/pkg/repository/payloadstore.go
+++ b/pkg/repository/payloadstore.go
@@ -294,9 +294,9 @@ func (p *payloadStoreRepositoryImpl) retrieve(ctx context.Context, tx sqlcv1.DBT
 	}
 
 	payloads, err := p.queries.ReadPayloads(ctx, tx, sqlcv1.ReadPayloadsParams{
-		Tenantids:     tenantIds,
-		Externalids:   externalIds,
-		Mininsertedat: sqlchelpers.TimestamptzFromTime(minInsertedAt),
+		Tenantids:         tenantIds,
+		Externalids:       externalIds,
+		Mininsertedatdate: sqlchelpers.DateFromTime(minInsertedAt),
 	})
 
 	if err != nil {

--- a/pkg/repository/payloadstore.go
+++ b/pkg/repository/payloadstore.go
@@ -205,6 +205,7 @@ func (p *payloadStoreRepositoryImpl) Store(ctx context.Context, tx sqlcv1.DBTX, 
 		uniqueKey := PayloadUniqueKey{
 			InsertedAtMicro: payload.InsertedAt.Time.UnixMicro(),
 			TenantId:        tenantId,
+			ExternalId:      payload.ExternalId,
 		}
 
 		if _, exists := seenPayloadUniqueKeys[uniqueKey]; exists {

--- a/pkg/repository/payloadstore.go
+++ b/pkg/repository/payloadstore.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -492,48 +491,6 @@ func (p *payloadStoreRepositoryImpl) OptimizePayloadWindowSize(ctx context.Conte
 	)
 }
 
-type DuplicatedExternalIdRow struct {
-	ExternalId uuid.UUID
-	Count      int64
-}
-
-func (p *payloadStoreRepositoryImpl) ValidateNoDuplicateExternalIds(ctx context.Context, tx sqlcv1.DBTX, partitionDate PartitionDate) ([]*DuplicatedExternalIdRow, error) {
-	tableName := fmt.Sprintf("v1_payload_%s", partitionDate.String())
-	rows, err := tx.Query(
-		ctx,
-		fmt.Sprintf(
-			`
-			SELECT external_id, COUNT(*)
-			FROM %s
-			GROUP BY external_id
-			HAVING COUNT(*) > 1
-			LIMIT 100
-			`,
-			tableName,
-		),
-	)
-
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*DuplicatedExternalIdRow
-	for rows.Next() {
-		var i DuplicatedExternalIdRow
-		if err := rows.Scan(
-			&i.ExternalId,
-			&i.Count,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 func (p *payloadStoreRepositoryImpl) ProcessPayloadCutoverBatch(ctx context.Context, processId uuid.UUID, partitionDate PartitionDate, lastExternalId uuid.UUID) (*CutoverBatchOutcome, error) {
 	ctx, span := telemetry.NewSpan(ctx, "PayloadStoreRepository.ProcessPayloadCutoverBatch")
 	defer span.End()
@@ -799,74 +756,6 @@ func (p *payloadStoreRepositoryImpl) processSinglePartition(ctx context.Context,
 
 	if !jobMeta.ShouldRun {
 		return nil
-	}
-
-	// if the job is running for the first time, check that there aren't any duplicate external ids before proceeding
-	if jobMeta.LastExternalId == uuid.Nil {
-		connStatementTimeout := 15 * 60 * 1000 // 15 minutes
-
-		conn, release, err := sqlchelpers.AcquireConnectionWithStatementTimeout(ctx, p.pool, p.l, connStatementTimeout)
-
-		if err != nil {
-			return fmt.Errorf("failed to acquire connection with statement timeout: %w", err)
-		}
-
-		defer release()
-
-		stopLeaseExtension := make(chan struct{})
-		leaseExtensionDone := make(chan struct{})
-
-		go func() {
-			defer close(leaseExtensionDone)
-
-			ticker := time.NewTicker(30 * time.Second)
-			defer ticker.Stop()
-
-			for {
-				select {
-				case <-stopLeaseExtension:
-					return
-				case <-ticker.C:
-					leaseTx, leaseCommit, leaseRollback, txErr := sqlchelpers.PrepareTx(ctx, p.pool, p.l)
-
-					if txErr != nil {
-						p.l.Error().Err(txErr).Msg("failed to prepare transaction for lease extension during duplicate check")
-						continue
-					}
-
-					_, txErr = p.acquireOrExtendJobLease(ctx, leaseTx, processId, partitionDate, jobMeta.LastExternalId)
-
-					if txErr != nil {
-						leaseRollback()
-						p.l.Error().Err(txErr).Msg("failed to extend lease during duplicate check")
-						continue
-					}
-
-					if txErr = leaseCommit(ctx); txErr != nil {
-						leaseRollback()
-						p.l.Error().Err(txErr).Msg("failed to commit lease extension during duplicate check")
-					}
-				}
-			}
-		}()
-
-		duplicatedExternalIds, err := p.ValidateNoDuplicateExternalIds(ctx, conn, partitionDate)
-		close(stopLeaseExtension)
-		<-leaseExtensionDone
-
-		if err != nil {
-			return fmt.Errorf("failed to validate no duplicate external ids: %w", err)
-		}
-
-		if len(duplicatedExternalIds) > 0 {
-			var duplicatedIds []string
-
-			for _, row := range duplicatedExternalIds {
-				duplicatedIds = append(duplicatedIds, row.ExternalId.String())
-			}
-
-			return fmt.Errorf("found duplicate external ids in partition %s. Sampled ids: %s", partitionDate.String(), strings.Join(duplicatedIds, ", "))
-		}
 	}
 
 	lastExternalId := jobMeta.LastExternalId

--- a/pkg/repository/payloadstore.go
+++ b/pkg/repository/payloadstore.go
@@ -46,9 +46,7 @@ type OffloadToExternalStoreOpts struct {
 
 type RetrievePayloadOpts struct {
 	TenantId   uuid.UUID
-	Id         int64
 	InsertedAt pgtype.Timestamptz
-	Type       sqlcv1.V1PayloadType
 	ExternalId uuid.UUID
 }
 
@@ -161,27 +159,24 @@ func NewPayloadStoreRepository(
 }
 
 type PayloadUniqueKey struct {
-	ID              int64
 	InsertedAtMicro int64 // Unix microseconds — avoids time.Time map-key pitfalls (mono clock, location, sub-μs precision)
 	TenantId        uuid.UUID
-	Type            sqlcv1.V1PayloadType
+	ExternalId      uuid.UUID
 }
 
 func payloadUniqueKeyFromRetrieveOpt(opt RetrievePayloadOpts) PayloadUniqueKey {
 	return PayloadUniqueKey{
-		ID:              opt.Id,
+		ExternalId:      opt.ExternalId,
 		InsertedAtMicro: opt.InsertedAt.Time.UnixMicro(),
 		TenantId:        opt.TenantId,
-		Type:            opt.Type,
 	}
 }
 
 func payloadUniqueKeyFromRow(payload *sqlcv1.V1Payload) PayloadUniqueKey {
 	return PayloadUniqueKey{
-		ID:              payload.ID,
 		InsertedAtMicro: payload.InsertedAt.Time.UnixMicro(),
 		TenantId:        payload.TenantID,
-		Type:            payload.Type,
+		ExternalId:      payload.ExternalID,
 	}
 }
 
@@ -209,10 +204,8 @@ func (p *payloadStoreRepositoryImpl) Store(ctx context.Context, tx sqlcv1.DBTX, 
 	for _, payload := range payloads {
 		tenantId := payload.TenantId
 		uniqueKey := PayloadUniqueKey{
-			ID:              payload.Id,
 			InsertedAtMicro: payload.InsertedAt.Time.UnixMicro(),
 			TenantId:        tenantId,
-			Type:            payload.Type,
 		}
 
 		if _, exists := seenPayloadUniqueKeys[uniqueKey]; exists {
@@ -288,23 +281,23 @@ func (p *payloadStoreRepositoryImpl) retrieve(ctx context.Context, tx sqlcv1.DBT
 		return make(map[RetrievePayloadOpts][]byte), nil
 	}
 
-	ids := make([]int64, len(opts))
-	insertedAts := make([]pgtype.Timestamptz, len(opts))
-	types := make([]string, len(opts))
 	tenantIds := make([]uuid.UUID, len(opts))
+	externalIds := make([]uuid.UUID, len(opts))
+	minInsertedAt := opts[0].InsertedAt.Time.UTC()
 
 	for i, opt := range opts {
-		ids[i] = opt.Id
-		insertedAts[i] = opt.InsertedAt
-		types[i] = string(opt.Type)
 		tenantIds[i] = opt.TenantId
+		externalIds[i] = opt.ExternalId
+
+		if opt.InsertedAt.Time.Before(minInsertedAt) {
+			minInsertedAt = opt.InsertedAt.Time
+		}
 	}
 
 	payloads, err := p.queries.ReadPayloads(ctx, tx, sqlcv1.ReadPayloadsParams{
-		Ids:         ids,
-		Insertedats: insertedAts,
-		Tenantids:   tenantIds,
-		Types:       types,
+		Tenantids:     tenantIds,
+		Externalids:   externalIds,
+		Mininsertedat: sqlchelpers.TimestamptzFromTime(minInsertedAt),
 	})
 
 	if err != nil {
@@ -333,9 +326,7 @@ func (p *payloadStoreRepositoryImpl) retrieve(ctx context.Context, tx sqlcv1.DBT
 		opt, ok := originalOptsByKey[payloadKey]
 		if !ok {
 			opt = RetrievePayloadOpts{
-				Id:         payload.ID,
 				InsertedAt: payload.InsertedAt,
-				Type:       payload.Type,
 				TenantId:   payload.TenantID,
 				ExternalId: payload.ExternalID,
 			}

--- a/pkg/repository/sqlchelpers/timestamp.go
+++ b/pkg/repository/sqlchelpers/timestamp.go
@@ -43,3 +43,14 @@ func TimestamptzFromTime(t time.Time) pgtype.Timestamptz {
 
 	return pgTs
 }
+
+func DateFromTime(t time.Time) pgtype.Date {
+	if t.IsZero() {
+		return pgtype.Date{}
+	}
+
+	return pgtype.Date{
+		Time:  t,
+		Valid: true,
+	}
+}

--- a/pkg/repository/sqlcv1/payload-store.sql
+++ b/pkg/repository/sqlcv1/payload-store.sql
@@ -49,12 +49,16 @@ SELECT
 FROM
     inputs i
 ORDER BY i.tenant_id, i.inserted_at, i.id, i.type
-ON CONFLICT (tenant_id, id, inserted_at, type)
+ON CONFLICT (external_id, inserted_at)
 DO UPDATE SET
     location = EXCLUDED.location,
     external_location_key = CASE WHEN EXCLUDED.external_location_key = '' OR EXCLUDED.location != 'EXTERNAL' THEN NULL ELSE EXCLUDED.external_location_key END,
     inline_content = EXCLUDED.inline_content,
     updated_at = NOW()
+WHERE
+    v1_payload.location IS DISTINCT FROM EXCLUDED.location
+    OR v1_payload.external_location_key IS DISTINCT FROM EXCLUDED.external_location_key
+    OR v1_payload.inline_content IS DISTINCT FROM EXCLUDED.inline_content
 ;
 
 -- name: AnalyzeV1Payload :exec

--- a/pkg/repository/sqlcv1/payload-store.sql
+++ b/pkg/repository/sqlcv1/payload-store.sql
@@ -1,18 +1,15 @@
 -- name: ReadPayloads :many
 WITH inputs AS (
     SELECT
-        UNNEST(@ids::BIGINT[]) AS id,
-        UNNEST(@insertedAts::TIMESTAMPTZ[]) AS inserted_at,
         UNNEST(@tenantIds::UUID[]) AS tenant_id,
-        UNNEST(CAST(@types::TEXT[] AS v1_payload_type[])) AS type
+        UNNEST(@externalIds::UUID[]) AS external_id
 )
 
 SELECT *
 FROM v1_payload
-WHERE (tenant_id, id, inserted_at, type) IN (
-        SELECT tenant_id, id, inserted_at, type
-        FROM inputs
-    )
+WHERE
+    (external_id, tenant_id) IN (SELECT external_id, tenant_id FROM inputs)
+    AND inserted_at >= @minInsertedAt::TIMESTAMPTZ
 ;
 
 -- name: WritePayloads :exec

--- a/pkg/repository/sqlcv1/payload-store.sql
+++ b/pkg/repository/sqlcv1/payload-store.sql
@@ -9,7 +9,7 @@ SELECT *
 FROM v1_payload
 WHERE
     (external_id, tenant_id) IN (SELECT external_id, tenant_id FROM inputs)
-    AND inserted_at >= @minInsertedAt::TIMESTAMPTZ
+    AND inserted_at_date >= @minInsertedAtDate::DATE
 ;
 
 -- name: WritePayloads :exec
@@ -49,7 +49,7 @@ SELECT
 FROM
     inputs i
 ORDER BY i.tenant_id, i.inserted_at, i.id, i.type
-ON CONFLICT (external_id, inserted_at)
+ON CONFLICT (external_id, inserted_at_date)
 DO UPDATE SET
     location = EXCLUDED.location,
     external_location_key = CASE WHEN EXCLUDED.external_location_key = '' OR EXCLUDED.location != 'EXTERNAL' THEN NULL ELSE EXCLUDED.external_location_key END,

--- a/pkg/repository/sqlcv1/payload-store.sql.go
+++ b/pkg/repository/sqlcv1/payload-store.sql.go
@@ -356,34 +356,25 @@ func (q *Queries) MarkCutoverJobAsCompleted(ctx context.Context, db DBTX, key pg
 const readPayloads = `-- name: ReadPayloads :many
 WITH inputs AS (
     SELECT
-        UNNEST($1::BIGINT[]) AS id,
-        UNNEST($2::TIMESTAMPTZ[]) AS inserted_at,
-        UNNEST($3::UUID[]) AS tenant_id,
-        UNNEST(CAST($4::TEXT[] AS v1_payload_type[])) AS type
+        UNNEST($2::UUID[]) AS tenant_id,
+        UNNEST($3::UUID[]) AS external_id
 )
 
 SELECT tenant_id, id, inserted_at, inserted_at_date, external_id, type, location, external_location_key, inline_content, updated_at
 FROM v1_payload
-WHERE (tenant_id, id, inserted_at, type) IN (
-        SELECT tenant_id, id, inserted_at, type
-        FROM inputs
-    )
+WHERE
+    (external_id, tenant_id) IN (SELECT external_id, tenant_id FROM inputs)
+    AND inserted_at >= $1::TIMESTAMPTZ
 `
 
 type ReadPayloadsParams struct {
-	Ids         []int64              `json:"ids"`
-	Insertedats []pgtype.Timestamptz `json:"insertedats"`
-	Tenantids   []uuid.UUID          `json:"tenantids"`
-	Types       []string             `json:"types"`
+	Mininsertedat pgtype.Timestamptz `json:"mininsertedat"`
+	Tenantids     []uuid.UUID        `json:"tenantids"`
+	Externalids   []uuid.UUID        `json:"externalids"`
 }
 
 func (q *Queries) ReadPayloads(ctx context.Context, db DBTX, arg ReadPayloadsParams) ([]*V1Payload, error) {
-	rows, err := db.Query(ctx, readPayloads,
-		arg.Ids,
-		arg.Insertedats,
-		arg.Tenantids,
-		arg.Types,
-	)
+	rows, err := db.Query(ctx, readPayloads, arg.Mininsertedat, arg.Tenantids, arg.Externalids)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repository/sqlcv1/payload-store.sql.go
+++ b/pkg/repository/sqlcv1/payload-store.sql.go
@@ -450,12 +450,16 @@ SELECT
 FROM
     inputs i
 ORDER BY i.tenant_id, i.inserted_at, i.id, i.type
-ON CONFLICT (tenant_id, id, inserted_at, type)
+ON CONFLICT (external_id, inserted_at)
 DO UPDATE SET
     location = EXCLUDED.location,
     external_location_key = CASE WHEN EXCLUDED.external_location_key = '' OR EXCLUDED.location != 'EXTERNAL' THEN NULL ELSE EXCLUDED.external_location_key END,
     inline_content = EXCLUDED.inline_content,
     updated_at = NOW()
+WHERE
+    v1_payload.location IS DISTINCT FROM EXCLUDED.location
+    OR v1_payload.external_location_key IS DISTINCT FROM EXCLUDED.external_location_key
+    OR v1_payload.inline_content IS DISTINCT FROM EXCLUDED.inline_content
 `
 
 type WritePayloadsParams struct {

--- a/pkg/repository/sqlcv1/payload-store.sql.go
+++ b/pkg/repository/sqlcv1/payload-store.sql.go
@@ -364,17 +364,17 @@ SELECT tenant_id, id, inserted_at, inserted_at_date, external_id, type, location
 FROM v1_payload
 WHERE
     (external_id, tenant_id) IN (SELECT external_id, tenant_id FROM inputs)
-    AND inserted_at >= $1::TIMESTAMPTZ
+    AND inserted_at_date >= $1::DATE
 `
 
 type ReadPayloadsParams struct {
-	Mininsertedat pgtype.Timestamptz `json:"mininsertedat"`
-	Tenantids     []uuid.UUID        `json:"tenantids"`
-	Externalids   []uuid.UUID        `json:"externalids"`
+	Mininsertedatdate pgtype.Date `json:"mininsertedatdate"`
+	Tenantids         []uuid.UUID `json:"tenantids"`
+	Externalids       []uuid.UUID `json:"externalids"`
 }
 
 func (q *Queries) ReadPayloads(ctx context.Context, db DBTX, arg ReadPayloadsParams) ([]*V1Payload, error) {
-	rows, err := db.Query(ctx, readPayloads, arg.Mininsertedat, arg.Tenantids, arg.Externalids)
+	rows, err := db.Query(ctx, readPayloads, arg.Mininsertedatdate, arg.Tenantids, arg.Externalids)
 	if err != nil {
 		return nil, err
 	}
@@ -450,7 +450,7 @@ SELECT
 FROM
     inputs i
 ORDER BY i.tenant_id, i.inserted_at, i.id, i.type
-ON CONFLICT (external_id, inserted_at)
+ON CONFLICT (external_id, inserted_at_date)
 DO UPDATE SET
     location = EXCLUDED.location,
     external_location_key = CASE WHEN EXCLUDED.external_location_key = '' OR EXCLUDED.location != 'EXTERNAL' THEN NULL ELSE EXCLUDED.external_location_key END,

--- a/pkg/repository/sqlcv1/queue.sql
+++ b/pkg/repository/sqlcv1/queue.sql
@@ -890,6 +890,7 @@ WITH locked_qis AS (
         ON p.tenant_id = lqi.tenant_id
         AND p.id = lqi.task_id
         AND p.inserted_at = lqi.task_inserted_at
+        AND p.inserted_at_date = lqi.task_inserted_at::DATE
         AND p.type = 'TASK_INPUT'::v1_payload_type
     ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
     RETURNING task_id

--- a/pkg/repository/sqlcv1/queue.sql.go
+++ b/pkg/repository/sqlcv1/queue.sql.go
@@ -1811,6 +1811,7 @@ WITH locked_qis AS (
         ON p.tenant_id = lqi.tenant_id
         AND p.id = lqi.task_id
         AND p.inserted_at = lqi.task_inserted_at
+        AND p.inserted_at_date = lqi.task_inserted_at::DATE
         AND p.type = 'TASK_INPUT'::v1_payload_type
     ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
     RETURNING task_id

--- a/pkg/repository/task.go
+++ b/pkg/repository/task.go
@@ -1352,9 +1352,7 @@ func (r *TaskRepositoryImpl) listTaskOutputEvents(ctx context.Context, tx sqlcv1
 
 	for i, event := range matchedEvents {
 		opt := RetrievePayloadOpts{
-			Id:         event.ID,
 			InsertedAt: event.InsertedAt,
-			Type:       sqlcv1.V1PayloadTypeTASKEVENTDATA,
 			TenantId:   tenantId,
 			ExternalId: event.ExternalID,
 		}
@@ -3744,9 +3742,7 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 
 	for i, task := range lockedTasks {
 		retrieveOpts[i] = RetrievePayloadOpts{
-			Id:         task.ID,
 			InsertedAt: task.InsertedAt,
-			Type:       sqlcv1.V1PayloadTypeTASKINPUT,
 			TenantId:   tenantId,
 			ExternalId: task.ExternalID,
 		}
@@ -3830,9 +3826,7 @@ func (r *TaskRepositoryImpl) ReplayTasks(ctx context.Context, tenantId uuid.UUID
 		}
 
 		retrieveOpt := RetrievePayloadOpts{
-			Id:         task.ID,
 			InsertedAt: task.InsertedAt,
-			Type:       sqlcv1.V1PayloadTypeTASKINPUT,
 			TenantId:   tenantId,
 			ExternalId: task.ExternalID,
 		}
@@ -4363,9 +4357,7 @@ func (r *TaskRepositoryImpl) ListTaskParentOutputs(ctx context.Context, tenantId
 		}
 
 		opt := RetrievePayloadOpts{
-			Id:         outputTask.TaskEventID,
 			InsertedAt: outputTask.TaskEventInsertedAt,
-			Type:       sqlcv1.V1PayloadTypeTASKEVENTDATA,
 			TenantId:   tenantId,
 			ExternalId: outputTask.OutputEventExternalID,
 		}
@@ -4445,9 +4437,7 @@ func (r *TaskRepositoryImpl) ListSignalCompletedEvents(ctx context.Context, tena
 
 	for i, event := range signalEvents {
 		retrieveOpt := RetrievePayloadOpts{
-			Id:         event.ID,
 			InsertedAt: event.InsertedAt,
-			Type:       sqlcv1.V1PayloadTypeTASKEVENTDATA,
 			TenantId:   tenantId,
 			ExternalId: event.ExternalID,
 		}
@@ -4465,9 +4455,7 @@ func (r *TaskRepositoryImpl) ListSignalCompletedEvents(ctx context.Context, tena
 
 	for i, event := range signalEvents {
 		retrieveOpt := RetrievePayloadOpts{
-			Id:         event.ID,
 			InsertedAt: event.InsertedAt,
-			Type:       sqlcv1.V1PayloadTypeTASKEVENTDATA,
 			TenantId:   tenantId,
 			ExternalId: event.ExternalID,
 		}
@@ -4976,17 +4964,13 @@ func (r *TaskRepositoryImpl) GetWorkflowRunResultDetails(ctx context.Context, te
 
 	if isDag {
 		inputRetrieveOpt = RetrievePayloadOpts{
-			Id:         firstTask.DagID.Int64,
 			InsertedAt: firstTask.DagInsertedAt,
-			Type:       sqlcv1.V1PayloadTypeDAGINPUT,
 			TenantId:   tenantId,
 			ExternalId: firstTask.WorkflowRunExternalID,
 		}
 	} else {
 		inputRetrieveOpt = RetrievePayloadOpts{
-			Id:         firstTask.ID,
 			InsertedAt: firstTask.InsertedAt,
-			Type:       sqlcv1.V1PayloadTypeTASKINPUT,
 			TenantId:   tenantId,
 			ExternalId: firstTask.ExternalID,
 		}

--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -1942,9 +1942,7 @@ func (r *sharedRepository) registerChildWorkflows(
 		}
 
 		retrievePayloadOpts = append(retrievePayloadOpts, RetrievePayloadOpts{
-			Id:         event.ID,
 			InsertedAt: event.InsertedAt,
-			Type:       sqlcv1.V1PayloadTypeTASKEVENTDATA,
 			TenantId:   tenantId,
 			ExternalId: event.ExternalID,
 		})
@@ -1971,9 +1969,7 @@ func (r *sharedRepository) registerChildWorkflows(
 			childExternalId = *event.ChildExternalID
 		} else {
 			payload, ok := payloads[RetrievePayloadOpts{
-				Id:         event.ID,
 				InsertedAt: event.InsertedAt,
-				Type:       sqlcv1.V1PayloadTypeTASKEVENTDATA,
 				TenantId:   tenantId,
 				ExternalId: event.ExternalID,
 			}]
@@ -2973,9 +2969,7 @@ func (r *sharedRepository) lookupParentOutputsByWorkflowRunIds(ctx context.Conte
 
 	for _, row := range rows {
 		retrieveOpts = append(retrieveOpts, RetrievePayloadOpts{
-			Id:         row.TaskEventID,
 			InsertedAt: row.TaskEventInsertedAt,
-			Type:       sqlcv1.V1PayloadTypeTASKEVENTDATA,
 			TenantId:   tenantId,
 			ExternalId: row.OutputEventExternalID,
 		})

--- a/sdks/python/examples/concurrency_cancel_newest/test_concurrency_cancel_newest.py
+++ b/sdks/python/examples/concurrency_cancel_newest/test_concurrency_cancel_newest.py
@@ -44,16 +44,31 @@ async def test_run(hatchet: Hatchet) -> None:
         except Exception:
             pass
 
-    ## wait for the olap repo to catch up
-    await asyncio.sleep(5)
+    timeout = 30
+    start = time.time()
+    successful_status = None
+    cancelled_statuses: list[V1TaskStatus] = []
 
-    successful_run = hatchet.runs.get(to_run.workflow_run_id)
+    while time.time() - start < timeout:
+        successful_status = hatchet.runs.get(to_run.workflow_run_id).run.status
+        cancelled_statuses = [
+            r.status
+            for r in hatchet.runs.list(
+                additional_metadata={"test_run_id": test_run_id}
+            ).rows
+            if r.metadata.id != to_run.workflow_run_id
+        ]
 
-    assert successful_run.run.status == V1TaskStatus.COMPLETED
-    assert all(
-        r.status == V1TaskStatus.CANCELLED
-        for r in hatchet.runs.list(
-            additional_metadata={"test_run_id": test_run_id}
-        ).rows
-        if r.metadata.id != to_run.workflow_run_id
+        if (
+            successful_status == V1TaskStatus.COMPLETED
+            and len(cancelled_statuses) == 10
+            and all(s == V1TaskStatus.CANCELLED for s in cancelled_statuses)
+        ):
+            return
+
+        await asyncio.sleep(1)
+
+    assert False, (
+        f"Expected the first run to be COMPLETED and the other 10 to be CANCELLED within {timeout} seconds, "
+        f"but got first={successful_status} and others={cancelled_statuses}"
     )

--- a/sdks/python/examples/workflow_pause/test_workflow_pause.py
+++ b/sdks/python/examples/workflow_pause/test_workflow_pause.py
@@ -19,20 +19,20 @@ async def test_workflow_pause_cancel_after_ttl(hatchet: Hatchet) -> None:
 
     start_time = time.time()
     run_id = ref.workflow_run_id
-    timeout = 10  # seconds
-
-    while True:
+    timeout = 30
+    while time.time() - start_time < timeout:
         details = await hatchet.runs.aio_get_details(run_id)
 
         if details.status == RunStatus.CANCELLED:
             return
 
-        assert details.status == RunStatus.QUEUED, f"Run {run_id} is not queued."
-
-        if time.time() - start_time > timeout:
-            assert False, f"Run {run_id} was not cancelled within {timeout} seconds."
+        assert (
+            details.status != RunStatus.COMPLETED
+        ), f"Run {run_id} completed, but it should have been cancelled by the queue TTL."
 
         await asyncio.sleep(1)
+
+    assert False, f"Run {run_id} was not cancelled within {timeout} seconds."
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -2166,7 +2166,7 @@ CREATE TYPE v1_payload_location AS ENUM ('INLINE', 'EXTERNAL');
 
 CREATE TABLE v1_payload (
     tenant_id UUID NOT NULL,
-    id BIGINT NOT NULL,
+    id BIGINT NOT NULL, -- deprecated
     inserted_at TIMESTAMPTZ NOT NULL,
     inserted_at_date DATE NOT NULL DEFAULT CURRENT_TIMESTAMP::DATE,
     external_id UUID NOT NULL DEFAULT gen_random_uuid(),
@@ -2184,7 +2184,7 @@ CREATE TABLE v1_payload (
     )
 ) PARTITION BY RANGE(inserted_at);
 
-CREATE INDEX v1_payload_external_id_idx ON v1_payload (external_id ASC);
+CREATE INDEX v1_payload_external_id_idx ON v1_payload (external_id ASC); -- todo: unique constraint for this
 
 CREATE TABLE v1_payload_cutover_job_offset (
     key DATE PRIMARY KEY,

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -2168,7 +2168,7 @@ CREATE TABLE v1_payload (
     tenant_id UUID NOT NULL,
     id BIGINT NOT NULL, -- deprecated
     inserted_at TIMESTAMPTZ NOT NULL,
-    inserted_at_date DATE NOT NULL DEFAULT CURRENT_TIMESTAMP::DATE,
+    inserted_at_date DATE NOT NULL,
     external_id UUID NOT NULL DEFAULT gen_random_uuid(),
     type v1_payload_type NOT NULL,
     location v1_payload_location NOT NULL,

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -2176,15 +2176,13 @@ CREATE TABLE v1_payload (
     inline_content JSONB,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-    PRIMARY KEY (tenant_id, inserted_at, id, type),
-    CHECK (
+    PRIMARY KEY (external_id, inserted_at_date),
+    CONSTRAINT v1_payload_location_check CHECK (
         location = 'INLINE'
         OR
         (location = 'EXTERNAL' AND inline_content IS NULL AND external_location_key IS NOT NULL)
     )
-) PARTITION BY RANGE(inserted_at);
-
-CREATE UNIQUE INDEX v1_payload_external_id_ins_at_uq ON v1_payload (external_id ASC, inserted_at ASC);
+) PARTITION BY RANGE(inserted_at_date);
 
 CREATE TABLE v1_payload_cutover_job_offset (
     key DATE PRIMARY KEY,
@@ -2252,9 +2250,9 @@ BEGIN
         ALTER TABLE %I
         ADD CONSTRAINT %I
         CHECK (
-            inserted_at IS NOT NULL
-            AND inserted_at >= %L::TIMESTAMPTZ
-            AND inserted_at < %L::TIMESTAMPTZ
+            inserted_at_date IS NOT NULL
+            AND inserted_at_date >= %L::DATE
+            AND inserted_at_date < %L::DATE
         )
         ',
         target_table_name,
@@ -2268,9 +2266,9 @@ BEGIN
             LANGUAGE plpgsql AS $func$
         BEGIN
             IF TG_OP = ''INSERT'' THEN
-                INSERT INTO %I (tenant_id, id, inserted_at, external_id, type, location, external_location_key, inline_content, updated_at)
-                VALUES (NEW.tenant_id, NEW.id, NEW.inserted_at, NEW.external_id, NEW.type, NEW.location, NEW.external_location_key, NEW.inline_content, NEW.updated_at)
-                ON CONFLICT (tenant_id, id, inserted_at, type) DO UPDATE
+                INSERT INTO %I (tenant_id, id, inserted_at, inserted_at_date, external_id, type, location, external_location_key, inline_content, updated_at)
+                VALUES (NEW.tenant_id, NEW.id, NEW.inserted_at, NEW.inserted_at_date, NEW.external_id, NEW.type, NEW.location, NEW.external_location_key, NEW.inline_content, NEW.updated_at)
+                ON CONFLICT (external_id, inserted_at_date) DO UPDATE
                 SET
                     location = EXCLUDED.location,
                     external_location_key = EXCLUDED.external_location_key,
@@ -2285,18 +2283,14 @@ BEGIN
                     inline_content = NEW.inline_content,
                     updated_at = NEW.updated_at
                 WHERE
-                    tenant_id = NEW.tenant_id
-                    AND id = NEW.id
-                    AND inserted_at = NEW.inserted_at
-                    AND type = NEW.type;
+                    external_id = NEW.external_id
+                    AND inserted_at_date = NEW.inserted_at_date;
                 RETURN NEW;
             ELSIF TG_OP = ''DELETE'' THEN
                 DELETE FROM %I
                 WHERE
-                    tenant_id = OLD.tenant_id
-                    AND id = OLD.id
-                    AND inserted_at = OLD.inserted_at
-                    AND type = OLD.type;
+                    external_id = OLD.external_id
+                    AND inserted_at_date = OLD.inserted_at_date;
                 RETURN OLD;
             END IF;
             RETURN NULL;
@@ -2489,57 +2483,6 @@ BEGIN
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION diff_payload_source_and_target_partitions(
-    partition_date date
-) RETURNS TABLE (
-    tenant_id UUID,
-    id BIGINT,
-    inserted_at TIMESTAMPTZ,
-    external_id UUID,
-    type v1_payload_type,
-    location v1_payload_location,
-    external_location_key TEXT,
-    inline_content JSONB,
-    updated_at TIMESTAMPTZ
-)
-    LANGUAGE plpgsql AS
-$$
-DECLARE
-    partition_date_str varchar;
-    source_partition_name varchar;
-    temp_partition_name varchar;
-    query text;
-BEGIN
-    IF partition_date IS NULL THEN
-        RAISE EXCEPTION 'partition_date parameter cannot be NULL';
-    END IF;
-
-    SELECT to_char(partition_date, 'YYYYMMDD') INTO partition_date_str;
-    SELECT format('v1_payload_%s', partition_date_str) INTO source_partition_name;
-    SELECT format('v1_payload_offload_tmp_%s', partition_date_str) INTO temp_partition_name;
-
-    IF NOT EXISTS (SELECT 1 FROM pg_tables WHERE tablename = source_partition_name) THEN
-        RAISE EXCEPTION 'Partition % does not exist', source_partition_name;
-    END IF;
-
-    query := format('
-        SELECT tenant_id, id, inserted_at, external_id, type, location, external_location_key, inline_content, updated_at
-        FROM %I source
-        WHERE NOT EXISTS (
-            SELECT 1
-            FROM %I AS target
-            WHERE
-                source.tenant_id = target.tenant_id
-                AND source.inserted_at = target.inserted_at
-                AND source.id = target.id
-                AND source.type = target.type
-        )
-    ', source_partition_name, temp_partition_name);
-
-    RETURN QUERY EXECUTE query;
-END;
-$$;
-
 CREATE OR REPLACE FUNCTION swap_v1_payload_partition_with_temp(
     partition_date date
 ) RETURNS text
@@ -2551,8 +2494,6 @@ DECLARE
     temp_table_name varchar;
     old_pk_name varchar;
     new_pk_name varchar;
-    old_ext_id_idx_name varchar;
-    new_ext_id_idx_name varchar;
     partition_start date;
     partition_end date;
     trigger_function_name varchar;
@@ -2567,8 +2508,6 @@ BEGIN
     SELECT format('v1_payload_offload_tmp_%s', partition_date_str) INTO temp_table_name;
     SELECT format('v1_payload_offload_tmp_%s_pkey', partition_date_str) INTO old_pk_name;
     SELECT format('v1_payload_%s_pkey', partition_date_str) INTO new_pk_name;
-    SELECT format('v1_payload_offload_tmp_%s_external_id_idx', partition_date_str) INTO old_ext_id_idx_name;
-    SELECT format('v1_payload_%s_external_id_idx', partition_date_str) INTO new_ext_id_idx_name;
     SELECT format('sync_to_%s', temp_table_name) INTO trigger_function_name;
     SELECT format('trigger_sync_to_%s', temp_table_name) INTO trigger_name;
 
@@ -2608,9 +2547,6 @@ BEGIN
 
     RAISE NOTICE 'Renaming primary key % to %', old_pk_name, new_pk_name;
     EXECUTE format('ALTER INDEX %I RENAME TO %I', old_pk_name, new_pk_name);
-
-    RAISE NOTICE 'Renaming external_id index % to %', old_ext_id_idx_name, new_ext_id_idx_name;
-    EXECUTE format('ALTER INDEX %I RENAME TO %I', old_ext_id_idx_name, new_ext_id_idx_name);
 
     RAISE NOTICE 'Renaming temp table % to %', temp_table_name, source_partition_name;
     EXECUTE format('ALTER TABLE %I RENAME TO %I', temp_table_name, source_partition_name);

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -2184,7 +2184,7 @@ CREATE TABLE v1_payload (
     )
 ) PARTITION BY RANGE(inserted_at);
 
-CREATE INDEX v1_payload_external_id_idx ON v1_payload (external_id ASC); -- todo: unique constraint for this
+CREATE UNIQUE INDEX v1_payload_external_id_ins_at_uq ON v1_payload (external_id ASC, inserted_at ASC);
 
 CREATE TABLE v1_payload_cutover_job_offset (
     key DATE PRIMARY KEY,


### PR DESCRIPTION
# Description

Couple things here:

1. Read payloads by their external id rather than the id tuple
2. Add a unique constraint on `(external_id, inserted_at)` to prevent duplicate payloads
3. Remove the need to dedupe now that we have the unique constraint

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking changes to code which doesn't change any behaviour)

## Checklist

Changes have been:

- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

No AI here

</details>
