### PR TITLE
fix(engine): attempt to optimize concurrency query planning

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/202609101223115_v1_0_153.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/202609101223115_v1_0_153.sql
@@ -42,9 +42,7 @@ BEGIN
         WHERE
             dr.retry_after <= NOW()
             AND t.initial_state = 'QUEUED'
-            -- Check to see if the task has a concurrency strategy
             AND t.concurrency_strategy_ids[1] IS NOT NULL
-            -- A retry queue item for an older attempt must not create a slot for the current one
             AND dr.task_retry_count = t.retry_count
     )
     INSERT INTO v1_concurrency_slot (
@@ -101,6 +99,7 @@ BEGIN
             dr.retry_after <= NOW()
             AND t.initial_state = 'QUEUED'
             AND t.concurrency_strategy_ids[1] IS NULL
+            AND dr.task_retry_count = t.retry_count
     )
     INSERT INTO v1_queue_item (
         tenant_id,

--- a/cmd/hatchet-migrate/migrate/migrations/202609101223115_v1_0_153.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/202609101223115_v1_0_153.sql
@@ -1,0 +1,298 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION v1_retry_queue_item_delete_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    WITH new_slot_rows AS (
+        SELECT
+            t.id,
+            t.inserted_at,
+            t.retry_count,
+            t.tenant_id,
+            t.workflow_run_id,
+            t.external_id,
+            t.concurrency_parent_strategy_ids[1] AS parent_strategy_id,
+            CASE
+                WHEN array_length(t.concurrency_parent_strategy_ids, 1) > 1 THEN t.concurrency_parent_strategy_ids[2:array_length(t.concurrency_parent_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_parent_strategy_ids,
+            t.concurrency_strategy_ids[1] AS strategy_id,
+            CASE
+                WHEN array_length(t.concurrency_strategy_ids, 1) > 1 THEN t.concurrency_strategy_ids[2:array_length(t.concurrency_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_strategy_ids,
+            t.concurrency_keys[1] AS key,
+            CASE
+                WHEN array_length(t.concurrency_keys, 1) > 1 THEN t.concurrency_keys[2:array_length(t.concurrency_keys, 1)]
+                ELSE '{}'::text[]
+            END AS next_keys,
+            t.concurrency_max_runs[1] AS max_runs,
+            CASE
+                WHEN array_length(t.concurrency_max_runs, 1) > 1 THEN t.concurrency_max_runs[2:array_length(t.concurrency_max_runs, 1)]
+                ELSE '{}'::integer[]
+            END AS next_max_runs,
+            t.workflow_id,
+            t.workflow_version_id,
+            t.queue,
+            CURRENT_TIMESTAMP + convert_duration_to_interval(t.schedule_timeout) AS schedule_timeout_at
+        FROM deleted_rows dr
+        JOIN
+            v1_task t ON t.id = dr.task_id AND t.inserted_at = dr.task_inserted_at
+        WHERE
+            dr.retry_after <= NOW()
+            AND t.initial_state = 'QUEUED'
+            -- Check to see if the task has a concurrency strategy
+            AND t.concurrency_strategy_ids[1] IS NOT NULL
+            -- A retry queue item for an older attempt must not create a slot for the current one
+            AND dr.task_retry_count = t.retry_count
+    )
+    INSERT INTO v1_concurrency_slot (
+        task_id,
+        task_inserted_at,
+        task_retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        priority,
+        key,
+        next_keys,
+        max_runs,
+        next_max_runs,
+        queue_to_notify,
+        schedule_timeout_at
+    )
+    SELECT
+        id,
+        inserted_at,
+        retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        4,
+        key,
+        next_keys,
+        max_runs,
+        next_max_runs,
+        queue,
+        schedule_timeout_at
+    FROM new_slot_rows
+    ON CONFLICT (task_id, task_inserted_at, task_retry_count, strategy_id) DO NOTHING;
+
+    WITH tasks AS (
+        SELECT
+            t.*
+        FROM
+            deleted_rows dr
+        JOIN v1_task t ON t.id = dr.task_id AND t.inserted_at = dr.task_inserted_at
+        WHERE
+            dr.retry_after <= NOW()
+            AND t.initial_state = 'QUEUED'
+            AND t.concurrency_strategy_ids[1] IS NULL
+    )
+    INSERT INTO v1_queue_item (
+        tenant_id,
+        queue,
+        task_id,
+        task_inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        schedule_timeout_at,
+        step_timeout,
+        priority,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label,
+        batch_key
+    )
+    SELECT
+        tenant_id,
+        queue,
+        id,
+        inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        CURRENT_TIMESTAMP + convert_duration_to_interval(schedule_timeout),
+        step_timeout,
+        4,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label,
+        batch_key
+    FROM tasks
+    ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
+    ;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION v1_retry_queue_item_delete_function()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    WITH new_slot_rows AS (
+        SELECT
+            t.id,
+            t.inserted_at,
+            t.retry_count,
+            t.tenant_id,
+            t.workflow_run_id,
+            t.external_id,
+            t.concurrency_parent_strategy_ids[1] AS parent_strategy_id,
+            CASE
+                WHEN array_length(t.concurrency_parent_strategy_ids, 1) > 1 THEN t.concurrency_parent_strategy_ids[2:array_length(t.concurrency_parent_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_parent_strategy_ids,
+            t.concurrency_strategy_ids[1] AS strategy_id,
+            CASE
+                WHEN array_length(t.concurrency_strategy_ids, 1) > 1 THEN t.concurrency_strategy_ids[2:array_length(t.concurrency_strategy_ids, 1)]
+                ELSE '{}'::bigint[]
+            END AS next_strategy_ids,
+            t.concurrency_keys[1] AS key,
+            CASE
+                WHEN array_length(t.concurrency_keys, 1) > 1 THEN t.concurrency_keys[2:array_length(t.concurrency_keys, 1)]
+                ELSE '{}'::text[]
+            END AS next_keys,
+            t.concurrency_max_runs[1] AS max_runs,
+            CASE
+                WHEN array_length(t.concurrency_max_runs, 1) > 1 THEN t.concurrency_max_runs[2:array_length(t.concurrency_max_runs, 1)]
+                ELSE '{}'::integer[]
+            END AS next_max_runs,
+            t.workflow_id,
+            t.workflow_version_id,
+            t.queue,
+            CURRENT_TIMESTAMP + convert_duration_to_interval(t.schedule_timeout) AS schedule_timeout_at
+        FROM deleted_rows dr
+        JOIN
+            v1_task t ON t.id = dr.task_id AND t.inserted_at = dr.task_inserted_at
+        WHERE
+            dr.retry_after <= NOW()
+            AND t.initial_state = 'QUEUED'
+            -- Check to see if the task has a concurrency strategy
+            AND t.concurrency_strategy_ids[1] IS NOT NULL
+    )
+    INSERT INTO v1_concurrency_slot (
+        task_id,
+        task_inserted_at,
+        task_retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        priority,
+        key,
+        next_keys,
+        max_runs,
+        next_max_runs,
+        queue_to_notify,
+        schedule_timeout_at
+    )
+    SELECT
+        id,
+        inserted_at,
+        retry_count,
+        external_id,
+        tenant_id,
+        workflow_id,
+        workflow_version_id,
+        workflow_run_id,
+        parent_strategy_id,
+        next_parent_strategy_ids,
+        strategy_id,
+        next_strategy_ids,
+        4,
+        key,
+        next_keys,
+        max_runs,
+        next_max_runs,
+        queue,
+        schedule_timeout_at
+    FROM new_slot_rows;
+
+    WITH tasks AS (
+        SELECT
+            t.*
+        FROM
+            deleted_rows dr
+        JOIN v1_task t ON t.id = dr.task_id AND t.inserted_at = dr.task_inserted_at
+        WHERE
+            dr.retry_after <= NOW()
+            AND t.initial_state = 'QUEUED'
+            AND t.concurrency_strategy_ids[1] IS NULL
+    )
+    INSERT INTO v1_queue_item (
+        tenant_id,
+        queue,
+        task_id,
+        task_inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        schedule_timeout_at,
+        step_timeout,
+        priority,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label,
+        batch_key
+    )
+    SELECT
+        tenant_id,
+        queue,
+        id,
+        inserted_at,
+        external_id,
+        action_id,
+        step_id,
+        workflow_id,
+        workflow_run_id,
+        CURRENT_TIMESTAMP + convert_duration_to_interval(schedule_timeout),
+        step_timeout,
+        4,
+        sticky,
+        desired_worker_id,
+        retry_count,
+        desired_worker_label,
+        batch_key
+    FROM tasks
+    ON CONFLICT (task_id, task_inserted_at, retry_count) DO NOTHING
+    ;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/pkg/repository/sqlcv1/concurrency-overwrite.go
+++ b/pkg/repository/sqlcv1/concurrency-overwrite.go
@@ -264,7 +264,9 @@ WITH slots AS (
     FROM
         v1_concurrency_slot
     WHERE
-        (task_inserted_at, task_id, task_retry_count, tenant_id, strategy_id) IN (
+        tenant_id = $1::uuid AND
+        strategy_id = $2::bigint AND
+        ((task_inserted_at, task_id, task_retry_count, tenant_id, strategy_id) IN (
             SELECT
                 ers.task_inserted_at,
                 ers.task_id,
@@ -276,8 +278,6 @@ WITH slots AS (
             ORDER BY
                 rn, seqnum
         ) OR (
-            tenant_id = $1::uuid AND
-            strategy_id = $2::bigint AND
             (task_inserted_at, task_id, task_retry_count) NOT IN (
                 SELECT
                     ers.task_inserted_at,
@@ -290,7 +290,7 @@ WITH slots AS (
                 SELECT wcs.strategy_id, wcs.workflow_version_id, wcs.workflow_run_id
                 FROM tmp_workflow_concurrency_slot wcs
             )
-        )
+        ))
     ORDER BY task_id ASC, task_inserted_at ASC, task_retry_count ASC
     FOR UPDATE
 ), updated_slots AS (
@@ -518,7 +518,9 @@ WITH slots AS (
     FROM
         v1_concurrency_slot cs
     WHERE
-        (cs.task_inserted_at, cs.task_id, cs.task_retry_count, cs.tenant_id, cs.strategy_id) IN (
+        cs.tenant_id = $1::uuid AND
+        cs.strategy_id = $2::bigint AND
+        ((cs.task_inserted_at, cs.task_id, cs.task_retry_count, cs.tenant_id, cs.strategy_id) IN (
             SELECT
                 ers.task_inserted_at,
                 ers.task_id,
@@ -530,8 +532,6 @@ WITH slots AS (
             ORDER BY
                 rn, seqnum
         ) OR (
-            cs.tenant_id = $1::uuid AND
-            cs.strategy_id = $2::bigint AND
             (cs.task_inserted_at, cs.task_id, cs.task_retry_count) NOT IN (
                 SELECT
                     ers.task_inserted_at,
@@ -544,7 +544,7 @@ WITH slots AS (
                 SELECT wcs.strategy_id, wcs.workflow_version_id, wcs.workflow_run_id
                 FROM tmp_workflow_concurrency_slot wcs
             )
-        )
+        ))
     ORDER BY
         cs.task_id ASC, cs.task_inserted_at ASC, cs.task_retry_count ASC
     FOR UPDATE
@@ -817,7 +817,9 @@ WITH slots AS (
     FROM
         v1_concurrency_slot cs
     WHERE
-        (cs.task_inserted_at, cs.task_id, cs.task_retry_count, cs.tenant_id, cs.strategy_id) IN (
+        cs.tenant_id = $1::uuid AND
+        cs.strategy_id = $2::bigint AND
+        ((cs.task_inserted_at, cs.task_id, cs.task_retry_count, cs.tenant_id, cs.strategy_id) IN (
             SELECT
                 ers.task_inserted_at,
                 ers.task_id,
@@ -829,8 +831,6 @@ WITH slots AS (
             ORDER BY
                 rn, seqnum
         ) OR (
-            cs.tenant_id = $1::uuid AND
-            cs.strategy_id = $2::bigint AND
             (cs.task_inserted_at, cs.task_id, cs.task_retry_count) NOT IN (
                 SELECT
                     ers.task_inserted_at,
@@ -851,7 +851,7 @@ WITH slots AS (
                 SELECT wcs.strategy_id, wcs.workflow_version_id, wcs.workflow_run_id
                 FROM tmp_workflow_concurrency_slot wcs
             )
-        )
+        ))
     ORDER BY
         cs.task_id ASC, cs.task_inserted_at ASC, cs.task_retry_count ASC
     FOR UPDATE
@@ -1131,7 +1131,9 @@ WITH slots AS (
     FROM
         v1_concurrency_slot cs
     WHERE
-        (cs.task_inserted_at, cs.task_id, cs.task_retry_count, cs.tenant_id, cs.strategy_id) IN (
+        cs.tenant_id = $1::uuid AND
+        cs.strategy_id = $2::bigint AND
+        ((cs.task_inserted_at, cs.task_id, cs.task_retry_count, cs.tenant_id, cs.strategy_id) IN (
             SELECT
                 ers.task_inserted_at,
                 ers.task_id,
@@ -1143,8 +1145,6 @@ WITH slots AS (
             ORDER BY
                 rn, seqnum
         ) OR (
-            cs.tenant_id = $1::uuid AND
-            cs.strategy_id = $2::bigint AND
             (cs.task_inserted_at, cs.task_id, cs.task_retry_count) NOT IN (
                 SELECT
                     ers.task_inserted_at,
@@ -1165,7 +1165,7 @@ WITH slots AS (
                 SELECT wcs.strategy_id, wcs.workflow_version_id, wcs.workflow_run_id
                 FROM tmp_workflow_concurrency_slot wcs
             )
-        )
+        ))
     ORDER BY
         cs.task_id ASC, cs.task_inserted_at ASC, cs.task_retry_count ASC
     FOR UPDATE

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -1819,9 +1819,7 @@ BEGIN
         WHERE
             dr.retry_after <= NOW()
             AND t.initial_state = 'QUEUED'
-            -- Check to see if the task has a concurrency strategy
             AND t.concurrency_strategy_ids[1] IS NOT NULL
-            -- A retry queue item for an older attempt must not create a slot for the current one
             AND dr.task_retry_count = t.retry_count
     )
     INSERT INTO v1_concurrency_slot (
@@ -1878,6 +1876,7 @@ BEGIN
             dr.retry_after <= NOW()
             AND t.initial_state = 'QUEUED'
             AND t.concurrency_strategy_ids[1] IS NULL
+            AND dr.task_retry_count = t.retry_count
     )
     INSERT INTO v1_queue_item (
         tenant_id,

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -1821,6 +1821,8 @@ BEGIN
             AND t.initial_state = 'QUEUED'
             -- Check to see if the task has a concurrency strategy
             AND t.concurrency_strategy_ids[1] IS NOT NULL
+            -- A retry queue item for an older attempt must not create a slot for the current one
+            AND dr.task_retry_count = t.retry_count
     )
     INSERT INTO v1_concurrency_slot (
         task_id,
@@ -1863,7 +1865,8 @@ BEGIN
         next_max_runs,
         queue,
         schedule_timeout_at
-    FROM new_slot_rows;
+    FROM new_slot_rows
+    ON CONFLICT (task_id, task_inserted_at, task_retry_count, strategy_id) DO NOTHING;
 
     WITH tasks AS (
         SELECT


### PR DESCRIPTION
# Description

We have some `OR` conditions on these queries that were causing the planner to seq scan - changed things around a bit to help with that

## Type of change

- [x] Performance improvement (non-breaking change which improves performance)

## Checklist

<!-- Check all that apply. -->

Changes have been:

- [x] Documented (where applicable)
- [x] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

<!-- Optional: How are the proposed changes tested? -->
<!-- ## Testing

-->

<!-- Optional: Include additional material to supplement your changes (e.g screenshots for frontend changes) -->
<!-- ## Related

-->

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

<!-- In accordance with Hatchet's AI_POLICY.md, LLM usage must be explicitly disclosed. -->

No AI

</details>
