### PR TITLE
feat: allow custom `io.Writer` destination for the shared logger

### DIFF
--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -5,6 +5,7 @@ package loader
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"os"
@@ -90,10 +91,47 @@ func parseRetentionDuration(name, value string) (time.Duration, error) {
 
 type ConfigLoader struct {
 	directory string
+
+	// logWriter is an optional runtime override for where loggers built by this
+	// loader write. Nil means os.Stderr.
+	logWriter io.Writer
 }
 
-func NewConfigLoader(directory string) *ConfigLoader {
-	return &ConfigLoader{directory: directory}
+type ConfigLoaderOpt func(*ConfigLoader)
+
+// WithLogWriter routes the loggers this loader constructs (database, server and
+// the additional per-service loggers) to w instead of os.Stderr. This is a
+// runtime-only override intended for embedding callers; it cannot be expressed
+// in a config file. Explicit writers set by a ServerConfigFileOverride take
+// precedence over w.
+func WithLogWriter(w io.Writer) ConfigLoaderOpt {
+	return func(c *ConfigLoader) {
+		c.logWriter = w
+	}
+}
+
+func NewConfigLoader(directory string, opts ...ConfigLoaderOpt) *ConfigLoader {
+	c := &ConfigLoader{directory: directory}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+// applyLogWriter sets the loader's log writer on the given logger configs,
+// leaving any config that already carries an explicit writer untouched.
+func (c *ConfigLoader) applyLogWriter(cfs ...*shared.LoggerConfigFile) {
+	if c.logWriter == nil {
+		return
+	}
+
+	for _, cf := range cfs {
+		if cf.Writer == nil {
+			cf.Writer = c.logWriter
+		}
+	}
 }
 
 // InitDataLayer initializes the database layer from the configuration
@@ -123,6 +161,8 @@ func (c *ConfigLoader) InitDataLayer() (res *database.Layer, err error) {
 	if err != nil {
 		return nil, err
 	}
+
+	c.applyLogWriter(&cf.Logger)
 
 	l := logger.NewStdErr(&cf.Logger, "database")
 
@@ -456,6 +496,8 @@ func (c *ConfigLoader) CreateServerFromConfig(version string, overrides ...Serve
 	for _, override := range overrides {
 		override(cf)
 	}
+
+	c.applyLogWriter(&cf.Logger, &cf.AdditionalLoggers.Queue, &cf.AdditionalLoggers.PgxStats)
 
 	if cf.VersionOverride != "" {
 		version = cf.VersionOverride

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -97,6 +97,7 @@ type ConfigLoader struct {
 	logWriter io.Writer
 }
 
+// ConfigLoaderOpt configures a ConfigLoader created by NewConfigLoader.
 type ConfigLoaderOpt func(*ConfigLoader)
 
 // WithLogWriter routes the loggers this loader constructs (database, server and
@@ -104,12 +105,18 @@ type ConfigLoaderOpt func(*ConfigLoader)
 // runtime-only override intended for embedding callers; it cannot be expressed
 // in a config file. Explicit writers set by a ServerConfigFileOverride take
 // precedence over w.
+//
+// The loader hands the same writer to several independent loggers that log
+// concurrently, so w is wrapped in a mutex-guarded writer here; callers can
+// pass writers that are not safe for concurrent use, such as a bytes.Buffer.
 func WithLogWriter(w io.Writer) ConfigLoaderOpt {
 	return func(c *ConfigLoader) {
-		c.logWriter = w
+		c.logWriter = zerolog.SyncWriter(w)
 	}
 }
 
+// NewConfigLoader creates a ConfigLoader that reads server and database
+// configuration from the given directory, applying any options.
 func NewConfigLoader(directory string, opts ...ConfigLoaderOpt) *ConfigLoader {
 	c := &ConfigLoader{directory: directory}
 

--- a/pkg/config/shared/shared.go
+++ b/pkg/config/shared/shared.go
@@ -1,5 +1,7 @@
 package shared
 
+import "io"
+
 type TLSConfigFile struct {
 	// TLSStrategy can be "tls", "mtls", or "none"
 	TLSStrategy string `mapstructure:"tlsStrategy" json:"tlsStrategy,omitempty" default:"tls"`
@@ -20,6 +22,14 @@ type LoggerConfigFile struct {
 
 	// format can be "json" or "console"
 	Format string `mapstructure:"format" json:"format,omitempty" default:"console"`
+
+	// Writer is an optional runtime override for the log output destination. It
+	// is a runtime object, not a config-file field: it cannot be set from yaml
+	// or environment variables. Embedding callers can set it programmatically
+	// (for example inside a loader.ServerConfigFileOverride) to route engine,
+	// API and database log output somewhere other than os.Stderr. When nil,
+	// loggers built with logger.NewStdErr write to os.Stderr as before.
+	Writer io.Writer `mapstructure:"-" json:"-"`
 }
 
 type OpenTelemetryConfigFile struct {

--- a/pkg/config/shared/shared.go
+++ b/pkg/config/shared/shared.go
@@ -29,6 +29,10 @@ type LoggerConfigFile struct {
 	// (for example inside a loader.ServerConfigFileOverride) to route engine,
 	// API and database log output somewhere other than os.Stderr. When nil,
 	// loggers built with logger.NewStdErr write to os.Stderr as before.
+	//
+	// A writer shared across several logger configs must be safe for concurrent
+	// use (wrap it with zerolog.SyncWriter if it is not); loader.WithLogWriter
+	// applies that wrapping automatically.
 	Writer io.Writer `mapstructure:"-" json:"-"`
 }
 

--- a/pkg/logger/stderr.go
+++ b/pkg/logger/stderr.go
@@ -42,7 +42,23 @@ func NewDefaultLogger(service string) zerolog.Logger {
 	return NewStdErr(&shared.LoggerConfigFile{}, service)
 }
 
+// NewStdErr creates a logger that writes to os.Stderr, unless the config
+// carries a runtime writer override (cf.Writer), in which case output is
+// routed there instead.
 func NewStdErr(cf *shared.LoggerConfigFile, service string) zerolog.Logger {
+	var w io.Writer = os.Stderr
+
+	if cf.Writer != nil {
+		w = cf.Writer
+	}
+
+	return NewWithWriter(cf, service, w)
+}
+
+// NewWithWriter creates a logger that writes to w in the configured format
+// (console or json). The explicit writer always wins: any cf.Writer override
+// is ignored. w must be non-nil.
+func NewWithWriter(cf *shared.LoggerConfigFile, service string, w io.Writer) zerolog.Logger {
 	lvl := zerolog.DebugLevel
 	var err error
 
@@ -54,11 +70,11 @@ func NewStdErr(cf *shared.LoggerConfigFile, service string) zerolog.Logger {
 		}
 	}
 
-	var out io.Writer = os.Stderr
+	out := w
 
 	if cf.Format == "console" {
 		out = zerolog.ConsoleWriter{
-			Out:        os.Stderr,
+			Out:        w,
 			TimeFormat: "2006-01-02T15:04:05.999Z07:00",
 		}
 	}

--- a/pkg/logger/stderr_test.go
+++ b/pkg/logger/stderr_test.go
@@ -1,0 +1,118 @@
+package logger
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/hatchet-dev/hatchet/pkg/config/shared"
+)
+
+func TestNewWithWriterJSON(t *testing.T) {
+	buf := &bytes.Buffer{}
+
+	l := NewWithWriter(&shared.LoggerConfigFile{Level: "info", Format: "json"}, "test-service", buf)
+
+	l.Info().Str("key", "value").Msg("hello")
+
+	var parsed map[string]interface{}
+
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("expected json output, got %q: %v", buf.String(), err)
+	}
+
+	if parsed["message"] != "hello" {
+		t.Errorf("expected message %q, got %v", "hello", parsed["message"])
+	}
+
+	if parsed["service"] != "test-service" {
+		t.Errorf("expected service %q, got %v", "test-service", parsed["service"])
+	}
+
+	if parsed["key"] != "value" {
+		t.Errorf("expected key %q, got %v", "value", parsed["key"])
+	}
+}
+
+func TestNewWithWriterConsole(t *testing.T) {
+	buf := &bytes.Buffer{}
+
+	l := NewWithWriter(&shared.LoggerConfigFile{Level: "info", Format: "console"}, "test-service", buf)
+
+	l.Info().Msg("hello")
+
+	out := buf.String()
+
+	if out == "" {
+		t.Fatal("expected console output, got empty buffer")
+	}
+
+	if json.Valid(bytes.TrimSpace(buf.Bytes())) {
+		t.Errorf("expected console-formatted output, got json: %q", out)
+	}
+
+	if !strings.Contains(out, "hello") {
+		t.Errorf("expected output to contain %q, got %q", "hello", out)
+	}
+
+	if !strings.Contains(out, "test-service") {
+		t.Errorf("expected output to contain %q, got %q", "test-service", out)
+	}
+}
+
+func TestNewWithWriterRespectsLevel(t *testing.T) {
+	buf := &bytes.Buffer{}
+
+	l := NewWithWriter(&shared.LoggerConfigFile{Level: "warn", Format: "json"}, "", buf)
+
+	l.Info().Msg("filtered")
+
+	if buf.Len() != 0 {
+		t.Errorf("expected info message to be filtered at warn level, got %q", buf.String())
+	}
+
+	l.Warn().Msg("kept")
+
+	if !strings.Contains(buf.String(), "kept") {
+		t.Errorf("expected warn message to be written, got %q", buf.String())
+	}
+}
+
+// TestNewStdErrWriterOverride asserts that the runtime writer on the config is
+// honored by NewStdErr, which is the seam embedding callers use.
+func TestNewStdErrWriterOverride(t *testing.T) {
+	buf := &bytes.Buffer{}
+
+	for _, format := range []string{"json", "console"} {
+		buf.Reset()
+
+		l := NewStdErr(&shared.LoggerConfigFile{Level: "info", Format: format, Writer: buf}, "svc")
+
+		l.Info().Msg("routed")
+
+		if !strings.Contains(buf.String(), "routed") {
+			t.Errorf("format %s: expected output in injected writer, got %q", format, buf.String())
+		}
+	}
+}
+
+// TestNewStdErrDefaultsToStderr asserts that without a writer override the
+// default construction path is unchanged and writes nothing to an injected
+// buffer. zerolog does not expose its writer, so this checks that construction
+// succeeds and that output does not land anywhere the test can observe.
+func TestNewStdErrDefaultsToStderr(t *testing.T) {
+	buf := &bytes.Buffer{}
+
+	l := NewStdErr(&shared.LoggerConfigFile{Level: "info", Format: "json"}, "svc")
+
+	l.Info().Msg("to stderr")
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no output in unrelated buffer, got %q", buf.String())
+	}
+
+	d := NewDefaultLogger("svc")
+
+	d.Debug().Msg("to stderr")
+}


### PR DESCRIPTION
# Description

Allows engine callers to route engine output to an `io.Writer` destination for more flexibility. Needed as part of the logging cleanup for embedded mode. 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Documented (where applicable)
- [X] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [X] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude w/ Fable 5.1

</details>
