### PR TITLE
fix(ts): resolve yaml config paths against the caller cwd

### DIFF
--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hatchet's TypeScript SDK will be documented in this chang
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.31.2] - 2026-09-05
+
+### Fixed
+
+- `ConfigLoader.loadYamlConfig` resolved config paths against the SDK's own install directory instead of the caller's working directory, so a `.hatchet.yaml` in the project root was silently never loaded and explicit relative `config_path` values never resolved. Paths now resolve against `process.cwd()`, matching the documented behavior.
+
 ## [1.31.1] - 2026-09-03
 
 ### Security

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchet-dev/typescript-sdk",
-  "version": "1.31.1",
+  "version": "1.31.2",
   "description": "Background task orchestration & visibility for developers",
   "types": "dist/index.d.ts",
   "files": [

--- a/sdks/typescript/src/util/config-loader/config-loader.test.ts
+++ b/sdks/typescript/src/util/config-loader/config-loader.test.ts
@@ -1,6 +1,12 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { ChannelCredentials } from 'nice-grpc';
 import { ConfigLoader } from './config-loader';
 import { HatchetClient } from '@hatchet/v1';
+
+// config paths resolve against the caller's working directory, not __dirname
+const fixturePath = (file: string) => path.join(__dirname, 'fixtures', file);
 
 describe('ConfigLoader', () => {
   beforeEach(() => {
@@ -72,7 +78,7 @@ describe('ConfigLoader', () => {
       ConfigLoader.loadClientConfig(
         {},
         {
-          path: './fixtures/not-found.yaml',
+          path: fixturePath('not-found.yaml'),
         }
       )
     ).toThrow();
@@ -84,7 +90,7 @@ describe('ConfigLoader', () => {
       ConfigLoader.loadClientConfig(
         {},
         {
-          path: './fixtures/.hatchet-invalid.yaml',
+          path: fixturePath('.hatchet-invalid.yaml'),
         }
       )
     ).toThrow();
@@ -94,7 +100,7 @@ describe('ConfigLoader', () => {
     const config = ConfigLoader.loadClientConfig(
       {},
       {
-        path: './fixtures/.hatchet.yaml',
+        path: fixturePath('.hatchet.yaml'),
       }
     );
     expect(config).toEqual({
@@ -145,7 +151,7 @@ describe('ConfigLoader', () => {
     const config = ConfigLoader.loadClientConfig(
       {},
       {
-        path: './fixtures/.hatchet.yaml',
+        path: fixturePath('.hatchet.yaml'),
       }
     );
     expect(config).toEqual({
@@ -164,5 +170,38 @@ describe('ConfigLoader', () => {
         port: 8002,
       },
     });
+  });
+
+  it('should load the default .hatchet.yaml from the caller cwd', () => {
+    const originalCwd = process.cwd();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hatchet-config-'));
+    fs.writeFileSync(
+      path.join(tmp, '.hatchet.yaml'),
+      'namespace: from-cwd-yaml\n'
+    );
+
+    process.chdir(tmp);
+    try {
+      const config = ConfigLoader.loadYamlConfig();
+      expect(config).toEqual({ namespace: 'from-cwd-yaml' });
+    } finally {
+      process.chdir(originalCwd);
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('should load an explicit relative config path from the caller cwd', () => {
+    const originalCwd = process.cwd();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hatchet-config-'));
+    fs.writeFileSync(path.join(tmp, 'custom.yaml'), 'namespace: from-cwd\n');
+
+    process.chdir(tmp);
+    try {
+      const config = ConfigLoader.loadYamlConfig('custom.yaml');
+      expect(config).toEqual({ namespace: 'from-cwd' });
+    } finally {
+      process.chdir(originalCwd);
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/sdks/typescript/src/util/config-loader/config-loader.ts
+++ b/sdks/typescript/src/util/config-loader/config-loader.ts
@@ -216,10 +216,13 @@ export class ConfigLoader {
 
   static loadYamlConfig(path?: string): ClientConfig | undefined {
     try {
-      const configFile = readFileSync(
-        p.join(__dirname, path ?? this.default_yaml_config_path),
-        'utf8'
-      );
+      // Caller-supplied paths resolve against the caller's working directory;
+      // an absolute path is used as-is. The default path is already absolute
+      // (cwd-relative), so it is used directly.
+      const configPath = path
+        ? p.resolve(process.cwd(), path)
+        : this.default_yaml_config_path;
+      const configFile = readFileSync(configPath, 'utf8');
 
       const config = parse(configFile);
 


### PR DESCRIPTION
Fixes #4591

## What

`ConfigLoader.loadYamlConfig` joined the caller path onto `__dirname`:

```ts
p.join(__dirname, path ?? this.default_yaml_config_path)
```

Since `default_yaml_config_path` is already an absolute cwd-based path, `path.join` concatenated it onto the SDK install directory, so a real `.hatchet.yaml` in the project root was never found — and because the default case swallows the error, the file was **silently** never loaded. Explicit relative `config_path` values were resolved relative to `node_modules` rather than the caller's project.

The fix resolves caller-supplied paths with `path.resolve(process.cwd(), path)` (absolute paths pass through) and uses the default absolute path directly. This also fixes the previously accidental `\./fixtures` tests by passing them absolute fixture paths, and adds two regression tests covering the default cwd path and an explicit relative path (both fail on `main`).

Per the SDK release conventions, this bumps `@hatchet-dev/typescript-sdk` to 1.31.2 with a changelog entry.

## Validation

- `pnpm jest src/util/config-loader/config-loader.test.ts` — 9 passed, 2 skipped (pre-existing skips); the two new tests fail before the fix
- `pnpm tsc --noEmit` clean

## 🤖 AI Disclosure

- [x] _I acknowledge that an LLM was used in the creation of this PR, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: ZCode (GLM agent) implemented the fix and tests for the accepted issue #4591, following the reproduction and root cause documented in the issue. Commands were run and the diff was reviewed by me before submission.