### PR TITLE
chore: apply autovacuum overrides to high-churn v1 tables

### DIFF
--- a/cmd/hatchet-migrate/migrate/migrations/20260911235038_v1_0_154.sql
+++ b/cmd/hatchet-migrate/migrate/migrations/20260911235038_v1_0_154.sql
@@ -1,0 +1,149 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE v1_match SET (
+    autovacuum_vacuum_scale_factor = '0.1',
+    autovacuum_analyze_scale_factor = '0.05',
+    autovacuum_vacuum_threshold = '25',
+    autovacuum_analyze_threshold = '25',
+    autovacuum_vacuum_cost_delay = '10',
+    autovacuum_vacuum_cost_limit = '1000'
+);
+
+ALTER TABLE v1_match_condition SET (
+    autovacuum_vacuum_scale_factor = '0.1',
+    autovacuum_analyze_scale_factor = '0.05',
+    autovacuum_vacuum_threshold = '25',
+    autovacuum_analyze_threshold = '25',
+    autovacuum_vacuum_cost_delay = '10',
+    autovacuum_vacuum_cost_limit = '1000'
+);
+
+ALTER TABLE v1_workflow_concurrency_slot SET (
+    autovacuum_vacuum_scale_factor = '0.1',
+    autovacuum_analyze_scale_factor = '0.05',
+    autovacuum_vacuum_threshold = '25',
+    autovacuum_analyze_threshold = '25',
+    autovacuum_vacuum_cost_delay = '10',
+    autovacuum_vacuum_cost_limit = '1000'
+);
+
+ALTER TABLE v1_concurrency_slot SET (
+    autovacuum_vacuum_scale_factor = '0.1',
+    autovacuum_analyze_scale_factor = '0.05',
+    autovacuum_vacuum_threshold = '25',
+    autovacuum_analyze_threshold = '25',
+    autovacuum_vacuum_cost_delay = '10',
+    autovacuum_vacuum_cost_limit = '1000'
+);
+
+ALTER TABLE v1_retry_queue_item SET (
+    autovacuum_vacuum_scale_factor = '0.1',
+    autovacuum_analyze_scale_factor = '0.05',
+    autovacuum_vacuum_threshold = '25',
+    autovacuum_analyze_threshold = '25',
+    autovacuum_vacuum_cost_delay = '10',
+    autovacuum_vacuum_cost_limit = '1000'
+);
+
+ALTER TABLE v1_durable_sleep SET (
+    autovacuum_vacuum_scale_factor = '0.1',
+    autovacuum_analyze_scale_factor = '0.05',
+    autovacuum_vacuum_threshold = '25',
+    autovacuum_analyze_threshold = '25',
+    autovacuum_vacuum_cost_delay = '10',
+    autovacuum_vacuum_cost_limit = '1000'
+);
+
+ALTER TABLE v1_task_runtime_slot SET (
+    autovacuum_vacuum_scale_factor = '0.1',
+    autovacuum_analyze_scale_factor = '0.05',
+    autovacuum_vacuum_threshold = '25',
+    autovacuum_analyze_threshold = '25',
+    autovacuum_vacuum_cost_delay = '10',
+    autovacuum_vacuum_cost_limit = '1000'
+);
+
+ALTER TABLE v1_batch_runtime SET (
+    autovacuum_vacuum_scale_factor = '0.1',
+    autovacuum_analyze_scale_factor = '0.05',
+    autovacuum_vacuum_threshold = '25',
+    autovacuum_analyze_threshold = '25',
+    autovacuum_vacuum_cost_delay = '10',
+    autovacuum_vacuum_cost_limit = '1000'
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE v1_match RESET (
+    autovacuum_vacuum_scale_factor,
+    autovacuum_analyze_scale_factor,
+    autovacuum_vacuum_threshold,
+    autovacuum_analyze_threshold,
+    autovacuum_vacuum_cost_delay,
+    autovacuum_vacuum_cost_limit
+);
+
+ALTER TABLE v1_match_condition RESET (
+    autovacuum_vacuum_scale_factor,
+    autovacuum_analyze_scale_factor,
+    autovacuum_vacuum_threshold,
+    autovacuum_analyze_threshold,
+    autovacuum_vacuum_cost_delay,
+    autovacuum_vacuum_cost_limit
+);
+
+ALTER TABLE v1_workflow_concurrency_slot RESET (
+    autovacuum_vacuum_scale_factor,
+    autovacuum_analyze_scale_factor,
+    autovacuum_vacuum_threshold,
+    autovacuum_analyze_threshold,
+    autovacuum_vacuum_cost_delay,
+    autovacuum_vacuum_cost_limit
+);
+
+ALTER TABLE v1_concurrency_slot RESET (
+    autovacuum_vacuum_scale_factor,
+    autovacuum_analyze_scale_factor,
+    autovacuum_vacuum_threshold,
+    autovacuum_analyze_threshold,
+    autovacuum_vacuum_cost_delay,
+    autovacuum_vacuum_cost_limit
+);
+
+ALTER TABLE v1_retry_queue_item RESET (
+    autovacuum_vacuum_scale_factor,
+    autovacuum_analyze_scale_factor,
+    autovacuum_vacuum_threshold,
+    autovacuum_analyze_threshold,
+    autovacuum_vacuum_cost_delay,
+    autovacuum_vacuum_cost_limit
+);
+
+ALTER TABLE v1_durable_sleep RESET (
+    autovacuum_vacuum_scale_factor,
+    autovacuum_analyze_scale_factor,
+    autovacuum_vacuum_threshold,
+    autovacuum_analyze_threshold,
+    autovacuum_vacuum_cost_delay,
+    autovacuum_vacuum_cost_limit
+);
+
+ALTER TABLE v1_task_runtime_slot RESET (
+    autovacuum_vacuum_scale_factor,
+    autovacuum_analyze_scale_factor,
+    autovacuum_vacuum_threshold,
+    autovacuum_analyze_threshold,
+    autovacuum_vacuum_cost_delay,
+    autovacuum_vacuum_cost_limit
+);
+
+ALTER TABLE v1_batch_runtime RESET (
+    autovacuum_vacuum_scale_factor,
+    autovacuum_analyze_scale_factor,
+    autovacuum_vacuum_threshold,
+    autovacuum_analyze_threshold,
+    autovacuum_vacuum_cost_delay,
+    autovacuum_vacuum_cost_limit
+);
+-- +goose StatementEnd

--- a/sql/schema/v1-core.sql
+++ b/sql/schema/v1-core.sql
@@ -663,6 +663,15 @@ CREATE TABLE v1_batch_runtime (
 CREATE INDEX v1_batch_runtime_key_idx
     ON v1_batch_runtime (tenant_id, step_id, batch_key);
 
+ALTER TABLE v1_batch_runtime SET (
+    autovacuum_vacuum_scale_factor = '0.1',
+    autovacuum_analyze_scale_factor = '0.05',
+    autovacuum_vacuum_threshold = '25',
+    autovacuum_analyze_threshold = '25',
+    autovacuum_vacuum_cost_delay = '10',
+    autovacuum_vacuum_cost_limit = '1000'
+);
+
 -- Per-step batching configuration
 CREATE TABLE v1_step_batch_config (
     step_id UUID NOT NULL,
@@ -726,6 +735,15 @@ CREATE TABLE v1_task_runtime_slot (
 
 CREATE INDEX v1_task_runtime_slot_tenant_worker_type_idx
     ON v1_task_runtime_slot (tenant_id ASC, worker_id ASC, slot_type ASC);
+
+ALTER TABLE v1_task_runtime_slot SET (
+    autovacuum_vacuum_scale_factor = '0.1',
+    autovacuum_analyze_scale_factor = '0.05',
+    autovacuum_vacuum_threshold = '25',
+    autovacuum_analyze_threshold = '25',
+    autovacuum_vacuum_cost_delay = '10',
+    autovacuum_vacuum_cost_limit = '1000'
+);
 
 -- v1_rate_limited_queue_items represents a queue item that has been rate limited and removed from the v1_queue_item table.
 CREATE TABLE v1_rate_limited_queue_items (
@@ -898,6 +916,15 @@ CREATE TABLE v1_match (
     CONSTRAINT v1_match_pkey PRIMARY KEY (id)
 );
 
+ALTER TABLE v1_match SET (
+    autovacuum_vacuum_scale_factor = '0.1',
+    autovacuum_analyze_scale_factor = '0.05',
+    autovacuum_vacuum_threshold = '25',
+    autovacuum_analyze_threshold = '25',
+    autovacuum_vacuum_cost_delay = '10',
+    autovacuum_vacuum_cost_limit = '1000'
+);
+
 CREATE TYPE v1_event_type AS ENUM ('USER', 'INTERNAL');
 
 -- Provides information to the caller about the action to take. This is used to differentiate
@@ -1030,6 +1057,15 @@ CREATE INDEX v1_match_condition_filter_idx ON v1_match_condition (
     event_resource_hint ASC
 );
 
+ALTER TABLE v1_match_condition SET (
+    autovacuum_vacuum_scale_factor = '0.1',
+    autovacuum_analyze_scale_factor = '0.05',
+    autovacuum_vacuum_threshold = '25',
+    autovacuum_analyze_threshold = '25',
+    autovacuum_vacuum_cost_delay = '10',
+    autovacuum_vacuum_cost_limit = '1000'
+);
+
 CREATE TABLE v1_dag (
     id bigint GENERATED ALWAYS AS IDENTITY,
     inserted_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -1082,6 +1118,15 @@ CREATE INDEX v1_workflow_concurrency_slot_query_idx ON v1_workflow_concurrency_s
 CREATE INDEX v1_workflow_concurrency_slot_filled_idx ON v1_workflow_concurrency_slot (tenant_id, strategy_id, workflow_version_id, workflow_run_id)
     WHERE is_filled = TRUE;
 
+ALTER TABLE v1_workflow_concurrency_slot SET (
+    autovacuum_vacuum_scale_factor = '0.1',
+    autovacuum_analyze_scale_factor = '0.05',
+    autovacuum_vacuum_threshold = '25',
+    autovacuum_analyze_threshold = '25',
+    autovacuum_vacuum_cost_delay = '10',
+    autovacuum_vacuum_cost_limit = '1000'
+);
+
 -- CreateTable
 CREATE TABLE v1_concurrency_slot (
     sort_id BIGINT GENERATED ALWAYS AS IDENTITY,
@@ -1115,6 +1160,15 @@ CREATE INDEX v1_concurrency_slot_query_idx ON v1_concurrency_slot (tenant_id, st
 
 CREATE INDEX v1_concurrency_slot_timeout_idx ON v1_concurrency_slot (tenant_id, strategy_id, task_id, task_inserted_at)
     WHERE is_filled = FALSE;
+
+ALTER TABLE v1_concurrency_slot SET (
+    autovacuum_vacuum_scale_factor = '0.1',
+    autovacuum_analyze_scale_factor = '0.05',
+    autovacuum_vacuum_threshold = '25',
+    autovacuum_analyze_threshold = '25',
+    autovacuum_vacuum_cost_delay = '10',
+    autovacuum_vacuum_cost_limit = '1000'
+);
 
 -- When concurrency slot is CREATED, we should check whether the parent concurrency slot exists; if not, we should create
 -- the parent concurrency slot as well.
@@ -1389,6 +1443,15 @@ CREATE TABLE v1_retry_queue_item (
 );
 
 CREATE INDEX v1_retry_queue_item_tenant_id_retry_after_idx ON v1_retry_queue_item (tenant_id ASC, retry_after ASC);
+
+ALTER TABLE v1_retry_queue_item SET (
+    autovacuum_vacuum_scale_factor = '0.1',
+    autovacuum_analyze_scale_factor = '0.05',
+    autovacuum_vacuum_threshold = '25',
+    autovacuum_analyze_threshold = '25',
+    autovacuum_vacuum_cost_delay = '10',
+    autovacuum_vacuum_cost_limit = '1000'
+);
 
 CREATE OR REPLACE FUNCTION v1_task_insert_function()
 RETURNS TRIGGER AS $$
@@ -2159,6 +2222,15 @@ CREATE TABLE v1_durable_sleep (
     sleep_until TIMESTAMPTZ NOT NULL,
     sleep_duration TEXT NOT NULL,
     PRIMARY KEY (tenant_id, sleep_until, id)
+);
+
+ALTER TABLE v1_durable_sleep SET (
+    autovacuum_vacuum_scale_factor = '0.1',
+    autovacuum_analyze_scale_factor = '0.05',
+    autovacuum_vacuum_threshold = '25',
+    autovacuum_analyze_threshold = '25',
+    autovacuum_vacuum_cost_delay = '10',
+    autovacuum_vacuum_cost_limit = '1000'
 );
 
 CREATE TYPE v1_payload_type AS ENUM ('TASK_INPUT', 'DAG_INPUT', 'TASK_OUTPUT', 'TASK_EVENT_DATA', 'USER_EVENT_INPUT', 'DURABLE_EVENT_LOG_ENTRY_DATA', 'DURABLE_EVENT_LOG_ENTRY_RESULT_DATA');


### PR DESCRIPTION
# Description

Apply the same autovacuum settings used on `v1_task` partitions to other high-churn unpartitioned tables so they vacuum and analyze sooner.

## Type of change

- [x] Chore (changes which are not directly related to any business logic)

## What's Changed

- [x] Add `v1_0_154` to set autovacuum overrides on `v1_match`, `v1_match_condition`, `v1_workflow_concurrency_slot`, `v1_concurrency_slot`, `v1_retry_queue_item`, `v1_durable_sleep`, `v1_task_runtime_slot`, and `v1_batch_runtime`
- [x] Keep the same storage params in `v1-core.sql` for new installs

## Checklist

Changes have been:

- [ ] Tested (unit, integration, or manually with steps specified)
- [x] Linted and formatted
- [ ] Documented (where applicable)
- [ ] Added to CHANGELOG (where applicable) -- see [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

---

<details id="ai-disclosure">
<summary><b>🤖 AI Disclosure</b></summary>

- [x] _I acknowledge that an LLM was used in the creation of this Pull Request, in accordance with Hatchet's [AI_POLICY.md](./AI_POLICY.md)._

- **Details**: Wrote the goose migration and matching schema updates.

</details>