### PR TITLE
Fix CANCEL_IN_PROGRESS replacement during retry backoff

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260905190000_v1_0_152.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260905190000_v1_0_152.sql
@@ -1,0 +1,1113 @@
+-- +goose Up
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION v1_task_update_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    WITH new_retry_rows AS (
+        SELECT
+            nt.id,
+            nt.inserted_at,
+            nt.retry_count,
+            nt.tenant_id,
+            -- NOTE: cap in log space before POWER. POWER(backoff_factor, app_retry_count)
+            -- overflows float8 (SQLSTATE 22003) for large retry counts, and LEAST cannot
+            -- prevent that because POWER is evaluated first. b^n > cap iff
+            -- n * ln(b) > ln(cap), so compare logs and skip POWER when the result
+            -- would exceed retry_max_backoff.
+            NOW() + (
+                LEAST(
+                    COALESCE(nt.retry_max_backoff, 86400)::double precision,
+                    CASE
+                        WHEN nt.retry_backoff_factor <= 1 THEN
+                            POWER(nt.retry_backoff_factor, nt.app_retry_count)
+                        WHEN LN(nt.retry_backoff_factor) * nt.app_retry_count
+                            >= LN(GREATEST(COALESCE(nt.retry_max_backoff, 86400), 1)::double precision) THEN
+                            COALESCE(nt.retry_max_backoff, 86400)::double precision
+                        ELSE
+                            POWER(nt.retry_backoff_factor, nt.app_retry_count)
+                    END
+                ) * interval '1 second'
+            ) AS retry_after
+        FROM new_table nt
+        JOIN old_table ot ON ot.id = nt.id
+        WHERE nt.initial_state = 'QUEUED'
+            AND nt.retry_backoff_factor IS NOT NULL
+            AND ot.app_retry_count IS DISTINCT FROM nt.app_retry_count
+            AND nt.app_retry_count != 0
+    )
+    INSERT INTO v1_retry_queue_item (
+        task_id,
+        task_inserted_at,
+        task_retry_count,
+        retry_after,
+        tenant_id
+    )
+    SELECT
+        id,
+        inserted_at,
+        retry_count,
+        retry_after,
+        tenant_id
+    FROM new_retry_rows;
+
+    -- A pending retry remains unfinished work for replacement policies. Keep its
+    -- filled slot at the accepted invocation's position until retry admission.
+    UPDATE v1_concurrency_slot cs
+    SET task_retry_count = nt.retry_count
+    FROM new_table nt
+    JOIN old_table ot ON ot.id = nt.id AND ot.inserted_at = nt.inserted_at
+    JOIN v1_step_concurrency sc ON sc.id = ANY(nt.concurrency_strategy_ids)
+    WHERE cs.task_id = nt.id
+        AND cs.task_inserted_at = nt.inserted_at
+        AND cs.task_retry_count = ot.retry_count
+        AND cs.strategy_id = sc.id
+        AND sc.strategy = 'CANCEL_IN_PROGRESS'
+        AND cs.is_filled
+        AND nt.initial_state = 'QUEUED'
+        AND nt.retry_backoff_factor IS NOT NULL
+        AND ot.app_retry_count IS DISTINCT FROM nt.app_retry_count
+        AND nt.app_retry_count != 0;
+
+    WITH new_slot_rows AS (
+        SELECT
+            nt.id,
+            nt.inserted_at,
+            nt.retry_count,
+            nt.tenant_id,
+            nt.workflow_run_id,
+            nt.external_id,
+            nt.concurrency_parent_strategy_ids[1] AS parent_strategy_id,
+            CASE
+                WHEN array_length(nt.concurrency_parent_strategy_ids, 1) > 1 THEN nt.concurrency_parent_strategy_ids[2:array_length(nt.concurrency_parent_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_parent_strategy_ids,
+            nt.concurrency_strategy_ids[1] AS strategy_id,
+            CASE
+                WHEN array_length(nt.concurrency_strategy_ids, 1) > 1 THEN nt.concurrency_strategy_ids[2:array_length(nt.concurrency_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_strategy_ids,
+            nt.concurrency_keys[1] AS key,
+            CASE
+                WHEN array_length(nt.concurrency_keys, 1) > 1 THEN nt.concurrency_keys[2:array_length(nt.concurrency_keys, 1)]
+                ELSE '{}'::text[]
+            END AS next_keys,
+            nt.concurrency_max_runs[1] AS max_runs,
+            CASE
+                WHEN array_length(nt.concurrency_max_runs, 1) > 1 THEN nt.concurrency_max_runs[2:array_length(nt.concurrency_max_runs, 1)]
+                ELSE '{}'::integer[]
+            END AS next_max_runs,
+            nt.workflow_id,
+            nt.workflow_version_id,
+            nt.queue,
+            CURRENT_TIMESTAMP + convert_duration_to_interval(nt.schedule_timeout) AS schedule_timeout_at
+        FROM new_table nt
+        JOIN old_table ot ON ot.id = nt.id
+        WHERE nt.initial_state = 'QUEUED'
+            -- Concurrency strategy id should never be null
+            AND nt.concurrency_strategy_ids[1] IS NOT NULL
+            AND (nt.retry_backoff_factor IS NULL OR ot.app_retry_count IS NOT DISTINCT FROM nt.app_retry_count OR nt.app_retry_count = 0)
+            AND ot.retry_count IS DISTINCT FROM nt.retry_count
+    ), updated_slot AS (
+        UPDATE
+            v1_concurrency_slot cs
+        SET
+            task_retry_count = nt.retry_count,
+            schedule_timeout_at = nt.schedule_timeout_at,
+            is_filled = FALSE,
+            priority = 4
+        FROM
+            new_slot_rows nt
+        WHERE
+            cs.task_id = nt.id
+            AND cs.task_inserted_at = nt.inserted_at
+            AND cs.strategy_id = nt.strategy_id
+        RETURNING cs.*
+    ), slots_to_insert AS (
+        -- select the rows that were not updated
+        SELECT
+            nt.*
+        FROM
+            new_slot_rows nt
+        LEFT JOIN
+            updated_slot cs ON cs.task_id = nt.id AND cs.task_inserted_at = nt.inserted_at AND cs.strategy_id = nt.strategy_id
+        WHERE
+            cs.task_id IS NULL
+    )
+    INSERT INTO v1_concurrency_slot (
+        task_id,
+        task_inserted_at,
+        task_retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        priority,
+        key,
+        next_keys,
+        max_runs,
+        next_max_runs,
+        queue_to_notify,
+        schedule_timeout_at
+    )
+    SELECT
+        id,
+        inserted_at,
+        retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        4,
+        key,
+        next_keys,
+        max_runs,
+        next_max_runs,
+        queue,
+        schedule_timeout_at
+    FROM slots_to_insert;
+
+    INSERT INTO v1_queue_item (
+        tenant_id,
+        queue,
+        task_id,
+        task_inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        schedule_timeout_at,
+        step_timeout,
+        priority,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label,
+        batch_key
+    )
+    SELECT
+        nt.tenant_id,
+        nt.queue,
+        nt.id,
+        nt.inserted_at,
+        nt.external_id,
+        nt.action_id,
+        nt.step_id,
+        nt.workflow_id,
+        nt.workflow_run_id,
+        CURRENT_TIMESTAMP + convert_duration_to_interval(nt.schedule_timeout),
+        nt.step_timeout,
+        4,
+        nt.sticky,
+        nt.desired_worker_id,
+        nt.retry_count,
+        nt.desired_worker_label,
+        nt.batch_key
+    FROM new_table nt
+    JOIN old_table ot ON ot.id = nt.id
+    WHERE nt.initial_state = 'QUEUED'
+        AND nt.concurrency_strategy_ids[1] IS NULL
+        AND (nt.retry_backoff_factor IS NULL OR ot.app_retry_count IS NOT DISTINCT FROM nt.app_retry_count OR nt.app_retry_count = 0)
+        AND ot.retry_count IS DISTINCT FROM nt.retry_count
+    ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
+    ;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION v1_retry_queue_item_delete_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    WITH new_slot_rows AS (
+        SELECT
+            t.id,
+            t.inserted_at,
+            t.retry_count,
+            t.tenant_id,
+            t.workflow_run_id,
+            t.external_id,
+            t.concurrency_parent_strategy_ids[1] AS parent_strategy_id,
+            CASE
+                WHEN array_length(t.concurrency_parent_strategy_ids, 1) > 1 THEN t.concurrency_parent_strategy_ids[2:array_length(t.concurrency_parent_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_parent_strategy_ids,
+            t.concurrency_strategy_ids[1] AS strategy_id,
+            CASE
+                WHEN array_length(t.concurrency_strategy_ids, 1) > 1 THEN t.concurrency_strategy_ids[2:array_length(t.concurrency_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_strategy_ids,
+            t.concurrency_keys[1] AS key,
+            CASE
+                WHEN array_length(t.concurrency_keys, 1) > 1 THEN t.concurrency_keys[2:array_length(t.concurrency_keys, 1)]
+                ELSE '{}'::text[]
+            END AS next_keys,
+            t.concurrency_max_runs[1] AS max_runs,
+            CASE
+                WHEN array_length(t.concurrency_max_runs, 1) > 1 THEN t.concurrency_max_runs[2:array_length(t.concurrency_max_runs, 1)]
+                ELSE '{}'::integer[]
+            END AS next_max_runs,
+            t.workflow_id,
+            t.workflow_version_id,
+            t.queue,
+            CURRENT_TIMESTAMP + convert_duration_to_interval(t.schedule_timeout) AS schedule_timeout_at
+        FROM deleted_rows dr
+        JOIN
+            v1_task t ON t.id = dr.task_id AND t.inserted_at = dr.task_inserted_at
+        WHERE
+            dr.retry_after <= NOW()
+            AND t.initial_state = 'QUEUED'
+            -- Check to see if the task has a concurrency strategy
+            AND t.concurrency_strategy_ids[1] IS NOT NULL
+    )
+    INSERT INTO v1_concurrency_slot (
+        task_id,
+        task_inserted_at,
+        task_retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        priority,
+        key,
+        next_keys,
+        max_runs,
+        next_max_runs,
+        queue_to_notify,
+        schedule_timeout_at
+    )
+    SELECT
+        id,
+        inserted_at,
+        retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        4,
+        key,
+        next_keys,
+        max_runs,
+        next_max_runs,
+        queue,
+        schedule_timeout_at
+    FROM new_slot_rows
+    ON CONFLICT (task_id, task_inserted_at, task_retry_count, strategy_id)
+    DO UPDATE SET is_filled = FALSE, schedule_timeout_at = EXCLUDED.schedule_timeout_at;
+
+    WITH tasks AS (
+        SELECT
+            t.*
+        FROM
+            deleted_rows dr
+        JOIN v1_task t ON t.id = dr.task_id AND t.inserted_at = dr.task_inserted_at
+        WHERE
+            dr.retry_after <= NOW()
+            AND t.initial_state = 'QUEUED'
+            AND t.concurrency_strategy_ids[1] IS NULL
+    )
+    INSERT INTO v1_queue_item (
+        tenant_id,
+        queue,
+        task_id,
+        task_inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        schedule_timeout_at,
+        step_timeout,
+        priority,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label,
+        batch_key
+    )
+    SELECT
+        tenant_id,
+        queue,
+        id,
+        inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        CURRENT_TIMESTAMP + convert_duration_to_interval(schedule_timeout),
+        step_timeout,
+        4,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label,
+        batch_key
+    FROM tasks
+    ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
+    ;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION after_v1_concurrency_slot_delete_function()
+RETURNS trigger AS $$
+DECLARE
+    rec RECORD;
+BEGIN
+    -- Removing a retained replacement slot must suppress retry admission in the
+    -- same transaction, including retries whose deadline has already elapsed.
+    UPDATE v1_retry_queue_item r
+    SET retry_after = 'infinity'::timestamptz
+    FROM deleted_rows d
+    WHERE r.task_id = d.task_id
+        AND r.task_inserted_at = d.task_inserted_at
+        AND r.task_retry_count = d.task_retry_count;
+
+    DELETE FROM v1_retry_queue_item r
+    USING deleted_rows d
+    WHERE r.task_id = d.task_id
+        AND r.task_inserted_at = d.task_inserted_at
+        AND r.task_retry_count = d.task_retry_count;
+
+    FOR rec IN SELECT * FROM deleted_rows ORDER BY parent_strategy_id, workflow_version_id, workflow_run_id LOOP
+        IF rec.parent_strategy_id IS NOT NULL THEN
+            PERFORM cleanup_workflow_concurrency_slots(
+                rec.parent_strategy_id,
+                rec.workflow_version_id,
+                rec.workflow_run_id
+            );
+        END IF;
+    END LOOP;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION v1_concurrency_slot_update_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    -- Chained-slot upserts invoke statement-level UPDATE triggers even when
+    -- there are no rows to advance.
+    IF NOT EXISTS (SELECT 1 FROM new_table) THEN
+        RETURN NULL;
+    END IF;
+
+    -- If the concurrency slot has next_keys, insert a new slot for the next key
+    WITH new_slot_rows AS (
+        SELECT
+            t.id,
+            t.inserted_at,
+            t.retry_count,
+            t.tenant_id,
+            t.priority,
+            t.queue,
+            t.workflow_run_id,
+            t.external_id,
+            nt.next_parent_strategy_ids[1] AS parent_strategy_id,
+            CASE
+                WHEN array_length(nt.next_parent_strategy_ids, 1) > 1 THEN nt.next_parent_strategy_ids[2:array_length(nt.next_parent_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_parent_strategy_ids,
+            nt.next_strategy_ids[1] AS strategy_id,
+            CASE
+                WHEN array_length(nt.next_strategy_ids, 1) > 1 THEN nt.next_strategy_ids[2:array_length(nt.next_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_strategy_ids,
+            nt.next_keys[1] AS key,
+            CASE
+                WHEN array_length(nt.next_keys, 1) > 1 THEN nt.next_keys[2:array_length(nt.next_keys, 1)]
+                ELSE '{}'::text[]
+            END AS next_keys,
+            nt.next_max_runs[1] AS max_runs,
+            CASE
+                WHEN array_length(nt.next_max_runs, 1) > 1 THEN nt.next_max_runs[2:array_length(nt.next_max_runs, 1)]
+                ELSE '{}'::integer[]
+            END AS next_max_runs,
+            t.workflow_id,
+            t.workflow_version_id,
+            CURRENT_TIMESTAMP + convert_duration_to_interval(t.schedule_timeout) AS schedule_timeout_at
+        FROM new_table nt
+        JOIN old_table ot USING (task_id, task_inserted_at, task_retry_count, key)
+        JOIN v1_task t ON t.id = nt.task_id AND t.inserted_at = nt.task_inserted_at
+        WHERE
+            COALESCE(array_length(nt.next_keys, 1), 0) != 0
+            AND nt.is_filled = TRUE
+            AND nt.is_filled IS DISTINCT FROM ot.is_filled
+    )
+    INSERT INTO v1_concurrency_slot (
+        task_id,
+        task_inserted_at,
+        task_retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        priority,
+        key,
+        next_keys,
+        max_runs,
+        next_max_runs,
+        schedule_timeout_at,
+        queue_to_notify
+    )
+    SELECT
+        id,
+        inserted_at,
+        retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        COALESCE(priority, 1),
+        key,
+        next_keys,
+        max_runs,
+        next_max_runs,
+        schedule_timeout_at,
+        queue
+    FROM new_slot_rows
+    ON CONFLICT (task_id, task_inserted_at, task_retry_count, strategy_id)
+    DO UPDATE SET is_filled = FALSE, schedule_timeout_at = EXCLUDED.schedule_timeout_at;
+
+    -- If the concurrency slot does not have next_keys, insert an item into v1_queue_item
+    WITH tasks AS (
+        SELECT
+            t.*
+        FROM
+            new_table nt
+        JOIN old_table ot USING (task_id, task_inserted_at, task_retry_count, key)
+        JOIN v1_task t ON t.id = nt.task_id AND t.inserted_at = nt.task_inserted_at
+        WHERE
+            COALESCE(array_length(nt.next_keys, 1), 0) = 0
+            AND nt.is_filled = TRUE
+            AND nt.is_filled IS DISTINCT FROM ot.is_filled
+    )
+    INSERT INTO v1_queue_item (
+        tenant_id,
+        queue,
+        task_id,
+        task_inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        schedule_timeout_at,
+        step_timeout,
+        priority,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label,
+        batch_key
+    )
+    SELECT
+        tenant_id,
+        queue,
+        id,
+        inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        CURRENT_TIMESTAMP + convert_duration_to_interval(schedule_timeout),
+        step_timeout,
+        COALESCE(priority, 1),
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label,
+        batch_key
+    FROM tasks
+    ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
+    ;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION v1_task_update_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    WITH new_retry_rows AS (
+        SELECT
+            nt.id,
+            nt.inserted_at,
+            nt.retry_count,
+            nt.tenant_id,
+            -- NOTE: cap in log space before POWER. POWER(backoff_factor, app_retry_count)
+            -- overflows float8 (SQLSTATE 22003) for large retry counts, and LEAST cannot
+            -- prevent that because POWER is evaluated first. b^n > cap iff
+            -- n * ln(b) > ln(cap), so compare logs and skip POWER when the result
+            -- would exceed retry_max_backoff.
+            NOW() + (
+                LEAST(
+                    COALESCE(nt.retry_max_backoff, 86400)::double precision,
+                    CASE
+                        WHEN nt.retry_backoff_factor <= 1 THEN
+                            POWER(nt.retry_backoff_factor, nt.app_retry_count)
+                        WHEN LN(nt.retry_backoff_factor) * nt.app_retry_count
+                            >= LN(GREATEST(COALESCE(nt.retry_max_backoff, 86400), 1)::double precision) THEN
+                            COALESCE(nt.retry_max_backoff, 86400)::double precision
+                        ELSE
+                            POWER(nt.retry_backoff_factor, nt.app_retry_count)
+                    END
+                ) * interval '1 second'
+            ) AS retry_after
+        FROM new_table nt
+        JOIN old_table ot ON ot.id = nt.id
+        WHERE nt.initial_state = 'QUEUED'
+            AND nt.retry_backoff_factor IS NOT NULL
+            AND ot.app_retry_count IS DISTINCT FROM nt.app_retry_count
+            AND nt.app_retry_count != 0
+    )
+    INSERT INTO v1_retry_queue_item (
+        task_id,
+        task_inserted_at,
+        task_retry_count,
+        retry_after,
+        tenant_id
+    )
+    SELECT
+        id,
+        inserted_at,
+        retry_count,
+        retry_after,
+        tenant_id
+    FROM new_retry_rows;
+
+    WITH new_slot_rows AS (
+        SELECT
+            nt.id,
+            nt.inserted_at,
+            nt.retry_count,
+            nt.tenant_id,
+            nt.workflow_run_id,
+            nt.external_id,
+            nt.concurrency_parent_strategy_ids[1] AS parent_strategy_id,
+            CASE
+                WHEN array_length(nt.concurrency_parent_strategy_ids, 1) > 1 THEN nt.concurrency_parent_strategy_ids[2:array_length(nt.concurrency_parent_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_parent_strategy_ids,
+            nt.concurrency_strategy_ids[1] AS strategy_id,
+            CASE
+                WHEN array_length(nt.concurrency_strategy_ids, 1) > 1 THEN nt.concurrency_strategy_ids[2:array_length(nt.concurrency_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_strategy_ids,
+            nt.concurrency_keys[1] AS key,
+            CASE
+                WHEN array_length(nt.concurrency_keys, 1) > 1 THEN nt.concurrency_keys[2:array_length(nt.concurrency_keys, 1)]
+                ELSE '{}'::text[]
+            END AS next_keys,
+            nt.concurrency_max_runs[1] AS max_runs,
+            CASE
+                WHEN array_length(nt.concurrency_max_runs, 1) > 1 THEN nt.concurrency_max_runs[2:array_length(nt.concurrency_max_runs, 1)]
+                ELSE '{}'::integer[]
+            END AS next_max_runs,
+            nt.workflow_id,
+            nt.workflow_version_id,
+            nt.queue,
+            CURRENT_TIMESTAMP + convert_duration_to_interval(nt.schedule_timeout) AS schedule_timeout_at
+        FROM new_table nt
+        JOIN old_table ot ON ot.id = nt.id
+        WHERE nt.initial_state = 'QUEUED'
+            -- Concurrency strategy id should never be null
+            AND nt.concurrency_strategy_ids[1] IS NOT NULL
+            AND (nt.retry_backoff_factor IS NULL OR ot.app_retry_count IS NOT DISTINCT FROM nt.app_retry_count OR nt.app_retry_count = 0)
+            AND ot.retry_count IS DISTINCT FROM nt.retry_count
+    ), updated_slot AS (
+        UPDATE
+            v1_concurrency_slot cs
+        SET
+            task_retry_count = nt.retry_count,
+            schedule_timeout_at = nt.schedule_timeout_at,
+            is_filled = FALSE,
+            priority = 4
+        FROM
+            new_slot_rows nt
+        WHERE
+            cs.task_id = nt.id
+            AND cs.task_inserted_at = nt.inserted_at
+            AND cs.strategy_id = nt.strategy_id
+        RETURNING cs.*
+    ), slots_to_insert AS (
+        -- select the rows that were not updated
+        SELECT
+            nt.*
+        FROM
+            new_slot_rows nt
+        LEFT JOIN
+            updated_slot cs ON cs.task_id = nt.id AND cs.task_inserted_at = nt.inserted_at AND cs.strategy_id = nt.strategy_id
+        WHERE
+            cs.task_id IS NULL
+    )
+    INSERT INTO v1_concurrency_slot (
+        task_id,
+        task_inserted_at,
+        task_retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        priority,
+        key,
+        next_keys,
+        max_runs,
+        next_max_runs,
+        queue_to_notify,
+        schedule_timeout_at
+    )
+    SELECT
+        id,
+        inserted_at,
+        retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        4,
+        key,
+        next_keys,
+        max_runs,
+        next_max_runs,
+        queue,
+        schedule_timeout_at
+    FROM slots_to_insert;
+
+    INSERT INTO v1_queue_item (
+        tenant_id,
+        queue,
+        task_id,
+        task_inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        schedule_timeout_at,
+        step_timeout,
+        priority,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label,
+        batch_key
+    )
+    SELECT
+        nt.tenant_id,
+        nt.queue,
+        nt.id,
+        nt.inserted_at,
+        nt.external_id,
+        nt.action_id,
+        nt.step_id,
+        nt.workflow_id,
+        nt.workflow_run_id,
+        CURRENT_TIMESTAMP + convert_duration_to_interval(nt.schedule_timeout),
+        nt.step_timeout,
+        4,
+        nt.sticky,
+        nt.desired_worker_id,
+        nt.retry_count,
+        nt.desired_worker_label,
+        nt.batch_key
+    FROM new_table nt
+    JOIN old_table ot ON ot.id = nt.id
+    WHERE nt.initial_state = 'QUEUED'
+        AND nt.concurrency_strategy_ids[1] IS NULL
+        AND (nt.retry_backoff_factor IS NULL OR ot.app_retry_count IS NOT DISTINCT FROM nt.app_retry_count OR nt.app_retry_count = 0)
+        AND ot.retry_count IS DISTINCT FROM nt.retry_count
+    ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
+    ;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION v1_retry_queue_item_delete_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    WITH new_slot_rows AS (
+        SELECT
+            t.id,
+            t.inserted_at,
+            t.retry_count,
+            t.tenant_id,
+            t.workflow_run_id,
+            t.external_id,
+            t.concurrency_parent_strategy_ids[1] AS parent_strategy_id,
+            CASE
+                WHEN array_length(t.concurrency_parent_strategy_ids, 1) > 1 THEN t.concurrency_parent_strategy_ids[2:array_length(t.concurrency_parent_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_parent_strategy_ids,
+            t.concurrency_strategy_ids[1] AS strategy_id,
+            CASE
+                WHEN array_length(t.concurrency_strategy_ids, 1) > 1 THEN t.concurrency_strategy_ids[2:array_length(t.concurrency_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_strategy_ids,
+            t.concurrency_keys[1] AS key,
+            CASE
+                WHEN array_length(t.concurrency_keys, 1) > 1 THEN t.concurrency_keys[2:array_length(t.concurrency_keys, 1)]
+                ELSE '{}'::text[]
+            END AS next_keys,
+            t.concurrency_max_runs[1] AS max_runs,
+            CASE
+                WHEN array_length(t.concurrency_max_runs, 1) > 1 THEN t.concurrency_max_runs[2:array_length(t.concurrency_max_runs, 1)]
+                ELSE '{}'::integer[]
+            END AS next_max_runs,
+            t.workflow_id,
+            t.workflow_version_id,
+            t.queue,
+            CURRENT_TIMESTAMP + convert_duration_to_interval(t.schedule_timeout) AS schedule_timeout_at
+        FROM deleted_rows dr
+        JOIN
+            v1_task t ON t.id = dr.task_id AND t.inserted_at = dr.task_inserted_at
+        WHERE
+            dr.retry_after <= NOW()
+            AND t.initial_state = 'QUEUED'
+            -- Check to see if the task has a concurrency strategy
+            AND t.concurrency_strategy_ids[1] IS NOT NULL
+    )
+    INSERT INTO v1_concurrency_slot (
+        task_id,
+        task_inserted_at,
+        task_retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        priority,
+        key,
+        next_keys,
+        max_runs,
+        next_max_runs,
+        queue_to_notify,
+        schedule_timeout_at
+    )
+    SELECT
+        id,
+        inserted_at,
+        retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        4,
+        key,
+        next_keys,
+        max_runs,
+        next_max_runs,
+        queue,
+        schedule_timeout_at
+    FROM new_slot_rows;
+
+    WITH tasks AS (
+        SELECT
+            t.*
+        FROM
+            deleted_rows dr
+        JOIN v1_task t ON t.id = dr.task_id AND t.inserted_at = dr.task_inserted_at
+        WHERE
+            dr.retry_after <= NOW()
+            AND t.initial_state = 'QUEUED'
+            AND t.concurrency_strategy_ids[1] IS NULL
+    )
+    INSERT INTO v1_queue_item (
+        tenant_id,
+        queue,
+        task_id,
+        task_inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        schedule_timeout_at,
+        step_timeout,
+        priority,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label,
+        batch_key
+    )
+    SELECT
+        tenant_id,
+        queue,
+        id,
+        inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        CURRENT_TIMESTAMP + convert_duration_to_interval(schedule_timeout),
+        step_timeout,
+        4,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label,
+        batch_key
+    FROM tasks
+    ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
+    ;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION after_v1_concurrency_slot_delete_function()
+RETURNS trigger AS $$
+DECLARE
+    rec RECORD;
+BEGIN
+    FOR rec IN SELECT * FROM deleted_rows ORDER BY parent_strategy_id, workflow_version_id, workflow_run_id LOOP
+        IF rec.parent_strategy_id IS NOT NULL THEN
+            PERFORM cleanup_workflow_concurrency_slots(
+                rec.parent_strategy_id,
+                rec.workflow_version_id,
+                rec.workflow_run_id
+            );
+        END IF;
+    END LOOP;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION v1_concurrency_slot_update_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    -- If the concurrency slot has next_keys, insert a new slot for the next key
+    WITH new_slot_rows AS (
+        SELECT
+            t.id,
+            t.inserted_at,
+            t.retry_count,
+            t.tenant_id,
+            t.priority,
+            t.queue,
+            t.workflow_run_id,
+            t.external_id,
+            nt.next_parent_strategy_ids[1] AS parent_strategy_id,
+            CASE
+                WHEN array_length(nt.next_parent_strategy_ids, 1) > 1 THEN nt.next_parent_strategy_ids[2:array_length(nt.next_parent_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_parent_strategy_ids,
+            nt.next_strategy_ids[1] AS strategy_id,
+            CASE
+                WHEN array_length(nt.next_strategy_ids, 1) > 1 THEN nt.next_strategy_ids[2:array_length(nt.next_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_strategy_ids,
+            nt.next_keys[1] AS key,
+            CASE
+                WHEN array_length(nt.next_keys, 1) > 1 THEN nt.next_keys[2:array_length(nt.next_keys, 1)]
+                ELSE '{}'::text[]
+            END AS next_keys,
+            nt.next_max_runs[1] AS max_runs,
+            CASE
+                WHEN array_length(nt.next_max_runs, 1) > 1 THEN nt.next_max_runs[2:array_length(nt.next_max_runs, 1)]
+                ELSE '{}'::integer[]
+            END AS next_max_runs,
+            t.workflow_id,
+            t.workflow_version_id,
+            CURRENT_TIMESTAMP + convert_duration_to_interval(t.schedule_timeout) AS schedule_timeout_at
+        FROM new_table nt
+        JOIN old_table ot USING (task_id, task_inserted_at, task_retry_count, key)
+        JOIN v1_task t ON t.id = nt.task_id AND t.inserted_at = nt.task_inserted_at
+        WHERE
+            COALESCE(array_length(nt.next_keys, 1), 0) != 0
+            AND nt.is_filled = TRUE
+            AND nt.is_filled IS DISTINCT FROM ot.is_filled
+    )
+    INSERT INTO v1_concurrency_slot (
+        task_id,
+        task_inserted_at,
+        task_retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        priority,
+        key,
+        next_keys,
+        max_runs,
+        next_max_runs,
+        schedule_timeout_at,
+        queue_to_notify
+    )
+    SELECT
+        id,
+        inserted_at,
+        retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        COALESCE(priority, 1),
+        key,
+        next_keys,
+        max_runs,
+        next_max_runs,
+        schedule_timeout_at,
+        queue
+    FROM new_slot_rows;
+
+    -- If the concurrency slot does not have next_keys, insert an item into v1_queue_item
+    WITH tasks AS (
+        SELECT
+            t.*
+        FROM
+            new_table nt
+        JOIN old_table ot USING (task_id, task_inserted_at, task_retry_count, key)
+        JOIN v1_task t ON t.id = nt.task_id AND t.inserted_at = nt.task_inserted_at
+        WHERE
+            COALESCE(array_length(nt.next_keys, 1), 0) = 0
+            AND nt.is_filled = TRUE
+            AND nt.is_filled IS DISTINCT FROM ot.is_filled
+    )
+    INSERT INTO v1_queue_item (
+        tenant_id,
+        queue,
+        task_id,
+        task_inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        schedule_timeout_at,
+        step_timeout,
+        priority,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label,
+        batch_key
+    )
+    SELECT
+        tenant_id,
+        queue,
+        id,
+        inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        CURRENT_TIMESTAMP + convert_duration_to_interval(schedule_timeout),
+        step_timeout,
+        COALESCE(priority, 1),
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label,
+        batch_key
+    FROM tasks
+    ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
+    ;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- Pending retries must be admitted without conflicting with retained slots.
+DELETE FROM v1_concurrency_slot cs
+USING v1_retry_queue_item r
+WHERE cs.task_id = r.task_id
+    AND cs.task_inserted_at = r.task_inserted_at
+    AND cs.task_retry_count = r.task_retry_count;

--- a/pkg/scheduling/v1/workflow_replacement_retry_integration_test.go
+++ b/pkg/scheduling/v1/workflow_replacement_retry_integration_test.go
@@ -1,0 +1,151 @@
+//go:build integration
+
+package v1_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hatchet-dev/hatchet/pkg/config/database"
+	repo "github.com/hatchet-dev/hatchet/pkg/repository"
+	"github.com/hatchet-dev/hatchet/pkg/repository/sqlcv1"
+)
+
+func TestConcurrency_WorkflowReplacementDuringRetryBackoff(t *testing.T) {
+	for _, standalone := range []bool{false, true} {
+		for _, expired := range []bool{false, true} {
+			t.Run(fmt.Sprintf("standalone_%t/retry_due_%t", standalone, expired), func(t *testing.T) {
+				runWithDatabase(t, func(conf *database.Layer) error {
+					ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+					defer cancel()
+					requireSchedulerSchema(t, ctx, conf)
+					tenantID := uuid.New()
+					_, err := conf.V1.Tenant().CreateTenant(ctx, &repo.CreateTenantOpts{
+						ID: &tenantID, Name: "replacement-retry", Slug: fmt.Sprintf("replacement-retry-%s", tenantID),
+					})
+					require.NoError(t, err)
+					strategy := "CANCEL_IN_PROGRESS"
+					maxRuns := int32(1)
+					retries := 1
+					description := "workflow replacement during retry backoff"
+					tasks := []repo.CreateStepOpts{
+						{ReadableId: "work", Action: "test:work", Retries: &retries},
+					}
+					if !standalone {
+						tasks = append(tasks, repo.CreateStepOpts{ReadableId: "publish", Action: "test:publish", Parents: []string{"work"}})
+					}
+					version, err := conf.V1.Workflows().PutWorkflowVersion(ctx, tenantID, &repo.CreateWorkflowVersionOpts{
+						Name:        "replacement-retry",
+						Description: &description,
+						Concurrency: []repo.CreateConcurrencyOpts{{MaxRuns: &maxRuns, LimitStrategy: &strategy, Expression: "input.key"}},
+						Tasks:       tasks,
+					})
+					require.NoError(t, err)
+					queries := sqlcv1.New()
+					strategies, err := queries.ListActiveConcurrencyStrategies(ctx, conf.Pool, tenantID)
+					require.NoError(t, err)
+					require.NotEmpty(t, strategies)
+					child := strategies[0]
+					for _, candidate := range strategies {
+						var readableID string
+						err = conf.Pool.QueryRow(ctx, `SELECT "readableId" FROM "Step" WHERE id = $1`, candidate.StepID).Scan(&readableID)
+						require.NoError(t, err)
+						if readableID == "work" {
+							child = candidate
+						}
+					}
+					require.Equal(t, !standalone, child.ParentStrategyID.Valid)
+
+					create := func(key string) *repo.TaskIdInsertedAtRetryCount {
+						params := newCreateTasksParams(1)
+						params.Tenantids[0] = tenantID
+						params.Queues[0] = "default"
+						params.Actionids[0] = "test:work"
+						params.Stepids[0] = child.StepID
+						params.Stepreadableids[0] = "work"
+						params.Workflowids[0] = version.WorkflowVersion.WorkflowId
+						params.Scheduletimeouts[0] = "5m"
+						params.Priorities[0] = 1
+						params.Stickies[0] = "NONE"
+						params.Externalids[0] = uuid.New()
+						params.Displaynames[0] = "replacement-retry"
+						params.Additionalmetadatas[0] = []byte(`{}`)
+						params.InitialStates[0] = "QUEUED"
+						params.Concurrencyparentstrategyids[0] = []pgtype.Int8{child.ParentStrategyID}
+						params.ConcurrencyStrategyIds[0] = []int64{child.ID}
+						params.ConcurrencyKeys[0] = []string{key}
+						params.WorkflowVersionIds[0] = version.WorkflowVersion.ID
+						params.WorkflowRunIds[0] = params.Externalids[0]
+						params.RetryBackoffFactor[0] = pgtype.Float8{Float64: 30, Valid: true}
+						tasks, err := queries.CreateTasks(ctx, conf.Pool, params)
+						require.NoError(t, err)
+						require.Len(t, tasks, 1)
+						return &repo.TaskIdInsertedAtRetryCount{Id: tasks[0].ID, InsertedAt: tasks[0].InsertedAt, RetryCount: 0}
+					}
+					old := create("same-key")
+					concurrency := conf.V1.Scheduler().Concurrency()
+					admitted, err := concurrency.RunConcurrencyStrategy(ctx, tenantID, child)
+					require.NoError(t, err)
+					require.Len(t, admitted.Queued, 1)
+					_, err = conf.Pool.Exec(ctx, `INSERT INTO v1_task_runtime (task_id, task_inserted_at, retry_count, tenant_id, timeout_at) VALUES ($1, $2, 0, $3, NOW() + INTERVAL '5 minutes')`, old.Id, old.InsertedAt, tenantID)
+					require.NoError(t, err)
+					failed, err := conf.V1.Tasks().FailTasks(ctx, tenantID, []repo.FailTaskOpts{{TaskIdInsertedAtRetryCount: old, IsAppError: true, ErrorMessage: "retryable"}})
+					require.NoError(t, err)
+					require.Len(t, failed.RetriedTasks, 1)
+					var pending int
+					err = conf.Pool.QueryRow(ctx, "SELECT count(*) FROM v1_retry_queue_item WHERE task_id = $1", old.Id).Scan(&pending)
+					require.NoError(t, err)
+					require.Equal(t, 1, pending)
+					// Move the stored deadline instead of sleeping so both sides of retry
+					// admission are exercised deterministically.
+					if expired {
+						_, err = conf.Pool.Exec(ctx, "UPDATE v1_retry_queue_item SET retry_after = NOW() - INTERVAL '1 second' WHERE task_id = $1", old.Id)
+						require.NoError(t, err)
+					}
+					create("same-key")
+					replaced, err := concurrency.RunConcurrencyStrategy(ctx, tenantID, child)
+					require.NoError(t, err)
+					require.Len(t, replaced.Queued, 1)
+					require.Len(t, replaced.Cancelled, 1, "replacement must cancel the superseded pending retry")
+					require.Equal(t, old.Id, replaced.Cancelled[0].Id)
+					require.Equal(t, int32(1), replaced.Cancelled[0].RetryCount)
+					err = conf.Pool.QueryRow(ctx, "SELECT count(*) FROM v1_retry_queue_item WHERE task_id = $1", old.Id).Scan(&pending)
+					require.NoError(t, err)
+					require.Zero(t, pending, "replacement must remove the retry before asynchronous cancellation delivery")
+					_, err = conf.V1.Tasks().CancelTasks(ctx, tenantID, []repo.TaskIdInsertedAtRetryCount{*replaced.Cancelled[0].TaskIdInsertedAtRetryCount})
+					require.NoError(t, err)
+					// A different key can still fail, wait in backoff, and retry normally.
+					independent := create("other-key")
+					admitted, err = concurrency.RunConcurrencyStrategy(ctx, tenantID, child)
+					require.NoError(t, err)
+					require.Len(t, admitted.Queued, 1)
+					_, err = conf.Pool.Exec(ctx, `INSERT INTO v1_task_runtime (task_id, task_inserted_at, retry_count, tenant_id, timeout_at) VALUES ($1, $2, 0, $3, NOW() + INTERVAL '5 minutes')`, independent.Id, independent.InsertedAt, tenantID)
+					require.NoError(t, err)
+					failed, err = conf.V1.Tasks().FailTasks(ctx, tenantID, []repo.FailTaskOpts{{TaskIdInsertedAtRetryCount: independent, IsAppError: true}})
+					require.NoError(t, err)
+					require.Len(t, failed.RetriedTasks, 1)
+					waiting, err := concurrency.RunConcurrencyStrategy(ctx, tenantID, child)
+					require.NoError(t, err)
+					require.Empty(t, waiting.Queued, "the retained slot must not admit a retry before its deadline")
+					require.Empty(t, waiting.Cancelled)
+					_, err = conf.Pool.Exec(ctx, "UPDATE v1_retry_queue_item SET retry_after = NOW() - INTERVAL '1 second' WHERE task_id = $1", independent.Id)
+					require.NoError(t, err)
+					_, err = conf.Pool.Exec(ctx, "DELETE FROM v1_retry_queue_item WHERE task_id = $1", independent.Id)
+					require.NoError(t, err)
+					admitted, err = concurrency.RunConcurrencyStrategy(ctx, tenantID, child)
+					require.NoError(t, err)
+					require.Len(t, admitted.Queued, 1)
+					require.Equal(t, independent.Id, admitted.Queued[0].Id)
+					require.Equal(t, int32(1), admitted.Queued[0].RetryCount)
+					return nil
+				})
+			})
+		}
+	}
+}

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -1358,6 +1358,21 @@ RETURNS trigger AS $$
 DECLARE
     rec RECORD;
 BEGIN
+    -- Removing a retained replacement slot must suppress retry admission in the
+    -- same transaction, including retries whose deadline has already elapsed.
+    UPDATE v1_retry_queue_item r
+    SET retry_after = 'infinity'::timestamptz
+    FROM deleted_rows d
+    WHERE r.task_id = d.task_id
+        AND r.task_inserted_at = d.task_inserted_at
+        AND r.task_retry_count = d.task_retry_count;
+
+    DELETE FROM v1_retry_queue_item r
+    USING deleted_rows d
+    WHERE r.task_id = d.task_id
+        AND r.task_inserted_at = d.task_inserted_at
+        AND r.task_retry_count = d.task_retry_count;
+
     FOR rec IN SELECT * FROM deleted_rows ORDER BY parent_strategy_id, workflow_version_id, workflow_run_id LOOP
         IF rec.parent_strategy_id IS NOT NULL THEN
             PERFORM cleanup_workflow_concurrency_slots(
@@ -1612,6 +1627,24 @@ BEGIN
         tenant_id
     FROM new_retry_rows;
 
+    -- A pending retry remains unfinished work for replacement policies. Keep its
+    -- filled slot at the accepted invocation's position until retry admission.
+    UPDATE v1_concurrency_slot cs
+    SET task_retry_count = nt.retry_count
+    FROM new_table nt
+    JOIN old_table ot ON ot.id = nt.id AND ot.inserted_at = nt.inserted_at
+    JOIN v1_step_concurrency sc ON sc.id = ANY(nt.concurrency_strategy_ids)
+    WHERE cs.task_id = nt.id
+        AND cs.task_inserted_at = nt.inserted_at
+        AND cs.task_retry_count = ot.retry_count
+        AND cs.strategy_id = sc.id
+        AND sc.strategy = 'CANCEL_IN_PROGRESS'
+        AND cs.is_filled
+        AND nt.initial_state = 'QUEUED'
+        AND nt.retry_backoff_factor IS NOT NULL
+        AND ot.app_retry_count IS DISTINCT FROM nt.app_retry_count
+        AND nt.app_retry_count != 0;
+
     WITH new_slot_rows AS (
         SELECT
             nt.id,
@@ -1863,7 +1896,9 @@ BEGIN
         next_max_runs,
         queue,
         schedule_timeout_at
-    FROM new_slot_rows;
+    FROM new_slot_rows
+    ON CONFLICT (task_id, task_inserted_at, task_retry_count, strategy_id)
+    DO UPDATE SET is_filled = FALSE, schedule_timeout_at = EXCLUDED.schedule_timeout_at;
 
     WITH tasks AS (
         SELECT
@@ -1932,6 +1967,12 @@ CREATE OR REPLACE FUNCTION v1_concurrency_slot_update_function()
 RETURNS TRIGGER AS
 $$
 BEGIN
+    -- Chained-slot upserts invoke statement-level UPDATE triggers even when
+    -- there are no rows to advance.
+    IF NOT EXISTS (SELECT 1 FROM new_table) THEN
+        RETURN NULL;
+    END IF;
+
     -- If the concurrency slot has next_keys, insert a new slot for the next key
     WITH new_slot_rows AS (
         SELECT
@@ -2015,7 +2056,9 @@ BEGIN
         next_max_runs,
         schedule_timeout_at,
         queue
-    FROM new_slot_rows;
+    FROM new_slot_rows
+    ON CONFLICT (task_id, task_inserted_at, task_retry_count, strategy_id)
+    DO UPDATE SET is_filled = FALSE, schedule_timeout_at = EXCLUDED.schedule_timeout_at;
 
     -- If the concurrency slot does not have next_keys, insert an item into v1_queue_item
     WITH tasks AS (


### PR DESCRIPTION
Keep filled CANCEL_IN_PROGRESS slots attached to the current retry during backoff, preserving replacement ownership and ordering. Remove pending retries atomically when their retained slots are cancelled, and reuse retained slots when retries become eligible. Includes a reversible database migration.

Adds database regressions for workflow and single-task declarations, future and already-due retries, cancellation before asynchronous delivery, and ordinary retry admission on another key. All four cases fail without the change; the concurrency integration suite and concurrency unit tests pass with it. Migration rollback was also exercised with a pending retained retry.

**Draft:** the standalone first-step and durable-wait → later-step reproductions pass on v0.105.16 with the SQL fix backported. End-to-end validation on current main is blocked by a separate first-task dispatch failure that also occurs with this migration rolled back. Concurrent retry-admission interleavings and chained-policy retry coverage still need validation before this is ready.

Fixes #4900