### PR TITLE
fix(typescript-sdk): preserve desiredWorkerLabels in DurableContext.spawnChild

### DIFF
--- a/sdks/typescript/src/v1/client/admin.ts
+++ b/sdks/typescript/src/v1/client/admin.ts
@@ -119,14 +119,14 @@ function extractRunIdFromNiceGrpcMetadata(metadata: NiceGrpcMetadata | undefined
   return '';
 }
 
-type DesiredWorkerLabelOpt = {
+export type DesiredWorkerLabelOpt = {
   value: string | number;
   required?: boolean;
   weight?: number;
   comparator?: WorkerLabelComparator;
 };
 
-function convertDesiredWorkerLabels(
+export function convertDesiredWorkerLabels(
   labels: Record<string, DesiredWorkerLabelOpt>
 ): Record<string, DesiredWorkerLabels> {
   return Object.fromEntries(

--- a/sdks/typescript/src/v1/client/worker/context.test.ts
+++ b/sdks/typescript/src/v1/client/worker/context.test.ts
@@ -1,8 +1,9 @@
 import { createAction } from '@hatchet/clients/dispatcher/action-listener';
 import { ActionType } from '@hatchet-dev/typescript-sdk/protoc/dispatcher';
 import type { HatchetClient } from '@hatchet/v1';
-import { Context } from './context';
+import { Context, DurableContext } from './context';
 import type { InternalWorker } from './worker-internal';
+import type { DurableListenerClient } from '@hatchet/clients/listeners/durable-listener/durable-listener-client';
 
 describe('Context', () => {
   it('returns the workflow name without changing the deprecated method', () => {
@@ -38,5 +39,136 @@ describe('Context', () => {
     expect(context.workflowName()).toBe('my-task');
     expect(context.workflowNameV1()).toBe('my-workflow');
     expect(context.taskName()).toBe('my-task');
+  });
+});
+
+describe('DurableContext', () => {
+  function buildDurableContext() {
+    const action = createAction({
+      tenantId: 'tenant-id',
+      workflowRunId: 'workflow-run-id',
+      getGroupKeyRunId: '',
+      jobId: 'task-id',
+      jobName: 'my-task',
+      jobRunId: 'task-run-id',
+      taskId: 'task-id',
+      taskRunExternalId: 'task-run-id',
+      actionId: 'my-workflow:my-task',
+      actionType: ActionType.START_STEP_RUN,
+      actionPayload: JSON.stringify({ input: {} }),
+      taskName: 'my-task',
+      retryCount: 0,
+      priority: 1,
+    });
+    const logger = {
+      error: jest.fn(),
+    };
+    const client = {
+      config: {
+        logger: () => logger,
+        log_level: 'INFO',
+        namespace: '',
+      },
+    } as unknown as HatchetClient;
+    const worker = {} as InternalWorker;
+    const durableListener = {} as DurableListenerClient;
+
+    // The eviction-enabled durable trigger-opts path is only reachable once the
+    // engine version supports eviction (see `supportsEviction`).
+    return new DurableContext(action, client, worker, durableListener, undefined, 'v0.105.16');
+  }
+
+  // Regression test for https://github.com/hatchet-dev/hatchet/issues/4904:
+  // DurableContext's eviction-enabled trigger-opts builder hard-coded
+  // `desiredWorkerLabels: {}` instead of converting the caller-supplied labels,
+  // so labels passed to `spawnChild`/`spawnChildren` were silently dropped.
+  it('preserves desiredWorkerLabels when building durable child trigger opts', () => {
+    const context = buildDurableContext();
+
+    const desiredWorkerLabels = {
+      color: { value: 'blue', required: true, comparator: 0 },
+    };
+
+    const { triggerOpts } = (context as any)._buildTriggerOpts(
+      'child-workflow',
+      { foo: 'bar' },
+      {
+        key: 'child-key',
+        desiredWorkerLabels,
+      }
+    );
+
+    expect(triggerOpts.desiredWorkerLabels).toEqual({
+      color: {
+        strValue: 'blue',
+        intValue: undefined,
+        required: true,
+        weight: undefined,
+        comparator: 0,
+      },
+    });
+
+    // Other fields must remain correctly populated (unchanged by this fix).
+    expect(triggerOpts.parentId).toBe('workflow-run-id');
+    expect(triggerOpts.parentTaskRunExternalId).toBe('task-run-id');
+    expect(triggerOpts.childIndex).toBeDefined();
+    expect(triggerOpts.childKey).toBe('child-key');
+  });
+
+  it('produces empty desiredWorkerLabels when the caller does not supply labels', () => {
+    const context = buildDurableContext();
+
+    const { triggerOpts } = (context as any)._buildTriggerOpts(
+      'child-workflow',
+      { foo: 'bar' },
+      {
+        key: 'child-key',
+      }
+    );
+
+    expect(triggerOpts.desiredWorkerLabels).toEqual({});
+  });
+
+  it('preserves desiredWorkerLabels for each child when building bulk durable trigger opts', () => {
+    const context = buildDurableContext();
+
+    const blueLabels = { color: { value: 'blue', required: true, comparator: 0 } };
+    const redLabels = { color: { value: 'red', required: true, comparator: 0 } };
+
+    const first = (context as any)._buildTriggerOpts(
+      'child-workflow-1',
+      { foo: 'bar' },
+      {
+        key: 'child-1',
+        desiredWorkerLabels: blueLabels,
+      }
+    );
+    const second = (context as any)._buildTriggerOpts(
+      'child-workflow-2',
+      { foo: 'baz' },
+      {
+        key: 'child-2',
+        desiredWorkerLabels: redLabels,
+      }
+    );
+
+    expect(first.triggerOpts.desiredWorkerLabels).toEqual({
+      color: {
+        strValue: 'blue',
+        intValue: undefined,
+        required: true,
+        weight: undefined,
+        comparator: 0,
+      },
+    });
+    expect(second.triggerOpts.desiredWorkerLabels).toEqual({
+      color: {
+        strValue: 'red',
+        intValue: undefined,
+        required: true,
+        weight: undefined,
+        comparator: 0,
+      },
+    });
   });
 });

--- a/sdks/typescript/src/v1/client/worker/context.ts
+++ b/sdks/typescript/src/v1/client/worker/context.ts
@@ -33,6 +33,7 @@ import { WorkerLabels } from '@hatchet/clients/dispatcher/dispatcher-client';
 import { parentRunContextManager } from '@hatchet/v1/parent-run-context-vars';
 import { NextStep } from '@hatchet-dev/typescript-sdk/legacy/step';
 import { DurableListenerClient } from '@hatchet/clients/listeners/durable-listener/durable-listener-client';
+import { convertDesiredWorkerLabels } from '@hatchet/v1/client/admin';
 import { createHash } from 'crypto';
 import { z } from 'zod/v4';
 import { InternalWorker } from './worker-internal';
@@ -1209,7 +1210,9 @@ export class DurableContext<T, K = {}> extends Context<T, K> {
         : undefined,
       desiredWorkerId: options?.sticky ? this.worker.id() : undefined,
       priority: options?.priority,
-      desiredWorkerLabels: {},
+      desiredWorkerLabels: options?.desiredWorkerLabels
+        ? convertDesiredWorkerLabels(options.desiredWorkerLabels)
+        : {},
     };
 
     return { workflowName, triggerOpts };


### PR DESCRIPTION
## Summary

Fixes #4904.

`DurableContext.spawnChild()` / `spawnChildren()` silently dropped the caller-supplied `desiredWorkerLabels` whenever the eviction-enabled durable protocol was in use (i.e. once the connected engine supports eviction, per `supportsEviction()`). The outgoing `runChildren.triggerOpts[*].desiredWorkerLabels` ended up as `{}` even when the caller passed labels like `{ color: { value: 'blue', required: true, comparator: 0 } }`.

## Root cause

`DurableContext._buildTriggerOpts()` in `sdks/typescript/src/v1/client/worker/context.ts` hard-coded:

```ts
desiredWorkerLabels: {},
```

instead of converting `options?.desiredWorkerLabels`. The ordinary (non-durable) path, `Context.runChild()` / `runNoWaitChild()`, works correctly because it ultimately calls `AdminClient.runWorkflow()`, which converts labels via a local `convertDesiredWorkerLabels()` helper in `admin.ts`. The durable trigger-opts builder never called that helper — it just always emitted an empty map, dropping every field, static or overridden. `parentId`, `parentTaskRunExternalId`, `childIndex`, and `childKey` were unaffected since those are set directly from other fields.

## Fix

- Exported `convertDesiredWorkerLabels` (and its `DesiredWorkerLabelOpt` type) from `sdks/typescript/src/v1/client/admin.ts` so the conversion logic has a single source of truth instead of being duplicated.
- Updated `_buildTriggerOpts()` in `context.ts` to call `convertDesiredWorkerLabels(options.desiredWorkerLabels)` when labels are supplied, falling back to `{}` only when the caller didn't pass any — mirroring exactly what the ordinary path already does. No other field in `triggerOpts` was touched.

## Test plan

Added regression tests in `sdks/typescript/src/v1/client/worker/context.test.ts` that construct a `DurableContext` with an engine version that supports eviction (`v0.105.16`) and call the private `_buildTriggerOpts()` directly (mirroring how the issue reporter isolated the bug):

- A required label survives single durable child triggering, and `parentId` / `parentTaskRunExternalId` / `childIndex` / `childKey` remain correctly populated.
- Omitting labels still produces `desiredWorkerLabels: {}` (no regression for the common case).
- Bulk durable child triggering (`spawnChildren`) preserves distinct label overrides per child.

Verified locally:
- Confirmed the added tests fail against the pre-fix code (label objects come back as `{}`) and pass after the fix.
- `npx jest --testMatch='**/context.test.ts'` — 4/4 passing.
- `npm run test:unit` (full TypeScript SDK unit suite) — 29 suites, 244 passed / 2 skipped (pre-existing skips, unrelated to this change).
- `npx tsc --noEmit` — clean.
- `npx eslint` on all changed files — clean.