### PR TITLE
fix(engine): fix more sources of orphaned `v1_match` rows

### DIFF
--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -1900,9 +1900,20 @@ func (r *sharedRepository) registerChildWorkflows(
 			continue
 		}
 
+		if spawnsAsOperatorRun(tuple, steps) {
+			continue
+		}
+
 		for stepIndex, step := range orderSteps(steps) {
 			stepId := step.ID
-			stepExternalId := stepsToExternalIds[i][stepId]
+			stepExternalId, hasExternalId := stepsToExternalIds[i][stepId]
+
+			// stepsToExternalIds only contains regular user steps. The DAG orchestrator step's
+			// task runs under the run's external id and its completion is handled by the operator
+			// paths, so a per-step match here would hint at a zero UUID and never be satisfied.
+			if !hasExternalId {
+				continue
+			}
 
 			k := getChildSignalEventKey(*tuple.parentExternalId, int64(stepIndex), *tuple.childIndex, tuple.childKey)
 
@@ -2037,10 +2048,18 @@ func (r *sharedRepository) registerChildWorkflows(
 				continue
 			}
 
+			if spawnsAsOperatorRun(tuple, steps) {
+				continue
+			}
+
 			for _, step := range orderSteps(steps) {
 				stepId := step.ID
 				stepReadableId := step.ReadableId.String
-				stepExternalId := stepsToExternalIds[i][stepId]
+				stepExternalId, hasExternalId := stepsToExternalIds[i][stepId]
+
+				if !hasExternalId {
+					continue
+				}
 
 				key := externalIdsToKeys[stepExternalId]
 
@@ -2281,6 +2300,20 @@ func filterStepsByActionId(steps []*sqlcv1.ListStepsByWorkflowVersionIdsRow, act
 		}
 	}
 	return nil
+}
+
+func spawnsAsOperatorRun(tuple triggerTuple, steps []*sqlcv1.ListStepsByWorkflowVersionIdsRow) bool {
+	if tuple.targetActionId != nil {
+		return false
+	}
+
+	for _, s := range steps {
+		if s.IsDagOrchestrator {
+			return true
+		}
+	}
+
+	return false
 }
 
 func regularUserSteps(steps []*sqlcv1.ListStepsByWorkflowVersionIdsRow) []*sqlcv1.ListStepsByWorkflowVersionIdsRow {

--- a/pkg/repository/trigger.go
+++ b/pkg/repository/trigger.go
@@ -1900,10 +1900,6 @@ func (r *sharedRepository) registerChildWorkflows(
 			continue
 		}
 
-		if spawnsAsOperatorRun(tuple, steps) {
-			continue
-		}
-
 		for stepIndex, step := range orderSteps(steps) {
 			stepId := step.ID
 			stepExternalId, hasExternalId := stepsToExternalIds[i][stepId]


### PR DESCRIPTION
# Description

One more of these, fixing more sources of orphaned rows in `v1_match`. Was easy to repro locally by spawning a dag as a child, which would result in a match write that never got cleaned up, causing the match table to grow indefinitely

Made sure on this branch that when we spawn child dags (and just run the test suite in general), no match rows are left behind so the table stays small

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Fable to help repro + fix

</details>
