### PR TITLE
fix(sdk-python): fail fast on duplicate worker action ids

### DIFF
--- a/sdks/python/hatchet_sdk/worker/worker.py
+++ b/sdks/python/hatchet_sdk/worker/worker.py
@@ -353,6 +353,24 @@ class Worker:
             msg = f"failed to register workflow: {workflow.name}. Workflows must have at least one task registered before registering"
             raise ValueError(msg)
 
+        # Fail fast on action-id collisions before anything is registered server-side.
+        # Action ids are namespaced and lowercased, so tasks whose names differ only by case
+        # (or that share an explicit name) map to the same action id. A bare registry
+        # assignment would silently overwrite the first task, and the worker would then run
+        # the wrong function for one of the workflows with no warning anywhere.
+        new_actions: dict[str, Task[Any, Any]] = {}
+        for step in workflow.tasks:
+            action_name = workflow._create_action_name(step)
+            existing = self._action_registry.get(action_name) or new_actions.get(action_name)
+            if existing is not None and existing is not step:
+                msg = (
+                    f"failed to register workflow: {workflow.name}. Action id '{action_name}' is already "
+                    f"registered to another task. Action ids are lowercased, so task names that differ "
+                    f"only by case (or share an explicit name) collide; rename one of the tasks."
+                )
+                raise ValueError(msg)
+            new_actions[action_name] = step
+
         try:
             self._client.admin.put_workflow(workflow.to_proto())
         except Exception:

--- a/sdks/python/tests/test_worker_action_registry_collisions.py
+++ b/sdks/python/tests/test_worker_action_registry_collisions.py
@@ -1,0 +1,108 @@
+"""Unit tests for duplicate action-id handling in Worker.register_workflow.
+
+Regression tests for https://github.com/hatchet-dev/hatchet/issues/4922 : action ids are
+namespaced and lowercased, so tasks whose names differ only by case (or share an explicit
+name) used to silently overwrite each other in the worker's action registry, leaving one of
+the workflows routing to the wrong function with no warning.
+"""
+
+import base64
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from hatchet_sdk import Context, EmptyModel, Hatchet
+from hatchet_sdk.config import ClientConfig
+from hatchet_sdk.worker.worker import Worker
+
+
+def _fake_token() -> str:
+    def b64(data: bytes) -> str:
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+    claims = {
+        "sub": "00000000-0000-0000-0000-000000000000",
+        "server_url": "http://localhost:8080",
+        "grpc_broadcast_address": "localhost:7077",
+    }
+    return ".".join([b64(json.dumps({"alg": "none"}).encode()), b64(json.dumps(claims).encode()), b64(b"sig")])
+
+
+def _make_worker(hatchet: Hatchet) -> Worker:
+    worker = hatchet.worker("registry-test-worker", slots=1, workflows=[])
+    # Stub the only network call register_workflow makes.
+    worker._client.admin.put_workflow = MagicMock()
+    return worker
+
+
+def test_case_only_name_difference_raises() -> None:
+    hatchet = Hatchet(config=ClientConfig(token=_fake_token()))
+
+    @hatchet.task(name="SendEmail")
+    def send_email_a(input: EmptyModel, ctx: Context) -> dict[str, Any]:
+        return {"who": "a"}
+
+    @hatchet.task(name="sendemail")
+    def send_email_b(input: EmptyModel, ctx: Context) -> dict[str, Any]:
+        return {"who": "b"}
+
+    worker = _make_worker(hatchet)
+    worker.register_workflow(send_email_a)
+
+    with pytest.raises(ValueError, match="already registered"):
+        worker.register_workflow(send_email_b)
+
+    # The first registration must be intact - no silent overwrite happened.
+    assert list(worker._action_registry.keys()) == ["sendemail:sendemail"]
+
+
+def test_same_explicit_name_on_two_functions_raises() -> None:
+    hatchet = Hatchet(config=ClientConfig(token=_fake_token()))
+
+    @hatchet.task(name="process")
+    def process_email(input: EmptyModel, ctx: Context) -> dict[str, Any]:
+        return {"who": "email"}
+
+    @hatchet.task(name="process")
+    def process_billing(input: EmptyModel, ctx: Context) -> dict[str, Any]:
+        return {"who": "billing"}
+
+    worker = _make_worker(hatchet)
+    worker.register_workflow(process_email)
+
+    with pytest.raises(ValueError, match="already registered"):
+        worker.register_workflow(process_billing)
+
+
+def test_distinct_names_still_register() -> None:
+    hatchet = Hatchet(config=ClientConfig(token=_fake_token()))
+
+    @hatchet.task(name="charge")
+    def charge(input: EmptyModel, ctx: Context) -> dict[str, Any]:
+        return {}
+
+    @hatchet.task(name="notify")
+    def notify(input: EmptyModel, ctx: Context) -> dict[str, Any]:
+        return {}
+
+    worker = _make_worker(hatchet)
+    worker.register_workflow(charge)
+    worker.register_workflow(notify)
+
+    assert sorted(worker._action_registry.keys()) == ["charge:charge", "notify:notify"]
+
+
+def test_reregistering_same_workflow_is_idempotent() -> None:
+    hatchet = Hatchet(config=ClientConfig(token=_fake_token()))
+
+    @hatchet.task(name="sendemail")
+    def send_email(input: EmptyModel, ctx: Context) -> dict[str, Any]:
+        return {}
+
+    worker = _make_worker(hatchet)
+    worker.register_workflow(send_email)
+    worker.register_workflow(send_email)
+
+    assert list(worker._action_registry.keys()) == ["sendemail:sendemail"]


### PR DESCRIPTION
Fixes #4922.

Worker.register_workflow assigned `self._action_registry[action_name] = step` with no membership test, and since action ids are lowercased (service_name + task name), two tasks whose names differ only by case - or that share an explicit name - collapsed into one registry entry. The server still saw two distinct workflows, so one of them would silently execute the wrong function on the worker.

register_workflow now validates the workflow's action ids against the registry (and within the workflow itself) before calling put_workflow, and raises a ValueError naming the colliding action id on any duplicate - same fail-fast style as the existing "no tasks registered" error, and early enough that nothing is left registered server-side. Re-registering the same task object stays idempotent.

Tests: test_worker_action_registry_collisions.py covers the case-only collision, the explicit-name collision, distinct names, and idempotent re-registration. They're engine-free unit tests (put_workflow stubbed); verified locally with `pytest --noconftest` since the tests/ conftest autouse-spawns an engine worker - in CI they run under the normal suite. Red-green confirmed: the two collision tests fail against unpatched worker.py, all four pass with the fix.

> Built by breken, your AI support engineer - breken.ai - this one's on us.