### PR TITLE
fix(go-sdk): ensure workers get client logger

### DIFF
--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -201,6 +201,14 @@ func (c *Client) NewWorker(name string, options ...WorkerOption) (*Worker, error
 		opt(config)
 	}
 
+	// Default the worker's logger to a sub-logger of the client's configured
+	// logger so that worker output follows the client's log level and format
+	// instead of pkg/worker's standalone default (debug-level JSON). This
+	// intentionally changes the default worker log output for SDK users: level
+	// and format now follow the client configuration. An explicit WithLogger on
+	// the worker still takes precedence.
+	config.logger = resolveWorkerLogger(config.logger, c.legacyClient.Logger())
+
 	dumps := gatherWorkflowDumps(config.workflows)
 
 	// Check engine version to decide between new and legacy worker architecture

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -201,12 +201,8 @@ func (c *Client) NewWorker(name string, options ...WorkerOption) (*Worker, error
 		opt(config)
 	}
 
-	// Default the worker's logger to a sub-logger of the client's configured
-	// logger so that worker output follows the client's log level and format
-	// instead of pkg/worker's standalone default (debug-level JSON). This
-	// intentionally changes the default worker log output for SDK users: level
-	// and format now follow the client configuration. An explicit WithLogger on
-	// the worker still takes precedence.
+	// Worker log output follows the client's configured level and format by
+	// default; an explicit WithLogger on the worker takes precedence.
 	config.logger = resolveWorkerLogger(config.logger, c.legacyClient.Logger())
 
 	dumps := gatherWorkflowDumps(config.workflows)

--- a/sdks/go/worker.go
+++ b/sdks/go/worker.go
@@ -59,19 +59,15 @@ func WithLogger(logger *zerolog.Logger) WorkerOption {
 	}
 }
 
-// resolveWorkerLogger picks the logger a worker should use. An explicitly
-// configured worker logger (via WithLogger) always wins; otherwise the worker
-// inherits the client's logger as a sub-logger tagged with service=worker,
-// following the same derivation pattern as other service loggers. Returns nil
-// only if neither logger is available, in which case pkg/worker falls back to
-// its standalone default.
+// resolveWorkerLogger picks the logger a worker should use: an explicitly
+// configured worker logger (via WithLogger) always wins; otherwise the client's
+// logger is inherited as a sub-logger tagged with service=worker, so worker
+// output follows the client's configured level and format. Returns nil when
+// neither logger is available.
 //
-// Inheriting means the worker's log level and format follow the client
-// configuration instead of pkg/worker's debug-level JSON default; this is a
-// deliberate change to default worker output. As with the engine's service
-// loggers, the client logger already carries its own service field, so the
-// emitted JSON repeats the key with the worker value last (JSON consumers and
-// zerolog's console writer both resolve to service=worker).
+// The client logger already carries its own service field, so the emitted JSON
+// repeats the key with the worker value last; JSON consumers and zerolog's
+// console writer both resolve to service=worker.
 func resolveWorkerLogger(configured *zerolog.Logger, clientLogger *zerolog.Logger) *zerolog.Logger {
 	if configured != nil {
 		return configured

--- a/sdks/go/worker.go
+++ b/sdks/go/worker.go
@@ -52,11 +52,38 @@ func WithLabels(labels map[string]any) WorkerOption {
 	}
 }
 
-// WithLogger sets a custom logger for the worker.
+// WithLogger sets a custom logger for the worker. When not set, the worker inherits the client's logger.
 func WithLogger(logger *zerolog.Logger) WorkerOption {
 	return func(config *workerConfig) {
 		config.logger = logger
 	}
+}
+
+// resolveWorkerLogger picks the logger a worker should use. An explicitly
+// configured worker logger (via WithLogger) always wins; otherwise the worker
+// inherits the client's logger as a sub-logger tagged with service=worker,
+// following the same derivation pattern as other service loggers. Returns nil
+// only if neither logger is available, in which case pkg/worker falls back to
+// its standalone default.
+//
+// Inheriting means the worker's log level and format follow the client
+// configuration instead of pkg/worker's debug-level JSON default; this is a
+// deliberate change to default worker output. As with the engine's service
+// loggers, the client logger already carries its own service field, so the
+// emitted JSON repeats the key with the worker value last (JSON consumers and
+// zerolog's console writer both resolve to service=worker).
+func resolveWorkerLogger(configured *zerolog.Logger, clientLogger *zerolog.Logger) *zerolog.Logger {
+	if configured != nil {
+		return configured
+	}
+
+	if clientLogger == nil {
+		return nil
+	}
+
+	derived := clientLogger.With().Str("service", "worker").Logger()
+
+	return &derived
 }
 
 // WithDurableSlots sets the maximum number of concurrent durable task runs.

--- a/sdks/go/worker_logger_test.go
+++ b/sdks/go/worker_logger_test.go
@@ -1,0 +1,43 @@
+package hatchet
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveWorkerLogger_ExplicitLoggerWins(t *testing.T) {
+	configured := zerolog.New(&bytes.Buffer{}).Level(zerolog.WarnLevel)
+	clientLogger := zerolog.New(&bytes.Buffer{}).Level(zerolog.DebugLevel)
+
+	resolved := resolveWorkerLogger(&configured, &clientLogger)
+
+	require.NotNil(t, resolved)
+	assert.Same(t, &configured, resolved, "an explicit worker logger must be returned unchanged")
+}
+
+func TestResolveWorkerLogger_InheritsClientLogger(t *testing.T) {
+	var buf bytes.Buffer
+	clientLogger := zerolog.New(&buf).Level(zerolog.WarnLevel)
+
+	resolved := resolveWorkerLogger(nil, &clientLogger)
+
+	require.NotNil(t, resolved)
+
+	// Inherits the client's level: debug output is suppressed.
+	resolved.Debug().Msg("should be filtered")
+	assert.Empty(t, buf.String(), "inherited logger must respect the client's log level")
+
+	// Warn output is emitted and tagged with the worker service field.
+	resolved.Warn().Msg("visible")
+	out := buf.String()
+	assert.Contains(t, out, `"message":"visible"`)
+	assert.Contains(t, out, `"service":"worker"`)
+}
+
+func TestResolveWorkerLogger_NilClientLogger(t *testing.T) {
+	assert.Nil(t, resolveWorkerLogger(nil, nil), "with no logger available, pkg/worker's standalone default applies")
+}


### PR DESCRIPTION
# Description

Updates `NewWorker` so that it uses the client's configured logger by default, but still supports the `WithLogger` option on the worker if necessary. Should be a non-breaking change for existing users. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [X] Documented (where applicable)
- [X] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

- [X] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

<!-- Please specify the tooling/model and the extent to which it was used. -->

- **Details**: Claude w/ Fable 5.1

</details>
