### PR TITLE
refactor: consolidate logging output for migrations, seed, and config loader

### DIFF
--- a/cmd/hatchet-admin/cli/seed.go
+++ b/cmd/hatchet-admin/cli/seed.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/hatchet-dev/hatchet/cmd/hatchet-admin/cli/seed"
 	"github.com/hatchet-dev/hatchet/pkg/config/loader"
+	"github.com/hatchet-dev/hatchet/pkg/config/shared"
+	"github.com/hatchet-dev/hatchet/pkg/logger"
 )
 
 // seedCmd seeds the database with initial data
@@ -57,6 +59,13 @@ func runSeed(cf *loader.ConfigLoader) error {
 	}
 
 	defer dc.Disconnect() // nolint: errcheck
+
+	// the database logger defaults to warn, which would hide what this command
+	// did. seeding is the whole point of the command, so run it against a
+	// console logger at info instead. In-process callers (embedded mode, the
+	// test harness) keep the configured database logger and stay quiet.
+	l := logger.NewStdErr(&shared.LoggerConfigFile{Level: "info", Format: "console"}, "seed")
+	dc.Logger = &l
 
 	return seed.SeedDatabase(dc)
 }

--- a/cmd/hatchet-admin/cli/seed/seed.go
+++ b/cmd/hatchet-admin/cli/seed/seed.go
@@ -16,6 +16,7 @@ import (
 )
 
 func SeedDatabase(dc *database.Layer) error {
+	l := dc.GetLogger()
 	shouldSeedUser := dc.Seed.AdminEmail != "" && dc.Seed.AdminPassword != ""
 	var userID uuid.UUID
 
@@ -86,7 +87,7 @@ func SeedDatabase(dc *database.Layer) error {
 				return err
 			}
 
-			fmt.Println("created tenant", tenant.ID.String())
+			l.Info().Str("tenant_id", tenant.ID.String()).Msg("created tenant")
 
 			// add the user to the tenant
 			_, err = dc.V1.Tenant().CreateTenantMember(context.Background(), tenant.ID, &v1.CreateTenantMemberOpts{

--- a/cmd/hatchet-migrate/main.go
+++ b/cmd/hatchet-migrate/main.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/hatchet-dev/hatchet/cmd/hatchet-migrate/migrate"
 	"github.com/hatchet-dev/hatchet/pkg/cmdutils"
+	"github.com/hatchet-dev/hatchet/pkg/config/shared"
+	"github.com/hatchet-dev/hatchet/pkg/logger"
 )
 
 var printVersion bool
@@ -30,15 +32,19 @@ var rootCmd = &cobra.Command{
 		ctx, cancel := cmdutils.NewInterruptContext()
 		defer cancel()
 
+		// the standalone command prints every migration diagnostic, so it runs
+		// at debug level with the human-readable console writer
+		l := logger.NewStdErr(&shared.LoggerConfigFile{Level: "debug", Format: "console"}, "migrate")
+
 		if migrateDown != "" {
-			migrate.RunDownMigration(ctx, migrateDown)
+			migrate.RunDownMigration(ctx, migrateDown, migrate.WithLogger(&l))
 		} else {
 			if upToPenultimate && upToVersion != "" {
 				fmt.Println("cannot use --up-to-penultimate and --up-to together")
 				os.Exit(1)
 			}
 
-			var opts []migrate.RunMigrationsOpt
+			opts := []migrate.RunMigrationsOpt{migrate.WithLogger(&l)}
 			if upToPenultimate {
 				opts = append(opts, migrate.WithUpToPenultimate())
 			}

--- a/cmd/hatchet-migrate/migrate/run.go
+++ b/cmd/hatchet-migrate/migrate/run.go
@@ -33,7 +33,7 @@ type runMigrationsOpt struct {
 	upToPenultimate bool
 	upToVersion     int64
 	databaseURL     string
-	logger          *zerolog.Logger
+	l               *zerolog.Logger
 }
 
 // resolveLogger returns the caller-supplied logger, or the package default.
@@ -44,8 +44,8 @@ type runMigrationsOpt struct {
 // command wires a console logger at debug level, which keeps every line it
 // printed before visible.
 func (o *runMigrationsOpt) resolveLogger() *zerolog.Logger {
-	if o.logger != nil {
-		return o.logger
+	if o.l != nil {
+		return o.l
 	}
 
 	l := logger.NewStdErr(&shared.LoggerConfigFile{Level: "info", Format: "json"}, "migrate")
@@ -82,7 +82,7 @@ func WithDatabaseURL(url string) RunMigrationsOpt {
 // that migrations do not write to stdout/stderr on their own terms.
 func WithLogger(l *zerolog.Logger) RunMigrationsOpt {
 	return func(o *runMigrationsOpt) {
-		o.logger = l
+		o.l = l
 	}
 }
 
@@ -147,11 +147,11 @@ func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) error {
 
 	defer func() {
 		if err := conn.Close(); err != nil {
-			l.Warn().Msgf("%v", migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "close DB connection", err))
+			l.Error().Err(migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "close DB connection", err)).Msg("close DB connection failed")
 		}
 
 		if err := db.Close(); err != nil {
-			l.Warn().Msgf("%v", migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "close DB", err))
+			l.Error().Err(migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "close DB", err)).Msg("close DB failed")
 		}
 	}()
 
@@ -432,7 +432,7 @@ func RunDownMigration(ctx context.Context, targetVersion string, opts ...RunMigr
 	l := options.resolveLogger()
 
 	if err := runDownMigrationImpl(ctx, targetVersion, l); err != nil {
-		l.Fatal().Msgf("%v", err)
+		l.Fatal().Err(err).Msg("down migration failed")
 	}
 }
 
@@ -486,13 +486,13 @@ func runDownMigrationImpl(ctx context.Context, targetVersion string, l *zerolog.
 	defer func() {
 		if conn != nil {
 			if err := conn.Close(); err != nil {
-				l.Warn().Msgf("%v", migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "close DB connection", err))
+				l.Error().Err(migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "close DB connection", err)).Msg("close DB connection failed")
 			}
 		}
 
 		if db != nil {
 			if err := db.Close(); err != nil {
-				l.Warn().Msgf("%v", migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "close DB", err))
+				l.Error().Err(migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "close DB", err)).Msg("close DB failed")
 			}
 		}
 	}()
@@ -511,7 +511,7 @@ func runDownMigrationImpl(ctx context.Context, targetVersion string, l *zerolog.
 
 	defer func() {
 		if err := locker.SessionUnlock(ctx, conn); err != nil {
-			l.Warn().Msgf("%v", migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "session unlock", err))
+			l.Error().Err(migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "session unlock", err)).Msg("session unlock failed")
 		}
 	}()
 

--- a/cmd/hatchet-migrate/migrate/run.go
+++ b/cmd/hatchet-migrate/migrate/run.go
@@ -6,7 +6,6 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
-	"log"
 	"os"
 	"sort"
 	"strconv"
@@ -18,9 +17,12 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib" // register the pgx driver for database/sql
 	"github.com/pressly/goose/v3"
 	"github.com/pressly/goose/v3/lock"
+	"github.com/rs/zerolog"
 	"github.com/sethvargo/go-retry"
 
 	_ "github.com/hatchet-dev/hatchet/cmd/hatchet-migrate/migrate/migrations" // register go migrations
+	"github.com/hatchet-dev/hatchet/pkg/config/shared"
+	"github.com/hatchet-dev/hatchet/pkg/logger"
 	"github.com/hatchet-dev/hatchet/pkg/migratediag"
 )
 
@@ -31,6 +33,24 @@ type runMigrationsOpt struct {
 	upToPenultimate bool
 	upToVersion     int64
 	databaseURL     string
+	logger          *zerolog.Logger
+}
+
+// resolveLogger returns the caller-supplied logger, or the package default.
+//
+// The default writes to stderr at info level so that in-process consumers
+// (e.g. embedded mode, the test harness) do not get migration diagnostics on
+// their output unless something goes wrong. The standalone hatchet-migrate
+// command wires a console logger at debug level, which keeps every line it
+// printed before visible.
+func (o *runMigrationsOpt) resolveLogger() *zerolog.Logger {
+	if o.logger != nil {
+		return o.logger
+	}
+
+	l := logger.NewStdErr(&shared.LoggerConfigFile{Level: "info", Format: "json"}, "migrate")
+
+	return &l
 }
 
 type RunMigrationsOpt func(*runMigrationsOpt)
@@ -57,6 +77,15 @@ func WithDatabaseURL(url string) RunMigrationsOpt {
 	}
 }
 
+// WithLogger routes migration output through the given logger. Callers that
+// embed the engine in their own process should pass their configured logger so
+// that migrations do not write to stdout/stderr on their own terms.
+func WithLogger(l *zerolog.Logger) RunMigrationsOpt {
+	return func(o *runMigrationsOpt) {
+		o.logger = l
+	}
+}
+
 func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) error {
 	// Set default options
 	options := &runMigrationsOpt{}
@@ -64,6 +93,8 @@ func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) error {
 	for _, opt := range opts {
 		opt(options)
 	}
+
+	l := options.resolveLogger()
 
 	const (
 		databaseEnvVar = "DATABASE_URL"
@@ -116,11 +147,11 @@ func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) error {
 
 	defer func() {
 		if err := conn.Close(); err != nil {
-			log.Printf("%v", migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "close DB connection", err))
+			l.Warn().Msgf("%v", migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "close DB connection", err))
 		}
 
 		if err := db.Close(); err != nil {
-			log.Printf("%v", migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "close DB", err))
+			l.Warn().Msgf("%v", migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "close DB", err))
 		}
 	}()
 
@@ -174,7 +205,7 @@ func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) error {
 			return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "check atlas_schema_revisions existence", err)
 		}
 
-		fmt.Printf("Does existing atlas schema exist? %v\n", atlasExists)
+		l.Debug().Msgf("Does existing atlas schema exist? %v", atlasExists)
 
 		// 2. If it does, check for the latest migration in the atlas schema.
 		if atlasExists {
@@ -183,7 +214,7 @@ func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) error {
 			err = conn.QueryRowContext(ctx, atlasLatestQuery).Scan(&version)
 			if err == nil {
 				baseline = version
-				fmt.Printf("Baseline version from atlas: %s\n", baseline)
+				l.Debug().Msgf("Baseline version from atlas: %s", baseline)
 			}
 		}
 
@@ -196,7 +227,7 @@ func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) error {
 				return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "check _prisma_migrations existence", err)
 			}
 
-			fmt.Printf("Does existing prisma schema exist? %v\n", prismaExists)
+			l.Debug().Msgf("Does existing prisma schema exist? %v", prismaExists)
 
 			// 4. If it does, check for the latest migration in the prisma schema.
 			if prismaExists {
@@ -205,7 +236,7 @@ func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) error {
 				err = conn.QueryRowContext(ctx, prismaLatestQuery).Scan(&migrationName)
 				if err == nil {
 					baseline = migrationName
-					fmt.Printf("Baseline version from prisma: %s\n", baseline)
+					l.Debug().Msgf("Baseline version from prisma: %s", baseline)
 				}
 			}
 		}
@@ -237,7 +268,7 @@ func RunMigrations(ctx context.Context, opts ...RunMigrationsOpt) error {
 				}
 				version := parts[0]
 				if version <= baseline {
-					fmt.Printf("Including version %s from %s\n", version, name)
+					l.Debug().Msgf("Including version %s from %s", version, name)
 					migrations = append(migrations, migration{version: version, filename: name})
 				}
 			}
@@ -391,13 +422,21 @@ func listMigrations() (goose.Migrations, error) {
 }
 
 // RunDownMigration runs down migrations to a specific version.
-func RunDownMigration(ctx context.Context, targetVersion string) {
-	if err := runDownMigrationImpl(ctx, targetVersion); err != nil {
-		log.Fatal(err)
+func RunDownMigration(ctx context.Context, targetVersion string, opts ...RunMigrationsOpt) {
+	options := &runMigrationsOpt{}
+
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	l := options.resolveLogger()
+
+	if err := runDownMigrationImpl(ctx, targetVersion, l); err != nil {
+		l.Fatal().Msgf("%v", err)
 	}
 }
 
-func runDownMigrationImpl(ctx context.Context, targetVersion string) error {
+func runDownMigrationImpl(ctx context.Context, targetVersion string, l *zerolog.Logger) error {
 	const (
 		databaseEnvVar = "DATABASE_URL"
 		phaseName      = "oss-down"
@@ -447,13 +486,13 @@ func runDownMigrationImpl(ctx context.Context, targetVersion string) error {
 	defer func() {
 		if conn != nil {
 			if err := conn.Close(); err != nil {
-				log.Printf("%v", migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "close DB connection", err))
+				l.Warn().Msgf("%v", migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "close DB connection", err))
 			}
 		}
 
 		if db != nil {
 			if err := db.Close(); err != nil {
-				log.Printf("%v", migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "close DB", err))
+				l.Warn().Msgf("%v", migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "close DB", err))
 			}
 		}
 	}()
@@ -472,7 +511,7 @@ func runDownMigrationImpl(ctx context.Context, targetVersion string) error {
 
 	defer func() {
 		if err := locker.SessionUnlock(ctx, conn); err != nil {
-			log.Printf("%v", migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "session unlock", err))
+			l.Warn().Msgf("%v", migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "session unlock", err))
 		}
 	}()
 
@@ -497,17 +536,17 @@ func runDownMigrationImpl(ctx context.Context, targetVersion string) error {
 	}
 
 	if currentVersion == targetVersionInt {
-		fmt.Printf("Database is already at version %d. No migration needed.\n", targetVersionInt)
+		l.Info().Msgf("Database is already at version %d. No migration needed.", targetVersionInt)
 		return nil
 	}
 
-	fmt.Printf("Migrating down from version %d to version %d\n", currentVersion, targetVersionInt)
+	l.Info().Msgf("Migrating down from version %d to version %d", currentVersion, targetVersionInt)
 
 	err = goose.DownTo(db, ".", targetVersionInt)
 	if err != nil {
 		return migratediag.PhaseError(databaseEnvVar, phaseName, dsn, "apply down migration", fmt.Errorf("target version %d: %w", targetVersionInt, err))
 	}
 
-	fmt.Printf("Successfully migrated down to version %d\n", targetVersionInt)
+	l.Info().Msgf("Successfully migrated down to version %d", targetVersionInt)
 	return nil
 }

--- a/pkg/config/database/config.go
+++ b/pkg/config/database/config.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog"
 	"github.com/spf13/viper"
 
 	"github.com/hatchet-dev/hatchet/pkg/config/shared"
@@ -84,6 +85,25 @@ type Layer struct {
 	V1 v1.Repository
 
 	Seed SeedConfigFile
+
+	// Logger is the configured database logger. Consumers should read it via
+	// GetLogger, which falls back to a disabled logger when the layer was
+	// constructed without one.
+	Logger *zerolog.Logger
+}
+
+// GetLogger returns the layer's configured logger, or a disabled logger if the
+// layer was constructed without one. Library code writing diagnostics should
+// use this rather than printing to stdout/stderr directly, so that embedders
+// keep control over the output.
+func (l *Layer) GetLogger() *zerolog.Logger {
+	if l == nil || l.Logger == nil {
+		nop := zerolog.Nop()
+
+		return &nop
+	}
+
+	return l.Logger
 }
 
 func BindAllEnv(v *viper.Viper) {

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -5,7 +5,6 @@ package loader
 import (
 	"context"
 	"fmt"
-	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -428,6 +427,7 @@ func (c *ConfigLoader) InitDataLayer() (res *database.Layer, err error) {
 		DDLPool:           ddlPool,
 		V1:                v1,
 		Seed:              cf.Seed,
+		Logger:            &l,
 	}, nil
 }
 
@@ -865,7 +865,7 @@ func createControllerLayer(dc *database.Layer, cf *server.ServerConfigFile, vers
 	schedulingPoolV1.AddExtension(v1.NewPrometheusExtension(promGate))
 
 	cleanup = func() error {
-		log.Printf("cleaning up server config")
+		l.Debug().Msg("cleaning up server config")
 
 		cleanupSecurityCheck()
 


### PR DESCRIPTION
# Description

The engine and API are pretty good about using the shared logger, but these three places aren't: the migration package, config loader, and seed command. This fixes the logging behavior for these three. 

Doing this because the embedded mode output was driving me crazy. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Refactor (non-breaking changes to code which doesn't change any behaviour)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Documented (where applicable)
- [X] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [X] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude w/ Fable 5.1

</details>
