### PR TITLE
fix: guard worker `isActive` using a session id instead of just a timestamp

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260908090000_v1_0_152.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260908090000_v1_0_152.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Identifies the listener session that last activated the worker, so only that session can
+-- deactivate it when listener sessions overlap.
+ALTER TABLE "Worker" ADD COLUMN "lastListenerSessionId" UUID;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE "Worker" DROP COLUMN "lastListenerSessionId";
+-- +goose StatementEnd

--- a/internal/services/dispatcher/dispatcher.go
+++ b/internal/services/dispatcher/dispatcher.go
@@ -99,20 +99,20 @@ func (d *DispatcherImpl) CancelDAGChildren(ctx context.Context, tenantId uuid.UU
 var ErrWorkerNotFound = fmt.Errorf("worker not found")
 
 type workers struct {
-	innerMap syncx.Map[uuid.UUID, *syncx.Map[string, *subscribedWorker]]
+	innerMap syncx.Map[uuid.UUID, *syncx.Map[uuid.UUID, *subscribedWorker]]
 }
 
-func (w *workers) Range(f func(key uuid.UUID, value *syncx.Map[string, *subscribedWorker]) bool) {
+func (w *workers) Range(f func(key uuid.UUID, value *syncx.Map[uuid.UUID, *subscribedWorker]) bool) {
 	w.innerMap.Range(f)
 }
 
-func (w *workers) Add(workerId uuid.UUID, sessionId string, worker *subscribedWorker) {
-	actual, _ := w.innerMap.LoadOrStore(workerId, &syncx.Map[string, *subscribedWorker]{})
+func (w *workers) Add(workerId uuid.UUID, sessionId uuid.UUID, worker *subscribedWorker) {
+	actual, _ := w.innerMap.LoadOrStore(workerId, &syncx.Map[uuid.UUID, *subscribedWorker]{})
 
 	actual.Store(sessionId, worker)
 }
 
-func (w *workers) GetForSession(workerId uuid.UUID, sessionId string) (*subscribedWorker, error) {
+func (w *workers) GetForSession(workerId uuid.UUID, sessionId uuid.UUID) (*subscribedWorker, error) {
 	actual, ok := w.innerMap.Load(workerId)
 	if !ok {
 		return nil, ErrWorkerNotFound
@@ -135,7 +135,7 @@ func (w *workers) Get(workerId uuid.UUID) ([]*subscribedWorker, error) {
 
 	workers := []*subscribedWorker{}
 
-	actual.Range(func(key string, value *subscribedWorker) bool {
+	actual.Range(func(key uuid.UUID, value *subscribedWorker) bool {
 		workers = append(workers, value)
 		return true
 	})
@@ -143,7 +143,7 @@ func (w *workers) Get(workerId uuid.UUID) ([]*subscribedWorker, error) {
 	return workers, nil
 }
 
-func (w *workers) DeleteForSession(workerId uuid.UUID, sessionId string) {
+func (w *workers) DeleteForSession(workerId uuid.UUID, sessionId uuid.UUID) {
 	actual, ok := w.innerMap.Load(workerId)
 
 	if !ok {
@@ -445,8 +445,8 @@ func (d *DispatcherImpl) Start() (func() error, error) {
 		// drain the existing connections
 		d.l.Debug().Ctx(ctx).Msg("draining existing connections")
 
-		d.workers.Range(func(key uuid.UUID, value *syncx.Map[string, *subscribedWorker]) bool {
-			value.Range(func(key string, value *subscribedWorker) bool {
+		d.workers.Range(func(key uuid.UUID, value *syncx.Map[uuid.UUID, *subscribedWorker]) bool {
+			value.Range(func(key uuid.UUID, value *subscribedWorker) bool {
 				w := value
 
 				// operator-backed workers have no stream goroutine reading `finished`; the
@@ -492,7 +492,7 @@ func (d *DispatcherImpl) listenForOperators(ch <-chan []operator.Operator) {
 	// workerId -> sessionId for the operator-backed entries this loop has added; only this
 	// goroutine touches it. operator workers are exclusive to their operator instance, so a
 	// stable session per worker is sufficient.
-	sessions := make(map[uuid.UUID]string)
+	sessions := make(map[uuid.UUID]uuid.UUID)
 
 	for operators := range ch {
 		current := make(map[uuid.UUID]struct{}, len(operators))
@@ -505,7 +505,7 @@ func (d *DispatcherImpl) listenForOperators(ch <-chan []operator.Operator) {
 				continue
 			}
 
-			sessionId := uuid.NewString()
+			sessionId := uuid.New()
 			sessions[workerId] = sessionId
 
 			d.workers.Add(
@@ -682,7 +682,7 @@ func (d *DispatcherImpl) handleTaskBulkAssignedTask(ctx context.Context, msg *ms
 func (d *DispatcherImpl) GetLocalWorkerIds() map[uuid.UUID]struct{} {
 	workerIds := make(map[uuid.UUID]struct{})
 
-	d.workers.Range(func(workerId uuid.UUID, value *syncx.Map[string, *subscribedWorker]) bool {
+	d.workers.Range(func(workerId uuid.UUID, value *syncx.Map[uuid.UUID, *subscribedWorker]) bool {
 		workerIds[workerId] = struct{}{}
 
 		return true

--- a/internal/services/dispatcher/dispatcher_operators_test.go
+++ b/internal/services/dispatcher/dispatcher_operators_test.go
@@ -49,7 +49,7 @@ func TestListenForOperatorsReconcilesWorkerEntries(t *testing.T) {
 	op2 := &stubOperator{workerId: uuid.New()}
 
 	grpcWorkerId := uuid.New()
-	d.workers.Add(grpcWorkerId, "session", newGRPCSubscribedWorker(nil, nil, grpcWorkerId, time.Second, nil))
+	d.workers.Add(grpcWorkerId, uuid.New(), newGRPCSubscribedWorker(nil, nil, grpcWorkerId, time.Second, nil))
 
 	ch := make(chan []operator.Operator)
 	done := make(chan struct{})

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -297,7 +297,7 @@ func (s *DispatcherImpl) ListenV2(request *contracts.WorkerListenRequest, stream
 	tenant := ctx.Value("tenant").(*sqlcv1.Tenant)
 	tenantId := tenant.ID
 	s.analytics.Count(stream.Context(), analytics.Worker, analytics.Listen)
-	sessionId := uuid.New().String()
+	sessionId := uuid.New()
 	workerId, err := uuid.Parse(request.WorkerId)
 
 	if err != nil {
@@ -332,28 +332,23 @@ func (s *DispatcherImpl) ListenV2(request *contracts.WorkerListenRequest, stream
 		}
 	}
 
-	sessionEstablished := time.Now().UTC()
-
-	_, err = s.repov1.Workers().UpdateWorkerActiveStatus(ctx, tenantId, workerId, true, sessionEstablished)
+	// Activation records this session's id on the worker; deactivation below only succeeds
+	// while that id is still the one on the row, so a session that has been superseded by a
+	// newer listener can never mark the live session's worker inactive.
+	_, err = s.repov1.Workers().ActivateWorkerListener(ctx, tenantId, workerId, sessionId)
 
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil
 		}
 
-		lastSessionEstablished := "NULL"
-
-		if worker.LastListenerEstablished.Valid {
-			lastSessionEstablished = worker.LastListenerEstablished.Time.String()
-		}
-
-		s.l.Error().Ctx(ctx).Err(err).Msgf("could not update worker %s active status to true (session established %s, last session established %s)", request.WorkerId, sessionEstablished.String(), lastSessionEstablished)
+		s.l.Error().Ctx(ctx).Err(err).Msgf("could not activate worker %s for listener session %s", request.WorkerId, sessionId)
 		return err
 	}
 
 	fin := make(chan bool)
 
-	s.workers.Add(workerId, sessionId, newGRPCSubscribedWorker(stream, fin, workerId, s.defaultMaxWorkerLockAcquisitionTime, s.pubBuffer))
+	s.workers.Add(workerId, sessionId.String(), newGRPCSubscribedWorker(stream, fin, workerId, s.defaultMaxWorkerLockAcquisitionTime, s.pubBuffer))
 
 	defer func() {
 		// non-blocking send
@@ -362,7 +357,7 @@ func (s *DispatcherImpl) ListenV2(request *contracts.WorkerListenRequest, stream
 		default:
 		}
 
-		s.workers.DeleteForSession(workerId, sessionId)
+		s.workers.DeleteForSession(workerId, sessionId.String())
 	}()
 
 	// Keep the connection alive for sending messages
@@ -371,30 +366,37 @@ func (s *DispatcherImpl) ListenV2(request *contracts.WorkerListenRequest, stream
 		case <-fin:
 			s.l.Debug().Ctx(ctx).Msgf("closing stream for worker id: %s", request.WorkerId)
 
-			_, err = s.repov1.Workers().UpdateWorkerActiveStatus(ctx, tenantId, workerId, false, sessionEstablished)
-
-			if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-				s.l.Error().Ctx(ctx).Err(err).Msgf("could not update worker %s active status to false due to worker stream closing (session established %s)", request.WorkerId, sessionEstablished.String())
-				return err
-			}
-
-			return nil
+			return s.deactivateWorkerListener(ctx, tenantId, workerId, sessionId, "worker stream closing")
 		case <-ctx.Done():
 			s.l.Debug().Ctx(ctx).Msgf("worker id %s has disconnected", request.WorkerId)
 
+			// The stream context is already done, so the deactivation runs on a detached
+			// context with its own deadline.
 			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 			defer cancel()
 
-			_, err = s.repov1.Workers().UpdateWorkerActiveStatus(ctx, tenantId, workerId, false, sessionEstablished)
-
-			if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-				s.l.Error().Ctx(ctx).Err(err).Msgf("could not update worker %s active status due to worker disconnecting (session established %s)", request.WorkerId, sessionEstablished.String())
-				return err
-			}
-
-			return nil
+			return s.deactivateWorkerListener(ctx, tenantId, workerId, sessionId, "worker disconnecting")
 		}
 	}
+}
+
+// deactivateWorkerListener marks the worker inactive on behalf of the given listener
+// session. A superseded session (one whose id is no longer recorded on the worker) has
+// nothing to do, because the newer session owns the worker's active flag.
+func (s *DispatcherImpl) deactivateWorkerListener(ctx context.Context, tenantId, workerId, sessionId uuid.UUID, reason string) error {
+	_, err := s.repov1.Workers().DeactivateWorkerListener(ctx, tenantId, workerId, sessionId)
+
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, pgx.ErrNoRows) {
+		s.l.Debug().Ctx(ctx).Msgf("listener session %s for worker %s was superseded by a newer session, leaving worker active (%s)", sessionId, workerId, reason)
+		return nil
+	}
+
+	s.l.Error().Ctx(ctx).Err(err).Msgf("could not deactivate worker %s for listener session %s due to %s", workerId, sessionId, reason)
+	return err
 }
 
 const HeartbeatInterval = 4 * time.Second

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -188,7 +188,7 @@ func (s *DispatcherImpl) Listen(request *contracts.WorkerListenRequest, stream c
 	tenant := ctx.Value("tenant").(*sqlcv1.Tenant)
 	tenantId := tenant.ID
 	s.analytics.Count(ctx, analytics.Worker, analytics.Listen)
-	sessionId := uuid.New().String()
+	sessionId := uuid.New()
 	workerId, err := uuid.Parse(request.WorkerId)
 
 	if err != nil {
@@ -223,9 +223,23 @@ func (s *DispatcherImpl) Listen(request *contracts.WorkerListenRequest, stream c
 		}
 	}
 
+	// Activation records this session's id on the worker; deactivation below only succeeds
+	// while that id is still the one on the row, so a session superseded by a newer listener
+	// can never mark the live session's worker inactive.
+	_, err = s.repov1.Workers().ActivateWorkerListener(ctx, tenantId, workerId, sessionId)
+
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+
+		s.l.Error().Ctx(ctx).Err(err).Msgf("could not activate worker %s for listener session %s", request.WorkerId, sessionId)
+		return err
+	}
+
 	fin := make(chan bool)
 
-	s.workers.Add(workerId, sessionId, newGRPCSubscribedWorker(stream, fin, workerId, s.defaultMaxWorkerLockAcquisitionTime, s.pubBuffer))
+	s.workers.Add(workerId, sessionId.String(), newGRPCSubscribedWorker(stream, fin, workerId, s.defaultMaxWorkerLockAcquisitionTime, s.pubBuffer))
 
 	defer func() {
 		// non-blocking send
@@ -234,10 +248,11 @@ func (s *DispatcherImpl) Listen(request *contracts.WorkerListenRequest, stream c
 		default:
 		}
 
-		s.workers.DeleteForSession(workerId, sessionId)
+		s.workers.DeleteForSession(workerId, sessionId.String())
 	}()
 
-	// update the worker with a last heartbeat time every 5 seconds as long as the worker is connected
+	// legacy SDK clients do not call Heartbeat, so the worker's heartbeat is written here every
+	// 4 seconds for as long as the stream is open
 	go func() {
 		timer := time.NewTicker(100 * time.Millisecond)
 
@@ -257,16 +272,7 @@ func (s *DispatcherImpl) Listen(request *contracts.WorkerListenRequest, stream c
 				if now := time.Now().UTC(); lastHeartbeat.Add(4 * time.Second).Before(now) {
 					s.l.Debug().Ctx(ctx).Msgf("updating worker %s heartbeat", request.WorkerId)
 
-					_, err := s.repov1.Workers().UpdateWorker(ctx, tenantId, workerId, &v1.UpdateWorkerOpts{
-						LastHeartbeatAt: &now,
-						IsActive:        v1.BoolPtr(true),
-					})
-
-					if err != nil {
-						if errors.Is(err, pgx.ErrNoRows) {
-							return
-						}
-
+					if err := s.repov1.Workers().UpdateWorkerHeartbeat(ctx, tenantId, workerId, now); err != nil {
 						s.l.Error().Ctx(ctx).Err(err).Msgf("could not update worker %s heartbeat", request.WorkerId)
 						return
 					}
@@ -282,10 +288,17 @@ func (s *DispatcherImpl) Listen(request *contracts.WorkerListenRequest, stream c
 		select {
 		case <-fin:
 			s.l.Debug().Ctx(ctx).Msgf("closing stream for worker id: %s", request.WorkerId)
-			return nil
+
+			return s.deactivateWorkerListener(ctx, tenantId, workerId, sessionId, "worker stream closing")
 		case <-ctx.Done():
 			s.l.Debug().Ctx(ctx).Msgf("worker id %s has disconnected", request.WorkerId)
-			return nil
+
+			// The stream context is already done, so the deactivation runs on a detached
+			// context with its own deadline.
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+
+			return s.deactivateWorkerListener(ctx, tenantId, workerId, sessionId, "worker disconnecting")
 		}
 	}
 }

--- a/internal/services/dispatcher/server.go
+++ b/internal/services/dispatcher/server.go
@@ -239,7 +239,7 @@ func (s *DispatcherImpl) Listen(request *contracts.WorkerListenRequest, stream c
 
 	fin := make(chan bool)
 
-	s.workers.Add(workerId, sessionId.String(), newGRPCSubscribedWorker(stream, fin, workerId, s.defaultMaxWorkerLockAcquisitionTime, s.pubBuffer))
+	s.workers.Add(workerId, sessionId, newGRPCSubscribedWorker(stream, fin, workerId, s.defaultMaxWorkerLockAcquisitionTime, s.pubBuffer))
 
 	defer func() {
 		// non-blocking send
@@ -248,7 +248,7 @@ func (s *DispatcherImpl) Listen(request *contracts.WorkerListenRequest, stream c
 		default:
 		}
 
-		s.workers.DeleteForSession(workerId, sessionId.String())
+		s.workers.DeleteForSession(workerId, sessionId)
 	}()
 
 	// legacy SDK clients do not call Heartbeat, so the worker's heartbeat is written here every
@@ -361,7 +361,7 @@ func (s *DispatcherImpl) ListenV2(request *contracts.WorkerListenRequest, stream
 
 	fin := make(chan bool)
 
-	s.workers.Add(workerId, sessionId.String(), newGRPCSubscribedWorker(stream, fin, workerId, s.defaultMaxWorkerLockAcquisitionTime, s.pubBuffer))
+	s.workers.Add(workerId, sessionId, newGRPCSubscribedWorker(stream, fin, workerId, s.defaultMaxWorkerLockAcquisitionTime, s.pubBuffer))
 
 	defer func() {
 		// non-blocking send
@@ -370,7 +370,7 @@ func (s *DispatcherImpl) ListenV2(request *contracts.WorkerListenRequest, stream
 		default:
 		}
 
-		s.workers.DeleteForSession(workerId, sessionId.String())
+		s.workers.DeleteForSession(workerId, sessionId)
 	}()
 
 	// Keep the connection alive for sending messages

--- a/pkg/repository/sqlcv1/models.go
+++ b/pkg/repository/sqlcv1/models.go
@@ -4058,6 +4058,7 @@ type Worker struct {
 	MaxRuns                 int32            `json:"maxRuns"`
 	IsActive                bool             `json:"isActive"`
 	LastListenerEstablished pgtype.Timestamp `json:"lastListenerEstablished"`
+	LastListenerSessionId   *uuid.UUID       `json:"lastListenerSessionId"`
 	IsPaused                bool             `json:"isPaused"`
 	Type                    WorkerType       `json:"type"`
 	WebhookId               *uuid.UUID       `json:"webhookId"`

--- a/pkg/repository/sqlcv1/operator.sql.go
+++ b/pkg/repository/sqlcv1/operator.sql.go
@@ -181,7 +181,7 @@ INSERT INTO "Worker" (
     $5::uuid,
     -- operator workers have no gRPC listener to activate them, so they are born active.
     true
-) RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "lastHeartbeatAt", name, "dispatcherId", "maxRuns", "isActive", "lastListenerEstablished", "isPaused", type, "webhookId", "operatorId", language, "languageVersion", os, "runtimeExtra", "sdkVersion", "durableTaskDispatcherId", "actionHash"
+) RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "lastHeartbeatAt", name, "dispatcherId", "maxRuns", "isActive", "lastListenerEstablished", "lastListenerSessionId", "isPaused", type, "webhookId", "operatorId", language, "languageVersion", os, "runtimeExtra", "sdkVersion", "durableTaskDispatcherId", "actionHash"
 `
 
 type CreateOperatorWorkerParams struct {
@@ -216,6 +216,7 @@ func (q *Queries) CreateOperatorWorker(ctx context.Context, db DBTX, arg CreateO
 		&i.MaxRuns,
 		&i.IsActive,
 		&i.LastListenerEstablished,
+		&i.LastListenerSessionId,
 		&i.IsPaused,
 		&i.Type,
 		&i.WebhookId,

--- a/pkg/repository/sqlcv1/workers.sql
+++ b/pkg/repository/sqlcv1/workers.sql
@@ -528,17 +528,31 @@ WHERE
   "id" = @id::uuid
 RETURNING *;
 
--- name: UpdateWorkerActiveStatus :one
+-- name: ActivateWorkerListener :one
+-- Marks the worker active for the given listener session. lastListenerEstablished is
+-- stamped alongside the session id because Heartbeat uses it to tell a worker that never
+-- opened a listener from one whose listener has gone away.
 UPDATE "Worker"
 SET
-    "isActive" = @isActive::boolean,
-    "lastListenerEstablished" = sqlc.narg('lastListenerEstablished')::timestamp
+    "isActive" = TRUE,
+    "lastListenerSessionId" = @sessionId::uuid,
+    "lastListenerEstablished" = CURRENT_TIMESTAMP
 WHERE
     "id" = @id::uuid
-    AND (
-        "lastListenerEstablished" IS NULL
-        OR "lastListenerEstablished" <= sqlc.narg('lastListenerEstablished')::timestamp
-        )
+    AND "tenantId" = @tenantId::uuid
+RETURNING *;
+
+-- name: DeactivateWorkerListener :one
+-- Marks the worker inactive only while the given session is still the one recorded on the
+-- row. A session whose id is no longer on the row was superseded by a newer session and
+-- must not touch it, so this returns no rows in that case.
+UPDATE "Worker"
+SET
+    "isActive" = FALSE
+WHERE
+    "id" = @id::uuid
+    AND "tenantId" = @tenantId::uuid
+    AND "lastListenerSessionId" = @sessionId::uuid
 RETURNING *;
 
 -- name: UpsertWorkerLabel :one

--- a/pkg/repository/sqlcv1/workers.sql
+++ b/pkg/repository/sqlcv1/workers.sql
@@ -478,7 +478,6 @@ SET
     "updatedAt" = CURRENT_TIMESTAMP,
     "dispatcherId" = coalesce(sqlc.narg('dispatcherId')::uuid, "dispatcherId"),
     "lastHeartbeatAt" = coalesce(sqlc.narg('lastHeartbeatAt')::timestamp, "lastHeartbeatAt"),
-    "isActive" = coalesce(sqlc.narg('isActive')::boolean, "isActive"),
     "isPaused" = coalesce(sqlc.narg('isPaused')::boolean, "isPaused")
 WHERE
     "id" = @id::uuid

--- a/pkg/repository/sqlcv1/workers.sql.go
+++ b/pkg/repository/sqlcv1/workers.sql.go
@@ -13,6 +13,58 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const activateWorkerListener = `-- name: ActivateWorkerListener :one
+UPDATE "Worker"
+SET
+    "isActive" = TRUE,
+    "lastListenerSessionId" = $1::uuid,
+    "lastListenerEstablished" = CURRENT_TIMESTAMP
+WHERE
+    "id" = $2::uuid
+    AND "tenantId" = $3::uuid
+RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "lastHeartbeatAt", name, "dispatcherId", "maxRuns", "isActive", "lastListenerEstablished", "lastListenerSessionId", "isPaused", type, "webhookId", "operatorId", language, "languageVersion", os, "runtimeExtra", "sdkVersion", "durableTaskDispatcherId", "actionHash"
+`
+
+type ActivateWorkerListenerParams struct {
+	Sessionid uuid.UUID `json:"sessionid"`
+	ID        uuid.UUID `json:"id"`
+	Tenantid  uuid.UUID `json:"tenantid"`
+}
+
+// Marks the worker active for the given listener session. lastListenerEstablished is
+// stamped alongside the session id because Heartbeat uses it to tell a worker that never
+// opened a listener from one whose listener has gone away.
+func (q *Queries) ActivateWorkerListener(ctx context.Context, db DBTX, arg ActivateWorkerListenerParams) (*Worker, error) {
+	row := db.QueryRow(ctx, activateWorkerListener, arg.Sessionid, arg.ID, arg.Tenantid)
+	var i Worker
+	err := row.Scan(
+		&i.ID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.TenantId,
+		&i.LastHeartbeatAt,
+		&i.Name,
+		&i.DispatcherId,
+		&i.MaxRuns,
+		&i.IsActive,
+		&i.LastListenerEstablished,
+		&i.LastListenerSessionId,
+		&i.IsPaused,
+		&i.Type,
+		&i.WebhookId,
+		&i.OperatorId,
+		&i.Language,
+		&i.LanguageVersion,
+		&i.Os,
+		&i.RuntimeExtra,
+		&i.SdkVersion,
+		&i.DurableTaskDispatcherId,
+		&i.ActionHash,
+	)
+	return &i, err
+}
+
 const cleanupOldWorkers = `-- name: CleanupOldWorkers :execresult
 WITH old_workers AS (
     SELECT "id"
@@ -169,7 +221,7 @@ INSERT INTO "Worker" (
     $8::text,
     $9::text,
     $10::bytea
-) RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "lastHeartbeatAt", name, "dispatcherId", "maxRuns", "isActive", "lastListenerEstablished", "isPaused", type, "webhookId", "operatorId", language, "languageVersion", os, "runtimeExtra", "sdkVersion", "durableTaskDispatcherId", "actionHash"
+) RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "lastHeartbeatAt", name, "dispatcherId", "maxRuns", "isActive", "lastListenerEstablished", "lastListenerSessionId", "isPaused", type, "webhookId", "operatorId", language, "languageVersion", os, "runtimeExtra", "sdkVersion", "durableTaskDispatcherId", "actionHash"
 `
 
 type CreateWorkerParams struct {
@@ -211,6 +263,7 @@ func (q *Queries) CreateWorker(ctx context.Context, db DBTX, arg CreateWorkerPar
 		&i.MaxRuns,
 		&i.IsActive,
 		&i.LastListenerEstablished,
+		&i.LastListenerSessionId,
 		&i.IsPaused,
 		&i.Type,
 		&i.WebhookId,
@@ -265,12 +318,63 @@ func (q *Queries) CreateWorkerSlotConfigs(ctx context.Context, db DBTX, arg Crea
 	return err
 }
 
+const deactivateWorkerListener = `-- name: DeactivateWorkerListener :one
+UPDATE "Worker"
+SET
+    "isActive" = FALSE
+WHERE
+    "id" = $1::uuid
+    AND "tenantId" = $2::uuid
+    AND "lastListenerSessionId" = $3::uuid
+RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "lastHeartbeatAt", name, "dispatcherId", "maxRuns", "isActive", "lastListenerEstablished", "lastListenerSessionId", "isPaused", type, "webhookId", "operatorId", language, "languageVersion", os, "runtimeExtra", "sdkVersion", "durableTaskDispatcherId", "actionHash"
+`
+
+type DeactivateWorkerListenerParams struct {
+	ID        uuid.UUID `json:"id"`
+	Tenantid  uuid.UUID `json:"tenantid"`
+	Sessionid uuid.UUID `json:"sessionid"`
+}
+
+// Marks the worker inactive only while the given session is still the one recorded on the
+// row. A session whose id is no longer on the row was superseded by a newer session and
+// must not touch it, so this returns no rows in that case.
+func (q *Queries) DeactivateWorkerListener(ctx context.Context, db DBTX, arg DeactivateWorkerListenerParams) (*Worker, error) {
+	row := db.QueryRow(ctx, deactivateWorkerListener, arg.ID, arg.Tenantid, arg.Sessionid)
+	var i Worker
+	err := row.Scan(
+		&i.ID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.TenantId,
+		&i.LastHeartbeatAt,
+		&i.Name,
+		&i.DispatcherId,
+		&i.MaxRuns,
+		&i.IsActive,
+		&i.LastListenerEstablished,
+		&i.LastListenerSessionId,
+		&i.IsPaused,
+		&i.Type,
+		&i.WebhookId,
+		&i.OperatorId,
+		&i.Language,
+		&i.LanguageVersion,
+		&i.Os,
+		&i.RuntimeExtra,
+		&i.SdkVersion,
+		&i.DurableTaskDispatcherId,
+		&i.ActionHash,
+	)
+	return &i, err
+}
+
 const deleteWorker = `-- name: DeleteWorker :one
 DELETE FROM
   "Worker"
 WHERE
   "id" = $1::uuid
-RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "lastHeartbeatAt", name, "dispatcherId", "maxRuns", "isActive", "lastListenerEstablished", "isPaused", type, "webhookId", "operatorId", language, "languageVersion", os, "runtimeExtra", "sdkVersion", "durableTaskDispatcherId", "actionHash"
+RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "lastHeartbeatAt", name, "dispatcherId", "maxRuns", "isActive", "lastListenerEstablished", "lastListenerSessionId", "isPaused", type, "webhookId", "operatorId", language, "languageVersion", os, "runtimeExtra", "sdkVersion", "durableTaskDispatcherId", "actionHash"
 `
 
 func (q *Queries) DeleteWorker(ctx context.Context, db DBTX, id uuid.UUID) (*Worker, error) {
@@ -288,6 +392,7 @@ func (q *Queries) DeleteWorker(ctx context.Context, db DBTX, id uuid.UUID) (*Wor
 		&i.MaxRuns,
 		&i.IsActive,
 		&i.LastListenerEstablished,
+		&i.LastListenerSessionId,
 		&i.IsPaused,
 		&i.Type,
 		&i.WebhookId,
@@ -305,7 +410,7 @@ func (q *Queries) DeleteWorker(ctx context.Context, db DBTX, id uuid.UUID) (*Wor
 
 const getActiveWorkerById = `-- name: GetActiveWorkerById :one
 SELECT
-    w.id, w."createdAt", w."updatedAt", w."deletedAt", w."tenantId", w."lastHeartbeatAt", w.name, w."dispatcherId", w."maxRuns", w."isActive", w."lastListenerEstablished", w."isPaused", w.type, w."webhookId", w."operatorId", w.language, w."languageVersion", w.os, w."runtimeExtra", w."sdkVersion", w."durableTaskDispatcherId", w."actionHash",
+    w.id, w."createdAt", w."updatedAt", w."deletedAt", w."tenantId", w."lastHeartbeatAt", w.name, w."dispatcherId", w."maxRuns", w."isActive", w."lastListenerEstablished", w."lastListenerSessionId", w."isPaused", w.type, w."webhookId", w."operatorId", w.language, w."languageVersion", w.os, w."runtimeExtra", w."sdkVersion", w."durableTaskDispatcherId", w."actionHash",
     ww."url" AS "webhookUrl",
     w."maxRuns" - (
         SELECT COUNT(*)
@@ -353,6 +458,7 @@ func (q *Queries) GetActiveWorkerById(ctx context.Context, db DBTX, arg GetActiv
 		&i.Worker.MaxRuns,
 		&i.Worker.IsActive,
 		&i.Worker.LastListenerEstablished,
+		&i.Worker.LastListenerSessionId,
 		&i.Worker.IsPaused,
 		&i.Worker.Type,
 		&i.Worker.WebhookId,
@@ -469,7 +575,7 @@ func (q *Queries) GetWorkerActionsByWorkerId(ctx context.Context, db DBTX, arg G
 
 const getWorkerById = `-- name: GetWorkerById :one
 SELECT
-    w.id, w."createdAt", w."updatedAt", w."deletedAt", w."tenantId", w."lastHeartbeatAt", w.name, w."dispatcherId", w."maxRuns", w."isActive", w."lastListenerEstablished", w."isPaused", w.type, w."webhookId", w."operatorId", w.language, w."languageVersion", w.os, w."runtimeExtra", w."sdkVersion", w."durableTaskDispatcherId", w."actionHash",
+    w.id, w."createdAt", w."updatedAt", w."deletedAt", w."tenantId", w."lastHeartbeatAt", w.name, w."dispatcherId", w."maxRuns", w."isActive", w."lastListenerEstablished", w."lastListenerSessionId", w."isPaused", w.type, w."webhookId", w."operatorId", w.language, w."languageVersion", w.os, w."runtimeExtra", w."sdkVersion", w."durableTaskDispatcherId", w."actionHash",
     w."maxRuns" - (
         SELECT
             COALESCE(SUM(CASE WHEN runtime.batch_id IS NULL THEN 1 ELSE 0 END), 0)::integer
@@ -505,6 +611,7 @@ func (q *Queries) GetWorkerById(ctx context.Context, db DBTX, id uuid.UUID) (*Ge
 		&i.Worker.MaxRuns,
 		&i.Worker.IsActive,
 		&i.Worker.LastListenerEstablished,
+		&i.Worker.LastListenerSessionId,
 		&i.Worker.IsPaused,
 		&i.Worker.Type,
 		&i.Worker.WebhookId,
@@ -1398,7 +1505,7 @@ func (q *Queries) ListWorkerSlotConfigs(ctx context.Context, db DBTX, arg ListWo
 
 const listWorkers = `-- name: ListWorkers :many
 SELECT
-    workers.id, workers."createdAt", workers."updatedAt", workers."deletedAt", workers."tenantId", workers."lastHeartbeatAt", workers.name, workers."dispatcherId", workers."maxRuns", workers."isActive", workers."lastListenerEstablished", workers."isPaused", workers.type, workers."webhookId", workers."operatorId", workers.language, workers."languageVersion", workers.os, workers."runtimeExtra", workers."sdkVersion", workers."durableTaskDispatcherId", workers."actionHash"
+    workers.id, workers."createdAt", workers."updatedAt", workers."deletedAt", workers."tenantId", workers."lastHeartbeatAt", workers.name, workers."dispatcherId", workers."maxRuns", workers."isActive", workers."lastListenerEstablished", workers."lastListenerSessionId", workers."isPaused", workers.type, workers."webhookId", workers."operatorId", workers.language, workers."languageVersion", workers.os, workers."runtimeExtra", workers."sdkVersion", workers."durableTaskDispatcherId", workers."actionHash"
 FROM
     "Worker" workers
 WHERE
@@ -1527,6 +1634,7 @@ func (q *Queries) ListWorkers(ctx context.Context, db DBTX, arg ListWorkersParam
 			&i.Worker.MaxRuns,
 			&i.Worker.IsActive,
 			&i.Worker.LastListenerEstablished,
+			&i.Worker.LastListenerSessionId,
 			&i.Worker.IsPaused,
 			&i.Worker.Type,
 			&i.Worker.WebhookId,
@@ -1575,7 +1683,7 @@ SET
     "isPaused" = coalesce($4::boolean, "isPaused")
 WHERE
     "id" = $5::uuid
-RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "lastHeartbeatAt", name, "dispatcherId", "maxRuns", "isActive", "lastListenerEstablished", "isPaused", type, "webhookId", "operatorId", language, "languageVersion", os, "runtimeExtra", "sdkVersion", "durableTaskDispatcherId", "actionHash"
+RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "lastHeartbeatAt", name, "dispatcherId", "maxRuns", "isActive", "lastListenerEstablished", "lastListenerSessionId", "isPaused", type, "webhookId", "operatorId", language, "languageVersion", os, "runtimeExtra", "sdkVersion", "durableTaskDispatcherId", "actionHash"
 `
 
 type UpdateWorkerParams struct {
@@ -1607,56 +1715,7 @@ func (q *Queries) UpdateWorker(ctx context.Context, db DBTX, arg UpdateWorkerPar
 		&i.MaxRuns,
 		&i.IsActive,
 		&i.LastListenerEstablished,
-		&i.IsPaused,
-		&i.Type,
-		&i.WebhookId,
-		&i.OperatorId,
-		&i.Language,
-		&i.LanguageVersion,
-		&i.Os,
-		&i.RuntimeExtra,
-		&i.SdkVersion,
-		&i.DurableTaskDispatcherId,
-		&i.ActionHash,
-	)
-	return &i, err
-}
-
-const updateWorkerActiveStatus = `-- name: UpdateWorkerActiveStatus :one
-UPDATE "Worker"
-SET
-    "isActive" = $1::boolean,
-    "lastListenerEstablished" = $2::timestamp
-WHERE
-    "id" = $3::uuid
-    AND (
-        "lastListenerEstablished" IS NULL
-        OR "lastListenerEstablished" <= $2::timestamp
-        )
-RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "lastHeartbeatAt", name, "dispatcherId", "maxRuns", "isActive", "lastListenerEstablished", "isPaused", type, "webhookId", "operatorId", language, "languageVersion", os, "runtimeExtra", "sdkVersion", "durableTaskDispatcherId", "actionHash"
-`
-
-type UpdateWorkerActiveStatusParams struct {
-	Isactive                bool             `json:"isactive"`
-	LastListenerEstablished pgtype.Timestamp `json:"lastListenerEstablished"`
-	ID                      uuid.UUID        `json:"id"`
-}
-
-func (q *Queries) UpdateWorkerActiveStatus(ctx context.Context, db DBTX, arg UpdateWorkerActiveStatusParams) (*Worker, error) {
-	row := db.QueryRow(ctx, updateWorkerActiveStatus, arg.Isactive, arg.LastListenerEstablished, arg.ID)
-	var i Worker
-	err := row.Scan(
-		&i.ID,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.DeletedAt,
-		&i.TenantId,
-		&i.LastHeartbeatAt,
-		&i.Name,
-		&i.DispatcherId,
-		&i.MaxRuns,
-		&i.IsActive,
-		&i.LastListenerEstablished,
+		&i.LastListenerSessionId,
 		&i.IsPaused,
 		&i.Type,
 		&i.WebhookId,
@@ -1702,7 +1761,7 @@ SET
     "lastHeartbeatAt" = $1::timestamp
 WHERE
     "id" = $2::uuid
-RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "lastHeartbeatAt", name, "dispatcherId", "maxRuns", "isActive", "lastListenerEstablished", "isPaused", type, "webhookId", "operatorId", language, "languageVersion", os, "runtimeExtra", "sdkVersion", "durableTaskDispatcherId", "actionHash"
+RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "lastHeartbeatAt", name, "dispatcherId", "maxRuns", "isActive", "lastListenerEstablished", "lastListenerSessionId", "isPaused", type, "webhookId", "operatorId", language, "languageVersion", os, "runtimeExtra", "sdkVersion", "durableTaskDispatcherId", "actionHash"
 `
 
 type UpdateWorkerHeartbeatParams struct {
@@ -1725,6 +1784,7 @@ func (q *Queries) UpdateWorkerHeartbeat(ctx context.Context, db DBTX, arg Update
 		&i.MaxRuns,
 		&i.IsActive,
 		&i.LastListenerEstablished,
+		&i.LastListenerSessionId,
 		&i.IsPaused,
 		&i.Type,
 		&i.WebhookId,

--- a/pkg/repository/sqlcv1/workers.sql.go
+++ b/pkg/repository/sqlcv1/workers.sql.go
@@ -1679,17 +1679,15 @@ SET
     "updatedAt" = CURRENT_TIMESTAMP,
     "dispatcherId" = coalesce($1::uuid, "dispatcherId"),
     "lastHeartbeatAt" = coalesce($2::timestamp, "lastHeartbeatAt"),
-    "isActive" = coalesce($3::boolean, "isActive"),
-    "isPaused" = coalesce($4::boolean, "isPaused")
+    "isPaused" = coalesce($3::boolean, "isPaused")
 WHERE
-    "id" = $5::uuid
+    "id" = $4::uuid
 RETURNING id, "createdAt", "updatedAt", "deletedAt", "tenantId", "lastHeartbeatAt", name, "dispatcherId", "maxRuns", "isActive", "lastListenerEstablished", "lastListenerSessionId", "isPaused", type, "webhookId", "operatorId", language, "languageVersion", os, "runtimeExtra", "sdkVersion", "durableTaskDispatcherId", "actionHash"
 `
 
 type UpdateWorkerParams struct {
 	DispatcherId    *uuid.UUID       `json:"dispatcherId"`
 	LastHeartbeatAt pgtype.Timestamp `json:"lastHeartbeatAt"`
-	IsActive        pgtype.Bool      `json:"isActive"`
 	IsPaused        pgtype.Bool      `json:"isPaused"`
 	ID              uuid.UUID        `json:"id"`
 }
@@ -1698,7 +1696,6 @@ func (q *Queries) UpdateWorker(ctx context.Context, db DBTX, arg UpdateWorkerPar
 	row := db.QueryRow(ctx, updateWorker,
 		arg.DispatcherId,
 		arg.LastHeartbeatAt,
-		arg.IsActive,
 		arg.IsPaused,
 		arg.ID,
 	)

--- a/pkg/repository/worker.go
+++ b/pkg/repository/worker.go
@@ -144,7 +144,15 @@ type WorkerRepository interface {
 
 	GetWorkerForEngine(ctx context.Context, tenantId uuid.UUID, workerId uuid.UUID) (*sqlcv1.GetWorkerForEngineRow, error)
 
-	UpdateWorkerActiveStatus(ctx context.Context, tenantId uuid.UUID, workerId uuid.UUID, isActive bool, timestamp time.Time) (*sqlcv1.Worker, error)
+	// ActivateWorkerListener marks the worker active on behalf of the listener session
+	// identified by sessionId and records that id on the worker, so only this session can
+	// later deactivate it.
+	ActivateWorkerListener(ctx context.Context, tenantId uuid.UUID, workerId uuid.UUID, sessionId uuid.UUID) (*sqlcv1.Worker, error)
+
+	// DeactivateWorkerListener marks the worker inactive if sessionId is still the session
+	// recorded by ActivateWorkerListener. It returns pgx.ErrNoRows when a newer session has
+	// superseded this one, in which case the worker is left untouched.
+	DeactivateWorkerListener(ctx context.Context, tenantId uuid.UUID, workerId uuid.UUID, sessionId uuid.UUID) (*sqlcv1.Worker, error)
 
 	UpsertWorkerLabels(ctx context.Context, workerId uuid.UUID, opts []UpsertWorkerLabelOpts) ([]*sqlcv1.WorkerLabel, error)
 
@@ -845,15 +853,29 @@ func (w *workerRepository) DeleteWorker(ctx context.Context, tenantId uuid.UUID,
 	return err
 }
 
-func (w *workerRepository) UpdateWorkerActiveStatus(ctx context.Context, tenantId uuid.UUID, workerId uuid.UUID, isActive bool, timestamp time.Time) (*sqlcv1.Worker, error) {
-	worker, err := w.queries.UpdateWorkerActiveStatus(ctx, w.pool, sqlcv1.UpdateWorkerActiveStatusParams{
-		ID:                      workerId,
-		Isactive:                isActive,
-		LastListenerEstablished: sqlchelpers.TimestampFromTime(timestamp),
+func (w *workerRepository) ActivateWorkerListener(ctx context.Context, tenantId uuid.UUID, workerId uuid.UUID, sessionId uuid.UUID) (*sqlcv1.Worker, error) {
+	worker, err := w.queries.ActivateWorkerListener(ctx, w.pool, sqlcv1.ActivateWorkerListenerParams{
+		ID:        workerId,
+		Tenantid:  tenantId,
+		Sessionid: sessionId,
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("could not update worker active status: %w", err)
+		return nil, fmt.Errorf("could not activate worker listener: %w", err)
+	}
+
+	return worker, nil
+}
+
+func (w *workerRepository) DeactivateWorkerListener(ctx context.Context, tenantId uuid.UUID, workerId uuid.UUID, sessionId uuid.UUID) (*sqlcv1.Worker, error) {
+	worker, err := w.queries.DeactivateWorkerListener(ctx, w.pool, sqlcv1.DeactivateWorkerListenerParams{
+		ID:        workerId,
+		Tenantid:  tenantId,
+		Sessionid: sessionId,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("could not deactivate worker listener: %w", err)
 	}
 
 	return worker, nil

--- a/pkg/repository/worker.go
+++ b/pkg/repository/worker.go
@@ -54,9 +54,6 @@ type UpdateWorkerOpts struct {
 	// When the last worker heartbeat was
 	LastHeartbeatAt *time.Time
 
-	// If the worker is active and accepting new runs
-	IsActive *bool
-
 	// A list of actions this worker can run
 	Actions []string `validate:"dive,actionId"`
 
@@ -746,13 +743,6 @@ func (w *workerRepository) UpdateWorker(ctx context.Context, tenantId uuid.UUID,
 	if opts.DispatcherId != nil {
 		parsed := *opts.DispatcherId
 		updateParams.DispatcherId = &parsed
-	}
-
-	if opts.IsActive != nil {
-		updateParams.IsActive = pgtype.Bool{
-			Bool:  *opts.IsActive,
-			Valid: true,
-		}
 	}
 
 	if opts.IsPaused != nil {

--- a/pkg/scheduling/v1/scheduler_integration_test.go
+++ b/pkg/scheduling/v1/scheduler_integration_test.go
@@ -126,10 +126,11 @@ func createTenantDispatcherWorker(
 	now := time.Now().UTC()
 	require.NoError(t, r.Workers().UpdateWorkerHeartbeat(ctx, tenantId, worker.ID, now))
 
-	isActive := true
+	_, err = r.Workers().ActivateWorkerListener(ctx, tenantId, worker.ID, uuid.New())
+	require.NoError(t, err)
+
 	isPaused := false
 	_, err = r.Workers().UpdateWorker(ctx, tenantId, worker.ID, &repo.UpdateWorkerOpts{
-		IsActive: &isActive,
 		IsPaused: &isPaused,
 	})
 	require.NoError(t, err)

--- a/sql/schema/v0.sql
+++ b/sql/schema/v0.sql
@@ -860,6 +860,10 @@ CREATE TABLE "Worker" (
     "maxRuns" INTEGER NOT NULL DEFAULT 100,
     "isActive" BOOLEAN NOT NULL DEFAULT false,
     "lastListenerEstablished" TIMESTAMP(3),
+    -- Identifies the listener session that last activated the worker. A session may only
+    -- deactivate the worker while its id is still stored here; a session whose id has been
+    -- replaced was superseded by a newer listener and must not mark the worker inactive.
+    "lastListenerSessionId" UUID,
     "isPaused" BOOLEAN NOT NULL DEFAULT false,
     "type" "WorkerType" NOT NULL DEFAULT 'SELFHOSTED',
     "webhookId" UUID,


### PR DESCRIPTION
# Description

There's a very rare edge case where a worker which is reconnecting via `ListenV2` is marked as inactive when it's still active, because the successful reconnect `ListenV2()` happens before the previous `ListenV2` stream has fully shut down. There are really two separate issues here:
1. `lastListenerEstablished` is a `TIMESTAMP(3)` (thanks Prisma) which means it truncates to milliseconds, so if this happened in the same millisecond it's super racy
2. The fact that a new `ListenV2` could be superseded by an old `ListenV2` which no longer had worker stream ownership in the first place 

There's some improved / more explicit timestamp handling for the first issue, and a new column `lastListenerSessionId` for the second issue.

This was uncovered during reconnect tests for gRPC-based operators which hook into worker `isActive`. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Documented (where applicable)
- [X] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [X] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude w/ Fable 5.1 

</details>
